### PR TITLE
Fix docker-compose call

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -19,3 +19,4 @@ packages:
 - name: golang/go@go1.23.4
 - name: abiosoft/colima@v0.8.1
 - name: docker/cli@v27.4.1
+- name: securego/gosec@v2.21.4

--- a/pkg/virt/docker_virt.go
+++ b/pkg/virt/docker_virt.go
@@ -2,6 +2,7 @@ package virt
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -15,7 +16,8 @@ import (
 // DockerVirt implements the ContainerInterface for Docker
 type DockerVirt struct {
 	BaseVirt
-	services []services.Service
+	services       []services.Service
+	composeCommand string
 }
 
 // NewDockerVirt creates a new instance of DockerVirt using a DI injector
@@ -60,15 +62,33 @@ func (v *DockerVirt) Initialize() error {
 
 	// Set the services
 	v.services = serviceSlice
+
+	// Determine the correct docker compose command
+	if err := v.determineComposeCommand(); err != nil {
+		return fmt.Errorf("error determining docker compose command: %w", err)
+	}
+
 	return nil
 }
 
-// Up starts docker-compose
+// determineComposeCommand checks for available docker compose commands
+func (v *DockerVirt) determineComposeCommand() error {
+	commands := []string{"docker-compose", "docker-cli-plugin-docker-compose", "docker compose"}
+	for _, cmd := range commands {
+		if _, err := v.shell.ExecSilent(cmd, "--version"); err == nil {
+			v.composeCommand = cmd
+			return nil
+		}
+	}
+	return fmt.Errorf("no valid docker compose command found")
+}
+
+// Up starts docker compose
 func (v *DockerVirt) Up() error {
 	// Get the context configuration
 	contextConfig := v.configHandler.GetConfig()
 
-	// Check if Docker is enabled and run "docker-compose up" in daemon mode if necessary
+	// Check if Docker is enabled and run "docker compose up" in daemon mode if necessary
 	if contextConfig != nil && contextConfig.Docker != nil && *contextConfig.Docker.Enabled {
 		// Ensure Docker daemon is running
 		if err := v.checkDockerDaemon(); err != nil {
@@ -82,18 +102,20 @@ func (v *DockerVirt) Up() error {
 		}
 		composeFilePath := filepath.Join(configRoot, "compose.yaml")
 
-		// Retry logic for docker-compose up with progress display
+		// Set the COMPOSE_FILE environment variable
+		os.Setenv("COMPOSE_FILE", composeFilePath)
+
+		// Retry logic for docker compose up with progress display
 		retries := 3
 		var lastErr error
 		var lastOutput string
 		for i := 0; i < retries; i++ {
-			command := "docker-compose"
-			args := []string{"-f", composeFilePath, "up", "-d", "--remove-orphans"}
-			message := "📦 Running docker-compose up"
+			args := []string{"up", "--detach", "--remove-orphans"}
+			message := "📦 Running docker compose up"
 
 			// Use ExecProgress for the first attempt to show progress
 			if i == 0 {
-				output, err := v.shell.ExecProgress(message, command, args...)
+				output, err := v.shell.ExecProgress(message, v.composeCommand, args...)
 				if err == nil {
 					return nil
 				}
@@ -101,7 +123,7 @@ func (v *DockerVirt) Up() error {
 				lastOutput = output
 			} else {
 				// Use ExecSilent for retries to avoid multiple progress messages
-				output, err := v.shell.ExecSilent(command, args...)
+				output, err := v.shell.ExecSilent(v.composeCommand, args...)
 				if err == nil {
 					return nil
 				}
@@ -114,7 +136,7 @@ func (v *DockerVirt) Up() error {
 			}
 		}
 		if lastErr != nil {
-			return fmt.Errorf("Error executing command %s %v: %w\n%s", "docker-compose", []string{"-f", composeFilePath, "up", "-d", "--remove-orphans"}, lastErr, lastOutput)
+			return fmt.Errorf("Error executing command %s %v: %w\n%s", v.composeCommand, []string{"up", "--detach", "--remove-orphans"}, lastErr, lastOutput)
 		}
 	}
 	return nil
@@ -122,7 +144,7 @@ func (v *DockerVirt) Up() error {
 
 // Down stops the Docker container
 func (v *DockerVirt) Down() error {
-	// Check if Docker is enabled and run "docker-compose down" if necessary
+	// Check if Docker is enabled and run "docker compose down" if necessary
 	if v.configHandler.GetBool("docker.enabled") {
 		// Ensure Docker daemon is running
 		if err := v.checkDockerDaemon(); err != nil {
@@ -136,10 +158,13 @@ func (v *DockerVirt) Down() error {
 		}
 		composeFilePath := filepath.Join(configRoot, "compose.yaml")
 
-		// Run docker-compose down with clean flags using the Exec function from shell.go
-		output, err := v.shell.ExecProgress("📦 Running docker-compose down", "docker-compose", "-f", composeFilePath, "down", "--remove-orphans", "--volumes")
+		// Set the COMPOSE_FILE environment variable
+		os.Setenv("COMPOSE_FILE", composeFilePath)
+
+		// Run docker compose down with clean flags using the Exec function from shell.go
+		output, err := v.shell.ExecProgress("📦 Running docker compose down", v.composeCommand, "down", "--remove-orphans", "--volumes")
 		if err != nil {
-			return fmt.Errorf("Error executing command docker-compose down: %w\n%s", err, output)
+			return fmt.Errorf("Error executing command %s down: %w\n%s", v.composeCommand, err, output)
 		}
 	}
 	return nil
@@ -165,16 +190,16 @@ func (v *DockerVirt) WriteConfig() error {
 		return fmt.Errorf("error getting full compose config: %w", err)
 	}
 
-	// Serialize the docker-compose config to YAML
+	// Serialize the docker compose config to YAML
 	yamlData, err := yamlMarshal(project)
 	if err != nil {
-		return fmt.Errorf("error marshaling docker-compose config to YAML: %w", err)
+		return fmt.Errorf("error marshaling docker compose config to YAML: %w", err)
 	}
 
 	// Write the YAML data to the specified file
 	err = writeFile(composeFilePath, yamlData, 0644)
 	if err != nil {
-		return fmt.Errorf("error writing docker-compose file: %w", err)
+		return fmt.Errorf("error writing docker compose file: %w", err)
 	}
 
 	return nil

--- a/pkg/virt/docker_virt.go
+++ b/pkg/virt/docker_virt.go
@@ -2,7 +2,6 @@ package virt
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -102,8 +101,10 @@ func (v *DockerVirt) Up() error {
 		}
 		composeFilePath := filepath.Join(configRoot, "compose.yaml")
 
-		// Set the COMPOSE_FILE environment variable
-		os.Setenv("COMPOSE_FILE", composeFilePath)
+		// Set the COMPOSE_FILE environment variable and handle potential error
+		if err := osSetenv("COMPOSE_FILE", composeFilePath); err != nil {
+			return fmt.Errorf("failed to set COMPOSE_FILE environment variable: %w", err)
+		}
 
 		// Retry logic for docker compose up with progress display
 		retries := 3
@@ -158,8 +159,10 @@ func (v *DockerVirt) Down() error {
 		}
 		composeFilePath := filepath.Join(configRoot, "compose.yaml")
 
-		// Set the COMPOSE_FILE environment variable
-		os.Setenv("COMPOSE_FILE", composeFilePath)
+		// Set the COMPOSE_FILE environment variable and handle potential error
+		if err := osSetenv("COMPOSE_FILE", composeFilePath); err != nil {
+			return fmt.Errorf("error setting COMPOSE_FILE environment variable: %w", err)
+		}
 
 		// Run docker compose down with clean flags using the Exec function from shell.go
 		output, err := v.shell.ExecProgress("📦 Running docker compose down", v.composeCommand, "down", "--remove-orphans", "--volumes")

--- a/pkg/virt/docker_virt_test.go
+++ b/pkg/virt/docker_virt_test.go
@@ -133,6 +133,14 @@ func TestDockerVirt_Initialize(t *testing.T) {
 		mocks := setupSafeDockerContainerMocks()
 		dockerVirt := NewDockerVirt(mocks.Injector)
 
+		// Mock the shell's ExecSilent function to simulate a valid docker compose command
+		mocks.MockShell.ExecSilentFunc = func(command string, args ...string) (string, error) {
+			if command == "docker-compose" && len(args) > 0 && args[0] == "--version" {
+				return "docker-compose version 1.29.2, build 5becea4c", nil
+			}
+			return "", fmt.Errorf("unknown command")
+		}
+
 		// Call the Initialize method
 		err := dockerVirt.Initialize()
 
@@ -191,6 +199,31 @@ func TestDockerVirt_Initialize(t *testing.T) {
 			t.Errorf("expected error message to contain %q, got %q", expectedErrorSubstring, err.Error())
 		}
 	})
+
+	t.Run("ErrorDeterminingComposeCommand", func(t *testing.T) {
+		// Setup mock components
+		mocks := setupSafeDockerContainerMocks()
+		dockerVirt := NewDockerVirt(mocks.Injector)
+
+		// Mock the shell's ExecSilent function to simulate no valid docker compose command found
+		mocks.MockShell.ExecSilentFunc = func(command string, args ...string) (string, error) {
+			return "", fmt.Errorf("command not found")
+		}
+
+		// Call the Initialize method
+		err := dockerVirt.Initialize()
+
+		// Assert that an error occurred
+		if err == nil {
+			t.Errorf("expected error, got none")
+		}
+
+		// Verify the error message contains the expected substring
+		expectedErrorSubstring := "error determining docker compose command"
+		if !strings.Contains(err.Error(), expectedErrorSubstring) {
+			t.Errorf("expected error message to contain %q, got %q", expectedErrorSubstring, err.Error())
+		}
+	})
 }
 
 func TestDockerVirt_Up(t *testing.T) {
@@ -200,33 +233,26 @@ func TestDockerVirt_Up(t *testing.T) {
 		dockerVirt := NewDockerVirt(mocks.Injector)
 		dockerVirt.Initialize()
 
-		// Mock the shell's Exec function to handle the callback
-		execCalled := false
+		// Mock the shell Exec function to simulate successful docker info and docker compose up
 		mocks.MockShell.ExecSilentFunc = func(command string, args ...string) (string, error) {
 			if command == "docker" && len(args) > 0 && args[0] == "info" {
-				return "", nil // Simulate successful Docker daemon check
+				return "docker info", nil
 			}
-			return "", fmt.Errorf("unexpected command")
+			return "", fmt.Errorf("unknown command")
 		}
 		mocks.MockShell.ExecProgressFunc = func(message string, command string, args ...string) (string, error) {
-			if command == "docker-compose" && len(args) > 0 && args[2] == "up" {
-				execCalled = true
-				return "", nil
+			if command == dockerVirt.composeCommand && args[0] == "up" {
+				return "docker compose up successful", nil
 			}
-			return "", fmt.Errorf("unexpected command")
+			return "", fmt.Errorf("unknown command")
 		}
 
 		// Call the Up method
 		err := dockerVirt.Up()
 
-		// Assert no error occurred
+		// Assert that no error occurred
 		if err != nil {
 			t.Errorf("expected no error, got %v", err)
-		}
-
-		// Verify that the mock shell's Exec function was called with the expected command
-		if !execCalled {
-			t.Errorf("expected Exec to be called with 'docker-compose up', but it was not")
 		}
 	})
 
@@ -307,7 +333,7 @@ func TestDockerVirt_Up(t *testing.T) {
 			if command == "docker" && len(args) > 0 && args[0] == "info" {
 				return "docker info", nil
 			}
-			if command == "docker-compose" && len(args) > 2 && args[2] == "up" {
+			if command == dockerVirt.composeCommand && len(args) > 0 && args[0] == "up" {
 				execCallCount++
 				if execCallCount < 3 {
 					return "", fmt.Errorf("temporary error")
@@ -317,7 +343,7 @@ func TestDockerVirt_Up(t *testing.T) {
 			return "", fmt.Errorf("unknown command")
 		}
 		mocks.MockShell.ExecProgressFunc = func(message string, command string, args ...string) (string, error) {
-			if command == "docker-compose" && len(args) > 2 && args[2] == "up" {
+			if command == dockerVirt.composeCommand && len(args) > 0 && args[0] == "up" {
 				execCallCount++
 				if execCallCount < 3 {
 					return "", fmt.Errorf("temporary error")
@@ -355,21 +381,15 @@ func TestDockerVirt_Up(t *testing.T) {
 			if command == "docker" && len(args) > 0 && args[0] == "info" {
 				return "docker info", nil
 			}
-			if command == "docker-compose" && len(args) > 2 && args[2] == "up" {
+			if command == dockerVirt.composeCommand && len(args) > 0 && args[0] == "up" {
 				execCallCount++
-				if execCallCount < 3 {
-					return "", fmt.Errorf("temporary error")
-				}
 				return "", fmt.Errorf("persistent error")
 			}
 			return "", fmt.Errorf("unknown command")
 		}
 		mocks.MockShell.ExecProgressFunc = func(message string, command string, args ...string) (string, error) {
-			if command == "docker-compose" && len(args) > 2 && args[2] == "up" {
+			if command == dockerVirt.composeCommand && len(args) > 0 && args[0] == "up" {
 				execCallCount++
-				if execCallCount < 3 {
-					return "", fmt.Errorf("temporary error")
-				}
 				return "", fmt.Errorf("persistent error")
 			}
 			return "", fmt.Errorf("unknown command")
@@ -403,13 +423,13 @@ func TestDockerVirt_Down(t *testing.T) {
 		dockerVirt := NewDockerVirt(mocks.Injector)
 		dockerVirt.Initialize()
 
-		// Mock the shell Exec function to simulate successful docker info and docker-compose down commands
+		// Mock the shell Exec function to simulate successful docker info and docker compose down commands
 		mocks.MockShell.ExecSilentFunc = func(command string, args ...string) (string, error) {
 			if command == "docker" && len(args) > 0 && args[0] == "info" {
 				return "docker info", nil
 			}
-			if command == "docker-compose" && len(args) > 2 && args[2] == "down" {
-				return "docker-compose down", nil
+			if command == "docker compose" && len(args) > 2 && args[2] == "down" {
+				return "docker compose down", nil
 			}
 			return "", fmt.Errorf("unknown command")
 		}
@@ -500,8 +520,8 @@ func TestDockerVirt_Down(t *testing.T) {
 			return "", fmt.Errorf("unknown command")
 		}
 		mocks.MockShell.ExecProgressFunc = func(message string, command string, args ...string) (string, error) {
-			if command == "docker-compose" && len(args) > 0 && args[0] == "-f" && args[2] == "down" {
-				return "", fmt.Errorf("error executing docker-compose down")
+			if command == dockerVirt.composeCommand && len(args) > 0 && args[0] == "down" {
+				return "", fmt.Errorf("error executing docker compose down")
 			}
 			return "", fmt.Errorf("unknown command")
 		}
@@ -514,10 +534,10 @@ func TestDockerVirt_Down(t *testing.T) {
 			t.Errorf("expected an error, got nil")
 		}
 
-		// Verify that the error message is as expected
-		expectedErrorMsg := "error executing docker-compose down"
-		if err != nil && !strings.Contains(err.Error(), expectedErrorMsg) {
-			t.Errorf("expected error message to contain %q, got %v", expectedErrorMsg, err)
+		// Verify that the error message contains the expected substring
+		expectedErrorSubstring := "docker compose down"
+		if err != nil && !strings.Contains(err.Error(), expectedErrorSubstring) {
+			t.Errorf("expected error message to contain %q, got %v", expectedErrorSubstring, err)
 		}
 	})
 }

--- a/pkg/virt/shims.go
+++ b/pkg/virt/shims.go
@@ -10,6 +10,9 @@ import (
 	"github.com/shirou/gopsutil/mem"
 )
 
+// osSetenv is a variable that holds the os.Setenv function to set an environment variable.
+var osSetenv = os.Setenv
+
 // jsonUnmarshal is a variable that holds the json.Unmarshal function for decoding JSON data.
 var jsonUnmarshal = json.Unmarshal
 


### PR DESCRIPTION
Docker compose may be installed in a variety of ways, and be called differently depending on the system. This fix implements a change that tries to determine the correct one to use before calling it.