### PR TITLE
Use CoreDNS in docker network and for node endpoints

### DIFF
--- a/pkg/network/darwin_network.go
+++ b/pkg/network/darwin_network.go
@@ -70,7 +70,16 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 	if tld == "" {
 		return fmt.Errorf("DNS domain is not configured")
 	}
-	dnsIP := n.configHandler.GetString("dns.address")
+
+	var dnsIP string
+	if n.isLocalhostMode() {
+		dnsIP = "127.0.0.1"
+	} else {
+		dnsIP = n.configHandler.GetString("dns.address")
+		if dnsIP == "" {
+			return fmt.Errorf("DNS address is not configured")
+		}
+	}
 
 	resolverDir := "/etc/resolver"
 	resolverFile := fmt.Sprintf("%s/%s", resolverDir, tld)

--- a/pkg/network/darwin_network_test.go
+++ b/pkg/network/darwin_network_test.go
@@ -360,29 +360,6 @@ func TestDarwinNetworkManager_ConfigureDNS(t *testing.T) {
 		}
 	})
 
-	t.Run("SuccessLocalhost", func(t *testing.T) {
-		mocks := setupDarwinNetworkManagerMocks()
-
-		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "vm.driver" {
-				return "docker-desktop"
-			}
-			return "some_value"
-		}
-
-		nm := NewBaseNetworkManager(mocks.Injector)
-
-		err := nm.Initialize()
-		if err != nil {
-			t.Fatalf("expected no error during initialization, got %v", err)
-		}
-
-		err = nm.ConfigureDNS()
-		if err != nil {
-			t.Fatalf("expected no error, got %v", err)
-		}
-	})
-
 	t.Run("NoDNSDomainConfigured", func(t *testing.T) {
 		mocks := setupDarwinNetworkManagerMocks()
 

--- a/pkg/network/darwin_network_test.go
+++ b/pkg/network/darwin_network_test.go
@@ -360,6 +360,50 @@ func TestDarwinNetworkManager_ConfigureDNS(t *testing.T) {
 		}
 	})
 
