### PR TITLE
fix(terraform): add -upgrade flag to terraform init for latest module versions

### DIFF
--- a/pkg/generators/terraform_generator.go
+++ b/pkg/generators/terraform_generator.go
@@ -194,6 +194,7 @@ func (g *TerraformGenerator) initializeTerraformModule(component blueprintv1alph
 		"init",
 		"--backend=false",
 		"-input=false",
+		"-upgrade",
 		"-json",
 	)
 	if err != nil {


### PR DESCRIPTION
Adds `-upgrade` when performing the `terraform init` during the module loading phase. Fixes lockfile failures.