### PR TITLE
Implement custom env printer

### DIFF
--- a/pkg/config/config_handler.go
+++ b/pkg/config/config_handler.go
@@ -35,6 +35,9 @@ type ConfigHandler interface {
 	// GetStringSlice retrieves a slice of strings for the specified key from the configuration
 	GetStringSlice(key string, defaultValue ...[]string) []string
 
+	// GetStringMap retrieves a map of string key-value pairs for the specified key from the configuration
+	GetStringMap(key string, defaultValue ...map[string]string) map[string]string
+
 	// Set sets the value for the specified key in the configuration
 	Set(key string, value interface{}) error
 

--- a/pkg/config/mock_config_handler.go
+++ b/pkg/config/mock_config_handler.go
@@ -10,6 +10,7 @@ type MockConfigHandler struct {
 	GetIntFunc          func(key string, defaultValue ...int) int
 	GetBoolFunc         func(key string, defaultValue ...bool) bool
 	GetStringSliceFunc  func(key string, defaultValue ...[]string) []string
+	GetStringMapFunc    func(key string, defaultValue ...map[string]string) map[string]string
 	SetFunc             func(key string, value interface{}) error
 	SetContextValueFunc func(key string, value interface{}) error
 	SaveConfigFunc      func(path string) error
@@ -85,6 +86,17 @@ func (m *MockConfigHandler) GetStringSlice(key string, defaultValue ...[]string)
 		return defaultValue[0]
 	}
 	return []string{}
+}
+
+// GetStringMap calls the mock GetStringMapFunc if set, otherwise returns a reasonable default map of strings
+func (m *MockConfigHandler) GetStringMap(key string, defaultValue ...map[string]string) map[string]string {
+	if m.GetStringMapFunc != nil {
+		return m.GetStringMapFunc(key, defaultValue...)
+	}
+	if len(defaultValue) > 0 {
+		return defaultValue[0]
+	}
+	return map[string]string{}
 }
 
 // Set calls the mock SetFunc if set, otherwise returns nil

--- a/pkg/config/mock_config_handler_test.go
+++ b/pkg/config/mock_config_handler_test.go
@@ -298,6 +298,50 @@ func TestMockConfigHandler_GetStringSlice(t *testing.T) {
 	})
 }
 
