### PR TITLE
Fix docker host and aws var issue

### DIFF
--- a/pkg/controller/mock_controller.go
+++ b/pkg/controller/mock_controller.go
@@ -137,13 +137,17 @@ func (m *MockController) CreateEnvComponents() error {
 		return m.CreateEnvComponentsFunc()
 	}
 
-	// Create mock aws env printer
-	awsEnv := env.NewMockEnvPrinter()
-	m.injector.Register("awsEnv", awsEnv)
+	// Create mock aws env printer only if aws.enabled is true
+	if m.configHandler.GetBool("aws.enabled") {
+		awsEnv := env.NewMockEnvPrinter()
+		m.injector.Register("awsEnv", awsEnv)
+	}
 
-	// Create mock docker env printer
-	dockerEnv := env.NewMockEnvPrinter()
-	m.injector.Register("dockerEnv", dockerEnv)
+	// Create mock docker env printer only if docker.enabled is true
+	if m.configHandler.GetBool("docker.enabled") {
+		dockerEnv := env.NewMockEnvPrinter()
+		m.injector.Register("dockerEnv", dockerEnv)
+	}
 
 	// Create mock kube env printer
 	kubeEnv := env.NewMockEnvPrinter()

--- a/pkg/controller/mock_controller_test.go
+++ b/pkg/controller/mock_controller_test.go
@@ -144,9 +144,16 @@ func TestMockController_CreateEnvComponents(t *testing.T) {
 	})
 
 	t.Run("NoCreateEnvComponentsFunc", func(t *testing.T) {
+		// Use setSafeControllerMocks to set up the mock environment
+		mocks := setSafeControllerMocks()
 		// Given a new injector and mock controller
-		injector := di.NewInjector()
-		mockCtrl := NewMockController(injector)
+		mockCtrl := NewMockController(mocks.Injector)
+
+		// Initialize the mock controller and check for error
+		if err := mockCtrl.Initialize(); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
 		// When CreateEnvComponents is called without setting CreateEnvComponentsFunc
 		if err := mockCtrl.CreateEnvComponents(); err != nil {
 			// Then no error should be returned

--- a/pkg/controller/real_controller.go
+++ b/pkg/controller/real_controller.go
@@ -84,13 +84,17 @@ func (c *RealController) CreateProjectComponents() error {
 
 // CreateEnvComponents creates components required for env and exec commands
 func (c *RealController) CreateEnvComponents() error {
-	// Create aws env printer
-	awsEnv := env.NewAwsEnvPrinter(c.injector)
-	c.injector.Register("awsEnv", awsEnv)
+	// Create aws env printer only if aws.enabled is true
+	if c.configHandler.GetBool("aws.enabled") {
+		awsEnv := env.NewAwsEnvPrinter(c.injector)
+		c.injector.Register("awsEnv", awsEnv)
+	}
 
-	// Create docker env printer
-	dockerEnv := env.NewDockerEnvPrinter(c.injector)
-	c.injector.Register("dockerEnv", dockerEnv)
+	// Create docker env printer only if docker is enabled
+	if c.configHandler.GetBool("docker.enabled") {
+		dockerEnv := env.NewDockerEnvPrinter(c.injector)
+		c.injector.Register("dockerEnv", dockerEnv)
+	}
 
 	// Create kube env printer
 	kubeEnv := env.NewKubeEnvPrinter(c.injector)

--- a/pkg/controller/real_controller_test.go
+++ b/pkg/controller/real_controller_test.go
@@ -89,6 +89,23 @@ func TestRealController_CreateEnvComponents(t *testing.T) {
 		injector := di.NewInjector()
 		controller := NewRealController(injector)
 
+		// Override the existing configHandler with a mock configHandler
+		mockConfigHandler := config.NewMockConfigHandler()
+
+		// Configure the mock to return necessary values for testing CreateEnvComponents
+		mockConfigHandler.GetBoolFunc = func(key string, defaultValue ...bool) bool {
+			switch key {
+			case "aws.enabled":
+				return true
+			case "docker.enabled":
+				return true
+			default:
+				return false
+			}
+		}
+		injector.Register("configHandler", mockConfigHandler)
+		controller.configHandler = mockConfigHandler
+
 		// When creating env components
 		err := controller.CreateEnvComponents()
 
@@ -139,6 +156,8 @@ func TestRealController_CreateServiceComponents(t *testing.T) {
 		// Configure the mock to return necessary values for testing CreateServiceComponents
 		mockConfigHandler.GetBoolFunc = func(key string, defaultValue ...bool) bool {
 			switch key {
+			case "aws.enabled":
+				return true
 			case "docker.enabled":
 				return true
 			case "dns.enabled":

--- a/pkg/env/docker_env.go
+++ b/pkg/env/docker_env.go
@@ -45,6 +45,17 @@ func (e *DockerEnvPrinter) GetEnvVars() (map[string]string, error) {
 	// Populate environment variables with Docker configuration data.
 	envVars["COMPOSE_FILE"] = composeFilePath
 
+	// Set DOCKER_HOST if vm.driver is colima
+	if e.configHandler.GetString("vm.driver") == "colima" {
+		homeDir, err := osUserHomeDir()
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving user home directory: %w", err)
+		}
+		contextName := e.contextHandler.GetContext()
+		dockerSockPath := filepath.Join(homeDir, ".colima", contextName, "docker.sock")
+		envVars["DOCKER_HOST"] = dockerSockPath
+	}
+
 	return envVars, nil
 }
 

--- a/pkg/env/docker_env.go
+++ b/pkg/env/docker_env.go
@@ -45,7 +45,7 @@ func (e *DockerEnvPrinter) GetEnvVars() (map[string]string, error) {
 	// Populate environment variables with Docker configuration data.
 	envVars["COMPOSE_FILE"] = composeFilePath
 
-	// Set DOCKER_HOST if vm.driver is colima
+	// Set DOCKER_SOCK if vm.driver is colima
 	if e.configHandler.GetString("vm.driver") == "colima" {
 		homeDir, err := osUserHomeDir()
 		if err != nil {
@@ -53,7 +53,7 @@ func (e *DockerEnvPrinter) GetEnvVars() (map[string]string, error) {
 		}
 		contextName := e.contextHandler.GetContext()
 		dockerSockPath := filepath.Join(homeDir, ".colima", contextName, "docker.sock")
-		envVars["DOCKER_HOST"] = dockerSockPath
+		envVars["DOCKER_SOCK"] = dockerSockPath
 	}
 
 	return envVars, nil

--- a/pkg/env/docker_env_test.go
+++ b/pkg/env/docker_env_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/windsorcli/cli/pkg/config"
 	"github.com/windsorcli/cli/pkg/context"
 	"github.com/windsorcli/cli/pkg/di"
 	"github.com/windsorcli/cli/pkg/shell"
@@ -17,6 +18,7 @@ type DockerEnvPrinterMocks struct {
 	Injector       di.Injector
 	ContextHandler *context.MockContext
 	Shell          *shell.MockShell
+	ConfigHandler  *config.MockConfigHandler
 }
 
 func setupSafeDockerEnvPrinterMocks(injector ...di.Injector) *DockerEnvPrinterMocks {
@@ -34,13 +36,20 @@ func setupSafeDockerEnvPrinterMocks(injector ...di.Injector) *DockerEnvPrinterMo
 
 	mockShell := shell.NewMockShell()
 
+	mockConfigHandler := config.NewMockConfigHandler()
+	mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+		return "mock-value"
+	}
+
 	mockInjector.Register("contextHandler", mockContext)
 	mockInjector.Register("shell", mockShell)
+	mockInjector.Register("configHandler", mockConfigHandler)
 
 	return &DockerEnvPrinterMocks{
 		Injector:       mockInjector,
 		ContextHandler: mockContext,
 		Shell:          mockShell,
+		ConfigHandler:  mockConfigHandler,
 	}
 }
 
@@ -67,6 +76,54 @@ func TestDockerEnvPrinter_GetEnvVars(t *testing.T) {
 
 		if envVars["COMPOSE_FILE"] != filepath.FromSlash("/mock/config/root/compose.yaml") && envVars["COMPOSE_FILE"] != filepath.FromSlash("/mock/config/root/compose.yml") {
 			t.Errorf("COMPOSE_FILE = %v, want %v or %v", envVars["COMPOSE_FILE"], filepath.FromSlash("/mock/config/root/compose.yaml"), filepath.FromSlash("/mock/config/root/compose.yml"))
+		}
+
+		if envVars["DOCKER_HOST"] != "" {
+			t.Errorf("DOCKER_HOST = %v, want empty", envVars["DOCKER_HOST"])
+		}
+	})
+
+	t.Run("ColimaDriver", func(t *testing.T) {
+		mocks := setupSafeDockerEnvPrinterMocks()
+		mocks.ContextHandler.GetContextFunc = func() string {
+			return "test-context"
+		}
+
+		originalStat := stat
+		defer func() { stat = originalStat }()
+		stat = func(name string) (os.FileInfo, error) {
+			if name == filepath.FromSlash("/mock/config/root/compose.yaml") {
+				return nil, nil
+			}
+			return nil, os.ErrNotExist
+		}
+
+		originalUserHomeDir := osUserHomeDir
+		defer func() { osUserHomeDir = originalUserHomeDir }()
+		osUserHomeDir = func() (string, error) {
+			return "/mock/home", nil
+		}
+
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "vm.driver" {
+				return "colima"
+			}
+			return ""
+		}
+		mocks.Injector.Register("configHandler", mockConfigHandler)
+
+		dockerEnvPrinter := NewDockerEnvPrinter(mocks.Injector)
+		dockerEnvPrinter.Initialize()
+
+		envVars, err := dockerEnvPrinter.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars returned an error: %v", err)
+		}
+
+		expectedDockerHost := filepath.Join("/mock/home", ".colima", "test-context", "docker.sock")
+		if envVars["DOCKER_HOST"] != expectedDockerHost {
+			t.Errorf("DOCKER_HOST = %v, want %v", envVars["DOCKER_HOST"], expectedDockerHost)
 		}
 	})
 
@@ -130,6 +187,32 @@ func TestDockerEnvPrinter_GetEnvVars(t *testing.T) {
 
 		if envVars["COMPOSE_FILE"] != filepath.FromSlash("/mock/config/root/compose.yml") {
 			t.Errorf("COMPOSE_FILE = %v, want %v", envVars["COMPOSE_FILE"], filepath.FromSlash("/mock/config/root/compose.yml"))
+		}
+	})
+
+	t.Run("GetUserHomeDirError", func(t *testing.T) {
+		mocks := setupSafeDockerEnvPrinterMocks()
+		mocks.ConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "vm.driver" {
+				return "colima"
+			}
+			return ""
+		}
+
+		originalUserHomeDir := osUserHomeDir
+		defer func() { osUserHomeDir = originalUserHomeDir }()
+		osUserHomeDir = func() (string, error) {
+			return "", errors.New("mock user home dir error")
+		}
+
+		dockerEnvPrinter := NewDockerEnvPrinter(mocks.Injector)
+		dockerEnvPrinter.Initialize()
+
+		_, err := dockerEnvPrinter.GetEnvVars()
+		if err == nil {
+			t.Error("expected an error, got nil")
+		} else if !strings.Contains(err.Error(), "mock user home dir error") {
+			t.Errorf("error = %v, want error containing 'mock user home dir error'", err)
 		}
 	})
 }

--- a/pkg/env/docker_env_test.go
+++ b/pkg/env/docker_env_test.go
@@ -78,8 +78,8 @@ func TestDockerEnvPrinter_GetEnvVars(t *testing.T) {
 			t.Errorf("COMPOSE_FILE = %v, want %v or %v", envVars["COMPOSE_FILE"], filepath.FromSlash("/mock/config/root/compose.yaml"), filepath.FromSlash("/mock/config/root/compose.yml"))
 		}
 
-		if envVars["DOCKER_HOST"] != "" {
-			t.Errorf("DOCKER_HOST = %v, want empty", envVars["DOCKER_HOST"])
+		if envVars["DOCKER_SOCK"] != "" {
+			t.Errorf("DOCKER_SOCK = %v, want empty", envVars["DOCKER_SOCK"])
 		}
 	})
 
@@ -122,8 +122,8 @@ func TestDockerEnvPrinter_GetEnvVars(t *testing.T) {
 		}
 
 		expectedDockerHost := filepath.Join("/mock/home", ".colima", "test-context", "docker.sock")
-		if envVars["DOCKER_HOST"] != expectedDockerHost {
-			t.Errorf("DOCKER_HOST = %v, want %v", envVars["DOCKER_HOST"], expectedDockerHost)
+		if envVars["DOCKER_SOCK"] != expectedDockerHost {
+			t.Errorf("DOCKER_SOCK = %v, want %v", envVars["DOCKER_SOCK"], expectedDockerHost)
 		}
 	})
 

--- a/pkg/env/shims.go
+++ b/pkg/env/shims.go
@@ -32,3 +32,6 @@ func stringPtr(s string) *string {
 var goos = func() string {
 	return runtime.GOOS
 }
+
+// Define a variable for os.UserHomeDir for easier testing
+var osUserHomeDir = os.UserHomeDir


### PR DESCRIPTION
This fixes an issue related to the `DOCKER_HOST` not being set, and thus causing issues connecting to the Docker daemon. Additionally, environment variables were also often not being print fully when encountering an issue with aws. Now, both the docker env and aws env components won't be created if not enabled.