### PR TITLE
Include WINDSOR_SESSION_TOKEN

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 	ctrl "github.com/windsorcli/cli/pkg/controller"
+	"github.com/windsorcli/cli/pkg/env"
 )
 
 // getContextCmd represents the get command
@@ -22,6 +23,11 @@ var getContextCmd = &cobra.Command{
 		// Check if config is loaded
 		if !configHandler.IsLoaded() {
 			return fmt.Errorf("No context is available. Have you run `windsor init`?")
+		}
+
+		// Initialize environment components
+		if err := controller.CreateEnvComponents(); err != nil {
+			return fmt.Errorf("Error initializing environment components: %w", err)
 		}
 
 		// Initialize components
@@ -47,6 +53,11 @@ var setContextCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		controller := cmd.Context().Value(controllerKey).(ctrl.Controller)
 
+		// Initialize environment components
+		if err := controller.CreateEnvComponents(); err != nil {
+			return fmt.Errorf("Error initializing environment components: %w", err)
+		}
+
 		// Initialize components
 		if err := controller.InitializeComponents(); err != nil {
 			return fmt.Errorf("Error initializing components: %w", err)
@@ -64,6 +75,21 @@ var setContextCmd = &cobra.Command{
 		contextName := args[0]
 		if err := configHandler.SetContext(contextName); err != nil {
 			return fmt.Errorf("Error setting context: %w", err)
+		}
+
+		// Create a session invalidation signal to force regeneration of the session token
+		// since the context has changed
+		windsorEnvPrinter := controller.ResolveEnvPrinter("windsorEnv")
+		if windsorEnvPrinter != nil {
+			// Note: This type assertion makes testing challenging as mock implementations
+			// in tests won't pass this check. However, keeping this assertion ensures type safety
+			// in production code. The token invalidation functionality is tested at the
+			// WindsorEnvPrinter level instead.
+			if wEnv, ok := windsorEnvPrinter.(*env.WindsorEnvPrinter); ok {
+				if err := wEnv.CreateSessionInvalidationSignal(); err != nil {
+					return fmt.Errorf("Warning: Failed to reset session token: %w", err)
+				}
+			}
 		}
 
 		// Print the context

--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -136,6 +136,29 @@ func TestContext_Get(t *testing.T) {
 			t.Errorf("Expected output to contain %q, got %q", expectedOutput, output)
 		}
 	})
+
+	t.Run("ErrorCreatingEnvComponents", func(t *testing.T) {
+		// Given an error creating environment components
+		mocks := setupSafeContextCmdMocks()
+		mocks.Controller.CreateEnvComponentsFunc = func() error {
+			return fmt.Errorf("env components error")
+		}
+
+		// When the get context command is executed
+		output := captureStderr(func() {
+			rootCmd.SetArgs([]string{"context", "get"})
+			err := Execute(mocks.Controller)
+			if err == nil {
+				t.Fatalf("Expected error, got nil")
+			}
+		})
+
+		// Then the output should indicate the error
+		expectedOutput := "Error initializing environment components: env components error"
+		if !strings.Contains(output, expectedOutput) {
+			t.Errorf("Expected output to contain %q, got %q", expectedOutput, output)
+		}
+	})
 }
 
 func TestContext_Set(t *testing.T) {
@@ -219,6 +242,27 @@ func TestContext_Set(t *testing.T) {
 
 		// Then the output should indicate the config is not loaded
 		expectedOutput := "Configuration is not loaded. Please ensure it is initialized."
+		if !strings.Contains(err.Error(), expectedOutput) {
+			t.Errorf("Expected output to contain %q, got %q", expectedOutput, err.Error())
+		}
+	})
+
+	t.Run("ErrorCreatingEnvComponents", func(t *testing.T) {
+		// Given an error creating environment components
+		mocks := setupSafeContextCmdMocks()
+		mocks.Controller.CreateEnvComponentsFunc = func() error {
+			return fmt.Errorf("env components error")
+		}
+
+		// When the set context command is executed
+		rootCmd.SetArgs([]string{"context", "set", "new-context"})
+		err := Execute(mocks.Controller)
+		if err == nil {
+			t.Fatalf("Expected error, got nil")
+		}
+
+		// Then the output should indicate the error
+		expectedOutput := "Error initializing environment components: env components error"
 		if !strings.Contains(err.Error(), expectedOutput) {
 			t.Errorf("Expected output to contain %q, got %q", expectedOutput, err.Error())
 		}

--- a/pkg/env/shims.go
+++ b/pkg/env/shims.go
@@ -1,6 +1,7 @@
 package env
 
 import (
+	"crypto/rand"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -29,6 +30,17 @@ var yamlUnmarshal = yaml.Unmarshal
 
 // Wrapper function for yaml.Marshal
 var yamlMarshal = yaml.Marshal
+
+// Wrapper for os.Remove for mocking in tests
+var osRemove = os.Remove
+
+// Wrapper for os.RemoveAll for mocking in tests
+var osRemoveAll = os.RemoveAll
+
+// Wrapper for crypto/rand.Read for mocking in tests
+var cryptoRandRead = func(b []byte) (int, error) {
+	return rand.Read(b)
+}
 
 // intPtr returns a pointer to an int value
 func intPtr(i int) *int {

--- a/pkg/env/windsor_env.go
+++ b/pkg/env/windsor_env.go
@@ -2,13 +2,21 @@ package env
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	"github.com/windsorcli/cli/pkg/di"
+)
+
+const (
+	SessionTokenPrefix = ".session."
+	EnvSessionTokenVar = "WINDSOR_SESSION_TOKEN"
 )
 
 // WindsorEnvPrinter is a struct that simulates a Kubernetes environment for testing purposes.
 type WindsorEnvPrinter struct {
 	BaseEnvPrinter
+	sessionToken string
 }
 
 // NewWindsorEnvPrinter initializes a new WindsorEnvPrinter instance using the provided dependency injector.
@@ -20,20 +28,26 @@ func NewWindsorEnvPrinter(injector di.Injector) *WindsorEnvPrinter {
 	}
 }
 
-// GetEnvVars retrieves the environment variables for the Windsor environment.
+// GetEnvVars returns a map of Windsor-specific environment variables, including the current context,
+// project root, and session token. It retrieves the current context from the config handler, the
+// project root from the shell, and generates or retrieves a session token.
 func (e *WindsorEnvPrinter) GetEnvVars() (map[string]string, error) {
 	envVars := make(map[string]string)
 
-	// Add WINDSOR_CONTEXT to the environment variables
 	currentContext := e.configHandler.GetContext()
 	envVars["WINDSOR_CONTEXT"] = currentContext
 
-	// Get the project root and add WINDSOR_PROJECT_ROOT to the environment variables
 	projectRoot, err := e.shell.GetProjectRoot()
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving project root: %w", err)
 	}
 	envVars["WINDSOR_PROJECT_ROOT"] = projectRoot
+
+	sessionToken, err := e.getSessionToken()
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving session token: %w", err)
+	}
+	envVars[EnvSessionTokenVar] = sessionToken
 
 	return envVars, nil
 }
