### PR TITLE
Don't ignore eth0 on docker

### DIFF
--- a/pkg/blueprint/templates/local.jsonnet
+++ b/pkg/blueprint/templates/local.jsonnet
@@ -114,14 +114,14 @@ local registryMirrors = std.foldl(
                   forwardKubeDNSToHost: true,
                 },
               },
-              network: {
+              network: if context.vm.driver == "docker-desktop" then {
                 interfaces: [
                   {
                     ignore: true,
                     interface: "eth0",
                   },
                 ],
-              },
+              } else {},
               kubelet: {
                 extraArgs: {
                   "rotate-server-certificates": "true",


### PR DESCRIPTION
We do not need to ignore the `eth0` interface if running docker directly on linux.