### PR TITLE
Dns helper

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,7 @@
         "request": "launch",
         "mode": "auto",
         "program": "${workspaceFolder}/cmd/windsor/main.go",
-        "args": ["init", "test"]
+        "args": ["init", "local"]
     },
   ]
 }

--- a/cmd/windsor/main.go
+++ b/cmd/windsor/main.go
@@ -100,6 +100,13 @@ func main() {
 	}
 	container.Register("colimaHelper", colimaHelper)
 
+	// Create and register the DNSHelper instance
+	dnsHelper, err := helpers.NewDNSHelper(container)
+	if err != nil {
+		log.Fatalf("failed to create dns helper: %v", err)
+	}
+	container.Register("dnsHelper", dnsHelper)
+
 	// Create and register the DockerHelper instance
 	// This should go last!
 	dockerHelper, err := helpers.NewDockerHelper(container)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,9 +63,9 @@ type VMConfig struct {
 
 // DNSConfig represents the DNS configuration
 type DNSConfig struct {
-	Enabled *bool   `yaml:"enabled"`
-	Name    *string `yaml:"name"`
-	IP      *string `yaml:"ip"`
+	Create *bool   `yaml:"enabled"`
+	Name   *string `yaml:"name"`
+	IP     *string `yaml:"ip"`
 }
 
 // ClusterConfig represents the cluster configuration
@@ -92,6 +92,7 @@ type Context struct {
 	Terraform   *TerraformConfig  `yaml:"terraform"`
 	VM          *VMConfig         `yaml:"vm"`
 	Cluster     *ClusterConfig    `yaml:"cluster"`
+	DNS         *DNSConfig        `yaml:"dns"`
 }
 
 // Config represents the entire configuration
@@ -122,6 +123,11 @@ var DefaultConfig = Context{
 		Backend: nil,
 	},
 	Cluster: nil,
+	DNS: &DNSConfig{
+		Create: nil,
+		Name:   nil,
+		IP:     nil,
+	},
 }
 
 // DefaultLocalConfig returns the default configuration for the "local" context
@@ -202,5 +208,10 @@ var DefaultLocalConfig = Context{
 			CPU:    ptrInt(4),
 			Memory: ptrInt(4),
 		},
+	},
+	DNS: &DNSConfig{
+		Create: ptrBool(true),
+		Name:   ptrString("test"),
+		IP:     nil,
 	},
 }

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -28,3 +28,8 @@ const (
 	// renovate: datasource=docker depName=localstack/localstack-pro
 	DEFAULT_AWS_LOCALSTACK_PRO_IMAGE = "localstack/localstack-pro:3.8.1"
 )
+
+// Default DNS settings
+const (
+	DEFAULT_DNS_IMAGE = "coredns/coredns:1.11.3"
+)

--- a/internal/helpers/dns_helper.go
+++ b/internal/helpers/dns_helper.go
@@ -2,25 +2,25 @@ package helpers
 
 import (
 	"fmt"
+	"path/filepath"
 
 	"github.com/compose-spec/compose-go/types"
 	"github.com/windsor-hotel/cli/internal/config"
+	"github.com/windsor-hotel/cli/internal/constants"
+	"github.com/windsor-hotel/cli/internal/context"
 	"github.com/windsor-hotel/cli/internal/di"
 )
 
 // DNSHelper handles DNS configuration
 type DNSHelper struct {
-	ConfigHandler config.ConfigHandler
+	DIContainer *di.DIContainer
 }
 
 // NewDNSHelper creates a new DNSHelper
 func NewDNSHelper(di *di.DIContainer) (*DNSHelper, error) {
-	cliConfigHandler, err := di.Resolve("cliConfigHandler")
-	if err != nil {
-		return nil, fmt.Errorf("error resolving cliConfigHandler: %w", err)
-	}
-
-	return &DNSHelper{ConfigHandler: cliConfigHandler.(config.ConfigHandler)}, nil
+	return &DNSHelper{
+		DIContainer: di,
+	}, nil
 }
 
 // Initialize performs any necessary initialization for the helper.
@@ -40,11 +40,133 @@ func (h *DNSHelper) PostEnvExec() error {
 
 // GetComposeConfig returns the compose configuration
 func (h *DNSHelper) GetComposeConfig() (*types.Config, error) {
-	return nil, nil
+	// Retrieve the context configuration
+	cliConfigHandler, err := h.DIContainer.Resolve("cliConfigHandler")
+	if err != nil {
+		return nil, fmt.Errorf("error resolving cliConfigHandler: %w", err)
+	}
+	contextConfig, err := cliConfigHandler.(config.ConfigHandler).GetConfig()
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving context configuration: %w", err)
+	}
+
+	// Check if the DNS is enabled
+	if contextConfig.DNS == nil || contextConfig.DNS.Create == nil || !*contextConfig.DNS.Create {
+		return nil, nil
+	}
+
+	// Get the Name from the configuration
+	name := "test"
+	if contextConfig.DNS.Name != nil && *contextConfig.DNS.Name != "" {
+		name = *contextConfig.DNS.Name
+	}
+
+	// Common configuration for CoreDNS container
+	corednsConfig := types.ServiceConfig{
+		Name:    fmt.Sprintf("dns.%s", name),
+		Image:   constants.DEFAULT_DNS_IMAGE,
+		Restart: "always",
+		Volumes: []types.ServiceVolumeConfig{
+			{Type: "bind", Source: "./Corefile", Target: "/etc/coredns/Corefile"},
+		},
+		Environment: map[string]*string{
+			"COREDNS_CONFIG": strPtr("/etc/coredns/Corefile"),
+		},
+	}
+
+	services := []types.ServiceConfig{corednsConfig}
+	volumes := map[string]types.VolumeConfig{
+		"coredns_config": {},
+	}
+
+	return &types.Config{Services: services, Volumes: volumes}, nil
 }
 
