### PR TITLE
windsor down

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -37,5 +37,18 @@
         "WINDSOR_PROJECT_ROOT": "${workspaceFolder}"
       }
     },
+    {
+      "name": "Windsor Down",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/cmd/windsor/main.go",
+      "args": ["down", "--verbose"],
+      "env": {
+        "COMPOSE_FILE": "${workspaceFolder}/contexts/local/compose.yaml",
+        "WINDSOR_CONTEXT": "local",
+        "WINDSOR_PROJECT_ROOT": "${workspaceFolder}"
+      }
+    },
   ]
 }

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -1,0 +1,70 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	cleanFlag bool
+)
+
+var downCmd = &cobra.Command{
+	Use:          "down",
+	Short:        "Tear down the Windsor environment",
+	Long:         "Tear down the Windsor environment by executing necessary shell commands.",
+	SilenceUsage: true,
+	PreRunE:      preRunEInitializeCommonComponents,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// Create virtualization components
+		if err := controller.CreateVirtualizationComponents(); err != nil {
+			return fmt.Errorf("Error creating virtualization components: %w", err)
+		}
+
+		// Initialize all components
+		if err := controller.InitializeComponents(); err != nil {
+			return fmt.Errorf("Error initializing components: %w", err)
+		}
+
+		// Resolve the config handler
+		configHandler := controller.ResolveConfigHandler()
+		if configHandler == nil {
+			return fmt.Errorf("No config handler found")
+		}
+
+		// Determine if the container runtime is enabled
+		containerRuntimeEnabled := configHandler.GetBool("docker.enabled")
+
+		// Tear down the container runtime if enabled in configuration
+		if containerRuntimeEnabled {
+			// Resolve container runtime
+			containerRuntime := controller.ResolveContainerRuntime()
+			if containerRuntime == nil {
+				return fmt.Errorf("No container runtime found")
+			}
+
+			// Tear down the container runtime
+			if err := containerRuntime.Down(); err != nil {
+				return fmt.Errorf("Error running container runtime Down command: %w", err)
+			}
+		}
+
+		// Clean up context specific artifacts if --clean flag is set
+		if cleanFlag {
+			if err := controller.ResolveContextHandler().Clean(); err != nil {
+				return fmt.Errorf("Error cleaning up context specific artifacts: %w", err)
+			}
+		}
+
+		// Print success message
+		fmt.Println("Windsor environment torn down successfully.")
+
+		return nil
+	},
+}
+
+func init() {
+	downCmd.Flags().BoolVar(&cleanFlag, "clean", false, "Clean up context specific artifacts")
+	rootCmd.AddCommand(downCmd)
+}

