### PR TITLE
REGISTRY_URL environment variable

### DIFF
--- a/api/v1alpha1/docker/docker_config.go
+++ b/api/v1alpha1/docker/docker_config.go
@@ -2,8 +2,9 @@ package docker
 
 // DockerConfig represents the Docker configuration
 type DockerConfig struct {
-	Enabled    *bool                     `yaml:"enabled"`
-	Registries map[string]RegistryConfig `yaml:"registries,omitempty"`
+	Enabled     *bool                     `yaml:"enabled"`
+	RegistryURL string                    `yaml:"registry_url,omitempty"`
+	Registries  map[string]RegistryConfig `yaml:"registries,omitempty"`
 }
 
 // RegistryConfig represents the registry configuration
@@ -11,7 +12,7 @@ type RegistryConfig struct {
 	Remote   string `yaml:"remote,omitempty"`
 	Local    string `yaml:"local,omitempty"`
 	HostName string `yaml:"hostname,omitempty"`
-	HostPort int    `yaml:"host_port,omitempty"`
+	HostPort int    `yaml:"hostport,omitempty"`
 }
 
 // Merge performs a deep merge of the current DockerConfig with another DockerConfig.

--- a/api/v1alpha1/docker/docker_config.go
+++ b/api/v1alpha1/docker/docker_config.go
@@ -10,7 +10,8 @@ type DockerConfig struct {
 type RegistryConfig struct {
 	Remote   string `yaml:"remote,omitempty"`
 	Local    string `yaml:"local,omitempty"`
-	Hostname string `yaml:"hostname,omitempty"`
+	HostName string `yaml:"hostname,omitempty"`
+	HostPort int    `yaml:"host_port,omitempty"`
 }
 
 // Merge performs a deep merge of the current DockerConfig with another DockerConfig.
@@ -41,7 +42,8 @@ func (c *DockerConfig) Copy() *DockerConfig {
 		registriesCopy[name] = RegistryConfig{
 			Remote:   registry.Remote,
 			Local:    registry.Local,
-			Hostname: registry.Hostname,
+			HostName: registry.HostName,
+			HostPort: registry.HostPort,
 		}
 	}
 

--- a/api/v1alpha1/docker/docker_config_test.go
+++ b/api/v1alpha1/docker/docker_config_test.go
@@ -9,16 +9,16 @@ func TestDockerConfig_Merge(t *testing.T) {
 		base := &DockerConfig{
 			Enabled: ptrBool(true),
 			Registries: map[string]RegistryConfig{
-				"base-registry1": {Remote: "base-remote1", Local: "base-local1", Hostname: "base-hostname1"},
-				"base-registry2": {Remote: "base-remote2", Local: "base-local2", Hostname: "base-hostname2"},
+				"base-registry1": {Remote: "base-remote1", Local: "base-local1", HostName: "base-hostname1"},
+				"base-registry2": {Remote: "base-remote2", Local: "base-local2", HostName: "base-hostname2"},
 			},
 		}
 
 		overlay := &DockerConfig{
 			Enabled: ptrBool(false),
 			Registries: map[string]RegistryConfig{
-				"base-registry1": {Remote: "overlay-remote1", Local: "overlay-local1", Hostname: "overlay-hostname1"},
-				"new-registry":   {Remote: "overlay-remote2", Local: "overlay-local2", Hostname: "overlay-hostname2"},
+				"base-registry1": {Remote: "overlay-remote1", Local: "overlay-local1", HostName: "overlay-hostname1"},
+				"new-registry":   {Remote: "overlay-remote2", Local: "overlay-local2", HostName: "overlay-hostname2"},
 			},
 		}
 
@@ -33,8 +33,8 @@ func TestDockerConfig_Merge(t *testing.T) {
 
 		// Create a map to verify registries without relying on order
 		expectedRegistries := map[string]RegistryConfig{
-			"base-registry1": {Remote: "overlay-remote1", Local: "overlay-local1", Hostname: "overlay-hostname1"},
-			"new-registry":   {Remote: "overlay-remote2", Local: "overlay-local2", Hostname: "overlay-hostname2"},
+			"base-registry1": {Remote: "overlay-remote1", Local: "overlay-local1", HostName: "overlay-hostname1"},
+			"new-registry":   {Remote: "overlay-remote2", Local: "overlay-local2", HostName: "overlay-hostname2"},
 		}
 
 		for name, registry := range base.Registries {
@@ -43,8 +43,8 @@ func TestDockerConfig_Merge(t *testing.T) {
 				t.Errorf("Unexpected registry: %v", name)
 				continue
 			}
-			if registry.Remote != expected.Remote || registry.Local != expected.Local || registry.Hostname != expected.Hostname {
-				t.Errorf("Registry %v mismatch: expected remote %v, local %v, hostname %v, got remote %v, local %v, hostname %v", name, expected.Remote, expected.Local, expected.Hostname, registry.Remote, registry.Local, registry.Hostname)
+			if registry.Remote != expected.Remote || registry.Local != expected.Local || registry.HostName != expected.HostName {
+				t.Errorf("Registry %v mismatch: expected remote %v, local %v, hostname %v, got remote %v, local %v, hostname %v", name, expected.Remote, expected.Local, expected.HostName, registry.Remote, registry.Local, registry.HostName)
 			}
 		}
 	})
@@ -53,7 +53,7 @@ func TestDockerConfig_Merge(t *testing.T) {
 		base := &DockerConfig{
 			Enabled: ptrBool(true),
 			Registries: map[string]RegistryConfig{
-				"base-registry1": {Remote: "base-remote1", Local: "base-local1", Hostname: "base-hostname1"},
+				"base-registry1": {Remote: "base-remote1", Local: "base-local1", HostName: "base-hostname1"},
 			},
 		}
 
@@ -67,7 +67,7 @@ func TestDockerConfig_Merge(t *testing.T) {
 		if base.Enabled == nil || *base.Enabled != true {
 			t.Errorf("Enabled mismatch: expected %v, got %v", true, *base.Enabled)
 		}
-		if len(base.Registries) != 1 || base.Registries["base-registry1"].Remote != "base-remote1" || base.Registries["base-registry1"].Local != "base-local1" || base.Registries["base-registry1"].Hostname != "base-hostname1" {
+		if len(base.Registries) != 1 || base.Registries["base-registry1"].Remote != "base-remote1" || base.Registries["base-registry1"].Local != "base-local1" || base.Registries["base-registry1"].HostName != "base-hostname1" {
 			t.Errorf("Registries mismatch: expected %v, got %v", "base-registry1", base.Registries["base-registry1"])
 		}
 	})
@@ -78,8 +78,8 @@ func TestDockerConfig_Copy(t *testing.T) {
 		original := &DockerConfig{
 			Enabled: ptrBool(true),
 			Registries: map[string]RegistryConfig{
-				"registry1": {Remote: "remote1", Local: "local1", Hostname: "hostname1"},
-				"registry2": {Remote: "remote2", Local: "local2", Hostname: "hostname2"},
+				"registry1": {Remote: "remote1", Local: "local1", HostName: "hostname1"},
+				"registry2": {Remote: "remote2", Local: "local2", HostName: "hostname2"},
 			},
 		}
 
@@ -98,8 +98,8 @@ func TestDockerConfig_Copy(t *testing.T) {
 			if registry.Local != copy.Registries[name].Local {
 				t.Errorf("Registry Local mismatch for %v: expected %v, got %v", name, registry.Local, copy.Registries[name].Local)
 			}
-			if registry.Hostname != copy.Registries[name].Hostname {
-				t.Errorf("Registry Hostname mismatch for %v: expected %v, got %v", name, registry.Hostname, copy.Registries[name].Hostname)
+			if registry.HostName != copy.Registries[name].HostName {
+				t.Errorf("Registry HostName mismatch for %v: expected %v, got %v", name, registry.HostName, copy.Registries[name].HostName)
 			}
 		}
 
@@ -109,7 +109,7 @@ func TestDockerConfig_Copy(t *testing.T) {
 			t.Errorf("Original Enabled was modified: expected %v, got %v", true, *copy.Enabled)
 		}
 
-		copy.Registries["new-registry"] = RegistryConfig{Remote: "new-remote", Local: "new-local", Hostname: "new-hostname"}
+		copy.Registries["new-registry"] = RegistryConfig{Remote: "new-remote", Local: "new-local", HostName: "new-hostname"}
 		if len(original.Registries) == len(copy.Registries) {
 			t.Errorf("Original Registries were modified: expected length %d, got %d", len(original.Registries), len(copy.Registries))
 		}

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -23,6 +23,14 @@ var envCmd = &cobra.Command{
 			return nil
 		}
 
+		// Create service components
+		if err := controller.CreateServiceComponents(); err != nil {
+			if verbose {
+				return fmt.Errorf("Error creating service components: %w", err)
+			}
+			return nil
+		}
+
 		// Create environment components
 		if err := controller.CreateEnvComponents(); err != nil {
 			if verbose {

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -23,6 +23,14 @@ var envCmd = &cobra.Command{
 			return nil
 		}
 
+		// Create virtualization components
+		if err := controller.CreateVirtualizationComponents(); err != nil {
+			if verbose {
+				return fmt.Errorf("Error creating virtualization components: %w", err)
+			}
+			return nil
+		}
+
 		// Create service components
 		if err := controller.CreateServiceComponents(); err != nil {
 			if verbose {

--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -106,6 +106,96 @@ func TestEnvCmd(t *testing.T) {
 		}
 	})
 
+	for _, verbose := range []bool{true, false} {
+		t.Run(fmt.Sprintf("ErrorCreatingVirtualizationComponentsWithVerbose=%v", verbose), func(t *testing.T) {
+			defer resetRootCmd()
+
+			// Save the original controller and restore it after the test
+			originalController := controller
+			defer func() {
+				controller = originalController
+			}()
+
+			// Given a mock controller that returns an error when creating virtualization components
+			injector := di.NewInjector()
+			mockController := ctrl.NewMockController(injector)
+			mockController.CreateVirtualizationComponentsFunc = func() error {
+				return fmt.Errorf("error creating virtualization components")
+			}
+
+			// Set the global controller to the mock controller
+			controller = mockController
+
+			// When the env command is executed with or without verbose flag
+			if verbose {
+				rootCmd.SetArgs([]string{"env", "--verbose"})
+			} else {
+				rootCmd.SetArgs([]string{"env"})
+			}
+			err := Execute(mockController)
+
+			// Then check the error contents
+			if verbose {
+				if err == nil {
+					t.Fatalf("Expected an error, got nil")
+				}
+				expectedError := "Error creating virtualization components: error creating virtualization components"
+				if err.Error() != expectedError {
+					t.Fatalf("Expected error %q, got %q", expectedError, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Expected no error, got %v", err)
+				}
+			}
+		})
+	}
+
+	for _, verbose := range []bool{true, false} {
+		t.Run(fmt.Sprintf("ErrorCreatingServiceComponentsWithVerbose=%v", verbose), func(t *testing.T) {
+			defer resetRootCmd()
+
+			// Save the original controller and restore it after the test
+			originalController := controller
+			defer func() {
+				controller = originalController
+			}()
+
+			// Given a mock controller that returns an error when creating service components
+			injector := di.NewInjector()
+			mockController := ctrl.NewMockController(injector)
+			mockController.CreateServiceComponentsFunc = func() error {
+				return fmt.Errorf("error creating service components")
+			}
+
+			// Set the global controller to the mock controller
+			controller = mockController
+
+			// When the env command is executed with or without verbose flag
+			if verbose {
+				rootCmd.SetArgs([]string{"env", "--verbose"})
+			} else {
+				rootCmd.SetArgs([]string{"env"})
+			}
+			err := Execute(mockController)
+
+			// Then check the error contents
+			if verbose {
+				if err == nil {
+					t.Fatalf("Expected an error, got nil")
+				}
+				expectedError := "Error creating service components: error creating service components"
+				if err.Error() != expectedError {
+					t.Fatalf("Expected error %q, got %q", expectedError, err.Error())
+				}
+			} else {
+				if err != nil {
+					t.Fatalf("Expected no error, got %v", err)
+				}
+			}
+		})
+	}
+
 	t.Run("ErrorCreatingEnvComponents", func(t *testing.T) {
 		defer resetRootCmd()
 

--- a/pkg/blueprint/blueprint_handler.go
+++ b/pkg/blueprint/blueprint_handler.go
@@ -887,6 +887,7 @@ func (b *BaseBlueprintHandler) applyConfigMap() error {
 	context := b.configHandler.GetContext()
 	lbStart := b.configHandler.GetString("network.loadbalancer_ips.start")
 	lbEnd := b.configHandler.GetString("network.loadbalancer_ips.end")
+	registryURL := b.configHandler.GetString("docker.registry_url")
 
 	// Generate LOADBALANCER_IP_RANGE from the start and end IPs for network
 	loadBalancerIPRange := fmt.Sprintf("%s-%s", lbStart, lbEnd)
@@ -904,6 +905,7 @@ func (b *BaseBlueprintHandler) applyConfigMap() error {
 			"DOMAIN":                domain,
 			"CONTEXT":               context,
 			"LOADBALANCER_IP_RANGE": loadBalancerIPRange,
+			"REGISTRY_URL":          registryURL,
 		},
 	}
 

--- a/pkg/blueprint/blueprint_handler_test.go
+++ b/pkg/blueprint/blueprint_handler_test.go
@@ -209,6 +209,8 @@ func setupSafeMocks(injector ...di.Injector) MockSafeComponents {
 			return "192.168.1.1"
 		case "network.loadbalancer_ips.end":
 			return "192.168.1.100"
+		case "docker.registry_url":
+			return "mock.registry.com"
 		default:
 			if len(defaultValue) > 0 {
 				return defaultValue[0]
@@ -1464,6 +1466,9 @@ func TestBlueprintHandler_Install(t *testing.T) {
 				}
 				if configMap.Data["LOADBALANCER_IP_RANGE"] != "192.168.1.1-192.168.1.100" {
 					return fmt.Errorf("unexpected LOADBALANCER_IP_RANGE value: got %s, want %s", configMap.Data["LOADBALANCER_IP_RANGE"], "192.168.1.1-192.168.1.100")
+				}
+				if configMap.Data["REGISTRY_URL"] != "mock.registry.com" {
+					return fmt.Errorf("unexpected REGISTRY_URL value: got %s, want %s", configMap.Data["REGISTRY_URL"], "mock.registry.com")
 				}
 			}
 			return nil

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -54,7 +54,8 @@ const (
 // Default Registry settings
 const (
 	// renovate: datasource=docker depName=registry
-	REGISTRY_DEFAULT_IMAGE = "registry:2.8.3"
+	REGISTRY_DEFAULT_IMAGE     = "registry:2.8.3"
+	REGISTRY_DEFAULT_HOST_PORT = 5002
 )
 
 // Default network settings

--- a/pkg/env/docker_env_test.go
+++ b/pkg/env/docker_env_test.go
@@ -110,7 +110,7 @@ func TestDockerEnvPrinter_GetEnvVars(t *testing.T) {
 			t.Fatalf("GetEnvVars returned an error: %v", err)
 		}
 
-		expectedDockerHost := fmt.Sprintf("unix://%s/.colima/windsor-mock-context/docker.sock", os.Getenv("HOME"))
+		expectedDockerHost := fmt.Sprintf("unix://%s/.colima/windsor-mock-context/docker.sock", filepath.ToSlash(os.Getenv("HOME")))
 		if envVars["DOCKER_HOST"] != expectedDockerHost {
 			t.Errorf("DOCKER_HOST = %v, want %v", envVars["DOCKER_HOST"], expectedDockerHost)
 		}
@@ -141,7 +141,7 @@ func TestDockerEnvPrinter_GetEnvVars(t *testing.T) {
 			t.Fatalf("GetEnvVars returned an error: %v", err)
 		}
 
-		expectedDockerHost := fmt.Sprintf("unix://%s/.colima/windsor-%s/docker.sock", "/mock/home", "test-context")
+		expectedDockerHost := fmt.Sprintf("unix://%s/.colima/windsor-%s/docker.sock", filepath.ToSlash("/mock/home"), "test-context")
 		if envVars["DOCKER_HOST"] != expectedDockerHost {
 			t.Errorf("DOCKER_HOST = %v, want %v", envVars["DOCKER_HOST"], expectedDockerHost)
 		}
@@ -207,7 +207,7 @@ func TestDockerEnvPrinter_GetEnvVars(t *testing.T) {
 			t.Fatalf("GetEnvVars returned an error: %v", err)
 		}
 
-		expectedDockerHost := fmt.Sprintf("unix://%s/.docker/run/docker.sock", "/mock/home")
+		expectedDockerHost := fmt.Sprintf("unix://%s/.docker/run/docker.sock", filepath.ToSlash("/mock/home"))
 		if envVars["DOCKER_HOST"] != expectedDockerHost {
 			t.Errorf("DOCKER_HOST = %v, want %v", envVars["DOCKER_HOST"], expectedDockerHost)
 		}
@@ -220,7 +220,7 @@ func TestDockerEnvPrinter_GetEnvVars(t *testing.T) {
 		if !mkdirAllCalled {
 			t.Error("mkdirAll was not called")
 		} else {
-			expectedMkdirAllPath := "/mock/home/.config/windsor/docker"
+			expectedMkdirAllPath := filepath.ToSlash("/mock/home/.config/windsor/docker")
 			if mkdirAllPath != expectedMkdirAllPath {
 				t.Errorf("mkdirAll path = %v, want %v", mkdirAllPath, expectedMkdirAllPath)
 			}
@@ -229,7 +229,7 @@ func TestDockerEnvPrinter_GetEnvVars(t *testing.T) {
 		if !writeFileCalled {
 			t.Error("writeFile was not called")
 		} else {
-			expectedWriteFilePath := "/mock/home/.config/windsor/docker/config.json"
+			expectedWriteFilePath := filepath.ToSlash("/mock/home/.config/windsor/docker/config.json")
 			if writeFilePath != expectedWriteFilePath {
 				t.Errorf("writeFile path = %v, want %v", writeFilePath, expectedWriteFilePath)
 			}

--- a/pkg/services/dns_service.go
+++ b/pkg/services/dns_service.go
@@ -72,7 +72,7 @@ func (s *DNSService) GetComposeConfig() (*types.Config, error) {
 		},
 	}
 
-	if isLocalhost(s.address) {
+	if s.IsLocalhost() {
 		corednsConfig.Ports = []types.ServicePortConfig{
 			{
 				Target:    53,

--- a/pkg/services/registry_service.go
+++ b/pkg/services/registry_service.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/compose-spec/compose-go/types"
+	"github.com/windsorcli/cli/api/v1alpha1/docker"
 	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/di"
 )
@@ -14,7 +15,7 @@ import (
 // RegistryService is a service struct that provides Registry-specific utility functions
 type RegistryService struct {
 	BaseService
-	nextPort int
+	HostPort int
 }
 
 // NewRegistryService is a constructor for RegistryService
@@ -23,25 +24,19 @@ func NewRegistryService(injector di.Injector) *RegistryService {
 		BaseService: BaseService{
 			injector: injector,
 		},
-		nextPort: 5000, // Initialize the next available port for localhost
 	}
 }
 
-// GetComposeConfig returns a compose configuration for the registry matching the current s.name value.
+// GetComposeConfig returns a Docker Compose configuration for the registry matching s.name.
+// It retrieves the context configuration, finds the registry, and generates a service config.
+// If no matching registry is found, it returns an error.
 func (s *RegistryService) GetComposeConfig() (*types.Config, error) {
-	// Retrieve the context configuration using GetConfig
 	contextConfig := s.configHandler.GetConfig()
-
-	// Retrieve the list of registries from the context configuration
 	registries := contextConfig.Docker.Registries
 
-	// Find the registry matching the current s.name value
 	if registry, exists := registries[s.name]; exists {
-		// Get the service hostname
 		hostname := s.GetHostname()
-
-		// Pass the hostname to generateRegistryService
-		service, err := s.generateRegistryService(hostname, registry.Remote, registry.Local)
+		service, err := s.generateRegistryService(hostname, registry)
 		if err != nil {
 			return nil, fmt.Errorf("failed to generate registry service: %w", err)
 		}
@@ -51,20 +46,35 @@ func (s *RegistryService) GetComposeConfig() (*types.Config, error) {
 	return nil, fmt.Errorf("no registry found with name: %s", s.name)
 }
 
-// SetAddress configures the registry address, forms a hostname, updates the
-// registry config, and returns an error if any step fails. It appends the domain
-// to the service name to form the hostname.
+// SetAddress configures the registry's address, forms a hostname, and updates the registry config.
+// It selects a port by checking the registry's HostPort; if unset and on localhost, it defaults to
+// REGISTRY_DEFAULT_HOST_PORT. The port's availability is verified before assignment. Errors in any
+// step result in a returned error.
 func (s *RegistryService) SetAddress(address string) error {
 	if err := s.BaseService.SetAddress(address); err != nil {
 		return fmt.Errorf("failed to set address for base service: %w", err)
 	}
 
-	// Get the hostname using the GetHostname method
+	defaultPort := constants.REGISTRY_DEFAULT_HOST_PORT
 	hostName := s.GetHostname()
 
 	err := s.configHandler.SetContextValue(fmt.Sprintf("docker.registries[%s].hostname", s.name), hostName)
 	if err != nil {
 		return fmt.Errorf("failed to set hostname for registry %s: %w", s.name, err)
+	}
+
+	registryConfig := s.configHandler.GetConfig().Docker.Registries[s.name]
+	portToCheck := registryConfig.HostPort
+	if portToCheck == 0 && s.IsLocalhost() {
+		portToCheck = defaultPort
+	}
+
+	if portToCheck != 0 {
+		if isPortAvailable(portToCheck) {
+			s.HostPort = portToCheck
+		} else {
+			return fmt.Errorf("port %d is not available", portToCheck)
+		}
 	}
 
 	return nil
@@ -81,17 +91,16 @@ func (s *RegistryService) GetHostname() string {
 	return nameWithoutDomain + "." + domain
 }
 
-// generateRegistryService creates a ServiceConfig for a Registry service
-// with the specified name, remote URL, and local URL.
-func (s *RegistryService) generateRegistryService(hostName, remoteURL, localURL string) (types.ServiceConfig, error) {
-	// Retrieve the context name
+// This function generates a ServiceConfig for a Registry service. It sets up the service's name, image,
+// restart policy, and labels. It configures environment variables based on registry URLs, creates a
+// cache directory, and sets volume mounts. Ports are assigned only for non-proxy registries when the
+// network mode is localhost. It returns the configured ServiceConfig or an error if any step fails.
+func (s *RegistryService) generateRegistryService(hostname string, registry docker.RegistryConfig) (types.ServiceConfig, error) {
 	contextName := s.configHandler.GetContext()
 
-	// Initialize the ServiceConfig with the provided name, a predefined image,
-	// a restart policy, and labels indicating the role and manager.
 	service := types.ServiceConfig{
-		Name:          hostName,
-		ContainerName: hostName,
+		Name:          hostname,
+		ContainerName: hostname,
 		Image:         constants.REGISTRY_DEFAULT_IMAGE,
 		Restart:       "always",
 		Labels: map[string]string{
@@ -101,25 +110,20 @@ func (s *RegistryService) generateRegistryService(hostName, remoteURL, localURL 
 		},
 	}
 
-	// Initialize the environment variables map.
 	env := make(types.MappingWithEquals)
 
-	// Add the remote URL to the environment variables if specified.
-	if remoteURL != "" {
-		env["REGISTRY_PROXY_REMOTEURL"] = &remoteURL
+	if registry.Remote != "" {
+		env["REGISTRY_PROXY_REMOTEURL"] = &registry.Remote
 	}
 
-	// Add the local URL to the environment variables if specified.
-	if localURL != "" {
-		env["REGISTRY_PROXY_LOCALURL"] = &localURL
+	if registry.Local != "" {
+		env["REGISTRY_PROXY_LOCALURL"] = &registry.Local
 	}
 
-	// If any environment variables were added, assign them to the service.
 	if len(env) > 0 {
 		service.Environment = env
 	}
 
-	// Create a .docker-cache directory at the project root
 	projectRoot, err := s.shell.GetProjectRoot()
 	if err != nil {
 		return types.ServiceConfig{}, fmt.Errorf("error retrieving project root: %w", err)
@@ -129,36 +133,25 @@ func (s *RegistryService) generateRegistryService(hostName, remoteURL, localURL 
 		return service, fmt.Errorf("error creating .docker-cache directory: %w", err)
 	}
 
-	// Use the WINDSOR_PROJECT_ROOT environment variable for the volume mount
 	service.Volumes = []types.ServiceVolumeConfig{
 		{Type: "bind", Source: "${WINDSOR_PROJECT_ROOT}/.windsor/.docker-cache", Target: "/var/lib/registry"},
 	}
 
-	// Check if the address is localhost and assign ports if it is
-	// Only forward port 5000 if the registry is not used as a proxy
-	if isLocalhost(s.address) && remoteURL == "" {
-		for {
-			if isPortAvailable(s.nextPort) {
-				service.Ports = []types.ServicePortConfig{
-					{
-						Target:    5000,
-						Published: fmt.Sprintf("%d", s.nextPort),
-						Protocol:  "tcp",
-					},
-				}
-				s.nextPort++
-				break
-			}
-			s.nextPort++
+	if registry.Remote == "" && s.IsLocalhost() {
+		service.Ports = []types.ServicePortConfig{
+			{
+				Target:    5000,
+				Published: fmt.Sprintf("%d", s.HostPort),
+				Protocol:  "tcp",
+			},
 		}
 	}
 
-	// Return the configured ServiceConfig and nil error.
 	return service, nil
 }
 
 // isPortAvailable checks if a port is available for use
-func isPortAvailable(port int) bool {
+var isPortAvailable = func(port int) bool {
 	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
 		return false

--- a/pkg/services/registry_service.go
+++ b/pkg/services/registry_service.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"fmt"
-	"net"
 	"os"
 	"strings"
 
@@ -78,14 +77,10 @@ func (s *RegistryService) SetAddress(address string) error {
 	}
 
 	if hostPort != 0 {
-		if isPortAvailable(hostPort) {
-			s.HostPort = hostPort
-			err := s.configHandler.SetContextValue(fmt.Sprintf("docker.registries[%s].hostport", s.name), hostPort)
-			if err != nil {
-				return fmt.Errorf("failed to set host port for registry %s: %w", s.name, err)
-			}
-		} else {
-			return fmt.Errorf("port %d is not available", hostPort)
+		s.HostPort = hostPort
+		err := s.configHandler.SetContextValue(fmt.Sprintf("docker.registries[%s].hostport", s.name), hostPort)
+		if err != nil {
+			return fmt.Errorf("failed to set host port for registry %s: %w", s.name, err)
 		}
 	}
 
@@ -160,16 +155,6 @@ func (s *RegistryService) generateRegistryService(hostname string, registry dock
 	}
 
 	return service, nil
-}
-
-// isPortAvailable checks if a port is available for use
-var isPortAvailable = func(port int) bool {
-	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
-	if err != nil {
-		return false
-	}
-	defer ln.Close()
-	return true
 }
 
 // Ensure RegistryService implements Service interface

--- a/pkg/services/registry_service.go
+++ b/pkg/services/registry_service.go
@@ -71,6 +71,10 @@ func (s *RegistryService) SetAddress(address string) error {
 		hostPort = registryConfig.HostPort
 	} else if registryConfig.Remote == "" && s.IsLocalhost() {
 		hostPort = defaultPort
+		err = s.configHandler.SetContextValue("docker.registry_url", hostName)
+		if err != nil {
+			return fmt.Errorf("failed to set registry URL for registry %s: %w", s.name, err)
+		}
 	}
 
 	if hostPort != 0 {

--- a/pkg/services/registry_service_test.go
+++ b/pkg/services/registry_service_test.go
@@ -6,9 +6,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/compose-spec/compose-go/types"
 	"github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/api/v1alpha1/docker"
 	"github.com/windsorcli/cli/pkg/config"
+	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/di"
 	"github.com/windsorcli/cli/pkg/shell"
 )
@@ -66,6 +68,11 @@ func setupSafeRegistryServiceMocks(optionalInjector ...di.Injector) *MockCompone
 		}
 	}
 
+	// Mock mkdirAll to simulate success by default
+	mkdirAll = func(path string, perm os.FileMode) error {
+		return nil
+	}
+
 	return &MockComponents{
 		Injector:          injector,
 		MockShell:         mockShell,
@@ -76,13 +83,13 @@ func setupSafeRegistryServiceMocks(optionalInjector ...di.Injector) *MockCompone
 
 func TestRegistryService_NewRegistryService(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		// Given: a set of mock components
+		// Given a set of mock components
 		mocks := setupSafeRegistryServiceMocks()
 
-		// When: a new RegistryService is created
+		// When a new RegistryService is created
 		registryService := NewRegistryService(mocks.Injector)
 
-		// Then: the RegistryService should not be nil
+		// Then the RegistryService should not be nil
 		if registryService == nil {
 			t.Fatalf("expected RegistryService, got nil")
 		}
@@ -96,7 +103,7 @@ func TestRegistryService_NewRegistryService(t *testing.T) {
 
 func TestRegistryService_GetComposeConfig(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		// Given: a mock config handler, shell, context, and service
+		// Given a mock config handler, shell, context, and service
 		mocks := setupSafeRegistryServiceMocks()
 		registryService := NewRegistryService(mocks.Injector)
 		registryService.SetName("registry")
@@ -105,13 +112,13 @@ func TestRegistryService_GetComposeConfig(t *testing.T) {
 			t.Fatalf("Initialize() error = %v", err)
 		}
 
-		// When: GetComposeConfig is called
+		// When GetComposeConfig is called
 		composeConfig, err := registryService.GetComposeConfig()
 		if err != nil {
 			t.Fatalf("GetComposeConfig() error = %v", err)
 		}
 
-		// Then: check for characteristic properties in the configuration
+		// Then check for characteristic properties in the configuration
 		expectedName := "registry.test"
 		expectedRemoteURL := "registry.remote"
 		expectedLocalURL := "registry.local"
@@ -135,10 +142,10 @@ func TestRegistryService_GetComposeConfig(t *testing.T) {
 	})
 
 	t.Run("NoRegistryFound", func(t *testing.T) {
-		// Given: a mock config handler, shell, context, and service
+		// Given a mock config handler, shell, context, and service
 		mocks := setupSafeRegistryServiceMocks()
 
-		// When: a new RegistryService is created and initialized
+		// When a new RegistryService is created and initialized
 		registryService := NewRegistryService(mocks.Injector)
 		registryService.SetName("nonexistent-registry")
 		err := registryService.Initialize()
@@ -146,16 +153,25 @@ func TestRegistryService_GetComposeConfig(t *testing.T) {
 			t.Fatalf("Initialize() error = %v", err)
 		}
 
-		// When: GetComposeConfig is called
+		// When GetComposeConfig is called
 		_, err = registryService.GetComposeConfig()
 
-		// Then: an error should be returned indicating no registry was found
+		// Then an error should be returned indicating no registry was found
 		if err == nil || !strings.Contains(err.Error(), "no registry found with name") {
 			t.Fatalf("expected error indicating no registry found, got %v", err)
 		}
 	})
 
 	t.Run("MkdirAllFailure", func(t *testing.T) {
+		// Given a mock config handler, shell, context, and service
+		mocks := setupSafeRegistryServiceMocks()
+		registryService := NewRegistryService(mocks.Injector)
+		registryService.SetName("registry")
+		err := registryService.Initialize()
+		if err != nil {
+			t.Fatalf("Initialize() error = %v", err)
+		}
+
 		// Mock mkdirAll to simulate a failure
 		originalMkdirAll := mkdirAll
 		defer func() { mkdirAll = originalMkdirAll }()
@@ -163,81 +179,17 @@ func TestRegistryService_GetComposeConfig(t *testing.T) {
 			return fmt.Errorf("mock error creating directory")
 		}
 
-		// Given: a mock config handler, shell, context, and service
-		mocks := setupSafeRegistryServiceMocks()
-		registryService := NewRegistryService(mocks.Injector)
-		registryService.SetName("registry")
-		err := registryService.Initialize()
-		if err != nil {
-			t.Fatalf("Initialize() error = %v", err)
-		}
-
-		// When: GetComposeConfig is called
+		// When GetComposeConfig is called
 		_, err = registryService.GetComposeConfig()
 
-		// Then: an error should be returned indicating directory creation failure
+		// Then an error should be returned indicating directory creation failure
 		if err == nil || !strings.Contains(err.Error(), "mock error creating directory") {
 			t.Fatalf("expected error indicating directory creation failure, got %v", err)
 		}
 	})
 
-	t.Run("LocalhostPortAssignment", func(t *testing.T) {
-		// Mock mkdirAll to simulate successful directory creation
-		originalMkdirAll := mkdirAll
-		defer func() { mkdirAll = originalMkdirAll }()
-		mkdirAll = func(path string, perm os.FileMode) error {
-			return nil
-		}
-
-		// Given: a mock config handler, shell, context, and service
-		mocks := setupSafeRegistryServiceMocks()
-		mocks.MockConfigHandler.GetConfigFunc = func() *v1alpha1.Context {
-			return &v1alpha1.Context{
-				Docker: &docker.DockerConfig{
-					Enabled: ptrBool(true),
-					Registries: map[string]docker.RegistryConfig{
-						"registry": {
-							Remote: "",
-							Local:  "",
-						},
-					},
-				},
-			}
-		}
-		registryService := NewRegistryService(mocks.Injector)
-		err := registryService.Initialize()
-		if err != nil {
-			t.Fatalf("Initialize() error = %v", err)
-		}
-		registryService.SetName("registry")
-		registryService.SetAddress("127.0.0.1")
-
-		// When: GetComposeConfig is called
-		composeConfig, err := registryService.GetComposeConfig()
-		if err != nil {
-			t.Fatalf("GetComposeConfig() error = %v", err)
-		}
-
-		// Then: check if a port greater than or equal to 5000 is assigned
-		found := false
-		for _, config := range composeConfig.Services {
-			if config.Name == "registry.test" {
-				for _, portConfig := range config.Ports {
-					if portConfig.Published >= "5000" {
-						found = true
-						break
-					}
-				}
-			}
-		}
-
-		if !found {
-			t.Errorf("expected a port >= 5000 to be assigned for localhost, but none was found in the configuration:\n%+v", composeConfig.Services)
-		}
-	})
-
 	t.Run("ProjectRootRetrievalFailure", func(t *testing.T) {
-		// Given: a mock config handler, shell, context, and service
+		// Given a mock config handler, shell, context, and service
 		mocks := setupSafeRegistryServiceMocks()
 		mocks.MockShell.GetProjectRootFunc = func() (string, error) {
 			return "", fmt.Errorf("mock error retrieving project root")
@@ -249,19 +201,77 @@ func TestRegistryService_GetComposeConfig(t *testing.T) {
 			t.Fatalf("Initialize() error = %v", err)
 		}
 
-		// When: GetComposeConfig is called
+		// When GetComposeConfig is called
 		_, err = registryService.GetComposeConfig()
 
-		// Then: an error should be returned indicating project root retrieval failure
+		// Then an error should be returned indicating project root retrieval failure
 		if err == nil || !strings.Contains(err.Error(), "mock error retrieving project root") {
 			t.Fatalf("expected error indicating project root retrieval failure, got %v", err)
+		}
+	})
+
+	t.Run("LocalRegistry", func(t *testing.T) {
+		// Given a mock config handler, shell, context, and service
+		mocks := setupSafeRegistryServiceMocks()
+		registryService := NewRegistryService(mocks.Injector)
+		registryService.SetName("local-registry")
+		err := registryService.Initialize()
+		if err != nil {
+			t.Fatalf("Initialize() error = %v", err)
+		}
+
+		// Mock the registry configuration to ensure it exists without a remote value
+		mocks.MockConfigHandler.GetConfigFunc = func() *v1alpha1.Context {
+			return &v1alpha1.Context{
+				Docker: &docker.DockerConfig{
+					Registries: map[string]docker.RegistryConfig{
+						"local-registry": {
+							HostPort: 5000, // Ensure HostPort is set
+						},
+					},
+				},
+			}
+		}
+
+		// Set the address to localhost directly
+		registryService.address = "localhost"
+
+		// When GetComposeConfig is called
+		composeConfig, err := registryService.GetComposeConfig()
+		if err != nil {
+			t.Fatalf("GetComposeConfig() error = %v", err)
+		}
+
+		// Then check that the service has the expected port configuration
+		expectedPortConfig := types.ServicePortConfig{
+			Target:    5000,
+			Published: fmt.Sprintf("%d", registryService.HostPort),
+			Protocol:  "tcp",
+		}
+		found := false
+
+		for _, config := range composeConfig.Services {
+			if config.Name == "local-registry.test" {
+				for _, portConfig := range config.Ports {
+					if portConfig.Target == expectedPortConfig.Target &&
+						portConfig.Published == expectedPortConfig.Published &&
+						portConfig.Protocol == expectedPortConfig.Protocol {
+						found = true
+						break
+					}
+				}
+			}
+		}
+
+		if !found {
+			t.Errorf("expected service with name %q to have port configuration %+v in the list of configurations:\n%+v", "local-registry.test", expectedPortConfig, composeConfig.Services)
 		}
 	})
 }
 
 func TestRegistryService_SetAddress(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		// Given: a mock config handler, shell, context, and service
+		// Given a mock config handler, shell, context, and service
 		mocks := setupSafeRegistryServiceMocks()
 		registryService := NewRegistryService(mocks.Injector)
 		registryService.SetName("registry")
@@ -277,21 +287,21 @@ func TestRegistryService_SetAddress(t *testing.T) {
 			return nil
 		}
 
-		// When: SetAddress is called with a valid address
+		// When SetAddress is called with a valid address
 		address := "192.168.1.1"
 		err = registryService.SetAddress(address)
 		if err != nil {
 			t.Fatalf("SetAddress() error = %v", err)
 		}
 
-		// Then: verify SetContextValue was called
+		// Then verify SetContextValue was called
 		if !setContextValueCalled {
 			t.Errorf("expected SetContextValue to be called, but it was not")
 		}
 	})
 
 	t.Run("SetAddressError", func(t *testing.T) {
-		// Given: a mock config handler, shell, context, and service
+		// Given a mock config handler, shell, context, and service
 		mocks := setupSafeRegistryServiceMocks()
 		registryService := NewRegistryService(mocks.Injector)
 		registryService.SetName("registry")
@@ -300,18 +310,18 @@ func TestRegistryService_SetAddress(t *testing.T) {
 			t.Fatalf("Initialize() error = %v", err)
 		}
 
-		// When: SetAddress is called with an invalid address
+		// When SetAddress is called with an invalid address
 		address := "invalid-address"
 		err = registryService.SetAddress(address)
 
-		// Then: an error should be returned indicating invalid IPv4 address
+		// Then an error should be returned indicating invalid IPv4 address
 		if err == nil || !strings.Contains(err.Error(), "invalid IPv4 address") {
 			t.Fatalf("expected error indicating invalid IPv4 address, got %v", err)
 		}
 	})
 
 	t.Run("SetHostnameError", func(t *testing.T) {
-		// Given: a mock config handler that will fail to set context value
+		// Given a mock config handler that will fail to set context value
 		mocks := setupSafeRegistryServiceMocks()
 		mocks.MockConfigHandler.SetContextValueFunc = func(path string, value interface{}) error {
 			return fmt.Errorf("failed to set context value")
@@ -323,20 +333,134 @@ func TestRegistryService_SetAddress(t *testing.T) {
 			t.Fatalf("Initialize() error = %v", err)
 		}
 
-		// When: SetAddress is called
+		// When SetAddress is called
 		address := "192.168.1.1"
 		err = registryService.SetAddress(address)
 
-		// Then: an error should be returned
+		// Then an error should be returned
 		if err == nil || !strings.Contains(err.Error(), "failed to set hostname for registry") {
 			t.Fatalf("expected error indicating failure to set hostname, got %v", err)
+		}
+	})
+
+	t.Run("NoHostPortSetAndLocalhost", func(t *testing.T) {
+		// Mock isPortAvailable to always return true
+		originalIsPortAvailable := isPortAvailable
+		defer func() { isPortAvailable = originalIsPortAvailable }()
+		isPortAvailable = func(port int) bool {
+			return true
+		}
+
+		// Given a mock config handler, shell, context, and service with no HostPort set
+		mocks := setupSafeRegistryServiceMocks()
+		mocks.MockConfigHandler.GetConfigFunc = func() *v1alpha1.Context {
+			return &v1alpha1.Context{
+				Docker: &docker.DockerConfig{
+					Registries: map[string]docker.RegistryConfig{
+						"registry": {HostPort: 0},
+					},
+				},
+			}
+		}
+		registryService := NewRegistryService(mocks.Injector)
+		registryService.SetName("registry")
+		err := registryService.Initialize()
+		if err != nil {
+			t.Fatalf("Initialize() error = %v", err)
+		}
+
+		// When SetAddress is called with localhost
+		address := "127.0.0.1"
+		err = registryService.SetAddress(address)
+		if err != nil {
+			t.Fatalf("SetAddress() error = %v", err)
+		}
+
+		// Then the default port should be set
+		if registryService.HostPort != constants.REGISTRY_DEFAULT_HOST_PORT {
+			t.Errorf("expected HostPort to be set to default, got %v", registryService.HostPort)
+		}
+	})
+
+	t.Run("HostPortSetAndAvailable", func(t *testing.T) {
+		// Mock isPortAvailable to always return true
+		originalIsPortAvailable := isPortAvailable
+		defer func() { isPortAvailable = originalIsPortAvailable }()
+		isPortAvailable = func(port int) bool {
+			return true
+		}
+
+		// Given a mock config handler, shell, context, and service with HostPort set
+		mocks := setupSafeRegistryServiceMocks()
+		mocks.MockConfigHandler.GetConfigFunc = func() *v1alpha1.Context {
+			return &v1alpha1.Context{
+				Docker: &docker.DockerConfig{
+					Registries: map[string]docker.RegistryConfig{
+						"registry": {HostPort: 5000},
+					},
+				},
+			}
+		}
+		registryService := NewRegistryService(mocks.Injector)
+		registryService.SetName("registry")
+		err := registryService.Initialize()
+		if err != nil {
+			t.Fatalf("Initialize() error = %v", err)
+		}
+
+		// When SetAddress is called
+		address := "192.168.1.1"
+		err = registryService.SetAddress(address)
+		if err != nil {
+			t.Fatalf("SetAddress() error = %v", err)
+		}
+
+		// Then the HostPort should be set to the configured port
+		if registryService.HostPort != 5000 {
+			t.Errorf("expected HostPort to be 5000, got %v", registryService.HostPort)
+		}
+	})
+
+	t.Run("HostPortSetAndUnavailable", func(t *testing.T) {
+		// Mock isPortAvailable to return false for port 1
+		originalIsPortAvailable := isPortAvailable
+		defer func() { isPortAvailable = originalIsPortAvailable }()
+		isPortAvailable = func(port int) bool {
+			return port != 1
+		}
+
+		// Given a mock config handler, shell, context, and service with HostPort set to an unavailable port
+		mocks := setupSafeRegistryServiceMocks()
+		mocks.MockConfigHandler.GetConfigFunc = func() *v1alpha1.Context {
+			return &v1alpha1.Context{
+				Docker: &docker.DockerConfig{
+					Registries: map[string]docker.RegistryConfig{
+						"registry": {HostPort: 1}, // Port 1 is typically unavailable
+					},
+				},
+			}
+		}
+		registryService := NewRegistryService(mocks.Injector)
+		registryService.SetName("registry")
+		err := registryService.Initialize()
+		if err != nil {
+			t.Fatalf("Initialize() error = %v", err)
+		}
+
+		// When SetAddress is called
+		address := "192.168.1.1"
+		err = registryService.SetAddress(address)
+
+		// Then an error should be returned indicating port is not available
+		if err == nil || !strings.Contains(err.Error(), "port 1 is not available") {
+			t.Fatalf("expected error indicating port is not available, got %v", err)
 		}
 	})
 }
 
 func TestRegistryService_GetHostname(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		// Given: a mock config handler, shell, context, and service
+		// Given a mock config handler, shell, context, and service
 		mocks := setupSafeRegistryServiceMocks()
 		registryService := NewRegistryService(mocks.Injector)
 		registryService.SetName("registry.oldtld")
@@ -345,10 +469,10 @@ func TestRegistryService_GetHostname(t *testing.T) {
 			t.Fatalf("Initialize() error = %v", err)
 		}
 
-		// When: GetHostname is called
+		// When GetHostname is called
 		hostname := registryService.GetHostname()
 
-		// Then: the hostname should be as expected, with the old domain removed
+		// Then the hostname should be as expected, with the old domain removed
 		expectedHostname := "registry.test"
 		if hostname != expectedHostname {
 			t.Fatalf("expected hostname '%s', got %v", expectedHostname, hostname)

--- a/pkg/services/registry_service_test.go
+++ b/pkg/services/registry_service_test.go
@@ -344,13 +344,6 @@ func TestRegistryService_SetAddress(t *testing.T) {
 	})
 
 	t.Run("NoHostPortSetAndLocalhost", func(t *testing.T) {
-		// Mock isPortAvailable to always return true
-		originalIsPortAvailable := isPortAvailable
-		defer func() { isPortAvailable = originalIsPortAvailable }()
-		isPortAvailable = func(port int) bool {
-			return true
-		}
-
 		// Given a mock config handler, shell, context, and service with no HostPort set
 		mocks := setupSafeRegistryServiceMocks()
 		mocks.MockConfigHandler.GetConfigFunc = func() *v1alpha1.Context {
@@ -383,13 +376,6 @@ func TestRegistryService_SetAddress(t *testing.T) {
 	})
 
 	t.Run("HostPortSetAndAvailable", func(t *testing.T) {
-		// Mock isPortAvailable to always return true
-		originalIsPortAvailable := isPortAvailable
-		defer func() { isPortAvailable = originalIsPortAvailable }()
-		isPortAvailable = func(port int) bool {
-			return true
-		}
-
 		// Given a mock config handler, shell, context, and service with HostPort set
 		mocks := setupSafeRegistryServiceMocks()
 		mocks.MockConfigHandler.GetConfigFunc = func() *v1alpha1.Context {
@@ -421,50 +407,7 @@ func TestRegistryService_SetAddress(t *testing.T) {
 		}
 	})
 
-	t.Run("HostPortSetAndUnavailable", func(t *testing.T) {
-		// Mock isPortAvailable to return false for port 1
-		originalIsPortAvailable := isPortAvailable
-		defer func() { isPortAvailable = originalIsPortAvailable }()
-		isPortAvailable = func(port int) bool {
-			return port != 1
-		}
-
-		// Given a mock config handler, shell, context, and service with HostPort set to an unavailable port
-		mocks := setupSafeRegistryServiceMocks()
-		mocks.MockConfigHandler.GetConfigFunc = func() *v1alpha1.Context {
-			return &v1alpha1.Context{
-				Docker: &docker.DockerConfig{
-					Registries: map[string]docker.RegistryConfig{
-						"registry": {HostPort: 1}, // Port 1 is typically unavailable
-					},
-				},
-			}
-		}
-		registryService := NewRegistryService(mocks.Injector)
-		registryService.SetName("registry")
-		err := registryService.Initialize()
-		if err != nil {
-			t.Fatalf("Initialize() error = %v", err)
-		}
-
-		// When SetAddress is called
-		address := "192.168.1.1"
-		err = registryService.SetAddress(address)
-
-		// Then an error should be returned indicating port is not available
-		if err == nil || !strings.Contains(err.Error(), "port 1 is not available") {
-			t.Fatalf("expected error indicating port is not available, got %v", err)
-		}
-	})
-
 	t.Run("SetRegistryURLAndHostPort", func(t *testing.T) {
-		// Mock isPortAvailable to always return true
-		originalIsPortAvailable := isPortAvailable
-		defer func() { isPortAvailable = originalIsPortAvailable }()
-		isPortAvailable = func(port int) bool {
-			return true
-		}
-
 		// Given a mock config handler, shell, context, and service with no HostPort and no Remote
 		mocks := setupSafeRegistryServiceMocks()
 		mocks.MockConfigHandler.GetConfigFunc = func() *v1alpha1.Context {
@@ -509,13 +452,6 @@ func TestRegistryService_SetAddress(t *testing.T) {
 	})
 
 	t.Run("SetContextValueErrorForHostPort", func(t *testing.T) {
-		// Mock isPortAvailable to always return true
-		originalIsPortAvailable := isPortAvailable
-		defer func() { isPortAvailable = originalIsPortAvailable }()
-		isPortAvailable = func(port int) bool {
-			return true
-		}
-
 		// Given a mock config handler that will fail to set context value for host port
 		mocks := setupSafeRegistryServiceMocks()
 		mocks.MockConfigHandler.SetContextValueFunc = func(key string, value interface{}) error {
@@ -551,13 +487,6 @@ func TestRegistryService_SetAddress(t *testing.T) {
 	})
 
 	t.Run("SetContextValueErrorForRegistryURL", func(t *testing.T) {
-		// Mock isPortAvailable to always return true
-		originalIsPortAvailable := isPortAvailable
-		defer func() { isPortAvailable = originalIsPortAvailable }()
-		isPortAvailable = func(port int) bool {
-			return true
-		}
-
 		// Given a mock config handler that will fail to set context value for registry URL
 		mocks := setupSafeRegistryServiceMocks()
 		mocks.MockConfigHandler.SetContextValueFunc = func(key string, value interface{}) error {

--- a/pkg/services/service.go
+++ b/pkg/services/service.go
@@ -37,6 +37,9 @@ type Service interface {
 
 	// GetHostname returns the name plus the tld from the config
 	GetHostname() string
+
+	// IsLocalhost checks if the current address is a localhost address
+	IsLocalhost() bool
 }
 
 // BaseService is a base implementation of the Service interface
@@ -48,16 +51,14 @@ type BaseService struct {
 	name          string
 }
 
-// Initialize is a no-op for the Service interface
+// Initialize resolves and assigns configHandler and shell dependencies using the injector.
 func (s *BaseService) Initialize() error {
-	// Resolve the configHandler dependency
 	configHandler, ok := s.injector.Resolve("configHandler").(config.ConfigHandler)
 	if !ok {
 		return fmt.Errorf("error resolving configHandler")
 	}
 	s.configHandler = configHandler
 
-	// Resolve the shell dependency
 	shell, ok := s.injector.Resolve("shell").(shell.Shell)
 	if !ok {
 		return fmt.Errorf("error resolving shell")
@@ -103,11 +104,11 @@ func (s *BaseService) GetHostname() string {
 	return fmt.Sprintf("%s.%s", s.name, tld)
 }
 
-// isLocalhost checks if the given address is a localhost address
-func isLocalhost(address string) bool {
+// IsLocalhost checks if the current address is a localhost address
+func (s *BaseService) IsLocalhost() bool {
 	localhostAddresses := []string{"localhost", "127.0.0.1", "::1"}
 	for _, localhost := range localhostAddresses {
-		if address == localhost {
+		if s.address == localhost {
 			return true
 		}
 	}

--- a/pkg/services/service_test.go
+++ b/pkg/services/service_test.go
@@ -192,7 +192,7 @@ func TestBaseService_GetHostname(t *testing.T) {
 	})
 }
 
-func TestBaseService_isLocalhost(t *testing.T) {
+func TestBaseService_IsLocalhost(t *testing.T) {
 	tests := []struct {
 		name          string
 		address       string
@@ -208,12 +208,16 @@ func TestBaseService_isLocalhost(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// When: isLocalhost is called with the test address
-			isLocal := isLocalhost(tt.address)
+			// Given: a new BaseService with a mocked IsLocalhost method
+			service := &BaseService{}
+			service.address = tt.address
+
+			// Mocking IsLocalhost by directly setting the address
+			isLocal := service.IsLocalhost()
 
 			// Then: the result should match the expected outcome
 			if isLocal != tt.expectedLocal {
-				t.Fatalf("expected isLocalhost to be %v for address '%s', got %v", tt.expectedLocal, tt.address, isLocal)
+				t.Fatalf("expected IsLocalhost to be %v for address '%s', got %v", tt.expectedLocal, tt.address, isLocal)
 			}
 		})
 	}

--- a/pkg/services/talos_service.go
+++ b/pkg/services/talos_service.go
@@ -59,6 +59,10 @@ func NewTalosService(injector di.Injector, mode string) *TalosService {
 // is used to safely manage concurrent access to the port allocation. Node ports
 // are configured based on the cluster configuration, ensuring no conflicts.
 func (s *TalosService) SetAddress(address string) error {
+	if err := s.BaseService.SetAddress(address); err != nil {
+		return err
+	}
+
 	tld := s.configHandler.GetString("dns.domain", "test")
 	nodeType := "workers"
 	if s.mode == "controlplane" {
@@ -140,7 +144,7 @@ func (s *TalosService) SetAddress(address string) error {
 		return err
 	}
 
-	return s.BaseService.SetAddress(address)
+	return nil
 }
 
 // GetComposeConfig creates a Docker Compose configuration for Talos services.

--- a/pkg/services/talos_service.go
+++ b/pkg/services/talos_service.go
@@ -76,7 +76,7 @@ func (s *TalosService) SetAddress(address string) error {
 	defer portLock.Unlock()
 
 	var port int
-	if s.isLeader || !isLocalhost(address) {
+	if s.isLeader || !s.IsLocalhost() {
 		port = defaultAPIPort
 	} else {
 		port = nextAPIPort
@@ -241,7 +241,7 @@ func (s *TalosService) GetComposeConfig() (*types.Config, error) {
 	}
 	defaultAPIPortUint32 := uint32(defaultAPIPort)
 
-	if isLocalhost(s.address) {
+	if s.IsLocalhost() {
 		ports = append(ports, types.ServicePortConfig{
 			Target:    defaultAPIPortUint32,
 			Published: publishedPort,


### PR DESCRIPTION
The `REGISTRY_URL` environment variable is now injected in to the environment automatically when a local registry is available. Furthermore, this variable is made available to all kustomizations as a post-rendered value.