### PR TITLE
Wildcard service DNS entries

### DIFF
--- a/pkg/services/dns_service.go
+++ b/pkg/services/dns_service.go
@@ -117,6 +117,9 @@ func (s *DNSService) WriteConfig() error {
 				if address != "" {
 					hostname := service.GetHostname()
 					hostEntries += fmt.Sprintf("        %s %s\n", address, hostname)
+					if service.SupportsWildcard() {
+						hostEntries += fmt.Sprintf("        %s *.%s\n", address, hostname)
+					}
 				}
 			}
 		}

--- a/pkg/services/localstack_service.go
+++ b/pkg/services/localstack_service.go
@@ -127,5 +127,10 @@ func validateServices(services []string) ([]string, []string) {
 	return validServices, invalidServices
 }
 
+// SupportsWildcard returns true if the Localstack service supports wildcard subdomains
+func (s *LocalstackService) SupportsWildcard() bool {
+	return true
+}
+
 // Ensure LocalstackService implements Service interface
 var _ Service = (*LocalstackService)(nil)

--- a/pkg/services/localstack_service_test.go
+++ b/pkg/services/localstack_service_test.go
@@ -200,3 +200,27 @@ func TestLocalstackService_GetComposeConfig(t *testing.T) {
 		}
 	})
 }
+
+func TestLocalstackService_SupportsWildcard(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Create mock injector with necessary mocks
+		mocks := createLocalstackServiceMocks()
+
+		// Create an instance of LocalstackService
+		localstackService := NewLocalstackService(mocks.Injector)
+
+		// Initialize the service
+		if err := localstackService.Initialize(); err != nil {
+			t.Fatalf("Initialize() error = %v", err)
+		}
+
+		// When: SupportsWildcard is called
+		supportsWildcard := localstackService.SupportsWildcard()
+
+		// Then: the result should match the expected outcome
+		expectedSupportsWildcard := true
+		if supportsWildcard != expectedSupportsWildcard {
+			t.Fatalf("expected SupportsWildcard to be %v, got %v", expectedSupportsWildcard, supportsWildcard)
+		}
+	})
+}

--- a/pkg/services/mock_service.go
+++ b/pkg/services/mock_service.go
@@ -23,6 +23,8 @@ type MockService struct {
 	GetNameFunc func() string
 	// GetHostnameFunc is a function that mocks the GetHostname method
 	GetHostnameFunc func() string
+	// SupportsWildcardFunc is a function that mocks the SupportsWildcard method
+	SupportsWildcardFunc func() bool
 }
 
 // NewMockService is a constructor for MockService
@@ -92,6 +94,14 @@ func (m *MockService) GetHostname() string {
 		return m.GetHostnameFunc()
 	}
 	return ""
+}
+
+// SupportsWildcard calls the mock SupportsWildcardFunc if it is set, otherwise returns false
+func (m *MockService) SupportsWildcard() bool {
+	if m.SupportsWildcardFunc != nil {
+		return m.SupportsWildcardFunc()
+	}
+	return false
 }
 
 // Ensure MockService implements Service interface

--- a/pkg/services/mock_service_test.go
+++ b/pkg/services/mock_service_test.go
@@ -381,3 +381,34 @@ func TestMockService_GetHostname(t *testing.T) {
 		}
 	})
 }
+
+func TestMockService_SupportsWildcard(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Given: a mock service with a SupportsWildcardFunc
+		mockService := NewMockService()
+		mockService.SupportsWildcardFunc = func() bool {
+			return true
+		}
+
+		// When: SupportsWildcard is called
+		supportsWildcard := mockService.SupportsWildcard()
+
+		// Then: true should be returned
+		if !supportsWildcard {
+			t.Errorf("expected true, got %v", supportsWildcard)
+		}
+	})
+
+	t.Run("SuccessNoMock", func(t *testing.T) {
+		// Given: a mock service with no SupportsWildcardFunc
+		mockService := NewMockService()
+
+		// When: SupportsWildcard is called
+		supportsWildcard := mockService.SupportsWildcard()
+
+		// Then: false should be returned
+		if supportsWildcard {
+			t.Errorf("expected false, got %v", supportsWildcard)
+		}
+	})
+}

--- a/pkg/services/service.go
+++ b/pkg/services/service.go
@@ -40,6 +40,9 @@ type Service interface {
 
 	// IsLocalhost checks if the current address is a localhost address
 	IsLocalhost() bool
+
+	// SupportsWildcard checks if the service supports wildcard subdomains
+	SupportsWildcard() bool
 }
 
 // BaseService is a base implementation of the Service interface
@@ -106,11 +109,16 @@ func (s *BaseService) GetHostname() string {
 
 // IsLocalhost checks if the current address is a localhost address
 func (s *BaseService) IsLocalhost() bool {
-	localhostAddresses := []string{"localhost", "127.0.0.1", "::1"}
-	for _, localhost := range localhostAddresses {
-		if s.address == localhost {
-			return true
-		}
+	localhostAddresses := map[string]struct{}{
+		"localhost": {},
+		"127.0.0.1": {},
+		"::1":       {},
 	}
+	_, isLocalhost := localhostAddresses[s.address]
+	return isLocalhost
+}
+
+// SupportsWildcard checks if the service supports wildcard subdomains
+func (s *BaseService) SupportsWildcard() bool {
 	return false
 }

--- a/pkg/services/service_test.go
+++ b/pkg/services/service_test.go
@@ -222,3 +222,19 @@ func TestBaseService_IsLocalhost(t *testing.T) {
 		})
 	}
 }
+
+func TestBaseService_SupportsWildcard(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Given: a new BaseService
+		service := &BaseService{}
+
+		// When: SupportsWildcard is called
+		supportsWildcard := service.SupportsWildcard()
+
+		// Then: the result should match the expected outcome
+		expectedSupportsWildcard := false
+		if supportsWildcard != expectedSupportsWildcard {
+			t.Fatalf("expected SupportsWildcard to be %v, got %v", expectedSupportsWildcard, supportsWildcard)
+		}
+	})
+}


### PR DESCRIPTION
Some services now allow wildcard DNS. For example, `*.aws.test` can now accept requests for s3 subdomains.