### PR TITLE
Worker nodeports

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,7 @@
       "request": "launch",
       "mode": "auto",
       "program": "${workspaceFolder}/cmd/windsor/main.go",
-      "args": ["init"]
+      "args": ["init", "local"]
     },
     {
       "name": "Windsor Up",

--- a/api/v1alpha1/cluster/cluster_config.go
+++ b/api/v1alpha1/cluster/cluster_config.go
@@ -16,13 +16,15 @@ type ClusterConfig struct {
 		Memory *int                  `yaml:"memory,omitempty"`
 		Nodes  map[string]NodeConfig `yaml:"nodes,omitempty"`
 	} `yaml:"workers,omitempty"`
+	NodePorts []string `yaml:"nodeports,omitempty"`
 }
 
 // NodeConfig represents the node configuration
 type NodeConfig struct {
-	Hostname *string `yaml:"hostname"`
-	Node     *string `yaml:"node,omitempty"`
-	Endpoint *string `yaml:"endpoint,omitempty"`
+	Hostname  *string  `yaml:"hostname"`
+	Node      *string  `yaml:"node,omitempty"`
+	Endpoint  *string  `yaml:"endpoint,omitempty"`
+	NodePorts []string `yaml:"nodeports,omitempty"`
 }
 
 // Merge performs a deep merge of the current ClusterConfig with another ClusterConfig.
@@ -63,6 +65,10 @@ func (base *ClusterConfig) Merge(overlay *ClusterConfig) {
 			base.Workers.Nodes[key] = node
 		}
 	}
+	if overlay.NodePorts != nil {
+		base.NodePorts = make([]string, len(overlay.NodePorts))
+		copy(base.NodePorts, overlay.NodePorts)
+	}
 }
 
 // Copy creates a deep copy of the ClusterConfig object
@@ -73,19 +79,23 @@ func (c *ClusterConfig) Copy() *ClusterConfig {
 	controlPlanesNodesCopy := make(map[string]NodeConfig, len(c.ControlPlanes.Nodes))
 	for key, node := range c.ControlPlanes.Nodes {
 		controlPlanesNodesCopy[key] = NodeConfig{
-			Hostname: node.Hostname,
-			Node:     node.Node,
-			Endpoint: node.Endpoint,
+			Hostname:  node.Hostname,
+			Node:      node.Node,
+			Endpoint:  node.Endpoint,
+			NodePorts: append([]string{}, node.NodePorts...), // Copy NodePorts for each node
 		}
 	}
 	workersNodesCopy := make(map[string]NodeConfig, len(c.Workers.Nodes))
 	for key, node := range c.Workers.Nodes {
 		workersNodesCopy[key] = NodeConfig{
-			Hostname: node.Hostname,
-			Node:     node.Node,
-			Endpoint: node.Endpoint,
+			Hostname:  node.Hostname,
+			Node:      node.Node,
+			Endpoint:  node.Endpoint,
+			NodePorts: append([]string{}, node.NodePorts...), // Copy NodePorts for each node
 		}
 	}
+	NodePortsCopy := make([]string, len(c.NodePorts))
+	copy(NodePortsCopy, c.NodePorts)
 	return &ClusterConfig{
 		Enabled: c.Enabled,
 		Driver:  c.Driver,
@@ -111,5 +121,6 @@ func (c *ClusterConfig) Copy() *ClusterConfig {
 			Memory: c.Workers.Memory,
 			Nodes:  workersNodesCopy,
 		},
+		NodePorts: NodePortsCopy,
 	}
 }

