### PR TITLE
Add gitops/flux to local.jsonnet

### DIFF
--- a/pkg/blueprint/blueprint_v1alpha1.go
+++ b/pkg/blueprint/blueprint_v1alpha1.go
@@ -38,6 +38,7 @@ type TerraformVariableV1Alpha1 struct {
 	Type        string      `yaml:"type,omitempty"`        // The Type of the variable
 	Default     interface{} `yaml:"default,omitempty"`     // The Default value of the variable
 	Description string      `yaml:"description,omitempty"` // The Description of the variable
+	Sensitive   bool        `yaml:"sensitive,omitempty"`   // Whether to treat the variable as sensitive
 }
 
 // Merge merges another BlueprintV1Alpha1 into the current one.

--- a/pkg/blueprint/templates/local.jsonnet
+++ b/pkg/blueprint/templates/local.jsonnet
@@ -48,8 +48,8 @@ local registryMirrors = std.foldl(
       ref: "v0.1.0",
     },
   ],
-  terraform: [
-    if firstNode != null then {
+  terraform: if firstNode != null then [
+    {
       path: "cluster/talos",
       source: "core",
       values: {
@@ -185,6 +185,65 @@ local registryMirrors = std.foldl(
           default: "",
         },
       }
-    } else {}
-  ],
+    },
+    {
+      path: "gitops/flux",
+      source: "core",
+      values: {
+        git_username: "local",
+        git_password: "local",
+      },
+      variables: {
+        flux_namespace: {
+          description: "The namespace in which Flux will be installed",
+          type: "string",
+          default: "system-gitops",
+        },
+        flux_helm_version: {
+          description: "The version of Flux Helm chart to install",
+          type: "string",
+          default: "2.14.0",
+        },
+        flux_version: {
+          description: "The version of Flux to install",
+          type: "string",
+          default: "2.4.0",
+        },
+        ssh_private_key: {
+          description: "The private key to use for SSH authentication",
+          type: "string",
+          default: "",
+          sensitive: true,
+        },
+        ssh_public_key: {
+          description: "The public key to use for SSH authentication",
+          type: "string",
+          default: "",
+          sensitive: true,
+        },
+        ssh_known_hosts: {
+          description: "The known hosts to use for SSH authentication",
+          type: "string",
+          default: "",
+          sensitive: true,
+        },
+        git_auth_secret: {
+          description: "The name of the secret to store the git authentication details",
+          type: "string",
+          default: "flux-system",
+        },
+        git_username: {
+          description: "The git user to use to authenticate with the git provider",
+          type: "string",
+          default: "git",
+        },
+        git_password: {
+          description: "The git password or PAT used to authenticate with the git provider",
+          type: "string",
+          default: "",
+          sensitive: true,
+        },
+      }
+    }
+  ] else [],
 }

--- a/pkg/generators/terraform_generator.go
+++ b/pkg/generators/terraform_generator.go
@@ -141,6 +141,11 @@ func (g *TerraformGenerator) writeVariableFile(dirPath string, component bluepri
 		if variable.Description != "" {
 			blockBody.SetAttributeValue("description", cty.StringVal(variable.Description))
 		}
+
+		// Set the sensitive attribute if it exists
+		if variable.Sensitive {
+			blockBody.SetAttributeValue("sensitive", cty.BoolVal(variable.Sensitive))
+		}
 	}
 
 	// Define the path for the variables file.


### PR DESCRIPTION
Adds the gitops/flux template to the `local.jsonnet` file. This allow for bootstrapping a gitops operator on to the cluster.