@@ -42,11 +56,69 @@ func (e *WindsorEnvPrinter) GetEnvVars() (map[string]string, error) {
 func (e *WindsorEnvPrinter) Print() error {
 	envVars, err := e.GetEnvVars()
 	if err != nil {
-		// Return the error if GetEnvVars fails
 		return fmt.Errorf("error getting environment variables: %w", err)
 	}
-	// Call the Print method of the embedded BaseEnvPrinter struct with the retrieved environment variables
 	return e.BaseEnvPrinter.Print(envVars)
+}
+
+// getSessionToken retrieves or generates a session token. It first checks if a token is already stored in memory.
+// If not, it looks for a token in the environment variable. If an environment token is found, it verifies the
+// existence of a corresponding signal file. If the signal file exists, it deletes the file and generates a new token.
+// If no token is found in the environment or no signal file exists, it generates a new token.
+func (e *WindsorEnvPrinter) getSessionToken() (string, error) {
+	if e.sessionToken != "" {
+		return e.sessionToken, nil
+	}
+
+	envToken := os.Getenv(EnvSessionTokenVar)
+	if envToken != "" {
+		projectRoot, err := e.shell.GetProjectRoot()
+		if err != nil {
+			return "", fmt.Errorf("error getting project root: %w", err)
+		}
+
+		windsorDir := filepath.Join(projectRoot, ".windsor")
+		tokenFilePath := filepath.Join(windsorDir, SessionTokenPrefix+envToken)
+		if _, err := stat(tokenFilePath); err == nil {
+			osRemoveAll(tokenFilePath)
+			token, err := e.generateRandomString(7)
+			if err != nil {
+				return "", fmt.Errorf("error generating session token: %w", err)
+			}
+
+			e.sessionToken = token
+			return token, nil
+		}
+
+		e.sessionToken = envToken
+		return envToken, nil
+	}
+
+	token, err := e.generateRandomString(7)
+	if err != nil {
+		return "", fmt.Errorf("error generating session token: %w", err)
+	}
+
+	e.sessionToken = token
+	return token, nil
+}
+
+// generateRandomString creates a secure random string of the given length using a predefined charset.
+func (e *WindsorEnvPrinter) generateRandomString(length int) (string, error) {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	randomBytes := make([]byte, length)
+
+	_, err := cryptoRandRead(randomBytes)
+	if err != nil {
+		return "", err
+	}
+
+	// Map random bytes to charset
+	for i, b := range randomBytes {
+		randomBytes[i] = charset[b%byte(len(charset))]
+	}
+
+	return string(randomBytes), nil
 }
 
 // Ensure WindsorEnvPrinter implements the EnvPrinter interface

--- a/pkg/env/windsor_env_test.go
+++ b/pkg/env/windsor_env_test.go
@@ -51,6 +51,18 @@ func setupSafeWindsorEnvMocks(injector ...di.Injector) *WindsorEnvMocks {
 }
 
 func TestWindsorEnv_GetEnvVars(t *testing.T) {
+	// Save original functions
+	originalStat := stat
+	originalOsRemoveAll := osRemoveAll
+	originalCryptoRandRead := cryptoRandRead
+
+	// Restore original functions after tests
+	defer func() {
+		stat = originalStat
+		osRemoveAll = originalOsRemoveAll
+		cryptoRandRead = originalCryptoRandRead
+	}()
+
 	t.Run("Success", func(t *testing.T) {
 		mocks := setupSafeWindsorEnvMocks()
 
@@ -70,6 +82,228 @@ func TestWindsorEnv_GetEnvVars(t *testing.T) {
 		if envVars["WINDSOR_PROJECT_ROOT"] != expectedProjectRoot {
 			t.Errorf("WINDSOR_PROJECT_ROOT = %v, want %v", envVars["WINDSOR_PROJECT_ROOT"], expectedProjectRoot)
 		}
+
+		// Verify session token is generated
+		if envVars[EnvSessionTokenVar] == "" {
+			t.Errorf("Expected session token to be generated, but it was empty")
+		}
+		if len(envVars[EnvSessionTokenVar]) != 7 {
+			t.Errorf("Expected session token to have length 7, got %d", len(envVars[EnvSessionTokenVar]))
+		}
+	})
+
+	t.Run("ExistingSessionToken", func(t *testing.T) {
+		mocks := setupSafeWindsorEnvMocks()
+
+		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Injector)
+		windsorEnvPrinter.Initialize()
+
+		// Set a session token directly
+		windsorEnvPrinter.sessionToken = "existing"
+
+		envVars, err := windsorEnvPrinter.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars returned an error: %v", err)
+		}
+
+		// Verify the existing session token is used
+		if envVars[EnvSessionTokenVar] != "existing" {
+			t.Errorf("Expected session token to be 'existing', got %s", envVars[EnvSessionTokenVar])
+		}
+	})
+
+	t.Run("EnvironmentTokenWithoutSignalFile", func(t *testing.T) {
+		mocks := setupSafeWindsorEnvMocks()
+
+		// Set up environment variable with a token
+		t.Setenv(EnvSessionTokenVar, "envtoken")
+
+		// Mock stat to simulate no signal file
+		stat = func(name string) (os.FileInfo, error) {
+			return nil, os.ErrNotExist
+		}
+
+		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Injector)
+		windsorEnvPrinter.Initialize()
+
+		envVars, err := windsorEnvPrinter.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars returned an error: %v", err)
+		}
+
+		// Verify the environment token is used
+		if envVars[EnvSessionTokenVar] != "envtoken" {
+			t.Errorf("Expected session token to be 'envtoken', got %s", envVars[EnvSessionTokenVar])
+		}
+	})
+
+	t.Run("EnvironmentTokenWithStatError", func(t *testing.T) {
+		mocks := setupSafeWindsorEnvMocks()
+
+		// Set up environment variable with a token
+		t.Setenv(EnvSessionTokenVar, "envtoken")
+
+		// Mock stat to return an error that is not os.ErrNotExist
+		stat = func(name string) (os.FileInfo, error) {
+			return nil, fmt.Errorf("mock stat error")
+		}
+
+		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Injector)
+		windsorEnvPrinter.Initialize()
+
+		envVars, err := windsorEnvPrinter.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars returned an error: %v", err)
+		}
+
+		// Verify the environment token is used, since the error is not specifically ErrNotExist
+		if envVars[EnvSessionTokenVar] != "envtoken" {
+			t.Errorf("Expected session token to be 'envtoken', got %s", envVars[EnvSessionTokenVar])
+		}
+	})
+
+	t.Run("EnvironmentTokenWithSignalFile", func(t *testing.T) {
+		// Mock file system functions
+		stat = func(name string) (os.FileInfo, error) {
+			if strings.Contains(name, ".session.envtoken") {
+				return nil, nil // File exists
+			}
+			return nil, os.ErrNotExist
+		}
+
+		osRemoveAll = func(path string) error {
+			return nil
+		}
+
+		// Mock crypto functions for predictable output
+		cryptoRandRead = func(b []byte) (n int, err error) {
+			for i := range b {
+				b[i] = byte(i % 62) // Will map to characters in charset
+			}
+			return len(b), nil
+		}
+
+		mocks := setupSafeWindsorEnvMocks()
+
+		// Set up environment variable with a token
+		t.Setenv(EnvSessionTokenVar, "envtoken")
+
+		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Injector)
+		windsorEnvPrinter.Initialize()
+
+		envVars, err := windsorEnvPrinter.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars returned an error: %v", err)
+		}
+
+		// Verify a new token was generated (not the env token)
+		if envVars[EnvSessionTokenVar] == "envtoken" {
+			t.Errorf("Expected a new token to be generated, but got the environment token")
+		}
+		if len(envVars[EnvSessionTokenVar]) != 7 {
+			t.Errorf("Expected session token to have length 7, got %d", len(envVars[EnvSessionTokenVar]))
+		}
+	})
+
+	t.Run("SignalFileRemovalError", func(t *testing.T) {
+		// Mock file system functions
+		stat = func(name string) (os.FileInfo, error) {
+			if strings.Contains(name, ".session.envtoken") {
+				return nil, nil // File exists
+			}
+			return nil, os.ErrNotExist
+		}
+
+		// Mock osRemoveAll to fail
+		osRemoveAll = func(path string) error {
+			return fmt.Errorf("mock error removing signal file")
+		}
+
+		// Mock crypto functions for predictable output
+		cryptoRandRead = func(b []byte) (n int, err error) {
+			for i := range b {
+				b[i] = byte(i % 62) // Will map to characters in charset
+			}
+			return len(b), nil
+		}
+
+		mocks := setupSafeWindsorEnvMocks()
+
+		// Set up environment variable with a token
+		t.Setenv(EnvSessionTokenVar, "envtoken")
+
+		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Injector)
+		windsorEnvPrinter.Initialize()
+
+		// Call should still succeed even if file removal fails
+		envVars, err := windsorEnvPrinter.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars returned an error: %v", err)
+		}
+
+		// Verify a new token was still generated
+		if envVars[EnvSessionTokenVar] == "envtoken" {
+			t.Errorf("Expected a new token to be generated, but got the environment token")
+		}
+		if len(envVars[EnvSessionTokenVar]) != 7 {
+			t.Errorf("Expected session token to have length 7, got %d", len(envVars[EnvSessionTokenVar]))
+		}
+	})
+
+	t.Run("ProjectRootErrorDuringEnvTokenSignalFileCheck", func(t *testing.T) {
+		// Mock file system and crypto functions
+		stat = func(name string) (os.FileInfo, error) {
+			// This mock won't be reached because we'll error out earlier
+			return nil, nil
+		}
+
+		// Set up environment variable with a token
+		t.Setenv(EnvSessionTokenVar, "envtoken")
+
+		mocks := setupSafeWindsorEnvMocks()
+
+		// First call succeeds, second fails
+		callCount := 0
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			callCount++
+			if callCount == 1 {
+				return filepath.FromSlash("/mock/project/root"), nil
+			}
+			return "", fmt.Errorf("mock error getting project root during token check")
+		}
+
+		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Injector)
+		windsorEnvPrinter.Initialize()
+
+		_, err := windsorEnvPrinter.GetEnvVars()
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+
+		expectedErr := "error retrieving session token: error getting project root: mock error getting project root during token check"
+		if err.Error() != expectedErr {
+			t.Errorf("Expected error %q, got %q", expectedErr, err.Error())
+		}
+	})
+
+	t.Run("RandomGenerationError", func(t *testing.T) {
+		// Mock crypto functions to return an error
+		cryptoRandRead = func(b []byte) (n int, err error) {
+			return 0, fmt.Errorf("mock random generation error")
+		}
+
+		mocks := setupSafeWindsorEnvMocks()
+
+		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Injector)
+		windsorEnvPrinter.Initialize()
+
+		_, err := windsorEnvPrinter.GetEnvVars()
+		if err == nil {
+			t.Fatal("Expected error from random generation, got nil")
+		}
+		if !strings.Contains(err.Error(), "error retrieving session token") {
+			t.Errorf("Unexpected error message: %v", err)
+		}
 	})
 
 	t.Run("GetProjectRootError", func(t *testing.T) {
@@ -87,6 +321,162 @@ func TestWindsorEnv_GetEnvVars(t *testing.T) {
 			t.Errorf("Expected error %q, got %v", expectedErrorMessage, err)
 		}
 	})
