### PR TITLE
fix: always use forward slashes in flux kustomizations

### DIFF
--- a/pkg/blueprint/blueprint_handler.go
+++ b/pkg/blueprint/blueprint_handler.go
@@ -417,7 +417,7 @@ func (b *BaseBlueprintHandler) GetKustomizations() []blueprintv1alpha1.Kustomiza
 		if kustomizations[i].Path == "" {
 			kustomizations[i].Path = "kustomize"
 		} else {
-			kustomizations[i].Path = filepath.Join("kustomize", kustomizations[i].Path)
+			kustomizations[i].Path = "kustomize/" + strings.ReplaceAll(kustomizations[i].Path, "\\", "/")
 		}
 
 		if kustomizations[i].Interval == nil || kustomizations[i].Interval.Duration == 0 {

--- a/pkg/blueprint/blueprint_handler_test.go
+++ b/pkg/blueprint/blueprint_handler_test.go
@@ -2224,7 +2224,7 @@ func TestBlueprintHandler_GetKustomizations(t *testing.T) {
 		expectedKustomizations := []blueprintv1alpha1.Kustomization{
 			{
 				Name:          "kustomization1",
-				Path:          filepath.FromSlash("kustomize/overlays/dev"),
+				Path:          "kustomize/overlays/dev",
 				Source:        "source1",
 				Interval:      &metav1.Duration{Duration: constants.DEFAULT_FLUX_KUSTOMIZATION_INTERVAL},
 				RetryInterval: &metav1.Duration{Duration: constants.DEFAULT_FLUX_KUSTOMIZATION_RETRY_INTERVAL},


### PR DESCRIPTION
Resolves:

```
 message: 'kustomization path not found: stat /tmp/kustomization-3255846827/kustomize\policy\base: no such file or directory'
  reason: ArtifactFailed
```