### PR TITLE
Reorg blueprint types => api/ folder

### DIFF
--- a/api/v1alpha1/blueprint_types_test.go
+++ b/api/v1alpha1/blueprint_types_test.go
@@ -1,4 +1,4 @@
-package blueprint
+package v1alpha1
 
 import (
 	"sort"
@@ -7,26 +7,26 @@ import (
 
 func TestBlueprintV1Alpha1_Merge(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		dst := &BlueprintV1Alpha1{
+		dst := &Blueprint{
 			Kind:       "Blueprint",
 			ApiVersion: "v1alpha1",
-			Metadata: MetadataV1Alpha1{
+			Metadata: Metadata{
 				Name:        "original",
 				Description: "original description",
 				Authors:     []string{"author1"},
 			},
-			Sources: []SourceV1Alpha1{
+			Sources: []Source{
 				{
 					Name: "source1",
 					Url:  "http://example.com/source1",
 					Ref:  "v1.0.0",
 				},
 			},
-			TerraformComponents: []TerraformComponentV1Alpha1{
+			TerraformComponents: []TerraformComponent{
 				{
 					Source: "source1",
 					Path:   "path1",
-					Variables: map[string]TerraformVariableV1Alpha1{
+					Variables: map[string]TerraformVariable{
 						"var1": {Default: "default1"},
 					},
 					Values:   nil, // Set Values to nil to test initialization
@@ -35,26 +35,26 @@ func TestBlueprintV1Alpha1_Merge(t *testing.T) {
 			},
 		}
 
-		src := &BlueprintV1Alpha1{
+		src := &Blueprint{
 			Kind:       "Blueprint",
 			ApiVersion: "v1alpha1",
-			Metadata: MetadataV1Alpha1{
+			Metadata: Metadata{
 				Name:        "updated",
 				Description: "updated description",
 				Authors:     []string{"author2"},
 			},
-			Sources: []SourceV1Alpha1{
+			Sources: []Source{
 				{
 					Name: "source2",
 					Url:  "http://example.com/source2",
 					Ref:  "v2.0.0",
 				},
 			},
-			TerraformComponents: []TerraformComponentV1Alpha1{
+			TerraformComponents: []TerraformComponent{
 				{
 					Source: "source1",
 					Path:   "path1",
-					Variables: map[string]TerraformVariableV1Alpha1{
+					Variables: map[string]TerraformVariable{
 						"var2": {Default: "default2"},
 					},
 					Values: map[string]interface{}{
@@ -65,7 +65,7 @@ func TestBlueprintV1Alpha1_Merge(t *testing.T) {
 				{
 					Source: "source3",
 					Path:   "path3",
-					Variables: map[string]TerraformVariableV1Alpha1{
+					Variables: map[string]TerraformVariable{
 						"var3": {Default: "default3"},
 					},
 					Values: map[string]interface{}{
@@ -88,7 +88,7 @@ func TestBlueprintV1Alpha1_Merge(t *testing.T) {
 			t.Errorf("Expected Metadata.Authors to be ['author2'], but got %v", dst.Metadata.Authors)
 		}
 
-		expectedSources := map[string]SourceV1Alpha1{
+		expectedSources := map[string]Source{
 			"source1": {Name: "source1", Url: "http://example.com/source1", Ref: "v1.0.0"},
 			"source2": {Name: "source2", Url: "http://example.com/source2", Ref: "v2.0.0"},
 		}
@@ -133,10 +133,10 @@ func TestBlueprintV1Alpha1_Merge(t *testing.T) {
 	})
 
 	t.Run("NoMergeWhenSrcIsNil", func(t *testing.T) {
-		dst := &BlueprintV1Alpha1{
+		dst := &Blueprint{
 			Kind:       "Blueprint",
 			ApiVersion: "v1alpha1",
-			Metadata: MetadataV1Alpha1{
+			Metadata: Metadata{
 				Name:        "original",
 				Description: "original description",
 				Authors:     []string{"author1"},
@@ -160,14 +160,14 @@ func TestBlueprintV1Alpha1_Merge(t *testing.T) {
 	})
 
 	t.Run("MatchingPathNotSource", func(t *testing.T) {
-		dst := &BlueprintV1Alpha1{
+		dst := &Blueprint{
 			Kind:       "Blueprint",
 			ApiVersion: "v1alpha1",
-			TerraformComponents: []TerraformComponentV1Alpha1{
+			TerraformComponents: []TerraformComponent{
 				{
 					Source: "source1",
 					Path:   "module/path1",
-					Variables: map[string]TerraformVariableV1Alpha1{
+					Variables: map[string]TerraformVariable{
 						"var1": {Default: "default1"},
 					},
 					Values: map[string]interface{}{
@@ -178,12 +178,12 @@ func TestBlueprintV1Alpha1_Merge(t *testing.T) {
 			},
 		}
 
-		overlay := &BlueprintV1Alpha1{
-			TerraformComponents: []TerraformComponentV1Alpha1{
+		overlay := &Blueprint{
+			TerraformComponents: []TerraformComponent{
 				{
 					Source: "source2",      // Different source
 					Path:   "module/path1", // Same path
-					Variables: map[string]TerraformVariableV1Alpha1{
+					Variables: map[string]TerraformVariable{
 						"var2": {Default: "default2"},
 					},
 					Values: map[string]interface{}{
@@ -216,14 +216,14 @@ func TestBlueprintV1Alpha1_Merge(t *testing.T) {
 	})
 
 	t.Run("OverlayWithoutComponents", func(t *testing.T) {
-		dst := &BlueprintV1Alpha1{
+		dst := &Blueprint{
 			Kind:       "Blueprint",
 			ApiVersion: "v1alpha1",
-			TerraformComponents: []TerraformComponentV1Alpha1{
+			TerraformComponents: []TerraformComponent{
 				{
 					Source: "source1",
 					Path:   "module/path1",
-					Variables: map[string]TerraformVariableV1Alpha1{
+					Variables: map[string]TerraformVariable{
 						"var1": {Default: "default1"},
 					},
 					Values: map[string]interface{}{
@@ -234,8 +234,8 @@ func TestBlueprintV1Alpha1_Merge(t *testing.T) {
 			},
 		}
 
-		overlay := &BlueprintV1Alpha1{
-			TerraformComponents: []TerraformComponentV1Alpha1{},
+		overlay := &Blueprint{
+			TerraformComponents: []TerraformComponent{},
 		}
 
 		dst.Merge(overlay)
@@ -260,18 +260,18 @@ func TestBlueprintV1Alpha1_Merge(t *testing.T) {
 	})
 
 	t.Run("EmptyDstWithOverlayComponents", func(t *testing.T) {
-		dst := &BlueprintV1Alpha1{
+		dst := &Blueprint{
 			Kind:                "Blueprint",
 			ApiVersion:          "v1alpha1",
-			TerraformComponents: []TerraformComponentV1Alpha1{},
+			TerraformComponents: []TerraformComponent{},
 		}
 
-		overlay := &BlueprintV1Alpha1{
-			TerraformComponents: []TerraformComponentV1Alpha1{
+		overlay := &Blueprint{
+			TerraformComponents: []TerraformComponent{
 				{
 					Source: "source1",
 					Path:   "module/path1",
-					Variables: map[string]TerraformVariableV1Alpha1{
+					Variables: map[string]TerraformVariable{
 						"var1": {Default: "default1"},
 					},
 					Values: map[string]interface{}{
@@ -306,11 +306,11 @@ func TestBlueprintV1Alpha1_Merge(t *testing.T) {
 
 func TestBlueprintV1Alpha1_Copy(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		blueprint := &BlueprintV1Alpha1{
-			Metadata: MetadataV1Alpha1{
+		blueprint := &Blueprint{
+			Metadata: Metadata{
 				Name: "test-blueprint",
 			},
-			Sources: []SourceV1Alpha1{
+			Sources: []Source{
 				{
 					Name:       "source1",
 					Url:        "https://example.com/repo1.git",
@@ -318,11 +318,11 @@ func TestBlueprintV1Alpha1_Copy(t *testing.T) {
 					Ref:        "main",
 				},
 			},
-			TerraformComponents: []TerraformComponentV1Alpha1{
+			TerraformComponents: []TerraformComponent{
 				{
 					Source: "source1",
 					Path:   "module/path1",
-					Variables: map[string]TerraformVariableV1Alpha1{
+					Variables: map[string]TerraformVariable{
 						"var1": {
 							Type:        "string",
 							Default:     "default1",
@@ -351,7 +351,7 @@ func TestBlueprintV1Alpha1_Copy(t *testing.T) {
 	})
 
 	t.Run("EmptyBlueprint", func(t *testing.T) {
-		var blueprint *BlueprintV1Alpha1
+		var blueprint *Blueprint
 		copy := blueprint.DeepCopy()
 		if copy != nil {
 			t.Errorf("Expected copy to be nil, but got non-nil")

--- a/pkg/blueprint/blueprint_handler_test.go
+++ b/pkg/blueprint/blueprint_handler_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/smithy-go/ptr"
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
+	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/config"
 	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/context"
@@ -946,7 +947,7 @@ func TestBlueprintHandler_WriteConfig(t *testing.T) {
 		}
 
 		// Mock the TerraformComponents to include in the blueprint
-		mockTerraformComponents := []TerraformComponentV1Alpha1{
+		mockTerraformComponents := []blueprintv1alpha1.TerraformComponent{
 			{
 				Source: "source1",
 				Path:   "path/to/code",
@@ -970,7 +971,7 @@ func TestBlueprintHandler_WriteConfig(t *testing.T) {
 		}
 
 		// Unmarshal the written data to validate its content
-		var writtenBlueprint BlueprintV1Alpha1
+		var writtenBlueprint blueprintv1alpha1.Blueprint
 		err = yamlUnmarshal(data, &writtenBlueprint)
 		if err != nil {
 			t.Fatalf("Failed to unmarshal written blueprint data: %v", err)
@@ -1028,7 +1029,7 @@ func TestBlueprintHandler_WriteConfig(t *testing.T) {
 		}
 
 		// Unmarshal the written data to validate its content
-		var writtenBlueprint BlueprintV1Alpha1
+		var writtenBlueprint blueprintv1alpha1.Blueprint
 		err = yamlUnmarshal(data, &writtenBlueprint)
 		if err != nil {
 			t.Fatalf("Failed to unmarshal written blueprint data: %v", err)
@@ -1189,7 +1190,7 @@ func TestBlueprintHandler_Install(t *testing.T) {
 		}
 
 		// Set the sources and kustomizations for the blueprint
-		expectedSources := []SourceV1Alpha1{
+		expectedSources := []blueprintv1alpha1.Source{
 			{
 				Name: "source1",
 				Url:  "git::https://example.com/source1.git",
@@ -1198,7 +1199,7 @@ func TestBlueprintHandler_Install(t *testing.T) {
 		}
 		blueprintHandler.SetSources(expectedSources)
 
-		expectedKustomizations := []KustomizationV1Alpha1{
+		expectedKustomizations := []blueprintv1alpha1.Kustomization{
 			{
 				Name:      "kustomization1",
 				DependsOn: []string{"dependency1", "dependency2"},
@@ -1230,7 +1231,7 @@ func TestBlueprintHandler_Install(t *testing.T) {
 		}
 
 		// Set the sources and kustomizations for the blueprint
-		expectedSources := []SourceV1Alpha1{
+		expectedSources := []blueprintv1alpha1.Source{
 			{
 				Name: "source1",
 				Url:  "git::https://example.com/source1.git",
@@ -1239,7 +1240,7 @@ func TestBlueprintHandler_Install(t *testing.T) {
 		}
 		blueprintHandler.SetSources(expectedSources)
 
-		expectedKustomizations := []KustomizationV1Alpha1{
+		expectedKustomizations := []blueprintv1alpha1.Kustomization{
 			{
 				Name:      "kustomization1",
 				DependsOn: []string{"dependency1", "dependency2"},
@@ -1271,7 +1272,7 @@ func TestBlueprintHandler_Install(t *testing.T) {
 		}
 
 		// Set the sources and kustomizations for the blueprint
-		expectedSources := []SourceV1Alpha1{
+		expectedSources := []blueprintv1alpha1.Source{
 			{
 				Name: "source1",
 				Url:  "git::https://example.com/source1.git",
@@ -1280,7 +1281,7 @@ func TestBlueprintHandler_Install(t *testing.T) {
 		}
 		blueprintHandler.SetSources(expectedSources)
 
-		expectedKustomizations := []KustomizationV1Alpha1{
+		expectedKustomizations := []blueprintv1alpha1.Kustomization{
 			{
 				Name:      "kustomization1",
 				DependsOn: []string{"dependency1", "dependency2"},
@@ -1309,7 +1310,7 @@ func TestBlueprintHandler_GetMetadata(t *testing.T) {
 		}
 
 		// Set the metadata for the blueprint
-		expectedMetadata := MetadataV1Alpha1{
+		expectedMetadata := blueprintv1alpha1.Metadata{
 			Name:        "test-blueprint",
 			Description: "A test blueprint",
 			Authors:     []string{"John Doe"},
@@ -1339,7 +1340,7 @@ func TestBlueprintHandler_GetSources(t *testing.T) {
 		}
 
 		// Set the sources for the blueprint
-		expectedSources := []SourceV1Alpha1{
+		expectedSources := []blueprintv1alpha1.Source{
 			{
 				Name: "source1",
 				Url:  "git::https://example.com/source1.git",
@@ -1371,7 +1372,7 @@ func TestBlueprintHandler_GetTerraformComponents(t *testing.T) {
 		}
 
 		// Set the Terraform components for the blueprint
-		expectedComponents := []TerraformComponentV1Alpha1{
+		expectedComponents := []blueprintv1alpha1.TerraformComponent{
 			{
 				Source:   "source1",
 				Path:     "path/to/code",
@@ -1405,7 +1406,7 @@ func TestBlueprintHandler_GetKustomizations(t *testing.T) {
 		}
 
 		// Set the Kustomizations for the blueprint
-		expectedKustomizations := []KustomizationV1Alpha1{
+		expectedKustomizations := []blueprintv1alpha1.Kustomization{
 			{
 				Name:          "kustomization1",
 				Interval:      &metav1.Duration{Duration: constants.DEFAULT_FLUX_KUSTOMIZATION_INTERVAL},
@@ -1437,7 +1438,7 @@ func TestBlueprintHandler_GetKustomizations(t *testing.T) {
 		}
 
 		// Set the Kustomizations with zero values
-		inputKustomizations := []KustomizationV1Alpha1{
+		inputKustomizations := []blueprintv1alpha1.Kustomization{
 			{
 				Name:          "kustomization1",
 				Interval:      &metav1.Duration{Duration: 0},
@@ -1453,7 +1454,7 @@ func TestBlueprintHandler_GetKustomizations(t *testing.T) {
 		actualKustomizations := blueprintHandler.GetKustomizations()
 
 		// Define the expected Kustomizations with default values from constants
-		expectedKustomizations := []KustomizationV1Alpha1{
+		expectedKustomizations := []blueprintv1alpha1.Kustomization{
 			{
 				Name:          "kustomization1",
 				Interval:      &metav1.Duration{Duration: constants.DEFAULT_FLUX_KUSTOMIZATION_INTERVAL},
@@ -1508,7 +1509,7 @@ func TestBlueprintHandler_SetMetadata(t *testing.T) {
 		}
 
 		// Set the metadata for the blueprint
-		expectedMetadata := MetadataV1Alpha1{
+		expectedMetadata := blueprintv1alpha1.Metadata{
 			Name:        "test-blueprint",
 			Description: "A test blueprint",
 			Authors:     []string{"John Doe"},
@@ -1538,7 +1539,7 @@ func TestBlueprintHandler_SetSources(t *testing.T) {
 		}
 
 		// Set the sources for the blueprint
-		expectedSources := []SourceV1Alpha1{
+		expectedSources := []blueprintv1alpha1.Source{
 			{
 				Name: "source1",
 				Url:  "git::https://example.com/source1.git",
@@ -1570,7 +1571,7 @@ func TestBlueprintHandler_SetTerraformComponents(t *testing.T) {
 		}
 
 		// Set the Terraform components for the blueprint
-		expectedComponents := []TerraformComponentV1Alpha1{
+		expectedComponents := []blueprintv1alpha1.TerraformComponent{
 			{
 				Source:   "source1",
 				Path:     "path/to/code",
@@ -1605,7 +1606,7 @@ func TestBlueprintHandler_SetKustomizations(t *testing.T) {
 		}
 
 		// Set the Kustomizations for the blueprint
-		expectedKustomizations := []KustomizationV1Alpha1{
+		expectedKustomizations := []blueprintv1alpha1.Kustomization{
 			{
 				Name:          "kustomization1",
 				Path:          "overlays/dev",
@@ -1665,7 +1666,7 @@ func TestBlueprintHandler_resolveComponentSources(t *testing.T) {
 		}
 
 		// Set the sources for the blueprint with an empty PathPrefix to test the default behavior
-		expectedSources := []SourceV1Alpha1{
+		expectedSources := []blueprintv1alpha1.Source{
 			{
 				Name:       "source1",
 				Url:        "git::https://example.com/source1.git",
@@ -1676,7 +1677,7 @@ func TestBlueprintHandler_resolveComponentSources(t *testing.T) {
 		blueprintHandler.SetSources(expectedSources)
 
 		// Set the Terraform components for the blueprint
-		expectedComponents := []TerraformComponentV1Alpha1{
+		expectedComponents := []blueprintv1alpha1.TerraformComponent{
 			{
 				Source: "source1",
 				Path:   "path/to/code",
@@ -1714,7 +1715,7 @@ func TestBlueprintHandler_resolveComponentPaths(t *testing.T) {
 		blueprintHandler.projectRoot = "/mock/project/root"
 
 		// Set the Terraform components for the blueprint
-		expectedComponents := []TerraformComponentV1Alpha1{
+		expectedComponents := []blueprintv1alpha1.TerraformComponent{
 			{
 				Source: "source1",
 				Path:   "path/to/code",
@@ -1772,14 +1773,14 @@ func TestBlueprintHandler_resolveComponentPaths(t *testing.T) {
 		blueprintHandler := NewBlueprintHandler(setupSafeMocks().Injector)
 		_ = blueprintHandler.Initialize()
 
-		blueprintHandler.SetSources([]SourceV1Alpha1{{
+		blueprintHandler.SetSources([]blueprintv1alpha1.Source{{
 			Name:       "test-source",
 			Url:        "https://github.com/user/repo.git",
 			PathPrefix: "terraform",
 			Ref:        "main",
 		}})
 
-		blueprintHandler.SetTerraformComponents([]TerraformComponentV1Alpha1{{
+		blueprintHandler.SetTerraformComponents([]blueprintv1alpha1.TerraformComponent{{
 			Source: "test-source",
 			Path:   "module/path",
 		}})
@@ -1826,7 +1827,7 @@ kustomizations:
     path: ./kustomize
 `)
 
-		var blueprint BlueprintV1Alpha1
+		var blueprint blueprintv1alpha1.Blueprint
 		if err := blueprintHandler.processBlueprintData(data, &blueprint); err != nil {
 			t.Fatalf("processBlueprintData() error: %v", err)
 		}
@@ -1866,7 +1867,7 @@ kustomizations:
     path: ./kustomize
 `)
 
-		var blueprint BlueprintV1Alpha1
+		var blueprint blueprintv1alpha1.Blueprint
 		if err := blueprintHandler.processBlueprintData(data, &blueprint); err == nil || !strings.Contains(err.Error(), "mocked error in yamlUnmarshal") {
 			t.Fatalf("Expected mocked unmarshalling error, got %v", err)
 		}
@@ -1893,7 +1894,7 @@ kustomizations:
     path: ./kustomize
 `)
 
-		var blueprint BlueprintV1Alpha1
+		var blueprint blueprintv1alpha1.Blueprint
 		if err := blueprintHandler.processBlueprintData(data, &blueprint); err == nil || !strings.Contains(err.Error(), "mocked error in yamlMarshal") {
 			t.Fatalf("Expected mocked marshalling error, got %v", err)
 		}
@@ -1920,7 +1921,7 @@ kustomizations:
     path: ./kustomize
 `)
 
-		var blueprint BlueprintV1Alpha1
+		var blueprint blueprintv1alpha1.Blueprint
 		if err := blueprintHandler.processBlueprintData(data, &blueprint); err == nil || !strings.Contains(err.Error(), "mocked error in k8sYamlUnmarshal") {
 			t.Fatalf("Expected mocked k8s unmarshalling error, got %v", err)
 		}

--- a/pkg/blueprint/defaults.go
+++ b/pkg/blueprint/defaults.go
@@ -1,13 +1,15 @@
 package blueprint
 
-var DefaultBlueprint = BlueprintV1Alpha1{
+import blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+
+var DefaultBlueprint = blueprintv1alpha1.Blueprint{
 	Kind:       "Blueprint",
 	ApiVersion: "blueprints.windsorcli.dev/v1alpha1",
-	Metadata: MetadataV1Alpha1{
+	Metadata: blueprintv1alpha1.Metadata{
 		Name:        "default",
 		Description: "A default blueprint",
 		Authors:     []string{},
 	},
-	Sources:             []SourceV1Alpha1{},
-	TerraformComponents: []TerraformComponentV1Alpha1{},
+	Sources:             []blueprintv1alpha1.Source{},
+	TerraformComponents: []blueprintv1alpha1.TerraformComponent{},
 }

--- a/pkg/blueprint/mock_blueprint_handler.go
+++ b/pkg/blueprint/mock_blueprint_handler.go
@@ -1,6 +1,7 @@
 package blueprint
 
 import (
+	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/di"
 )
 
@@ -8,14 +9,14 @@ import (
 type MockBlueprintHandler struct {
 	InitializeFunc             func() error
 	LoadConfigFunc             func(path ...string) error
-	GetMetadataFunc            func() MetadataV1Alpha1
-	GetSourcesFunc             func() []SourceV1Alpha1
-	GetTerraformComponentsFunc func() []TerraformComponentV1Alpha1
-	GetKustomizationsFunc      func() []KustomizationV1Alpha1
-	SetMetadataFunc            func(metadata MetadataV1Alpha1) error
-	SetSourcesFunc             func(sources []SourceV1Alpha1) error
-	SetTerraformComponentsFunc func(terraformComponents []TerraformComponentV1Alpha1) error
-	SetKustomizationsFunc      func(kustomizations []KustomizationV1Alpha1) error
+	GetMetadataFunc            func() blueprintv1alpha1.Metadata
+	GetSourcesFunc             func() []blueprintv1alpha1.Source
+	GetTerraformComponentsFunc func() []blueprintv1alpha1.TerraformComponent
+	GetKustomizationsFunc      func() []blueprintv1alpha1.Kustomization
+	SetMetadataFunc            func(metadata blueprintv1alpha1.Metadata) error
+	SetSourcesFunc             func(sources []blueprintv1alpha1.Source) error
+	SetTerraformComponentsFunc func(terraformComponents []blueprintv1alpha1.TerraformComponent) error
+	SetKustomizationsFunc      func(kustomizations []blueprintv1alpha1.Kustomization) error
 	WriteConfigFunc            func(path ...string) error
 	InstallFunc                func() error
 }
@@ -42,39 +43,39 @@ func (m *MockBlueprintHandler) LoadConfig(path ...string) error {
 }
 
 // GetMetadata calls the mock GetMetadataFunc if set, otherwise returns a reasonable default MetadataV1Alpha1
-func (m *MockBlueprintHandler) GetMetadata() MetadataV1Alpha1 {
+func (m *MockBlueprintHandler) GetMetadata() blueprintv1alpha1.Metadata {
 	if m.GetMetadataFunc != nil {
 		return m.GetMetadataFunc()
 	}
-	return MetadataV1Alpha1{}
+	return blueprintv1alpha1.Metadata{}
 }
 
 // GetSources calls the mock GetSourcesFunc if set, otherwise returns a reasonable default slice of SourceV1Alpha1
-func (m *MockBlueprintHandler) GetSources() []SourceV1Alpha1 {
+func (m *MockBlueprintHandler) GetSources() []blueprintv1alpha1.Source {
 	if m.GetSourcesFunc != nil {
 		return m.GetSourcesFunc()
 	}
-	return []SourceV1Alpha1{}
+	return []blueprintv1alpha1.Source{}
 }
 
 // GetTerraformComponents calls the mock GetTerraformComponentsFunc if set, otherwise returns a reasonable default slice of TerraformComponentV1Alpha1
-func (m *MockBlueprintHandler) GetTerraformComponents() []TerraformComponentV1Alpha1 {
+func (m *MockBlueprintHandler) GetTerraformComponents() []blueprintv1alpha1.TerraformComponent {
 	if m.GetTerraformComponentsFunc != nil {
 		return m.GetTerraformComponentsFunc()
 	}
-	return []TerraformComponentV1Alpha1{}
+	return []blueprintv1alpha1.TerraformComponent{}
 }
 
 // GetKustomizations calls the mock GetKustomizationsFunc if set, otherwise returns a reasonable default slice of kustomizev1.Kustomization
-func (m *MockBlueprintHandler) GetKustomizations() []KustomizationV1Alpha1 {
+func (m *MockBlueprintHandler) GetKustomizations() []blueprintv1alpha1.Kustomization {
 	if m.GetKustomizationsFunc != nil {
 		return m.GetKustomizationsFunc()
 	}
-	return []KustomizationV1Alpha1{}
+	return []blueprintv1alpha1.Kustomization{}
 }
 
 // SetMetadata calls the mock SetMetadataFunc if set, otherwise returns nil
-func (m *MockBlueprintHandler) SetMetadata(metadata MetadataV1Alpha1) error {
+func (m *MockBlueprintHandler) SetMetadata(metadata blueprintv1alpha1.Metadata) error {
 	if m.SetMetadataFunc != nil {
 		return m.SetMetadataFunc(metadata)
 	}
@@ -82,7 +83,7 @@ func (m *MockBlueprintHandler) SetMetadata(metadata MetadataV1Alpha1) error {
 }
 
 // SetSources calls the mock SetSourcesFunc if set, otherwise returns nil
-func (m *MockBlueprintHandler) SetSources(sources []SourceV1Alpha1) error {
+func (m *MockBlueprintHandler) SetSources(sources []blueprintv1alpha1.Source) error {
 	if m.SetSourcesFunc != nil {
 		return m.SetSourcesFunc(sources)
 	}
@@ -90,7 +91,7 @@ func (m *MockBlueprintHandler) SetSources(sources []SourceV1Alpha1) error {
 }
 
 // SetTerraformComponents calls the mock SetTerraformComponentsFunc if set, otherwise returns nil
-func (m *MockBlueprintHandler) SetTerraformComponents(terraformComponents []TerraformComponentV1Alpha1) error {
+func (m *MockBlueprintHandler) SetTerraformComponents(terraformComponents []blueprintv1alpha1.TerraformComponent) error {
 	if m.SetTerraformComponentsFunc != nil {
 		return m.SetTerraformComponentsFunc(terraformComponents)
 	}
@@ -98,7 +99,7 @@ func (m *MockBlueprintHandler) SetTerraformComponents(terraformComponents []Terr
 }
 
 // SetKustomizations calls the mock SetKustomizationsFunc if set, otherwise returns nil
-func (m *MockBlueprintHandler) SetKustomizations(kustomizations []KustomizationV1Alpha1) error {
+func (m *MockBlueprintHandler) SetKustomizations(kustomizations []blueprintv1alpha1.Kustomization) error {
 	if m.SetKustomizationsFunc != nil {
 		return m.SetKustomizationsFunc(kustomizations)
 	}

--- a/pkg/blueprint/mock_blueprint_handler_test.go
+++ b/pkg/blueprint/mock_blueprint_handler_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/di"
 )
 
@@ -60,8 +61,8 @@ func TestMockBlueprintHandler_GetMetadata(t *testing.T) {
 	t.Run("WithFuncSet", func(t *testing.T) {
 		injector := di.NewInjector()
 		handler := NewMockBlueprintHandler(injector)
-		expectedMetadata := MetadataV1Alpha1{}
-		handler.GetMetadataFunc = func() MetadataV1Alpha1 {
+		expectedMetadata := blueprintv1alpha1.Metadata{}
+		handler.GetMetadataFunc = func() blueprintv1alpha1.Metadata {
 			return expectedMetadata
 		}
 		metadata := handler.GetMetadata()
@@ -74,8 +75,8 @@ func TestMockBlueprintHandler_GetMetadata(t *testing.T) {
 		injector := di.NewInjector()
 		handler := NewMockBlueprintHandler(injector)
 		metadata := handler.GetMetadata()
-		if !reflect.DeepEqual(metadata, MetadataV1Alpha1{}) {
-			t.Errorf("Expected metadata = %v, got = %v", MetadataV1Alpha1{}, metadata)
+		if !reflect.DeepEqual(metadata, blueprintv1alpha1.Metadata{}) {
+			t.Errorf("Expected metadata = %v, got = %v", blueprintv1alpha1.Metadata{}, metadata)
 		}
 	})
 }
@@ -84,8 +85,8 @@ func TestMockBlueprintHandler_GetSources(t *testing.T) {
 	t.Run("WithFuncSet", func(t *testing.T) {
 		injector := di.NewInjector()
 		handler := NewMockBlueprintHandler(injector)
-		expectedSources := []SourceV1Alpha1{}
-		handler.GetSourcesFunc = func() []SourceV1Alpha1 {
+		expectedSources := []blueprintv1alpha1.Source{}
+		handler.GetSourcesFunc = func() []blueprintv1alpha1.Source {
 			return expectedSources
 		}
 		sources := handler.GetSources()
@@ -98,8 +99,8 @@ func TestMockBlueprintHandler_GetSources(t *testing.T) {
 		injector := di.NewInjector()
 		handler := NewMockBlueprintHandler(injector)
 		sources := handler.GetSources()
-		if !reflect.DeepEqual(sources, []SourceV1Alpha1{}) {
-			t.Errorf("Expected sources = %v, got = %v", []SourceV1Alpha1{}, sources)
+		if !reflect.DeepEqual(sources, []blueprintv1alpha1.Source{}) {
+			t.Errorf("Expected sources = %v, got = %v", []blueprintv1alpha1.Source{}, sources)
 		}
 	})
 }
@@ -108,8 +109,8 @@ func TestMockBlueprintHandler_GetTerraformComponents(t *testing.T) {
 	t.Run("WithFuncSet", func(t *testing.T) {
 		injector := di.NewInjector()
 		handler := NewMockBlueprintHandler(injector)
-		expectedComponents := []TerraformComponentV1Alpha1{}
-		handler.GetTerraformComponentsFunc = func() []TerraformComponentV1Alpha1 {
+		expectedComponents := []blueprintv1alpha1.TerraformComponent{}
+		handler.GetTerraformComponentsFunc = func() []blueprintv1alpha1.TerraformComponent {
 			return expectedComponents
 		}
 		components := handler.GetTerraformComponents()
@@ -122,8 +123,8 @@ func TestMockBlueprintHandler_GetTerraformComponents(t *testing.T) {
 		injector := di.NewInjector()
 		handler := NewMockBlueprintHandler(injector)
 		components := handler.GetTerraformComponents()
-		if !reflect.DeepEqual(components, []TerraformComponentV1Alpha1{}) {
-			t.Errorf("Expected components = %v, got = %v", []TerraformComponentV1Alpha1{}, components)
+		if !reflect.DeepEqual(components, []blueprintv1alpha1.TerraformComponent{}) {
+			t.Errorf("Expected components = %v, got = %v", []blueprintv1alpha1.TerraformComponent{}, components)
 		}
 	})
 }
@@ -132,8 +133,8 @@ func TestMockBlueprintHandler_GetKustomizations(t *testing.T) {
 	t.Run("WithFuncSet", func(t *testing.T) {
 		injector := di.NewInjector()
 		handler := NewMockBlueprintHandler(injector)
-		expectedKustomizations := []KustomizationV1Alpha1{}
-		handler.GetKustomizationsFunc = func() []KustomizationV1Alpha1 {
+		expectedKustomizations := []blueprintv1alpha1.Kustomization{}
+		handler.GetKustomizationsFunc = func() []blueprintv1alpha1.Kustomization {
 			return expectedKustomizations
 		}
 		kustomizations := handler.GetKustomizations()
@@ -146,8 +147,8 @@ func TestMockBlueprintHandler_GetKustomizations(t *testing.T) {
 		injector := di.NewInjector()
 		handler := NewMockBlueprintHandler(injector)
 		kustomizations := handler.GetKustomizations()
-		if !reflect.DeepEqual(kustomizations, []KustomizationV1Alpha1{}) {
-			t.Errorf("Expected kustomizations = %v, got = %v", []KustomizationV1Alpha1{}, kustomizations)
+		if !reflect.DeepEqual(kustomizations, []blueprintv1alpha1.Kustomization{}) {
+			t.Errorf("Expected kustomizations = %v, got = %v", []blueprintv1alpha1.Kustomization{}, kustomizations)
 		}
 	})
 }
@@ -158,10 +159,10 @@ func TestMockBlueprintHandler_SetMetadata(t *testing.T) {
 	t.Run("WithFuncSet", func(t *testing.T) {
 		injector := di.NewInjector()
 		handler := NewMockBlueprintHandler(injector)
-		handler.SetMetadataFunc = func(metadata MetadataV1Alpha1) error {
+		handler.SetMetadataFunc = func(metadata blueprintv1alpha1.Metadata) error {
 			return mockSetErr
 		}
-		err := handler.SetMetadata(MetadataV1Alpha1{})
+		err := handler.SetMetadata(blueprintv1alpha1.Metadata{})
 		if err != mockSetErr {
 			t.Errorf("Expected error = %v, got = %v", mockSetErr, err)
 		}
@@ -170,7 +171,7 @@ func TestMockBlueprintHandler_SetMetadata(t *testing.T) {
 	t.Run("WithNoFuncSet", func(t *testing.T) {
 		injector := di.NewInjector()
 		handler := NewMockBlueprintHandler(injector)
-		err := handler.SetMetadata(MetadataV1Alpha1{})
+		err := handler.SetMetadata(blueprintv1alpha1.Metadata{})
 		if err != nil {
 			t.Errorf("Expected error = %v, got = %v", nil, err)
 		}
@@ -183,10 +184,10 @@ func TestMockBlueprintHandler_SetSources(t *testing.T) {
 	t.Run("WithFuncSet", func(t *testing.T) {
 		injector := di.NewInjector()
 		handler := NewMockBlueprintHandler(injector)
-		handler.SetSourcesFunc = func(sources []SourceV1Alpha1) error {
+		handler.SetSourcesFunc = func(sources []blueprintv1alpha1.Source) error {
 			return mockSetErr
 		}
-		err := handler.SetSources([]SourceV1Alpha1{})
+		err := handler.SetSources([]blueprintv1alpha1.Source{})
 		if err != mockSetErr {
 			t.Errorf("Expected error = %v, got = %v", mockSetErr, err)
 		}
@@ -195,7 +196,7 @@ func TestMockBlueprintHandler_SetSources(t *testing.T) {
 	t.Run("WithNoFuncSet", func(t *testing.T) {
 		injector := di.NewInjector()
 		handler := NewMockBlueprintHandler(injector)
-		err := handler.SetSources([]SourceV1Alpha1{})
+		err := handler.SetSources([]blueprintv1alpha1.Source{})
 		if err != nil {
 			t.Errorf("Expected error = %v, got = %v", nil, err)
 		}
@@ -208,10 +209,10 @@ func TestMockBlueprintHandler_SetTerraformComponents(t *testing.T) {
 	t.Run("WithFuncSet", func(t *testing.T) {
 		injector := di.NewInjector()
 		handler := NewMockBlueprintHandler(injector)
-		handler.SetTerraformComponentsFunc = func(components []TerraformComponentV1Alpha1) error {
+		handler.SetTerraformComponentsFunc = func(components []blueprintv1alpha1.TerraformComponent) error {
 			return mockSetErr
 		}
-		err := handler.SetTerraformComponents([]TerraformComponentV1Alpha1{})
+		err := handler.SetTerraformComponents([]blueprintv1alpha1.TerraformComponent{})
 		if err != mockSetErr {
 			t.Errorf("Expected error = %v, got = %v", mockSetErr, err)
 		}
@@ -220,7 +221,7 @@ func TestMockBlueprintHandler_SetTerraformComponents(t *testing.T) {
 	t.Run("WithNoFuncSet", func(t *testing.T) {
 		injector := di.NewInjector()
 		handler := NewMockBlueprintHandler(injector)
-		err := handler.SetTerraformComponents([]TerraformComponentV1Alpha1{})
+		err := handler.SetTerraformComponents([]blueprintv1alpha1.TerraformComponent{})
 		if err != nil {
 			t.Errorf("Expected error = %v, got = %v", nil, err)
 		}
@@ -233,10 +234,10 @@ func TestMockBlueprintHandler_SetKustomizations(t *testing.T) {
 	t.Run("WithFuncSet", func(t *testing.T) {
 		injector := di.NewInjector()
 		handler := NewMockBlueprintHandler(injector)
-		handler.SetKustomizationsFunc = func(kustomizations []KustomizationV1Alpha1) error {
+		handler.SetKustomizationsFunc = func(kustomizations []blueprintv1alpha1.Kustomization) error {
 			return mockSetErr
 		}
-		err := handler.SetKustomizations([]KustomizationV1Alpha1{})
+		err := handler.SetKustomizations([]blueprintv1alpha1.Kustomization{})
 		if err != mockSetErr {
 			t.Errorf("Expected error = %v, got = %v", mockSetErr, err)
 		}
@@ -245,7 +246,7 @@ func TestMockBlueprintHandler_SetKustomizations(t *testing.T) {
 	t.Run("WithNoFuncSet", func(t *testing.T) {
 		injector := di.NewInjector()
 		handler := NewMockBlueprintHandler(injector)
-		err := handler.SetKustomizations([]KustomizationV1Alpha1{})
+		err := handler.SetKustomizations([]blueprintv1alpha1.Kustomization{})
 		if err != nil {
 			t.Errorf("Expected error = %v, got = %v", nil, err)
 		}

--- a/pkg/generators/generator_test.go
+++ b/pkg/generators/generator_test.go
@@ -4,6 +4,7 @@ import (
 	"io/fs"
 	"testing"
 
+	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/blueprint"
 	"github.com/windsorcli/cli/pkg/context"
 	"github.com/windsorcli/cli/pkg/di"
@@ -51,9 +52,9 @@ func setupSafeMocks(injector ...di.Injector) MockComponents {
 	mockInjector.Register("blueprintHandler", mockBlueprintHandler)
 
 	// Mock the GetTerraformComponents method
-	mockBlueprintHandler.GetTerraformComponentsFunc = func() []blueprint.TerraformComponentV1Alpha1 {
+	mockBlueprintHandler.GetTerraformComponentsFunc = func() []blueprintv1alpha1.TerraformComponent {
 		// Common components setup
-		remoteComponent := blueprint.TerraformComponentV1Alpha1{
+		remoteComponent := blueprintv1alpha1.TerraformComponent{
 			Source: "git::https://github.com/terraform-aws-modules/terraform-aws-vpc.git//terraform/remote/path@v1.0.0",
 			Path:   "/mock/project/root/.tf_modules/remote/path",
 			Values: map[string]interface{}{
@@ -61,7 +62,7 @@ func setupSafeMocks(injector ...di.Injector) MockComponents {
 			},
 		}
 
-		localComponent := blueprint.TerraformComponentV1Alpha1{
+		localComponent := blueprintv1alpha1.TerraformComponent{
 			Source: "local/path",
 			Path:   "/mock/project/root/terraform/local/path",
 			Values: map[string]interface{}{
@@ -69,7 +70,7 @@ func setupSafeMocks(injector ...di.Injector) MockComponents {
 			},
 		}
 
-		return []blueprint.TerraformComponentV1Alpha1{remoteComponent, localComponent}
+		return []blueprintv1alpha1.TerraformComponent{remoteComponent, localComponent}
 	}
 
 	// Create a new mock shell

--- a/pkg/generators/terraform_generator.go
+++ b/pkg/generators/terraform_generator.go
@@ -10,7 +10,7 @@ import (
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
-	"github.com/windsorcli/cli/pkg/blueprint"
+	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/di"
 	"github.com/zclconf/go-cty/cty"
 )
@@ -67,7 +67,7 @@ func (g *TerraformGenerator) Write() error {
 }
 
 // writeModule writes the Terraform module file for the given component
-func (g *TerraformGenerator) writeModuleFile(dirPath string, component blueprint.TerraformComponentV1Alpha1) error {
+func (g *TerraformGenerator) writeModuleFile(dirPath string, component blueprintv1alpha1.TerraformComponent) error {
 	// Create a new empty HCL file
 	moduleContent := hclwrite.NewEmptyFile()
 
@@ -105,7 +105,7 @@ func (g *TerraformGenerator) writeModuleFile(dirPath string, component blueprint
 }
 
 // writeVariableFile generates and writes the Terraform variable definitions to a file.
-func (g *TerraformGenerator) writeVariableFile(dirPath string, component blueprint.TerraformComponentV1Alpha1) error {
+func (g *TerraformGenerator) writeVariableFile(dirPath string, component blueprintv1alpha1.TerraformComponent) error {
 	// Create a new empty HCL file to hold variable definitions.
 	variablesContent := hclwrite.NewEmptyFile()
 	body := variablesContent.Body()
@@ -162,7 +162,7 @@ func (g *TerraformGenerator) writeVariableFile(dirPath string, component bluepri
 // writeTfvarsFile orchestrates writing a .tfvars file for the specified Terraform component,
 // preserving existing attributes and integrating any new values. If the component includes a
 // 'source' attribute, it indicates the component's origin or external module reference.
-func (g *TerraformGenerator) writeTfvarsFile(dirPath string, component blueprint.TerraformComponentV1Alpha1) error {
+func (g *TerraformGenerator) writeTfvarsFile(dirPath string, component blueprintv1alpha1.TerraformComponent) error {
 	// Define the path for the tfvars file relative to the component's path.
 	componentPath := filepath.Join(dirPath, "terraform", component.Path)
 	tfvarsFilePath := componentPath + ".tfvars"

--- a/pkg/generators/terraform_generator_test.go
+++ b/pkg/generators/terraform_generator_test.go
@@ -7,8 +7,9 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/windsorcli/cli/pkg/blueprint"
 	"github.com/zclconf/go-cty/cty"
+
+	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 )
 
 func TestNewTerraformGenerator(t *testing.T) {
@@ -197,9 +198,9 @@ func TestTerraformGenerator_writeModuleFile(t *testing.T) {
 		}
 
 		// And the writeModuleFile method is called
-		err := generator.writeModuleFile("/fake/dir", blueprint.TerraformComponentV1Alpha1{
+		err := generator.writeModuleFile("/fake/dir", blueprintv1alpha1.TerraformComponent{
 			Source: "fake-source",
-			Variables: map[string]blueprint.TerraformVariableV1Alpha1{
+			Variables: map[string]blueprintv1alpha1.TerraformVariable{
 				"var1": {Type: "string", Default: "default1", Description: "description1"},
 				"var2": {Type: "number", Default: 2, Description: "description2"},
 			},
@@ -224,8 +225,8 @@ func TestTerraformGenerator_writeVariableFile(t *testing.T) {
 		}
 
 		// And the writeVariableFile method is called
-		err := generator.writeVariableFile("/fake/dir", blueprint.TerraformComponentV1Alpha1{
-			Variables: map[string]blueprint.TerraformVariableV1Alpha1{
+		err := generator.writeVariableFile("/fake/dir", blueprintv1alpha1.TerraformComponent{
+			Variables: map[string]blueprintv1alpha1.TerraformVariable{
 				"var1": {Type: "string", Default: "default1", Description: "description1"},
 				"var2": {Type: "number", Default: 2, Description: "description2"},
 			},
@@ -251,8 +252,8 @@ func TestTerraformGenerator_writeTfvarsFile(t *testing.T) {
 		}
 
 		// And the writeTfvarsFile method is called with no existing tfvars file
-		err := generator.writeTfvarsFile("/fake/dir", blueprint.TerraformComponentV1Alpha1{
-			Variables: map[string]blueprint.TerraformVariableV1Alpha1{
+		err := generator.writeTfvarsFile("/fake/dir", blueprintv1alpha1.TerraformComponent{
+			Variables: map[string]blueprintv1alpha1.TerraformVariable{
 				"var1": {Type: "string", Default: "default1", Description: "desc1"},
 				"var2": {Type: "bool", Default: true, Description: "desc2"},
 			},
@@ -301,9 +302,9 @@ var1 = "oldval1"
 		}
 
 		// And the writeTfvarsFile method is called
-		err := generator.writeTfvarsFile("/fake/dir", blueprint.TerraformComponentV1Alpha1{
+		err := generator.writeTfvarsFile("/fake/dir", blueprintv1alpha1.TerraformComponent{
 			Source: "some-module-source", // to test source comment insertion
-			Variables: map[string]blueprint.TerraformVariableV1Alpha1{
+			Variables: map[string]blueprintv1alpha1.TerraformVariable{
 				"var1": {Type: "string", Default: "default1", Description: "desc1"},
 				"var2": {Type: "list", Default: []interface{}{"item1"}, Description: "desc2"},
 			},
@@ -339,8 +340,8 @@ var1 = "oldval1"
 		}
 
 		// And the writeTfvarsFile method is called
-		err := generator.writeTfvarsFile("/fake/dir", blueprint.TerraformComponentV1Alpha1{
-			Variables: map[string]blueprint.TerraformVariableV1Alpha1{
+		err := generator.writeTfvarsFile("/fake/dir", blueprintv1alpha1.TerraformComponent{
+			Variables: map[string]blueprintv1alpha1.TerraformVariable{
 				"var1": {Type: "string", Default: "defval", Description: "desc"},
 			},
 			Values: map[string]interface{}{
@@ -383,7 +384,7 @@ var1 = "oldval1"
 		}
 
 		// And we call writeTfvarsFile
-		err := generator.writeTfvarsFile("/fake/dir", blueprint.TerraformComponentV1Alpha1{
+		err := generator.writeTfvarsFile("/fake/dir", blueprintv1alpha1.TerraformComponent{
 			Values: map[string]interface{}{
 				"var1": "value1",
 			},
@@ -425,7 +426,7 @@ var1 = "oldval1"
 		}
 
 		// And we call writeTfvarsFile
-		err := generator.writeTfvarsFile("/fake/dir", blueprint.TerraformComponentV1Alpha1{
+		err := generator.writeTfvarsFile("/fake/dir", blueprintv1alpha1.TerraformComponent{
 			Values: map[string]interface{}{
 				"var1": "val1",
 			},
@@ -457,7 +458,7 @@ var1 = "oldval1"
 		}
 
 		// And we call writeTfvarsFile
-		err := generator.writeTfvarsFile("/fake/dir", blueprint.TerraformComponentV1Alpha1{
+		err := generator.writeTfvarsFile("/fake/dir", blueprintv1alpha1.TerraformComponent{
 			Values: map[string]interface{}{
 				"var1": "val1",
 			},
@@ -489,8 +490,8 @@ var1 = "oldval1"
 		}
 
 		// And the writeTfvarsFile method is called
-		err := generator.writeTfvarsFile("/fake/dir", blueprint.TerraformComponentV1Alpha1{
-			Variables: map[string]blueprint.TerraformVariableV1Alpha1{
+		err := generator.writeTfvarsFile("/fake/dir", blueprintv1alpha1.TerraformComponent{
+			Variables: map[string]blueprintv1alpha1.TerraformVariable{
 				"var1": {Type: "string", Default: "default1", Description: "description1"},
 			},
 			Values: map[string]interface{}{

--- a/pkg/stack/stack_test.go
+++ b/pkg/stack/stack_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/blueprint"
 	"github.com/windsorcli/cli/pkg/di"
 	"github.com/windsorcli/cli/pkg/env"
@@ -30,9 +31,9 @@ func setupSafeMocks(injector ...di.Injector) MockSafeComponents {
 
 	// Create a mock blueprint handler
 	mockBlueprintHandler := blueprint.NewMockBlueprintHandler(mockInjector)
-	mockBlueprintHandler.GetTerraformComponentsFunc = func() []blueprint.TerraformComponentV1Alpha1 {
+	mockBlueprintHandler.GetTerraformComponentsFunc = func() []blueprintv1alpha1.TerraformComponent {
 		// Define common components
-		remoteComponent := blueprint.TerraformComponentV1Alpha1{
+		remoteComponent := blueprintv1alpha1.TerraformComponent{
 			Source:   "git::https://github.com/terraform-aws-modules/terraform-aws-vpc.git//terraform/remote/path@v1.0.0",
 			Path:     "remote/path",
 			FullPath: "/mock/project/root/.tf_modules/remote/path",
@@ -40,7 +41,7 @@ func setupSafeMocks(injector ...di.Injector) MockSafeComponents {
 				"remote_variable1": "default_value",
 			},
 		}
-		localComponent := blueprint.TerraformComponentV1Alpha1{
+		localComponent := blueprintv1alpha1.TerraformComponent{
 			Source:   "",
 			Path:     "local/path",
 			FullPath: "/mock/project/root/terraform/local/path",
@@ -49,7 +50,7 @@ func setupSafeMocks(injector ...di.Injector) MockSafeComponents {
 			},
 		}
 
-		return []blueprint.TerraformComponentV1Alpha1{remoteComponent, localComponent}
+		return []blueprintv1alpha1.TerraformComponent{remoteComponent, localComponent}
 	}
 	mockInjector.Register("blueprintHandler", mockBlueprintHandler)
 


### PR DESCRIPTION
Properly organizes the blueprint type in to an api folder, in line with common practices