### PR TITLE
Check that a project has initialized before running commands

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -15,6 +15,14 @@ var checkCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		controller := cmd.Context().Value(controllerKey).(ctrl.Controller)
 
+		// Check if projectName is set in the configuration
+		configHandler := controller.ResolveConfigHandler()
+		projectName := configHandler.GetString("projectName")
+		if projectName == "" {
+			fmt.Println("Nothing to check. Have you run \033[1mwindsor init\033[0m?")
+			return nil
+		}
+
 		// Create project components
 		if err := controller.CreateProjectComponents(); err != nil {
 			return fmt.Errorf("Error creating project components: %w", err)

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -16,13 +16,21 @@ var getContextCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		controller := cmd.Context().Value(controllerKey).(ctrl.Controller)
 
+		// New snippet: Ensure projectName is set
+		configHandler := controller.ResolveConfigHandler()
+		projectName := configHandler.GetString("projectName")
+		if projectName == "" {
+			fmt.Println("Cannot manage contexts. Please run `windsor init` to set up your project first.")
+			return nil
+		}
+
 		// Initialize components
 		if err := controller.InitializeComponents(); err != nil {
 			return fmt.Errorf("Error initializing components: %w", err)
 		}
 
 		// Resolve config handler
-		configHandler := controller.ResolveConfigHandler()
+		configHandler = controller.ResolveConfigHandler()
 
 		// Get the current context
 		currentContext := configHandler.GetContext()
@@ -41,13 +49,22 @@ var setContextCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1), // Ensure exactly one argument is provided
 	RunE: func(cmd *cobra.Command, args []string) error {
 		controller := cmd.Context().Value(controllerKey).(ctrl.Controller)
+
+		// New snippet: Ensure projectName is set
+		configHandler := controller.ResolveConfigHandler()
+		projectName := configHandler.GetString("projectName")
+		if projectName == "" {
+			fmt.Println("Cannot manage contexts. Please run `windsor init` to set up your project first.")
+			return nil
+		}
+
 		// Initialize components
 		if err := controller.InitializeComponents(); err != nil {
 			return fmt.Errorf("Error initializing components: %w", err)
 		}
 
 		// Resolve config handler
-		configHandler := controller.ResolveConfigHandler()
+		configHandler = controller.ResolveConfigHandler()
 
 		// Set the context
 		contextName := args[0]

--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -101,6 +101,33 @@ func TestContext_Get(t *testing.T) {
 			t.Errorf("Expected output to contain %q, got %q", expectedOutput, output)
 		}
 	})
+
+	t.Run("NoProjectNameSet", func(t *testing.T) {
+		// Given a mock controller that returns an empty projectName
+		mocks := setupSafeContextCmdMocks()
+		mocks.MockController.ResolveConfigHandlerFunc = func() config.ConfigHandler {
+			mockConfigHandler := config.NewMockConfigHandler()
+			mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+				return "" // Return empty string to simulate missing projectName
+			}
+			return mockConfigHandler
+		}
+
+		// When running the "context get" command
+		output := captureStdout(func() {
+			rootCmd.SetArgs([]string{"context", "get"})
+			err := Execute(mocks.MockController)
+			if err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+		})
+
+		// Then the output should contain the new message
+		expectedOutput := "Cannot manage contexts. Please run `windsor init` to set up your project first."
+		if !strings.Contains(output, expectedOutput) {
+			t.Errorf("Expected output to contain %q, got %q", expectedOutput, output)
+		}
+	})
 }
 
 func TestContext_Set(t *testing.T) {
@@ -267,4 +294,28 @@ func TestContext_SetAlias(t *testing.T) {
 			t.Errorf("Expected error to contain %q, got %q", expectedOutput, err.Error())
 		}
 	})
+}
+
+func TestContext_Set_NoProjectNameSet(t *testing.T) {
+	// Given a mock controller that returns an empty projectName
+	mocks := setupSafeContextCmdMocks()
+	mocks.MockController.ResolveConfigHandlerFunc = func() config.ConfigHandler {
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+			return ""
+		}
+		return mockConfigHandler
+	}
+
+	// When running the "context set" command
+	output := captureStdout(func() {
+		rootCmd.SetArgs([]string{"context", "set", "dev"})
+		_ = Execute(mocks.MockController)
+	})
+
+	// Then the output should show the new message
+	expectedOutput := "Cannot manage contexts. Please run `windsor init` to set up your project first."
+	if !strings.Contains(output, expectedOutput) {
+		t.Errorf("Expected output to contain %q, got %q", expectedOutput, output)
+	}
 }

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -21,6 +21,14 @@ var downCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		controller := cmd.Context().Value(controllerKey).(ctrl.Controller)
 
