### PR TITLE
fix(secrets): prevent secret leakage in verbose shell output

### DIFF
--- a/pkg/secrets/op_sdk_secrets_provider.go
+++ b/pkg/secrets/op_sdk_secrets_provider.go
@@ -1,7 +1,7 @@
 // The OnePasswordSDKSecretsProvider is an implementation of the SecretsProvider interface
-// It provides integration with the 1Password SDK for secret management
-// It serves as a bridge between the application and 1Password's secure storage
-// It enables retrieval and parsing of secrets from 1Password vaults using the official SDK
+// It provides integration with the 1Password SDK for secret management with automatic shell scrubbing registration
+// It serves as a bridge between the application and 1Password's secure storage with built-in security features
+// It enables retrieval and parsing of secrets from 1Password vaults using the official SDK while automatically registering secrets for output scrubbing
 
 package secrets
 
@@ -69,11 +69,11 @@ func (s *OnePasswordSDKSecretsProvider) Initialize() error {
 	return nil
 }
 
-// GetSecret retrieves a secret value for the specified key. It first checks if the provider is unlocked.
-// If not, it returns a masked value. It then ensures the 1Password client is initialized using a
-// service account token from the environment. The key is split into item and field parts, and the
-// item name is sanitized. A secret reference URI is constructed and used to resolve the secret value
-// from 1Password. If successful, the secret value is returned; otherwise, an error is reported.
+// GetSecret retrieves a secret value for the specified key and automatically registers it with the shell for output scrubbing.
+// It first checks if the provider is unlocked. If not, it returns a masked value. It then ensures the 1Password client
+// is initialized using a service account token from the environment. The key is split into item and field parts, and the
+// item name is sanitized. A secret reference URI is constructed and used to resolve the secret value from 1Password.
+// If successful, the secret value is registered with the shell's scrubbing system and returned; otherwise, an error is reported.
 func (s *OnePasswordSDKSecretsProvider) GetSecret(key string) (string, error) {
 	if !s.unlocked {
 		return "********", nil
@@ -120,6 +120,7 @@ func (s *OnePasswordSDKSecretsProvider) GetSecret(key string) (string, error) {
 		return "", fmt.Errorf("failed to resolve secret: %w", err)
 	}
 
+	s.shell.RegisterSecret(value)
 	return value, nil
 }
 

--- a/pkg/shell/mock_shell.go
+++ b/pkg/shell/mock_shell.go
@@ -35,6 +35,7 @@ type MockShell struct {
 	GetSessionTokenFunc            func() (string, error)
 	CheckResetFlagsFunc            func() (bool, error)
 	ResetFunc                      func()
+	RegisterSecretFunc             func(value string)
 }
 
 // =============================================================================
@@ -196,6 +197,13 @@ func (s *MockShell) CheckResetFlags() (bool, error) {
 func (s *MockShell) Reset() {
 	if s.ResetFunc != nil {
 		s.ResetFunc()
+	}
+}
+
+// RegisterSecret calls the custom RegisterSecretFunc if provided.
+func (s *MockShell) RegisterSecret(value string) {
+	if s.RegisterSecretFunc != nil {
+		s.RegisterSecretFunc(value)
 	}
 }
 

--- a/pkg/shell/mock_shell_test.go
+++ b/pkg/shell/mock_shell_test.go
@@ -1114,3 +1114,37 @@ func TestMockShell_Reset(t *testing.T) {
 		mockShell.Reset()
 	})
 }
