### PR TITLE
Extend config to include node info

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -73,15 +73,24 @@ type ClusterConfig struct {
 	Enabled       *bool   `yaml:"enabled"`
 	Driver        *string `yaml:"driver"`
 	ControlPlanes struct {
-		Count  *int `yaml:"count"`
-		CPU    *int `yaml:"cpu"`
-		Memory *int `yaml:"memory"`
+		Count  *int                  `yaml:"count"`
+		CPU    *int                  `yaml:"cpu"`
+		Memory *int                  `yaml:"memory"`
+		Nodes  map[string]NodeConfig `yaml:"nodes"`
 	} `yaml:"controlplanes"`
 	Workers struct {
-		Count  *int `yaml:"count"`
-		CPU    *int `yaml:"cpu"`
-		Memory *int `yaml:"memory"`
+		Count  *int                  `yaml:"count"`
+		CPU    *int                  `yaml:"cpu"`
+		Memory *int                  `yaml:"memory"`
+		Nodes  map[string]NodeConfig `yaml:"nodes"`
 	} `yaml:"workers"`
+}
+
+// NodeConfig represents the node configuration
+type NodeConfig struct {
+	Hostname *string `yaml:"hostname"`
+	Node     *string `yaml:"node"`
+	Endpoint *string `yaml:"endpoint"`
 }
 
 // Context represents the context configuration

--- a/internal/config/defaults.go
+++ b/internal/config/defaults.go
@@ -84,22 +84,26 @@ var DefaultLocalConfig = Context{
 		Enabled: ptrBool(true),
 		Driver:  ptrString("talos"),
 		ControlPlanes: struct {
-			Count  *int `yaml:"count"`
-			CPU    *int `yaml:"cpu"`
-			Memory *int `yaml:"memory"`
+			Count  *int                  `yaml:"count"`
+			CPU    *int                  `yaml:"cpu"`
+			Memory *int                  `yaml:"memory"`
+			Nodes  map[string]NodeConfig `yaml:"nodes"`
 		}{
 			Count:  ptrInt(1),
 			CPU:    ptrInt(2),
 			Memory: ptrInt(2),
+			Nodes:  make(map[string]NodeConfig),
 		},
 		Workers: struct {
-			Count  *int `yaml:"count"`
-			CPU    *int `yaml:"cpu"`
-			Memory *int `yaml:"memory"`
+			Count  *int                  `yaml:"count"`
+			CPU    *int                  `yaml:"cpu"`
+			Memory *int                  `yaml:"memory"`
+			Nodes  map[string]NodeConfig `yaml:"nodes"`
 		}{
 			Count:  ptrInt(1),
 			CPU:    ptrInt(4),
 			Memory: ptrInt(4),
+			Nodes:  make(map[string]NodeConfig),
 		},
 	},
 	DNS: &DNSConfig{

--- a/internal/services/talos_controlplane_service.go
+++ b/internal/services/talos_controlplane_service.go
@@ -26,11 +26,17 @@ func NewTalosControlPlaneService(injector di.Injector) *TalosControlPlaneService
 func (s *TalosControlPlaneService) SetAddress(address string) error {
 	tld := s.configHandler.GetString("dns.name", "test")
 
-	s.BaseService.SetAddress(address)
-	s.configHandler.Set("cluster.controlplanes.nodes."+s.name+".hostname", s.name+"."+tld)
-	s.configHandler.Set("cluster.controlplanes.nodes."+s.name+".node", address+":50000")
-	s.configHandler.Set("cluster.controlplanes.nodes."+s.name+".endpoint", address)
-	return nil
+	if err := s.configHandler.Set("cluster.controlplanes.nodes."+s.name+".hostname", s.name+"."+tld); err != nil {
+		return err
+	}
+	if err := s.configHandler.Set("cluster.controlplanes.nodes."+s.name+".node", address+":50000"); err != nil {
+		return err
+	}
+	if err := s.configHandler.Set("cluster.controlplanes.nodes."+s.name+".endpoint", address); err != nil {
+		return err
+	}
+
+	return s.BaseService.SetAddress(address)
 }
 
 // GetComposeConfig returns a list of container data for docker-compose.

--- a/internal/services/talos_controlplane_service.go
+++ b/internal/services/talos_controlplane_service.go
@@ -21,6 +21,18 @@ func NewTalosControlPlaneService(injector di.Injector) *TalosControlPlaneService
 	}
 }
 
