### PR TITLE
Fixed windsor exec extra print data

### DIFF
--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -38,18 +38,12 @@ var execCmd = &cobra.Command{
 		// Collect environment variables from all printers
 		envVars := make(map[string]string)
 		for _, envPrinter := range envPrinters {
-			if err := envPrinter.Print(); err != nil {
-				return fmt.Errorf("Error executing Print: %w", err)
-			}
 			vars, err := envPrinter.GetEnvVars()
 			if err != nil {
 				return fmt.Errorf("Error getting environment variables: %w", err)
 			}
 			for k, v := range vars {
 				envVars[k] = v
-			}
-			if err := envPrinter.PostEnvHook(); err != nil {
-				return fmt.Errorf("Error executing PostEnvHook: %w", err)
 			}
 		}
 
@@ -67,13 +61,10 @@ var execCmd = &cobra.Command{
 		}
 
 		// Execute the command using the resolved shell instance
-		output, err := shellInstance.Exec(args[0], args[1:]...)
+		_, err := shellInstance.Exec(args[0], args[1:]...)
 		if err != nil {
 			return fmt.Errorf("command execution failed: %w", err)
 		}
-
-		// Print the command output
-		fmt.Println(output)
 
 		return nil
 	},


### PR DESCRIPTION
The windsor exec command was printing out the windsor env contents and the output from the command twice.