### PR TITLE
Improve port assignment between virt options

### DIFF
--- a/api/v1alpha1/config_types_test.go
+++ b/api/v1alpha1/config_types_test.go
@@ -40,6 +40,12 @@ func TestConfig_Merge(t *testing.T) {
 			DNS: &dns.DNSConfig{
 				Enabled: ptrBool(true),
 			},
+			Environment: map[string]string{
+				"KEY1": "value1",
+			},
+			Network: &network.NetworkConfig{
+				CIDRBlock: ptrString("192.168.0.0/16"),
+			},
 		}
 
 		overlay := &Context{
@@ -66,6 +72,12 @@ func TestConfig_Merge(t *testing.T) {
 			DNS: &dns.DNSConfig{
 				Enabled: ptrBool(false),
 			},
+			Environment: map[string]string{
+				"KEY2": "value2",
+			},
+			Network: &network.NetworkConfig{
+				CIDRBlock: ptrString("10.0.0.0/8"),
+			},
 		}
 
 		base.Merge(overlay)
@@ -90,6 +102,12 @@ func TestConfig_Merge(t *testing.T) {
 		}
 		if base.DNS.Enabled == nil || *base.DNS.Enabled != false {
 			t.Errorf("DNS Enabled mismatch: expected false, got %v", *base.DNS.Enabled)
+		}
+		if len(base.Environment) != 2 || base.Environment["KEY1"] != "value1" || base.Environment["KEY2"] != "value2" {
+			t.Errorf("Environment merge mismatch: expected map with 'KEY1' and 'KEY2', got %v", base.Environment)
+		}
+		if base.Network.CIDRBlock == nil || *base.Network.CIDRBlock != "10.0.0.0/8" {
+			t.Errorf("Network CIDRBlock mismatch: expected '10.0.0.0/8', got '%s'", *base.Network.CIDRBlock)
 		}
 	})
 
@@ -119,6 +137,12 @@ func TestConfig_Merge(t *testing.T) {
 			DNS: &dns.DNSConfig{
 				Enabled: ptrBool(true),
 			},
+			Environment: map[string]string{
+				"KEY1": "value1",
+			},
+			Network: &network.NetworkConfig{
+				CIDRBlock: ptrString("192.168.0.0/16"),
+			},
 		}
 
 		var overlay *Context = nil
@@ -144,6 +168,12 @@ func TestConfig_Merge(t *testing.T) {
 		}
 		if base.DNS.Enabled == nil || *base.DNS.Enabled != true {
 			t.Errorf("DNS Enabled mismatch: expected true, got %v", *base.DNS.Enabled)
+		}
+		if len(base.Environment) != 1 || base.Environment["KEY1"] != "value1" {
+			t.Errorf("Environment mismatch: expected map with 'KEY1', got %v", base.Environment)
+		}
+		if base.Network.CIDRBlock == nil || *base.Network.CIDRBlock != "192.168.0.0/16" {
+			t.Errorf("Network CIDRBlock mismatch: expected '192.168.0.0/16', got '%s'", *base.Network.CIDRBlock)
 		}
 	})
 
@@ -174,6 +204,12 @@ func TestConfig_Merge(t *testing.T) {
 			DNS: &dns.DNSConfig{
 				Enabled: ptrBool(false),
 			},
+			Environment: map[string]string{
+				"KEY2": "value2",
+			},
+			Network: &network.NetworkConfig{
+				CIDRBlock: ptrString("10.0.0.0/8"),
+			},
 		}
 
 		base.Merge(overlay)
