### PR TITLE
DockerShell ExecProgress

### DIFF
--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -397,37 +397,6 @@ func TestExecCmd(t *testing.T) {
 		}
 	})
 
-	t.Run("NoShellResolved", func(t *testing.T) {
-		defer resetRootCmd()
-
-		// Setup mock controller
-		mocks := setupSafeExecCmdMocks()
-		callCount := 0
-		originalResolveShellFunc := mocks.Controller.ResolveShellFunc
-		mocks.Controller.ResolveShellFunc = func(name ...string) shell.Shell {
-			callCount++
-			if callCount == 2 {
-				return nil
-			}
-			return originalResolveShellFunc()
-		}
-
-		// Capture stderr
-		output := captureStderr(func() {
-			rootCmd.SetArgs([]string{"exec", "echo", "hello"})
-			err := Execute(mocks.Controller)
-			if err == nil {
-				t.Fatalf("Expected error, got nil")
-			}
-		})
-
-		// Then the output should indicate the error
-		expectedOutput := "No shell found"
-		if !strings.Contains(output, expectedOutput) {
-			t.Errorf("Expected output to contain %q, got %q", expectedOutput, output)
-		}
-	})
-
 	t.Run("ErrorExecutingCommand", func(t *testing.T) {
 		defer resetRootCmd()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -79,6 +79,12 @@ func preRunEInitializeCommonComponents(cmd *cobra.Command, args []string) error 
 		shell.SetVerbosity(verbose)
 	}
 
+	// Set the verbosity
+	dockerShell := controller.ResolveShell("dockerShell")
+	if dockerShell != nil {
+		dockerShell.SetVerbosity(verbose)
+	}
+
 	// Determine the cliConfig path
 	var cliConfigPath string
 	if cliConfigPath = os.Getenv("WINDSORCONFIG"); cliConfigPath == "" {

--- a/pkg/shell/docker_shell.go
+++ b/pkg/shell/docker_shell.go
@@ -8,7 +8,9 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
+	"github.com/briandowns/spinner"
 	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/di"
 )
@@ -28,66 +30,63 @@ func NewDockerShell(injector di.Injector) *DockerShell {
 }
 
 // Exec runs a command in a Docker container labeled "role=windsor_exec".
-// It retrieves the container ID, calculates the relative path, and executes
-// the command inside the container, streaming the output to stdout and stderr,
-// and also returning the output as a string.
 func (s *DockerShell) Exec(command string, args ...string) (string, int, error) {
 	containerID, err := s.getWindsorExecContainerID()
 	if err != nil {
 		return "", 0, fmt.Errorf("failed to get Windsor exec container ID: %w", err)
 	}
 
-	projectRoot, err := s.GetProjectRoot()
+	workDir, err := s.getWorkDir()
 	if err != nil {
-		return "", 0, fmt.Errorf("failed to get project root: %w", err)
+		return "", 0, err
 	}
 
-	currentDir, err := getwd()
-	if err != nil {
-		return "", 0, fmt.Errorf("failed to get current working directory: %w", err)
-	}
-
-	relativeDir, err := filepathRel(projectRoot, currentDir)
-	if err != nil {
-		return "", 0, fmt.Errorf("failed to determine relative directory: %w", err)
-	}
-
-	relativeDir = filepath.ToSlash(relativeDir)
-
-	workDir := filepath.ToSlash(filepath.Join(constants.CONTAINER_EXEC_WORKDIR, relativeDir))
-
-	combinedCmd := command
-	if len(args) > 0 {
-		combinedCmd += " " + strings.Join(args, " ")
-	}
-	shellCmd := fmt.Sprintf("cd %s && windsor --silent exec -- sh -c '%s'", workDir, combinedCmd)
-
+	shellCmd := s.buildShellCommand(workDir, command, args...)
 	cmdArgs := []string{"exec", "-i", containerID, "sh", "-c", shellCmd}
 
-	cmd := execCommand("docker", cmdArgs...)
+	// Directly write the output to os.Stdout and os.Stderr
 	var stdoutBuf, stderrBuf bytes.Buffer
-	cmd.Stdout = io.MultiWriter(os.Stdout, &stdoutBuf)
-	cmd.Stderr = io.MultiWriter(os.Stderr, &stderrBuf)
+	stdoutWriter := io.MultiWriter(&stdoutBuf, os.Stdout)
+	stderrWriter := io.MultiWriter(&stderrBuf, os.Stderr)
 
-	// Start the command
-	if err := cmdStart(cmd); err != nil {
-		return "", 1, fmt.Errorf("command start failed: %w", err)
+	return s.runDockerCommand(cmdArgs, stdoutWriter, stderrWriter)
+}
+
+// ExecProgress runs a command in a Docker container labeled "role=windsor_exec" with a progress indicator.
+func (s *DockerShell) ExecProgress(message string, command string, args ...string) (string, int, error) {
+	if s.verbose {
+		return s.Exec(command, args...)
 	}
 
-	// Wait for the command to finish and capture the exit code
-	if err := cmdWait(cmd); err != nil {
-		if exitError, ok := err.(*exec.ExitError); ok {
-			return stdoutBuf.String(), exitError.ExitCode(), err
-		}
-		return "", 1, fmt.Errorf("unexpected error during command execution: %w", err)
+	containerID, err := s.getWindsorExecContainerID()
+	if err != nil {
+		return "", 0, fmt.Errorf("failed to get Windsor exec container ID: %w", err)
 	}
 
-	// Capture the exit code from the process state
-	exitCode := cmd.ProcessState.ExitCode()
-	if exitCode != 0 {
-		return stdoutBuf.String(), exitCode, fmt.Errorf("command execution failed with exit code %d", exitCode)
+	workDir, err := s.getWorkDir()
+	if err != nil {
+		return "", 0, err
 	}
-	return stdoutBuf.String(), exitCode, nil
+
+	// Adjust the shell command to change directory first, then execute within 'windsor exec'
+	shellCmd := s.buildShellCommand(workDir, command, args...)
+	cmdArgs := []string{"exec", "-i", containerID, "sh", "-c", shellCmd}
+
+	spin := spinner.New(spinner.CharSets[14], 100*time.Millisecond, spinner.WithColor("green"))
+	spin.Suffix = " " + message
+	spin.Start()
+
+	var stdoutBuf, stderrBuf bytes.Buffer
+	stdout, exitCode, err := s.runDockerCommand(cmdArgs, &stdoutBuf, &stderrBuf)
+	spin.Stop()
+
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "\033[31m✗ %s - Failed\033[0m\n%s", message, stderrBuf.String())
+		return stdout, exitCode, fmt.Errorf("Error: %w\n%s", err, stderrBuf.String())
+	}
+
+	fmt.Fprintf(os.Stderr, "\033[32m✔\033[0m %s - \033[32mDone\033[0m\n", message)
+	return stdout, exitCode, nil
 }
 
 // getWindsorExecContainerID retrieves the container ID of the Windsor exec container.
@@ -104,6 +103,60 @@ func (s *DockerShell) getWindsorExecContainerID() (string, error) {
 	}
 
 	return containerID, nil
+}
+
+// getWorkDir calculates the working directory inside the container.
+func (s *DockerShell) getWorkDir() (string, error) {
+	projectRoot, err := s.GetProjectRoot()
+	if err != nil {
+		return "", fmt.Errorf("failed to get project root: %w", err)
+	}
+
+	currentDir, err := getwd()
+	if err != nil {
+		return "", fmt.Errorf("failed to get current working directory: %w", err)
+	}
+
+	relativeDir, err := filepathRel(projectRoot, currentDir)
+	if err != nil {
+		return "", fmt.Errorf("failed to determine relative directory: %w", err)
+	}
+
+	return filepath.ToSlash(filepath.Join(constants.CONTAINER_EXEC_WORKDIR, relativeDir)), nil
+}
+
+// buildShellCommand constructs the shell command to be executed in the container.
+func (s *DockerShell) buildShellCommand(workDir, command string, args ...string) string {
+	combinedCmd := command
+	if len(args) > 0 {
+		combinedCmd += " " + strings.Join(args, " ")
+	}
+	finalCmd := fmt.Sprintf("cd %s && windsor exec -- %s", workDir, combinedCmd)
+	return finalCmd
+}
+
+// runDockerCommand executes the Docker command and writes the output to provided writers.
+func (s *DockerShell) runDockerCommand(cmdArgs []string, stdoutWriter, stderrWriter io.Writer) (string, int, error) {
+	cmd := execCommand("docker", cmdArgs...)
+	cmd.Stdout = stdoutWriter
+	cmd.Stderr = stderrWriter
+
+	if err := cmdStart(cmd); err != nil {
+		return "", 1, fmt.Errorf("command start failed: %w", err)
+	}
+
+	if err := cmdWait(cmd); err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			return "", exitError.ExitCode(), fmt.Errorf("Error: %w", err)
+		}
+		return "", 1, fmt.Errorf("unexpected error during command execution: %w", err)
+	}
+
+	exitCode := cmd.ProcessState.ExitCode()
+	if exitCode != 0 {
+		return "", exitCode, fmt.Errorf("command execution failed with exit code %d", exitCode)
+	}
+	return "", exitCode, nil
 }
 
 // Ensure DockerShell implements the Shell interface

