### PR TITLE
Fix blueprint terraform component merge logic

### DIFF
--- a/pkg/blueprint/blueprint_v1alpha1.go
+++ b/pkg/blueprint/blueprint_v1alpha1.go
@@ -41,7 +41,15 @@ type TerraformVariableV1Alpha1 struct {
 	Sensitive   bool        `yaml:"sensitive,omitempty"`   // Whether to treat the variable as sensitive
 }
 
-// Merge merges another BlueprintV1Alpha1 into the current one.
+// Merge integrates another BlueprintV1Alpha1 into the current one, with a focus on maintaining a comprehensive and
+// context-aware combination of blueprint data. The merge process includes:
+//   - Sources: Merged uniquely by their name to ensure each source remains distinct and is updated appropriately.
+//   - TerraformComponents: Merged intricately using the path as the primary key and source as the secondary key. This
+//     ensures precise integration and updates of components. The logic respects the overlay's components, allowing
+//     them to replace or update existing components based on these keys, while maintaining the order of components
+//     from the overlay.
+//   - Metadata: Fields such as name, description, and authors are merged by prioritizing non-empty values from the
+//     overlay, ensuring the most complete and relevant metadata is preserved.
 func (b *BlueprintV1Alpha1) Merge(overlay *BlueprintV1Alpha1) {
 	if overlay == nil {
 		return
@@ -87,45 +95,49 @@ func (b *BlueprintV1Alpha1) Merge(overlay *BlueprintV1Alpha1) {
 		key := component.Path
 		componentMap[key] = component
 	}
-	for _, overlayComponent := range overlay.TerraformComponents {
-		key := overlayComponent.Path
-		if existingComponent, exists := componentMap[key]; exists {
-			// Perform a full merge if both path and source match
-			if existingComponent.Source == overlayComponent.Source {
-				mergedComponent := existingComponent
 
-				// Merge Values
-				if mergedComponent.Values == nil {
-					mergedComponent.Values = make(map[string]interface{})
-				}
-				for k, v := range overlayComponent.Values {
-					mergedComponent.Values[k] = v
-				}
+	// Only merge components that exist in the overlay, preserving order
+	if len(overlay.TerraformComponents) == 0 {
+		// If overlay has no terraform components, use the target's list
+		b.TerraformComponents = append(b.TerraformComponents[:0], b.TerraformComponents...)
+	} else {
+		b.TerraformComponents = make([]TerraformComponentV1Alpha1, 0, len(overlay.TerraformComponents))
+		for _, overlayComponent := range overlay.TerraformComponents {
+			key := overlayComponent.Path
+			if existingComponent, exists := componentMap[key]; exists {
+				// Perform a full merge if both path and source match
+				if existingComponent.Source == overlayComponent.Source {
+					mergedComponent := existingComponent
 
-				// Merge Variables
-				if mergedComponent.Variables == nil {
-					mergedComponent.Variables = make(map[string]TerraformVariableV1Alpha1)
-				}
-				for k, v := range overlayComponent.Variables {
-					mergedComponent.Variables[k] = v
-				}
+					// Merge Values
+					if mergedComponent.Values == nil {
+						mergedComponent.Values = make(map[string]interface{})
+					}
+					for k, v := range overlayComponent.Values {
+						mergedComponent.Values[k] = v
+					}
 
-				if overlayComponent.FullPath != "" {
-					mergedComponent.FullPath = overlayComponent.FullPath
+					// Merge Variables
+					if mergedComponent.Variables == nil {
+						mergedComponent.Variables = make(map[string]TerraformVariableV1Alpha1)
+					}
+					for k, v := range overlayComponent.Variables {
+						mergedComponent.Variables[k] = v
+					}
+
+					if overlayComponent.FullPath != "" {
+						mergedComponent.FullPath = overlayComponent.FullPath
+					}
+					b.TerraformComponents = append(b.TerraformComponents, mergedComponent)
+				} else {
+					// Use the overlay component if the path matches but the source doesn't
+					b.TerraformComponents = append(b.TerraformComponents, overlayComponent)
 				}
-				componentMap[key] = mergedComponent
 			} else {
-				// Use the overlay component if the path matches but the source doesn't
-				componentMap[key] = overlayComponent
+				// Add the overlay component if it doesn't exist in the target
+				b.TerraformComponents = append(b.TerraformComponents, overlayComponent)
 			}
-		} else {
-			// Add the overlay component if it doesn't exist in the target
-			componentMap[key] = overlayComponent
 		}
-	}
-	b.TerraformComponents = make([]TerraformComponentV1Alpha1, 0, len(componentMap))
-	for _, component := range componentMap {
-		b.TerraformComponents = append(b.TerraformComponents, component)
 	}
 }
 

--- a/pkg/blueprint/blueprint_v1alpha1_test.go
+++ b/pkg/blueprint/blueprint_v1alpha1_test.go
@@ -214,6 +214,94 @@ func TestBlueprintV1Alpha1_Merge(t *testing.T) {
 			t.Errorf("Expected FullPath to be 'updated/full/path', but got '%s'", component.FullPath)
 		}
 	})
+
+	t.Run("OverlayWithoutComponents", func(t *testing.T) {
+		dst := &BlueprintV1Alpha1{
+			Kind:       "Blueprint",
+			ApiVersion: "v1alpha1",
+			TerraformComponents: []TerraformComponentV1Alpha1{
+				{
+					Source: "source1",
+					Path:   "module/path1",
+					Variables: map[string]TerraformVariableV1Alpha1{
+						"var1": {Default: "default1"},
+					},
+					Values: map[string]interface{}{
+						"key1": "value1",
+					},
+					FullPath: "original/full/path",
+				},
+			},
+		}
+
+		overlay := &BlueprintV1Alpha1{
+			TerraformComponents: []TerraformComponentV1Alpha1{},
+		}
+
+		dst.Merge(overlay)
+
+		if len(dst.TerraformComponents) != 1 {
+			t.Fatalf("Expected 1 TerraformComponent, but got %d", len(dst.TerraformComponents))
+		}
+
+		component := dst.TerraformComponents[0]
+		if component.Source != "source1" {
+			t.Errorf("Expected Source to be 'source1', but got '%s'", component.Source)
+		}
+		if len(component.Variables) != 1 || component.Variables["var1"].Default != "default1" {
+			t.Errorf("Expected Variables to be ['var1'], but got %v", component.Variables)
+		}
+		if component.Values == nil || len(component.Values) != 1 || component.Values["key1"] != "value1" {
+			t.Errorf("Expected Values to contain 'key1', but got %v", component.Values)
+		}
+		if component.FullPath != "original/full/path" {
+			t.Errorf("Expected FullPath to be 'original/full/path', but got '%s'", component.FullPath)
+		}
+	})
+
+	t.Run("EmptyDstWithOverlayComponents", func(t *testing.T) {
+		dst := &BlueprintV1Alpha1{
+			Kind:                "Blueprint",
+			ApiVersion:          "v1alpha1",
+			TerraformComponents: []TerraformComponentV1Alpha1{},
+		}
+
+		overlay := &BlueprintV1Alpha1{
+			TerraformComponents: []TerraformComponentV1Alpha1{
+				{
+					Source: "source1",
+					Path:   "module/path1",
+					Variables: map[string]TerraformVariableV1Alpha1{
+						"var1": {Default: "default1"},
+					},
+					Values: map[string]interface{}{
+						"key1": "value1",
+					},
+					FullPath: "overlay/full/path",
+				},
+			},
+		}
+
+		dst.Merge(overlay)
+
+		if len(dst.TerraformComponents) != 1 {
+			t.Fatalf("Expected 1 TerraformComponent, but got %d", len(dst.TerraformComponents))
+		}
+
+		component := dst.TerraformComponents[0]
+		if component.Source != "source1" {
+			t.Errorf("Expected Source to be 'source1', but got '%s'", component.Source)
+		}
+		if len(component.Variables) != 1 || component.Variables["var1"].Default != "default1" {
+			t.Errorf("Expected Variables to be ['var1'], but got %v", component.Variables)
+		}
+		if component.Values == nil || len(component.Values) != 1 || component.Values["key1"] != "value1" {
+			t.Errorf("Expected Values to contain 'key1', but got %v", component.Values)
+		}
+		if component.FullPath != "overlay/full/path" {
+			t.Errorf("Expected FullPath to be 'overlay/full/path', but got '%s'", component.FullPath)
+		}
+	})
 }
 
 func TestBlueprintV1Alpha1_Copy(t *testing.T) {


### PR DESCRIPTION
The blueprint yaml was being merged improperly and messing up existing content. This change enhances the merge logic so that it prefers the existing `blueprint.yaml` terraform components and ordering. This makes it so the routine will seldom modify existing `blueprint.yaml` files inappropriately.