### PR TITLE
fix(blueprint): use blueprint name as default source and add Prune field for kustomizations

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -155,6 +155,9 @@ type Kustomization struct {
 	// Force apply the kustomization.
 	Force *bool `yaml:"force,omitempty"`
 
+	// Prune enables garbage collection of resources that are no longer present in the source.
+	Prune *bool `yaml:"prune,omitempty"`
+
 	// Components to include in the kustomization.
 	Components []string `yaml:"components,omitempty"`
 
@@ -270,6 +273,7 @@ func (b *Blueprint) DeepCopy() *Blueprint {
 			Patches:       slices.Clone(kustomization.Patches),
 			Wait:          kustomization.Wait,
 			Force:         kustomization.Force,
+			Prune:         kustomization.Prune,
 			Components:    slices.Clone(kustomization.Components),
 			Cleanup:       slices.Clone(kustomization.Cleanup),
 			PostBuild:     postBuildCopy,
@@ -418,6 +422,7 @@ func (k *Kustomization) DeepCopy() *Kustomization {
 		Patches:       slices.Clone(k.Patches),
 		Wait:          k.Wait,
 		Force:         k.Force,
+		Prune:         k.Prune,
 		Components:    slices.Clone(k.Components),
 		Cleanup:       slices.Clone(k.Cleanup),
 		PostBuild:     postBuildCopy,

--- a/pkg/blueprint/blueprint_handler_private_test.go
+++ b/pkg/blueprint/blueprint_handler_private_test.go
@@ -581,6 +581,32 @@ metadata:
 	})
 }
 
+func TestBaseBlueprintHandler_getKustomizations(t *testing.T) {
+	t.Run("UsesBlueprintNameAsSource", func(t *testing.T) {
+		handler := &BaseBlueprintHandler{
+			blueprint: blueprintv1alpha1.Blueprint{
+				Metadata: blueprintv1alpha1.Metadata{
+					Name: "test-blueprint",
+				},
+				Kustomizations: []blueprintv1alpha1.Kustomization{
+					{
+						Name: "test-kustomization",
+					},
+				},
+			},
+		}
+
+		kustomizations := handler.getKustomizations()
+		if len(kustomizations) != 1 {
+			t.Fatalf("expected 1 kustomization, got %d", len(kustomizations))
+		}
+
+		if kustomizations[0].Source != "test-blueprint" {
+			t.Errorf("expected source to be 'test-blueprint', got '%s'", kustomizations[0].Source)
+		}
+	})
+}
+
 // mockConfigHandler implements config.ConfigHandler for testing
 // Only the methods used in applyConfigMap are implemented
 

--- a/pkg/blueprint/blueprint_handler_test.go
+++ b/pkg/blueprint/blueprint_handler_test.go
@@ -7,11 +7,13 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/config"
+	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/di"
 	"github.com/windsorcli/cli/pkg/kubernetes"
 	"github.com/windsorcli/cli/pkg/shell"
