### PR TITLE
Terraform state key prefix

### DIFF
--- a/api/v1alpha1/terraform/terraform_config.go
+++ b/api/v1alpha1/terraform/terraform_config.go
@@ -11,6 +11,7 @@ type BackendConfig struct {
 	S3         *S3Backend         `yaml:"s3,omitempty"`
 	Kubernetes *KubernetesBackend `yaml:"kubernetes,omitempty"`
 	Local      *LocalBackend      `yaml:"local,omitempty"`
+	Prefix     *string            `yaml:"prefix,omitempty"`
 }
 
 // https://developer.hashicorp.com/terraform/language/backend/s3#configuration

--- a/api/v1alpha1/terraform/terraform_config_test.go
+++ b/api/v1alpha1/terraform/terraform_config_test.go
@@ -13,7 +13,7 @@ func TestTerraformConfig_Merge(t *testing.T) {
 		}
 		overlay := &TerraformConfig{
 			Enabled: ptrBool(true),
-			Backend: &BackendConfig{Type: "s3"},
+			Backend: &BackendConfig{Type: "s3", Prefix: stringPtr("mock-prefix")},
 		}
 		base.Merge(overlay)
 		if base.Enabled == nil || *base.Enabled != true {
@@ -22,12 +22,15 @@ func TestTerraformConfig_Merge(t *testing.T) {
 		if base.Backend == nil || base.Backend.Type != "s3" {
 			t.Errorf("Backend mismatch: expected %v, got %v", "s3", base.Backend.Type)
 		}
+		if base.Backend.Prefix == nil || *base.Backend.Prefix != "mock-prefix" {
+			t.Errorf("Prefix mismatch: expected %v, got %v", "mock-prefix", base.Backend.Prefix)
+		}
 	})
 
 	t.Run("MergeWithNilValues", func(t *testing.T) {
 		base := &TerraformConfig{
 			Enabled: ptrBool(false),
-			Backend: &BackendConfig{Type: "s3"},
+			Backend: &BackendConfig{Type: "s3", Prefix: stringPtr("base-prefix")},
 		}
 		overlay := &TerraformConfig{
 			Enabled: nil,
@@ -40,6 +43,9 @@ func TestTerraformConfig_Merge(t *testing.T) {
 		if base.Backend == nil || base.Backend.Type != "s3" {
 			t.Errorf("Backend mismatch: expected %v, got %v", "s3", base.Backend.Type)
 		}
+		if base.Backend.Prefix == nil || *base.Backend.Prefix != "base-prefix" {
+			t.Errorf("Prefix mismatch: expected %v, got %v", "base-prefix", base.Backend.Prefix)
+		}
 	})
 }
 
@@ -47,7 +53,7 @@ func TestTerraformConfig_Copy(t *testing.T) {
 	t.Run("CopyWithNonNilValues", func(t *testing.T) {
 		original := &TerraformConfig{
 			Enabled: ptrBool(true),
-			Backend: &BackendConfig{Type: "s3"},
+			Backend: &BackendConfig{Type: "s3", Prefix: stringPtr("original-prefix")},
 		}
 
 		copy := original.Copy()
@@ -61,9 +67,12 @@ func TestTerraformConfig_Copy(t *testing.T) {
 		if original.Enabled == nil || *original.Enabled == *copy.Enabled {
 			t.Errorf("Original Enabled was modified: expected %v, got %v", true, *copy.Enabled)
 		}
-		copy.Backend = &BackendConfig{Type: "local"}
+		copy.Backend = &BackendConfig{Type: "local", Prefix: stringPtr("copy-prefix")}
 		if original.Backend == nil || original.Backend.Type == copy.Backend.Type {
 			t.Errorf("Original Backend was modified: expected %v, got %v", "s3", copy.Backend.Type)
+		}
+		if original.Backend.Prefix == nil || *original.Backend.Prefix == *copy.Backend.Prefix {
+			t.Errorf("Original Prefix was modified: expected %v, got %v", "original-prefix", *copy.Backend.Prefix)
 		}
 	})
 
@@ -92,4 +101,8 @@ func TestTerraformConfig_Copy(t *testing.T) {
 // Helper functions to create pointers for basic types
 func ptrBool(b bool) *bool {
 	return &b
+}
+
+func stringPtr(s string) *string {
+	return &s
 }

--- a/pkg/env/terraform_env.go
+++ b/pkg/env/terraform_env.go
@@ -283,10 +283,11 @@ func (e *TerraformEnvPrinter) generateBackendConfigArgs(projectPath, configRoot 
 			}
 		}
 	case "kubernetes":
-		secretSuffix := sanitizeForK8s(projectPath)
+		secretSuffix := projectPath
 		if prefix != "" {
 			secretSuffix = fmt.Sprintf("%s-%s", strings.ReplaceAll(prefix, "/", "-"), secretSuffix)
 		}
+		secretSuffix = sanitizeForK8s(secretSuffix)
 		addBackendConfigArg("secret_suffix", secretSuffix)
 		if backend := e.configHandler.GetConfig().Terraform.Backend.Kubernetes; backend != nil {
 			if err := processBackendConfig(backend, addBackendConfigArg); err != nil {

--- a/pkg/env/terraform_env.go
+++ b/pkg/env/terraform_env.go
@@ -269,11 +269,11 @@ func (e *TerraformEnvPrinter) generateBackendConfigArgs(projectPath, configRoot 
 
 	switch backendType {
 	case "local":
-		path := filepath.Join(configRoot, ".tfstate", projectPath)
+		path := filepath.Join(configRoot, ".tfstate")
 		if prefix != "" {
 			path = filepath.Join(path, prefix)
 		}
-		path = filepath.Join(path, "terraform.tfstate")
+		path = filepath.Join(path, projectPath, "terraform.tfstate")
 		addBackendConfigArg("path", filepath.ToSlash(path))
 	case "s3":
 		keyPath := fmt.Sprintf("%s%s", prefix, filepath.ToSlash(filepath.Join(projectPath, "terraform.tfstate")))

--- a/pkg/env/terraform_env.go
+++ b/pkg/env/terraform_env.go
@@ -269,10 +269,11 @@ func (e *TerraformEnvPrinter) generateBackendConfigArgs(projectPath, configRoot 
 
 	switch backendType {
 	case "local":
-		path := filepath.Join(configRoot, ".tfstate", projectPath, "terraform.tfstate")
+		path := filepath.Join(configRoot, ".tfstate", projectPath)
 		if prefix != "" {
-			path = filepath.Join(prefix, path)
+			path = filepath.Join(path, prefix)
 		}
+		path = filepath.Join(path, "terraform.tfstate")
 		addBackendConfigArg("path", filepath.ToSlash(path))
 	case "s3":
 		keyPath := fmt.Sprintf("%s%s", prefix, filepath.ToSlash(filepath.Join(projectPath, "terraform.tfstate")))

--- a/pkg/env/terraform_env.go
+++ b/pkg/env/terraform_env.go
@@ -265,18 +265,29 @@ func (e *TerraformEnvPrinter) generateBackendConfigArgs(projectPath, configRoot 
 		}
 	}
 
+	prefix := e.configHandler.GetString("terraform.backend.prefix", "")
+
 	switch backendType {
 	case "local":
-		addBackendConfigArg("path", filepath.ToSlash(filepath.Join(configRoot, ".tfstate", projectPath, "terraform.tfstate")))
+		path := filepath.Join(configRoot, ".tfstate", projectPath, "terraform.tfstate")
+		if prefix != "" {
+			path = filepath.Join(prefix, path)
+		}
+		addBackendConfigArg("path", filepath.ToSlash(path))
 	case "s3":
-		addBackendConfigArg("key", filepath.ToSlash(filepath.Join(projectPath, "terraform.tfstate")))
+		keyPath := fmt.Sprintf("%s%s", prefix, filepath.ToSlash(filepath.Join(projectPath, "terraform.tfstate")))
+		addBackendConfigArg("key", keyPath)
 		if backend := e.configHandler.GetConfig().Terraform.Backend.S3; backend != nil {
 			if err := processBackendConfig(backend, addBackendConfigArg); err != nil {
 				return nil, fmt.Errorf("error processing S3 backend config: %w", err)
 			}
 		}
 	case "kubernetes":
-		addBackendConfigArg("secret_suffix", sanitizeForK8s(projectPath))
+		secretSuffix := sanitizeForK8s(projectPath)
+		if prefix != "" {
+			secretSuffix = fmt.Sprintf("%s-%s", strings.ReplaceAll(prefix, "/", "-"), secretSuffix)
+		}
+		addBackendConfigArg("secret_suffix", secretSuffix)
 		if backend := e.configHandler.GetConfig().Terraform.Backend.Kubernetes; backend != nil {
 			if err := processBackendConfig(backend, addBackendConfigArg); err != nil {
 				return nil, fmt.Errorf("error processing Kubernetes backend config: %w", err)

--- a/pkg/env/terraform_env_test.go
+++ b/pkg/env/terraform_env_test.go
@@ -948,7 +948,7 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 		}
 	})
 
-	t.Run("LocalBackend", func(t *testing.T) {
+	t.Run("LocalBackendWithPrefix", func(t *testing.T) {
 		mocks := setupSafeTerraformEnvMocks()
 		mocks.ConfigHandler.GetConfigFunc = func() *v1alpha1.Context {
 			return &v1alpha1.Context{
@@ -960,6 +960,15 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 					},
 				},
 			}
+		}
+		mocks.ConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "terraform.backend.prefix" {
+				return "mock-prefix/"
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
 		}
 		terraformEnvPrinter := NewTerraformEnvPrinter(mocks.Injector)
 		terraformEnvPrinter.Initialize()
@@ -974,7 +983,7 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 
 		expectedArgs := []string{
 			fmt.Sprintf(`-backend-config="%s"`, filepath.ToSlash(filepath.Join(configRoot, "terraform", "backend.tfvars"))),
-			fmt.Sprintf(`-backend-config="path=%s"`, filepath.ToSlash(filepath.Join(configRoot, ".tfstate", projectPath, "terraform.tfstate"))),
+			fmt.Sprintf(`-backend-config="path=%s"`, filepath.ToSlash(filepath.Join("mock-prefix", configRoot, ".tfstate", projectPath, "terraform.tfstate"))),
 		}
 
 		if !reflect.DeepEqual(backendConfigArgs, expectedArgs) {
@@ -982,7 +991,7 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 		}
 	})
 
-	t.Run("S3Backend", func(t *testing.T) {
+	t.Run("S3BackendWithPrefix", func(t *testing.T) {
 		mocks := setupSafeTerraformEnvMocks()
 		mocks.ConfigHandler.GetConfigFunc = func() *v1alpha1.Context {
 			return &v1alpha1.Context{
@@ -1002,6 +1011,9 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 			if key == "terraform.backend.type" {
 				return "s3"
 			}
+			if key == "terraform.backend.prefix" {
+				return "mock-prefix/"
+			}
 			if len(defaultValue) > 0 {
 				return defaultValue[0]
 			}
@@ -1020,7 +1032,7 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 
 		expectedArgs := []string{
 			fmt.Sprintf(`-backend-config="%s"`, filepath.ToSlash(filepath.Join(configRoot, "terraform", "backend.tfvars"))),
-			`-backend-config="key=project/path/terraform.tfstate"`,
+			`-backend-config="key=mock-prefix/project/path/terraform.tfstate"`,
 			`-backend-config="bucket=mock-bucket"`,
 			`-backend-config="max_retries=5"`,
 			`-backend-config="region=mock-region"`,
@@ -1032,23 +1044,62 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 		}
 	})
 
-	t.Run("KubernetesBackend", func(t *testing.T) {
+	t.Run("KubernetesBackendWithPrefix", func(t *testing.T) {
 		mocks := setupSafeTerraformEnvMocks()
 		mocks.ConfigHandler.GetConfigFunc = func() *v1alpha1.Context {
 			return &v1alpha1.Context{
 				Terraform: &terraform.TerraformConfig{
 					Backend: &terraform.BackendConfig{
 						Kubernetes: &terraform.KubernetesBackend{
-							SecretSuffix: stringPtr("mock-secret-suffix"),
-							Namespace:    stringPtr("mock-namespace"),
+							Namespace: stringPtr("mock-namespace"),
 						},
 					},
 				},
 			}
 		}
 		mocks.ConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "terraform.backend.type" {
+			switch key {
+			case "terraform.backend.type":
 				return "kubernetes"
+			case "terraform.backend.prefix":
+				return "mock-prefix"
+			default:
+				if len(defaultValue) > 0 {
+					return defaultValue[0]
+				}
+				return ""
+			}
+		}
+		terraformEnvPrinter := NewTerraformEnvPrinter(mocks.Injector)
+		terraformEnvPrinter.Initialize()
+
+		projectPath := filepath.FromSlash("project/path")
+		configRoot := filepath.FromSlash("/mock/config/root")
+
+		backendConfigArgs, err := terraformEnvPrinter.generateBackendConfigArgs(projectPath, configRoot)
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+
+		expectedArgs := []string{
+			fmt.Sprintf(`-backend-config="%s"`, filepath.ToSlash(filepath.Join(configRoot, "terraform", "backend.tfvars"))),
+			`-backend-config="secret_suffix=mock-prefix-project-path"`,
+			`-backend-config="namespace=mock-namespace"`,
+		}
+
+		if !reflect.DeepEqual(backendConfigArgs, expectedArgs) {
+			t.Errorf("expected %v, got %v", expectedArgs, backendConfigArgs)
+		}
+	})
+
+	t.Run("BackendTfvarsFileExistsWithPrefix", func(t *testing.T) {
+		mocks := setupSafeTerraformEnvMocks()
+		mocks.ConfigHandler.GetContextFunc = func() string {
+			return "mock-context"
+		}
+		mocks.ConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "terraform.backend.prefix" {
+				return "mock-prefix/"
 			}
 			if len(defaultValue) > 0 {
 				return defaultValue[0]
@@ -1068,35 +1119,7 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 
 		expectedArgs := []string{
 			fmt.Sprintf(`-backend-config="%s"`, filepath.ToSlash(filepath.Join(configRoot, "terraform", "backend.tfvars"))),
-			`-backend-config="secret_suffix=project-path"`,
-			`-backend-config="namespace=mock-namespace"`,
-			`-backend-config="secret_suffix=mock-secret-suffix"`,
-		}
-
-		if !reflect.DeepEqual(backendConfigArgs, expectedArgs) {
-			t.Errorf("expected %v, got %v", expectedArgs, backendConfigArgs)
-		}
-	})
-
-	t.Run("BackendTfvarsFileExists", func(t *testing.T) {
-		mocks := setupSafeTerraformEnvMocks()
-		mocks.ConfigHandler.GetContextFunc = func() string {
-			return "mock-context"
-		}
-		terraformEnvPrinter := NewTerraformEnvPrinter(mocks.Injector)
-		terraformEnvPrinter.Initialize()
-
-		projectPath := filepath.FromSlash("project/path")
-		configRoot := filepath.FromSlash("/mock/config/root")
-
-		backendConfigArgs, err := terraformEnvPrinter.generateBackendConfigArgs(projectPath, configRoot)
-		if err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-
-		expectedArgs := []string{
-			fmt.Sprintf(`-backend-config="%s"`, filepath.ToSlash(filepath.Join(configRoot, "terraform", "backend.tfvars"))),
-			fmt.Sprintf(`-backend-config="path=%s"`, filepath.ToSlash(filepath.Join(configRoot, ".tfstate", projectPath, "terraform.tfstate"))),
+			fmt.Sprintf(`-backend-config="path=%s"`, filepath.ToSlash(filepath.Join("mock-prefix", configRoot, ".tfstate", projectPath, "terraform.tfstate"))),
 		}
 
 		if !reflect.DeepEqual(backendConfigArgs, expectedArgs) {

--- a/pkg/env/terraform_env_test.go
+++ b/pkg/env/terraform_env_test.go
@@ -950,17 +950,6 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 
 	t.Run("LocalBackendWithPrefix", func(t *testing.T) {
 		mocks := setupSafeTerraformEnvMocks()
-		mocks.ConfigHandler.GetConfigFunc = func() *v1alpha1.Context {
-			return &v1alpha1.Context{
-				Terraform: &terraform.TerraformConfig{
-					Backend: &terraform.BackendConfig{
-						Local: &terraform.LocalBackend{
-							Path: stringPtr(filepath.FromSlash("/mock/config/root/.tfstate/project/path/terraform.tfstate")),
-						},
-					},
-				},
-			}
-		}
 		mocks.ConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
 			if key == "terraform.backend.prefix" {
 				return "mock-prefix/"
@@ -983,7 +972,7 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 
 		expectedArgs := []string{
 			fmt.Sprintf(`-backend-config="%s"`, filepath.ToSlash(filepath.Join(configRoot, "terraform", "backend.tfvars"))),
-			fmt.Sprintf(`-backend-config="path=%s"`, filepath.ToSlash(filepath.Join("mock-prefix", configRoot, ".tfstate", projectPath, "terraform.tfstate"))),
+			fmt.Sprintf(`-backend-config="path=%s"`, filepath.ToSlash(filepath.Join(configRoot, ".tfstate", projectPath, "mock-prefix", "terraform.tfstate"))),
 		}
 
 		if !reflect.DeepEqual(backendConfigArgs, expectedArgs) {
@@ -1119,7 +1108,7 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 
 		expectedArgs := []string{
 			fmt.Sprintf(`-backend-config="%s"`, filepath.ToSlash(filepath.Join(configRoot, "terraform", "backend.tfvars"))),
-			fmt.Sprintf(`-backend-config="path=%s"`, filepath.ToSlash(filepath.Join("mock-prefix", configRoot, ".tfstate", projectPath, "terraform.tfstate"))),
+			fmt.Sprintf(`-backend-config="path=%s"`, filepath.ToSlash(filepath.Join(configRoot, ".tfstate", "project/path/mock-prefix/terraform.tfstate"))),
 		}
 
 		if !reflect.DeepEqual(backendConfigArgs, expectedArgs) {
@@ -1154,8 +1143,9 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 			t.Errorf("expected error, got nil")
 		}
 
-		if !strings.Contains(err.Error(), "error marshalling backend to YAML: mock marshalling error") {
-			t.Errorf("expected error to contain %v, got %v", "error marshalling backend to YAML: mock marshalling error", err.Error())
+		expectedErrorMsg := "error marshalling backend to YAML: mock marshalling error"
+		if !strings.Contains(err.Error(), expectedErrorMsg) {
+			t.Errorf("expected error to contain %v, got %v", expectedErrorMsg, err.Error())
 		}
 	})
 

--- a/pkg/env/terraform_env_test.go
+++ b/pkg/env/terraform_env_test.go
@@ -972,7 +972,7 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 
 		expectedArgs := []string{
 			fmt.Sprintf(`-backend-config="%s"`, filepath.ToSlash(filepath.Join(configRoot, "terraform", "backend.tfvars"))),
-			fmt.Sprintf(`-backend-config="path=%s"`, filepath.ToSlash(filepath.Join(configRoot, ".tfstate", projectPath, "mock-prefix", "terraform.tfstate"))),
+			fmt.Sprintf(`-backend-config="path=%s"`, filepath.ToSlash(filepath.Join(configRoot, ".tfstate", "mock-prefix", projectPath, "terraform.tfstate"))),
 		}
 
 		if !reflect.DeepEqual(backendConfigArgs, expectedArgs) {
@@ -1108,7 +1108,7 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 
 		expectedArgs := []string{
 			fmt.Sprintf(`-backend-config="%s"`, filepath.ToSlash(filepath.Join(configRoot, "terraform", "backend.tfvars"))),
-			fmt.Sprintf(`-backend-config="path=%s"`, filepath.ToSlash(filepath.Join(configRoot, ".tfstate", "project/path/mock-prefix/terraform.tfstate"))),
+			fmt.Sprintf(`-backend-config="path=%s"`, filepath.ToSlash(filepath.Join(configRoot, ".tfstate", "mock-prefix/project/path/terraform.tfstate"))),
 		}
 
 		if !reflect.DeepEqual(backendConfigArgs, expectedArgs) {


### PR DESCRIPTION
Adds a configuration value that allows for prefixing Terraform state backends. This can be done by setting `terraform.backend.prefix`.

This implements the prefix uniquely across `s3`, `kubernetes`, and `local` backends.