+// SetAddress sets the address of the service
+// This turns out to be a convenient place to set node information
+func (s *TalosControlPlaneService) SetAddress(address string) error {
+	tld := s.configHandler.GetString("dns.name", "test")
+
+	s.BaseService.SetAddress(address)
+	s.configHandler.Set("cluster.controlplanes.nodes."+s.name+".hostname", s.name+"."+tld)
+	s.configHandler.Set("cluster.controlplanes.nodes."+s.name+".node", address+":50000")
+	s.configHandler.Set("cluster.controlplanes.nodes."+s.name+".endpoint", address)
+	return nil
+}
+
 // GetComposeConfig returns a list of container data for docker-compose.
 func (s *TalosControlPlaneService) GetComposeConfig() (*types.Config, error) {
 	// Retrieve CPU and RAM settings for control planes from the configuration

--- a/internal/services/talos_controlplane_service_test.go
+++ b/internal/services/talos_controlplane_service_test.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/windsorcli/cli/internal/config"
@@ -134,6 +135,74 @@ func TestTalosControlPlaneService_SetAddress(t *testing.T) {
 
 		if setCalls[expectedEndpointKey] != expectedEndpointValue {
 			t.Errorf("expected %s to be set to %s, got %v", expectedEndpointKey, expectedEndpointValue, setCalls[expectedEndpointKey])
+		}
+	})
+
+	t.Run("SetFailures", func(t *testing.T) {
+		// Given: a set of mock components
+		mocks := setupSafeTalosControlPlaneServiceMocks()
+		service := NewTalosControlPlaneService(mocks.Injector)
+
+		// Initialize the service
+		err := service.Initialize()
+		if err != nil {
+			t.Fatalf("expected no error during initialization, got %v", err)
+		}
+		service.SetName("controlplane-1")
+
+		// Define the error scenarios
+		errorScenarios := []struct {
+			description string
+			setup       func()
+		}{
+			{
+				description: "configHandler.Set hostname fails",
+				setup: func() {
+					mocks.MockConfigHandler.SetFunc = func(key string, value interface{}) error {
+						if key == "cluster.controlplanes.nodes.controlplane-1.hostname" {
+							return fmt.Errorf("configHandler.Set hostname error")
+						}
+						return nil
+					}
+				},
+			},
+			{
+				description: "configHandler.Set node fails",
+				setup: func() {
+					mocks.MockConfigHandler.SetFunc = func(key string, value interface{}) error {
+						if key == "cluster.controlplanes.nodes.controlplane-1.node" {
+							return fmt.Errorf("configHandler.Set node error")
+						}
+						return nil
+					}
+				},
+			},
+			{
+				description: "configHandler.Set endpoint fails",
+				setup: func() {
+					mocks.MockConfigHandler.SetFunc = func(key string, value interface{}) error {
+						if key == "cluster.controlplanes.nodes.controlplane-1.endpoint" {
+							return fmt.Errorf("configHandler.Set endpoint error")
+						}
+						return nil
+					}
+				},
+			},
+		}
+
+		for _, scenario := range errorScenarios {
+			t.Run(scenario.description, func(t *testing.T) {
+				// Setup the specific error scenario
+				scenario.setup()
+
+				// When: the SetAddress method is called
+				err := service.SetAddress("192.168.1.1")
+
+				// Then: an error should be returned
+				if err == nil {
+					t.Fatalf("expected error, got nil")
+				}
+			})
 		}
 	})
 }

--- a/internal/services/talos_worker_service.go
+++ b/internal/services/talos_worker_service.go
@@ -23,6 +23,18 @@ func NewTalosWorkerService(injector di.Injector) *TalosWorkerService {
 	}
 }
 