+
+	t.Run("ProjectRootErrorDuringTokenCheck", func(t *testing.T) {
+		mocks := setupSafeWindsorEnvMocks()
+
+		// Set up environment variable with a token to trigger the token check code path
+		t.Setenv(EnvSessionTokenVar, "envtoken")
+
+		// First call succeeds, second fails (for project root during token check)
+		callCount := 0
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			callCount++
+			if callCount == 1 {
+				return filepath.FromSlash("/mock/project/root"), nil
+			}
+			return "", fmt.Errorf("mock shell error during token check")
+		}
+
+		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Injector)
+		windsorEnvPrinter.Initialize()
+
+		_, err := windsorEnvPrinter.GetEnvVars()
+		if err == nil {
+			t.Error("Expected error, got nil")
+		} else if !strings.Contains(err.Error(), "error retrieving session token") {
+			t.Errorf("Unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("ComprehensiveEnvironmentTokenTest", func(t *testing.T) {
+		// Save original functions to restore later for this test case
+		origStat := stat
+		origOsRemoveAll := osRemoveAll
+		origCryptoRandRead := cryptoRandRead
+
+		// First clear any existing env token
+		t.Setenv(EnvSessionTokenVar, "")
+
+		// Mock random generation for first call
+		cryptoRandRead = func(b []byte) (n int, err error) {
+			for i := range b {
+				// Generate a predictable but distinct token for the first call
+				b[i] = byte('a' + (i % 26))
+			}
+			return len(b), nil
+		}
+
+		// Mock for initial call with no env token
+		mocks := setupSafeWindsorEnvMocks()
+		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Injector)
+		windsorEnvPrinter.Initialize()
+
+		// First get a token with no env set (should generate a new one)
+		envVars, err := windsorEnvPrinter.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars returned an error: %v", err)
+		}
+		firstToken := envVars[EnvSessionTokenVar]
+
+		// Now set the env token
+		t.Setenv(EnvSessionTokenVar, "testtoken")
+
+		// Reset the session token to force checking env
+		windsorEnvPrinter.sessionToken = ""
+
+		// Mock stat to return nil, nil for signal file (exists)
+		stat = func(name string) (os.FileInfo, error) {
+			if strings.Contains(name, ".session.testtoken") {
+				return nil, nil // File exists
+			}
+			return nil, os.ErrNotExist
+		}
+
+		// Mock removal to succeed
+		osRemoveAll = func(path string) error {
+			return nil
+		}
+
+		// Update crypto function to generate a different token for the second call
+		cryptoRandRead = func(b []byte) (n int, err error) {
+			for i := range b {
+				// Generate a predictable but distinct token from the first
+				b[i] = byte('A' + (i % 26))
+			}
+			return len(b), nil
+		}
+
+		// Second call with env token and signal file (should regenerate)
+		envVars, err = windsorEnvPrinter.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars returned an error: %v", err)
+		}
+		secondToken := envVars[EnvSessionTokenVar]
+
+		// Verify token was regenerated and is different from both env token and first token
+		if secondToken == "testtoken" {
+			t.Errorf("Token should not be the environment token, got %s", secondToken)
+		}
+		if secondToken == firstToken {
+			t.Errorf("Second token %s should be different from first token %s", secondToken, firstToken)
+		}
+
+		// Third call should use the cached session token
+		envVars, err = windsorEnvPrinter.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars returned an error: %v", err)
+		}
+		thirdToken := envVars[EnvSessionTokenVar]
+
+		// Verify cached token was used
+		if thirdToken != secondToken {
+			t.Errorf("Expected same token %s to be returned, but got %s", secondToken, thirdToken)
+		}
+
+		// Restore original functions
+		stat = origStat
+		osRemoveAll = origOsRemoveAll
+		cryptoRandRead = origCryptoRandRead
+	})
+
+	t.Run("RandomErrorDuringSignalFileRegeneration", func(t *testing.T) {
+		// Mock file system functions
+		stat = func(name string) (os.FileInfo, error) {
+			if strings.Contains(name, ".session.envtoken") {
+				return nil, nil // File exists
+			}
+			return nil, os.ErrNotExist
+		}
+
+		// Mock osRemoveAll to succeed
+		osRemoveAll = func(path string) error {
+			return nil
+		}
+
+		// Mock crypto functions to return an error during regeneration
+		cryptoRandRead = func(b []byte) (n int, err error) {
+			return 0, fmt.Errorf("mock random generation error during token regeneration")
+		}
+
+		mocks := setupSafeWindsorEnvMocks()
+
+		// Set up environment variable with a token
+		t.Setenv(EnvSessionTokenVar, "envtoken")
+
+		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Injector)
+		windsorEnvPrinter.Initialize()
+
+		// Call should fail with random generation error
+		_, err := windsorEnvPrinter.GetEnvVars()
+		if err == nil {
+			t.Fatal("Expected error from random generation during token regeneration, got nil")
+		}
+		if !strings.Contains(err.Error(), "error retrieving session token") ||
+			!strings.Contains(err.Error(), "error generating session token") {
+			t.Errorf("Unexpected error message: %v", err)
+		}
+	})
 }
 
 func TestWindsorEnv_PostEnvHook(t *testing.T) {
@@ -101,6 +491,12 @@ func TestWindsorEnv_PostEnvHook(t *testing.T) {
 }
 
 func TestWindsorEnv_Print(t *testing.T) {
+	// Save original stat function
+	originalStat := stat
+	defer func() {
+		stat = originalStat
+	}()
+
 	t.Run("Success", func(t *testing.T) {
 		// Use setupSafeWindsorEnvMocks to create mocks
 		mocks := setupSafeWindsorEnvMocks()
@@ -131,8 +527,9 @@ func TestWindsorEnv_Print(t *testing.T) {
 
 		// Verify that PrintEnvVarsFunc was called with the correct envVars
 		expectedEnvVars := map[string]string{
-			"WINDSOR_CONTEXT":      "mock-context",
-			"WINDSOR_PROJECT_ROOT": filepath.FromSlash("/mock/project/root"),
+			"WINDSOR_CONTEXT":       "mock-context",
+			"WINDSOR_PROJECT_ROOT":  filepath.FromSlash("/mock/project/root"),
+			"WINDSOR_SESSION_TOKEN": capturedEnvVars["WINDSOR_SESSION_TOKEN"], // Include session token
 		}
 		if !reflect.DeepEqual(capturedEnvVars, expectedEnvVars) {
 			t.Errorf("capturedEnvVars = %v, want %v", capturedEnvVars, expectedEnvVars)


### PR DESCRIPTION
The `WINDSOR_SESSION_TOKEN` is a session token that will be used to facilitate further encapsulation of the environment. It uses a session invalidation file to refresh the token on `windsor context set`. Additionally, new shell sessions get their own unique session token.