### PR TITLE
PV_ discovery mechanism causing slow shell

### DIFF
--- a/pkg/env/kube_env.go
+++ b/pkg/env/kube_env.go
@@ -89,7 +89,10 @@ func (e *KubeEnvPrinter) GetEnvVars() (map[string]string, error) {
 		return envVars, nil
 	}
 
-	pvcs, _ := queryPersistentVolumeClaims(kubeConfigPath) // ignores error
+	pvcs, err := queryPersistentVolumeClaims(kubeConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query persistent volume claims: %w", err)
+	}
 
 	if pvcs != nil && pvcs.Items != nil {
 		for _, dir := range volumeDirs {


### PR DESCRIPTION
Added error handling for pvc lookup query and tests for both cases, the commented test will pass when the error is not handled appropriately, and the uncommented test will pass when it is, leaving both in for now for visibility