+	t.Run("SuccessLocalhostMode", func(t *testing.T) {
+		mocks := setupDarwinNetworkManagerMocks()
+
+		// Mock the config handler to return docker-desktop for vm.driver
+		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+			switch key {
+			case "vm.driver":
+				return "docker-desktop"
+			case "dns.domain":
+				return "example.com"
+			default:
+				if len(defaultValue) > 0 {
+					return defaultValue[0]
+				}
+				return ""
+			}
+		}
+
+		nm := NewBaseNetworkManager(mocks.Injector)
+
+		err := nm.Initialize()
+		if err != nil {
+			t.Fatalf("expected no error during initialization, got %v", err)
+		}
+
+		// Mock the writeFile function to capture the content
+		var capturedContent []byte
+		writeFile = func(_ string, content []byte, _ os.FileMode) error {
+			capturedContent = content
+			return nil
+		}
+
+		err = nm.ConfigureDNS()
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Verify that the resolver file contains 127.0.0.1
+		expectedContent := "nameserver 127.0.0.1\n"
+		if string(capturedContent) != expectedContent {
+			t.Errorf("expected resolver file content to be %q, got %q", expectedContent, string(capturedContent))
+		}
+	})
+
 	t.Run("NoDNSDomainConfigured", func(t *testing.T) {
 		mocks := setupDarwinNetworkManagerMocks()
 
@@ -382,6 +426,43 @@ func TestDarwinNetworkManager_ConfigureDNS(t *testing.T) {
 			t.Fatalf("expected error, got nil")
 		}
 		expectedError := "DNS domain is not configured"
+		if err.Error() != expectedError {
+			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("NoDNSAddressConfigured", func(t *testing.T) {
+		mocks := setupDarwinNetworkManagerMocks()
+
+		// Mock the config handler to return empty DNS address but valid domain
+		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+			switch key {
+			case "dns.domain":
+				return "example.com"
+			case "dns.address":
+				return ""
+			case "vm.driver":
+				return "lima" // Not localhost mode
+			default:
+				if len(defaultValue) > 0 {
+					return defaultValue[0]
+				}
+				return ""
+			}
+		}
+
+		nm := NewBaseNetworkManager(mocks.Injector)
+
+		err := nm.Initialize()
+		if err != nil {
+			t.Fatalf("expected no error during initialization, got %v", err)
+		}
+
+		err = nm.ConfigureDNS()
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		expectedError := "DNS address is not configured"
 		if err.Error() != expectedError {
 			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
 		}

--- a/pkg/network/linux_network.go
+++ b/pkg/network/linux_network.go
@@ -74,7 +74,16 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 	if tld == "" {
 		return fmt.Errorf("DNS domain is not configured")
 	}
-	dnsIP := n.configHandler.GetString("dns.address")
+
+	var dnsIP string
+	if n.isLocalhostMode() {
+		dnsIP = "127.0.0.1"
+	} else {
+		dnsIP = n.configHandler.GetString("dns.address")
+		if dnsIP == "" {
+			return fmt.Errorf("DNS address is not configured")
+		}
+	}
 
 	// If DNS address is configured, use systemd-resolved
 	resolvConf, err := readLink("/etc/resolv.conf")

--- a/pkg/network/linux_network_test.go
+++ b/pkg/network/linux_network_test.go
@@ -388,7 +388,12 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 				// Extract the content from the echo command
 				content := args[1]
 				if strings.HasPrefix(content, "echo '") {
-					content = content[5 : len(content)-1]
+					// Extract the content between the first and last single quote
+					start := 5
+					end := strings.LastIndex(content, "'")
+					if end > start {
+						content = content[start:end]
+					}
 				}
 				capturedContent = []byte(content)
 				return "", nil

--- a/pkg/network/linux_network_test.go
+++ b/pkg/network/linux_network_test.go
@@ -6,6 +6,7 @@ package network
 import (
 	"fmt"
 	"net"
+	"os"
 	"strings"
 	"testing"
 
@@ -338,6 +339,76 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 		}
 	})
 
+	t.Run("SuccessLocalhostMode", func(t *testing.T) {
+		mocks := setupLinuxNetworkManagerMocks()
+
+		// Mock the config handler to return docker-desktop for vm.driver
+		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+			switch key {
+			case "vm.driver":
+				return "docker-desktop"
+			case "dns.domain":
+				return "example.com"
+			default:
+				if len(defaultValue) > 0 {
+					return defaultValue[0]
+				}
+				return ""
+			}
+		}
+
+		// Mock the readLink function to simulate systemd-resolved being in use
+		originalReadLink := readLink
+		defer func() { readLink = originalReadLink }()
+		readLink = func(_ string) (string, error) {
+			return "../run/systemd/resolve/stub-resolv.conf", nil
+		}
+
+		// Mock the readFile function to capture the content
+		var capturedContent []byte
+		originalReadFile := readFile
+		defer func() { readFile = originalReadFile }()
+		readFile = func(_ string) ([]byte, error) {
+			if capturedContent != nil {
+				return capturedContent, nil
+			}
+			return nil, os.ErrNotExist
+		}
+
+		// Create a networkManager using NewBaseNetworkManager with the mock DI container
+		nm := NewBaseNetworkManager(mocks.Injector)
+		err := nm.Initialize()
+		if err != nil {
+			t.Fatalf("expected no error during initialization, got %v", err)
+		}
+
+		// Mock the shell.ExecSudo function to capture the content
+		mocks.MockShell.ExecSudoFunc = func(description, command string, args ...string) (string, error) {
+			if command == "bash" && args[0] == "-c" {
+				// Extract the content from the echo command
+				content := args[1]
+				if strings.HasPrefix(content, "echo '") {
+					content = content[5 : len(content)-1]
+				}
+				capturedContent = []byte(content)
+				return "", nil
+			}
+			return "", nil
+		}
+
+		// Call the ConfigureDNS method
+		err = nm.ConfigureDNS()
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Verify that the drop-in file contains 127.0.0.1
+		expectedContent := "[Resolve]\nDNS=127.0.0.1\n"
+		if string(capturedContent) != expectedContent {
+			t.Errorf("expected drop-in file content to be %q, got %q", expectedContent, string(capturedContent))
+		}
+	})
+
 	t.Run("domainNotConfigured", func(t *testing.T) {
 		mocks := setupLinuxNetworkManagerMocks()
 
@@ -362,6 +433,51 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 			t.Fatalf("expected error, got nil")
 		}
 		expectedError := "DNS domain is not configured"
+		if !strings.Contains(err.Error(), expectedError) {
+			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("NoDNSAddressConfigured", func(t *testing.T) {
+		mocks := setupLinuxNetworkManagerMocks()
+
+		// Mock the config handler to return empty DNS address but valid domain
+		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+			switch key {
+			case "dns.domain":
+				return "example.com"
+			case "dns.address":
+				return ""
+			case "vm.driver":
+				return "lima" // Not localhost mode
+			default:
+				if len(defaultValue) > 0 {
+					return defaultValue[0]
+				}
+				return ""
+			}
+		}
+
+		// Mock the readLink function to simulate systemd-resolved being in use
+		originalReadLink := readLink
+		defer func() { readLink = originalReadLink }()
+		readLink = func(_ string) (string, error) {
+			return "../run/systemd/resolve/stub-resolv.conf", nil
+		}
+
+		// Create a networkManager using NewBaseNetworkManager with the mock DI container
+		nm := NewBaseNetworkManager(mocks.Injector)
+		err := nm.Initialize()
+		if err != nil {
+			t.Fatalf("expected no error during initialization, got %v", err)
+		}
+
+		// Call the ConfigureDNS method and expect an error due to missing DNS address
+		err = nm.ConfigureDNS()
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		expectedError := "DNS address is not configured"
 		if !strings.Contains(err.Error(), expectedError) {
 			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
 		}

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -75,26 +75,15 @@ func (n *BaseNetworkManager) Initialize() error {
 
 	n.services = serviceList
 
-	vmDriver := n.configHandler.GetString("vm.driver")
-	n.isLocalhost = vmDriver == "docker-desktop"
-
-	if n.isLocalhost {
-		for _, service := range n.services {
-			if err := service.SetAddress("127.0.0.1"); err != nil {
-				return fmt.Errorf("error setting address for service: %w", err)
-			}
+	networkCIDR := n.configHandler.GetString("network.cidr_block")
+	if networkCIDR == "" {
+		networkCIDR = constants.DEFAULT_NETWORK_CIDR
+		if err := n.configHandler.SetContextValue("network.cidr_block", networkCIDR); err != nil {
+			return fmt.Errorf("error setting default network CIDR: %w", err)
 		}
-	} else {
-		networkCIDR := n.configHandler.GetString("network.cidr_block")
-		if networkCIDR == "" {
-			networkCIDR = constants.DEFAULT_NETWORK_CIDR
-			if err := n.configHandler.SetContextValue("network.cidr_block", networkCIDR); err != nil {
-				return fmt.Errorf("error setting default network CIDR: %w", err)
-			}
-		}
-		if err := assignIPAddresses(n.services, &networkCIDR); err != nil {
-			return fmt.Errorf("error assigning IP addresses: %w", err)
-		}
+	}
+	if err := assignIPAddresses(n.services, &networkCIDR); err != nil {
+		return fmt.Errorf("error assigning IP addresses: %w", err)
 	}
 
 	return nil

--- a/pkg/network/network.go
+++ b/pkg/network/network.go
@@ -34,7 +34,6 @@ type BaseNetworkManager struct {
 	configHandler            config.ConfigHandler
 	networkInterfaceProvider NetworkInterfaceProvider
 	services                 []services.Service
-	isLocalhost              bool
 }
 
 // NewNetworkManager creates a new NetworkManager
@@ -97,6 +96,11 @@ func (n *BaseNetworkManager) ConfigureGuest() error {
 
 // Ensure BaseNetworkManager implements NetworkManager
 var _ NetworkManager = (*BaseNetworkManager)(nil)
+
+// isLocalhostMode checks if the system is in localhost mode
+func (n *BaseNetworkManager) isLocalhostMode() bool {
+	return n.configHandler.GetString("vm.driver") == "docker-desktop"
+}
 
 // assignIPAddresses assigns IP addresses to services based on the network CIDR.
 var assignIPAddresses = func(services []services.Service, networkCIDR *string) error {

--- a/pkg/network/windows_network.go
+++ b/pkg/network/windows_network.go
@@ -68,10 +68,14 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 		return fmt.Errorf("DNS domain is not configured")
 	}
 
-	dnsIP := n.configHandler.GetString("dns.address")
-	if dnsIP == "" {
-		// If there's no DNS address to configure, we simply skip
-		return nil
+	var dnsIP string
+	if n.isLocalhostMode() {
+		dnsIP = "127.0.0.1"
+	} else {
+		dnsIP = n.configHandler.GetString("dns.address")
+		if dnsIP == "" {
+			return fmt.Errorf("DNS address is not configured")
+		}
 	}
 
 	// Prepend a "." to the domain for the namespace

--- a/pkg/services/dns_service.go
+++ b/pkg/services/dns_service.go
@@ -116,6 +116,9 @@ func (s *DNSService) WriteConfig() error {
 				address := service.GetAddress()
 				if address != "" {
 					hostname := service.GetHostname()
+					if s.IsLocalhostMode() {
+						address = "127.0.0.1"
+					}
 					hostEntries += fmt.Sprintf("        %s %s\n", address, hostname)
 				}
 			}

--- a/pkg/services/dns_service.go
+++ b/pkg/services/dns_service.go
@@ -139,14 +139,19 @@ func (s *DNSService) WriteConfig() error {
 	var corefileContent string
 	corefileContent = fmt.Sprintf(`
 %s:53 {
+    errors
+    reload
+    loop
     hosts {
 %s        fallthrough
     }
-
+    forward . %s
+}
+.:53 {
+    errors
     reload
     loop
-
-    forward . %s
+    forward . 1.1.1.1 8.8.8.8
 }
 `, tld, hostEntries, forwardAddressesStr)
 

--- a/pkg/services/dns_service.go
+++ b/pkg/services/dns_service.go
@@ -72,7 +72,7 @@ func (s *DNSService) GetComposeConfig() (*types.Config, error) {
 		},
 	}
 
-	if s.IsLocalhost() {
+	if s.IsLocalhostMode() {
 		corednsConfig.Ports = []types.ServicePortConfig{
 			{
 				Target:    53,

--- a/pkg/services/dns_service_test.go
+++ b/pkg/services/dns_service_test.go
@@ -277,19 +277,24 @@ func TestDNSService_GetComposeConfig(t *testing.T) {
 	})
 
 	t.Run("LocalhostPorts", func(t *testing.T) {
-		// Create a mock injector with necessary mocks
+		// Setup mock components
 		mocks := createDNSServiceMocks()
-
-		// Given: a DNSService with the mock injector
 		service := NewDNSService(mocks.Injector)
+		service.Initialize()
 
-		// Initialize the service
-		if err := service.Initialize(); err != nil {
-			t.Fatalf("Initialize() error = %v", err)
+		// Set vm.driver to docker-desktop to simulate localhost mode
+		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "vm.driver" {
+				return "docker-desktop"
+			}
+			if key == "dns.domain" {
+				return "test"
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
 		}
-
-		// Set the address to localhost
-		service.SetAddress("127.0.0.1")
 
 		// When: GetComposeConfig is called
 		cfg, err := service.GetComposeConfig()

--- a/pkg/services/dns_service_test.go
+++ b/pkg/services/dns_service_test.go
@@ -349,20 +349,25 @@ func TestDNSService_WriteConfig(t *testing.T) {
 		// Verify that the Corefile content is correctly formatted
 		expectedCorefileContent := `
 test:53 {
+    errors
+    reload
+    loop
     hosts {
         127.0.0.1 test
         192.168.1.1 test
         fallthrough
     }
-
+    forward . 1.1.1.1 8.8.8.8
+}
+.:53 {
+    errors
     reload
     loop
-
     forward . 1.1.1.1 8.8.8.8
 }
 `
 		if string(writtenContent) != expectedCorefileContent {
-			t.Errorf("Expected Corefile content:\n%s\nGot:\n%s", expectedCorefileContent, string(writtenContent))
+			t.Errorf("Expected Corefile content:\\n%s\\nGot:\\n%s", expectedCorefileContent, string(writtenContent))
 		}
 	})
 	t.Run("SuccessLocalhost", func(t *testing.T) {
@@ -400,20 +405,25 @@ test:53 {
 		// Verify that the Corefile content is correctly formatted for localhost
 		expectedCorefileContent := `
 test:53 {
+    errors
+    reload
+    loop
     hosts {
         127.0.0.1 test
         192.168.1.1 test
         fallthrough
     }
-
+    forward . 1.1.1.1 8.8.8.8
+}
+.:53 {
+    errors
     reload
     loop
-
     forward . 1.1.1.1 8.8.8.8
 }
 `
 		if string(writtenContent) != expectedCorefileContent {
-			t.Errorf("Expected Corefile content:\n%s\nGot:\n%s", expectedCorefileContent, string(writtenContent))
+			t.Errorf("Expected Corefile content:\\n%s\\nGot:\\n%s", expectedCorefileContent, string(writtenContent))
 		}
 	})
 

--- a/pkg/services/registry_service.go
+++ b/pkg/services/registry_service.go
@@ -68,7 +68,7 @@ func (s *RegistryService) SetAddress(address string) error {
 
 	if registryConfig.HostPort != 0 {
 		hostPort = registryConfig.HostPort
-	} else if registryConfig.Remote == "" && s.IsLocalhost() {
+	} else if registryConfig.Remote == "" && s.IsLocalhostMode() {
 		hostPort = defaultPort
 		err = s.configHandler.SetContextValue("docker.registry_url", hostName)
 		if err != nil {
@@ -144,7 +144,7 @@ func (s *RegistryService) generateRegistryService(hostname string, registry dock
 		{Type: "bind", Source: "${WINDSOR_PROJECT_ROOT}/.windsor/.docker-cache", Target: "/var/lib/registry"},
 	}
 
-	if registry.Remote == "" && s.IsLocalhost() {
+	if registry.Remote == "" && s.IsLocalhostMode() {
 		service.Ports = []types.ServicePortConfig{
 			{
 				Target:    5000,

--- a/pkg/services/registry_service_test.go
+++ b/pkg/services/registry_service_test.go
@@ -213,6 +213,28 @@ func TestRegistryService_GetComposeConfig(t *testing.T) {
 	t.Run("LocalRegistry", func(t *testing.T) {
 		// Given a mock config handler, shell, context, and service
 		mocks := setupSafeRegistryServiceMocks()
+		mocks.MockConfigHandler.GetConfigFunc = func() *v1alpha1.Context {
+			return &v1alpha1.Context{
+				Docker: &docker.DockerConfig{
+					Registries: map[string]docker.RegistryConfig{
+						"local-registry": {HostPort: 5000},
+					},
+				},
+			}
+		}
+		// Set vm.driver to docker-desktop for localhost tests
+		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "vm.driver" {
+				return "docker-desktop"
+			}
+			if key == "dns.domain" {
+				return "test"
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
 		registryService := NewRegistryService(mocks.Injector)
 		registryService.SetName("local-registry")
 		err := registryService.Initialize()
@@ -344,7 +366,7 @@ func TestRegistryService_SetAddress(t *testing.T) {
 	})
 
 	t.Run("NoHostPortSetAndLocalhost", func(t *testing.T) {
-		// Given a mock config handler, shell, context, and service with no HostPort set
+		// Given a mock config handler, shell, context, and service with no HostPort
 		mocks := setupSafeRegistryServiceMocks()
 		mocks.MockConfigHandler.GetConfigFunc = func() *v1alpha1.Context {
 			return &v1alpha1.Context{
@@ -354,6 +376,19 @@ func TestRegistryService_SetAddress(t *testing.T) {
 					},
 				},
 			}
+		}
+		// Set vm.driver to docker-desktop for localhost tests
+		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "vm.driver" {
+				return "docker-desktop"
+			}
+			if key == "dns.domain" {
+				return "test"
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
 		}
 		registryService := NewRegistryService(mocks.Injector)
 		registryService.SetName("registry")
@@ -418,6 +453,19 @@ func TestRegistryService_SetAddress(t *testing.T) {
 					},
 				},
 			}
+		}
+		// Set vm.driver to docker-desktop for localhost tests
+		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "vm.driver" {
+				return "docker-desktop"
+			}
+			if key == "dns.domain" {
+				return "test"
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
 		}
 		registryService := NewRegistryService(mocks.Injector)
 		registryService.SetName("registry")
@@ -487,14 +535,8 @@ func TestRegistryService_SetAddress(t *testing.T) {
 	})
 
 	t.Run("SetContextValueErrorForRegistryURL", func(t *testing.T) {
-		// Given a mock config handler that will fail to set context value for registry URL
+		// Given a mock config handler, shell, context, and service with no HostPort and no Remote
 		mocks := setupSafeRegistryServiceMocks()
-		mocks.MockConfigHandler.SetContextValueFunc = func(key string, value interface{}) error {
-			if key == "docker.registry_url" {
-				return fmt.Errorf("failed to set registry URL")
-			}
-			return nil
-		}
 		mocks.MockConfigHandler.GetConfigFunc = func() *v1alpha1.Context {
 			return &v1alpha1.Context{
 				Docker: &docker.DockerConfig{
@@ -503,6 +545,26 @@ func TestRegistryService_SetAddress(t *testing.T) {
 					},
 				},
 			}
+		}
+		// Set vm.driver to docker-desktop for localhost tests
+		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "vm.driver" {
+				return "docker-desktop"
+			}
+			if key == "dns.domain" {
+				return "test"
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
+		// Mock the SetContextValue function to return an error for registry URL
+		mocks.MockConfigHandler.SetContextValueFunc = func(key string, value interface{}) error {
+			if key == "docker.registry_url" {
+				return fmt.Errorf("failed to set registry URL")
+			}
+			return nil
 		}
 		registryService := NewRegistryService(mocks.Injector)
 		registryService.SetName("registry")

--- a/pkg/services/service.go
+++ b/pkg/services/service.go
@@ -38,8 +38,8 @@ type Service interface {
 	// GetHostname returns the name plus the tld from the config
 	GetHostname() string
 
-	// IsLocalhost checks if the current address is a localhost address
-	IsLocalhost() bool
+	// IsLocalhostMode checks if we are in localhost mode (vm.driver == "docker-desktop")
+	IsLocalhostMode() bool
 }
 
 // BaseService is a base implementation of the Service interface
@@ -104,13 +104,8 @@ func (s *BaseService) GetHostname() string {
 	return fmt.Sprintf("%s.%s", s.name, tld)
 }
 
-// IsLocalhost checks if the current address is a localhost address
-func (s *BaseService) IsLocalhost() bool {
-	localhostAddresses := []string{"localhost", "127.0.0.1", "::1"}
-	for _, localhost := range localhostAddresses {
-		if s.address == localhost {
-			return true
-		}
-	}
-	return false
+// IsLocalhostMode checks if we are in localhost mode (vm.driver == "docker-desktop")
+func (s *BaseService) IsLocalhostMode() bool {
+	vmDriver := s.configHandler.GetString("vm.driver")
+	return vmDriver == "docker-desktop"
 }

--- a/pkg/services/talos_service.go
+++ b/pkg/services/talos_service.go
@@ -68,10 +68,13 @@ func (s *TalosService) SetAddress(address string) error {
 		nodeType = "controlplanes"
 	}
 
+	// Always use DNS name for hostname
 	if err := s.configHandler.SetContextValue(fmt.Sprintf("cluster.%s.nodes.%s.hostname", nodeType, s.name), s.name+"."+tld); err != nil {
 		return err
 	}
-	if err := s.configHandler.SetContextValue(fmt.Sprintf("cluster.%s.nodes.%s.node", nodeType, s.name), address); err != nil {
+
+	// Always use DNS name for node
+	if err := s.configHandler.SetContextValue(fmt.Sprintf("cluster.%s.nodes.%s.node", nodeType, s.name), s.name+"."+tld); err != nil {
 		return err
 	}
 
@@ -86,7 +89,7 @@ func (s *TalosService) SetAddress(address string) error {
 		nextAPIPort++
 	}
 
-	if err := s.configHandler.SetContextValue(fmt.Sprintf("cluster.%s.nodes.%s.endpoint", nodeType, s.name), fmt.Sprintf("%s:%d", address, port)); err != nil {
+	if err := s.configHandler.SetContextValue(fmt.Sprintf("cluster.%s.nodes.%s.endpoint", nodeType, s.name), fmt.Sprintf("%s.%s:%d", s.name, tld, port)); err != nil {
 		return err
 	}
 

--- a/pkg/services/talos_service.go
+++ b/pkg/services/talos_service.go
@@ -79,7 +79,7 @@ func (s *TalosService) SetAddress(address string) error {
 	defer portLock.Unlock()
 
 	var port int
-	if s.isLeader || !s.IsLocalhost() {
+	if s.isLeader || !s.IsLocalhostMode() {
 		port = defaultAPIPort
 	} else {
 		port = nextAPIPort
@@ -251,7 +251,7 @@ func (s *TalosService) GetComposeConfig() (*types.Config, error) {
 	}
 	defaultAPIPortUint32 := uint32(defaultAPIPort)
 
-	if s.IsLocalhost() {
+	if s.IsLocalhostMode() {
 		ports = append(ports, types.ServicePortConfig{
 			Target:    defaultAPIPortUint32,
 			Published: publishedPort,

--- a/pkg/virt/docker_virt.go
+++ b/pkg/virt/docker_virt.go
@@ -380,7 +380,7 @@ func (v *DockerVirt) getFullComposeConfig() (*types.Project, error) {
 					}
 
 					networkCIDR := v.configHandler.GetString("network.cidr_block")
-					if networkCIDR != "" && ipAddress != "127.0.0.1" && ipAddress != "" {
+					if networkCIDR != "" && ipAddress != "" {
 						containerConfig.Networks[networkName].Ipv4Address = ipAddress
 					}
 

--- a/pkg/virt/docker_virt_test.go
+++ b/pkg/virt/docker_virt_test.go
@@ -1346,241 +1346,241 @@ func TestDockerVirt_getFullComposeConfig(t *testing.T) {
 			t.Errorf("expected %d networks, got %d", expectedNetworks, len(project.Networks))
 		}
 	})
-}
 
-func TestDockerVirt_getFullComposeConfig_WithDNS(t *testing.T) {
-	// Setup mock components
-	mocks := setupSafeDockerContainerMocks()
-	dockerVirt := NewDockerVirt(mocks.Injector)
-	dockerVirt.services = []services.Service{}         // Initialize empty services slice
-	dockerVirt.configHandler = mocks.MockConfigHandler // Set the config handler
+	t.Run("WithDNS", func(t *testing.T) {
+		// Setup mock components
+		mocks := setupSafeDockerContainerMocks()
+		dockerVirt := NewDockerVirt(mocks.Injector)
+		dockerVirt.services = []services.Service{}         // Initialize empty services slice
+		dockerVirt.configHandler = mocks.MockConfigHandler // Set the config handler
 
-	// Configure mock behavior for DNS
-	mocks.MockConfigHandler.GetBoolFunc = func(key string, defaultValue ...bool) bool {
-		if key == "docker.enabled" {
-			return true
-		}
-		if key == "dns.enabled" {
-			return true
-		}
-		if len(defaultValue) > 0 {
-			return defaultValue[0]
-		}
-		return false
-	}
-
-	mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-		if key == "network.cidr_block" {
-			return "10.0.0.0/24"
-		}
-		if key == "dns.address" {
-			return ""
-		}
-		if len(defaultValue) > 0 {
-			return defaultValue[0]
-		}
-		return ""
-	}
-
-	mocks.MockConfigHandler.GetContextFunc = func() string {
-		return "mock-context"
-	}
-
-	// Setup mock DNS service
-	mockDNS := services.NewMockService()
-	mockDNS.GetAddressFunc = func() string {
-		return "10.0.0.53"
-	}
-	mocks.Injector.Register("dns", mockDNS)
-
-	// Call the function
-	project, err := dockerVirt.getFullComposeConfig()
-
-	// Assertions
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if project == nil {
-		t.Fatal("expected project to be non-nil")
-	}
-	if project.Networks == nil {
-		t.Fatal("expected networks to be non-nil")
-	}
-
-	// Check network configuration
-	networkName := "windsor-mock-context"
-	network, exists := project.Networks[networkName]
-	if !exists {
-		t.Fatalf("expected network %s to exist", networkName)
-	}
-	if network.Driver != "bridge" {
-		t.Errorf("expected driver to be bridge, got %s", network.Driver)
-	}
-	if network.Ipam.Config == nil {
-		t.Fatal("expected Ipam config to be non-nil")
-	}
-	if len(network.Ipam.Config) != 1 {
-		t.Fatalf("expected 1 Ipam config, got %d", len(network.Ipam.Config))
-	}
-	if network.Ipam.Config[0].Subnet != "10.0.0.0/24" {
-		t.Errorf("expected subnet to be 10.0.0.0/24, got %s", network.Ipam.Config[0].Subnet)
-	}
-}
-
-func TestDockerVirt_getFullComposeConfig_Disabled(t *testing.T) {
-	// Setup mock components
-	mocks := setupSafeDockerContainerMocks()
-	dockerVirt := NewDockerVirt(mocks.Injector)
-	dockerVirt.services = []services.Service{}         // Initialize empty services slice
-	dockerVirt.configHandler = mocks.MockConfigHandler // Set the config handler
-
-	// Configure mock behavior
-	mocks.MockConfigHandler.GetBoolFunc = func(key string, defaultValue ...bool) bool {
-		if key == "docker.enabled" {
+		// Configure mock behavior for DNS
+		mocks.MockConfigHandler.GetBoolFunc = func(key string, defaultValue ...bool) bool {
+			if key == "docker.enabled" {
+				return true
+			}
+			if key == "dns.enabled" {
+				return true
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
 			return false
 		}
-		if len(defaultValue) > 0 {
-			return defaultValue[0]
-		}
-		return false
-	}
 
-	// Call the function
-	project, err := dockerVirt.getFullComposeConfig()
-
-	// Assertions
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if project != nil {
-		t.Fatal("expected project to be nil")
-	}
-}
-
-func TestDockerVirt_getFullComposeConfig_WithServices(t *testing.T) {
-	// Setup mock components
-	mocks := setupSafeDockerContainerMocks()
-	dockerVirt := NewDockerVirt(mocks.Injector)
-	dockerVirt.configHandler = mocks.MockConfigHandler // Set the config handler
-
-	// Configure mock behavior
-	mocks.MockConfigHandler.GetBoolFunc = func(key string, defaultValue ...bool) bool {
-		if key == "docker.enabled" {
-			return true
-		}
-		if key == "dns.enabled" {
-			return true
-		}
-		if len(defaultValue) > 0 {
-			return defaultValue[0]
-		}
-		return false
-	}
-
-	mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-		if key == "network.cidr_block" {
-			return "10.0.0.0/24"
-		}
-		if key == "dns.address" {
+		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "network.cidr_block" {
+				return "10.0.0.0/24"
+			}
+			if key == "dns.address" {
+				return ""
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
 			return ""
 		}
-		if len(defaultValue) > 0 {
-			return defaultValue[0]
+
+		mocks.MockConfigHandler.GetContextFunc = func() string {
+			return "mock-context"
 		}
-		return ""
-	}
 
-	mocks.MockConfigHandler.GetContextFunc = func() string {
-		return "mock-context"
-	}
+		// Setup mock DNS service
+		mockDNS := services.NewMockService()
+		mockDNS.GetAddressFunc = func() string {
+			return "10.0.0.53"
+		}
+		mocks.Injector.Register("dns", mockDNS)
 
-	// Create a mock service
-	mockService := services.NewMockService()
-	mockService.GetNameFunc = func() string {
-		return "test-service"
-	}
-	mockService.GetAddressFunc = func() string {
-		return "10.0.0.2"
-	}
-	mockService.GetComposeConfigFunc = func() (*types.Config, error) {
-		return &types.Config{
-			Services: []types.ServiceConfig{
-				{
-					Name:  "test-service",
-					Image: "test-image:latest",
-					Ports: []types.ServicePortConfig{
-						{
-							Published: "8080",
-							Target:    80,
+		// Call the function
+		project, err := dockerVirt.getFullComposeConfig()
+
+		// Assertions
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if project == nil {
+			t.Fatal("expected project to be non-nil")
+		}
+		if project.Networks == nil {
+			t.Fatal("expected networks to be non-nil")
+		}
+
+		// Check network configuration
+		networkName := "windsor-mock-context"
+		network, exists := project.Networks[networkName]
+		if !exists {
+			t.Fatalf("expected network %s to exist", networkName)
+		}
+		if network.Driver != "bridge" {
+			t.Errorf("expected driver to be bridge, got %s", network.Driver)
+		}
+		if network.Ipam.Config == nil {
+			t.Fatal("expected Ipam config to be non-nil")
+		}
+		if len(network.Ipam.Config) != 1 {
+			t.Fatalf("expected 1 Ipam config, got %d", len(network.Ipam.Config))
+		}
+		if network.Ipam.Config[0].Subnet != "10.0.0.0/24" {
+			t.Errorf("expected subnet to be 10.0.0.0/24, got %s", network.Ipam.Config[0].Subnet)
+		}
+	})
+
+	t.Run("Disabled", func(t *testing.T) {
+		// Setup mock components
+		mocks := setupSafeDockerContainerMocks()
+		dockerVirt := NewDockerVirt(mocks.Injector)
+		dockerVirt.services = []services.Service{}         // Initialize empty services slice
+		dockerVirt.configHandler = mocks.MockConfigHandler // Set the config handler
+
+		// Configure mock behavior
+		mocks.MockConfigHandler.GetBoolFunc = func(key string, defaultValue ...bool) bool {
+			if key == "docker.enabled" {
+				return false
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return false
+		}
+
+		// Call the function
+		project, err := dockerVirt.getFullComposeConfig()
+
+		// Assertions
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if project != nil {
+			t.Fatal("expected project to be nil")
+		}
+	})
+
+	t.Run("WithServices", func(t *testing.T) {
+		// Setup mock components
+		mocks := setupSafeDockerContainerMocks()
+		dockerVirt := NewDockerVirt(mocks.Injector)
+		dockerVirt.configHandler = mocks.MockConfigHandler // Set the config handler
+
+		// Configure mock behavior
+		mocks.MockConfigHandler.GetBoolFunc = func(key string, defaultValue ...bool) bool {
+			if key == "docker.enabled" {
+				return true
+			}
+			if key == "dns.enabled" {
+				return true
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return false
+		}
+
+		mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "network.cidr_block" {
+				return "10.0.0.0/24"
+			}
+			if key == "dns.address" {
+				return ""
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
+
+		mocks.MockConfigHandler.GetContextFunc = func() string {
+			return "mock-context"
+		}
+
+		// Create a mock service
+		mockService := services.NewMockService()
+		mockService.GetNameFunc = func() string {
+			return "test-service"
+		}
+		mockService.GetAddressFunc = func() string {
+			return "10.0.0.2"
+		}
+		mockService.GetComposeConfigFunc = func() (*types.Config, error) {
+			return &types.Config{
+				Services: []types.ServiceConfig{
+					{
+						Name:  "test-service",
+						Image: "test-image:latest",
+						Ports: []types.ServicePortConfig{
+							{
+								Published: "8080",
+								Target:    80,
+							},
 						},
-					},
-					Environment: map[string]*string{
-						"ENV": ptrString("test"),
-					},
-					Volumes: []types.ServiceVolumeConfig{
-						{
-							Source: "/host:/container",
+						Environment: map[string]*string{
+							"ENV": ptrString("test"),
+						},
+						Volumes: []types.ServiceVolumeConfig{
+							{
+								Source: "/host:/container",
+							},
 						},
 					},
 				},
-			},
-		}, nil
-	}
+			}, nil
+		}
 
-	// Register the mock service
-	mocks.Injector.Register("test-service", mockService)
-	dockerVirt.services = []services.Service{mockService}
+		// Register the mock service
+		mocks.Injector.Register("test-service", mockService)
+		dockerVirt.services = []services.Service{mockService}
 
-	// Setup mock DNS service
-	mockDNS := services.NewMockService()
-	mockDNS.GetAddressFunc = func() string {
-		return "10.0.0.53"
-	}
-	mocks.Injector.Register("dns", mockDNS)
+		// Setup mock DNS service
+		mockDNS := services.NewMockService()
+		mockDNS.GetAddressFunc = func() string {
+			return "10.0.0.53"
+		}
+		mocks.Injector.Register("dns", mockDNS)
 
-	// Call the function
-	project, err := dockerVirt.getFullComposeConfig()
+		// Call the function
+		project, err := dockerVirt.getFullComposeConfig()
 
-	// Assertions
-	if err != nil {
-		t.Fatalf("expected no error, got %v", err)
-	}
-	if project == nil {
-		t.Fatal("expected project to be non-nil")
-	}
-	if len(project.Services) != 1 {
-		t.Fatalf("expected 1 service, got %d", len(project.Services))
-	}
+		// Assertions
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if project == nil {
+			t.Fatal("expected project to be non-nil")
+		}
+		if len(project.Services) != 1 {
+			t.Fatalf("expected 1 service, got %d", len(project.Services))
+		}
 
-	service := project.Services[0]
-	if service.Name != "test-service" {
-		t.Errorf("expected service name to be test-service, got %s", service.Name)
-	}
-	if service.Image != "test-image:latest" {
-		t.Errorf("expected image to be test-image:latest, got %s", service.Image)
-	}
-	if len(service.Ports) != 1 {
-		t.Fatalf("expected 1 port, got %d", len(service.Ports))
-	}
-	if service.Ports[0].Published != "8080" || service.Ports[0].Target != 80 {
-		t.Errorf("expected port to be 8080:80, got %s:%d", service.Ports[0].Published, service.Ports[0].Target)
-	}
-	if service.Environment["ENV"] == nil || *service.Environment["ENV"] != "test" {
-		t.Errorf("expected environment ENV to be test, got %v", service.Environment["ENV"])
-	}
-	if len(service.Volumes) != 1 {
-		t.Fatalf("expected 1 volume, got %d", len(service.Volumes))
-	}
-	if service.Volumes[0].Source != "/host:/container" {
-		t.Errorf("expected volume source to be /host:/container, got %s", service.Volumes[0].Source)
-	}
-	if len(service.Networks) != 1 {
-		t.Fatalf("expected 1 network, got %d", len(service.Networks))
-	}
-	if service.Networks["windsor-mock-context"] == nil {
-		t.Error("expected network windsor-mock-context to exist")
-	}
-	if service.DNS == nil || len(service.DNS) != 1 || service.DNS[0] != "10.0.0.53" {
-		t.Errorf("expected DNS to be [10.0.0.53], got %v", service.DNS)
-	}
+		service := project.Services[0]
+		if service.Name != "test-service" {
+			t.Errorf("expected service name to be test-service, got %s", service.Name)
+		}
+		if service.Image != "test-image:latest" {
+			t.Errorf("expected image to be test-image:latest, got %s", service.Image)
+		}
+		if len(service.Ports) != 1 {
+			t.Fatalf("expected 1 port, got %d", len(service.Ports))
+		}
+		if service.Ports[0].Published != "8080" || service.Ports[0].Target != 80 {
+			t.Errorf("expected port to be 8080:80, got %s:%d", service.Ports[0].Published, service.Ports[0].Target)
+		}
+		if service.Environment["ENV"] == nil || *service.Environment["ENV"] != "test" {
+			t.Errorf("expected environment ENV to be test, got %v", service.Environment["ENV"])
+		}
+		if len(service.Volumes) != 1 {
+			t.Fatalf("expected 1 volume, got %d", len(service.Volumes))
+		}
+		if service.Volumes[0].Source != "/host:/container" {
+			t.Errorf("expected volume source to be /host:/container, got %s", service.Volumes[0].Source)
+		}
+		if len(service.Networks) != 1 {
+			t.Fatalf("expected 1 network, got %d", len(service.Networks))
+		}
+		if service.Networks["windsor-mock-context"] == nil {
+			t.Error("expected network windsor-mock-context to exist")
+		}
+		if service.DNS == nil || len(service.DNS) != 1 || service.DNS[0] != "10.0.0.53" {
+			t.Errorf("expected DNS to be [10.0.0.53], got %v", service.DNS)
+		}
+	})
 }

--- a/pkg/virt/docker_virt_test.go
+++ b/pkg/virt/docker_virt_test.go
@@ -1347,3 +1347,240 @@ func TestDockerVirt_getFullComposeConfig(t *testing.T) {
 		}
 	})
 }
+
+func TestDockerVirt_getFullComposeConfig_WithDNS(t *testing.T) {
+	// Setup mock components
+	mocks := setupSafeDockerContainerMocks()
+	dockerVirt := NewDockerVirt(mocks.Injector)
+	dockerVirt.services = []services.Service{}         // Initialize empty services slice
+	dockerVirt.configHandler = mocks.MockConfigHandler // Set the config handler
+
+	// Configure mock behavior for DNS
+	mocks.MockConfigHandler.GetBoolFunc = func(key string, defaultValue ...bool) bool {
+		if key == "docker.enabled" {
+			return true
+		}
+		if key == "dns.enabled" {
+			return true
+		}
+		if len(defaultValue) > 0 {
+			return defaultValue[0]
+		}
+		return false
+	}
+
+	mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+		if key == "network.cidr_block" {
+			return "10.0.0.0/24"
+		}
+		if key == "dns.address" {
+			return ""
+		}
+		if len(defaultValue) > 0 {
+			return defaultValue[0]
+		}
+		return ""
+	}
+
+	mocks.MockConfigHandler.GetContextFunc = func() string {
+		return "mock-context"
+	}
+
+	// Setup mock DNS service
+	mockDNS := services.NewMockService()
+	mockDNS.GetAddressFunc = func() string {
+		return "10.0.0.53"
+	}
+	mocks.Injector.Register("dns", mockDNS)
+
+	// Call the function
+	project, err := dockerVirt.getFullComposeConfig()
+
+	// Assertions
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if project == nil {
+		t.Fatal("expected project to be non-nil")
+	}
+	if project.Networks == nil {
+		t.Fatal("expected networks to be non-nil")
+	}
+
+	// Check network configuration
+	networkName := "windsor-mock-context"
+	network, exists := project.Networks[networkName]
+	if !exists {
+		t.Fatalf("expected network %s to exist", networkName)
+	}
+	if network.Driver != "bridge" {
+		t.Errorf("expected driver to be bridge, got %s", network.Driver)
+	}
+	if network.Ipam.Config == nil {
+		t.Fatal("expected Ipam config to be non-nil")
+	}
+	if len(network.Ipam.Config) != 1 {
+		t.Fatalf("expected 1 Ipam config, got %d", len(network.Ipam.Config))
+	}
+	if network.Ipam.Config[0].Subnet != "10.0.0.0/24" {
+		t.Errorf("expected subnet to be 10.0.0.0/24, got %s", network.Ipam.Config[0].Subnet)
+	}
+}
+
+func TestDockerVirt_getFullComposeConfig_Disabled(t *testing.T) {
+	// Setup mock components
+	mocks := setupSafeDockerContainerMocks()
+	dockerVirt := NewDockerVirt(mocks.Injector)
+	dockerVirt.services = []services.Service{}         // Initialize empty services slice
+	dockerVirt.configHandler = mocks.MockConfigHandler // Set the config handler
+
+	// Configure mock behavior
+	mocks.MockConfigHandler.GetBoolFunc = func(key string, defaultValue ...bool) bool {
+		if key == "docker.enabled" {
+			return false
+		}
+		if len(defaultValue) > 0 {
+			return defaultValue[0]
+		}
+		return false
+	}
+
+	// Call the function
+	project, err := dockerVirt.getFullComposeConfig()
+
+	// Assertions
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if project != nil {
+		t.Fatal("expected project to be nil")
+	}
+}
+
+func TestDockerVirt_getFullComposeConfig_WithServices(t *testing.T) {
+	// Setup mock components
+	mocks := setupSafeDockerContainerMocks()
+	dockerVirt := NewDockerVirt(mocks.Injector)
+	dockerVirt.configHandler = mocks.MockConfigHandler // Set the config handler
+
+	// Configure mock behavior
+	mocks.MockConfigHandler.GetBoolFunc = func(key string, defaultValue ...bool) bool {
+		if key == "docker.enabled" {
+			return true
+		}
+		if key == "dns.enabled" {
+			return true
+		}
+		if len(defaultValue) > 0 {
+			return defaultValue[0]
+		}
+		return false
+	}
+
+	mocks.MockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+		if key == "network.cidr_block" {
+			return "10.0.0.0/24"
+		}
+		if key == "dns.address" {
+			return ""
+		}
+		if len(defaultValue) > 0 {
+			return defaultValue[0]
+		}
+		return ""
+	}
+
+	mocks.MockConfigHandler.GetContextFunc = func() string {
+		return "mock-context"
+	}
+
+	// Create a mock service
+	mockService := services.NewMockService()
+	mockService.GetNameFunc = func() string {
+		return "test-service"
+	}
+	mockService.GetAddressFunc = func() string {
+		return "10.0.0.2"
+	}
+	mockService.GetComposeConfigFunc = func() (*types.Config, error) {
+		return &types.Config{
+			Services: []types.ServiceConfig{
+				{
+					Name:  "test-service",
+					Image: "test-image:latest",
+					Ports: []types.ServicePortConfig{
+						{
+							Published: "8080",
+							Target:    80,
+						},
+					},
+					Environment: map[string]*string{
+						"ENV": ptrString("test"),
+					},
+					Volumes: []types.ServiceVolumeConfig{
+						{
+							Source: "/host:/container",
+						},
+					},
+				},
+			},
+		}, nil
+	}
+
+	// Register the mock service
+	mocks.Injector.Register("test-service", mockService)
+	dockerVirt.services = []services.Service{mockService}
+
+	// Setup mock DNS service
+	mockDNS := services.NewMockService()
+	mockDNS.GetAddressFunc = func() string {
+		return "10.0.0.53"
+	}
+	mocks.Injector.Register("dns", mockDNS)
+
+	// Call the function
+	project, err := dockerVirt.getFullComposeConfig()
+
+	// Assertions
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if project == nil {
+		t.Fatal("expected project to be non-nil")
+	}
+	if len(project.Services) != 1 {
+		t.Fatalf("expected 1 service, got %d", len(project.Services))
+	}
+
+	service := project.Services[0]
+	if service.Name != "test-service" {
+		t.Errorf("expected service name to be test-service, got %s", service.Name)
+	}
+	if service.Image != "test-image:latest" {
+		t.Errorf("expected image to be test-image:latest, got %s", service.Image)
+	}
+	if len(service.Ports) != 1 {
+		t.Fatalf("expected 1 port, got %d", len(service.Ports))
+	}
+	if service.Ports[0].Published != "8080" || service.Ports[0].Target != 80 {
+		t.Errorf("expected port to be 8080:80, got %s:%d", service.Ports[0].Published, service.Ports[0].Target)
+	}
+	if service.Environment["ENV"] == nil || *service.Environment["ENV"] != "test" {
+		t.Errorf("expected environment ENV to be test, got %v", service.Environment["ENV"])
+	}
+	if len(service.Volumes) != 1 {
+		t.Fatalf("expected 1 volume, got %d", len(service.Volumes))
+	}
+	if service.Volumes[0].Source != "/host:/container" {
+		t.Errorf("expected volume source to be /host:/container, got %s", service.Volumes[0].Source)
+	}
+	if len(service.Networks) != 1 {
+		t.Fatalf("expected 1 network, got %d", len(service.Networks))
+	}
+	if service.Networks["windsor-mock-context"] == nil {
+		t.Error("expected network windsor-mock-context to exist")
+	}
+	if service.DNS == nil || len(service.DNS) != 1 || service.DNS[0] != "10.0.0.53" {
+		t.Errorf("expected DNS to be [10.0.0.53], got %v", service.DNS)
+	}
+}


### PR DESCRIPTION
Since we operate CoreDNS amongst our local development services, it seems reasonable to use it as our docker network DNS. This will eventually allow us to define hostnames and domain routing independently.

The code changes to make this possible are co-dependent on how we generate and template values in our default blueprints. As such, we now also use DNS names instead of IPs for looking up our nodes.