### PR TITLE
Support for local volume storage driver

### DIFF
--- a/api/v1alpha1/cluster/cluster_config.go
+++ b/api/v1alpha1/cluster/cluster_config.go
@@ -12,11 +12,12 @@ type ClusterConfig struct {
 		HostPorts []string              `yaml:"hostports,omitempty"`
 	} `yaml:"controlplanes,omitempty"`
 	Workers struct {
-		Count     *int                  `yaml:"count,omitempty"`
-		CPU       *int                  `yaml:"cpu,omitempty"`
-		Memory    *int                  `yaml:"memory,omitempty"`
-		Nodes     map[string]NodeConfig `yaml:"nodes,omitempty"`
-		HostPorts []string              `yaml:"hostports,omitempty"`
+		Count           *int                  `yaml:"count,omitempty"`
+		CPU             *int                  `yaml:"cpu,omitempty"`
+		Memory          *int                  `yaml:"memory,omitempty"`
+		Nodes           map[string]NodeConfig `yaml:"nodes,omitempty"`
+		HostPorts       []string              `yaml:"hostports,omitempty"`
+		LocalVolumePath *string               `yaml:"local_volume_path,omitempty"`
 	} `yaml:"workers,omitempty"`
 }
 
@@ -70,6 +71,9 @@ func (base *ClusterConfig) Merge(overlay *ClusterConfig) {
 		base.Workers.HostPorts = make([]string, len(overlay.Workers.HostPorts))
 		copy(base.Workers.HostPorts, overlay.Workers.HostPorts)
 	}
+	if overlay.Workers.LocalVolumePath != nil {
+		base.Workers.LocalVolumePath = overlay.Workers.LocalVolumePath
+	}
 }
 
 // Copy creates a deep copy of the ClusterConfig object
@@ -84,7 +88,7 @@ func (c *ClusterConfig) Copy() *ClusterConfig {
 			Hostname:  node.Hostname,
 			Node:      node.Node,
 			Endpoint:  node.Endpoint,
-			HostPorts: append([]string{}, node.HostPorts...), // Copy HostPorts for each node
+			HostPorts: append([]string{}, node.HostPorts...),
 		}
 	}
 	controlPlanesHostPortsCopy := make([]string, len(c.ControlPlanes.HostPorts))
@@ -96,7 +100,7 @@ func (c *ClusterConfig) Copy() *ClusterConfig {
 			Hostname:  node.Hostname,
 			Node:      node.Node,
 			Endpoint:  node.Endpoint,
-			HostPorts: append([]string{}, node.HostPorts...), // Copy HostPorts for each node
+			HostPorts: append([]string{}, node.HostPorts...),
 		}
 	}
 	workersHostPortsCopy := make([]string, len(c.Workers.HostPorts))
@@ -119,17 +123,19 @@ func (c *ClusterConfig) Copy() *ClusterConfig {
 			HostPorts: controlPlanesHostPortsCopy,
 		},
 		Workers: struct {
-			Count     *int                  `yaml:"count,omitempty"`
-			CPU       *int                  `yaml:"cpu,omitempty"`
-			Memory    *int                  `yaml:"memory,omitempty"`
-			Nodes     map[string]NodeConfig `yaml:"nodes,omitempty"`
-			HostPorts []string              `yaml:"hostports,omitempty"`
+			Count           *int                  `yaml:"count,omitempty"`
+			CPU             *int                  `yaml:"cpu,omitempty"`
+			Memory          *int                  `yaml:"memory,omitempty"`
+			Nodes           map[string]NodeConfig `yaml:"nodes,omitempty"`
+			HostPorts       []string              `yaml:"hostports,omitempty"`
+			LocalVolumePath *string               `yaml:"local_volume_path,omitempty"`
 		}{
-			Count:     c.Workers.Count,
-			CPU:       c.Workers.CPU,
-			Memory:    c.Workers.Memory,
-			Nodes:     workersNodesCopy,
-			HostPorts: workersHostPortsCopy,
+			Count:           c.Workers.Count,
+			CPU:             c.Workers.CPU,
+			Memory:          c.Workers.Memory,
+			Nodes:           workersNodesCopy,
+			HostPorts:       workersHostPortsCopy,
+			LocalVolumePath: c.Workers.LocalVolumePath,
 		},
 	}
 }

--- a/api/v1alpha1/cluster/cluster_config.go
+++ b/api/v1alpha1/cluster/cluster_config.go
@@ -2,23 +2,10 @@ package cluster
 
 // ClusterConfig represents the cluster configuration
 type ClusterConfig struct {
-	Enabled       *bool   `yaml:"enabled"`
-	Driver        *string `yaml:"driver"`
-	ControlPlanes struct {
-		Count     *int                  `yaml:"count,omitempty"`
-		CPU       *int                  `yaml:"cpu,omitempty"`
-		Memory    *int                  `yaml:"memory,omitempty"`
-		Nodes     map[string]NodeConfig `yaml:"nodes,omitempty"`
-		HostPorts []string              `yaml:"hostports,omitempty"`
-	} `yaml:"controlplanes,omitempty"`
-	Workers struct {
-		Count           *int                  `yaml:"count,omitempty"`
-		CPU             *int                  `yaml:"cpu,omitempty"`
-		Memory          *int                  `yaml:"memory,omitempty"`
-		Nodes           map[string]NodeConfig `yaml:"nodes,omitempty"`
-		HostPorts       []string              `yaml:"hostports,omitempty"`
-		LocalVolumePath *string               `yaml:"local_volume_path,omitempty"`
-	} `yaml:"workers,omitempty"`
+	Enabled       *bool           `yaml:"enabled"`
+	Driver        *string         `yaml:"driver"`
+	ControlPlanes NodeGroupConfig `yaml:"controlplanes,omitempty"`
+	Workers       NodeGroupConfig `yaml:"workers,omitempty"`
 }
 
 // NodeConfig represents the node configuration
@@ -27,6 +14,16 @@ type NodeConfig struct {
 	Node      *string  `yaml:"node,omitempty"`
 	Endpoint  *string  `yaml:"endpoint,omitempty"`
 	HostPorts []string `yaml:"hostports,omitempty"`
+}
+
+// NodeGroupConfig represents the configuration for a group of nodes
+type NodeGroupConfig struct {
+	Count     *int                  `yaml:"count,omitempty"`
+	CPU       *int                  `yaml:"cpu,omitempty"`
+	Memory    *int                  `yaml:"memory,omitempty"`
+	Nodes     map[string]NodeConfig `yaml:"nodes,omitempty"`
+	HostPorts []string              `yaml:"hostports,omitempty"`
+	Volumes   []string              `yaml:"volumes,omitempty"`
 }
 
 // Merge performs a deep merge of the current ClusterConfig with another ClusterConfig.
@@ -52,6 +49,14 @@ func (base *ClusterConfig) Merge(overlay *ClusterConfig) {
 			base.ControlPlanes.Nodes[key] = node
 		}
 	}
+	if overlay.ControlPlanes.HostPorts != nil {
+		base.ControlPlanes.HostPorts = make([]string, len(overlay.ControlPlanes.HostPorts))
+		copy(base.ControlPlanes.HostPorts, overlay.ControlPlanes.HostPorts)
+	}
+	if overlay.ControlPlanes.Volumes != nil {
+		base.ControlPlanes.Volumes = make([]string, len(overlay.ControlPlanes.Volumes))
+		copy(base.ControlPlanes.Volumes, overlay.ControlPlanes.Volumes)
+	}
 	if overlay.Workers.Count != nil {
 		base.Workers.Count = overlay.Workers.Count
 	}
@@ -71,8 +76,9 @@ func (base *ClusterConfig) Merge(overlay *ClusterConfig) {
 		base.Workers.HostPorts = make([]string, len(overlay.Workers.HostPorts))
 		copy(base.Workers.HostPorts, overlay.Workers.HostPorts)
 	}
