### PR TITLE
Remove split DNS

### DIFF
--- a/pkg/services/dns_service.go
+++ b/pkg/services/dns_service.go
@@ -119,7 +119,6 @@ func (s *DNSService) WriteConfig() error {
 	}
 
 	tld := s.configHandler.GetString("dns.domain", "test")
-	networkCIDR := s.configHandler.GetString("network.cidr_block")
 
 	var (
 		hostEntries              string
@@ -199,9 +198,7 @@ func (s *DNSService) WriteConfig() error {
 
 	var corefileContent string
 	if s.isLocalhostMode() {
-		internalView := fmt.Sprintf("    view internal {\n        expr incidr(client_ip(), '%s')\n    }\n", networkCIDR)
-		corefileContent = fmt.Sprintf(serverBlockTemplate, tld, internalView, hostEntries, wildcardEntries, forwardAddressesStr)
-		corefileContent += fmt.Sprintf(serverBlockTemplate, tld, "", localhostHostEntries, localhostWildcardEntries, forwardAddressesStr)
+		corefileContent = fmt.Sprintf(serverBlockTemplate, tld, "", localhostHostEntries, localhostWildcardEntries, forwardAddressesStr)
 	} else {
 		corefileContent = fmt.Sprintf(serverBlockTemplate, tld, "", hostEntries, wildcardEntries, forwardAddressesStr)
 	}


### PR DESCRIPTION
The direction of using split DNS turned out to be dubious. There was a case in which the internal IPs were being reported to the host, even when in localhost mode. This mode has been removed.

Additionally, the talos service needed to be updated to no longer expect a DNS oriented configuration.