### PR TITLE
Fix missing registry url

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -60,7 +60,8 @@
       "env": {
         "COMPOSE_FILE": "${workspaceFolder}/.windsor/docker-compose.yaml",
         "WINDSOR_CONTEXT": "local",
-        "WINDSOR_PROJECT_ROOT": "${workspaceFolder}"
+        "WINDSOR_PROJECT_ROOT": "${workspaceFolder}",
+        "KUBECONFIG": "${workspaceFolder}/contexts/local/.kube/config"
       }
     },
     {

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -18,6 +18,16 @@ var installCmd = &cobra.Command{
 			return fmt.Errorf("Error creating project components: %w", err)
 		}
 
+		// Create service components
+		if err := controller.CreateServiceComponents(); err != nil {
+			return fmt.Errorf("Error creating service components: %w", err)
+		}
+
+		// Create virtualization components
+		if err := controller.CreateVirtualizationComponents(); err != nil {
+			return fmt.Errorf("Error creating virtualization components: %w", err)
+		}
+
 		// Initialize all components
 		if err := controller.InitializeComponents(); err != nil {
 			return fmt.Errorf("Error initializing components: %w", err)

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -78,6 +78,64 @@ func TestInstallCmd(t *testing.T) {
 		}
 	})
 
+	t.Run("ErrorCreatingServiceComponents", func(t *testing.T) {
+		defer resetRootCmd()
+
+		// Given a mock controller that returns an error when creating service components
+		injector := di.NewInjector()
+		mockController := ctrl.NewMockController(injector)
+		mockController.CreateServiceComponentsFunc = func() error {
+			return fmt.Errorf("error creating service components")
+		}
+
+		// Use a mock blueprint handler
+		mockController.ResolveBlueprintHandlerFunc = func() bp.BlueprintHandler {
+			return bp.NewMockBlueprintHandler(injector)
+		}
+
+		// When the install command is executed
+		rootCmd.SetArgs([]string{"install"})
+		err := Execute(mockController)
+
+		// Then check the error contents
+		if err == nil {
+			t.Fatalf("Expected an error, got nil")
+		}
+		expectedError := "Error creating service components: error creating service components"
+		if err.Error() != expectedError {
+			t.Fatalf("Expected error %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("ErrorCreatingVirtualizationComponents", func(t *testing.T) {
+		defer resetRootCmd()
+
+		// Given a mock controller that returns an error when creating virtualization components
+		injector := di.NewInjector()
+		mockController := ctrl.NewMockController(injector)
+		mockController.CreateVirtualizationComponentsFunc = func() error {
+			return fmt.Errorf("error creating virtualization components")
+		}
+
+		// Use a mock blueprint handler
+		mockController.ResolveBlueprintHandlerFunc = func() bp.BlueprintHandler {
+			return bp.NewMockBlueprintHandler(injector)
+		}
+
+		// When the install command is executed
+		rootCmd.SetArgs([]string{"install"})
+		err := Execute(mockController)
+
+		// Then check the error contents
+		if err == nil {
+			t.Fatalf("Expected an error, got nil")
+		}
+		expectedError := "Error creating virtualization components: error creating virtualization components"
+		if err.Error() != expectedError {
+			t.Fatalf("Expected error %q, got %q", expectedError, err.Error())
+		}
+	})
+
 	t.Run("NoBlueprintHandlerFound", func(t *testing.T) {
 		defer resetRootCmd()
 


### PR DESCRIPTION
The `REGISTRY_URL` was not being injected properly in to post-build args. This was due to not creating resources necessary to infer this value in the local environment if not explicitly set.