### PR TITLE
Strategic clearing of environment variables

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -14,7 +14,10 @@
         "request": "launch",
         "mode": "auto",
         "program": "${workspaceFolder}/cmd/windsor/main.go",
-        "args": ["env", "--verbose"]
+        "args": ["env", "--verbose"],
+        "env": {
+          "WINDSOR_SESSION_TOKEN": "local"
+        }
     },
     {
       "name": "Windsor Init",
@@ -74,6 +77,17 @@
       "env": {
         "WINDSOR_CONTEXT": "local",
         "WINDSOR_PROJECT_ROOT": "${workspaceFolder}"
+      }
+    },
+    {
+      "name": "Windsor Context Set",
+      "type": "go",
+      "request": "launch",
+      "mode": "auto",
+      "program": "${workspaceFolder}/cmd/windsor/main.go",
+      "args": ["context", "set", "local"],
+      "env": {
+        "WINDSOR_SESSION_TOKEN": "local",
       }
     }
   ]

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -16,6 +16,7 @@ var envCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		controller := cmd.Context().Value(controllerKey).(ctrl.Controller)
 		shell := controller.ResolveShell()
+		configHandler := controller.ResolveConfigHandler()
 
 		// Check trusted status
 		isTrusted := shell.CheckTrustedDirectory() == nil
@@ -23,13 +24,69 @@ var envCmd = &cobra.Command{
 		// Check if WINDSOR_SESSION_TOKEN is set - indicates we've been in a Windsor session
 		hasSessionToken := os.Getenv("WINDSOR_SESSION_TOKEN") != ""
 
+		// Check if a reset signal file exists for the current session
+		shouldReset, err := shell.CheckResetFlags()
+		if err != nil && verbose {
+			return fmt.Errorf("Error checking reset signal: %w", err)
+		}
+
+		// Set shouldReset to true if session token is not present
+		if !hasSessionToken {
+			shouldReset = true
+		}
+
 		// Early exit condition: Not trusted AND no session token
 		if !isTrusted && !hasSessionToken {
 			return nil
 		}
 
+		// Reset only when shouldReset is true (not based on trusted status)
+		if shouldReset {
+			shell.Reset()
+
+			// Set NO_CACHE=true to force fresh environment variable resolution
+			if err := osSetenv("NO_CACHE", "true"); err != nil && verbose {
+				return fmt.Errorf("Error setting NO_CACHE: %w", err)
+			}
+
+			// Only re-initialize components if we're in a trusted directory
+			if isTrusted {
+				// After reset, re-initialize the common components
+				if err := preRunEInitializeCommonComponents(cmd, args); err != nil {
+					return fmt.Errorf("Error initializing components after reset: %w", err)
+				}
+			}
+		}
+
+		// Create environment components
+		if err := controller.CreateEnvComponents(); err != nil {
+			if verbose {
+				return fmt.Errorf("Error creating environment components: %w", err)
+			}
+			return nil
+		}
+
+		if err := controller.InitializeComponents(); err != nil {
+			if verbose {
+				return fmt.Errorf("Error initializing components: %w", err)
+			}
+			return nil
+		}
+
+		// Set the environment variables internally in the process
+		if err := controller.SetEnvironmentVariables(); err != nil {
+			return fmt.Errorf("Error setting environment variables: %w", err)
+		}
+
+		envPrinters := controller.ResolveAllEnvPrinters()
+		if len(envPrinters) == 0 {
+			if verbose {
+				return fmt.Errorf("Error resolving environment printers: no printers returned")
+			}
+			return nil
+		}
+
 		// Resolve config handler to check vm.driver
-		configHandler := controller.ResolveConfigHandler()
 		vmDriver := configHandler.GetString("vm.driver")
 
 		// Create virtualization and service components only if vm.driver is configured
@@ -49,48 +106,25 @@ var envCmd = &cobra.Command{
 			}
 		}
 
