### PR TITLE
Add LoadConfigString

### DIFF
--- a/pkg/config/config_handler.go
+++ b/pkg/config/config_handler.go
@@ -24,6 +24,9 @@ type ConfigHandler interface {
 	// LoadConfig loads the configuration from the specified path
 	LoadConfig(path string) error
 
+	// LoadConfigString loads the configuration from the provided string content
+	LoadConfigString(content string) error
+
 	// GetString retrieves a string value for the specified key from the configuration
 	GetString(key string, defaultValue ...string) string
 
@@ -78,7 +81,6 @@ type ConfigHandler interface {
 
 // BaseConfigHandler is a base implementation of the ConfigHandler interface
 type BaseConfigHandler struct {
-	ConfigHandler
 	injector         di.Injector
 	shell            shell.Shell
 	config           v1alpha1.Config

--- a/pkg/config/mock_config_handler.go
+++ b/pkg/config/mock_config_handler.go
@@ -10,6 +10,7 @@ type MockConfigHandler struct {
 	InitializeFunc         func() error
 	SetSecretsProviderFunc func(provider secrets.SecretsProvider)
 	LoadConfigFunc         func(path string) error
+	LoadConfigStringFunc   func(content string) error
 	IsLoadedFunc           func() bool
 	GetStringFunc          func(key string, defaultValue ...string) string
 	GetIntFunc             func(key string, defaultValue ...int) int
@@ -52,6 +53,14 @@ func (m *MockConfigHandler) SetSecretsProvider(provider secrets.SecretsProvider)
 func (m *MockConfigHandler) LoadConfig(path string) error {
 	if m.LoadConfigFunc != nil {
 		return m.LoadConfigFunc(path)
+	}
+	return nil
+}
+
+// LoadConfigString calls the mock LoadConfigStringFunc if set, otherwise returns nil
+func (m *MockConfigHandler) LoadConfigString(content string) error {
+	if m.LoadConfigStringFunc != nil {
+		return m.LoadConfigStringFunc(content)
 	}
 	return nil
 }


### PR DESCRIPTION
LoadConfigString is used to load YAML directly in to the config structure. This will allow a cleaner test setup in the future.