### PR TITLE
Don't throw error when determining compose command

### DIFF
--- a/pkg/virt/docker_virt.go
+++ b/pkg/virt/docker_virt.go
@@ -69,7 +69,8 @@ func (v *DockerVirt) Initialize() error {
 	return nil
 }
 
-// determineComposeCommand checks for available docker compose commands
+// determineComposeCommand checks for available docker compose commands. If a docker-compose
+// command is not available, none is set.
 func (v *DockerVirt) determineComposeCommand() error {
 	commands := []string{"docker-compose", "docker-cli-plugin-docker-compose", "docker compose"}
 	for _, cmd := range commands {
@@ -78,7 +79,7 @@ func (v *DockerVirt) determineComposeCommand() error {
 			return nil
 		}
 	}
-	return fmt.Errorf("no valid docker compose command found")
+	return nil
 }
 
 // Up starts docker compose

--- a/pkg/virt/docker_virt_test.go
+++ b/pkg/virt/docker_virt_test.go
@@ -214,31 +214,6 @@ func TestDockerVirt_Initialize(t *testing.T) {
 			t.Errorf("expected error message to contain %q, got %q", expectedErrorSubstring, err.Error())
 		}
 	})
-
-	t.Run("ErrorDeterminingComposeCommand", func(t *testing.T) {
-		// Setup mock components
-		mocks := setupSafeDockerContainerMocks()
-		dockerVirt := NewDockerVirt(mocks.Injector)
-
-		// Mock the shell's ExecSilent function to simulate no valid docker compose command found
-		mocks.MockShell.ExecSilentFunc = func(command string, args ...string) (string, error) {
-			return "", fmt.Errorf("command not found")
-		}
-
-		// Call the Initialize method
-		err := dockerVirt.Initialize()
-
-		// Assert that an error occurred
-		if err == nil {
-			t.Errorf("expected error, got none")
-		}
-
-		// Verify the error message contains the expected substring
-		expectedErrorSubstring := "error determining docker compose command"
-		if !strings.Contains(err.Error(), expectedErrorSubstring) {
-			t.Errorf("expected error message to contain %q, got %q", expectedErrorSubstring, err.Error())
-		}
-	})
 }
 
 func TestDockerVirt_Up(t *testing.T) {


### PR DESCRIPTION
If a compose command isn't found, it doesn't need to throw an error, it just doesn't need to set it. This allows us to perform `windsor check` without triggering an error.