### PR TITLE
Isolate contexts across shells

### DIFF
--- a/pkg/config/mock_config_handler.go
+++ b/pkg/config/mock_config_handler.go
@@ -167,12 +167,12 @@ func (m *MockConfigHandler) GetConfig() *v1alpha1.Context {
 	return &v1alpha1.Context{}
 }
 
-// GetContext calls the mock GetContextFunc if set, otherwise returns a reasonable default string
+// GetContext calls the mock GetContextFunc if set, otherwise returns "local"
 func (m *MockConfigHandler) GetContext() string {
 	if m.GetContextFunc != nil {
 		return m.GetContextFunc()
 	}
-	return "mock-context"
+	return "local"
 }
 
 // SetContext calls the mock SetContextFunc if set, otherwise returns nil

--- a/pkg/config/shims.go
+++ b/pkg/config/shims.go
@@ -3,6 +3,8 @@ package config
 import (
 	"os"
 
+	"os/exec"
+
 	"github.com/goccy/go-yaml"
 )
 
@@ -15,6 +17,20 @@ var osWriteFile = os.WriteFile
 // osRemoveAll is a variable to allow mocking os.RemoveAll in tests
 var osRemoveAll = os.RemoveAll
 
+// osRemove is a variable to allow mocking os.Remove in tests
+var osRemove = os.Remove
+
+// execCommand is a variable to allow mocking exec.Command in tests
+var execCommand = exec.Command
+
+// cmdOutput is a variable to allow mocking exec.Command.Output in tests
+var cmdOutput = func(cmd *exec.Cmd) ([]byte, error) {
+	return cmd.Output()
+}
+
+// osUserHomeDir is a variable to allow mocking os.UserHomeDir in tests
+var osUserHomeDir = os.UserHomeDir
+
 // Override variable for yamlMarshal
 var yamlMarshal = yaml.Marshal
 
@@ -26,6 +42,12 @@ var osStat = os.Stat
 
 // osMkdirAll is a variable to allow mocking os.MkdirAll in tests
 var osMkdirAll = os.MkdirAll
+
+// osGetppid is a variable to allow mocking os.Getppid in tests
+var osGetppid = os.Getppid
+
+// osGetpid is a variable to allow mocking os.Getpid in tests
+var osGetpid = os.Getpid
 
 // Helper functions to create pointers for basic types
 func ptrString(s string) *string {

--- a/pkg/shell/mock_shell.go
+++ b/pkg/shell/mock_shell.go
@@ -20,6 +20,7 @@ type MockShell struct {
 	SetVerbosityFunc               func(verbose bool)
 	AddCurrentDirToTrustedFileFunc func() error
 	CheckTrustedDirectoryFunc      func() error
+	GetSessionTokenFunc            func() string
 }
 
 // NewMockShell creates a new instance of MockShell. If injector is provided, it sets the injector on MockShell.
@@ -137,6 +138,14 @@ func (s *MockShell) Reset() error {
 		return s.ResetFunc()
 	}
 	return nil
+}
+
+// GetSessionToken calls the custom GetSessionTokenFunc if provided.
+func (s *MockShell) GetSessionToken() string {
+	if s.GetSessionTokenFunc != nil {
+		return s.GetSessionTokenFunc()
+	}
+	return "mock-session-token"
 }
 
 // Ensure MockShell implements the Shell interface

--- a/pkg/shell/mock_shell_test.go
+++ b/pkg/shell/mock_shell_test.go
@@ -511,3 +511,28 @@ func TestMockShell_Reset(t *testing.T) {
 		}
 	})
 }
+
+func TestMockShell_GetSessionToken(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		injector := di.NewInjector()
+		mockShell := NewMockShell(injector)
+		expectedToken := "mock-session-token"
+		mockShell.GetSessionTokenFunc = func() string {
+			return expectedToken
+		}
+		token := mockShell.GetSessionToken()
+		if token != expectedToken {
+			t.Errorf("Expected token %q, got %q", expectedToken, token)
+		}
+	})
+
+	t.Run("NotImplemented", func(t *testing.T) {
+		injector := di.NewInjector()
+		mockShell := NewMockShell(injector)
+		expectedToken := "mock-session-token"
+		token := mockShell.GetSessionToken()
+		if token != expectedToken {
+			t.Errorf("Expected token %q, got %q", expectedToken, token)
+		}
+	})
+}

--- a/pkg/shell/shims.go
+++ b/pkg/shell/shims.go
@@ -15,7 +15,7 @@ import (
 var getwd = os.Getwd
 
 // Command execution
-var execCommand = osExecCommand
+var execCommand = exec.Command
 
 // Process state exit code retrieval
 var processStateExitCode = func(ps *os.ProcessState) int {
@@ -117,3 +117,9 @@ var execCommandOutput = func(name string, arg ...string) (string, error) {
 	cmd := execCommand(name, arg...)
 	return cmdOutput(cmd)
 }
+
+// osGetppid is a variable to allow mocking os.Getppid in tests
+var osGetppid = os.Getppid
+
+// osGetpid is a variable to allow mocking os.Getpid in tests
+var osGetpid = os.Getpid


### PR DESCRIPTION
When opening a new shell, it is now possible to set a context without interfering with another shell's context. Previously, only a single global context was set.