+
+func TestMockShell_RegisterSecret(t *testing.T) {
+	t.Run("CallsRegisterSecretFunc", func(t *testing.T) {
+		// Given a mock shell with RegisterSecretFunc configured to track calls
+		mockShell := setupMockShellMocks(t)
+		called := false
+		expectedValue := "test-secret-value"
+		var receivedValue string
+		mockShell.RegisterSecretFunc = func(value string) {
+			called = true
+			receivedValue = value
+		}
+
+		// When RegisterSecret is called with a secret value
+		mockShell.RegisterSecret(expectedValue)
+
+		// Then the mock function should be called with the expected secret value
+		if !called {
+			t.Error("Expected RegisterSecretFunc to be called")
+		}
+		if receivedValue != expectedValue {
+			t.Errorf("Expected value %v, got %v", expectedValue, receivedValue)
+		}
+	})
+
+	t.Run("NilFuncDoesNotPanic", func(t *testing.T) {
+		// Given a mock shell without RegisterSecretFunc configured
+		mockShell := setupMockShellMocks(t)
+
+		// When RegisterSecret is called with no function set
+		// Then it should not panic and handle the nil function gracefully
+		mockShell.RegisterSecret("test-secret")
+	})
+}

--- a/pkg/shell/scrubbing_writer.go
+++ b/pkg/shell/scrubbing_writer.go
@@ -1,0 +1,37 @@
+package shell
+
+import "io"
+
+// scrubbingWriter wraps an io.Writer and scrubs secrets from content before writing
+type scrubbingWriter struct {
+	writer    io.Writer
+	scrubFunc func(string) string
+}
+
+// Write scrubs secrets from content and writes to the underlying writer.
+// If scrubbing changes the content length, it pads with spaces or truncates
+// to maintain the original byte length for consistent output formatting.
+func (sw *scrubbingWriter) Write(p []byte) (n int, err error) {
+	original := string(p)
+	scrubbed := sw.scrubFunc(original)
+
+	if scrubbed != original {
+		scrubbedBytes := []byte(scrubbed)
+		originalLen := len(p)
+		scrubbedLen := len(scrubbedBytes)
+
+		if scrubbedLen < originalLen {
+			padding := make([]byte, originalLen-scrubbedLen)
+			for i := range padding {
+				padding[i] = ' '
+			}
+			scrubbedBytes = append(scrubbedBytes, padding...)
+		} else if scrubbedLen > originalLen {
+			scrubbedBytes = scrubbedBytes[:originalLen]
+		}
+
+		return sw.writer.Write(scrubbedBytes)
+	}
+
+	return sw.writer.Write(p)
+}

