### PR TITLE
Automatically migrate state on windsor up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ contexts/**/.kube/
 contexts/**/.talos/
 contexts/**/.aws/
 contexts/**/.omni/
+contexts/**/.azure/

--- a/pkg/stack/windsor_stack.go
+++ b/pkg/stack/windsor_stack.go
@@ -87,7 +87,7 @@ func (s *WindsorStack) Up() error {
 		}
 
 		// Execute 'terraform init' in the dirPath
-		_, err = s.shell.ExecProgress(fmt.Sprintf("🌎 Initializing Terraform in %s", component.Path), "terraform", "init", "-migrate-state", "-upgrade")
+		_, err = s.shell.ExecProgress(fmt.Sprintf("🌎 Initializing Terraform in %s", component.Path), "terraform", "init", "-migrate-state", "-upgrade", "-force-copy")
 		if err != nil {
 			return fmt.Errorf("error initializing Terraform in %s: %w", component.FullPath, err)
 		}


### PR DESCRIPTION
In windsor, the terraform backend is managed. As such, we don't need the prompts from the terraform tool when state is being migrated. This change fixes broken stacks when changing backends.