--- a/pkg/shell/docker_shell.go
+++ b/pkg/shell/docker_shell.go
@@ -147,12 +147,12 @@ func (s *DockerShell) runDockerCommand(cmdArgs []string, stdoutWriter, stderrWri
 
 	if err := cmdWait(cmd); err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {
-			return "", exitError.ExitCode(), fmt.Errorf("Error: %w", err)
+			return "", processStateExitCode(exitError.ProcessState), fmt.Errorf("Error: %w", err)
 		}
 		return "", 1, fmt.Errorf("unexpected error during command execution: %w", err)
 	}
 
-	exitCode := cmd.ProcessState.ExitCode()
+	exitCode := processStateExitCode(cmd.ProcessState)
 	if exitCode != 0 {
 		return "", exitCode, fmt.Errorf("command execution failed with exit code %d", exitCode)
 	}

--- a/pkg/shell/docker_shell_test.go
+++ b/pkg/shell/docker_shell_test.go
@@ -2,8 +2,10 @@ package shell
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/windsorcli/cli/pkg/di"
@@ -27,9 +29,22 @@ func setSafeDockerShellMocks(injector ...di.Injector) struct {
 		return mockEchoCommand("mock output")
 	}
 
+	// Mock the cmdOutput to return a specific container ID
+	cmdOutput = func(cmd *exec.Cmd) (string, error) {
+		if cmd.Path == "docker" && len(cmd.Args) > 1 && cmd.Args[1] == "ps" {
+			return "mock-container-id", nil
+		}
+		return "mock output", nil
+	}
+
 	// Mock the getwd to simulate a specific working directory
 	getwd = func() (string, error) {
 		return "/mock/project/root", nil
+	}
+
+	// Mock the processStateExitCode to always return 0
+	processStateExitCode = func(state *os.ProcessState) int {
+		return 0
 	}
 
 	return struct {
@@ -54,34 +69,26 @@ func TestDockerShell_Exec(t *testing.T) {
 		mocks := setSafeDockerShellMocks(injector)
 		dockerShell := NewDockerShell(mocks.Injector)
 
-		// Save the original execCommand function
+		// Preserve the original execCommand function
 		originalExecCommand := execCommand
+		defer func() { execCommand = originalExecCommand }() // Restore it after the test
 
-		// Defer restoring the original function
-		defer func() {
-			execCommand = originalExecCommand
-		}()
-
-		// Mock the necessary functions to simulate a successful execution
+		// Flag to verify if execCommand is invoked with 'docker exec'
+		execCommandCalled := false
 		execCommand = func(name string, arg ...string) *exec.Cmd {
-			if name == "docker" && len(arg) > 0 {
-				switch {
-				case arg[0] == "ps" && len(arg) > 4 && arg[1] == "--filter" && arg[2] == "label=role=windsor_exec" && arg[3] == "--format" && arg[4] == "{{.ID}}":
-					return mockEchoCommand("mock-container-id")
-				case len(arg) > 5 && arg[0] == "exec" && arg[1] == "-i" && arg[2] == "mock-container-id" && arg[3] == "sh" && arg[4] == "-c":
-					expectedCmd := "cd /work && windsor --silent exec -- sh -c 'echo hello'"
-					if arg[5] == expectedCmd {
-						return mockEchoCommand("mock output\n")
-					}
-				}
+			if name == "docker" && len(arg) > 0 && arg[0] == "exec" {
+				execCommandCalled = true
 			}
-			t.Fatalf("unexpected command %s with args %v", name, arg)
-			return nil
+			return mockEchoCommand("mock output")
 		}
 
 		_, _, err := dockerShell.Exec("echo", "hello")
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if !execCommandCalled {
+			t.Fatalf("expected execCommand to be called with 'docker exec', but it was not")
 		}
 	})
 
@@ -90,13 +97,9 @@ func TestDockerShell_Exec(t *testing.T) {
 		mocks := setSafeDockerShellMocks(injector)
 		dockerShell := NewDockerShell(mocks.Injector)
 
-		// Save the original cmdOutput function
+		// Backup the original cmdOutput function to restore it later
 		originalCmdOutput := cmdOutput
-
-		// Defer restoring the original function
-		defer func() {
-			cmdOutput = originalCmdOutput
-		}()
+		defer func() { cmdOutput = originalCmdOutput }()
 
 		// Mock cmdOutput to simulate a command execution failure
 		cmdOutput = func(cmd *exec.Cmd) (string, error) {
@@ -109,48 +112,14 @@ func TestDockerShell_Exec(t *testing.T) {
 		}
 	})
 
-	t.Run("ContainerIDError", func(t *testing.T) {
-		injector := di.NewMockInjector()
-		mocks := setSafeDockerShellMocks(injector)
-		dockerShell := NewDockerShell(mocks.Injector)
-
-		// Save the original execCommand function
-		originalExecCommand := execCommand
-
-		// Defer restoring the original function
-		defer func() {
-			execCommand = originalExecCommand
-		}()
-
-		// Mock execCommand to simulate an empty container ID
-		execCommand = func(name string, arg ...string) *exec.Cmd {
-			if name == "docker" && len(arg) > 0 && arg[0] == "ps" {
-				if runtime.GOOS == "windows" {
-					return exec.Command("cmd", "/C", "echo.")
-				}
-				return exec.Command("echo", "")
-			}
-			return mockEchoCommand("mock output")
-		}
-
-		_, _, err := dockerShell.Exec("echo", "hello")
-		if err == nil || err.Error() != "failed to get Windsor exec container ID: no Windsor exec container found" {
-			t.Fatalf("expected error 'failed to get Windsor exec container ID: no Windsor exec container found', got %v", err)
-		}
-	})
-
 	t.Run("ErrorGettingProjectRoot", func(t *testing.T) {
 		injector := di.NewMockInjector()
 		mocks := setSafeDockerShellMocks(injector)
 		dockerShell := NewDockerShell(mocks.Injector)
 
-		// Save the original getwd function
+		// Backup the original getwd function to restore it later
 		originalGetwd := getwd
-
-		// Defer restoring the original function
-		defer func() {
-			getwd = originalGetwd
-		}()
+		defer func() { getwd = originalGetwd }()
 
 		// Mock getwd to simulate an error
 		getwd = func() (string, error) {
@@ -168,13 +137,9 @@ func TestDockerShell_Exec(t *testing.T) {
 		mocks := setSafeDockerShellMocks(injector)
 		dockerShell := NewDockerShell(mocks.Injector)
 
-		// Save the original getwd function
+		// Preserve the original getwd function to ensure it is restored after the test
 		originalGetwd := getwd
-
-		// Defer restoring the original function
-		defer func() {
-			getwd = originalGetwd
-		}()
+		defer func() { getwd = originalGetwd }()
 
 		// Counter to track the number of calls to getwd
 		callCount := 0
@@ -199,10 +164,8 @@ func TestDockerShell_Exec(t *testing.T) {
 		mocks := setSafeDockerShellMocks(injector)
 		dockerShell := NewDockerShell(mocks.Injector)
 
-		// Save the original filepathRel function
+		// Preserve the original filepathRel function to ensure it is restored after the test
 		originalFilepathRel := filepathRel
-
-		// Defer restoring the original function
 		defer func() {
 			filepathRel = originalFilepathRel
 		}()
@@ -223,13 +186,9 @@ func TestDockerShell_Exec(t *testing.T) {
 		mocks := setSafeDockerShellMocks(injector)
 		dockerShell := NewDockerShell(mocks.Injector)
 
-		// Save the original cmdStart function
+		// Preserve the original cmdStart function and ensure it's restored after the test
 		originalCmdStart := cmdStart
-
-		// Defer restoring the original function
-		defer func() {
-			cmdStart = originalCmdStart
-		}()
+		defer func() { cmdStart = originalCmdStart }()
 
 		// Mock cmdStart to simulate a command start error
 		cmdStart = func(cmd *exec.Cmd) error {
@@ -247,13 +206,9 @@ func TestDockerShell_Exec(t *testing.T) {
 		mocks := setSafeDockerShellMocks(injector)
 		dockerShell := NewDockerShell(mocks.Injector)
 
-		// Save the original cmdWait function
+		// Preserve the original cmdWait function and ensure it's restored after the test
 		originalCmdWait := cmdWait
-
-		// Defer restoring the original function
-		defer func() {
-			cmdWait = originalCmdWait
-		}()
+		defer func() { cmdWait = originalCmdWait }()
 
 		// Mock cmdWait to simulate an unexpected error during command wait
 		cmdWait = func(cmd *exec.Cmd) error {
@@ -267,28 +222,273 @@ func TestDockerShell_Exec(t *testing.T) {
 	})
 }
 
-// isEchoCommand checks if the command is an echo command with the expected output
-func isEchoCommand(cmd *exec.Cmd, expectedOutput string) bool {
-	if runtime.GOOS == "windows" {
-		return cmd.Path == "cmd" && len(cmd.Args) == 4 && cmd.Args[3] == expectedOutput
-	}
-	return cmd.Path == "echo" && len(cmd.Args) == 2 && cmd.Args[1] == expectedOutput
+// TestDockerShell_ExecProgress tests the ExecProgress method of DockerShell.
+func TestDockerShell_ExecProgress(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		injector := di.NewMockInjector()
+		mocks := setSafeDockerShellMocks(injector)
+		dockerShell := NewDockerShell(mocks.Injector)
+
+		// Preserve the original execCommand function
+		originalExecCommand := execCommand
+		defer func() { execCommand = originalExecCommand }() // Restore it after the test
+
+		// Flag to verify if execCommand is invoked with 'docker exec'
+		execCommandCalled := false
+		execCommand = func(name string, arg ...string) *exec.Cmd {
+			if name == "docker" && len(arg) > 0 && arg[0] == "exec" {
+				execCommandCalled = true
+			}
+			return mockEchoCommand("mock output")
+		}
+
+		_, _, err := dockerShell.ExecProgress("Running command", "echo", "hello")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if !execCommandCalled {
+			t.Fatalf("expected execCommand to be called with 'docker exec', but it was not")
+		}
+	})
+
+	t.Run("ExecProgressWithVerbose", func(t *testing.T) {
+		injector := di.NewMockInjector()
+		mocks := setSafeDockerShellMocks(injector)
+		dockerShell := NewDockerShell(mocks.Injector)
+		dockerShell.verbose = true
+
+		// Preserve the original execCommand function
+		originalExecCommand := execCommand
+		defer func() { execCommand = originalExecCommand }() // Restore it after the test
+
+		// Flag to verify if execCommand is invoked with 'docker exec'
+		execCommandCalled := false
+		execCommand = func(name string, arg ...string) *exec.Cmd {
+			if name == "docker" && len(arg) > 0 && arg[0] == "exec" {
+				execCommandCalled = true
+			}
+			return mockEchoCommand("mock output")
+		}
+
+		_, _, err := dockerShell.ExecProgress("Running command", "echo", "hello")
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if !execCommandCalled {
+			t.Fatalf("expected execCommand to be called with 'docker exec', but it was not")
+		}
+	})
+
+	t.Run("GetWindsorExecContainerIDError", func(t *testing.T) {
+		injector := di.NewMockInjector()
+		mocks := setSafeDockerShellMocks(injector)
+		dockerShell := NewDockerShell(mocks.Injector)
+
+		// Backup the original cmdOutput function to restore it later
+		originalCmdOutput := cmdOutput
+		defer func() { cmdOutput = originalCmdOutput }()
+
+		// Mock cmdOutput to simulate a failure in retrieving the container ID
+		cmdOutput = func(cmd *exec.Cmd) (string, error) {
+			return "", fmt.Errorf("failed to get Windsor exec container ID")
+		}
+
+		_, _, err := dockerShell.ExecProgress("Running command", "echo", "hello")
+		if err == nil || !strings.Contains(err.Error(), "failed to get Windsor exec container ID") {
+			t.Fatalf("expected error containing 'failed to get Windsor exec container ID', got %v", err)
+		}
+	})
+
+	t.Run("GetWorkDirError", func(t *testing.T) {
+		injector := di.NewMockInjector()
+		mocks := setSafeDockerShellMocks(injector)
+		dockerShell := NewDockerShell(mocks.Injector)
+
+		// Backup the original getwd function to restore it later
+		originalGetwd := getwd
+		defer func() { getwd = originalGetwd }()
+
+		// Mock getwd to simulate an error in retrieving the current working directory
+		getwd = func() (string, error) {
+			return "", fmt.Errorf("failed to get current working directory")
+		}
+
+		_, _, err := dockerShell.ExecProgress("Running command", "echo", "hello")
+		if err == nil || !strings.Contains(err.Error(), "failed to get current working directory") {
+			t.Fatalf("expected error containing 'failed to get current working directory', got %v", err)
+		}
+	})
+
+	t.Run("ErrorRunningDockerCommand", func(t *testing.T) {
+		injector := di.NewMockInjector()
+		mocks := setSafeDockerShellMocks(injector)
+		dockerShell := NewDockerShell(mocks.Injector)
+
+		// Backup the original execCommand function to restore it later
+		originalExecCommand := execCommand
+		defer func() { execCommand = originalExecCommand }()
+
+		// Mock execCommand to simulate a failure inside runDockerCommand
+		execCommand = func(name string, arg ...string) *exec.Cmd {
+			if name == "docker" && len(arg) > 0 && arg[0] == "exec" {
+				return exec.Command("false") // Simulate a command that fails
+			}
+			return mockEchoCommand("mock output")
+		}
+
+		_, _, err := dockerShell.ExecProgress("Running command", "echo", "hello")
+		if err == nil || !strings.Contains(err.Error(), "Error: exit status 1") {
+			t.Fatalf("expected error containing 'Error: exit status 1', got %v", err)
+		}
+	})
 }
 
 // TestDockerShell_GetWindsorExecContainerID tests the getWindsorExecContainerID method of DockerShell.
 func TestDockerShell_GetWindsorExecContainerID(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		// Setup for getWindsorExecContainerID success test
-		// Test successful container ID retrieval
+		injector := di.NewMockInjector()
+		mocks := setSafeDockerShellMocks(injector)
+		dockerShell := NewDockerShell(mocks.Injector)
+
+		// Mock the cmdOutput function to simulate successful retrieval of container ID
+		originalCmdOutput := cmdOutput
+		defer func() { cmdOutput = originalCmdOutput }()
+		cmdOutput = func(cmd *exec.Cmd) (string, error) {
+			return "mock-container-id", nil
+		}
+
+		containerID, err := dockerShell.getWindsorExecContainerID()
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if containerID != "mock-container-id" {
+			t.Fatalf("expected container ID 'mock-container-id', got %v", containerID)
+		}
 	})
 
 	t.Run("NoContainerFound", func(t *testing.T) {
-		// Setup for getWindsorExecContainerID no container found test
-		// Test scenario where no container with the specified label is found
+		injector := di.NewMockInjector()
+		mocks := setSafeDockerShellMocks(injector)
+		dockerShell := NewDockerShell(mocks.Injector)
+
+		// Mock the cmdOutput function to simulate no container found
+		originalCmdOutput := cmdOutput
+		defer func() { cmdOutput = originalCmdOutput }()
+		cmdOutput = func(cmd *exec.Cmd) (string, error) {
+			return "", nil
+		}
+
+		_, err := dockerShell.getWindsorExecContainerID()
+		if err == nil || err.Error() != "no Windsor exec container found" {
+			t.Fatalf("expected error 'no Windsor exec container found', got %v", err)
+		}
 	})
 
 	t.Run("DockerCommandError", func(t *testing.T) {
-		// Setup for getWindsorExecContainerID Docker command error test
-		// Test error when Docker command execution fails
+		injector := di.NewMockInjector()
+		mocks := setSafeDockerShellMocks(injector)
+		dockerShell := NewDockerShell(mocks.Injector)
+
+		// Mock the cmdOutput function to simulate a Docker command error
+		originalCmdOutput := cmdOutput
+		defer func() { cmdOutput = originalCmdOutput }()
+		cmdOutput = func(cmd *exec.Cmd) (string, error) {
+			return "", fmt.Errorf("failed to list Docker containers")
+		}
+
+		_, err := dockerShell.getWindsorExecContainerID()
+		if err == nil || !strings.Contains(err.Error(), "failed to list Docker containers") {
+			t.Fatalf("expected error containing 'failed to list Docker containers', got %v", err)
+		}
+	})
+}
+
+// TestDockerShell_runDockerCommand tests the runDockerCommand method of DockerShell.
+func TestDockerShell_runDockerCommand(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		injector := di.NewMockInjector()
+		mocks := setSafeDockerShellMocks(injector)
+		dockerShell := NewDockerShell(mocks.Injector)
+
+		var stdoutBuf, stderrBuf strings.Builder
+		_, exitCode, err := dockerShell.runDockerCommand([]string{"echo", "hello"}, &stdoutBuf, &stderrBuf)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if exitCode != 0 {
+			t.Fatalf("expected exit code 0, got %d", exitCode)
+		}
+		if stdoutBuf.String() != "mock output\n" {
+			t.Fatalf("expected stdout 'mock output', got %s", stdoutBuf.String())
+		}
+	})
+
+	t.Run("CommandWaitFailed", func(t *testing.T) {
+		injector := di.NewMockInjector()
+		mocks := setSafeDockerShellMocks(injector)
+		dockerShell := NewDockerShell(mocks.Injector)
+
+		// Mock the cmdWait function to simulate a command wait failure
+		originalCmdWait := cmdWait
+		defer func() { cmdWait = originalCmdWait }()
+		cmdWait = func(cmd *exec.Cmd) error {
+			return fmt.Errorf("command wait failed")
+		}
+
+		var stdoutBuf, stderrBuf strings.Builder
+		_, _, err := dockerShell.runDockerCommand([]string{"echo", "hello"}, &stdoutBuf, &stderrBuf)
+		if err == nil || !strings.Contains(err.Error(), "command wait failed") {
+			t.Fatalf("expected error containing 'command wait failed', got %v", err)
+		}
+	})
+
+	t.Run("CommandExecutionFailed", func(t *testing.T) {
+		injector := di.NewMockInjector()
+		mocks := setSafeDockerShellMocks(injector)
+		dockerShell := NewDockerShell(mocks.Injector)
+
+		// Mock the cmdWait function to simulate a command execution failure
+		originalCmdWait := cmdWait
+		defer func() { cmdWait = originalCmdWait }()
+		cmdWait = func(cmd *exec.Cmd) error {
+			return &exec.ExitError{ProcessState: &os.ProcessState{}}
+		}
+
+		// Mock the processStateExitCode function to return a non-zero exit code
+		originalProcessStateExitCode := processStateExitCode
+		defer func() { processStateExitCode = originalProcessStateExitCode }()
+		processStateExitCode = func(ps *os.ProcessState) int {
+			return 1
+		}
+
+		var stdoutBuf, stderrBuf strings.Builder
+		_, exitCode, err := dockerShell.runDockerCommand([]string{"echo", "hello"}, &stdoutBuf, &stderrBuf)
+		if err == nil || exitCode == 0 {
+			t.Fatalf("expected command execution failure with non-zero exit code, got error: %v, exit code: %d", err, exitCode)
+		}
+	})
+
+	t.Run("CommandExecutionFailedWithNonZeroExitCode", func(t *testing.T) {
+		injector := di.NewMockInjector()
+		mocks := setSafeDockerShellMocks(injector)
+		dockerShell := NewDockerShell(mocks.Injector)
+
+		// Mock the processStateExitCode function to return a non-zero exit code
+		originalProcessStateExitCode := processStateExitCode
+		defer func() { processStateExitCode = originalProcessStateExitCode }()
+		processStateExitCode = func(ps *os.ProcessState) int {
+			return 2
+		}
+
+		var stdoutBuf, stderrBuf strings.Builder
+		_, exitCode, err := dockerShell.runDockerCommand([]string{"echo", "hello"}, &stdoutBuf, &stderrBuf)
+		if err == nil || exitCode == 0 {
+			t.Fatalf("expected command execution failure with non-zero exit code, got error: %v, exit code: %d", err, exitCode)
+		}
+		if exitCode != 2 {
+			t.Fatalf("expected exit code 2, got %d", exitCode)
+		}
 	})
 }

--- a/pkg/shell/docker_shell_test.go
+++ b/pkg/shell/docker_shell_test.go
@@ -420,8 +420,8 @@ func TestDockerShell_runDockerCommand(t *testing.T) {
 		if exitCode != 0 {
 			t.Fatalf("expected exit code 0, got %d", exitCode)
 		}
-		if stdoutBuf.String() != "mock output\n" {
-			t.Fatalf("expected stdout 'mock output', got %s", stdoutBuf.String())
+		if !strings.Contains(stdoutBuf.String(), "mock output") {
+			t.Fatalf("expected stdout to contain 'mock output', got %s", stdoutBuf.String())
 		}
 	})
 


### PR DESCRIPTION
The docker shell can now be called with ExecProgress as we can with the default shell. This allows for an abbreviated command output with regular updates when executing commands in this mode.