### PR TITLE
Windsor docker image

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -77,12 +77,12 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "^pkg/constants/constants.go$",
-        "^Taskfile.yaml$",
-        "^Dockerfile$"
+        "^Dockerfile$",
+        "^.*\\.yaml$",
+        "^.*\\.go$"
       ],
       "matchStrings": [
-        "(//|#) renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\n\\s*const\\s+\\S+\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+        "(//|#)\\s*renovate\\s*:\\s*datasource\\s*=\\s*(?<datasource>\\S+)\\s*depName\\s*=\\s*(?<depName>\\S+)\\s*\\n.*?(?<currentValue>v?\\d+\\.\\d+\\.\\d+)"
       ],
       "datasourceTemplate": "{{datasource}}",
       "versioningTemplate": "semver"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -77,34 +77,14 @@
     {
       "customType": "regex",
       "fileMatch": [
-        "^pkg/constants/constants.go$"
+        "^pkg/constants/constants.go$",
+        "^Taskfile.yaml$",
+        "^Dockerfile$"
       ],
       "matchStrings": [
-        "// renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\n\\s*const\\s+\\S+\\s*=\\s*\"(?<currentValue>[^\"]+)\""
+        "(//|#) renovate: datasource=(?<datasource>\\S+) depName=(?<depName>\\S+)\n\\s*const\\s+\\S+\\s*=\\s*\"(?<currentValue>[^\"]+)\""
       ],
       "datasourceTemplate": "{{datasource}}",
-      "versioningTemplate": "semver"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": [
-        "^Taskfile.yaml$"
-      ],
-      "matchStrings": [
-        "go install (?<depName>\\S+)@(?<currentValue>\\S+)"
-      ],
-      "datasourceTemplate": "go",
-      "versioningTemplate": "semver"
-    },
-    {
-      "customType": "regex",
-      "fileMatch": [
-        "^Taskfile.yaml$"
-      ],
-      "matchStrings": [
-        "choco install (?<depName>\\S+) --version=(?<currentValue>\\S+)"
-      ],
-      "datasourceTemplate": "chocolatey",
       "versioningTemplate": "semver"
     }
   ],

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,9 +8,11 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+'
       
 permissions:
-  contents: write  # Allows creating releases
+  contents: write
   issues: read
-  pull-requests: read  
+  pull-requests: read
+  packages: write
+
 jobs:
   build-and-test:
     strategy:
@@ -158,3 +160,42 @@ jobs:
           GPG_FINGERPRINT: ${{ env.GPG_FINGERPRINT }}
           HOMEBREW_CLI_WRITE_PAT: ${{ secrets.HOMEBREW_CLI_WRITE_PAT }}
           GITHUB_SHA: ${{ github.sha }}
