### PR TITLE
Windsor down destroys terraform

### DIFF
--- a/api/v1alpha1/azure/azure_config_test.go
+++ b/api/v1alpha1/azure/azure_config_test.go
@@ -6,41 +6,193 @@ import (
 
 func TestAzureConfig(t *testing.T) {
 	t.Run("Merge", func(t *testing.T) {
-		base := &AzureConfig{
-			Enabled: boolPtr(false),
-		}
-		overlay := &AzureConfig{
-			Enabled: boolPtr(true),
+		tests := []struct {
+			name     string
+			base     *AzureConfig
+			overlay  *AzureConfig
+			expected *AzureConfig
+		}{
+			{
+				name: "AllFields",
+				base: &AzureConfig{
+					Enabled:        boolPtr(false),
+					SubscriptionID: stringPtr("old-sub"),
+					TenantID:       stringPtr("old-tenant"),
+					Environment:    stringPtr("old-env"),
+				},
+				overlay: &AzureConfig{
+					Enabled:        boolPtr(true),
+					SubscriptionID: stringPtr("new-sub"),
+					TenantID:       stringPtr("new-tenant"),
+					Environment:    stringPtr("new-env"),
+				},
+				expected: &AzureConfig{
+					Enabled:        boolPtr(true),
+					SubscriptionID: stringPtr("new-sub"),
+					TenantID:       stringPtr("new-tenant"),
+					Environment:    stringPtr("new-env"),
+				},
+			},
+			{
+				name: "PartialOverlay",
+				base: &AzureConfig{
+					Enabled:        boolPtr(false),
+					SubscriptionID: stringPtr("old-sub"),
+					TenantID:       stringPtr("old-tenant"),
+					Environment:    stringPtr("old-env"),
+				},
+				overlay: &AzureConfig{
+					Enabled: boolPtr(true),
+				},
+				expected: &AzureConfig{
+					Enabled:        boolPtr(true),
+					SubscriptionID: stringPtr("old-sub"),
+					TenantID:       stringPtr("old-tenant"),
+					Environment:    stringPtr("old-env"),
+				},
+			},
+			{
+				name: "NilOverlay",
+				base: &AzureConfig{
+					Enabled:        boolPtr(false),
+					SubscriptionID: stringPtr("old-sub"),
+					TenantID:       stringPtr("old-tenant"),
+					Environment:    stringPtr("old-env"),
+				},
+				overlay: nil,
+				expected: &AzureConfig{
+					Enabled:        boolPtr(false),
+					SubscriptionID: stringPtr("old-sub"),
+					TenantID:       stringPtr("old-tenant"),
+					Environment:    stringPtr("old-env"),
+				},
+			},
 		}
 
-		base.Merge(overlay)
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				tt.base.Merge(tt.overlay)
 
-		if *base.Enabled != true {
-			t.Errorf("Expected Enabled to be true, got %v", *base.Enabled)
+				if tt.base.Enabled == nil || tt.expected.Enabled == nil {
+					if tt.base.Enabled != tt.expected.Enabled {
+						t.Errorf("Expected Enabled to be %v, got %v", tt.expected.Enabled, tt.base.Enabled)
+					}
+				} else if *tt.base.Enabled != *tt.expected.Enabled {
+					t.Errorf("Expected Enabled to be %v, got %v", *tt.expected.Enabled, *tt.base.Enabled)
+				}
+
+				if tt.base.SubscriptionID == nil || tt.expected.SubscriptionID == nil {
+					if tt.base.SubscriptionID != tt.expected.SubscriptionID {
+						t.Errorf("Expected SubscriptionID to be %v, got %v", tt.expected.SubscriptionID, tt.base.SubscriptionID)
+					}
+				} else if *tt.base.SubscriptionID != *tt.expected.SubscriptionID {
+					t.Errorf("Expected SubscriptionID to be %v, got %v", *tt.expected.SubscriptionID, *tt.base.SubscriptionID)
+				}
+
+				if tt.base.TenantID == nil || tt.expected.TenantID == nil {
+					if tt.base.TenantID != tt.expected.TenantID {
+						t.Errorf("Expected TenantID to be %v, got %v", tt.expected.TenantID, tt.base.TenantID)
+					}
+				} else if *tt.base.TenantID != *tt.expected.TenantID {
+					t.Errorf("Expected TenantID to be %v, got %v", *tt.expected.TenantID, *tt.base.TenantID)
+				}
+
+				if tt.base.Environment == nil || tt.expected.Environment == nil {
+					if tt.base.Environment != tt.expected.Environment {
+						t.Errorf("Expected Environment to be %v, got %v", tt.expected.Environment, tt.base.Environment)
+					}
+				} else if *tt.base.Environment != *tt.expected.Environment {
+					t.Errorf("Expected Environment to be %v, got %v", *tt.expected.Environment, *tt.base.Environment)
+				}
+			})
 		}
 	})
 
 	t.Run("Copy", func(t *testing.T) {
-		original := &AzureConfig{
-			Enabled: boolPtr(true),
+		tests := []struct {
+			name     string
+			original *AzureConfig
+		}{
+			{
+				name: "AllFields",
+				original: &AzureConfig{
+					Enabled:        boolPtr(true),
+					SubscriptionID: stringPtr("sub"),
+					TenantID:       stringPtr("tenant"),
+					Environment:    stringPtr("env"),
+				},
+			},
+			{
+				name: "SomeFields",
+				original: &AzureConfig{
+					Enabled: boolPtr(true),
+				},
+			},
+			{
+				name:     "Nil",
+				original: nil,
+			},
 		}
 
-		copy := original.Copy()
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				copy := tt.original.Copy()
 
-		if copy == nil {
-			t.Fatal("Expected non-nil copy")
-		}
+				if tt.original == nil {
+					if copy != nil {
+						t.Error("Expected nil copy for nil original")
+					}
+					return
+				}
 
-		if copy == original {
-			t.Error("Expected copy to be a new instance")
-		}
+				if copy == nil {
+					t.Fatal("Expected non-nil copy")
+				}
 
-		if *copy.Enabled != *original.Enabled {
-			t.Errorf("Expected Enabled to be %v, got %v", *original.Enabled, *copy.Enabled)
+				if copy == tt.original {
+					t.Error("Expected copy to be a new instance")
+				}
+
+				if tt.original.Enabled == nil {
+					if copy.Enabled != nil {
+						t.Error("Expected Enabled to be nil")
+					}
+				} else if copy.Enabled == nil || *copy.Enabled != *tt.original.Enabled {
+					t.Errorf("Expected Enabled to be %v, got %v", tt.original.Enabled, copy.Enabled)
+				}
+
+				if tt.original.SubscriptionID == nil {
+					if copy.SubscriptionID != nil {
+						t.Error("Expected SubscriptionID to be nil")
+					}
+				} else if copy.SubscriptionID == nil || *copy.SubscriptionID != *tt.original.SubscriptionID {
+					t.Errorf("Expected SubscriptionID to be %v, got %v", tt.original.SubscriptionID, copy.SubscriptionID)
+				}
+
+				if tt.original.TenantID == nil {
+					if copy.TenantID != nil {
+						t.Error("Expected TenantID to be nil")
+					}
+				} else if copy.TenantID == nil || *copy.TenantID != *tt.original.TenantID {
+					t.Errorf("Expected TenantID to be %v, got %v", tt.original.TenantID, copy.TenantID)
+				}
+
+				if tt.original.Environment == nil {
+					if copy.Environment != nil {
+						t.Error("Expected Environment to be nil")
+					}
+				} else if copy.Environment == nil || *copy.Environment != *tt.original.Environment {
+					t.Errorf("Expected Environment to be %v, got %v", tt.original.Environment, copy.Environment)
+				}
+			})
 		}
 	})
 }
 
 func boolPtr(b bool) *bool {
 	return &b
+}
+
+func stringPtr(s string) *string {
+	return &s
 }