-	if overlay.Workers.LocalVolumePath != nil {
-		base.Workers.LocalVolumePath = overlay.Workers.LocalVolumePath
+	if overlay.Workers.Volumes != nil {
+		base.Workers.Volumes = make([]string, len(overlay.Workers.Volumes))
+		copy(base.Workers.Volumes, overlay.Workers.Volumes)
 	}
 }
 
@@ -93,6 +99,8 @@ func (c *ClusterConfig) Copy() *ClusterConfig {
 	}
 	controlPlanesHostPortsCopy := make([]string, len(c.ControlPlanes.HostPorts))
 	copy(controlPlanesHostPortsCopy, c.ControlPlanes.HostPorts)
+	controlPlanesVolumesCopy := make([]string, len(c.ControlPlanes.Volumes))
+	copy(controlPlanesVolumesCopy, c.ControlPlanes.Volumes)
 
 	workersNodesCopy := make(map[string]NodeConfig, len(c.Workers.Nodes))
 	for key, node := range c.Workers.Nodes {
@@ -105,37 +113,27 @@ func (c *ClusterConfig) Copy() *ClusterConfig {
 	}
 	workersHostPortsCopy := make([]string, len(c.Workers.HostPorts))
 	copy(workersHostPortsCopy, c.Workers.HostPorts)
+	workersVolumesCopy := make([]string, len(c.Workers.Volumes))
+	copy(workersVolumesCopy, c.Workers.Volumes)
 
 	return &ClusterConfig{
 		Enabled: c.Enabled,
 		Driver:  c.Driver,
-		ControlPlanes: struct {
-			Count     *int                  `yaml:"count,omitempty"`
-			CPU       *int                  `yaml:"cpu,omitempty"`
-			Memory    *int                  `yaml:"memory,omitempty"`
-			Nodes     map[string]NodeConfig `yaml:"nodes,omitempty"`
-			HostPorts []string              `yaml:"hostports,omitempty"`
-		}{
+		ControlPlanes: NodeGroupConfig{
 			Count:     c.ControlPlanes.Count,
 			CPU:       c.ControlPlanes.CPU,
 			Memory:    c.ControlPlanes.Memory,
 			Nodes:     controlPlanesNodesCopy,
 			HostPorts: controlPlanesHostPortsCopy,
+			Volumes:   controlPlanesVolumesCopy,
 		},
-		Workers: struct {
-			Count           *int                  `yaml:"count,omitempty"`
-			CPU             *int                  `yaml:"cpu,omitempty"`
-			Memory          *int                  `yaml:"memory,omitempty"`
-			Nodes           map[string]NodeConfig `yaml:"nodes,omitempty"`
-			HostPorts       []string              `yaml:"hostports,omitempty"`
-			LocalVolumePath *string               `yaml:"local_volume_path,omitempty"`
-		}{
-			Count:           c.Workers.Count,
-			CPU:             c.Workers.CPU,
-			Memory:          c.Workers.Memory,
-			Nodes:           workersNodesCopy,
-			HostPorts:       workersHostPortsCopy,
-			LocalVolumePath: c.Workers.LocalVolumePath,
+		Workers: NodeGroupConfig{
+			Count:     c.Workers.Count,
+			CPU:       c.Workers.CPU,
+			Memory:    c.Workers.Memory,
+			Nodes:     workersNodesCopy,
+			HostPorts: workersHostPortsCopy,
+			Volumes:   workersVolumesCopy,
 		},
 	}
 }

--- a/api/v1alpha1/cluster/cluster_config_test.go
+++ b/api/v1alpha1/cluster/cluster_config_test.go
@@ -33,23 +33,29 @@ func TestClusterConfig_Merge(t *testing.T) {
 				CPU:    ptrInt(4),
 				Memory: ptrInt(8192),
 				Nodes: map[string]NodeConfig{
-					"node1": {Hostname: ptrString("base-node1")},
+					"node1": {
+						Hostname: ptrString("base-node1"),
+					},
 				},
 			},
 			Workers: struct {
-				Count     *int                  `yaml:"count,omitempty"`
-				CPU       *int                  `yaml:"cpu,omitempty"`
-				Memory    *int                  `yaml:"memory,omitempty"`
-				Nodes     map[string]NodeConfig `yaml:"nodes,omitempty"`
-				HostPorts []string              `yaml:"hostports,omitempty"`
+				Count           *int                  `yaml:"count,omitempty"`
+				CPU             *int                  `yaml:"cpu,omitempty"`
+				Memory          *int                  `yaml:"memory,omitempty"`
+				Nodes           map[string]NodeConfig `yaml:"nodes,omitempty"`
+				HostPorts       []string              `yaml:"hostports,omitempty"`
+				LocalVolumePath *string               `yaml:"local_volume_path,omitempty"`
 			}{
 				Count:  ptrInt(5),
 				CPU:    ptrInt(2),
 				Memory: ptrInt(4096),
 				Nodes: map[string]NodeConfig{
-					"worker1": {Hostname: ptrString("base-worker1")},
+					"worker1": {
+						Hostname: ptrString("base-worker1"),
+					},
 				},
-				HostPorts: []string{"8080", "9090"},
+				HostPorts:       []string{"8080", "9090"},
+				LocalVolumePath: ptrString("/base/worker1/path"),
 			},
 		}
 
@@ -67,23 +73,29 @@ func TestClusterConfig_Merge(t *testing.T) {
 				CPU:    ptrInt(2),
 				Memory: ptrInt(4096),
 				Nodes: map[string]NodeConfig{
-					"node2": {Hostname: ptrString("overlay-node2")},
+					"node2": {
+						Hostname: ptrString("overlay-node2"),
+					},
 				},
 			},
 			Workers: struct {
-				Count     *int                  `yaml:"count,omitempty"`
-				CPU       *int                  `yaml:"cpu,omitempty"`
-				Memory    *int                  `yaml:"memory,omitempty"`
-				Nodes     map[string]NodeConfig `yaml:"nodes,omitempty"`
-				HostPorts []string              `yaml:"hostports,omitempty"`
+				Count           *int                  `yaml:"count,omitempty"`
+				CPU             *int                  `yaml:"cpu,omitempty"`
+				Memory          *int                  `yaml:"memory,omitempty"`
+				Nodes           map[string]NodeConfig `yaml:"nodes,omitempty"`
+				HostPorts       []string              `yaml:"hostports,omitempty"`
+				LocalVolumePath *string               `yaml:"local_volume_path,omitempty"`
 			}{
 				Count:  ptrInt(3),
 				CPU:    ptrInt(1),
 				Memory: ptrInt(2048),
 				Nodes: map[string]NodeConfig{
-					"worker2": {Hostname: ptrString("overlay-worker2")},
+					"worker2": {
+						Hostname: ptrString("overlay-worker2"),
+					},
 				},
-				HostPorts: []string{"8082", "9092"},
+				HostPorts:       []string{"8082", "9092"},
+				LocalVolumePath: ptrString("/overlay/worker2/path"),
 			},
 		}
 
