### PR TITLE
Return correct error codes from exec

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -171,6 +171,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f7ce87c1d6bead3e36075b2ce75da1f6cc28aaca # v3.9.0
 
+      - name: Cache Docker layers
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-docker-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-docker-
+
       - name: Log in to GitHub Container Registry
         if: startsWith(github.ref, 'refs/tags/')
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
@@ -187,6 +195,8 @@ jobs:
           tags: ghcr.io/windsorcli/windsorcli:latest
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
 
       - name: Push Docker image
         if: startsWith(github.ref, 'refs/tags/')
@@ -199,3 +209,5 @@ jobs:
             ghcr.io/windsorcli/windsorcli:${{ github.ref_name }}
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -75,6 +75,18 @@
         "WINDSOR_CONTEXT": "local",
         "WINDSOR_PROJECT_ROOT": "${workspaceFolder}"
       }
+    },
+    {
+      "name": "Windsor Exec",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/cmd/windsor/main.go",
+      "args": ["exec", "--", "sh", "-c", "exit 2"],
+      "env": {
+        "WINDSOR_CONTEXT": "local",
+        "WINDSOR_PROJECT_ROOT": "${workspaceFolder}"
+      }
     }
   ]
 }

--- a/cmd/down_test.go
+++ b/cmd/down_test.go
@@ -242,11 +242,11 @@ func TestDownCmd(t *testing.T) {
 		}
 
 		// Mock the shell's Exec function to simulate successful deletion of the .volumes folder