+func TestMockConfigHandler_GetStringMap(t *testing.T) {
+	t.Run("WithKey", func(t *testing.T) {
+		// Given a mock config handler with GetStringMapFunc set to return a specific map
+		handler := NewMockConfigHandler()
+		expectedMap := map[string]string{"key1": "value1", "key2": "value2"}
+		handler.GetStringMapFunc = func(key string, defaultValue ...map[string]string) map[string]string { return expectedMap }
+
+		// When GetStringMap is called with a key
+		value := handler.GetStringMap("someKey")
+
+		// Then the returned value should match the expected map
+		if !reflect.DeepEqual(value, expectedMap) {
+			t.Errorf("Expected GetStringMap with key to return %v, got %v", expectedMap, value)
+		}
+	})
+
+	t.Run("WithNoFuncSet", func(t *testing.T) {
+		// Given a mock config handler without GetStringMapFunc set
+		handler := NewMockConfigHandler()
+
+		// When GetStringMap is called with a key
+		value := handler.GetStringMap("someKey")
+
+		// Then the returned value should be the default empty map
+		if len(value) != 0 {
+			t.Errorf("Expected GetStringMap with no func set to return an empty map, got %v", value)
+		}
+	})
+
+	t.Run("WithDefaultValue", func(t *testing.T) {
+		// Given a mock config handler
+		handler := NewMockConfigHandler()
+		defaultValue := map[string]string{"defaultKey1": "defaultValue1", "defaultKey2": "defaultValue2"}
+
+		// When GetStringMap is called with a key and a default value
+		value := handler.GetStringMap("someKey", defaultValue)
+
+		// Then the returned value should match the default value
+		if !reflect.DeepEqual(value, defaultValue) {
+			t.Errorf("Expected GetStringMap with default to return %v, got %v", defaultValue, value)
+		}
+	})
+}
+
 func TestMockConfigHandler_Set(t *testing.T) {
 	t.Run("WithKeyAndValue", func(t *testing.T) {
 		// Given a mock config handler with SetFunc set to do nothing

--- a/pkg/config/yaml_config_handler.go
+++ b/pkg/config/yaml_config_handler.go
@@ -171,6 +171,19 @@ func (y *YamlConfigHandler) GetStringSlice(key string, defaultValue ...[]string)
 	return value.([]string)
 }
 
+// GetStringMap retrieves a map of string key-value pairs for the specified key from the configuration, with an optional default value.
+func (y *YamlConfigHandler) GetStringMap(key string, defaultValue ...map[string]string) map[string]string {
+	contextKey := fmt.Sprintf("contexts.%s.%s", y.context, key)
+	value := y.Get(contextKey)
+	if value == nil {
+		if len(defaultValue) > 0 {
+			return defaultValue[0]
+		}
+		return map[string]string{}
+	}
+	return value.(map[string]string)
+}
+
 // Set updates the value at the specified path in the configuration using reflection.
 func (y *YamlConfigHandler) Set(path string, value interface{}) error {
 	if path == "" {

--- a/pkg/config/yaml_config_handler_test.go
+++ b/pkg/config/yaml_config_handler_test.go
@@ -707,6 +707,66 @@ func TestYamlConfigHandler_GetStringSlice(t *testing.T) {
 	})
 }
 
+func TestYamlConfigHandler_GetStringMap(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Given a handler with a context set
+		mocks := setupSafeMocks()
+		handler := NewYamlConfigHandler(mocks.Injector)
+		handler.Initialize()
+		handler.context = "default"
+		handler.config.Contexts = map[string]*v1alpha1.Context{
+			"default": {
+				Environment: map[string]string{
+					"KEY1": "value1",
+					"KEY2": "value2",
+				},
+			},
+		}
+
+		// When retrieving the map value using GetStringMap
+		value := handler.GetStringMap("environment")
+
+		// Then the returned map should match the expected map
+		expectedMap := map[string]string{"KEY1": "value1", "KEY2": "value2"}
+		if !reflect.DeepEqual(value, expectedMap) {
+			t.Errorf("Expected GetStringMap to return %v, got %v", expectedMap, value)
+		}
+	})
+
+	t.Run("WithNonExistentKey", func(t *testing.T) {
+		// Given a handler with a context set
+		mocks := setupSafeMocks()
+		handler := NewYamlConfigHandler(mocks.Injector)
+		handler.Initialize()
+		handler.context = "default"
+
+		// When retrieving a non-existent key using GetStringMap
+		value := handler.GetStringMap("nonExistentKey")
+
+		// Then the returned value should be an empty map
+		if !reflect.DeepEqual(value, map[string]string{}) {
+			t.Errorf("Expected GetStringMap with non-existent key to return an empty map, got %v", value)
+		}
+	})
+
+	t.Run("WithNonExistentKeyAndDefaultValue", func(t *testing.T) {
+		// Given a handler with a context set
+		mocks := setupSafeMocks()
+		handler := NewYamlConfigHandler(mocks.Injector)
+		handler.Initialize()
+		handler.context = "default"
+		defaultValue := map[string]string{"defaultKey1": "defaultValue1", "defaultKey2": "defaultValue2"}
+
+		// When retrieving a non-existent key with a default value
+		value := handler.GetStringMap("nonExistentKey", defaultValue)
+
+		// Then the returned value should match the default value
+		if !reflect.DeepEqual(value, defaultValue) {
+			t.Errorf("Expected GetStringMap with default to return %v, got %v", defaultValue, value)
+		}
+	})
+}
+
 func TestYamlConfigHandler_GetConfig(t *testing.T) {
 	t.Run("ContextIsSet", func(t *testing.T) {
 		// Given a handler with a context set

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -288,10 +288,21 @@ func (c *BaseController) ResolveEnvPrinter(name string) env.EnvPrinter {
 func (c *BaseController) ResolveAllEnvPrinters() []env.EnvPrinter {
 	instances, _ := c.injector.ResolveAll((*env.EnvPrinter)(nil))
 	envPrinters := make([]env.EnvPrinter, 0, len(instances))
+	var customEnvPrinter env.EnvPrinter
+
 	for _, instance := range instances {
 		envPrinter, _ := instance.(env.EnvPrinter)
-		envPrinters = append(envPrinters, envPrinter)
+		if _, ok := envPrinter.(*env.CustomEnvPrinter); ok {
+			customEnvPrinter = envPrinter
+		} else {
+			envPrinters = append(envPrinters, envPrinter)
+		}
 	}
+
+	if customEnvPrinter != nil {
+		envPrinters = append(envPrinters, customEnvPrinter)
+	}
+
 	return envPrinters
 }
 

--- a/pkg/controller/mock_controller.go
+++ b/pkg/controller/mock_controller.go
@@ -177,6 +177,10 @@ func (m *MockController) CreateEnvComponents() error {
 	windsorEnv := env.NewMockEnvPrinter()
 	m.injector.Register("windsorEnv", windsorEnv)
 
+	// Create mock custom env printer
+	customEnv := env.NewMockEnvPrinter()
+	m.injector.Register("customEnv", customEnv)
+
 	return nil
 }
 

--- a/pkg/controller/mock_controller_test.go
+++ b/pkg/controller/mock_controller_test.go
@@ -451,7 +451,7 @@ func TestMockController_ResolveAllEnvPrinters(t *testing.T) {
 		mockCtrl := NewMockController(mocks.Injector)
 		// When ResolveAllEnvPrinters is called without setting ResolveAllEnvPrintersFunc
 		envPrinters := mockCtrl.ResolveAllEnvPrinters()
-		if len(envPrinters) != 2 {
+		if len(envPrinters) != 3 {
 			// Then the length of the returned env printers list should be 0
 			t.Fatalf("expected %v, got %v", 0, len(envPrinters))
 		}

--- a/pkg/controller/real_controller.go
+++ b/pkg/controller/real_controller.go
@@ -138,6 +138,9 @@ func (c *RealController) CreateEnvComponents() error {
 	windsorEnv := env.NewWindsorEnvPrinter(c.injector)
 	c.injector.Register("windsorEnv", windsorEnv)
 
+	customEnv := env.NewCustomEnvPrinter(c.injector)
+	c.injector.Register("customEnv", customEnv)
+
 	return nil
 }
 

--- a/pkg/env/custom_env.go
+++ b/pkg/env/custom_env.go
@@ -1,0 +1,38 @@
+package env
+
+import (
+	"github.com/windsorcli/cli/pkg/di"
+)
+
+// CustomEnvPrinter is a struct that implements the EnvPrinter interface and handles custom environment variables.
+type CustomEnvPrinter struct {
+	BaseEnvPrinter
+}
+
+// NewCustomEnvPrinter initializes a new CustomEnvPrinter instance using the provided dependency injector.
+func NewCustomEnvPrinter(injector di.Injector) *CustomEnvPrinter {
+	return &CustomEnvPrinter{
+		BaseEnvPrinter: BaseEnvPrinter{
+			injector: injector,
+		},
+	}
+}
+
+// Print outputs the environment variables to the console.
+func (e *CustomEnvPrinter) Print() error {
+	envVars, _ := e.GetEnvVars()
+
+	return e.shell.PrintEnvVars(envVars)
+}
+
+// GetEnvVars retrieves environment variables from the context config.
+func (e *CustomEnvPrinter) GetEnvVars() (map[string]string, error) {
+	envVars := e.configHandler.GetStringMap("environment")
+	if envVars == nil {
+		envVars = make(map[string]string)
+	}
+	return envVars, nil
+}
+
+// Ensure customEnv implements the EnvPrinter interface
+var _ EnvPrinter = (*CustomEnvPrinter)(nil)

--- a/pkg/env/custom_env_test.go
+++ b/pkg/env/custom_env_test.go
@@ -1,0 +1,132 @@
+package env
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/windsorcli/cli/pkg/config"
+	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/shell"
+)
+
+type CustomEnvMocks struct {
+	Injector      di.Injector
+	ConfigHandler *config.MockConfigHandler
+	Shell         *shell.MockShell
+}
+
+func setupSafeCustomEnvMocks(injector ...di.Injector) *CustomEnvMocks {
+	// Use the provided injector or create a new one if not provided
+	var mockInjector di.Injector
+	if len(injector) > 0 {
+		mockInjector = injector[0]
+	} else {
+		mockInjector = di.NewMockInjector()
+	}
+
+	// Create a mock ConfigHandler using its constructor
+	mockConfigHandler := config.NewMockConfigHandler()
+	mockConfigHandler.GetStringMapFunc = func(key string, defaultValue ...map[string]string) map[string]string {
+		if key == "environment" {
+			return map[string]string{
+				"VAR1": "value1",
+				"VAR2": "value2",
+			}
+		}
+		return nil
+	}
+
+	// Create a mock Shell using its constructor
+	mockShell := shell.NewMockShell()
+
+	// Register the mocks in the DI injector
+	mockInjector.Register("configHandler", mockConfigHandler)
+	mockInjector.Register("shell", mockShell)
+
+	return &CustomEnvMocks{
+		Injector:      mockInjector,
+		ConfigHandler: mockConfigHandler,
+		Shell:         mockShell,
+	}
+}
+
+func TestCustomEnv_GetEnvVars(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Use setupSafeCustomEnvMocks to create mocks
+		mocks := setupSafeCustomEnvMocks()
+
+		customEnvPrinter := NewCustomEnvPrinter(mocks.Injector)
+		customEnvPrinter.Initialize()
+
+		// When calling GetEnvVars
+		envVars, err := customEnvPrinter.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars returned an error: %v", err)
+		}
+
+		// Then the environment variables should be set correctly
+		expectedEnvVars := map[string]string{
+			"VAR1": "value1",
+			"VAR2": "value2",
+		}
+		if !reflect.DeepEqual(envVars, expectedEnvVars) {
+			t.Errorf("envVars = %v, want %v", envVars, expectedEnvVars)
+		}
+	})
+
+	t.Run("MissingConfiguration", func(t *testing.T) {
+		// Use setupSafeCustomEnvMocks to create mocks
+		mocks := setupSafeCustomEnvMocks()
+
+		// Override the GetStringMapFunc to return nil for environment configuration
+		mocks.ConfigHandler.GetStringMapFunc = func(key string, defaultValue ...map[string]string) map[string]string {
+			return nil
+		}
+
+		customEnvPrinter := NewCustomEnvPrinter(mocks.Injector)
+		customEnvPrinter.Initialize()
+
+		// When calling GetEnvVars
+		envVars, err := customEnvPrinter.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars returned an error: %v", err)
+		}
+
+		// Then the environment variables should be an empty map
+		expectedEnvVars := map[string]string{}
+		if !reflect.DeepEqual(envVars, expectedEnvVars) {
+			t.Errorf("envVars = %v, want %v", envVars, expectedEnvVars)
+		}
+	})
+}
+
+func TestCustomEnv_Print(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Use setupSafeCustomEnvMocks to create mocks
+		mocks := setupSafeCustomEnvMocks()
+		customEnvPrinter := NewCustomEnvPrinter(mocks.Injector)
+		customEnvPrinter.Initialize()
+
+		// Mock the PrintEnvVarsFunc to verify it is called with the correct envVars
+		var capturedEnvVars map[string]string
+		mocks.Shell.PrintEnvVarsFunc = func(envVars map[string]string) error {
+			capturedEnvVars = envVars
+			return nil
+		}
+
+		// Call Print and check for errors
+		err := customEnvPrinter.Print()
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		// Verify that PrintEnvVarsFunc was called with the correct envVars
+		expectedEnvVars := map[string]string{
+			"VAR1": "value1",
+			"VAR2": "value2",
+		}
+		if !reflect.DeepEqual(capturedEnvVars, expectedEnvVars) {
+			t.Errorf("capturedEnvVars = %v, want %v", capturedEnvVars, expectedEnvVars)
+		}
+	})
+}


### PR DESCRIPTION
We have the `environment` configuration but hadn't fully implemented a handler for it that printed the env vars. This implements the `custom env` handler, allowing the user to add or override any environment variable on a per-context basis.