### PR TITLE
Windsor Exec container mode

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -180,7 +180,7 @@ jobs:
             ${{ runner.os }}-docker-
 
       - name: Log in to GitHub Container Registry
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') || github.ref == 'refs/heads/main'
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ghcr.io
@@ -204,9 +204,19 @@ jobs:
         with:
           context: .
           push: true
-          tags: |
-            ghcr.io/windsorcli/windsorcli:latest
-            ghcr.io/windsorcli/windsorcli:${{ github.ref_name }}
+          tags: ghcr.io/windsorcli/windsorcli:${{ github.ref_name }}
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache
+
+      - name: Push Docker image latest
+        if: github.ref == 'refs/heads/main'
+        uses: docker/build-push-action@471d1dc4e07e5cdedd4c2171150001c434f0b7a4 # v6.15.0
+        with:
+          context: .
+          push: true
+          tags: ghcr.io/windsorcli/windsorcli:latest
           file: ./Dockerfile
           platforms: linux/amd64,linux/arm64
           cache-from: type=local,src=/tmp/.buildx-cache

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -87,11 +87,11 @@
       "request": "launch",
       "mode": "auto",
       "program": "${workspaceFolder}/cmd/windsor/main.go",
-      "args": ["exec", "--", "ls"],
+      "args": ["exec", "--verbose", "--", "sh", "-c", "exit 2"],
       "env": {
         "WINDSOR_EXEC_MODE": "container",
         "WINDSOR_CONTEXT": "local",
-        "WINDSOR_PROJECT_ROOT": "${workspaceFolder}"
+        "WINDSOR_PROJECT_ROOT": "/Users/ryanvangundy/Developer/windsorcli/core"
       }
     }
   ]

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -22,7 +22,12 @@
       "request": "launch",
       "mode": "auto",
       "program": "${workspaceFolder}/cmd/windsor/main.go",
-      "args": ["init", "local"]
+      "args": ["init", "local"],
+      "env": {
+        "WINDSOR_EXEC_MODE": "container",
+        "WINDSOR_CONTEXT": "local",
+        "WINDSOR_PROJECT_ROOT": "${workspaceFolder}"
+      }
     },
     {
       "name": "Windsor Up",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -87,8 +87,9 @@
       "request": "launch",
       "mode": "auto",
       "program": "${workspaceFolder}/cmd/windsor/main.go",
-      "args": ["exec", "--", "sh", "-c", "exit 2"],
+      "args": ["exec", "--", "ls"],
       "env": {
+        "WINDSOR_EXEC_MODE": "container",
         "WINDSOR_CONTEXT": "local",
         "WINDSOR_PROJECT_ROOT": "${workspaceFolder}"
       }

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,9 @@ USER windsor
 # Copy windsor binary
 COPY --from=builder /work/windsor /usr/local/bin/
 
+# Create the .trusted file and add the file pointing to /work
+RUN mkdir -p /home/windsor/.config/windsor && echo "/work" > /home/windsor/.config/windsor/.trusted
+
 # Set working directory
 WORKDIR /work
 

--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -55,6 +55,8 @@ func setupSafeContextCmdMocks(optionalInjector ...di.Injector) MockSafeContextCm
 		return true
 	}
 
