### PR TITLE
Add windsor env command

### DIFF
--- a/cmd/env.go
+++ b/cmd/env.go
@@ -1,0 +1,37 @@
+package cmd
+
+import (
+	"fmt"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+var goos = runtime.GOOS
+
+var envCmd = &cobra.Command{
+	Use:   "env",
+	Short: "Output commands to set environment variables",
+	Long:  "Output commands to set environment variables for the application.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Get the current context value
+		contextName, err := configHandler.GetConfigValue("context")
+		if err != nil {
+			return fmt.Errorf("Error getting config value: %w", err)
+		}
+
+		// Determine the command based on the OS
+		var command string
+		if goos == "windows" {
+			command = fmt.Sprintf("set WINDSORCONTEXT=%s", contextName)
+		} else {
+			command = fmt.Sprintf("export WINDSORCONTEXT=%s", contextName)
+		}
+		fmt.Println(command)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(envCmd)
+}

--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -1,0 +1,146 @@
+package cmd
+
+import (
+	"bytes"
+	"errors"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/windsor-hotel/cli/internal/config"
+)
+
+func TestEnvCmd_Success_Linux(t *testing.T) {
+	mockHandler := &config.MockConfigHandler{
+		GetConfigValueFunc: func(key string) (string, error) {
+			if key == "context" {
+				return "test-context", nil
+			}
+			return "", errors.New("key not found")
+		},
+	}
+
+	configHandler = mockHandler
+
+	// Mock the OS
+	originalGOOS := goos
+	goos = "linux"
+	defer func() { goos = originalGOOS }()
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	// Add the env command
+	rootCmd.AddCommand(envCmd)
+	rootCmd.SetArgs([]string{"env"})
+
+	// Execute the command
+	err := rootCmd.Execute()
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	os.Stdout = oldStdout
+	actualOutput := buf.String()
+
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	// Verify the output
+	expectedOutput := "export WINDSORCONTEXT=test-context\n"
+	if actualOutput != expectedOutput {
+		t.Errorf("Expected output '%s', got '%s'", expectedOutput, actualOutput)
+	}
+
+	// Remove the env command after the test
+	rootCmd.RemoveCommand(envCmd)
+}
+
+func TestEnvCmd_Success_Windows(t *testing.T) {
+	mockHandler := &config.MockConfigHandler{
+		GetConfigValueFunc: func(key string) (string, error) {
+			if key == "context" {
+				return "test-context", nil
+			}
+			return "", errors.New("key not found")
+		},
+	}
+
+	configHandler = mockHandler
+
+	// Mock the OS
+	originalGOOS := goos
+	goos = "windows"
+	defer func() { goos = originalGOOS }()
+
+	// Capture stdout
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	// Add the env command
+	rootCmd.AddCommand(envCmd)
+	rootCmd.SetArgs([]string{"env"})
+
+	// Execute the command
+	err := rootCmd.Execute()
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	os.Stdout = oldStdout
+	actualOutput := buf.String()
+
+	if err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	// Verify the output
+	expectedOutput := "set WINDSORCONTEXT=test-context\n"
+	if actualOutput != expectedOutput {
+		t.Errorf("Expected output '%s', got '%s'", expectedOutput, actualOutput)
+	}
+
+	// Remove the env command after the test
+	rootCmd.RemoveCommand(envCmd)
+}
+
+func TestEnvCmd_GetConfigValueError(t *testing.T) {
+	mockHandler := &config.MockConfigHandler{
+		GetConfigValueFunc: func(key string) (string, error) {
+			return "", errors.New("get config value error")
+		},
+	}
+
+	configHandler = mockHandler
+
+	// Capture stderr
+	oldStderr := os.Stderr
+	r, w, _ := os.Pipe()
+	os.Stderr = w
+
+	// Add the env command
+	rootCmd.AddCommand(envCmd)
+	rootCmd.SetArgs([]string{"env"})
+
+	// Execute the command
+	err := rootCmd.Execute()
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	os.Stderr = oldStderr
+	actualErrorMsg := buf.String()
+
+	if err == nil {
+		t.Fatalf("Expected error, got nil")
+	}
+
+	if !strings.Contains(actualErrorMsg, "get config value error") {
+		t.Errorf("Expected error message to contain 'get config value error', got '%s'", actualErrorMsg)
+	}
+
+	// Remove the env command after the test
+	rootCmd.RemoveCommand(envCmd)
+}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -13,9 +13,9 @@ import (
 
 func TestInitCmd_Success(t *testing.T) {
 	mockHandler := &config.MockConfigHandler{
-		LoadConfigErr:     nil,
-		SetConfigValueErr: nil,
-		SaveConfigErr:     nil,
+		LoadConfigFunc:     func(path string) error { return nil },
+		SetConfigValueFunc: func(key, value string) error { return nil },
+		SaveConfigFunc:     func(path string) error { return nil },
 	}
 
 	configHandler = mockHandler
@@ -64,7 +64,7 @@ func TestInitCmd_Success(t *testing.T) {
 
 func TestInitCmd_SetConfigValueError(t *testing.T) {
 	mockHandler := &config.MockConfigHandler{
-		SetConfigValueErr: errors.New("set config value error"),
+		SetConfigValueFunc: func(key, value string) error { return errors.New("set config value error") },
 	}
 
 	configHandler = mockHandler
@@ -107,7 +107,7 @@ func TestInitCmd_SetConfigValueError(t *testing.T) {
 
 func TestInitCmd_SaveConfigError(t *testing.T) {
 	mockHandler := &config.MockConfigHandler{
-		SaveConfigErr: errors.New("save config error"),
+		SaveConfigFunc: func(path string) error { return errors.New("save config error") },
 	}
 
 	configHandler = mockHandler

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestPreRunLoadConfig_Success(t *testing.T) {
 	mockHandler := &config.MockConfigHandler{
-		LoadConfigErr: nil,
+		LoadConfigFunc: func(path string) error { return nil },
 	}
 
 	Initialize(mockHandler)
@@ -26,7 +26,7 @@ func TestPreRunLoadConfig_Success(t *testing.T) {
 
 func TestPreRunLoadConfig_Failure(t *testing.T) {
 	mockHandler := &config.MockConfigHandler{
-		LoadConfigErr: errors.New("config load error"),
+		LoadConfigFunc: func(path string) error { return errors.New("config load error") },
 	}
 
 	Initialize(mockHandler)
@@ -63,7 +63,7 @@ func TestExecute(t *testing.T) {
 
 	// Initialize with a successful config handler
 	mockHandler := &config.MockConfigHandler{
-		LoadConfigErr: nil,
+		LoadConfigFunc: func(path string) error { return nil },
 	}
 	Initialize(mockHandler)
 
@@ -98,7 +98,7 @@ func TestExecute_LoadConfigError(t *testing.T) {
 	}
 
 	mockHandler := &config.MockConfigHandler{
-		LoadConfigErr: errors.New("config load error"),
+		LoadConfigFunc: func(path string) error { return errors.New("config load error") },
 	}
 	Initialize(mockHandler)
 

--- a/internal/config/mock_config_handler.go
+++ b/internal/config/mock_config_handler.go
@@ -2,26 +2,38 @@ package config
 
 // MockConfigHandler is a mock implementation of the ConfigHandler interface
 type MockConfigHandler struct {
-	LoadConfigErr     error
-	GetConfigValueErr error
-	SetConfigValueErr error
-	SaveConfigErr     error
+	LoadConfigFunc     func(path string) error
+	GetConfigValueFunc func(key string) (string, error)
+	SetConfigValueFunc func(key, value string) error
+	SaveConfigFunc     func(path string) error
 }
 
 func (m *MockConfigHandler) LoadConfig(path string) error {
-	return m.LoadConfigErr
+	if m.LoadConfigFunc != nil {
+		return m.LoadConfigFunc(path)
+	}
+	return nil
 }
 
 func (m *MockConfigHandler) GetConfigValue(key string) (string, error) {
-	return "", m.GetConfigValueErr
+	if m.GetConfigValueFunc != nil {
+		return m.GetConfigValueFunc(key)
+	}
+	return "", nil
 }
 
 func (m *MockConfigHandler) SetConfigValue(key, value string) error {
-	return m.SetConfigValueErr
+	if m.SetConfigValueFunc != nil {
+		return m.SetConfigValueFunc(key, value)
+	}
+	return nil
 }
 
 func (m *MockConfigHandler) SaveConfig(path string) error {
-	return m.SaveConfigErr
+	if m.SaveConfigFunc != nil {
+		return m.SaveConfigFunc(path)
+	}
+	return nil
 }
 
 // Ensure MockConfigHandler implements ConfigHandler

--- a/internal/config/mock_config_handler_test.go
+++ b/internal/config/mock_config_handler_test.go
@@ -7,7 +7,11 @@ import (
 
 func TestMockConfigHandler_LoadConfig(t *testing.T) {
 	mockErr := errors.New("mock load config error")
-	handler := &MockConfigHandler{LoadConfigErr: mockErr}
+	handler := &MockConfigHandler{
+		LoadConfigFunc: func(path string) error {
+			return mockErr
+		},
+	}
 
 	err := handler.LoadConfig("some/path")
 	if err != mockErr {
@@ -17,7 +21,11 @@ func TestMockConfigHandler_LoadConfig(t *testing.T) {
 
 func TestMockConfigHandler_GetConfigValue(t *testing.T) {
 	mockErr := errors.New("mock get config value error")
-	handler := &MockConfigHandler{GetConfigValueErr: mockErr}
+	handler := &MockConfigHandler{
+		GetConfigValueFunc: func(key string) (string, error) {
+			return "", mockErr
+		},
+	}
 
 	_, err := handler.GetConfigValue("someKey")
 	if err != mockErr {
@@ -27,7 +35,11 @@ func TestMockConfigHandler_GetConfigValue(t *testing.T) {
 
 func TestMockConfigHandler_SetConfigValue(t *testing.T) {
 	mockErr := errors.New("mock set config value error")
-	handler := &MockConfigHandler{SetConfigValueErr: mockErr}
+	handler := &MockConfigHandler{
+		SetConfigValueFunc: func(key, value string) error {
+			return mockErr
+		},
+	}
 
 	err := handler.SetConfigValue("someKey", "someValue")
 	if err != mockErr {
@@ -37,10 +49,49 @@ func TestMockConfigHandler_SetConfigValue(t *testing.T) {
 
 func TestMockConfigHandler_SaveConfig(t *testing.T) {
 	mockErr := errors.New("mock save config error")
-	handler := &MockConfigHandler{SaveConfigErr: mockErr}
+	handler := &MockConfigHandler{
+		SaveConfigFunc: func(path string) error {
+			return mockErr
+		},
+	}
 
 	err := handler.SaveConfig("some/path")
 	if err != mockErr {
 		t.Errorf("SaveConfig() error = %v, wantErr %v", err, mockErr)
+	}
+}
+
+func TestMockConfigHandler_LoadConfig_Default(t *testing.T) {
+	handler := &MockConfigHandler{}
+	err := handler.LoadConfig("some/path")
+	if err != nil {
+		t.Errorf("Expected nil, got %v", err)
+	}
+}
+
+func TestMockConfigHandler_GetConfigValue_Default(t *testing.T) {
+	handler := &MockConfigHandler{}
+	value, err := handler.GetConfigValue("someKey")
+	if err != nil {
+		t.Errorf("Expected nil error, got %v", err)
+	}
+	if value != "" {
+		t.Errorf("Expected empty string, got %v", value)
+	}
+}
+
+func TestMockConfigHandler_SetConfigValue_Default(t *testing.T) {
+	handler := &MockConfigHandler{}
+	err := handler.SetConfigValue("someKey", "someValue")
+	if err != nil {
+		t.Errorf("Expected nil, got %v", err)
+	}
+}
+
+func TestMockConfigHandler_SaveConfig_Default(t *testing.T) {
+	handler := &MockConfigHandler{}
+	err := handler.SaveConfig("some/path")
+	if err != nil {
+		t.Errorf("Expected nil, got %v", err)
 	}
 }


### PR DESCRIPTION
Adds `windsor env`. This command exports environment variables. For now, this only includes `WINDSORCONTEXT=`.

Testing this command required generalizing the config mock to use functions.