--- a/cmd/down_test.go
+++ b/cmd/down_test.go
@@ -1,0 +1,220 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/windsorcli/cli/internal/config"
+	"github.com/windsorcli/cli/internal/context"
+	"github.com/windsorcli/cli/internal/network"
+
+	ctrl "github.com/windsorcli/cli/internal/controller"
+	"github.com/windsorcli/cli/internal/di"
+	"github.com/windsorcli/cli/internal/shell"
+	"github.com/windsorcli/cli/internal/virt"
+)
+
+type MockSafeDownCmdComponents struct {
+	Injector             di.Injector
+	MockController       *ctrl.MockController
+	MockContextHandler   *context.MockContext
+	MockConfigHandler    *config.MockConfigHandler
+	MockShell            *shell.MockShell
+	MockNetworkManager   *network.MockNetworkManager
+	MockVirtualMachine   *virt.MockVirt
+	MockContainerRuntime *virt.MockVirt
+}
+
+// setupSafeDownCmdMocks creates mock components for testing the down command
+func setupSafeDownCmdMocks(optionalInjector ...di.Injector) MockSafeDownCmdComponents {
+	var mockController *ctrl.MockController
+	var injector di.Injector
+
+	// Use the provided injector if passed, otherwise create a new one
+	if len(optionalInjector) > 0 {
+		injector = optionalInjector[0]
+	} else {
+		injector = di.NewInjector()
+	}
+
+	// Use the injector to create a mock controller
+	mockController = ctrl.NewMockController(injector)
+
+	// Manually override and set up components
+	mockController.CreateCommonComponentsFunc = func() error {
+		return nil
+	}
+
+	// Setup mock context handler
+	mockContextHandler := context.NewMockContext()
+	mockContextHandler.GetContextFunc = func() string {
+		return "test-context"
+	}
+	injector.Register("contextHandler", mockContextHandler)
+
+	// Setup mock config handler
+	mockConfigHandler := config.NewMockConfigHandler()
+	mockConfigHandler.SetFunc = func(key string, value interface{}) error {
+		return nil
+	}
+	injector.Register("configHandler", mockConfigHandler)
+
+	// Setup mock shell
+	mockShell := shell.NewMockShell()
+	injector.Register("shell", mockShell)
+
+	// Setup mock network manager
+	mockNetworkManager := network.NewMockNetworkManager()
+	injector.Register("networkManager", mockNetworkManager)
+
+	// Setup mock virtual machine
+	mockVirtualMachine := virt.NewMockVirt()
+	injector.Register("virtualMachine", mockVirtualMachine)
+
+	// Setup mock container runtime
+	mockContainerRuntime := virt.NewMockVirt()
+	injector.Register("containerRuntime", mockContainerRuntime)
+
+	return MockSafeDownCmdComponents{
+		Injector:             injector,
+		MockController:       mockController,
+		MockContextHandler:   mockContextHandler,
+		MockConfigHandler:    mockConfigHandler,
+		MockShell:            mockShell,
+		MockNetworkManager:   mockNetworkManager,
+		MockVirtualMachine:   mockVirtualMachine,
+		MockContainerRuntime: mockContainerRuntime,
+	}
+}
+
+func TestDownCmd(t *testing.T) {
+	originalExitFunc := exitFunc
+	exitFunc = mockExit
+	t.Cleanup(func() {
+		exitFunc = originalExitFunc
+	})
+
+	t.Run("Success", func(t *testing.T) {
+		// Given a set of mock components
+		mocks := setupSafeDownCmdMocks()
+
+		// When the down command is executed
+		output := captureStdout(func() {
+			rootCmd.SetArgs([]string{"down"})
+			if err := Execute(mocks.MockController); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+		})
+
+		// Then the output should indicate success
+		expectedOutput := "Windsor environment torn down successfully.\n"
+		if output != expectedOutput {
+			t.Errorf("Expected output %q, got %q", expectedOutput, output)
+		}
+	})
+
+	t.Run("ErrorCreatingVirtualizationComponents", func(t *testing.T) {
+		mocks := setupSafeDownCmdMocks()
+		mocks.MockController.CreateVirtualizationComponentsFunc = func() error {
+			return fmt.Errorf("Error creating virtualization components: %w", fmt.Errorf("error creating virtualization components"))
+		}
+
+		// Given a mock controller that returns an error when creating virtualization components
+		rootCmd.SetArgs([]string{"down"})
+		err := Execute(mocks.MockController)
+		// Then the error should contain the expected message
+		if err == nil || !strings.Contains(err.Error(), "Error creating virtualization components: error creating virtualization components") {
+			t.Fatalf("Expected error containing 'Error creating virtualization components: error creating virtualization components', got %v", err)
+		}
+	})
+
+	t.Run("ErrorInitializingComponents", func(t *testing.T) {
+		mocks := setupSafeDownCmdMocks()
+		mocks.MockController.InitializeComponentsFunc = func() error {
+			return fmt.Errorf("Error initializing components: %w", fmt.Errorf("error initializing components"))
+		}
+
+		// Given a mock controller that returns an error when initializing components
+		rootCmd.SetArgs([]string{"down"})
+		err := Execute(mocks.MockController)
+		// Then the error should contain the expected message
+		if err == nil || !strings.Contains(err.Error(), "Error initializing components: error initializing components") {
+			t.Fatalf("Expected error containing 'Error initializing components: error initializing components', got %v", err)
+		}
+	})
+
+	t.Run("ErrorResolvingConfigHandler", func(t *testing.T) {
+		mocks := setupSafeDownCmdMocks()
+		// Allows for reaching the second call of the function
+		callCount := 0
+		mocks.MockController.ResolveConfigHandlerFunc = func() config.ConfigHandler {
+			callCount++
+			if callCount == 2 {
+				return nil
+			}
+			return config.NewMockConfigHandler()
+		}
+
+		// Given a mock controller that returns nil on the second call to ResolveConfigHandler
+		rootCmd.SetArgs([]string{"down"})
+		err := Execute(mocks.MockController)
+		// Then the error should contain the expected message
+		if err == nil || !strings.Contains(err.Error(), "No config handler found") {
+			t.Fatalf("Expected error containing 'No config handler found', got %v", err)
+		}
+	})
+
+	t.Run("ErrorResolvingContainerRuntime", func(t *testing.T) {
+		mocks := setupSafeDownCmdMocks()
+		mocks.MockController.ResolveContainerRuntimeFunc = func() virt.ContainerRuntime {
+			return nil
+		}
+
+		// Given a mock controller that returns nil when resolving the container runtime
+		rootCmd.SetArgs([]string{"down"})
+		err := Execute(mocks.MockController)
+		// Then the error should contain the expected message
+		if err == nil || !strings.Contains(err.Error(), "No container runtime found") {
+			t.Fatalf("Expected error containing 'No container runtime found', got %v", err)
+		}
+	})
+
+	t.Run("ErrorRunningContainerRuntimeDown", func(t *testing.T) {
+		mocks := setupSafeDownCmdMocks()
+		mocks.MockController.ResolveContainerRuntimeFunc = func() virt.ContainerRuntime {
+			mockCR := virt.NewMockVirt()
+			mockCR.DownFunc = func() error {
+				return fmt.Errorf("Error running container runtime Down command: %w", fmt.Errorf("error running container runtime down"))
+			}
+			return mockCR
+		}
+
+		// Given a mock container runtime that returns an error when running the Down command
+		rootCmd.SetArgs([]string{"down"})
+		err := Execute(mocks.MockController)
+		// Then the error should contain the expected message
+		if err == nil || !strings.Contains(err.Error(), "Error running container runtime Down command: error running container runtime down") {
+			t.Fatalf("Expected error containing 'Error running container runtime Down command: error running container runtime down', got %v", err)
+		}
+	})
+
+	t.Run("ErrorCleaningContextArtifacts", func(t *testing.T) {
+		mocks := setupSafeDownCmdMocks()
+		mocks.MockController.ResolveContextHandlerFunc = func() context.ContextHandler {
+			mockContextHandler := context.NewMockContext()
+			mockContextHandler.CleanFunc = func() error {
+				return fmt.Errorf("Error cleaning up context specific artifacts: %w", fmt.Errorf("error cleaning context artifacts"))
+			}
+			return mockContextHandler
+		}
+
+		// Given a mock context handler that returns an error when cleaning context specific artifacts
+		rootCmd.SetArgs([]string{"down", "--clean"})
+		err := Execute(mocks.MockController)
+		// Then the error should contain the expected message
+		if err == nil || !strings.Contains(err.Error(), "Error cleaning up context specific artifacts: error cleaning context artifacts") {
+			t.Fatalf("Expected error containing 'Error cleaning up context specific artifacts: error cleaning context artifacts', got %v", err)
+		}
+	})
+}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -58,7 +58,7 @@ var upCmd = &cobra.Command{
 			if virtualMachine == nil {
 				return fmt.Errorf("No virtual machine found")
 			}
-			if err := virtualMachine.Up(verbose); err != nil {
+			if err := virtualMachine.Up(); err != nil {
 				return fmt.Errorf("Error running virtual machine Up command: %w", err)
 			}
 		}
@@ -75,7 +75,7 @@ var upCmd = &cobra.Command{
 			}
 
 			// Run the container runtime Up command
-			if err := containerRuntime.Up(verbose); err != nil {
+			if err := containerRuntime.Up(); err != nil {
 				return fmt.Errorf("Error running container runtime Up command: %w", err)
 			}
 		}

--- a/internal/context/mock_context.go
+++ b/internal/context/mock_context.go
@@ -6,6 +6,7 @@ type MockContext struct {
 	GetContextFunc    func() string              // Function to mock GetContext
 	SetContextFunc    func(context string) error // Function to mock SetContext
 	GetConfigRootFunc func() (string, error)     // Function to mock GetConfigRoot
+	CleanFunc         func() error               // Function to mock Clean
 }
 
 // NewMockContext creates a new instance of MockContext
@@ -43,6 +44,14 @@ func (m *MockContext) GetConfigRoot() (string, error) {
 		return m.GetConfigRootFunc()
 	}
 	return "/mock/config/root", nil
+}
+
+// Clean calls the mock CleanFunc if set, otherwise returns nil
+func (m *MockContext) Clean() error {
+	if m.CleanFunc != nil {
+		return m.CleanFunc()
+	}
+	return nil
 }
 
 // Ensure MockContext implements the ContextHandler interface

