### PR TITLE
fix: Intermittent wait failure

### DIFF
--- a/pkg/blueprint/blueprint_handler_test.go
+++ b/pkg/blueprint/blueprint_handler_test.go
@@ -3946,4 +3946,144 @@ func TestBaseBlueprintHandler_WaitForKustomizations(t *testing.T) {
 			t.Errorf("expected kustomization error, got %v", err)
 		}
 	})
+
+	t.Run("RecoverFromGitRepositoryError", func(t *testing.T) {
+		// Given a blueprint handler with a kustomization
+		handler := &BaseBlueprintHandler{
+			blueprint: blueprintv1alpha1.Blueprint{
+				Kustomizations: []blueprintv1alpha1.Kustomization{
+					{Name: "k1", Timeout: &metav1.Duration{Duration: 100 * time.Millisecond}},
+				},
+			},
+		}
+		handler.kustomizationWaitPollInterval = 10 * time.Millisecond
+
+		// And a Git repository status check that fails twice then succeeds
+		failCount := 0
+		origCheckGit := checkGitRepositoryStatus
+		origCheckKustom := checkKustomizationStatus
+		defer func() {
+			checkGitRepositoryStatus = origCheckGit
+			checkKustomizationStatus = origCheckKustom
+		}()
+		checkGitRepositoryStatus = func(string) error {
+			if failCount < 2 {
+				failCount++
+				return fmt.Errorf("git repo error")
+			}
+			return nil
+		}
+		checkKustomizationStatus = func(string, []string) (map[string]bool, error) {
+			return map[string]bool{"k1": true}, nil
+		}
+
+		// When waiting for kustomizations to be ready
+		err := handler.WaitForKustomizations()
+
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("RecoverFromKustomizationError", func(t *testing.T) {
+		// Given a blueprint handler with a kustomization
+		handler := &BaseBlueprintHandler{
+			blueprint: blueprintv1alpha1.Blueprint{
+				Kustomizations: []blueprintv1alpha1.Kustomization{
+					{Name: "k1", Timeout: &metav1.Duration{Duration: 100 * time.Millisecond}},
+				},
+			},
+		}
+		handler.kustomizationWaitPollInterval = 10 * time.Millisecond
+
+		// And a kustomization status check that fails twice then succeeds
+		failCount := 0
+		origCheckGit := checkGitRepositoryStatus
+		origCheckKustom := checkKustomizationStatus
+		defer func() {
+			checkGitRepositoryStatus = origCheckGit
+			checkKustomizationStatus = origCheckKustom
+		}()
+		checkGitRepositoryStatus = func(string) error { return nil }
+		checkKustomizationStatus = func(string, []string) (map[string]bool, error) {
+			if failCount < 2 {
+				failCount++
+				return nil, fmt.Errorf("kustomization error")
+			}
+			return map[string]bool{"k1": true}, nil
+		}
+
+		// When waiting for kustomizations to be ready
+		err := handler.WaitForKustomizations()
+
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("MaxGitRepositoryFailures", func(t *testing.T) {
+		// Given a blueprint handler with a kustomization
+		handler := &BaseBlueprintHandler{
+			blueprint: blueprintv1alpha1.Blueprint{
+				Kustomizations: []blueprintv1alpha1.Kustomization{
+					{Name: "k1", Timeout: &metav1.Duration{Duration: 100 * time.Millisecond}},
+				},
+			},
+		}
+		handler.kustomizationWaitPollInterval = 10 * time.Millisecond
+
+		// And a Git repository status check that always fails
+		origCheckGit := checkGitRepositoryStatus
+		origCheckKustom := checkKustomizationStatus
+		defer func() {
+			checkGitRepositoryStatus = origCheckGit
+			checkKustomizationStatus = origCheckKustom
+		}()
+		checkGitRepositoryStatus = func(string) error { return fmt.Errorf("git repo error") }
+		checkKustomizationStatus = func(string, []string) (map[string]bool, error) {
+			return map[string]bool{"k1": true}, nil
+		}
+
+		// When waiting for kustomizations to be ready
+		err := handler.WaitForKustomizations()
+
+		// Then a Git repository error should be returned with failure count
+		if err == nil || !strings.Contains(err.Error(), "after 3 consecutive failures") {
+			t.Errorf("expected error with failure count, got %v", err)
+		}
+	})
+
+	t.Run("MaxKustomizationFailures", func(t *testing.T) {
+		// Given a blueprint handler with a kustomization
+		handler := &BaseBlueprintHandler{
+			blueprint: blueprintv1alpha1.Blueprint{
+				Kustomizations: []blueprintv1alpha1.Kustomization{
+					{Name: "k1", Timeout: &metav1.Duration{Duration: 100 * time.Millisecond}},
+				},
+			},
+		}
+		handler.kustomizationWaitPollInterval = 10 * time.Millisecond
+
+		// And a kustomization status check that always fails
+		origCheckGit := checkGitRepositoryStatus
+		origCheckKustom := checkKustomizationStatus
+		defer func() {
+			checkGitRepositoryStatus = origCheckGit
+			checkKustomizationStatus = origCheckKustom
+		}()
+		checkGitRepositoryStatus = func(string) error { return nil }
+		checkKustomizationStatus = func(string, []string) (map[string]bool, error) {
+			return nil, fmt.Errorf("kustomization error")
+		}
+
+		// When waiting for kustomizations to be ready
+		err := handler.WaitForKustomizations()
+
+		// Then a kustomization error should be returned with failure count
+		if err == nil || !strings.Contains(err.Error(), "after 3 consecutive failures") {
+			t.Errorf("expected error with failure count, got %v", err)
+		}
+	})
 }

--- a/pkg/blueprint/blueprint_handler_test.go
+++ b/pkg/blueprint/blueprint_handler_test.go
@@ -4050,7 +4050,8 @@ func TestBaseBlueprintHandler_WaitForKustomizations(t *testing.T) {
 		err := handler.WaitForKustomizations()
 
 		// Then a Git repository error should be returned with failure count
-		if err == nil || !strings.Contains(err.Error(), "after 3 consecutive failures") {
+		expectedMsg := fmt.Sprintf("after %d consecutive failures", constants.DEFAULT_KUSTOMIZATION_WAIT_MAX_FAILURES)
+		if err == nil || !strings.Contains(err.Error(), expectedMsg) {
 			t.Errorf("expected error with failure count, got %v", err)
 		}
 	})
@@ -4082,7 +4083,8 @@ func TestBaseBlueprintHandler_WaitForKustomizations(t *testing.T) {
 		err := handler.WaitForKustomizations()
 
 		// Then a kustomization error should be returned with failure count
-		if err == nil || !strings.Contains(err.Error(), "after 3 consecutive failures") {
+		expectedMsg := fmt.Sprintf("after %d consecutive failures", constants.DEFAULT_KUSTOMIZATION_WAIT_MAX_FAILURES)
+		if err == nil || !strings.Contains(err.Error(), expectedMsg) {
 			t.Errorf("expected error with failure count, got %v", err)
 		}
 	})

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -41,6 +41,8 @@ const (
 	DEFAULT_KUSTOMIZATION_WAIT_TOTAL_TIMEOUT = 10 * time.Minute
 	// Poll interval for CLI WaitForKustomizations
 	DEFAULT_KUSTOMIZATION_WAIT_POLL_INTERVAL = 5 * time.Second
+	// Maximum number of consecutive failures before giving up
+	DEFAULT_KUSTOMIZATION_WAIT_MAX_FAILURES = 5
 )
 
 // Default AWS settings


### PR DESCRIPTION
Adds retries when waiting for flux resources, as these can sometimes fail briefly when bootstrapping. This does not necessarily represent a system failure if the systems eventually recover.

Now while waiting, we will continue to wait through up to 5 failures to make sure the system has a chance to recover.