+// SetAddress sets the address of the service
+// This turns out to be a convenient place to set node information
+func (s *TalosWorkerService) SetAddress(address string) error {
+	tld := s.configHandler.GetString("dns.name", "test")
+
+	s.BaseService.SetAddress(address)
+	s.configHandler.Set("cluster.workers.nodes."+s.name+".hostname", s.name+"."+tld)
+	s.configHandler.Set("cluster.workers.nodes."+s.name+".node", address+":50000")
+	s.configHandler.Set("cluster.workers.nodes."+s.name+".endpoint", address)
+	return nil
+}
+
 // GetComposeConfig returns a list of container data for docker-compose.
 func (s *TalosWorkerService) GetComposeConfig() (*types.Config, error) {
 	// Retrieve CPU and RAM settings for workers from the configuration

--- a/internal/services/talos_worker_service.go
+++ b/internal/services/talos_worker_service.go
@@ -28,11 +28,17 @@ func NewTalosWorkerService(injector di.Injector) *TalosWorkerService {
 func (s *TalosWorkerService) SetAddress(address string) error {
 	tld := s.configHandler.GetString("dns.name", "test")
 
-	s.BaseService.SetAddress(address)
-	s.configHandler.Set("cluster.workers.nodes."+s.name+".hostname", s.name+"."+tld)
-	s.configHandler.Set("cluster.workers.nodes."+s.name+".node", address+":50000")
-	s.configHandler.Set("cluster.workers.nodes."+s.name+".endpoint", address)
-	return nil
+	if err := s.configHandler.Set("cluster.workers.nodes."+s.name+".hostname", s.name+"."+tld); err != nil {
+		return err
+	}
+	if err := s.configHandler.Set("cluster.workers.nodes."+s.name+".node", address+":50000"); err != nil {
+		return err
+	}
+	if err := s.configHandler.Set("cluster.workers.nodes."+s.name+".endpoint", address); err != nil {
+		return err
+	}
+
+	return s.BaseService.SetAddress(address)
 }
 
 // GetComposeConfig returns a list of container data for docker-compose.

--- a/internal/services/talos_worker_service_test.go
+++ b/internal/services/talos_worker_service_test.go
@@ -77,6 +77,57 @@ func TestTalosWorkerService_NewTalosWorkerService(t *testing.T) {
 	})
 }
 
+func TestTalosWorkerService_SetAddress(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Given: a set of mock components
+		mocks := setupSafeTalosWorkerServiceMocks()
+		service := NewTalosWorkerService(mocks.Injector)
+
+		// Create a map to track the calls to SetFunc
+		setCalls := make(map[string]interface{})
+
+		mocks.MockConfigHandler.SetFunc = func(key string, value interface{}) error {
+			setCalls[key] = value
+			return nil
+		}
+
+		// Initialize the service
+		err := service.Initialize()
+		if err != nil {
+			t.Fatalf("expected no error during initialization, got %v", err)
+		}
+
+		// When: the SetAddress method is called
+		service.SetName("worker-1")
+		err = service.SetAddress("192.168.1.1")
+
+		// Then: no error should be returned
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// And: configHandler.Set should be called with the expected node and endpoint
+		expectedHostnameKey := "cluster.workers.nodes.worker-1.hostname"
+		expectedNodeKey := "cluster.workers.nodes.worker-1.node"
+		expectedEndpointKey := "cluster.workers.nodes.worker-1.endpoint"
+		expectedHostnameValue := "worker-1.test"
+		expectedNodeValue := "192.168.1.1:50000"
+		expectedEndpointValue := "192.168.1.1"
+
+		if setCalls[expectedHostnameKey] != expectedHostnameValue {
+			t.Errorf("expected %s to be set to %s, got %v", expectedHostnameKey, expectedHostnameValue, setCalls[expectedHostnameKey])
+		}
+
+		if setCalls[expectedNodeKey] != expectedNodeValue {
+			t.Errorf("expected %s to be set to %s, got %v", expectedNodeKey, expectedNodeValue, setCalls[expectedNodeKey])
+		}
+
+		if setCalls[expectedEndpointKey] != expectedEndpointValue {
+			t.Errorf("expected %s to be set to %s, got %v", expectedEndpointKey, expectedEndpointValue, setCalls[expectedEndpointKey])
+		}
+	})
+}
+
 func TestTalosWorkerService_GetComposeConfig(t *testing.T) {
 	// Mock the os functions to avoid actual file system operations
 	originalStat := stat

--- a/internal/virt/docker_virt.go
+++ b/internal/virt/docker_virt.go
@@ -253,6 +253,7 @@ func (v *DockerVirt) GetContainerInfo(name ...string) ([]ContainerInfo, error) {
 	return containerInfos, nil
 }
 
+// PrintInfo prints the container information
 func (v *DockerVirt) PrintInfo() error {
 	containerInfos, err := v.GetContainerInfo()
 	if err != nil {


### PR DESCRIPTION
The config object is now dynamically populate with a value for nodes, e.g.,

```
cluster:
  controlplanes:
    ...
    nodes:
      controlplane-1:
       hostname: controlplane-1.test
       node: 10.5.0.3
       endpoint: 10.5.0.3:50000

  workers:
    ...
    nodes:
      worker-1:
       hostname: worker-1.test
       node: 10.5.0.13
       endpoint: 10.5.0.13:50000
```

This will help support templating in upcoming work.