### PR TITLE
Corrected registry mirrors

### DIFF
--- a/pkg/blueprint/templates/local.jsonnet
+++ b/pkg/blueprint/templates/local.jsonnet
@@ -11,23 +11,14 @@ local firstNode = if std.length(cpNodes) > 0 then cpNodes[0] else null;
 // Build the mirrors dynamically
 local registryMirrors = std.foldl(
   function(acc, key)
-    local regData = context.docker.registries[key];
-
-    // Figure out which endpoint to use:
-    //   1) local, if present
-    //   2) remote, if present
-    local endpointsVal =
-      if std.objectHas(regData, "local") && regData["local"] != "" then regData["local"]
-      else if std.objectHas(regData, "remote") && regData["remote"] != "" then regData["remote"]
-      else null;
-
-    // Must have a non-empty hostname, and endpointsVal must be non-null
-    if !(std.objectHas(regData, "hostname")) || regData.hostname == "" || endpointsVal == null then
+    local registryInfo = context.docker.registries[key];
+    // Must have a non-empty hostname
+    if !(std.objectHas(registryInfo, "hostname")) || registryInfo.hostname == "" then
       acc
     else
       acc + {
-        [regData["hostname"]]: {
-          endpoints: [endpointsVal],
+        [key]: {
+          endpoints: ["http://" + registryInfo["hostname"] + ":5000"],
         },
       },
   std.objectFields(context.docker.registries),

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -48,21 +48,21 @@ var DefaultLocalConfig = Context{
 	Docker: &docker.DockerConfig{
 		Enabled: ptrBool(true),
 		Registries: map[string]docker.RegistryConfig{
-			"registry": {},
-			"registry-1.docker": {
+			"registry.io": {},
+			"registry-1.docker.io": {
 				Remote: "https://registry-1.docker.io",
 				Local:  "https://docker.io",
 			},
-			"registry.k8s": {
+			"registry.k8s.io": {
 				Remote: "https://registry.k8s.io",
 			},
-			"gcr": {
+			"gcr.io": {
 				Remote: "https://gcr.io",
 			},
-			"ghcr": {
+			"ghcr.io": {
 				Remote: "https://ghcr.io",
 			},
-			"quay": {
+			"quay.io": {
 				Remote: "https://quay.io",
 			},
 		},

--- a/pkg/services/dns_service.go
+++ b/pkg/services/dns_service.go
@@ -116,7 +116,7 @@ func (s *DNSService) WriteConfig() error {
 	// Get the TLD from the configuration
 	tld := s.configHandler.GetString("dns.name", "test")
 
-	// Gather the IP address of each service using the Address field
+	// Gather the IP address of each service using the GetHostname method
 	var hostEntries string
 	for _, service := range s.services {
 		composeConfig, err := service.GetComposeConfig()
@@ -125,12 +125,10 @@ func (s *DNSService) WriteConfig() error {
 		}
 		for _, svc := range composeConfig.Services {
 			if svc.Name != "" {
-				if addressService, ok := service.(interface{ GetAddress() string }); ok {
-					address := addressService.GetAddress()
-					if address != "" {
-						fullName := svc.Name
-						hostEntries += fmt.Sprintf("        %s %s\n", address, fullName)
-					}
+				address := service.GetAddress()
+				if address != "" {
+					hostname := service.GetHostname()
+					hostEntries += fmt.Sprintf("        %s %s\n", address, hostname)
 				}
 			}
 		}

--- a/pkg/services/dns_service_test.go
+++ b/pkg/services/dns_service_test.go
@@ -405,6 +405,9 @@ func TestDNSService_WriteConfig(t *testing.T) {
 		mockService.GetAddressFunc = func() string {
 			return "192.168.1.1"
 		}
+		mockService.GetHostnameFunc = func() string {
+			return "mockService.test"
+		}
 		mocks.Injector.Register("dockerService", mockService)
 
 		// Given: a DNSService with the mock config handler, context, and DockerService

--- a/pkg/services/mock_service.go
+++ b/pkg/services/mock_service.go
@@ -21,6 +21,8 @@ type MockService struct {
 	SetNameFunc func(name string)
 	// GetNameFunc is a function that mocks the GetName method
 	GetNameFunc func() string
+	// GetHostnameFunc is a function that mocks the GetHostname method
+	GetHostnameFunc func() string
 }
 
 // NewMockService is a constructor for MockService
@@ -80,6 +82,14 @@ func (m *MockService) SetName(name string) {
 func (m *MockService) GetName() string {
 	if m.GetNameFunc != nil {
 		return m.GetNameFunc()
+	}
+	return ""
+}
+
+// GetHostname calls the mock GetHostnameFunc if it is set, otherwise returns an empty string
+func (m *MockService) GetHostname() string {
+	if m.GetHostnameFunc != nil {
+		return m.GetHostnameFunc()
 	}
 	return ""
 }

--- a/pkg/services/mock_service_test.go
+++ b/pkg/services/mock_service_test.go
@@ -350,3 +350,36 @@ func TestMockService_GetName(t *testing.T) {
 		}
 	})
 }
+
+func TestMockService_GetHostname(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Given: a mock service
+		mockService := NewMockService()
+		expectedHostname := "localhost"
+
+		// When: GetHostnameFunc is called
+		mockGetHostnameFunc := func() string {
+			return expectedHostname
+		}
+		mockService.GetHostnameFunc = mockGetHostnameFunc
+
+		// Then: the GetHostnameFunc should be set and return the expected hostname
+		hostname := mockService.GetHostname()
+		if hostname != expectedHostname {
+			t.Errorf("expected hostname %v, got %v", expectedHostname, hostname)
+		}
+	})
+
+	t.Run("SuccessNoMock", func(t *testing.T) {
+		// Given: a mock service with no GetHostnameFunc
+		mockService := NewMockService()
+
+		// When: GetHostname is called
+		hostname := mockService.GetHostname()
+
+		// Then: an empty string should be returned
+		if hostname != "" {
+			t.Errorf("expected empty hostname, got %v", hostname)
+		}
+	})
+}

--- a/pkg/services/registry_service_test.go
+++ b/pkg/services/registry_service_test.go
@@ -316,3 +316,25 @@ func TestRegistryService_SetAddress(t *testing.T) {
 		}
 	})
 }
+
+func TestRegistryService_GetHostname(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Given: a mock config handler, shell, context, and service
+		mocks := setupSafeRegistryServiceMocks()
+		registryService := NewRegistryService(mocks.Injector)
+		registryService.SetName("registry.oldtld")
+		err := registryService.Initialize()
+		if err != nil {
+			t.Fatalf("Initialize() error = %v", err)
+		}
+
+		// When: GetHostname is called
+		hostname := registryService.GetHostname()
+
+		// Then: the hostname should be as expected, with the old TLD removed
+		expectedHostname := "registry.test"
+		if hostname != expectedHostname {
+			t.Fatalf("expected hostname '%s', got %v", expectedHostname, hostname)
+		}
+	})
+}

--- a/pkg/services/service.go
+++ b/pkg/services/service.go
@@ -35,6 +35,9 @@ type Service interface {
 
 	// Initialize performs any necessary initialization for the service.
 	Initialize() error
+
+	// GetHostname returns the name plus the tld from the config
+	GetHostname() string
 }
 
 // BaseService is a base implementation of the Service interface
@@ -101,6 +104,12 @@ func (s *BaseService) SetName(name string) {
 // GetName returns the current name of the service
 func (s *BaseService) GetName() string {
 	return s.name
+}
+
+// GetHostname returns the name plus the tld from the config
+func (s *BaseService) GetHostname() string {
+	tld := s.configHandler.GetString("dns.name", "test")
+	return fmt.Sprintf("%s.%s", s.name, tld)
 }
 
 // isLocalhost checks if the given address is a localhost address

--- a/pkg/services/service_test.go
+++ b/pkg/services/service_test.go
@@ -191,6 +191,32 @@ func TestBaseService_GetName(t *testing.T) {
 	})
 }
 
+func TestBaseService_GetHostname(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Given: a new BaseService with a mock config handler
+		mocks := setupSafeBaseServiceMocks()
+		service := &BaseService{injector: mocks.Injector}
+		service.SetName("TestService")
+		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "dns.name" {
+				return "example"
+			}
+			return ""
+		}
+
+		service.Initialize()
+
+		// When: GetHostname is called
+		hostname := service.GetHostname()
+
+		// Then: the hostname should be as expected
+		expectedHostname := "TestService.example"
+		if hostname != expectedHostname {
+			t.Fatalf("expected hostname '%s', got %v", expectedHostname, hostname)
+		}
+	})
+}
+
 func TestBaseService_isLocalhost(t *testing.T) {
 	tests := []struct {
 		name          string


### PR DESCRIPTION
Registry mirrors were reversed in the Talos machine config. This fixes that, but also introduces a `GetHostname` function that allows us to transform things like `ghcr.io` => `ghcr.test` based on use case.