### PR TITLE
Update git-livereload image reference

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -5,7 +5,7 @@ import "time"
 // Default git livereload settings
 const (
 	// renovate: datasource=docker depName=ghcr.io/windsorcli/git-livereload-server
-	DEFAULT_GIT_LIVE_RELOAD_IMAGE         = "ghcr.io/windsorcli/git-livereload-server:v0.2.1"
+	DEFAULT_GIT_LIVE_RELOAD_IMAGE         = "ghcr.io/windsorcli/git-livereload:v0.1.0"
 	DEFAULT_GIT_LIVE_RELOAD_RSYNC_EXCLUDE = ".windsor,.terraform,data,.volumes,.venv"
 	DEFAULT_GIT_LIVE_RELOAD_RSYNC_PROTECT = "flux-system"
 	DEFAULT_GIT_LIVE_RELOAD_USERNAME      = "local"


### PR DESCRIPTION
We now build and push our git-livereload image to windsorcli/git-livereload, this changes the reference.