### PR TITLE
Selectively load env vars internally

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -45,6 +45,11 @@ var downCmd = &cobra.Command{
 			return fmt.Errorf("Error initializing components: %w", err)
 		}
 
+		// Set the environment variables internally in the process
+		if err := controller.SetEnvironmentVariables(); err != nil {
+			return fmt.Errorf("Error setting environment variables: %w", err)
+		}
+
 		// Resolve the shell
 		shell := controller.ResolveShell()
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -163,6 +163,11 @@ var initCmd = &cobra.Command{
 			return fmt.Errorf("Error initializing components: %w", err)
 		}
 
+		// Set the environment variables internally in the process
+		if err := controller.SetEnvironmentVariables(); err != nil {
+			return fmt.Errorf("Error setting environment variables: %w", err)
+		}
+
 		// Write configurations to file
 		if err := controller.WriteConfigurationFiles(); err != nil {
 			return fmt.Errorf("Error writing configuration files: %w", err)

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -55,6 +55,11 @@ var installCmd = &cobra.Command{
 			return fmt.Errorf("Error initializing components: %w", err)
 		}
 
+		// Set the environment variables internally in the process
+		if err := controller.SetEnvironmentVariables(); err != nil {
+			return fmt.Errorf("Error setting environment variables: %w", err)
+		}
+
 		// Resolve the blueprint handler
 		blueprintHandler := controller.ResolveBlueprintHandler()
 		if blueprintHandler == nil {

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -312,4 +312,51 @@ func TestInstallCmd(t *testing.T) {
 			t.Fatalf("Expected error about configuration not loaded, got %v", err.Error())
 		}
 	})
+
+	t.Run("ErrorSettingEnvironmentVariables", func(t *testing.T) {
+		defer resetRootCmd()
+
+		// Initialize mocks
+		mocks := setupMockInstallCmdComponents()
+		mocks.Controller.SetEnvironmentVariablesFunc = func() error {
+			return fmt.Errorf("error setting environment variables")
+		}
+
+		// When the install command is executed
+		rootCmd.SetArgs([]string{"install"})
+		err := Execute(mocks.Controller)
+
+		// Then check the error contents
+		if err == nil {
+			t.Fatalf("Expected an error, got nil")
+		}
+		expectedError := "Error setting environment variables: error setting environment variables"
+		if err.Error() != expectedError {
+			t.Fatalf("Expected error %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("SuccessSettingEnvironmentVariables", func(t *testing.T) {
+		defer resetRootCmd()
+
+		// Initialize mocks
+		mocks := setupMockInstallCmdComponents()
+		setEnvVarsCalled := false
+		mocks.Controller.SetEnvironmentVariablesFunc = func() error {
+			setEnvVarsCalled = true
+			return nil
+		}
+
+		// When the install command is executed
+		rootCmd.SetArgs([]string{"install"})
+		err := Execute(mocks.Controller)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then SetEnvironmentVariables should have been called
+		if !setEnvVarsCalled {
+			t.Fatal("Expected SetEnvironmentVariables to be called, but it wasn't")
+		}
+	})
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -64,6 +64,12 @@ var upCmd = &cobra.Command{
 		if err := controller.InitializeComponents(); err != nil {
 			return fmt.Errorf("Error initializing components: %w", err)
 		}
+
+		// Set the environment variables internally in the process
+		if err := controller.SetEnvironmentVariables(); err != nil {
+			return fmt.Errorf("Error setting environment variables: %w", err)
+		}
+
 		if err := controller.WriteConfigurationFiles(); err != nil {
 			return fmt.Errorf("Error writing configuration files: %w", err)
 		}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -178,11 +178,6 @@ func (c *BaseController) InitializeComponents() error {
 		}
 	}
 
-	// Set the environment variables
-	if err := c.SetEnvironmentVariables(); err != nil {
-		return fmt.Errorf("error setting environment variables: %w", err)
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
We don't always want to implicitly load environment variables in to the running process. In order to handle environment cache properly, this should not occur during `windsor env`, for instance. This PR moves the internal environment injection routine in to the appropriate commands and out of the broader `InitializeComponents` method.