--- a/internal/context/mock_context_test.go
+++ b/internal/context/mock_context_test.go
@@ -178,3 +178,34 @@ func TestMockContext_GetConfigRoot(t *testing.T) {
 		}
 	})
 }
+
+func TestMockContext_Clean(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Given a mock context that cleans up successfully
+		mockContext := NewMockContext()
+		mockContext.CleanFunc = func() error {
+			return nil
+		}
+
+		// When calling Clean
+		err := mockContext.Clean()
+
+		// Then no error should be returned
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("NotImplemented", func(t *testing.T) {
+		// Given a mock context with no implementation
+		mockContext := NewMockContext()
+
+		// When calling Clean
+		err := mockContext.Clean()
+
+		// Then no error should be returned
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+}

--- a/internal/context/shims.go
+++ b/internal/context/shims.go
@@ -1,0 +1,9 @@
+package context
+
+import "os"
+
+// osStat is a shim for os.Stat
+var osStat = os.Stat
+
+// osRemoveAll is a shim for os.RemoveAll
+var osRemoveAll = os.RemoveAll

--- a/internal/virt/colima_virt.go
+++ b/internal/virt/colima_virt.go
@@ -30,11 +30,8 @@ func NewColimaVirt(injector di.Injector) *ColimaVirt {
 }
 
 // Up starts the Colima VM
-func (v *ColimaVirt) Up(verbose ...bool) error {
-	if len(verbose) == 0 {
-		verbose = append(verbose, false)
-	}
-
+func (v *ColimaVirt) Up() error {
+	// Start the Colima VM
 	info, err := v.startColima()
 	if err != nil {
 		return err
@@ -48,13 +45,15 @@ func (v *ColimaVirt) Up(verbose ...bool) error {
 	return nil
 }
 
-// Down stops the Colima VM
-func (v *ColimaVirt) Down(verbose ...bool) error {
-	if len(verbose) == 0 {
-		verbose = append(verbose, false)
+// Down stops and deletes the Colima VM
+func (v *ColimaVirt) Down() error {
+	// Stop the Colima VM
+	if err := v.executeColimaCommand("stop"); err != nil {
+		return err
 	}
 
-	return v.executeColimaCommand("stop")
+	// Delete the Colima VM
+	return v.executeColimaCommand("delete")
 }
 
 // GetVMInfo returns the information about the Colima VM
@@ -212,15 +211,6 @@ func (v *ColimaVirt) PrintInfo() error {
 	fmt.Println()
 
 	return nil
-}
-
-// Delete removes the Colima VM
-func (v *ColimaVirt) Delete(verbose ...bool) error {
-	if len(verbose) == 0 {
-		verbose = append(verbose, false)
-	}
-
-	return v.executeColimaCommand("delete")
 }
 
 // Ensure ColimaVirt implements Virt and VirtualMachine

--- a/internal/virt/colima_virt_test.go
+++ b/internal/virt/colima_virt_test.go
@@ -250,49 +250,6 @@ func TestColimaVirt_GetVMInfo(t *testing.T) {
 	})
 }
 
-// TestColimaVirt_Delete tests the Delete method of ColimaVirt.
-func TestColimaVirt_Delete(t *testing.T) {
-	t.Run("Success", func(t *testing.T) {
-		// Given a ColimaVirt with mock components
-		mocks := setupSafeColimaVmMocks()
-		colimaVirt := NewColimaVirt(mocks.Injector)
-		colimaVirt.Initialize()
-
-		// Mock the necessary methods to simulate a successful delete
-		mocks.MockShell.ExecFunc = func(message string, command string, args ...string) (string, error) {
-			return "VM deleted successfully", nil
-		}
-
-		// When calling Delete
-		err := colimaVirt.Delete()
-
-		// Then no error should be returned
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-	})
-
-	t.Run("Error", func(t *testing.T) {
-		// Given a ColimaVirt with mock components
-		mocks := setupSafeColimaVmMocks()
-		colimaVirt := NewColimaVirt(mocks.Injector)
-		colimaVirt.Initialize()
-
-		// Mock the necessary methods to return an error
-		mocks.MockShell.ExecFunc = func(message string, command string, args ...string) (string, error) {
-			return "", fmt.Errorf("mock error")
-		}
-
-		// When calling Delete
-		err := colimaVirt.Delete()
-
-		// Then an error should be returned
-		if err == nil {
-			t.Fatalf("Expected an error, got nil")
-		}
-	})
-}
-
 func TestColimaVirt_PrintInfo(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		// Setup mock components

--- a/internal/virt/mock_virt.go
+++ b/internal/virt/mock_virt.go
@@ -4,8 +4,7 @@ package virt
 type MockVirt struct {
 	InitializeFunc       func() error
 	UpFunc               func(verbose ...bool) error
-	DownFunc             func(verbose ...bool) error
-	DeleteFunc           func(verbose ...bool) error
+	DownFunc             func() error
 	PrintInfoFunc        func() error
 	WriteConfigFunc      func() error
 	GetVMInfoFunc        func() (VMInfo, error)
@@ -28,27 +27,18 @@ func (m *MockVirt) Initialize() error {
 
 // Up starts the mock virt.
 // If a custom UpFunc is provided, it will use that function instead.
-func (m *MockVirt) Up(verbose ...bool) error {
+func (m *MockVirt) Up() error {
 	if m.UpFunc != nil {
-		return m.UpFunc(verbose...)
+		return m.UpFunc()
 	}
 	return nil
 }
 
 // Down stops the mock virt.
 // If a custom DownFunc is provided, it will use that function instead.
-func (m *MockVirt) Down(verbose ...bool) error {
+func (m *MockVirt) Down() error {
 	if m.DownFunc != nil {
-		return m.DownFunc(verbose...)
-	}
-	return nil
-}
-
-// Delete removes the mock virt.
-// If a custom DeleteFunc is provided, it will use that function instead.
-func (m *MockVirt) Delete(verbose ...bool) error {
-	if m.DeleteFunc != nil {
-		return m.DeleteFunc(verbose...)
+		return m.DownFunc()
 	}
 	return nil
 }

--- a/internal/virt/mock_virt_test.go
+++ b/internal/virt/mock_virt_test.go
@@ -100,7 +100,7 @@ func TestMockVirt_Down(t *testing.T) {
 	t.Run("DownFuncImplemented", func(t *testing.T) {
 		// Given a MockVirt with a custom DownFunc
 		mockVirt := NewMockVirt()
-		mockVirt.DownFunc = func(verbose ...bool) error {
+		mockVirt.DownFunc = func() error {
 			return nil
 		}
 
@@ -119,38 +119,6 @@ func TestMockVirt_Down(t *testing.T) {
 
 		// When calling Down
 		err := mockVirt.Down()
-
-		// Then no error should be returned
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-	})
-}
-
-// TestMockVirt_Delete tests the Delete method of MockVirt.
-func TestMockVirt_Delete(t *testing.T) {
-	t.Run("DeleteFuncImplemented", func(t *testing.T) {
-		// Given a MockVirt with a custom DeleteFunc
-		mockVirt := NewMockVirt()
-		mockVirt.DeleteFunc = func(verbose ...bool) error {
-			return nil
-		}
-
-		// When calling Delete
-		err := mockVirt.Delete()
-
-		// Then no error should be returned
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-	})
-
-	t.Run("DeleteFuncNotImplemented", func(t *testing.T) {
-		// Given a MockVirt without a custom DeleteFunc
-		mockVirt := NewMockVirt()
-
-		// When calling Delete
-		err := mockVirt.Delete()
 
 		// Then no error should be returned
 		if err != nil {

--- a/internal/virt/virt.go
+++ b/internal/virt/virt.go
@@ -36,9 +36,8 @@ type ContainerInfo struct {
 // Virt defines methods for the virt operations
 type Virt interface {
 	Initialize() error
-	Up(verbose ...bool) error
-	Down(verbose ...bool) error
-	Delete(verbose ...bool) error
+	Up() error
+	Down() error
 	PrintInfo() error
 	WriteConfig() error
 }


### PR DESCRIPTION
There is now a `windsor down` with a `--clean` flag. This will tear down the container runtime environment, removing any lingering resources. The additional `--clean` option also removes generated credential or configuration files.