@@ -198,6 +234,28 @@ func TestConfig_Merge(t *testing.T) {
 		}
 		if base.DNS.Enabled == nil || *base.DNS.Enabled != false {
 			t.Errorf("DNS Enabled mismatch: expected false, got %v", *base.DNS.Enabled)
+		}
+		if len(base.Environment) != 1 || base.Environment["KEY2"] != "value2" {
+			t.Errorf("Environment mismatch: expected map with 'KEY2', got %v", base.Environment)
+		}
+		if base.Network.CIDRBlock == nil || *base.Network.CIDRBlock != "10.0.0.0/8" {
+			t.Errorf("Network CIDRBlock mismatch: expected '10.0.0.0/8', got '%s'", *base.Network.CIDRBlock)
+		}
+	})
+
+	t.Run("MergeWithProjectName", func(t *testing.T) {
+		base := &Context{
+			ProjectName: ptrString("BaseProject"),
+		}
+
+		overlay := &Context{
+			ProjectName: ptrString("OverlayProject"),
+		}
+
+		base.Merge(overlay)
+
+		if base.ProjectName == nil || *base.ProjectName != "OverlayProject" {
+			t.Errorf("ProjectName mismatch: expected 'OverlayProject', got '%s'", *base.ProjectName)
 		}
 	})
 }

--- a/api/v1alpha1/docker/docker_config.go
+++ b/api/v1alpha1/docker/docker_config.go
@@ -51,11 +51,6 @@ func (c *DockerConfig) Copy() *DockerConfig {
 	}
 }
 
-// Helper functions to create pointers for basic types
-func ptrString(s string) *string {
-	return &s
-}
-
 func ptrBool(b bool) *bool {
 	return &b
 }