--- a/pkg/shell/shell_test.go
+++ b/pkg/shell/shell_test.go
@@ -68,10 +68,8 @@ func setupMocks(t *testing.T) *Mocks {
 	// Mock command execution methods with proper cleanup
 	shims.CmdStart = func(cmd *exec.Cmd) error {
 		if cmd.Stdout != nil {
-			if w, ok := cmd.Stdout.(io.Writer); ok {
-				if _, err := w.Write([]byte("test\n")); err != nil {
-					return fmt.Errorf("failed to write to stdout: %v", err)
-				}
+			if _, err := cmd.Stdout.Write([]byte("test\n")); err != nil {
+				return fmt.Errorf("failed to write to stdout: %v", err)
 			}
 		}
 		return nil
@@ -83,10 +81,8 @@ func setupMocks(t *testing.T) *Mocks {
 
 	shims.CmdRun = func(cmd *exec.Cmd) error {
 		if cmd.Stdout != nil {
-			if w, ok := cmd.Stdout.(io.Writer); ok {
-				if _, err := w.Write([]byte("test\n")); err != nil {
-					return fmt.Errorf("failed to write to stdout: %v", err)
-				}
+			if _, err := cmd.Stdout.Write([]byte("test\n")); err != nil {
+				return fmt.Errorf("failed to write to stdout: %v", err)
 			}
 		}
 		return nil
@@ -409,8 +405,8 @@ func TestShell_Exec(t *testing.T) {
 			return cmd
 		}
 		mocks.Shims.CmdStart = func(cmd *exec.Cmd) error {
-			if w, ok := cmd.Stdout.(io.Writer); ok {
-				if _, err := w.Write([]byte("test\n")); err != nil {
+			if cmd.Stdout != nil {
+				if _, err := cmd.Stdout.Write([]byte("test\n")); err != nil {
 					return fmt.Errorf("failed to write to stdout: %v", err)
 				}
 			}
@@ -519,10 +515,8 @@ func TestShell_ExecSudo(t *testing.T) {
 		// Mock successful command execution
 		mocks.Shims.CmdStart = func(cmd *exec.Cmd) error {
 			if cmd.Stdout != nil {
-				if w, ok := cmd.Stdout.(io.Writer); ok {
-					if _, err := w.Write([]byte("test output")); err != nil {
-						return fmt.Errorf("failed to write to stdout: %v", err)
-					}
+				if _, err := cmd.Stdout.Write([]byte("test output")); err != nil {
+					return fmt.Errorf("failed to write to stdout: %v", err)
 				}
 			}
 			return nil
@@ -562,10 +556,8 @@ func TestShell_ExecSudo(t *testing.T) {
 		// Mock successful command execution
 		mocks.Shims.CmdStart = func(cmd *exec.Cmd) error {
 			if cmd.Stdout != nil {
-				if w, ok := cmd.Stdout.(io.Writer); ok {
-					if _, err := w.Write([]byte("test\n")); err != nil {
-						return fmt.Errorf("failed to write to stdout: %v", err)
-					}
+				if _, err := cmd.Stdout.Write([]byte("test\n")); err != nil {
+					return fmt.Errorf("failed to write to stdout: %v", err)
 				}
 			}
 			return nil
@@ -1347,25 +1339,6 @@ func (m *mockReadCloser) Close() error {
 // =============================================================================
 // Test Helpers
 // =============================================================================
-
-// Helper function to create a temporary directory for testing
-func createTempDir(t *testing.T, prefix string) string {
-	t.Helper()
-	dir, err := os.MkdirTemp("", prefix)
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	return dir
-}
-
-// Helper function to create a file in a directory
-func createFile(t *testing.T, dir, name, content string) {
-	t.Helper()
-	path := filepath.Join(dir, name)
-	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
-		t.Fatalf("Failed to create file %s: %v", path, err)
-	}
-}
 
 // Helper function to capture stdout
 func captureStdout(t *testing.T, f func()) string {
@@ -2334,8 +2307,8 @@ func TestShell_ExecProgress(t *testing.T) {
 
 		// Mock command start to write output
 		mocks.Shims.CmdStart = func(cmd *exec.Cmd) error {
-			if w, ok := cmd.Stdout.(io.Writer); ok {
-				w.Write([]byte(expectedOutput))
+			if cmd.Stdout != nil {
+				cmd.Stdout.Write([]byte(expectedOutput))
 			}
 			return nil
 		}
@@ -2739,8 +2712,8 @@ func TestShell_ExecProgress(t *testing.T) {
 
 		// Mock command start to write output
 		mocks.Shims.CmdStart = func(cmd *exec.Cmd) error {
-			if w, ok := cmd.Stdout.(io.Writer); ok {
-				w.Write([]byte(expectedOutput))
+			if cmd.Stdout != nil {
+				cmd.Stdout.Write([]byte(expectedOutput))
 			}
 			return nil
 		}
@@ -2798,6 +2771,420 @@ func TestShell_ExecProgress(t *testing.T) {
 		}
 		if output != "test output\n" {
 			t.Errorf("Expected output 'test output', got '%s'", output)
+		}
+	})
+}
+
+// =============================================================================
+// Secret Management Tests
+// =============================================================================
+
+func TestShell_RegisterSecret(t *testing.T) {
+	// setup creates a new shell with mocked dependencies for testing
+	setup := func(t *testing.T) (*DefaultShell, *Mocks) {
+		t.Helper()
+		mocks := setupMocks(t)
+		shell := NewDefaultShell(mocks.Injector)
+		shell.Initialize()
+		return shell, mocks
+	}
+
+	t.Run("RegisterSingleSecret", func(t *testing.T) {
+		// Given a shell instance with no registered secrets
+		shell, _ := setup(t)
+
+		// When registering a single secret value
+		shell.RegisterSecret("mysecret123")
+
+		// Then the secret should be stored in the secrets list
+		if len(shell.secrets) != 1 {
+			t.Errorf("Expected 1 secret, got %d", len(shell.secrets))
+		}
+		if shell.secrets[0] != "mysecret123" {
+			t.Errorf("Expected secret 'mysecret123', got '%s'", shell.secrets[0])
+		}
+	})
+
+	t.Run("RegisterMultipleSecrets", func(t *testing.T) {
+		// Given a shell instance with no registered secrets
+		shell, _ := setup(t)
+
+		// When registering multiple different secret values
+		shell.RegisterSecret("secret1")
+		shell.RegisterSecret("secret2")
+		shell.RegisterSecret("secret3")
+
+		// Then all secrets should be stored in the secrets list
+		if len(shell.secrets) != 3 {
+			t.Errorf("Expected 3 secrets, got %d", len(shell.secrets))
+		}
+		expectedSecrets := []string{"secret1", "secret2", "secret3"}
+		for i, expected := range expectedSecrets {
+			if shell.secrets[i] != expected {
+				t.Errorf("Expected secret[%d] to be '%s', got '%s'", i, expected, shell.secrets[i])
+			}
+		}
+	})
+
+	t.Run("RegisterEmptySecret", func(t *testing.T) {
+		// Given a shell instance with no registered secrets
+		shell, _ := setup(t)
+
+		// When attempting to register an empty string as a secret
+		shell.RegisterSecret("")
+
+		// Then the empty secret should be ignored and not stored
+		if len(shell.secrets) != 0 {
+			t.Errorf("Expected 0 secrets, got %d", len(shell.secrets))
+		}
+	})
+
+	t.Run("RegisterDuplicateSecrets", func(t *testing.T) {
+		// Given a shell instance with no registered secrets
+		shell, _ := setup(t)
+
+		// When registering the same secret value multiple times
+		shell.RegisterSecret("duplicate")
+		shell.RegisterSecret("duplicate")
+		shell.RegisterSecret("duplicate")
+
+		// Then only one instance should be stored to prevent duplicates
+		if len(shell.secrets) != 1 {
+			t.Errorf("Expected 1 secret, got %d", len(shell.secrets))
+		}
+		if shell.secrets[0] != "duplicate" {
+			t.Errorf("Expected secret to be 'duplicate', got '%s'", shell.secrets[0])
+		}
+	})
+}
+
+func TestShell_scrubString(t *testing.T) {
+	// setup creates a new shell with mocked dependencies for testing
+	setup := func(t *testing.T) (*DefaultShell, *Mocks) {
+		t.Helper()
+		mocks := setupMocks(t)
+		shell := NewDefaultShell(mocks.Injector)
+		shell.Initialize()
+		return shell, mocks
+	}
+
+	t.Run("ScrubSingleSecret", func(t *testing.T) {
+		// Given a shell with one registered secret value
+		shell, _ := setup(t)
+		shell.RegisterSecret("mysecret123")
+
+		// When scrubbing a string that contains the registered secret
+		input := "The password is mysecret123 and it's confidential"
+		result := shell.scrubString(input)
+
+		// Then the secret should be replaced with asterisks while preserving the rest of the text
+		expected := "The password is ******** and it's confidential"
+		if result != expected {
+			t.Errorf("Expected '%s', got '%s'", expected, result)
+		}
+	})
+
+	t.Run("ScrubMultipleSecrets", func(t *testing.T) {
+		// Given a shell with multiple registered secret values
+		shell, _ := setup(t)
+		shell.RegisterSecret("secret1")
+		shell.RegisterSecret("secret2")
+		shell.RegisterSecret("secret3")
+
+		// When scrubbing a string that contains multiple registered secrets
+		input := "First secret1, then secret2, finally secret3"
+		result := shell.scrubString(input)
+
+		// Then all secrets should be replaced with asterisks
+		expected := "First ********, then ********, finally ********"
+		if result != expected {
+			t.Errorf("Expected '%s', got '%s'", expected, result)
+		}
+	})
+
+	t.Run("ScrubNoSecrets", func(t *testing.T) {
+		// Given a shell with no registered secrets
+		shell, _ := setup(t)
+
+		// When scrubbing a string that contains no sensitive information
+		input := "This string contains no secrets"
+		result := shell.scrubString(input)
+
+		// Then the string should remain completely unchanged
+		if result != input {
+			t.Errorf("Expected unchanged string '%s', got '%s'", input, result)
+		}
+	})
+
+	t.Run("ScrubEmptyString", func(t *testing.T) {
+		// Given a shell with registered secrets
+		shell, _ := setup(t)
+		shell.RegisterSecret("secret")
+
+		// When scrubbing an empty input string
+		input := ""
+		result := shell.scrubString(input)
+
+		// Then the result should remain empty
+		if result != "" {
+			t.Errorf("Expected empty string, got '%s'", result)
+		}
+	})
+
+	t.Run("ScrubEmptySecret", func(t *testing.T) {
+		// Given a shell with an empty string registered as a secret
+		shell, _ := setup(t)
+		shell.RegisterSecret("")
+
+		// When scrubbing a normal text string
+		input := "This is a test string"
+		result := shell.scrubString(input)
+
+		// Then the string should remain unchanged since empty secrets don't match anything
+		if result != input {
+			t.Errorf("Expected unchanged string '%s', got '%s'", input, result)
+		}
+	})
+
+	t.Run("ScrubSecretAtBeginning", func(t *testing.T) {
+		// Given a shell with a registered secret value
+		shell, _ := setup(t)
+		shell.RegisterSecret("secret123")
+
+		// When scrubbing a string where the secret appears at the beginning
+		input := "secret123 is at the start"
+		result := shell.scrubString(input)
+
+		// Then the secret should be replaced with asterisks
+		expected := "******** is at the start"
+		if result != expected {
+			t.Errorf("Expected '%s', got '%s'", expected, result)
+		}
+	})
+
+	t.Run("ScrubSecretAtEnd", func(t *testing.T) {
+		// Given a shell with a registered secret value
+		shell, _ := setup(t)
+		shell.RegisterSecret("secret123")
+
+		// When scrubbing a string where the secret appears at the end
+		input := "The secret is secret123"
+		result := shell.scrubString(input)
+
+		// Then the secret should be replaced with asterisks
+		expected := "The secret is ********"
+		if result != expected {
+			t.Errorf("Expected '%s', got '%s'", expected, result)
+		}
+	})
+
+	t.Run("ScrubSecretMultipleOccurrences", func(t *testing.T) {
+		// Given a shell with a registered secret value
+		shell, _ := setup(t)
+		shell.RegisterSecret("secret")
+
+		// When scrubbing a string where the same secret appears multiple times
+		input := "secret appears here and secret appears there, secret everywhere"
+		result := shell.scrubString(input)
+
+		// Then all occurrences of the secret should be replaced with asterisks
+		expected := "******** appears here and ******** appears there, ******** everywhere"
+		if result != expected {
+			t.Errorf("Expected '%s', got '%s'", expected, result)
+		}
+	})
+
+	t.Run("ScrubSecretPartialMatch", func(t *testing.T) {
+		// Given a shell with a registered secret value
+		shell, _ := setup(t)
+		shell.RegisterSecret("secret")
+
+		// When scrubbing a string containing words that partially match the secret
+		input := "secretive and secrets contain secret"
+		result := shell.scrubString(input)
+
+		// Then all occurrences should be replaced using simple string replacement
+		expected := "********ive and ********s contain ********"
+		if result != expected {
+			t.Errorf("Expected '%s', got '%s'", expected, result)
+		}
+	})
+
+	t.Run("ScrubLongSecret", func(t *testing.T) {
+		// Given a shell with a very long secret value registered
+		shell, _ := setup(t)
+		longSecret := "this-is-a-very-long-secret-key-with-many-characters-1234567890"
+		shell.RegisterSecret(longSecret)
+
+		// When scrubbing a string containing the long secret
+		input := fmt.Sprintf("The key is %s and should be hidden", longSecret)
+		result := shell.scrubString(input)
+
+		// Then the long secret should be replaced with a fixed-length asterisk string
+		expected := "The key is ******** and should be hidden"
+		if result != expected {
+			t.Errorf("Expected '%s', got '%s'", expected, result)
+		}
+	})
+
+	t.Run("ScrubSpecialCharacters", func(t *testing.T) {
+		// Given a shell with a secret containing special characters
+		shell, _ := setup(t)
+		specialSecret := "p@ssw0rd!#$%^&*()"
+		shell.RegisterSecret(specialSecret)
+
+		// When scrubbing a string containing the special character secret
+		input := fmt.Sprintf("Password: %s", specialSecret)
+		result := shell.scrubString(input)
+
+		// Then the special character secret should be replaced with asterisks
+		expected := "Password: ********"
+		if result != expected {
+			t.Errorf("Expected '%s', got '%s'", expected, result)
+		}
+	})
+
+	t.Run("ScrubComplexMultipleSecrets", func(t *testing.T) {
+		// Given a shell with multiple different registered secrets
+		shell, _ := setup(t)
+		shell.RegisterSecret("secret123")
+		shell.RegisterSecret("password456")
+		shell.RegisterSecret("token789")
+
+		// When scrubbing a complex configuration-like string with multiple secrets
+		input := "Config: secret123, Auth: password456, API: token789, Normal: text"
+		result := shell.scrubString(input)
+
+		// Then all secrets should be scrubbed while preserving non-secret text
+		expected := "Config: ********, Auth: ********, API: ********, Normal: text"
+		if result != expected {
+			t.Errorf("Expected '%s', got '%s'", expected, result)
+		}
+	})
+
+	t.Run("ScrubSecretsInJSON", func(t *testing.T) {
+		// Given a shell with registered password and token secrets
+		shell, _ := setup(t)
+		shell.RegisterSecret("mypassword")
+		shell.RegisterSecret("mytoken")
+
+		// When scrubbing a JSON-formatted string containing secrets
+		input := `{"password": "mypassword", "token": "mytoken", "user": "admin"}`
+		result := shell.scrubString(input)
+
+		// Then the secrets should be scrubbed while preserving JSON structure
+		expected := `{"password": "********", "token": "********", "user": "admin"}`
+		if result != expected {
+			t.Errorf("Expected '%s', got '%s'", expected, result)
+		}
+	})
+
+	t.Run("ScrubSecretsInCommandLine", func(t *testing.T) {
+		// Given a shell with a registered secret value
+		shell, _ := setup(t)
+		shell.RegisterSecret("supersecret")
+
+		// When scrubbing a command line string containing the secret
+		input := "terraform apply -var password=supersecret -var user=admin"
+		result := shell.scrubString(input)
+
+		// Then the secret should be scrubbed while preserving the command structure
+		expected := "terraform apply -var password=******** -var user=admin"
+		if result != expected {
+			t.Errorf("Expected '%s', got '%s'", expected, result)
+		}
+	})
+
+	t.Run("ScrubSecretsInErrorMessages", func(t *testing.T) {
+		// Given a shell with a registered password secret
+		shell, _ := setup(t)
+		shell.RegisterSecret("badpassword")
+
+		// When scrubbing an error message that accidentally contains the secret
+		input := "Error: authentication failed with password 'badpassword'"
+		result := shell.scrubString(input)
+
+		// Then the secret should be scrubbed to prevent leakage in error logs
+		expected := "Error: authentication failed with password '********'"
+		if result != expected {
+			t.Errorf("Expected '%s', got '%s'", expected, result)
+		}
+	})
+}
+
+func TestScrubbingWriter(t *testing.T) {
+	setup := func(t *testing.T) (*DefaultShell, *bytes.Buffer) {
+		t.Helper()
+		mocks := setupMocks(t)
+		shell := NewDefaultShell(mocks.Injector)
+		shell.shims = mocks.Shims
+
+		// Register a test secret
+		shell.RegisterSecret("secret123")
+
+		// Create a buffer to capture output
+		var buf bytes.Buffer
+		return shell, &buf
+	}
+
+	t.Run("ScrubsSecretsFromOutput", func(t *testing.T) {
+		// Given a shell with registered secrets and a scrubbing writer configured
+		shell, buf := setup(t)
+		writer := &scrubbingWriter{writer: buf, scrubFunc: shell.scrubString}
+
+		// When writing content that contains registered secrets to the scrubbing writer
+		testContent := "This contains secret123 and other text"
+		n, err := writer.Write([]byte(testContent))
+
+		// Then the secrets should be scrubbed from the output while maintaining byte count consistency
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+
+		output := buf.String()
+		if strings.Contains(output, "secret123") {
+			t.Errorf("Expected secret to be scrubbed, but found in output: %s", output)
+		}
+		// Should replace with fixed ******** and pad to maintain length
+		if !strings.Contains(output, "********") {
+			t.Errorf("Expected scrubbed output to contain ********, got: %s", output)
+		}
+		// Byte counts should match due to padding
+		if n != len(testContent) {
+			t.Errorf("Expected bytes written to match content length %d, got %d", len(testContent), n)
+		}
+		// Output length should match input length due to padding
+		if len(output) != len(testContent) {
+			t.Errorf("Expected output length %d to match input length %d", len(output), len(testContent))
+		}
+	})
+
+	t.Run("HandlesMultipleSecrets", func(t *testing.T) {
+		// Given a shell with multiple registered secrets and a scrubbing writer
+		shell, buf := setup(t)
+		shell.RegisterSecret("password456")
+		writer := &scrubbingWriter{writer: buf, scrubFunc: shell.scrubString}
+
+		// When writing content that contains multiple different secrets
+		testContent := "User secret123 has password456 for access"
+		_, err := writer.Write([]byte(testContent))
+
+		// Then all secrets should be scrubbed while maintaining output length consistency
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+
+		output := buf.String()
+		if strings.Contains(output, "secret123") || strings.Contains(output, "password456") {
+			t.Errorf("Expected all secrets to be scrubbed, got: %s", output)
+		}
+		// Should contain fixed ******** replacements
+		if !strings.Contains(output, "********") {
+			t.Errorf("Expected scrubbed output to contain ********, got: %s", output)
+		}
+		// Output length should match input due to padding
+		if len(output) != len(testContent) {
+			t.Errorf("Expected output length %d to match input length %d", len(output), len(testContent))
 		}
 	})
 }

--- a/pkg/shell/unix_shell_test.go
+++ b/pkg/shell/unix_shell_test.go
@@ -153,8 +153,8 @@ func TestDefaultShell_PrintAlias(t *testing.T) {
 		})
 
 		// Then the output should contain the expected alias and unalias commands
-		expectedAliasLine := fmt.Sprintf("alias ALIAS1=\"command1\"\n")
-		expectedUnaliasLine := fmt.Sprintf("unalias ALIAS2\n")
+		expectedAliasLine := "alias ALIAS1=\"command1\"\n"
+		expectedUnaliasLine := "unalias ALIAS2\n"
 
 		if !strings.Contains(output, expectedAliasLine) {
 			t.Errorf("PrintAlias() output missing expected line: %v", expectedAliasLine)


### PR DESCRIPTION
## Summary
Prevents secrets from leaking into terminal output when using `--verbose` flag

## Changes
- Added `RegisterSecret()` method to shell interface
- Secrets providers register actual secret values with shell when resolved
- All shell command output scrubs registered secrets, replacing them with `********`