### PR TITLE
Run dual DNS servers when running in container exec mode

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -86,6 +86,5 @@ const (
 
 const (
 	// renovate: datasource=docker depName=ghcr.io/windsorcli/windsorcli
-	// DEFAULT_WINDSOR_IMAGE = "ghcr.io/windsorcli/windsorcli:latest"
-	DEFAULT_WINDSOR_IMAGE = "windsorcli:latest"
+	DEFAULT_WINDSOR_IMAGE = "ghcr.io/windsorcli/windsorcli:latest"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -86,5 +86,6 @@ const (
 
 const (
 	// renovate: datasource=docker depName=ghcr.io/windsorcli/windsorcli
-	DEFAULT_WINDSOR_IMAGE = "ghcr.io/windsorcli/windsorcli:latest"
+	// DEFAULT_WINDSOR_IMAGE = "ghcr.io/windsorcli/windsorcli:latest"
+	DEFAULT_WINDSOR_IMAGE = "windsorcli:latest"
 )

--- a/pkg/network/darwin_network.go
+++ b/pkg/network/darwin_network.go
@@ -68,7 +68,11 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 	if tld == "" {
 		return fmt.Errorf("DNS domain is not configured")
 	}
-	dnsIP := n.configHandler.GetString("dns.address")
+
+	dnsIP := "127.0.0.1"
+	if !n.UseHostNetwork() {
+		dnsIP = n.configHandler.GetString("dns.address")
+	}
 
 	resolverDir := "/etc/resolver"
 	if _, err := stat(resolverDir); os.IsNotExist(err) {

--- a/pkg/network/darwin_network_test.go
+++ b/pkg/network/darwin_network_test.go
@@ -360,29 +360,6 @@ func TestDarwinNetworkManager_ConfigureDNS(t *testing.T) {
 		}
 	})
 
-	t.Run("SuccessLocalhost", func(t *testing.T) {
-		mocks := setupDarwinNetworkManagerMocks()
-
-		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "vm.driver" {
-				return "docker-desktop"
-			}
-			return "some_value"
-		}
-
-		nm := NewBaseNetworkManager(mocks.Injector)
-
-		err := nm.Initialize()
-		if err != nil {
-			t.Fatalf("expected no error during initialization, got %v", err)
-		}
-
-		err = nm.ConfigureDNS()
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
-	})
-
 	t.Run("NoDNSDomainConfigured", func(t *testing.T) {
 		mocks := setupDarwinNetworkManagerMocks()
 
@@ -588,7 +565,7 @@ func TestDarwinNetworkManager_ConfigureDNS(t *testing.T) {
 		}
 	})
 
-	t.Run("IsLocalhostScenario", func(t *testing.T) {
+	t.Run("UseHostNetworkScenario", func(t *testing.T) {
 		mocks := setupDarwinNetworkManagerMocks()
 
 		nm := NewBaseNetworkManager(mocks.Injector)

--- a/pkg/network/linux_network.go
+++ b/pkg/network/linux_network.go
@@ -74,7 +74,11 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 	if tld == "" {
 		return fmt.Errorf("DNS domain is not configured")
 	}
-	dnsIP := n.configHandler.GetString("dns.address")
+
+	dnsIP := "127.0.0.1"
+	if !n.UseHostNetwork() {
+		dnsIP = n.configHandler.GetString("dns.address")
+	}
 
 	// If DNS address is configured, use systemd-resolved
 	resolvConf, err := readLink("/etc/resolv.conf")

--- a/pkg/network/network_test.go
+++ b/pkg/network/network_test.go
@@ -141,38 +141,6 @@ func TestNetworkManager_Initialize(t *testing.T) {
 		}
 	})
 
-	t.Run("SuccessLocalhost", func(t *testing.T) {
-		mocks := setupNetworkManagerMocks()
-		nm := NewBaseNetworkManager(mocks.Injector)
-
-		// Set the configuration to simulate docker-desktop
-		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "vm.driver" {
-				return "docker-desktop"
-			}
-			return ""
-		}
-
-		// Capture the SetAddress calls
-		mockService := services.NewMockService()
-		mockService.SetAddressFunc = func(address string) error {
-			if address != "127.0.0.1" {
-				return fmt.Errorf("expected address to be 127.0.0.1, got %v", address)
-			}
-			return nil
-		}
-		mocks.Injector.Register("service", mockService)
-
-		err := nm.Initialize()
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
-
-		if !nm.isLocalhost {
-			t.Fatalf("expected isLocalhost to be true, got false")
-		}
-	})
-
 	t.Run("SetAddressFailure", func(t *testing.T) {
 		mocks := setupNetworkManagerMocks()
 		nm := NewBaseNetworkManager(mocks.Injector)
@@ -252,49 +220,6 @@ func TestNetworkManager_Initialize(t *testing.T) {
 		expectedErrorSubstring := "error resolving services"
 		if !strings.Contains(err.Error(), expectedErrorSubstring) {
 			t.Errorf("expected error message to contain %q, got %q", expectedErrorSubstring, err.Error())
-		}
-	})
-
-	t.Run("ErrorSettingLocalhostAddresses", func(t *testing.T) {
-		// Setup mock components
-		mocks := setupNetworkManagerMocks()
-		nm := NewBaseNetworkManager(mocks.Injector)
-
-		// Set the configuration to simulate docker-desktop
-		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "vm.driver" {
-				return "docker-desktop"
-			}
-			return ""
-		}
-
-		// Mock SetAddress to return an error
-		mockService := services.NewMockService()
-		mockService.SetAddressFunc = func(address string) error {
-			if address == "127.0.0.1" {
-				return fmt.Errorf("mock error setting address")
-			}
-			return nil
-		}
-		mocks.Injector.Register("service", mockService)
-
-		// Call the Initialize method
-		err := nm.Initialize()
-
-		// Assert that an error occurred
-		if err == nil {
-			t.Errorf("expected error, got none")
-		}
-
-		// Verify the error message contains the expected substring
-		expectedErrorSubstring := "error setting address for service"
-		if !strings.Contains(err.Error(), expectedErrorSubstring) {
-			t.Errorf("expected error message to contain %q, got %q", expectedErrorSubstring, err.Error())
-		}
-
-		// Verify that isLocalhost is true
-		if !nm.isLocalhost {
-			t.Errorf("expected isLocalhost to be true, got false")
 		}
 	})
 

--- a/pkg/network/windows_network.go
+++ b/pkg/network/windows_network.go
@@ -68,16 +68,13 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 		return fmt.Errorf("DNS domain is not configured")
 	}
 
-	dnsIP := n.configHandler.GetString("dns.address")
-	if dnsIP == "" {
-		// If there's no DNS address to configure, we simply skip
-		return nil
+	dnsIP := "127.0.0.1"
+	if !n.UseHostNetwork() {
+		dnsIP = n.configHandler.GetString("dns.address")
 	}
 
-	// Prepend a "." to the domain for the namespace
 	namespace := "." + tld
 
-	// Check if the DNS rule for the host name is already set
 	checkScript := fmt.Sprintf(`
 $namespace = '%s'
 $allRules = Get-DnsClientNrptRule
@@ -103,7 +100,6 @@ if ($existingRule) {
 		return fmt.Errorf("failed to check existing DNS rules for %s: %w", tld, err)
 	}
 
-	// Add or update the DNS rule for the host name if necessary
 	if strings.TrimSpace(output) == "False" || output == "" {
 		addOrUpdateScript := fmt.Sprintf(`
 $namespace = '%s'

--- a/pkg/network/windows_network_test.go
+++ b/pkg/network/windows_network_test.go
@@ -354,6 +354,11 @@ func TestWindowsNetworkManager_ConfigureDNS(t *testing.T) {
 			return ""
 		}
 		mocks.MockShell.ExecSilentFunc = func(command string, args ...string) (string, int, error) {
+			if command == "powershell" && args[0] == "-Command" {
+				if strings.Contains(args[1], "Get-DnsClientNrptRule") {
+					return "", 0, nil
+				}
+			}
 			return "", 0, fmt.Errorf("unexpected command")
 		}
 

--- a/pkg/services/mock_service.go
+++ b/pkg/services/mock_service.go
@@ -25,6 +25,8 @@ type MockService struct {
 	GetHostnameFunc func() string
 	// SupportsWildcardFunc is a function that mocks the SupportsWildcard method
 	SupportsWildcardFunc func() bool
+	// UseHostNetworkFunc is a function that mocks the UseHostNetwork method
+	UseHostNetworkFunc func() bool
 }
 
 // NewMockService is a constructor for MockService
@@ -100,6 +102,14 @@ func (m *MockService) GetHostname() string {
 func (m *MockService) SupportsWildcard() bool {
 	if m.SupportsWildcardFunc != nil {
 		return m.SupportsWildcardFunc()
+	}
+	return false
+}
+
+// UseHostNetwork calls the mock UseHostNetworkFunc if it is set, otherwise returns false
+func (m *MockService) UseHostNetwork() bool {
+	if m.UseHostNetworkFunc != nil {
+		return m.UseHostNetworkFunc()
 	}
 	return false
 }

--- a/pkg/services/mock_service_test.go
+++ b/pkg/services/mock_service_test.go
@@ -412,3 +412,34 @@ func TestMockService_SupportsWildcard(t *testing.T) {
 		}
 	})
 }
+
+func TestMockService_UseHostNetwork(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Given: a mock service with a UseHostNetworkFunc
+		mockService := NewMockService()
+		mockService.UseHostNetworkFunc = func() bool {
+			return true
+		}
+
+		// When: UseHostNetwork is called
+		useHostNetwork := mockService.UseHostNetwork()
+
+		// Then: true should be returned
+		if !useHostNetwork {
+			t.Errorf("expected true, got %v", useHostNetwork)
+		}
+	})
+
+	t.Run("SuccessNoMock", func(t *testing.T) {
+		// Given: a mock service with no UseHostNetworkFunc
+		mockService := NewMockService()
+
+		// When: UseHostNetwork is called
+		useHostNetwork := mockService.UseHostNetwork()
+
+		// Then: false should be returned
+		if useHostNetwork {
+			t.Errorf("expected false, got %v", useHostNetwork)
+		}
+	})
+}