-		// Create environment components
-		if err := controller.CreateEnvComponents(); err != nil {
-			if verbose {
-				return fmt.Errorf("Error creating environment components: %w", err)
-			}
-			return nil
-		}
-
-		// Initialize components
-		if err := controller.InitializeComponents(); err != nil {
-			if verbose {
-				return fmt.Errorf("Error initializing components: %w", err)
-			}
-			return nil
-		}
-
-		// Resolve environment printers
-		envPrinters := controller.ResolveAllEnvPrinters()
-		if len(envPrinters) == 0 {
-			if verbose {
-				return fmt.Errorf("Error resolving environment printers: no printers returned")
-			}
-			return nil
-		}
-
-		// Handle untrusted case with session token - reset and exit
-		if !isTrusted && hasSessionToken {
-			envPrinters[0].Reset()
-			return nil
-		}
-
 		// Check if --decrypt flag is set
 		decrypt, _ := cmd.Flags().GetBool("decrypt")
 		if decrypt {
 			// Unlock the SecretProvider
 			secretsProviders := controller.ResolveAllSecretsProviders()
-			for _, secretsProvider := range secretsProviders {
-				if err := secretsProvider.LoadSecrets(); err != nil {
-					if verbose {
-						return fmt.Errorf("Error loading secrets provider: %w", err)
+
+			// Check if there are any secrets providers available
+			if len(secretsProviders) == 0 {
+				if verbose {
+					fmt.Println("Warning: No secrets providers found. If you recently changed contexts, try running the command again.")
+				}
+			} else {
+				for _, secretsProvider := range secretsProviders {
+					if err := secretsProvider.LoadSecrets(); err != nil {
+						if verbose {
+							return fmt.Errorf("Error loading secrets provider: %w", err)
+						}
+						return nil
 					}
-					return nil
 				}
 			}
 		}

--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -1,10 +1,14 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
+	"github.com/windsorcli/cli/pkg/config"
 	ctrl "github.com/windsorcli/cli/pkg/controller"
 	"github.com/windsorcli/cli/pkg/di"
 	"github.com/windsorcli/cli/pkg/env"
@@ -12,109 +16,224 @@ import (
 	"github.com/windsorcli/cli/pkg/shell"
 )
 
+// TestMocks holds common mock objects used across tests
+type TestMocks struct {
+	Controller      *ctrl.MockController
+	Shell           *shell.MockShell
+	ConfigHandler   *config.MockConfigHandler
+	EnvPrinter      *env.MockEnvPrinter
+	SecretsProvider *secrets.MockSecretsProvider
+	Injector        di.Injector
+}
+
+func setupSafeMocks() *TestMocks {
+	injector := di.NewInjector()
+	mockController := ctrl.NewMockController(injector)
+
+	// Set up mock shell
+	mockShell := shell.NewMockShell(injector)
+	mockShell.CheckTrustedDirectoryFunc = func() error {
+		return nil // Directory is trusted by default
+	}
+	mockShell.CheckResetFlagsFunc = func() (bool, error) {
+		return false, nil // No reset needed by default
+	}
+	mockController.ResolveShellFunc = func() shell.Shell {
+		return mockShell
+	}
+
+	// Set up mock configuration handler
+	mockConfigHandler := config.NewMockConfigHandler()
+	mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+		if key == "vm.driver" {
+			return "mock-driver" // Return a value to trigger virtualization
+		}
+		return ""
+	}
+	mockController.ResolveConfigHandlerFunc = func() config.ConfigHandler {
+		return mockConfigHandler
+	}
+
+	// Set up mock env printer
+	mockEnvPrinter := env.NewMockEnvPrinter()
+	mockController.ResolveAllEnvPrintersFunc = func() []env.EnvPrinter {
+		return []env.EnvPrinter{mockEnvPrinter}
+	}
+
+	// Set up mock secrets provider
+	mockSecretsProvider := secrets.NewMockSecretsProvider()
+	mockController.ResolveAllSecretsProvidersFunc = func() []secrets.SecretsProvider {
+		return []secrets.SecretsProvider{mockSecretsProvider}
+	}
+
+	// Set up successful component mocks
+	mockController.CreateEnvComponentsFunc = func() error {
+		return nil
+	}
+	mockController.InitializeComponentsFunc = func() error {
+		return nil
+	}
+	mockController.CreateVirtualizationComponentsFunc = func() error {
+		return nil
+	}
+	mockController.CreateServiceComponentsFunc = func() error {
+		return nil
+	}
+
+	return &TestMocks{
+		Controller:      mockController,
+		Shell:           mockShell,
+		ConfigHandler:   mockConfigHandler,
+		EnvPrinter:      mockEnvPrinter,
+		SecretsProvider: mockSecretsProvider,
+		Injector:        injector,
+	}
+}
+
+// Creates a command for direct execution with the RunE function
+func createCommand(controller ctrl.Controller, setDecrypt bool) *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.Flags().Bool("decrypt", setDecrypt, "")
+	cmd.SetContext(context.WithValue(context.Background(), controllerKey, controller))
+	return cmd
+}
+
 func TestEnvCmd(t *testing.T) {
+	// Save original exit function
 	originalExitFunc := exitFunc
 	exitFunc = mockExit
 	t.Cleanup(func() {
 		exitFunc = originalExitFunc
 	})
 
+	// Save and restore all environment variables that might affect the tests
+	originalEnvVars := map[string]string{
+		"WINDSOR_SESSION_TOKEN": os.Getenv("WINDSOR_SESSION_TOKEN"),
+	}
+
+	// Unset the session token to start with a clean environment
+	os.Unsetenv("WINDSOR_SESSION_TOKEN")
+
+	// Restore the environment variables after the test
+	t.Cleanup(func() {
+		for name, value := range originalEnvVars {
+			if value != "" {
+				os.Setenv(name, value)
+			} else {
+				os.Unsetenv(name)
+			}
+		}
+	})
+
+	// Also reset the session token in the shell package
+	shell.ResetSessionToken()
+	t.Cleanup(func() {
+		shell.ResetSessionToken()
+	})
+
 	t.Run("Success", func(t *testing.T) {
 		defer resetRootCmd()
 
-		// Initialize mocks and set the injector
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
+		// Setup safe mocks
+		mocks := setupSafeMocks()
 
-		// Mock the GetEnvPrinters method to return the mockEnv
-		mockEnv := env.NewMockEnvPrinter()
-		mockEnv.PrintFunc = func() error {
+		// Set up specific mock for this test
+		printCalled := false
+		mocks.EnvPrinter.PrintFunc = func() error {
+			printCalled = true
 			fmt.Println("export VAR=value")
 			return nil
 		}
-		mockController.ResolveAllEnvPrintersFunc = func() []env.EnvPrinter {
-			return []env.EnvPrinter{mockEnv}
-		}
 
-		// Capture the output using captureStdout
+		// Force verbosity on the shell directly
+		mocks.Shell.SetVerbosity(true)
+
+		// Set a session token to avoid reset logic
+		os.Setenv("WINDSOR_SESSION_TOKEN", "test-token")
+		defer os.Unsetenv("WINDSOR_SESSION_TOKEN")
+
+		// Set up verbose mode for this test
+		verbose = true
+		defer func() { verbose = false }()
+
+		// Capture stdout and execute command directly
 		output := captureStdout(func() {
-			rootCmd.SetArgs([]string{"env", "--verbose"})
-			err := Execute(mockController)
+			cmd := createCommand(mocks.Controller, false)
+			err := envCmd.RunE(cmd, []string{})
 			if err != nil {
 				t.Fatalf("Expected no error, got %v", err)
 			}
 		})
 
-		// Verify the output
-		expectedOutput := "export VAR=value\n"
-		if output != expectedOutput {
-			t.Errorf("Expected output %q, got %q", expectedOutput, output)
+		// Check if Print method was called
+		if !printCalled {
+			t.Fatalf("Print method was not called")
+		}
+
+		// Verify the output contains the expected string
+		if !strings.Contains(output, "export VAR=value") {
+			t.Errorf("Expected output to contain %q, but got %q", "export VAR=value", output)
 		}
 	})
 
 	t.Run("ResetWhenInUntrustedDirectoryWithSession", func(t *testing.T) {
 		defer resetRootCmd()
 
-		// Given a mock shell that returns an error when checking trusted directory
-		injector := di.NewInjector()
-		mockShell := shell.NewMockShell(injector)
-		mockShell.CheckTrustedDirectoryFunc = func() error {
+		// Setup safe mocks
+		mocks := setupSafeMocks()
+
+		// Mock the shell to return an untrusted directory
+		mocks.Shell.CheckTrustedDirectoryFunc = func() error {
 			return fmt.Errorf("error checking trusted directory")
 		}
 
-		// Set the shell in the controller to the mock shell
-		mockController := ctrl.NewMockController(injector)
-		mockController.ResolveShellFunc = func() shell.Shell {
-			return mockShell
+		// Make sure CheckResetFlags behaves as expected
+		mocks.Shell.CheckResetFlagsFunc = func() (bool, error) {
+			// Confirm the environment variable is set
+			if os.Getenv("WINDSOR_SESSION_TOKEN") != "test-session" {
+				t.Fatalf("Expected WINDSOR_SESSION_TOKEN to be 'test-session', got '%s'", os.Getenv("WINDSOR_SESSION_TOKEN"))
+			}
+			return false, nil
+		}
+
+		// Track calls to shell.Reset
+		resetCalled := false
+		mocks.Shell.ResetFunc = func() {
+			resetCalled = true
 		}
 
 		// Set WINDSOR_SESSION_TOKEN to simulate being in a Windsor session
-		oldToken := os.Getenv("WINDSOR_SESSION_TOKEN")
 		os.Setenv("WINDSOR_SESSION_TOKEN", "test-session")
-		defer os.Setenv("WINDSOR_SESSION_TOKEN", oldToken)
-
-		// Mock environment printer to capture the Reset call
-		mockEnv := env.NewMockEnvPrinter()
-		resetCalled := false
-		mockEnv.ResetFunc = func() {
-			resetCalled = true
-		}
-		mockController.ResolveAllEnvPrintersFunc = func() []env.EnvPrinter {
-			return []env.EnvPrinter{mockEnv}
-		}
+		// Clean up after the test
+		defer os.Unsetenv("WINDSOR_SESSION_TOKEN")
 
 		// When the env command is executed with verbose flag
 		rootCmd.SetArgs([]string{"env", "--verbose"})
-		err := Execute(mockController)
+		err := Execute(mocks.Controller)
 
-		// Then no error should be returned, but Reset should be called
+		// Then no error should be returned, and Reset should NOT be called
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
-		if !resetCalled {
-			t.Fatalf("Expected Reset to be called, but it wasn't")
+		if resetCalled {
+			t.Fatalf("Expected Reset NOT to be called, but it was")
 		}
 	})
 
 	t.Run("NoActionWhenInUntrustedDirectoryWithoutSession", func(t *testing.T) {
 		defer resetRootCmd()
 
-		// Given a mock shell that returns an error when checking trusted directory
-		injector := di.NewInjector()
-		mockShell := shell.NewMockShell(injector)
-		mockShell.CheckTrustedDirectoryFunc = func() error {
-			return fmt.Errorf("error checking trusted directory")
-		}
+		// Setup safe mocks
+		mocks := setupSafeMocks()
 
-		// Set the shell in the controller to the mock shell
-		mockController := ctrl.NewMockController(injector)
-		mockController.ResolveShellFunc = func() shell.Shell {
-			return mockShell
+		// Mock the shell to return an untrusted directory
+		mocks.Shell.CheckTrustedDirectoryFunc = func() error {
+			return fmt.Errorf("error checking trusted directory")
 		}
 
 		// When the env command is executed without verbose flag
 		rootCmd.SetArgs([]string{"env"})
-		err := Execute(mockController)
+		err := Execute(mocks.Controller)
 
 		// Then no error should be returned
 		if err != nil {
@@ -122,27 +241,35 @@ func TestEnvCmd(t *testing.T) {
 		}
 	})
 
-	for _, verbose := range []bool{true, false} {
-		t.Run(fmt.Sprintf("ErrorCreatingVirtualizationComponentsWithVerbose=%v", verbose), func(t *testing.T) {
+	for _, verboseFlag := range []bool{true, false} {
+		t.Run(fmt.Sprintf("ErrorCreatingVirtualizationComponentsWithVerbose=%v", verboseFlag), func(t *testing.T) {
 			defer resetRootCmd()
 
-			// Given a mock controller that returns an error when creating virtualization components
-			injector := di.NewInjector()
-			mockController := ctrl.NewMockController(injector)
-			mockController.CreateVirtualizationComponentsFunc = func() error {
+			// Setup safe mocks
+			mocks := setupSafeMocks()
+
+			// Force verbosity on the shell directly
+			mocks.Shell.SetVerbosity(verboseFlag)
+
+			// Set up failing virtualization component
+			mocks.Controller.CreateVirtualizationComponentsFunc = func() error {
 				return fmt.Errorf("error creating virtualization components")
 			}
 
-			// When the env command is executed with or without verbose flag
-			if verbose {
-				rootCmd.SetArgs([]string{"env", "--verbose"})
-			} else {
-				rootCmd.SetArgs([]string{"env"})
-			}
-			err := Execute(mockController)
+			// Set a session token to avoid reset logic
+			os.Setenv("WINDSOR_SESSION_TOKEN", "test-token")
+			defer os.Unsetenv("WINDSOR_SESSION_TOKEN")
 
-			// Then check the error contents
-			if verbose {
+			// Set verbose flag for this test
+			verbose = verboseFlag
+			defer func() { verbose = false }()
+
+			// Create command and execute directly
+			cmd := createCommand(mocks.Controller, false)
+			err := envCmd.RunE(cmd, []string{})
+
+			// Then check for the expected result based on verbosity
+			if verboseFlag {
 				if err == nil {
 					t.Fatalf("Expected an error, got nil")
 				}
@@ -158,27 +285,35 @@ func TestEnvCmd(t *testing.T) {
 		})
 	}
 
-	for _, verbose := range []bool{true, false} {
-		t.Run(fmt.Sprintf("ErrorCreatingServiceComponentsWithVerbose=%v", verbose), func(t *testing.T) {
+	for _, verboseFlag := range []bool{true, false} {
+		t.Run(fmt.Sprintf("ErrorCreatingServiceComponentsWithVerbose=%v", verboseFlag), func(t *testing.T) {
 			defer resetRootCmd()
 
-			// Given a mock controller that returns an error when creating service components
-			injector := di.NewInjector()
-			mockController := ctrl.NewMockController(injector)
-			mockController.CreateServiceComponentsFunc = func() error {
+			// Setup safe mocks
+			mocks := setupSafeMocks()
+
+			// Force verbosity on the shell directly
+			mocks.Shell.SetVerbosity(verboseFlag)
+
+			// Set up failing service component
+			mocks.Controller.CreateServiceComponentsFunc = func() error {
 				return fmt.Errorf("error creating service components")
 			}
 
-			// When the env command is executed with or without verbose flag
-			if verbose {
-				rootCmd.SetArgs([]string{"env", "--verbose"})
-			} else {
-				rootCmd.SetArgs([]string{"env"})
-			}
-			err := Execute(mockController)
+			// Set a session token to avoid reset logic
+			os.Setenv("WINDSOR_SESSION_TOKEN", "test-token")
+			defer os.Unsetenv("WINDSOR_SESSION_TOKEN")
 
-			// Then check the error contents
-			if verbose {
+			// Set verbose flag for this test
+			verbose = verboseFlag
+			defer func() { verbose = false }()
+
+			// Create command and execute directly
+			cmd := createCommand(mocks.Controller, false)
+			err := envCmd.RunE(cmd, []string{})
+
+			// Then check for the expected result based on verbosity
+			if verboseFlag {
 				if err == nil {
 					t.Fatalf("Expected an error, got nil")
 				}
@@ -197,16 +332,17 @@ func TestEnvCmd(t *testing.T) {
 	t.Run("ErrorCreatingEnvComponents", func(t *testing.T) {
 		defer resetRootCmd()
 
-		// Given a mock controller that returns an error when creating environment components
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
-		mockController.CreateEnvComponentsFunc = func() error {
+		// Setup safe mocks
+		mocks := setupSafeMocks()
+
+		// Set failing env components creation
+		mocks.Controller.CreateEnvComponentsFunc = func() error {
 			return fmt.Errorf("error creating environment components")
 		}
 
 		// When the env command is executed with verbose flag
 		rootCmd.SetArgs([]string{"env", "--verbose"})
-		err := Execute(mockController)
+		err := Execute(mocks.Controller)
 
 		// Then check the error contents
 		if err == nil {
@@ -221,16 +357,17 @@ func TestEnvCmd(t *testing.T) {
 	t.Run("ErrorCreatingEnvComponentsWithoutVerbose", func(t *testing.T) {
 		defer resetRootCmd()
 
-		// Given a mock controller that returns an error when creating environment components
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
-		mockController.CreateEnvComponentsFunc = func() error {
+		// Setup safe mocks
+		mocks := setupSafeMocks()
+
+		// Set failing env components creation
+		mocks.Controller.CreateEnvComponentsFunc = func() error {
 			return fmt.Errorf("error creating environment components")
 		}
 
 		// When the env command is executed without verbose flag
 		rootCmd.SetArgs([]string{"env"})
-		err := Execute(mockController)
+		err := Execute(mocks.Controller)
 
 		// Then the error should be nil and no output should be produced
 		if err != nil {
@@ -241,16 +378,22 @@ func TestEnvCmd(t *testing.T) {
 	t.Run("ErrorInitializingComponents", func(t *testing.T) {
 		defer resetRootCmd()
 
-		// Given a mock controller that returns an error when initializing components
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
-		mockController.InitializeComponentsFunc = func() error {
+		// Setup safe mocks
+		mocks := setupSafeMocks()
+
+		// Setup that a reset is needed
+		mocks.Shell.CheckResetFlagsFunc = func() (bool, error) {
+			return true, nil
+		}
+
+		// Set failing component initialization
+		mocks.Controller.InitializeComponentsFunc = func() error {
 			return fmt.Errorf("error initializing components")
 		}
 
 		// When the env command is executed with verbose flag
 		rootCmd.SetArgs([]string{"env", "--verbose"})
-		err := Execute(mockController)
+		err := Execute(mocks.Controller)
 
 		// Then check the error contents
 		if err == nil {
@@ -265,16 +408,17 @@ func TestEnvCmd(t *testing.T) {
 	t.Run("ErrorInitializingComponentsWithoutVerbose", func(t *testing.T) {
 		defer resetRootCmd()
 
-		// Given a mock controller that returns an error when initializing components
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
-		mockController.InitializeComponentsFunc = func() error {
+		// Setup safe mocks
+		mocks := setupSafeMocks()
+
+		// Set failing component initialization
+		mocks.Controller.InitializeComponentsFunc = func() error {
 			return fmt.Errorf("error initializing components")
 		}
 
 		// When the env command is executed without verbose flag
 		rootCmd.SetArgs([]string{"env"})
-		err := Execute(mockController)
+		err := Execute(mocks.Controller)
 
 		// Then the error should be nil and no output should be produced
 		if err != nil {
@@ -285,16 +429,17 @@ func TestEnvCmd(t *testing.T) {
 	t.Run("ResolveAllEnvPrintersErrorWithoutVerbose", func(t *testing.T) {
 		defer resetRootCmd()
 
-		// Given a mock controller that returns an error when resolving all environment printers
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
-		mockController.ResolveAllEnvPrintersFunc = func() []env.EnvPrinter {
+		// Setup safe mocks
+		mocks := setupSafeMocks()
+
+		// Return nil for env printers
+		mocks.Controller.ResolveAllEnvPrintersFunc = func() []env.EnvPrinter {
 			return nil
 		}
 
 		// When the env command is executed without verbose flag
 		rootCmd.SetArgs([]string{"env"})
-		err := Execute(mockController)
+		err := Execute(mocks.Controller)
 
 		// Then the error should be nil and no output should be produced
 		if err != nil {
@@ -305,16 +450,17 @@ func TestEnvCmd(t *testing.T) {
 	t.Run("ErrorResolvingAllEnvPrinters", func(t *testing.T) {
 		defer resetRootCmd()
 
-		// Given a mock controller that returns an empty list of environment printers
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
-		mockController.ResolveAllEnvPrintersFunc = func() []env.EnvPrinter {
+		// Setup safe mocks
+		mocks := setupSafeMocks()
+
+		// Return empty list for env printers
+		mocks.Controller.ResolveAllEnvPrintersFunc = func() []env.EnvPrinter {
 			return []env.EnvPrinter{}
 		}
 
 		// When the env command is executed with verbose flag
 		rootCmd.SetArgs([]string{"env", "--verbose"})
-		err := Execute(mockController)
+		err := Execute(mocks.Controller)
 
 		// Then check the error contents
 		if err == nil {
@@ -329,20 +475,25 @@ func TestEnvCmd(t *testing.T) {
 	t.Run("PrintError", func(t *testing.T) {
 		defer resetRootCmd()
 
-		// Given a mock controller that returns a valid list of environment printers
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
-		mockEnvPrinter := env.NewMockEnvPrinter()
-		mockEnvPrinter.PrintFunc = func() error {
+		// Setup safe mocks
+		mocks := setupSafeMocks()
+
+		// Set up mock environment printer that returns an error on Print
+		mocks.EnvPrinter.PrintFunc = func() error {
 			return fmt.Errorf("print error")
 		}
-		mockController.ResolveAllEnvPrintersFunc = func() []env.EnvPrinter {
-			return []env.EnvPrinter{mockEnvPrinter}
-		}
 
-		// When the env command is executed with verbose flag
-		rootCmd.SetArgs([]string{"env", "--verbose"})
-		err := Execute(mockController)
+		// Set a session token to avoid reset logic
+		os.Setenv("WINDSOR_SESSION_TOKEN", "test-token")
+		defer os.Unsetenv("WINDSOR_SESSION_TOKEN")
+
+		// Set verbose flag for this test
+		verbose = true
+		defer func() { verbose = false }()
+
+		// Create command and execute directly
+		cmd := createCommand(mocks.Controller, false)
+		err := envCmd.RunE(cmd, []string{})
 
 		// Then check the error contents
 		if err == nil {
@@ -357,20 +508,17 @@ func TestEnvCmd(t *testing.T) {
 	t.Run("PrintErrorWithoutVerbose", func(t *testing.T) {
 		defer resetRootCmd()
 
-		// Given a mock controller that returns a valid list of environment printers
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
-		mockEnvPrinter := env.NewMockEnvPrinter()
-		mockEnvPrinter.PrintFunc = func() error {
+		// Setup safe mocks
+		mocks := setupSafeMocks()
+
+		// Set up mock environment printer that returns an error on Print
+		mocks.EnvPrinter.PrintFunc = func() error {
 			return fmt.Errorf("print error")
-		}
-		mockController.ResolveAllEnvPrintersFunc = func() []env.EnvPrinter {
-			return []env.EnvPrinter{mockEnvPrinter}
 		}
 
 		// When the env command is executed without verbose flag
 		rootCmd.SetArgs([]string{"env"})
-		err := Execute(mockController)
+		err := Execute(mocks.Controller)
 
 		// Then the error should be nil and no output should be produced
 		if err != nil {
@@ -381,20 +529,25 @@ func TestEnvCmd(t *testing.T) {
 	t.Run("PostEnvHookError", func(t *testing.T) {
 		defer resetRootCmd()
 
-		// Given a mock controller that returns a valid list of environment printers
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
-		mockEnvPrinter := env.NewMockEnvPrinter()
-		mockEnvPrinter.PostEnvHookFunc = func() error {
+		// Setup safe mocks
+		mocks := setupSafeMocks()
+
+		// Set up mock environment printer that returns an error on PostEnvHook
+		mocks.EnvPrinter.PostEnvHookFunc = func() error {
 			return fmt.Errorf("post env hook error")
 		}
-		mockController.ResolveAllEnvPrintersFunc = func() []env.EnvPrinter {
-			return []env.EnvPrinter{mockEnvPrinter}
-		}
 
-		// When the env command is executed with verbose flag
-		rootCmd.SetArgs([]string{"env", "--verbose"})
-		err := Execute(mockController)
+		// Set a session token to avoid reset logic
+		os.Setenv("WINDSOR_SESSION_TOKEN", "test-token")
+		defer os.Unsetenv("WINDSOR_SESSION_TOKEN")
+
+		// Set verbose flag for this test
+		verbose = true
+		defer func() { verbose = false }()
+
+		// Create command and execute directly
+		cmd := createCommand(mocks.Controller, false)
+		err := envCmd.RunE(cmd, []string{})
 
 		// Then check the error contents
 		if err == nil {
@@ -409,20 +562,17 @@ func TestEnvCmd(t *testing.T) {
 	t.Run("PostEnvHookErrorWithoutVerbose", func(t *testing.T) {
 		defer resetRootCmd()
 
-		// Given a mock controller that returns a valid list of environment printers
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
-		mockEnvPrinter := env.NewMockEnvPrinter()
-		mockEnvPrinter.PostEnvHookFunc = func() error {
+		// Setup safe mocks
+		mocks := setupSafeMocks()
+
+		// Set up mock environment printer that returns an error on PostEnvHook
+		mocks.EnvPrinter.PostEnvHookFunc = func() error {
 			return fmt.Errorf("post env hook error")
-		}
-		mockController.ResolveAllEnvPrintersFunc = func() []env.EnvPrinter {
-			return []env.EnvPrinter{mockEnvPrinter}
 		}
 
 		// When the env command is executed without verbose flag
 		rootCmd.SetArgs([]string{"env"})
-		err := Execute(mockController)
+		err := Execute(mocks.Controller)
 
 		// Then the error should be nil and no output should be produced
 		if err != nil {
@@ -433,22 +583,23 @@ func TestEnvCmd(t *testing.T) {
 	t.Run("DecryptFlag", func(t *testing.T) {
 		defer resetRootCmd()
 
-		// Given a mock controller with a mock secrets provider
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
-		mockSecretsProvider := secrets.NewMockSecretsProvider()
+		// Setup safe mocks
+		mocks := setupSafeMocks()
+
+		// Set up mock secrets provider to track when it's loaded
 		loadCalled := false
-		mockSecretsProvider.LoadSecretsFunc = func() error {
+		mocks.SecretsProvider.LoadSecretsFunc = func() error {
 			loadCalled = true
-			return nil // or return an error if needed for testing
-		}
-		mockController.ResolveAllSecretsProvidersFunc = func() []secrets.SecretsProvider {
-			return []secrets.SecretsProvider{mockSecretsProvider}
+			return nil
 		}
 
-		// When the env command is executed with the --decrypt flag
-		rootCmd.SetArgs([]string{"env", "--decrypt"})
-		err := Execute(mockController)
+		// Set a session token to avoid reset logic
+		os.Setenv("WINDSOR_SESSION_TOKEN", "test-token")
+		defer os.Unsetenv("WINDSOR_SESSION_TOKEN")
+
+		// Create command with decrypt flag set to true and execute directly
+		cmd := createCommand(mocks.Controller, true)
+		err := envCmd.RunE(cmd, []string{})
 
 		// Then the secrets provider's LoadSecrets function should be called
 		if err != nil {
@@ -462,20 +613,25 @@ func TestEnvCmd(t *testing.T) {
 	t.Run("ErrorLoadingSecretsProvider", func(t *testing.T) {
 		defer resetRootCmd()
 
-		// Given a mock controller with a mock secrets provider that returns an error on load
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
-		mockSecretsProvider := secrets.NewMockSecretsProvider()
-		mockSecretsProvider.LoadSecretsFunc = func() error {
+		// Setup safe mocks
+		mocks := setupSafeMocks()
+
+		// Set up mock secrets provider that returns an error
+		mocks.SecretsProvider.LoadSecretsFunc = func() error {
 			return fmt.Errorf("load error")
 		}
-		mockController.ResolveAllSecretsProvidersFunc = func() []secrets.SecretsProvider {
-			return []secrets.SecretsProvider{mockSecretsProvider}
-		}
 
-		// When the env command is executed with the --decrypt flag and verbose mode
-		rootCmd.SetArgs([]string{"env", "--decrypt", "--verbose"})
-		err := Execute(mockController)
+		// Set a session token to avoid reset logic
+		os.Setenv("WINDSOR_SESSION_TOKEN", "test-token")
+		defer os.Unsetenv("WINDSOR_SESSION_TOKEN")
+
+		// Set verbose flag for this test
+		verbose = true
+		defer func() { verbose = false }()
+
+		// Create command with decrypt flag set to true and execute directly
+		cmd := createCommand(mocks.Controller, true)
+		err := envCmd.RunE(cmd, []string{})
 
 		// Then the error should indicate the load error
 		if err == nil || err.Error() != "Error loading secrets provider: load error" {
@@ -483,20 +639,316 @@ func TestEnvCmd(t *testing.T) {
 		}
 	})
 
+	t.Run("ErrorCheckingResetFlags", func(t *testing.T) {
+		defer resetRootCmd()
+
+		// Setup safe mocks
+		mocks := setupSafeMocks()
+
+		// Mock the shell to return an error when checking reset flags
+		mocks.Shell.CheckResetFlagsFunc = func() (bool, error) {
+			return false, fmt.Errorf("error checking reset flags")
+		}
+
+		// Set a session token to avoid early exit from missing token
+		os.Setenv("WINDSOR_SESSION_TOKEN", "test-token")
+		defer os.Unsetenv("WINDSOR_SESSION_TOKEN")
+
+		// Set verbose flag for this test
+		verbose = true
+		defer func() { verbose = false }()
+
+		// When env command is executed with verbose flag
+		cmd := createCommand(mocks.Controller, false)
+		err := envCmd.RunE(cmd, []string{})
+
+		// Then check the error contents
+		if err == nil {
+			t.Fatalf("Expected an error, got nil")
+		}
+		expectedError := "Error checking reset signal: error checking reset flags"
+		if err.Error() != expectedError {
+			t.Fatalf("Expected error %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("ErrorCheckingResetFlagsWithoutVerbose", func(t *testing.T) {
+		defer resetRootCmd()
+
+		// Setup safe mocks
+		mocks := setupSafeMocks()
+
+		// Mock the shell to return an error when checking reset flags
+		mocks.Shell.CheckResetFlagsFunc = func() (bool, error) {
+			return false, fmt.Errorf("error checking reset flags")
+		}
+
+		// Set a session token to avoid early exit from missing token
+		os.Setenv("WINDSOR_SESSION_TOKEN", "test-token")
+		defer os.Unsetenv("WINDSOR_SESSION_TOKEN")
+
+		// Ensure verbose flag is not set for this test
+		verbose = false
+
+		// When env command is executed without verbose flag
+		cmd := createCommand(mocks.Controller, false)
+		err := envCmd.RunE(cmd, []string{})
+
+		// Then no error should be returned
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("ResetWithDecryptFlagStillLoadsSecrets", func(t *testing.T) {
+		defer resetRootCmd()
+
+		// Setup safe mocks
+		mocks := setupSafeMocks()
+
+		// Set up tracking variables to check execution order
+		resetCalled := false
+		loadSecretsCalled := false
+
+		// Mock shell.CheckResetFlags to return shouldReset=true (simulating post-context change)
+		mocks.Shell.CheckResetFlagsFunc = func() (bool, error) {
+			return true, nil // Indicate reset is needed
+		}
+
+		// Mock shell.Reset to track when it's called
+		mocks.Shell.ResetFunc = func() {
+			resetCalled = true
+		}
+
+		// Mock secrets provider LoadSecrets to track when it's called
+		mocks.SecretsProvider.LoadSecretsFunc = func() error {
+			// Ensure Reset was called before LoadSecrets
+			if !resetCalled {
+				t.Fatalf("Expected Reset to be called before LoadSecrets")
+			}
+			loadSecretsCalled = true
+			return nil
+		}
+
+		// Set a session token to avoid early exit from missing token
+		os.Setenv("WINDSOR_SESSION_TOKEN", "test-token")
+		defer os.Unsetenv("WINDSOR_SESSION_TOKEN")
+
+		// Create command with decrypt flag enabled
+		cmd := createCommand(mocks.Controller, true) // Set decrypt flag to true
+		err := envCmd.RunE(cmd, []string{})
+
+		// Verify no errors occurred
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Verify Reset was called
+		if !resetCalled {
+			t.Fatalf("Expected Reset to be called")
+		}
+
+		// Verify LoadSecrets was called after Reset
+		if !loadSecretsCalled {
+			t.Fatalf("Expected LoadSecrets to be called after Reset")
+		}
+	})
+
+	t.Run("ContextSwitchSimulation", func(t *testing.T) {
+		defer resetRootCmd()
+
+		// Setup safe mocks
+		mocks := setupSafeMocks()
+
+		// Track all method calls to observe execution flow
+		var callOrder []string
+
+		// Set up reset condition (simulating post-context change)
+		mocks.Shell.CheckResetFlagsFunc = func() (bool, error) {
+			callOrder = append(callOrder, "CheckResetFlags")
+			return true, nil // Indicate reset is needed
+		}
+
+		mocks.Shell.ResetFunc = func() {
+			callOrder = append(callOrder, "Reset")
+		}
+
+		// Track component initialization
+		mocks.Controller.CreateEnvComponentsFunc = func() error {
+			callOrder = append(callOrder, "CreateEnvComponents")
+			return nil
+		}
+
+		mocks.Controller.InitializeComponentsFunc = func() error {
+			callOrder = append(callOrder, "InitializeComponents")
+			return nil
+		}
+
+		// Track service and virtualization components
+		mocks.Controller.CreateServiceComponentsFunc = func() error {
+			callOrder = append(callOrder, "CreateServiceComponents")
+			return nil
+		}
+
+		mocks.Controller.CreateVirtualizationComponentsFunc = func() error {
+			callOrder = append(callOrder, "CreateVirtualizationComponents")
+			return nil
+		}
+
+		// Track secrets provider loading
+		secretsLoaded := false
+		mocks.SecretsProvider.LoadSecretsFunc = func() error {
+			callOrder = append(callOrder, "LoadSecrets")
+			secretsLoaded = true
+			return nil
+		}
+
+		// Track environment printer methods
+		mocks.EnvPrinter.PrintFunc = func() error {
+			callOrder = append(callOrder, "EnvPrinter.Print")
+			return nil
+		}
+
+		mocks.EnvPrinter.PostEnvHookFunc = func() error {
+			callOrder = append(callOrder, "EnvPrinter.PostEnvHook")
+			return nil
+		}
+
+		// Set session token
+		os.Setenv("WINDSOR_SESSION_TOKEN", "test-token")
+		defer os.Unsetenv("WINDSOR_SESSION_TOKEN")
+
+		// Create command with decrypt flag enabled
+		cmd := createCommand(mocks.Controller, true) // Set decrypt flag to true
+		err := envCmd.RunE(cmd, []string{})
+
+		// Verify no errors occurred
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Check if all expected methods were called
+		expectedCalls := []string{
+			"CheckResetFlags",
+			"Reset",
+			"CreateEnvComponents",
+			"InitializeComponents",
+			"CreateVirtualizationComponents",
+			"CreateServiceComponents",
+			"LoadSecrets",
+			"EnvPrinter.Print",
+			"EnvPrinter.PostEnvHook",
+		}
+
+		// Verify all expected calls are in callOrder (though not necessarily in this exact order)
+		for _, expectedCall := range expectedCalls {
+			found := false
+			for _, actualCall := range callOrder {
+				if actualCall == expectedCall {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Fatalf("Expected method '%s' to be called, but it wasn't. Call order: %v", expectedCall, callOrder)
+			}
+		}
+
+		// Verify secrets were loaded
+		if !secretsLoaded {
+			t.Fatalf("Expected secrets to be loaded")
+		}
+
+		// Check specific order of key operations
+		resetIndex := -1
+		loadSecretsIndex := -1
+
+		for i, call := range callOrder {
+			if call == "Reset" {
+				resetIndex = i
+			}
+			if call == "LoadSecrets" {
+				loadSecretsIndex = i
+			}
+		}
+
+		if resetIndex >= loadSecretsIndex {
+			t.Fatalf("Expected LoadSecrets (%d) to be called after Reset (%d), but it wasn't", loadSecretsIndex, resetIndex)
+		}
+	})
+
+	t.Run("ResetWithNoSecretsProviders", func(t *testing.T) {
+		defer resetRootCmd()
+
+		// Setup safe mocks
+		mocks := setupSafeMocks()
+
+		// Set up reset condition (simulating post-context change)
+		mocks.Shell.CheckResetFlagsFunc = func() (bool, error) {
+			return true, nil // Indicate reset is needed
+		}
+
+		// Track what happens during Reset
+		var resolveAllSecretProvidersCalled bool
+		var secretsProvidersAfterReset []secrets.SecretsProvider
+
+		// Override the controller's ResolveAllSecretsProviders function to track when it's called
+		mocks.Controller.ResolveAllSecretsProvidersFunc = func() []secrets.SecretsProvider {
+			resolveAllSecretProvidersCalled = true
+
+			// For testing, return empty list first time after reset, then return a provider on subsequent calls
+			if secretsProvidersAfterReset == nil {
+				secretsProvidersAfterReset = []secrets.SecretsProvider{}
+				return secretsProvidersAfterReset
+			}
+
+			// On any subsequent calls, add a provider
+			mockProvider := secrets.NewMockSecretsProvider()
+			return []secrets.SecretsProvider{mockProvider}
+		}
+
+		// Set session token
+		os.Setenv("WINDSOR_SESSION_TOKEN", "test-token")
+		defer os.Unsetenv("WINDSOR_SESSION_TOKEN")
+
+		// Create command with decrypt flag enabled
+		cmd := createCommand(mocks.Controller, true) // Set decrypt flag to true
+		err := envCmd.RunE(cmd, []string{})
+
+		// Check for errors
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Verify the function was called
+		if !resolveAllSecretProvidersCalled {
+			t.Fatalf("Expected ResolveAllSecretsProviders to be called")
+		}
+
+		// Verify the list returned no providers after reset
+		if len(secretsProvidersAfterReset) != 0 {
+			t.Fatalf("Expected empty list of secrets providers after reset, but got %d providers", len(secretsProvidersAfterReset))
+		}
+
+		// Simulate a second call - the controller should now return a provider
+		providers := mocks.Controller.ResolveAllSecretsProviders()
+		if len(providers) == 0 {
+			t.Fatalf("Expected at least one secrets provider on second call")
+		}
+	})
+
 	t.Run("ContinuesThroughPrinterErrors", func(t *testing.T) {
 		defer resetRootCmd()
 
-		// Given a mock controller with multiple environment printers
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
+		// Setup safe mocks
+		mocks := setupSafeMocks()
 
-		// First printer that will error on Print
+		// Set up multiple printers - first one fails, second one succeeds
 		failingPrinter := env.NewMockEnvPrinter()
 		failingPrinter.PrintFunc = func() error {
 			return fmt.Errorf("first printer error")
 		}
 
-		// Second printer to verify it still gets called
 		secondPrinterCalled := false
 		successPrinter := env.NewMockEnvPrinter()
 		successPrinter.PrintFunc = func() error {
@@ -504,20 +956,24 @@ func TestEnvCmd(t *testing.T) {
 			return nil
 		}
 
-		mockController.ResolveAllEnvPrintersFunc = func() []env.EnvPrinter {
+		// Override the printer list with our custom printers
+		mocks.Controller.ResolveAllEnvPrintersFunc = func() []env.EnvPrinter {
 			return []env.EnvPrinter{failingPrinter, successPrinter}
 		}
 
-		// When the env command is executed without verbose flag
-		rootCmd.SetArgs([]string{"env"})
-		err := Execute(mockController)
+		// Set a session token to avoid reset logic
+		os.Setenv("WINDSOR_SESSION_TOKEN", "test-token")
+		defer os.Unsetenv("WINDSOR_SESSION_TOKEN")
+
+		// Create command and execute directly
+		cmd := createCommand(mocks.Controller, false)
+		err := envCmd.RunE(cmd, []string{})
 
 		// Then no error should be returned
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
-
-		// And the second printer should have been called
+		// And the second printer should be called
 		if !secondPrinterCalled {
 			t.Fatalf("Second printer was not called, command stopped at first error")
 		}
@@ -526,17 +982,15 @@ func TestEnvCmd(t *testing.T) {
 	t.Run("ContinuesThroughPrinterErrorsInVerboseMode", func(t *testing.T) {
 		defer resetRootCmd()
 
-		// Given a mock controller with multiple environment printers
-		injector := di.NewInjector()
-		mockController := ctrl.NewMockController(injector)
+		// Setup safe mocks
+		mocks := setupSafeMocks()
 
-		// First printer that will error on Print
+		// Set up multiple printers - first one fails, second one succeeds
 		failingPrinter := env.NewMockEnvPrinter()
 		failingPrinter.PrintFunc = func() error {
 			return fmt.Errorf("first printer error")
 		}
 
-		// Second printer to verify it still gets called
 		secondPrinterCalled := false
 		successPrinter := env.NewMockEnvPrinter()
 		successPrinter.PrintFunc = func() error {
@@ -544,13 +998,22 @@ func TestEnvCmd(t *testing.T) {
 			return nil
 		}
 
-		mockController.ResolveAllEnvPrintersFunc = func() []env.EnvPrinter {
+		// Override the printer list with our custom printers
+		mocks.Controller.ResolveAllEnvPrintersFunc = func() []env.EnvPrinter {
 			return []env.EnvPrinter{failingPrinter, successPrinter}
 		}
 
-		// When the env command is executed with verbose flag
-		rootCmd.SetArgs([]string{"env", "--verbose"})
-		err := Execute(mockController)
+		// Set a session token to avoid reset logic
+		os.Setenv("WINDSOR_SESSION_TOKEN", "test-token")
+		defer os.Unsetenv("WINDSOR_SESSION_TOKEN")
+
+		// Set verbose flag for this test
+		verbose = true
+		defer func() { verbose = false }()
+
+		// Create command and execute directly
+		cmd := createCommand(mocks.Controller, false)
+		err := envCmd.RunE(cmd, []string{})
 
 		// Then an error should be returned for the first printer
 		if err == nil {
@@ -565,6 +1028,423 @@ func TestEnvCmd(t *testing.T) {
 		// we collect all errors first, then return the first one if we're in verbose mode
 		if !secondPrinterCalled {
 			t.Fatalf("Second printer was not called, but all printers should be processed")
+		}
+	})
+
+	t.Run("ResetWithPreRunECall", func(t *testing.T) {
+		defer resetRootCmd()
+
+		// Setup safe mocks
+		mocks := setupSafeMocks()
+
+		// Set up reset condition
+		mocks.Shell.CheckResetFlagsFunc = func() (bool, error) {
+			return true, nil // Indicate reset is needed
+		}
+
+		// Track function calls
+		var callOrder []string
+		resetCalled := false
+		initializeControllerCalled := false
+		createCommonComponentsCalled := false
+		createSecretsProvidersCalled := false
+
+		// Set up mocks to track calls
+		mocks.Shell.ResetFunc = func() {
+			resetCalled = true
+			callOrder = append(callOrder, "Reset")
+		}
+
+		mocks.Controller.InitializeFunc = func() error {
+			initializeControllerCalled = true
+			callOrder = append(callOrder, "InitializeController")
+			return nil
+		}
+
+		mocks.Controller.CreateCommonComponentsFunc = func() error {
+			createCommonComponentsCalled = true
+			callOrder = append(callOrder, "CreateCommonComponents")
+			return nil
+		}
+
+		mocks.Controller.CreateSecretsProvidersFunc = func() error {
+			createSecretsProvidersCalled = true
+			callOrder = append(callOrder, "CreateSecretsProviders")
+			return nil
+		}
+
+		// Set session token
+		os.Setenv("WINDSOR_SESSION_TOKEN", "test-token")
+		defer os.Unsetenv("WINDSOR_SESSION_TOKEN")
+
+		// Create command and execute
+		rootCmd.SetArgs([]string{"env"})
+		err := Execute(mocks.Controller)
+
+		// No error should occur
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Verify the appropriate functions were called
+		if !resetCalled {
+			t.Error("Expected Reset to be called, but it wasn't")
+		}
+		if !initializeControllerCalled {
+			t.Error("Expected InitializeController to be called during preRunE, but it wasn't")
+		}
+		if !createCommonComponentsCalled {
+			t.Error("Expected CreateCommonComponents to be called during preRunE, but it wasn't")
+		}
+		if !createSecretsProvidersCalled {
+			t.Error("Expected CreateSecretsProviders to be called during preRunE, but it wasn't")
+		}
+
+		// Verify order - Reset should happen before all preRunE steps
+		resetIndex := -1
+		for i, call := range callOrder {
+			if call == "Reset" {
+				resetIndex = i
+				break
+			}
+		}
+
+		if resetIndex == -1 {
+			t.Fatal("Reset was not called at all")
+		}
+
+		// Verify all these happen after Reset
+		for _, call := range []string{"InitializeController", "CreateCommonComponents", "CreateSecretsProviders"} {
+			found := false
+			for i, actualCall := range callOrder {
+				if actualCall == call && i > resetIndex {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("Expected %s to be called after Reset, but it wasn't in the correct order", call)
+			}
+		}
+	})
+
+	t.Run("ErrorCreatingSecretsAfterReset", func(t *testing.T) {
+		defer resetRootCmd()
+
+		// Setup safe mocks
+		mocks := setupSafeMocks()
+
+		// Set up reset condition
+		mocks.Shell.CheckResetFlagsFunc = func() (bool, error) {
+			return true, nil // Indicate reset is needed
+		}
+
+		// Mock CreateSecretsProviders to return an error
+		mocks.Controller.CreateSecretsProvidersFunc = func() error {
+			return fmt.Errorf("error creating secrets providers")
+		}
+
+		// Set session token and verbose mode
+		os.Setenv("WINDSOR_SESSION_TOKEN", "test-token")
+		defer os.Unsetenv("WINDSOR_SESSION_TOKEN")
+
+		// Create command and execute with verbose flag
+		rootCmd.SetArgs([]string{"env", "--verbose"})
+		err := Execute(mocks.Controller)
+
+		// We should get an error
+		if err == nil {
+			t.Fatalf("Expected an error, got nil")
+		}
+
+		expectedError := "Error creating secrets provider: error creating secrets providers"
+		if err.Error() != expectedError {
+			t.Fatalf("Expected error %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("ResetSetsNoCacheEnvironmentVariable", func(t *testing.T) {
+		defer resetRootCmd()
+
+		// Setup safe mocks
+		mocks := setupSafeMocks()
+
+		// Setup reset condition
+		mocks.Shell.CheckResetFlagsFunc = func() (bool, error) {
+			return true, nil
+		}
+
+		// Track if NO_CACHE is set during reset
+		var noCacheValue string
+		noCacheWasSet := false
+
+		// Original osSetenv value
+		originalOsSetenv := osSetenv
+		// Mock osSetenv to track NO_CACHE setting
+		osSetenv = func(key, value string) error {
+			if key == "NO_CACHE" {
+				noCacheWasSet = true
+				noCacheValue = value
+			}
+			return nil
+		}
+
+		// Restore original function after test
+		defer func() {
+			osSetenv = originalOsSetenv
+		}()
+
+		// Mock reset function to implement setting NO_CACHE
+		mocks.Shell.ResetFunc = func() {
+			osSetenv("NO_CACHE", "true")
+		}
+
+		// Set session token
+		os.Setenv("WINDSOR_SESSION_TOKEN", "test-token")
+		defer os.Unsetenv("WINDSOR_SESSION_TOKEN")
+
+		// Run the env command
+		rootCmd.SetArgs([]string{"env"})
+		err := Execute(mocks.Controller)
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		// Verify NO_CACHE was set to "true"
+		if !noCacheWasSet {
+			t.Error("Expected NO_CACHE to be set during reset, but it wasn't")
+		}
+
+		if noCacheValue != "true" {
+			t.Errorf("Expected NO_CACHE to be set to 'true', got %q", noCacheValue)
+		}
+	})
+
+	t.Run("ErrorSettingEnvironmentVariables", func(t *testing.T) {
+		defer resetRootCmd()
+
+		// Setup safe mocks
+		mocks := setupSafeMocks()
+
+		// Mock SetEnvironmentVariables to return an error
+		mocks.Controller.SetEnvironmentVariablesFunc = func() error {
+			return fmt.Errorf("error setting environment variables")
+		}
+
+		// Run the env command
+		rootCmd.SetArgs([]string{"env"})
+		err := Execute(mocks.Controller)
+
+		// Expect an error
+		if err == nil {
+			t.Fatalf("Expected an error, got nil")
+		}
+
+		expectedError := "Error setting environment variables: error setting environment variables"
+		if err.Error() != expectedError {
+			t.Errorf("Expected error %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("SetNoCacheAfterReset", func(t *testing.T) {
+		defer resetRootCmd()
+
+		// Setup safe mocks
+		mocks := setupSafeMocks()
+
+		// Setup that a reset is needed
+		mocks.Shell.CheckResetFlagsFunc = func() (bool, error) {
+			t.Log("CheckResetFlags called")
+			return true, nil
+		}
+
+		// Mock the Reset function to verify it's called
+		resetCalled := false
+		mocks.Shell.ResetFunc = func() {
+			t.Log("Reset called")
+			resetCalled = true
+		}
+
+		// Track whether we're in a trusted directory
+		mocks.Shell.CheckTrustedDirectoryFunc = func() error {
+			t.Log("CheckTrustedDirectory called")
+			return nil // Return nil to indicate we're in a trusted directory
+		}
+
+		// Set a session token to avoid early exit
+		os.Setenv("WINDSOR_SESSION_TOKEN", "test-token")
+		defer os.Unsetenv("WINDSOR_SESSION_TOKEN")
+
+		// Check if NO_CACHE is set after reset
+		noCacheSet := false
+		originalOsSetenv := osSetenv
+		osSetenv = func(key, value string) error {
+			t.Logf("osSetenv called with key=%s, value=%s", key, value)
+			if key == "NO_CACHE" && value == "true" {
+				noCacheSet = true
+			}
+			return originalOsSetenv(key, value)
+		}
+		defer func() { osSetenv = originalOsSetenv }()
+
+		// Enable preRunEInitializeCommonComponents to work
+		mocks.Controller.InitializeFunc = func() error {
+			t.Log("Controller.Initialize called")
+			return nil
+		}
+		mocks.Controller.CreateCommonComponentsFunc = func() error {
+			t.Log("Controller.CreateCommonComponents called")
+			return nil
+		}
+		mocks.Controller.CreateSecretsProvidersFunc = func() error {
+			t.Log("Controller.CreateSecretsProviders called")
+			return nil
+		}
+
+		// Set up verbose mode
+		verbose = true
+		defer func() { verbose = false }()
+
+		// When env command is executed
+		cmd := createCommand(mocks.Controller, false)
+		err := envCmd.RunE(cmd, []string{})
+
+		// Then
+		t.Logf("Test result: err=%v, resetCalled=%v, noCacheSet=%v", err, resetCalled, noCacheSet)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !resetCalled {
+			t.Errorf("Expected Reset to be called, but it wasn't")
+		}
+		if !noCacheSet {
+			t.Errorf("Expected NO_CACHE environment variable to be set, but it wasn't")
+		}
+	})
+
+	t.Run("SetNoCacheErrorWithVerbose", func(t *testing.T) {
+		defer resetRootCmd()
+
+		// Setup safe mocks
+		mocks := setupSafeMocks()
+
+		// Setup that a reset is needed
+		mocks.Shell.CheckResetFlagsFunc = func() (bool, error) {
+			return true, nil
+		}
+
+		// Set a session token to avoid early exit
+		os.Setenv("WINDSOR_SESSION_TOKEN", "test-token")
+		defer os.Unsetenv("WINDSOR_SESSION_TOKEN")
+
+		// Track whether we're in a trusted directory
+		mocks.Shell.CheckTrustedDirectoryFunc = func() error {
+			return nil // Return nil to indicate we're in a trusted directory
+		}
+
+		// Mock osSetenv to return an error for NO_CACHE
+		noCacheAttempted := false
+		originalOsSetenv := osSetenv
+		osSetenv = func(key, value string) error {
+			if key == "NO_CACHE" && value == "true" {
+				noCacheAttempted = true
+				return fmt.Errorf("mock error setting NO_CACHE")
+			}
+			return originalOsSetenv(key, value)
+		}
+		defer func() { osSetenv = originalOsSetenv }()
+
+		// Enable preRunEInitializeCommonComponents to work
+		mocks.Controller.InitializeFunc = func() error {
+			return nil
+		}
+		mocks.Controller.CreateCommonComponentsFunc = func() error {
+			return nil
+		}
+		mocks.Controller.CreateSecretsProvidersFunc = func() error {
+			return nil
+		}
+
+		// Set up verbose mode
+		verbose = true
+		defer func() { verbose = false }()
+
+		// When env command is executed
+		cmd := createCommand(mocks.Controller, false)
+		err := envCmd.RunE(cmd, []string{})
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("Expected error, got nil")
+		}
+
+		if !noCacheAttempted {
+			t.Errorf("Expected attempt to set NO_CACHE, but no attempt was made")
+		}
+
+		expectedError := "Error setting NO_CACHE: mock error setting NO_CACHE"
+		if err.Error() != expectedError {
+			t.Errorf("Expected error: %q, got: %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("SetNoCacheErrorWithoutVerbose", func(t *testing.T) {
+		defer resetRootCmd()
+
+		// Setup safe mocks
+		mocks := setupSafeMocks()
+
+		// Setup that a reset is needed
+		mocks.Shell.CheckResetFlagsFunc = func() (bool, error) {
+			return true, nil
+		}
+
+		// Set a session token to avoid early exit
+		os.Setenv("WINDSOR_SESSION_TOKEN", "test-token")
+		defer os.Unsetenv("WINDSOR_SESSION_TOKEN")
+
+		// Track whether we're in a trusted directory
+		mocks.Shell.CheckTrustedDirectoryFunc = func() error {
+			return nil // Return nil to indicate we're in a trusted directory
+		}
+
+		// Mock osSetenv to return an error for NO_CACHE
+		noCacheAttempted := false
+		originalOsSetenv := osSetenv
+		osSetenv = func(key, value string) error {
+			if key == "NO_CACHE" && value == "true" {
+				noCacheAttempted = true
+				return fmt.Errorf("mock error setting NO_CACHE")
+			}
+			return originalOsSetenv(key, value)
+		}
+		defer func() { osSetenv = originalOsSetenv }()
+
+		// Enable preRunEInitializeCommonComponents to work
+		mocks.Controller.InitializeFunc = func() error {
+			return nil
+		}
+		mocks.Controller.CreateCommonComponentsFunc = func() error {
+			return nil
+		}
+		mocks.Controller.CreateSecretsProvidersFunc = func() error {
+			return nil
+		}
+
+		// Set verbose mode to false
+		verbose = false
+
+		// When env command is executed
+		cmd := createCommand(mocks.Controller, false)
+		err := envCmd.RunE(cmd, []string{})
+
+		// Then no error should be returned when not in verbose mode
+		if err != nil {
+			t.Fatalf("Expected no error in non-verbose mode, got: %v", err)
+		}
+
+		if !noCacheAttempted {
+			t.Errorf("Expected attempt to set NO_CACHE, but no attempt was made")
 		}
 	})
 }

--- a/pkg/config/shims.go
+++ b/pkg/config/shims.go
@@ -15,6 +15,9 @@ var osWriteFile = os.WriteFile
 // osRemoveAll is a variable to allow mocking os.RemoveAll in tests
 var osRemoveAll = os.RemoveAll
 
+// osGetenv is a variable to allow mocking os.Getenv in tests
+var osGetenv = os.Getenv
+
 // Override variable for yamlMarshal
 var yamlMarshal = yaml.Marshal
 

--- a/pkg/config/yaml_config_handler.go
+++ b/pkg/config/yaml_config_handler.go
@@ -201,7 +201,7 @@ func (y *YamlConfigHandler) GetStringMap(key string, defaultValue ...map[string]
 }
 
 // Set updates the value at the specified path in the configuration using reflection.
-func (y *YamlConfigHandler) Set(path string, value interface{}) error {
+func (y *YamlConfigHandler) Set(path string, value any) error {
 	if path == "" {
 		return nil
 	}
@@ -211,10 +211,14 @@ func (y *YamlConfigHandler) Set(path string, value interface{}) error {
 }
 
 // SetContextValue sets a configuration value within the current context.
-func (y *YamlConfigHandler) SetContextValue(path string, value interface{}) error {
-	y.GetContext()
+func (y *YamlConfigHandler) SetContextValue(path string, value any) error {
+	if path == "" {
+		return fmt.Errorf("path cannot be empty")
+	}
 
-	currentContext := y.context
+	// Ensure we have a current context
+	currentContext := y.GetContext()
+
 	fullPath := fmt.Sprintf("contexts.%s.%s", currentContext, path)
 	return y.Set(fullPath, value)
 }
@@ -308,7 +312,7 @@ func getFieldByYamlTag(v reflect.Value, tag string) reflect.Value {
 }
 
 // setValueByPath sets a value in a struct or map by navigating through it using YAML tags.
-func setValueByPath(currValue reflect.Value, pathKeys []string, value interface{}, fullPath string) error {
+func setValueByPath(currValue reflect.Value, pathKeys []string, value any, fullPath string) error {
 	if len(pathKeys) == 0 {
 		return fmt.Errorf("pathKeys cannot be empty")
 	}
@@ -394,7 +398,7 @@ func setValueByPath(currValue reflect.Value, pathKeys []string, value interface{
 }
 
 // assignValue assigns a value to a field, converting types if necessary.
-func assignValue(fieldValue reflect.Value, value interface{}) (reflect.Value, error) {
+func assignValue(fieldValue reflect.Value, value any) (reflect.Value, error) {
 	if !fieldValue.CanSet() {
 		return reflect.Value{}, fmt.Errorf("cannot set field")
 	}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -377,9 +377,9 @@ func (c *BaseController) ResolveBlueprintHandler() blueprint.BlueprintHandler {
 
 // ResolveService resolves the requested service instance.
 func (c *BaseController) ResolveService(name string) services.Service {
-	instance := c.injector.Resolve(name)
-	serviceInstance, _ := instance.(services.Service)
-	return serviceInstance
+	instance := c.injector.Resolve(fmt.Sprintf("%s", name))
+	service, _ := instance.(services.Service)
+	return service
 }
 
 // ResolveAllServices resolves all service instances.

--- a/pkg/env/aws_env_test.go
+++ b/pkg/env/aws_env_test.go
@@ -212,9 +212,8 @@ func TestAwsEnv_Print(t *testing.T) {
 
 		// Mock the PrintEnvVarsFunc to verify it is called with the correct envVars
 		var capturedEnvVars map[string]string
-		mocks.Shell.PrintEnvVarsFunc = func(envVars map[string]string) error {
+		mocks.Shell.PrintEnvVarsFunc = func(envVars map[string]string) {
 			capturedEnvVars = envVars
-			return nil
 		}
 
 		// Call Print and check for errors

--- a/pkg/env/docker_env_test.go
+++ b/pkg/env/docker_env_test.go
@@ -445,9 +445,8 @@ func TestDockerEnvPrinter_Print(t *testing.T) {
 
 		// Mock the Print method of BaseEnvPrinter to capture the envVars
 		var capturedEnvVars map[string]string
-		mocks.Shell.PrintEnvVarsFunc = func(envVars map[string]string) error {
+		mocks.Shell.PrintEnvVarsFunc = func(envVars map[string]string) {
 			capturedEnvVars = envVars
-			return nil
 		}
 
 		// Call Print and check for errors

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -77,7 +77,8 @@ func (e *BaseEnvPrinter) Print(customVars ...map[string]string) error {
 		e.SetManagedEnv(key)
 	}
 
-	return e.shell.PrintEnvVars(envVars)
+	e.shell.PrintEnvVars(envVars)
+	return nil
 }
 
 // GetEnvVars is a placeholder for retrieving environment variables.
@@ -106,7 +107,8 @@ func (e *BaseEnvPrinter) PrintAlias(customAlias ...map[string]string) error {
 		e.SetManagedAlias(key)
 	}
 
-	return e.shell.PrintAlias(aliasMap)
+	e.shell.PrintAlias(aliasMap)
+	return nil
 }
 
 // GetAlias is a placeholder for creating an alias for a command.

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -129,9 +129,8 @@ func TestEnv_Print(t *testing.T) {
 
 		// Mock the PrintEnvVarsFunc to verify it is called
 		var capturedEnvVars map[string]string
-		mocks.Shell.PrintEnvVarsFunc = func(envVars map[string]string) error {
+		mocks.Shell.PrintEnvVarsFunc = func(envVars map[string]string) {
 			capturedEnvVars = envVars
-			return nil
 		}
 
 		// Set up test environment variables
@@ -162,9 +161,8 @@ func TestEnv_Print(t *testing.T) {
 
 		// Mock the PrintEnvVarsFunc to verify it is called
 		var capturedEnvVars map[string]string
-		mocks.Shell.PrintEnvVarsFunc = func(envVars map[string]string) error {
+		mocks.Shell.PrintEnvVarsFunc = func(envVars map[string]string) {
 			capturedEnvVars = envVars
-			return nil
 		}
 
 		// Call Print without custom vars and check for errors
@@ -195,9 +193,8 @@ func TestEnv_PrintAlias(t *testing.T) {
 
 		// Mock the PrintAliasFunc to verify it is called
 		var capturedAlias map[string]string
-		mocks.Shell.PrintAliasFunc = func(alias map[string]string) error {
+		mocks.Shell.PrintAliasFunc = func(alias map[string]string) {
 			capturedAlias = alias
-			return nil
 		}
 
 		// Set up test alias
@@ -228,9 +225,8 @@ func TestEnv_PrintAlias(t *testing.T) {
 
 		// Mock the PrintAliasFunc to verify it is called
 		var capturedAlias map[string]string
-		mocks.Shell.PrintAliasFunc = func(alias map[string]string) error {
+		mocks.Shell.PrintAliasFunc = func(alias map[string]string) {
 			capturedAlias = alias
-			return nil
 		}
 
 		// Call PrintAlias without custom alias

--- a/pkg/env/kube_env_test.go
+++ b/pkg/env/kube_env_test.go
@@ -283,9 +283,8 @@ func TestKubeEnvPrinter_Print(t *testing.T) {
 
 		// Mock the PrintEnvVarsFunc to verify it is called with the correct envVars
 		var capturedEnvVars map[string]string
-		mocks.Shell.PrintEnvVarsFunc = func(envVars map[string]string) error {
+		mocks.Shell.PrintEnvVarsFunc = func(envVars map[string]string) {
 			capturedEnvVars = envVars
-			return nil
 		}
 
 		// Call Print and check for errors

--- a/pkg/env/mock_env.go
+++ b/pkg/env/mock_env.go
@@ -9,6 +9,7 @@ type MockEnvPrinter struct {
 	PostEnvHookFunc func() error
 	GetEnvVarsFunc  func() (map[string]string, error)
 	GetAliasFunc    func() (map[string]string, error)
+	ResetFunc       func()
 }
 
 // NewMockEnvPrinter creates a new instance of MockEnvPrinter.
@@ -70,6 +71,15 @@ func (m *MockEnvPrinter) PostEnvHook() error {
 	}
 	// Simulate post environment setup without doing anything real
 	return nil
+}
+
+// Reset simulates resetting environment variables.
+// If a custom ResetFunc is provided, it will use that function instead.
+func (m *MockEnvPrinter) Reset() {
+	if m.ResetFunc != nil {
+		m.ResetFunc()
+	}
+	// Do nothing if no custom function is provided
 }
 
 // Ensure MockEnvPrinter implements the EnvPrinter interface

--- a/pkg/env/mock_env.go
+++ b/pkg/env/mock_env.go
@@ -3,14 +3,13 @@ package env
 // MockEnvPrinter is a struct that simulates an environment for testing purposes.
 type MockEnvPrinter struct {
 	BaseEnvPrinter
-	InitializeFunc      func() error
-	PrintFunc           func() error
-	PrintAliasFunc      func() error
-	PostEnvHookFunc     func() error
-	GetEnvVarsFunc      func() (map[string]string, error)
-	GetAliasFunc        func() (map[string]string, error)
-	ResetFunc           func()
-	WriteResetTokenFunc func() (string, error)
+	InitializeFunc  func() error
+	PrintFunc       func() error
+	PrintAliasFunc  func() error
+	PostEnvHookFunc func() error
+	GetEnvVarsFunc  func() (map[string]string, error)
+	GetAliasFunc    func() (map[string]string, error)
+	ResetFunc       func()
 }
 
 // NewMockEnvPrinter creates a new instance of MockEnvPrinter.
@@ -79,18 +78,8 @@ func (m *MockEnvPrinter) PostEnvHook() error {
 func (m *MockEnvPrinter) Reset() {
 	if m.ResetFunc != nil {
 		m.ResetFunc()
+		return
 	}
-	// Do nothing if no custom function is provided
-}
-
-// WriteResetToken simulates writing a reset token file.
-// If a custom WriteResetTokenFunc is provided, it will use that function instead.
-func (m *MockEnvPrinter) WriteResetToken() (string, error) {
-	if m.WriteResetTokenFunc != nil {
-		return m.WriteResetTokenFunc()
-	}
-	// Return empty string and nil error as the default behavior
-	return "", nil
 }
 
 // Ensure MockEnvPrinter implements the EnvPrinter interface

--- a/pkg/env/mock_env.go
+++ b/pkg/env/mock_env.go
@@ -3,13 +3,14 @@ package env
 // MockEnvPrinter is a struct that simulates an environment for testing purposes.
 type MockEnvPrinter struct {
 	BaseEnvPrinter
-	InitializeFunc  func() error
-	PrintFunc       func() error
-	PrintAliasFunc  func() error
-	PostEnvHookFunc func() error
-	GetEnvVarsFunc  func() (map[string]string, error)
-	GetAliasFunc    func() (map[string]string, error)
-	ResetFunc       func()
+	InitializeFunc      func() error
+	PrintFunc           func() error
+	PrintAliasFunc      func() error
+	PostEnvHookFunc     func() error
+	GetEnvVarsFunc      func() (map[string]string, error)
+	GetAliasFunc        func() (map[string]string, error)
+	ResetFunc           func()
+	WriteResetTokenFunc func() (string, error)
 }
 
 // NewMockEnvPrinter creates a new instance of MockEnvPrinter.
@@ -80,6 +81,16 @@ func (m *MockEnvPrinter) Reset() {
 		m.ResetFunc()
 	}
 	// Do nothing if no custom function is provided
+}
+
+// WriteResetToken simulates writing a reset token file.
+// If a custom WriteResetTokenFunc is provided, it will use that function instead.
+func (m *MockEnvPrinter) WriteResetToken() (string, error) {
+	if m.WriteResetTokenFunc != nil {
+		return m.WriteResetTokenFunc()
+	}
+	// Return empty string and nil error as the default behavior
+	return "", nil
 }
 
 // Ensure MockEnvPrinter implements the EnvPrinter interface

--- a/pkg/env/mock_env_test.go
+++ b/pkg/env/mock_env_test.go
@@ -243,10 +243,9 @@ func TestMockEnvPrinter_Reset(t *testing.T) {
 		// Given a mock environment with default Reset implementation
 		mockEnv := NewMockEnvPrinter()
 
-		// When calling Reset
-		// Then it should not panic
+		// When calling Reset (without a custom implementation)
+		// This is a no-op, so we just call it to ensure it doesn't panic
 		mockEnv.Reset()
-		// No assertion needed as default implementation does nothing
 	})
 
 	t.Run("CustomReset", func(t *testing.T) {
@@ -260,67 +259,9 @@ func TestMockEnvPrinter_Reset(t *testing.T) {
 		// When calling Reset
 		mockEnv.Reset()
 
-		// Then the custom function should have been called
+		// Then it should call the custom reset function
 		if !resetCalled {
-			t.Errorf("Reset() did not call the custom ResetFunc")
-		}
-	})
-}
-
-func TestMockEnvPrinter_WriteResetToken(t *testing.T) {
-	t.Run("DefaultWriteResetToken", func(t *testing.T) {
-		// Given a mock environment with default WriteResetToken implementation
-		mockEnv := NewMockEnvPrinter()
-
-		// When calling WriteResetToken
-		path, err := mockEnv.WriteResetToken()
-
-		// Then it should not return an error and path should be empty
-		if err != nil {
-			t.Errorf("WriteResetToken() error = %v, want nil", err)
-		}
-		if path != "" {
-			t.Errorf("WriteResetToken() path = %v, want empty string", path)
-		}
-	})
-
-	t.Run("CustomWriteResetToken", func(t *testing.T) {
-		// Given a mock environment with custom WriteResetToken implementation
-		mockEnv := NewMockEnvPrinter()
-		expectedPath := "/tmp/.session.abc123"
-		mockEnv.WriteResetTokenFunc = func() (string, error) {
-			return expectedPath, nil
-		}
-
-		// When calling WriteResetToken
-		path, err := mockEnv.WriteResetToken()
-
-		// Then it should return the expected path and no error
-		if err != nil {
-			t.Errorf("WriteResetToken() error = %v, want nil", err)
-		}
-		if path != expectedPath {
-			t.Errorf("WriteResetToken() path = %v, want %v", path, expectedPath)
-		}
-	})
-
-	t.Run("CustomWriteResetTokenWithError", func(t *testing.T) {
-		// Given a mock environment with custom WriteResetToken implementation that returns an error
-		mockEnv := NewMockEnvPrinter()
-		expectedError := fmt.Errorf("custom error")
-		mockEnv.WriteResetTokenFunc = func() (string, error) {
-			return "", expectedError
-		}
-
-		// When calling WriteResetToken
-		path, err := mockEnv.WriteResetToken()
-
-		// Then it should return the expected error
-		if err != expectedError {
-			t.Errorf("WriteResetToken() error = %v, want %v", err, expectedError)
-		}
-		if path != "" {
-			t.Errorf("WriteResetToken() path = %v, want empty string", path)
+			t.Error("Reset() did not call ResetFunc")
 		}
 	})
 }

--- a/pkg/env/mock_env_test.go
+++ b/pkg/env/mock_env_test.go
@@ -266,3 +266,61 @@ func TestMockEnvPrinter_Reset(t *testing.T) {
 		}
 	})
 }
+
+func TestMockEnvPrinter_WriteResetToken(t *testing.T) {
+	t.Run("DefaultWriteResetToken", func(t *testing.T) {
+		// Given a mock environment with default WriteResetToken implementation
+		mockEnv := NewMockEnvPrinter()
+
+		// When calling WriteResetToken
+		path, err := mockEnv.WriteResetToken()
+
+		// Then it should not return an error and path should be empty
+		if err != nil {
+			t.Errorf("WriteResetToken() error = %v, want nil", err)
+		}
+		if path != "" {
+			t.Errorf("WriteResetToken() path = %v, want empty string", path)
+		}
+	})
+
+	t.Run("CustomWriteResetToken", func(t *testing.T) {
+		// Given a mock environment with custom WriteResetToken implementation
+		mockEnv := NewMockEnvPrinter()
+		expectedPath := "/tmp/.session.abc123"
+		mockEnv.WriteResetTokenFunc = func() (string, error) {
+			return expectedPath, nil
+		}
+
+		// When calling WriteResetToken
+		path, err := mockEnv.WriteResetToken()
+
+		// Then it should return the expected path and no error
+		if err != nil {
+			t.Errorf("WriteResetToken() error = %v, want nil", err)
+		}
+		if path != expectedPath {
+			t.Errorf("WriteResetToken() path = %v, want %v", path, expectedPath)
+		}
+	})
+
+	t.Run("CustomWriteResetTokenWithError", func(t *testing.T) {
+		// Given a mock environment with custom WriteResetToken implementation that returns an error
+		mockEnv := NewMockEnvPrinter()
+		expectedError := fmt.Errorf("custom error")
+		mockEnv.WriteResetTokenFunc = func() (string, error) {
+			return "", expectedError
+		}
+
+		// When calling WriteResetToken
+		path, err := mockEnv.WriteResetToken()
+
+		// Then it should return the expected error
+		if err != expectedError {
+			t.Errorf("WriteResetToken() error = %v, want %v", err, expectedError)
+		}
+		if path != "" {
+			t.Errorf("WriteResetToken() path = %v, want empty string", path)
+		}
+	})
+}

--- a/pkg/env/mock_env_test.go
+++ b/pkg/env/mock_env_test.go
@@ -237,3 +237,32 @@ func TestMockEnvPrinter_PostEnvHook(t *testing.T) {
 		}
 	})
 }
+
+func TestMockEnvPrinter_Reset(t *testing.T) {
+	t.Run("DefaultReset", func(t *testing.T) {
+		// Given a mock environment with default Reset implementation
+		mockEnv := NewMockEnvPrinter()
+
+		// When calling Reset
+		// Then it should not panic
+		mockEnv.Reset()
+		// No assertion needed as default implementation does nothing
+	})
+
+	t.Run("CustomReset", func(t *testing.T) {
+		// Given a mock environment with custom Reset implementation
+		mockEnv := NewMockEnvPrinter()
+		resetCalled := false
+		mockEnv.ResetFunc = func() {
+			resetCalled = true
+		}
+
+		// When calling Reset
+		mockEnv.Reset()
+
+		// Then the custom function should have been called
+		if !resetCalled {
+			t.Errorf("Reset() did not call the custom ResetFunc")
+		}
+	})
+}

--- a/pkg/env/omni_env_test.go
+++ b/pkg/env/omni_env_test.go
@@ -128,9 +128,8 @@ func TestOmniEnvPrinter_Print(t *testing.T) {
 
 		// Mock the PrintEnvVarsFunc to verify it is called with the correct envVars
 		var capturedEnvVars map[string]string
-		mocks.Shell.PrintEnvVarsFunc = func(envVars map[string]string) error {
+		mocks.Shell.PrintEnvVarsFunc = func(envVars map[string]string) {
 			capturedEnvVars = envVars
-			return nil
 		}
 
 		// Call Print and check for errors

--- a/pkg/env/talos_env_test.go
+++ b/pkg/env/talos_env_test.go
@@ -128,9 +128,8 @@ func TestTalosEnv_Print(t *testing.T) {
 
 		// Mock the PrintEnvVarsFunc to verify it is called with the correct envVars
 		var capturedEnvVars map[string]string
-		mocks.Shell.PrintEnvVarsFunc = func(envVars map[string]string) error {
+		mocks.Shell.PrintEnvVarsFunc = func(envVars map[string]string) {
 			capturedEnvVars = envVars
-			return nil
 		}
 
 		// Call Print and check for errors

--- a/pkg/env/terraform_env_test.go
+++ b/pkg/env/terraform_env_test.go
@@ -517,9 +517,8 @@ func TestTerraformEnv_Print(t *testing.T) {
 
 		// Mock the PrintEnvVarsFunc to verify it is called with the correct envVars
 		var capturedEnvVars map[string]string
-		mocks.Shell.PrintEnvVarsFunc = func(envVars map[string]string) error {
+		mocks.Shell.PrintEnvVarsFunc = func(envVars map[string]string) {
 			capturedEnvVars = envVars
-			return nil
 		}
 
 		// Call Print and check for errors

--- a/pkg/env/windsor_env.go
+++ b/pkg/env/windsor_env.go
@@ -3,7 +3,6 @@ package env
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -22,7 +21,6 @@ var WindsorPrefixedVars = []string{
 // WindsorEnvPrinter is a struct that simulates a Kubernetes environment for testing purposes.
 type WindsorEnvPrinter struct {
 	BaseEnvPrinter
-	sessionToken     string
 	secretsProviders []secrets.SecretsProvider
 }
 
@@ -79,7 +77,7 @@ func (e *WindsorEnvPrinter) GetEnvVars() (map[string]string, error) {
 	}
 	envVars["WINDSOR_PROJECT_ROOT"] = projectRoot
 
-	sessionToken, err := e.getSessionToken()
+	sessionToken, err := e.shell.GetSessionToken()
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving session token: %w", err)
 	}
@@ -152,102 +150,6 @@ func (e *WindsorEnvPrinter) Print() error {
 		return fmt.Errorf("error getting environment variables: %w", err)
 	}
 	return e.BaseEnvPrinter.Print(envVars)
-}
-
-// CreateSessionInvalidationSignal creates a session file to invalidate the session token
-// when the environment changes, ensuring a new token is generated during the next command
-// execution.
-func (e *WindsorEnvPrinter) CreateSessionInvalidationSignal() error {
-	envToken := os.Getenv("WINDSOR_SESSION_TOKEN")
-	if envToken == "" {
-		return nil
-	}
-
-	projectRoot, err := e.shell.GetProjectRoot()
-	if err != nil {
-		return fmt.Errorf("failed to get project root: %w", err)
-	}
-
-	windsorDir := filepath.Join(projectRoot, ".windsor")
-	if err := mkdirAll(windsorDir, 0755); err != nil {
-		return fmt.Errorf("failed to create .windsor directory: %w", err)
-	}
-
-	sessionFilePath := filepath.Join(windsorDir, SessionTokenPrefix+envToken)
-	if err := writeFile(sessionFilePath, []byte{}, 0644); err != nil {
-		return fmt.Errorf("failed to create signal file: %w", err)
-	}
-
-	return nil
-}
-
-// getSessionToken retrieves or generates a session token. It first checks if a token is already stored in memory.
-// If not, it looks for a token in the environment variable. If an environment token is found, it verifies the
-// existence of a corresponding session file. If the specific session file exists, it deletes all session files and
-// generates a new token. If no token is found in the environment or the specific session file does not exist, it
-// generates a new token.
-func (e *WindsorEnvPrinter) getSessionToken() (string, error) {
-	envToken := os.Getenv("WINDSOR_SESSION_TOKEN")
-	if envToken != "" {
-		projectRoot, err := e.shell.GetProjectRoot()
-		if err != nil {
-			return "", fmt.Errorf("error getting project root: %w", err)
-		}
-
-		windsorDir := filepath.Join(projectRoot, ".windsor")
-		tokenFilePath := filepath.Join(windsorDir, SessionTokenPrefix+envToken)
-		if _, err := stat(tokenFilePath); err == nil {
-			defer func() {
-				sessionFilesPattern := filepath.Join(windsorDir, SessionTokenPrefix+"*")
-				sessionFiles, err := filepath.Glob(sessionFilesPattern)
-				if err != nil {
-					fmt.Printf("error finding session files: %v\n", err)
-					return
-				}
-				for _, file := range sessionFiles {
-					if err := osRemoveAll(file); err != nil {
-						fmt.Printf("error removing session file %s: %v\n", file, err)
-					}
-				}
-			}()
-			token, err := e.generateRandomString(7)
-			if err != nil {
-				return "", fmt.Errorf("error generating session token: %w", err)
-			}
-
-			e.sessionToken = token
-			return token, nil
-		}
-
-		e.sessionToken = envToken
-		return envToken, nil
-	}
-
-	token, err := e.generateRandomString(7)
-	if err != nil {
-		return "", fmt.Errorf("error generating session token: %w", err)
-	}
-
-	e.sessionToken = token
-	return token, nil
-}
-
-// generateRandomString creates a secure random string of the given length using a predefined charset.
-func (e *WindsorEnvPrinter) generateRandomString(length int) (string, error) {
-	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
-	randomBytes := make([]byte, length)
-
-	_, err := cryptoRandRead(randomBytes)
-	if err != nil {
-		return "", err
-	}
-
-	// Map random bytes to charset
-	for i, b := range randomBytes {
-		randomBytes[i] = charset[b%byte(len(charset))]
-	}
-
-	return string(randomBytes), nil
 }
 
 // Ensure WindsorEnvPrinter implements the EnvPrinter interface

--- a/pkg/env/windsor_env.go
+++ b/pkg/env/windsor_env.go
@@ -11,10 +11,6 @@ import (
 	"github.com/windsorcli/cli/pkg/secrets"
 )
 
-const (
-	SessionTokenPrefix = ".session."
-)
-
 var WindsorPrefixedVars = []string{
 	"WINDSOR_CONTEXT",
 	"WINDSOR_PROJECT_ROOT",

--- a/pkg/env/windsor_env_test.go
+++ b/pkg/env/windsor_env_test.go
@@ -1096,9 +1096,8 @@ func TestWindsorEnv_Print(t *testing.T) {
 
 		// Mock the PrintEnvVarsFunc to verify it is called with the correct envVars
 		var capturedEnvVars map[string]string
-		mocks.Shell.PrintEnvVarsFunc = func(envVars map[string]string) error {
+		mocks.Shell.PrintEnvVarsFunc = func(envVars map[string]string) {
 			capturedEnvVars = envVars
-			return nil
 		}
 
 		// Call Print and check for errors

--- a/pkg/env/windsor_env_test.go
+++ b/pkg/env/windsor_env_test.go
@@ -40,6 +40,23 @@ func setupSafeWindsorEnvMocks(injector ...di.Injector) *WindsorEnvMocks {
 		return filepath.FromSlash("/mock/project/root"), nil
 	}
 
+	// Default behavior for GetSessionToken that matches test expectations
+	mockShell.GetSessionTokenFunc = func() (string, error) {
+		// If WINDSOR_SESSION_TOKEN is set in the environment, check it
+		if envToken := os.Getenv("WINDSOR_SESSION_TOKEN"); envToken != "" {
+			// Check for signal file if env token exists
+			tokenFilePath := filepath.Join("/mock/project/root", ".windsor", ".session."+envToken)
+			if _, err := stat(tokenFilePath); err == nil {
+				// Signal file exists, generate new token
+				return "abcdefg", nil
+			}
+			// Signal file doesn't exist, return environment token
+			return envToken, nil
+		}
+		// No env token, return default mock token
+		return "mock-token", nil
+	}
+
 	mockInjector.Register("configHandler", mockConfigHandler)
 	mockInjector.Register("shell", mockShell)
 
@@ -65,90 +82,156 @@ func (c *customMockInjector) ResolveAll(targetType interface{}) ([]interface{}, 
 }
 
 func TestWindsorEnv_GetEnvVars(t *testing.T) {
-	// Save original functions
-	originalStat := stat
-	originalOsRemoveAll := osRemoveAll
-	originalCryptoRandRead := cryptoRandRead
-
-	// Restore original functions after tests
+	originalOsLookupEnv := osLookupEnv
 	defer func() {
-		stat = originalStat
-		osRemoveAll = originalOsRemoveAll
-		cryptoRandRead = originalCryptoRandRead
+		osLookupEnv = originalOsLookupEnv
 	}()
 
+	// Reset session token before each test
+	shell.ResetSessionToken()
+
+	// Set up mock environment variables
+	t.Setenv("NO_CACHE", "")
+
 	t.Run("Success", func(t *testing.T) {
+		// Reset session token to ensure consistent behavior
+		shell.ResetSessionToken()
+
+		// Given a WindsorEnvPrinter with mock dependencies
 		mocks := setupSafeWindsorEnvMocks()
+
+		// Make the shell return a consistent mock token
+		mocks.Shell.GetSessionTokenFunc = func() (string, error) {
+			return "mock-token", nil
+		}
 
 		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Injector)
 		windsorEnvPrinter.Initialize()
 
+		// When GetEnvVars is called
 		envVars, err := windsorEnvPrinter.GetEnvVars()
+
+		// Then the result should not contain an error
 		if err != nil {
-			t.Fatalf("GetEnvVars returned an error: %v", err)
+			t.Fatalf("Expected no error, got %v", err)
 		}
 
-		if envVars["WINDSOR_CONTEXT"] != "mock-context" {
-			t.Errorf("WINDSOR_CONTEXT = %v, want %v", envVars["WINDSOR_CONTEXT"], "mock-context")
+		// And the environment variables should contain the expected values
+		expectedContext := "mock-context"
+		if envVars["WINDSOR_CONTEXT"] != expectedContext {
+			t.Errorf("Expected WINDSOR_CONTEXT to be %q, got %q", expectedContext, envVars["WINDSOR_CONTEXT"])
 		}
 
-		expectedProjectRoot := filepath.FromSlash("/mock/project/root")
-		if envVars["WINDSOR_PROJECT_ROOT"] != expectedProjectRoot {
-			t.Errorf("WINDSOR_PROJECT_ROOT = %v, want %v", envVars["WINDSOR_PROJECT_ROOT"], expectedProjectRoot)
+		expectedProjectRoot := "/mock/project/root"
+		if filepath.ToSlash(envVars["WINDSOR_PROJECT_ROOT"]) != expectedProjectRoot {
+			t.Errorf("Expected WINDSOR_PROJECT_ROOT to be %q, got %q", expectedProjectRoot, envVars["WINDSOR_PROJECT_ROOT"])
 		}
 
-		// Verify session token is generated
-		if envVars["WINDSOR_SESSION_TOKEN"] == "" {
-			t.Errorf("Expected session token to be generated, but it was empty")
-		}
-		if len(envVars["WINDSOR_SESSION_TOKEN"]) != 7 {
-			t.Errorf("Expected session token to have length 7, got %d", len(envVars["WINDSOR_SESSION_TOKEN"]))
+		expectedSessionToken := "mock-token"
+		if envVars["WINDSOR_SESSION_TOKEN"] != expectedSessionToken {
+			t.Errorf("Expected WINDSOR_SESSION_TOKEN to be %q, got %q", expectedSessionToken, envVars["WINDSOR_SESSION_TOKEN"])
 		}
 	})
 
 	t.Run("ExistingSessionToken", func(t *testing.T) {
+		// Reset session token to ensure consistent behavior
+		shell.ResetSessionToken()
+
 		mocks := setupSafeWindsorEnvMocks()
 
-		// Add custom random generator to create a predictable "existing" token
-		origCryptoRandRead := cryptoRandRead
-		cryptoRandRead = func(b []byte) (n int, err error) {
-			// Generate predictable output that will produce "existing"
-			for i := range b {
-				// This is simplified but works for our test
-				b[i] = "existing"[i%8]
+		// Setup mock shell to simulate token regeneration
+		mockShell := shell.NewMockShell()
+		var callCount int
+		mockShell.GetSessionTokenFunc = func() (string, error) {
+			callCount++
+			if callCount == 1 {
+				return "first-token", nil
 			}
-			return len(b), nil
+			return "regenerated-token", nil
 		}
-		// Restore after test
-		defer func() {
-			cryptoRandRead = origCryptoRandRead
-		}()
+		mocks.Injector.Register("shell", mockShell)
 
-		// First generate a token
 		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Injector)
 		windsorEnvPrinter.Initialize()
 
-		// Set the environment to empty to ensure we use the generated token
-		t.Setenv("WINDSOR_SESSION_TOKEN", "")
-
-		// Get the token for the first time
+		// First call
 		envVars, err := windsorEnvPrinter.GetEnvVars()
 		if err != nil {
 			t.Fatalf("GetEnvVars returned an error: %v", err)
 		}
+		firstToken := envVars["WINDSOR_SESSION_TOKEN"]
+		if firstToken != "first-token" {
+			t.Errorf("Expected first token to be 'first-token', got %s", firstToken)
+		}
 
-		// Now get it again to ensure we use the cached token
+		// Second call
 		envVars, err = windsorEnvPrinter.GetEnvVars()
 		if err != nil {
 			t.Fatalf("GetEnvVars returned an error: %v", err)
 		}
+		secondToken := envVars["WINDSOR_SESSION_TOKEN"]
+		if secondToken != "regenerated-token" {
+			t.Errorf("Expected second token to be 'regenerated-token', got %s", secondToken)
+		}
+	})
 
-		// Check that we get the expected token
-		if len(envVars["WINDSOR_SESSION_TOKEN"]) != 7 {
-			t.Errorf("Expected session token to have length 7, got %d", len(envVars["WINDSOR_SESSION_TOKEN"]))
+	t.Run("SessionTokenError", func(t *testing.T) {
+		mocks := setupSafeWindsorEnvMocks()
+
+		// Setup mock shell to simulate token error
+		mockShell := shell.NewMockShell()
+		mockShell.GetSessionTokenFunc = func() (string, error) {
+			return "", fmt.Errorf("mock session token error")
+		}
+		mocks.Injector.Register("shell", mockShell)
+
+		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Injector)
+		windsorEnvPrinter.Initialize()
+
+		// Call should fail with session token error
+		_, err := windsorEnvPrinter.GetEnvVars()
+		if err == nil {
+			t.Fatal("Expected error from session token generation, got nil")
+		}
+		if !strings.Contains(err.Error(), "error retrieving session token") {
+			t.Errorf("Unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("NoEnvironmentVarsInConfig", func(t *testing.T) {
+		mocks := setupSafeWindsorEnvMocks()
+
+		// Set GetStringMap to return an empty map to simulate no environment vars in config
+		mocks.ConfigHandler.GetStringMapFunc = func(key string, defaultValue ...map[string]string) map[string]string {
+			if key == "environment" {
+				return map[string]string{}
+			}
+			return map[string]string{}
 		}
 
-		// Skip the exact token check for now since the random generation makes it difficult to test deterministically
+		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Injector)
+		windsorEnvPrinter.Initialize()
+
+		envVars, err := windsorEnvPrinter.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars should not return an error: %v", err)
+		}
+
+		// Verify we still have the base environment variables
+		if envVars["WINDSOR_CONTEXT"] != "mock-context" {
+			t.Errorf("WINDSOR_CONTEXT should be set even when no environment vars are in config")
+		}
+		if filepath.ToSlash(envVars["WINDSOR_PROJECT_ROOT"]) != "/mock/project/root" {
+			t.Errorf("WINDSOR_PROJECT_ROOT should be set")
+		}
+		if envVars["WINDSOR_SESSION_TOKEN"] == "" {
+			t.Errorf("Session token should be generated")
+		}
+
+		// Verify no additional variables were added from config (since there were none)
+		if len(envVars) != 5 {
+			t.Errorf("Should have five base environment variables")
+		}
 	})
 
 	t.Run("EnvironmentTokenWithoutSignalFile", func(t *testing.T) {
@@ -203,6 +286,11 @@ func TestWindsorEnv_GetEnvVars(t *testing.T) {
 
 	t.Run("EnvironmentTokenWithSignalFile", func(t *testing.T) {
 		// Mock file system functions
+		originalStat := stat
+		defer func() {
+			stat = originalStat
+		}()
+
 		stat = func(name string) (os.FileInfo, error) {
 			if strings.Contains(name, ".session.envtoken") {
 				return nil, nil // File exists
@@ -210,11 +298,21 @@ func TestWindsorEnv_GetEnvVars(t *testing.T) {
 			return nil, os.ErrNotExist
 		}
 
+		originalOsRemoveAll := osRemoveAll
+		defer func() {
+			osRemoveAll = originalOsRemoveAll
+		}()
+
 		osRemoveAll = func(path string) error {
 			return nil
 		}
 
 		// Mock crypto functions for predictable output
+		origCryptoRandRead := cryptoRandRead
+		defer func() {
+			cryptoRandRead = origCryptoRandRead
+		}()
+
 		cryptoRandRead = func(b []byte) (n int, err error) {
 			for i := range b {
 				b[i] = byte(i % 62) // Will map to characters in charset
@@ -235,17 +333,22 @@ func TestWindsorEnv_GetEnvVars(t *testing.T) {
 			t.Fatalf("GetEnvVars returned an error: %v", err)
 		}
 
-		// Verify a new token was generated (not the env token)
+		// Verify a new token was generated (should be "abcdefg" per our mock)
 		if envVars["WINDSOR_SESSION_TOKEN"] == "envtoken" {
 			t.Errorf("Expected a new token to be generated, but got the environment token")
 		}
-		if len(envVars["WINDSOR_SESSION_TOKEN"]) != 7 {
-			t.Errorf("Expected session token to have length 7, got %d", len(envVars["WINDSOR_SESSION_TOKEN"]))
+		if envVars["WINDSOR_SESSION_TOKEN"] != "abcdefg" {
+			t.Errorf("Expected session token to be 'abcdefg', got %s", envVars["WINDSOR_SESSION_TOKEN"])
 		}
 	})
 
 	t.Run("SignalFileRemovalError", func(t *testing.T) {
 		// Mock file system functions
+		originalStat := stat
+		defer func() {
+			stat = originalStat
+		}()
+
 		stat = func(name string) (os.FileInfo, error) {
 			if strings.Contains(name, ".session.envtoken") {
 				return nil, nil // File exists
@@ -254,21 +357,27 @@ func TestWindsorEnv_GetEnvVars(t *testing.T) {
 		}
 
 		// Mock osRemoveAll to return an error
+		originalOsRemoveAll := osRemoveAll
+		defer func() {
+			osRemoveAll = originalOsRemoveAll
+		}()
+
 		osRemoveAll = func(path string) error {
 			return fmt.Errorf("mock error removing signal file")
 		}
 
 		// Mock crypto functions for predictable output
 		origCryptoRandRead := cryptoRandRead
+		defer func() {
+			cryptoRandRead = origCryptoRandRead
+		}()
+
 		cryptoRandRead = func(b []byte) (n int, err error) {
 			for i := range b {
 				b[i] = byte(i % 62) // Will map to characters in charset
 			}
 			return len(b), nil
 		}
-		defer func() {
-			cryptoRandRead = origCryptoRandRead
-		}()
 
 		mocks := setupSafeWindsorEnvMocks()
 
@@ -291,35 +400,34 @@ func TestWindsorEnv_GetEnvVars(t *testing.T) {
 			t.Fatalf("GetEnvVars returned an error: %v", err)
 		}
 
-		// Verify a new token was generated (not the env token)
+		// Verify a new token was generated (should be "abcdefg" per our mock)
 		if envVars["WINDSOR_SESSION_TOKEN"] == "envtoken" {
 			t.Errorf("Expected a new token to be generated, but got the environment token")
 		}
-		if len(envVars["WINDSOR_SESSION_TOKEN"]) != 7 {
-			t.Errorf("Expected session token to have length 7, got %d", len(envVars["WINDSOR_SESSION_TOKEN"]))
+		if envVars["WINDSOR_SESSION_TOKEN"] != "abcdefg" {
+			t.Errorf("Expected session token to be 'abcdefg', got %s", envVars["WINDSOR_SESSION_TOKEN"])
 		}
 	})
 
 	t.Run("ProjectRootErrorDuringEnvTokenSignalFileCheck", func(t *testing.T) {
-		// Mock file system and crypto functions
-		stat = func(name string) (os.FileInfo, error) {
-			// This mock won't be reached because we'll error out earlier
-			return nil, nil
-		}
-
 		// Set up environment variable with a token
 		t.Setenv("WINDSOR_SESSION_TOKEN", "envtoken")
 
 		mocks := setupSafeWindsorEnvMocks()
 
-		// First call succeeds, second fails
-		callCount := 0
+		// First call succeeds, second fails (during token check)
+		var callCount int
 		mocks.Shell.GetProjectRootFunc = func() (string, error) {
 			callCount++
-			if callCount == 1 {
-				return filepath.FromSlash("/mock/project/root"), nil
+			return filepath.FromSlash("/mock/project/root"), nil
+		}
+
+		// Make GetSessionToken return an error during the signal file check
+		mocks.Shell.GetSessionTokenFunc = func() (string, error) {
+			if envToken := os.Getenv("WINDSOR_SESSION_TOKEN"); envToken != "" {
+				return "", fmt.Errorf("error getting project root: mock error getting project root during token check")
 			}
-			return "", fmt.Errorf("mock error getting project root during token check")
+			return "mock-token", nil
 		}
 
 		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Injector)
@@ -337,19 +445,46 @@ func TestWindsorEnv_GetEnvVars(t *testing.T) {
 	})
 
 	t.Run("RandomGenerationError", func(t *testing.T) {
-		// Mock crypto functions to return an error
-		cryptoRandRead = func(b []byte) (n int, err error) {
-			return 0, fmt.Errorf("mock random generation error")
+		// Mock file system functions
+		originalStat := stat
+		defer func() {
+			stat = originalStat
+		}()
+
+		stat = func(name string) (os.FileInfo, error) {
+			if strings.Contains(name, ".session.envtoken") {
+				return nil, nil // File exists
+			}
+			return nil, os.ErrNotExist
 		}
 
+		// Set up environment variable to trigger token regeneration
+		t.Setenv("WINDSOR_SESSION_TOKEN", "envtoken")
+
 		mocks := setupSafeWindsorEnvMocks()
+
+		// Make the shell's GetSessionToken return an error when regenerating token
+		mocks.Shell.GetSessionTokenFunc = func() (string, error) {
+			// Check if we are being called for the environment token check
+			if envToken := os.Getenv("WINDSOR_SESSION_TOKEN"); envToken != "" {
+				// We are doing the check for the environment token
+				tokenFilePath := filepath.Join("/mock/project/root", ".windsor", ".session."+envToken)
+				if _, err := stat(tokenFilePath); err == nil {
+					// Signal file exists, mock error during regeneration
+					return "", fmt.Errorf("mock random generation error during token regeneration")
+				}
+				return envToken, nil
+			}
+			return "mock-token", nil
+		}
 
 		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Injector)
 		windsorEnvPrinter.Initialize()
 
+		// This should trigger an error in token regeneration
 		_, err := windsorEnvPrinter.GetEnvVars()
 		if err == nil {
-			t.Fatal("Expected error from random generation, got nil")
+			t.Fatal("Expected error from random generation during token regeneration, got nil")
 		}
 		if !strings.Contains(err.Error(), "error retrieving session token") {
 			t.Errorf("Unexpected error message: %v", err)
@@ -378,14 +513,12 @@ func TestWindsorEnv_GetEnvVars(t *testing.T) {
 		// Set up environment variable with a token to trigger the token check code path
 		t.Setenv("WINDSOR_SESSION_TOKEN", "envtoken")
 
-		// First call succeeds, second fails (for project root during token check)
-		callCount := 0
-		mocks.Shell.GetProjectRootFunc = func() (string, error) {
-			callCount++
-			if callCount == 1 {
-				return filepath.FromSlash("/mock/project/root"), nil
+		// Make GetSessionToken return an error during the project root check
+		mocks.Shell.GetSessionTokenFunc = func() (string, error) {
+			if envToken := os.Getenv("WINDSOR_SESSION_TOKEN"); envToken != "" {
+				return "", fmt.Errorf("error getting project root: mock shell error during token check")
 			}
-			return "", fmt.Errorf("mock shell error during token check")
+			return "mock-token", nil
 		}
 
 		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Injector)
@@ -393,49 +526,82 @@ func TestWindsorEnv_GetEnvVars(t *testing.T) {
 
 		_, err := windsorEnvPrinter.GetEnvVars()
 		if err == nil {
-			t.Error("Expected error, got nil")
-		} else if !strings.Contains(err.Error(), "error retrieving session token") {
-			t.Errorf("Unexpected error message: %v", err)
+			t.Fatal("Expected error, got nil")
+		}
+
+		expectedErr := "error retrieving session token: error getting project root: mock shell error during token check"
+		if err.Error() != expectedErr {
+			t.Errorf("Expected error %q, got %q", expectedErr, err.Error())
 		}
 	})
 
 	t.Run("ComprehensiveEnvironmentTokenTest", func(t *testing.T) {
-		// Save original functions to restore later for this test case
-		origStat := stat
-		origOsRemoveAll := osRemoveAll
-		origCryptoRandRead := cryptoRandRead
+		// Mock file system functions to handle various cases
+		originalStat := stat
+		defer func() {
+			stat = originalStat
+		}()
 
-		// First clear any existing env token
-		t.Setenv("WINDSOR_SESSION_TOKEN", "")
-
-		// Mock random generation for first call
-		cryptoRandRead = func(b []byte) (n int, err error) {
-			for i := range b {
-				// Generate a predictable but distinct token for the first call
-				b[i] = byte('a' + (i % 26))
+		stat = func(name string) (os.FileInfo, error) {
+			if strings.Contains(name, ".session.testtoken") {
+				return nil, nil // Session file exists
 			}
-			return len(b), nil
+			return nil, os.ErrNotExist
 		}
 
-		// Mock for initial call with no env token
 		mocks := setupSafeWindsorEnvMocks()
+
+		// Phase 1: No environment token present
+		// Should generate a new token
 		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Injector)
 		windsorEnvPrinter.Initialize()
 
-		// First get a token with no env set (should generate a new one)
 		envVars, err := windsorEnvPrinter.GetEnvVars()
 		if err != nil {
 			t.Fatalf("GetEnvVars returned an error: %v", err)
 		}
 		firstToken := envVars["WINDSOR_SESSION_TOKEN"]
 
-		// Now set the env token
+		// Phase 2: Set environment token
+		// The mock should return this token since no signal file exists for it
 		t.Setenv("WINDSOR_SESSION_TOKEN", "testtoken")
 
-		// Reset the session token to force checking env
-		windsorEnvPrinter.sessionToken = ""
+		// Update the mock to handle the testtoken case
+		mocks.Shell.GetSessionTokenFunc = func() (string, error) {
+			if envToken := os.Getenv("WINDSOR_SESSION_TOKEN"); envToken != "" {
+				// Our testtoken has a signal file
+				tokenFilePath := filepath.Join("/mock/project/root", ".windsor", ".session."+envToken)
+				if _, err := stat(tokenFilePath); err == nil {
+					return "newtoken", nil // Return a different token to show regeneration
+				}
+				return envToken, nil
+			}
+			return "mock-token", nil
+		}
 
-		// Mock stat to return nil, nil for signal file (exists)
+		// Now the test token should come back
+		envVars, err = windsorEnvPrinter.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars returned an error in phase 2: %v", err)
+		}
+
+		secondToken := envVars["WINDSOR_SESSION_TOKEN"]
+		if secondToken != "newtoken" {
+			t.Errorf("Expected token 'newtoken', got %q", secondToken)
+		}
+
+		if secondToken == firstToken {
+			t.Errorf("Second token %q should be different from the first token %q", secondToken, firstToken)
+		}
+	})
+
+	t.Run("RandomErrorDuringSignalFileRegeneration", func(t *testing.T) {
+		// Mock file system functions
+		originalStat := stat
+		defer func() {
+			stat = originalStat
+		}()
+
 		stat = func(name string) (os.FileInfo, error) {
 			if strings.Contains(name, ".session.testtoken") {
 				return nil, nil // File exists
@@ -443,163 +609,41 @@ func TestWindsorEnv_GetEnvVars(t *testing.T) {
 			return nil, os.ErrNotExist
 		}
 
-		// Mock removal to succeed
-		osRemoveAll = func(path string) error {
-			return nil
-		}
-
-		// Update crypto function to generate a different token for the second call
-		cryptoRandRead = func(b []byte) (n int, err error) {
-			for i := range b {
-				// Generate a predictable but distinct token from the first
-				b[i] = byte('A' + (i % 26))
-			}
-			return len(b), nil
-		}
-
-		// Second call with env token and signal file (should regenerate)
-		envVars, err = windsorEnvPrinter.GetEnvVars()
-		if err != nil {
-			t.Fatalf("GetEnvVars returned an error: %v", err)
-		}
-		secondToken := envVars["WINDSOR_SESSION_TOKEN"]
-
-		// Verify token was regenerated and is different from both env token and first token
-		if secondToken == "testtoken" {
-			t.Errorf("Token should not be the environment token, got %s", secondToken)
-		}
-		if secondToken == firstToken {
-			t.Errorf("Second token %s should be different from first token %s", secondToken, firstToken)
-		}
-
-		// Third call should use the cached session token
-		envVars, err = windsorEnvPrinter.GetEnvVars()
-		if err != nil {
-			t.Fatalf("GetEnvVars returned an error: %v", err)
-		}
-		thirdToken := envVars["WINDSOR_SESSION_TOKEN"]
-
-		// Verify cached token was used
-		if thirdToken != secondToken {
-			t.Errorf("Expected same token %s to be returned, but got %s", secondToken, thirdToken)
-		}
-
-		// Restore original functions
-		stat = origStat
-		osRemoveAll = origOsRemoveAll
-		cryptoRandRead = origCryptoRandRead
-	})
-
-	t.Run("RandomErrorDuringSignalFileRegeneration", func(t *testing.T) {
-		// Mock file system functions
-		stat = func(name string) (os.FileInfo, error) {
-			if strings.Contains(name, ".session.envtoken") {
-				return nil, nil // File exists
-			}
-			return nil, os.ErrNotExist
-		}
-
-		// Mock osRemoveAll to succeed
-		osRemoveAll = func(path string) error {
-			return nil
-		}
-
-		// Mock crypto functions to return an error during regeneration
-		cryptoRandRead = func(b []byte) (n int, err error) {
-			return 0, fmt.Errorf("mock random generation error during token regeneration")
-		}
+		// Set up environment variable to trigger token regeneration
+		t.Setenv("WINDSOR_SESSION_TOKEN", "testtoken")
 
 		mocks := setupSafeWindsorEnvMocks()
 
-		// Set up environment variable with a token
-		t.Setenv("WINDSOR_SESSION_TOKEN", "envtoken")
+		// Make the shell's GetSessionToken return an error when regenerating token
+		mocks.Shell.GetSessionTokenFunc = func() (string, error) {
+			// Check if we are being called for the environment token check
+			if envToken := os.Getenv("WINDSOR_SESSION_TOKEN"); envToken != "" {
+				// We are doing the check for the environment token
+				tokenFilePath := filepath.Join("/mock/project/root", ".windsor", ".session."+envToken)
+				if _, err := stat(tokenFilePath); err == nil {
+					// Signal file exists, mock error during regeneration
+					return "", fmt.Errorf("mock random generation error during token regeneration")
+				}
+				return envToken, nil
+			}
+			return "mock-token", nil
+		}
 
 		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Injector)
 		windsorEnvPrinter.Initialize()
 
-		// Call should fail with random generation error
+		// This should trigger an error in token regeneration
 		_, err := windsorEnvPrinter.GetEnvVars()
 		if err == nil {
 			t.Fatal("Expected error from random generation during token regeneration, got nil")
 		}
-		if !strings.Contains(err.Error(), "error retrieving session token") ||
-			!strings.Contains(err.Error(), "error generating session token") {
+		if !strings.Contains(err.Error(), "error retrieving session token") {
 			t.Errorf("Unexpected error message: %v", err)
-		}
-	})
-
-	t.Run("NoEnvironmentVarsInConfig", func(t *testing.T) {
-		mocks := setupSafeWindsorEnvMocks()
-
-		// Override random generation to avoid token generation errors
-		origCryptoRandRead := cryptoRandRead
-		cryptoRandRead = func(b []byte) (n int, err error) {
-			for i := range b {
-				b[i] = byte(i%26) + 'a' // Generate predictable letters
-			}
-			return len(b), nil
-		}
-		defer func() {
-			cryptoRandRead = origCryptoRandRead
-		}()
-
-		// Ensure environment is clean
-		originalEnvContext := os.Getenv("WINDSOR_CONTEXT")
-		originalEnvToken := os.Getenv("WINDSOR_SESSION_TOKEN")
-		t.Setenv("WINDSOR_CONTEXT", "")
-		t.Setenv("WINDSOR_SESSION_TOKEN", "")
-		defer func() {
-			os.Setenv("WINDSOR_CONTEXT", originalEnvContext)
-			os.Setenv("WINDSOR_SESSION_TOKEN", originalEnvToken)
-		}()
-
-		// Set GetStringMap to return an empty map to simulate no environment vars in config
-		mocks.ConfigHandler.GetStringMapFunc = func(key string, defaultValue ...map[string]string) map[string]string {
-			if key == "environment" {
-				return map[string]string{}
-			}
-			return map[string]string{}
-		}
-
-		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Injector)
-		windsorEnvPrinter.Initialize()
-
-		envVars, err := windsorEnvPrinter.GetEnvVars()
-		if err != nil {
-			t.Fatalf("GetEnvVars should not return an error: %v", err)
-		}
-
-		// Verify we still have the base environment variables
-		if envVars["WINDSOR_CONTEXT"] != "mock-context" {
-			t.Errorf("WINDSOR_CONTEXT should be set even when no environment vars are in config")
-		}
-		if envVars["WINDSOR_PROJECT_ROOT"] != filepath.FromSlash("/mock/project/root") {
-			t.Errorf("WINDSOR_PROJECT_ROOT should be set")
-		}
-		if envVars["WINDSOR_SESSION_TOKEN"] == "" {
-			t.Errorf("Session token should be generated")
-		}
-
-		// Verify no additional variables were added from config (since there were none)
-		if len(envVars) != 5 {
-			t.Errorf("Should have five base environment variables")
 		}
 	})
 
 	t.Run("DifferentContextDisablesCache", func(t *testing.T) {
 		mocks := setupSafeWindsorEnvMocks()
-
-		// Override random generation to avoid token generation errors
-		origCryptoRandRead := cryptoRandRead
-		cryptoRandRead = func(b []byte) (n int, err error) {
-			for i := range b {
-				b[i] = byte(i%26) + 'a' // Generate predictable letters
-			}
-			return len(b), nil
-		}
-		defer func() {
-			cryptoRandRead = origCryptoRandRead
-		}()
 
 		// Set up test environment
 		envVarKey := "TEST_VAR_WITH_SECRET"
@@ -1149,180 +1193,6 @@ func TestWindsorEnv_Print(t *testing.T) {
 			t.Error("expected error, got nil")
 		} else if !strings.Contains(err.Error(), "mock project root error") {
 			t.Errorf("unexpected error message: %v", err)
-		}
-	})
-}
-
-// TestWindsorEnv_CreateSessionInvalidationSignal tests the CreateSessionInvalidationSignal method
-func TestWindsorEnv_CreateSessionInvalidationSignal(t *testing.T) {
-	// Save original functions
-	originalWriteFile := writeFile
-	originalMkdirAll := mkdirAll
-
-	// Restore original functions after tests
-	defer func() {
-		writeFile = originalWriteFile
-		mkdirAll = originalMkdirAll
-	}()
-
-	t.Run("SuccessfulSignalCreation", func(t *testing.T) {
-		// Set up environment variable with a token
-		t.Setenv("WINDSOR_SESSION_TOKEN", "testtoken")
-
-		// Mock file system functions
-		var capturedMkdirPath string
-		var capturedMkdirPerm os.FileMode
-		mkdirAll = func(path string, perm os.FileMode) error {
-			capturedMkdirPath = path
-			capturedMkdirPerm = perm
-			return nil
-		}
-
-		var capturedWritePath string
-		var capturedWriteData []byte
-		var capturedWritePerm os.FileMode
-		writeFile = func(name string, data []byte, perm os.FileMode) error {
-			capturedWritePath = name
-			capturedWriteData = data
-			capturedWritePerm = perm
-			return nil
-		}
-
-		mocks := setupSafeWindsorEnvMocks()
-		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Injector)
-		windsorEnvPrinter.Initialize()
-
-		// Create session invalidation signal
-		err := windsorEnvPrinter.CreateSessionInvalidationSignal()
-		if err != nil {
-			t.Fatalf("CreateSessionInvalidationSignal returned an error: %v", err)
-		}
-
-		// Verify mkdir was called correctly
-		expectedMkdirPath := filepath.FromSlash("/mock/project/root/.windsor")
-		if capturedMkdirPath != expectedMkdirPath {
-			t.Errorf("mkdirAll path = %q, want %q", capturedMkdirPath, expectedMkdirPath)
-		}
-		if capturedMkdirPerm != 0755 {
-			t.Errorf("mkdirAll perm = %v, want %v", capturedMkdirPerm, 0755)
-		}
-
-		// Verify writeFile was called correctly
-		expectedWritePath := filepath.FromSlash("/mock/project/root/.windsor/.session.testtoken")
-		if capturedWritePath != expectedWritePath {
-			t.Errorf("writeFile path = %q, want %q", capturedWritePath, expectedWritePath)
-		}
-		if len(capturedWriteData) != 0 {
-			t.Errorf("writeFile data should be empty, got %v", capturedWriteData)
-		}
-		if capturedWritePerm != 0644 {
-			t.Errorf("writeFile perm = %v, want %v", capturedWritePerm, 0644)
-		}
-	})
-
-	t.Run("NoSessionToken", func(t *testing.T) {
-		// Clear environment variable
-		t.Setenv("WINDSOR_SESSION_TOKEN", "")
-
-		// Mock file system functions to ensure they are not called
-		mkdirAll = func(path string, perm os.FileMode) error {
-			t.Error("mkdirAll should not be called")
-			return nil
-		}
-
-		writeFile = func(name string, data []byte, perm os.FileMode) error {
-			t.Error("writeFile should not be called")
-			return nil
-		}
-
-		mocks := setupSafeWindsorEnvMocks()
-		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Injector)
-		windsorEnvPrinter.Initialize()
-
-		// Create session invalidation signal
-		err := windsorEnvPrinter.CreateSessionInvalidationSignal()
-		if err != nil {
-			t.Fatalf("CreateSessionInvalidationSignal returned an error: %v", err)
-		}
-	})
-
-	t.Run("GetProjectRootError", func(t *testing.T) {
-		// Set up environment variable with a token
-		t.Setenv("WINDSOR_SESSION_TOKEN", "testtoken")
-
-		mocks := setupSafeWindsorEnvMocks()
-
-		// Mock GetProjectRootFunc to return an error
-		mocks.Shell.GetProjectRootFunc = func() (string, error) {
-			return "", fmt.Errorf("mock project root error")
-		}
-
-		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Injector)
-		windsorEnvPrinter.Initialize()
-
-		// Create session invalidation signal
-		err := windsorEnvPrinter.CreateSessionInvalidationSignal()
-		if err == nil {
-			t.Fatal("Expected error, got nil")
-		}
-
-		expectedErrMsg := "failed to get project root: mock project root error"
-		if err.Error() != expectedErrMsg {
-			t.Errorf("Error message = %q, want %q", err.Error(), expectedErrMsg)
-		}
-	})
-
-	t.Run("MkdirAllError", func(t *testing.T) {
-		// Set up environment variable with a token
-		t.Setenv("WINDSOR_SESSION_TOKEN", "testtoken")
-
-		// Mock mkdir to return an error
-		mkdirAll = func(path string, perm os.FileMode) error {
-			return fmt.Errorf("mock mkdir error")
-		}
-
-		mocks := setupSafeWindsorEnvMocks()
-		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Injector)
-		windsorEnvPrinter.Initialize()
-
-		// Create session invalidation signal
-		err := windsorEnvPrinter.CreateSessionInvalidationSignal()
-		if err == nil {
-			t.Fatal("Expected error, got nil")
-		}
-
-		expectedErrMsg := "failed to create .windsor directory: mock mkdir error"
-		if err.Error() != expectedErrMsg {
-			t.Errorf("Error message = %q, want %q", err.Error(), expectedErrMsg)
-		}
-	})
-
-	t.Run("WriteFileError", func(t *testing.T) {
-		// Set up environment variable with a token
-		t.Setenv("WINDSOR_SESSION_TOKEN", "testtoken")
-
-		// Mock file system functions
-		mkdirAll = func(path string, perm os.FileMode) error {
-			return nil
-		}
-
-		writeFile = func(name string, data []byte, perm os.FileMode) error {
-			return fmt.Errorf("mock write file error")
-		}
-
-		mocks := setupSafeWindsorEnvMocks()
-		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Injector)
-		windsorEnvPrinter.Initialize()
-
-		// Create session invalidation signal
-		err := windsorEnvPrinter.CreateSessionInvalidationSignal()
-		if err == nil {
-			t.Fatal("Expected error, got nil")
-		}
-
-		expectedErrMsg := "failed to create signal file: mock write file error"
-		if err.Error() != expectedErrMsg {
-			t.Errorf("Error message = %q, want %q", err.Error(), expectedErrMsg)
 		}
 	})
 }

--- a/pkg/shell/mock_shell.go
+++ b/pkg/shell/mock_shell.go
@@ -8,8 +8,8 @@ import (
 type MockShell struct {
 	DefaultShell
 	InitializeFunc                 func() error
-	PrintEnvVarsFunc               func(envVars map[string]string) error
-	PrintAliasFunc                 func(envVars map[string]string) error
+	PrintEnvVarsFunc               func(envVars map[string]string)
+	PrintAliasFunc                 func(envVars map[string]string)
 	GetProjectRootFunc             func() (string, error)
 	ExecFunc                       func(command string, args ...string) (string, error)
 	ExecSilentFunc                 func(command string, args ...string) (string, error)
@@ -43,19 +43,17 @@ func (s *MockShell) Initialize() error {
 }
 
 // PrintEnvVars calls the custom PrintEnvVarsFunc if provided.
-func (s *MockShell) PrintEnvVars(envVars map[string]string) error {
+func (s *MockShell) PrintEnvVars(envVars map[string]string) {
 	if s.PrintEnvVarsFunc != nil {
-		return s.PrintEnvVarsFunc(envVars)
+		s.PrintEnvVarsFunc(envVars)
 	}
-	return nil
 }
 
 // PrintAlias calls the custom PrintAliasFunc if provided.
-func (s *MockShell) PrintAlias(envVars map[string]string) error {
+func (s *MockShell) PrintAlias(envVars map[string]string) {
 	if s.PrintAliasFunc != nil {
-		return s.PrintAliasFunc(envVars)
+		s.PrintAliasFunc(envVars)
 	}
-	return nil
 }
 
 // GetProjectRoot calls the custom GetProjectRootFunc if provided.

--- a/pkg/shell/mock_shell.go
+++ b/pkg/shell/mock_shell.go
@@ -21,6 +21,7 @@ type MockShell struct {
 	CheckTrustedDirectoryFunc      func() error
 	UnsetEnvsFunc                  func(envVars []string)
 	UnsetAliasFunc                 func(aliases []string)
+	WriteResetTokenFunc            func() (string, error)
 }
 
 // NewMockShell creates a new instance of MockShell. If injector is provided, it sets the injector on MockShell.
@@ -141,6 +142,14 @@ func (s *MockShell) UnsetAlias(aliases []string) {
 	if s.UnsetAliasFunc != nil {
 		s.UnsetAliasFunc(aliases)
 	}
+}
+
+// WriteResetToken calls the custom WriteResetTokenFunc if provided.
+func (s *MockShell) WriteResetToken() (string, error) {
+	if s.WriteResetTokenFunc != nil {
+		return s.WriteResetTokenFunc()
+	}
+	return "", nil
 }
 
 // Ensure MockShell implements the Shell interface

--- a/pkg/shell/mock_shell.go
+++ b/pkg/shell/mock_shell.go
@@ -19,6 +19,8 @@ type MockShell struct {
 	SetVerbosityFunc               func(verbose bool)
 	AddCurrentDirToTrustedFileFunc func() error
 	CheckTrustedDirectoryFunc      func() error
+	UnsetEnvsFunc                  func(envVars []string)
+	UnsetAliasFunc                 func(aliases []string)
 }
 
 // NewMockShell creates a new instance of MockShell. If injector is provided, it sets the injector on MockShell.
@@ -125,6 +127,20 @@ func (s *MockShell) CheckTrustedDirectory() error {
 		return s.CheckTrustedDirectoryFunc()
 	}
 	return nil
+}
+
+// UnsetEnvs calls the custom UnsetEnvsFunc if provided.
+func (s *MockShell) UnsetEnvs(envVars []string) {
+	if s.UnsetEnvsFunc != nil {
+		s.UnsetEnvsFunc(envVars)
+	}
+}
+
+// UnsetAlias calls the custom UnsetAliasFunc if provided.
+func (s *MockShell) UnsetAlias(aliases []string) {
+	if s.UnsetAliasFunc != nil {
+		s.UnsetAliasFunc(aliases)
+	}
 }
 
 // Ensure MockShell implements the Shell interface

--- a/pkg/shell/mock_shell.go
+++ b/pkg/shell/mock_shell.go
@@ -1,6 +1,8 @@
 package shell
 
 import (
+	"fmt"
+
 	"github.com/windsorcli/cli/pkg/di"
 )
 
@@ -22,6 +24,9 @@ type MockShell struct {
 	UnsetEnvsFunc                  func(envVars []string)
 	UnsetAliasFunc                 func(aliases []string)
 	WriteResetTokenFunc            func() (string, error)
+	GetSessionTokenFunc            func() (string, error)
+	CheckResetFlagsFunc            func() (bool, error)
+	ResetFunc                      func()
 }
 
 // NewMockShell creates a new instance of MockShell. If injector is provided, it sets the injector on MockShell.
@@ -30,11 +35,14 @@ func NewMockShell(injectors ...di.Injector) *MockShell {
 	if len(injectors) > 0 {
 		injector = injectors[0]
 	}
-	return &MockShell{
+
+	mockShell := &MockShell{
 		DefaultShell: DefaultShell{
 			injector: injector,
 		},
 	}
+
+	return mockShell
 }
 
 // Initialize calls the custom InitializeFunc if provided.
@@ -144,12 +152,35 @@ func (s *MockShell) UnsetAlias(aliases []string) {
 	}
 }
 
-// WriteResetToken calls the custom WriteResetTokenFunc if provided.
+// WriteResetToken writes a reset token file
 func (s *MockShell) WriteResetToken() (string, error) {
 	if s.WriteResetTokenFunc != nil {
 		return s.WriteResetTokenFunc()
 	}
-	return "", nil
+	return "", fmt.Errorf("WriteResetToken not implemented")
+}
+
+// GetSessionToken retrieves or generates a session token
+func (s *MockShell) GetSessionToken() (string, error) {
+	if s.GetSessionTokenFunc != nil {
+		return s.GetSessionTokenFunc()
+	}
+	return "", fmt.Errorf("GetSessionToken not implemented")
+}
+
+// CheckResetFlags checks if a reset signal file exists for the current session
+func (s *MockShell) CheckResetFlags() (bool, error) {
+	if s.CheckResetFlagsFunc != nil {
+		return s.CheckResetFlagsFunc()
+	}
+	return false, nil
+}
+
+// Reset calls the custom ResetFunc if provided.
+func (s *MockShell) Reset() {
+	if s.ResetFunc != nil {
+		s.ResetFunc()
+	}
 }
 
 // Ensure MockShell implements the Shell interface

--- a/pkg/shell/mock_shell_test.go
+++ b/pkg/shell/mock_shell_test.go
@@ -706,14 +706,45 @@ func TestMockShell_WriteResetToken(t *testing.T) {
 		mockShell := NewMockShell(injector)
 
 		// When calling WriteResetToken
-		path, err := mockShell.WriteResetToken()
+		_, err := mockShell.WriteResetToken()
 
-		// Then no error should be returned and the path should be empty
-		if err != nil {
-			t.Errorf("WriteResetToken() error = %v, want nil", err)
+		// Then an error should be returned
+		if err == nil {
+			t.Errorf("WriteResetToken() expected error, got nil")
 		}
-		if path != "" {
-			t.Errorf("WriteResetToken() path = %v, want empty string", path)
+		if err.Error() != "WriteResetToken not implemented" {
+			t.Errorf("WriteResetToken() error = %v, want %v", err, "WriteResetToken not implemented")
+		}
+	})
+}
+
+// TestMockShell_Reset tests the Reset method of the MockShell struct
+func TestMockShell_Reset(t *testing.T) {
+	t.Run("DefaultReset", func(t *testing.T) {
+		// Given a mock shell with default Reset implementation
+		injector := di.NewInjector()
+		mockShell := NewMockShell(injector)
+
+		// When calling Reset (without a custom implementation)
+		// This is a no-op, so we just call it to ensure it doesn't panic
+		mockShell.Reset()
+	})
+
+	t.Run("CustomReset", func(t *testing.T) {
+		// Given a mock shell with custom Reset implementation
+		injector := di.NewInjector()
+		mockShell := NewMockShell(injector)
+		resetCalled := false
+		mockShell.ResetFunc = func() {
+			resetCalled = true
+		}
+
+		// When calling Reset
+		mockShell.Reset()
+
+		// Then it should call the custom reset function
+		if !resetCalled {
+			t.Error("Reset() did not call ResetFunc")
 		}
 	})
 }

--- a/pkg/shell/mock_shell_test.go
+++ b/pkg/shell/mock_shell_test.go
@@ -654,3 +654,66 @@ func TestMockShell_PrintAlias(t *testing.T) {
 		mockShell.PrintAlias(map[string]string{"alias1": "command1"})
 	})
 }
+
+func TestMockShell_WriteResetToken(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Given a mock shell with a custom WriteResetTokenFunc implementation
+		injector := di.NewInjector()
+		mockShell := NewMockShell(injector)
+
+		expectedPath := "/test/project/root/.windsor/.session.test-token"
+		mockShell.WriteResetTokenFunc = func() (string, error) {
+			return expectedPath, nil
+		}
+
+		// When calling WriteResetToken
+		path, err := mockShell.WriteResetToken()
+
+		// Then no error should be returned and the expected path should be returned
+		if err != nil {
+			t.Errorf("WriteResetToken() error = %v, want nil", err)
+		}
+		if path != expectedPath {
+			t.Errorf("WriteResetToken() path = %v, want %v", path, expectedPath)
+		}
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		// Given a mock shell whose WriteResetTokenFunc returns an error
+		injector := di.NewInjector()
+		mockShell := NewMockShell(injector)
+
+		expectedError := fmt.Errorf("error writing reset token")
+		mockShell.WriteResetTokenFunc = func() (string, error) {
+			return "", expectedError
+		}
+
+		// When calling WriteResetToken
+		path, err := mockShell.WriteResetToken()
+
+		// Then the expected error should be returned
+		if err != expectedError {
+			t.Errorf("WriteResetToken() error = %v, want %v", err, expectedError)
+		}
+		if path != "" {
+			t.Errorf("WriteResetToken() path = %v, want empty string", path)
+		}
+	})
+
+	t.Run("NotImplemented", func(t *testing.T) {
+		// Given a mock shell with no WriteResetTokenFunc implementation
+		injector := di.NewInjector()
+		mockShell := NewMockShell(injector)
+
+		// When calling WriteResetToken
+		path, err := mockShell.WriteResetToken()
+
+		// Then no error should be returned and the path should be empty
+		if err != nil {
+			t.Errorf("WriteResetToken() error = %v, want nil", err)
+		}
+		if path != "" {
+			t.Errorf("WriteResetToken() path = %v, want empty string", path)
+		}
+	})
+}

--- a/pkg/shell/mock_shell_test.go
+++ b/pkg/shell/mock_shell_test.go
@@ -396,3 +396,261 @@ func TestMockShell_CheckTrustedDirectory(t *testing.T) {
 		assertError(t, err, false)
 	})
 }
+
+func TestMockShell_UnsetEnvs(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Given a mock shell with a custom UnsetEnvsFunc implementation
+		injector := di.NewInjector()
+		mockShell := NewMockShell(injector)
+
+		// Track which variables were passed to the function
+		var capturedEnvVars []string
+		mockShell.UnsetEnvsFunc = func(envVars []string) {
+			capturedEnvVars = envVars
+		}
+
+		// When calling UnsetEnvs with a list of environment variables
+		envVarsToUnset := []string{"VAR1", "VAR2", "VAR3"}
+		mockShell.UnsetEnvs(envVarsToUnset)
+
+		// Then the function should be called with the correct variables
+		if len(capturedEnvVars) != len(envVarsToUnset) {
+			t.Errorf("Expected %d env vars, got %d", len(envVarsToUnset), len(capturedEnvVars))
+		}
+
+		for i, envVar := range envVarsToUnset {
+			if capturedEnvVars[i] != envVar {
+				t.Errorf("Expected env var %s at position %d, got %s", envVar, i, capturedEnvVars[i])
+			}
+		}
+	})
+
+	t.Run("EmptyList", func(t *testing.T) {
+		// Given a mock shell with a custom UnsetEnvsFunc implementation
+		injector := di.NewInjector()
+		mockShell := NewMockShell(injector)
+
+		// Track if the function was called
+		functionCalled := false
+		mockShell.UnsetEnvsFunc = func(envVars []string) {
+			functionCalled = true
+		}
+
+		// When calling UnsetEnvs with an empty list
+		mockShell.UnsetEnvs([]string{})
+
+		// Then the function should still be called
+		if !functionCalled {
+			t.Errorf("Expected UnsetEnvsFunc to be called even with empty list")
+		}
+	})
+
+	t.Run("NotImplemented", func(t *testing.T) {
+		// Given a mock shell with no UnsetEnvsFunc implementation
+		injector := di.NewInjector()
+		mockShell := NewMockShell(injector)
+
+		// When calling UnsetEnvs
+		// Then no error should occur (function should not panic)
+		mockShell.UnsetEnvs([]string{"VAR1", "VAR2"})
+	})
+}
+
+func TestMockShell_UnsetAlias(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Given a mock shell with a custom UnsetAliasFunc implementation
+		injector := di.NewInjector()
+		mockShell := NewMockShell(injector)
+
+		// Track which aliases were passed to the function
+		var capturedAliases []string
+		mockShell.UnsetAliasFunc = func(aliases []string) {
+			capturedAliases = aliases
+		}
+
+		// When calling UnsetAlias with a list of aliases
+		aliasesToUnset := []string{"alias1", "alias2", "alias3"}
+		mockShell.UnsetAlias(aliasesToUnset)
+
+		// Then the function should be called with the correct aliases
+		if len(capturedAliases) != len(aliasesToUnset) {
+			t.Errorf("Expected %d aliases, got %d", len(aliasesToUnset), len(capturedAliases))
+		}
+
+		for i, alias := range aliasesToUnset {
+			if capturedAliases[i] != alias {
+				t.Errorf("Expected alias %s at position %d, got %s", alias, i, capturedAliases[i])
+			}
+		}
+	})
+
+	t.Run("EmptyList", func(t *testing.T) {
+		// Given a mock shell with a custom UnsetAliasFunc implementation
+		injector := di.NewInjector()
+		mockShell := NewMockShell(injector)
+
+		// Track if the function was called
+		functionCalled := false
+		mockShell.UnsetAliasFunc = func(aliases []string) {
+			functionCalled = true
+		}
+
+		// When calling UnsetAlias with an empty list
+		mockShell.UnsetAlias([]string{})
+
+		// Then the function should still be called
+		if !functionCalled {
+			t.Errorf("Expected UnsetAliasFunc to be called even with empty list")
+		}
+	})
+
+	t.Run("NotImplemented", func(t *testing.T) {
+		// Given a mock shell with no UnsetAliasFunc implementation
+		injector := di.NewInjector()
+		mockShell := NewMockShell(injector)
+
+		// When calling UnsetAlias
+		// Then no error should occur (function should not panic)
+		mockShell.UnsetAlias([]string{"alias1", "alias2"})
+	})
+}
+
+func TestMockShell_PrintEnvVars(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Given a mock shell with a custom PrintEnvVarsFunc implementation
+		injector := di.NewInjector()
+		mockShell := NewMockShell(injector)
+
+		// Track which environment variables were passed to the function
+		var capturedEnvVars map[string]string
+		mockShell.PrintEnvVarsFunc = func(envVars map[string]string) {
+			capturedEnvVars = envVars
+		}
+
+		// When calling PrintEnvVars with a map of environment variables
+		envVarsToPrint := map[string]string{
+			"VAR1": "value1",
+			"VAR2": "value2",
+			"VAR3": "value3",
+		}
+		mockShell.PrintEnvVars(envVarsToPrint)
+
+		// Then the function should be called with the correct variables
+		if len(capturedEnvVars) != len(envVarsToPrint) {
+			t.Errorf("Expected %d env vars, got %d", len(envVarsToPrint), len(capturedEnvVars))
+		}
+
+		for key, value := range envVarsToPrint {
+			capturedValue, exists := capturedEnvVars[key]
+			if !exists {
+				t.Errorf("Expected env var %s to be passed to PrintEnvVarsFunc, but it wasn't", key)
+			}
+			if capturedValue != value {
+				t.Errorf("Expected env var %s to have value %s, got %s", key, value, capturedValue)
+			}
+		}
+	})
+
+	t.Run("EmptyMap", func(t *testing.T) {
+		// Given a mock shell with a custom PrintEnvVarsFunc implementation
+		injector := di.NewInjector()
+		mockShell := NewMockShell(injector)
+
+		// Track if the function was called
+		functionCalled := false
+		mockShell.PrintEnvVarsFunc = func(envVars map[string]string) {
+			functionCalled = true
+			if len(envVars) != 0 {
+				t.Errorf("Expected empty map, got map with %d elements", len(envVars))
+			}
+		}
+
+		// When calling PrintEnvVars with an empty map
+		mockShell.PrintEnvVars(map[string]string{})
+
+		// Then the function should still be called
+		if !functionCalled {
+			t.Errorf("Expected PrintEnvVarsFunc to be called even with empty map")
+		}
+	})
+
+	t.Run("NotImplemented", func(t *testing.T) {
+		// Given a mock shell with no PrintEnvVarsFunc implementation
+		injector := di.NewInjector()
+		mockShell := NewMockShell(injector)
+
+		// When calling PrintEnvVars
+		// Then no error should occur (function should not panic)
+		mockShell.PrintEnvVars(map[string]string{"VAR1": "value1"})
+	})
+}
+
+func TestMockShell_PrintAlias(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Given a mock shell with a custom PrintAliasFunc implementation
+		injector := di.NewInjector()
+		mockShell := NewMockShell(injector)
+
+		// Track which aliases were passed to the function
+		var capturedAliases map[string]string
+		mockShell.PrintAliasFunc = func(aliases map[string]string) {
+			capturedAliases = aliases
+		}
+
+		// When calling PrintAlias with a map of aliases
+		aliasesToPrint := map[string]string{
+			"alias1": "command1",
+			"alias2": "command2",
+			"alias3": "command3",
+		}
+		mockShell.PrintAlias(aliasesToPrint)
+
+		// Then the function should be called with the correct aliases
+		if len(capturedAliases) != len(aliasesToPrint) {
+			t.Errorf("Expected %d aliases, got %d", len(aliasesToPrint), len(capturedAliases))
+		}
+
+		for key, value := range aliasesToPrint {
+			capturedValue, exists := capturedAliases[key]
+			if !exists {
+				t.Errorf("Expected alias %s to be passed to PrintAliasFunc, but it wasn't", key)
+			}
+			if capturedValue != value {
+				t.Errorf("Expected alias %s to have value %s, got %s", key, value, capturedValue)
+			}
+		}
+	})
+
+	t.Run("EmptyMap", func(t *testing.T) {
+		// Given a mock shell with a custom PrintAliasFunc implementation
+		injector := di.NewInjector()
+		mockShell := NewMockShell(injector)
+
+		// Track if the function was called
+		functionCalled := false
+		mockShell.PrintAliasFunc = func(aliases map[string]string) {
+			functionCalled = true
+			if len(aliases) != 0 {
+				t.Errorf("Expected empty map, got map with %d elements", len(aliases))
+			}
+		}
+
+		// When calling PrintAlias with an empty map
+		mockShell.PrintAlias(map[string]string{})
+
+		// Then the function should still be called
+		if !functionCalled {
+			t.Errorf("Expected PrintAliasFunc to be called even with empty map")
+		}
+	})
+
+	t.Run("NotImplemented", func(t *testing.T) {
+		// Given a mock shell with no PrintAliasFunc implementation
+		injector := di.NewInjector()
+		mockShell := NewMockShell(injector)
+
+		// When calling PrintAlias
+		// Then no error should occur (function should not panic)
+		mockShell.PrintAlias(map[string]string{"alias1": "command1"})
+	})
+}

--- a/pkg/shell/mock_shell_test.go
+++ b/pkg/shell/mock_shell_test.go
@@ -2,7 +2,6 @@ package shell
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/windsorcli/cli/pkg/di"
@@ -57,95 +56,6 @@ func TestMockShell_Initialize(t *testing.T) {
 
 		// Then no error should be returned as the default implementation does nothing
 		assertError(t, err, false)
-	})
-}
-
-func TestMockShell_PrintEnvVars(t *testing.T) {
-	envVars := map[string]string{
-		"VAR1": "value1",
-		"VAR2": "value2",
-	}
-
-	t.Run("DefaultPrintEnvVars", func(t *testing.T) {
-		injector := di.NewInjector()
-
-		// Given a mock shell with default PrintEnvVars implementation
-		mockShell := NewMockShell(injector)
-		// When calling PrintEnvVars
-		output := captureStdout(t, func() {
-			mockShell.PrintEnvVars(envVars)
-		})
-		// Then the output should be empty as the default implementation does nothing
-		if output != "" {
-			t.Errorf("PrintEnvVars() output = %v, want %v", output, "")
-		}
-	})
-
-	t.Run("CustomPrintEnvVars", func(t *testing.T) {
-		injector := di.NewInjector()
-		// Given a mock shell with custom PrintEnvVars implementation
-		mockShell := NewMockShell(injector)
-		mockShell.PrintEnvVarsFunc = func(envVars map[string]string) error {
-			for key, value := range envVars {
-				fmt.Printf("%s=%s\n", key, value)
-			}
-			return nil
-		}
-		// When calling PrintEnvVars
-		output := captureStdout(t, func() {
-			mockShell.PrintEnvVars(envVars)
-		})
-		// Then the output should contain all expected environment variables
-		for key, value := range envVars {
-			expectedLine := fmt.Sprintf("%s=%s\n", key, value)
-			if !strings.Contains(output, expectedLine) {
-				t.Errorf("PrintEnvVars() output missing expected line: %v", expectedLine)
-			}
-		}
-	})
-}
-
-func TestMockShell_PrintAlias(t *testing.T) {
-	aliasVars := map[string]string{
-		"ALIAS1": "command1",
-		"ALIAS2": "command2",
-	}
-
-	t.Run("DefaultPrintAlias", func(t *testing.T) {
-		injector := di.NewInjector()
-		// Given a mock shell with default PrintAlias implementation
-		mockShell := NewMockShell(injector)
-		// When calling PrintAlias
-		output := captureStdout(t, func() {
-			mockShell.PrintAlias(aliasVars)
-		})
-		// Then the output should be empty as the default implementation does nothing
-		if output != "" {
-			t.Errorf("PrintAlias() output = %v, want %v", output, "")
-		}
-	})
-
-	t.Run("CustomPrintAlias", func(t *testing.T) {
-		injector := di.NewInjector()
-		// Given a mock shell with custom PrintAlias implementation
-		mockShell := NewMockShell(injector)
-		mockShell.PrintAliasFunc = func(aliasVars map[string]string) error {
-			for key, value := range aliasVars {
-				fmt.Printf("%s=%s\n", key, value)
-			}
-			return nil
-		}
-		// When calling PrintAlias
-		output := captureStdout(t, func() {
-			mockShell.PrintAlias(aliasVars)
-		})
-		// Then the output should contain all expected alias variables
-		for key, value := range aliasVars {
-			expectedLine := fmt.Sprintf("%s=%s\n", key, value)
-			if !strings.Contains(output, expectedLine) {
-				t.Errorf("PrintAlias() output missing expected line: %v", expectedLine)
-			}
-		}
 	})
 }
 

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -51,6 +51,10 @@ type Shell interface {
 	AddCurrentDirToTrustedFile() error
 	// CheckTrustedDirectory verifies if the current directory is in the trusted file list.
 	CheckTrustedDirectory() error
+	// UnsetEnvs generates a command to unset multiple environment variables
+	UnsetEnvs(envVars []string) error
+	// UnsetAlias generates commands to unset multiple aliases
+	UnsetAlias(aliases []string) error
 }
 
 // DefaultShell is the default implementation of the Shell interface

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -19,6 +19,19 @@ import (
 // maxFolderSearchDepth is the maximum depth to search for the project root
 const maxFolderSearchDepth = 10
 
+// Constants
+const (
+	SessionTokenPrefix = ".session."
+)
+
+// Static private variable to store the session token
+var sessionToken string
+
+// Reset the session token - used primarily for testing
+func ResetSessionToken() {
+	sessionToken = ""
+}
+
 // HookContext are the variables available during hook template evaluation
 type HookContext struct {
 	// SelfPath is the unescaped absolute path to direnv
@@ -57,6 +70,12 @@ type Shell interface {
 	UnsetAlias(aliases []string)
 	// WriteResetToken writes a reset token file based on the session token
 	WriteResetToken() (string, error)
+	// GetSessionToken retrieves or generates a session token
+	GetSessionToken() (string, error)
+	// CheckResetFlags checks if a reset signal file exists for the current session
+	CheckResetFlags() (bool, error)
+	// Reset removes all managed environment variables and aliases
+	Reset()
 }
 
 // DefaultShell is the default implementation of the Shell interface
@@ -66,11 +85,6 @@ type DefaultShell struct {
 	injector    di.Injector
 	verbose     bool
 }
-
-// Constants
-const (
-	SessionTokenPrefix = ".session."
-)
 
 // NewDefaultShell creates a new instance of DefaultShell
 func NewDefaultShell(injector di.Injector) *DefaultShell {
@@ -451,3 +465,120 @@ func (s *DefaultShell) WriteResetToken() (string, error) {
 
 	return sessionFilePath, nil
 }
+
+// GetSessionToken retrieves or generates a session token. It first checks if a token is already stored in memory.
+// If not, it looks for a token in the environment variable. If no token is found in the environment, it generates a new token.
+func (s *DefaultShell) GetSessionToken() (string, error) {
+	// If we already have a token in memory, return it
+	if sessionToken != "" {
+		return sessionToken, nil
+	}
+
+	envToken := osGetenv("WINDSOR_SESSION_TOKEN")
+	if envToken != "" {
+		sessionToken = envToken
+		return envToken, nil
+	}
+
+	token, err := s.generateRandomString(7)
+	if err != nil {
+		return "", fmt.Errorf("error generating session token: %w", err)
+	}
+
+	sessionToken = token
+	return token, nil
+}
+
+// Reset removes all managed environment variables and aliases.
+// It uses the environment variables "WINDSOR_MANAGED_ENV" and "WINDSOR_MANAGED_ALIAS"
+// to retrieve the previous set of managed environment variables and aliases, respectively.
+// These environment variables represent the previous set of managed values that need to be reset.
+func (s *DefaultShell) Reset() {
+	var managedEnvs []string
+	if envStr := os.Getenv("WINDSOR_MANAGED_ENV"); envStr != "" {
+		for _, env := range strings.Split(envStr, ",") {
+			env = strings.TrimSpace(env)
+			if env != "" {
+				managedEnvs = append(managedEnvs, env)
+				os.Unsetenv(env)
+			}
+		}
+	}
+
+	var managedAliases []string
+	if aliasStr := os.Getenv("WINDSOR_MANAGED_ALIAS"); aliasStr != "" {
+		for _, alias := range strings.Split(aliasStr, ",") {
+			alias = strings.TrimSpace(alias)
+			if alias != "" {
+				managedAliases = append(managedAliases, alias)
+			}
+		}
+	}
+
+	if len(managedEnvs) > 0 {
+		s.UnsetEnvs(managedEnvs)
+	}
+
+	if len(managedAliases) > 0 {
+		s.UnsetAlias(managedAliases)
+	}
+}
+
+// generateRandomString creates a secure random string of the given length using a predefined charset.
+func (s *DefaultShell) generateRandomString(length int) (string, error) {
+	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	randomBytes := make([]byte, length)
+
+	_, err := randRead(randomBytes)
+	if err != nil {
+		return "", err
+	}
+
+	// Map random bytes to charset
+	for i, b := range randomBytes {
+		randomBytes[i] = charset[b%byte(len(charset))]
+	}
+
+	return string(randomBytes), nil
+}
+
+// CheckResetFlags checks if a reset signal file exists for the current session token.
+// It returns true if the specific session token file exists and always removes all .session.* files.
+func (s *DefaultShell) CheckResetFlags() (bool, error) {
+	// Get current session token from environment
+	envToken := osGetenv("WINDSOR_SESSION_TOKEN")
+	if envToken == "" {
+		return false, nil
+	}
+
+	projectRoot, err := s.GetProjectRoot()
+	if err != nil {
+		return false, fmt.Errorf("error getting project root: %w", err)
+	}
+
+	windsorDir := filepath.Join(projectRoot, ".windsor")
+	tokenFilePath := filepath.Join(windsorDir, ".session."+envToken)
+
+	// Check for the specific session token file
+	tokenFileExists := false
+	if _, err := osStat(tokenFilePath); err == nil {
+		tokenFileExists = true
+	}
+
+	// Remove all .session.* files
+	sessionFiles, err := filepathGlob(filepath.Join(windsorDir, SessionTokenPrefix+"*"))
+	if err != nil {
+		return false, fmt.Errorf("error finding session files: %w", err)
+	}
+
+	for _, file := range sessionFiles {
+		if err := osRemoveAll(file); err != nil {
+			return false, fmt.Errorf("error removing session file %s: %w", file, err)
+		}
+	}
+
+	return tokenFileExists, nil
+}
+
+// Ensure DefaultShell implements the Shell interface
+var _ Shell = (*DefaultShell)(nil)

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -32,9 +32,9 @@ type Shell interface {
 	// SetVerbosity sets the verbosity flag
 	SetVerbosity(verbose bool)
 	// PrintEnvVars prints the provided environment variables
-	PrintEnvVars(envVars map[string]string) error
+	PrintEnvVars(envVars map[string]string)
 	// PrintAlias retrieves the shell alias
-	PrintAlias(envVars map[string]string) error
+	PrintAlias(envVars map[string]string)
 	// GetProjectRoot retrieves the project root directory
 	GetProjectRoot() (string, error)
 	// Exec executes a command with optional privilege elevation
@@ -52,9 +52,9 @@ type Shell interface {
 	// CheckTrustedDirectory verifies if the current directory is in the trusted file list.
 	CheckTrustedDirectory() error
 	// UnsetEnvs generates a command to unset multiple environment variables
-	UnsetEnvs(envVars []string) error
+	UnsetEnvs(envVars []string)
 	// UnsetAlias generates commands to unset multiple aliases
-	UnsetAlias(aliases []string) error
+	UnsetAlias(aliases []string)
 }
 
 // DefaultShell is the default implementation of the Shell interface

--- a/pkg/shell/shell_test.go
+++ b/pkg/shell/shell_test.go
@@ -18,6 +18,48 @@ import (
 	"github.com/windsorcli/cli/pkg/di"
 )
 
+// Test utilities for shell tests
+
+// setupShellTest creates a new DefaultShell for testing
+func setupShellTest(t *testing.T) *DefaultShell {
+	// Create a new injector
+	injector := di.NewInjector()
+	// Create a new default shell
+	shell := NewDefaultShell(injector)
+	// Initialize the shell
+	err := shell.Initialize()
+	if err != nil {
+		t.Fatalf("Failed to initialize shell: %v", err)
+	}
+	return shell
+}
+
+// Helper function to test random string generation
+func testRandomStringGeneration(t *testing.T, shell *DefaultShell, length int) {
+	t.Helper()
+
+	// Generate a string of the specified length
+	token, err := shell.generateRandomString(length)
+
+	// Verify no errors
+	if err != nil {
+		t.Fatalf("generateRandomString() error: %v", err)
+	}
+
+	// Verify correct length
+	if len(token) != length {
+		t.Errorf("Expected token to have length %d, got %d", length, len(token))
+	}
+
+	// Check that token only contains expected characters
+	validChars := "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+	for _, char := range token {
+		if !strings.ContainsRune(validChars, char) {
+			t.Errorf("Token contains unexpected character: %c", char)
+		}
+	}
+}
+
 func TestShell_Initialize(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		injector := di.NewInjector()
@@ -935,15 +977,6 @@ func TestShell_InstallHook(t *testing.T) {
 	})
 }
 
-// Helper function to resolve symlinks
-func resolveSymlinks(t *testing.T, path string) string {
-	resolvedPath, err := filepath.EvalSymlinks(path)
-	if err != nil {
-		t.Fatalf("Failed to evaluate symlinks for %s: %v", path, err)
-	}
-	return resolvedPath
-}
-
 var tempDirs []string
 
 // Helper function to create a temporary directory
@@ -980,15 +1013,6 @@ func changeDir(t *testing.T, dir string) {
 	})
 }
 
-// Helper function to initialize a git repository
-func initGitRepo(t *testing.T, dir string) {
-	cmd := exec.Command("git", "init")
-	cmd.Dir = dir
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("Failed to initialize git repository: %v", err)
-	}
-}
-
 // Helper function to normalize a path
 func normalizePath(path string) string {
 	return strings.ReplaceAll(filepath.Clean(path), "\\", "/")
@@ -1015,25 +1039,6 @@ func captureStdout(t *testing.T, f func()) string {
 	<-done
 	os.Stdout = originalStdout
 	return output.String()
-}
-
-// Mock execCommand to simulate git command failure
-func mockCommand(_ string, _ ...string) *exec.Cmd {
-	return exec.Command("false")
-}
-
-// Updated helper function to mock exec.Command for successful execution using PowerShell
-func mockExecCommandSuccess(command string, args ...string) *exec.Cmd {
-	if runtime.GOOS == "windows" {
-		// Use PowerShell to execute the echo command
-		fullCommand := fmt.Sprintf("Write-Output 'mock output for: %s %s'", command, strings.Join(args, " "))
-		cmdArgs := []string{"-Command", fullCommand}
-		return exec.Command("powershell.exe", cmdArgs...)
-	} else {
-		// Use 'echo' on Unix-like systems
-		fullArgs := append([]string{"mock output for:", command}, args...)
-		return exec.Command("echo", fullArgs...)
-	}
 }
 
 // Updated helper function to mock exec.Command for failed execution using PowerShell
@@ -1221,219 +1226,195 @@ func TestEnv_CheckTrustedDirectory(t *testing.T) {
 	})
 }
 
-func TestDefaultShell_AddCurrentDirToTrustedFile(t *testing.T) {
-	// Mock the os functions at the top
-	originalGetwd := getwd
-	originalOsUserHomeDir := osUserHomeDir
-	originalReadFile := osReadFile
-	originalMkdirAll := osMkdirAll
-	originalWriteFile := osWriteFile
+func TestDefaultShell_GetSessionToken(t *testing.T) {
+	t.Run("GenerateNewToken", func(t *testing.T) {
+		// Given
+		ResetSessionToken()
+		shell := setupShellTest(t)
 
-	defer func() {
-		getwd = originalGetwd
-		osUserHomeDir = originalOsUserHomeDir
-		osReadFile = originalReadFile
-		osMkdirAll = originalMkdirAll
-		osWriteFile = originalWriteFile
-	}()
+		// Save original functions to restore later
+		originalRandRead := randRead
+		originalOsGetenv := osGetenv
+		defer func() {
+			randRead = originalRandRead
+			osGetenv = originalOsGetenv
+		}()
 
-	// Default mock implementations for success scenarios
-	getwd = func() (string, error) {
-		return "/mock/current/dir", nil
-	}
+		// Mock osGetenv to return empty string (no env token)
+		osGetenv = func(key string) string {
+			return ""
+		}
 
-	osUserHomeDir = func() (string, error) {
-		return "/mock/home/dir", nil
-	}
+		// Create a deterministic token generator
+		randRead = func(b []byte) (n int, err error) {
+			for i := range b {
+				b[i] = byte(i % 62) // Use a deterministic pattern
+			}
+			return len(b), nil
+		}
 
-	osReadFile = func(filename string) ([]byte, error) {
-		return []byte{}, nil
-	}
+		// When
+		token, err := shell.GetSessionToken()
 
-	osMkdirAll = func(path string, perm os.FileMode) error {
-		return nil
-	}
-
-	var capturedData []byte
-	osWriteFile = func(filename string, data []byte, perm os.FileMode) error {
-		capturedData = data
-		return nil
-	}
-
-	t.Run("Success", func(t *testing.T) {
-		// Create a default shell for testing
-		shell := &DefaultShell{}
-
-		// Call AddCurrentDirToTrustedFile and check for errors
-		err := shell.AddCurrentDirToTrustedFile()
+		// Then
 		if err != nil {
-			t.Errorf("unexpected error: %v", err)
+			t.Errorf("GetSessionToken() error = %v, want nil", err)
 		}
-
-		// Verify that the current directory was added to the trusted file
-		expectedData := "/mock/current/dir\n"
-		if string(capturedData) != expectedData {
-			t.Errorf("capturedData = %v, want %v", string(capturedData), expectedData)
+		if len(token) != 7 {
+			t.Errorf("GetSessionToken() token length = %d, want 7", len(token))
 		}
 	})
 
-	t.Run("SuccessAlreadyTrusted", func(t *testing.T) {
-		// Save the original osReadFile function
-		originalReadFile := osReadFile
-		defer func() { osReadFile = originalReadFile }()
+	t.Run("ReuseExistingToken", func(t *testing.T) {
+		// Given
+		ResetSessionToken()
+		shell := setupShellTest(t)
 
-		// Override the osReadFile function locally to simulate a trusted directory already present
-		osReadFile = func(filename string) ([]byte, error) {
-			return []byte("/mock/current/dir\n"), nil
+		// Save original functions
+		originalRandRead := randRead
+		originalOsGetenv := osGetenv
+		defer func() {
+			randRead = originalRandRead
+			osGetenv = originalOsGetenv
+		}()
+
+		// Mock rand.Read to generate a predictable token
+		randRead = func(b []byte) (n int, err error) {
+			for i := range b {
+				b[i] = byte(i % 62) // Use a deterministic pattern
+			}
+			return len(b), nil
 		}
 
-		// Create a default shell for testing
-		shell := &DefaultShell{}
+		// Generate a first token to cache it
+		firstToken, _ := shell.GetSessionToken()
 
-		// Call AddCurrentDirToTrustedFile and check for errors
-		err := shell.AddCurrentDirToTrustedFile()
+		// When getting a second token
+		secondToken, err := shell.GetSessionToken()
+
+		// Then
 		if err != nil {
-			t.Errorf("unexpected error: %v", err)
+			t.Errorf("GetSessionToken() error = %v, want nil", err)
+		}
+		if firstToken != secondToken {
+			t.Errorf("GetSessionToken() token = %s, want %s", secondToken, firstToken)
 		}
 	})
 
-	t.Run("ErrorGettingProjectRoot", func(t *testing.T) {
-		// Save the original getwd function
-		originalGetwd := getwd
-		defer func() { getwd = originalGetwd }()
+	t.Run("UseEnvironmentToken", func(t *testing.T) {
+		// Given
+		ResetSessionToken()
+		shell := setupShellTest(t)
 
-		// Override the getwd function locally to simulate an error
-		getwd = func() (string, error) {
-			return "", fmt.Errorf("error getting project root directory")
+		// Save original functions
+		originalOsGetenv := osGetenv
+		defer func() {
+			osGetenv = originalOsGetenv
+		}()
+
+		// Mock osGetenv to return a specific token
+		osGetenv = func(key string) string {
+			if key == "WINDSOR_SESSION_TOKEN" {
+				return "testtoken"
+			}
+			return ""
 		}
 
-		// Create a default shell for testing
-		shell := &DefaultShell{}
+		// When
+		token, err := shell.GetSessionToken()
 
-		// Call AddCurrentDirToTrustedFile and expect an error
-		err := shell.AddCurrentDirToTrustedFile()
-		if err == nil {
-			t.Errorf("expected error, got nil")
+		// Then
+		if err != nil {
+			t.Errorf("GetSessionToken() error = %v, want nil", err)
 		}
-		expectedError := "Error getting project root directory: error getting project root directory"
-		if err.Error() != expectedError {
-			t.Errorf("expected error %q, got %q", expectedError, err.Error())
-		}
-	})
-
-	t.Run("ErrorGettingUserHomeDir", func(t *testing.T) {
-		// Save the original osUserHomeDir function
-		originalOsUserHomeDir := osUserHomeDir
-		defer func() { osUserHomeDir = originalOsUserHomeDir }()
-
-		// Override the osUserHomeDir function locally to simulate an error
-		osUserHomeDir = func() (string, error) {
-			return "", fmt.Errorf("error getting user home directory")
-		}
-
-		// Create a default shell for testing
-		shell := &DefaultShell{}
-
-		// Call AddCurrentDirToTrustedFile and expect an error
-		err := shell.AddCurrentDirToTrustedFile()
-		if err == nil {
-			t.Errorf("expected error, got nil")
-		}
-		expectedError := "Error getting user home directory: error getting user home directory"
-		if err.Error() != expectedError {
-			t.Errorf("expected error %q, got %q", expectedError, err.Error())
+		if token != "testtoken" {
+			t.Errorf("GetSessionToken() token = %s, want testtoken", token)
 		}
 	})
 
-	t.Run("ErrorCreatingDirectories", func(t *testing.T) {
-		// Save the original osMkdirAll function
-		originalMkdirAll := osMkdirAll
-		defer func() { osMkdirAll = originalMkdirAll }()
+	t.Run("ErrorGeneratingRandomString", func(t *testing.T) {
+		// Given
+		ResetSessionToken()
+		shell := setupShellTest(t)
 
-		// Override the osMkdirAll function locally to simulate an error
-		osMkdirAll = func(path string, perm os.FileMode) error {
-			return fmt.Errorf("error creating directories")
+		// Save original functions
+		originalRandRead := randRead
+		originalOsGetenv := osGetenv
+		defer func() {
+			randRead = originalRandRead
+			osGetenv = originalOsGetenv
+		}()
+
+		// Mock osGetenv to return empty string (no env token)
+		osGetenv = func(key string) string {
+			return ""
 		}
 
-		// Create a default shell for testing
-		shell := &DefaultShell{}
+		// Mock random generation to fail
+		randRead = func(b []byte) (n int, err error) {
+			return 0, fmt.Errorf("mock random generation error")
+		}
 
-		// Call AddCurrentDirToTrustedFile and expect an error
-		err := shell.AddCurrentDirToTrustedFile()
+		// When
+		token, err := shell.GetSessionToken()
+
+		// Then
 		if err == nil {
-			t.Errorf("expected error, got nil")
+			t.Error("GetSessionToken() expected error, got nil")
+			return
 		}
-		expectedError := "Error creating directories for trusted file: error creating directories"
-		if err.Error() != expectedError {
-			t.Errorf("expected error %q, got %q", expectedError, err.Error())
+		if token != "" {
+			t.Errorf("GetSessionToken() token = %s, want empty string", token)
+		}
+		expectedErr := "error generating session token: mock random generation error"
+		if err.Error() != expectedErr {
+			t.Errorf("GetSessionToken() error = %v, want %v", err, expectedErr)
 		}
 	})
 
-	t.Run("ErrorReadingTrustedFile", func(t *testing.T) {
-		// Save the original osReadFile function
-		originalReadFile := osReadFile
-		defer func() { osReadFile = originalReadFile }()
+	t.Run("GenerateRandomString", func(t *testing.T) {
+		// This test checks that generateRandomString properly generates strings of the right length
+		shell := setupShellTest(t)
 
-		// Override the osReadFile function locally to simulate an error
-		osReadFile = func(filename string) ([]byte, error) {
-			return nil, fmt.Errorf("error reading trusted file")
+		// Save original randRead
+		originalRandRead := randRead
+		defer func() { randRead = originalRandRead }()
+
+		// Make randRead produce deterministic output for testing
+		randRead = func(b []byte) (n int, err error) {
+			for i := range b {
+				b[i] = byte(i % 62) // Use a deterministic pattern
+			}
+			return len(b), nil
 		}
 
-		// Create a default shell for testing
-		shell := &DefaultShell{}
-
-		// Call AddCurrentDirToTrustedFile and expect an error
-		err := shell.AddCurrentDirToTrustedFile()
-		if err == nil {
-			t.Errorf("expected error, got nil")
-		}
-		expectedError := "Error reading trusted file: error reading trusted file"
-		if err.Error() != expectedError {
-			t.Errorf("expected error %q, got %q", expectedError, err.Error())
-		}
-	})
-
-	t.Run("ErrorWritingToTrustedFile", func(t *testing.T) {
-		// Save the original osWriteFile function
-		originalWriteFile := osWriteFile
-		defer func() { osWriteFile = originalWriteFile }()
-
-		// Override the osWriteFile function locally to simulate an error
-		osWriteFile = func(filename string, data []byte, perm os.FileMode) error {
-			return fmt.Errorf("error writing to trusted file")
-		}
-
-		// Create a default shell for testing
-		shell := &DefaultShell{}
-
-		// Call AddCurrentDirToTrustedFile and expect an error
-		err := shell.AddCurrentDirToTrustedFile()
-		if err == nil {
-			t.Errorf("expected error, got nil")
-		}
-		expectedError := "Error writing to trusted file: error writing to trusted file"
-		if err.Error() != expectedError {
-			t.Errorf("expected error %q, got %q", expectedError, err.Error())
-		}
+		testRandomStringGeneration(t, shell, 7)
+		testRandomStringGeneration(t, shell, 10)
+		testRandomStringGeneration(t, shell, 15)
 	})
 }
 
+// TestDefaultShell_WriteResetToken tests the WriteResetToken method
 func TestDefaultShell_WriteResetToken(t *testing.T) {
-	// Save original OS functions and environment variables
+	// Save original functions and environment
 	originalOsMkdirAll := osMkdirAll
 	originalOsWriteFile := osWriteFile
-	originalSessionToken := os.Getenv("WINDSOR_SESSION_TOKEN")
+	originalEnvValue := os.Getenv("WINDSOR_SESSION_TOKEN")
 
 	// Restore original functions and environment after all tests
 	defer func() {
 		osMkdirAll = originalOsMkdirAll
 		osWriteFile = originalOsWriteFile
-		os.Setenv("WINDSOR_SESSION_TOKEN", originalSessionToken)
+		if originalEnvValue != "" {
+			os.Setenv("WINDSOR_SESSION_TOKEN", originalEnvValue)
+		} else {
+			os.Unsetenv("WINDSOR_SESSION_TOKEN")
+		}
 	}()
 
 	t.Run("NoSessionToken", func(t *testing.T) {
-		// Use the real DefaultShell implementation for this test
-		shell := NewDefaultShell(nil)
+		// Given a default shell with no session token in environment
+		shell := setupShellTest(t)
 
 		// Ensure the environment variable is not set
 		os.Unsetenv("WINDSOR_SESSION_TOKEN")
@@ -1443,26 +1424,26 @@ func TestDefaultShell_WriteResetToken(t *testing.T) {
 
 		// Then no error should be returned and path should be empty
 		if err != nil {
-			t.Errorf("expected nil error, got %v", err)
+			t.Errorf("WriteResetToken() error = %v, want nil", err)
 		}
 		if path != "" {
-			t.Errorf("expected empty path, got %s", path)
+			t.Errorf("WriteResetToken() path = %v, want empty string", path)
 		}
 	})
 
 	t.Run("SuccessfulTokenWrite", func(t *testing.T) {
-		// Set up test data
-		testProjectRoot := "/test/project/root"
+		// Given a default shell with a session token
+		shell := setupShellTest(t)
+
+		// Set up test data using platform-specific path functions
+		testProjectRoot := filepath.FromSlash("/test/project/root")
 		testToken := "test-token-123"
 		expectedDirPath := filepath.Join(testProjectRoot, ".windsor")
 		expectedFilePath := filepath.Join(expectedDirPath, SessionTokenPrefix+testToken)
 
-		// Create a DefaultShell for testing
-		shell := NewDefaultShell(nil)
-
-		// Mock GetProjectRoot to return our test path
-		// We don't need to keep a reference to the original since we're not restoring it
-		// This is just to show our intention in the test
+		// For comparison in errors, we'll use ToSlash to show normalized paths
+		expectedDirPathNormalized := filepath.ToSlash(expectedDirPath)
+		expectedFilePathNormalized := filepath.ToSlash(expectedFilePath)
 
 		// Track function calls
 		var mkdirAllCalled bool
@@ -1489,68 +1470,65 @@ func TestDefaultShell_WriteResetToken(t *testing.T) {
 			return nil
 		}
 
+		// Mock getwd to return our test project root
+		originalGetwd := getwd
+		defer func() { getwd = originalGetwd }()
+		getwd = func() (string, error) {
+			return testProjectRoot, nil
+		}
+
 		// Set the environment variable
 		os.Setenv("WINDSOR_SESSION_TOKEN", testToken)
 
-		// When calling WriteResetToken - use our helper to call the real function with mocked deps
-		var path string
-		var err error
+		// When calling WriteResetToken
+		path, err := shell.WriteResetToken()
 
-		// Create a function that will run with our mocked GetProjectRoot
-		testFunc := func() {
-			// Override getwd to return our test project root
-			originalGetwd := getwd
-			defer func() { getwd = originalGetwd }()
-			getwd = func() (string, error) {
-				return testProjectRoot, nil
-			}
-
-			// Call the real function
-			path, err = shell.WriteResetToken()
-		}
-		testFunc()
-
-		// Then no error should be returned and path should match expected value
+		// Then no error should be returned and the path should match expected
 		if err != nil {
-			t.Errorf("unexpected error: %v", err)
+			t.Errorf("WriteResetToken() error = %v, want nil", err)
 		}
-		if path != expectedFilePath {
-			t.Errorf("expected path %s, got %s", expectedFilePath, path)
+
+		// Use ToSlash to normalize paths for comparison
+		if filepath.ToSlash(path) != expectedFilePathNormalized {
+			t.Errorf("WriteResetToken() path = %v, want %v",
+				filepath.ToSlash(path), expectedFilePathNormalized)
 		}
 
 		// Verify that MkdirAll was called with correct parameters
 		if !mkdirAllCalled {
-			t.Error("expected MkdirAll to be called, but it wasn't")
+			t.Error("Expected MkdirAll to be called, but it wasn't")
 		} else {
-			if mkdirAllPath != expectedDirPath {
-				t.Errorf("expected MkdirAll path %s, got %s", expectedDirPath, mkdirAllPath)
+			if filepath.ToSlash(mkdirAllPath) != expectedDirPathNormalized {
+				t.Errorf("Expected MkdirAll path %s, got %s",
+					expectedDirPathNormalized, filepath.ToSlash(mkdirAllPath))
 			}
 			if mkdirAllPerm != 0750 {
-				t.Errorf("expected MkdirAll permissions 0750, got %v", mkdirAllPerm)
+				t.Errorf("Expected MkdirAll permissions 0750, got %v", mkdirAllPerm)
 			}
 		}
 
 		// Verify that WriteFile was called with correct parameters
 		if !writeFileCalled {
-			t.Error("expected WriteFile to be called, but it wasn't")
+			t.Error("Expected WriteFile to be called, but it wasn't")
 		} else {
-			if writeFilePath != expectedFilePath {
-				t.Errorf("expected WriteFile path %s, got %s", expectedFilePath, writeFilePath)
+			if filepath.ToSlash(writeFilePath) != expectedFilePathNormalized {
+				t.Errorf("Expected WriteFile path %s, got %s",
+					expectedFilePathNormalized, filepath.ToSlash(writeFilePath))
 			}
 			if len(writeFileData) != 0 {
-				t.Errorf("expected empty file, got %v bytes", len(writeFileData))
+				t.Errorf("Expected empty file, got %v bytes", len(writeFileData))
 			}
 			if writeFilePerm != 0600 {
-				t.Errorf("expected WriteFile permissions 0600, got %v", writeFilePerm)
+				t.Errorf("Expected WriteFile permissions 0600, got %v", writeFilePerm)
 			}
 		}
 	})
 
 	t.Run("ErrorGettingProjectRoot", func(t *testing.T) {
-		// Create a DefaultShell for testing
-		shell := NewDefaultShell(nil)
+		// Given a default shell with a session token
+		shell := setupShellTest(t)
 
-		// Override getwd to simulate an error
+		// Mock getwd to return an error
 		originalGetwd := getwd
 		defer func() { getwd = originalGetwd }()
 		getwd = func() (string, error) {
@@ -1563,30 +1541,30 @@ func TestDefaultShell_WriteResetToken(t *testing.T) {
 		// When calling WriteResetToken
 		path, err := shell.WriteResetToken()
 
-		// Then the expected error should be returned and path should be empty
+		// Then an error should be returned and the path should be empty
 		if err == nil {
-			t.Error("expected error, got nil")
+			t.Error("WriteResetToken() expected error, got nil")
 		}
 		if !strings.Contains(err.Error(), "error getting project root") {
-			t.Errorf("expected error containing %q, got %q", "error getting project root", err.Error())
+			t.Errorf("WriteResetToken() error = %v, want error containing 'error getting project root'", err)
 		}
 		if path != "" {
-			t.Errorf("expected empty path, got %s", path)
+			t.Errorf("WriteResetToken() path = %v, want empty string", path)
 		}
 	})
 
 	t.Run("ErrorCreatingDirectory", func(t *testing.T) {
-		// Create a DefaultShell for testing
-		shell := NewDefaultShell(nil)
+		// Given a default shell with a session token
+		shell := setupShellTest(t)
 
-		// Override getwd to return a test path
+		// Mock getwd to return a test path
 		originalGetwd := getwd
 		defer func() { getwd = originalGetwd }()
 		getwd = func() (string, error) {
 			return "/test/project/root", nil
 		}
 
-		// Override MkdirAll to simulate an error
+		// Mock MkdirAll to return an error
 		expectedError := fmt.Errorf("error creating directory")
 		osMkdirAll = func(path string, perm os.FileMode) error {
 			return expectedError
@@ -1598,30 +1576,30 @@ func TestDefaultShell_WriteResetToken(t *testing.T) {
 		// When calling WriteResetToken
 		path, err := shell.WriteResetToken()
 
-		// Then the expected error should be returned and path should be empty
+		// Then an error should be returned and the path should be empty
 		if err == nil {
-			t.Error("expected error, got nil")
+			t.Error("WriteResetToken() expected error, got nil")
 		}
 		if !strings.Contains(err.Error(), expectedError.Error()) {
-			t.Errorf("expected error containing %q, got %q", expectedError.Error(), err.Error())
+			t.Errorf("WriteResetToken() error = %v, want error containing %v", err, expectedError)
 		}
 		if path != "" {
-			t.Errorf("expected empty path, got %s", path)
+			t.Errorf("WriteResetToken() path = %v, want empty string", path)
 		}
 	})
 
 	t.Run("ErrorWritingFile", func(t *testing.T) {
-		// Create a DefaultShell for testing
-		shell := NewDefaultShell(nil)
+		// Given a default shell with a session token
+		shell := setupShellTest(t)
 
-		// Override getwd to return a test path
+		// Mock getwd to return a test path
 		originalGetwd := getwd
 		defer func() { getwd = originalGetwd }()
 		getwd = func() (string, error) {
 			return "/test/project/root", nil
 		}
 
-		// Override MkdirAll to succeed but WriteFile to fail
+		// Mock MkdirAll to succeed but WriteFile to fail
 		osMkdirAll = func(path string, perm os.FileMode) error {
 			return nil
 		}
@@ -1637,15 +1615,863 @@ func TestDefaultShell_WriteResetToken(t *testing.T) {
 		// When calling WriteResetToken
 		path, err := shell.WriteResetToken()
 
-		// Then the expected error should be returned and path should be empty
+		// Then an error should be returned and the path should be empty
 		if err == nil {
-			t.Error("expected error, got nil")
+			t.Error("WriteResetToken() expected error, got nil")
 		}
 		if !strings.Contains(err.Error(), expectedError.Error()) {
-			t.Errorf("expected error containing %q, got %q", expectedError.Error(), err.Error())
+			t.Errorf("WriteResetToken() error = %v, want error containing %v", err, expectedError)
 		}
 		if path != "" {
-			t.Errorf("expected empty path, got %s", path)
+			t.Errorf("WriteResetToken() path = %v, want empty string", path)
+		}
+	})
+}
+
+// TestDefaultShell_AddCurrentDirToTrustedFile tests the AddCurrentDirToTrustedFile method
+func TestDefaultShell_AddCurrentDirToTrustedFile(t *testing.T) {
+	// Save original functions and environment
+	originalGetwd := getwd
+	originalOsUserHomeDir := osUserHomeDir
+	originalOsReadFile := osReadFile
+	originalOsMkdirAll := osMkdirAll
+	originalOsWriteFile := osWriteFile
+
+	// Restore original functions after all tests
+	defer func() {
+		getwd = originalGetwd
+		osUserHomeDir = originalOsUserHomeDir
+		osReadFile = originalOsReadFile
+		osMkdirAll = originalOsMkdirAll
+		osWriteFile = originalOsWriteFile
+	}()
+
+	t.Run("Success", func(t *testing.T) {
+		// Given a default shell
+		shell := setupShellTest(t)
+
+		// Mock required functions
+		getwd = func() (string, error) {
+			return "/mock/current/dir", nil
+		}
+
+		osUserHomeDir = func() (string, error) {
+			return "/mock/home/dir", nil
+		}
+
+		osReadFile = func(filename string) ([]byte, error) {
+			return []byte{}, nil // Empty trusted file
+		}
+
+		osMkdirAll = func(path string, perm os.FileMode) error {
+			expectedPath := "/mock/home/dir/.config/windsor"
+			if filepath.ToSlash(path) != expectedPath {
+				t.Errorf("Expected MkdirAll path %s, got %s", expectedPath, path)
+			}
+			if perm != 0750 {
+				t.Errorf("Expected MkdirAll permissions 0750, got %v", perm)
+			}
+			return nil
+		}
+
+		var capturedData []byte
+		osWriteFile = func(filename string, data []byte, perm os.FileMode) error {
+			expectedPath := "/mock/home/dir/.config/windsor/.trusted"
+			if filepath.ToSlash(filename) != expectedPath {
+				t.Errorf("Expected WriteFile path %s, got %s", expectedPath, filename)
+			}
+			capturedData = data
+			if perm != 0600 {
+				t.Errorf("Expected WriteFile permissions 0600, got %v", perm)
+			}
+			return nil
+		}
+
+		// When adding the current directory to the trusted file
+		err := shell.AddCurrentDirToTrustedFile()
+
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("AddCurrentDirToTrustedFile() error = %v, want nil", err)
+		}
+
+		// Verify that the current directory was added to the trusted file
+		expectedData := "/mock/current/dir\n"
+		if string(capturedData) != expectedData {
+			t.Errorf("Expected data %q, got %q", expectedData, string(capturedData))
+		}
+	})
+
+	t.Run("SuccessAlreadyTrusted", func(t *testing.T) {
+		// Given a default shell
+		shell := setupShellTest(t)
+
+		// Mock required functions
+		getwd = func() (string, error) {
+			return "/mock/current/dir", nil
+		}
+
+		osUserHomeDir = func() (string, error) {
+			return "/mock/home/dir", nil
+		}
+
+		osReadFile = func(filename string) ([]byte, error) {
+			return []byte("/mock/current/dir\n"), nil // Directory already in trusted file
+		}
+
+		// Track if WriteFile is called (it shouldn't be)
+		writeFileCalled := false
+		osWriteFile = func(filename string, data []byte, perm os.FileMode) error {
+			writeFileCalled = true
+			return nil
+		}
+
+		// When adding the current directory to the trusted file
+		err := shell.AddCurrentDirToTrustedFile()
+
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("AddCurrentDirToTrustedFile() error = %v, want nil", err)
+		}
+
+		// Verify that WriteFile was not called
+		if writeFileCalled {
+			t.Error("Expected WriteFile not to be called, but it was")
+		}
+	})
+
+	t.Run("ErrorGettingProjectRoot", func(t *testing.T) {
+		// Given a default shell
+		shell := setupShellTest(t)
+
+		// Mock getwd to return an error
+		getwd = func() (string, error) {
+			return "", fmt.Errorf("error getting project root directory")
+		}
+
+		// When adding the current directory to the trusted file
+		err := shell.AddCurrentDirToTrustedFile()
+
+		// Then an error should be returned
+		if err == nil {
+			t.Error("AddCurrentDirToTrustedFile() expected error, got nil")
+		}
+		expectedError := "Error getting project root directory: error getting project root directory"
+		if err.Error() != expectedError {
+			t.Errorf("AddCurrentDirToTrustedFile() error = %q, want %q", err.Error(), expectedError)
+		}
+	})
+
+	t.Run("ErrorGettingUserHomeDir", func(t *testing.T) {
+		// Given a default shell
+		shell := setupShellTest(t)
+
+		// Mock getwd to succeed but osUserHomeDir to fail
+		getwd = func() (string, error) {
+			return "/mock/current/dir", nil
+		}
+
+		osUserHomeDir = func() (string, error) {
+			return "", fmt.Errorf("error getting user home directory")
+		}
+
+		// When adding the current directory to the trusted file
+		err := shell.AddCurrentDirToTrustedFile()
+
+		// Then an error should be returned
+		if err == nil {
+			t.Error("AddCurrentDirToTrustedFile() expected error, got nil")
+		}
+		expectedError := "Error getting user home directory: error getting user home directory"
+		if err.Error() != expectedError {
+			t.Errorf("AddCurrentDirToTrustedFile() error = %q, want %q", err.Error(), expectedError)
+		}
+	})
+
+	t.Run("ErrorCreatingDirectories", func(t *testing.T) {
+		// Given a default shell
+		shell := setupShellTest(t)
+
+		// Mock getwd and osUserHomeDir to succeed but osMkdirAll to fail
+		getwd = func() (string, error) {
+			return "/mock/current/dir", nil
+		}
+
+		osUserHomeDir = func() (string, error) {
+			return "/mock/home/dir", nil
+		}
+
+		expectedError := fmt.Errorf("error creating directories")
+		osMkdirAll = func(path string, perm os.FileMode) error {
+			return expectedError
+		}
+
+		// When adding the current directory to the trusted file
+		err := shell.AddCurrentDirToTrustedFile()
+
+		// Then an error should be returned
+		if err == nil {
+			t.Error("AddCurrentDirToTrustedFile() expected error, got nil")
+		}
+
+		expectedErrorMsg := "Error creating directories for trusted file: error creating directories"
+		if err.Error() != expectedErrorMsg {
+			t.Errorf("AddCurrentDirToTrustedFile() error = %q, want %q", err.Error(), expectedErrorMsg)
+		}
+	})
+
+	t.Run("ErrorReadingTrustedFile", func(t *testing.T) {
+		// Given a default shell
+		shell := setupShellTest(t)
+
+		// Mock getwd, osUserHomeDir, and osMkdirAll to succeed but osReadFile to fail
+		getwd = func() (string, error) {
+			return "/mock/current/dir", nil
+		}
+
+		osUserHomeDir = func() (string, error) {
+			return "/mock/home/dir", nil
+		}
+
+		osMkdirAll = func(path string, perm os.FileMode) error {
+			return nil
+		}
+
+		expectedError := fmt.Errorf("error reading trusted file")
+		osReadFile = func(filename string) ([]byte, error) {
+			return nil, expectedError
+		}
+
+		// When adding the current directory to the trusted file
+		err := shell.AddCurrentDirToTrustedFile()
+
+		// Then an error should be returned
+		if err == nil {
+			t.Error("AddCurrentDirToTrustedFile() expected error, got nil")
+		}
+
+		expectedErrorMsg := "Error reading trusted file: error reading trusted file"
+		if err.Error() != expectedErrorMsg {
+			t.Errorf("AddCurrentDirToTrustedFile() error = %q, want %q", err.Error(), expectedErrorMsg)
+		}
+	})
+
+	t.Run("ErrorReadingNonExistentTrustedFile", func(t *testing.T) {
+		// Given a default shell
+		shell := setupShellTest(t)
+
+		// Mock getwd, osUserHomeDir, and osMkdirAll to succeed but osReadFile to return file not exist error
+		getwd = func() (string, error) {
+			return "/mock/current/dir", nil
+		}
+
+		osUserHomeDir = func() (string, error) {
+			return "/mock/home/dir", nil
+		}
+
+		osMkdirAll = func(path string, perm os.FileMode) error {
+			return nil
+		}
+
+		osReadFile = func(filename string) ([]byte, error) {
+			return nil, os.ErrNotExist
+		}
+
+		var capturedData []byte
+		osWriteFile = func(filename string, data []byte, perm os.FileMode) error {
+			capturedData = data
+			return nil
+		}
+
+		// When adding the current directory to the trusted file
+		err := shell.AddCurrentDirToTrustedFile()
+
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("AddCurrentDirToTrustedFile() error = %v, want nil", err)
+		}
+
+		// Verify that the current directory was added to the trusted file
+		expectedData := "/mock/current/dir\n"
+		if string(capturedData) != expectedData {
+			t.Errorf("Expected data %q, got %q", expectedData, string(capturedData))
+		}
+	})
+
+	t.Run("ErrorWritingToTrustedFile", func(t *testing.T) {
+		// Given a default shell
+		shell := setupShellTest(t)
+
+		// Mock getwd, osUserHomeDir, osMkdirAll, and osReadFile to succeed but osWriteFile to fail
+		getwd = func() (string, error) {
+			return "/mock/current/dir", nil
+		}
+
+		osUserHomeDir = func() (string, error) {
+			return "/mock/home/dir", nil
+		}
+
+		osMkdirAll = func(path string, perm os.FileMode) error {
+			return nil
+		}
+
+		osReadFile = func(filename string) ([]byte, error) {
+			return []byte{}, nil
+		}
+
+		expectedError := fmt.Errorf("error writing to trusted file")
+		osWriteFile = func(filename string, data []byte, perm os.FileMode) error {
+			return expectedError
+		}
+
+		// When adding the current directory to the trusted file
+		err := shell.AddCurrentDirToTrustedFile()
+
+		// Then an error should be returned
+		if err == nil {
+			t.Error("AddCurrentDirToTrustedFile() expected error, got nil")
+		}
+
+		expectedErrorMsg := "Error writing to trusted file: error writing to trusted file"
+		if err.Error() != expectedErrorMsg {
+			t.Errorf("AddCurrentDirToTrustedFile() error = %q, want %q", err.Error(), expectedErrorMsg)
+		}
+	})
+}
+
+// TestMockShell_GetSessionToken tests the MockShell's GetSessionToken method
+func TestMockShell_GetSessionToken(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Given
+		injector := di.NewInjector()
+		mockShell := NewMockShell(injector)
+
+		expectedToken := "mock-token"
+		mockShell.GetSessionTokenFunc = func() (string, error) {
+			return expectedToken, nil
+		}
+
+		// When
+		token, err := mockShell.GetSessionToken()
+
+		// Then
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if token != expectedToken {
+			t.Errorf("Expected token %s, got %s", expectedToken, token)
+		}
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		// Given
+		injector := di.NewInjector()
+		mockShell := NewMockShell(injector)
+
+		expectedError := "custom error"
+		mockShell.GetSessionTokenFunc = func() (string, error) {
+			return "", fmt.Errorf(expectedError)
+		}
+
+		// When
+		token, err := mockShell.GetSessionToken()
+
+		// Then
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if err.Error() != expectedError {
+			t.Errorf("Expected error %s, got %s", expectedError, err.Error())
+		}
+		if token != "" {
+			t.Errorf("Expected empty token, got %s", token)
+		}
+	})
+
+	t.Run("NotImplemented", func(t *testing.T) {
+		// Given
+		injector := di.NewInjector()
+		mockShell := NewMockShell(injector)
+
+		// Don't set GetSessionTokenFunc
+
+		// When
+		token, err := mockShell.GetSessionToken()
+
+		// Then
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		expectedError := "GetSessionToken not implemented"
+		if err.Error() != expectedError {
+			t.Errorf("Expected error %s, got %s", expectedError, err.Error())
+		}
+		if token != "" {
+			t.Errorf("Expected empty token, got %s", token)
+		}
+	})
+}
+
+// TestDefaultShell_CheckResetFlags tests the CheckResetFlags method of DefaultShell
+func TestDefaultShell_CheckResetFlags(t *testing.T) {
+	// Save original environment variable and restore it after all tests
+	origEnv := os.Getenv("WINDSOR_SESSION_TOKEN")
+	defer func() { os.Setenv("WINDSOR_SESSION_TOKEN", origEnv) }()
+
+	// Save original session token and restore it after all tests
+	origSessionToken := sessionToken
+	defer func() { sessionToken = origSessionToken }()
+
+	t.Run("NoSessionToken", func(t *testing.T) {
+		// Given
+		shell := setupShellTest(t)
+		ResetSessionToken()
+
+		// When no session token is set in the environment
+		osSetenv("WINDSOR_SESSION_TOKEN", "")
+		result, err := shell.CheckResetFlags()
+
+		// Then
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if result {
+			t.Errorf("Expected result to be false when no session token exists")
+		}
+	})
+
+	t.Run("ErrorGettingProjectRoot", func(t *testing.T) {
+		// Given
+		shell := setupShellTest(t)
+		ResetSessionToken()
+
+		// Save original getwd function
+		originalGetwd := getwd
+		defer func() { getwd = originalGetwd }()
+
+		// Mock the getwd function to return an error
+		getwd = func() (string, error) {
+			return "", fmt.Errorf("error getting working directory")
+		}
+
+		// Set a test session token
+		osSetenv("WINDSOR_SESSION_TOKEN", "test-token")
+
+		// When
+		result, err := shell.CheckResetFlags()
+
+		// Then
+		if err == nil {
+			t.Errorf("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "error getting project root") {
+			t.Errorf("Expected error to contain 'error getting project root', got: %v", err)
+		}
+		if result {
+			t.Errorf("Expected result to be false when error occurs")
+		}
+	})
+
+	t.Run("WindsorDirectoryDoesNotExist", func(t *testing.T) {
+		// Given
+		shell := setupShellTest(t)
+		ResetSessionToken()
+
+		// Save original functions
+		originalGetwd := getwd
+		originalOsStat := osStat
+		defer func() {
+			getwd = originalGetwd
+			osStat = originalOsStat
+		}()
+
+		// Mock the getwd function
+		getwd = func() (string, error) {
+			return "/test/project", nil
+		}
+
+		// Mock the osStat function to simulate .windsor directory not existing
+		osStat = func(name string) (os.FileInfo, error) {
+			if strings.Contains(name, "windsor.yaml") || strings.Contains(name, "windsor.yml") {
+				return nil, os.ErrNotExist
+			}
+			if strings.Contains(name, ".windsor") {
+				return nil, os.ErrNotExist
+			}
+			return nil, os.ErrNotExist
+		}
+
+		// Set a test session token
+		osSetenv("WINDSOR_SESSION_TOKEN", "test-token")
+
+		// When
+		result, err := shell.CheckResetFlags()
+
+		// Then
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if result {
+			t.Errorf("Expected result to be false when .windsor directory doesn't exist")
+		}
+	})
+
+	t.Run("ResetFileExists", func(t *testing.T) {
+		// Given
+		shell := setupShellTest(t)
+		ResetSessionToken()
+
+		// Save original functions
+		originalGetwd := getwd
+		originalOsStat := osStat
+		defer func() {
+			getwd = originalGetwd
+			osStat = originalOsStat
+		}()
+
+		// Mock the getwd function
+		getwd = func() (string, error) {
+			return "/test/project", nil
+		}
+
+		// Mock the osStat function to simulate reset file existing
+		osStat = func(name string) (os.FileInfo, error) {
+			if strings.Contains(name, "windsor.yaml") {
+				return nil, nil // windsor.yaml exists
+			}
+			if strings.Contains(name, ".windsor") {
+				return nil, nil // .windsor directory exists
+			}
+			if strings.Contains(name, ".session.test-token") {
+				return nil, nil // Reset file exists
+			}
+			return nil, os.ErrNotExist
+		}
+
+		// Set a test session token
+		osSetenv("WINDSOR_SESSION_TOKEN", "test-token")
+
+		// When
+		result, err := shell.CheckResetFlags()
+
+		// Then
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if !result {
+			t.Errorf("Expected result to be true when reset file exists")
+		}
+	})
+
+	t.Run("ResetFileDoesNotExist", func(t *testing.T) {
+		// Given
+		shell := setupShellTest(t)
+		ResetSessionToken()
+
+		// Save original functions
+		originalGetwd := getwd
+		originalOsStat := osStat
+		defer func() {
+			getwd = originalGetwd
+			osStat = originalOsStat
+		}()
+
+		// Mock the getwd function
+		getwd = func() (string, error) {
+			return "/test/project", nil
+		}
+
+		// Mock the osStat function to simulate reset file not existing
+		osStat = func(name string) (os.FileInfo, error) {
+			if strings.Contains(name, "windsor.yaml") {
+				return nil, nil // windsor.yaml exists
+			}
+			if strings.Contains(name, ".windsor") && !strings.Contains(name, ".session.") {
+				return nil, nil // .windsor directory exists
+			}
+			// Reset file does not exist
+			return nil, os.ErrNotExist
+		}
+
+		// Set a test session token
+		osSetenv("WINDSOR_SESSION_TOKEN", "test-token")
+
+		// When
+		result, err := shell.CheckResetFlags()
+
+		// Then
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if result {
+			t.Errorf("Expected result to be false when reset file doesn't exist")
+		}
+	})
+
+	t.Run("ErrorFindingSessionFiles", func(t *testing.T) {
+		// Given
+		shell := setupShellTest(t)
+		ResetSessionToken()
+
+		// Save original functions
+		originalGetwd := getwd
+		originalOsStat := osStat
+		originalFilepathGlob := filepathGlob
+		defer func() {
+			getwd = originalGetwd
+			osStat = originalOsStat
+			filepathGlob = originalFilepathGlob
+		}()
+
+		// Mock the getwd function
+		getwd = func() (string, error) {
+			return "/test/project", nil
+		}
+
+		// Mock osStat to simulate .windsor dir exists
+		osStat = func(name string) (os.FileInfo, error) {
+			if strings.Contains(name, "windsor.yaml") {
+				return nil, nil // windsor.yaml exists
+			}
+			return nil, os.ErrNotExist
+		}
+
+		// Mock filepath.Glob to return an error
+		filepathGlob = func(pattern string) ([]string, error) {
+			return nil, fmt.Errorf("mock error finding session files")
+		}
+
+		// Set a test session token
+		osSetenv("WINDSOR_SESSION_TOKEN", "test-token")
+
+		// When
+		result, err := shell.CheckResetFlags()
+
+		// Then
+		if err == nil {
+			t.Errorf("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "error finding session files") {
+			t.Errorf("Expected error to contain 'error finding session files', got: %v", err)
+		}
+		if result {
+			t.Errorf("Expected result to be false when error occurs")
+		}
+	})
+
+	t.Run("ErrorRemovingSessionFiles", func(t *testing.T) {
+		// Given
+		shell := setupShellTest(t)
+		ResetSessionToken()
+
+		// Save original functions
+		originalGetwd := getwd
+		originalOsStat := osStat
+		originalFilepathGlob := filepathGlob
+		originalOsRemoveAll := osRemoveAll
+		defer func() {
+			getwd = originalGetwd
+			osStat = originalOsStat
+			filepathGlob = originalFilepathGlob
+			osRemoveAll = originalOsRemoveAll
+		}()
+
+		// Mock the getwd function
+		getwd = func() (string, error) {
+			return "/test/project", nil
+		}
+
+		// Mock osStat to simulate .windsor dir exists
+		osStat = func(name string) (os.FileInfo, error) {
+			if strings.Contains(name, "windsor.yaml") || strings.Contains(name, ".windsor") {
+				return nil, nil // both config file and directory exist
+			}
+			return nil, os.ErrNotExist
+		}
+
+		// Mock filepath.Glob to return some session files
+		filepathGlob = func(pattern string) ([]string, error) {
+			return []string{"/test/project/.windsor/.session.test-token"}, nil
+		}
+
+		// Mock osRemoveAll to return an error
+		osRemoveAll = func(path string) error {
+			return fmt.Errorf("mock error removing session file")
+		}
+
+		// Set a test session token
+		osSetenv("WINDSOR_SESSION_TOKEN", "test-token")
+
+		// When
+		result, err := shell.CheckResetFlags()
+
+		// Then
+		if err == nil {
+			t.Errorf("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "error removing session file") {
+			t.Errorf("Expected error to contain 'error removing session file', got: %v", err)
+		}
+		if result {
+			t.Errorf("Expected result to be false when error occurs")
+		}
+	})
+}
+
+// TestMockShell_CheckReset tests the MockShell's CheckReset method
+func TestMockShell_CheckReset(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Given
+		injector := di.NewInjector()
+		mockShell := NewMockShell(injector)
+
+		// Configure the mock to return a success response
+		mockShell.CheckResetFlagsFunc = func() (bool, error) {
+			return true, nil
+		}
+
+		// When
+		result, err := mockShell.CheckResetFlags()
+
+		// Then
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if !result {
+			t.Errorf("Expected result to be true, got false")
+		}
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		// Given
+		injector := di.NewInjector()
+		mockShell := NewMockShell(injector)
+
+		// Configure the mock to return an error
+		expectedError := fmt.Errorf("custom error")
+		mockShell.CheckResetFlagsFunc = func() (bool, error) {
+			return false, expectedError
+		}
+
+		// When
+		result, err := mockShell.CheckResetFlags()
+
+		// Then
+		if err == nil || err.Error() != expectedError.Error() {
+			t.Errorf("Expected error %v, got %v", expectedError, err)
+		}
+		if result {
+			t.Errorf("Expected result to be false, got true")
+		}
+	})
+
+	t.Run("DefaultImplementation", func(t *testing.T) {
+		// Given
+		injector := di.NewInjector()
+		mockShell := NewMockShell(injector)
+
+		// When CheckResetFunc isn't set, the default implementation should be used
+		result, err := mockShell.CheckResetFlags()
+
+		// Then
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if result {
+			t.Errorf("Expected result to be false by default, got true")
+		}
+	})
+}
+
+// TestDefaultShell_Reset tests the Reset method of the DefaultShell struct
+func TestDefaultShell_Reset(t *testing.T) {
+	t.Run("ResetWithNoEnvVars", func(t *testing.T) {
+		// Given a default shell
+		shell := setupShellTest(t)
+
+		// Make sure environment variables are not set
+		os.Unsetenv("WINDSOR_MANAGED_ENV")
+		os.Unsetenv("WINDSOR_MANAGED_ALIAS")
+
+		// Set up the test
+		origStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		// When calling Reset
+		shell.Reset()
+
+		// Capture and restore stdout
+		w.Close()
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+		os.Stdout = origStdout
+
+		// Then no unset commands should be issued
+		output := buf.String()
+		if strings.Contains(output, "unset") {
+			t.Errorf("Expected no unset commands, but got: %s", output)
+		}
+	})
+
+	t.Run("ResetWithEnvironmentVariables", func(t *testing.T) {
+		// Given a default shell
+		shell := setupShellTest(t)
+
+		// Set environment variables
+		os.Setenv("WINDSOR_MANAGED_ENV", "ENV1,ENV2, ENV3")
+		os.Setenv("WINDSOR_MANAGED_ALIAS", "alias1,alias2, alias3")
+		defer func() {
+			os.Unsetenv("WINDSOR_MANAGED_ENV")
+			os.Unsetenv("WINDSOR_MANAGED_ALIAS")
+		}()
+
+		// Set up the test
+		origStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		// When calling Reset
+		shell.Reset()
+
+		// Capture and restore stdout
+		w.Close()
+		var buf bytes.Buffer
+		io.Copy(&buf, r)
+		os.Stdout = origStdout
+
+		// Then unset commands should be issued
+		output := buf.String()
+		// Check for unset ENV1 ENV2 ENV3 (on Unix) or Remove-Item ENV:ENV1, etc on Windows
+		if runtime.GOOS == "windows" {
+			if !strings.Contains(output, "Remove-Item Env:ENV1") {
+				t.Errorf("Expected Remove-Item Env:ENV1 command, but got: %s", output)
+			}
+			if !strings.Contains(output, "Remove-Item Env:ENV2") {
+				t.Errorf("Expected Remove-Item Env:ENV2 command, but got: %s", output)
+			}
+			if !strings.Contains(output, "Remove-Item Env:ENV3") {
+				t.Errorf("Expected Remove-Item Env:ENV3 command, but got: %s", output)
+			}
+			// And unalias for aliases
+			if !strings.Contains(output, "Remove-Item Alias:alias1") {
+				t.Errorf("Expected Remove-Item Alias:alias1 command, but got: %s", output)
+			}
+		} else {
+			// For Unix
+			if !strings.Contains(output, "unset ENV1 ENV2 ENV3") {
+				t.Errorf("Expected unset ENV1 ENV2 ENV3 command, but got: %s", output)
+			}
+			// And unalias for aliases
+			if !strings.Contains(output, "unalias alias1") {
+				t.Errorf("Expected unalias alias1 command, but got: %s", output)
+			}
+			if !strings.Contains(output, "unalias alias2") {
+				t.Errorf("Expected unalias alias2 command, but got: %s", output)
+			}
+			if !strings.Contains(output, "unalias alias3") {
+				t.Errorf("Expected unalias alias3 command, but got: %s", output)
+			}
 		}
 	})
 }

--- a/pkg/shell/shims.go
+++ b/pkg/shell/shims.go
@@ -3,8 +3,10 @@ package shell
 import (
 	"bufio"
 	"io"
+	"math/rand"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"text/template"
 )
 
@@ -89,3 +91,18 @@ var hookTemplateParse = func(tmpl *template.Template, text string) (*template.Te
 var hookTemplateExecute = func(tmpl *template.Template, wr io.Writer, data interface{}) error {
 	return tmpl.Execute(wr, data)
 }
+
+// randRead is a variable that points to rand.Read, allowing it to be overridden in tests
+var randRead = rand.Read
+
+// osGetenv is a variable that points to os.Getenv, allowing it to be overridden in tests
+var osGetenv = os.Getenv
+
+// filepathGlob is a variable that points to filepath.Glob, allowing it to be overridden in tests
+var filepathGlob = filepath.Glob
+
+// osRemoveAll is a variable that points to os.RemoveAll, allowing it to be overridden in tests
+var osRemoveAll = os.RemoveAll
+
+// osSetenv is a variable that points to os.Setenv, allowing it to be overridden in tests
+var osSetenv = os.Setenv

--- a/pkg/shell/unix_shell.go
+++ b/pkg/shell/unix_shell.go
@@ -11,7 +11,7 @@ import (
 
 // PrintEnvVars prints the provided environment variables in a sorted order.
 // If the value of an environment variable is an empty string, it will print an unset command.
-func (s *DefaultShell) PrintEnvVars(envVars map[string]string) error {
+func (s *DefaultShell) PrintEnvVars(envVars map[string]string) {
 	// Create a slice to hold the keys of the envVars map
 	keys := make([]string, 0, len(envVars))
 
@@ -33,11 +33,10 @@ func (s *DefaultShell) PrintEnvVars(envVars map[string]string) error {
 			fmt.Printf("export %s=\"%s\"\n", k, envVars[k])
 		}
 	}
-	return nil
 }
 
 // PrintAlias prints the aliases for the shell.
-func (s *DefaultShell) PrintAlias(aliases map[string]string) error {
+func (s *DefaultShell) PrintAlias(aliases map[string]string) {
 	// Create a slice to hold the keys of the aliases map
 	keys := make([]string, 0, len(aliases))
 
@@ -59,33 +58,28 @@ func (s *DefaultShell) PrintAlias(aliases map[string]string) error {
 			fmt.Printf("alias %s=\"%s\"\n", k, aliases[k])
 		}
 	}
-	return nil
 }
 
 // UnsetEnvs generates a command to unset multiple environment variables.
 // For Unix shells, this produces a single 'unset' command with all variables in one line.
-func (s *DefaultShell) UnsetEnvs(envVars []string) error {
+func (s *DefaultShell) UnsetEnvs(envVars []string) {
 	if len(envVars) == 0 {
-		return nil
+		return
 	}
 
 	// Create a single unset command with all environment variables
 	fmt.Printf("unset %s\n", strings.Join(envVars, " "))
-
-	return nil
 }
 
 // UnsetAlias generates commands to unset multiple aliases.
 // For Unix shells, this produces a separate 'unalias' command for each alias.
-func (s *DefaultShell) UnsetAlias(aliases []string) error {
+func (s *DefaultShell) UnsetAlias(aliases []string) {
 	if len(aliases) == 0 {
-		return nil
+		return
 	}
 
 	// Print individual unalias commands for each alias
 	for _, alias := range aliases {
 		fmt.Printf("unalias %s\n", alias)
 	}
-
-	return nil
 }

--- a/pkg/shell/unix_shell.go
+++ b/pkg/shell/unix_shell.go
@@ -6,6 +6,7 @@ package shell
 import (
 	"fmt"
 	"sort"
+	"strings"
 )
 
 // PrintEnvVars prints the provided environment variables in a sorted order.
@@ -58,5 +59,33 @@ func (s *DefaultShell) PrintAlias(aliases map[string]string) error {
 			fmt.Printf("alias %s=\"%s\"\n", k, aliases[k])
 		}
 	}
+	return nil
+}
+
+// UnsetEnvs generates a command to unset multiple environment variables.
+// For Unix shells, this produces a single 'unset' command with all variables in one line.
+func (s *DefaultShell) UnsetEnvs(envVars []string) error {
+	if len(envVars) == 0 {
+		return nil
+	}
+
+	// Create a single unset command with all environment variables
+	fmt.Printf("unset %s\n", strings.Join(envVars, " "))
+
+	return nil
+}
+
+// UnsetAlias generates commands to unset multiple aliases.
+// For Unix shells, this produces a separate 'unalias' command for each alias.
+func (s *DefaultShell) UnsetAlias(aliases []string) error {
+	if len(aliases) == 0 {
+		return nil
+	}
+
+	// Print individual unalias commands for each alias
+	for _, alias := range aliases {
+		fmt.Printf("unalias %s\n", alias)
+	}
+
 	return nil
 }

--- a/pkg/shell/unix_test.go
+++ b/pkg/shell/unix_test.go
@@ -103,10 +103,7 @@ func TestDefaultShell_PrintAlias(t *testing.T) {
 
 		// Capture the output of PrintAlias
 		output := captureStdout(t, func() {
-			err := shell.PrintAlias(aliasVars)
-			if err != nil {
-				t.Fatalf("PrintAlias returned an error: %v", err)
-			}
+			shell.PrintAlias(aliasVars)
 		})
 
 		// Then the output should contain all expected alias variables
@@ -130,10 +127,7 @@ func TestDefaultShell_PrintAlias(t *testing.T) {
 
 		// Capture the output of PrintAlias
 		output := captureStdout(t, func() {
-			err := shell.PrintAlias(aliasVarsWithEmpty)
-			if err != nil {
-				t.Fatalf("PrintAlias returned an error: %v", err)
-			}
+			shell.PrintAlias(aliasVarsWithEmpty)
 		})
 
 		// Then the output should contain the expected alias and unalias commands
@@ -159,10 +153,7 @@ func TestDefaultShell_UnsetEnvs(t *testing.T) {
 
 	// When capturing the output of UnsetEnvs
 	output := captureStdout(t, func() {
-		err := shell.UnsetEnvs(envVars)
-		if err != nil {
-			t.Fatalf("UnsetEnvs returned an error: %v", err)
-		}
+		shell.UnsetEnvs(envVars)
 	})
 
 	// Then the output should match the expected output
@@ -172,10 +163,7 @@ func TestDefaultShell_UnsetEnvs(t *testing.T) {
 
 	// Test with empty list
 	emptyOutput := captureStdout(t, func() {
-		err := shell.UnsetEnvs([]string{})
-		if err != nil {
-			t.Fatalf("UnsetEnvs with empty list returned an error: %v", err)
-		}
+		shell.UnsetEnvs([]string{})
 	})
 
 	// Then the output should be empty
@@ -194,10 +182,7 @@ func TestDefaultShell_UnsetAlias(t *testing.T) {
 
 	// When capturing the output of UnsetAlias
 	output := captureStdout(t, func() {
-		err := shell.UnsetAlias(aliases)
-		if err != nil {
-			t.Fatalf("UnsetAlias returned an error: %v", err)
-		}
+		shell.UnsetAlias(aliases)
 	})
 
 	// Then the output should match the expected output
@@ -207,10 +192,7 @@ func TestDefaultShell_UnsetAlias(t *testing.T) {
 
 	// Test with empty list
 	emptyOutput := captureStdout(t, func() {
-		err := shell.UnsetAlias([]string{})
-		if err != nil {
-			t.Fatalf("UnsetAlias with empty list returned an error: %v", err)
-		}
+		shell.UnsetAlias([]string{})
 	})
 
 	// Then the output should be empty

--- a/pkg/shell/unix_test.go
+++ b/pkg/shell/unix_test.go
@@ -148,3 +148,73 @@ func TestDefaultShell_PrintAlias(t *testing.T) {
 		}
 	})
 }
+
+func TestDefaultShell_UnsetEnvs(t *testing.T) {
+	injector := di.NewInjector()
+
+	// Given a set of environment variables to unset
+	shell := NewDefaultShell(injector)
+	envVars := []string{"VAR1", "VAR2", "VAR3"}
+	expectedOutput := "unset VAR1 VAR2 VAR3\n"
+
+	// When capturing the output of UnsetEnvs
+	output := captureStdout(t, func() {
+		err := shell.UnsetEnvs(envVars)
+		if err != nil {
+			t.Fatalf("UnsetEnvs returned an error: %v", err)
+		}
+	})
+
+	// Then the output should match the expected output
+	if output != expectedOutput {
+		t.Errorf("UnsetEnvs() output = %v, want %v", output, expectedOutput)
+	}
+
+	// Test with empty list
+	emptyOutput := captureStdout(t, func() {
+		err := shell.UnsetEnvs([]string{})
+		if err != nil {
+			t.Fatalf("UnsetEnvs with empty list returned an error: %v", err)
+		}
+	})
+
+	// Then the output should be empty
+	if emptyOutput != "" {
+		t.Errorf("UnsetEnvs() with empty list should produce no output, got %v", emptyOutput)
+	}
+}
+
+func TestDefaultShell_UnsetAlias(t *testing.T) {
+	injector := di.NewInjector()
+
+	// Given a set of aliases to unset
+	shell := NewDefaultShell(injector)
+	aliases := []string{"ALIAS1", "ALIAS2", "ALIAS3"}
+	expectedOutput := "unalias ALIAS1\nunalias ALIAS2\nunalias ALIAS3\n"
+
+	// When capturing the output of UnsetAlias
+	output := captureStdout(t, func() {
+		err := shell.UnsetAlias(aliases)
+		if err != nil {
+			t.Fatalf("UnsetAlias returned an error: %v", err)
+		}
+	})
+
+	// Then the output should match the expected output
+	if output != expectedOutput {
+		t.Errorf("UnsetAlias() output = %v, want %v", output, expectedOutput)
+	}
+
+	// Test with empty list
+	emptyOutput := captureStdout(t, func() {
+		err := shell.UnsetAlias([]string{})
+		if err != nil {
+			t.Fatalf("UnsetAlias with empty list returned an error: %v", err)
+		}
+	})
+
+	// Then the output should be empty
+	if emptyOutput != "" {
+		t.Errorf("UnsetAlias() with empty list should produce no output, got %v", emptyOutput)
+	}
+}

--- a/pkg/shell/windows_shell.go
+++ b/pkg/shell/windows_shell.go
@@ -9,7 +9,7 @@ import (
 )
 
 // PrintEnvVars sorts and prints environment variables. Empty values trigger a removal command.
-func (s *DefaultShell) PrintEnvVars(envVars map[string]string) error {
+func (s *DefaultShell) PrintEnvVars(envVars map[string]string) {
 	keys := make([]string, 0, len(envVars))
 	for k := range envVars {
 		keys = append(keys, k)
@@ -22,11 +22,10 @@ func (s *DefaultShell) PrintEnvVars(envVars map[string]string) error {
 			fmt.Printf("$env:%s='%s'\n", k, envVars[k])
 		}
 	}
-	return nil
 }
 
 // PrintAlias prints the aliases for the shell.
-func (s *DefaultShell) PrintAlias(aliases map[string]string) error {
+func (s *DefaultShell) PrintAlias(aliases map[string]string) {
 	// Create a slice to hold the keys of the aliases map
 	keys := make([]string, 0, len(aliases))
 
@@ -48,35 +47,30 @@ func (s *DefaultShell) PrintAlias(aliases map[string]string) error {
 			fmt.Printf("Set-Alias -Name %s -Value \"%s\"\n", k, aliases[k])
 		}
 	}
-	return nil
 }
 
 // UnsetEnvs generates commands to unset multiple environment variables.
 // For Windows PowerShell, this produces a Remove-Item command for each environment variable.
-func (s *DefaultShell) UnsetEnvs(envVars []string) error {
+func (s *DefaultShell) UnsetEnvs(envVars []string) {
 	if len(envVars) == 0 {
-		return nil
+		return
 	}
 
 	// Print Remove-Item commands for each environment variable
 	for _, env := range envVars {
 		fmt.Printf("Remove-Item Env:%s\n", env)
 	}
-
-	return nil
 }
 
 // UnsetAlias generates commands to unset multiple aliases.
 // For Windows PowerShell, this produces a Remove-Item command for each alias.
-func (s *DefaultShell) UnsetAlias(aliases []string) error {
+func (s *DefaultShell) UnsetAlias(aliases []string) {
 	if len(aliases) == 0 {
-		return nil
+		return
 	}
 
 	// Print Remove-Item commands for each alias
 	for _, alias := range aliases {
 		fmt.Printf("Remove-Item Alias:%s\n", alias)
 	}
-
-	return nil
 }

--- a/pkg/shell/windows_shell.go
+++ b/pkg/shell/windows_shell.go
@@ -50,3 +50,33 @@ func (s *DefaultShell) PrintAlias(aliases map[string]string) error {
 	}
 	return nil
 }
+
+// UnsetEnvs generates commands to unset multiple environment variables.
+// For Windows PowerShell, this produces a Remove-Item command for each environment variable.
+func (s *DefaultShell) UnsetEnvs(envVars []string) error {
+	if len(envVars) == 0 {
+		return nil
+	}
+
+	// Print Remove-Item commands for each environment variable
+	for _, env := range envVars {
+		fmt.Printf("Remove-Item Env:%s\n", env)
+	}
+
+	return nil
+}
+
+// UnsetAlias generates commands to unset multiple aliases.
+// For Windows PowerShell, this produces a Remove-Item command for each alias.
+func (s *DefaultShell) UnsetAlias(aliases []string) error {
+	if len(aliases) == 0 {
+		return nil
+	}
+
+	// Print Remove-Item commands for each alias
+	for _, alias := range aliases {
+		fmt.Printf("Remove-Item Alias:%s\n", alias)
+	}
+
+	return nil
+}

--- a/pkg/shell/windows_test.go
+++ b/pkg/shell/windows_test.go
@@ -140,10 +140,7 @@ func TestDefaultShell_PrintAlias(t *testing.T) {
 
 		// Capture the output of PrintAlias
 		output := captureStdout(t, func() {
-			err := shell.PrintAlias(aliasVars)
-			if err != nil {
-				t.Fatalf("PrintAlias returned an error: %v", err)
-			}
+			shell.PrintAlias(aliasVars)
 		})
 
 		// Then the output should contain all expected alias variables
@@ -166,10 +163,7 @@ func TestDefaultShell_PrintAlias(t *testing.T) {
 
 		// Capture the output of PrintAlias
 		output := captureStdout(t, func() {
-			err := shell.PrintAlias(aliasVarsWithEmpty)
-			if err != nil {
-				t.Fatalf("PrintAlias returned an error: %v", err)
-			}
+			shell.PrintAlias(aliasVarsWithEmpty)
 		})
 
 		// Then the output should contain the expected alias and remove alias commands
@@ -195,10 +189,7 @@ func TestDefaultShell_UnsetEnvs(t *testing.T) {
 
 	// When capturing the output of UnsetEnvs
 	output := captureStdout(t, func() {
-		err := shell.UnsetEnvs(envVars)
-		if err != nil {
-			t.Fatalf("UnsetEnvs returned an error: %v", err)
-		}
+		shell.UnsetEnvs(envVars)
 	})
 
 	// Then the output should match the expected output
@@ -208,10 +199,7 @@ func TestDefaultShell_UnsetEnvs(t *testing.T) {
 
 	// Test with empty list
 	emptyOutput := captureStdout(t, func() {
-		err := shell.UnsetEnvs([]string{})
-		if err != nil {
-			t.Fatalf("UnsetEnvs with empty list returned an error: %v", err)
-		}
+		shell.UnsetEnvs([]string{})
 	})
 
 	// Then the output should be empty
@@ -230,10 +218,7 @@ func TestDefaultShell_UnsetAlias(t *testing.T) {
 
 	// When capturing the output of UnsetAlias
 	output := captureStdout(t, func() {
-		err := shell.UnsetAlias(aliases)
-		if err != nil {
-			t.Fatalf("UnsetAlias returned an error: %v", err)
-		}
+		shell.UnsetAlias(aliases)
 	})
 
 	// Then the output should match the expected output
@@ -243,10 +228,7 @@ func TestDefaultShell_UnsetAlias(t *testing.T) {
 
 	// Test with empty list
 	emptyOutput := captureStdout(t, func() {
-		err := shell.UnsetAlias([]string{})
-		if err != nil {
-			t.Fatalf("UnsetAlias with empty list returned an error: %v", err)
-		}
+		shell.UnsetAlias([]string{})
 	})
 
 	// Then the output should be empty

--- a/pkg/shell/windows_test.go
+++ b/pkg/shell/windows_test.go
@@ -184,3 +184,73 @@ func TestDefaultShell_PrintAlias(t *testing.T) {
 		}
 	})
 }
+
+func TestDefaultShell_UnsetEnvs(t *testing.T) {
+	injector := di.NewInjector()
+
+	// Given a set of environment variables to unset
+	shell := NewDefaultShell(injector)
+	envVars := []string{"VAR1", "VAR2", "VAR3"}
+	expectedOutput := "Remove-Item Env:VAR1\nRemove-Item Env:VAR2\nRemove-Item Env:VAR3\n"
+
+	// When capturing the output of UnsetEnvs
+	output := captureStdout(t, func() {
+		err := shell.UnsetEnvs(envVars)
+		if err != nil {
+			t.Fatalf("UnsetEnvs returned an error: %v", err)
+		}
+	})
+
+	// Then the output should match the expected output
+	if output != expectedOutput {
+		t.Errorf("UnsetEnvs() output = %v, want %v", output, expectedOutput)
+	}
+
+	// Test with empty list
+	emptyOutput := captureStdout(t, func() {
+		err := shell.UnsetEnvs([]string{})
+		if err != nil {
+			t.Fatalf("UnsetEnvs with empty list returned an error: %v", err)
+		}
+	})
+
+	// Then the output should be empty
+	if emptyOutput != "" {
+		t.Errorf("UnsetEnvs() with empty list should produce no output, got %v", emptyOutput)
+	}
+}
+
+func TestDefaultShell_UnsetAlias(t *testing.T) {
+	injector := di.NewInjector()
+
+	// Given a set of aliases to unset
+	shell := NewDefaultShell(injector)
+	aliases := []string{"ALIAS1", "ALIAS2", "ALIAS3"}
+	expectedOutput := "Remove-Item Alias:ALIAS1\nRemove-Item Alias:ALIAS2\nRemove-Item Alias:ALIAS3\n"
+
+	// When capturing the output of UnsetAlias
+	output := captureStdout(t, func() {
+		err := shell.UnsetAlias(aliases)
+		if err != nil {
+			t.Fatalf("UnsetAlias returned an error: %v", err)
+		}
+	})
+
+	// Then the output should match the expected output
+	if output != expectedOutput {
+		t.Errorf("UnsetAlias() output = %v, want %v", output, expectedOutput)
+	}
+
+	// Test with empty list
+	emptyOutput := captureStdout(t, func() {
+		err := shell.UnsetAlias([]string{})
+		if err != nil {
+			t.Fatalf("UnsetAlias with empty list returned an error: %v", err)
+		}
+	})
+
+	// Then the output should be empty
+	if emptyOutput != "" {
+		t.Errorf("UnsetAlias() with empty list should produce no output, got %v", emptyOutput)
+	}
+}


### PR DESCRIPTION
Clears out all managed environment variables strategically. This occurs when changing contexts, for example. Also occurs when leaving a terraform project.

Also improves stability of environment variable injection by continuing to render variables even if one fails. 