-// WriteConfig writes the configuration to the specified file
+// WriteConfig writes any necessary configuration files needed by the helper
 func (h *DNSHelper) WriteConfig() error {
+	// Retrieve the context configuration
+	cliConfigHandler, err := h.DIContainer.Resolve("cliConfigHandler")
+	if err != nil {
+		return fmt.Errorf("error resolving cliConfigHandler: %w", err)
+	}
+	contextConfig, err := cliConfigHandler.(config.ConfigHandler).GetConfig()
+	if err != nil {
+		return fmt.Errorf("error retrieving context configuration: %w", err)
+	}
+
+	// Check if DNS is defined and DNS Create is enabled
+	if contextConfig.DNS == nil || contextConfig.DNS.Create == nil || !*contextConfig.DNS.Create {
+		return nil
+	}
+
+	// Check if Docker is enabled
+	if contextConfig.Docker == nil || contextConfig.Docker.Enabled == nil || !*contextConfig.Docker.Enabled {
+		return nil
+	}
+
+	// Retrieve the configuration directory for the current context
+	resolvedContext, err := h.DIContainer.Resolve("context")
+	if err != nil {
+		return fmt.Errorf("error resolving context: %w", err)
+	}
+	configDir, err := resolvedContext.(context.ContextInterface).GetConfigRoot()
+	if err != nil {
+		return fmt.Errorf("error retrieving config root: %w", err)
+	}
+
+	// Get the TLD from the configuration
+	name := "test"
+	if contextConfig.DNS.Name != nil && *contextConfig.DNS.Name != "" {
+		name = *contextConfig.DNS.Name
+	}
+
+	// Retrieve the compose configuration from DockerHelper
+	dockerHelper, err := h.DIContainer.Resolve("dockerHelper")
+	if err != nil {
+		return fmt.Errorf("error resolving dockerHelper: %w", err)
+	}
+	dockerHelperInstance, ok := dockerHelper.(*DockerHelper)
+	if !ok {
+		return fmt.Errorf("error casting to DockerHelper")
+	}
+	composeConfig, err := dockerHelperInstance.GetFullComposeConfig()
+	if err != nil {
+		return fmt.Errorf("error retrieving compose configuration: %w", err)
+	}
+
+	// Gather the IP address of each service
+	var hostEntries string
+	for _, service := range composeConfig.Services {
+		for _, networkConfig := range service.Networks {
+			if networkConfig.Ipv4Address != "" {
+				hostEntries += fmt.Sprintf("        %s %s\n", networkConfig.Ipv4Address, service.Name)
+			}
+		}
+	}
+
+	// Template out the Corefile with information from the compose configuration
+	corefileContent := fmt.Sprintf(`
+%s:53 {
+    hosts {
+%s        fallthrough
+    }
+
+    forward . /etc/resolv.conf
+}
+`, name, hostEntries)
+
+	corefilePath := filepath.Join(configDir, "Corefile")
+
+	// Ensure the parent folders exist
+	if err := mkdirAll(filepath.Dir(corefilePath), 0755); err != nil {
+		return fmt.Errorf("error creating parent folders: %w", err)
+	}
+
+	err = writeFile(corefilePath, []byte(corefileContent), 0644)
+	if err != nil {
+		return fmt.Errorf("error writing Corefile: %w", err)
+	}
+
 	return nil
 }
 

--- a/internal/helpers/dns_helper_test.go
+++ b/internal/helpers/dns_helper_test.go
@@ -1,52 +1,54 @@
 package helpers
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/windsor-hotel/cli/internal/config"
+	"github.com/windsor-hotel/cli/internal/constants"
+	"github.com/windsor-hotel/cli/internal/context"
 	"github.com/windsor-hotel/cli/internal/di"
 )
 
