### PR TITLE
Support for dual DNS servers

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -87,6 +87,5 @@ const (
 
 const (
 	// renovate: datasource=docker depName=ghcr.io/windsorcli/windsorcli
-	// DEFAULT_WINDSOR_IMAGE = "ghcr.io/windsorcli/windsorcli:latest"
-	DEFAULT_WINDSOR_IMAGE = "windsorcli:latest"
+	DEFAULT_WINDSOR_IMAGE = "ghcr.io/windsorcli/windsorcli:latest"
 )


### PR DESCRIPTION
Two DNS servers now run and support selective wildcard DNS. This capability is triggered when we're using the windsor exec environment, so that the windsor container can leverage its DNS internally.