### PR TITLE
Removes the projectConfigHandler

### DIFF
--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -27,7 +27,11 @@ func TestContextSubcommand(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewMockShell() error = %v", err)
 			}
-			setupContainer(mockHandler, mockHandler, mockShell, nil, nil, nil, nil)
+			deps := MockDependencies{
+				CLIConfigHandler: mockHandler,
+				Shell:            mockShell,
+			}
+			setupContainer(deps)
 
 			// When the get context command is executed
 			output := captureStdout(func() {
@@ -55,7 +59,11 @@ func TestContextSubcommand(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewMockShell() error = %v", err)
 			}
-			setupContainer(mockHandler, mockHandler, mockShell, nil, nil, nil, nil)
+			deps := MockDependencies{
+				CLIConfigHandler: mockHandler,
+				Shell:            mockShell,
+			}
+			setupContainer(deps)
 
 			// When the get context command is executed
 			output := captureStderr(func() {
@@ -84,7 +92,11 @@ func TestContextSubcommand(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewMockShell() error = %v", err)
 			}
-			setupContainer(mockHandler, mockHandler, mockShell, nil, nil, nil, nil)
+			deps := MockDependencies{
+				CLIConfigHandler: mockHandler,
+				Shell:            mockShell,
+			}
+			setupContainer(deps)
 
 			// When the set context command is executed with a valid context
 			output := captureStdout(func() {
@@ -110,7 +122,11 @@ func TestContextSubcommand(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewMockShell() error = %v", err)
 			}
-			setupContainer(mockHandler, mockHandler, mockShell, nil, nil, nil, nil)
+			deps := MockDependencies{
+				CLIConfigHandler: mockHandler,
+				Shell:            mockShell,
+			}
+			setupContainer(deps)
 
 			// When the set context command is executed
 			output := captureStderr(func() {
@@ -137,7 +153,11 @@ func TestContextSubcommand(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewMockShell() error = %v", err)
 			}
-			setupContainer(mockHandler, mockHandler, mockShell, nil, nil, nil, nil)
+			deps := MockDependencies{
+				CLIConfigHandler: mockHandler,
+				Shell:            mockShell,
+			}
+			setupContainer(deps)
 
 			// When the set context command is executed
 			output := captureStderr(func() {
@@ -167,7 +187,11 @@ func TestContextSubcommand(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewMockShell() error = %v", err)
 			}
-			setupContainer(mockHandler, mockHandler, mockShell, nil, nil, nil, nil)
+			deps := MockDependencies{
+				CLIConfigHandler: mockHandler,
+				Shell:            mockShell,
+			}
+			setupContainer(deps)
 
 			// When the get-context alias command is executed
 			output := captureStdout(func() {
@@ -195,7 +219,11 @@ func TestContextSubcommand(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewMockShell() error = %v", err)
 			}
-			setupContainer(mockHandler, mockHandler, mockShell, nil, nil, nil, nil)
+			deps := MockDependencies{
+				CLIConfigHandler: mockHandler,
+				Shell:            mockShell,
+			}
+			setupContainer(deps)
 
 			// When the get-context alias command is executed
 			output := captureStderr(func() {
@@ -224,7 +252,11 @@ func TestContextSubcommand(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewMockShell() error = %v", err)
 			}
-			setupContainer(mockHandler, mockHandler, mockShell, nil, nil, nil, nil)
+			deps := MockDependencies{
+				CLIConfigHandler: mockHandler,
+				Shell:            mockShell,
+			}
+			setupContainer(deps)
 
 			// When the set-context alias command is executed with a valid context
 			output := captureStdout(func() {
@@ -250,7 +282,11 @@ func TestContextSubcommand(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewMockShell() error = %v", err)
 			}
-			setupContainer(mockHandler, mockHandler, mockShell, nil, nil, nil, nil)
+			deps := MockDependencies{
+				CLIConfigHandler: mockHandler,
+				Shell:            mockShell,
+			}
+			setupContainer(deps)
 
 			// When the set-context alias command is executed
 			output := captureStderr(func() {
@@ -277,7 +313,11 @@ func TestContextSubcommand(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewMockShell() error = %v", err)
 			}
-			setupContainer(mockHandler, mockHandler, mockShell, nil, nil, nil, nil)
+			deps := MockDependencies{
+				CLIConfigHandler: mockHandler,
+				Shell:            mockShell,
+			}
+			setupContainer(deps)
 
 			// When the set-context alias command is executed
 			output := captureStderr(func() {

--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -27,7 +27,6 @@ func TestEnvCmd(t *testing.T) {
 
 		// Given a valid config handler, shell, and helper
 		mockCliConfigHandler := config.NewMockConfigHandler()
-		mockProjectConfigHandler := config.NewMockConfigHandler()
 		mockShell, err := shell.NewMockShell("cmd")
 		if err != nil {
 			t.Fatalf("NewMockShell() error = %v", err)
@@ -42,7 +41,12 @@ func TestEnvCmd(t *testing.T) {
 		mockHelper.SetPostEnvExecFunc(func() error {
 			return nil
 		})
-		setupContainer(mockCliConfigHandler, mockProjectConfigHandler, mockShell, mockHelper, nil, nil, nil)
+		deps := MockDependencies{
+			CLIConfigHandler: mockCliConfigHandler,
+			Shell:            mockShell,
+			TerraformHelper:  mockHelper,
+		}
+		setupContainer(deps)
 
 		// When the env command is executed
 		output := captureStdout(func() {
@@ -66,7 +70,6 @@ func TestEnvCmd(t *testing.T) {
 
 		// Given a container that returns an error when resolving helpers
 		mockCliConfigHandler := config.NewMockConfigHandler()
-		mockProjectConfigHandler := config.NewMockConfigHandler()
 		mockShell, err := shell.NewMockShell("cmd")
 		if err != nil {
 			t.Fatalf("NewMockShell() error = %v", err)
@@ -78,7 +81,6 @@ func TestEnvCmd(t *testing.T) {
 		mockContainer := di.NewMockContainer()
 		mockContainer.SetResolveAllError(errors.New("resolve helpers error")) // Simulate error
 		mockContainer.Register("cliConfigHandler", mockCliConfigHandler)
-		mockContainer.Register("projectConfigHandler", mockProjectConfigHandler)
 		mockContainer.Register("shell", mockShell)
 		mockContainer.Register("terraformHelper", mockHelper)
 		mockContainer.Register("awsHelper", mockHelper)
@@ -108,7 +110,6 @@ func TestEnvCmd(t *testing.T) {
 
 		// Given a container that returns an error when resolving helpers
 		mockCliConfigHandler := config.NewMockConfigHandler()
-		mockProjectConfigHandler := config.NewMockConfigHandler()
 		mockShell, err := shell.NewMockShell("cmd")
 		if err != nil {
 			t.Fatalf("NewMockShell() error = %v", err)
@@ -120,7 +121,6 @@ func TestEnvCmd(t *testing.T) {
 		mockContainer := di.NewMockContainer()
 		mockContainer.SetResolveAllError(errors.New("resolve helpers error")) // Simulate error
 		mockContainer.Register("cliConfigHandler", mockCliConfigHandler)
-		mockContainer.Register("projectConfigHandler", mockProjectConfigHandler)
 		mockContainer.Register("shell", mockShell)
 		mockContainer.Register("terraformHelper", mockHelper)
 		mockContainer.Register("awsHelper", mockHelper)
@@ -151,11 +151,9 @@ func TestEnvCmd(t *testing.T) {
 
 		// Given a container that returns an error when resolving the shell
 		mockCliConfigHandler := config.NewMockConfigHandler()
-		mockProjectConfigHandler := config.NewMockConfigHandler()
 		mockContainer := di.NewMockContainer()
 		mockContainer.SetResolveError("shell", errors.New("resolve shell error")) // Simulate error
 		mockContainer.Register("cliConfigHandler", mockCliConfigHandler)
-		mockContainer.Register("projectConfigHandler", mockProjectConfigHandler)
 		Initialize(mockContainer)
 
 		// When the env command is executed with verbose flag
@@ -188,7 +186,6 @@ func TestEnvCmd(t *testing.T) {
 
 		// Given a helper that returns an error when getting environment variables
 		mockCliConfigHandler := config.NewMockConfigHandler()
-		mockProjectConfigHandler := config.NewMockConfigHandler()
 		mockShell, err := shell.NewMockShell("cmd")
 		if err != nil {
 			t.Fatalf("NewMockShell() error = %v", err)
@@ -200,7 +197,15 @@ func TestEnvCmd(t *testing.T) {
 		mockHelper.SetPostEnvExecFunc(func() error {
 			return nil
 		})
-		setupContainer(mockCliConfigHandler, mockProjectConfigHandler, mockShell, mockHelper, nil, nil, nil)
+		deps := MockDependencies{
+			CLIConfigHandler: mockCliConfigHandler,
+			Shell:            mockShell,
+			TerraformHelper:  mockHelper,
+			AwsHelper:        mockHelper,
+			ColimaHelper:     mockHelper,
+			DockerHelper:     mockHelper,
+		}
+		setupContainer(deps)
 
 		// When the env command is executed with verbose flag
 		output := captureStderr(func() {
@@ -224,7 +229,6 @@ func TestEnvCmd(t *testing.T) {
 
 		// Given a helper that returns an error when getting environment variables
 		mockCliConfigHandler := config.NewMockConfigHandler()
-		mockProjectConfigHandler := config.NewMockConfigHandler()
 		mockShell, err := shell.NewMockShell("cmd")
 		if err != nil {
 			t.Fatalf("NewMockShell() error = %v", err)
@@ -236,7 +240,15 @@ func TestEnvCmd(t *testing.T) {
 		mockHelper.SetPostEnvExecFunc(func() error {
 			return nil
 		})
-		setupContainer(mockCliConfigHandler, mockProjectConfigHandler, mockShell, mockHelper, nil, nil, nil)
+		deps := MockDependencies{
+			CLIConfigHandler: mockCliConfigHandler,
+			Shell:            mockShell,
+			TerraformHelper:  mockHelper,
+			AwsHelper:        mockHelper,
+			ColimaHelper:     mockHelper,
+			DockerHelper:     mockHelper,
+		}
+		setupContainer(deps)
 
 		// Capture the output
 		var buf bytes.Buffer
@@ -262,7 +274,6 @@ func TestEnvCmd(t *testing.T) {
 
 		// Given a helper that returns an error when executing PostEnvExec
 		mockCliConfigHandler := config.NewMockConfigHandler()
-		mockProjectConfigHandler := config.NewMockConfigHandler()
 		mockShell, err := shell.NewMockShell("cmd")
 		if err != nil {
 			t.Fatalf("NewMockShell() error = %v", err)
@@ -277,7 +288,15 @@ func TestEnvCmd(t *testing.T) {
 		mockHelper.SetPostEnvExecFunc(func() error {
 			return errors.New("post env exec error")
 		})
-		setupContainer(mockCliConfigHandler, mockProjectConfigHandler, mockShell, mockHelper, nil, nil, nil)
+		deps := MockDependencies{
+			CLIConfigHandler: mockCliConfigHandler,
+			Shell:            mockShell,
+			TerraformHelper:  mockHelper,
+			AwsHelper:        mockHelper,
+			ColimaHelper:     mockHelper,
+			DockerHelper:     mockHelper,
+		}
+		setupContainer(deps)
 
 		// When the env command is executed with verbose flag
 		output := captureStderr(func() {
@@ -301,7 +320,6 @@ func TestEnvCmd(t *testing.T) {
 
 		// Given a helper that returns an error when executing PostEnvExec
 		mockCliConfigHandler := config.NewMockConfigHandler()
-		mockProjectConfigHandler := config.NewMockConfigHandler()
 		mockShell, err := shell.NewMockShell("cmd")
 		if err != nil {
 			t.Fatalf("NewMockShell() error = %v", err)
@@ -316,7 +334,15 @@ func TestEnvCmd(t *testing.T) {
 		mockHelper.SetPostEnvExecFunc(func() error {
 			return errors.New("post env exec error")
 		})
-		setupContainer(mockCliConfigHandler, mockProjectConfigHandler, mockShell, mockHelper, nil, nil, nil)
+		deps := MockDependencies{
+			CLIConfigHandler: mockCliConfigHandler,
+			Shell:            mockShell,
+			TerraformHelper:  mockHelper,
+			AwsHelper:        mockHelper,
+			ColimaHelper:     mockHelper,
+			DockerHelper:     mockHelper,
+		}
+		setupContainer(deps)
 
 		// Capture the output
 		var buf bytes.Buffer

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -41,9 +41,6 @@ var initCmd = &cobra.Command{
 			cliConfigPath = filepath.Join(homeDir, ".config", "windsor", "config.yaml")
 		}
 
-		// Determine the projectConfig path
-		projectConfigPath := getProjectConfigPath()
-
 		// Set the context value
 		if err := cliConfigHandler.Set("context", contextName); err != nil {
 			return fmt.Errorf("Error setting config value: %w", err)
@@ -123,13 +120,6 @@ var initCmd = &cobra.Command{
 		// Save the cli configuration
 		if err := cliConfigHandler.SaveConfig(cliConfigPath); err != nil {
 			return fmt.Errorf("Error saving config file: %w", err)
-		}
-
-		// Save the project configuration only if projectConfigPath is present
-		if projectConfigPath != "" {
-			if err := projectConfigHandler.SaveConfig(projectConfigPath); err != nil {
-				return fmt.Errorf("Error saving project config file: %w", err)
-			}
 		}
 
 		// Initialize and write the vendor config files using the DI container

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,7 +25,6 @@ var (
 
 // ConfigHandler instances
 var cliConfigHandler config.ConfigHandler
-var projectConfigHandler config.ConfigHandler
 
 // shell instance
 var shellInstance shell.Shell
@@ -93,23 +92,10 @@ func preRunLoadConfig(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("cliConfigHandler is not initialized")
 	}
 
-	// Check if projectConfigHandler is initialized
-	if projectConfigHandler == nil {
-		return fmt.Errorf("projectConfigHandler is not initialized")
-	}
-
 	// Load CLI configuration
 	cliConfigPath := getCLIConfigPath()
 	if err := cliConfigHandler.LoadConfig(cliConfigPath); err != nil {
 		return fmt.Errorf("error loading CLI config: %w", err)
-	}
-
-	// Load project configuration
-	projectConfigPath := getProjectConfigPath()
-	if projectConfigPath != "" {
-		if err := projectConfigHandler.LoadConfig(projectConfigPath); err != nil {
-			return fmt.Errorf("error loading project config: %w", err)
-		}
 	}
 
 	return nil
@@ -173,7 +159,6 @@ func Initialize(cont di.ContainerInterface) {
 	}
 
 	resolveAndAssign("cliConfigHandler", &cliConfigHandler)
-	resolveAndAssign("projectConfigHandler", &projectConfigHandler)
 	resolveAndAssign("shell", &shellInstance)
 	resolveAndAssign("terraformHelper", &terraformHelper)
 	resolveAndAssign("awsHelper", &awsHelper)

--- a/cmd/windsor/main.go
+++ b/cmd/windsor/main.go
@@ -26,13 +26,6 @@ func main() {
 	shellInstance := shell.NewDefaultShell()
 	container.Register("shell", shellInstance)
 
-	// Register the Project Config Handler (to be initialized later)
-	projectConfigHandler, err := config.NewYamlConfigHandler("")
-	if err != nil {
-		log.Fatalf("failed to create project config handler: %v", err)
-	}
-	container.Register("projectConfigHandler", projectConfigHandler)
-
 	// Create and register the Context instance
 	contextInstance := context.NewContext(cliConfigHandler, shellInstance)
 	container.Register("context", contextInstance)


### PR DESCRIPTION
We're not yet using the project config, and likely will want to do this differently in the future. 