+	osExit = func(code int) {}
+
 	return MockSafeContextCmdComponents{
 		Injector:      injector,
 		Controller:    mockController,
@@ -63,12 +65,6 @@ func setupSafeContextCmdMocks(optionalInjector ...di.Injector) MockSafeContextCm
 }
 
 func TestContext_Get(t *testing.T) {
-	originalExitFunc := exitFunc
-	exitFunc = mockExit
-	t.Cleanup(func() {
-		exitFunc = originalExitFunc
-	})
-
 	t.Run("Success", func(t *testing.T) {
 		// Given a valid config handler
 		mocks := setupSafeContextCmdMocks()
@@ -139,12 +135,6 @@ func TestContext_Get(t *testing.T) {
 }
 
 func TestContext_Set(t *testing.T) {
-	originalExitFunc := exitFunc
-	exitFunc = mockExit
-	t.Cleanup(func() {
-		exitFunc = originalExitFunc
-	})
-
 	t.Run("Success", func(t *testing.T) {
 		// Given a valid config handler
 		mocks := setupSafeContextCmdMocks()
@@ -226,12 +216,6 @@ func TestContext_Set(t *testing.T) {
 }
 
 func TestContext_GetAlias(t *testing.T) {
-	originalExitFunc := exitFunc
-	exitFunc = mockExit
-	t.Cleanup(func() {
-		exitFunc = originalExitFunc
-	})
-
 	t.Run("Success", func(t *testing.T) {
 		// Given a valid config handler
 		mocks := setupSafeContextCmdMocks()
@@ -256,12 +240,6 @@ func TestContext_GetAlias(t *testing.T) {
 }
 
 func TestContext_SetAlias(t *testing.T) {
-	originalExitFunc := exitFunc
-	exitFunc = mockExit
-	t.Cleanup(func() {
-		exitFunc = originalExitFunc
-	})
-
 	t.Run("Success", func(t *testing.T) {
 		defer resetRootCmd()
 

--- a/cmd/down_test.go
+++ b/cmd/down_test.go
@@ -74,6 +74,8 @@ func setupSafeDownCmdMocks(optionalInjector ...di.Injector) MockSafeDownCmdCompo
 	mockContainerRuntime := virt.NewMockVirt()
 	injector.Register("containerRuntime", mockContainerRuntime)
 
+	osExit = func(code int) {}
+
 	return MockSafeDownCmdComponents{
 		Injector:             injector,
 		MockController:       mockController,
@@ -86,12 +88,6 @@ func setupSafeDownCmdMocks(optionalInjector ...di.Injector) MockSafeDownCmdCompo
 }
 
 func TestDownCmd(t *testing.T) {
-	originalExitFunc := exitFunc
-	exitFunc = mockExit
-	t.Cleanup(func() {
-		exitFunc = originalExitFunc
-	})
-
 	t.Run("Success", func(t *testing.T) {
 		// Given a set of mock components
 		mocks := setupSafeDownCmdMocks()

--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -63,7 +63,7 @@ func TestEnvCmd(t *testing.T) {
 
 		// Set the shell in the controller to the mock shell
 		mockController := ctrl.NewMockController(injector)
-		mockController.ResolveShellFunc = func() shell.Shell {
+		mockController.ResolveShellFunc = func(name ...string) shell.Shell {
 			return mockShell
 		}
 
@@ -93,7 +93,7 @@ func TestEnvCmd(t *testing.T) {
 
 		// Set the shell in the controller to the mock shell
 		mockController := ctrl.NewMockController(injector)
-		mockController.ResolveShellFunc = func() shell.Shell {
+		mockController.ResolveShellFunc = func(name ...string) shell.Shell {
 			return mockShell
 		}
 

--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -11,19 +11,29 @@ import (
 	"github.com/windsorcli/cli/pkg/shell"
 )
 
-func TestEnvCmd(t *testing.T) {
-	originalExitFunc := exitFunc
-	exitFunc = mockExit
-	t.Cleanup(func() {
-		exitFunc = originalExitFunc
-	})
+func setupSafeEnvCmdMocks(optionalInjector ...di.Injector) (*MockObjects, di.Injector) {
+	var injector di.Injector
+	if len(optionalInjector) > 0 {
+		injector = optionalInjector[0]
+	} else {
+		injector = di.NewInjector()
+	}
+	mockController := ctrl.NewMockController(injector)
 
+	osExit = func(code int) {}
+
+	return &MockObjects{
+		Controller: mockController,
+	}, injector
+}
+
+func TestEnvCmd(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		defer resetRootCmd()
 
 		// Initialize mocks and set the injector
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
+		mocks, _ := setupSafeEnvCmdMocks()
+		mockController := mocks.Controller
 
 		// Mock the GetEnvPrinters method to return the mockEnv
 		mockEnv := env.NewMockEnvPrinter()
@@ -55,14 +65,14 @@ func TestEnvCmd(t *testing.T) {
 		defer resetRootCmd()
 
 		// Given a mock shell that returns an error when checking trusted directory
-		injector := di.NewInjector()
+		mocks, injector := setupSafeEnvCmdMocks()
 		mockShell := shell.NewMockShell(injector)
 		mockShell.CheckTrustedDirectoryFunc = func() error {
 			return fmt.Errorf("error checking trusted directory")
 		}
 
 		// Set the shell in the controller to the mock shell
-		mockController := ctrl.NewMockController(injector)
+		mockController := mocks.Controller
 		mockController.ResolveShellFunc = func(name ...string) shell.Shell {
 			return mockShell
 		}
@@ -85,14 +95,14 @@ func TestEnvCmd(t *testing.T) {
 		defer resetRootCmd()
 
 		// Given a mock shell that returns an error when checking trusted directory
-		injector := di.NewInjector()
+		mocks, injector := setupSafeEnvCmdMocks()
 		mockShell := shell.NewMockShell(injector)
 		mockShell.CheckTrustedDirectoryFunc = func() error {
 			return fmt.Errorf("error checking trusted directory")
 		}
 
 		// Set the shell in the controller to the mock shell
-		mockController := ctrl.NewMockController(injector)
+		mockController := mocks.Controller
 		mockController.ResolveShellFunc = func(name ...string) shell.Shell {
 			return mockShell
 		}
@@ -112,8 +122,8 @@ func TestEnvCmd(t *testing.T) {
 			defer resetRootCmd()
 
 			// Given a mock controller that returns an error when creating virtualization components
-			injector := di.NewInjector()
-			mockController := ctrl.NewMockController(injector)
+			mocks, _ := setupSafeEnvCmdMocks()
+			mockController := mocks.Controller
 			mockController.CreateVirtualizationComponentsFunc = func() error {
 				return fmt.Errorf("error creating virtualization components")
 			}
@@ -148,8 +158,8 @@ func TestEnvCmd(t *testing.T) {
 			defer resetRootCmd()
 
 			// Given a mock controller that returns an error when creating service components
-			injector := di.NewInjector()
-			mockController := ctrl.NewMockController(injector)
+			mocks, _ := setupSafeEnvCmdMocks()
+			mockController := mocks.Controller
 			mockController.CreateServiceComponentsFunc = func() error {
 				return fmt.Errorf("error creating service components")
 			}
@@ -183,8 +193,8 @@ func TestEnvCmd(t *testing.T) {
 		defer resetRootCmd()
 
 		// Given a mock controller that returns an error when creating environment components
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
+		mocks, _ := setupSafeEnvCmdMocks()
+		mockController := mocks.Controller
 		mockController.CreateEnvComponentsFunc = func() error {
 			return fmt.Errorf("error creating environment components")
 		}
@@ -207,8 +217,8 @@ func TestEnvCmd(t *testing.T) {
 		defer resetRootCmd()
 
 		// Given a mock controller that returns an error when creating environment components
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
+		mocks, _ := setupSafeEnvCmdMocks()
+		mockController := mocks.Controller
 		mockController.CreateEnvComponentsFunc = func() error {
 			return fmt.Errorf("error creating environment components")
 		}
@@ -227,8 +237,8 @@ func TestEnvCmd(t *testing.T) {
 		defer resetRootCmd()
 
 		// Given a mock controller that returns an error when initializing components
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
+		mocks, _ := setupSafeEnvCmdMocks()
+		mockController := mocks.Controller
 		mockController.InitializeComponentsFunc = func() error {
 			return fmt.Errorf("error initializing components")
 		}
@@ -251,8 +261,8 @@ func TestEnvCmd(t *testing.T) {
 		defer resetRootCmd()
 
 		// Given a mock controller that returns an error when initializing components
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
+		mocks, _ := setupSafeEnvCmdMocks()
+		mockController := mocks.Controller
 		mockController.InitializeComponentsFunc = func() error {
 			return fmt.Errorf("error initializing components")
 		}
@@ -271,8 +281,8 @@ func TestEnvCmd(t *testing.T) {
 		defer resetRootCmd()
 
 		// Given a mock controller that returns an error when resolving all environment printers
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
+		mocks, _ := setupSafeEnvCmdMocks()
+		mockController := mocks.Controller
 		mockController.ResolveAllEnvPrintersFunc = func() []env.EnvPrinter {
 			return nil
 		}
@@ -291,8 +301,8 @@ func TestEnvCmd(t *testing.T) {
 		defer resetRootCmd()
 
 		// Given a mock controller that returns an empty list of environment printers
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
+		mocks, _ := setupSafeEnvCmdMocks()
+		mockController := mocks.Controller
 		mockController.ResolveAllEnvPrintersFunc = func() []env.EnvPrinter {
 			return []env.EnvPrinter{}
 		}
@@ -315,8 +325,8 @@ func TestEnvCmd(t *testing.T) {
 		defer resetRootCmd()
 
 		// Given a mock controller that returns a valid list of environment printers
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
+		mocks, _ := setupSafeEnvCmdMocks()
+		mockController := mocks.Controller
 		mockEnvPrinter := env.NewMockEnvPrinter()
 		mockEnvPrinter.PrintFunc = func() error {
 			return fmt.Errorf("print error")
@@ -343,8 +353,8 @@ func TestEnvCmd(t *testing.T) {
 		defer resetRootCmd()
 
 		// Given a mock controller that returns a valid list of environment printers
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
+		mocks, _ := setupSafeEnvCmdMocks()
+		mockController := mocks.Controller
 		mockEnvPrinter := env.NewMockEnvPrinter()
 		mockEnvPrinter.PrintFunc = func() error {
 			return fmt.Errorf("print error")
@@ -367,8 +377,8 @@ func TestEnvCmd(t *testing.T) {
 		defer resetRootCmd()
 
 		// Given a mock controller that returns a valid list of environment printers
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
+		mocks, _ := setupSafeEnvCmdMocks()
+		mockController := mocks.Controller
 		mockEnvPrinter := env.NewMockEnvPrinter()
 		mockEnvPrinter.PostEnvHookFunc = func() error {
 			return fmt.Errorf("post env hook error")
@@ -395,8 +405,8 @@ func TestEnvCmd(t *testing.T) {
 		defer resetRootCmd()
 
 		// Given a mock controller that returns a valid list of environment printers
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
+		mocks, _ := setupSafeEnvCmdMocks()
+		mockController := mocks.Controller
 		mockEnvPrinter := env.NewMockEnvPrinter()
 		mockEnvPrinter.PostEnvHookFunc = func() error {
 			return fmt.Errorf("post env hook error")
@@ -419,8 +429,8 @@ func TestEnvCmd(t *testing.T) {
 		defer resetRootCmd()
 
 		// Given a mock controller with a mock secrets provider
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
+		mocks, _ := setupSafeEnvCmdMocks()
+		mockController := mocks.Controller
 		mockSecretsProvider := secrets.NewMockSecretsProvider()
 		loadCalled := false
 		mockSecretsProvider.LoadSecretsFunc = func() error {
@@ -448,8 +458,8 @@ func TestEnvCmd(t *testing.T) {
 		defer resetRootCmd()
 
 		// Given a mock controller with a mock secrets provider that returns an error on load
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
+		mocks, _ := setupSafeEnvCmdMocks()
+		mockController := mocks.Controller
 		mockSecretsProvider := secrets.NewMockSecretsProvider()
 		mockSecretsProvider.LoadSecretsFunc = func() error {
 			return fmt.Errorf("load error")

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -28,6 +28,14 @@ var execCmd = &cobra.Command{
 			return fmt.Errorf("no command provided")
 		}
 
+		// Create service components
+		if err := controller.CreateServiceComponents(); err != nil {
+			if verbose {
+				return fmt.Errorf("Error creating service components: %w", err)
+			}
+			return nil
+		}
+
 		// Create environment components
 		if err := controller.CreateEnvComponents(); err != nil {
 			return fmt.Errorf("Error creating environment components: %w", err)
@@ -88,8 +96,7 @@ var execCmd = &cobra.Command{
 		// Execute the command using the resolved shell instance
 		output, exitCode, err := shellInstance.Exec(args[0], args[1:]...)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "command execution failed: %v\n", err)
-			osExit(exitCode)
+			return err
 		}
 
 		// Print the command output

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -47,11 +47,7 @@ func setupSafeExecCmdMocks() *MockObjects {
 		return mockConfigHandler
 	}
 
-	// Mock osExit function
-	mockOsExit := func(code int) {
-		fmt.Printf("osExit called with code: %d\n", code)
-	}
-	osExit = mockOsExit
+	osExit = func(code int) {}
 
 	return &MockObjects{
 		Controller:      mockController,
@@ -62,12 +58,6 @@ func setupSafeExecCmdMocks() *MockObjects {
 }
 
 func TestExecCmd(t *testing.T) {
-	originalExitFunc := exitFunc
-	exitFunc = mockExit
-	t.Cleanup(func() {
-		exitFunc = originalExitFunc
-	})
-
 	t.Run("Success", func(t *testing.T) {
 		defer resetRootCmd()
 
@@ -98,9 +88,9 @@ func TestExecCmd(t *testing.T) {
 		// Setup mock controller
 		mocks := setupSafeExecCmdMocks()
 		execCalled := false
-		mocks.Shell.ExecFunc = func(command string, args ...string) (string, error) {
+		mocks.Shell.ExecFunc = func(command string, args ...string) (string, int, error) {
 			execCalled = true
-			return "container execution", nil
+			return "container execution", 0, nil
 		}
 
 		// Set environment variable to simulate container mode
@@ -443,7 +433,7 @@ func TestExecCmd(t *testing.T) {
 		}
 
 		// Mock osExit function to capture the exit code
-		exitCode := 0
+		exitCode = 0
 		mockOsExit := func(code int) {
 			exitCode = code
 		}

--- a/cmd/hook_test.go
+++ b/cmd/hook_test.go
@@ -34,6 +34,8 @@ func setupSafeHookCmdMocks() *MockObjects {
 		return mockShell
 	}
 
+	osExit = func(code int) {}
+
 	return &MockObjects{
 		Controller: mockController,
 		Shell:      mockShell,
@@ -41,12 +43,6 @@ func setupSafeHookCmdMocks() *MockObjects {
 }
 
 func TestHookCmd(t *testing.T) {
-	originalExitFunc := exitFunc
-	exitFunc = mockExit
-	t.Cleanup(func() {
-		exitFunc = originalExitFunc
-	})
-
 	t.Run("Success", func(t *testing.T) {
 		defer resetRootCmd()
 

--- a/cmd/hook_test.go
+++ b/cmd/hook_test.go
@@ -30,7 +30,7 @@ func setupSafeHookCmdMocks() *MockObjects {
 		}
 		return nil
 	}
-	mockController.ResolveShellFunc = func() shell.Shell {
+	mockController.ResolveShellFunc = func(name ...string) shell.Shell {
 		return mockShell
 	}
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -57,6 +57,8 @@ func setupSafeInitCmdMocks(existingInjectors ...di.Injector) *initMockObjects {
 	blueprint = ""
 	toolsManager = ""
 
+	osExit = func(code int) {}
+
 	return &initMockObjects{
 		Controller:    mockController,
 		Injector:      injector,
@@ -76,16 +78,14 @@ type initMockObjects struct {
 // TestInitCmd tests the init command
 func TestInitCmd(t *testing.T) {
 	originalArgs := rootCmd.Args
-	originalExitFunc := exitFunc
 
 	t.Cleanup(func() {
 		rootCmd.Args = originalArgs
-		exitFunc = originalExitFunc
 		resetRootCmd()
 	})
 
 	// Mock the exit function to prevent the test from exiting
-	exitFunc = func(code int) {
+	osExit = func(code int) {
 		panic("exit called")
 	}
 
@@ -103,9 +103,9 @@ func TestInitCmd(t *testing.T) {
 		})
 
 		// Validate the output
-		expectedOutput := "Initialization successful\n"
-		if output != expectedOutput {
-			t.Errorf("Expected output %q, got %q", expectedOutput, output)
+		expectedOutput := "Initialization successful"
+		if !strings.Contains(output, expectedOutput) {
+			t.Errorf("Expected output to contain %q, got %q", expectedOutput, output)
 		}
 	})
 
@@ -135,9 +135,9 @@ func TestInitCmd(t *testing.T) {
 		})
 
 		// Then the output should indicate success
-		expectedOutput := "Initialization successful\n"
-		if output != expectedOutput {
-			t.Errorf("Expected output %q, got %q", expectedOutput, output)
+		expectedOutput := "Initialization successful"
+		if !strings.Contains(output, expectedOutput) {
+			t.Errorf("Expected output to contain %q, got %q", expectedOutput, output)
 		}
 	})
 
@@ -243,9 +243,9 @@ func TestInitCmd(t *testing.T) {
 				})
 
 				// Then the output should indicate success
-				expectedOutput := "Initialization successful\n"
-				if output != expectedOutput {
-					t.Errorf("Expected output %q, got %q", expectedOutput, output)
+				expectedOutput := "Initialization successful"
+				if !strings.Contains(output, expectedOutput) {
+					t.Errorf("Expected output to contain %q, got %q", expectedOutput, output)
 				}
 
 				// Validate that SetDefault and SetContextValue were called with the correct configuration
@@ -302,9 +302,9 @@ func TestInitCmd(t *testing.T) {
 		})
 
 		// Then the output should indicate success
-		expectedOutput := "Initialization successful\n"
-		if output != expectedOutput {
-			t.Errorf("Expected output %q, got %q", expectedOutput, output)
+		expectedOutput := "Initialization successful"
+		if !strings.Contains(output, expectedOutput) {
+			t.Errorf("Expected output to contain %q, got %q", expectedOutput, output)
 		}
 	})
 
@@ -322,9 +322,9 @@ func TestInitCmd(t *testing.T) {
 		})
 
 		// Then the output should indicate success
-		expectedOutput := "Initialization successful\n"
-		if output != expectedOutput {
-			t.Errorf("Expected output %q, got %q", expectedOutput, output)
+		expectedOutput := "Initialization successful"
+		if !strings.Contains(output, expectedOutput) {
+			t.Errorf("Expected output to contain %q, got %q", expectedOutput, output)
 		}
 	})
 
@@ -342,9 +342,9 @@ func TestInitCmd(t *testing.T) {
 		})
 
 		// Then the output should indicate success
-		expectedOutput := "Initialization successful\n"
-		if output != expectedOutput {
-			t.Errorf("Expected output %q, got %q", expectedOutput, output)
+		expectedOutput := "Initialization successful"
+		if !strings.Contains(output, expectedOutput) {
+			t.Errorf("Expected output to contain %q, got %q", expectedOutput, output)
 		}
 	})
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -41,7 +41,7 @@ func setupSafeInitCmdMocks(existingInjectors ...di.Injector) *initMockObjects {
 	osStat = func(_ string) (os.FileInfo, error) { return nil, nil }
 
 	mockController.ResolveConfigHandlerFunc = func() config.ConfigHandler { return mockConfigHandler }
-	mockController.ResolveShellFunc = func() shell.Shell { return mockShell }
+	mockController.ResolveShellFunc = func(name ...string) shell.Shell { return mockShell }
 
 	// Reset global variables in init.go
 	backend = ""
@@ -270,7 +270,7 @@ func TestInitCmd(t *testing.T) {
 
 		// Set the shell in the controller to the mock shell
 		mocks := setupSafeInitCmdMocks()
-		mocks.Controller.ResolveShellFunc = func() shell.Shell {
+		mocks.Controller.ResolveShellFunc = func(name ...string) shell.Shell {
 			return mockShell
 		}
 

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -64,6 +64,8 @@ func setupMockInstallCmdComponents(optionalInjector ...di.Injector) InstallCmdCo
 	}
 	injector.Register("blueprintHandler", blueprintHandler)
 
+	osExit = func(code int) {}
+
 	return InstallCmdComponents{
 		Injector:         injector,
 		Controller:       controller,
@@ -74,12 +76,6 @@ func setupMockInstallCmdComponents(optionalInjector ...di.Injector) InstallCmdCo
 }
 
 func TestInstallCmd(t *testing.T) {
-	originalExitFunc := exitFunc
-	exitFunc = mockExit
-	t.Cleanup(func() {
-		exitFunc = originalExitFunc
-	})
-
 	t.Run("Success", func(t *testing.T) {
 		defer resetRootCmd()
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -196,7 +196,7 @@ func TestRoot_preRunEInitializeCommonComponents(t *testing.T) {
 
 		// Mock ResolveShell to return a mock shell
 		mockShell := &shell.MockShell{}
-		mocks.Controller.ResolveShellFunc = func() shell.Shell {
+		mocks.Controller.ResolveShellFunc = func(name ...string) shell.Shell {
 			return mockShell
 		}
 

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -56,9 +56,6 @@ func captureStderr(f func()) string {
 	return buf.String()
 }
 
-// Mock exit function to capture exit code
-var exitCode int
-
 func mockExit(code int) {
 	exitCode = code
 }
@@ -89,7 +86,7 @@ func setupSafeRootMocks(optionalInjector ...di.Injector) *MockObjects {
 	injector.Register("configHandler", mockConfigHandler)
 	injector.Register("secretsProvider", mockSecretsProvider)
 
-	// No cleanup function is returned
+	osExit = func(code int) {}
 
 	return &MockObjects{
 		Controller:      mockController,
@@ -101,10 +98,10 @@ func setupSafeRootMocks(optionalInjector ...di.Injector) *MockObjects {
 }
 
 func TestRoot_Execute(t *testing.T) {
-	originalExitFunc := exitFunc
-	exitFunc = mockExit
+	originalExitFunc := osExit
+	osExit = mockExit
 	t.Cleanup(func() {
-		exitFunc = originalExitFunc
+		osExit = originalExitFunc
 	})
 }
 

--- a/cmd/shims.go
+++ b/cmd/shims.go
@@ -7,9 +7,6 @@ import (
 	"runtime"
 )
 
-// exitFunc is a function to exit the program
-var exitFunc = os.Exit
-
 // osUserHomeDir retrieves the user's home directory
 var osUserHomeDir = os.UserHomeDir
 
@@ -24,9 +21,6 @@ var osExit = os.Exit
 
 // getwd retrieves the current working directory
 var getwd = os.Getwd
-
-// verbose is a flag for verbose output
-var verbose bool
 
 // osSetenv sets an environment variable
 var osSetenv = os.Setenv

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -94,6 +94,8 @@ func setupSafeUpCmdMocks(optionalInjector ...di.Injector) SafeUpCmdComponents {
 	mockToolsManager := tools.NewMockToolsManager()
 	injector.Register("toolsManager", mockToolsManager)
 
+	osExit = func(code int) {}
+
 	return SafeUpCmdComponents{
 		Injector:         injector,
 		Controller:       mockController,
@@ -107,12 +109,6 @@ func setupSafeUpCmdMocks(optionalInjector ...di.Injector) SafeUpCmdComponents {
 }
 
 func TestUpCmd(t *testing.T) {
-	originalExitFunc := exitFunc
-	exitFunc = mockExit
-	t.Cleanup(func() {
-		exitFunc = originalExitFunc
-	})
-
 	t.Run("Success", func(t *testing.T) {
 		// Given a set of mock components
 		mocks := setupSafeUpCmdMocks()
@@ -126,9 +122,8 @@ func TestUpCmd(t *testing.T) {
 		})
 
 		// Then the output should indicate success
-		expectedOutput := "Windsor environment set up successfully.\n"
-		if output != expectedOutput {
-			t.Errorf("Expected output %q, got %q", expectedOutput, output)
+		if !strings.Contains(output, "Windsor environment set up successfully.") {
+			t.Errorf("Expected output to contain %q, got %q", "Windsor environment set up successfully.", output)
 		}
 	})
 

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -10,10 +10,10 @@ import (
 )
 
 func TestVersionCommand(t *testing.T) {
-	originalExitFunc := exitFunc
-	exitFunc = mockExit
+	originalExitFunc := osExit
+	osExit = mockExit
 	t.Cleanup(func() {
-		exitFunc = originalExitFunc
+		osExit = originalExitFunc
 	})
 
 	t.Run("VersionOutput", func(t *testing.T) {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   windsorcli:
     build:

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -81,5 +81,7 @@ const (
 )
 
 const (
-	DEFAULT_WINDSOR_IMAGE = "ghcr.io/windsorcli/windsor:v0.5.1"
+	// renovate: datasource=docker depName=ghcr.io/windsorcli/windsorcli
+	// DEFAULT_WINDSOR_IMAGE = "ghcr.io/windsorcli/windsorcli:0.5.1"
+	DEFAULT_WINDSOR_IMAGE = "windsorcli:latest"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -2,6 +2,10 @@ package constants
 
 import "time"
 
+const (
+	CONTAINER_EXEC_WORKDIR = "/work"
+)
+
 // Default git livereload settings
 const (
 	// renovate: datasource=docker depName=ghcr.io/windsorcli/git-livereload-server

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -86,6 +86,5 @@ const (
 
 const (
 	// renovate: datasource=docker depName=ghcr.io/windsorcli/windsorcli
-	// DEFAULT_WINDSOR_IMAGE = "ghcr.io/windsorcli/windsorcli:0.5.1"
-	DEFAULT_WINDSOR_IMAGE = "windsorcli:latest"
+	DEFAULT_WINDSOR_IMAGE = "ghcr.io/windsorcli/windsorcli:latest"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -79,3 +79,7 @@ const (
 	MINIMUM_VERSION_TERRAFORM      = "1.7.0"
 	MINIMUM_VERSION_1PASSWORD      = "2.25.0"
 )
+
+const (
+	DEFAULT_WINDSOR_IMAGE = "ghcr.io/windsorcli/windsor:v0.5.1"
+)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -33,7 +33,7 @@ type Controller interface {
 	ResolveAllSecretsProviders() []secrets.SecretsProvider
 	ResolveEnvPrinter(name string) env.EnvPrinter
 	ResolveAllEnvPrinters() []env.EnvPrinter
-	ResolveShell() shell.Shell
+	ResolveShell(name ...string) shell.Shell
 	ResolveSecureShell() shell.Shell
 	ResolveNetworkManager() network.NetworkManager
 	ResolveToolsManager() tools.ToolsManager
@@ -339,9 +339,13 @@ func (c *BaseController) ResolveAllEnvPrinters() []env.EnvPrinter {
 	return envPrinters
 }
 
-// ResolveShell resolves the shell instance.
-func (c *BaseController) ResolveShell() shell.Shell {
-	instance := c.injector.Resolve("shell")
+// ResolveShell resolves the shell instance, with an optional name parameter.
+func (c *BaseController) ResolveShell(name ...string) shell.Shell {
+	shellName := "shell"
+	if len(name) > 0 {
+		shellName = name[0]
+	}
+	instance := c.injector.Resolve(shellName)
 	shellInstance, _ := instance.(shell.Shell)
 	return shellInstance
 }

--- a/pkg/controller/mock_controller.go
+++ b/pkg/controller/mock_controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/windsorcli/cli/pkg/blueprint"
 	"github.com/windsorcli/cli/pkg/config"
@@ -262,6 +263,13 @@ func (m *MockController) CreateServiceComponents() error {
 				m.injector.Register(serviceName, workerService)
 			}
 		}
+	}
+
+	// Check if WINDSOR_EXEC_MODE is "container" and register Windsor service
+	windsorExecMode := os.Getenv("WINDSOR_EXEC_MODE")
+	if windsorExecMode == "container" {
+		windsorService := services.NewMockService()
+		m.injector.Register("windsorService", windsorService)
 	}
 
 	return nil

--- a/pkg/controller/mock_controller.go
+++ b/pkg/controller/mock_controller.go
@@ -35,7 +35,7 @@ type MockController struct {
 	ResolveConfigHandlerFunc           func() config.ConfigHandler
 	ResolveEnvPrinterFunc              func(name string) env.EnvPrinter
 	ResolveAllEnvPrintersFunc          func() []env.EnvPrinter
-	ResolveShellFunc                   func() shell.Shell
+	ResolveShellFunc                   func(name ...string) shell.Shell
 	ResolveSecureShellFunc             func() shell.Shell
 	ResolveToolsManagerFunc            func() tools.ToolsManager
 	ResolveNetworkManagerFunc          func() network.NetworkManager
@@ -372,11 +372,11 @@ func (c *MockController) ResolveAllEnvPrinters() []env.EnvPrinter {
 }
 
 // ResolveShell calls the mock ResolveShellFunc if set, otherwise calls the parent function
-func (c *MockController) ResolveShell() shell.Shell {
+func (c *MockController) ResolveShell(name ...string) shell.Shell {
 	if c.ResolveShellFunc != nil {
-		return c.ResolveShellFunc()
+		return c.ResolveShellFunc(name...)
 	}
-	return c.BaseController.ResolveShell()
+	return c.BaseController.ResolveShell(name...)
 }
 
 // ResolveSecureShell calls the mock ResolveSecureShellFunc if set, otherwise calls the parent function

--- a/pkg/controller/mock_controller_test.go
+++ b/pkg/controller/mock_controller_test.go
@@ -553,7 +553,7 @@ func TestMockController_ResolveShell(t *testing.T) {
 		mocks := setSafeControllerMocks()
 		mockCtrl := NewMockController(mocks.Injector)
 		// And the ResolveShellFunc is set to return the expected shell
-		mockCtrl.ResolveShellFunc = func() shell.Shell {
+		mockCtrl.ResolveShellFunc = func(name ...string) shell.Shell {
 			return mocks.Shell
 		}
 		// When ResolveShell is called

--- a/pkg/controller/mock_controller_test.go
+++ b/pkg/controller/mock_controller_test.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"os"
 	"testing"
 
 	"github.com/windsorcli/cli/api/v1alpha1"
@@ -264,6 +265,31 @@ func TestMockController_CreateServiceComponents(t *testing.T) {
 		if err := mockCtrl.CreateServiceComponents(); err != nil {
 			// Then no error should be returned
 			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("CreateServiceComponentsWithWindsorExecModeContainer", func(t *testing.T) {
+		// Given a new injector and a new mock controller
+		mocks := setSafeControllerMocks()
+		mockCtrl := NewMockController(mocks.Injector)
+
+		// And a mock config handler is created and assigned to the controller
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockCtrl.configHandler = mockConfigHandler
+
+		// Set WINDSOR_EXEC_MODE in the environment to "container"
+		os.Setenv("WINDSOR_EXEC_MODE", "container")
+		defer os.Unsetenv("WINDSOR_EXEC_MODE")
+
+		// When CreateServiceComponents is called
+		if err := mockCtrl.CreateServiceComponents(); err != nil {
+			// Then no error should be returned
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// And the Windsor service should be registered
+		if mocks.Injector.Resolve("windsorService") == nil {
+			t.Fatalf("expected windsorService to be registered, got nil")
 		}
 	})
 }

--- a/pkg/controller/real_controller.go
+++ b/pkg/controller/real_controller.go
@@ -2,6 +2,7 @@ package controller
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -147,7 +148,8 @@ func (c *RealController) CreateEnvComponents() error {
 
 // CreateServiceComponents sets up services based on config, including DNS,
 // Git livereload, Localstack, and Docker registries. If Talos is used, it
-// registers control plane and worker services for the cluster.
+// registers control plane and worker services for the cluster. Additionally,
+// if WINDSOR_EXEC_MODE is "container", it registers the Windsor service.
 func (c *RealController) CreateServiceComponents() error {
 	configHandler := c.configHandler
 	contextConfig := configHandler.GetConfig()
@@ -205,6 +207,13 @@ func (c *RealController) CreateServiceComponents() error {
 				c.injector.Register(serviceName, workerService)
 			}
 		}
+	}
+
+	// Check if WINDSOR_EXEC_MODE is "container" and register Windsor service
+	windsorExecMode := os.Getenv("WINDSOR_EXEC_MODE")
+	if windsorExecMode == "container" {
+		windsorService := services.NewWindsorService(c.injector)
+		c.injector.Register("windsorService", windsorService)
 	}
 
 	return nil

--- a/pkg/controller/real_controller_test.go
+++ b/pkg/controller/real_controller_test.go
@@ -428,6 +428,39 @@ func TestRealController_CreateServiceComponents(t *testing.T) {
 			t.Fatalf("expected no error, got %v", err)
 		}
 	})
+
+	t.Run("WindsorExecModeContainer", func(t *testing.T) {
+		// Given a new injector and a new real controller
+		injector := di.NewInjector()
+		controller := NewRealController(injector)
+
+		// When the controller is initialized
+		if err := controller.Initialize(); err != nil {
+			t.Fatalf("failed to initialize controller: %v", err)
+		}
+
+		// And common components are created
+		controller.CreateCommonComponents()
+
+		controller.configHandler.SetContextValue("docker.enabled", true)
+
+		// And WINDSOR_EXEC_MODE is set to "container"
+		os.Setenv("WINDSOR_EXEC_MODE", "container")
+		defer os.Unsetenv("WINDSOR_EXEC_MODE")
+
+		// And service components are created
+		err := controller.CreateServiceComponents()
+
+		// Then no error should occur
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// And the Windsor service should be registered
+		if injector.Resolve("windsorService") == nil {
+			t.Fatalf("expected windsorService to be registered, got error")
+		}
+	})
 }
 
 func TestRealController_CreateVirtualizationComponents(t *testing.T) {

--- a/pkg/env/aws_env.go
+++ b/pkg/env/aws_env.go
@@ -13,13 +13,14 @@ type AwsEnvPrinter struct {
 	BaseEnvPrinter
 }
 
-// NewAwsEnvPrinter initializes a new awsEnv instance using the provided dependency injector.
+// NewAwsEnvPrinter initializes a new AwsEnvPrinter instance using the provided dependency injector.
 func NewAwsEnvPrinter(injector di.Injector) *AwsEnvPrinter {
-	return &AwsEnvPrinter{
-		BaseEnvPrinter: BaseEnvPrinter{
-			injector: injector,
-		},
+	awsEnvPrinter := &AwsEnvPrinter{}
+	awsEnvPrinter.BaseEnvPrinter = BaseEnvPrinter{
+		injector:   injector,
+		EnvPrinter: awsEnvPrinter,
 	}
+	return awsEnvPrinter
 }
 
 // GetEnvVars retrieves the environment variables for the AWS environment.
@@ -50,17 +51,6 @@ func (e *AwsEnvPrinter) GetEnvVars() (map[string]string, error) {
 	}
 
 	return envVars, nil
-}
-
-// Print prints the environment variables for the AWS environment.
-func (e *AwsEnvPrinter) Print() error {
-	envVars, err := e.GetEnvVars()
-	if err != nil {
-		// Return the error if GetEnvVars fails
-		return fmt.Errorf("error getting environment variables: %w", err)
-	}
-	// Call the Print method of the embedded envPrinter struct with the retrieved environment variables
-	return e.BaseEnvPrinter.Print(envVars)
 }
 
 // Ensure awsEnv implements the EnvPrinter interface

--- a/pkg/env/custom_env.go
+++ b/pkg/env/custom_env.go
@@ -21,11 +21,12 @@ type CustomEnvPrinter struct {
 
 // NewCustomEnvPrinter initializes a new CustomEnvPrinter instance using the provided dependency injector.
 func NewCustomEnvPrinter(injector di.Injector) *CustomEnvPrinter {
-	return &CustomEnvPrinter{
-		BaseEnvPrinter: BaseEnvPrinter{
-			injector: injector,
-		},
+	customEnvPrinter := &CustomEnvPrinter{}
+	customEnvPrinter.BaseEnvPrinter = BaseEnvPrinter{
+		injector:   injector,
+		EnvPrinter: customEnvPrinter,
 	}
+	return customEnvPrinter
 }
 
 // Initialize sets up the CustomEnvPrinter, including resolving secrets providers.

--- a/pkg/env/docker_env.go
+++ b/pkg/env/docker_env.go
@@ -14,13 +14,14 @@ type DockerEnvPrinter struct {
 	BaseEnvPrinter
 }
 
-// NewDockerEnvPrinter initializes a new dockerEnv instance using the provided dependency injector.
+// NewDockerEnvPrinter initializes a new DockerEnvPrinter instance using the provided dependency injector.
 func NewDockerEnvPrinter(injector di.Injector) *DockerEnvPrinter {
-	return &DockerEnvPrinter{
-		BaseEnvPrinter: BaseEnvPrinter{
-			injector: injector,
-		},
+	dockerEnvPrinter := &DockerEnvPrinter{}
+	dockerEnvPrinter.BaseEnvPrinter = BaseEnvPrinter{
+		injector:   injector,
+		EnvPrinter: dockerEnvPrinter,
 	}
+	return dockerEnvPrinter
 }
 
 // GetEnvVars returns Docker-specific env vars, setting DOCKER_HOST based on vm.driver config.
@@ -99,15 +100,6 @@ func (e *DockerEnvPrinter) GetAlias() (map[string]string, error) {
 		aliasMap["docker-compose"] = "docker-cli-plugin-docker-compose"
 	}
 	return aliasMap, nil
-}
-
-// Print retrieves and prints the environment variables for the Docker environment.
-func (e *DockerEnvPrinter) Print() error {
-	envVars, err := e.GetEnvVars()
-	if err != nil {
-		return fmt.Errorf("error getting environment variables: %w", err)
-	}
-	return e.BaseEnvPrinter.Print(envVars)
 }
 
 // getRegistryURL retrieves a registry URL, appending a port if not present.

--- a/pkg/env/kube_env.go
+++ b/pkg/env/kube_env.go
@@ -20,13 +20,14 @@ type KubeEnvPrinter struct {
 	BaseEnvPrinter
 }
 
-// NewKubeEnv initializes a new kubeEnv instance using the provided dependency injector.
+// NewKubeEnvPrinter initializes a new KubeEnvPrinter instance using the provided dependency injector.
 func NewKubeEnvPrinter(injector di.Injector) *KubeEnvPrinter {
-	return &KubeEnvPrinter{
-		BaseEnvPrinter: BaseEnvPrinter{
-			injector: injector,
-		},
+	kubeEnvPrinter := &KubeEnvPrinter{}
+	kubeEnvPrinter.BaseEnvPrinter = BaseEnvPrinter{
+		injector:   injector,
+		EnvPrinter: kubeEnvPrinter,
 	}
+	return kubeEnvPrinter
 }
 
 // GetEnvVars constructs a map of Kubernetes environment variables by setting
@@ -107,18 +108,6 @@ func (e *KubeEnvPrinter) GetEnvVars() (map[string]string, error) {
 	}
 
 	return envVars, nil
-}
-
-// Print prints the environment variables for the Kube environment.
-func (e *KubeEnvPrinter) Print() error {
-	envVars, err := e.GetEnvVars()
-	if err != nil {
-		// Return the error if GetEnvVars fails
-		return fmt.Errorf("error getting environment variables: %w", err)
-	}
-
-	// Call the Print method of the embedded BaseEnvPrinter struct with the retrieved environment variables
-	return e.BaseEnvPrinter.Print(envVars)
 }
 
 // Ensure kubeEnv implements the EnvPrinter interface

--- a/pkg/env/mock_env.go
+++ b/pkg/env/mock_env.go
@@ -7,6 +7,7 @@ type MockEnvPrinter struct {
 	PrintFunc       func() error
 	PostEnvHookFunc func() error
 	GetEnvVarsFunc  func() (map[string]string, error)
+	GetAliasFunc    func() (map[string]string, error)
 }
 
 // NewMockEnvPrinter creates a new instance of MockEnvPrinter.
@@ -49,6 +50,15 @@ func (m *MockEnvPrinter) PostEnvHook() error {
 	}
 	// Simulate post environment setup without doing anything real
 	return nil
+}
+
+// GetAlias simulates retrieving aliases.
+// If a custom GetAliasFunc is provided, it will use that function instead.
+func (m *MockEnvPrinter) GetAlias() (map[string]string, error) {
+	if m.GetAliasFunc != nil {
+		return m.GetAliasFunc()
+	}
+	return nil, nil
 }
 
 // Ensure MockEnvPrinter implements the EnvPrinter interface

--- a/pkg/env/mock_env_test.go
+++ b/pkg/env/mock_env_test.go
@@ -174,3 +174,47 @@ func TestMockEnvPrinter_PostEnvHook(t *testing.T) {
 		}
 	})
 }
+
+func TestMockEnvPrinter_GetAlias(t *testing.T) {
+	t.Run("DefaultGetAlias", func(t *testing.T) {
+		// Given a mock environment with default GetAlias implementation
+		mockEnv := NewMockEnvPrinter()
+
+		// When calling GetAlias
+		alias, err := mockEnv.GetAlias()
+		// Then no error should be returned and alias should be nil
+		if err != nil {
+			t.Errorf("GetAlias() error = %v, want nil", err)
+		}
+		if alias != nil {
+			t.Errorf("GetAlias() = %v, want nil", alias)
+		}
+	})
+
+	t.Run("CustomGetAlias", func(t *testing.T) {
+		// Given a mock environment with custom GetAlias implementation
+		mockEnv := NewMockEnvPrinter()
+		expectedAlias := map[string]string{
+			"alias1": "command1",
+			"alias2": "command2",
+		}
+		mockEnv.GetAliasFunc = func() (map[string]string, error) {
+			return expectedAlias, nil
+		}
+
+		// When calling GetAlias
+		alias, err := mockEnv.GetAlias()
+		// Then no error should be returned and alias should match expectedAlias
+		if err != nil {
+			t.Errorf("GetAlias() error = %v, want nil", err)
+		}
+		if len(alias) != len(expectedAlias) {
+			t.Errorf("GetAlias() = %v, want %v", alias, expectedAlias)
+		}
+		for key, value := range expectedAlias {
+			if alias[key] != value {
+				t.Errorf("GetAlias()[%v] = %v, want %v", key, alias[key], value)
+			}
+		}
+	})
+}

--- a/pkg/env/omni_env.go
+++ b/pkg/env/omni_env.go
@@ -12,13 +12,14 @@ type OmniEnvPrinter struct {
 	BaseEnvPrinter
 }
 
-// NewOmniEnv initializes a new omniEnv instance using the provided dependency injector.
+// NewOmniEnvPrinter initializes a new OmniEnvPrinter instance using the provided dependency injector.
 func NewOmniEnvPrinter(injector di.Injector) *OmniEnvPrinter {
-	return &OmniEnvPrinter{
-		BaseEnvPrinter: BaseEnvPrinter{
-			injector: injector,
-		},
+	omniEnvPrinter := &OmniEnvPrinter{}
+	omniEnvPrinter.BaseEnvPrinter = BaseEnvPrinter{
+		injector:   injector,
+		EnvPrinter: omniEnvPrinter,
 	}
+	return omniEnvPrinter
 }
 
 // GetEnvVars retrieves the environment variables for the Omni environment.
@@ -38,17 +39,6 @@ func (e *OmniEnvPrinter) GetEnvVars() (map[string]string, error) {
 	envVars["OMNICONFIG"] = omniConfigPath
 
 	return envVars, nil
-}
-
-// Print prints the environment variables for the Omni environment.
-func (e *OmniEnvPrinter) Print() error {
-	envVars, err := e.GetEnvVars()
-	if err != nil {
-		// Return the error if GetEnvVars fails
-		return fmt.Errorf("error getting environment variables: %w", err)
-	}
-	// Call the Print method of the embedded BaseEnvPrinter struct with the retrieved environment variables
-	return e.BaseEnvPrinter.Print(envVars)
 }
 
 // Ensure OmniEnvPrinter implements the EnvPrinter interface

--- a/pkg/env/talos_env.go
+++ b/pkg/env/talos_env.go
@@ -12,13 +12,14 @@ type TalosEnvPrinter struct {
 	BaseEnvPrinter
 }
 
-// NewTalosEnvPrinter initializes a new talosEnvPrinter instance using the provided dependency injector.
+// NewTalosEnvPrinter initializes a new TalosEnvPrinter instance using the provided dependency injector.
 func NewTalosEnvPrinter(injector di.Injector) *TalosEnvPrinter {
-	return &TalosEnvPrinter{
-		BaseEnvPrinter: BaseEnvPrinter{
-			injector: injector,
-		},
+	talosEnvPrinter := &TalosEnvPrinter{}
+	talosEnvPrinter.BaseEnvPrinter = BaseEnvPrinter{
+		injector:   injector,
+		EnvPrinter: talosEnvPrinter,
 	}
+	return talosEnvPrinter
 }
 
 // GetEnvVars retrieves the environment variables for the Talos environment.
@@ -38,17 +39,6 @@ func (e *TalosEnvPrinter) GetEnvVars() (map[string]string, error) {
 	envVars["TALOSCONFIG"] = talosConfigPath
 
 	return envVars, nil
-}
-
-// Print prints the environment variables for the Talos environment.
-func (e *TalosEnvPrinter) Print() error {
-	envVars, err := e.GetEnvVars()
-	if err != nil {
-		// Return the error if GetEnvVars fails
-		return fmt.Errorf("error getting environment variables: %w", err)
-	}
-	// Call the Print method of the embedded BaseEnvPrinter struct with the retrieved environment variables
-	return e.BaseEnvPrinter.Print(envVars)
 }
 
 // Ensure TalosEnvPrinter implements the EnvPrinter interface

--- a/pkg/env/windsor_env.go
+++ b/pkg/env/windsor_env.go
@@ -13,11 +13,12 @@ type WindsorEnvPrinter struct {
 
 // NewWindsorEnvPrinter initializes a new WindsorEnvPrinter instance using the provided dependency injector.
 func NewWindsorEnvPrinter(injector di.Injector) *WindsorEnvPrinter {
-	return &WindsorEnvPrinter{
-		BaseEnvPrinter: BaseEnvPrinter{
-			injector: injector,
-		},
+	windsorEnvPrinter := &WindsorEnvPrinter{}
+	windsorEnvPrinter.BaseEnvPrinter = BaseEnvPrinter{
+		injector:   injector,
+		EnvPrinter: windsorEnvPrinter,
 	}
+	return windsorEnvPrinter
 }
 
 // GetEnvVars retrieves the environment variables for the Windsor environment.
@@ -35,18 +36,12 @@ func (e *WindsorEnvPrinter) GetEnvVars() (map[string]string, error) {
 	}
 	envVars["WINDSOR_PROJECT_ROOT"] = projectRoot
 
-	return envVars, nil
-}
-
-// Print prints the environment variables for the Windsor environment.
-func (e *WindsorEnvPrinter) Print() error {
-	envVars, err := e.GetEnvVars()
-	if err != nil {
-		// Return the error if GetEnvVars fails
-		return fmt.Errorf("error getting environment variables: %w", err)
+	// Set WINDSOR_EXEC_MODE to "container" if the OS is Darwin
+	if goos() == "darwin" {
+		envVars["WINDSOR_EXEC_MODE"] = "container"
 	}
-	// Call the Print method of the embedded BaseEnvPrinter struct with the retrieved environment variables
-	return e.BaseEnvPrinter.Print(envVars)
+
+	return envVars, nil
 }
 
 // Ensure WindsorEnvPrinter implements the EnvPrinter interface

--- a/pkg/env/windsor_env_test.go
+++ b/pkg/env/windsor_env_test.go
@@ -2,7 +2,6 @@ package env
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
@@ -102,59 +101,56 @@ func TestWindsorEnv_PostEnvHook(t *testing.T) {
 
 func TestWindsorEnv_Print(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		// Use setupSafeWindsorEnvMocks to create mocks
 		mocks := setupSafeWindsorEnvMocks()
-		mockInjector := mocks.Injector
-		windsorEnvPrinter := NewWindsorEnvPrinter(mockInjector)
-		windsorEnvPrinter.Initialize()
-
-		// Mock the stat function to simulate the existence of the Windsor config file
-		stat = func(name string) (os.FileInfo, error) {
-			if filepath.Clean(name) == filepath.FromSlash("/mock/config/root/.windsor/config") {
-				return nil, nil // Simulate that the file exists
-			}
-			return nil, os.ErrNotExist
+		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Injector)
+		err := windsorEnvPrinter.Initialize()
+		if err != nil {
+			t.Fatalf("unexpected error during initialization: %v", err)
 		}
 
-		// Mock the PrintEnvVarsFunc to verify it is called with the correct envVars
-		var capturedEnvVars map[string]string
+		originalGoos := goos
+		defer func() { goos = originalGoos }()
+		goos = func() string {
+			return "darwin"
+		}
+
+		expectedEnvVars := map[string]string{
+			"WINDSOR_CONTEXT":      "mock-context",
+			"WINDSOR_PROJECT_ROOT": filepath.FromSlash("/mock/project/root"),
+			"WINDSOR_EXEC_MODE":    "container",
+		}
+
+		capturedEnvVars := make(map[string]string)
 		mocks.Shell.PrintEnvVarsFunc = func(envVars map[string]string) error {
-			capturedEnvVars = envVars
+			for k, v := range envVars {
+				capturedEnvVars[k] = v
+			}
 			return nil
 		}
 
-		// Call Print and check for errors
-		err := windsorEnvPrinter.Print()
+		err = windsorEnvPrinter.Print()
 		if err != nil {
 			t.Errorf("unexpected error: %v", err)
 		}
 
-		// Verify that PrintEnvVarsFunc was called with the correct envVars
-		expectedEnvVars := map[string]string{
-			"WINDSOR_CONTEXT":      "mock-context",
-			"WINDSOR_PROJECT_ROOT": filepath.FromSlash("/mock/project/root"),
-		}
 		if !reflect.DeepEqual(capturedEnvVars, expectedEnvVars) {
 			t.Errorf("capturedEnvVars = %v, want %v", capturedEnvVars, expectedEnvVars)
 		}
 	})
 
 	t.Run("GetProjectRootError", func(t *testing.T) {
-		// Use setupSafeWindsorEnvMocks to create mocks
 		mocks := setupSafeWindsorEnvMocks()
-
-		// Override the GetProjectRootFunc to simulate an error
 		mocks.Shell.GetProjectRootFunc = func() (string, error) {
 			return "", fmt.Errorf("mock project root error")
 		}
 
-		mockInjector := mocks.Injector
+		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Injector)
+		err := windsorEnvPrinter.Initialize()
+		if err != nil {
+			t.Fatalf("unexpected error during initialization: %v", err)
+		}
 
-		windsorEnvPrinter := NewWindsorEnvPrinter(mockInjector)
-		windsorEnvPrinter.Initialize()
-
-		// Call Print and check for errors
-		err := windsorEnvPrinter.Print()
+		err = windsorEnvPrinter.Print()
 		if err == nil {
 			t.Error("expected error, got nil")
 		} else if !strings.Contains(err.Error(), "mock project root error") {

--- a/pkg/services/windsor_service.go
+++ b/pkg/services/windsor_service.go
@@ -56,6 +56,7 @@ func (s *WindsorService) GetComposeConfig() (*types.Config, error) {
 				Target: "/work",
 			},
 		},
+		Entrypoint: []string{"tail", "-f", "/dev/null"},
 	}
 
 	if envVarList != nil {

--- a/pkg/services/windsor_service.go
+++ b/pkg/services/windsor_service.go
@@ -1,0 +1,71 @@
+package services
+
+import (
+	"fmt"
+
+	"github.com/compose-spec/compose-go/types"
+	"github.com/windsorcli/cli/pkg/constants"
+	"github.com/windsorcli/cli/pkg/di"
+)
+
+// WindsorService is a service struct that provides Windsor-specific utility functions
+type WindsorService struct {
+	BaseService
+}
+
+// NewWindsorService is a constructor for WindsorService
+func NewWindsorService(injector di.Injector) *WindsorService {
+	return &WindsorService{
+		BaseService: BaseService{
+			injector: injector,
+			name:     "windsor",
+		},
+	}
+}
+
+// GetComposeConfig returns the docker-compose configuration for the Windsor service
+func (s *WindsorService) GetComposeConfig() (*types.Config, error) {
+	fullName := s.name
+
+	// Retrieve environment keys
+	originalEnvVars := s.configHandler.GetStringMap("environment")
+
+	var envVarList types.MappingWithEquals
+	if originalEnvVars != nil {
+		// Create environment variable mappings in the format KEY: ${KEY}
+		envVarList = make(types.MappingWithEquals, len(originalEnvVars))
+		for k := range originalEnvVars {
+			value := fmt.Sprintf("${%s}", k)
+			envVarList[k] = &value
+		}
+	}
+
+	serviceConfig := types.ServiceConfig{
+		Name:          fullName,
+		ContainerName: fullName,
+		Image:         constants.DEFAULT_WINDSOR_IMAGE,
+		Restart:       "always",
+		Labels: map[string]string{
+			"role":       "windsor_exec",
+			"managed_by": "windsor",
+		},
+		Volumes: []types.ServiceVolumeConfig{
+			{
+				Type:   "bind",
+				Source: "${WINDSOR_PROJECT_ROOT}",
+				Target: "/work",
+			},
+		},
+	}
+
+	if envVarList != nil {
+		serviceConfig.Environment = envVarList
+	}
+
+	services := []types.ServiceConfig{serviceConfig}
+
+	return &types.Config{Services: services}, nil
+}
+
+// Ensure WindsorService implements Service interface
+var _ Service = (*WindsorService)(nil)

--- a/pkg/services/windsor_service_test.go
+++ b/pkg/services/windsor_service_test.go
@@ -1,0 +1,94 @@
+package services
+
+import (
+	"testing"
+
+	"github.com/windsorcli/cli/pkg/config"
+	"github.com/windsorcli/cli/pkg/constants"
+	"github.com/windsorcli/cli/pkg/di"
+)
+
+// setupSafeWindsorServiceMocks sets up mock components for WindsorService
+func setupSafeWindsorServiceMocks(optionalInjector ...di.Injector) *MockComponents {
+	var injector di.Injector
+	if len(optionalInjector) > 0 {
+		injector = optionalInjector[0]
+	} else {
+		injector = di.NewMockInjector()
+	}
+
+	mockConfigHandler := config.NewMockConfigHandler()
+
+	// Mock some environment variables
+	mockEnvVars := map[string]string{
+		"ENV_VAR_1": "value1",
+		"ENV_VAR_2": "value2",
+	}
+	mockConfigHandler.GetStringMapFunc = func(key string, defaultValue ...map[string]string) map[string]string {
+		if key == "environment" {
+			return mockEnvVars
+		}
+		if len(defaultValue) > 0 {
+			return defaultValue[0]
+		}
+		return nil
+	}
+
+	// Register mock instances in the injector
+	injector.Register("configHandler", mockConfigHandler)
+
+	return &MockComponents{
+		Injector:          injector,
+		MockConfigHandler: mockConfigHandler,
+	}
+}
+
+func TestWindsorService_NewWindsorService(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Given: a set of mock components
+		mocks := setupSafeWindsorServiceMocks()
+
+		// When: a new WindsorService is created
+		windsorService := NewWindsorService(mocks.Injector)
+		if windsorService == nil {
+			t.Fatalf("expected WindsorService, got nil")
+		}
+
+		// Then: the WindsorService should have the correct injector
+		if windsorService.injector != mocks.Injector {
+			t.Errorf("expected injector %v, got %v", mocks.Injector, windsorService.injector)
+		}
+	})
+}
+
+func TestWindsorService_GetComposeConfig(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Given: a WindsorService instance
+		mocks := setupSafeWindsorServiceMocks()
+		windsorService := NewWindsorService(mocks.Injector)
+
+		windsorService.Initialize()
+
+		// When: GetComposeConfig is called
+		composeConfig, err := windsorService.GetComposeConfig()
+		if err != nil {
+			t.Fatalf("GetComposeConfig() error = %v", err)
+		}
+
+		// Then: verify the configuration contains the expected service
+		expectedName := "windsor"
+		expectedImage := constants.DEFAULT_WINDSOR_IMAGE
+		serviceFound := false
+
+		for _, service := range composeConfig.Services {
+			if service.Name == expectedName && service.Image == expectedImage {
+				serviceFound = true
+				break
+			}
+		}
+
+		if !serviceFound {
+			t.Errorf("expected service with name %q and image %q to be in the list of configurations:\n%+v", expectedName, expectedImage, composeConfig.Services)
+		}
+	})
+}

--- a/pkg/shell/docker_shell.go
+++ b/pkg/shell/docker_shell.go
@@ -1,0 +1,93 @@
+package shell
+
+import (
+	"bytes"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/windsorcli/cli/pkg/di"
+)
+
+// DockerShell implements the Shell interface using Docker.
+type DockerShell struct {
+	DefaultShell
+}
+
+// NewDockerShell creates a new instance of DockerShell.
+func NewDockerShell(injector di.Injector) *DockerShell {
+	return &DockerShell{
+		DefaultShell: DefaultShell{
+			injector: injector,
+		},
+	}
+}
+
+// Exec executes a command inside a Docker container with the label "role=windsor_exec".
+func (s *DockerShell) Exec(command string, args ...string) (string, error) {
+	// Get the container ID
+	containerID, err := s.getWindsorExecContainerID()
+	if err != nil {
+		return "", fmt.Errorf("failed to get Windsor exec container ID: %w", err)
+	}
+
+	// Get the project root
+	projectRoot, err := s.GetProjectRoot()
+	if err != nil {
+		return "", fmt.Errorf("failed to get project root: %w", err)
+	}
+
+	// Determine the current working directory relative to the project root
+	currentDir, err := getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get current working directory: %w", err)
+	}
+	relativeDir, err := filepathRel(projectRoot, currentDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to determine relative directory: %w", err)
+	}
+
+	// Construct the working directory inside the container and build the shell command.
+	workDir := filepath.Join("/work", relativeDir)
+
+	// Combine 'command' and its 'args' into a single command string.
+	combinedCmd := command
+	if len(args) > 0 {
+		combinedCmd += " " + strings.Join(args, " ")
+	}
+	shellCmd := fmt.Sprintf("cd %s && windsor exec -- %s", workDir, combinedCmd)
+
+	// Execute the command using the execCommand shim for better testability.
+	cmd := execCommand("docker", "exec", "-it", containerID, "sh", "-c", shellCmd)
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+
+	if err := cmdStart(cmd); err != nil {
+		return stdoutBuf.String(), fmt.Errorf("command start failed: %w", err)
+	}
+	if err := cmdWait(cmd); err != nil {
+		return stdoutBuf.String(), fmt.Errorf("command execution failed: %w\n%s", err, stderrBuf.String())
+	}
+
+	return stdoutBuf.String(), nil
+}
+
+// getWindsorExecContainerID retrieves the container ID of the Windsor exec container.
+func (s *DockerShell) getWindsorExecContainerID() (string, error) {
+	cmd := execCommand("docker", "ps", "--filter", "label=role=windsor_exec", "--format", "{{.ID}}")
+	output, err := cmdOutput(cmd)
+	if err != nil {
+		return "", fmt.Errorf("failed to list Docker containers: %w", err)
+	}
+
+	containerID := strings.TrimSpace(output)
+	if containerID == "" {
+		return "", fmt.Errorf("no Windsor exec container found")
+	}
+
+	return containerID, nil
+}
+
+// Ensure DockerShell implements the Shell interface
+var _ Shell = (*DockerShell)(nil)

--- a/pkg/shell/docker_shell_test.go
+++ b/pkg/shell/docker_shell_test.go
@@ -1,0 +1,290 @@
+package shell
+
+import (
+	"fmt"
+	"os/exec"
+	"testing"
+
+	"github.com/windsorcli/cli/pkg/di"
+)
+
+// setSafeDockerShellMocks creates a safe "supermock" where all components are mocked except for DockerShell.
+func setSafeDockerShellMocks(injector ...di.Injector) struct {
+	Injector di.Injector
+} {
+	if len(injector) == 0 {
+		injector = []di.Injector{di.NewMockInjector()}
+	}
+
+	i := injector[0]
+
+	// Mock the execCommand to simulate successful command execution for specific Docker command
+	execCommand = func(name string, arg ...string) *exec.Cmd {
+		if name == "docker" && len(arg) > 0 && arg[0] == "ps" {
+			cmd := exec.Command("echo", "mock-container-id")
+			return cmd
+		}
+		cmd := exec.Command("echo", "mock output")
+		return cmd
+	}
+
+	// Mock the getwd to simulate a specific working directory
+	getwd = func() (string, error) {
+		return "/mock/project/root", nil
+	}
+
+	return struct {
+		Injector di.Injector
+	}{
+		Injector: i,
+	}
+}
+
+// TestDockerShell_Exec tests the Exec method of DockerShell.
+func TestDockerShell_Exec(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		injector := di.NewMockInjector()
+		mocks := setSafeDockerShellMocks(injector)
+		dockerShell := NewDockerShell(mocks.Injector)
+
+		// Save the original cmdOutput and execCommand functions
+		originalCmdOutput := cmdOutput
+		originalExecCommand := execCommand
+
+		// Defer restoring the original functions
+		defer func() {
+			cmdOutput = originalCmdOutput
+			execCommand = originalExecCommand
+		}()
+
+		// Mock the necessary functions to simulate a successful execution
+		cmdOutput = func(cmd *exec.Cmd) (string, error) {
+			if cmd.Path == "/bin/echo" && len(cmd.Args) == 2 && cmd.Args[1] == "mock-container-id" {
+				return "mock-container-id", nil
+			}
+			return "", fmt.Errorf("unexpected command %s with args %v", cmd.Path, cmd.Args)
+		}
+
+		execCommand = func(name string, arg ...string) *exec.Cmd {
+			if name == "docker" && len(arg) > 0 {
+				switch {
+				case arg[0] == "ps" && len(arg) > 4 && arg[1] == "--filter" && arg[2] == "label=role=windsor_exec" && arg[3] == "--format" && arg[4] == "{{.ID}}":
+					return exec.Command("/bin/echo", "mock-container-id")
+				case len(arg) > 5 && arg[0] == "exec" && arg[1] == "-it" && arg[2] == "mock-container-id" && arg[3] == "sh" && arg[4] == "-c":
+					expectedCmd := "cd /work && windsor exec -- echo hello"
+					if arg[5] == expectedCmd {
+						return exec.Command("/bin/echo", "mock output")
+					}
+				}
+			}
+			t.Fatalf("unexpected command %s with args %v", name, arg)
+			return nil
+		}
+
+		output, err := dockerShell.Exec("echo", "hello")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		expectedOutput := "mock output\n"
+		if output != expectedOutput {
+			t.Errorf("expected %q, got %q", expectedOutput, output)
+		}
+	})
+
+	t.Run("CommandError", func(t *testing.T) {
+		injector := di.NewMockInjector()
+		mocks := setSafeDockerShellMocks(injector)
+		dockerShell := NewDockerShell(mocks.Injector)
+
+		// Save the original cmdOutput function
+		originalCmdOutput := cmdOutput
+
+		// Defer restoring the original function
+		defer func() {
+			cmdOutput = originalCmdOutput
+		}()
+
+		// Mock cmdOutput to simulate a command execution failure
+		cmdOutput = func(cmd *exec.Cmd) (string, error) {
+			return "", fmt.Errorf("command execution failed")
+		}
+
+		_, err := dockerShell.Exec("echo", "hello")
+		if err == nil {
+			t.Fatalf("expected an error, got none")
+		}
+	})
+
+	t.Run("ContainerIDError", func(t *testing.T) {
+		injector := di.NewMockInjector()
+		mocks := setSafeDockerShellMocks(injector)
+		dockerShell := NewDockerShell(mocks.Injector)
+
+		// Save the original execCommand function
+		originalExecCommand := execCommand
+
+		// Defer restoring the original function
+		defer func() {
+			execCommand = originalExecCommand
+		}()
+
+		// Mock execCommand to simulate an empty container ID
+		execCommand = func(name string, arg ...string) *exec.Cmd {
+			if name == "docker" && len(arg) > 0 && arg[0] == "ps" {
+				return exec.Command("/bin/echo", "")
+			}
+			return exec.Command(name, arg...)
+		}
+
+		_, err := dockerShell.Exec("echo", "hello")
+		if err == nil || err.Error() != "failed to get Windsor exec container ID: no Windsor exec container found" {
+			t.Fatalf("expected error 'failed to get Windsor exec container ID: no Windsor exec container found', got %v", err)
+		}
+	})
+
+	t.Run("ErrorGettingProjectRoot", func(t *testing.T) {
+		injector := di.NewMockInjector()
+		mocks := setSafeDockerShellMocks(injector)
+		dockerShell := NewDockerShell(mocks.Injector)
+
+		// Save the original getwd function
+		originalGetwd := getwd
+
+		// Defer restoring the original function
+		defer func() {
+			getwd = originalGetwd
+		}()
+
+		// Mock getwd to simulate an error
+		getwd = func() (string, error) {
+			return "", fmt.Errorf("failed to get project root")
+		}
+
+		_, err := dockerShell.Exec("echo", "hello")
+		if err == nil || err.Error() != "failed to get project root: failed to get project root" {
+			t.Fatalf("expected error 'failed to get project root: failed to get project root', got %v", err)
+		}
+	})
+
+	t.Run("ErrorGettingWorkingDirectory", func(t *testing.T) {
+		injector := di.NewMockInjector()
+		mocks := setSafeDockerShellMocks(injector)
+		dockerShell := NewDockerShell(mocks.Injector)
+
+		// Save the original getwd function
+		originalGetwd := getwd
+
+		// Defer restoring the original function
+		defer func() {
+			getwd = originalGetwd
+		}()
+
+		// Counter to track the number of calls to getwd
+		callCount := 0
+
+		// Mock getwd to simulate an error on the second call
+		getwd = func() (string, error) {
+			callCount++
+			if callCount == 2 {
+				return "", fmt.Errorf("failed to get working directory on second call")
+			}
+			return "/mock/path", nil
+		}
+
+		_, err := dockerShell.Exec("echo", "hello")
+		if err == nil || err.Error() != "failed to get current working directory: failed to get working directory on second call" {
+			t.Fatalf("expected error 'failed to get current working directory: failed to get working directory on second call', got %v", err)
+		}
+	})
+
+	t.Run("ErrorDeterminingRelativeDirectory", func(t *testing.T) {
+		injector := di.NewMockInjector()
+		mocks := setSafeDockerShellMocks(injector)
+		dockerShell := NewDockerShell(mocks.Injector)
+
+		// Save the original filepathRel function
+		originalFilepathRel := filepathRel
+
+		// Defer restoring the original function
+		defer func() {
+			filepathRel = originalFilepathRel
+		}()
+
+		// Mock filepathRel to simulate an error
+		filepathRel = func(basepath, targpath string) (string, error) {
+			return "", fmt.Errorf("failed to determine relative directory")
+		}
+
+		_, err := dockerShell.Exec("echo", "hello")
+		if err == nil || err.Error() != "failed to determine relative directory: failed to determine relative directory" {
+			t.Fatalf("expected error 'failed to determine relative directory: failed to determine relative directory', got %v", err)
+		}
+	})
+
+	t.Run("CommandStartError", func(t *testing.T) {
+		injector := di.NewMockInjector()
+		mocks := setSafeDockerShellMocks(injector)
+		dockerShell := NewDockerShell(mocks.Injector)
+
+		// Save the original cmdStart function
+		originalCmdStart := cmdStart
+
+		// Defer restoring the original function
+		defer func() {
+			cmdStart = originalCmdStart
+		}()
+
+		// Mock cmdStart to simulate a command start error
+		cmdStart = func(cmd *exec.Cmd) error {
+			return fmt.Errorf("command start failed")
+		}
+
+		_, err := dockerShell.Exec("echo", "hello")
+		if err == nil || err.Error() != "command start failed: command start failed" {
+			t.Fatalf("expected error 'command start failed: command start failed', got %v", err)
+		}
+	})
+
+	t.Run("CommandWaitError", func(t *testing.T) {
+		injector := di.NewMockInjector()
+		mocks := setSafeDockerShellMocks(injector)
+		dockerShell := NewDockerShell(mocks.Injector)
+
+		// Save the original cmdWait function
+		originalCmdWait := cmdWait
+
+		// Defer restoring the original function
+		defer func() {
+			cmdWait = originalCmdWait
+		}()
+
+		// Mock cmdWait to simulate a command wait error
+		cmdWait = func(cmd *exec.Cmd) error {
+			return fmt.Errorf("command execution failed")
+		}
+
+		_, err := dockerShell.Exec("echo", "hello")
+		if err == nil || err.Error() != "command execution failed: command execution failed\n" {
+			t.Fatalf("expected error 'command execution failed: command execution failed', got %v", err)
+		}
+	})
+}
+
+// TestDockerShell_GetWindsorExecContainerID tests the getWindsorExecContainerID method of DockerShell.
+func TestDockerShell_GetWindsorExecContainerID(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Setup for getWindsorExecContainerID success test
+		// Test successful container ID retrieval
+	})
+
+	t.Run("NoContainerFound", func(t *testing.T) {
+		// Setup for getWindsorExecContainerID no container found test
+		// Test scenario where no container with the specified label is found
+	})
+
+	t.Run("DockerCommandError", func(t *testing.T) {
+		// Setup for getWindsorExecContainerID Docker command error test
+		// Test error when Docker command execution fails
+	})
+}

--- a/pkg/shell/docker_shell_test.go
+++ b/pkg/shell/docker_shell_test.go
@@ -70,7 +70,7 @@ func TestDockerShell_Exec(t *testing.T) {
 				switch {
 				case arg[0] == "ps" && len(arg) > 4 && arg[1] == "--filter" && arg[2] == "label=role=windsor_exec" && arg[3] == "--format" && arg[4] == "{{.ID}}":
 					return exec.Command("/bin/echo", "mock-container-id")
-				case len(arg) > 5 && arg[0] == "exec" && arg[1] == "-it" && arg[2] == "mock-container-id" && arg[3] == "sh" && arg[4] == "-c":
+				case len(arg) > 5 && arg[0] == "exec" && arg[1] == "-i" && arg[2] == "mock-container-id" && arg[3] == "sh" && arg[4] == "-c":
 					expectedCmd := "cd /work && windsor exec -- echo hello"
 					if arg[5] == expectedCmd {
 						return exec.Command("/bin/echo", "mock output")
@@ -81,7 +81,7 @@ func TestDockerShell_Exec(t *testing.T) {
 			return nil
 		}
 
-		output, err := dockerShell.Exec("echo", "hello")
+		output, _, err := dockerShell.Exec("echo", "hello")
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
 		}
@@ -110,7 +110,7 @@ func TestDockerShell_Exec(t *testing.T) {
 			return "", fmt.Errorf("command execution failed")
 		}
 
-		_, err := dockerShell.Exec("echo", "hello")
+		_, _, err := dockerShell.Exec("echo", "hello")
 		if err == nil {
 			t.Fatalf("expected an error, got none")
 		}
@@ -137,7 +137,7 @@ func TestDockerShell_Exec(t *testing.T) {
 			return exec.Command(name, arg...)
 		}
 
-		_, err := dockerShell.Exec("echo", "hello")
+		_, _, err := dockerShell.Exec("echo", "hello")
 		if err == nil || err.Error() != "failed to get Windsor exec container ID: no Windsor exec container found" {
 			t.Fatalf("expected error 'failed to get Windsor exec container ID: no Windsor exec container found', got %v", err)
 		}
@@ -161,7 +161,7 @@ func TestDockerShell_Exec(t *testing.T) {
 			return "", fmt.Errorf("failed to get project root")
 		}
 
-		_, err := dockerShell.Exec("echo", "hello")
+		_, _, err := dockerShell.Exec("echo", "hello")
 		if err == nil || err.Error() != "failed to get project root: failed to get project root" {
 			t.Fatalf("expected error 'failed to get project root: failed to get project root', got %v", err)
 		}
@@ -192,7 +192,7 @@ func TestDockerShell_Exec(t *testing.T) {
 			return "/mock/path", nil
 		}
 
-		_, err := dockerShell.Exec("echo", "hello")
+		_, _, err := dockerShell.Exec("echo", "hello")
 		if err == nil || err.Error() != "failed to get current working directory: failed to get working directory on second call" {
 			t.Fatalf("expected error 'failed to get current working directory: failed to get working directory on second call', got %v", err)
 		}
@@ -216,7 +216,7 @@ func TestDockerShell_Exec(t *testing.T) {
 			return "", fmt.Errorf("failed to determine relative directory")
 		}
 
-		_, err := dockerShell.Exec("echo", "hello")
+		_, _, err := dockerShell.Exec("echo", "hello")
 		if err == nil || err.Error() != "failed to determine relative directory: failed to determine relative directory" {
 			t.Fatalf("expected error 'failed to determine relative directory: failed to determine relative directory', got %v", err)
 		}
@@ -240,7 +240,7 @@ func TestDockerShell_Exec(t *testing.T) {
 			return fmt.Errorf("command start failed")
 		}
 
-		_, err := dockerShell.Exec("echo", "hello")
+		_, _, err := dockerShell.Exec("echo", "hello")
 		if err == nil || err.Error() != "command start failed: command start failed" {
 			t.Fatalf("expected error 'command start failed: command start failed', got %v", err)
 		}
@@ -264,7 +264,7 @@ func TestDockerShell_Exec(t *testing.T) {
 			return fmt.Errorf("command execution failed")
 		}
 
-		_, err := dockerShell.Exec("echo", "hello")
+		_, _, err := dockerShell.Exec("echo", "hello")
 		if err == nil || err.Error() != "command execution failed: command execution failed\n" {
 			t.Fatalf("expected error 'command execution failed: command execution failed', got %v", err)
 		}

--- a/pkg/shell/shell_test.go
+++ b/pkg/shell/shell_test.go
@@ -12,7 +12,6 @@ import (
 	"reflect"
 	"runtime"
 	"strings"
-	"sync"
 	"testing"
 	"text/template"
 
@@ -285,7 +284,9 @@ func TestShell_Exec(t *testing.T) {
 
 		// Mock execCommand to simulate command execution
 		originalExecCommand := execCommand
-		execCommand = mockExecCommandError
+		execCommand = func(name string, arg ...string) *exec.Cmd {
+			return exec.Command("false")
+		}
 		defer func() { execCommand = originalExecCommand }()
 
 		// Mock cmdStart to simulate successful command start
@@ -494,6 +495,39 @@ func TestShell_ExecSilent(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		command := "go"
 		args := []string{"version"}
+
+		// Mock execCommand to simulate command execution and validate inputs
+		originalExecCommand := execCommand
+		execCommand = func(name string, arg ...string) *exec.Cmd {
+			if name != command {
+				t.Fatalf("Expected command %q, got %q", command, name)
+			}
+			if len(arg) != len(args) || arg[0] != args[0] {
+				t.Fatalf("Expected args %v, got %v", args, arg)
+			}
+			cmd := &exec.Cmd{
+				Stdout: &bytes.Buffer{},
+				Stderr: &bytes.Buffer{},
+			}
+			cmd.Stdout.Write([]byte("go version go1.16.3\n"))
+
+			// Validate the output within the mock
+			expectedOutputPrefix := "go version"
+			output := cmd.Stdout.(*bytes.Buffer).String()
+			if !strings.HasPrefix(output, expectedOutputPrefix) {
+				t.Fatalf("Expected output to start with %q, got %q", expectedOutputPrefix, output)
+			}
+
+			return cmd
+		}
+		defer func() { execCommand = originalExecCommand }()
+
+		// Mock cmdRun to simulate successful command execution
+		originalCmdRun := cmdRun
+		cmdRun = func(cmd *exec.Cmd) error {
+			return nil
+		}
+		defer func() { cmdRun = originalCmdRun }()
 
 		shell := NewDefaultShell(nil)
 		output, code, err := shell.ExecSilent(command, args...)
@@ -979,79 +1013,6 @@ func TestShell_InstallHook(t *testing.T) {
 	})
 }
 
-// Helper function to resolve symlinks
-func resolveSymlinks(t *testing.T, path string) string {
-	resolvedPath, err := filepath.EvalSymlinks(path)
-	if err != nil {
-		t.Fatalf("Failed to evaluate symlinks for %s: %v", path, err)
-	}
-	return resolvedPath
-}
-
-var tempDirs []string
-
-// Helper function to create a temporary directory
-func createTempDir(t *testing.T, name string) string {
-	dir, err := os.MkdirTemp("", name)
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	tempDirs = append(tempDirs, dir)
-	return dir
-}
-
-// Helper function to create a file with specified content
-func createFile(t *testing.T, dir, name, content string) {
-	filePath := filepath.Join(dir, name)
-	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
-		t.Fatalf("Failed to create file %s: %v", filePath, err)
-	}
-}
-
-// Helper function to change the working directory
-func changeDir(t *testing.T, dir string) {
-	originalDir, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("Failed to get current directory: %v", err)
-	}
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("Failed to change directory: %v", err)
-	}
-	t.Cleanup(func() {
-		if err := os.Chdir(originalDir); err != nil {
-			t.Fatalf("Failed to revert to original directory: %v", err)
-		}
-	})
-}
-
-// Helper function to normalize a path
-func normalizePath(path string) string {
-	return strings.ReplaceAll(filepath.Clean(path), "\\", "/")
-}
-
-// Helper function to capture stdout
-func captureStdout(t *testing.T, f func()) string {
-	var output bytes.Buffer
-	originalStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		f()
-		w.Close()
-	}()
-
-	_, err := output.ReadFrom(r)
-	if err != nil {
-		t.Fatalf("Failed to read from pipe: %v", err)
-	}
-	<-done
-	os.Stdout = originalStdout
-	return output.String()
-}
-
 // Updated helper function to mock exec.Command for failed execution using PowerShell
 func mockExecCommandError(command string, args ...string) *exec.Cmd {
 	if runtime.GOOS == "windows" {
@@ -1063,51 +1024,6 @@ func mockExecCommandError(command string, args ...string) *exec.Cmd {
 		// Use 'false' command on Unix-like systems
 		return exec.Command("false")
 	}
-}
-
-// captureStdoutAndStderr captures output sent to os.Stdout and os.Stderr during the execution of f()
-func captureStdoutAndStderr(t *testing.T, f func()) (string, string) {
-	// Save the original os.Stdout and os.Stderr
-	originalStdout := os.Stdout
-	originalStderr := os.Stderr
-
-	// Create pipes for os.Stdout and os.Stderr
-	rOut, wOut, _ := os.Pipe()
-	rErr, wErr, _ := os.Pipe()
-	os.Stdout = wOut
-	os.Stderr = wErr
-
-	// Channel to signal completion
-	done := make(chan struct{})
-	go func() {
-		defer close(done)
-		f()
-		wOut.Close()
-		wErr.Close()
-	}()
-
-	// Read from the pipes
-	var stdoutBuf, stderrBuf bytes.Buffer
-	var wg sync.WaitGroup
-	wg.Add(2)
-	readFromPipe := func(pipe *os.File, buf *bytes.Buffer, pipeName string) {
-		defer wg.Done()
-		if _, err := buf.ReadFrom(pipe); err != nil {
-			t.Errorf("Failed to read from %s pipe: %v", pipeName, err)
-		}
-	}
-	go readFromPipe(rOut, &stdoutBuf, "stdout")
-	go readFromPipe(rErr, &stderrBuf, "stderr")
-
-	// Wait for reading to complete
-	wg.Wait()
-	<-done
-
-	// Restore os.Stdout and os.Stderr
-	os.Stdout = originalStdout
-	os.Stderr = originalStderr
-
-	return stdoutBuf.String(), stderrBuf.String()
 }
 
 func TestEnv_CheckTrustedDirectory(t *testing.T) {

--- a/pkg/shell/shims.go
+++ b/pkg/shell/shims.go
@@ -5,100 +5,109 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"text/template"
 )
 
 // Shims for system functions to facilitate testing by allowing overrides.
-var (
-	// Current working directory retrieval
-	getwd = os.Getwd
 
-	// Command execution
-	execCommand = osExecCommand
+// Current working directory retrieval
+var getwd = os.Getwd
 
-	// Command run execution
-	cmdRun = func(cmd *exec.Cmd) error {
-		return cmd.Run()
-	}
+// Command execution
+var execCommand = osExecCommand
 
-	// Command start execution
-	cmdStart = func(cmd *exec.Cmd) error {
-		return cmd.Start()
-	}
+// Process state exit code retrieval
+var processStateExitCode = func(ps *os.ProcessState) int {
+	return ps.ExitCode()
+}
 
-	// User home directory retrieval
-	osUserHomeDir = os.UserHomeDir
-
-	// File status retrieval
-	osStat = os.Stat
-
-	// File opening
-	osOpenFile = os.OpenFile
-
-	// File reading
-	osReadFile = os.ReadFile
-
-	// File writing
-	osWriteFile = os.WriteFile
-
-	// Directory creation
-	osMkdirAll = os.MkdirAll
-
-	// Command wait execution
-	cmdWait = func(cmd *exec.Cmd) error {
-		return cmd.Wait()
-	}
-
-	// Command stdout pipe
-	cmdStdoutPipe = func(cmd *exec.Cmd) (io.ReadCloser, error) {
-		return cmd.StdoutPipe()
-	}
-
-	// Command stderr pipe
-	cmdStderrPipe = func(cmd *exec.Cmd) (io.ReadCloser, error) {
-		return cmd.StderrPipe()
-	}
-
-	// Scanner scan operation
-	bufioScannerScan = func(scanner *bufio.Scanner) bool {
-		return scanner.Scan()
-	}
-
-	// Scanner error retrieval
-	bufioScannerErr = func(scanner *bufio.Scanner) error {
-		return scanner.Err()
-	}
-
-	// Executable path retrieval
-	osExecutable = os.Executable
-
-	// Template creation
-	hookTemplateNew = func(name string) *template.Template {
-		return template.New(name)
-	}
-
-	// Template parsing
-	hookTemplateParse = func(tmpl *template.Template, text string) (*template.Template, error) {
-		return tmpl.Parse(text)
-	}
-
-	// Template execution
-	hookTemplateExecute = func(tmpl *template.Template, wr io.Writer, data interface{}) error {
-		return tmpl.Execute(wr, data)
-	}
-
-	// Process state exit code retrieval
-	processStateExitCode = func(ps *os.ProcessState) int {
-		return ps.ExitCode()
-	}
-
-	// Process state creation
-	newProcessState = func() *os.ProcessState {
-		return &os.ProcessState{}
-	}
-)
+// Process state creation
+var newProcessState = func() *os.ProcessState {
+	return &os.ProcessState{}
+}
 
 // osExecCommand wraps exec.Command for testing purposes.
 func osExecCommand(name string, arg ...string) *exec.Cmd {
 	return exec.Command(name, arg...)
 }
+
+// cmdRun is a variable that points to cmd.Run, allowing it to be overridden in tests
+var cmdRun = func(cmd *exec.Cmd) error {
+	return cmd.Run()
+}
+
+// cmdStart is a variable that points to cmd.Start, allowing it to be overridden in tests
+var cmdStart = func(cmd *exec.Cmd) error {
+	return cmd.Start()
+}
+
+// osUserHomeDir is a variable that points to os.UserHomeDir, allowing it to be overridden in tests
+var osUserHomeDir = os.UserHomeDir
+
+// osStat is a variable that points to os.Stat, allowing it to be overridden in tests
+var osStat = os.Stat
+
+// osOpenFile is a variable that points to os.OpenFile, allowing it to be overridden in tests
+var osOpenFile = os.OpenFile
+
+// osReadFile is a variable that points to os.ReadFile, allowing it to be overridden in tests
+var osReadFile = os.ReadFile
+
+// osWriteFile is a variable that points to os.WriteFile, allowing it to be overridden in tests
+var osWriteFile = os.WriteFile
+
+// osMkdirAll is a variable that points to os.MkdirAll, allowing it to be overridden in tests
+var osMkdirAll = os.MkdirAll
+
+// cmdOutput is a shim for cmd.Output, allowing it to be overridden in tests
+var cmdOutput = func(cmd *exec.Cmd) (string, error) {
+	output, err := cmd.Output()
+	return string(output), err
+}
+
+// cmdWait is a variable that points to cmd.Wait, allowing it to be overridden in tests
+var cmdWait = func(cmd *exec.Cmd) error {
+	return cmd.Wait()
+}
+
+// cmdStdoutPipe is a variable that points to cmd.StdoutPipe, allowing it to be overridden in tests
+var cmdStdoutPipe = func(cmd *exec.Cmd) (io.ReadCloser, error) {
+	return cmd.StdoutPipe()
+}
+
+// cmdStderrPipe is a variable that points to cmd.StderrPipe, allowing it to be overridden in tests
+var cmdStderrPipe = func(cmd *exec.Cmd) (io.ReadCloser, error) {
+	return cmd.StderrPipe()
+}
+
+// bufioScannerScan is a variable that points to bufio.Scanner.Scan, allowing it to be overridden in tests
+var bufioScannerScan = func(scanner *bufio.Scanner) bool {
+	return scanner.Scan()
+}
+
+// bufioScannerErr is a variable that points to bufio.Scanner.Err, allowing it to be overridden in tests
+var bufioScannerErr = func(scanner *bufio.Scanner) error {
+	return scanner.Err()
+}
+
+// osExecutable is a variable that points to os.Executable, allowing it to be overridden in tests
+var osExecutable = os.Executable
+
+// hookTemplateNew is a variable that points to template.New, allowing it to be overridden in tests
+var hookTemplateNew = func(name string) *template.Template {
+	return template.New(name)
+}
+
+// hookTemplateParse is a variable that points to template.Template.Parse, allowing it to be overridden in tests
+var hookTemplateParse = func(tmpl *template.Template, text string) (*template.Template, error) {
+	return tmpl.Parse(text)
+}
+
+// hookTemplateExecute is a variable that points to template.Template.Execute, allowing it to be overridden in tests
+var hookTemplateExecute = func(tmpl *template.Template, wr io.Writer, data interface{}) error {
+	return tmpl.Execute(wr, data)
+}
+
+// filepathRel is a variable that points to filepath.Rel, allowing it to be overridden in tests
+var filepathRel = filepath.Rel

--- a/pkg/shell/test_helpers_test.go
+++ b/pkg/shell/test_helpers_test.go
@@ -1,0 +1,138 @@
+package shell
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+)
+
+// Helper function to resolve symlinks
+func resolveSymlinks(t *testing.T, path string) string {
+	resolvedPath, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatalf("Failed to evaluate symlinks for %s: %v", path, err)
+	}
+	return resolvedPath
+}
+
+var tempDirs []string
+
+// Helper function to create a temporary directory
+func createTempDir(t *testing.T, name string) string {
+	dir, err := os.MkdirTemp("", name)
+	if err != nil {
+		t.Fatalf("Failed to create temp dir: %v", err)
+	}
+	tempDirs = append(tempDirs, dir)
+	return dir
+}
+
+// Helper function to create a file with specified content
+func createFile(t *testing.T, dir, name, content string) {
+	filePath := filepath.Join(dir, name)
+	if err := os.WriteFile(filePath, []byte(content), 0644); err != nil {
+		t.Fatalf("Failed to create file %s: %v", filePath, err)
+	}
+}
+
+// Helper function to change the working directory
+func changeDir(t *testing.T, dir string) {
+	originalDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get current directory: %v", err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("Failed to change directory: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(originalDir); err != nil {
+			t.Fatalf("Failed to revert to original directory: %v", err)
+		}
+	})
+}
+
+// Helper function to initialize a git repository
+func initGitRepo(t *testing.T, dir string) {
+	cmd := exec.Command("git", "init")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("Failed to initialize git repository: %v", err)
+	}
+}
+
+// Helper function to normalize a path
+func normalizePath(path string) string {
+	return strings.ReplaceAll(filepath.Clean(path), "\\", "/")
+}
+
+// Helper function to capture stdout
+func captureStdout(t *testing.T, f func()) string {
+	var output bytes.Buffer
+	originalStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		f()
+		w.Close()
+	}()
+
+	_, err := output.ReadFrom(r)
+	if err != nil {
+		t.Fatalf("Failed to read from pipe: %v", err)
+	}
+	<-done
+	os.Stdout = originalStdout
+	return output.String()
+}
+
+// captureStdoutAndStderr captures output sent to os.Stdout and os.Stderr during the execution of f()
+func captureStdoutAndStderr(t *testing.T, f func()) (string, string) {
+	// Save the original os.Stdout and os.Stderr
+	originalStdout := os.Stdout
+	originalStderr := os.Stderr
+
+	// Create pipes for os.Stdout and os.Stderr
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+	os.Stdout = wOut
+	os.Stderr = wErr
+
+	// Channel to signal completion
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		f()
+		wOut.Close()
+		wErr.Close()
+	}()
+
+	// Read from the pipes
+	var stdoutBuf, stderrBuf bytes.Buffer
+	var wg sync.WaitGroup
+	wg.Add(2)
+	readFromPipe := func(pipe *os.File, buf *bytes.Buffer, pipeName string) {
+		defer wg.Done()
+		if _, err := buf.ReadFrom(pipe); err != nil {
+			t.Errorf("Failed to read from %s pipe: %v", pipeName, err)
+		}
+	}
+	go readFromPipe(rOut, &stdoutBuf, "stdout")
+	go readFromPipe(rErr, &stderrBuf, "stderr")
+
+	// Wait for reading to complete
+	wg.Wait()
+	<-done
+
+	// Restore os.Stdout and os.Stderr
+	os.Stdout = originalStdout
+	os.Stderr = originalStderr
+
+	return stdoutBuf.String(), stderrBuf.String()
+}

--- a/pkg/shell/windows_test.go
+++ b/pkg/shell/windows_test.go
@@ -79,11 +79,12 @@ func TestDefaultShell_GetProjectRoot(t *testing.T) {
 	injector := di.NewInjector()
 
 	testCases := []struct {
-		name     string
-		fileName string
+		name         string
+		fileName     string
+		expectedRoot string
 	}{
-		{"WindsorYaml", "windsor.yaml"},
-		{"WindsorYml", "windsor.yml"},
+		{"WindsorYaml", "windsor.yaml", "/mock/project/root"},
+		{"WindsorYml", "windsor.yml", "/mock/project/root"},
 	}
 
 	for _, tc := range testCases {
@@ -109,14 +110,8 @@ func TestDefaultShell_GetProjectRoot(t *testing.T) {
 				t.Fatalf("GetProjectRoot returned an error: %v", err)
 			}
 
-			// Resolve symlinks to handle macOS /private prefix
-			expectedRootDir, err := filepath.EvalSymlinks(rootDir)
-			if err != nil {
-				t.Fatalf("Failed to evaluate symlinks for rootDir: %v", err)
-			}
-
 			// Normalize paths for comparison
-			expectedRootDir = normalizeWindowsPath(expectedRootDir)
+			expectedRootDir := normalizeWindowsPath(tc.expectedRoot)
 			projectRoot = normalizeWindowsPath(projectRoot)
 
 			// Then the project root should match the expected root directory


### PR DESCRIPTION
Now, when setting `WINDSOR_EXEC_MODE=container` or by default on MacOS, the `windsor exec` command will execute inside the windsor container environment. This makes it possible to leverage a more reliable execution environment when necessary. Specifically, this permits us to alias terraform to use this approach.

Also, now build and tag `latest` on the windsor docker container on main.

Various test cleanup.