--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -117,6 +117,10 @@ type TerraformComponent struct {
 
 	// Values are configuration values for the module.
 	Values map[string]any `yaml:"values,omitempty"`
+
+	// Destroy determines if the component should be destroyed during down operations.
+	// Defaults to true if not specified.
+	Destroy *bool `yaml:"destroy,omitempty"`
 }
 
 // Kustomization defines a kustomization config in a blueprint.
@@ -230,6 +234,7 @@ func (b *Blueprint) DeepCopy() *Blueprint {
 			Path:     component.Path,
 			FullPath: component.FullPath,
 			Values:   valuesCopy,
+			Destroy:  component.Destroy,
 		}
 	}
 
@@ -360,6 +365,11 @@ func (b *Blueprint) Merge(overlay *Blueprint) {
 					if overlayComponent.FullPath != "" {
 						mergedComponent.FullPath = overlayComponent.FullPath
 					}
+
+					if overlayComponent.Destroy != nil {
+						mergedComponent.Destroy = overlayComponent.Destroy
+					}
+
 					b.TerraformComponents = append(b.TerraformComponents, mergedComponent)
 				} else {
 					b.TerraformComponents = append(b.TerraformComponents, overlayComponent)

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -29,6 +29,8 @@ var downCmd = &cobra.Command{
 			VM:           true,
 			Containers:   true,
 			Network:      true,
+			Blueprint:    true,
+			Stack:        true,
 			CommandName:  cmd.Name(),
 			Flags: map[string]bool{
 				"verbose": verbose,
@@ -45,6 +47,15 @@ var downCmd = &cobra.Command{
 		// Resolve components
 		shell := controller.ResolveShell()
 		configHandler := controller.ResolveConfigHandler()
+
+		// Tear down the stack components
+		stack := controller.ResolveStack()
+		if stack == nil {
+			return fmt.Errorf("No stack found")
+		}
+		if err := stack.Down(); err != nil {
+			return fmt.Errorf("Error running stack Down command: %w", err)
+		}
 
 		// Determine if the container runtime is enabled
 		containerRuntimeEnabled := configHandler.GetBool("docker.enabled")

--- a/pkg/blueprint/templates/default.jsonnet
+++ b/pkg/blueprint/templates/default.jsonnet
@@ -227,6 +227,7 @@ local terraformConfig = if platform == "local" || platform == "metal" then [
   {
     path: "gitops/flux",
     source: "core",
+    destroy: false,
     values: if platform == "local" then {
       git_username: "local",
       git_password: "local",

--- a/pkg/stack/mock_stack.go
+++ b/pkg/stack/mock_stack.go
@@ -15,6 +15,7 @@ import "github.com/windsorcli/cli/pkg/di"
 type MockStack struct {
 	InitializeFunc func() error
 	UpFunc         func() error
+	DownFunc       func() error
 }
 
 // =============================================================================
@@ -42,6 +43,14 @@ func (m *MockStack) Initialize() error {
 func (m *MockStack) Up() error {
 	if m.UpFunc != nil {
 		return m.UpFunc()
+	}
+	return nil
+}
+
+// Down is a mock implementation of the Down method.
+func (m *MockStack) Down() error {
+	if m.DownFunc != nil {
+		return m.DownFunc()
 	}
 	return nil
 }

--- a/pkg/stack/mock_stack_test.go
+++ b/pkg/stack/mock_stack_test.go
@@ -77,3 +77,36 @@ func TestMockStack_Up(t *testing.T) {
 		}
 	})
 }
+
+func TestMockStack_Down(t *testing.T) {
+	mockDownErr := fmt.Errorf("mock down error")
+
+	t.Run("WithFuncSet", func(t *testing.T) {
+		// Given a new MockStack with a custom DownFunc that returns an error
+		mock := NewMockStack(nil)
+		mock.DownFunc = func() error {
+			return mockDownErr
+		}
+
+		// When Down is called
+		err := mock.Down()
+
+		// Then the custom error should be returned
+		if err != mockDownErr {
+			t.Errorf("Expected error = %v, got = %v", mockDownErr, err)
+		}
+	})
+
+	t.Run("WithNoFuncSet", func(t *testing.T) {
+		// Given a new MockStack without a custom DownFunc
+		mock := NewMockStack(nil)
+
+		// When Down is called
+		err := mock.Down()
+
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected error = %v, got = %v", nil, err)
+		}
+	})
+}

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -23,6 +23,7 @@ import (
 type Stack interface {
 	Initialize() error
 	Up() error
+	Down() error
 }
 
 // =============================================================================
@@ -86,6 +87,11 @@ func (s *BaseStack) Initialize() error {
 
 // Up creates a new stack of components.
 func (s *BaseStack) Up() error {
+	return nil
+}
+
+// Down destroys a stack of components.
+func (s *BaseStack) Down() error {
 	return nil
 }
 

--- a/pkg/stack/stack_test.go
+++ b/pkg/stack/stack_test.go
@@ -338,6 +338,54 @@ func TestStack_Up(t *testing.T) {
 	})
 }
 
+func TestStack_Down(t *testing.T) {
+	setup := func(t *testing.T) (*BaseStack, *Mocks) {
+		t.Helper()
+		mocks := setupMocks(t)
+		stack := NewBaseStack(mocks.Injector)
+		stack.shims = mocks.Shims
+		return stack, mocks
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		// Given safe mock components
+		stack, _ := setup(t)
+
+		// When a new BaseStack is created and initialized
+		if err := stack.Initialize(); err != nil {
+			t.Fatalf("Expected no error during initialization, got %v", err)
+		}
+
+		// And when Down is called
+		if err := stack.Down(); err != nil {
+			// Then no error should occur
+			t.Errorf("Expected Down to return nil, got %v", err)
+		}
+	})
+
+	t.Run("UninitializedStack", func(t *testing.T) {
+		// Given a new BaseStack without initialization
+		stack, _ := setup(t)
+
+		// When Down is called without initializing
+		if err := stack.Down(); err != nil {
+			// Then no error should occur since base implementation is empty
+			t.Errorf("Expected Down to return nil even without initialization, got %v", err)
+		}
+	})
+
+	t.Run("NilInjector", func(t *testing.T) {
+		// Given a BaseStack with nil injector
+		stack := NewBaseStack(nil)
+
+		// When Down is called
+		if err := stack.Down(); err != nil {
+			// Then no error should occur since base implementation is empty
+			t.Errorf("Expected Down to return nil even with nil injector, got %v", err)
+		}
+	})
+}
+
 func TestStack_Interface(t *testing.T) {
 	t.Run("BaseStackImplementsStack", func(t *testing.T) {
 		// Given a type assertion for Stack interface

--- a/pkg/stack/windsor_stack.go
+++ b/pkg/stack/windsor_stack.go
@@ -164,7 +164,7 @@ func (s *WindsorStack) Down() error {
 			return fmt.Errorf("error planning Terraform destruction in %s: %w", component.FullPath, err)
 		}
 
-		_, err = s.shell.ExecProgress(fmt.Sprintf("🗑️ Destroying Terraform resources in %s", component.Path), "terraform", "apply")
+		_, err = s.shell.ExecProgress(fmt.Sprintf("🗑️ Destroying Terraform resources in %s", component.Path), "terraform", "destroy", "-auto-approve")
 		if err != nil {
 			return fmt.Errorf("error destroying Terraform resources in %s: %w", component.FullPath, err)
 		}

--- a/pkg/stack/windsor_stack.go
+++ b/pkg/stack/windsor_stack.go
@@ -41,35 +41,31 @@ func NewWindsorStack(injector di.Injector) *WindsorStack {
 // Public Methods
 // =============================================================================
 
-// Up creates a new stack of components.
+// Up creates a new stack of components by initializing and applying Terraform configurations.
+// It processes components in order, setting up environment variables, running Terraform init,
+// plan, and apply operations, and cleaning up backend override files.
+// The method ensures proper directory management and environment setup for each component.
 func (s *WindsorStack) Up() error {
-	// Store the current directory
 	currentDir, err := s.shims.Getwd()
 	if err != nil {
 		return fmt.Errorf("error getting current directory: %v", err)
 	}
 
-	// Ensure we change back to the original directory once the function completes
 	defer func() {
 		_ = s.shims.Chdir(currentDir)
 	}()
 
-	// Get the Terraform components from the blueprint
 	components := s.blueprintHandler.GetTerraformComponents()
 
-	// Iterate over the components
 	for _, component := range components {
-		// Ensure the directory exists
 		if _, err := s.shims.Stat(component.FullPath); os.IsNotExist(err) {
 			return fmt.Errorf("directory %s does not exist", component.FullPath)
 		}
 
-		// Change to the component directory
 		if err := s.shims.Chdir(component.FullPath); err != nil {
 			return fmt.Errorf("error changing to directory %s: %v", component.FullPath, err)
 		}
 
-		// Iterate over all envPrinters and load the environment variables
 		for _, envPrinter := range s.envPrinters {
 			envVars, err := envPrinter.GetEnvVars()
 			if err != nil {
@@ -80,31 +76,99 @@ func (s *WindsorStack) Up() error {
 					return fmt.Errorf("error setting environment variable %s: %v", key, err)
 				}
 			}
-			// Run the post environment hook
 			if err := envPrinter.PostEnvHook(); err != nil {
 				return fmt.Errorf("error running post environment hook: %v", err)
 			}
 		}
 
-		// Execute 'terraform init' in the dirPath
 		_, err = s.shell.ExecProgress(fmt.Sprintf("🌎 Initializing Terraform in %s", component.Path), "terraform", "init", "-migrate-state", "-upgrade", "-force-copy")
 		if err != nil {
 			return fmt.Errorf("error initializing Terraform in %s: %w", component.FullPath, err)
 		}
 
-		// Execute 'terraform plan' in the dirPath
 		_, err = s.shell.ExecProgress(fmt.Sprintf("🌎 Planning Terraform changes in %s", component.Path), "terraform", "plan")
 		if err != nil {
 			return fmt.Errorf("error planning Terraform changes in %s: %w", component.FullPath, err)
 		}
 
-		// Execute 'terraform apply' in the dirPath
 		_, err = s.shell.ExecProgress(fmt.Sprintf("🌎 Applying Terraform changes in %s", component.Path), "terraform", "apply")
 		if err != nil {
 			return fmt.Errorf("error applying Terraform changes in %s: %w", component.FullPath, err)
 		}
 
-		// Attempt to clean up 'backend_override.tf' if it exists
+		backendOverridePath := filepath.Join(component.FullPath, "backend_override.tf")
+		if _, err := s.shims.Stat(backendOverridePath); err == nil {
+			if err := s.shims.Remove(backendOverridePath); err != nil {
+				return fmt.Errorf("error removing backend_override.tf in %s: %v", component.FullPath, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// Down destroys a stack of components by executing Terraform destroy operations in reverse order.
+// It processes components in reverse order, skipping any marked with destroy: false.
+// For each component, it sets up environment variables, runs Terraform init, plan -destroy,
+// and destroy operations, and cleans up backend override files.
+// The method ensures proper directory management and environment setup for each component.
+func (s *WindsorStack) Down() error {
+	currentDir, err := s.shims.Getwd()
+	if err != nil {
+		return fmt.Errorf("error getting current directory: %v", err)
+	}
+
+	defer func() {
+		_ = s.shims.Chdir(currentDir)
+	}()
+
+	components := s.blueprintHandler.GetTerraformComponents()
+
+	for i := len(components) - 1; i >= 0; i-- {
+		component := components[i]
+
+		if component.Destroy != nil && !*component.Destroy {
+			continue
+		}
+
+		if _, err := s.shims.Stat(component.FullPath); os.IsNotExist(err) {
+			return fmt.Errorf("directory %s does not exist", component.FullPath)
+		}
+
+		if err := s.shims.Chdir(component.FullPath); err != nil {
+			return fmt.Errorf("error changing to directory %s: %v", component.FullPath, err)
+		}
+
+		for _, envPrinter := range s.envPrinters {
+			envVars, err := envPrinter.GetEnvVars()
+			if err != nil {
+				return fmt.Errorf("error getting environment variables: %v", err)
+			}
+			for key, value := range envVars {
+				if err := s.shims.Setenv(key, value); err != nil {
+					return fmt.Errorf("error setting environment variable %s: %v", key, err)
+				}
+			}
+			if err := envPrinter.PostEnvHook(); err != nil {
+				return fmt.Errorf("error running post environment hook: %v", err)
+			}
+		}
+
+		_, err = s.shell.ExecProgress(fmt.Sprintf("🗑️ Initializing Terraform in %s", component.Path), "terraform", "init", "-migrate-state", "-upgrade", "-force-copy")
+		if err != nil {
+			return fmt.Errorf("error initializing Terraform in %s: %w", component.FullPath, err)
+		}
+
+		_, err = s.shell.ExecProgress(fmt.Sprintf("🗑️ Planning Terraform destruction in %s", component.Path), "terraform", "plan", "-destroy")
+		if err != nil {
+			return fmt.Errorf("error planning Terraform destruction in %s: %w", component.FullPath, err)
+		}
+
+		_, err = s.shell.ExecProgress(fmt.Sprintf("🗑️ Destroying Terraform resources in %s", component.Path), "terraform", "apply")
+		if err != nil {
+			return fmt.Errorf("error destroying Terraform resources in %s: %w", component.FullPath, err)
+		}
+
 		backendOverridePath := filepath.Join(component.FullPath, "backend_override.tf")
 		if _, err := s.shims.Stat(backendOverridePath); err == nil {
 			if err := s.shims.Remove(backendOverridePath); err != nil {

--- a/pkg/stack/windsor_stack_test.go
+++ b/pkg/stack/windsor_stack_test.go
@@ -342,6 +342,18 @@ func TestWindsorStack_Down(t *testing.T) {
 		if err := stack.Initialize(); err != nil {
 			t.Fatalf("Expected no error during initialization, got %v", err)
 		}
+
+		// Set up default components for the blueprint handler
+		mocks.Blueprint.GetTerraformComponentsFunc = func() []blueprintv1alpha1.TerraformComponent {
+			return []blueprintv1alpha1.TerraformComponent{
+				{
+					Source:   "source1",
+					Path:     "module/path1",
+					FullPath: filepath.Join(os.Getenv("WINDSOR_PROJECT_ROOT"), ".windsor", ".tf_modules", "remote", "path"),
+				},
+			}
+		}
+
 		return stack, mocks
 	}
 

--- a/pkg/stack/windsor_stack_test.go
+++ b/pkg/stack/windsor_stack_test.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"testing"
 
+	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/di"
 	"github.com/windsorcli/cli/pkg/env"
 )
@@ -330,4 +331,216 @@ func TestWindsorStack_Up(t *testing.T) {
 			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
 		}
 	})
+}
+
+func TestWindsorStack_Down(t *testing.T) {
+	setup := func(t *testing.T) (*WindsorStack, *Mocks) {
+		t.Helper()
+		mocks := setupWindsorStackMocks(t)
+		stack := NewWindsorStack(mocks.Injector)
+		stack.shims = mocks.Shims
+		if err := stack.Initialize(); err != nil {
+			t.Fatalf("Expected no error during initialization, got %v", err)
+		}
+		return stack, mocks
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		stack, _ := setup(t)
+
+		// And when the stack is brought down
+		if err := stack.Down(); err != nil {
+			// Then no error should occur
+			t.Errorf("Expected Down to return nil, got %v", err)
+		}
+	})
+
+	t.Run("ErrorGettingCurrentDirectory", func(t *testing.T) {
+		stack, mocks := setup(t)
+		mocks.Shims.Getwd = func() (string, error) {
+			return "", fmt.Errorf("mock error getting current directory")
+		}
+
+		// And when Down is called
+		err := stack.Down()
+		// Then the expected error is contained in err
+		expectedError := "error getting current directory"
+		if !strings.Contains(err.Error(), expectedError) {
+			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("ErrorCheckingDirectoryExists", func(t *testing.T) {
+		stack, mocks := setup(t)
+		mocks.Shims.Stat = func(path string) (os.FileInfo, error) {
+			return nil, os.ErrNotExist
+		}
+
+		// And when Down is called
+		err := stack.Down()
+		if err == nil {
+			t.Fatalf("Expected an error, but got nil")
+		}
+
+		// Then the expected error is contained in err
+		expectedError := "directory"
+		if !strings.Contains(err.Error(), expectedError) {
+			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("ErrorChangingDirectory", func(t *testing.T) {
+		stack, mocks := setup(t)
+		mocks.Shims.Chdir = func(_ string) error {
+			return fmt.Errorf("mock error changing directory")
+		}
+
+		// And when Down is called
+		err := stack.Down()
+		// Then the expected error is contained in err
+		expectedError := "error changing to directory"
+		if !strings.Contains(err.Error(), expectedError) {
+			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("ErrorGettingEnvVars", func(t *testing.T) {
+		stack, mocks := setup(t)
+		mocks.EnvPrinter.GetEnvVarsFunc = func() (map[string]string, error) {
+			return nil, fmt.Errorf("mock error getting environment variables")
+		}
+
+		// And when Down is called
+		err := stack.Down()
+		// Then the expected error is contained in err
+		expectedError := "error getting environment variables"
+		if !strings.Contains(err.Error(), expectedError) {
+			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("ErrorSettingEnvVars", func(t *testing.T) {
+		stack, mocks := setup(t)
+		mocks.Shims.Setenv = func(_ string, _ string) error {
+			return fmt.Errorf("mock error setting environment variable")
+		}
+
+		// And when Down is called
+		err := stack.Down()
+		// Then the expected error is contained in err
+		expectedError := "error setting environment variable"
+		if !strings.Contains(err.Error(), expectedError) {
+			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("ErrorRunningPostEnvHook", func(t *testing.T) {
+		stack, mocks := setup(t)
+		mocks.EnvPrinter.PostEnvHookFunc = func() error {
+			return fmt.Errorf("mock error running post environment hook")
+		}
+
+		// And when Down is called
+		err := stack.Down()
+		// Then the expected error is contained in err
+		expectedError := "error running post environment hook"
+		if !strings.Contains(err.Error(), expectedError) {
+			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("ErrorRunningTerraformInit", func(t *testing.T) {
+		stack, mocks := setup(t)
+		mocks.Shell.ExecProgressFunc = func(message string, command string, args ...string) (string, error) {
+			if command == "terraform" && len(args) > 0 && args[0] == "init" {
+				return "", fmt.Errorf("mock error running terraform init")
+			}
+			return "", nil
+		}
+
+		// And when Down is called
+		err := stack.Down()
+		// Then the expected error is contained in err
+		expectedError := "error initializing Terraform"
+		if !strings.Contains(err.Error(), expectedError) {
+			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("ErrorRunningTerraformPlanDestroy", func(t *testing.T) {
+		stack, mocks := setup(t)
+		mocks.Shell.ExecProgressFunc = func(message string, command string, args ...string) (string, error) {
+			if command == "terraform" && len(args) > 0 && args[0] == "plan" && len(args) > 1 && args[1] == "-destroy" {
+				return "", fmt.Errorf("mock error running terraform plan -destroy")
+			}
+			return "", nil
+		}
+
+		// And when Down is called
+		err := stack.Down()
+		// Then the expected error is contained in err
+		expectedError := "error planning Terraform destruction"
+		if !strings.Contains(err.Error(), expectedError) {
+			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("ErrorRunningTerraformDestroy", func(t *testing.T) {
+		stack, mocks := setup(t)
+		mocks.Shell.ExecProgressFunc = func(message string, command string, args ...string) (string, error) {
+			if command == "terraform" && len(args) > 0 && args[0] == "destroy" {
+				return "", fmt.Errorf("mock error running terraform destroy")
+			}
+			return "", nil
+		}
+
+		// And when Down is called
+		err := stack.Down()
+		// Then the expected error is contained in err
+		expectedError := "error destroying Terraform resources"
+		if !strings.Contains(err.Error(), expectedError) {
+			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("ErrorRemovingBackendOverride", func(t *testing.T) {
+		stack, mocks := setup(t)
+		mocks.Shims.Remove = func(_ string) error {
+			return fmt.Errorf("mock error removing backend override")
+		}
+
+		// And when Down is called
+		err := stack.Down()
+		// Then the expected error is contained in err
+		expectedError := "error removing backend_override.tf"
+		if !strings.Contains(err.Error(), expectedError) {
+			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("SkipComponentWithDestroyFalse", func(t *testing.T) {
+		stack, mocks := setup(t)
+		mocks.Blueprint.GetTerraformComponentsFunc = func() []blueprintv1alpha1.TerraformComponent {
+			return []blueprintv1alpha1.TerraformComponent{
+				{
+					Source:   "source1",
+					Path:     "module/path1",
+					FullPath: filepath.Join(os.Getenv("WINDSOR_PROJECT_ROOT"), ".windsor", ".tf_modules", "remote", "path"),
+					Destroy:  ptrBool(false),
+				},
+			}
+		}
+
+		// And when Down is called
+		err := stack.Down()
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("Expected Down to return nil, got %v", err)
+		}
+	})
+}
+
+// Helper functions to create pointers for basic types
+func ptrBool(b bool) *bool {
+	return &b
 }


### PR DESCRIPTION
The `windsor down` command will now perform a `terraform plan -destroy` and take down terraform resources. If performing a destroy on a particular component isn't desired, setting `destroy: false` on a terraform component will skip destruction of that component.