--- a/api/v1alpha1/cluster/cluster_config_test.go
+++ b/api/v1alpha1/cluster/cluster_config_test.go
@@ -20,8 +20,9 @@ func ptrInt(i int) *int {
 func TestClusterConfig_Merge(t *testing.T) {
 	t.Run("MergeWithNoNils", func(t *testing.T) {
 		base := &ClusterConfig{
-			Enabled: ptrBool(true),
-			Driver:  ptrString("base-driver"),
+			Enabled:   ptrBool(true),
+			Driver:    ptrString("base-driver"),
+			NodePorts: []string{"8080", "9090"},
 			ControlPlanes: struct {
 				Count  *int                  `yaml:"count,omitempty"`
 				CPU    *int                  `yaml:"cpu,omitempty"`
@@ -51,8 +52,9 @@ func TestClusterConfig_Merge(t *testing.T) {
 		}
 
 		overlay := &ClusterConfig{
-			Enabled: ptrBool(false),
-			Driver:  ptrString("overlay-driver"),
+			Enabled:   ptrBool(false),
+			Driver:    ptrString("overlay-driver"),
+			NodePorts: []string{"8082", "9092"},
 			ControlPlanes: struct {
 				Count  *int                  `yaml:"count,omitempty"`
 				CPU    *int                  `yaml:"cpu,omitempty"`
@@ -89,6 +91,9 @@ func TestClusterConfig_Merge(t *testing.T) {
 		if base.Driver == nil || *base.Driver != "overlay-driver" {
 			t.Errorf("Driver mismatch: expected 'overlay-driver', got '%s'", *base.Driver)
 		}
+		if len(base.NodePorts) != 2 || base.NodePorts[0] != "8082" || base.NodePorts[1] != "9092" {
+			t.Errorf("NodePorts mismatch: expected ['8082', '9092'], got %v", base.NodePorts)
+		}
 		if base.ControlPlanes.Count == nil || *base.ControlPlanes.Count != 1 {
 			t.Errorf("ControlPlanes Count mismatch: expected 1, got %v", *base.ControlPlanes.Count)
 		}
@@ -117,8 +122,9 @@ func TestClusterConfig_Merge(t *testing.T) {
 
 	t.Run("MergeWithAllNils", func(t *testing.T) {
 		base := &ClusterConfig{
-			Enabled: nil,
-			Driver:  nil,
+			Enabled:   nil,
+			Driver:    nil,
+			NodePorts: nil,
 			ControlPlanes: struct {
 				Count  *int                  `yaml:"count,omitempty"`
 				CPU    *int                  `yaml:"cpu,omitempty"`
@@ -144,8 +150,9 @@ func TestClusterConfig_Merge(t *testing.T) {
 		}
 
 		overlay := &ClusterConfig{
-			Enabled: nil,
-			Driver:  nil,
+			Enabled:   nil,
+			Driver:    nil,
+			NodePorts: nil,
 			ControlPlanes: struct {
 				Count  *int                  `yaml:"count,omitempty"`
 				CPU    *int                  `yaml:"cpu,omitempty"`
@@ -178,6 +185,9 @@ func TestClusterConfig_Merge(t *testing.T) {
 		if base.Driver != nil {
 			t.Errorf("Driver mismatch: expected nil, got '%s'", *base.Driver)
 		}
+		if base.NodePorts != nil {
+			t.Errorf("NodePorts mismatch: expected nil, got %v", base.NodePorts)
+		}
 		if base.ControlPlanes.Count != nil {
 			t.Errorf("ControlPlanes Count mismatch: expected nil, got %v", *base.ControlPlanes.Count)
 		}
@@ -208,8 +218,9 @@ func TestClusterConfig_Merge(t *testing.T) {
 func TestClusterConfig_Copy(t *testing.T) {
 	t.Run("CopyWithNonNilValues", func(t *testing.T) {
 		original := &ClusterConfig{
-			Enabled: ptrBool(true),
-			Driver:  ptrString("original-driver"),
+			Enabled:   ptrBool(true),
+			Driver:    ptrString("original-driver"),
+			NodePorts: []string{"8080", "9090"},
 			ControlPlanes: struct {
 				Count  *int                  `yaml:"count,omitempty"`
 				CPU    *int                  `yaml:"cpu,omitempty"`
@@ -245,6 +256,9 @@ func TestClusterConfig_Copy(t *testing.T) {
 		}
 		if original.Driver == nil || copy.Driver == nil || *original.Driver != *copy.Driver {
 			t.Errorf("Driver mismatch: expected %v, got %v", *original.Driver, *copy.Driver)
+		}
+		if len(original.NodePorts) != len(copy.NodePorts) || original.NodePorts[0] != copy.NodePorts[0] || original.NodePorts[1] != copy.NodePorts[1] {
+			t.Errorf("NodePorts mismatch: expected %v, got %v", original.NodePorts, copy.NodePorts)
 		}
 		if original.ControlPlanes.Count == nil || copy.ControlPlanes.Count == nil || *original.ControlPlanes.Count != *copy.ControlPlanes.Count {
 			t.Errorf("ControlPlanes Count mismatch: expected %v, got %v", *original.ControlPlanes.Count, *copy.ControlPlanes.Count)

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -72,20 +72,24 @@ cluster:
     count: 1
     cpu: 4
     memory: 4
+  nodeports:
+    - 8080:30080/tcp
+    - 8443:30443/tcp
 ```
 
-| Field                     | Type     | Description                                                                 |
-|---------------------------|----------|-----------------------------------------------------------------------------|
-| `enabled`                 | `bool`   | Indicates whether the cluster is enabled.                                   |
-| `driver`                  | `string` | Specifies the driver used for the cluster. Only supports 'talos'.           |
-| `controlplanes`           | `struct` | Configuration for the control plane nodes.                                  |
-| `controlplanes.count`     | `int`    | Number of control plane nodes.                                              |
-| `controlplanes.cpu`       | `int`    | CPU allocation for each control plane node.                                 |
-| `controlplanes.memory`    | `int`    | Memory allocation for each control plane node.                              |
-| `workers`                 | `struct` | Configuration for the worker nodes.                                         |
-| `workers.count`           | `int`    | Number of worker nodes.                                                     |
-| `workers.cpu`             | `int`    | CPU allocation for each worker node.                                        |
-| `workers.memory`          | `int`    | Memory allocation for each worker node.                                     |
+| Field                  | Type       | Description                                                        |
+|------------------------|------------|--------------------------------------------------------------------|
+| `enabled`              | `bool`     | Indicates if the cluster is active.                                |
+| `driver`               | `string`   | Defines the cluster driver. Currently, only 'talos' is supported.  |
+| `controlplanes`        | `struct`   | Settings for control plane nodes.                                  |
+| `controlplanes.count`  | `int`      | Total number of control plane nodes.                               |
+| `controlplanes.cpu`    | `int`      | CPU resources allocated per control plane node.                    |
+| `controlplanes.memory` | `int`      | Memory resources allocated per control plane node.                 |
+| `workers`              | `struct`   | Settings for worker nodes.                                         |
+| `workers.count`        | `int`      | Total number of worker nodes.                                      |
+| `workers.cpu`          | `int`      | CPU resources allocated per worker node.                           |
+| `workers.memory`       | `int`      | Memory resources allocated per worker node.                        |
+| `nodeports`            | `[]string` | List of nodeports for host forwarding.                             |
 
 ### DNS
 Configures details related to the local DNS service. The service is available at `dns.test:53`. Presently, the local DNS server runs CoreDNS.
@@ -252,6 +256,9 @@ contexts:
         count: 1
         cpu: 4
         memory: 4
+      nodeports:
+        - 8080:30080
+        - 8443:30443
     dns:
       enabled: true
       name: test

--- a/pkg/config/config_handler.go
+++ b/pkg/config/config_handler.go
@@ -32,6 +32,9 @@ type ConfigHandler interface {
 	// GetBool retrieves a boolean value for the specified key from the configuration
 	GetBool(key string, defaultValue ...bool) bool
 
+	// GetStringSlice retrieves a slice of strings for the specified key from the configuration
+	GetStringSlice(key string, defaultValue ...[]string) []string
+
 	// Set sets the value for the specified key in the configuration
 	Set(key string, value interface{}) error
 

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -110,6 +110,7 @@ var DefaultLocalConfig = v1alpha1.Context{
 			Memory: ptrInt(4),
 			Nodes:  make(map[string]cluster.NodeConfig),
 		},
+		NodePorts: []string{"8080:30080/tcp", "8443:30443/tcp"},
 	},
 	DNS: &dns.DNSConfig{
 		Enabled: ptrBool(true),

--- a/pkg/config/mock_config_handler.go
+++ b/pkg/config/mock_config_handler.go
@@ -9,6 +9,7 @@ type MockConfigHandler struct {
 	GetStringFunc       func(key string, defaultValue ...string) string
 	GetIntFunc          func(key string, defaultValue ...int) int
 	GetBoolFunc         func(key string, defaultValue ...bool) bool
+	GetStringSliceFunc  func(key string, defaultValue ...[]string) []string
 	SetFunc             func(key string, value interface{}) error
 	SetContextValueFunc func(key string, value interface{}) error
 	SaveConfigFunc      func(path string) error
@@ -73,6 +74,17 @@ func (m *MockConfigHandler) GetBool(key string, defaultValue ...bool) bool {
 		return defaultValue[0]
 	}
 	return true
+}
+
+// GetStringSlice calls the mock GetStringSliceFunc if set, otherwise returns a reasonable default slice of strings
+func (m *MockConfigHandler) GetStringSlice(key string, defaultValue ...[]string) []string {
+	if m.GetStringSliceFunc != nil {
+		return m.GetStringSliceFunc(key, defaultValue...)
+	}
+	if len(defaultValue) > 0 {
+		return defaultValue[0]
+	}
+	return []string{}
 }
 
 // Set calls the mock SetFunc if set, otherwise returns nil

--- a/pkg/config/mock_config_handler_test.go
+++ b/pkg/config/mock_config_handler_test.go
@@ -254,6 +254,50 @@ func TestMockConfigHandler_GetBool(t *testing.T) {
 	})
 }
 
+func TestMockConfigHandler_GetStringSlice(t *testing.T) {
+	t.Run("WithKey", func(t *testing.T) {
+		// Given a mock config handler with GetStringSliceFunc set to return a specific slice
+		handler := NewMockConfigHandler()
+		expectedSlice := []string{"value1", "value2"}
+		handler.GetStringSliceFunc = func(key string, defaultValue ...[]string) []string { return expectedSlice }
+
+		// When GetStringSlice is called with a key
+		value := handler.GetStringSlice("someKey")
+
+		// Then the returned value should match the expected slice
+		if !reflect.DeepEqual(value, expectedSlice) {
+			t.Errorf("Expected GetStringSlice with key to return %v, got %v", expectedSlice, value)
+		}
+	})
+
+	t.Run("WithNoFuncSet", func(t *testing.T) {
+		// Given a mock config handler without GetStringSliceFunc set
+		handler := NewMockConfigHandler()
+
+		// When GetStringSlice is called with a key
+		value := handler.GetStringSlice("someKey")
+
+		// Then the returned value should be the default empty slice
+		if len(value) != 0 {
+			t.Errorf("Expected GetStringSlice with no func set to return an empty slice, got %v", value)
+		}
+	})
+
+	t.Run("WithDefaultValue", func(t *testing.T) {
+		// Given a mock config handler
+		handler := NewMockConfigHandler()
+		defaultValue := []string{"default1", "default2"}
+
+		// When GetStringSlice is called with a key and a default value
+		value := handler.GetStringSlice("someKey", defaultValue)
+
+		// Then the returned value should match the default value
+		if !reflect.DeepEqual(value, defaultValue) {
+			t.Errorf("Expected GetStringSlice with default to return %v, got %v", defaultValue, value)
+		}
+	})
+}
+
 func TestMockConfigHandler_Set(t *testing.T) {
 	t.Run("WithKeyAndValue", func(t *testing.T) {
 		// Given a mock config handler with SetFunc set to do nothing

--- a/pkg/config/yaml_config_handler.go
+++ b/pkg/config/yaml_config_handler.go
@@ -158,6 +158,19 @@ func (y *YamlConfigHandler) GetBool(key string, defaultValue ...bool) bool {
 	return false
 }
 
+// GetStringSlice retrieves a slice of strings for the specified key from the configuration, with an optional default value.
+func (y *YamlConfigHandler) GetStringSlice(key string, defaultValue ...[]string) []string {
+	contextKey := fmt.Sprintf("contexts.%s.%s", y.context, key)
+	value := y.Get(contextKey)
+	if value == nil {
+		if len(defaultValue) > 0 {
+			return defaultValue[0]
+		}
+		return []string{}
+	}
+	return value.([]string)
+}
+
 // Set updates the value at the specified path in the configuration using reflection.
 func (y *YamlConfigHandler) Set(path string, value interface{}) error {
 	if path == "" {

--- a/pkg/config/yaml_config_handler_test.go
+++ b/pkg/config/yaml_config_handler_test.go
@@ -651,6 +651,65 @@ func TestYamlConfigHandler_GetBool(t *testing.T) {
 	})
 }
 
+func TestYamlConfigHandler_GetStringSlice(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Given a handler with a context containing a slice value
+		mocks := setupSafeMocks()
+		handler := NewYamlConfigHandler(mocks.Injector)
+		handler.Initialize()
+		handler.context = "default"
+		handler.config.Contexts = map[string]*v1alpha1.Context{
+			"default": {
+				Cluster: &cluster.ClusterConfig{
+					NodePorts: []string{"50000:50002/tcp", "30080:8080/tcp", "30443:8443/tcp"},
+				},
+			},
+		}
+
+		// When retrieving the slice value using GetStringSlice
+		value := handler.GetStringSlice("cluster.nodeports")
+
+		// Then the returned slice should match the expected slice
+		expectedSlice := []string{"50000:50002/tcp", "30080:8080/tcp", "30443:8443/tcp"}
+		if !reflect.DeepEqual(value, expectedSlice) {
+			t.Errorf("Expected GetStringSlice to return %v, got %v", expectedSlice, value)
+		}
+	})
+
+	t.Run("WithNonExistentKey", func(t *testing.T) {
+		// Given a handler with a context set
+		mocks := setupSafeMocks()
+		handler := NewYamlConfigHandler(mocks.Injector)
+		handler.Initialize()
+		handler.context = "default"
+
+		// When retrieving a non-existent key using GetStringSlice
+		value := handler.GetStringSlice("nonExistentKey")
+
+		// Then the returned value should be an empty slice
+		if len(value) != 0 {
+			t.Errorf("Expected GetStringSlice with non-existent key to return an empty slice, got %v", value)
+		}
+	})
+
+	t.Run("WithNonExistentKeyAndDefaultValue", func(t *testing.T) {
+		// Given a handler with a context set
+		mocks := setupSafeMocks()
+		handler := NewYamlConfigHandler(mocks.Injector)
+		handler.Initialize()
+		handler.context = "default"
+		defaultValue := []string{"default1", "default2"}
+
+		// When retrieving a non-existent key with a default value
+		value := handler.GetStringSlice("nonExistentKey", defaultValue)
+
+		// Then the returned value should match the default value
+		if !reflect.DeepEqual(value, defaultValue) {
+			t.Errorf("Expected GetStringSlice with default to return %v, got %v", defaultValue, value)
+		}
+	})
+}
+
 func TestYamlConfigHandler_GetConfig(t *testing.T) {
 	t.Run("ContextIsSet", func(t *testing.T) {
 		// Given a handler with a context set

--- a/pkg/services/talos_worker_service.go
+++ b/pkg/services/talos_worker_service.go
@@ -2,6 +2,7 @@ package services
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"strconv"

--- a/pkg/services/talos_worker_service.go
+++ b/pkg/services/talos_worker_service.go
@@ -198,6 +198,12 @@ func (s *TalosWorkerService) GetComposeConfig() (*types.Config, error) {
 	}
 
 	var ports []types.ServicePortConfig
+
+	// Ensure defaultAPIPort is within the valid range for uint32
+	if defaultAPIPort < 0 || defaultAPIPort > math.MaxUint32 {
+		return nil, fmt.Errorf("defaultAPIPort value out of range: %d", defaultAPIPort)
+	}
+
 	ports = append(ports, types.ServicePortConfig{
 		Target:    uint32(defaultAPIPort),
 		Published: publishedPort,

--- a/pkg/services/talos_worker_service.go
+++ b/pkg/services/talos_worker_service.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -12,10 +13,13 @@ import (
 	"github.com/windsorcli/cli/pkg/di"
 )
 
-// Initialize the global port for all workers
+// Initialize the global port settings
 var (
-	globalPort     = 50001
-	globalPortLock sync.Mutex
+	localhostAPIPort = 50001
+	defaultAPIPort   = 50000
+	portLock         sync.Mutex
+	extraPortIndex   = 0
+	nextNodePorts    = []string{}
 )
 
 type TalosWorkerService struct {
@@ -31,9 +35,11 @@ func NewTalosWorkerService(injector di.Injector) *TalosWorkerService {
 	}
 }
 
-// SetAddress configures the network address for the Talos worker service.
-// It also sets node-specific information such as hostname and endpoint in the configuration.
-// If the address is localhost (127.0.0.1), it assigns a unique port starting from 50001.
+// SetAddress configures the Talos worker's hostname and endpoint using the
+// provided address. For localhost addresses, it assigns unique ports starting
+// from 50001, incrementing for each node. A mutex is used to safely increment
+// the port for each localhost node. Node ports are adjusted to avoid conflicts.
+// Each node is assigned a unique host port by incrementing the port number.
 func (s *TalosWorkerService) SetAddress(address string) error {
 	tld := s.configHandler.GetString("dns.name", "test")
 
@@ -44,37 +50,110 @@ func (s *TalosWorkerService) SetAddress(address string) error {
 		return err
 	}
 
-	port := 50000
+	port := defaultAPIPort
 	if isLocalhost(address) {
-		globalPortLock.Lock()
-		port = globalPort
-		globalPort++
-		globalPortLock.Unlock()
+		portLock.Lock()
+		port = localhostAPIPort
+		localhostAPIPort++
+		portLock.Unlock()
 	}
 
 	if err := s.configHandler.SetContextValue("cluster.workers.nodes."+s.name+".endpoint", fmt.Sprintf("%s:%d", address, port)); err != nil {
 		return err
 	}
 
+	config := s.configHandler.GetConfig()
+	if config.Cluster != nil {
+		nodePorts := config.Cluster.NodePorts
+		if nodePorts != nil && (nextNodePorts == nil || len(nextNodePorts) == 0) {
+			nextNodePorts = make([]string, len(nodePorts))
+			copy(nextNodePorts, nodePorts)
+		}
+
+		currentNodePorts := make([]string, len(nextNodePorts))
+		copy(currentNodePorts, nextNodePorts)
+
+		if nextNodePorts != nil {
+			for i := 0; i < len(nextNodePorts); i++ {
+				parts := strings.Split(nextNodePorts[i], ":")
+				var hostPort, nodePort int
+				protocol := "tcp"
+
+				switch len(parts) {
+				case 1: // nodePort only
+					var err error
+					nodePort, err = strconv.Atoi(parts[0])
+					if err != nil {
+						return fmt.Errorf("invalid nodePort value: %s", parts[0])
+					}
+					hostPort = nodePort
+				case 2: // hostPort and nodePort/protocol
+					var err error
+					hostPort, err = strconv.Atoi(parts[0])
+					if err != nil {
+						return fmt.Errorf("invalid hostPort value: %s", parts[0])
+					}
+					nodePortProtocol := strings.Split(parts[1], "/")
+					nodePort, err = strconv.Atoi(nodePortProtocol[0])
+					if err != nil {
+						return fmt.Errorf("invalid nodePort value: %s", nodePortProtocol[0])
+					}
+					if len(nodePortProtocol) == 2 {
+						if nodePortProtocol[1] == "tcp" || nodePortProtocol[1] == "udp" {
+							protocol = nodePortProtocol[1]
+						} else {
+							return fmt.Errorf("invalid protocol value: %s", nodePortProtocol[1])
+						}
+					}
+				default:
+					return fmt.Errorf("invalid nodePort format: %s", nextNodePorts[i])
+				}
+
+				if isLocalhost(address) {
+					nextNodePorts[i] = fmt.Sprintf("%d:%d/%s", hostPort+1, nodePort, protocol)
+				} else {
+					nextNodePorts[i] = fmt.Sprintf("%d:%d/%s", hostPort, nodePort, protocol)
+				}
+			}
+		}
+
+		if err := s.configHandler.SetContextValue("cluster.workers.nodes."+s.name+".nodeports", currentNodePorts); err != nil {
+			return err
+		}
+	}
+
 	return s.BaseService.SetAddress(address)
 }
 
-// GetComposeConfig returns a list of container data for docker-compose. It retrieves CPU and
-// RAM settings for workers from the configuration and determines the port for the endpoint.
-// The function ensures the project root's .volumes folder exists and sets up a common
-// configuration for Talos containers. Finally, it creates a single worker service and includes
-// volume specifications in the compose config.
+// GetComposeConfig creates a docker-compose setup for Talos workers. It fetches CPU/RAM settings,
+// determines endpoint ports, and ensures the .volumes directory exists. The function configures
+// the container with image, environment, security, and volume settings. It constructs the service
+// name using the TLD and sets up port mappings for network communication, including default and
+// node-specific ports. The final configuration includes service and volume details for deployment.
 func (s *TalosWorkerService) GetComposeConfig() (*types.Config, error) {
-	// Retrieve configuration settings and endpoint details
+	config := s.configHandler.GetConfig()
+	if config.Cluster == nil {
+		return &types.Config{
+			Services: []types.ServiceConfig{},
+			Volumes:  map[string]types.VolumeConfig{},
+		}, nil
+	}
+
 	workerCPU := s.configHandler.GetInt("cluster.workers.cpu", constants.DEFAULT_TALOS_WORKER_CPU)
 	workerRAM := s.configHandler.GetInt("cluster.workers.memory", constants.DEFAULT_TALOS_WORKER_RAM)
-	endpoint := s.configHandler.GetString("cluster.workers.nodes."+s.name+".endpoint", "50000")
-	publishedPort := "50000"
+
+	// Define a default name if s.name is not set
+	nodeName := s.name
+	if nodeName == "" {
+		nodeName = "worker"
+	}
+
+	endpoint := s.configHandler.GetString("cluster.workers.nodes."+nodeName+".endpoint", fmt.Sprintf("%d", defaultAPIPort))
+	publishedPort := fmt.Sprintf("%d", defaultAPIPort)
 	if parts := strings.Split(endpoint, ":"); len(parts) == 2 {
 		publishedPort = parts[1]
 	}
 
-	// Ensure necessary directories exist
 	projectRoot, err := s.shell.GetProjectRoot()
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving project root: %w", err)
@@ -86,7 +165,6 @@ func (s *TalosWorkerService) GetComposeConfig() (*types.Config, error) {
 		}
 	}
 
-	// Construct the common configuration for the Talos worker service
 	commonConfig := types.ServiceConfig{
 		Image:       constants.DEFAULT_TALOS_IMAGE,
 		Environment: map[string]*string{"PLATFORM": ptrString("container")},
@@ -96,35 +174,18 @@ func (s *TalosWorkerService) GetComposeConfig() (*types.Config, error) {
 		SecurityOpt: []string{"seccomp=unconfined"},
 		Tmpfs:       []string{"/run", "/system", "/tmp"},
 		Volumes: []types.ServiceVolumeConfig{
-			{Type: "volume", Source: strings.ReplaceAll(s.name+"_system_state", "-", "_"), Target: "/system/state"},
-			{Type: "volume", Source: strings.ReplaceAll(s.name+"_var", "-", "_"), Target: "/var"},
-			{Type: "volume", Source: strings.ReplaceAll(s.name+"_etc_cni", "-", "_"), Target: "/etc/cni"},
-			{Type: "volume", Source: strings.ReplaceAll(s.name+"_etc_kubernetes", "-", "_"), Target: "/etc/kubernetes"},
-			{Type: "volume", Source: strings.ReplaceAll(s.name+"_usr_libexec_kubernetes", "-", "_"), Target: "/usr/libexec/kubernetes"},
-			{Type: "volume", Source: strings.ReplaceAll(s.name+"_opt", "-", "_"), Target: "/opt"},
+			{Type: "volume", Source: strings.ReplaceAll(nodeName+"_system_state", "-", "_"), Target: "/system/state"},
+			{Type: "volume", Source: strings.ReplaceAll(nodeName+"_var", "-", "_"), Target: "/var"},
+			{Type: "volume", Source: strings.ReplaceAll(nodeName+"_etc_cni", "-", "_"), Target: "/etc/cni"},
+			{Type: "volume", Source: strings.ReplaceAll(nodeName+"_etc_kubernetes", "-", "_"), Target: "/etc/kubernetes"},
+			{Type: "volume", Source: strings.ReplaceAll(nodeName+"_usr_libexec_kubernetes", "-", "_"), Target: "/usr/libexec/kubernetes"},
+			{Type: "volume", Source: strings.ReplaceAll(nodeName+"_opt", "-", "_"), Target: "/opt"},
 			{Type: "bind", Source: "${WINDSOR_PROJECT_ROOT}/.volumes", Target: "/var/local"},
 		},
 	}
 
-	// Check if the address is localhost and assign ports if it is
-	if isLocalhost(s.address) {
-		commonConfig.Ports = []types.ServicePortConfig{
-			{
-				Target:    50000,
-				Published: publishedPort,
-				Protocol:  "tcp",
-			},
-		}
-	}
-
-	// Finalize the worker configuration with specific settings
 	tld := s.configHandler.GetString("dns.name", "test")
-	fullName := s.name + "." + tld
-	if s.name == "" {
-		fullName = "worker" + "." + tld
-	} else {
-		fullName = s.name + "." + tld
-	}
+	fullName := nodeName + "." + tld
 
 	workerConfig := commonConfig
 	workerConfig.Name = fullName
@@ -135,13 +196,46 @@ func (s *TalosWorkerService) GetComposeConfig() (*types.Config, error) {
 		"TALOSSKU": ptrString(fmt.Sprintf("%dCPU-%dRAM", workerCPU, workerRAM*1024)),
 	}
 
+	var ports []types.ServicePortConfig
+	ports = append(ports, types.ServicePortConfig{
+		Target:    uint32(defaultAPIPort),
+		Published: publishedPort,
+		Protocol:  "tcp",
+	})
+
+	nodePortsKey := "cluster.workers.nodes." + nodeName + ".nodeports"
+	nodePorts := s.configHandler.GetStringSlice(nodePortsKey)
+	for _, nodePortStr := range nodePorts {
+		parts := strings.Split(nodePortStr, ":")
+		hostPort, err := strconv.Atoi(parts[0])
+		if err != nil {
+			return nil, fmt.Errorf("invalid hostPort value: %s", parts[0])
+		}
+		nodePortProtocol := strings.Split(parts[1], "/")
+		nodePort, err := strconv.Atoi(nodePortProtocol[0])
+		if err != nil {
+			return nil, fmt.Errorf("invalid nodePort value: %s", nodePortProtocol[0])
+		}
+		protocol := "tcp"
+		if len(nodePortProtocol) == 2 {
+			protocol = nodePortProtocol[1]
+		}
+		ports = append(ports, types.ServicePortConfig{
+			Target:    uint32(nodePort),
+			Published: fmt.Sprintf("%d", hostPort),
+			Protocol:  protocol,
+		})
+	}
+
+	workerConfig.Ports = ports
+
 	volumes := map[string]types.VolumeConfig{
-		strings.ReplaceAll(s.name+"_system_state", "-", "_"):           {},
-		strings.ReplaceAll(s.name+"_var", "-", "_"):                    {},
-		strings.ReplaceAll(s.name+"_etc_cni", "-", "_"):                {},
-		strings.ReplaceAll(s.name+"_etc_kubernetes", "-", "_"):         {},
-		strings.ReplaceAll(s.name+"_usr_libexec_kubernetes", "-", "_"): {},
-		strings.ReplaceAll(s.name+"_opt", "-", "_"):                    {},
+		strings.ReplaceAll(nodeName+"_system_state", "-", "_"):           {},
+		strings.ReplaceAll(nodeName+"_var", "-", "_"):                    {},
+		strings.ReplaceAll(nodeName+"_etc_cni", "-", "_"):                {},
+		strings.ReplaceAll(nodeName+"_etc_kubernetes", "-", "_"):         {},
+		strings.ReplaceAll(nodeName+"_usr_libexec_kubernetes", "-", "_"): {},
+		strings.ReplaceAll(nodeName+"_opt", "-", "_"):                    {},
 	}
 
 	return &types.Config{

--- a/pkg/services/talos_worker_service.go
+++ b/pkg/services/talos_worker_service.go
@@ -207,13 +207,13 @@ func (s *TalosWorkerService) GetComposeConfig() (*types.Config, error) {
 	nodePorts := s.configHandler.GetStringSlice(nodePortsKey)
 	for _, nodePortStr := range nodePorts {
 		parts := strings.Split(nodePortStr, ":")
-		hostPort, err := strconv.Atoi(parts[0])
-		if err != nil {
+		hostPort, err := strconv.ParseUint(parts[0], 10, 32)
+		if err != nil || hostPort > math.MaxUint32 {
 			return nil, fmt.Errorf("invalid hostPort value: %s", parts[0])
 		}
 		nodePortProtocol := strings.Split(parts[1], "/")
-		nodePort, err := strconv.Atoi(nodePortProtocol[0])
-		if err != nil {
+		nodePort, err := strconv.ParseUint(nodePortProtocol[0], 10, 32)
+		if err != nil || nodePort > math.MaxUint32 {
 			return nil, fmt.Errorf("invalid nodePort value: %s", nodePortProtocol[0])
 		}
 		protocol := "tcp"


### PR DESCRIPTION
It's now possible to set nodeports on workers as follows:

```
contexts:
  local:
    cluster:
      nodeports:
        - 8080:30080/tcp
        - 8443:30443/tcp
```