### PR TITLE
Stop prerelease shipping to homebrew

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -13,7 +13,9 @@ categories:
   - title: 'Maintenance'
     label: 'chore'
   - title: 'Dependencies'
-    label: 'dependencies'
+    collapse-after: 3
+    labels:
+      - 'dependencies'
 change-template: '- $TITLE @$AUTHOR (#$NUMBER)'
 change-title-escapes: '\<*_&'
 version-resolver:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -121,11 +121,15 @@ jobs:
       - name: Set pre-release flag
         id: prerelease
         run: |
+          echo "Tag: ${{ github.ref }}"
           if [[ "${{ github.ref }}" =~ -[a-zA-Z0-9]+$ ]]; then
+            echo "Matched prerelease pattern"
             echo "prerelease=true" >> $GITHUB_OUTPUT
           else
+            echo "Did not match prerelease pattern"
             echo "prerelease=false" >> $GITHUB_OUTPUT
           fi
+          echo "Set prerelease to: ${{ steps.prerelease.outputs.prerelease }}"
 
       - name: Install GPG
         run: sudo apt-get update && sudo apt-get install -y gnupg

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,7 +9,7 @@ on:
       - 'v[0-9]+.[0-9]+.[0-9]+-*'
       
 permissions:
-  contents: write  # Allows creating releases
+  contents: write
   issues: read
   pull-requests: read  
 jobs:
@@ -117,24 +117,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-
-      - name: Set pre-release flag
-        id: prerelease
-        run: |
-          echo "Tag: ${{ github.ref }}"
-          if [[ "${{ github.ref }}" =~ -[a-zA-Z0-9]+$ ]]; then
-            echo "Matched prerelease pattern"
-            echo "prerelease=true" >> $GITHUB_OUTPUT
-            echo "Set prerelease to: true"
-          else
-            echo "Did not match prerelease pattern"
-            echo "prerelease=false" >> $GITHUB_OUTPUT
-            echo "Set prerelease to: false"
-          fi
-
-      - name: Debug prerelease value
-        run: |
-          echo "Prerelease value: ${{ steps.prerelease.outputs.prerelease }}"
 
       - name: Install GPG
         run: sudo apt-get update && sudo apt-get install -y gnupg

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -177,5 +177,5 @@ jobs:
           GPG_FINGERPRINT: ${{ env.GPG_FINGERPRINT }}
           HOMEBREW_CLI_WRITE_PAT: ${{ secrets.HOMEBREW_CLI_WRITE_PAT }}
           GITHUB_SHA: ${{ github.sha }}
-          PRERELEASE: ${{ steps.prerelease.outputs.prerelease }}
+          PRERELEASE: ${{ steps.prerelease.outputs.prerelease == 'true' }}
           SKIP_HOMEBREW: ${{ steps.prerelease.outputs.prerelease == 'true' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -171,11 +171,10 @@ jobs:
         uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
         with:
           version: "~> v2"
-          args: release --clean --debug
+          args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ env.GPG_FINGERPRINT }}
           HOMEBREW_CLI_WRITE_PAT: ${{ secrets.HOMEBREW_CLI_WRITE_PAT }}
           GITHUB_SHA: ${{ github.sha }}
-          PRERELEASE: ${{ steps.prerelease.outputs.prerelease == 'true' }}
           SKIP_HOMEBREW: ${{ steps.prerelease.outputs.prerelease == 'true' }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -125,11 +125,16 @@ jobs:
           if [[ "${{ github.ref }}" =~ -[a-zA-Z0-9]+$ ]]; then
             echo "Matched prerelease pattern"
             echo "prerelease=true" >> $GITHUB_OUTPUT
+            echo "Set prerelease to: true"
           else
             echo "Did not match prerelease pattern"
             echo "prerelease=false" >> $GITHUB_OUTPUT
+            echo "Set prerelease to: false"
           fi
-          echo "Set prerelease to: ${{ steps.prerelease.outputs.prerelease }}"
+
+      - name: Debug prerelease value
+        run: |
+          echo "Prerelease value: ${{ steps.prerelease.outputs.prerelease }}"
 
       - name: Install GPG
         run: sudo apt-get update && sudo apt-get install -y gnupg

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -171,7 +171,7 @@ jobs:
         uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
         with:
           version: "~> v2"
-          args: release --clean
+          args: release --clean --debug
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ env.GPG_FINGERPRINT }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -44,7 +44,7 @@ release:
     owner: windsorcli
     name: cli
   draft: false
-  prerelease: "{{ eq .Env.PRERELEASE \"true\" }}"
+  prerelease: auto
 
 binary_signs:
   - cmd: gpg

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -44,7 +44,7 @@ release:
     owner: windsorcli
     name: cli
   draft: false
-  prerelease: "{{ eq .Env.PRERELEASE \"true\" }}"
+  prerelease: "true"
 
 binary_signs:
   - cmd: gpg

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -44,7 +44,7 @@ release:
     owner: windsorcli
     name: cli
   draft: false
-  prerelease: false
+  prerelease: "{{ .Env.PRERELEASE }}"
 
 binary_signs:
   - cmd: gpg
@@ -62,7 +62,7 @@ signs:
 brews:
   - name: windsor
     directory: Formula
-    skip_upload: false
+    skip_upload: "{{ eq .Env.SKIP_HOMEBREW \"true\" }}"
     repository:
       owner: windsorcli
       name: homebrew-cli

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -44,7 +44,7 @@ release:
     owner: windsorcli
     name: cli
   draft: false
-  prerelease: "true"
+  prerelease: "{{ .Env.PRERELEASE }}"
 
 binary_signs:
   - cmd: gpg

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -44,7 +44,7 @@ release:
     owner: windsorcli
     name: cli
   draft: false
-  prerelease: "{{ .Env.PRERELEASE }}"
+  prerelease: "{{ eq .Env.PRERELEASE \"true\" }}"
 
 binary_signs:
   - cmd: gpg


### PR DESCRIPTION
This disables packaging and shipping homebrew when we run goreleaser. Also includes a small change to make Dependencies collapse on the release page.