--- a/api/v1alpha1/utils.go
+++ b/api/v1alpha1/utils.go
@@ -8,7 +8,3 @@ func ptrString(s string) *string {
 func ptrBool(b bool) *bool {
 	return &b
 }
-
-func ptrInt(i int) *int {
-	return &i
-}

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -92,6 +92,17 @@ cluster:
 | `workers.memory`             | `int`      | Memory resources allocated per worker node.                        |
 | `workers.nodeports`          | `[]string` | List of nodeports for host forwarding specific to workers.         |
 
+### Network
+Configures details related to local networking. This includes both the CIDR block range used by the network, as well as the range of IPs to be used when acquiring load balancer IP addresses.
+
+```yaml
+network:
+  cidr_block: 10.5.0.0/16
+  loadbalancer_ips:
+    start: 10.5.1.1
+    end: 10.5.1.10
+```
+
 ### DNS
 Configures details related to the local DNS service. The service is available at `dns.test:53`. Presently, the local DNS server runs CoreDNS.
 
@@ -116,14 +127,12 @@ Configures details related to using Docker locally.
 ```yaml
 docker:
   enabled: true
-  network_cidr: 10.5.0.0/16
   registries: #...
 ```
 
 | Field          | Type                       | Description                                                                 |
 |----------------|----------------------------|-----------------------------------------------------------------------------|
 | `enabled`      | `bool`                     | Indicates whether the Docker service is enabled.                            |
-| `network_cidr` | `string`                   | Specifies the network CIDR for Docker.                                      |
 | `registries`   | `map[string]RegistryConfig`| Configuration for Docker registries, mapping registry names to their config.|
 
 #### RegistryConfig
@@ -263,6 +272,11 @@ contexts:
         nodeports:
           - 8080:30080
           - 8443:30443
+    network:
+      cidr_block: 10.5.0.0/16
+      loadbalancer_ips:
+        start: 10.5.1.1
+        end: 10.5.1.10
     dns:
       enabled: true
       domain: test

--- a/pkg/network/colima_network.go
+++ b/pkg/network/colima_network.go
@@ -38,8 +38,8 @@ func (n *ColimaNetworkManager) Initialize() error {
 	}
 
 	// Set docker.NetworkCIDR to the default value if it's not set
-	if n.configHandler.GetString("docker.network_cidr") == "" {
-		return n.configHandler.SetContextValue("docker.network_cidr", constants.DEFAULT_NETWORK_CIDR)
+	if n.configHandler.GetString("network.cidr_block") == "" {
+		return n.configHandler.SetContextValue("network.cidr_block", constants.DEFAULT_NETWORK_CIDR)
 	}
 
 	return nil
@@ -72,7 +72,7 @@ func (n *ColimaNetworkManager) resolveDependencies() error {
 // It identifies the Docker bridge interface and ensures iptables rules are set.
 // If the rule doesn't exist, it adds a new one to allow traffic forwarding.
 func (n *ColimaNetworkManager) ConfigureGuest() error {
-	networkCIDR := n.configHandler.GetString("docker.network_cidr")
+	networkCIDR := n.configHandler.GetString("network.cidr_block")
 	if networkCIDR == "" {
 		return fmt.Errorf("network CIDR is not configured")
 	}

--- a/pkg/network/colima_network_test.go
+++ b/pkg/network/colima_network_test.go
@@ -44,7 +44,7 @@ func setupColimaNetworkManagerMocks() *ColimaNetworkManagerMocks {
 	mockConfigHandler := config.NewMockConfigHandler()
 	mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
 		switch key {
-		case "docker.network_cidr":
+		case "network.cidr_block":
 			return "192.168.5.0/24"
 		case "vm.driver":
 			return "colima"
@@ -150,7 +150,7 @@ func TestColimaNetworkManager_Initialize(t *testing.T) {
 
 		// Mock the configHandler to return a specific CIDR for testing
 		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "docker.network_cidr" {
+			if key == "network.cidr_block" {
 				return "10.5.0.0/16"
 			}
 			if len(defaultValue) > 0 {
@@ -159,9 +159,9 @@ func TestColimaNetworkManager_Initialize(t *testing.T) {
 			return ""
 		}
 
-		// Verify that docker.network_cidr is set to the mocked value
-		if actualCIDR := nm.configHandler.GetString("docker.network_cidr"); actualCIDR != "10.5.0.0/16" {
-			t.Fatalf("expected docker.network_cidr to be 10.5.0.0/16, got %s", actualCIDR)
+		// Verify that network.cidr_block is set to the mocked value
+		if actualCIDR := nm.configHandler.GetString("network.cidr_block"); actualCIDR != "10.5.0.0/16" {
+			t.Fatalf("expected network.cidr_block to be 10.5.0.0/16, got %s", actualCIDR)
 		}
 	})
 
@@ -224,9 +224,9 @@ func TestColimaNetworkManager_ConfigureGuest(t *testing.T) {
 		// Setup mocks using setupColimaNetworkManagerMocks
 		mocks := setupColimaNetworkManagerMocks()
 
-		// Override the GetString method to return an empty string for "docker.network_cidr"
+		// Override the GetString method to return an empty string for "network.cidr_block"
 		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "docker.network_cidr" {
+			if key == "network.cidr_block" {
 				return ""
 			}
 			if len(defaultValue) > 0 {
@@ -261,7 +261,7 @@ func TestColimaNetworkManager_ConfigureGuest(t *testing.T) {
 
 		// Override the GetString method to return an empty string for "vm.address"
 		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "docker.network_cidr" {
+			if key == "network.cidr_block" {
 				return "192.168.5.0/24"
 			}
 			if key == "vm.address" {

--- a/pkg/network/darwin_network.go
+++ b/pkg/network/darwin_network.go
@@ -14,7 +14,7 @@ import (
 // If the route does not exist, it adds a new route using elevated permissions to facilitate communication
 // between the host and the guest VM.
 func (n *BaseNetworkManager) ConfigureHostRoute() error {
-	networkCIDR := n.configHandler.GetString("docker.network_cidr")
+	networkCIDR := n.configHandler.GetString("network.cidr_block")
 	if networkCIDR == "" {
 		return fmt.Errorf("network CIDR is not configured")
 	}

--- a/pkg/network/darwin_network_test.go
+++ b/pkg/network/darwin_network_test.go
@@ -59,7 +59,7 @@ func setupDarwinNetworkManagerMocks() *DarwinNetworkManagerMocks {
 	mockConfigHandler := config.NewMockConfigHandler()
 	mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
 		switch key {
-		case "docker.network_cidr":
+		case "network.cidr_block":
 			return "192.168.5.0/24"
 		case "vm.address":
 			return "192.168.5.100"
@@ -158,9 +158,9 @@ func TestDarwinNetworkManager_ConfigureHostRoute(t *testing.T) {
 	t.Run("NoNetworkCIDRConfigured", func(t *testing.T) {
 		mocks := setupDarwinNetworkManagerMocks()
 
-		// Mock the GetString function to return an empty string for "docker.network_cidr"
+		// Mock the GetString function to return an empty string for "network.cidr_block"
 		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "docker.network_cidr" {
+			if key == "network.cidr_block" {
 				return ""
 			}
 			if len(defaultValue) > 0 {
@@ -194,7 +194,7 @@ func TestDarwinNetworkManager_ConfigureHostRoute(t *testing.T) {
 
 		// Mock the GetString function to return valid CIDR but an empty string for "vm.address"
 		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "docker.network_cidr" {
+			if key == "network.cidr_block" {
 				return "192.168.1.0/24"
 			}
 			if key == "vm.address" {

--- a/pkg/network/linux_network.go
+++ b/pkg/network/linux_network.go
@@ -11,7 +11,7 @@ import (
 // ConfigureHostRoute sets up the local development network for Linux
 func (n *BaseNetworkManager) ConfigureHostRoute() error {
 	// Access the Docker configuration
-	networkCIDR := n.configHandler.GetString("docker.network_cidr")
+	networkCIDR := n.configHandler.GetString("network.cidr_block")
 	if networkCIDR == "" {
 		return fmt.Errorf("network CIDR is not configured")
 	}

--- a/pkg/network/linux_network_test.go
+++ b/pkg/network/linux_network_test.go
@@ -52,7 +52,7 @@ func setupLinuxNetworkManagerMocks() *LinuxNetworkManagerMocks {
 	mockConfigHandler := config.NewMockConfigHandler()
 	mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
 		switch key {
-		case "docker.network_cidr":
+		case "network.cidr_block":
 			return "192.168.5.0/24"
 		case "vm.address":
 			return "192.168.5.100"
@@ -128,9 +128,9 @@ func TestLinuxNetworkManager_ConfigureHostRoute(t *testing.T) {
 	t.Run("NoNetworkCIDRConfigured", func(t *testing.T) {
 		mocks := setupLinuxNetworkManagerMocks()
 
-		// Mock the GetString function to return an empty string for "docker.network_cidr"
+		// Mock the GetString function to return an empty string for "network.cidr_block"
 		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "docker.network_cidr" {
+			if key == "network.cidr_block" {
 				return ""
 			}
 			if len(defaultValue) > 0 {
@@ -184,7 +184,7 @@ func TestLinuxNetworkManager_ConfigureHostRoute(t *testing.T) {
 
 		// Mock the GetString function to return an empty string for "vm.address"
 		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "docker.network_cidr" {
+			if key == "network.cidr_block" {
 				return "192.168.5.0/24"
 			}
 			if key == "vm.address" {
@@ -224,7 +224,7 @@ func TestLinuxNetworkManager_ConfigureHostRoute(t *testing.T) {
 
 		// Mock the GetString function to return specific values for testing
 		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "docker.network_cidr" {
+			if key == "network.cidr_block" {
 				return "192.168.5.0/24"
 			}
 			if key == "vm.address" {
@@ -264,7 +264,7 @@ func TestLinuxNetworkManager_ConfigureHostRoute(t *testing.T) {
 
 		// Mock the GetString function to return specific values for testing
 		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "docker.network_cidr" {
+			if key == "network.cidr_block" {
 				return "192.168.5.0/24"
 			}
 			if key == "vm.address" {

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -85,10 +85,10 @@ func (n *BaseNetworkManager) Initialize() error {
 			}
 		}
 	} else {
-		networkCIDR := n.configHandler.GetString("docker.network_cidr")
+		networkCIDR := n.configHandler.GetString("network.cidr_block")
 		if networkCIDR == "" {
 			networkCIDR = constants.DEFAULT_NETWORK_CIDR
-			if err := n.configHandler.SetContextValue("docker.network_cidr", networkCIDR); err != nil {
+			if err := n.configHandler.SetContextValue("network.cidr_block", networkCIDR); err != nil {
 				return fmt.Errorf("error setting default network CIDR: %w", err)
 			}
 		}

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -45,7 +45,7 @@ func setupNetworkManagerMocks(optionalInjector ...di.Injector) *NetworkManagerMo
 	mockConfigHandler := config.NewMockConfigHandler()
 	mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
 		switch key {
-		case "docker.network_cidr":
+		case "network.cidr_block":
 			return "192.168.1.0/24"
 		case "vm.address":
 			return "192.168.1.10"
@@ -303,17 +303,17 @@ func TestNetworkManager_Initialize(t *testing.T) {
 		mocks := setupNetworkManagerMocks()
 		nm := NewBaseNetworkManager(mocks.Injector)
 
-		// Mock GetString to return an empty string for docker.network_cidr
+		// Mock GetString to return an empty string for network.cidr_block
 		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "docker.network_cidr" {
+			if key == "network.cidr_block" {
 				return ""
 			}
 			return ""
 		}
 
-		// Mock SetContextValue to return an error when setting docker.network_cidr
+		// Mock SetContextValue to return an error when setting network.cidr_block
 		mocks.MockConfigHandler.SetContextValueFunc = func(key string, value interface{}) error {
-			if key == "docker.network_cidr" {
+			if key == "network.cidr_block" {
 				return fmt.Errorf("mock error setting network CIDR")
 			}
 			return nil

--- a/pkg/network/windows_network.go
+++ b/pkg/network/windows_network.go
@@ -16,7 +16,7 @@ import (
 // already exists using a PowerShell command. If not, it adds a new route on the host
 // to the VM guest using another PowerShell command.
 func (n *BaseNetworkManager) ConfigureHostRoute() error {
-	networkCIDR := n.configHandler.GetString("docker.network_cidr")
+	networkCIDR := n.configHandler.GetString("network.cidr_block")
 	if networkCIDR == "" {
 		return fmt.Errorf("network CIDR is not configured")
 	}

--- a/pkg/network/windows_network_test.go
+++ b/pkg/network/windows_network_test.go
@@ -47,7 +47,7 @@ func setupWindowsNetworkManagerMocks() *WindowsNetworkManagerMocks {
 	mockConfigHandler := config.NewMockConfigHandler()
 	mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
 		switch key {
-		case "docker.network_cidr":
+		case "network.cidr_block":
 			return "192.168.1.0/24"
 		case "vm.address":
 			return "192.168.1.10"
@@ -122,7 +122,7 @@ func TestWindowsNetworkManager_ConfigureHostRoute(t *testing.T) {
 			t.Fatalf("expected no error during initialization, got %v", err)
 		}
 		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "docker.network_cidr" {
+			if key == "network.cidr_block" {
 				return ""
 			}
 			if len(defaultValue) > 0 {
@@ -151,7 +151,7 @@ func TestWindowsNetworkManager_ConfigureHostRoute(t *testing.T) {
 			t.Fatalf("expected no error during initialization, got %v", err)
 		}
 		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "docker.network_cidr" {
+			if key == "network.cidr_block" {
 				return "192.168.1.0/24"
 			}
 			if key == "vm.address" {
@@ -183,7 +183,7 @@ func TestWindowsNetworkManager_ConfigureHostRoute(t *testing.T) {
 			t.Fatalf("expected no error during initialization, got %v", err)
 		}
 		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "docker.network_cidr" {
+			if key == "network.cidr_block" {
 				return "192.168.1.0/24"
 			}
 			if key == "vm.address" {
@@ -223,7 +223,7 @@ func TestWindowsNetworkManager_ConfigureHostRoute(t *testing.T) {
 			t.Fatalf("expected no error during initialization, got %v", err)
 		}
 		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "docker.network_cidr" {
+			if key == "network.cidr_block" {
 				return "192.168.1.0/24"
 			}
 			if key == "vm.address" {

--- a/pkg/services/talos_service.go
+++ b/pkg/services/talos_service.go
@@ -235,13 +235,15 @@ func (s *TalosService) GetComposeConfig() (*types.Config, error) {
 
 	var ports []types.ServicePortConfig
 
+	// Convert defaultAPIPort to uint32 safely
 	if defaultAPIPort < 0 || defaultAPIPort > math.MaxUint32 {
 		return nil, fmt.Errorf("defaultAPIPort value out of range: %d", defaultAPIPort)
 	}
+	defaultAPIPortUint32 := uint32(defaultAPIPort)
 
 	if isLocalhost(s.address) {
 		ports = append(ports, types.ServicePortConfig{
-			Target:    uint32(defaultAPIPort),
+			Target:    defaultAPIPortUint32,
 			Published: publishedPort,
 			Protocol:  "tcp",
 		})

--- a/pkg/virt/docker_virt.go
+++ b/pkg/virt/docker_virt.go
@@ -374,7 +374,7 @@ func (v *DockerVirt) getFullComposeConfig() (*types.Project, error) {
 						networkName: {},
 					}
 
-					networkCIDR := v.configHandler.GetString("docker.network_cidr")
+					networkCIDR := v.configHandler.GetString("network.cidr_block")
 					if networkCIDR != "" && ipAddress != "127.0.0.1" && ipAddress != "" {
 						containerConfig.Networks[networkName].Ipv4Address = ipAddress
 					}

--- a/pkg/virt/docker_virt.go
+++ b/pkg/virt/docker_virt.go
@@ -53,9 +53,8 @@ func (v *DockerVirt) Initialize() error {
 		return fmt.Sprintf("%T", serviceSlice[i]) < fmt.Sprintf("%T", serviceSlice[j])
 	})
 
-	// Get the context configuration
-	contextConfig := v.configHandler.GetConfig()
-	if contextConfig == nil || contextConfig.Docker == nil {
+	// Check if Docker is enabled using configHandler
+	if !v.configHandler.GetBool("docker.enabled") {
 		return fmt.Errorf("Docker configuration is not defined")
 	}
 
@@ -84,11 +83,8 @@ func (v *DockerVirt) determineComposeCommand() error {
 
 // Up starts docker compose
 func (v *DockerVirt) Up() error {
-	// Get the context configuration
-	contextConfig := v.configHandler.GetConfig()
-
 	// Check if Docker is enabled and run "docker compose up" in daemon mode if necessary
-	if contextConfig != nil && contextConfig.Docker != nil && *contextConfig.Docker.Enabled {
+	if v.configHandler.GetBool("docker.enabled") {
 		// Ensure Docker daemon is running
 		if err := v.checkDockerDaemon(); err != nil {
 			return fmt.Errorf("Docker daemon is not running: %w", err)
@@ -321,9 +317,8 @@ func (v *DockerVirt) checkDockerDaemon() error {
 // and returns a Project with these combined settings.
 func (v *DockerVirt) getFullComposeConfig() (*types.Project, error) {
 	contextName := v.configHandler.GetContext()
-	contextConfig := v.configHandler.GetConfig()
 
-	if contextConfig.Docker == nil {
+	if v.configHandler.GetBool("docker.enabled") == false {
 		return nil, nil
 	}
 
@@ -339,6 +334,18 @@ func (v *DockerVirt) getFullComposeConfig() (*types.Project, error) {
 
 	networkConfig := types.NetworkConfig{
 		Driver: "bridge",
+	}
+
+	networkCIDR := v.configHandler.GetString("network.cidr_block")
+	if networkCIDR != "" {
+		networkConfig.Ipam = types.IPAMConfig{
+			Driver: "default",
+			Config: []*types.IPAMPool{
+				{
+					Subnet: networkCIDR,
+				},
+			},
+		}
 	}
 
 	combinedNetworks[networkName] = networkConfig
@@ -367,7 +374,8 @@ func (v *DockerVirt) getFullComposeConfig() (*types.Project, error) {
 						networkName: {},
 					}
 
-					if v.configHandler.GetString("network.cidr_block") != "" && ipAddress != "127.0.0.1" && ipAddress != "" {
+					networkCIDR := v.configHandler.GetString("docker.network_cidr")
+					if networkCIDR != "" && ipAddress != "127.0.0.1" && ipAddress != "" {
 						containerConfig.Networks[networkName].Ipv4Address = ipAddress
 					}
 


### PR DESCRIPTION
Port assignment, specifically port mappings between the "docker desktop" and "colima" drivers, was beginning to cause issues. The colima driver was breaking on `windsor up` when assigning more than one worker node.

In particular, we don't want to increment port assignments unless we're in "localhost" mode. Unless. we are assigning `nodeports` in which case we do want to increment host port values.

Also includes some necessary follow-up from a previous PR involving networking config changes.