@@ -122,6 +134,9 @@ func TestClusterConfig_Merge(t *testing.T) {
 		if len(base.Workers.Nodes) != 1 || base.Workers.Nodes["worker2"].Hostname == nil || *base.Workers.Nodes["worker2"].Hostname != "overlay-worker2" {
 			t.Errorf("Workers Nodes mismatch: expected 'overlay-worker2', got %v", base.Workers.Nodes)
 		}
+		if base.Workers.LocalVolumePath == nil || *base.Workers.LocalVolumePath != "/overlay/worker2/path" {
+			t.Errorf("Workers LocalVolumePath mismatch: expected '/overlay/worker2/path', got %v", *base.Workers.LocalVolumePath)
+		}
 	})
 
 	t.Run("MergeWithAllNils", func(t *testing.T) {
@@ -142,17 +157,19 @@ func TestClusterConfig_Merge(t *testing.T) {
 				HostPorts: nil,
 			},
 			Workers: struct {
-				Count     *int                  `yaml:"count,omitempty"`
-				CPU       *int                  `yaml:"cpu,omitempty"`
-				Memory    *int                  `yaml:"memory,omitempty"`
-				Nodes     map[string]NodeConfig `yaml:"nodes,omitempty"`
-				HostPorts []string              `yaml:"hostports,omitempty"`
+				Count           *int                  `yaml:"count,omitempty"`
+				CPU             *int                  `yaml:"cpu,omitempty"`
+				Memory          *int                  `yaml:"memory,omitempty"`
+				Nodes           map[string]NodeConfig `yaml:"nodes,omitempty"`
+				HostPorts       []string              `yaml:"hostports,omitempty"`
+				LocalVolumePath *string               `yaml:"local_volume_path,omitempty"`
 			}{
-				Count:     nil,
-				CPU:       nil,
-				Memory:    nil,
-				Nodes:     nil,
-				HostPorts: nil,
+				Count:           nil,
+				CPU:             nil,
+				Memory:          nil,
+				Nodes:           nil,
+				HostPorts:       nil,
+				LocalVolumePath: nil,
 			},
 		}
 
@@ -173,17 +190,19 @@ func TestClusterConfig_Merge(t *testing.T) {
 				HostPorts: nil,
 			},
 			Workers: struct {
-				Count     *int                  `yaml:"count,omitempty"`
-				CPU       *int                  `yaml:"cpu,omitempty"`
-				Memory    *int                  `yaml:"memory,omitempty"`
-				Nodes     map[string]NodeConfig `yaml:"nodes,omitempty"`
-				HostPorts []string              `yaml:"hostports,omitempty"`
+				Count           *int                  `yaml:"count,omitempty"`
+				CPU             *int                  `yaml:"cpu,omitempty"`
+				Memory          *int                  `yaml:"memory,omitempty"`
+				Nodes           map[string]NodeConfig `yaml:"nodes,omitempty"`
+				HostPorts       []string              `yaml:"hostports,omitempty"`
+				LocalVolumePath *string               `yaml:"local_volume_path,omitempty"`
 			}{
-				Count:     nil,
-				CPU:       nil,
-				Memory:    nil,
-				Nodes:     nil,
-				HostPorts: nil,
+				Count:           nil,
+				CPU:             nil,
+				Memory:          nil,
+				Nodes:           nil,
+				HostPorts:       nil,
+				LocalVolumePath: nil,
 			},
 		}
 
@@ -222,6 +241,9 @@ func TestClusterConfig_Merge(t *testing.T) {
 		if base.Workers.Nodes != nil {
 			t.Errorf("Workers Nodes mismatch: expected nil, got %v", base.Workers.Nodes)
 		}
+		if base.Workers.LocalVolumePath != nil {
+			t.Errorf("Workers LocalVolumePath mismatch: expected nil, got %v", *base.Workers.LocalVolumePath)
+		}
 	})
 }
 
@@ -241,24 +263,30 @@ func TestClusterConfig_Copy(t *testing.T) {
 				CPU:    ptrInt(4),
 				Memory: ptrInt(8192),
 				Nodes: map[string]NodeConfig{
-					"node1": {Hostname: ptrString("original-node1")},
+					"node1": {
+						Hostname: ptrString("original-node1"),
+					},
 				},
 				HostPorts: []string{"1000:1000/tcp", "2000:2000/tcp"},
 			},
 			Workers: struct {
-				Count     *int                  `yaml:"count,omitempty"`
-				CPU       *int                  `yaml:"cpu,omitempty"`
-				Memory    *int                  `yaml:"memory,omitempty"`
-				Nodes     map[string]NodeConfig `yaml:"nodes,omitempty"`
-				HostPorts []string              `yaml:"hostports,omitempty"`
+				Count           *int                  `yaml:"count,omitempty"`
+				CPU             *int                  `yaml:"cpu,omitempty"`
+				Memory          *int                  `yaml:"memory,omitempty"`
+				Nodes           map[string]NodeConfig `yaml:"nodes,omitempty"`
+				HostPorts       []string              `yaml:"hostports,omitempty"`
+				LocalVolumePath *string               `yaml:"local_volume_path,omitempty"`
 			}{
 				Count:  ptrInt(5),
 				CPU:    ptrInt(2),
 				Memory: ptrInt(4096),
 				Nodes: map[string]NodeConfig{
-					"worker1": {Hostname: ptrString("original-worker1")},
+					"worker1": {
+						Hostname: ptrString("original-worker1"),
+					},
 				},
-				HostPorts: []string{"3000:3000/tcp", "4000:4000/tcp"},
+				HostPorts:       []string{"3000:3000/tcp", "4000:4000/tcp"},
+				LocalVolumePath: ptrString("/original/worker1/path"),
 			},
 		}
 
