### PR TITLE
Include a context ID

### DIFF
--- a/api/v1alpha1/config_types.go
+++ b/api/v1alpha1/config_types.go
@@ -21,6 +21,7 @@ type Config struct {
 
 // Context represents the context configuration
 type Context struct {
+	ID          *string                    `yaml:"id,omitempty"`
 	ProjectName *string                    `yaml:"projectName,omitempty"`
 	Blueprint   *string                    `yaml:"blueprint,omitempty"`
 	Environment map[string]string          `yaml:"environment,omitempty"`
@@ -39,6 +40,9 @@ type Context struct {
 func (base *Context) Merge(overlay *Context) {
 	if overlay == nil {
 		return
+	}
+	if overlay.ID != nil {
+		base.ID = overlay.ID
 	}
 	if overlay.ProjectName != nil {
 		base.ProjectName = overlay.ProjectName
@@ -123,6 +127,7 @@ func (c *Context) DeepCopy() *Context {
 		}
 	}
 	return &Context{
+		ID:          c.ID,
 		ProjectName: c.ProjectName,
 		Blueprint:   c.Blueprint,
 		Environment: environmentCopy,

--- a/api/v1alpha1/config_types_test.go
+++ b/api/v1alpha1/config_types_test.go
@@ -309,6 +309,22 @@ func TestConfig_Merge(t *testing.T) {
 			t.Errorf("ProjectName mismatch: expected 'OverlayProject', got '%s'", *base.ProjectName)
 		}
 	})
+
+	t.Run("MergeWithID", func(t *testing.T) {
+		base := &Context{
+			ID: ptrString("base-id"),
+		}
+
+		overlay := &Context{
+			ID: ptrString("overlay-id"),
+		}
+
+		base.Merge(overlay)
+
+		if base.ID == nil || *base.ID != "overlay-id" {
+			t.Errorf("ID mismatch: expected 'overlay-id', got '%s'", *base.ID)
+		}
+	})
 }
 
 func TestConfig_Copy(t *testing.T) {

--- a/pkg/config/config_handler.go
+++ b/pkg/config/config_handler.go
@@ -38,6 +38,7 @@ type ConfigHandler interface {
 	Clean() error
 	IsLoaded() bool
 	SetSecretsProvider(provider secrets.SecretsProvider)
+	GenerateContextID() error
 }
 
 const (

--- a/pkg/config/mock_config_handler.go
+++ b/pkg/config/mock_config_handler.go
@@ -27,6 +27,7 @@ type MockConfigHandler struct {
 	GetConfigRootFunc      func() (string, error)
 	CleanFunc              func() error
 	SetSecretsProviderFunc func(provider secrets.SecretsProvider)
+	GenerateContextIDFunc  func() error
 }
 
 // =============================================================================
@@ -214,6 +215,14 @@ func (m *MockConfigHandler) SetSecretsProvider(provider secrets.SecretsProvider)
 	if m.SetSecretsProviderFunc != nil {
 		m.SetSecretsProviderFunc(provider)
 	}
+}
+
+// GenerateContextID calls the mock GenerateContextIDFunc if set, otherwise returns nil
+func (m *MockConfigHandler) GenerateContextID() error {
+	if m.GenerateContextIDFunc != nil {
+		return m.GenerateContextIDFunc()
+	}
+	return nil
 }
 
 // Ensure MockConfigHandler implements ConfigHandler

--- a/pkg/config/mock_config_handler_test.go
+++ b/pkg/config/mock_config_handler_test.go
@@ -705,3 +705,33 @@ func TestMockConfigHandler_SetSecretsProvider(t *testing.T) {
 		handler.SetSecretsProvider(mockProvider)
 	})
 }
+
+func TestMockConfigHandler_GenerateContextID(t *testing.T) {
+	t.Run("WithMockFunction", func(t *testing.T) {
+		// Given a mock config handler with GenerateContextIDFunc set
+		handler := NewMockConfigHandler()
+		mockErr := fmt.Errorf("mock generate context ID error")
+		handler.GenerateContextIDFunc = func() error { return mockErr }
+
+		// When GenerateContextID is called
+		err := handler.GenerateContextID()
+
+		// Then the error should match the expected mock error
+		if err != mockErr {
+			t.Errorf("Expected error = %v, got = %v", mockErr, err)
+		}
+	})
+
+	t.Run("WithNoFuncSet", func(t *testing.T) {
+		// Given a mock config handler without GenerateContextIDFunc set
+		handler := NewMockConfigHandler()
+
+		// When GenerateContextID is called
+		err := handler.GenerateContextID()
+
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected error = %v, got = %v", nil, err)
+		}
+	})
+}

--- a/pkg/config/shims.go
+++ b/pkg/config/shims.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"crypto/rand"
 	"os"
 
 	"github.com/goccy/go-yaml"
