### PR TITLE
Move platform => cluster.platform

### DIFF
--- a/api/v1alpha1/cluster/cluster_config.go
+++ b/api/v1alpha1/cluster/cluster_config.go
@@ -3,6 +3,7 @@ package cluster
 // ClusterConfig represents the cluster configuration
 type ClusterConfig struct {
 	Enabled       *bool           `yaml:"enabled,omitempty"`
+	Platform      *string         `yaml:"platform,omitempty"`
 	Driver        *string         `yaml:"driver,omitempty"`
 	Endpoint      *string         `yaml:"endpoint,omitempty"`
 	ControlPlanes NodeGroupConfig `yaml:"controlplanes,omitempty"`
@@ -31,6 +32,9 @@ type NodeGroupConfig struct {
 func (base *ClusterConfig) Merge(overlay *ClusterConfig) {
 	if overlay.Enabled != nil {
 		base.Enabled = overlay.Enabled
+	}
+	if overlay.Platform != nil {
+		base.Platform = overlay.Platform
 	}
 	if overlay.Driver != nil {
 		base.Driver = overlay.Driver
@@ -122,6 +126,7 @@ func (c *ClusterConfig) Copy() *ClusterConfig {
 
 	return &ClusterConfig{
 		Enabled:  c.Enabled,
+		Platform: c.Platform,
 		Driver:   c.Driver,
 		Endpoint: c.Endpoint,
 		ControlPlanes: NodeGroupConfig{

--- a/api/v1alpha1/cluster/cluster_config_test.go
+++ b/api/v1alpha1/cluster/cluster_config_test.go
@@ -20,8 +20,9 @@ func ptrInt(i int) *int {
 func TestClusterConfig_Merge(t *testing.T) {
 	t.Run("MergeWithNoNils", func(t *testing.T) {
 		base := &ClusterConfig{
-			Enabled: ptrBool(true),
-			Driver:  ptrString("base-driver"),
+			Enabled:  ptrBool(true),
+			Driver:   ptrString("base-driver"),
+			Platform: ptrString("base-platform"),
 			ControlPlanes: struct {
 				Count     *int                  `yaml:"count,omitempty"`
 				CPU       *int                  `yaml:"cpu,omitempty"`
@@ -63,8 +64,9 @@ func TestClusterConfig_Merge(t *testing.T) {
 		}
 
 		overlay := &ClusterConfig{
-			Enabled: ptrBool(false),
-			Driver:  ptrString("overlay-driver"),
+			Enabled:  ptrBool(false),
+			Driver:   ptrString("overlay-driver"),
+			Platform: ptrString("overlay-platform"),
 			ControlPlanes: struct {
 				Count     *int                  `yaml:"count,omitempty"`
 				CPU       *int                  `yaml:"cpu,omitempty"`
@@ -113,6 +115,9 @@ func TestClusterConfig_Merge(t *testing.T) {
 		if base.Driver == nil || *base.Driver != "overlay-driver" {
 			t.Errorf("Driver mismatch: expected 'overlay-driver', got '%s'", *base.Driver)
 		}
+		if base.Platform == nil || *base.Platform != "overlay-platform" {
+			t.Errorf("Platform mismatch: expected 'overlay-platform', got '%s'", *base.Platform)
+		}
 		if len(base.ControlPlanes.HostPorts) != 2 || base.ControlPlanes.HostPorts[0] != "3000:3000/tcp" || base.ControlPlanes.HostPorts[1] != "4000:4000/tcp" {
 			t.Errorf("ControlPlanes HostPorts mismatch: expected ['3000:3000/tcp', '4000:4000/tcp'], got %v", base.ControlPlanes.HostPorts)
 		}
@@ -150,8 +155,9 @@ func TestClusterConfig_Merge(t *testing.T) {
 
 	t.Run("MergeWithAllNils", func(t *testing.T) {
 		base := &ClusterConfig{
-			Enabled: nil,
-			Driver:  nil,
+			Enabled:  nil,
+			Driver:   nil,
+			Platform: nil,
 			ControlPlanes: struct {
 				Count     *int                  `yaml:"count,omitempty"`
 				CPU       *int                  `yaml:"cpu,omitempty"`
@@ -185,8 +191,9 @@ func TestClusterConfig_Merge(t *testing.T) {
 		}
 
 		overlay := &ClusterConfig{
-			Enabled: nil,
-			Driver:  nil,
+			Enabled:  nil,
+			Driver:   nil,
+			Platform: nil,
 			ControlPlanes: struct {
 				Count     *int                  `yaml:"count,omitempty"`
 				CPU       *int                  `yaml:"cpu,omitempty"`
@@ -227,6 +234,9 @@ func TestClusterConfig_Merge(t *testing.T) {
 		if base.Driver != nil {
 			t.Errorf("Driver mismatch: expected nil, got '%s'", *base.Driver)
 		}
+		if base.Platform != nil {
+			t.Errorf("Platform mismatch: expected nil, got '%s'", *base.Platform)
+		}
 		if base.Workers.HostPorts != nil {
 			t.Errorf("Workers HostPorts mismatch: expected nil, got %v", base.Workers.HostPorts)
 		}
@@ -266,8 +276,9 @@ func TestClusterConfig_Merge(t *testing.T) {
 func TestClusterConfig_Copy(t *testing.T) {
 	t.Run("CopyWithNonNilValues", func(t *testing.T) {
 		original := &ClusterConfig{
-			Enabled: ptrBool(true),
-			Driver:  ptrString("original-driver"),
+			Enabled:  ptrBool(true),
+			Driver:   ptrString("original-driver"),
+			Platform: ptrString("original-platform"),
 			ControlPlanes: struct {
 				Count     *int                  `yaml:"count,omitempty"`
 				CPU       *int                  `yaml:"cpu,omitempty"`
@@ -315,6 +326,9 @@ func TestClusterConfig_Copy(t *testing.T) {
 		}
 		if original.Driver == nil || copy.Driver == nil || *original.Driver != *copy.Driver {
 			t.Errorf("Driver mismatch: expected %v, got %v", *original.Driver, *copy.Driver)
+		}
+		if original.Platform == nil || copy.Platform == nil || *original.Platform != *copy.Platform {
+			t.Errorf("Platform mismatch: expected %v, got %v", *original.Platform, *copy.Platform)
 		}
 		if len(original.Workers.HostPorts) != len(copy.Workers.HostPorts) {
 			t.Errorf("Workers HostPorts length mismatch: expected %d, got %d", len(original.Workers.HostPorts), len(copy.Workers.HostPorts))

--- a/api/v1alpha1/config_types.go
+++ b/api/v1alpha1/config_types.go
@@ -22,7 +22,6 @@ type Config struct {
 // Context represents the context configuration
 type Context struct {
 	ProjectName *string                    `yaml:"projectName,omitempty"`
-	Platform    *string                    `yaml:"platform,omitempty"`
 	Blueprint   *string                    `yaml:"blueprint,omitempty"`
 	Environment map[string]string          `yaml:"environment,omitempty"`
 	Secrets     *secrets.SecretsConfig     `yaml:"secrets,omitempty"`
@@ -106,9 +105,6 @@ func (base *Context) Merge(overlay *Context) {
 		}
 		base.DNS.Merge(overlay.DNS)
 	}
-	if overlay.Platform != nil {
-		base.Platform = overlay.Platform
-	}
 	if overlay.Blueprint != nil {
 		base.Blueprint = overlay.Blueprint
 	}
@@ -128,7 +124,6 @@ func (c *Context) DeepCopy() *Context {
 	}
 	return &Context{
 		ProjectName: c.ProjectName,
-		Platform:    c.Platform,
 		Blueprint:   c.Blueprint,
 		Environment: environmentCopy,
 		Secrets:     c.Secrets.Copy(),

--- a/api/v1alpha1/config_types_test.go
+++ b/api/v1alpha1/config_types_test.go
@@ -54,7 +54,6 @@ func TestConfig_Merge(t *testing.T) {
 			Network: &network.NetworkConfig{
 				CIDRBlock: ptrString("192.168.0.0/16"),
 			},
-			Platform:  ptrString("base-platform"),
 			Blueprint: ptrString("1.0.0"),
 		}
 
@@ -95,7 +94,6 @@ func TestConfig_Merge(t *testing.T) {
 			Network: &network.NetworkConfig{
 				CIDRBlock: ptrString("10.0.0.0/8"),
 			},
-			Platform:  ptrString("overlay-platform"),
 			Blueprint: ptrString("2.0.0"),
 		}
 
@@ -130,9 +128,6 @@ func TestConfig_Merge(t *testing.T) {
 		}
 		if base.Network.CIDRBlock == nil || *base.Network.CIDRBlock != "10.0.0.0/8" {
 			t.Errorf("Network CIDRBlock mismatch: expected '10.0.0.0/8', got '%s'", *base.Network.CIDRBlock)
-		}
-		if base.Platform == nil || *base.Platform != "overlay-platform" {
-			t.Errorf("Platform mismatch: expected 'overlay-platform', got '%s'", *base.Platform)
 		}
 		if base.Blueprint == nil || *base.Blueprint != "2.0.0" {
 			t.Errorf("Blueprint mismatch: expected '2.0.0', got '%s'", *base.Blueprint)
@@ -178,7 +173,6 @@ func TestConfig_Merge(t *testing.T) {
 			Network: &network.NetworkConfig{
 				CIDRBlock: ptrString("192.168.0.0/16"),
 			},
-			Platform:  ptrString("base-platform"),
 			Blueprint: ptrString("1.0.0"),
 		}
 
@@ -214,9 +208,6 @@ func TestConfig_Merge(t *testing.T) {
 		}
 		if base.Network.CIDRBlock == nil || *base.Network.CIDRBlock != "192.168.0.0/16" {
 			t.Errorf("Network CIDRBlock mismatch: expected '192.168.0.0/16', got '%s'", *base.Network.CIDRBlock)
-		}
-		if base.Platform == nil || *base.Platform != "base-platform" {
-			t.Errorf("Platform mismatch: expected 'base-platform', got '%s'", *base.Platform)
 		}
 		if base.Blueprint == nil || *base.Blueprint != "1.0.0" {
 			t.Errorf("Blueprint mismatch: expected '1.0.0', got '%s'", *base.Blueprint)
@@ -263,7 +254,6 @@ func TestConfig_Merge(t *testing.T) {
 			Network: &network.NetworkConfig{
 				CIDRBlock: ptrString("10.0.0.0/8"),
 			},
-			Platform:  ptrString("overlay-platform"),
 			Blueprint: ptrString("2.0.0"),
 		}
 
@@ -298,9 +288,6 @@ func TestConfig_Merge(t *testing.T) {
 		}
 		if base.Network.CIDRBlock == nil || *base.Network.CIDRBlock != "10.0.0.0/8" {
 			t.Errorf("Network CIDRBlock mismatch: expected '10.0.0.0/8', got '%s'", *base.Network.CIDRBlock)
-		}
-		if base.Platform == nil || *base.Platform != "overlay-platform" {
-			t.Errorf("Platform mismatch: expected 'overlay-platform', got '%s'", *base.Platform)
 		}
 		if base.Blueprint == nil || *base.Blueprint != "2.0.0" {
 			t.Errorf("Blueprint mismatch: expected '2.0.0', got '%s'", *base.Blueprint)
@@ -364,7 +351,6 @@ func TestConfig_Copy(t *testing.T) {
 					End:   ptrString("192.168.0.255"),
 				},
 			},
-			Platform:  ptrString("original-platform"),
 			Blueprint: ptrString("1.0.0"),
 		}
 
@@ -394,9 +380,6 @@ func TestConfig_Copy(t *testing.T) {
 		}
 		if original.DNS.Enabled == nil || copy.DNS.Enabled == nil || *original.DNS.Enabled != *copy.DNS.Enabled {
 			t.Errorf("DNS Enabled mismatch: expected %v, got %v", *original.DNS.Enabled, *copy.DNS.Enabled)
-		}
-		if original.Platform == nil || copy.Platform == nil || *original.Platform != *copy.Platform {
-			t.Errorf("Platform mismatch: expected %v, got %v", *original.Platform, *copy.Platform)
 		}
 		if original.Blueprint == nil || copy.Blueprint == nil || *original.Blueprint != *copy.Blueprint {
 			t.Errorf("Blueprint mismatch: expected %v, got %v", *original.Blueprint, *copy.Blueprint)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -93,7 +93,7 @@ var initCmd = &cobra.Command{
 		configurations := []struct {
 			flagName   string
 			configPath string
-			value      interface{}
+			value      any
 		}{
 			{"aws-endpoint-url", "aws.aws_endpoint_url", awsEndpointURL},
 			{"aws-profile", "aws.aws_profile", awsProfile},
@@ -105,9 +105,9 @@ var initCmd = &cobra.Command{
 			{"vm-arch", "vm.arch", arch},
 			{"tools-manager", "toolsManager", toolsManager},
 			{"git-livereload", "git.livereload.enabled", gitLivereload},
-			{"platform", "platform", platform},
 			{"blueprint", "blueprint", blueprint},
 			{"endpoint", "cluster.endpoint", endpoint},
+			{"platform", "cluster.platform", platform},
 		}
 
 		for _, config := range configurations {

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -73,8 +73,9 @@ var commonTerraformConfig = terraform.TerraformConfig{
 }
 
 var commonClusterConfig = cluster.ClusterConfig{
-	Enabled: ptrBool(true),
-	Driver:  ptrString("talos"),
+	Enabled:  ptrBool(true),
+	Platform: ptrString("local"),
+	Driver:   ptrString("talos"),
 	ControlPlanes: cluster.NodeGroupConfig{
 		Count:  ptrInt(1),
 		CPU:    ptrInt(constants.DEFAULT_TALOS_CONTROL_PLANE_CPU),
@@ -98,14 +99,14 @@ var commonDNSConfig = dns.DNSConfig{
 
 var DefaultConfig_Localhost = v1alpha1.Context{
 	Blueprint:   ptrString("full"),
-	Platform:    ptrString("local"),
 	Environment: map[string]string{},
 	Docker:      commonDockerConfig.Copy(),
 	Git:         commonGitConfig.Copy(),
 	Terraform:   commonTerraformConfig.Copy(),
 	Cluster: &cluster.ClusterConfig{
-		Enabled: ptrBool(true),
-		Driver:  ptrString("talos"),
+		Enabled:  ptrBool(true),
+		Platform: ptrString("local"),
+		Driver:   ptrString("talos"),
 		ControlPlanes: cluster.NodeGroupConfig{
 			Count:  ptrInt(1),
 			CPU:    ptrInt(constants.DEFAULT_TALOS_CONTROL_PLANE_CPU),
@@ -135,7 +136,6 @@ var DefaultConfig_Localhost = v1alpha1.Context{
 
 var DefaultConfig_Full = v1alpha1.Context{
 	Blueprint:   ptrString("full"),
-	Platform:    ptrString("local"),
 	Environment: map[string]string{},
 	Docker:      commonDockerConfig.Copy(),
 	Git:         commonGitConfig.Copy(),


### PR DESCRIPTION
Platform really only applies to how a cluster is built, so is most appropriately configured there.