### PR TITLE
Pass controller through cli context

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	ctrl "github.com/windsorcli/cli/pkg/controller"
 )
 
 var checkCmd = &cobra.Command{
@@ -11,8 +12,9 @@ var checkCmd = &cobra.Command{
 	Short:        "Check the tool versions",
 	Long:         "Check the tool versions required by the project",
 	SilenceUsage: true,
-	PreRunE:      preRunEInitializeCommonComponents,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		controller := cmd.Context().Value(controllerKey).(ctrl.Controller)
+
 		// Create project components
 		if err := controller.CreateProjectComponents(); err != nil {
 			return fmt.Errorf("Error creating project components: %w", err)

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	ctrl "github.com/windsorcli/cli/pkg/controller"
 )
 
 // getContextCmd represents the get command
@@ -12,8 +13,9 @@ var getContextCmd = &cobra.Command{
 	Short:        "Get the current context",
 	Long:         "Retrieve and display the current context from the configuration",
 	SilenceUsage: true,
-	PreRunE:      preRunEInitializeCommonComponents,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		controller := cmd.Context().Value(controllerKey).(ctrl.Controller)
+
 		// Initialize components
 		if err := controller.InitializeComponents(); err != nil {
 			return fmt.Errorf("Error initializing components: %w", err)
@@ -33,12 +35,12 @@ var getContextCmd = &cobra.Command{
 
 // setContextCmd represents the set command
 var setContextCmd = &cobra.Command{
-	Use:     "set [context]",
-	Short:   "Set the current context",
-	Long:    "Set the current context in the configuration and save it",
-	Args:    cobra.ExactArgs(1), // Ensure exactly one argument is provided
-	PreRunE: preRunEInitializeCommonComponents,
+	Use:   "set [context]",
+	Short: "Set the current context",
+	Long:  "Set the current context in the configuration and save it",
+	Args:  cobra.ExactArgs(1), // Ensure exactly one argument is provided
 	RunE: func(cmd *cobra.Command, args []string) error {
+		controller := cmd.Context().Value(controllerKey).(ctrl.Controller)
 		// Initialize components
 		if err := controller.InitializeComponents(); err != nil {
 			return fmt.Errorf("Error initializing components: %w", err)

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	ctrl "github.com/windsorcli/cli/pkg/controller"
 )
 
 var (
@@ -16,8 +17,9 @@ var downCmd = &cobra.Command{
 	Short:        "Tear down the Windsor environment",
 	Long:         "Tear down the Windsor environment by executing necessary shell commands.",
 	SilenceUsage: true,
-	PreRunE:      preRunEInitializeCommonComponents,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		controller := cmd.Context().Value(controllerKey).(ctrl.Controller)
+
 		// Create virtualization components
 		if err := controller.CreateVirtualizationComponents(); err != nil {
 			return fmt.Errorf("Error creating virtualization components: %w", err)

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	ctrl "github.com/windsorcli/cli/pkg/controller"
 )
 
 var envCmd = &cobra.Command{
@@ -11,8 +12,8 @@ var envCmd = &cobra.Command{
 	Short:        "Output commands to set environment variables",
 	Long:         "Output commands to set environment variables for the application.",
 	SilenceUsage: true,
-	PreRunE:      preRunEInitializeCommonComponents,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		controller := cmd.Context().Value(controllerKey).(ctrl.Controller)
 
 		// Check if current directory is in the trusted list
 		shell := controller.ResolveShell()

--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -110,21 +110,12 @@ func TestEnvCmd(t *testing.T) {
 		t.Run(fmt.Sprintf("ErrorCreatingVirtualizationComponentsWithVerbose=%v", verbose), func(t *testing.T) {
 			defer resetRootCmd()
 
-			// Save the original controller and restore it after the test
-			originalController := controller
-			defer func() {
-				controller = originalController
-			}()
-
 			// Given a mock controller that returns an error when creating virtualization components
 			injector := di.NewInjector()
 			mockController := ctrl.NewMockController(injector)
 			mockController.CreateVirtualizationComponentsFunc = func() error {
 				return fmt.Errorf("error creating virtualization components")
 			}
-
-			// Set the global controller to the mock controller
-			controller = mockController
 
 			// When the env command is executed with or without verbose flag
 			if verbose {
@@ -155,21 +146,12 @@ func TestEnvCmd(t *testing.T) {
 		t.Run(fmt.Sprintf("ErrorCreatingServiceComponentsWithVerbose=%v", verbose), func(t *testing.T) {
 			defer resetRootCmd()
 
-			// Save the original controller and restore it after the test
-			originalController := controller
-			defer func() {
-				controller = originalController
-			}()
-
 			// Given a mock controller that returns an error when creating service components
 			injector := di.NewInjector()
 			mockController := ctrl.NewMockController(injector)
 			mockController.CreateServiceComponentsFunc = func() error {
 				return fmt.Errorf("error creating service components")
 			}
-
-			// Set the global controller to the mock controller
-			controller = mockController
 
 			// When the env command is executed with or without verbose flag
 			if verbose {
@@ -199,21 +181,12 @@ func TestEnvCmd(t *testing.T) {
 	t.Run("ErrorCreatingEnvComponents", func(t *testing.T) {
 		defer resetRootCmd()
 
-		// Save the original controller and restore it after the test
-		originalController := controller
-		defer func() {
-			controller = originalController
-		}()
-
 		// Given a mock controller that returns an error when creating environment components
 		injector := di.NewInjector()
 		mockController := ctrl.NewMockController(injector)
 		mockController.CreateEnvComponentsFunc = func() error {
 			return fmt.Errorf("error creating environment components")
 		}
-
-		// Set the global controller to the mock controller
-		controller = mockController
 
 		// When the env command is executed with verbose flag
 		rootCmd.SetArgs([]string{"env", "--verbose"})
@@ -239,9 +212,6 @@ func TestEnvCmd(t *testing.T) {
 			return fmt.Errorf("error creating environment components")
 		}
 
-		// Set the global controller to the mock controller
-		controller = mockController
-
 		// When the env command is executed without verbose flag
 		rootCmd.SetArgs([]string{"env"})
 		err := Execute(mockController)
@@ -261,9 +231,6 @@ func TestEnvCmd(t *testing.T) {
 		mockController.InitializeComponentsFunc = func() error {
 			return fmt.Errorf("error initializing components")
 		}
-
-		// Set the global controller to the mock controller
-		controller = mockController
 
 		// When the env command is executed with verbose flag
 		rootCmd.SetArgs([]string{"env", "--verbose"})
@@ -289,9 +256,6 @@ func TestEnvCmd(t *testing.T) {
 			return fmt.Errorf("error initializing components")
 		}
 
-		// Set the global controller to the mock controller
-		controller = mockController
-
 		// When the env command is executed without verbose flag
 		rootCmd.SetArgs([]string{"env"})
 		err := Execute(mockController)
@@ -312,9 +276,6 @@ func TestEnvCmd(t *testing.T) {
 			return nil
 		}
 
-		// Set the global controller to the mock controller
-		controller = mockController
-
 		// When the env command is executed without verbose flag
 		rootCmd.SetArgs([]string{"env"})
 		err := Execute(mockController)
@@ -334,9 +295,6 @@ func TestEnvCmd(t *testing.T) {
 		mockController.ResolveAllEnvPrintersFunc = func() []env.EnvPrinter {
 			return []env.EnvPrinter{}
 		}
-
-		// Set the global controller to the mock controller
-		controller = mockController
 
 		// When the env command is executed with verbose flag
 		rootCmd.SetArgs([]string{"env", "--verbose"})
@@ -366,9 +324,6 @@ func TestEnvCmd(t *testing.T) {
 			return []env.EnvPrinter{mockEnvPrinter}
 		}
 
-		// Set the global controller to the mock controller
-		controller = mockController
-
 		// When the env command is executed with verbose flag
 		rootCmd.SetArgs([]string{"env", "--verbose"})
 		err := Execute(mockController)
@@ -397,9 +352,6 @@ func TestEnvCmd(t *testing.T) {
 			return []env.EnvPrinter{mockEnvPrinter}
 		}
 
-		// Set the global controller to the mock controller
-		controller = mockController
-
 		// When the env command is executed without verbose flag
 		rootCmd.SetArgs([]string{"env"})
 		err := Execute(mockController)
@@ -423,9 +375,6 @@ func TestEnvCmd(t *testing.T) {
 		mockController.ResolveAllEnvPrintersFunc = func() []env.EnvPrinter {
 			return []env.EnvPrinter{mockEnvPrinter}
 		}
-
-		// Set the global controller to the mock controller
-		controller = mockController
 
 		// When the env command is executed with verbose flag
 		rootCmd.SetArgs([]string{"env", "--verbose"})
@@ -454,9 +403,6 @@ func TestEnvCmd(t *testing.T) {
 		mockController.ResolveAllEnvPrintersFunc = func() []env.EnvPrinter {
 			return []env.EnvPrinter{mockEnvPrinter}
 		}
-
-		// Set the global controller to the mock controller
-		controller = mockController
 
 		// When the env command is executed without verbose flag
 		rootCmd.SetArgs([]string{"env"})

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	ctrl "github.com/windsorcli/cli/pkg/controller"
 )
 
 var execCmd = &cobra.Command{
@@ -11,8 +12,9 @@ var execCmd = &cobra.Command{
 	Short:        "Execute a shell command with environment variables",
 	Long:         "Execute a shell command with environment variables set for the application.",
 	SilenceUsage: true,
-	PreRunE:      preRunEInitializeCommonComponents,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		controller := cmd.Context().Value(controllerKey).(ctrl.Controller)
+
 		if len(args) == 0 {
 			return fmt.Errorf("no command provided")
 		}

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	ctrl "github.com/windsorcli/cli/pkg/controller"
 )
 
 var hookCmd = &cobra.Command{
@@ -11,8 +12,9 @@ var hookCmd = &cobra.Command{
 	Short:        "Prints out shell hook information per platform (zsh,bash,fish,tcsh,powershell).",
 	Long:         "Prints out shell hook information for each platform (zsh,bash,fish,tcsh,powershell).",
 	SilenceUsage: true,
-	PreRunE:      preRunEInitializeCommonComponents,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		controller := cmd.Context().Value(controllerKey).(ctrl.Controller)
+
 		if len(args) == 0 {
 			return fmt.Errorf("No shell name provided")
 		}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	"github.com/spf13/cobra"
+	ctrl "github.com/windsorcli/cli/pkg/controller"
 )
 
 var (
@@ -29,8 +30,8 @@ var initCmd = &cobra.Command{
 	Long:         "Initialize the application by setting up necessary configurations and environment",
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
-	PreRunE:      preRunEInitializeCommonComponents,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		controller := cmd.Context().Value(controllerKey).(ctrl.Controller)
 
 		// Add the current directory to the trusted file list
 		shell := controller.ResolveShell()

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -21,7 +21,6 @@ func setupSafeInitCmdMocks(existingInjectors ...di.Injector) *initMockObjects {
 	}
 
 	mockController := ctrl.NewMockController(injector)
-	controller = mockController
 
 	mockController.CreateCommonComponentsFunc = func() error { return nil }
 	mockController.InitializeComponentsFunc = func() error { return nil }
@@ -445,7 +444,7 @@ func TestInitCmd(t *testing.T) {
 		// When the init command is executed
 		output := captureStderr(func() {
 			rootCmd.SetArgs([]string{"init", "test-context"})
-			err := Execute(controller)
+			err := Execute(mocks.Controller)
 			if err == nil {
 				t.Fatalf("Expected error, got nil")
 			}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -4,13 +4,15 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	ctrl "github.com/windsorcli/cli/pkg/controller"
 )
 
 var installCmd = &cobra.Command{
-	Use:     "install",
-	Short:   "Install the blueprint's cluster-level services",
-	PreRunE: preRunEInitializeCommonComponents,
+	Use:   "install",
+	Short: "Install the blueprint's cluster-level services",
 	RunE: func(cmd *cobra.Command, args []string) error {
+		controller := cmd.Context().Value(controllerKey).(ctrl.Controller)
+
 		// Create project components
 		if err := controller.CreateProjectComponents(); err != nil {
 			return fmt.Errorf("Error creating project components: %w", err)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -10,36 +11,35 @@ import (
 	ctrl "github.com/windsorcli/cli/pkg/controller"
 )
 
-// controller is the global controller
-var controller ctrl.Controller
+// Define a custom type for context keys
+type contextKey string
+
+const controllerKey = contextKey("controller")
 
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute(controllerInstance ctrl.Controller) error {
-	// Set the controller
-	controller = controllerInstance
+	// Create a context with the controller
+	ctx := context.WithValue(context.Background(), controllerKey, controllerInstance)
 
-	// Execute the root command
-	if err := rootCmd.Execute(); err != nil {
-		return err
-	}
-
-	return nil
+	// Execute the root command with the context
+	return rootCmd.ExecuteContext(ctx)
 }
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
-	Use:   "windsor",
-	Short: "A command line interface to assist in a context flow development environment",
-	Long:  "A command line interface to assist in a context flow development environment",
+	Use:               "windsor",
+	Short:             "A command line interface to assist your cloud native development workflow",
+	Long:              "A command line interface to assist your cloud native development workflow",
+	PersistentPreRunE: preRunEInitializeCommonComponents,
 }
 
-func init() {
-	// Define the --verbose flag
-	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
-}
-
-// initializeCommonComponents initializes the controller and creates common components
+// preRunEInitializeCommonComponents initializes the controller and creates common components
 func preRunEInitializeCommonComponents(cmd *cobra.Command, args []string) error {
+	cmd.SetContext(cmd.Root().Context())
+
+	// Retrieve the controller from the context
+	controller := cmd.Context().Value(controllerKey).(ctrl.Controller)
+
 	// Initialize the controller
 	if err := controller.Initialize(); err != nil {
 		return fmt.Errorf("Error initializing controller: %w", err)
@@ -106,4 +106,9 @@ func preRunEInitializeCommonComponents(cmd *cobra.Command, args []string) error 
 		}
 	}
 	return nil
+}
+
+func init() {
+	// Define the --verbose flag
+	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	ctrl "github.com/windsorcli/cli/pkg/controller"
 )
 
 var (
@@ -16,8 +17,9 @@ var upCmd = &cobra.Command{
 	Short:        "Set up the Windsor environment",
 	Long:         "Set up the Windsor environment by executing necessary shell commands.",
 	SilenceUsage: true,
-	PreRunE:      preRunEInitializeCommonComponents,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		controller := cmd.Context().Value(controllerKey).(ctrl.Controller)
+
 		// Create and initialize all necessary components for the Windsor environment.
 		// This includes project, environment, virtualization, service, and stack components.
 		if err := controller.CreateProjectComponents(); err != nil {


### PR DESCRIPTION
Passes the controller via Cobra's context vs. setting it globally. This improves the architecture to allow for the controller to be more cleanly injected, improving testability.