@@ -12,29 +13,31 @@ import (
 
 // Shims provides mockable wrappers around system and runtime functions
 type Shims struct {
-	ReadFile      func(string) ([]byte, error)
-	WriteFile     func(string, []byte, os.FileMode) error
-	RemoveAll     func(string) error
-	Getenv        func(string) string
-	Setenv        func(string, string) error
-	Stat          func(string) (os.FileInfo, error)
-	MkdirAll      func(string, os.FileMode) error
-	YamlMarshal   func(any) ([]byte, error)
-	YamlUnmarshal func([]byte, any) error
+	ReadFile       func(string) ([]byte, error)
+	WriteFile      func(string, []byte, os.FileMode) error
+	RemoveAll      func(string) error
+	Getenv         func(string) string
+	Setenv         func(string, string) error
+	Stat           func(string) (os.FileInfo, error)
+	MkdirAll       func(string, os.FileMode) error
+	YamlMarshal    func(any) ([]byte, error)
+	YamlUnmarshal  func([]byte, any) error
+	CryptoRandRead func([]byte) (int, error)
 }
 
 // NewShims creates a new Shims instance with default implementations
 func NewShims() *Shims {
 	return &Shims{
-		ReadFile:      os.ReadFile,
-		WriteFile:     os.WriteFile,
-		RemoveAll:     os.RemoveAll,
-		Getenv:        os.Getenv,
-		Setenv:        os.Setenv,
-		Stat:          os.Stat,
-		MkdirAll:      os.MkdirAll,
-		YamlMarshal:   yaml.Marshal,
-		YamlUnmarshal: yaml.Unmarshal,
+		ReadFile:       os.ReadFile,
+		WriteFile:      os.WriteFile,
+		RemoveAll:      os.RemoveAll,
+		Getenv:         os.Getenv,
+		Setenv:         os.Setenv,
+		Stat:           os.Stat,
+		MkdirAll:       os.MkdirAll,
+		YamlMarshal:    yaml.Marshal,
+		YamlUnmarshal:  yaml.Unmarshal,
+		CryptoRandRead: func(b []byte) (int, error) { return rand.Read(b) },
 	}
 }
 

--- a/pkg/config/yaml_config_handler.go
+++ b/pkg/config/yaml_config_handler.go
@@ -645,3 +645,23 @@ func convertValue(value string, targetType reflect.Type) (any, error) {
 
 	return convertedValue, nil
 }
+
+// GenerateContextID generates a random context ID if one doesn't exist
+func (y *YamlConfigHandler) GenerateContextID() error {
+	if y.GetString("id") != "" {
+		return nil
+	}
+
+	const charset = "abcdefghijklmnopqrstuvwxyz0123456789"
+	b := make([]byte, 7)
+	if _, err := y.shims.CryptoRandRead(b); err != nil {
+		return fmt.Errorf("failed to generate random context ID: %w", err)
+	}
+
+	for i := range b {
+		b[i] = charset[int(b[i])%len(charset)]
+	}
+
+	id := "w" + string(b)
+	return y.SetContextValue("id", id)
+}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -411,6 +411,7 @@ func (c *BaseController) InitializeWithRequirements(req Requirements) error {
 	if err := c.CreateComponents(); err != nil {
 		return fmt.Errorf("failed to create components: %w", err)
 	}
+
 	if err := c.InitializeComponents(); err != nil {
 		return fmt.Errorf("failed to initialize components: %w", err)
 	}
@@ -746,6 +747,11 @@ func (c *BaseController) createConfigComponent(req Requirements) error {
 	if req.ConfigLoaded && !configHandler.IsLoaded() {
 		fmt.Fprintln(os.Stderr, "Cannot execute commands. Please run 'windsor init' to set up your project first.")
 		return nil
+	}
+
+	// Generate context ID
+	if err := configHandler.GenerateContextID(); err != nil {
+		return fmt.Errorf("failed to generate context ID: %w", err)
 	}
 
 	return nil

--- a/pkg/env/terraform_env.go
+++ b/pkg/env/terraform_env.go
@@ -67,6 +67,7 @@ func (e *TerraformEnvPrinter) GetEnvVars() (map[string]string, error) {
 			"TF_CLI_ARGS_import",
 			"TF_CLI_ARGS_destroy",
 			"TF_VAR_context_path",
+			"TF_VAR_context_id",
 			"TF_VAR_os_type",
 		}
 
@@ -119,6 +120,7 @@ func (e *TerraformEnvPrinter) GetEnvVars() (map[string]string, error) {
 	envVars["TF_CLI_ARGS_import"] = strings.TrimSpace(strings.Join(varFileArgs, " "))
 	envVars["TF_CLI_ARGS_destroy"] = strings.TrimSpace(strings.Join(varFileArgs, " "))
 	envVars["TF_VAR_context_path"] = strings.TrimSpace(filepath.ToSlash(configRoot))
+	envVars["TF_VAR_context_id"] = strings.TrimSpace(e.configHandler.GetString("id", ""))
 
 	// Set os_type based on the OS
 	if e.shims.Goos() == "windows" {

--- a/pkg/env/terraform_env_test.go
+++ b/pkg/env/terraform_env_test.go
@@ -486,6 +486,7 @@ func TestTerraformEnv_Print(t *testing.T) {
 				filepath.Join(configRoot, "terraform/project/path.tfvars"),
 				filepath.Join(configRoot, "terraform/project/path.tfvars.json")),
 			"TF_VAR_context_path": configRoot,
+			"TF_VAR_context_id":   "",
 			"TF_VAR_os_type":      expectedOSType,
 		}
 


### PR DESCRIPTION
A context ID is now generated for a context. This value is prefixed with `w` and followed by 7 random lowercase alphanumeric characters. It is automatically written to the `windsor.yaml` config file.

The context ID is available to all Terraform components via the `TF_VAR_context_id` variable.