### PR TITLE
Add aqua for tool management

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,5 +1,8 @@
 {
-  "extends": ["config:recommended"],
+  "extends": [
+    "config:recommended",
+    "github>aquaproj/aqua-renovate-config#2.2.1"
+  ],
   "packageRules": [
     {
       "description": "Pin GitHub Actions to specific commit SHAs",

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -25,54 +25,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Set up Go
-        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
-        with:
-          go-version: '1.23.1'
-          check-latest: true
+      - name: Install Aqua
+        uses: aquaproj/aqua-installer@7b6e2c92250ab08b58f5c665f6e2ca4712bee2c3 # v3.1.0
 
-      - name: Cache Go modules
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
-        with:
-          path: |
-            ~/.cache/go-build
-            ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
-      # Non-Windows specific steps
-      - name: Generate hash of .tool-versions
-        if: runner.os != 'Windows'
-        id: generate_hash
-        run: echo "hash=$(sha256sum .tool-versions | cut -d ' ' -f 1)" >> $GITHUB_ENV
-
-      - name: Cache asdf tools
-        if: runner.os != 'Windows'
-        uses: actions/cache@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
-        with:
-          path: ~/.asdf
-          key: ${{ runner.os }}-asdf-${{ steps.generate_hash.outputs.hash }}
-          restore-keys: |
-            ${{ runner.os }}-asdf-
-
-      - name: Install asdf plugins
-        if: runner.os != 'Windows'
-        uses: asdf-vm/actions/plugins-add@05e0d2ed97b598bfce82fd30daf324ae0c4570e6 # v3.0.2
-
-      - name: Install tools from .tool-versions
-        if: runner.os != 'Windows'
-        run: asdf install
-      
-      - name: Install dependencies on Windows
-        if: runner.os == 'Windows'
-        run: |
-          choco install go-task --version=3.37.2 -y
-          choco install age.portable
-          choco install sops 
-
-      - name: Install dependencies
-        run: task setup
+      - name: Install tools using Aqua
+        run: aqua install
 
       - name: Run tests
         run: task test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,7 +26,9 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
       - name: Install Aqua
-        uses: aquaproj/aqua-installer@7b6e2c92250ab08b58f5c665f6e2ca4712bee2c3 # v3.1.0
+        uses: aquaproj/aqua-installer@v3.0.1
+        with:
+          aqua_version: v2.28.0
 
       - name: Install tools using Aqua
         run: aqua install

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -1,0 +1,21 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/aquaproj/aqua/main/json-schema/aqua-yaml.json
+# aqua - Declarative CLI Version Manager
+# https://aquaproj.github.io/
+# checksum:
+#   enabled: true
+#   require_checksum: true
+#   supported_envs:
+#   - all
+registries:
+- type: standard
+  ref: v4.283.0 # renovate: depName=aquaproj/aqua-registry
+packages:
+- name: hashicorp/terraform@v1.10.3
+- name: siderolabs/talos@v1.9.0
+- name: siderolabs/omni/omnictl@v0.45.0
+- name: kubernetes/kubectl@v1.32.0
+- name: go-task/task@v3.40.1
+- name: golang/go@go1.23.4
+- name: abiosoft/colima@v0.8.1
+- name: docker/cli@v27.4.1


### PR DESCRIPTION
Adds aqua to manage our local CLI tools. We'll leave `.tool-versions` in for a little while.