### PR TITLE
feat(init): add --reset flag for clean initialization

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -27,6 +27,7 @@ var (
 	initPlatform       string
 	initEndpoint       string
 	initSetFlags       []string
+	reset              bool
 )
 
 var initCmd = &cobra.Command{
@@ -212,6 +213,7 @@ var initCmd = &cobra.Command{
 			Blueprint:   true,
 			Generators:  true,
 			Stack:       true,
+			Reset:       reset,
 			CommandName: cmd.Name(),
 			Flags: map[string]bool{
 				"verbose": verbose,
@@ -251,5 +253,6 @@ func init() {
 	initCmd.Flags().StringVar(&initBlueprint, "blueprint", "", "Specify the blueprint to use")
 	initCmd.Flags().StringVar(&initEndpoint, "endpoint", "", "Specify the kubernetes API endpoint")
 	initCmd.Flags().StringSliceVar(&initSetFlags, "set", []string{}, "Override configuration values. Example: --set dns.enabled=false --set cluster.endpoint=https://localhost:6443")
+	initCmd.Flags().BoolVar(&reset, "reset", false, "Reset/overwrite existing files and clean .terraform directory")
 	rootCmd.AddCommand(initCmd)
 }

--- a/pkg/blueprint/blueprint_handler_test.go
+++ b/pkg/blueprint/blueprint_handler_test.go
@@ -569,9 +569,8 @@ func TestBlueprintHandler_LoadConfig(t *testing.T) {
 			return nil, os.ErrNotExist
 		}
 
-		// When loading config with a custom path
-		customPath := "/custom/path/blueprint"
-		err := handler.LoadConfig(customPath)
+		// When loading config
+		err := handler.LoadConfig()
 
 		// Then no error should be returned
 		if err != nil {
@@ -580,12 +579,12 @@ func TestBlueprintHandler_LoadConfig(t *testing.T) {
 
 		// And only yaml path should be checked since it exists
 		expectedPaths := []string{
-			customPath + ".yaml",
+			"blueprint.yaml",
 		}
 		for _, expected := range expectedPaths {
 			found := false
 			for _, checked := range checkedPaths {
-				if checked == expected {
+				if strings.HasSuffix(checked, expected) {
 					found = true
 					break
 				}

--- a/pkg/blueprint/mock_blueprint_handler.go
+++ b/pkg/blueprint/mock_blueprint_handler.go
@@ -8,7 +8,7 @@ import (
 // MockBlueprintHandler is a mock implementation of BlueprintHandler interface for testing
 type MockBlueprintHandler struct {
 	InitializeFunc             func() error
-	LoadConfigFunc             func(path ...string) error
+	LoadConfigFunc             func(reset ...bool) error
 	GetMetadataFunc            func() blueprintv1alpha1.Metadata
 	GetSourcesFunc             func() []blueprintv1alpha1.Source
 	GetTerraformComponentsFunc func() []blueprintv1alpha1.TerraformComponent
@@ -17,7 +17,7 @@ type MockBlueprintHandler struct {
 	SetSourcesFunc             func(sources []blueprintv1alpha1.Source) error
 	SetTerraformComponentsFunc func(terraformComponents []blueprintv1alpha1.TerraformComponent) error
 	SetKustomizationsFunc      func(kustomizations []blueprintv1alpha1.Kustomization) error
-	WriteConfigFunc            func(path ...string) error
+	WriteConfigFunc            func(overwrite ...bool) error
 	InstallFunc                func() error
 	GetRepositoryFunc          func() blueprintv1alpha1.Repository
 	SetRepositoryFunc          func(repository blueprintv1alpha1.Repository) error
@@ -47,9 +47,9 @@ func (m *MockBlueprintHandler) Initialize() error {
 }
 
 // LoadConfig calls the mock LoadConfigFunc if set, otherwise returns nil
-func (m *MockBlueprintHandler) LoadConfig(path ...string) error {
+func (m *MockBlueprintHandler) LoadConfig(reset ...bool) error {
 	if m.LoadConfigFunc != nil {
-		return m.LoadConfigFunc(path...)
+		return m.LoadConfigFunc(reset...)
 	}
 	return nil
 }
@@ -123,9 +123,9 @@ func (m *MockBlueprintHandler) SetKustomizations(kustomizations []blueprintv1alp
 }
 
 // WriteConfig calls the mock WriteConfigFunc if set, otherwise returns nil
-func (m *MockBlueprintHandler) WriteConfig(path ...string) error {
+func (m *MockBlueprintHandler) WriteConfig(overwrite ...bool) error {
 	if m.WriteConfigFunc != nil {
-		return m.WriteConfigFunc(path...)
+		return m.WriteConfigFunc(overwrite...)
 	}
 	return nil
 }

--- a/pkg/blueprint/mock_blueprint_handler_test.go
+++ b/pkg/blueprint/mock_blueprint_handler_test.go
@@ -57,14 +57,14 @@ func TestMockBlueprintHandler_LoadConfig(t *testing.T) {
 
 	mockLoadErr := fmt.Errorf("mock load config error")
 
-	t.Run("WithPath", func(t *testing.T) {
+	t.Run("WithReset", func(t *testing.T) {
 		// Given a mock handler with load config function
 		handler := setup(t)
-		handler.LoadConfigFunc = func(path ...string) error {
+		handler.LoadConfigFunc = func(reset ...bool) error {
 			return mockLoadErr
 		}
-		// When loading config with path
-		err := handler.LoadConfig("some/path")
+		// When loading config with reset
+		err := handler.LoadConfig(true)
 		// Then expected error should be returned
 		if err != mockLoadErr {
 			t.Errorf("Expected error = %v, got = %v", mockLoadErr, err)
@@ -75,7 +75,7 @@ func TestMockBlueprintHandler_LoadConfig(t *testing.T) {
 		// Given a mock handler without load config function
 		handler := setup(t)
 		// When loading config
-		err := handler.LoadConfig("some/path")
+		err := handler.LoadConfig()
 		// Then no error should be returned
 		if err != nil {
 			t.Errorf("Expected error = %v, got = %v", nil, err)
@@ -380,11 +380,11 @@ func TestMockBlueprintHandler_WriteConfig(t *testing.T) {
 	t.Run("WithFuncSet", func(t *testing.T) {
 		// Given a mock handler with write config function
 		handler := setup(t)
-		handler.WriteConfigFunc = func(path ...string) error {
+		handler.WriteConfigFunc = func(overwrite ...bool) error {
 			return mockWriteErr
 		}
 		// When writing config
-		err := handler.WriteConfig("some/path")
+		err := handler.WriteConfig()
 		// Then expected error should be returned
 		if err != mockWriteErr {
 			t.Errorf("Expected error = %v, got = %v", mockWriteErr, err)
@@ -395,7 +395,7 @@ func TestMockBlueprintHandler_WriteConfig(t *testing.T) {
 		// Given a mock handler without write config function
 		handler := setup(t)
 		// When writing config
-		err := handler.WriteConfig("some/path")
+		err := handler.WriteConfig()
 		// Then no error should be returned
 		if err != nil {
 			t.Errorf("Expected error = %v, got = %v", nil, err)

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -139,6 +139,7 @@ type Requirements struct {
 	// Command info for context-specific decisions
 	CommandName string          // Name of the command
 	Flags       map[string]bool // Important flags that affect initialization
+	Reset       bool            // Whether to reset/overwrite existing files
 }
 
 // =============================================================================
@@ -384,7 +385,7 @@ func (c *BaseController) InitializeComponents() error {
 		if err := blueprintHandler.Initialize(); err != nil {
 			return fmt.Errorf("error initializing blueprint handler: %w", err)
 		}
-		if err := blueprintHandler.LoadConfig(); err != nil {
+		if err := blueprintHandler.LoadConfig(c.requirements.Reset); err != nil {
 			return fmt.Errorf("error loading blueprint config: %w", err)
 		}
 	}
@@ -439,7 +440,7 @@ func (c *BaseController) WriteConfigurationFiles() error {
 	if req.Blueprint {
 		blueprintHandler := c.ResolveBlueprintHandler()
 		if blueprintHandler != nil {
-			if err := blueprintHandler.WriteConfig(); err != nil {
+			if err := blueprintHandler.WriteConfig(req.Reset); err != nil {
 				return fmt.Errorf("error writing blueprint config: %w", err)
 			}
 		}
@@ -482,7 +483,7 @@ func (c *BaseController) WriteConfigurationFiles() error {
 		generators := c.ResolveAllGenerators()
 		for _, generator := range generators {
 			if generator != nil {
-				if err := generator.Write(); err != nil {
+				if err := generator.Write(req.Reset); err != nil {
 					return fmt.Errorf("error writing generator config: %w", err)
 				}
 			}

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -800,7 +800,7 @@ func TestBaseController_InitializeComponents(t *testing.T) {
 		mockBlueprint.InitializeFunc = func() error {
 			return nil
 		}
-		mockBlueprint.LoadConfigFunc = func(path ...string) error {
+		mockBlueprint.LoadConfigFunc = func(reset ...bool) error {
 			return fmt.Errorf("blueprint config loading failed")
 		}
 		mocks.Injector.Register("blueprintHandler", mockBlueprint)
@@ -955,7 +955,7 @@ func TestBaseController_InitializeComponents(t *testing.T) {
 			return nil
 		}
 
-		mockBlueprint.LoadConfigFunc = func(path ...string) error {
+		mockBlueprint.LoadConfigFunc = func(reset ...bool) error {
 			initialized["blueprintHandlerLoadConfig"] = true
 			return nil
 		}
@@ -1053,7 +1053,7 @@ func TestBaseController_WriteConfigurationFiles(t *testing.T) {
 
 		// Mock blueprint handler
 		mockBlueprintHandler := blueprint.NewMockBlueprintHandler(mocks.Injector)
-		mockBlueprintHandler.WriteConfigFunc = func(path ...string) error {
+		mockBlueprintHandler.WriteConfigFunc = func(overwrite ...bool) error {
 			return nil
 		}
 		mocks.Injector.Register("blueprintHandler", mockBlueprintHandler)
@@ -1081,7 +1081,7 @@ func TestBaseController_WriteConfigurationFiles(t *testing.T) {
 
 		// Mock generators
 		mockGenerator := generators.NewMockGenerator()
-		mockGenerator.WriteFunc = func() error {
+		mockGenerator.WriteFunc = func(overwrite ...bool) error {
 			return nil
 		}
 		mocks.Injector.Register("generator", mockGenerator)
@@ -1166,7 +1166,7 @@ func TestBaseController_WriteConfigurationFiles(t *testing.T) {
 
 		// And a blueprint handler that fails to write config
 		mockBlueprintHandler := blueprint.NewMockBlueprintHandler(mocks.Injector)
-		mockBlueprintHandler.WriteConfigFunc = func(path ...string) error {
+		mockBlueprintHandler.WriteConfigFunc = func(overwrite ...bool) error {
 			return fmt.Errorf("blueprint config write failed")
 		}
 		mocks.Injector.Register("blueprintHandler", mockBlueprintHandler)
@@ -1290,7 +1290,7 @@ func TestBaseController_WriteConfigurationFiles(t *testing.T) {
 
 		// And a generator that fails to write config
 		mockGenerator := generators.NewMockGenerator()
-		mockGenerator.WriteFunc = func() error {
+		mockGenerator.WriteFunc = func(overwrite ...bool) error {
 			return fmt.Errorf("generator config write failed")
 		}
 		mocks.Injector.Register("generator", mockGenerator)
@@ -3876,4 +3876,17 @@ func TestBaseController_createVirtualizationComponents(t *testing.T) {
 			t.Errorf("Expected error about nil runtime, got %v", err)
 		}
 	})
+}
+
+// Helper: BlueprintHandlerMock implements blueprint.BlueprintHandler
+// (wraps the generated mock and adapts LoadConfig signature)
+type BlueprintHandlerMock struct {
+	*blueprint.MockBlueprintHandler
+}
+
+func (m *BlueprintHandlerMock) LoadConfig(reset ...bool) error {
+	if m.LoadConfigFunc != nil {
+		return m.LoadConfigFunc(reset...)
+	}
+	return nil
 }

--- a/pkg/generators/generator.go
+++ b/pkg/generators/generator.go
@@ -18,10 +18,12 @@ import (
 // Interfaces
 // =============================================================================
 
-// Generator is the interface that wraps the Write method
+// Generator is the interface for all code generators
+// It defines methods for initialization and file generation
+// All generators must implement this interface
 type Generator interface {
 	Initialize() error
-	Write() error
+	Write(overwrite ...bool) error
 }
 
 // =============================================================================
@@ -79,6 +81,6 @@ func (g *BaseGenerator) Initialize() error {
 
 // Write is a placeholder implementation of the Write method.
 // Concrete implementations should override this method to provide specific generation logic.
-func (g *BaseGenerator) Write() error {
+func (g *BaseGenerator) Write(overwrite ...bool) error {
 	return nil
 }

--- a/pkg/generators/git_generator.go
+++ b/pkg/generators/git_generator.go
@@ -59,7 +59,7 @@ func NewGitGenerator(injector di.Injector) *GitGenerator {
 
 // Write generates the Git configuration files by creating or updating the .gitignore file.
 // It ensures that Windsor-specific entries are added while preserving any existing user-defined entries.
-func (g *GitGenerator) Write() error {
+func (g *GitGenerator) Write(overwrite ...bool) error {
 	projectRoot, err := g.shell.GetProjectRoot()
 	if err != nil {
 		return fmt.Errorf("failed to get project root: %w", err)

--- a/pkg/generators/kustomize_generator_test.go
+++ b/pkg/generators/kustomize_generator_test.go
@@ -83,8 +83,8 @@ func TestKustomizeGenerator_Write(t *testing.T) {
 			if filename != expectedPath {
 				t.Errorf("expected filename %s, got %s", expectedPath, filename)
 			}
-			expectedContent := []byte("resources: []\n")
-			if string(data) != string(expectedContent) {
+			expectedContent := "apiVersion: kustomize.config.k8s.io/v1beta1\nkind: Kustomization\nresources: []\n"
+			if string(data) != expectedContent {
 				t.Errorf("expected content %s, got %s", expectedContent, string(data))
 			}
 			return nil

--- a/pkg/generators/mock_generator.go
+++ b/pkg/generators/mock_generator.go
@@ -12,7 +12,7 @@ package generators
 // MockGenerator is a mock implementation of the Generator interface for testing purposes
 type MockGenerator struct {
 	InitializeFunc func() error
-	WriteFunc      func() error
+	WriteFunc      func(overwrite ...bool) error
 }
 
 // =============================================================================
@@ -37,9 +37,9 @@ func (m *MockGenerator) Initialize() error {
 }
 
 // Write calls the mock WriteFunc if set, otherwise returns nil
-func (m *MockGenerator) Write() error {
+func (m *MockGenerator) Write(overwrite ...bool) error {
 	if m.WriteFunc != nil {
-		return m.WriteFunc()
+		return m.WriteFunc(overwrite...)
 	}
 	return nil
 }

--- a/pkg/generators/mock_generator_test.go
+++ b/pkg/generators/mock_generator_test.go
@@ -51,7 +51,7 @@ func TestMockGenerator_Write(t *testing.T) {
 		mock := NewMockGenerator()
 
 		// And the WriteFunc is set to return a mock error
-		mock.WriteFunc = func() error {
+		mock.WriteFunc = func(overwrite ...bool) error {
 			return mockWriteErr
 		}
 


### PR DESCRIPTION
Adds a new --reset flag to the init command that performs a clean
initialization by:
- Removing .terraform directory
- Resetting blueprint state
- Cleaning up any cached configurations
- Ensuring a fresh start for all components

This provides users with a way to force a complete reset of their
Windsor environment when needed, particularly useful when:
- Switching between different configurations
- Recovering from corrupted states
- Ensuring clean initialization of all components