### PR TITLE
Fix localstack pro configuration

### DIFF
--- a/pkg/services/localstack_service.go
+++ b/pkg/services/localstack_service.go
@@ -70,13 +70,9 @@ func (s *LocalstackService) GetComposeConfig() (*types.Config, error) {
 		},
 	}
 
-	// If the localstack auth token is set, add it to the secrets
+	// If the localstack auth token is set, add it to the environment
 	if localstackAuthToken != "" {
-		services[0].Secrets = []types.ServiceSecretConfig{
-			{
-				Source: "LOCALSTACK_AUTH_TOKEN",
-			},
-		}
+		services[0].Environment["LOCALSTACK_AUTH_TOKEN"] = ptrString("${LOCALSTACK_AUTH_TOKEN}")
 	}
 
 	return &types.Config{Services: services}, nil

--- a/pkg/services/localstack_service_test.go
+++ b/pkg/services/localstack_service_test.go
@@ -146,8 +146,8 @@ func TestLocalstackService_GetComposeConfig(t *testing.T) {
 		}
 
 		service := composeConfig.Services[0]
-		if len(service.Secrets) == 0 || service.Secrets[0].Source != "LOCALSTACK_AUTH_TOKEN" {
-			t.Errorf("expected service to have LOCALSTACK_AUTH_TOKEN secret, got %v", service.Secrets)
+		if service.Environment["LOCALSTACK_AUTH_TOKEN"] == nil || *service.Environment["LOCALSTACK_AUTH_TOKEN"] != "${LOCALSTACK_AUTH_TOKEN}" {
+			t.Errorf("expected service to have LOCALSTACK_AUTH_TOKEN environment variable, got %v", service.Environment["LOCALSTACK_AUTH_TOKEN"])
 		}
 	})
 }


### PR DESCRIPTION
Fixes the localstack pro configuration by configuring it as an environment variable vs. a docker-compose "secret"