### PR TITLE
[Kube Helper] Fix missing KUBE_CONFIG_PATH

### DIFF
--- a/internal/helpers/kube_helper.go
+++ b/internal/helpers/kube_helper.go
@@ -42,6 +42,7 @@ func (h *KubeHelper) GetEnvVars() (map[string]string, error) {
 
 	envVars := map[string]string{
 		"KUBECONFIG": kubeConfigPath,
+		"KUBE_CONFIG_PATH": kubeConfigPath,
 	}
 
 	return envVars, nil

--- a/internal/helpers/kube_helper_test.go
+++ b/internal/helpers/kube_helper_test.go
@@ -47,7 +47,8 @@ func TestKubeHelper_GetEnvVars(t *testing.T) {
 
 		// Then: the environment variables should be set correctly
 		expectedEnvVars := map[string]string{
-			"KUBECONFIG": kubeConfigPath,
+			"KUBECONFIG":       kubeConfigPath,
+			"KUBE_CONFIG_PATH": kubeConfigPath,
 		}
 		if !reflect.DeepEqual(envVars, expectedEnvVars) {
 			t.Errorf("expected %v, got %v", expectedEnvVars, envVars)
@@ -77,7 +78,8 @@ func TestKubeHelper_GetEnvVars(t *testing.T) {
 
 		// Then: the environment variables should be set correctly with an empty KUBECONFIG
 		expectedEnvVars := map[string]string{
-			"KUBECONFIG": kubeConfigPath,
+			"KUBECONFIG":       kubeConfigPath,
+			"KUBE_CONFIG_PATH": kubeConfigPath,
 		}
 		if !reflect.DeepEqual(envVars, expectedEnvVars) {
 			t.Errorf("expected %v, got %v", expectedEnvVars, envVars)


### PR DESCRIPTION
The `KUBE_CONFIG_PATH` was missing. This env var is used by Terraform providers.