+		// New snippet: Ensure projectName is set
+		configHandler := controller.ResolveConfigHandler()
+		projectName := configHandler.GetString("projectName")
+		if projectName == "" {
+			fmt.Println("Cannot tear down environment as it appears no project has been initialized.")
+			return nil
+		}
+
 		// Create virtualization components
 		if err := controller.CreateVirtualizationComponents(); err != nil {
 			return fmt.Errorf("Error creating virtualization components: %w", err)
@@ -32,7 +40,7 @@ var downCmd = &cobra.Command{
 		}
 
 		// Resolve the config handler
-		configHandler := controller.ResolveConfigHandler()
+		configHandler = controller.ResolveConfigHandler()
 		if configHandler == nil {
 			return fmt.Errorf("No config handler found")
 		}

--- a/cmd/down_test.go
+++ b/cmd/down_test.go
@@ -144,7 +144,7 @@ func TestDownCmd(t *testing.T) {
 		callCount := 0
 		mocks.MockController.ResolveConfigHandlerFunc = func() config.ConfigHandler {
 			callCount++
-			if callCount == 2 {
+			if callCount == 3 {
 				return nil
 			}
 			return config.NewMockConfigHandler()
@@ -281,6 +281,26 @@ func TestDownCmd(t *testing.T) {
 		err := Execute(mocks.MockController)
 		if err == nil || !strings.Contains(err.Error(), "Error retrieving project root") {
 			t.Fatalf("Expected error containing 'Error retrieving project root', got %v", err)
+		}
+	})
+
+	t.Run("NoProjectNameSet", func(t *testing.T) {
+		// Given a mock controller that returns an empty projectName
+		mocks := setupSafeDownCmdMocks()
+		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+			return ""
+		}
+
+		// When the "down" command is executed
+		output := captureStdout(func() {
+			rootCmd.SetArgs([]string{"down"})
+			_ = Execute(mocks.MockController)
+		})
+
+		// Then the output should contain the new message
+		expectedOutput := "Cannot tear down environment as it appears no project has been initialized.\n"
+		if !strings.Contains(output, expectedOutput) {
+			t.Errorf("Expected output to contain %q, got %q", expectedOutput, output)
 		}
 	})
 }

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -15,6 +15,14 @@ var execCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		controller := cmd.Context().Value(controllerKey).(ctrl.Controller)
 
+		// New snippet: Ensure projectName is set
+		configHandler := controller.ResolveConfigHandler()
+		projectName := configHandler.GetString("projectName")
+		if projectName == "" {
+			fmt.Println("Cannot execute commands. Please run `windsor init` to set up your project first.")
+			return nil
+		}
+
 		if len(args) == 0 {
 			return fmt.Errorf("no command provided")
 		}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -13,6 +13,14 @@ var installCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		controller := cmd.Context().Value(controllerKey).(ctrl.Controller)
 
+		// New snippet: Ensure projectName is set
+		configHandler := controller.ResolveConfigHandler()
+		projectName := configHandler.GetString("projectName")
+		if projectName == "" {
+			fmt.Println("Cannot install blueprint. Please run `windsor init` to set up your project first.")
+			return nil
+		}
+
 		// Unlock the SecretProvider
 		secretsProvider := controller.ResolveSecretsProvider()
 		if secretsProvider != nil {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -20,6 +20,14 @@ var upCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		controller := cmd.Context().Value(controllerKey).(ctrl.Controller)
 
+		// New snippet: Ensure projectName is set
+		configHandler := controller.ResolveConfigHandler()
+		projectName := configHandler.GetString("projectName")
+		if projectName == "" {
+			fmt.Println("Cannot set up environment. Please run `windsor init` to set up your project first.")
+			return nil
+		}
+
 		// Create and initialize all necessary components for the Windsor environment.
 		// This includes project, environment, virtualization, service, and stack components.
 		if err := controller.CreateProjectComponents(); err != nil {
@@ -55,7 +63,7 @@ var upCmd = &cobra.Command{
 
 		// Resolve configuration settings and determine if specific virtualization or container runtime
 		// actions are required based on the configuration.
-		configHandler := controller.ResolveConfigHandler()
+		configHandler = controller.ResolveConfigHandler()
 		if configHandler == nil {
 			return fmt.Errorf("No config handler found")
 		}


### PR DESCRIPTION
Some commands shouldn't be run if a project hasn't been initialized. We now give the user a friendly message when this has occurred.