+
+  docker:
+    runs-on: ubuntu-latest
+    needs: [build-and-test, sast-scan]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
+
+      - name: Log in to GitHub Container Registry
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build Docker image
+        uses: docker/build-push-action@0adf9959216b96bec444f325f1e493d4aa344497 # v6.14.0
+        with:
+          context: .
+          push: false
+          tags: ghcr.io/windsorcli/windsorcli:latest
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+
+      - name: Push Docker image
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/build-push-action@0adf9959216b96bec444f325f1e493d4aa344497 # v6.14.0
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/windsorcli/windsorcli:latest
+            ghcr.io/windsorcli/windsorcli:${{ github.ref_name }}
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,63 @@
+# Stage 1: Aqua Installer
+# -----------------------
+FROM alpine:3.21.3 AS aqua
+
+# Set environment variables
+ENV PATH="/root/.local/share/aquaproj-aqua/bin:$PATH"
+ENV AQUA_GLOBAL_CONFIG=/etc/aqua/aqua.yaml
+
+# renovate: datasource=github-releases depName=aquaproj/aqua-installer
+ARG AQUA_INSTALLER_VERSION=v3.1.1
+# renovate: datasource=github-releases depName=aquaproj/aqua
+ARG AQUA_VERSION=v2.45.0
+
+# Install dependencies
+RUN apk add --no-cache curl bash
+
+# Copy aqua configuration
+COPY aqua.docker.yaml /etc/aqua/aqua.yaml
+
+# Install Aqua and tools
+RUN curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/${AQUA_INSTALLER_VERSION}/aqua-installer && \
+    echo "e9d4c99577c6b2ce0b62edf61f089e9b9891af1708e88c6592907d2de66e3714  aqua-installer" | sha256sum -c - && \
+    chmod +x aqua-installer && \
+    ./aqua-installer -v ${AQUA_VERSION} && \
+    aqua i -a || { echo "Failed to install Aqua tools" >&2; exit 1; } && \
+    aqua cp -o /dist aws aws_completer containerd containerd-shim-runc-v2 ctr docker docker-cli-plugin-docker-compose docker-init docker-proxy dockerd flux helm kubectl runc talosctl terraform || { echo "Failed to copy some tools" >&2; exit 1; } && \
+    rm aqua-installer
+
+# Stage 2: Builder
+# ----------------
+FROM --platform=$BUILDPLATFORM golang:1.23.4-alpine AS builder
+
+# Install dependencies
+RUN apk add --no-cache git
+
+# Build the windsor binary
+COPY . .
+RUN go build -o /work/windsor ./cmd/windsor || { echo "Failed to build windsor binary" >&2; exit 1; }
+
+# Stage 3: Runtime
+# ----------------
+FROM alpine:3.21.3
+
+# Create a non-root user and group
+RUN addgroup -S appgroup && adduser -S windsor -G appgroup
+
+# Install runtime dependencies
+RUN apk add --no-cache bash
+
+# Copy tools from aqua-installer
+COPY --from=aqua /dist/* /usr/local/bin/
+
+# Create windsor user
+USER windsor
+
+# Copy windsor binary
+COPY --from=builder /work/windsor /usr/local/bin/
+
+# Set working directory
+WORKDIR /work
+
+# Set entrypoint
+ENTRYPOINT ["/usr/local/bin/windsor", "exec", "--"]

--- a/aqua.docker.yaml
+++ b/aqua.docker.yaml
@@ -1,0 +1,13 @@
+---
+registries:
+  - type: standard
+    ref: v4.319.1 # renovate: depName=aquaproj/aqua-registry
+packages:
+- name: hashicorp/terraform@v1.10.5
+- name: siderolabs/talos@v1.9.4
+- name: kubernetes/kubectl@v1.32.2
+- name: docker/cli@v27.4.1
+- name: docker/compose@v2.33.1
+- name: helm/helm@v3.17.1
+- name: fluxcd/flux2@v2.5.0
+- name: aws/aws-cli@2.24.10

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -14,7 +14,6 @@ packages:
 - name: hashicorp/terraform@v1.10.5
 - name: siderolabs/talos@v1.9.4
 - name: siderolabs/omni/omnictl@v0.46.3
-- name: siderolabs/omni/omni@v0.46.3
 - name: kubernetes/kubectl@v1.32.2
 - name: go-task/task@v3.41.0
 - name: golang/go@go1.23.4

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,15 @@
+version: '3.8'
+
+services:
+  windsorcli:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        BUILDPLATFORM: ${BUILDPLATFORM:-linux/arm64}
+        TARGETARCH: ${TARGETARCH:-arm64}
+    image: windsorcli:latest
+    container_name: windsorcli
+    entrypoint: /bin/sh
+    volumes:
+      - .:/work


### PR DESCRIPTION
Includes a new Dockerfile that builds the windsor cli and makes it available via a containerized image. This also installs the required toolchain dependencies.

This image uses an entrypoint `windsor exec --`. This means that anything passed to `docker run` will be executed within a windsor context.

The necessary actions are also included for uploading the image to ghcr using a multi-arch build.