### PR TITLE
Include patches and components when generating kustomization

### DIFF
--- a/pkg/blueprint/blueprint_handler.go
+++ b/pkg/blueprint/blueprint_handler.go
@@ -822,6 +822,8 @@ func (b *BaseBlueprintHandler) applyKustomization(kustomization blueprintv1alpha
 				Name:      kustomization.Source,
 				Namespace: constants.DEFAULT_FLUX_SYSTEM_NAMESPACE,
 			},
+			Patches:    kustomization.Patches,
+			Components: kustomization.Components,
 		},
 	}
 


### PR DESCRIPTION
When applying kustomizations, neither `components` nor `patches` were being included.