@@ -1649,7 +1651,7 @@ func TestBlueprintHandler_Install(t *testing.T) {
 	}
 
 	t.Run("Success", func(t *testing.T) {
-		// And a blueprint handler with repository, sources, and kustomizations
+		// Given a blueprint handler with repository, sources, and kustomizations
 		handler, _ := setup(t)
 
 		err := handler.SetRepository(blueprintv1alpha1.Repository{
@@ -1682,6 +1684,112 @@ func TestBlueprintHandler_Install(t *testing.T) {
 		// Then no error should be returned
 		if err != nil {
 			t.Fatalf("Expected successful installation, but got error: %v", err)
+		}
+	})
+
+	t.Run("KustomizationDefaults", func(t *testing.T) {
+		// Given a blueprint handler with repository and kustomizations
+		handler, mocks := setup(t)
+
+		err := handler.SetRepository(blueprintv1alpha1.Repository{
+			Url: "git::https://example.com/repo.git",
+			Ref: blueprintv1alpha1.Reference{Branch: "main"},
+		})
+		if err != nil {
+			t.Fatalf("Failed to set repository: %v", err)
+		}
+
+		// And a blueprint with metadata name
+		handler.(*BaseBlueprintHandler).blueprint.Metadata.Name = "test-blueprint"
+
+		// And kustomizations with various configurations
+		kustomizations := []blueprintv1alpha1.Kustomization{
+			{
+				Name: "k1", // No source, should use blueprint name
+			},
+			{
+				Name:   "k2",
+				Source: "custom-source", // Explicit source
+			},
+			{
+				Name: "k3", // No path, should default to "kustomize"
+			},
+			{
+				Name: "k4",
+				Path: "custom/path", // Custom path, should be prefixed with "kustomize/"
+			},
+			{
+				Name: "k5", // No intervals/timeouts, should use defaults
+			},
+			{
+				Name:          "k6",
+				Interval:      &metav1.Duration{Duration: 2 * time.Minute},
+				RetryInterval: &metav1.Duration{Duration: 30 * time.Second},
+				Timeout:       &metav1.Duration{Duration: 5 * time.Minute},
+			},
+		}
+		handler.SetKustomizations(kustomizations)
+
+		// And a mock that captures the applied kustomizations
+		var appliedKustomizations []kustomizev1.Kustomization
+		mocks.KubernetesManager.ApplyKustomizationFunc = func(k kustomizev1.Kustomization) error {
+			appliedKustomizations = append(appliedKustomizations, k)
+			return nil
+		}
+
+		// When installing the blueprint
+		err = handler.Install()
+
+		// Then no error should be returned
+		if err != nil {
+			t.Fatalf("Expected successful installation, but got error: %v", err)
+		}
+
+		// And the kustomizations should have the correct defaults
+		if len(appliedKustomizations) != 6 {
+			t.Fatalf("Expected 6 kustomizations to be applied, got %d", len(appliedKustomizations))
+		}
+
+		// Verify k1 (no source)
+		if appliedKustomizations[0].Spec.SourceRef.Name != "test-blueprint" {
+			t.Errorf("Expected k1 source to be 'test-blueprint', got '%s'", appliedKustomizations[0].Spec.SourceRef.Name)
+		}
+
+		// Verify k2 (explicit source)
+		if appliedKustomizations[1].Spec.SourceRef.Name != "custom-source" {
+			t.Errorf("Expected k2 source to be 'custom-source', got '%s'", appliedKustomizations[1].Spec.SourceRef.Name)
+		}
+
+		// Verify k3 (no path)
+		if appliedKustomizations[2].Spec.Path != "kustomize" {
+			t.Errorf("Expected k3 path to be 'kustomize', got '%s'", appliedKustomizations[2].Spec.Path)
+		}
+
+		// Verify k4 (custom path)
+		if appliedKustomizations[3].Spec.Path != "kustomize/custom/path" {
+			t.Errorf("Expected k4 path to be 'kustomize/custom/path', got '%s'", appliedKustomizations[3].Spec.Path)
+		}
+
+		// Verify k5 (default intervals/timeouts)
+		if appliedKustomizations[4].Spec.Interval.Duration != constants.DEFAULT_FLUX_KUSTOMIZATION_INTERVAL {
+			t.Errorf("Expected k5 interval to be %v, got %v", constants.DEFAULT_FLUX_KUSTOMIZATION_INTERVAL, appliedKustomizations[4].Spec.Interval.Duration)
+		}
+		if appliedKustomizations[4].Spec.RetryInterval.Duration != constants.DEFAULT_FLUX_KUSTOMIZATION_RETRY_INTERVAL {
+			t.Errorf("Expected k5 retry interval to be %v, got %v", constants.DEFAULT_FLUX_KUSTOMIZATION_RETRY_INTERVAL, appliedKustomizations[4].Spec.RetryInterval.Duration)
+		}
+		if appliedKustomizations[4].Spec.Timeout.Duration != constants.DEFAULT_FLUX_KUSTOMIZATION_TIMEOUT {
+			t.Errorf("Expected k5 timeout to be %v, got %v", constants.DEFAULT_FLUX_KUSTOMIZATION_TIMEOUT, appliedKustomizations[4].Spec.Timeout.Duration)
+		}
+
+		// Verify k6 (custom intervals/timeouts)
+		if appliedKustomizations[5].Spec.Interval.Duration != 2*time.Minute {
+			t.Errorf("Expected k6 interval to be 2m, got %v", appliedKustomizations[5].Spec.Interval.Duration)
+		}
+		if appliedKustomizations[5].Spec.RetryInterval.Duration != 30*time.Second {
+			t.Errorf("Expected k6 retry interval to be 30s, got %v", appliedKustomizations[5].Spec.RetryInterval.Duration)
+		}
+		if appliedKustomizations[5].Spec.Timeout.Duration != 5*time.Minute {
+			t.Errorf("Expected k6 timeout to be 5m, got %v", appliedKustomizations[5].Spec.Timeout.Duration)
 		}
 	})
 
@@ -2381,4 +2489,8 @@ func TestBlueprintHandler_GetTerraformComponents(t *testing.T) {
 			t.Errorf("Expected path %q, got %q", expectedPath, resolvedComponents[0].FullPath)
 		}
 	})
+}
+
+func TestBlueprintHandler_GetKustomizations(t *testing.T) {
+	// Test removed - moved to private test file
 }


### PR DESCRIPTION
- Use blueprint metadata name as default source for kustomizations and GitRepository resources instead of configHandler context.
- Add Prune field to Kustomization struct and update DeepCopy methods.
- Remove redundant wait for kustomizations in Install method.
- Update getKustomizations to set source to blueprint name if not specified.