-func TestDNSHelper_NewDNSHelper(t *testing.T) {
-	t.Run("ErrorResolvingConfigHandler", func(t *testing.T) {
-		// Create DI container without registering cliConfigHandler
-		diContainer := di.NewContainer()
+func TestNewDNSHelper(t *testing.T) {
+	// Create a mock DI container
+	mockDIContainer := di.NewMockContainer()
 
-		// Attempt to create DNSHelper
-		_, err := NewDNSHelper(diContainer)
-		if err == nil || !strings.Contains(err.Error(), "error resolving cliConfigHandler") {
-			t.Fatalf("expected error resolving cliConfigHandler, got %v", err)
-		}
-	})
+	// Call NewDNSHelper with the mock DI container
+	helper, err := NewDNSHelper(mockDIContainer.DIContainer)
 
-	t.Run("Success", func(t *testing.T) {
-		// Create DI container and register cliConfigHandler
-		diContainer := di.NewContainer()
-		mockConfigHandler := config.NewMockConfigHandler()
-		diContainer.Register("cliConfigHandler", mockConfigHandler)
+	// Verify that no error is returned
+	if err != nil {
+		t.Fatalf("NewDNSHelper() error = %v, wantErr %v", err, false)
+	}
 
-		// Attempt to create DNSHelper
-		helper, err := NewDNSHelper(diContainer)
-		if err != nil {
-			t.Fatalf("NewDNSHelper() error = %v", err)
-		}
+	// Verify that the helper is not nil
+	if helper == nil {
+		t.Fatalf("NewDNSHelper() returned nil, expected non-nil DNSHelper")
+	}
 
-		// Ensure the helper is not nil
-		if helper == nil {
-			t.Fatalf("expected helper to be non-nil")
-		}
-	})
+	// Verify that the DIContainer is correctly set
+	if helper.DIContainer != mockDIContainer.DIContainer {
+		t.Errorf("NewDNSHelper() DIContainer = %v, want %v", helper.DIContainer, mockDIContainer)
+	}
 }
 
 func TestDNSHelper_Initialize(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		// Given: a mock config handler and helper
 		mockConfigHandler := config.NewMockConfigHandler()
-		helper := &DNSHelper{ConfigHandler: mockConfigHandler}
+		diContainer := di.NewContainer()
+		diContainer.Register("cliConfigHandler", mockConfigHandler)
+		helper, err := NewDNSHelper(diContainer)
+		if err != nil {
+			t.Fatalf("NewDNSHelper() error = %v", err)
+		}
 
 		// When: Initialize is called
-		err := helper.Initialize()
+		err = helper.Initialize()
 
 		// Then: no error should be returned
 		if err != nil {
@@ -59,7 +61,12 @@ func TestDNSHelper_GetEnvVars(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		// Given: a mock config handler and helper
 		mockConfigHandler := config.NewMockConfigHandler()
-		helper := &DNSHelper{ConfigHandler: mockConfigHandler}
+		diContainer := di.NewContainer()
+		diContainer.Register("cliConfigHandler", mockConfigHandler)
+		helper, err := NewDNSHelper(diContainer)
+		if err != nil {
+			t.Fatalf("NewDNSHelper() error = %v", err)
+		}
 
 		// When: GetEnvVars is called
 		envVars, err := helper.GetEnvVars()
@@ -78,10 +85,15 @@ func TestDNSHelper_PostEnvExec(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		// Given: a mock config handler and helper
 		mockConfigHandler := config.NewMockConfigHandler()
-		helper := &DNSHelper{ConfigHandler: mockConfigHandler}
+		diContainer := di.NewContainer()
+		diContainer.Register("cliConfigHandler", mockConfigHandler)
+		helper, err := NewDNSHelper(diContainer)
+		if err != nil {
+			t.Fatalf("NewDNSHelper() error = %v", err)
+		}
 
 		// When: PostEnvExec is called
-		err := helper.PostEnvExec()
+		err = helper.PostEnvExec()
 
 		// Then: no error should be returned
 		if err != nil {
@@ -92,31 +104,844 @@ func TestDNSHelper_PostEnvExec(t *testing.T) {
 
 func TestDNSHelper_GetComposeConfig(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		// Given: a mock config handler and helper
+		// Create a mock DI container
+		mockDIContainer := di.NewMockContainer()
+
+		// Create a mock context
+		mockContext := context.NewMockContext()
+		mockContext.GetConfigRootFunc = func() (string, error) {
+			return "/mock/config/root", nil
+		}
+		mockDIContainer.Register("context", mockContext)
+
+		// Create a mock cliConfigHandler
 		mockConfigHandler := config.NewMockConfigHandler()
-		helper := &DNSHelper{ConfigHandler: mockConfigHandler}
+		mockConfigHandler.GetConfigFunc = func() (*config.Context, error) {
+			enabled := true
+			return &config.Context{
+				Docker: &config.DockerConfig{
+					Enabled: &enabled,
+				},
+				DNS: &config.DNSConfig{
+					Create: &enabled,
+					Name:   ptrString("test1"),
+				},
+			}, nil
+		}
+		mockDIContainer.Register("cliConfigHandler", mockConfigHandler)
+
+		// Create a mock dockerHelper using MakeDockerHelper
+		mockDockerHelper, err := NewDockerHelper(mockDIContainer.DIContainer)
+		if err != nil {
+			t.Fatalf("NewDockerHelper() error = %v", err)
+		}
+		mockDIContainer.Register("dockerHelper", mockDockerHelper)
+
+		// Given: a DNSHelper with the mock DI container
+		helper := &DNSHelper{
+			DIContainer: mockDIContainer.DIContainer,
+		}
 
 		// When: GetComposeConfig is called
-		config, err := helper.GetComposeConfig()
+		cfg, err := helper.GetComposeConfig()
 
-		// Then: no error should be returned and config should be nil
+		// Then: no error should be returned, and cfg should be correctly populated
 		if err != nil {
 			t.Fatalf("GetComposeConfig() error = %v", err)
 		}
-		if config != nil {
-			t.Errorf("expected config to be nil, got %v", config)
+		if cfg == nil {
+			t.Fatalf("Expected cfg to be non-nil when GetComposeConfig succeeds")
+		}
+		if len(cfg.Services) != 1 {
+			t.Errorf("Expected 1 service, got %d", len(cfg.Services))
+		}
+		if cfg.Services[0].Name != "dns.test1" {
+			t.Errorf("Expected service name to be 'dns.test1', got %s", cfg.Services[0].Name)
 		}
 	})
+
+	t.Run("DNSDisabled", func(t *testing.T) {
+		// Create a mock config handler that returns DNS disabled
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.GetConfigFunc = func() (*config.Context, error) {
+			return &config.Context{
+				DNS: &config.DNSConfig{
+					Create: ptrBool(false),
+				},
+			}, nil
+		}
+
+		// Given: a DNSHelper with the mock config handler
+		diContainer := di.NewContainer()
+		diContainer.Register("cliConfigHandler", mockConfigHandler)
+		helper, err := NewDNSHelper(diContainer)
+		if err != nil {
+			t.Fatalf("NewDNSHelper() error = %v", err)
+		}
+
+		// When: GetComposeConfig is called
+		cfg, err := helper.GetComposeConfig()
+
+		// Then: no error should be returned, and cfg should be nil
+		if err != nil {
+			t.Fatalf("GetComposeConfig() error = %v", err)
+		}
+		if cfg != nil {
+			t.Errorf("Expected cfg to be nil when DNS is disabled, got %v", cfg)
+		}
+	})
+
+	t.Run("DNSEnabled", func(t *testing.T) {
+		// Create a mock config handler that returns DNS enabled
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.GetConfigFunc = func() (*config.Context, error) {
+			return &config.Context{
+				DNS: &config.DNSConfig{
+					Create: ptrBool(true),
+				},
+			}, nil
+		}
+
+		// Given: a DNSHelper with the mock config handler
+		diContainer := di.NewContainer()
+		diContainer.Register("cliConfigHandler", mockConfigHandler)
+		helper, err := NewDNSHelper(diContainer)
+		if err != nil {
+			t.Fatalf("NewDNSHelper() error = %v", err)
+		}
+
+		// When: GetComposeConfig is called
+		cfg, err := helper.GetComposeConfig()
+
+		// Then: no error should be returned, and cfg should not be nil
+		if err != nil {
+			t.Fatalf("GetComposeConfig() error = %v", err)
+		}
+		if cfg == nil {
+			t.Fatalf("Expected cfg to be non-nil when DNS is enabled")
+		}
+
+		// Check that cfg contains the expected service configuration
+		if len(cfg.Services) != 1 {
+			t.Errorf("Expected 1 service, got %d", len(cfg.Services))
+		}
+		service := cfg.Services[0]
+		if service.Name != "dns.test" {
+			t.Errorf("Expected service name 'dns.test', got '%s'", service.Name)
+		}
+		if service.Image != constants.DEFAULT_DNS_IMAGE {
+			t.Errorf("Expected image '%s', got '%s'", constants.DEFAULT_DNS_IMAGE, service.Image)
+		}
+
+		// Additional assertions to verify Volumes, Environment, etc.
+		if len(service.Volumes) != 1 {
+			t.Errorf("Expected 1 volume, got %d", len(service.Volumes))
+		}
+
+		if service.Volumes[0].Source != "./Corefile" || service.Volumes[0].Target != "/etc/coredns/Corefile" {
+			t.Errorf("Unexpected volume configuration")
+		}
+
+		if val, ok := service.Environment["COREDNS_CONFIG"]; !ok || *val != "/etc/coredns/Corefile" {
+			t.Errorf("Expected environment variable COREDNS_CONFIG to be '/etc/coredns/Corefile'")
+		}
+	})
+
+	t.Run("ErrorRetrievingContextConfig", func(t *testing.T) {
+		// Create a mock config handler that returns an error
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.GetConfigFunc = func() (*config.Context, error) {
+			return nil, fmt.Errorf("mock error retrieving context configuration")
+		}
+
+		// Given: a DNSHelper with the mock config handler
+		diContainer := di.NewContainer()
+		diContainer.Register("cliConfigHandler", mockConfigHandler)
+		helper, err := NewDNSHelper(diContainer)
+		if err != nil {
+			t.Fatalf("NewDNSHelper() error = %v", err)
+		}
+
+		// When: GetComposeConfig is called
+		cfg, err := helper.GetComposeConfig()
+
+		// Then: an error should be returned, and cfg should be nil
+		if err == nil || !strings.Contains(err.Error(), "error retrieving context configuration") {
+			t.Fatalf("expected error retrieving context configuration, got %v", err)
+		}
+		if cfg != nil {
+			t.Errorf("Expected cfg to be nil when context config retrieval fails, got %v", cfg)
+		}
+	})
+
+	t.Run("ErrorResolvingCliConfigHandler", func(t *testing.T) {
+		// Create a mock DI container that fails to resolve cliConfigHandler
+		mockDIContainer := di.NewMockContainer()
+		mockDIContainer.SetResolveError("cliConfigHandler", fmt.Errorf("mock error resolving cliConfigHandler"))
+		// Given: a DNSHelper with the mock DI container
+		helper, err := NewDNSHelper(mockDIContainer.DIContainer)
+		if err != nil {
+			t.Fatalf("NewDNSHelper() error = %v", err)
+		}
+
+		// When: GetComposeConfig is called
+		cfg, err := helper.GetComposeConfig()
+
+		// Then: an error should be returned, and cfg should be nil
+		if err == nil || !strings.Contains(err.Error(), "error resolving cliConfigHandler") {
+			t.Fatalf("expected error resolving cliConfigHandler, got %v", err)
+		}
+		if cfg != nil {
+			t.Errorf("Expected cfg to be nil when cliConfigHandler resolution fails, got %v", cfg)
+		}
+	})
+
 }
 
 func TestDNSHelper_WriteConfig(t *testing.T) {
-	t.Run("Success", func(t *testing.T) {
-		// Given: a mock config handler and helper
+	// Shared resources
+	mockContext := context.NewMockContext()
+	mockConfigHandler := config.NewMockConfigHandler()
+	mockDockerHelper := NewMockHelper()
+
+	t.Run("DockerDisabled", func(t *testing.T) {
+		// Create a mock config handler that returns Docker disabled
+		mockConfigHandler.GetConfigFunc = func() (*config.Context, error) {
+			return &config.Context{
+				Docker: &config.DockerConfig{
+					Enabled: ptrBool(false),
+				},
+			}, nil
+		}
+
+		// Create a mock context
+		mockContext.GetConfigRootFunc = func() (string, error) {
+			return "/mock/config/root", nil
+		}
+
+		diContainer := di.NewContainer()
+		diContainer.Register("cliConfigHandler", mockConfigHandler)
+		diContainer.Register("context", mockContext)
+
+		helper, err := NewDNSHelper(diContainer)
+		if err != nil {
+			t.Fatalf("NewDNSHelper() error = %v", err)
+		}
+
+		// When: WriteConfig is called
+		err = helper.WriteConfig()
+
+		// Then: no error should be returned
+		if err != nil {
+			t.Fatalf("WriteConfig() error = %v", err)
+		}
+	})
+
+	t.Run("DockerEnabled", func(t *testing.T) {
+		// Create a temporary directory for config root
+		tempDir := t.TempDir()
+
+		// Create a mock context that returns the temp directory as config root
+		mockContext.GetConfigRootFunc = func() (string, error) {
+			return tempDir, nil
+		}
+
+		// Mock the GetContext function to avoid the error
+		mockContext.GetContextFunc = func() (string, error) {
+			return "test", nil
+		}
+
+		// Create a real DockerHelper
+		diContainer := di.NewContainer()
+		diContainer.Register("cliConfigHandler", mockConfigHandler)
+		diContainer.Register("context", mockContext)
+
+		dockerHelper, err := NewDockerHelper(diContainer)
+		if err != nil {
+			t.Fatalf("NewDockerHelper() error = %v", err)
+		}
+		diContainer.Register("dockerHelper", dockerHelper)
+
+		// Create a mock config handler that returns Docker enabled
+		mockConfigHandler.GetConfigFunc = func() (*config.Context, error) {
+			return &config.Context{
+				Docker: &config.DockerConfig{
+					Enabled:     ptrBool(true),
+					NetworkCIDR: ptrString("192.168.1.0/24"),
+					Registries: []config.Registry{
+						{
+							Name:   "service1",
+							Remote: "remote1",
+							Local:  "local1",
+						},
+						{
+							Name:   "service2",
+							Remote: "remote2",
+							Local:  "local2",
+						},
+					},
+				},
+				DNS: &config.DNSConfig{
+					Create: ptrBool(true),
+				},
+			}, nil
+		}
+
+		// Given: a DNSHelper with the mock config handler, context, and real DockerHelper
+		helper, err := NewDNSHelper(diContainer)
+		if err != nil {
+			t.Fatalf("NewDNSHelper() error = %v", err)
+		}
+
+		// When: WriteConfig is called
+		err = helper.WriteConfig()
+
+		// Then: no error should be returned
+		if err != nil {
+			t.Fatalf("WriteConfig() error = %v", err)
+		}
+
+		// Check that the Corefile is written correctly
+		corefilePath := filepath.Join(tempDir, "Corefile")
+		data, err := os.ReadFile(corefilePath)
+		if err != nil {
+			t.Fatalf("Failed to read Corefile: %v", err)
+		}
+		content := string(data)
+
+		expectedHostEntries := "        192.168.1.2 service1\n        192.168.1.3 service2\n"
+		if !strings.Contains(content, expectedHostEntries) {
+			t.Errorf("Corefile does not contain expected host entries.\nExpected:\n%s\nGot:\n%s", expectedHostEntries, content)
+		}
+
+		// Additional assertions can be made to check the content of the Corefile
+		expectedCorefileContent := fmt.Sprintf(`
+%s:53 {
+    hosts {
+%s        fallthrough
+    }
+
+    forward . /etc/resolv.conf
+}
+`, "test", expectedHostEntries)
+
+		if content != expectedCorefileContent {
+			t.Errorf("Corefile content does not match expected content.\nExpected:\n%s\nGot:\n%s", expectedCorefileContent, content)
+		}
+	})
+
+	t.Run("ErrorCastingToDockerHelper", func(t *testing.T) {
+		// Create a mock DI container that resolves to an incorrect type for dockerHelper
+		mockDIContainer := di.NewMockContainer()
+		mockDIContainer.Register("dockerHelper", "notADockerHelper") // Incorrect type
+
+		// Create a mock context
+		mockContext := context.NewMockContext()
+		mockContext.GetConfigRootFunc = func() (string, error) {
+			return "/mock/config/root", nil
+		}
+		mockDIContainer.Register("context", mockContext)
+
+		// Create a mock cliConfigHandler
 		mockConfigHandler := config.NewMockConfigHandler()
-		helper := &DNSHelper{ConfigHandler: mockConfigHandler}
+		mockConfigHandler.GetConfigFunc = func() (*config.Context, error) {
+			enabled := true
+			return &config.Context{
+				Docker: &config.DockerConfig{
+					Enabled: &enabled,
+				},
+				DNS: &config.DNSConfig{
+					Create: &enabled,
+				},
+			}, nil
+		}
+		mockDIContainer.Register("cliConfigHandler", mockConfigHandler)
+
+		// Given: a DNSHelper with the mock DI container
+		helper := &DNSHelper{
+			DIContainer: mockDIContainer.DIContainer,
+		}
 
 		// When: WriteConfig is called
 		err := helper.WriteConfig()
+
+		// Then: an error should be returned
+		if err == nil || !strings.Contains(err.Error(), "error casting to DockerHelper") {
+			t.Fatalf("expected error casting to DockerHelper, got %v", err)
+		}
+	})
+
+	t.Run("ErrorRetrievingConfigRoot", func(t *testing.T) {
+		// Create a mock context that returns an error on GetConfigRoot
+		mockContext.GetConfigRootFunc = func() (string, error) {
+			return "", fmt.Errorf("mock error retrieving config root")
+		}
+
+		diContainer := di.NewContainer()
+		diContainer.Register("cliConfigHandler", mockConfigHandler)
+		diContainer.Register("context", mockContext)
+		diContainer.Register("dockerHelper", mockDockerHelper)
+
+		// Given: a DNSHelper with the mock context
+		helper, err := NewDNSHelper(diContainer)
+		if err != nil {
+			t.Fatalf("NewDNSHelper() error = %v", err)
+		}
+
+		// When: WriteConfig is called
+		err = helper.WriteConfig()
+
+		// Then: an error should be returned
+		if err == nil || !strings.Contains(err.Error(), "error retrieving config root") {
+			t.Fatalf("expected error retrieving config root, got %v", err)
+		}
+	})
+
+	t.Run("ErrorRetrievingContextConfig", func(t *testing.T) {
+		// Create a mock context that returns a valid config root
+		mockContext.GetConfigRootFunc = func() (string, error) {
+			return "/mock/config/root", nil
+		}
+
+		// Create a mock config handler that returns an error on GetConfig
+		mockConfigHandler.GetConfigFunc = func() (*config.Context, error) {
+			return nil, fmt.Errorf("mock error retrieving context configuration")
+		}
+
+		diContainer := di.NewContainer()
+		diContainer.Register("cliConfigHandler", mockConfigHandler)
+		diContainer.Register("context", mockContext)
+		diContainer.Register("dockerHelper", mockDockerHelper)
+
+		// Given: a DNSHelper with the mock config handler and context
+		helper, err := NewDNSHelper(diContainer)
+		if err != nil {
+			t.Fatalf("NewDNSHelper() error = %v", err)
+		}
+
+		// When: WriteConfig is called
+		err = helper.WriteConfig()
+
+		// Then: an error should be returned
+		if err == nil || !strings.Contains(err.Error(), "error retrieving context configuration") {
+			t.Fatalf("expected error retrieving context configuration, got %v", err)
+		}
+	})
+
+	t.Run("ErrorWritingCorefile", func(t *testing.T) {
+		// Create a temporary directory for config root
+		tempDir := t.TempDir()
+
+		// Create a mock context that returns the temp directory as config root
+		mockContext.GetConfigRootFunc = func() (string, error) {
+			return tempDir, nil
+		}
+
+		// Create a mock config handler that returns Docker enabled
+		mockConfigHandler.GetConfigFunc = func() (*config.Context, error) {
+			return &config.Context{
+				Docker: &config.DockerConfig{
+					Enabled: ptrBool(true),
+				},
+				DNS: &config.DNSConfig{
+					Create: ptrBool(true),
+				},
+			}, nil
+		}
+
+		diContainer := di.NewContainer()
+		diContainer.Register("cliConfigHandler", mockConfigHandler)
+		diContainer.Register("context", mockContext)
+
+		// Create a real DockerHelper
+		dockerHelper, err := NewDockerHelper(diContainer)
+		if err != nil {
+			t.Fatalf("NewDockerHelper() error = %v", err)
+		}
+		diContainer.Register("dockerHelper", dockerHelper)
+
+		// Given: a DNSHelper with the mock config handler, context, and DockerHelper
+		helper, err := NewDNSHelper(diContainer)
+		if err != nil {
+			t.Fatalf("NewDNSHelper() error = %v", err)
+		}
+
+		// Override the writeFile function to return an error
+		originalWriteFile := writeFile
+		writeFile = func(filename string, data []byte, perm os.FileMode) error {
+			return fmt.Errorf("mock error writing file")
+		}
+		defer func() { writeFile = originalWriteFile }()
+
+		// When: WriteConfig is called
+		err = helper.WriteConfig()
+
+		// Then: an error should be returned
+		if err == nil || !strings.Contains(err.Error(), "error writing Corefile") {
+			t.Fatalf("expected error writing Corefile, got %v", err)
+		}
+	})
+
+	t.Run("ErrorResolvingContext", func(t *testing.T) {
+		// Create a mock DI container that fails to resolve context
+		mockDIContainer := di.NewMockContainer()
+		mockDIContainer.SetResolveError("context", fmt.Errorf("mock error resolving context"))
+
+		// Create a mock cliConfigHandler
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.GetConfigFunc = func() (*config.Context, error) {
+			return &config.Context{
+				Docker: &config.DockerConfig{
+					Enabled: ptrBool(true),
+				},
+				DNS: &config.DNSConfig{
+					Create: ptrBool(true),
+				},
+			}, nil
+		}
+		mockDIContainer.Register("cliConfigHandler", mockConfigHandler)
+
+		// Given: a DNSHelper with the mock DI container
+		helper, err := NewDNSHelper(mockDIContainer.DIContainer)
+		if err != nil {
+			t.Fatalf("NewDNSHelper() error = %v", err)
+		}
+
+		// When: WriteConfig is called
+		err = helper.WriteConfig()
+
+		// Then: an error should be returned
+		if err == nil || !strings.Contains(err.Error(), "error resolving context") {
+			t.Fatalf("expected error resolving context, got %v", err)
+		}
+	})
+
+	t.Run("ErrorResolvingCliConfigHandler", func(t *testing.T) {
+		// Create a mock DI container that fails to resolve cliConfigHandler
+		mockDIContainer := di.NewMockContainer()
+		mockDIContainer.SetResolveError("cliConfigHandler", fmt.Errorf("mock error resolving cliConfigHandler"))
+
+		// Create a mock context
+		mockContext := context.NewMockContext()
+		mockContext.GetConfigRootFunc = func() (string, error) {
+			return "/mock/config/root", nil
+		}
+		mockDIContainer.Register("context", mockContext)
+
+		// Create a mock DockerHelper
+		mockDockerHelper := NewMockHelper()
+		mockDIContainer.Register("dockerHelper", mockDockerHelper)
+
+		// Given: a DNSHelper with the mock DI container
+		helper, err := NewDNSHelper(mockDIContainer.DIContainer)
+		if err != nil {
+			t.Fatalf("NewDNSHelper() error = %v", err)
+		}
+
+		// When: WriteConfig is called
+		err = helper.WriteConfig()
+
+		// Then: an error should be returned
+		if err == nil || !strings.Contains(err.Error(), "error resolving cliConfigHandler") {
+			t.Fatalf("expected error resolving cliConfigHandler, got %v", err)
+		}
+	})
+
+	t.Run("ErrorResolvingDockerHelper", func(t *testing.T) {
+		// Create a mock DI container that fails to resolve dockerHelper
+		mockDIContainer := di.NewMockContainer()
+		mockDIContainer.SetResolveError("dockerHelper", fmt.Errorf("mock error resolving dockerHelper"))
+
+		// Create a mock context
+		mockContext := context.NewMockContext()
+		mockContext.GetConfigRootFunc = func() (string, error) {
+			return "/mock/config/root", nil
+		}
+		mockDIContainer.Register("context", mockContext)
+
+		// Create a mock cliConfigHandler
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.GetConfigFunc = func() (*config.Context, error) {
+			enabled := true
+			return &config.Context{
+				Docker: &config.DockerConfig{
+					Enabled: &enabled,
+				},
+				DNS: &config.DNSConfig{
+					Create: &enabled,
+				},
+			}, nil
+		}
+		mockDIContainer.Register("cliConfigHandler", mockConfigHandler)
+
+		// Given: a DNSHelper with the mock DI container
+		helper, err := NewDNSHelper(mockDIContainer.DIContainer)
+		if err != nil {
+			t.Fatalf("NewDNSHelper() error = %v", err)
+		}
+
+		// When: WriteConfig is called
+		err = helper.WriteConfig()
+
+		// Then: an error should be returned
+		if err == nil || !strings.Contains(err.Error(), "error resolving dockerHelper") {
+			t.Fatalf("expected error resolving dockerHelper, got %v", err)
+		}
+	})
+
+	t.Run("ErrorCastingToDockerHelper", func(t *testing.T) {
+		// Create a mock DI container that resolves to an incorrect type for dockerHelper
+		mockDIContainer := di.NewMockContainer()
+		mockDIContainer.Register("dockerHelper", "notADockerHelper") // Incorrect type
+
+		// Create a mock context
+		mockContext := context.NewMockContext()
+		mockContext.GetConfigRootFunc = func() (string, error) {
+			return "/mock/config/root", nil
+		}
+		mockDIContainer.Register("context", mockContext)
+
+		// Create a mock cliConfigHandler
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.GetConfigFunc = func() (*config.Context, error) {
+			enabled := true
+			return &config.Context{
+				Docker: &config.DockerConfig{
+					Enabled: &enabled,
+				},
+				DNS: &config.DNSConfig{
+					Create: &enabled,
+				},
+			}, nil
+		}
+		mockDIContainer.Register("cliConfigHandler", mockConfigHandler)
+
+		// Given: a DNSHelper with the mock DI container
+		helper := &DNSHelper{
+			DIContainer: mockDIContainer.DIContainer,
+		}
+
+		// When: WriteConfig is called
+		err := helper.WriteConfig()
+
+		// Then: an error should be returned
+		if err == nil || !strings.Contains(err.Error(), "error casting to DockerHelper") {
+			t.Fatalf("expected error casting to DockerHelper, got %v", err)
+		}
+	})
+
+	t.Run("ErrorRetrievingComposeConfig", func(t *testing.T) {
+		// Given: a DNSHelper with a DI container containing mocks
+		diContainer := di.NewContainer()
+
+		// Mock the cliConfigHandler
+		mockConfigHandler := config.NewMockConfigHandler()
+		callCount := 0
+		mockConfigHandler.GetConfigFunc = func() (*config.Context, error) {
+			callCount++
+			if callCount == 2 {
+				return nil, fmt.Errorf("mock error retrieving context configuration")
+			}
+			enabled := true
+			return &config.Context{
+				Docker: &config.DockerConfig{
+					Enabled: &enabled,
+				},
+				DNS: &config.DNSConfig{
+					Create: &enabled,
+				},
+			}, nil
+		}
+		diContainer.Register("cliConfigHandler", mockConfigHandler)
+
+		// Mock the context
+		mockContext := context.NewMockContext()
+		mockContext.GetConfigRootFunc = func() (string, error) {
+			return "/mock/config/root", nil
+		}
+		diContainer.Register("context", mockContext)
+
+		// Create the DockerHelper instance
+		dockerHelper, err := NewDockerHelper(diContainer)
+		if err != nil {
+			t.Fatalf("NewDockerHelper() error = %v", err)
+		}
+		diContainer.Register("dockerHelper", dockerHelper)
+
+		// Create the DNSHelper instance
+		dnsHelper, err := NewDNSHelper(diContainer)
+		if err != nil {
+			t.Fatalf("NewDNSHelper() error = %v", err)
+		}
+
+		// When: WriteConfig is called
+		err = dnsHelper.WriteConfig()
+
+		// Then: it should return an error indicating the failure to retrieve the context configuration
+		expectedError := "error retrieving context configuration: mock error retrieving context configuration"
+		if err == nil || !strings.Contains(err.Error(), expectedError) {
+			t.Fatalf("expected error %v, got %v", expectedError, err)
+		}
+	})
+
+	t.Run("MkdirAllError", func(t *testing.T) {
+		// Save the original mkdirAll function
+		originalMkdirAll := mkdirAll
+
+		// Override mkdirAll to simulate an error
+		mkdirAll = func(path string, perm os.FileMode) error {
+			return fmt.Errorf("mock error creating directories")
+		}
+
+		// Restore the original mkdirAll after the test
+		defer func() {
+			mkdirAll = originalMkdirAll
+		}()
+
+		// Setup DI container with mocks
+		diContainer := di.NewContainer()
+
+		// Mock the cliConfigHandler
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.GetConfigFunc = func() (*config.Context, error) {
+			// Return a context config where Docker is enabled
+			return &config.Context{
+				Docker: &config.DockerConfig{
+					Enabled: ptrBool(true),
+				},
+				DNS: &config.DNSConfig{
+					Create: ptrBool(true),
+				},
+			}, nil
+		}
+		diContainer.Register("cliConfigHandler", mockConfigHandler)
+
+		// Mock the context
+		mockContext := context.NewMockContext()
+		mockContext.GetConfigRootFunc = func() (string, error) {
+			return "/invalid/path", nil
+		}
+		mockContext.GetContextFunc = func() (string, error) {
+			return "test-context", nil
+		}
+		diContainer.Register("context", mockContext)
+
+		// Create the DockerHelper instance
+		dockerHelper, err := NewDockerHelper(diContainer)
+		if err != nil {
+			t.Fatalf("NewDockerHelper() error = %v", err)
+		}
+		diContainer.Register("dockerHelper", dockerHelper)
+
+		// Create the DNSHelper instance
+		dnsHelper, err := NewDNSHelper(diContainer)
+		if err != nil {
+			t.Fatalf("NewDNSHelper() error = %v", err)
+		}
+
+		// Call WriteConfig and expect an error
+		err = dnsHelper.WriteConfig()
+
+		// Check if the error matches the expected error
+		expectedError := "error creating parent folders: mock error creating directories"
+		if err == nil || err.Error() != expectedError {
+			t.Fatalf("expected error %v, got %v", expectedError, err)
+		}
+	})
+
+	t.Run("DNSEnabledDockerDisabled", func(t *testing.T) {
+		// Create a mock config handler that returns DNS enabled and Docker disabled
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.GetConfigFunc = func() (*config.Context, error) {
+			return &config.Context{
+				Docker: &config.DockerConfig{
+					Enabled: ptrBool(false),
+				},
+				DNS: &config.DNSConfig{
+					Create: ptrBool(true),
+				},
+			}, nil
+		}
+
+		// Create a mock context that returns a valid config root
+		mockContext := context.NewMockContext()
+		mockContext.GetConfigRootFunc = func() (string, error) {
+			return "/mock/config/root", nil
+		}
+		mockContext.GetContextFunc = func() (string, error) {
+			return "test-context", nil
+		}
+
+		diContainer := di.NewContainer()
+		diContainer.Register("cliConfigHandler", mockConfigHandler)
+		diContainer.Register("context", mockContext)
+
+		// Register a real DockerHelper instance
+		dockerHelper, err := NewDockerHelper(diContainer)
+		if err != nil {
+			t.Fatalf("NewDockerHelper() error = %v", err)
+		}
+		diContainer.Register("dockerHelper", dockerHelper)
+
+		helper, err := NewDNSHelper(diContainer)
+		if err != nil {
+			t.Fatalf("NewDNSHelper() error = %v", err)
+		}
+
+		// When: WriteConfig is called
+		err = helper.WriteConfig()
+
+		// Then: no error should be returned
+		if err != nil {
+			t.Fatalf("WriteConfig() error = %v", err)
+		}
+	})
+
+	t.Run("DNSEnabledDockerEnabledWithName", func(t *testing.T) {
+		// Create a mock config handler that returns DNS enabled, Docker enabled, and a DNS name defined
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.GetConfigFunc = func() (*config.Context, error) {
+			return &config.Context{
+				Docker: &config.DockerConfig{
+					Enabled: ptrBool(true),
+				},
+				DNS: &config.DNSConfig{
+					Create: ptrBool(true),
+					Name:   ptrString("custom-dns"),
+				},
+			}, nil
+		}
+
+		// Create a temporary directory for config root
+		tempDir := t.TempDir()
+
+		// Create a mock context that returns the temp directory as config root
+		mockContext := context.NewMockContext()
+		mockContext.GetConfigRootFunc = func() (string, error) {
+			return tempDir, nil
+		}
+		mockContext.GetContextFunc = func() (string, error) {
+			return "test-context", nil
+		}
+
+		diContainer := di.NewContainer()
+		diContainer.Register("cliConfigHandler", mockConfigHandler)
+		diContainer.Register("context", mockContext)
+
+		// Register a real DockerHelper instance
+		dockerHelper, err := NewDockerHelper(diContainer)
+		if err != nil {
+			t.Fatalf("NewDockerHelper() error = %v", err)
+		}
+		diContainer.Register("dockerHelper", dockerHelper)
+
+		helper, err := NewDNSHelper(diContainer)
+		if err != nil {
+			t.Fatalf("NewDNSHelper() error = %v", err)
+		}
+
+		// When: WriteConfig is called
+		err = helper.WriteConfig()
 
 		// Then: no error should be returned
 		if err != nil {


### PR DESCRIPTION
Adds a dns helper. This creates a coredns container and configures it with a Corefile pointing to other container services.