-		mocks.MockShell.ExecFunc = func(command string, args ...string) (string, error) {
+		mocks.MockShell.ExecFunc = func(command string, args ...string) (string, int, error) {
 			if command == "cmd" && len(args) > 0 && args[0] == "/C" && args[1] == "rmdir" && args[2] == "/S" && args[3] == "/Q" && args[4] == filepath.Join("mock", "project", "root", ".volumes") {
-				return "", nil
+				return "", 0, nil
 			}
-			return "", fmt.Errorf("Unexpected command: %s %v", command, args)
+			return "", 1, fmt.Errorf("Unexpected command: %s %v", command, args)
 		}
 
 		// Given a mock shell that successfully deletes the .volumes folder

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	ctrl "github.com/windsorcli/cli/pkg/controller"
@@ -78,9 +79,10 @@ var execCmd = &cobra.Command{
 		}
 
 		// Execute the command using the resolved shell instance
-		_, err := shellInstance.Exec(args[0], args[1:]...)
+		_, exitCode, err := shellInstance.Exec(args[0], args[1:]...)
 		if err != nil {
-			return fmt.Errorf("command execution failed: %w", err)
+			fmt.Fprintf(os.Stderr, "command execution failed: %v\n", err)
+			osExit(exitCode)
 		}
 
 		return nil

--- a/cmd/shims.go
+++ b/cmd/shims.go
@@ -19,6 +19,9 @@ var osStat = os.Stat
 // osRemoveAll removes a directory and all its contents
 var osRemoveAll = os.RemoveAll
 
+// osExit is a function to exit the program
+var osExit = os.Exit
+
 // getwd retrieves the current working directory
 var getwd = os.Getwd
 

--- a/pkg/network/colima_network.go
+++ b/pkg/network/colima_network.go
@@ -84,7 +84,7 @@ func (n *ColimaNetworkManager) ConfigureGuest() error {
 
 	contextName := n.configHandler.GetContext()
 
-	sshConfigOutput, err := n.shell.ExecSilent(
+	sshConfigOutput, _, err := n.shell.ExecSilent(
 		"colima",
 		"ssh-config",
 		"--profile",
@@ -98,7 +98,7 @@ func (n *ColimaNetworkManager) ConfigureGuest() error {
 		return fmt.Errorf("error setting SSH client config: %w", err)
 	}
 
-	output, err := n.secureShell.ExecSilent(
+	output, _, err := n.secureShell.ExecSilent(
 		"ls",
 		"/sys/class/net",
 	)
@@ -123,18 +123,19 @@ func (n *ColimaNetworkManager) ConfigureGuest() error {
 		return fmt.Errorf("error getting host IP: %w", err)
 	}
 
-	_, err = n.secureShell.ExecSilent(
+	_, _, err = n.secureShell.ExecSilent(
 		"sudo", "iptables", "-t", "filter", "-C", "FORWARD",
 		"-i", "col0", "-o", dockerBridgeInterface,
 		"-s", hostIP, "-d", networkCIDR, "-j", "ACCEPT",
 	)
 	if err != nil {
 		if strings.Contains(err.Error(), "Bad rule") {
-			if _, err := n.secureShell.ExecSilent(
+			_, _, err = n.secureShell.ExecSilent(
 				"sudo", "iptables", "-t", "filter", "-A", "FORWARD",
 				"-i", "col0", "-o", dockerBridgeInterface,
 				"-s", hostIP, "-d", networkCIDR, "-j", "ACCEPT",
-			); err != nil {
+			)
+			if err != nil {
 				return fmt.Errorf("error setting iptables rule: %w", err)
 			}
 		} else {

--- a/pkg/network/darwin_network.go
+++ b/pkg/network/darwin_network.go
@@ -24,7 +24,7 @@ func (n *BaseNetworkManager) ConfigureHostRoute() error {
 		return fmt.Errorf("guest IP is not configured")
 	}
 
-	output, err := n.shell.ExecSilent("route", "get", networkCIDR)
+	output, _, err := n.shell.ExecSilent("route", "get", networkCIDR)
 	if err != nil {
 		return fmt.Errorf("failed to check if route exists: %w", err)
 	}
@@ -45,7 +45,7 @@ func (n *BaseNetworkManager) ConfigureHostRoute() error {
 		return nil
 	}
 
-	output, err = n.shell.ExecSudo(
+	output, _, err = n.shell.ExecSudo(
 		"🔐 Adding host route",
 		"route",
 		"-nv",
@@ -72,12 +72,13 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 
 	resolverDir := "/etc/resolver"
 	if _, err := stat(resolverDir); os.IsNotExist(err) {
-		if _, err := n.shell.ExecSilent(
+		_, _, err := n.shell.ExecSilent(
 			"sudo",
 			"mkdir",
 			"-p",
 			resolverDir,
-		); err != nil {
+		)
+		if err != nil {
 			return fmt.Errorf("Error creating resolver directory: %w", err)
 		}
 	}
@@ -95,29 +96,32 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 		return fmt.Errorf("Error writing to temporary resolver file: %w", err)
 	}
 
-	if _, err := n.shell.ExecSudo(
+	_, _, err = n.shell.ExecSudo(
 		fmt.Sprintf("🔐 Configuring DNS resolver at %s\n", resolverFile),
 		"mv",
 		tempResolverFile,
 		resolverFile,
-	); err != nil {
+	)
+	if err != nil {
 		return fmt.Errorf("Error moving resolver file: %w", err)
 	}
 
-	if _, err := n.shell.ExecSudo(
+	_, _, err = n.shell.ExecSudo(
 		"🔐 Flushing DNS cache",
 		"dscacheutil",
 		"-flushcache",
-	); err != nil {
+	)
+	if err != nil {
 		return fmt.Errorf("Error flushing DNS cache: %w", err)
 	}
 
-	if _, err := n.shell.ExecSudo(
+	_, _, err = n.shell.ExecSudo(
 		"🔐 Restarting mDNSResponder",
 		"killall",
 		"-HUP",
 		"mDNSResponder",
-	); err != nil {
+	)
+	if err != nil {
 		return fmt.Errorf("Error restarting mDNSResponder: %w", err)
 	}
 

--- a/pkg/network/linux_network.go
+++ b/pkg/network/linux_network.go
@@ -23,7 +23,7 @@ func (n *BaseNetworkManager) ConfigureHostRoute() error {
 	}
 
 	// Use the shell to execute a command that checks the routing table for the specific route
-	output, err := n.shell.ExecSilent(
+	output, _, err := n.shell.ExecSilent(
 		"ip",
 		"route",
 		"show",
@@ -49,7 +49,7 @@ func (n *BaseNetworkManager) ConfigureHostRoute() error {
 
 	// Add route on the host to VM guest
 	fmt.Println("🔐 Configuring host route")
-	output, err = n.shell.ExecSilent(
+	output, _, err = n.shell.ExecSilent(
 		"sudo",
 		"ip",
 		"route",
@@ -91,7 +91,7 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 		return nil
 	}
 
-	_, err = n.shell.ExecSilent(
+	_, _, err = n.shell.ExecSilent(
 		"sudo",
 		"mkdir",
 		"-p",
@@ -101,7 +101,7 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 		return fmt.Errorf("failed to create drop-in directory: %w", err)
 	}
 
-	_, err = n.shell.ExecSudo(
+	_, _, err = n.shell.ExecSilent(
 		"🔐 Writing DNS configuration to "+dropInFile,
 		"bash",
 		"-c",
@@ -112,7 +112,7 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 	}
 
 	fmt.Println("🔐 Restarting systemd-resolved")
-	_, err = n.shell.ExecSudo(
+	_, _, err = n.shell.ExecSilent(
 		"🔐 Restarting systemd-resolved",
 		"systemctl",
 		"restart",

--- a/pkg/network/linux_network.go
+++ b/pkg/network/linux_network.go
@@ -102,7 +102,6 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 	}
 
 	_, _, err = n.shell.ExecSilent(
-		"🔐 Writing DNS configuration to "+dropInFile,
 		"bash",
 		"-c",
 		fmt.Sprintf("echo '%s' | sudo tee %s", expectedContent, dropInFile),
@@ -113,7 +112,6 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 
 	fmt.Println("🔐 Restarting systemd-resolved")
 	_, _, err = n.shell.ExecSilent(
-		"🔐 Restarting systemd-resolved",
 		"systemctl",
 		"restart",
 		"systemd-resolved",

--- a/pkg/network/linux_network_test.go
+++ b/pkg/network/linux_network_test.go
@@ -460,8 +460,8 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 
 		// Mock the shell.ExecSilent function to simulate an error when writing the DNS configuration
 		mocks.MockShell.ExecSilentFunc = func(command string, args ...string) (string, int, error) {
-			if command == "bash" && args[0] == "-c" {
-				return "", 0, fmt.Errorf("mock write DNS configuration error")
+			if command == "sudo" && args[0] == "bash" && args[1] == "-c" {
+				return "", 1, fmt.Errorf("mock write DNS configuration error")
 			}
 			return "", 0, nil
 		}
@@ -476,7 +476,7 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 		// Call the ConfigureDNS method and expect an error due to failure in writing the DNS configuration
 		err = nm.ConfigureDNS()
 		if err == nil {
-			t.Fatalf("expected error, got nil. Speculate why see @linux_network.go")
+			t.Fatalf("expected error, got nil. Check the implementation in linux_network.go")
 		}
 		expectedError := "failed to write DNS configuration: mock write DNS configuration error"
 		if !strings.Contains(err.Error(), expectedError) {
@@ -489,8 +489,8 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 
 		// Mock the shell.ExecSilent function to simulate an error when restarting systemd-resolved
 		mocks.MockShell.ExecSilentFunc = func(command string, args ...string) (string, int, error) {
-			if command == "systemctl" && args[0] == "restart" && args[1] == "systemd-resolved" {
-				return "", 0, fmt.Errorf("mock restart systemd-resolved error")
+			if command == "sudo" && args[0] == "systemctl" && args[1] == "restart" && args[2] == "systemd-resolved" {
+				return "", 1, fmt.Errorf("mock restart systemd-resolved error")
 			}
 			return "", 0, nil
 		}
@@ -505,7 +505,7 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 		// Call the ConfigureDNS method and expect an error due to failure in restarting systemd-resolved
 		err = nm.ConfigureDNS()
 		if err == nil {
-			t.Fatalf("expected error, got nil. Why see @linux_network.go")
+			t.Fatalf("expected error, got nil. Review the logic in linux_network.go")
 		}
 		expectedError := "failed to restart systemd-resolved: mock restart systemd-resolved error"
 		if !strings.Contains(err.Error(), expectedError) {

--- a/pkg/network/linux_network_test.go
+++ b/pkg/network/linux_network_test.go
@@ -29,20 +29,20 @@ func setupLinuxNetworkManagerMocks() *LinuxNetworkManagerMocks {
 
 	// Create a mock shell
 	mockShell := shell.NewMockShell(injector)
-	mockShell.ExecFunc = func(command string, args ...string) (string, error) {
+	mockShell.ExecFunc = func(command string, args ...string) (string, int, error) {
 		if command == "sudo" && args[0] == "ip" && args[1] == "route" && args[2] == "add" {
-			return "", nil
+			return "", 0, nil
 		}
 		if command == "sudo" && args[0] == "systemctl" && args[1] == "restart" && args[2] == "systemd-resolved" {
-			return "", nil
+			return "", 0, nil
 		}
 		if command == "sudo" && args[0] == "mkdir" && args[1] == "-p" {
-			return "", nil
+			return "", 0, nil
 		}
 		if command == "sudo" && args[0] == "bash" && args[1] == "-c" {
-			return "", nil
+			return "", 0, nil
 		}
-		return "", fmt.Errorf("mock error")
+		return "", 0, fmt.Errorf("mock error")
 	}
 
 	// Use the same mock shell for both shell and secure shell
@@ -111,11 +111,11 @@ func TestLinuxNetworkManager_ConfigureHostRoute(t *testing.T) {
 		}
 
 		// Mock the shell.ExecSilent function to simulate a successful route check
-		mocks.MockShell.ExecSilentFunc = func(command string, args ...string) (string, error) {
+		mocks.MockShell.ExecSilentFunc = func(command string, args ...string) (string, int, error) {
 			if command == "ip" && args[0] == "route" && args[1] == "show" {
-				return "192.168.5.0/24 via 192.168.5.100 dev eth0", nil
+				return "192.168.5.0/24 via 192.168.5.100 dev eth0", 0, nil
 			}
-			return "", nil
+			return "", 0, nil
 		}
 
 		// Call the ConfigureHostRoute method and expect no error since the route exists
@@ -157,11 +157,11 @@ func TestLinuxNetworkManager_ConfigureHostRoute(t *testing.T) {
 		mocks := setupLinuxNetworkManagerMocks()
 
 		// Mock the ExecSilent function to simulate an error when checking the routing table
-		mocks.MockShell.ExecSilentFunc = func(command string, args ...string) (string, error) {
+		mocks.MockShell.ExecSilentFunc = func(command string, args ...string) (string, int, error) {
 			if command == "ip" && args[0] == "route" && args[1] == "show" {
-				return "", fmt.Errorf("mock error checking route table")
+				return "", 0, fmt.Errorf("mock error checking route table")
 			}
-			return "", nil
+			return "", 0, nil
 		}
 
 		// Create a networkManager using NewBaseNetworkManager with the mock DI container
@@ -214,12 +214,12 @@ func TestLinuxNetworkManager_ConfigureHostRoute(t *testing.T) {
 		mocks := setupLinuxNetworkManagerMocks()
 
 		// Mock the ExecSilent function to simulate checking the routing table
-		mocks.MockShell.ExecSilentFunc = func(command string, args ...string) (string, error) {
+		mocks.MockShell.ExecSilentFunc = func(command string, args ...string) (string, int, error) {
 			if command == "ip" && args[0] == "route" && args[1] == "show" && args[2] == "192.168.5.0/24" {
 				// Simulate output that includes the guest IP to trigger routeExists = true
-				return "192.168.5.0/24 via 192.168.1.2 dev eth0", nil
+				return "192.168.5.0/24 via 192.168.1.2 dev eth0", 0, nil
 			}
-			return "", nil
+			return "", 0, nil
 		}
 
 		// Mock the GetString function to return specific values for testing
@@ -254,12 +254,12 @@ func TestLinuxNetworkManager_ConfigureHostRoute(t *testing.T) {
 		mocks := setupLinuxNetworkManagerMocks()
 
 		// Mock the ExecSilent function to simulate checking the routing table
-		mocks.MockShell.ExecSilentFunc = func(command string, args ...string) (string, error) {
+		mocks.MockShell.ExecSilentFunc = func(command string, args ...string) (string, int, error) {
 			if command == "ip" && args[0] == "route" && args[1] == "show" && args[2] == "192.168.5.0/24" {
 				// Simulate output that includes the guest IP to trigger routeExists = true
-				return "192.168.5.0/24 via 192.168.5.100 dev eth0", nil
+				return "192.168.5.0/24 via 192.168.5.100 dev eth0", 0, nil
 			}
-			return "", nil
+			return "", 0, nil
 		}
 
 		// Mock the GetString function to return specific values for testing
@@ -294,11 +294,11 @@ func TestLinuxNetworkManager_ConfigureHostRoute(t *testing.T) {
 		mocks := setupLinuxNetworkManagerMocks()
 
 		// Mock an error in the ExecSilent function to simulate a route addition failure
-		mocks.MockShell.ExecSilentFunc = func(command string, args ...string) (string, error) {
+		mocks.MockShell.ExecSilentFunc = func(command string, args ...string) (string, int, error) {
 			if command == "sudo" && args[0] == "ip" && args[1] == "route" && args[2] == "add" {
-				return "mock output", fmt.Errorf("mock error")
+				return "mock output", 0, fmt.Errorf("mock error")
 			}
-			return "", nil
+			return "", 0, nil
 		}
 
 		// Create a networkManager using NewBaseNetworkManager with the mock DI container
@@ -430,11 +430,11 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 		mocks := setupLinuxNetworkManagerMocks()
 
 		// Mock the shell.ExecSilent function to simulate an error when creating the drop-in directory
-		mocks.MockShell.ExecSilentFunc = func(command string, args ...string) (string, error) {
+		mocks.MockShell.ExecSilentFunc = func(command string, args ...string) (string, int, error) {
 			if command == "sudo" && args[0] == "mkdir" && args[1] == "-p" {
-				return "", fmt.Errorf("mock mkdir error")
+				return "", 0, fmt.Errorf("mock mkdir error")
 			}
-			return "", nil
+			return "", 0, nil
 		}
 
 		// Create a networkManager using NewBaseNetworkManager with the mock DI container
@@ -459,11 +459,11 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 		mocks := setupLinuxNetworkManagerMocks()
 
 		// Mock the shell.ExecSudo function to simulate an error when writing the DNS configuration
-		mocks.MockShell.ExecSudoFunc = func(description, command string, args ...string) (string, error) {
+		mocks.MockShell.ExecSudoFunc = func(description, command string, args ...string) (string, int, error) {
 			if command == "bash" && args[0] == "-c" {
-				return "", fmt.Errorf("mock write DNS configuration error")
+				return "", 0, fmt.Errorf("mock write DNS configuration error")
 			}
-			return "", nil
+			return "", 0, nil
 		}
 
 		// Create a networkManager using NewBaseNetworkManager with the mock DI container
@@ -488,11 +488,11 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 		mocks := setupLinuxNetworkManagerMocks()
 
 		// Mock the shell.ExecSudo function to simulate an error when restarting systemd-resolved
-		mocks.MockShell.ExecSudoFunc = func(description, command string, args ...string) (string, error) {
+		mocks.MockShell.ExecSudoFunc = func(message, command string, args ...string) (string, int, error) {
 			if command == "systemctl" && args[0] == "restart" && args[1] == "systemd-resolved" {
-				return "", fmt.Errorf("mock restart systemd-resolved error")
+				return "", 0, fmt.Errorf("mock restart systemd-resolved error")
 			}
-			return "", nil
+			return "", 0, nil
 		}
 
 		// Create a networkManager using NewBaseNetworkManager with the mock DI container

--- a/pkg/network/linux_network_test.go
+++ b/pkg/network/linux_network_test.go
@@ -489,7 +489,7 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 
 		// Mock the shell.ExecSilent function to simulate an error when restarting systemd-resolved
 		mocks.MockShell.ExecSilentFunc = func(command string, args ...string) (string, int, error) {
-			if command == "sudo" && args[0] == "systemctl" && args[1] == "restart" && args[2] == "systemd-resolved" {
+			if command == "systemctl" && args[0] == "restart" && args[1] == "systemd-resolved" {
 				return "", 1, fmt.Errorf("mock restart systemd-resolved error")
 			}
 			return "", 0, nil

--- a/pkg/network/linux_network_test.go
+++ b/pkg/network/linux_network_test.go
@@ -460,7 +460,7 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 
 		// Mock the shell.ExecSilent function to simulate an error when writing the DNS configuration
 		mocks.MockShell.ExecSilentFunc = func(command string, args ...string) (string, int, error) {
-			if command == "sudo" && args[0] == "bash" && args[1] == "-c" {
+			if command == "bash" && args[0] == "-c" {
 				return "", 1, fmt.Errorf("mock write DNS configuration error")
 			}
 			return "", 0, nil
@@ -495,21 +495,20 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 			return "", 0, nil
 		}
 
-		// Create a networkManager using NewBaseNetworkManager with the mock DI container
+		// Initialize the network manager
 		nm := NewBaseNetworkManager(mocks.Injector)
-		err := nm.Initialize()
-		if err != nil {
-			t.Fatalf("expected no error during initialization, got %v", err)
+		if err := nm.Initialize(); err != nil {
+			t.Fatalf("Initialization failed: %v", err)
 		}
 
-		// Call the ConfigureDNS method and expect an error due to failure in restarting systemd-resolved
-		err = nm.ConfigureDNS()
-		if err == nil {
-			t.Fatalf("expected error, got nil. Review the logic in linux_network.go")
-		}
-		expectedError := "failed to restart systemd-resolved: mock restart systemd-resolved error"
-		if !strings.Contains(err.Error(), expectedError) {
-			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
+		// Attempt to configure DNS and expect a specific error
+		if err := nm.ConfigureDNS(); err == nil {
+			t.Fatalf("Expected error, got nil. Check the implementation in linux_network.go")
+		} else {
+			expectedError := "failed to restart systemd-resolved: mock restart systemd-resolved error"
+			if !strings.Contains(err.Error(), expectedError) {
+				t.Fatalf("Expected error %q, got %q", expectedError, err.Error())
+			}
 		}
 	})
 }

--- a/pkg/network/linux_network_test.go
+++ b/pkg/network/linux_network_test.go
@@ -458,8 +458,8 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 	t.Run("FailedToWriteDNSConfiguration", func(t *testing.T) {
 		mocks := setupLinuxNetworkManagerMocks()
 
-		// Mock the shell.ExecSudo function to simulate an error when writing the DNS configuration
-		mocks.MockShell.ExecSudoFunc = func(description, command string, args ...string) (string, int, error) {
+		// Mock the shell.ExecSilent function to simulate an error when writing the DNS configuration
+		mocks.MockShell.ExecSilentFunc = func(command string, args ...string) (string, int, error) {
 			if command == "bash" && args[0] == "-c" {
 				return "", 0, fmt.Errorf("mock write DNS configuration error")
 			}
@@ -476,7 +476,7 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 		// Call the ConfigureDNS method and expect an error due to failure in writing the DNS configuration
 		err = nm.ConfigureDNS()
 		if err == nil {
-			t.Fatalf("expected error, got nil")
+			t.Fatalf("expected error, got nil. Speculate why see @linux_network.go")
 		}
 		expectedError := "failed to write DNS configuration: mock write DNS configuration error"
 		if !strings.Contains(err.Error(), expectedError) {
@@ -487,8 +487,8 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 	t.Run("FailedToRestartSystemdResolved", func(t *testing.T) {
 		mocks := setupLinuxNetworkManagerMocks()
 
-		// Mock the shell.ExecSudo function to simulate an error when restarting systemd-resolved
-		mocks.MockShell.ExecSudoFunc = func(message, command string, args ...string) (string, int, error) {
+		// Mock the shell.ExecSilent function to simulate an error when restarting systemd-resolved
+		mocks.MockShell.ExecSilentFunc = func(command string, args ...string) (string, int, error) {
 			if command == "systemctl" && args[0] == "restart" && args[1] == "systemd-resolved" {
 				return "", 0, fmt.Errorf("mock restart systemd-resolved error")
 			}
@@ -505,7 +505,7 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 		// Call the ConfigureDNS method and expect an error due to failure in restarting systemd-resolved
 		err = nm.ConfigureDNS()
 		if err == nil {
-			t.Fatalf("expected error, got nil")
+			t.Fatalf("expected error, got nil. Why see @linux_network.go")
 		}
 		expectedError := "failed to restart systemd-resolved: mock restart systemd-resolved error"
 		if !strings.Contains(err.Error(), expectedError) {

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -34,8 +34,8 @@ func setupNetworkManagerMocks(optionalInjector ...di.Injector) *NetworkManagerMo
 
 	// Create a mock shell
 	mockShell := shell.NewMockShell(injector)
-	mockShell.ExecFunc = func(command string, args ...string) (string, error) {
-		return "", nil
+	mockShell.ExecFunc = func(command string, args ...string) (string, int, error) {
+		return "", 0, nil
 	}
 
 	// Use the same mock shell for both shell and secure shell

--- a/pkg/network/windows_network.go
+++ b/pkg/network/windows_network.go
@@ -30,7 +30,7 @@ func (n *BaseNetworkManager) ConfigureHostRoute() error {
 	spin.Suffix = " 🔐 Configuring host route"
 	spin.Start()
 
-	output, err := n.shell.ExecSilent(
+	output, _, err := n.shell.ExecSilent(
 		"powershell",
 		"-Command",
 		fmt.Sprintf("Get-NetRoute -DestinationPrefix %s | Where-Object { $_.NextHop -eq '%s' }", networkCIDR, guestIP),
@@ -42,7 +42,7 @@ func (n *BaseNetworkManager) ConfigureHostRoute() error {
 	}
 
 	if output == "" {
-		output, err = n.shell.ExecSilent(
+		output, _, err = n.shell.ExecSilent(
 			"powershell",
 			"-Command",
 			fmt.Sprintf("New-NetRoute -DestinationPrefix %s -NextHop %s -RouteMetric 1", networkCIDR, guestIP),
@@ -93,7 +93,7 @@ if ($existingRule) {
 }
 `, namespace, dnsIP)
 
-	output, err := n.shell.ExecSilent(
+	output, _, err := n.shell.ExecSilent(
 		"powershell",
 		"-Command",
 		checkScript,
@@ -118,7 +118,7 @@ if ($?) {
 }
 `, namespace, dnsIP, dnsIP, tld)
 
-		_, err = n.shell.ExecProgress(
+		_, _, err = n.shell.ExecProgress(
 			fmt.Sprintf("🔐 Configuring DNS for '*.%s'", tld),
 			"powershell",
 			"-Command",

--- a/pkg/secrets/op_cli_secrets_provider.go
+++ b/pkg/secrets/op_cli_secrets_provider.go
@@ -37,7 +37,7 @@ func (s *OnePasswordCLISecretsProvider) GetSecret(key string) (string, error) {
 
 	args := []string{"item", "get", parts[0], "--vault", s.vault.Name, "--fields", parts[1], "--reveal", "--account", s.vault.URL}
 
-	output, err := s.shell.ExecSilent("op", args...)
+	output, _, err := s.shell.ExecSilent("op", args...)
 	if err != nil {
 		return "", fmt.Errorf("failed to retrieve secret from 1Password: %w", err)
 	}

--- a/pkg/secrets/op_cli_secrets_provider_test.go
+++ b/pkg/secrets/op_cli_secrets_provider_test.go
@@ -43,7 +43,7 @@ func TestOnePasswordCLISecretsProvider_GetSecret(t *testing.T) {
 		// Setup mocks
 		mocks := setupOnePasswordCLISecretsProviderMocks()
 		execSilentCalled := false
-		mocks.Shell.ExecSilentFunc = func(command string, args ...string) (string, error) {
+		mocks.Shell.ExecSilentFunc = func(command string, args ...string) (string, int, error) {
 			execSilentCalled = true
 			if command == "op" &&
 				args[0] == "item" &&
@@ -56,9 +56,9 @@ func TestOnePasswordCLISecretsProvider_GetSecret(t *testing.T) {
 				args[7] == "--reveal" &&
 				args[8] == "--account" &&
 				args[9] == "https://example.1password.com" {
-				return "secretValue", nil
+				return "secretValue", 0, nil
 			}
-			return "", fmt.Errorf("unexpected command: %s", command)
+			return "", 0, fmt.Errorf("unexpected command: %s", command)
 		}
 
 		// Pass the injector from mocks to the provider
@@ -162,12 +162,12 @@ func TestOnePasswordCLISecretsProvider_ParseSecrets(t *testing.T) {
 		// Setup mocks
 		mocks := setupOnePasswordCLISecretsProviderMocks()
 		execSilentCalled := false
-		mocks.Shell.ExecSilentFunc = func(command string, args ...string) (string, error) {
+		mocks.Shell.ExecSilentFunc = func(command string, args ...string) (string, int, error) {
 			execSilentCalled = true
 			if command == "op" && args[0] == "item" && args[1] == "get" && args[2] == "secretName" && args[3] == "--vault" && args[4] == "ExampleVault" && args[5] == "--fields" && args[6] == "fieldName" {
-				return "secretValue", nil
+				return "secretValue", 0, nil
 			}
-			return "", fmt.Errorf("unexpected command: %s", command)
+			return "", 0, fmt.Errorf("unexpected command: %s", command)
 		}
 
 		// Pass the injector from mocks to the provider
@@ -209,9 +209,9 @@ func TestOnePasswordCLISecretsProvider_ParseSecrets(t *testing.T) {
 		// Setup mocks
 		mocks := setupOnePasswordCLISecretsProviderMocks()
 		execSilentCalled := false
-		mocks.Shell.ExecSilentFunc = func(command string, args ...string) (string, error) {
+		mocks.Shell.ExecSilentFunc = func(command string, args ...string) (string, int, error) {
 			execSilentCalled = true
-			return "", fmt.Errorf("item not found")
+			return "", 0, fmt.Errorf("item not found")
 		}
 
 		// Pass the injector from mocks to the provider
@@ -287,12 +287,12 @@ func TestOnePasswordCLISecretsProvider_ParseSecrets(t *testing.T) {
 		// Setup mocks
 		mocks := setupOnePasswordCLISecretsProviderMocks()
 		execSilentCalled := false
-		mocks.Shell.ExecSilentFunc = func(command string, args ...string) (string, error) {
+		mocks.Shell.ExecSilentFunc = func(command string, args ...string) (string, int, error) {
 			execSilentCalled = true
 			if command == "op" && args[0] == "item" && args[1] == "get" && args[2] == "emptySecret" && args[3] == "--vault" && args[4] == "ExampleVault" && args[5] == "--fields" && args[6] == "fieldName" {
-				return "", nil
+				return "", 0, nil
 			}
-			return "", fmt.Errorf("unexpected command: %s", command)
+			return "", 0, fmt.Errorf("unexpected command: %s", command)
 		}
 
 		// Pass the injector from mocks to the provider

--- a/pkg/services/localstack_service_test.go
+++ b/pkg/services/localstack_service_test.go
@@ -42,8 +42,8 @@ func createLocalstackServiceMocks(mockInjector ...di.Injector) *LocalstackServic
 	}
 
 	mockShell := shell.NewMockShell()
-	mockShell.ExecFunc = func(command string, args ...string) (string, error) {
-		return "mock-exec-output", nil
+	mockShell.ExecFunc = func(command string, args ...string) (string, int, error) {
+		return "mock-exec-output", 0, nil
 	}
 	mockShell.GetProjectRootFunc = func() (string, error) { return filepath.FromSlash("/mock/project/root"), nil }
 

--- a/pkg/shell/mock_shell.go
+++ b/pkg/shell/mock_shell.go
@@ -11,10 +11,10 @@ type MockShell struct {
 	PrintEnvVarsFunc               func(envVars map[string]string) error
 	PrintAliasFunc                 func(envVars map[string]string) error
 	GetProjectRootFunc             func() (string, error)
-	ExecFunc                       func(command string, args ...string) (string, error)
-	ExecSilentFunc                 func(command string, args ...string) (string, error)
-	ExecProgressFunc               func(message string, command string, args ...string) (string, error)
-	ExecSudoFunc                   func(message string, command string, args ...string) (string, error)
+	ExecFunc                       func(command string, args ...string) (string, int, error)
+	ExecSilentFunc                 func(command string, args ...string) (string, int, error)
+	ExecProgressFunc               func(message string, command string, args ...string) (string, int, error)
+	ExecSudoFunc                   func(message string, command string, args ...string) (string, int, error)
 	InstallHookFunc                func(shellName string) error
 	SetVerbosityFunc               func(verbose bool)
 	AddCurrentDirToTrustedFileFunc func() error
@@ -67,35 +67,36 @@ func (s *MockShell) GetProjectRoot() (string, error) {
 }
 
 // Exec calls the custom ExecFunc if provided.
-func (s *MockShell) Exec(command string, args ...string) (string, error) {
+func (s *MockShell) Exec(command string, args ...string) (string, int, error) {
 	if s.ExecFunc != nil {
-		return s.ExecFunc(command, args...)
+		output, exitCode, err := s.ExecFunc(command, args...)
+		return output, exitCode, err
 	}
-	return "", nil
+	return "", 0, nil
 }
 
 // ExecSilent calls the custom ExecSilentFunc if provided.
-func (s *MockShell) ExecSilent(command string, args ...string) (string, error) {
+func (s *MockShell) ExecSilent(command string, args ...string) (string, int, error) {
 	if s.ExecSilentFunc != nil {
 		return s.ExecSilentFunc(command, args...)
 	}
-	return "", nil
+	return "", 0, nil
 }
 
 // ExecProgress calls the custom ExecProgressFunc if provided.
-func (s *MockShell) ExecProgress(message string, command string, args ...string) (string, error) {
+func (s *MockShell) ExecProgress(message string, command string, args ...string) (string, int, error) {
 	if s.ExecProgressFunc != nil {
 		return s.ExecProgressFunc(message, command, args...)
 	}
-	return "", nil
+	return "", 0, nil
 }
 
 // ExecSudo calls the custom ExecSudoFunc if provided.
-func (s *MockShell) ExecSudo(message string, command string, args ...string) (string, error) {
+func (s *MockShell) ExecSudo(message string, command string, args ...string) (string, int, error) {
 	if s.ExecSudoFunc != nil {
 		return s.ExecSudoFunc(message, command, args...)
 	}
-	return "", nil
+	return "", 0, nil
 }
 
 // InstallHook calls the custom InstallHook if provided.

--- a/pkg/shell/mock_shell_test.go
+++ b/pkg/shell/mock_shell_test.go
@@ -205,12 +205,12 @@ func TestMockShell_Exec(t *testing.T) {
 		// Given a mock shell with a custom ExecFn implementation
 		injector := di.NewInjector()
 		mockShell := NewMockShell(injector)
-		mockShell.ExecFunc = func(command string, args ...string) (string, error) {
+		mockShell.ExecFunc = func(command string, args ...string) (string, int, error) {
 			// Simulate command execution and return a mocked output
-			return "mocked output", nil
+			return "mocked output", 0, nil
 		}
 		// When calling Exec
-		output, err := mockShell.Exec("Executing command", "somecommand", "arg1", "arg2")
+		output, _, err := mockShell.Exec("Executing command", "somecommand", "arg1", "arg2")
 		// Then no error should be returned and output should be as expected
 		expectedOutput := "mocked output"
 		if err != nil {
@@ -225,12 +225,12 @@ func TestMockShell_Exec(t *testing.T) {
 		// Given a mock shell whose ExecFn returns an error
 		injector := di.NewInjector()
 		mockShell := NewMockShell(injector)
-		mockShell.ExecFunc = func(command string, args ...string) (string, error) {
+		mockShell.ExecFunc = func(command string, args ...string) (string, int, error) {
 			// Simulate command failure
-			return "", fmt.Errorf("execution error")
+			return "", 1, fmt.Errorf("execution error")
 		}
 		// When calling Exec
-		output, err := mockShell.Exec("somecommand", "arg1", "arg2")
+		output, _, err := mockShell.Exec("somecommand", "arg1", "arg2")
 		// Then an error should be returned
 		if err == nil {
 			t.Errorf("Expected an error but got none")
@@ -245,7 +245,7 @@ func TestMockShell_Exec(t *testing.T) {
 		injector := di.NewInjector()
 		mockShell := NewMockShell(injector)
 		// When calling Exec
-		output, err := mockShell.Exec("Executing command", "somecommand", "arg1", "arg2")
+		output, _, err := mockShell.Exec("Executing command", "somecommand", "arg1", "arg2")
 		// Then no error should be returned and the result should be empty
 		if err != nil {
 			t.Errorf("Exec() error = %v, want nil", err)
@@ -261,11 +261,11 @@ func TestMockShell_ExecSilent(t *testing.T) {
 		// Given a mock shell with a custom ExecSilentFn implementation
 		injector := di.NewInjector()
 		mockShell := NewMockShell(injector)
-		mockShell.ExecSilentFunc = func(command string, args ...string) (string, error) {
-			return "mocked output", nil
+		mockShell.ExecSilentFunc = func(command string, args ...string) (string, int, error) {
+			return "mocked output", 0, nil
 		}
 		// When calling ExecSilent
-		output, err := mockShell.ExecSilent("Executing command", "somecommand", "arg1", "arg2")
+		output, _, err := mockShell.ExecSilent("Executing command", "somecommand", "arg1", "arg2")
 		// Then no error should be returned and output should be as expected
 		expectedOutput := "mocked output"
 		if err != nil {
@@ -281,7 +281,7 @@ func TestMockShell_ExecSilent(t *testing.T) {
 		injector := di.NewInjector()
 		mockShell := NewMockShell(injector)
 		// When calling ExecSilent
-		output, err := mockShell.ExecSilent("Executing command", "somecommand", "arg1", "arg2")
+		output, _, err := mockShell.ExecSilent("Executing command", "somecommand", "arg1", "arg2")
 		// Then no error should be returned and the result should be empty
 		if err != nil {
 			t.Errorf("ExecSilent() error = %v, want nil", err)
@@ -297,11 +297,11 @@ func TestMockShell_ExecProgress(t *testing.T) {
 		// Given a mock shell with a custom ExecProgressFn implementation
 		injector := di.NewInjector()
 		mockShell := NewMockShell(injector)
-		mockShell.ExecProgressFunc = func(message string, command string, args ...string) (string, error) {
-			return "mocked output", nil
+		mockShell.ExecProgressFunc = func(message string, command string, args ...string) (string, int, error) {
+			return "mocked output", 0, nil
 		}
 		// When calling ExecProgress
-		output, err := mockShell.ExecProgress("Executing command", "somecommand", "arg1", "arg2")
+		output, _, err := mockShell.ExecProgress("Executing command", "somecommand", "arg1", "arg2")
 		// Then no error should be returned and output should be as expected
 		expectedOutput := "mocked output"
 		if err != nil {
@@ -317,7 +317,7 @@ func TestMockShell_ExecProgress(t *testing.T) {
 		injector := di.NewInjector()
 		mockShell := NewMockShell(injector)
 		// When calling ExecProgress
-		output, err := mockShell.ExecProgress("Executing command", "somecommand", "arg1", "arg2")
+		output, _, err := mockShell.ExecProgress("Executing command", "somecommand", "arg1", "arg2")
 		// Then no error should be returned and the result should be empty
 		if err != nil {
 			t.Errorf("ExecProgress() error = %v, want nil", err)
@@ -333,11 +333,11 @@ func TestMockShell_ExecSudo(t *testing.T) {
 		// Given a mock shell with a custom ExecSudoFn implementation
 		injector := di.NewInjector()
 		mockShell := NewMockShell(injector)
-		mockShell.ExecSudoFunc = func(message string, command string, args ...string) (string, error) {
-			return "mocked sudo output", nil
+		mockShell.ExecSudoFunc = func(message string, command string, args ...string) (string, int, error) {
+			return "mocked sudo output", 0, nil
 		}
 		// When calling ExecSudo
-		output, err := mockShell.ExecSudo("Executing sudo command", "somecommand", "arg1", "arg2")
+		output, _, err := mockShell.ExecSudo("Executing sudo command", "somecommand", "arg1", "arg2")
 		// Then no error should be returned and output should be as expected
 		expectedOutput := "mocked sudo output"
 		if err != nil {
@@ -353,7 +353,7 @@ func TestMockShell_ExecSudo(t *testing.T) {
 		injector := di.NewInjector()
 		mockShell := NewMockShell(injector)
 		// When calling ExecSudo
-		output, err := mockShell.ExecSudo("Executing sudo command", "somecommand", "arg1", "arg2")
+		output, _, err := mockShell.ExecSudo("Executing sudo command", "somecommand", "arg1", "arg2")
 		// Then no error should be returned and the result should be empty
 		if err != nil {
 			t.Errorf("ExecSudo() error = %v, want nil", err)

--- a/pkg/shell/secure_shell_test.go
+++ b/pkg/shell/secure_shell_test.go
@@ -128,7 +128,7 @@ func TestSecureShell_Exec(t *testing.T) {
 		secureShell := NewSecureShell(mocks.Injector)
 		secureShell.Initialize()
 
-		output, err := secureShell.Exec(command, args...)
+		output, _, err := secureShell.Exec(command, args...)
 		if err != nil {
 			t.Fatalf("Failed to execute command: %v", err)
 		}
@@ -157,7 +157,7 @@ func TestSecureShell_Exec(t *testing.T) {
 		secureShell := NewSecureShell(mocks.Injector)
 		secureShell.Initialize()
 
-		output, err := secureShell.Exec(command, args...)
+		output, _, err := secureShell.Exec(command, args...)
 		if err == nil {
 			t.Fatalf("Expected error, got nil")
 		}
@@ -175,7 +175,7 @@ func TestSecureShell_Exec(t *testing.T) {
 		secureShell := NewSecureShell(mocks.Injector)
 		secureShell.Initialize()
 
-		_, err := secureShell.Exec("Running command", "echo", "hello")
+		_, _, err := secureShell.Exec("Running command", "echo", "hello")
 		if err == nil {
 			t.Fatalf("Expected error, got nil")
 		}
@@ -194,7 +194,7 @@ func TestSecureShell_Exec(t *testing.T) {
 		secureShell := NewSecureShell(mocks.Injector)
 		secureShell.Initialize()
 
-		_, err := secureShell.Exec("Running command", "echo", "hello")
+		_, _, err := secureShell.Exec("Running command", "echo", "hello")
 		if err == nil {
 			t.Fatalf("Expected error, got nil")
 		}
@@ -228,121 +228,12 @@ func TestSecureShell_Exec(t *testing.T) {
 		secureShell := NewSecureShell(mocks.Injector)
 		secureShell.Initialize()
 
-		output, err := secureShell.Exec(command, args...)
+		output, _, err := secureShell.Exec(command, args...)
 		if err != nil {
 			t.Fatalf("Failed to execute command: %v", err)
 		}
 		if output != expectedOutput {
 			t.Fatalf("Expected output %q, got %q", expectedOutput, output)
-		}
-	})
-}
-
-func TestSecureShell_ExecProgress(t *testing.T) {
-	t.Run("Success", func(t *testing.T) {
-		expectedOutput := "command output"
-		message := "Executing command"
-		command := "echo"
-		args := []string{"hello"}
-
-		mocks := setSafeSecureShellMocks()
-		mocks.ClientConn.NewSessionFunc = func() (ssh.Session, error) {
-			return &ssh.MockSession{
-				RunFunc: func(cmd string) error {
-					if cmd != command+" "+strings.Join(args, " ") {
-						return fmt.Errorf("unexpected command: %s", cmd)
-					}
-					return nil
-				},
-				SetStdoutFunc: func(w io.Writer) {
-					w.Write([]byte(expectedOutput))
-				},
-				SetStderrFunc: func(w io.Writer) {},
-			}, nil
-		}
-
-		secureShell := NewSecureShell(mocks.Injector)
-		secureShell.Initialize()
-
-		output, err := secureShell.ExecProgress(message, command, args...)
-		if err != nil {
-			t.Fatalf("Failed to execute command: %v", err)
-		}
-		if output != expectedOutput {
-			t.Fatalf("Expected output %q, got %q", expectedOutput, output)
-		}
-	})
-
-	t.Run("Error", func(t *testing.T) {
-		mocks := setSafeSecureShellMocks()
-		mocks.ClientConn.NewSessionFunc = func() (ssh.Session, error) {
-			return nil, fmt.Errorf("failed to create SSH session")
-		}
-
-		secureShell := NewSecureShell(mocks.Injector)
-		secureShell.Initialize()
-
-		_, err := secureShell.ExecProgress("Executing command", "echo", "hello")
-		if err == nil {
-			t.Fatalf("Expected error, got nil")
-		}
-		expectedError := "failed to create SSH session"
-		if !strings.Contains(err.Error(), expectedError) {
-			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
-		}
-	})
-}
-
-func TestSecureShell_ExecSilent(t *testing.T) {
-	t.Run("Success", func(t *testing.T) {
-		expectedOutput := "command output"
-		command := "echo"
-		args := []string{"hello"}
-
-		mocks := setSafeSecureShellMocks()
-		mocks.ClientConn.NewSessionFunc = func() (ssh.Session, error) {
-			return &ssh.MockSession{
-				RunFunc: func(cmd string) error {
-					if cmd != command+" "+strings.Join(args, " ") {
-						return fmt.Errorf("unexpected command: %s", cmd)
-					}
-					return nil
-				},
-				SetStdoutFunc: func(w io.Writer) {
-					w.Write([]byte(expectedOutput))
-				},
-				SetStderrFunc: func(w io.Writer) {},
-			}, nil
-		}
-
-		secureShell := NewSecureShell(mocks.Injector)
-		secureShell.Initialize()
-
-		output, err := secureShell.ExecSilent(command, args...)
-		if err != nil {
-			t.Fatalf("Failed to execute command: %v", err)
-		}
-		if output != expectedOutput {
-			t.Fatalf("Expected output %q, got %q", expectedOutput, output)
-		}
-	})
-
-	t.Run("Error", func(t *testing.T) {
-		mocks := setSafeSecureShellMocks()
-		mocks.ClientConn.NewSessionFunc = func() (ssh.Session, error) {
-			return nil, fmt.Errorf("failed to create SSH session")
-		}
-
-		secureShell := NewSecureShell(mocks.Injector)
-		secureShell.Initialize()
-
-		_, err := secureShell.ExecSilent("echo", "hello")
-		if err == nil {
-			t.Fatalf("Expected error, got nil")
-		}
-		expectedError := "failed to create SSH session"
-		if !strings.Contains(err.Error(), expectedError) {
-			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
 		}
 	})
 }

--- a/pkg/shell/shims.go
+++ b/pkg/shell/shims.go
@@ -8,84 +8,97 @@ import (
 	"text/template"
 )
 
-// getwd is a variable that points to os.Getwd, allowing it to be overridden in tests
-var getwd = os.Getwd
+// Shims for system functions to facilitate testing by allowing overrides.
+var (
+	// Current working directory retrieval
+	getwd = os.Getwd
 
-// execCommand is a variable that points to exec.Command, allowing it to be overridden in tests
-var execCommand = osExecCommand
+	// Command execution
+	execCommand = osExecCommand
 
-// osExecCommand is a wrapper around exec.Command to allow it to be overridden in tests
+	// Command run execution
+	cmdRun = func(cmd *exec.Cmd) error {
+		return cmd.Run()
+	}
+
+	// Command start execution
+	cmdStart = func(cmd *exec.Cmd) error {
+		return cmd.Start()
+	}
+
+	// User home directory retrieval
+	osUserHomeDir = os.UserHomeDir
+
+	// File status retrieval
+	osStat = os.Stat
+
+	// File opening
+	osOpenFile = os.OpenFile
+
+	// File reading
+	osReadFile = os.ReadFile
+
+	// File writing
+	osWriteFile = os.WriteFile
+
+	// Directory creation
+	osMkdirAll = os.MkdirAll
+
+	// Command wait execution
+	cmdWait = func(cmd *exec.Cmd) error {
+		return cmd.Wait()
+	}
+
+	// Command stdout pipe
+	cmdStdoutPipe = func(cmd *exec.Cmd) (io.ReadCloser, error) {
+		return cmd.StdoutPipe()
+	}
+
+	// Command stderr pipe
+	cmdStderrPipe = func(cmd *exec.Cmd) (io.ReadCloser, error) {
+		return cmd.StderrPipe()
+	}
+
+	// Scanner scan operation
+	bufioScannerScan = func(scanner *bufio.Scanner) bool {
+		return scanner.Scan()
+	}
+
+	// Scanner error retrieval
+	bufioScannerErr = func(scanner *bufio.Scanner) error {
+		return scanner.Err()
+	}
+
+	// Executable path retrieval
+	osExecutable = os.Executable
+
+	// Template creation
+	hookTemplateNew = func(name string) *template.Template {
+		return template.New(name)
+	}
+
+	// Template parsing
+	hookTemplateParse = func(tmpl *template.Template, text string) (*template.Template, error) {
+		return tmpl.Parse(text)
+	}
+
+	// Template execution
+	hookTemplateExecute = func(tmpl *template.Template, wr io.Writer, data interface{}) error {
+		return tmpl.Execute(wr, data)
+	}
+
+	// Process state exit code retrieval
+	processStateExitCode = func(ps *os.ProcessState) int {
+		return ps.ExitCode()
+	}
+
+	// Process state creation
+	newProcessState = func() *os.ProcessState {
+		return &os.ProcessState{}
+	}
+)
+
+// osExecCommand wraps exec.Command for testing purposes.
 func osExecCommand(name string, arg ...string) *exec.Cmd {
 	return exec.Command(name, arg...)
-}
-
-// cmdRun is a variable that points to cmd.Run, allowing it to be overridden in tests
-var cmdRun = func(cmd *exec.Cmd) error {
-	return cmd.Run()
-}
-
-// cmdStart is a variable that points to cmd.Start, allowing it to be overridden in tests
-var cmdStart = func(cmd *exec.Cmd) error {
-	return cmd.Start()
-}
-
-// osUserHomeDir is a variable that points to os.UserHomeDir, allowing it to be overridden in tests
-var osUserHomeDir = os.UserHomeDir
-
-// osStat is a variable that points to os.Stat, allowing it to be overridden in tests
-var osStat = os.Stat
-
-// osOpenFile is a variable that points to os.OpenFile, allowing it to be overridden in tests
-var osOpenFile = os.OpenFile
-
-// osReadFile is a variable that points to os.ReadFile, allowing it to be overridden in tests
-var osReadFile = os.ReadFile
-
-// osWriteFile is a variable that points to os.WriteFile, allowing it to be overridden in tests
-var osWriteFile = os.WriteFile
-
-// osMkdirAll is a variable that points to os.MkdirAll, allowing it to be overridden in tests
-var osMkdirAll = os.MkdirAll
-
-// cmdWait is a variable that points to cmd.Wait, allowing it to be overridden in tests
-var cmdWait = func(cmd *exec.Cmd) error {
-	return cmd.Wait()
-}
-
-// cmdStdoutPipe is a variable that points to cmd.StdoutPipe, allowing it to be overridden in tests
-var cmdStdoutPipe = func(cmd *exec.Cmd) (io.ReadCloser, error) {
-	return cmd.StdoutPipe()
-}
-
-// cmdStderrPipe is a variable that points to cmd.StderrPipe, allowing it to be overridden in tests
-var cmdStderrPipe = func(cmd *exec.Cmd) (io.ReadCloser, error) {
-	return cmd.StderrPipe()
-}
-
-// bufioScannerScan is a variable that points to bufio.Scanner.Scan, allowing it to be overridden in tests
-var bufioScannerScan = func(scanner *bufio.Scanner) bool {
-	return scanner.Scan()
-}
-
-// bufioScannerErr is a variable that points to bufio.Scanner.Err, allowing it to be overridden in tests
-var bufioScannerErr = func(scanner *bufio.Scanner) error {
-	return scanner.Err()
-}
-
-// osExecutable is a variable that points to os.Executable, allowing it to be overridden in tests
-var osExecutable = os.Executable
-
-// hookTemplateNew is a variable that points to template.New, allowing it to be overridden in tests
-var hookTemplateNew = func(name string) *template.Template {
-	return template.New(name)
-}
-
-// hookTemplateParse is a variable that points to template.Template.Parse, allowing it to be overridden in tests
-var hookTemplateParse = func(tmpl *template.Template, text string) (*template.Template, error) {
-	return tmpl.Parse(text)
-}
-
-// hookTemplateExecute is a variable that points to template.Template.Execute, allowing it to be overridden in tests
-var hookTemplateExecute = func(tmpl *template.Template, wr io.Writer, data interface{}) error {
-	return tmpl.Execute(wr, data)
 }

--- a/pkg/stack/windsor_stack.go
+++ b/pkg/stack/windsor_stack.go
@@ -68,19 +68,19 @@ func (s *WindsorStack) Up() error {
 		}
 
 		// Execute 'terraform init' in the dirPath
-		_, err = s.shell.ExecProgress(fmt.Sprintf("🌎 Initializing Terraform in %s", component.Path), "terraform", "init", "-migrate-state", "-upgrade")
+		_, _, err = s.shell.ExecProgress(fmt.Sprintf("🌎 Initializing Terraform in %s", component.Path), "terraform", "init", "-migrate-state", "-upgrade")
 		if err != nil {
 			return fmt.Errorf("error initializing Terraform in %s: %w", component.FullPath, err)
 		}
 
 		// Execute 'terraform plan' in the dirPath
-		_, err = s.shell.ExecProgress(fmt.Sprintf("🌎 Planning Terraform changes in %s", component.Path), "terraform", "plan")
+		_, _, err = s.shell.ExecProgress(fmt.Sprintf("🌎 Planning Terraform changes in %s", component.Path), "terraform", "plan")
 		if err != nil {
 			return fmt.Errorf("error planning Terraform changes in %s: %w", component.FullPath, err)
 		}
 
 		// Execute 'terraform apply' in the dirPath
-		_, err = s.shell.ExecProgress(fmt.Sprintf("🌎 Applying Terraform changes in %s", component.Path), "terraform", "apply")
+		_, _, err = s.shell.ExecProgress(fmt.Sprintf("🌎 Applying Terraform changes in %s", component.Path), "terraform", "apply")
 		if err != nil {
 			return fmt.Errorf("error applying Terraform changes in %s: %w", component.FullPath, err)
 		}

--- a/pkg/stack/windsor_stack_test.go
+++ b/pkg/stack/windsor_stack_test.go
@@ -195,11 +195,11 @@ func TestWindsorStack_Up(t *testing.T) {
 	t.Run("ErrorRunningTerraformInit", func(t *testing.T) {
 		// Given shell.Exec is mocked to return an error
 		mocks := setupSafeMocks()
-		mocks.Shell.ExecProgressFunc = func(message string, command string, args ...string) (string, error) {
+		mocks.Shell.ExecProgressFunc = func(message string, command string, args ...string) (string, int, error) {
 			if command == "terraform" && len(args) > 0 && args[0] == "init" {
-				return "", fmt.Errorf("mock error running terraform init")
+				return "", 0, fmt.Errorf("mock error running terraform init")
 			}
-			return "", nil
+			return "", 0, nil
 		}
 
 		// When a new WindsorStack is created, initialized, and Up is called
@@ -226,11 +226,11 @@ func TestWindsorStack_Up(t *testing.T) {
 	t.Run("ErrorRunningTerraformPlan", func(t *testing.T) {
 		// Given shell.Exec is mocked to return an error
 		mocks := setupSafeMocks()
-		mocks.Shell.ExecProgressFunc = func(message string, command string, args ...string) (string, error) {
+		mocks.Shell.ExecProgressFunc = func(message string, command string, args ...string) (string, int, error) {
 			if command == "terraform" && len(args) > 0 && args[0] == "plan" {
-				return "", fmt.Errorf("mock error running terraform plan")
+				return "", 0, fmt.Errorf("mock error running terraform plan")
 			}
-			return "", nil
+			return "", 0, nil
 		}
 
 		// When a new WindsorStack is created, initialized, and Up is called
@@ -253,11 +253,11 @@ func TestWindsorStack_Up(t *testing.T) {
 	t.Run("ErrorRunningTerraformApply", func(t *testing.T) {
 		// Given shell.Exec is mocked to return an error
 		mocks := setupSafeMocks()
-		mocks.Shell.ExecProgressFunc = func(message string, command string, args ...string) (string, error) {
+		mocks.Shell.ExecProgressFunc = func(message string, command string, args ...string) (string, int, error) {
 			if command == "terraform" && len(args) > 0 && args[0] == "apply" {
-				return "", fmt.Errorf("mock error running terraform apply")
+				return "", 0, fmt.Errorf("mock error running terraform apply")
 			}
-			return "", nil
+			return "", 0, nil
 		}
 
 		// When a new WindsorStack is created, initialized, and Up is called

--- a/pkg/tools/tools_manager.go
+++ b/pkg/tools/tools_manager.go
@@ -157,7 +157,7 @@ func (t *BaseToolsManager) checkDocker() error {
 		return fmt.Errorf("docker is not available in the PATH")
 	}
 
-	output, _ := t.shell.ExecSilent("docker", "version", "--format", "{{.Client.Version}}")
+	output, _, _ := t.shell.ExecSilent("docker", "version", "--format", "{{.Client.Version}}")
 	dockerVersion := extractVersion(output)
 	if dockerVersion == "" {
 		return fmt.Errorf("failed to extract Docker version")
@@ -169,12 +169,12 @@ func (t *BaseToolsManager) checkDocker() error {
 	var dockerComposeVersion string
 
 	// Try to get docker-compose version using different methods
-	output, _ = t.shell.ExecSilent("docker", "compose", "version", "--short")
+	output, _, _ = t.shell.ExecSilent("docker", "compose", "version", "--short")
 	dockerComposeVersion = extractVersion(output)
 
 	if dockerComposeVersion == "" {
 		if _, err := execLookPath("docker-compose"); err == nil {
-			output, _ = t.shell.ExecSilent("docker-compose", "version", "--short")
+			output, _, _ = t.shell.ExecSilent("docker-compose", "version", "--short")
 			dockerComposeVersion = extractVersion(output)
 		}
 	}
@@ -201,7 +201,7 @@ func (t *BaseToolsManager) checkColima() error {
 	if _, err := execLookPath("colima"); err != nil {
 		return fmt.Errorf("colima is not available in the PATH")
 	}
-	output, _ := t.shell.ExecSilent("colima", "version")
+	output, _, _ := t.shell.ExecSilent("colima", "version")
 	colimaVersion := extractVersion(output)
 	if colimaVersion == "" {
 		return fmt.Errorf("failed to extract colima version")
@@ -213,7 +213,7 @@ func (t *BaseToolsManager) checkColima() error {
 	if _, err := execLookPath("limactl"); err != nil {
 		return fmt.Errorf("limactl is not available in the PATH")
 	}
-	output, _ = t.shell.ExecSilent("limactl", "--version")
+	output, _, _ = t.shell.ExecSilent("limactl", "--version")
 	limactlVersion := extractVersion(output)
 	if limactlVersion == "" {
 		return fmt.Errorf("failed to extract limactl version")
@@ -232,7 +232,7 @@ func (t *BaseToolsManager) checkKubectl() error {
 	if _, err := execLookPath("kubectl"); err != nil {
 		return fmt.Errorf("kubectl is not available in the PATH")
 	}
-	output, _ := t.shell.ExecSilent("kubectl", "version", "--client")
+	output, _, _ := t.shell.ExecSilent("kubectl", "version", "--client")
 	kubectlVersion := extractVersion(output)
 	if kubectlVersion == "" {
 		return fmt.Errorf("failed to extract kubectl version")
@@ -251,7 +251,7 @@ func (t *BaseToolsManager) checkTalosctl() error {
 	if _, err := execLookPath("talosctl"); err != nil {
 		return fmt.Errorf("talosctl is not available in the PATH")
 	}
-	output, _ := t.shell.ExecSilent("talosctl", "version", "--client", "--short")
+	output, _, _ := t.shell.ExecSilent("talosctl", "version", "--client", "--short")
 	talosctlVersion := extractVersion(output)
 	if talosctlVersion == "" {
 		return fmt.Errorf("failed to extract talosctl version")
@@ -270,7 +270,7 @@ func (t *BaseToolsManager) checkTerraform() error {
 	if _, err := execLookPath("terraform"); err != nil {
 		return fmt.Errorf("terraform is not available in the PATH")
 	}
-	output, _ := t.shell.ExecSilent("terraform", "version")
+	output, _, _ := t.shell.ExecSilent("terraform", "version")
 	terraformVersion := extractVersion(output)
 	if terraformVersion == "" {
 		return fmt.Errorf("failed to extract terraform version")
@@ -289,7 +289,7 @@ func (t *BaseToolsManager) checkOnePassword() error {
 	if _, err := execLookPath("op"); err != nil {
 		return fmt.Errorf("1Password CLI is not available in the PATH")
 	}
-	output, _ := t.shell.ExecSilent("op", "--version")
+	output, _, _ := t.shell.ExecSilent("op", "--version")
 	opVersion := extractVersion(output)
 	if opVersion == "" {
 		return fmt.Errorf("failed to extract 1Password CLI version")

--- a/pkg/virt/colima_virt.go
+++ b/pkg/virt/colima_virt.go
@@ -64,7 +64,7 @@ func (v *ColimaVirt) GetVMInfo() (VMInfo, error) {
 
 	command := "colima"
 	args := []string{"ls", "--profile", fmt.Sprintf("windsor-%s", contextName), "--json"}
-	out, err := v.shell.ExecSilent(command, args...)
+	out, _, err := v.shell.ExecSilent(command, args...)
 	if err != nil {
 		return VMInfo{}, err
 	}
@@ -262,9 +262,9 @@ func (v *ColimaVirt) executeColimaCommand(action string) error {
 	command := "colima"
 	args := []string{action, fmt.Sprintf("windsor-%s", contextName)}
 	formattedCommand := fmt.Sprintf("%s %s", command, strings.Join(args, " "))
-	output, err := v.shell.ExecProgress(fmt.Sprintf("🦙 Running %s", formattedCommand), command, args...)
+	_, _, err := v.shell.ExecProgress(fmt.Sprintf("🦙 Running %s", formattedCommand), command, args...)
 	if err != nil {
-		return fmt.Errorf("Error executing command %s %v: %w\n%s", command, args, err, output)
+		return fmt.Errorf("Error executing command %s %v: %w", command, args, err)
 	}
 
 	return nil
@@ -277,9 +277,9 @@ func (v *ColimaVirt) startColima() (VMInfo, error) {
 
 	command := "colima"
 	args := []string{"start", fmt.Sprintf("windsor-%s", contextName)}
-	output, err := v.shell.ExecProgress(fmt.Sprintf("🦙 Running %s %s", command, strings.Join(args, " ")), command, args...)
+	_, _, err := v.shell.ExecProgress(fmt.Sprintf("🦙 Running %s %s", command, strings.Join(args, " ")), command, args...)
 	if err != nil {
-		return VMInfo{}, fmt.Errorf("Error executing command %s %v: %w\n%s", command, args, err, output)
+		return VMInfo{}, fmt.Errorf("Error executing command %s %v: %w", command, args, err)
 	}
 
 	// Wait until the Colima VM has an assigned IP address, try three times

--- a/pkg/virt/docker_virt.go
+++ b/pkg/virt/docker_virt.go
@@ -74,7 +74,7 @@ func (v *DockerVirt) Initialize() error {
 func (v *DockerVirt) determineComposeCommand() error {
 	commands := []string{"docker-compose", "docker-cli-plugin-docker-compose", "docker compose"}
 	for _, cmd := range commands {
-		if _, err := v.shell.ExecSilent(cmd, "--version"); err == nil {
+		if _, _, err := v.shell.ExecSilent(cmd, "--version"); err == nil {
 			v.composeCommand = cmd
 			return nil
 		}
@@ -113,7 +113,7 @@ func (v *DockerVirt) Up() error {
 
 			// Use ExecProgress for the first attempt to show progress
 			if i == 0 {
-				output, err := v.shell.ExecProgress(message, v.composeCommand, args...)
+				output, _, err := v.shell.ExecProgress(message, v.composeCommand, args...)
 				if err == nil {
 					return nil
 				}
@@ -121,7 +121,7 @@ func (v *DockerVirt) Up() error {
 				lastOutput = output
 			} else {
 				// Use ExecSilent for retries to avoid multiple progress messages
-				output, err := v.shell.ExecSilent(v.composeCommand, args...)
+				output, _, err := v.shell.ExecSilent(v.composeCommand, args...)
 				if err == nil {
 					return nil
 				}
@@ -162,7 +162,7 @@ func (v *DockerVirt) Down() error {
 		}
 
 		// Run docker compose down with clean flags using the Exec function from shell.go
-		output, err := v.shell.ExecProgress("📦 Running docker compose down", v.composeCommand, "down", "--remove-orphans", "--volumes")
+		output, _, err := v.shell.ExecProgress("📦 Running docker compose down", v.composeCommand, "down", "--remove-orphans", "--volumes")
 		if err != nil {
 			return fmt.Errorf("Error executing command %s down: %w\n%s", v.composeCommand, err, output)
 		}
@@ -212,7 +212,7 @@ func (v *DockerVirt) GetContainerInfo(name ...string) ([]ContainerInfo, error) {
 
 	command := "docker"
 	args := []string{"ps", "--filter", "label=managed_by=windsor", "--filter", fmt.Sprintf("label=context=%s", contextName), "--format", "{{.ID}}"}
-	out, err := v.shell.ExecSilent(command, args...)
+	out, _, err := v.shell.ExecSilent(command, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +225,7 @@ func (v *DockerVirt) GetContainerInfo(name ...string) ([]ContainerInfo, error) {
 			continue
 		}
 		inspectArgs := []string{"inspect", containerID, "--format", "{{json .Config.Labels}}"}
-		inspectOut, err := v.shell.ExecSilent(command, inspectArgs...)
+		inspectOut, _, err := v.shell.ExecSilent(command, inspectArgs...)
 		if err != nil {
 			return nil, err
 		}
@@ -243,7 +243,7 @@ func (v *DockerVirt) GetContainerInfo(name ...string) ([]ContainerInfo, error) {
 		}
 
 		networkInspectArgs := []string{"inspect", containerID, "--format", "{{json .NetworkSettings.Networks}}"}
-		networkInspectOut, err := v.shell.ExecSilent(command, networkInspectArgs...)
+		networkInspectOut, _, err := v.shell.ExecSilent(command, networkInspectArgs...)
 		if err != nil {
 			return nil, err
 		}
@@ -307,7 +307,7 @@ var _ ContainerRuntime = (*DockerVirt)(nil)
 func (v *DockerVirt) checkDockerDaemon() error {
 	command := "docker"
 	args := []string{"info"}
-	_, err := v.shell.ExecSilent(command, args...)
+	_, _, err := v.shell.ExecSilent(command, args...)
 	return err
 }
 


### PR DESCRIPTION
`windsor exec` commands now return the exit codes from the command that err'd.