@@ -294,6 +322,10 @@ func TestClusterConfig_Copy(t *testing.T) {
 			if node.Hostname == nil || copy.Workers.Nodes[key].Hostname == nil || *node.Hostname != *copy.Workers.Nodes[key].Hostname {
 				t.Errorf("Workers Nodes mismatch for key %s: expected %v, got %v", key, *node.Hostname, *copy.Workers.Nodes[key].Hostname)
 			}
+		}
+
+		if original.Workers.LocalVolumePath == nil || copy.Workers.LocalVolumePath == nil || *original.Workers.LocalVolumePath != *copy.Workers.LocalVolumePath {
+			t.Errorf("Workers LocalVolumePath mismatch: expected %v, got %v", *original.Workers.LocalVolumePath, *copy.Workers.LocalVolumePath)
 		}
 
 		if len(original.Workers.HostPorts) != len(copy.Workers.HostPorts) || original.Workers.HostPorts[0] != copy.Workers.HostPorts[0] || original.Workers.HostPorts[1] != copy.Workers.HostPorts[1] {

--- a/cmd/down_test.go
+++ b/cmd/down_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -214,14 +215,14 @@ func TestDownCmd(t *testing.T) {
 	t.Run("ErrorDeletingVolumes", func(t *testing.T) {
 		mocks := setupSafeDownCmdMocks()
 		mocks.MockShell.GetProjectRootFunc = func() (string, error) {
-			return "/mock/project/root", nil
+			return filepath.Join("mock", "project", "root"), nil
 		}
 
 		// Mock the osRemoveAll function to simulate an error when attempting to delete the .volumes folder
 		originalOsRemoveAll := osRemoveAll
 		defer func() { osRemoveAll = originalOsRemoveAll }()
 		osRemoveAll = func(path string) error {
-			if path == "/mock/project/root/.volumes" {
+			if path == filepath.Join("mock", "project", "root", ".volumes") {
 				return fmt.Errorf("Error deleting .volumes folder")
 			}
 			return nil
@@ -239,12 +240,12 @@ func TestDownCmd(t *testing.T) {
 	t.Run("SuccessDeletingVolumes", func(t *testing.T) {
 		mocks := setupSafeDownCmdMocks()
 		mocks.MockShell.GetProjectRootFunc = func() (string, error) {
-			return "/mock/project/root", nil
+			return filepath.Join("mock", "project", "root"), nil
 		}
 
 		// Mock the shell's Exec function to simulate successful deletion of the .volumes folder
 		mocks.MockShell.ExecFunc = func(command string, args ...string) (string, error) {
-			if command == "rm" && len(args) > 0 && args[0] == "-rf" && args[1] == "/mock/project/root/.volumes" {
+			if command == "cmd" && len(args) > 0 && args[0] == "/C" && args[1] == "rmdir" && args[2] == "/S" && args[3] == "/Q" && args[4] == filepath.Join("mock", "project", "root", ".volumes") {
 				return "", nil
 			}
 			return "", fmt.Errorf("Unexpected command: %s %v", command, args)
@@ -273,7 +274,7 @@ func TestDownCmd(t *testing.T) {
 			if callCount == 2 {
 				return "", fmt.Errorf("Error retrieving project root")
 			}
-			return "/mock/project/root", nil
+			return filepath.Join("mock", "project", "root"), nil
 		}
 
 		rootCmd.SetArgs([]string{"down", "--clean"})

--- a/cmd/down_test.go
+++ b/cmd/down_test.go
@@ -210,4 +210,76 @@ func TestDownCmd(t *testing.T) {
 			t.Fatalf("Expected error containing 'Error cleaning up context specific artifacts: error cleaning context artifacts', got %v", err)
 		}
 	})
+
+	t.Run("ErrorDeletingVolumes", func(t *testing.T) {
+		mocks := setupSafeDownCmdMocks()
+		mocks.MockShell.GetProjectRootFunc = func() (string, error) {
+			return "/mock/project/root", nil
+		}
+
+		// Mock the osRemoveAll function to simulate an error when attempting to delete the .volumes folder
+		originalOsRemoveAll := osRemoveAll
+		defer func() { osRemoveAll = originalOsRemoveAll }()
+		osRemoveAll = func(path string) error {
+			if path == "/mock/project/root/.volumes" {
+				return fmt.Errorf("Error deleting .volumes folder")
+			}
+			return nil
+		}
+
+		// Given a mock osRemoveAll that returns an error when deleting the .volumes folder
+		rootCmd.SetArgs([]string{"down", "--clean"})
+		err := Execute(mocks.MockController)
+		// Then the error should contain the expected message
+		if err == nil || !strings.Contains(err.Error(), "Error deleting .volumes folder") {
+			t.Fatalf("Expected error containing 'Error deleting .volumes folder', got %v", err)
+		}
+	})
+
+	t.Run("SuccessDeletingVolumes", func(t *testing.T) {
+		mocks := setupSafeDownCmdMocks()
+		mocks.MockShell.GetProjectRootFunc = func() (string, error) {
+			return "/mock/project/root", nil
+		}
+
+		// Mock the shell's Exec function to simulate successful deletion of the .volumes folder
+		mocks.MockShell.ExecFunc = func(command string, args ...string) (string, error) {
+			if command == "rm" && len(args) > 0 && args[0] == "-rf" && args[1] == "/mock/project/root/.volumes" {
+				return "", nil
+			}
+			return "", fmt.Errorf("Unexpected command: %s %v", command, args)
+		}
+
+		// Given a mock shell that successfully deletes the .volumes folder
+		output := captureStderr(func() {
+			rootCmd.SetArgs([]string{"down", "--clean"})
+			if err := Execute(mocks.MockController); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+		})
+
+		// Then the output should indicate success
+		expectedOutput := "Windsor environment torn down successfully.\n"
+		if output != expectedOutput {
+			t.Errorf("Expected output %q, got %q", expectedOutput, output)
+		}
+	})
+
+	t.Run("ErrorGettingProjectRoot", func(t *testing.T) {
+		mocks := setupSafeDownCmdMocks()
+		callCount := 0
+		mocks.MockShell.GetProjectRootFunc = func() (string, error) {
+			callCount++
+			if callCount == 2 {
+				return "", fmt.Errorf("Error retrieving project root")
+			}
+			return "/mock/project/root", nil
+		}
+
+		rootCmd.SetArgs([]string{"down", "--clean"})
+		err := Execute(mocks.MockController)
+		if err == nil || !strings.Contains(err.Error(), "Error retrieving project root") {
+			t.Fatalf("Expected error containing 'Error retrieving project root', got %v", err)
+		}
+	})
 }

--- a/cmd/shims.go
+++ b/cmd/shims.go
@@ -16,6 +16,9 @@ var osUserHomeDir = os.UserHomeDir
 // osStat retrieves the file information
 var osStat = os.Stat
 
+// osRemoveAll removes a directory and all its contents
+var osRemoveAll = os.RemoveAll
+
 // getwd retrieves the current working directory
 var getwd = os.Getwd
 

--- a/pkg/blueprint/blueprint_handler.go
+++ b/pkg/blueprint/blueprint_handler.go
@@ -888,7 +888,7 @@ func (b *BaseBlueprintHandler) applyConfigMap() error {
 	lbStart := b.configHandler.GetString("network.loadbalancer_ips.start")
 	lbEnd := b.configHandler.GetString("network.loadbalancer_ips.end")
 	registryURL := b.configHandler.GetString("docker.registry_url")
-	localVolumePath := b.configHandler.GetString("cluster.workers.local_volume_path")
+	localVolumePath := b.configHandler.GetString("cluster.workers.local_volume_path", "/var/local")
 
 	// Generate LOADBALANCER_IP_RANGE from the start and end IPs for network
 	loadBalancerIPRange := fmt.Sprintf("%s-%s", lbStart, lbEnd)

--- a/pkg/blueprint/blueprint_handler.go
+++ b/pkg/blueprint/blueprint_handler.go
@@ -888,6 +888,7 @@ func (b *BaseBlueprintHandler) applyConfigMap() error {
 	lbStart := b.configHandler.GetString("network.loadbalancer_ips.start")
 	lbEnd := b.configHandler.GetString("network.loadbalancer_ips.end")
 	registryURL := b.configHandler.GetString("docker.registry_url")
+	localVolumePath := b.configHandler.GetString("cluster.workers.local_volume_path")
 
 	// Generate LOADBALANCER_IP_RANGE from the start and end IPs for network
 	loadBalancerIPRange := fmt.Sprintf("%s-%s", lbStart, lbEnd)
@@ -908,6 +909,7 @@ func (b *BaseBlueprintHandler) applyConfigMap() error {
 			"LOADBALANCER_IP_START": lbStart,
 			"LOADBALANCER_IP_END":   lbEnd,
 			"REGISTRY_URL":          registryURL,
+			"LOCAL_VOLUME_PATH":     localVolumePath,
 		},
 	}
 

--- a/pkg/blueprint/blueprint_handler.go
+++ b/pkg/blueprint/blueprint_handler.go
@@ -888,10 +888,18 @@ func (b *BaseBlueprintHandler) applyConfigMap() error {
 	lbStart := b.configHandler.GetString("network.loadbalancer_ips.start")
 	lbEnd := b.configHandler.GetString("network.loadbalancer_ips.end")
 	registryURL := b.configHandler.GetString("docker.registry_url")
-	localVolumePath := b.configHandler.GetString("cluster.workers.local_volume_path", "/var/local")
+	localVolumePaths := b.configHandler.GetStringSlice("cluster.workers.volumes")
 
 	// Generate LOADBALANCER_IP_RANGE from the start and end IPs for network
 	loadBalancerIPRange := fmt.Sprintf("%s-%s", lbStart, lbEnd)
+
+	// Handle the case where localVolumePaths might not be defined
+	var localVolumePath string
+	if len(localVolumePaths) > 0 {
+		localVolumePath = strings.Split(localVolumePaths[0], ":")[1]
+	} else {
+		localVolumePath = ""
+	}
 
 	configMap := &corev1.ConfigMap{
 		TypeMeta: metav1.TypeMeta{

--- a/pkg/blueprint/blueprint_handler_test.go
+++ b/pkg/blueprint/blueprint_handler_test.go
@@ -211,14 +211,23 @@ func setupSafeMocks(injector ...di.Injector) MockSafeComponents {
 			return "192.168.1.100"
 		case "docker.registry_url":
 			return "mock.registry.com"
-		case "cluster.workers.local_volume_path":
-			return "/var/local"
 		default:
 			if len(defaultValue) > 0 {
 				return defaultValue[0]
 			}
 			return ""
 		}
+	}
+
+	// Return mock volume paths
+	mockConfigHandler.GetStringSliceFunc = func(key string, defaultValue ...[]string) []string {
+		if key == "cluster.workers.volumes" {
+			return []string{"${WINDSOR_PROJECT_ROOT}/.volumes:/var/local"}
+		}
+		if len(defaultValue) > 0 {
+			return defaultValue[0]
+		}
+		return nil
 	}
 
 	mockConfigHandler.GetContextFunc = func() string {

--- a/pkg/blueprint/blueprint_handler_test.go
+++ b/pkg/blueprint/blueprint_handler_test.go
@@ -211,6 +211,8 @@ func setupSafeMocks(injector ...di.Injector) MockSafeComponents {
 			return "192.168.1.100"
 		case "docker.registry_url":
 			return "mock.registry.com"
+		case "cluster.workers.local_volume_path":
+			return "/var/local"
 		default:
 			if len(defaultValue) > 0 {
 				return defaultValue[0]
@@ -1469,6 +1471,9 @@ func TestBlueprintHandler_Install(t *testing.T) {
 				}
 				if configMap.Data["REGISTRY_URL"] != "mock.registry.com" {
 					return fmt.Errorf("unexpected REGISTRY_URL value: got %s, want %s", configMap.Data["REGISTRY_URL"], "mock.registry.com")
+				}
+				if configMap.Data["LOCAL_VOLUME_PATH"] != "/var/local" {
+					return fmt.Errorf("unexpected LOCAL_VOLUME_PATH value: got %s, want %s", configMap.Data["LOCAL_VOLUME_PATH"], "/var/local")
 				}
 			}
 			return nil

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -79,16 +79,19 @@ var commonClusterConfig = cluster.ClusterConfig{
 		Nodes:  make(map[string]cluster.NodeConfig),
 	},
 	Workers: struct {
-		Count     *int                          `yaml:"count,omitempty"`
-		CPU       *int                          `yaml:"cpu,omitempty"`
-		Memory    *int                          `yaml:"memory,omitempty"`
-		Nodes     map[string]cluster.NodeConfig `yaml:"nodes,omitempty"`
-		HostPorts []string                      `yaml:"hostports,omitempty"`
+		Count           *int                          `yaml:"count,omitempty"`
+		CPU             *int                          `yaml:"cpu,omitempty"`
+		Memory          *int                          `yaml:"memory,omitempty"`
+		Nodes           map[string]cluster.NodeConfig `yaml:"nodes,omitempty"`
+		HostPorts       []string                      `yaml:"hostports,omitempty"`
+		LocalVolumePath *string                       `yaml:"local_volume_path,omitempty"`
 	}{
-		Count:  ptrInt(1),
-		CPU:    ptrInt(constants.DEFAULT_TALOS_WORKER_CPU),
-		Memory: ptrInt(constants.DEFAULT_TALOS_WORKER_RAM),
-		Nodes:  make(map[string]cluster.NodeConfig),
+		Count:           ptrInt(1),
+		CPU:             ptrInt(constants.DEFAULT_TALOS_WORKER_CPU),
+		Memory:          ptrInt(constants.DEFAULT_TALOS_WORKER_RAM),
+		Nodes:           make(map[string]cluster.NodeConfig),
+		HostPorts:       []string{},
+		LocalVolumePath: ptrString("/var/local"),
 	},
 }
 
@@ -118,11 +121,12 @@ var DefaultConfig_Localhost = v1alpha1.Context{
 			Nodes:  make(map[string]cluster.NodeConfig),
 		},
 		Workers: struct {
-			Count     *int                          `yaml:"count,omitempty"`
-			CPU       *int                          `yaml:"cpu,omitempty"`
-			Memory    *int                          `yaml:"memory,omitempty"`
-			Nodes     map[string]cluster.NodeConfig `yaml:"nodes,omitempty"`
-			HostPorts []string                      `yaml:"hostports,omitempty"`
+			Count           *int                          `yaml:"count,omitempty"`
+			CPU             *int                          `yaml:"cpu,omitempty"`
+			Memory          *int                          `yaml:"memory,omitempty"`
+			Nodes           map[string]cluster.NodeConfig `yaml:"nodes,omitempty"`
+			HostPorts       []string                      `yaml:"hostports,omitempty"`
+			LocalVolumePath *string                       `yaml:"local_volume_path,omitempty"`
 		}{
 			Count:     ptrInt(1),
 			CPU:       ptrInt(constants.DEFAULT_TALOS_WORKER_CPU),

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -66,32 +66,19 @@ var commonTerraformConfig = terraform.TerraformConfig{
 var commonClusterConfig = cluster.ClusterConfig{
 	Enabled: ptrBool(true),
 	Driver:  ptrString("talos"),
-	ControlPlanes: struct {
-		Count     *int                          `yaml:"count,omitempty"`
-		CPU       *int                          `yaml:"cpu,omitempty"`
-		Memory    *int                          `yaml:"memory,omitempty"`
-		Nodes     map[string]cluster.NodeConfig `yaml:"nodes,omitempty"`
-		HostPorts []string                      `yaml:"hostports,omitempty"`
-	}{
+	ControlPlanes: cluster.NodeGroupConfig{
 		Count:  ptrInt(1),
 		CPU:    ptrInt(constants.DEFAULT_TALOS_CONTROL_PLANE_CPU),
 		Memory: ptrInt(constants.DEFAULT_TALOS_CONTROL_PLANE_RAM),
 		Nodes:  make(map[string]cluster.NodeConfig),
 	},
-	Workers: struct {
-		Count           *int                          `yaml:"count,omitempty"`
-		CPU             *int                          `yaml:"cpu,omitempty"`
-		Memory          *int                          `yaml:"memory,omitempty"`
-		Nodes           map[string]cluster.NodeConfig `yaml:"nodes,omitempty"`
-		HostPorts       []string                      `yaml:"hostports,omitempty"`
-		LocalVolumePath *string                       `yaml:"local_volume_path,omitempty"`
-	}{
-		Count:           ptrInt(1),
-		CPU:             ptrInt(constants.DEFAULT_TALOS_WORKER_CPU),
-		Memory:          ptrInt(constants.DEFAULT_TALOS_WORKER_RAM),
-		Nodes:           make(map[string]cluster.NodeConfig),
-		HostPorts:       []string{},
-		LocalVolumePath: ptrString("/var/local"),
+	Workers: cluster.NodeGroupConfig{
+		Count:     ptrInt(1),
+		CPU:       ptrInt(constants.DEFAULT_TALOS_WORKER_CPU),
+		Memory:    ptrInt(constants.DEFAULT_TALOS_WORKER_RAM),
+		Nodes:     make(map[string]cluster.NodeConfig),
+		HostPorts: []string{},
+		Volumes:   []string{"${WINDSOR_PROJECT_ROOT}/.volumes:/var/local"},
 	},
 }
 
@@ -108,31 +95,19 @@ var DefaultConfig_Localhost = v1alpha1.Context{
 	Cluster: &cluster.ClusterConfig{
 		Enabled: ptrBool(true),
 		Driver:  ptrString("talos"),
-		ControlPlanes: struct {
-			Count     *int                          `yaml:"count,omitempty"`
-			CPU       *int                          `yaml:"cpu,omitempty"`
-			Memory    *int                          `yaml:"memory,omitempty"`
-			Nodes     map[string]cluster.NodeConfig `yaml:"nodes,omitempty"`
-			HostPorts []string                      `yaml:"hostports,omitempty"`
-		}{
+		ControlPlanes: cluster.NodeGroupConfig{
 			Count:  ptrInt(1),
 			CPU:    ptrInt(constants.DEFAULT_TALOS_CONTROL_PLANE_CPU),
 			Memory: ptrInt(constants.DEFAULT_TALOS_CONTROL_PLANE_RAM),
 			Nodes:  make(map[string]cluster.NodeConfig),
 		},
-		Workers: struct {
-			Count           *int                          `yaml:"count,omitempty"`
-			CPU             *int                          `yaml:"cpu,omitempty"`
-			Memory          *int                          `yaml:"memory,omitempty"`
-			Nodes           map[string]cluster.NodeConfig `yaml:"nodes,omitempty"`
-			HostPorts       []string                      `yaml:"hostports,omitempty"`
-			LocalVolumePath *string                       `yaml:"local_volume_path,omitempty"`
-		}{
+		Workers: cluster.NodeGroupConfig{
 			Count:     ptrInt(1),
 			CPU:       ptrInt(constants.DEFAULT_TALOS_WORKER_CPU),
 			Memory:    ptrInt(constants.DEFAULT_TALOS_WORKER_RAM),
 			Nodes:     make(map[string]cluster.NodeConfig),
 			HostPorts: []string{"8080:30080/tcp", "8443:30443/tcp", "9292:30292/tcp", "8053:30053/udp"},
+			Volumes:   []string{"${WINDSOR_PROJECT_ROOT}/.volumes:/var/local"},
 		},
 	},
 	Network: &network.NetworkConfig{

--- a/pkg/config/yaml_config_handler_test.go
+++ b/pkg/config/yaml_config_handler_test.go
@@ -663,13 +663,15 @@ func TestYamlConfigHandler_GetStringSlice(t *testing.T) {
 			"default": {
 				Cluster: &cluster.ClusterConfig{
 					Workers: struct {
-						Count     *int                          `yaml:"count,omitempty"`
-						CPU       *int                          `yaml:"cpu,omitempty"`
-						Memory    *int                          `yaml:"memory,omitempty"`
-						Nodes     map[string]cluster.NodeConfig `yaml:"nodes,omitempty"`
-						HostPorts []string                      `yaml:"hostports,omitempty"`
+						Count           *int                          `yaml:"count,omitempty"`
+						CPU             *int                          `yaml:"cpu,omitempty"`
+						Memory          *int                          `yaml:"memory,omitempty"`
+						Nodes           map[string]cluster.NodeConfig `yaml:"nodes,omitempty"`
+						HostPorts       []string                      `yaml:"hostports,omitempty"`
+						LocalVolumePath *string                       `yaml:"local_volume_path,omitempty"`
 					}{
-						HostPorts: []string{"50000:50002/tcp", "30080:8080/tcp", "30443:8443/tcp"},
+						HostPorts:       []string{"50000:50002/tcp", "30080:8080/tcp", "30443:8443/tcp"},
+						LocalVolumePath: ptrString("/var/local"),
 					},
 				},
 			},

--- a/pkg/config/yaml_config_handler_test.go
+++ b/pkg/config/yaml_config_handler_test.go
@@ -547,13 +547,7 @@ func TestYamlConfigHandler_GetInt(t *testing.T) {
 			Contexts: map[string]*v1alpha1.Context{
 				"default": {
 					Cluster: &cluster.ClusterConfig{
-						ControlPlanes: struct {
-							Count     *int                          `yaml:"count,omitempty"`
-							CPU       *int                          `yaml:"cpu,omitempty"`
-							Memory    *int                          `yaml:"memory,omitempty"`
-							Nodes     map[string]cluster.NodeConfig `yaml:"nodes,omitempty"`
-							HostPorts []string                      `yaml:"hostports,omitempty"`
-						}{
+						ControlPlanes: cluster.NodeGroupConfig{
 							Count: ptrInt(3),
 						},
 					},
@@ -662,16 +656,8 @@ func TestYamlConfigHandler_GetStringSlice(t *testing.T) {
 		handler.config.Contexts = map[string]*v1alpha1.Context{
 			"default": {
 				Cluster: &cluster.ClusterConfig{
-					Workers: struct {
-						Count           *int                          `yaml:"count,omitempty"`
-						CPU             *int                          `yaml:"cpu,omitempty"`
-						Memory          *int                          `yaml:"memory,omitempty"`
-						Nodes           map[string]cluster.NodeConfig `yaml:"nodes,omitempty"`
-						HostPorts       []string                      `yaml:"hostports,omitempty"`
-						LocalVolumePath *string                       `yaml:"local_volume_path,omitempty"`
-					}{
-						HostPorts:       []string{"50000:50002/tcp", "30080:8080/tcp", "30443:8443/tcp"},
-						LocalVolumePath: ptrString("/var/local"),
+					Workers: cluster.NodeGroupConfig{
+						HostPorts: []string{"50000:50002/tcp", "30080:8080/tcp", "30443:8443/tcp"},
 					},
 				},
 			},

--- a/pkg/env/kube_env.go
+++ b/pkg/env/kube_env.go
@@ -1,10 +1,18 @@
 package env
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/windsorcli/cli/pkg/di"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 // KubeEnvPrinter is a struct that simulates a Kubernetes environment for testing purposes.
@@ -21,22 +29,82 @@ func NewKubeEnvPrinter(injector di.Injector) *KubeEnvPrinter {
 	}
 }
 
-// GetEnvVars retrieves the environment variables for the Kubernetes environment.
+// GetEnvVars constructs a map of Kubernetes environment variables by setting
+// KUBECONFIG and KUBE_CONFIG_PATH based on the configuration root directory.
+// It checks for a project-specific volume directory and returns current variables
+// if it doesn't exist. If it does, it ensures each PVC directory has a corresponding
+// "PV_" environment variable, returning the map if all are accounted for.
 func (e *KubeEnvPrinter) GetEnvVars() (map[string]string, error) {
 	envVars := make(map[string]string)
-
-	// Determine the root directory for configuration files.
 	configRoot, err := e.configHandler.GetConfigRoot()
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving configuration root directory: %w", err)
 	}
-
-	// Construct the path to the kubeconfig file.
 	kubeConfigPath := filepath.Join(configRoot, ".kube", "config")
-
-	// Populate environment variables with Kubernetes configuration data.
 	envVars["KUBECONFIG"] = kubeConfigPath
 	envVars["KUBE_CONFIG_PATH"] = kubeConfigPath
+
+	projectRoot := os.Getenv("WINDSOR_PROJECT_ROOT")
+	volumeDir := filepath.Join(projectRoot, ".volumes")
+
+	if _, err := stat(volumeDir); os.IsNotExist(err) {
+		return envVars, nil
+	}
+
+	volumeDirs, err := readDir(volumeDir)
+	if err != nil {
+		return nil, fmt.Errorf("error reading volume directories: %w", err)
+	}
+
+	existingEnvVars := make(map[string]string)
+	for _, env := range os.Environ() {
+		if strings.HasPrefix(env, "PV_") {
+			parts := strings.SplitN(env, "=", 2)
+			if len(parts) == 2 {
+				existingEnvVars[parts[0]] = parts[1]
+				envVars[parts[0]] = parts[1] // Include existing PV environment variables
+			}
+		}
+	}
+
+	allVolumesAccounted := true
+	for _, dir := range volumeDirs {
+		if strings.HasPrefix(dir.Name(), "pvc-") {
+			found := false
+			for _, envVarValue := range existingEnvVars {
+				if strings.HasSuffix(dir.Name(), filepath.Base(envVarValue)) {
+					found = true
+					break
+				}
+			}
+			if !found {
+				allVolumesAccounted = false
+				break
+			}
+		}
+	}
+
+	if allVolumesAccounted {
+		return envVars, nil
+	}
+
+	pvcs, _ := queryPersistentVolumeClaims(kubeConfigPath) // ignores error
+
+	if pvcs != nil && pvcs.Items != nil {
+		for _, dir := range volumeDirs {
+			if strings.HasPrefix(dir.Name(), "pvc-") {
+				for _, pvc := range pvcs.Items {
+					if strings.HasSuffix(dir.Name(), string(pvc.UID)) {
+						envVarName := fmt.Sprintf("PV_%s_%s", sanitizeEnvVar(pvc.Namespace), sanitizeEnvVar(pvc.Name))
+						if _, exists := existingEnvVars[envVarName]; !exists {
+							envVars[envVarName] = filepath.Join(volumeDir, dir.Name())
+						}
+						break
+					}
+				}
+			}
+		}
+	}
 
 	return envVars, nil
 }
@@ -48,9 +116,39 @@ func (e *KubeEnvPrinter) Print() error {
 		// Return the error if GetEnvVars fails
 		return fmt.Errorf("error getting environment variables: %w", err)
 	}
+
 	// Call the Print method of the embedded BaseEnvPrinter struct with the retrieved environment variables
 	return e.BaseEnvPrinter.Print(envVars)
 }
 
 // Ensure kubeEnv implements the EnvPrinter interface
 var _ EnvPrinter = (*KubeEnvPrinter)(nil)
+
+// sanitizeEnvVar converts a string to uppercase, trims whitespace, and replaces invalid characters with underscores.
+func sanitizeEnvVar(input string) string {
+	trimmed := strings.TrimSpace(input)
+	upper := strings.ToUpper(trimmed)
+	re := regexp.MustCompile(`[^A-Z0-9_]`)
+	sanitized := re.ReplaceAllString(upper, "_")
+	return strings.Trim(sanitized, "_")
+}
+
+// queryPersistentVolumeClaims retrieves a list of PersistentVolumeClaims (PVCs) from the Kubernetes cluster.
+// It returns a list of PVCs and an error if there is any issue in building the Kubernetes configuration
+var queryPersistentVolumeClaims = func(kubeConfigPath string) (*corev1.PersistentVolumeClaimList, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", kubeConfigPath)
+	if err != nil {
+		return nil, err
+	}
+	clientset, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+
+	pvcs, err := clientset.CoreV1().PersistentVolumeClaims("").List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	return pvcs, nil
+}

--- a/pkg/env/kube_env_test.go
+++ b/pkg/env/kube_env_test.go
@@ -7,10 +7,13 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/windsorcli/cli/pkg/config"
 	"github.com/windsorcli/cli/pkg/di"
 	"github.com/windsorcli/cli/pkg/shell"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 type KubeEnvPrinterMocks struct {
@@ -37,6 +40,36 @@ func setupSafeKubeEnvPrinterMocks(injector ...di.Injector) *KubeEnvPrinterMocks 
 	mockInjector.Register("configHandler", mockConfigHandler)
 	mockInjector.Register("shell", mockShell)
 
+	// Mock readDir to return some valid persistent volume folders
+	originalReadDir := readDir
+	readDir = func(dirname string) ([]os.DirEntry, error) {
+		if dirname == ".volumes" {
+			return []os.DirEntry{
+				mockDirEntry{name: "pvc-1234"},
+				mockDirEntry{name: "pvc-5678"},
+			}, nil
+		}
+		return originalReadDir(dirname)
+	}
+
+	// Mock stat to return nil
+	stat = func(name string) (os.FileInfo, error) {
+		if strings.HasSuffix(name, ".kube/config") || strings.HasSuffix(name, ".volumes") {
+			return nil, nil
+		}
+		return nil, os.ErrNotExist
+	}
+
+	// Mock queryPersistentVolumeClaims to return appropriate PVC claims
+	queryPersistentVolumeClaims = func(kubeConfigPath string) (*corev1.PersistentVolumeClaimList, error) {
+		return &corev1.PersistentVolumeClaimList{
+			Items: []corev1.PersistentVolumeClaim{
+				{ObjectMeta: metav1.ObjectMeta{UID: "1234", Namespace: "default", Name: "claim1"}},
+				{ObjectMeta: metav1.ObjectMeta{UID: "5678", Namespace: "default", Name: "claim2"}},
+			},
+		}, nil
+	}
+
 	return &KubeEnvPrinterMocks{
 		Injector:      mockInjector,
 		ConfigHandler: mockConfigHandler,
@@ -44,18 +77,31 @@ func setupSafeKubeEnvPrinterMocks(injector ...di.Injector) *KubeEnvPrinterMocks 
 	}
 }
 
+// mockDirEntry is a simple mock implementation of os.DirEntry
+type mockDirEntry struct {
+	name string
+}
+
+func (m mockDirEntry) Name() string               { return m.name }
+func (m mockDirEntry) IsDir() bool                { return true }
+func (m mockDirEntry) Type() os.FileMode          { return os.ModeDir }
+func (m mockDirEntry) Info() (os.FileInfo, error) { return mockFileInfo{name: m.name}, nil }
+
+// mockFileInfo is a simple mock implementation of os.FileInfo
+type mockFileInfo struct {
+	name string
+}
+
+func (m mockFileInfo) Name() string       { return m.name }
+func (m mockFileInfo) Size() int64        { return 0 }
+func (m mockFileInfo) Mode() os.FileMode  { return os.ModeDir }
+func (m mockFileInfo) ModTime() time.Time { return time.Time{} }
+func (m mockFileInfo) IsDir() bool        { return true }
+func (m mockFileInfo) Sys() interface{}   { return nil }
+
 func TestKubeEnvPrinter_GetEnvVars(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		mocks := setupSafeKubeEnvPrinterMocks()
-
-		originalStat := stat
-		defer func() { stat = originalStat }()
-		stat = func(name string) (os.FileInfo, error) {
-			if name == filepath.FromSlash("/mock/config/root/.kube/config") {
-				return nil, nil
-			}
-			return nil, os.ErrNotExist
-		}
 
 		kubeEnvPrinter := NewKubeEnvPrinter(mocks.Injector)
 		kubeEnvPrinter.Initialize()
@@ -107,6 +153,107 @@ func TestKubeEnvPrinter_GetEnvVars(t *testing.T) {
 		expectedError := "error retrieving configuration root directory: mock context error"
 		if err == nil || err.Error() != expectedError {
 			t.Errorf("error = %v, want %v", err, expectedError)
+		}
+	})
+
+	t.Run("ErrorReadingVolumes", func(t *testing.T) {
+		mocks := setupSafeKubeEnvPrinterMocks()
+		mocks.ConfigHandler.GetConfigRootFunc = func() (string, error) {
+			return "/mock/config/root", nil
+		}
+
+		originalReadDir := readDir
+		defer func() { readDir = originalReadDir }()
+		readDir = func(dirname string) ([]os.DirEntry, error) {
+			return nil, errors.New("mock readDir error")
+		}
+
+		kubeEnvPrinter := NewKubeEnvPrinter(mocks.Injector)
+		kubeEnvPrinter.Initialize()
+
+		_, err := kubeEnvPrinter.GetEnvVars()
+		expectedError := "error reading volume directories: mock readDir error"
+		if err == nil || err.Error() != expectedError {
+			t.Errorf("error = %v, want %v", err, expectedError)
+		}
+	})
+
+	t.Run("SuccessWithExistingPVCEnvVars", func(t *testing.T) {
+		// Use setupSafeKubeEnvPrinterMocks to create mocks
+		mocks := setupSafeKubeEnvPrinterMocks()
+		kubeEnvPrinter := NewKubeEnvPrinter(mocks.Injector)
+		kubeEnvPrinter.Initialize()
+
+		// Set up environment variables to simulate existing PVC environment variables
+		os.Setenv("PV_NAMESPACE_PVCNAME", "/mock/volume/dir/pvc-12345")
+		defer os.Unsetenv("PV_NAMESPACE_PVCNAME")
+
+		// Mock the readDir function to simulate reading the volume directory
+		readDir = func(dirname string) ([]os.DirEntry, error) {
+			return []os.DirEntry{
+				mockDirEntry{name: "pvc-12345"},
+			}, nil
+		}
+
+		// Call GetEnvVars and check for errors
+		envVars, err := kubeEnvPrinter.GetEnvVars()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		// Verify that GetEnvVars returns the correct envVars
+		expectedEnvVars := map[string]string{
+			"KUBECONFIG":           filepath.FromSlash("/mock/config/root/.kube/config"),
+			"KUBE_CONFIG_PATH":     filepath.FromSlash("/mock/config/root/.kube/config"),
+			"PV_NAMESPACE_PVCNAME": "/mock/volume/dir/pvc-12345",
+		}
+		if !reflect.DeepEqual(envVars, expectedEnvVars) {
+			t.Errorf("envVars = %v, want %v", envVars, expectedEnvVars)
+		}
+	})
+
+	t.Run("AllVolumesAccountedFor", func(t *testing.T) {
+		mocks := setupSafeKubeEnvPrinterMocks()
+		kubeEnvPrinter := NewKubeEnvPrinter(mocks.Injector)
+		kubeEnvPrinter.Initialize()
+
+		// Set up environment variables to simulate all PVCs being accounted for
+		os.Setenv("PV_DEFAULT_CLAIM1", "/mock/volume/dir/pvc-1234")
+		os.Setenv("PV_DEFAULT_CLAIM2", "/mock/volume/dir/pvc-5678")
+		defer os.Unsetenv("PV_DEFAULT_CLAIM1")
+		defer os.Unsetenv("PV_DEFAULT_CLAIM2")
+
+		// Mock the readDir function to simulate reading the volume directory
+		readDir = func(dirname string) ([]os.DirEntry, error) {
+			return []os.DirEntry{
+				mockDirEntry{name: "pvc-1234"},
+				mockDirEntry{name: "pvc-5678"},
+			}, nil
+		}
+
+		// Mock queryPersistentVolumeClaims to verify it is not called
+		originalQueryPVCs := queryPersistentVolumeClaims
+		defer func() { queryPersistentVolumeClaims = originalQueryPVCs }()
+		queryPersistentVolumeClaims = func(kubeConfigPath string) (*corev1.PersistentVolumeClaimList, error) {
+			t.Error("queryPersistentVolumeClaims should not be called")
+			return nil, nil
+		}
+
+		// Call GetEnvVars and check for errors
+		envVars, err := kubeEnvPrinter.GetEnvVars()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		// Verify that GetEnvVars returns the correct envVars without calling queryPersistentVolumeClaims
+		expectedEnvVars := map[string]string{
+			"KUBECONFIG":        filepath.FromSlash("/mock/config/root/.kube/config"),
+			"KUBE_CONFIG_PATH":  filepath.FromSlash("/mock/config/root/.kube/config"),
+			"PV_DEFAULT_CLAIM1": "/mock/volume/dir/pvc-1234",
+			"PV_DEFAULT_CLAIM2": "/mock/volume/dir/pvc-5678",
+		}
+		if !reflect.DeepEqual(envVars, expectedEnvVars) {
+			t.Errorf("envVars = %v, want %v", envVars, expectedEnvVars)
 		}
 	})
 }

--- a/pkg/env/shims.go
+++ b/pkg/env/shims.go
@@ -21,6 +21,9 @@ var glob = filepath.Glob
 // Wrapper function for os.WriteFile
 var writeFile = os.WriteFile
 
+// Wrapper function for os.ReadDir
+var readDir = os.ReadDir
+
 // Wrapper function for yaml.Unmarshal
 var yamlUnmarshal = yaml.Unmarshal
 

--- a/pkg/services/talos_service.go
+++ b/pkg/services/talos_service.go
@@ -218,7 +218,7 @@ func (s *TalosService) GetComposeConfig() (*types.Config, error) {
 		commonConfig.Volumes = append(commonConfig.Volumes, types.ServiceVolumeConfig{
 			Type:   "bind",
 			Source: "${WINDSOR_PROJECT_ROOT}/.volumes",
-			Target: "/var/local",
+			Target: s.configHandler.GetString("cluster.workers.local_volume_path", "/var/local"),
 		})
 	}
 

--- a/pkg/services/talos_service.go
+++ b/pkg/services/talos_service.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math"
 	"os"
-	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -204,21 +203,28 @@ func (s *TalosService) GetComposeConfig() (*types.Config, error) {
 		},
 	}
 
-	if s.mode != "controlplane" {
-		projectRoot, err := s.shell.GetProjectRoot()
-		if err != nil {
-			return nil, fmt.Errorf("error retrieving project root: %w", err)
+	// Use volumes from cluster configuration
+	volumesKey := fmt.Sprintf("cluster.%s.volumes", nodeType)
+	volumes := s.configHandler.GetStringSlice(volumesKey, []string{})
+	for _, volume := range volumes {
+		parts := strings.Split(volume, ":")
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("invalid volume format: %s", volume)
 		}
-		volumesPath := filepath.Join(projectRoot, ".volumes")
-		if _, err := stat(volumesPath); os.IsNotExist(err) {
-			if err := mkdir(volumesPath, os.ModePerm); err != nil {
-				return nil, fmt.Errorf("error creating .volumes directory: %w", err)
-			}
+
+		// Expand environment variables in the source path for directory creation
+		expandedSourcePath := os.ExpandEnv(parts[0])
+
+		// Create the directory if it doesn't exist
+		if err := mkdirAll(expandedSourcePath, os.ModePerm); err != nil {
+			return nil, fmt.Errorf("failed to create directory %s: %v", expandedSourcePath, err)
 		}
+
+		// Use the original, pre-expanded source path in the volume configuration
 		commonConfig.Volumes = append(commonConfig.Volumes, types.ServiceVolumeConfig{
 			Type:   "bind",
-			Source: "${WINDSOR_PROJECT_ROOT}/.volumes",
-			Target: s.configHandler.GetString("cluster.workers.local_volume_path", "/var/local"),
+			Source: parts[0],
+			Target: parts[1],
 		})
 	}
 
@@ -287,7 +293,7 @@ func (s *TalosService) GetComposeConfig() (*types.Config, error) {
 
 	serviceConfig.Ports = ports
 
-	volumes := map[string]types.VolumeConfig{
+	volumesMap := map[string]types.VolumeConfig{
 		strings.ReplaceAll(nodeName+"_system_state", "-", "_"):           {},
 		strings.ReplaceAll(nodeName+"_var", "-", "_"):                    {},
 		strings.ReplaceAll(nodeName+"_etc_cni", "-", "_"):                {},
@@ -298,6 +304,6 @@ func (s *TalosService) GetComposeConfig() (*types.Config, error) {
 
 	return &types.Config{
 		Services: []types.ServiceConfig{serviceConfig},
-		Volumes:  volumes,
+		Volumes:  volumesMap,
 	}, nil
 }

--- a/pkg/services/talos_service_test.go
+++ b/pkg/services/talos_service_test.go
@@ -56,6 +56,8 @@ func setupTalosServiceMocks(optionalInjector ...di.Injector) *MockComponents {
 			return "192.168.1.2:50001"
 		case "dns.domain":
 			return "test"
+		case "cluster.workers.local_volume_path":
+			return "/var/local"
 		default:
 			if len(defaultValue) > 0 {
 				return defaultValue[0]
@@ -84,17 +86,19 @@ func setupTalosServiceMocks(optionalInjector ...di.Injector) *MockComponents {
 		return &v1alpha1.Context{
 			Cluster: &cluster.ClusterConfig{
 				Workers: struct {
-					Count     *int                          `yaml:"count,omitempty"`
-					CPU       *int                          `yaml:"cpu,omitempty"`
-					Memory    *int                          `yaml:"memory,omitempty"`
-					Nodes     map[string]cluster.NodeConfig `yaml:"nodes,omitempty"`
-					HostPorts []string                      `yaml:"hostports,omitempty"`
+					Count           *int                          `yaml:"count,omitempty"`
+					CPU             *int                          `yaml:"cpu,omitempty"`
+					Memory          *int                          `yaml:"memory,omitempty"`
+					Nodes           map[string]cluster.NodeConfig `yaml:"nodes,omitempty"`
+					HostPorts       []string                      `yaml:"hostports,omitempty"`
+					LocalVolumePath *string                       `yaml:"local_volume_path,omitempty"`
 				}{
 					Nodes: map[string]cluster.NodeConfig{
 						"worker1": {},
 						"worker2": {},
 					},
-					HostPorts: []string{"30000:30000/tcp", "30001:30001/udp", "30002:30002/tcp", "30003:30003/udp"},
+					HostPorts:       []string{"30000:30000/tcp", "30001:30001/udp", "30002:30002/tcp", "30003:30003/udp"},
+					LocalVolumePath: ptrString("/var/local"),
 				},
 			},
 		}


### PR DESCRIPTION
With the addition of windsorcli/core#116 it's now possible to create HostPath style persistent volumes. This feature is now supported by the CLI. `PV_<NAMESPACE>_<NAME>` env vars are introduced that point to local paths that correspond to volumes in the cluster.