### PR TITLE
Remove extra tools from Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,19 +11,19 @@ ARG AQUA_INSTALLER_VERSION=v3.1.1
 # renovate: datasource=github-releases depName=aquaproj/aqua
 ARG AQUA_VERSION=v2.45.0
 
-# Install dependencies
-RUN apk add --no-cache curl bash
+# Update package index and install dependencies
+RUN apk update && apk add bash wget --no-cache wget
 
 # Copy aqua configuration
 COPY aqua.docker.yaml /etc/aqua/aqua.yaml
 
-# Install Aqua and tools
-RUN curl -sSfL -O https://raw.githubusercontent.com/aquaproj/aqua-installer/${AQUA_INSTALLER_VERSION}/aqua-installer && \
+# Install Aqua and tools from aqua.docker.yaml using wget instead of curl
+RUN wget -q https://raw.githubusercontent.com/aquaproj/aqua-installer/${AQUA_INSTALLER_VERSION}/aqua-installer -O aqua-installer && \
     echo "e9d4c99577c6b2ce0b62edf61f089e9b9891af1708e88c6592907d2de66e3714  aqua-installer" | sha256sum -c - && \
     chmod +x aqua-installer && \
     ./aqua-installer -v ${AQUA_VERSION} && \
-    aqua i -a || { echo "Failed to install Aqua tools" >&2; exit 1; } && \
-    aqua cp -o /dist aws aws_completer containerd containerd-shim-runc-v2 ctr docker docker-cli-plugin-docker-compose docker-init docker-proxy dockerd flux helm kubectl runc talosctl terraform || { echo "Failed to copy some tools" >&2; exit 1; } && \
+    aqua i && \
+    aqua cp -o /dist kubectl talosctl terraform && \
     rm aqua-installer
 
 # Stage 2: Builder
@@ -35,22 +35,22 @@ RUN apk add --no-cache git
 
 # Build the windsor binary
 COPY . .
-RUN go build -o /work/windsor ./cmd/windsor || { echo "Failed to build windsor binary" >&2; exit 1; }
+RUN go build -o /work/windsor ./cmd/windsor
 
 # Stage 3: Runtime
 # ----------------
 FROM alpine:3.21.3
 
-# Create a non-root user and group
-RUN addgroup -S appgroup && adduser -S windsor -G appgroup
-
 # Install runtime dependencies
-RUN apk add --no-cache bash
+RUN apk add --no-cache bash git wget unzip
 
 # Copy tools from aqua-installer
 COPY --from=aqua /dist/* /usr/local/bin/
 
-# Create windsor user
+# Create a non-root user and group
+RUN addgroup -S appgroup && adduser -S windsor -G appgroup
+
+# Switch to windsor user
 USER windsor
 
 # Copy windsor binary

--- a/aqua.docker.yaml
+++ b/aqua.docker.yaml
@@ -6,8 +6,3 @@ packages:
 - name: hashicorp/terraform@v1.10.5
 - name: siderolabs/talos@v1.9.4
 - name: kubernetes/kubectl@v1.32.2
-- name: docker/cli@v27.4.1
-- name: docker/compose@v2.33.1
-- name: helm/helm@v3.17.1
-- name: fluxcd/flux2@v2.5.0
-- name: aws/aws-cli@2.24.10


### PR DESCRIPTION
The purpose of the Windsor image is to ensure that everything required to build / deploy the local workstation is available. If a user needs these additional tools, they can install them on their own and run them locally.

This PR removes these unnecessary tools.