--- a/pkg/services/registry_service.go
+++ b/pkg/services/registry_service.go
@@ -68,7 +68,7 @@ func (s *RegistryService) SetAddress(address string) error {
 
 	if registryConfig.HostPort != 0 {
 		hostPort = registryConfig.HostPort
-	} else if registryConfig.Remote == "" && s.IsLocalhost() {
+	} else if registryConfig.Remote == "" && s.UseHostNetwork() {
 		hostPort = defaultPort
 		err = s.configHandler.SetContextValue("docker.registry_url", hostName)
 		if err != nil {
@@ -144,7 +144,7 @@ func (s *RegistryService) generateRegistryService(hostname string, registry dock
 		{Type: "bind", Source: "${WINDSOR_PROJECT_ROOT}/.windsor/.docker-cache", Target: "/var/lib/registry"},
 	}
 
-	if registry.Remote == "" && s.IsLocalhost() {
+	if registry.Remote == "" && s.UseHostNetwork() {
 		service.Ports = []types.ServicePortConfig{
 			{
 				Target:    5000,

--- a/pkg/services/service.go
+++ b/pkg/services/service.go
@@ -38,8 +38,8 @@ type Service interface {
 	// GetHostname returns the name plus the tld from the config
 	GetHostname() string
 
-	// IsLocalhost checks if the current address is a localhost address
-	IsLocalhost() bool
+	// UseHostNetwork checks if we are running in localhost mode
+	UseHostNetwork() bool
 
 	// SupportsWildcard checks if the service supports wildcard subdomains
 	SupportsWildcard() bool
@@ -107,15 +107,10 @@ func (s *BaseService) GetHostname() string {
 	return fmt.Sprintf("%s.%s", s.name, tld)
 }
 
-// IsLocalhost checks if the current address is a localhost address
-func (s *BaseService) IsLocalhost() bool {
-	localhostAddresses := map[string]struct{}{
-		"localhost": {},
-		"127.0.0.1": {},
-		"::1":       {},
-	}
-	_, isLocalhost := localhostAddresses[s.address]
-	return isLocalhost
+// UseHostNetwork checks if the current environment is running on docker-desktop
+func (s *BaseService) UseHostNetwork() bool {
+	driver := s.configHandler.GetString("vm.driver", "")
+	return driver == "docker-desktop"
 }
 
 // SupportsWildcard checks if the service supports wildcard subdomains

--- a/pkg/services/talos_service.go
+++ b/pkg/services/talos_service.go
@@ -79,7 +79,7 @@ func (s *TalosService) SetAddress(address string) error {
 	defer portLock.Unlock()
 
 	var port int
-	if s.isLeader || !s.IsLocalhost() {
+	if s.isLeader || !s.UseHostNetwork() {
 		port = defaultAPIPort
 	} else {
 		port = nextAPIPort
@@ -251,7 +251,7 @@ func (s *TalosService) GetComposeConfig() (*types.Config, error) {
 	}
 	defaultAPIPortUint32 := uint32(defaultAPIPort)
 
-	if s.IsLocalhost() {
+	if s.UseHostNetwork() {
 		ports = append(ports, types.ServicePortConfig{
 			Target:    defaultAPIPortUint32,
 			Published: publishedPort,

--- a/pkg/stack/windsor_stack.go
+++ b/pkg/stack/windsor_stack.go
@@ -3,7 +3,6 @@ package stack
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/windsorcli/cli/pkg/di"
 )
@@ -83,14 +82,6 @@ func (s *WindsorStack) Up() error {
 		_, _, err = s.shell.ExecProgress(fmt.Sprintf("🌎 Applying Terraform changes in %s", component.Path), "terraform", "apply")
 		if err != nil {
 			return fmt.Errorf("error applying Terraform changes in %s: %w", component.FullPath, err)
-		}
-
-		// Attempt to clean up 'backend_override.tf' if it exists
-		backendOverridePath := filepath.Join(component.FullPath, "backend_override.tf")
-		if _, err := osStat(backendOverridePath); err == nil {
-			if err := osRemove(backendOverridePath); err != nil {
-				return fmt.Errorf("error removing backend_override.tf in %s: %v", component.FullPath, err)
-			}
 		}
 	}
 

--- a/pkg/virt/docker_virt.go
+++ b/pkg/virt/docker_virt.go
@@ -28,19 +28,18 @@ func NewDockerVirt(injector di.Injector) *DockerVirt {
 	}
 }
 
-// Initialize resolves the dependencies for DockerVirt
+// Initialize sets up DockerVirt by resolving services, sorting them, checking Docker config,
+// and determining the compose command.
 func (v *DockerVirt) Initialize() error {
 	if err := v.BaseVirt.Initialize(); err != nil {
 		return fmt.Errorf("error initializing base: %w", err)
 	}
 
-	// Resolve all services
 	resolvedServices, err := v.injector.ResolveAll((*services.Service)(nil))
 	if err != nil {
 		return fmt.Errorf("error resolving services: %w", err)
 	}
 
-	// Convert the resolved services to the correct type
 	serviceSlice := make([]services.Service, len(resolvedServices))
 	for i, service := range resolvedServices {
 		if s, _ := service.(services.Service); s != nil {
@@ -48,20 +47,16 @@ func (v *DockerVirt) Initialize() error {
 		}
 	}
 
-	// Alphabetize the services by their name
 	sort.Slice(serviceSlice, func(i, j int) bool {
 		return fmt.Sprintf("%T", serviceSlice[i]) < fmt.Sprintf("%T", serviceSlice[j])
 	})
 
-	// Check if Docker is enabled using configHandler
 	if !v.configHandler.GetBool("docker.enabled") {
 		return fmt.Errorf("Docker configuration is not defined")
 	}
 
-	// Set the services
 	v.services = serviceSlice
 
-	// Determine the correct docker compose command
 	if err := v.determineComposeCommand(); err != nil {
 		return fmt.Errorf("error determining docker compose command: %w", err)
 	}
@@ -82,28 +77,26 @@ func (v *DockerVirt) determineComposeCommand() error {
 	return nil
 }
 
-// Up starts docker compose
+// Up initializes and starts Docker Compose in detached mode. It first checks if Docker is enabled
+// and ensures the Docker daemon is running. It sets the COMPOSE_FILE environment variable to the
+// path of the docker-compose.yaml file. The function attempts to run "docker compose up" with
+// retries, using progress display for the first attempt and silent execution for subsequent ones.
 func (v *DockerVirt) Up() error {
-	// Check if Docker is enabled and run "docker compose up" in daemon mode if necessary
 	if v.configHandler.GetBool("docker.enabled") {
-		// Ensure Docker daemon is running
 		if err := v.checkDockerDaemon(); err != nil {
 			return fmt.Errorf("Docker daemon is not running: %w", err)
 		}
 
-		// Get the path to the docker-compose.yaml file
 		projectRoot, err := v.shell.GetProjectRoot()
 		if err != nil {
 			return fmt.Errorf("error retrieving project root: %w", err)
 		}
 		composeFilePath := filepath.Join(projectRoot, ".windsor", "docker-compose.yaml")
 
-		// Set the COMPOSE_FILE environment variable and handle potential error
 		if err := osSetenv("COMPOSE_FILE", composeFilePath); err != nil {
 			return fmt.Errorf("failed to set COMPOSE_FILE environment variable: %w", err)
 		}
 
-		// Retry logic for docker compose up with progress display
 		retries := 3
 		var lastErr error
 		var lastOutput string
@@ -111,7 +104,6 @@ func (v *DockerVirt) Up() error {
 			args := []string{"up", "--detach", "--remove-orphans"}
 			message := "📦 Running docker compose up"
 
-			// Use ExecProgress for the first attempt to show progress
 			if i == 0 {
 				output, _, err := v.shell.ExecProgress(message, v.composeCommand, args...)
 				if err == nil {
@@ -120,7 +112,6 @@ func (v *DockerVirt) Up() error {
 				lastErr = err
 				lastOutput = output
 			} else {
-				// Use ExecSilent for retries to avoid multiple progress messages
 				output, _, err := v.shell.ExecSilent(v.composeCommand, args...)
 				if err == nil {
 					return nil
@@ -140,28 +131,23 @@ func (v *DockerVirt) Up() error {
 	return nil
 }
 
-// Down stops the Docker container
+// Down stops Docker containers if enabled, ensuring the daemon is running, and executes "docker compose down".
 func (v *DockerVirt) Down() error {
-	// Check if Docker is enabled and run "docker compose down" if necessary
 	if v.configHandler.GetBool("docker.enabled") {
-		// Ensure Docker daemon is running
 		if err := v.checkDockerDaemon(); err != nil {
 			return fmt.Errorf("Docker daemon is not running: %w", err)
 		}
 
-		// Get the path to the docker-compose.yaml file
 		projectRoot, err := v.shell.GetProjectRoot()
 		if err != nil {
 			return fmt.Errorf("error retrieving project root: %w", err)
 		}
 		composeFilePath := filepath.Join(projectRoot, ".windsor", "docker-compose.yaml")
 
-		// Set the COMPOSE_FILE environment variable and handle potential error
 		if err := osSetenv("COMPOSE_FILE", composeFilePath); err != nil {
 			return fmt.Errorf("error setting COMPOSE_FILE environment variable: %w", err)
 		}
 
-		// Run docker compose down with clean flags using the Exec function from shell.go
 		output, _, err := v.shell.ExecProgress("📦 Running docker compose down", v.composeCommand, "down", "--remove-orphans", "--volumes")
 		if err != nil {
 			return fmt.Errorf("Error executing command %s down: %w\n%s", v.composeCommand, err, output)
@@ -170,33 +156,28 @@ func (v *DockerVirt) Down() error {
 	return nil
 }
 
-// WriteConfig writes the Docker configuration file
+// WriteConfig generates and writes the Docker compose YAML file.
 func (v *DockerVirt) WriteConfig() error {
-	// Get the project root and construct the file path
 	projectRoot, err := v.shell.GetProjectRoot()
 	if err != nil {
 		return fmt.Errorf("error retrieving project root: %w", err)
 	}
 	composeFilePath := filepath.Join(projectRoot, ".windsor", "docker-compose.yaml")
 
-	// Ensure the parent context folder exists
 	if err := mkdirAll(filepath.Dir(composeFilePath), 0755); err != nil {
 		return fmt.Errorf("error creating parent context folder: %w", err)
 	}
 
-	// Retrieve the full compose configuration
 	project, err := v.getFullComposeConfig()
 	if err != nil {
 		return fmt.Errorf("error getting full compose config: %w", err)
 	}
 
-	// Serialize the docker compose config to YAML
 	yamlData, err := yamlMarshal(project)
 	if err != nil {
 		return fmt.Errorf("error marshaling docker compose config to YAML: %w", err)
 	}
 
-	// Write the YAML data to the specified file
 	err = writeFile(composeFilePath, yamlData, 0644)
 	if err != nil {
 		return fmt.Errorf("error writing docker compose file: %w", err)
@@ -205,9 +186,9 @@ func (v *DockerVirt) WriteConfig() error {
 	return nil
 }
 
-// GetContainerInfo returns a list of information about the Docker containers, including their labels
+// GetContainerInfo retrieves information about Docker containers managed by Windsor, filtered by context and optionally by service name.
+// It returns a list of ContainerInfo, which includes the container's name, IP address, and labels.
 func (v *DockerVirt) GetContainerInfo(name ...string) ([]ContainerInfo, error) {
-	// Get the context name
 	contextName := v.configHandler.GetContext()
 
 	command := "docker"
@@ -237,7 +218,6 @@ func (v *DockerVirt) GetContainerInfo(name ...string) ([]ContainerInfo, error) {
 
 		serviceName, _ := labels["com.docker.compose.service"]
 
-		// If a name is provided, check if it matches the current serviceName
 		if len(name) > 0 && serviceName != name[0] {
 			continue
 		}
@@ -267,7 +247,6 @@ func (v *DockerVirt) GetContainerInfo(name ...string) ([]ContainerInfo, error) {
 			Labels:  labels,
 		}
 
-		// If a name is provided and matches, return immediately with this containerInfo
 		if len(name) > 0 && serviceName == name[0] {
 			return []ContainerInfo{containerInfo}, nil
 		}
@@ -375,8 +354,7 @@ func (v *DockerVirt) getFullComposeConfig() (*types.Project, error) {
 						networkName: {},
 					}
 
-					networkCIDR := v.configHandler.GetString("network.cidr_block")
-					if networkCIDR != "" && ipAddress != "127.0.0.1" && ipAddress != "" {
+					if networkCIDR != "" && ipAddress != "" {
 						containerConfig.Networks[networkName].Ipv4Address = ipAddress
 					}
 


### PR DESCRIPTION
The local coredns service now creates two networks when we are running in container execution mode. The reason this is necessary is to allow for handling DNS when routing requests from within the Docker network.