### PR TITLE
Use local dns for container names

### DIFF
--- a/pkg/services/registry_service.go
+++ b/pkg/services/registry_service.go
@@ -113,12 +113,6 @@ func (s *RegistryService) SetAddress(address string) error {
 	return nil
 }
 
-// GetHostname returns the hostname for the registry service, removing the last domain part
-func (s *RegistryService) GetHostname() string {
-	tld := s.configHandler.GetString("dns.domain", "test")
-	return getBasename(s.GetName()) + "." + tld
-}
-
 // =============================================================================
 // Private Methods
 // =============================================================================

--- a/pkg/services/service.go
+++ b/pkg/services/service.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"strings"
 
 	"github.com/compose-spec/compose-go/types"
 	"github.com/windsorcli/cli/pkg/config"
@@ -110,10 +111,9 @@ func (s *BaseService) GetName() string {
 	return s.name
 }
 
-// GetContainerName returns the container name with the "windsor-" prefix and without the DNS domain
+// GetContainerName returns the container name with the DNS domain
 func (s *BaseService) GetContainerName() string {
-	contextName := s.configHandler.GetContext()
-	return fmt.Sprintf("windsor-%s-%s", contextName, s.name)
+	return s.GetHostname()
 }
 
 // =============================================================================
@@ -131,11 +131,17 @@ func (s *BaseService) SupportsWildcard() bool {
 	return false
 }
 
-// GetHostname returns the hostname for the service with the configured TLD
+// GetHostname returns the hostname for the service, handling domain names specially
 func (s *BaseService) GetHostname() string {
 	if s.name == "" {
 		return ""
 	}
 	tld := s.configHandler.GetString("dns.domain", "test")
+
+	if strings.Contains(s.name, ".") {
+		parts := strings.Split(s.name, ".")
+		return strings.Join(parts[:len(parts)-1], ".") + "." + tld
+	}
+
 	return s.name + "." + tld
 }

--- a/pkg/services/talos_service_test.go
+++ b/pkg/services/talos_service_test.go
@@ -1627,7 +1627,7 @@ contexts:
 		}
 
 		// And the container name should use the fallback name with context prefix
-		expectedContainerName := "windsor-mock-context-controlplane"
+		expectedContainerName := "controlplane.test"
 		if config.Services[0].ContainerName != expectedContainerName {
 			t.Errorf("expected container name %s, got %s", expectedContainerName, config.Services[0].ContainerName)
 		}


### PR DESCRIPTION
Fixes an issue where local DNS inside the container network was not properly resolving containers. This was due to the container name not matching a domain name, like git.test or ghcr.test.