### PR TITLE
feat(blueprint): Support OCI sources for terraform components

### DIFF
--- a/cmd/bundle_test.go
+++ b/cmd/bundle_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/windsorcli/cli/pkg/bundler"
@@ -40,7 +41,7 @@ contexts:
 		// Create mock artifact builder
 		artifactBuilder := bundler.NewMockArtifact()
 		artifactBuilder.InitializeFunc = func(injector di.Injector) error { return nil }
-		artifactBuilder.AddFileFunc = func(path string, content []byte) error { return nil }
+		artifactBuilder.AddFileFunc = func(path string, content []byte, mode os.FileMode) error { return nil }
 		artifactBuilder.CreateFunc = func(outputPath string, tag string) (string, error) {
 			if tag != "" {
 				return "test-v1.0.0.tar.gz", nil
@@ -351,7 +352,7 @@ func TestBundleCmd(t *testing.T) {
 		// Create a fresh artifact builder to avoid state contamination
 		freshArtifactBuilder := bundler.NewMockArtifact()
 		freshArtifactBuilder.InitializeFunc = func(injector di.Injector) error { return nil }
-		freshArtifactBuilder.AddFileFunc = func(path string, content []byte) error { return nil }
+		freshArtifactBuilder.AddFileFunc = func(path string, content []byte, mode os.FileMode) error { return nil }
 		freshArtifactBuilder.CreateFunc = func(outputPath string, tag string) (string, error) {
 			receivedOutputPath = outputPath
 			return "test-result.tar.gz", nil
@@ -386,7 +387,7 @@ func TestBundleCmd(t *testing.T) {
 		// Create a fresh artifact builder to avoid state contamination
 		freshArtifactBuilder := bundler.NewMockArtifact()
 		freshArtifactBuilder.InitializeFunc = func(injector di.Injector) error { return nil }
-		freshArtifactBuilder.AddFileFunc = func(path string, content []byte) error { return nil }
+		freshArtifactBuilder.AddFileFunc = func(path string, content []byte, mode os.FileMode) error { return nil }
 		freshArtifactBuilder.CreateFunc = func(outputPath string, tag string) (string, error) {
 			receivedTag = tag
 			return "test-result.tar.gz", nil

--- a/cmd/push_test.go
+++ b/cmd/push_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"os"
 	"testing"
 
 	"github.com/windsorcli/cli/pkg/bundler"
@@ -40,7 +41,7 @@ contexts:
 		// Create mock artifact builder
 		artifactBuilder := bundler.NewMockArtifact()
 		artifactBuilder.InitializeFunc = func(injector di.Injector) error { return nil }
-		artifactBuilder.AddFileFunc = func(path string, content []byte) error { return nil }
+		artifactBuilder.AddFileFunc = func(path string, content []byte, mode os.FileMode) error { return nil }
 		artifactBuilder.PushFunc = func(registryBase string, repoName string, tag string) error { return nil }
 
 		// Create mock template bundler

--- a/pkg/bundler/kustomize_bundler.go
+++ b/pkg/bundler/kustomize_bundler.go
@@ -67,7 +67,7 @@ func (k *KustomizeBundler) Bundle(artifact Artifact) error {
 		}
 
 		artifactPath := "kustomize/" + filepath.ToSlash(relPath)
-		return artifact.AddFile(artifactPath, data)
+		return artifact.AddFile(artifactPath, data, info.Mode())
 	})
 }
 

--- a/pkg/bundler/kustomize_bundler_test.go
+++ b/pkg/bundler/kustomize_bundler_test.go
@@ -56,7 +56,7 @@ func TestKustomizeBundler_Bundle(t *testing.T) {
 
 		// Set up mocks to simulate finding kustomize files
 		filesAdded := make(map[string][]byte)
-		mocks.Artifact.AddFileFunc = func(path string, content []byte) error {
+		mocks.Artifact.AddFileFunc = func(path string, content []byte, mode os.FileMode) error {
 			filesAdded[path] = content
 			return nil
 		}
@@ -145,7 +145,7 @@ func TestKustomizeBundler_Bundle(t *testing.T) {
 		}
 
 		filesAdded := make([]string, 0)
-		mocks.Artifact.AddFileFunc = func(path string, content []byte) error {
+		mocks.Artifact.AddFileFunc = func(path string, content []byte, mode os.FileMode) error {
 			filesAdded = append(filesAdded, path)
 			return nil
 		}
@@ -264,7 +264,7 @@ func TestKustomizeBundler_Bundle(t *testing.T) {
 		bundler.shims.ReadFile = func(filename string) ([]byte, error) {
 			return []byte("content"), nil
 		}
-		mocks.Artifact.AddFileFunc = func(path string, content []byte) error {
+		mocks.Artifact.AddFileFunc = func(path string, content []byte, mode os.FileMode) error {
 			return fmt.Errorf("artifact storage full")
 		}
 
@@ -285,7 +285,7 @@ func TestKustomizeBundler_Bundle(t *testing.T) {
 		bundler, mocks := setup(t)
 
 		filesAdded := make([]string, 0)
-		mocks.Artifact.AddFileFunc = func(path string, content []byte) error {
+		mocks.Artifact.AddFileFunc = func(path string, content []byte, mode os.FileMode) error {
 			filesAdded = append(filesAdded, path)
 			return nil
 		}
@@ -335,7 +335,7 @@ func TestKustomizeBundler_Bundle(t *testing.T) {
 		bundler, mocks := setup(t)
 
 		filesAdded := make([]string, 0)
-		mocks.Artifact.AddFileFunc = func(path string, content []byte) error {
+		mocks.Artifact.AddFileFunc = func(path string, content []byte, mode os.FileMode) error {
 			filesAdded = append(filesAdded, path)
 			return nil
 		}

--- a/pkg/bundler/mock_artifact.go
+++ b/pkg/bundler/mock_artifact.go
@@ -1,6 +1,8 @@
 package bundler
 
 import (
+	"os"
+
 	"github.com/windsorcli/cli/pkg/di"
 )
 
@@ -16,7 +18,7 @@ import (
 // MockArtifact is a mock implementation of the Artifact interface
 type MockArtifact struct {
 	InitializeFunc func(injector di.Injector) error
-	AddFileFunc    func(path string, content []byte) error
+	AddFileFunc    func(path string, content []byte, mode os.FileMode) error
 	CreateFunc     func(outputPath string, tag string) (string, error)
 	PushFunc       func(registryBase string, repoName string, tag string) error
 }
@@ -43,9 +45,9 @@ func (m *MockArtifact) Initialize(injector di.Injector) error {
 }
 
 // AddFile calls the mock AddFileFunc if set, otherwise returns nil
-func (m *MockArtifact) AddFile(path string, content []byte) error {
+func (m *MockArtifact) AddFile(path string, content []byte, mode os.FileMode) error {
 	if m.AddFileFunc != nil {
-		return m.AddFileFunc(path, content)
+		return m.AddFileFunc(path, content, mode)
 	}
 	return nil
 }

--- a/pkg/bundler/mock_artifact_test.go
+++ b/pkg/bundler/mock_artifact_test.go
@@ -1,6 +1,7 @@
 package bundler
 
 import (
+	"os"
 	"testing"
 
 	"github.com/windsorcli/cli/pkg/di"
@@ -64,13 +65,13 @@ func TestMockArtifact_AddFile(t *testing.T) {
 		// Given a mock with a custom add file function
 		mock := NewMockArtifact()
 		called := false
-		mock.AddFileFunc = func(path string, content []byte) error {
+		mock.AddFileFunc = func(path string, content []byte, mode os.FileMode) error {
 			called = true
 			return nil
 		}
 
 		// When calling AddFile
-		err := mock.AddFile("test/path", []byte("content"))
+		err := mock.AddFile("test/path", []byte("content"), 0644)
 
 		// Then the mock function should be called
 		if !called {
@@ -86,7 +87,7 @@ func TestMockArtifact_AddFile(t *testing.T) {
 		mock := NewMockArtifact()
 
 		// When calling AddFile
-		err := mock.AddFile("test/path", []byte("content"))
+		err := mock.AddFile("test/path", []byte("content"), 0644)
 
 		// Then no error should be returned
 		if err != nil {

--- a/pkg/bundler/template_bundler.go
+++ b/pkg/bundler/template_bundler.go
@@ -66,7 +66,7 @@ func (t *TemplateBundler) Bundle(artifact Artifact) error {
 		}
 
 		artifactPath := "_template/" + filepath.ToSlash(relPath)
-		return artifact.AddFile(artifactPath, data)
+		return artifact.AddFile(artifactPath, data, info.Mode())
 	})
 }
 

--- a/pkg/bundler/template_bundler_test.go
+++ b/pkg/bundler/template_bundler_test.go
@@ -56,7 +56,7 @@ func TestTemplateBundler_Bundle(t *testing.T) {
 
 		// Set up mocks to simulate finding template files
 		filesAdded := make(map[string][]byte)
-		mocks.Artifact.AddFileFunc = func(path string, content []byte) error {
+		mocks.Artifact.AddFileFunc = func(path string, content []byte, mode os.FileMode) error {
 			filesAdded[path] = content
 			return nil
 		}
@@ -257,7 +257,7 @@ func TestTemplateBundler_Bundle(t *testing.T) {
 		bundler.shims.ReadFile = func(filename string) ([]byte, error) {
 			return []byte("content"), nil
 		}
-		mocks.Artifact.AddFileFunc = func(path string, content []byte) error {
+		mocks.Artifact.AddFileFunc = func(path string, content []byte, mode os.FileMode) error {
 			return fmt.Errorf("artifact storage full")
 		}
 
@@ -278,7 +278,7 @@ func TestTemplateBundler_Bundle(t *testing.T) {
 		bundler, mocks := setup(t)
 
 		filesAdded := make([]string, 0)
-		mocks.Artifact.AddFileFunc = func(path string, content []byte) error {
+		mocks.Artifact.AddFileFunc = func(path string, content []byte, mode os.FileMode) error {
 			filesAdded = append(filesAdded, path)
 			return nil
 		}

--- a/pkg/bundler/terraform_bundler.go
+++ b/pkg/bundler/terraform_bundler.go
@@ -82,7 +82,7 @@ func (t *TerraformBundler) Bundle(artifact Artifact) error {
 		}
 
 		artifactPath := "terraform/" + filepath.ToSlash(relPath)
-		return artifact.AddFile(artifactPath, data)
+		return artifact.AddFile(artifactPath, data, info.Mode())
 	})
 }
 

--- a/pkg/bundler/terraform_bundler_test.go
+++ b/pkg/bundler/terraform_bundler_test.go
@@ -54,7 +54,7 @@ func TestTerraformBundler_Bundle(t *testing.T) {
 		// Given a terraform bundler with valid terraform files
 		bundler, mocks := setup(t)
 		filesAdded := make(map[string][]byte)
-		mocks.Artifact.AddFileFunc = func(path string, content []byte) error {
+		mocks.Artifact.AddFileFunc = func(path string, content []byte, mode os.FileMode) error {
 			filesAdded[path] = content
 			return nil
 		}
@@ -137,7 +137,7 @@ func TestTerraformBundler_Bundle(t *testing.T) {
 		// Given a terraform bundler with .terraform directories and override files
 		bundler, mocks := setup(t)
 		filesAdded := make(map[string][]byte)
-		mocks.Artifact.AddFileFunc = func(path string, content []byte) error {
+		mocks.Artifact.AddFileFunc = func(path string, content []byte, mode os.FileMode) error {
 			filesAdded[path] = content
 			return nil
 		}
@@ -245,7 +245,7 @@ func TestTerraformBundler_Bundle(t *testing.T) {
 		// Given a terraform bundler with .terraform directory containing files
 		bundler, mocks := setup(t)
 		filesAdded := make(map[string][]byte)
-		mocks.Artifact.AddFileFunc = func(path string, content []byte) error {
+		mocks.Artifact.AddFileFunc = func(path string, content []byte, mode os.FileMode) error {
 			filesAdded[path] = content
 			return nil
 		}
@@ -329,7 +329,7 @@ func TestTerraformBundler_Bundle(t *testing.T) {
 		// Given a terraform bundler with various terraform files including ones that should be filtered
 		bundler, mocks := setup(t)
 		filesAdded := make(map[string][]byte)
-		mocks.Artifact.AddFileFunc = func(path string, content []byte) error {
+		mocks.Artifact.AddFileFunc = func(path string, content []byte, mode os.FileMode) error {
 			filesAdded[path] = content
 			return nil
 		}
@@ -487,7 +487,7 @@ func TestTerraformBundler_Bundle(t *testing.T) {
 		}
 
 		filesAdded := make([]string, 0)
-		mocks.Artifact.AddFileFunc = func(path string, content []byte) error {
+		mocks.Artifact.AddFileFunc = func(path string, content []byte, mode os.FileMode) error {
 			filesAdded = append(filesAdded, path)
 			return nil
 		}
@@ -606,7 +606,7 @@ func TestTerraformBundler_Bundle(t *testing.T) {
 		bundler.shims.ReadFile = func(filename string) ([]byte, error) {
 			return []byte("content"), nil
 		}
-		mocks.Artifact.AddFileFunc = func(path string, content []byte) error {
+		mocks.Artifact.AddFileFunc = func(path string, content []byte, mode os.FileMode) error {
 			return fmt.Errorf("artifact storage full")
 		}
 
@@ -627,7 +627,7 @@ func TestTerraformBundler_Bundle(t *testing.T) {
 		bundler, mocks := setup(t)
 
 		filesAdded := make([]string, 0)
-		mocks.Artifact.AddFileFunc = func(path string, content []byte) error {
+		mocks.Artifact.AddFileFunc = func(path string, content []byte, mode os.FileMode) error {
 			filesAdded = append(filesAdded, path)
 			return nil
 		}
@@ -677,7 +677,7 @@ func TestTerraformBundler_Bundle(t *testing.T) {
 		bundler, mocks := setup(t)
 
 		filesAdded := make([]string, 0)
-		mocks.Artifact.AddFileFunc = func(path string, content []byte) error {
+		mocks.Artifact.AddFileFunc = func(path string, content []byte, mode os.FileMode) error {
 			filesAdded = append(filesAdded, path)
 			return nil
 		}

--- a/pkg/generators/generator_test.go
+++ b/pkg/generators/generator_test.go
@@ -23,7 +23,7 @@ import (
 type Mocks struct {
 	Injector         di.Injector
 	ConfigHandler    config.ConfigHandler
-	BlueprintHandler blueprint.MockBlueprintHandler
+	BlueprintHandler *blueprint.MockBlueprintHandler
 	Shell            *shell.MockShell
 	Shims            *Shims
 }
@@ -144,9 +144,6 @@ func setupMocks(t *testing.T, opts ...*SetupOptions) *Mocks {
 	shims.MkdirAll = func(path string, perm fs.FileMode) error {
 		return os.MkdirAll(path, perm)
 	}
-	shims.TempDir = func(_, _ string) (string, error) {
-		return t.TempDir(), nil
-	}
 	shims.RemoveAll = func(path string) error {
 		return os.RemoveAll(path)
 	}
@@ -210,7 +207,7 @@ output "local_output1" {
 	mocks := &Mocks{
 		Injector:         injector,
 		ConfigHandler:    configHandler,
-		BlueprintHandler: *mockBlueprintHandler,
+		BlueprintHandler: mockBlueprintHandler,
 		Shell:            mockShell,
 		Shims:            shims,
 	}

--- a/pkg/generators/shims.go
+++ b/pkg/generators/shims.go
@@ -1,11 +1,17 @@
 package generators
 
 import (
+	"archive/tar"
+	"bytes"
 	"encoding/json"
+	"io"
 	"os"
 	"path/filepath"
 
 	"github.com/goccy/go-yaml"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
 // The shims package is a system call abstraction layer for the generators package
@@ -19,20 +25,31 @@ import (
 
 // Shims provides mockable wrappers around system and runtime functions
 type Shims struct {
-	WriteFile     func(name string, data []byte, perm os.FileMode) error
-	ReadFile      func(name string) ([]byte, error)
-	MkdirAll      func(path string, perm os.FileMode) error
-	Stat          func(name string) (os.FileInfo, error)
-	MarshalYAML   func(v any) ([]byte, error)
-	TempDir       func(dir, pattern string) (string, error)
-	RemoveAll     func(path string) error
-	Chdir         func(dir string) error
-	ReadDir       func(name string) ([]os.DirEntry, error)
-	Setenv        func(key, value string) error
-	YamlUnmarshal func(data []byte, v any) error
-	JsonMarshal   func(v any) ([]byte, error)
-	JsonUnmarshal func(data []byte, v any) error
-	FilepathRel   func(basepath, targpath string) (string, error)
+	WriteFile         func(name string, data []byte, perm os.FileMode) error
+	ReadFile          func(name string) ([]byte, error)
+	MkdirAll          func(path string, perm os.FileMode) error
+	Stat              func(name string) (os.FileInfo, error)
+	MarshalYAML       func(v any) ([]byte, error)
+	RemoveAll         func(path string) error
+	Chdir             func(dir string) error
+	ReadDir           func(name string) ([]os.DirEntry, error)
+	Setenv            func(key, value string) error
+	YamlUnmarshal     func(data []byte, v any) error
+	JsonMarshal       func(v any) ([]byte, error)
+	JsonUnmarshal     func(data []byte, v any) error
+	FilepathRel       func(basepath, targpath string) (string, error)
+	NewTarReader      func(r io.Reader) *tar.Reader
+	NewBytesReader    func(data []byte) io.Reader
+	ReadAll           func(reader io.Reader) ([]byte, error)
+	ParseReference    func(ref string, opts ...name.Option) (name.Reference, error)
+	RemoteImage       func(ref name.Reference, options ...remote.Option) (v1.Image, error)
+	ImageLayers       func(img v1.Image) ([]v1.Layer, error)
+	LayerUncompressed func(layer v1.Layer) (io.ReadCloser, error)
+	Create            func(path string) (*os.File, error)
+	Copy              func(dst io.Writer, src io.Reader) (int64, error)
+	Chmod             func(name string, mode os.FileMode) error
+	EOFError          func() error
+	TypeDir           func() byte
 }
 
 // =============================================================================
@@ -42,19 +59,30 @@ type Shims struct {
 // NewShims creates a new Shims instance with default implementations
 func NewShims() *Shims {
 	return &Shims{
-		WriteFile:     os.WriteFile,
-		ReadFile:      os.ReadFile,
-		MkdirAll:      os.MkdirAll,
-		Stat:          os.Stat,
-		MarshalYAML:   yaml.Marshal,
-		TempDir:       os.MkdirTemp,
-		RemoveAll:     os.RemoveAll,
-		Chdir:         os.Chdir,
-		ReadDir:       os.ReadDir,
-		Setenv:        os.Setenv,
-		YamlUnmarshal: yaml.Unmarshal,
-		JsonMarshal:   json.Marshal,
-		JsonUnmarshal: json.Unmarshal,
-		FilepathRel:   filepath.Rel,
+		WriteFile:         os.WriteFile,
+		ReadFile:          os.ReadFile,
+		MkdirAll:          os.MkdirAll,
+		Stat:              os.Stat,
+		MarshalYAML:       yaml.Marshal,
+		RemoveAll:         os.RemoveAll,
+		Chdir:             os.Chdir,
+		ReadDir:           os.ReadDir,
+		Setenv:            os.Setenv,
+		YamlUnmarshal:     yaml.Unmarshal,
+		JsonMarshal:       json.Marshal,
+		JsonUnmarshal:     json.Unmarshal,
+		FilepathRel:       filepath.Rel,
+		NewTarReader:      tar.NewReader,
+		NewBytesReader:    func(data []byte) io.Reader { return bytes.NewReader(data) },
+		ReadAll:           io.ReadAll,
+		ParseReference:    func(ref string, opts ...name.Option) (name.Reference, error) { return name.ParseReference(ref) },
+		RemoteImage:       func(ref name.Reference, options ...remote.Option) (v1.Image, error) { return remote.Image(ref) },
+		ImageLayers:       func(img v1.Image) ([]v1.Layer, error) { return img.Layers() },
+		LayerUncompressed: func(layer v1.Layer) (io.ReadCloser, error) { return layer.Uncompressed() },
+		Create:            os.Create,
+		Copy:              io.Copy,
+		Chmod:             os.Chmod,
+		EOFError:          func() error { return io.EOF },
+		TypeDir:           func() byte { return tar.TypeDir },
 	}
 }

--- a/pkg/generators/terraform_generator_test.go
+++ b/pkg/generators/terraform_generator_test.go
@@ -1,743 +1,230 @@
 package generators
 
 import (
+	"archive/tar"
+	"bytes"
 	"fmt"
+	"io"
 	"io/fs"
+	"math/big"
 	"os"
 	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/goccy/go-yaml"
+	"github.com/google/go-containerregistry/pkg/name"
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/hashicorp/hcl/v2"
 	"github.com/hashicorp/hcl/v2/hclsyntax"
 	"github.com/hashicorp/hcl/v2/hclwrite"
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+	"github.com/windsorcli/cli/pkg/blueprint"
 	"github.com/windsorcli/cli/pkg/config"
 	"github.com/zclconf/go-cty/cty"
 )
 
-func TestConvertToCtyValue(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    any
-		expected cty.Value
-	}{
-		{
-			name:     "String",
-			input:    "test",
-			expected: cty.StringVal("test"),
-		},
-		{
-			name:     "Int",
-			input:    42,
-			expected: cty.NumberIntVal(42),
-		},
-		{
-			name:     "Float64",
-			input:    42.5,
-			expected: cty.NumberFloatVal(42.5),
-		},
-		{
-			name:     "Bool",
-			input:    true,
-			expected: cty.BoolVal(true),
-		},
-		{
-			name:     "EmptyList",
-			input:    []any{},
-			expected: cty.ListValEmpty(cty.DynamicPseudoType),
-		},
-		{
-			name:     "List",
-			input:    []any{"item1", "item2"},
-			expected: cty.ListVal([]cty.Value{cty.StringVal("item1"), cty.StringVal("item2")}),
-		},
-		{
-			name:     "Map",
-			input:    map[string]any{"key": "value"},
-			expected: cty.ObjectVal(map[string]cty.Value{"key": cty.StringVal("value")}),
-		},
-		{
-			name:     "Unsupported",
-			input:    struct{}{},
-			expected: cty.NilVal,
-		},
-		{
-			name:     "Nil",
-			input:    nil,
-			expected: cty.NilVal,
-		},
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+type simpleDirEntry struct {
+	name  string
+	isDir bool
+}
+
+func (s *simpleDirEntry) Name() string {
+	return s.name
+}
+
+func (s *simpleDirEntry) IsDir() bool {
+	return s.isDir
+}
+
+func (s *simpleDirEntry) Type() fs.FileMode {
+	if s.isDir {
+		return fs.ModeDir
+	}
+	return 0
+}
+
+func (s *simpleDirEntry) Info() (fs.FileInfo, error) {
+	return nil, fmt.Errorf("not implemented")
+}
+
+// Mock types for OCI testing
+type mockReference struct{}
+
+func (m *mockReference) Context() name.Repository {
+	return name.Repository{}
+}
+
+func (m *mockReference) Identifier() string {
+	return "v1.0.0"
+}
+
+func (m *mockReference) Name() string {
+	return "registry.example.com/my-repo:v1.0.0"
+}
+
+func (m *mockReference) String() string {
+	return "registry.example.com/my-repo:v1.0.0"
+}
+
+func (m *mockReference) Scope(action string) string {
+	return ""
+}
+
+type mockImage struct{}
+
+func (m *mockImage) Layers() ([]v1.Layer, error) {
+	return []v1.Layer{&mockLayer{}}, nil
+}
+
+func (m *mockImage) MediaType() (types.MediaType, error) {
+	return "", nil
+}
+
+func (m *mockImage) Size() (int64, error) {
+	return 0, nil
+}
+
+func (m *mockImage) ConfigName() (v1.Hash, error) {
+	return v1.Hash{}, nil
+}
+
+func (m *mockImage) ConfigFile() (*v1.ConfigFile, error) {
+	return nil, nil
+}
+
+func (m *mockImage) RawConfigFile() ([]byte, error) {
+	return nil, nil
+}
+
+func (m *mockImage) Digest() (v1.Hash, error) {
+	return v1.Hash{}, nil
+}
+
+func (m *mockImage) Manifest() (*v1.Manifest, error) {
+	return nil, nil
+}
+
+func (m *mockImage) RawManifest() ([]byte, error) {
+	return nil, nil
+}
+
+func (m *mockImage) LayerByDigest(hash v1.Hash) (v1.Layer, error) {
+	return &mockLayer{}, nil
+}
+
+func (m *mockImage) LayerByDiffID(hash v1.Hash) (v1.Layer, error) {
+	return &mockLayer{}, nil
+}
+
+type mockLayer struct{}
+
+func (m *mockLayer) Digest() (v1.Hash, error) {
+	return v1.Hash{}, nil
+}
+
+func (m *mockLayer) DiffID() (v1.Hash, error) {
+	return v1.Hash{}, nil
+}
+
+func (m *mockLayer) Compressed() (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (m *mockLayer) Uncompressed() (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (m *mockLayer) Size() (int64, error) {
+	return 0, nil
+}
+
+func (m *mockLayer) MediaType() (types.MediaType, error) {
+	return "", nil
+}
+
+// mockFileInfo implements os.FileInfo for testing
+type mockFileInfo struct {
+	name  string
+	isDir bool
+	mode  os.FileMode
+}
+
+func (m *mockFileInfo) Name() string       { return m.name }
+func (m *mockFileInfo) Size() int64        { return 0 }
+func (m *mockFileInfo) Mode() os.FileMode  { return m.mode }
+func (m *mockFileInfo) ModTime() time.Time { return time.Time{} }
+func (m *mockFileInfo) IsDir() bool        { return m.isDir }
+func (m *mockFileInfo) Sys() any           { return nil }
+
+// mockDirEntry implements os.DirEntry for testing
+type mockDirEntry struct {
+	name  string
+	isDir bool
+}
+
+func (m *mockDirEntry) Name() string      { return m.name }
+func (m *mockDirEntry) IsDir() bool       { return m.isDir }
+func (m *mockDirEntry) Type() os.FileMode { return 0 }
+func (m *mockDirEntry) Info() (os.FileInfo, error) {
+	return &mockFileInfo{name: m.name, isDir: m.isDir}, nil
+}
+
+// setupTerraformGeneratorMocks extends base mocks with terraform generator specific mocking
+func setupTerraformGeneratorMocks(mocks *Mocks) {
+	// OCI-related mocks
+	mocks.Shims.ParseReference = func(ref string, opts ...name.Option) (name.Reference, error) {
+		return &mockReference{}, nil
+	}
+	mocks.Shims.RemoteImage = func(ref name.Reference, options ...remote.Option) (v1.Image, error) {
+		return &mockImage{}, nil
+	}
+	mocks.Shims.ImageLayers = func(img v1.Image) ([]v1.Layer, error) {
+		return []v1.Layer{&mockLayer{}}, nil
+	}
+	mocks.Shims.LayerUncompressed = func(layer v1.Layer) (io.ReadCloser, error) {
+		testData := []byte("test artifact data")
+		return io.NopCloser(bytes.NewReader(testData)), nil
+	}
+	mocks.Shims.ReadAll = func(r io.Reader) ([]byte, error) {
+		return io.ReadAll(r)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := convertToCtyValue(tt.input)
-			if !result.RawEquals(tt.expected) {
-				t.Errorf("expected %#v, got %#v", tt.expected, result)
-			}
-		})
+	// Tar extraction mocks
+	mocks.Shims.NewBytesReader = func(data []byte) io.Reader {
+		return bytes.NewReader(data)
+	}
+	mocks.Shims.NewTarReader = func(r io.Reader) *tar.Reader {
+		return tar.NewReader(r)
+	}
+	mocks.Shims.EOFError = func() error {
+		return io.EOF
+	}
+	mocks.Shims.TypeDir = func() byte {
+		return tar.TypeDir
+	}
+	mocks.Shims.Create = func(path string) (*os.File, error) {
+		return os.Create(path)
+	}
+	mocks.Shims.Copy = func(dst io.Writer, src io.Reader) (int64, error) {
+		return io.Copy(dst, src)
+	}
+	mocks.Shims.Chmod = func(name string, mode os.FileMode) error {
+		return nil // Default to successful chmod
 	}
 }
 
-func TestConvertFromCtyValue(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    cty.Value
-		expected any
-	}{
-		{
-			name:     "String",
-			input:    cty.StringVal("test"),
-			expected: "test",
-		},
-		{
-			name:     "Int",
-			input:    cty.NumberIntVal(42),
-			expected: int64(42),
-		},
-		{
-			name:     "Float",
-			input:    cty.NumberFloatVal(42.5),
-			expected: float64(42.5),
-		},
-		{
-			name:     "Bool",
-			input:    cty.BoolVal(true),
-			expected: true,
-		},
-		{
-			name:     "List",
-			input:    cty.ListVal([]cty.Value{cty.StringVal("item1"), cty.StringVal("item2")}),
-			expected: []any{"item1", "item2"},
-		},
-		{
-			name:     "EmptyList",
-			input:    cty.ListValEmpty(cty.String),
-			expected: []any(nil),
-		},
-		{
-			name:     "Map",
-			input:    cty.MapVal(map[string]cty.Value{"key": cty.StringVal("value")}),
-			expected: map[string]any{"key": "value"},
-		},
-		{
-			name:     "EmptyMap",
-			input:    cty.MapValEmpty(cty.String),
-			expected: map[string]any{},
-		},
-		{
-			name:     "Object",
-			input:    cty.ObjectVal(map[string]cty.Value{"key": cty.StringVal("value")}),
-			expected: map[string]any{"key": "value"},
-		},
-		{
-			name:     "Null",
-			input:    cty.NullVal(cty.String),
-			expected: nil,
-		},
-		{
-			name:     "Unknown",
-			input:    cty.UnknownVal(cty.String),
-			expected: nil,
-		},
-		{
-			name:     "Set",
-			input:    cty.SetVal([]cty.Value{cty.StringVal("item1"), cty.StringVal("item2")}),
-			expected: []any{"item1", "item2"},
-		},
-		{
-			name:     "Tuple",
-			input:    cty.TupleVal([]cty.Value{cty.StringVal("item1"), cty.NumberIntVal(42)}),
-			expected: []any{"item1", int64(42)},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result := convertFromCtyValue(tt.input)
-			if !reflect.DeepEqual(result, tt.expected) {
-				t.Errorf("expected %#v (%T), got %#v (%T)", tt.expected, tt.expected, result, result)
-			}
-		})
-	}
-}
-
-func TestWriteVariableSensitive(t *testing.T) {
-	// Given a body and variables with a sensitive variable
-	file := hclwrite.NewEmptyFile()
-	body := file.Body()
-	variables := []VariableInfo{
-		{
-			Name:        "test_var",
-			Description: "Test variable",
-			Sensitive:   true,
-		},
-	}
-
-	// When writeVariable is called
-	writeVariable(body, "test_var", "value", variables)
-
-	// Then the variable should be commented out with (sensitive)
-	expected := `# Test variable
-# test_var = "(sensitive)"
-`
-	if string(file.Bytes()) != expected {
-		t.Errorf("expected %q, got %q", expected, string(file.Bytes()))
-	}
-}
-
-func TestWriteVariableNonSensitive(t *testing.T) {
-	// Given a body and variables with a non-sensitive variable
-	file := hclwrite.NewEmptyFile()
-	body := file.Body()
-	variables := []VariableInfo{
-		{
-			Name:        "test_var",
-			Description: "Test variable",
-			Sensitive:   false,
-		},
-	}
-
-	// When writeVariable is called
-	writeVariable(body, "test_var", "value", variables)
-
-	// Then the variable should be written with its value
-	expected := `# Test variable
-test_var = "value"
-`
-	if string(file.Bytes()) != expected {
-		t.Errorf("expected %q, got %q", expected, string(file.Bytes()))
-	}
-}
-
-func TestWriteVariableWithComment(t *testing.T) {
-	// Given a body and variables with a variable with comment
-	file := hclwrite.NewEmptyFile()
-	body := file.Body()
-	variables := []VariableInfo{
-		{
-			Name:        "test_var",
-			Description: "Test variable description",
-		},
-	}
-
-	// When writeVariable is called
-	writeVariable(body, "test_var", "value", variables)
-
-	// Then the variable should be written with its comment
-	expected := `# Test variable description
-test_var = "value"
-`
-	if string(file.Bytes()) != expected {
-		t.Errorf("expected %q, got %q", expected, string(file.Bytes()))
-	}
-}
-
-func TestWriteComponentValues(t *testing.T) {
-	// Given a body and variables with component values
-	file := hclwrite.NewEmptyFile()
-	body := file.Body()
-	variables := []VariableInfo{
-		{
-			Name:        "var1",
-			Description: "Variable 1",
-			Sensitive:   true,
-			Default:     "default1",
-		},
-		{
-			Name:        "var2",
-			Description: "Variable 2",
-			Sensitive:   false,
-			Default:     "default2",
-		},
-		{
-			Name:        "var3",
-			Description: "Variable 3",
-			Default:     "default3",
-		},
-	}
-	values := map[string]any{
-		"var2": "pinned_value",
-	}
-	protectedValues := map[string]bool{}
-
-	// When writeComponentValues is called
-	writeComponentValues(body, values, protectedValues, variables)
-
-	// Then the variables should be written in order with proper handling of sensitive values
-	expected := `
-# Variable 1
-# var1 = "(sensitive)"
-
-# Variable 2
-var2 = "pinned_value"
-
-# Variable 3
-# var3 = "default3"
-`
-	if string(file.Bytes()) != expected {
-		t.Errorf("expected %q, got %q", expected, string(file.Bytes()))
-	}
-}
-
-func TestWriteDefaultValues(t *testing.T) {
-	// Given a body and variables with default values
-	file := hclwrite.NewEmptyFile()
-	body := file.Body()
-	variables := []VariableInfo{
-		{
-			Name:        "var1",
-			Description: "Variable 1",
-			Sensitive:   true,
-			Default:     "default1",
-		},
-		{
-			Name:        "var2",
-			Description: "Variable 2",
-			Sensitive:   false,
-			Default:     "default2",
-		},
-		{
-			Name:        "var3",
-			Description: "Variable 3",
-			Default:     "default3",
-		},
-	}
-
-	// When writeDefaultValues is called
-	writeDefaultValues(body, variables, nil)
-
-	// Then the variables should be written in order with proper handling of sensitive values
-	expected := `
-# Variable 1
-# var1 = "(sensitive)"
-
-# Variable 2
-# var2 = "default2"
-
-# Variable 3
-# var3 = "default3"
-`
-	if string(file.Bytes()) != expected {
-		t.Errorf("expected %q, got %q", expected, string(file.Bytes()))
-	}
-}
-
-func TestWriteVariableYAML(t *testing.T) {
-	// Given a body and variables with a YAML multiline value
-	file := hclwrite.NewEmptyFile()
-	body := file.Body()
-	variables := []VariableInfo{
-		{
-			Name:        "worker_config_patches",
-			Description: "Worker configuration patches",
-		},
-	}
-
-	// When writeVariable is called with a YAML multiline string
-	yamlValue := `machine:
-  kubelet:
-    extraMounts:
-    - destination: /var/local
-      options:
-      - rbind
-      - rw
-      source: /var/local
-      type: bind`
-	writeVariable(body, "worker_config_patches", yamlValue, variables)
-
-	// Then the variable should be written as a heredoc with valid YAML
-	actual := string(file.Bytes())
-
-	// Extract the YAML content from the heredoc
-	lines := strings.Split(actual, "\n")
-	var yamlContent strings.Builder
-	inYAML := false
-	for _, line := range lines {
-		if strings.Contains(line, "<<EOF") {
-			inYAML = true
-			continue
-		}
-		if strings.Contains(line, "EOF") {
-			inYAML = false
-			continue
-		}
-		if inYAML {
-			yamlContent.WriteString(line + "\n")
-		}
-	}
-
-	// Parse both expected and actual YAML
-	var expectedData, actualData any
-	expectedYAML := `machine:
-  kubelet:
-    extraMounts:
-    - destination: /var/local
-      options:
-      - rbind
-      - rw
-      source: /var/local
-      type: bind`
-
-	if err := yaml.UnmarshalWithOptions([]byte(expectedYAML), &expectedData); err != nil {
-		t.Fatalf("failed to parse expected YAML: %v", err)
-	}
-	if err := yaml.UnmarshalWithOptions([]byte(yamlContent.String()), &actualData); err != nil {
-		t.Fatalf("failed to parse actual YAML: %v", err)
-	}
-
-	// Compare the YAML data structures
-	var expectedBytes, actualBytes []byte
-	expectedBytes, _ = yaml.MarshalWithOptions(expectedData)
-	actualBytes, _ = yaml.MarshalWithOptions(actualData)
-	if string(expectedBytes) != string(actualBytes) {
-		t.Errorf("YAML content does not match.\nExpected:\n%s\nGot:\n%s", expectedBytes, actualBytes)
-	}
-
-	// Verify the comment and heredoc syntax
-	if !strings.Contains(actual, "# Worker configuration patches") {
-		t.Error("missing description comment")
-	}
-	if !strings.Contains(actual, "worker_config_patches = <<EOF") {
-		t.Error("missing heredoc start")
-	}
-	if !strings.Contains(actual, "EOF") {
-		t.Error("missing heredoc end")
-	}
-}
-
-func TestWriteVariable(t *testing.T) {
-	tests := []struct {
-		name     string
-		value    any
-		expected string
-		checkMap bool
-	}{
-		{
-			name: "multiline string",
-			value: `first line
-  indented line
-    more indented
-last line`,
-			expected: `first line
-  indented line
-    more indented
-last line`,
-		},
-		{
-			name: "multiline with tabs",
-			value: `first line
-	tabbed line
-		more tabbed
-last line`,
-			expected: `first line
-	tabbed line
-		more tabbed
-last line`,
-		},
-		{
-			name: "map value",
-			value: map[string]any{
-				"string": "value",
-				"number": 42,
-				"bool":   true,
-				"nested": map[string]any{
-					"key": "value",
-				},
-			},
-			expected: `{
-  bool = true
-  nested = {
-    key = "value"
-  }
-  number = 42
-  string = "value"
-}`,
-			checkMap: true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			file := hclwrite.NewEmptyFile()
-			writeVariable(file.Body(), "test_var", tt.value, nil)
-
-			content := string(file.Bytes())
-
-			if tt.checkMap {
-				// For maps, extract the assignment (not heredoc)
-				assignmentPrefix := "test_var = "
-				idx := strings.Index(content, assignmentPrefix)
-				if idx == -1 {
-					t.Fatalf("assignment not found in output: %q", content)
-				}
-				actual := strings.TrimSpace(content[idx+len(assignmentPrefix):])
-				// Compare the formatted object string
-				if actual != tt.expected {
-					t.Errorf("map content does not match.\nExpected:\n%s\nGot:\n%s", tt.expected, actual)
-				}
-			} else {
-				// For heredoc, extract the heredoc content
-				lines := strings.Split(content, "\n")
-				var actualLines []string
-				inHeredoc := false
-				for _, line := range lines {
-					if strings.Contains(line, "<<EOF") {
-						inHeredoc = true
-						continue
-					}
-					if strings.Contains(line, "EOF") {
-						break
-					}
-					if inHeredoc {
-						actualLines = append(actualLines, line)
-					}
-				}
-				actual := strings.Join(actualLines, "\n")
-				if actual != tt.expected {
-					t.Errorf("content does not match.\nExpected:\n%s\nGot:\n%s", tt.expected, actual)
-				}
-			}
-		})
-	}
-}
-
-func TestParseVariablesFile(t *testing.T) {
-	setup := func(t *testing.T) (*TerraformGenerator, *Mocks) {
-		mocks := setupMocks(t)
-		generator := NewTerraformGenerator(mocks.Injector)
-		generator.shims = mocks.Shims
-		if err := generator.Initialize(); err != nil {
-			t.Fatalf("failed to initialize TerraformGenerator: %v", err)
-		}
-		return generator, mocks
-	}
-
-	t.Run("AllVariableTypes", func(t *testing.T) {
-		// Given a TerraformGenerator with mocks
-		generator, mocks := setup(t)
-
-		// And ReadFile is mocked to return variables with all types and attributes
-		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
-			return []byte(`
-variable "string_var" {
-  description = "String variable"
-  type        = string
-  default     = "default_value"
-  sensitive   = false
-}
-
-variable "number_var" {
-  description = "Number variable"
-  type        = number
-  default     = 42
-  sensitive   = false
-}
-
-variable "bool_var" {
-  description = "Boolean variable"
-  type        = bool
-  default     = true
-  sensitive   = true
-}
-
-variable "list_var" {
-  description = "List variable"
-  type        = list(string)
-  default     = ["item1", "item2"]
-}
-
-variable "map_var" {
-  description = "Map variable"
-  type        = map(string)
-  default     = { key = "value" }
-}
-
-variable "no_default" {
-  description = "Variable without default"
-  type        = string
-}
-
-variable "no_description" {
-  type    = string
-  default = "value"
-}
-
-variable "invalid_default" {
-  description = "Variable with invalid default"
-  type        = string
-  default     = invalid
-}
-
-variable "invalid_sensitive" {
-  description = "Variable with invalid sensitive"
-  type        = string
-  sensitive   = invalid
-}`), nil
-		}
-
-		// When parseVariablesFile is called
-		variables, err := generator.parseVariablesFile("test.tf", map[string]bool{})
-
-		// Then no error should occur
-		if err != nil {
-			t.Errorf("expected no error, got %v", err)
-		}
-
-		// And all variables should be parsed correctly
-		expectedVars := map[string]VariableInfo{
-			"string_var": {
-				Name:        "string_var",
-				Description: "String variable",
-				Default:     "default_value",
-				Sensitive:   false,
-			},
-			"number_var": {
-				Name:        "number_var",
-				Description: "Number variable",
-				Default:     int64(42),
-				Sensitive:   false,
-			},
-			"bool_var": {
-				Name:        "bool_var",
-				Description: "Boolean variable",
-				Default:     true,
-				Sensitive:   true,
-			},
-			"list_var": {
-				Name:        "list_var",
-				Description: "List variable",
-				Default:     []any{"item1", "item2"},
-			},
-			"map_var": {
-				Name:        "map_var",
-				Description: "Map variable",
-				Default:     map[string]any{"key": "value"},
-			},
-			"no_default": {
-				Name:        "no_default",
-				Description: "Variable without default",
-			},
-			"no_description": {
-				Name:    "no_description",
-				Default: "value",
-			},
-			"invalid_default": {
-				Name:        "invalid_default",
-				Description: "Variable with invalid default",
-			},
-			"invalid_sensitive": {
-				Name:        "invalid_sensitive",
-				Description: "Variable with invalid sensitive",
-			},
-		}
-
-		// Verify each variable
-		if len(variables) != len(expectedVars) {
-			t.Errorf("expected %d variables, got %d", len(expectedVars), len(variables))
-		}
-
-		for _, v := range variables {
-			expected, exists := expectedVars[v.Name]
-			if !exists {
-				t.Errorf("unexpected variable %s", v.Name)
-				continue
-			}
-
-			if v.Description != expected.Description {
-				t.Errorf("variable %s: expected description %q, got %q", v.Name, expected.Description, v.Description)
-			}
-			if !reflect.DeepEqual(v.Default, expected.Default) {
-				t.Errorf("variable %s: expected default %v (%T), got %v (%T)", v.Name, expected.Default, expected.Default, v.Default, v.Default)
-			}
-			if v.Sensitive != expected.Sensitive {
-				t.Errorf("variable %s: expected sensitive %v, got %v", v.Name, expected.Sensitive, v.Sensitive)
-			}
-		}
-	})
-
-	t.Run("ProtectedVariables", func(t *testing.T) {
-		// Given a TerraformGenerator with mocks
-		generator, mocks := setup(t)
-
-		// And ReadFile is mocked to return variables
-		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
-			return []byte(`
-variable "protected_var" {
-  description = "Protected variable"
-  type        = string
-}
-
-variable "normal_var" {
-  description = "Normal variable"
-  type        = string
-}`), nil
-		}
-
-		// And protected values are set
-		protectedValues := map[string]bool{
-			"protected_var": true,
-		}
-
-		// When parseVariablesFile is called
-		variables, err := generator.parseVariablesFile("test.tf", protectedValues)
-
-		// Then no error should occur
-		if err != nil {
-			t.Errorf("expected no error, got %v", err)
-		}
-
-		// And only non-protected variables should be included
-		if len(variables) != 1 {
-			t.Errorf("expected 1 variable, got %d", len(variables))
-		}
-		if variables[0].Name != "normal_var" {
-			t.Errorf("expected variable normal_var, got %s", variables[0].Name)
-		}
-	})
-
-	t.Run("InvalidHCL", func(t *testing.T) {
-		// Given a TerraformGenerator with mocks
-		generator, mocks := setup(t)
-
-		// And ReadFile is mocked to return invalid HCL
-		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
-			return []byte(`invalid hcl content`), nil
-		}
-
-		// When parseVariablesFile is called
-		_, err := generator.parseVariablesFile("test.tf", map[string]bool{})
-
-		// Then an error should occur
-		if err == nil {
-			t.Error("expected error, got nil")
-		}
-	})
-
-	t.Run("ReadFileError", func(t *testing.T) {
-		// Given a TerraformGenerator with mocks
-		generator, mocks := setup(t)
-
-		// And ReadFile is mocked to return an error
-		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
-			return nil, fmt.Errorf("read error")
-		}
-
-		// When parseVariablesFile is called
-		_, err := generator.parseVariablesFile("test.tf", map[string]bool{})
-
-		// Then an error should occur
-		if err == nil {
-			t.Error("expected error, got nil")
-		}
-		expectedError := "failed to read variables.tf: read error"
-		if err.Error() != expectedError {
-			t.Errorf("expected error %q, got %q", expectedError, err.Error())
-		}
-	})
-}
+// =============================================================================
+// Test Public Methods
+// =============================================================================
 
 func TestTerraformGenerator_Write(t *testing.T) {
 	setup := func(t *testing.T) (*TerraformGenerator, *Mocks) {
@@ -996,6 +483,1180 @@ func TestTerraformGenerator_Write(t *testing.T) {
 
 }
 
+// =============================================================================
+// Test Private Methods
+// =============================================================================
+
+func TestTerraformGenerator_processTemplates(t *testing.T) {
+	setup := func(t *testing.T) (*TerraformGenerator, *Mocks) {
+		mocks := setupMocks(t)
+		generator := NewTerraformGenerator(mocks.Injector)
+		generator.shims = mocks.Shims
+		if err := generator.Initialize(); err != nil {
+			t.Fatalf("failed to initialize TerraformGenerator: %v", err)
+		}
+		return generator, mocks
+	}
+
+	t.Run("TemplateDirectoryNotExists", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And Stat is mocked to return os.ErrNotExist for template directory
+		mocks.Shims.Stat = func(path string) (fs.FileInfo, error) {
+			if strings.Contains(path, "_template") {
+				return nil, os.ErrNotExist
+			}
+			return nil, nil
+		}
+
+		// When processTemplates is called
+		result, err := generator.processTemplates(false)
+
+		// Then no error should occur and result should be nil
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if result != nil {
+			t.Errorf("expected nil result, got %v", result)
+		}
+	})
+
+	t.Run("ErrorCheckingTemplateDirectory", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And Stat is mocked to return an error for template directory
+		mocks.Shims.Stat = func(path string) (fs.FileInfo, error) {
+			if strings.Contains(path, "_template") {
+				return nil, fmt.Errorf("permission denied")
+			}
+			return nil, nil
+		}
+
+		// When processTemplates is called
+		result, err := generator.processTemplates(false)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+		if result != nil {
+			t.Errorf("expected nil result, got %v", result)
+		}
+
+		// And the error should contain the expected message
+		if !strings.Contains(err.Error(), "failed to check template directory") {
+			t.Errorf("expected error to contain 'failed to check template directory', got %v", err)
+		}
+	})
+
+	t.Run("ErrorGettingProjectRoot", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And Shell.GetProjectRoot is mocked to return an error
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return "", fmt.Errorf("project root error")
+		}
+
+		// When processTemplates is called
+		result, err := generator.processTemplates(false)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+		if result != nil {
+			t.Errorf("expected nil result, got %v", result)
+		}
+
+		// And the error should contain the expected message
+		if !strings.Contains(err.Error(), "failed to get project root") {
+			t.Errorf("expected error to contain 'failed to get project root', got %v", err)
+		}
+	})
+
+	t.Run("SuccessWithEmptyDirectory", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And Stat is mocked to return success for template directory
+		mocks.Shims.Stat = func(path string) (fs.FileInfo, error) {
+			if strings.Contains(path, "_template") {
+				return nil, nil
+			}
+			return nil, nil
+		}
+
+		// And ReadDir is mocked to return empty directory
+		mocks.Shims.ReadDir = func(path string) ([]fs.DirEntry, error) {
+			return []fs.DirEntry{}, nil
+		}
+
+		// When processTemplates is called
+		result, err := generator.processTemplates(false)
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		// And result should be an empty map
+		if result == nil {
+			t.Errorf("expected non-nil result, got nil")
+		}
+		if len(result) != 0 {
+			t.Errorf("expected empty result, got %v", result)
+		}
+	})
+
+	t.Run("ProcessesJsonnetFiles", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// Create a simple mock for fs.DirEntry with jsonnet file
+		mockEntry := &simpleDirEntry{name: "test.jsonnet", isDir: false}
+
+		// And ReadDir is mocked to return a jsonnet file
+		mocks.Shims.ReadDir = func(path string) ([]fs.DirEntry, error) {
+			return []fs.DirEntry{mockEntry}, nil
+		}
+
+		// Mock all dependencies for processJsonnetTemplate
+		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
+			return []byte(`{
+  test_var: "test_value"
+}`), nil
+		}
+
+		mocks.ConfigHandler.(*config.MockConfigHandler).YamlMarshalWithDefinedPathsFunc = func(config any) ([]byte, error) {
+			return []byte("test: config"), nil
+		}
+
+		mocks.Shims.YamlUnmarshal = func(data []byte, v any) error {
+			if configMap, ok := v.(*map[string]any); ok {
+				*configMap = map[string]any{"test": "config"}
+			}
+			return nil
+		}
+
+		mocks.Shims.JsonMarshal = func(v any) ([]byte, error) {
+			return []byte(`{"test": "config", "name": "test-context"}`), nil
+		}
+
+		mocks.Shims.JsonUnmarshal = func(data []byte, v any) error {
+			if values, ok := v.(*map[string]any); ok {
+				*values = map[string]any{"test_var": "test_value"}
+			}
+			return nil
+		}
+
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return "/tmp", nil
+		}
+
+		templateValues := make(map[string]map[string]any)
+
+		// When walkTemplateDirectory is called
+		err := generator.walkTemplateDirectory("/tmp/contexts/_template/terraform", "/context/path", "test-context", false, templateValues)
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		// And template values should contain the processed template
+		if len(templateValues) != 1 {
+			t.Errorf("expected 1 template value, got %d", len(templateValues))
+		}
+	})
+
+	t.Run("ErrorProcessingJsonnetTemplate", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// Create a simple mock for fs.DirEntry with jsonnet file
+		mockEntry := &simpleDirEntry{name: "test.jsonnet", isDir: false}
+
+		// And ReadDir is mocked to return a jsonnet file
+		mocks.Shims.ReadDir = func(path string) ([]fs.DirEntry, error) {
+			return []fs.DirEntry{mockEntry}, nil
+		}
+
+		// And ReadFile is mocked to return an error for processJsonnetTemplate
+		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
+			return nil, fmt.Errorf("file read error")
+		}
+
+		templateValues := make(map[string]map[string]any)
+
+		// When walkTemplateDirectory is called
+		err := generator.walkTemplateDirectory("/template/dir", "/context/path", "test-context", false, templateValues)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+
+		// And the error should contain the expected message
+		if !strings.Contains(err.Error(), "error reading template file") {
+			t.Errorf("expected error to contain 'error reading template file', got %v", err)
+		}
+	})
+
+	t.Run("RecursivelyProcessesDirectories", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		callCount := 0
+		// Create mock directory entry
+		mockDirEntry := &simpleDirEntry{name: "subdir", isDir: true}
+
+		// And ReadDir is mocked to return a directory on first call, empty on second
+		mocks.Shims.ReadDir = func(path string) ([]fs.DirEntry, error) {
+			callCount++
+			if callCount == 1 {
+				return []fs.DirEntry{mockDirEntry}, nil
+			}
+			return []fs.DirEntry{}, nil // Empty subdirectory
+		}
+
+		templateValues := make(map[string]map[string]any)
+
+		// When walkTemplateDirectory is called
+		err := generator.walkTemplateDirectory("/template/dir", "/context/path", "test-context", false, templateValues)
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		// And ReadDir should have been called twice (once for root, once for subdir)
+		if callCount != 2 {
+			t.Errorf("expected ReadDir to be called 2 times, got %d", callCount)
+		}
+	})
+
+	t.Run("ErrorInRecursiveDirectoryCall", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		callCount := 0
+		// Create mock directory entry
+		mockDirEntry := &simpleDirEntry{name: "subdir", isDir: true}
+
+		// And ReadDir is mocked to return a directory on first call, error on second
+		mocks.Shims.ReadDir = func(path string) ([]fs.DirEntry, error) {
+			callCount++
+			if callCount == 1 {
+				return []fs.DirEntry{mockDirEntry}, nil
+			}
+			return nil, fmt.Errorf("subdirectory read error")
+		}
+
+		templateValues := make(map[string]map[string]any)
+
+		// When walkTemplateDirectory is called
+		err := generator.walkTemplateDirectory("/template/dir", "/context/path", "test-context", false, templateValues)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+
+		// And the error should contain the expected message
+		if !strings.Contains(err.Error(), "failed to read template directory") {
+			t.Errorf("expected error to contain 'failed to read template directory', got %v", err)
+		}
+	})
+
+	t.Run("ErrorGettingConfigRoot", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And Stat is mocked to return success for template directory
+		mocks.Shims.Stat = func(path string) (fs.FileInfo, error) {
+			if strings.Contains(path, "_template") {
+				return nil, nil
+			}
+			return nil, nil
+		}
+
+		// And GetConfigRoot is mocked to return an error
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetConfigRootFunc = func() (string, error) {
+			return "", fmt.Errorf("config root error")
+		}
+
+		// When processTemplates is called
+		result, err := generator.processTemplates(false)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+		if result != nil {
+			t.Errorf("expected nil result, got %v", result)
+		}
+
+		// And the error should contain the expected message
+		if !strings.Contains(err.Error(), "failed to get config root") {
+			t.Errorf("expected error to contain 'failed to get config root', got %v", err)
+		}
+	})
+
+	t.Run("UsesEnvironmentVariableForContextName", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And Stat is mocked to return success for template directory
+		mocks.Shims.Stat = func(path string) (fs.FileInfo, error) {
+			if strings.Contains(path, "_template") {
+				return nil, nil
+			}
+			return nil, nil
+		}
+
+		// And ReadDir is mocked to return empty directory
+		mocks.Shims.ReadDir = func(path string) ([]fs.DirEntry, error) {
+			return []fs.DirEntry{}, nil
+		}
+
+		// And GetString is mocked to return empty string (no context configured)
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "context" {
+				return "" // No context configured
+			}
+			return ""
+		}
+
+		// Mock environment variable
+		originalEnv := os.Getenv("WINDSOR_CONTEXT")
+		os.Setenv("WINDSOR_CONTEXT", "env-context")
+		defer os.Setenv("WINDSOR_CONTEXT", originalEnv)
+
+		// When processTemplates is called
+		result, err := generator.processTemplates(false)
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		// And result should be an empty map
+		if result == nil {
+			t.Errorf("expected non-nil result, got nil")
+		}
+		if len(result) != 0 {
+			t.Errorf("expected empty result, got %v", result)
+		}
+
+		// Note: The environment variable usage is tested by the fact that
+		// the function completes successfully and calls walkTemplateDirectory
+		// with the environment context name
+	})
+}
+
+func TestTerraformGenerator_walkTemplateDirectory(t *testing.T) {
+	setup := func(t *testing.T) (*TerraformGenerator, *Mocks) {
+		mocks := setupMocks(t)
+		generator := NewTerraformGenerator(mocks.Injector)
+		generator.shims = mocks.Shims
+		if err := generator.Initialize(); err != nil {
+			t.Fatalf("failed to initialize TerraformGenerator: %v", err)
+		}
+		return generator, mocks
+	}
+
+	t.Run("ErrorReadingDirectory", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And ReadDir is mocked to return an error
+		mocks.Shims.ReadDir = func(path string) ([]fs.DirEntry, error) {
+			return nil, fmt.Errorf("permission denied")
+		}
+
+		templateValues := make(map[string]map[string]any)
+
+		// When walkTemplateDirectory is called
+		err := generator.walkTemplateDirectory("/template/dir", "/context/path", "test-context", false, templateValues)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+
+		// And the error should contain the expected message
+		if !strings.Contains(err.Error(), "failed to read template directory") {
+			t.Errorf("expected error to contain 'failed to read template directory', got %v", err)
+		}
+	})
+
+	t.Run("IgnoresNonJsonnetFiles", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// Create a simple mock for fs.DirEntry
+		mockEntry := &simpleDirEntry{name: "test.txt", isDir: false}
+
+		// And ReadDir is mocked to return a non-jsonnet file
+		mocks.Shims.ReadDir = func(path string) ([]fs.DirEntry, error) {
+			return []fs.DirEntry{mockEntry}, nil
+		}
+
+		templateValues := make(map[string]map[string]any)
+
+		// When walkTemplateDirectory is called
+		err := generator.walkTemplateDirectory("/template/dir", "/context/path", "test-context", false, templateValues)
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		// And template values should be empty
+		if len(templateValues) != 0 {
+			t.Errorf("expected 0 template values, got %d", len(templateValues))
+		}
+	})
+
+	t.Run("ProcessesJsonnetFiles", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// Create a simple mock for fs.DirEntry with jsonnet file
+		mockEntry := &simpleDirEntry{name: "test.jsonnet", isDir: false}
+
+		// And ReadDir is mocked to return a jsonnet file
+		mocks.Shims.ReadDir = func(path string) ([]fs.DirEntry, error) {
+			return []fs.DirEntry{mockEntry}, nil
+		}
+
+		// Mock all dependencies for processJsonnetTemplate
+		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
+			return []byte(`{
+  test_var: "test_value"
+}`), nil
+		}
+
+		mocks.ConfigHandler.(*config.MockConfigHandler).YamlMarshalWithDefinedPathsFunc = func(config any) ([]byte, error) {
+			return []byte("test: config"), nil
+		}
+
+		mocks.Shims.YamlUnmarshal = func(data []byte, v any) error {
+			if configMap, ok := v.(*map[string]any); ok {
+				*configMap = map[string]any{"test": "config"}
+			}
+			return nil
+		}
+
+		mocks.Shims.JsonMarshal = func(v any) ([]byte, error) {
+			return []byte(`{"test": "config", "name": "test-context"}`), nil
+		}
+
+		mocks.Shims.JsonUnmarshal = func(data []byte, v any) error {
+			if values, ok := v.(*map[string]any); ok {
+				*values = map[string]any{"test_var": "test_value"}
+			}
+			return nil
+		}
+
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return "/tmp", nil
+		}
+
+		templateValues := make(map[string]map[string]any)
+
+		// When walkTemplateDirectory is called
+		err := generator.walkTemplateDirectory("/tmp/contexts/_template/terraform", "/context/path", "test-context", false, templateValues)
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		// And template values should contain the processed template
+		if len(templateValues) != 1 {
+			t.Errorf("expected 1 template value, got %d", len(templateValues))
+		}
+	})
+
+	t.Run("ErrorProcessingJsonnetTemplate", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// Create a simple mock for fs.DirEntry with jsonnet file
+		mockEntry := &simpleDirEntry{name: "test.jsonnet", isDir: false}
+
+		// And ReadDir is mocked to return a jsonnet file
+		mocks.Shims.ReadDir = func(path string) ([]fs.DirEntry, error) {
+			return []fs.DirEntry{mockEntry}, nil
+		}
+
+		// And ReadFile is mocked to return an error for processJsonnetTemplate
+		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
+			return nil, fmt.Errorf("file read error")
+		}
+
+		templateValues := make(map[string]map[string]any)
+
+		// When walkTemplateDirectory is called
+		err := generator.walkTemplateDirectory("/template/dir", "/context/path", "test-context", false, templateValues)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+
+		// And the error should contain the expected message
+		if !strings.Contains(err.Error(), "error reading template file") {
+			t.Errorf("expected error to contain 'error reading template file', got %v", err)
+		}
+	})
+
+	t.Run("RecursivelyProcessesDirectories", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		callCount := 0
+		// Create mock directory entry
+		mockDirEntry := &simpleDirEntry{name: "subdir", isDir: true}
+
+		// And ReadDir is mocked to return a directory on first call, empty on second
+		mocks.Shims.ReadDir = func(path string) ([]fs.DirEntry, error) {
+			callCount++
+			if callCount == 1 {
+				return []fs.DirEntry{mockDirEntry}, nil
+			}
+			return []fs.DirEntry{}, nil // Empty subdirectory
+		}
+
+		templateValues := make(map[string]map[string]any)
+
+		// When walkTemplateDirectory is called
+		err := generator.walkTemplateDirectory("/template/dir", "/context/path", "test-context", false, templateValues)
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		// And ReadDir should have been called twice (once for root, once for subdir)
+		if callCount != 2 {
+			t.Errorf("expected ReadDir to be called 2 times, got %d", callCount)
+		}
+	})
+
+	t.Run("ErrorInRecursiveDirectoryCall", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		callCount := 0
+		// Create mock directory entry
+		mockDirEntry := &simpleDirEntry{name: "subdir", isDir: true}
+
+		// And ReadDir is mocked to return a directory on first call, error on second
+		mocks.Shims.ReadDir = func(path string) ([]fs.DirEntry, error) {
+			callCount++
+			if callCount == 1 {
+				return []fs.DirEntry{mockDirEntry}, nil
+			}
+			return nil, fmt.Errorf("subdirectory read error")
+		}
+
+		templateValues := make(map[string]map[string]any)
+
+		// When walkTemplateDirectory is called
+		err := generator.walkTemplateDirectory("/template/dir", "/context/path", "test-context", false, templateValues)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+
+		// And the error should contain the expected message
+		if !strings.Contains(err.Error(), "failed to read template directory") {
+			t.Errorf("expected error to contain 'failed to read template directory', got %v", err)
+		}
+	})
+
+	t.Run("ErrorGettingConfigRoot", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And template directory exists
+		mocks.Shims.Stat = func(path string) (fs.FileInfo, error) {
+			if strings.Contains(path, "_template") {
+				return nil, nil
+			}
+			return nil, nil
+		}
+
+		// And GetConfigRoot is mocked to return an error
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetConfigRootFunc = func() (string, error) {
+			return "", fmt.Errorf("config root error")
+		}
+
+		// When processTemplates is called
+		result, err := generator.processTemplates(false)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+		if result != nil {
+			t.Errorf("expected nil result, got %v", result)
+		}
+
+		// And the error should contain the expected message
+		if !strings.Contains(err.Error(), "failed to get config root") {
+			t.Errorf("expected error to contain 'failed to get config root', got %v", err)
+		}
+	})
+
+	t.Run("ContextNameFromEnvironment", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And template directory exists
+		mocks.Shims.Stat = func(path string) (fs.FileInfo, error) {
+			if strings.Contains(path, "_template") {
+				return nil, nil
+			}
+			return nil, nil
+		}
+
+		// And GetString returns empty string (no context configured)
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "context" {
+				return ""
+			}
+			return ""
+		}
+
+		// And environment variable is set
+		originalEnv := os.Getenv("WINDSOR_CONTEXT")
+		defer func() {
+			if originalEnv == "" {
+				os.Unsetenv("WINDSOR_CONTEXT")
+			} else {
+				os.Setenv("WINDSOR_CONTEXT", originalEnv)
+			}
+		}()
+		os.Setenv("WINDSOR_CONTEXT", "env-context")
+
+		// And ReadDir is mocked to return empty directory
+		mocks.Shims.ReadDir = func(path string) ([]fs.DirEntry, error) {
+			return []fs.DirEntry{}, nil
+		}
+
+		// When processTemplates is called
+		result, err := generator.processTemplates(false)
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		// And result should be an empty map
+		if result == nil {
+			t.Errorf("expected non-nil result, got nil")
+		}
+		if len(result) != 0 {
+			t.Errorf("expected empty result, got %v", result)
+		}
+	})
+}
+
+func TestTerraformGenerator_processJsonnetTemplate(t *testing.T) {
+	setup := func(t *testing.T) (*TerraformGenerator, *Mocks) {
+		mocks := setupMocks(t)
+		generator := NewTerraformGenerator(mocks.Injector)
+		generator.shims = mocks.Shims
+		if err := generator.Initialize(); err != nil {
+			t.Fatalf("failed to initialize TerraformGenerator: %v", err)
+		}
+		return generator, mocks
+	}
+
+	t.Run("ErrorReadingTemplateFile", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And ReadFile is mocked to return an error
+		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
+			return nil, fmt.Errorf("file not found")
+		}
+
+		templateValues := make(map[string]map[string]any)
+
+		// When processJsonnetTemplate is called
+		err := generator.processJsonnetTemplate("/template/test.jsonnet", "test-context", templateValues)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+
+		// And the error should contain the expected message
+		if !strings.Contains(err.Error(), "error reading template file") {
+			t.Errorf("expected error to contain 'error reading template file', got %v", err)
+		}
+	})
+
+	t.Run("ErrorMarshallingContextToYAML", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And ReadFile is mocked to return jsonnet content
+		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
+			return []byte(`local context = std.extVar("context");
+{
+  test_var: context.test
+}`), nil
+		}
+
+		// And YamlMarshalWithDefinedPaths is mocked to return an error
+		mocks.ConfigHandler.(*config.MockConfigHandler).YamlMarshalWithDefinedPathsFunc = func(config any) ([]byte, error) {
+			return nil, fmt.Errorf("yaml marshal error")
+		}
+
+		templateValues := make(map[string]map[string]any)
+
+		// When processJsonnetTemplate is called
+		err := generator.processJsonnetTemplate("/template/test.jsonnet", "test-context", templateValues)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+
+		// And the error should contain the expected message
+		if !strings.Contains(err.Error(), "error marshalling context to YAML") {
+			t.Errorf("expected error to contain 'error marshalling context to YAML', got %v", err)
+		}
+	})
+
+	t.Run("ErrorUnmarshallingContextYAML", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And ReadFile is mocked to return jsonnet content
+		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
+			return []byte(`local context = std.extVar("context");
+{
+  test_var: context.test
+}`), nil
+		}
+
+		// And YamlMarshalWithDefinedPaths is mocked
+		mocks.ConfigHandler.(*config.MockConfigHandler).YamlMarshalWithDefinedPathsFunc = func(config any) ([]byte, error) {
+			return []byte("test: config"), nil
+		}
+
+		// And YamlUnmarshal is mocked to return an error
+		mocks.Shims.YamlUnmarshal = func(data []byte, v any) error {
+			return fmt.Errorf("yaml unmarshal error")
+		}
+
+		templateValues := make(map[string]map[string]any)
+
+		// When processJsonnetTemplate is called
+		err := generator.processJsonnetTemplate("/template/test.jsonnet", "test-context", templateValues)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+
+		// And the error should contain the expected message
+		if !strings.Contains(err.Error(), "error unmarshalling context YAML") {
+			t.Errorf("expected error to contain 'error unmarshalling context YAML', got %v", err)
+		}
+	})
+
+	t.Run("ErrorMarshallingContextToJSON", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And ReadFile is mocked to return jsonnet content
+		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
+			return []byte(`local context = std.extVar("context");
+{
+  test_var: context.test
+}`), nil
+		}
+
+		// And YamlMarshalWithDefinedPaths is mocked
+		mocks.ConfigHandler.(*config.MockConfigHandler).YamlMarshalWithDefinedPathsFunc = func(config any) ([]byte, error) {
+			return []byte("test: config"), nil
+		}
+
+		// And YamlUnmarshal is mocked
+		mocks.Shims.YamlUnmarshal = func(data []byte, v any) error {
+			if configMap, ok := v.(*map[string]any); ok {
+				*configMap = map[string]any{"test": "config"}
+			}
+			return nil
+		}
+
+		// And JsonMarshal is mocked to return an error
+		mocks.Shims.JsonMarshal = func(v any) ([]byte, error) {
+			return nil, fmt.Errorf("json marshal error")
+		}
+
+		templateValues := make(map[string]map[string]any)
+
+		// When processJsonnetTemplate is called
+		err := generator.processJsonnetTemplate("/template/test.jsonnet", "test-context", templateValues)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+
+		// And the error should contain the expected message
+		if !strings.Contains(err.Error(), "error marshalling context map to JSON") {
+			t.Errorf("expected error to contain 'error marshalling context map to JSON', got %v", err)
+		}
+	})
+
+	t.Run("ErrorEvaluatingJsonnet", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And ReadFile is mocked to return invalid jsonnet content
+		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
+			return []byte(`invalid jsonnet syntax {`), nil
+		}
+
+		// Mock the required dependencies
+		mocks.ConfigHandler.(*config.MockConfigHandler).YamlMarshalWithDefinedPathsFunc = func(config any) ([]byte, error) {
+			return []byte("test: config"), nil
+		}
+
+		mocks.Shims.YamlUnmarshal = func(data []byte, v any) error {
+			if configMap, ok := v.(*map[string]any); ok {
+				*configMap = map[string]any{"test": "config"}
+			}
+			return nil
+		}
+
+		mocks.Shims.JsonMarshal = func(v any) ([]byte, error) {
+			return []byte(`{"test": "config", "name": "test-context"}`), nil
+		}
+
+		templateValues := make(map[string]map[string]any)
+
+		// When processJsonnetTemplate is called
+		err := generator.processJsonnetTemplate("/template/test.jsonnet", "test-context", templateValues)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+
+		// And the error should contain the expected message
+		if !strings.Contains(err.Error(), "error evaluating jsonnet template") {
+			t.Errorf("expected error to contain 'error evaluating jsonnet template', got %v", err)
+		}
+	})
+
+	t.Run("ErrorUnmarshallingJsonnetResult", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And ReadFile is mocked to return jsonnet that produces valid output
+		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
+			return []byte(`{
+  test_var: "test_value"
+}`), nil
+		}
+
+		// Mock the required dependencies
+		mocks.ConfigHandler.(*config.MockConfigHandler).YamlMarshalWithDefinedPathsFunc = func(config any) ([]byte, error) {
+			return []byte("test: config"), nil
+		}
+
+		mocks.Shims.YamlUnmarshal = func(data []byte, v any) error {
+			if configMap, ok := v.(*map[string]any); ok {
+				*configMap = map[string]any{"test": "config"}
+			}
+			return nil
+		}
+
+		mocks.Shims.JsonMarshal = func(v any) ([]byte, error) {
+			return []byte(`{"test": "config", "name": "test-context"}`), nil
+		}
+
+		// And JsonUnmarshal is mocked to return an error
+		mocks.Shims.JsonUnmarshal = func(data []byte, v any) error {
+			return fmt.Errorf("json unmarshal error")
+		}
+
+		templateValues := make(map[string]map[string]any)
+
+		// When processJsonnetTemplate is called
+		err := generator.processJsonnetTemplate("/template/test.jsonnet", "test-context", templateValues)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+
+		// And the error should contain the expected message
+		if !strings.Contains(err.Error(), "jsonnet template must output valid JSON") {
+			t.Errorf("expected error to contain 'jsonnet template must output valid JSON', got %v", err)
+		}
+	})
+
+	t.Run("ErrorGettingProjectRoot", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And Shell.GetProjectRoot is mocked to return an error
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return "", fmt.Errorf("project root error")
+		}
+
+		// And ReadFile is mocked to return valid jsonnet content
+		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
+			return []byte(`{
+  test_var: "test_value"
+}`), nil
+		}
+
+		// Mock the required dependencies
+		mocks.ConfigHandler.(*config.MockConfigHandler).YamlMarshalWithDefinedPathsFunc = func(config any) ([]byte, error) {
+			return []byte("test: config"), nil
+		}
+
+		mocks.Shims.YamlUnmarshal = func(data []byte, v any) error {
+			if configMap, ok := v.(*map[string]any); ok {
+				*configMap = map[string]any{"test": "config"}
+			}
+			return nil
+		}
+
+		mocks.Shims.JsonMarshal = func(v any) ([]byte, error) {
+			return []byte(`{"test": "config", "name": "test-context"}`), nil
+		}
+
+		mocks.Shims.JsonUnmarshal = func(data []byte, v any) error {
+			if values, ok := v.(*map[string]any); ok {
+				*values = map[string]any{"test_var": "test_value"}
+			}
+			return nil
+		}
+
+		templateValues := make(map[string]map[string]any)
+
+		// When processJsonnetTemplate is called
+		err := generator.processJsonnetTemplate("/template/test.jsonnet", "test-context", templateValues)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+
+		// And the error should contain the expected message
+		if !strings.Contains(err.Error(), "failed to get project root") {
+			t.Errorf("expected error to contain 'failed to get project root', got %v", err)
+		}
+	})
+
+	t.Run("ErrorCalculatingRelativePath", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And Shell.GetProjectRoot is mocked to return expected path
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return "/tmp", nil
+		}
+
+		// And ReadFile is mocked to return valid jsonnet content
+		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
+			return []byte(`{
+  test_var: "test_value"
+}`), nil
+		}
+
+		// Mock the required dependencies
+		mocks.ConfigHandler.(*config.MockConfigHandler).YamlMarshalWithDefinedPathsFunc = func(config any) ([]byte, error) {
+			return []byte("test: config"), nil
+		}
+
+		mocks.Shims.YamlUnmarshal = func(data []byte, v any) error {
+			if configMap, ok := v.(*map[string]any); ok {
+				*configMap = map[string]any{"test": "config"}
+			}
+			return nil
+		}
+
+		mocks.Shims.JsonMarshal = func(v any) ([]byte, error) {
+			return []byte(`{"test": "config", "name": "test-context"}`), nil
+		}
+
+		mocks.Shims.JsonUnmarshal = func(data []byte, v any) error {
+			if values, ok := v.(*map[string]any); ok {
+				*values = map[string]any{"test_var": "test_value"}
+			}
+			return nil
+		}
+
+		// And FilepathRel is mocked to return an error
+		mocks.Shims.FilepathRel = func(basepath, targpath string) (string, error) {
+			return "", fmt.Errorf("relative path calculation error")
+		}
+
+		templateValues := make(map[string]map[string]any)
+
+		// When processJsonnetTemplate is called
+		err := generator.processJsonnetTemplate("/template/test.jsonnet", "test-context", templateValues)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+
+		// And the error should contain the expected message
+		if !strings.Contains(err.Error(), "failed to calculate relative path") {
+			t.Errorf("expected error to contain 'failed to calculate relative path', got %v", err)
+		}
+	})
+
+	t.Run("SuccessProcessingTemplate", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And Shell.GetProjectRoot is mocked to return expected path
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return "/tmp", nil
+		}
+
+		// And ReadFile is mocked to return valid jsonnet content
+		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
+			return []byte(`local context = std.extVar("context");
+{
+  test_var: context.test,
+  context_name: context.name
+}`), nil
+		}
+
+		// Mock the required dependencies
+		mocks.ConfigHandler.(*config.MockConfigHandler).YamlMarshalWithDefinedPathsFunc = func(config any) ([]byte, error) {
+			return []byte("test: config"), nil
+		}
+
+		mocks.Shims.YamlUnmarshal = func(data []byte, v any) error {
+			if configMap, ok := v.(*map[string]any); ok {
+				*configMap = map[string]any{"test": "config"}
+			}
+			return nil
+		}
+
+		mocks.Shims.JsonMarshal = func(v any) ([]byte, error) {
+			return []byte(`{"test": "config", "name": "test-context"}`), nil
+		}
+
+		mocks.Shims.JsonUnmarshal = func(data []byte, v any) error {
+			if values, ok := v.(*map[string]any); ok {
+				*values = map[string]any{
+					"test_var":     "config",
+					"context_name": "test-context",
+				}
+			}
+			return nil
+		}
+
+		templateValues := make(map[string]map[string]any)
+
+		// When processJsonnetTemplate is called
+		err := generator.processJsonnetTemplate("/tmp/contexts/_template/terraform/test.jsonnet", "test-context", templateValues)
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		// And template values should contain the processed template
+		if len(templateValues) != 1 {
+			t.Errorf("expected 1 template value, got %d", len(templateValues))
+		}
+		if _, exists := templateValues["test"]; !exists {
+			t.Errorf("expected template values to contain 'test' key")
+		}
+
+		// And the values should match expected content
+		values := templateValues["test"]
+		if values["test_var"] != "config" {
+			t.Errorf("expected test_var to be 'config', got %v", values["test_var"])
+		}
+		if values["context_name"] != "test-context" {
+			t.Errorf("expected context_name to be 'test-context', got %v", values["context_name"])
+		}
+	})
+
+	t.Run("SuccessWithNestedPath", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And Shell.GetProjectRoot is mocked to return expected path
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return "/tmp", nil
+		}
+
+		// And ReadFile is mocked to return valid jsonnet content
+		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
+			return []byte(`{
+  nested_var: "nested_value"
+}`), nil
+		}
+
+		// Mock the required dependencies
+		mocks.ConfigHandler.(*config.MockConfigHandler).YamlMarshalWithDefinedPathsFunc = func(config any) ([]byte, error) {
+			return []byte("test: config"), nil
+		}
+
+		mocks.Shims.YamlUnmarshal = func(data []byte, v any) error {
+			if configMap, ok := v.(*map[string]any); ok {
+				*configMap = map[string]any{"test": "config"}
+			}
+			return nil
+		}
+
+		mocks.Shims.JsonMarshal = func(v any) ([]byte, error) {
+			return []byte(`{"test": "config", "name": "test-context"}`), nil
+		}
+
+		mocks.Shims.JsonUnmarshal = func(data []byte, v any) error {
+			if values, ok := v.(*map[string]any); ok {
+				*values = map[string]any{"nested_var": "nested_value"}
+			}
+			return nil
+		}
+
+		templateValues := make(map[string]map[string]any)
+
+		// When processJsonnetTemplate is called with nested path
+		err := generator.processJsonnetTemplate("/tmp/contexts/_template/terraform/nested/path/component.jsonnet", "test-context", templateValues)
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		// And template values should contain the processed template with nested key
+		if len(templateValues) != 1 {
+			t.Errorf("expected 1 template value, got %d", len(templateValues))
+		}
+		if _, exists := templateValues["nested/path/component"]; !exists {
+			t.Errorf("expected template values to contain 'nested/path/component' key")
+		}
+	})
+}
+
 func TestTerraformGenerator_generateModuleShim(t *testing.T) {
 	setup := func(t *testing.T) (*TerraformGenerator, *Mocks) {
 		mocks := setupMocks(t)
@@ -1044,7 +1705,7 @@ func TestTerraformGenerator_generateModuleShim(t *testing.T) {
 		}
 
 		// When generateModuleShim is called
-		err := generator.generateModuleShim(component)
+		err := generator.generateModuleShim(component, make(map[string][]byte))
 
 		// Then no error should occur
 		if err != nil {
@@ -1069,7 +1730,7 @@ func TestTerraformGenerator_generateModuleShim(t *testing.T) {
 		}
 
 		// When generateModuleShim is called
-		err := generator.generateModuleShim(component)
+		err := generator.generateModuleShim(component, make(map[string][]byte))
 
 		// Then an error should be returned
 		if err == nil {
@@ -1100,7 +1761,7 @@ func TestTerraformGenerator_generateModuleShim(t *testing.T) {
 		}
 
 		// When generateModuleShim is called
-		err := generator.generateModuleShim(component)
+		err := generator.generateModuleShim(component, make(map[string][]byte))
 
 		// Then an error should be returned
 		if err == nil {
@@ -1131,7 +1792,7 @@ func TestTerraformGenerator_generateModuleShim(t *testing.T) {
 		}
 
 		// When generateModuleShim is called
-		err := generator.generateModuleShim(component)
+		err := generator.generateModuleShim(component, make(map[string][]byte))
 
 		// Then an error should be returned
 		if err == nil {
@@ -1162,7 +1823,7 @@ func TestTerraformGenerator_generateModuleShim(t *testing.T) {
 		}
 
 		// When generateModuleShim is called
-		err := generator.generateModuleShim(component)
+		err := generator.generateModuleShim(component, make(map[string][]byte))
 
 		// Then an error should be returned
 		if err == nil {
@@ -1193,7 +1854,7 @@ func TestTerraformGenerator_generateModuleShim(t *testing.T) {
 		}
 
 		// When generateModuleShim is called
-		err := generator.generateModuleShim(component)
+		err := generator.generateModuleShim(component, make(map[string][]byte))
 
 		// Then an error should be returned
 		if err == nil {
@@ -1241,7 +1902,7 @@ func TestTerraformGenerator_generateModuleShim(t *testing.T) {
 		}
 
 		// When generateModuleShim is called
-		err := generator.generateModuleShim(component)
+		err := generator.generateModuleShim(component, make(map[string][]byte))
 
 		// Then an error should be returned
 		if err == nil {
@@ -1300,7 +1961,7 @@ func TestTerraformGenerator_generateModuleShim(t *testing.T) {
 		}
 
 		// When generateModuleShim is called
-		err := generator.generateModuleShim(component)
+		err := generator.generateModuleShim(component, make(map[string][]byte))
 
 		// Then an error should be returned
 		if err == nil {
@@ -1359,7 +2020,7 @@ func TestTerraformGenerator_generateModuleShim(t *testing.T) {
 		}
 
 		// When generateModuleShim is called
-		err := generator.generateModuleShim(component)
+		err := generator.generateModuleShim(component, make(map[string][]byte))
 
 		// Then an error should be returned
 		if err == nil {
@@ -1423,7 +2084,7 @@ func TestTerraformGenerator_generateModuleShim(t *testing.T) {
 		}
 
 		// When generateModuleShim is called
-		err := generator.generateModuleShim(component)
+		err := generator.generateModuleShim(component, make(map[string][]byte))
 
 		// Then an error should be returned
 		if err == nil {
@@ -1477,7 +2138,7 @@ func TestTerraformGenerator_generateModuleShim(t *testing.T) {
 		}
 
 		// When generateModuleShim is called
-		err := generator.generateModuleShim(component)
+		err := generator.generateModuleShim(component, make(map[string][]byte))
 
 		// Then no error should occur
 		if err != nil {
@@ -1521,7 +2182,7 @@ func TestTerraformGenerator_generateModuleShim(t *testing.T) {
 		}
 
 		// When generateModuleShim is called
-		err := generator.generateModuleShim(component)
+		err := generator.generateModuleShim(component, make(map[string][]byte))
 
 		// Then no error should occur
 		if err != nil {
@@ -1559,7 +2220,7 @@ func TestTerraformGenerator_generateModuleShim(t *testing.T) {
 		}
 
 		// When generateModuleShim is called
-		err := generator.generateModuleShim(component)
+		err := generator.generateModuleShim(component, make(map[string][]byte))
 
 		// Then an error should be returned
 		if err == nil {
@@ -1612,7 +2273,7 @@ func TestTerraformGenerator_generateModuleShim(t *testing.T) {
 		}()
 
 		// When generateModuleShim is called
-		err := generator.generateModuleShim(component)
+		err := generator.generateModuleShim(component, make(map[string][]byte))
 
 		// Then no error should be returned because the function handles missing files
 		if err != nil {
@@ -1639,7 +2300,7 @@ func TestTerraformGenerator_generateModuleShim(t *testing.T) {
 			}
 			return nil, fmt.Errorf("unexpected file read: %s", path)
 		}
-		err := generator.generateModuleShim(component)
+		err := generator.generateModuleShim(component, make(map[string][]byte))
 		if err != nil {
 			t.Errorf("expected no error, got %v", err)
 		}
@@ -1664,7 +2325,7 @@ func TestTerraformGenerator_generateModuleShim(t *testing.T) {
 			}
 			return nil, fmt.Errorf("unexpected file read: %s", path)
 		}
-		err := generator.generateModuleShim(component)
+		err := generator.generateModuleShim(component, make(map[string][]byte))
 		if err != nil {
 			t.Errorf("expected no error, got %v", err)
 		}
@@ -1689,7 +2350,7 @@ func TestTerraformGenerator_generateModuleShim(t *testing.T) {
 			}
 			return nil, fmt.Errorf("unexpected file read: %s", path)
 		}
-		err := generator.generateModuleShim(component)
+		err := generator.generateModuleShim(component, make(map[string][]byte))
 		if err != nil {
 			t.Errorf("expected no error, got %v", err)
 		}
@@ -1714,7 +2375,7 @@ func TestTerraformGenerator_generateModuleShim(t *testing.T) {
 			}
 			return nil, fmt.Errorf("unexpected file read: %s", path)
 		}
-		err := generator.generateModuleShim(component)
+		err := generator.generateModuleShim(component, make(map[string][]byte))
 		if err != nil {
 			t.Errorf("expected no error, got %v", err)
 		}
@@ -1739,7 +2400,7 @@ func TestTerraformGenerator_generateModuleShim(t *testing.T) {
 			}
 			return nil, fmt.Errorf("unexpected file read: %s", path)
 		}
-		err := generator.generateModuleShim(component)
+		err := generator.generateModuleShim(component, make(map[string][]byte))
 		if err != nil {
 			t.Errorf("expected no error, got %v", err)
 		}
@@ -1764,11 +2425,92 @@ func TestTerraformGenerator_generateModuleShim(t *testing.T) {
 			}
 			return nil, fmt.Errorf("unexpected file read: %s", path)
 		}
-		err := generator.generateModuleShim(component)
+		err := generator.generateModuleShim(component, make(map[string][]byte))
 		if err != nil {
 			t.Errorf("expected no error, got %v", err)
 		}
 	})
+
+	t.Run("SuccessWithOCISource", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And a component with OCI source
+		component := blueprintv1alpha1.TerraformComponent{
+			Source:   "core-oci",
+			Path:     "cluster/talos",
+			FullPath: "/project/terraform/cluster/talos",
+		}
+
+		// And blueprint handler returns OCI sources
+		mocks.BlueprintHandler.GetSourcesFunc = func() []blueprintv1alpha1.Source {
+			return []blueprintv1alpha1.Source{
+				{
+					Name: "core-oci",
+					Url:  "oci://ghcr.io/windsorcli/core:v0.0.1",
+				},
+			}
+		}
+
+		// And shell GetProjectRoot returns project root
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return "/project", nil
+		}
+
+		// And FilepathRel calculates relative path
+		mocks.Shims.FilepathRel = func(basepath, targpath string) (string, error) {
+			return "../../../.windsor/.oci_extracted/ghcr.io-windsorcli_core-v0.0.1/terraform/cluster/talos", nil
+		}
+
+		// And the extracted module path exists
+		mocks.Shims.Stat = func(path string) (fs.FileInfo, error) {
+			if strings.Contains(path, ".oci_extracted") {
+				return &mockFileInfo{name: "talos", isDir: true}, nil
+			}
+			return nil, os.ErrNotExist
+		}
+
+		// And ReadFile returns content from extracted module
+		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
+			if strings.HasSuffix(path, "variables.tf") {
+				return []byte(`variable "cluster_name" {
+  description = "Name of the Talos cluster"
+  type        = string
+}`), nil
+			}
+			if strings.HasSuffix(path, "outputs.tf") {
+				return []byte(`output "cluster_endpoint" {
+  description = "Cluster endpoint"
+  value       = "https://cluster.example.com"
+}`), nil
+			}
+			return nil, fmt.Errorf("unexpected file read: %s", path)
+		}
+
+		// And MkdirAll is mocked to avoid filesystem operations
+		mocks.Shims.MkdirAll = func(path string, perm fs.FileMode) error {
+			return nil
+		}
+
+		// And WriteFile is mocked to avoid filesystem operations
+		mocks.Shims.WriteFile = func(path string, data []byte, perm fs.FileMode) error {
+			return nil
+		}
+
+		// And ociArtifacts contains pre-extracted data
+		ociArtifacts := map[string][]byte{
+			"ghcr.io/windsorcli/core:v0.0.1": []byte("mock-artifact-data"),
+		}
+
+		// When generateModuleShim is called with OCI source
+		err := generator.generateModuleShim(component, ociArtifacts)
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
 }
 
 func TestTerraformGenerator_writeModuleFile(t *testing.T) {
@@ -2294,199 +3036,6 @@ func TestTerraformGenerator_addTfvarsHeader(t *testing.T) {
 	})
 }
 
-func Test_formatValue(t *testing.T) {
-	t.Run("EmptyArray", func(t *testing.T) {
-		result := formatValue([]any{})
-		if result != "[]" {
-			t.Errorf("expected [] got %q", result)
-		}
-	})
-	t.Run("EmptyMap", func(t *testing.T) {
-		result := formatValue(map[string]any{})
-		if result != "{}" {
-			t.Errorf("expected {} got %q", result)
-		}
-	})
-	t.Run("NilValue", func(t *testing.T) {
-		result := formatValue(nil)
-		if result != "null" {
-			t.Errorf("expected null got %q", result)
-		}
-	})
-	t.Run("ComplexNestedObject", func(t *testing.T) {
-		input := map[string]any{
-			"node_groups": map[string]any{
-				"default": map[string]any{
-					"instance_types": []any{"t3.medium"},
-					"min_size":       1,
-					"max_size":       3,
-					"desired_size":   2,
-				},
-			},
-		}
-		expected := `{
-  node_groups = {
-    default = {
-      desired_size = 2
-      instance_types = ["t3.medium"]
-      max_size = 3
-      min_size = 1
-    }
-  }
-}`
-		result := formatValue(input)
-		if result != expected {
-			t.Errorf("expected %q, got %q", expected, result)
-		}
-	})
-	t.Run("EmptyAddons", func(t *testing.T) {
-		input := map[string]any{
-			"addons": map[string]any{
-				"vpc-cni":                map[string]any{},
-				"aws-efs-csi-driver":     map[string]any{},
-				"aws-ebs-csi-driver":     map[string]any{},
-				"eks-pod-identity-agent": map[string]any{},
-				"coredns":                map[string]any{},
-				"external-dns":           map[string]any{},
-			},
-		}
-		expected := `{
-  addons = {
-    aws-ebs-csi-driver = {}
-    aws-efs-csi-driver = {}
-    coredns = {}
-    eks-pod-identity-agent = {}
-    external-dns = {}
-    vpc-cni = {}
-  }
-}`
-		result := formatValue(input)
-		if result != expected {
-			t.Errorf("expected %q, got %q", expected, result)
-		}
-	})
-}
-
-func Test_writeVariable(t *testing.T) {
-	t.Run("ComplexObject_node_groups", func(t *testing.T) {
-		file := hclwrite.NewEmptyFile()
-		writeVariable(file.Body(), "node_groups", map[string]any{
-			"node_groups": map[string]any{
-				"default": map[string]any{
-					"instance_types": []any{"t3.medium"},
-					"min_size":       1,
-					"max_size":       3,
-					"desired_size":   2,
-				},
-			},
-		}, nil)
-		expected := "node_groups = {\n  node_groups = {\n    default = {\n      desired_size = 2\n      instance_types = [\"t3.medium\"]\n      max_size = 3\n      min_size = 1\n    }\n  }\n}"
-		result := strings.TrimSpace(string(file.Bytes()))
-		if result != expected {
-			t.Errorf("expected\n%s\ngot\n%s", expected, result)
-		}
-	})
-	t.Run("ComplexObject_addons", func(t *testing.T) {
-		file := hclwrite.NewEmptyFile()
-		writeVariable(file.Body(), "addons", map[string]any{
-			"addons": map[string]any{
-				"vpc-cni":                map[string]any{},
-				"aws-efs-csi-driver":     map[string]any{},
-				"aws-ebs-csi-driver":     map[string]any{},
-				"eks-pod-identity-agent": map[string]any{},
-				"coredns":                map[string]any{},
-				"external-dns":           map[string]any{},
-			},
-		}, nil)
-		expected := "addons = {\n  addons = {\n    aws-ebs-csi-driver = {}\n    aws-efs-csi-driver = {}\n    coredns = {}\n    eks-pod-identity-agent = {}\n    external-dns = {}\n    vpc-cni = {}\n  }\n}"
-		result := strings.TrimSpace(string(file.Bytes()))
-		if result != expected {
-			t.Errorf("expected\n%s\ngot\n%s", expected, result)
-		}
-	})
-	t.Run("ObjectAssignment_no_heredoc", func(t *testing.T) {
-		file := hclwrite.NewEmptyFile()
-		value := map[string]any{
-			"default": map[string]any{
-				"desired_size":   2,
-				"instance_types": []any{"t3.medium"},
-				"max_size":       3,
-				"min_size":       1,
-			},
-		}
-		writeVariable(file.Body(), "node_groups", value, nil)
-		expected := "node_groups = {\n  default = {\n    desired_size = 2\n    instance_types = [\"t3.medium\"]\n    max_size = 3\n    min_size = 1\n  }\n}"
-		result := strings.TrimSpace(string(file.Bytes()))
-		if result != expected {
-			t.Errorf("expected\n%s\ngot\n%s", expected, result)
-		}
-	})
-}
-
-func Test_writeComponentValues(t *testing.T) {
-	t.Run("ComplexDefaults_NodeGroups", func(t *testing.T) {
-		file := hclwrite.NewEmptyFile()
-		variable := VariableInfo{
-			Name:        "node_groups",
-			Description: "Map of EKS managed node group definitions to create.",
-			Default: map[string]any{
-				"default": map[string]any{
-					"instance_types": []any{"t3.medium"},
-					"min_size":       1,
-					"max_size":       3,
-					"desired_size":   2,
-				},
-			},
-		}
-		writeComponentValues(file.Body(), map[string]any{}, map[string]bool{}, []VariableInfo{variable})
-		expected := `
-# Map of EKS managed node group definitions to create.
-# node_groups = {
-#   default = {
-#     desired_size = 2
-#     instance_types = ["t3.medium"]
-#     max_size = 3
-#     min_size = 1
-#   }
-# }`
-		result := string(file.Bytes())
-		// Check that every line is commented
-		for _, line := range strings.Split(result, "\n") {
-			if strings.TrimSpace(line) == "" {
-				continue
-			}
-			if !strings.HasPrefix(line, "#") {
-				t.Errorf("uncommented line found: %q", line)
-			}
-		}
-		// Check that the output matches expected ignoring leading/trailing whitespace
-		if strings.TrimSpace(result) != strings.TrimSpace(expected) {
-			t.Errorf("expected\n%s\ngot\n%s", expected, result)
-		}
-	})
-	t.Run("ComplexDefaults_EmptyAddons", func(t *testing.T) {
-		file := hclwrite.NewEmptyFile()
-		variable := VariableInfo{
-			Name:        "addons",
-			Description: "Map of EKS add-ons",
-			Default: map[string]any{
-				"vpc-cni":                map[string]any{},
-				"aws-efs-csi-driver":     map[string]any{},
-				"aws-ebs-csi-driver":     map[string]any{},
-				"eks-pod-identity-agent": map[string]any{},
-				"coredns":                map[string]any{},
-				"external-dns":           map[string]any{},
-			},
-		}
-		writeComponentValues(file.Body(), map[string]any{}, map[string]bool{}, []VariableInfo{variable})
-		expected := "\n# Map of EKS add-ons\n# addons = {\n#   aws-ebs-csi-driver = {}\n#   aws-efs-csi-driver = {}\n#   coredns = {}\n#   eks-pod-identity-agent = {}\n#   external-dns = {}\n#   vpc-cni = {}\n# }\n"
-		result := string(file.Bytes())
-		if result != expected {
-			t.Errorf("expected %q, got %q", expected, result)
-		}
-	})
-}
-
 func TestTerraformGenerator_writeShimVariablesTf(t *testing.T) {
 	setup := func(t *testing.T) (*TerraformGenerator, *Mocks) {
 		mocks := setupMocks(t)
@@ -2745,11 +3294,7 @@ func TestTerraformGenerator_writeShimOutputsTf(t *testing.T) {
 	})
 }
 
-// =============================================================================
-// Test Template Processing Methods
-// =============================================================================
-
-func TestTerraformGenerator_processTemplates(t *testing.T) {
+func TestTerraformGenerator_isOCISource(t *testing.T) {
 	setup := func(t *testing.T) (*TerraformGenerator, *Mocks) {
 		mocks := setupMocks(t)
 		generator := NewTerraformGenerator(mocks.Injector)
@@ -2760,366 +3305,76 @@ func TestTerraformGenerator_processTemplates(t *testing.T) {
 		return generator, mocks
 	}
 
-	t.Run("TemplateDirectoryNotExists", func(t *testing.T) {
+	t.Run("DirectOCIURL", func(t *testing.T) {
 		// Given a TerraformGenerator with mocks
-		generator, mocks := setup(t)
+		generator, _ := setup(t)
 
-		// And Stat is mocked to return os.ErrNotExist for template directory
-		mocks.Shims.Stat = func(path string) (fs.FileInfo, error) {
-			if strings.Contains(path, "_template") {
-				return nil, os.ErrNotExist
-			}
-			return nil, nil
-		}
+		// When isOCISource is called with a direct OCI URL
+		result := generator.isOCISource("oci://registry.example.com/repo:tag")
 
-		// When processTemplates is called
-		result, err := generator.processTemplates(false)
-
-		// Then no error should occur and result should be nil
-		if err != nil {
-			t.Errorf("expected no error, got %v", err)
-		}
-		if result != nil {
-			t.Errorf("expected nil result, got %v", result)
+		// Then it should return true
+		if !result {
+			t.Error("expected isOCISource to return true for direct OCI URL")
 		}
 	})
 
-	t.Run("ErrorCheckingTemplateDirectory", func(t *testing.T) {
+	t.Run("NamedOCISource", func(t *testing.T) {
 		// Given a TerraformGenerator with mocks
 		generator, mocks := setup(t)
-
-		// And Stat is mocked to return an error for template directory
-		mocks.Shims.Stat = func(path string) (fs.FileInfo, error) {
-			if strings.Contains(path, "_template") {
-				return nil, fmt.Errorf("permission denied")
+		mockBH := mocks.Injector.Resolve("blueprintHandler").(*blueprint.MockBlueprintHandler)
+		mockBH.GetSourcesFunc = func() []blueprintv1alpha1.Source {
+			return []blueprintv1alpha1.Source{
+				{
+					Name: "oci-source",
+					Url:  "oci://registry.example.com/terraform-modules:v1.0.0",
+				},
 			}
-			return nil, nil
 		}
 
-		// When processTemplates is called
-		result, err := generator.processTemplates(false)
+		// When isOCISource is called with a named OCI source
+		result := generator.isOCISource("oci-source")
 
-		// Then an error should be returned
-		if err == nil {
-			t.Fatalf("expected an error, got nil")
-		}
-		if result != nil {
-			t.Errorf("expected nil result, got %v", result)
-		}
-
-		// And the error should contain the expected message
-		if !strings.Contains(err.Error(), "failed to check template directory") {
-			t.Errorf("expected error to contain 'failed to check template directory', got %v", err)
+		// Then it should return true
+		if !result {
+			t.Error("expected isOCISource to return true for named OCI source")
 		}
 	})
 
-	t.Run("ErrorGettingProjectRoot", func(t *testing.T) {
+	t.Run("NonOCISources", func(t *testing.T) {
 		// Given a TerraformGenerator with mocks
 		generator, mocks := setup(t)
-
-		// And Shell.GetProjectRoot is mocked to return an error
-		mocks.Shell.GetProjectRootFunc = func() (string, error) {
-			return "", fmt.Errorf("project root error")
-		}
-
-		// When processTemplates is called
-		result, err := generator.processTemplates(false)
-
-		// Then an error should be returned
-		if err == nil {
-			t.Fatalf("expected an error, got nil")
-		}
-		if result != nil {
-			t.Errorf("expected nil result, got %v", result)
-		}
-
-		// And the error should contain the expected message
-		if !strings.Contains(err.Error(), "failed to get project root") {
-			t.Errorf("expected error to contain 'failed to get project root', got %v", err)
-		}
-	})
-
-	t.Run("SuccessWithEmptyDirectory", func(t *testing.T) {
-		// Given a TerraformGenerator with mocks
-		generator, mocks := setup(t)
-
-		// And Stat is mocked to return success for template directory
-		mocks.Shims.Stat = func(path string) (fs.FileInfo, error) {
-			if strings.Contains(path, "_template") {
-				return nil, nil
+		mockBH := mocks.Injector.Resolve("blueprintHandler").(*blueprint.MockBlueprintHandler)
+		mockBH.GetSourcesFunc = func() []blueprintv1alpha1.Source {
+			return []blueprintv1alpha1.Source{
+				{
+					Name: "git-source",
+					Url:  "git::https://github.com/example/repo.git",
+				},
 			}
-			return nil, nil
 		}
 
-		// And ReadDir is mocked to return empty directory
-		mocks.Shims.ReadDir = func(path string) ([]fs.DirEntry, error) {
-			return []fs.DirEntry{}, nil
+		testCases := []string{
+			"/path/to/.oci_extracted/module",
+			"git::https://github.com/example/repo.git",
+			"./local/path",
+			"git-source",
+			"unknown-source",
+			"",
 		}
 
-		// When processTemplates is called
-		result, err := generator.processTemplates(false)
+		for _, source := range testCases {
+			// When isOCISource is called
+			result := generator.isOCISource(source)
 
-		// Then no error should occur
-		if err != nil {
-			t.Errorf("expected no error, got %v", err)
-		}
-
-		// And result should be an empty map
-		if result == nil {
-			t.Errorf("expected non-nil result, got nil")
-		}
-		if len(result) != 0 {
-			t.Errorf("expected empty result, got %v", result)
-		}
-	})
-
-	t.Run("ProcessesJsonnetFiles", func(t *testing.T) {
-		// Given a TerraformGenerator with mocks
-		generator, mocks := setup(t)
-
-		// Create a simple mock for fs.DirEntry with jsonnet file
-		mockEntry := &simpleDirEntry{name: "test.jsonnet", isDir: false}
-
-		// And ReadDir is mocked to return a jsonnet file
-		mocks.Shims.ReadDir = func(path string) ([]fs.DirEntry, error) {
-			return []fs.DirEntry{mockEntry}, nil
-		}
-
-		// Mock all dependencies for processJsonnetTemplate
-		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
-			return []byte(`{
-  test_var: "test_value"
-}`), nil
-		}
-
-		mocks.ConfigHandler.(*config.MockConfigHandler).YamlMarshalWithDefinedPathsFunc = func(config any) ([]byte, error) {
-			return []byte("test: config"), nil
-		}
-
-		mocks.Shims.YamlUnmarshal = func(data []byte, v any) error {
-			if configMap, ok := v.(*map[string]any); ok {
-				*configMap = map[string]any{"test": "config"}
+			// Then it should return false
+			if result {
+				t.Errorf("expected isOCISource to return false for %s", source)
 			}
-			return nil
 		}
-
-		mocks.Shims.JsonMarshal = func(v any) ([]byte, error) {
-			return []byte(`{"test": "config", "name": "test-context"}`), nil
-		}
-
-		mocks.Shims.JsonUnmarshal = func(data []byte, v any) error {
-			if values, ok := v.(*map[string]any); ok {
-				*values = map[string]any{"test_var": "test_value"}
-			}
-			return nil
-		}
-
-		mocks.Shell.GetProjectRootFunc = func() (string, error) {
-			return "/tmp", nil
-		}
-
-		templateValues := make(map[string]map[string]any)
-
-		// When walkTemplateDirectory is called
-		err := generator.walkTemplateDirectory("/tmp/contexts/_template/terraform", "/context/path", "test-context", false, templateValues)
-
-		// Then no error should occur
-		if err != nil {
-			t.Errorf("expected no error, got %v", err)
-		}
-
-		// And template values should contain the processed template
-		if len(templateValues) != 1 {
-			t.Errorf("expected 1 template value, got %d", len(templateValues))
-		}
-	})
-
-	t.Run("ErrorProcessingJsonnetTemplate", func(t *testing.T) {
-		// Given a TerraformGenerator with mocks
-		generator, mocks := setup(t)
-
-		// Create a simple mock for fs.DirEntry with jsonnet file
-		mockEntry := &simpleDirEntry{name: "test.jsonnet", isDir: false}
-
-		// And ReadDir is mocked to return a jsonnet file
-		mocks.Shims.ReadDir = func(path string) ([]fs.DirEntry, error) {
-			return []fs.DirEntry{mockEntry}, nil
-		}
-
-		// And ReadFile is mocked to return an error for processJsonnetTemplate
-		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
-			return nil, fmt.Errorf("file read error")
-		}
-
-		templateValues := make(map[string]map[string]any)
-
-		// When walkTemplateDirectory is called
-		err := generator.walkTemplateDirectory("/template/dir", "/context/path", "test-context", false, templateValues)
-
-		// Then an error should be returned
-		if err == nil {
-			t.Fatalf("expected an error, got nil")
-		}
-
-		// And the error should contain the expected message
-		if !strings.Contains(err.Error(), "error reading template file") {
-			t.Errorf("expected error to contain 'error reading template file', got %v", err)
-		}
-	})
-
-	t.Run("RecursivelyProcessesDirectories", func(t *testing.T) {
-		// Given a TerraformGenerator with mocks
-		generator, mocks := setup(t)
-
-		callCount := 0
-		// Create mock directory entry
-		mockDirEntry := &simpleDirEntry{name: "subdir", isDir: true}
-
-		// And ReadDir is mocked to return a directory on first call, empty on second
-		mocks.Shims.ReadDir = func(path string) ([]fs.DirEntry, error) {
-			callCount++
-			if callCount == 1 {
-				return []fs.DirEntry{mockDirEntry}, nil
-			}
-			return []fs.DirEntry{}, nil // Empty subdirectory
-		}
-
-		templateValues := make(map[string]map[string]any)
-
-		// When walkTemplateDirectory is called
-		err := generator.walkTemplateDirectory("/template/dir", "/context/path", "test-context", false, templateValues)
-
-		// Then no error should occur
-		if err != nil {
-			t.Errorf("expected no error, got %v", err)
-		}
-
-		// And ReadDir should have been called twice (once for root, once for subdir)
-		if callCount != 2 {
-			t.Errorf("expected ReadDir to be called 2 times, got %d", callCount)
-		}
-	})
-
-	t.Run("ErrorInRecursiveDirectoryCall", func(t *testing.T) {
-		// Given a TerraformGenerator with mocks
-		generator, mocks := setup(t)
-
-		callCount := 0
-		// Create mock directory entry
-		mockDirEntry := &simpleDirEntry{name: "subdir", isDir: true}
-
-		// And ReadDir is mocked to return a directory on first call, error on second
-		mocks.Shims.ReadDir = func(path string) ([]fs.DirEntry, error) {
-			callCount++
-			if callCount == 1 {
-				return []fs.DirEntry{mockDirEntry}, nil
-			}
-			return nil, fmt.Errorf("subdirectory read error")
-		}
-
-		templateValues := make(map[string]map[string]any)
-
-		// When walkTemplateDirectory is called
-		err := generator.walkTemplateDirectory("/template/dir", "/context/path", "test-context", false, templateValues)
-
-		// Then an error should be returned
-		if err == nil {
-			t.Fatalf("expected an error, got nil")
-		}
-
-		// And the error should contain the expected message
-		if !strings.Contains(err.Error(), "failed to read template directory") {
-			t.Errorf("expected error to contain 'failed to read template directory', got %v", err)
-		}
-	})
-
-	t.Run("ErrorGettingConfigRoot", func(t *testing.T) {
-		// Given a TerraformGenerator with mocks
-		generator, mocks := setup(t)
-
-		// And Stat is mocked to return success for template directory
-		mocks.Shims.Stat = func(path string) (fs.FileInfo, error) {
-			if strings.Contains(path, "_template") {
-				return nil, nil
-			}
-			return nil, nil
-		}
-
-		// And GetConfigRoot is mocked to return an error
-		mocks.ConfigHandler.(*config.MockConfigHandler).GetConfigRootFunc = func() (string, error) {
-			return "", fmt.Errorf("config root error")
-		}
-
-		// When processTemplates is called
-		result, err := generator.processTemplates(false)
-
-		// Then an error should be returned
-		if err == nil {
-			t.Fatalf("expected an error, got nil")
-		}
-		if result != nil {
-			t.Errorf("expected nil result, got %v", result)
-		}
-
-		// And the error should contain the expected message
-		if !strings.Contains(err.Error(), "failed to get config root") {
-			t.Errorf("expected error to contain 'failed to get config root', got %v", err)
-		}
-	})
-
-	t.Run("UsesEnvironmentVariableForContextName", func(t *testing.T) {
-		// Given a TerraformGenerator with mocks
-		generator, mocks := setup(t)
-
-		// And Stat is mocked to return success for template directory
-		mocks.Shims.Stat = func(path string) (fs.FileInfo, error) {
-			if strings.Contains(path, "_template") {
-				return nil, nil
-			}
-			return nil, nil
-		}
-
-		// And ReadDir is mocked to return empty directory
-		mocks.Shims.ReadDir = func(path string) ([]fs.DirEntry, error) {
-			return []fs.DirEntry{}, nil
-		}
-
-		// And GetString is mocked to return empty string (no context configured)
-		mocks.ConfigHandler.(*config.MockConfigHandler).GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "context" {
-				return "" // No context configured
-			}
-			return ""
-		}
-
-		// Mock environment variable
-		originalEnv := os.Getenv("WINDSOR_CONTEXT")
-		os.Setenv("WINDSOR_CONTEXT", "env-context")
-		defer os.Setenv("WINDSOR_CONTEXT", originalEnv)
-
-		// When processTemplates is called
-		result, err := generator.processTemplates(false)
-
-		// Then no error should occur
-		if err != nil {
-			t.Errorf("expected no error, got %v", err)
-		}
-
-		// And result should be an empty map
-		if result == nil {
-			t.Errorf("expected non-nil result, got nil")
-		}
-		if len(result) != 0 {
-			t.Errorf("expected empty result, got %v", result)
-		}
-
-		// Note: The environment variable usage is tested by the fact that
-		// the function completes successfully and calls walkTemplateDirectory
-		// with the environment context name
 	})
 }
 
-func TestTerraformGenerator_processJsonnetTemplate(t *testing.T) {
+func TestTerraformGenerator_extractOCIModule(t *testing.T) {
 	setup := func(t *testing.T) (*TerraformGenerator, *Mocks) {
 		mocks := setupMocks(t)
 		generator := NewTerraformGenerator(mocks.Injector)
@@ -3130,479 +3385,449 @@ func TestTerraformGenerator_processJsonnetTemplate(t *testing.T) {
 		return generator, mocks
 	}
 
-	t.Run("ErrorReadingTemplateFile", func(t *testing.T) {
+	t.Run("ModuleAlreadyExtracted", func(t *testing.T) {
+		// Given a TerraformGenerator with existing extracted module
+		generator, mocks := setup(t)
+		mockBH := mocks.Injector.Resolve("blueprintHandler").(*blueprint.MockBlueprintHandler)
+		mockBH.GetSourcesFunc = func() []blueprintv1alpha1.Source {
+			return []blueprintv1alpha1.Source{
+				{Name: "test-source", Url: "oci://registry.example.com/modules:v1.0.0"},
+			}
+		}
+
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return "/tmp/project", nil
+		}
+
+		mocks.Shims.Stat = func(path string) (os.FileInfo, error) {
+			return nil, nil // Module already exists
+		}
+
+		// When extractOCIModule is called
+		result, err := generator.extractOCIModule("test-source", "test/module", make(map[string][]byte))
+
+		// Then it should return the existing path without error
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		expectedPath := "/tmp/project/.windsor/.oci_extracted/registry.example.com-modules-v1.0.0/terraform/test/module"
+		if result != expectedPath {
+			t.Errorf("expected path %s, got %s", expectedPath, result)
+		}
+	})
+
+	t.Run("SourceNotFound", func(t *testing.T) {
+		// Given a TerraformGenerator with no matching source
+		generator, mocks := setup(t)
+		mockBH := mocks.Injector.Resolve("blueprintHandler").(*blueprint.MockBlueprintHandler)
+		mockBH.GetSourcesFunc = func() []blueprintv1alpha1.Source {
+			return []blueprintv1alpha1.Source{}
+		}
+
+		// When extractOCIModule is called with unknown source
+		_, err := generator.extractOCIModule("unknown-source", "test/module", make(map[string][]byte))
+
+		// Then it should return an error
+		if err == nil {
+			t.Error("expected error for unknown source")
+		}
+		if !strings.Contains(err.Error(), "source unknown-source not found") {
+			t.Errorf("expected 'source not found' error, got %v", err)
+		}
+	})
+
+	t.Run("UsesCachedArtifact", func(t *testing.T) {
+		// Given a TerraformGenerator with cached OCI artifact
+		generator, mocks := setup(t)
+		mockBH := mocks.Injector.Resolve("blueprintHandler").(*blueprint.MockBlueprintHandler)
+		mockBH.GetSourcesFunc = func() []blueprintv1alpha1.Source {
+			return []blueprintv1alpha1.Source{
+				{Name: "test-source", Url: "oci://registry.example.com/modules:v1.0.0"},
+			}
+		}
+
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return "/tmp/project", nil
+		}
+
+		mocks.Shims.Stat = func(path string) (os.FileInfo, error) {
+			return nil, os.ErrNotExist // Module doesn't exist yet
+		}
+
+		// Mock tar extraction - create a minimal valid tar stream
+		mocks.Shims.NewBytesReader = func(data []byte) io.Reader {
+			// Create a minimal tar file with just an EOF
+			var buf bytes.Buffer
+			tw := tar.NewWriter(&buf)
+			tw.Close() // This creates a valid empty tar file
+			return bytes.NewReader(buf.Bytes())
+		}
+
+		mocks.Shims.NewTarReader = func(r io.Reader) *tar.Reader {
+			return tar.NewReader(r)
+		}
+
+		mocks.Shims.EOFError = func() error { return io.EOF }
+
+		// And cached artifact data
+		cachedData := []byte("mock tar data")
+		ociArtifacts := map[string][]byte{
+			"registry.example.com/modules:v1.0.0": cachedData,
+		}
+
+		// When extractOCIModule is called
+		result, err := generator.extractOCIModule("test-source", "test/module", ociArtifacts)
+
+		// Then it should succeed and return correct path (even with empty tar)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		expectedPath := "/tmp/project/.windsor/.oci_extracted/registry.example.com-modules-v1.0.0/terraform/test/module"
+		if result != expectedPath {
+			t.Errorf("expected path %s, got %s", expectedPath, result)
+		}
+	})
+}
+
+func TestTerraformGenerator_downloadOCIArtifact(t *testing.T) {
+	setup := func(t *testing.T) (*TerraformGenerator, *Mocks) {
+		mocks := setupMocks(t)
+		generator := NewTerraformGenerator(mocks.Injector)
+		generator.shims = mocks.Shims
+		if err := generator.Initialize(); err != nil {
+			t.Fatalf("failed to initialize TerraformGenerator: %v", err)
+		}
+		return generator, mocks
+	}
+
+	t.Run("ParseReferenceSuccess", func(t *testing.T) {
+		// Given a TerraformGenerator with successful parse but failing remote
+		generator, mocks := setup(t)
+
+		mocks.Shims.ParseReference = func(ref string, opts ...name.Option) (name.Reference, error) {
+			return nil, nil // Success
+		}
+
+		mocks.Shims.RemoteImage = func(ref name.Reference, options ...remote.Option) (v1.Image, error) {
+			return nil, fmt.Errorf("remote image error") // Fail at next step
+		}
+
+		// When downloadOCIArtifact is called
+		_, err := generator.downloadOCIArtifact("registry.example.com", "modules", "v1.0.0")
+
+		// Then it should fail at remote image step
+		if err == nil {
+			t.Error("expected error for remote image failure")
+		}
+		if !strings.Contains(err.Error(), "failed to get image") {
+			t.Errorf("expected remote image error, got %v", err)
+		}
+	})
+
+	t.Run("ParseReferenceError", func(t *testing.T) {
+		// Given a TerraformGenerator with parse reference error
+		generator, mocks := setup(t)
+
+		mocks.Shims.ParseReference = func(ref string, opts ...name.Option) (name.Reference, error) {
+			return nil, fmt.Errorf("parse error")
+		}
+
+		// When downloadOCIArtifact is called
+		_, err := generator.downloadOCIArtifact("registry.example.com", "modules", "v1.0.0")
+
+		// Then it should return parse reference error
+		if err == nil {
+			t.Error("expected error for parse reference failure")
+		}
+		if !strings.Contains(err.Error(), "failed to parse reference") {
+			t.Errorf("expected parse reference error, got %v", err)
+		}
+	})
+
+	t.Run("RemoteImageError", func(t *testing.T) {
+		// Given a TerraformGenerator with remote image error
+		generator, mocks := setup(t)
+
+		mocks.Shims.ParseReference = func(ref string, opts ...name.Option) (name.Reference, error) {
+			return nil, nil
+		}
+
+		mocks.Shims.RemoteImage = func(ref name.Reference, options ...remote.Option) (v1.Image, error) {
+			return nil, fmt.Errorf("remote error")
+		}
+
+		// When downloadOCIArtifact is called
+		_, err := generator.downloadOCIArtifact("registry.example.com", "modules", "v1.0.0")
+
+		// Then it should return remote image error
+		if err == nil {
+			t.Error("expected error for remote image failure")
+		}
+		if !strings.Contains(err.Error(), "failed to get image") {
+			t.Errorf("expected remote image error, got %v", err)
+		}
+	})
+
+	t.Run("ImageLayersError", func(t *testing.T) {
+		// Given a TerraformGenerator with image layers error
+		generator, mocks := setup(t)
+
+		mocks.Shims.ParseReference = func(ref string, opts ...name.Option) (name.Reference, error) {
+			return nil, nil
+		}
+
+		mocks.Shims.RemoteImage = func(ref name.Reference, options ...remote.Option) (v1.Image, error) {
+			return nil, nil
+		}
+
+		mocks.Shims.ImageLayers = func(img v1.Image) ([]v1.Layer, error) {
+			return nil, fmt.Errorf("layers error")
+		}
+
+		// When downloadOCIArtifact is called
+		_, err := generator.downloadOCIArtifact("registry.example.com", "modules", "v1.0.0")
+
+		// Then it should return image layers error
+		if err == nil {
+			t.Error("expected error for image layers failure")
+		}
+		if !strings.Contains(err.Error(), "failed to get image layers") {
+			t.Errorf("expected image layers error, got %v", err)
+		}
+	})
+}
+
+func TestTerraformGenerator_parseVariablesFile(t *testing.T) {
+	setup := func(t *testing.T) (*TerraformGenerator, *Mocks) {
+		mocks := setupMocks(t)
+		generator := NewTerraformGenerator(mocks.Injector)
+		generator.shims = mocks.Shims
+		if err := generator.Initialize(); err != nil {
+			t.Fatalf("failed to initialize TerraformGenerator: %v", err)
+		}
+		return generator, mocks
+	}
+
+	t.Run("AllVariableTypes", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And ReadFile is mocked to return variables with all types and attributes
+		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
+			return []byte(`
+variable "string_var" {
+  description = "String variable"
+  type        = string
+  default     = "default_value"
+  sensitive   = false
+}
+
+variable "number_var" {
+  description = "Number variable"
+  type        = number
+  default     = 42
+  sensitive   = false
+}
+
+variable "bool_var" {
+  description = "Boolean variable"
+  type        = bool
+  default     = true
+  sensitive   = true
+}
+
+variable "list_var" {
+  description = "List variable"
+  type        = list(string)
+  default     = ["item1", "item2"]
+}
+
+variable "map_var" {
+  description = "Map variable"
+  type        = map(string)
+  default     = { key = "value" }
+}
+
+variable "no_default" {
+  description = "Variable without default"
+  type        = string
+}
+
+variable "no_description" {
+  type    = string
+  default = "value"
+}
+
+variable "invalid_default" {
+  description = "Variable with invalid default"
+  type        = string
+  default     = invalid
+}
+
+variable "invalid_sensitive" {
+  description = "Variable with invalid sensitive"
+  type        = string
+  sensitive   = invalid
+}`), nil
+		}
+
+		// When parseVariablesFile is called
+		variables, err := generator.parseVariablesFile("test.tf", map[string]bool{})
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		// And all variables should be parsed correctly
+		expectedVars := map[string]VariableInfo{
+			"string_var": {
+				Name:        "string_var",
+				Description: "String variable",
+				Default:     "default_value",
+				Sensitive:   false,
+			},
+			"number_var": {
+				Name:        "number_var",
+				Description: "Number variable",
+				Default:     int64(42),
+				Sensitive:   false,
+			},
+			"bool_var": {
+				Name:        "bool_var",
+				Description: "Boolean variable",
+				Default:     true,
+				Sensitive:   true,
+			},
+			"list_var": {
+				Name:        "list_var",
+				Description: "List variable",
+				Default:     []any{"item1", "item2"},
+			},
+			"map_var": {
+				Name:        "map_var",
+				Description: "Map variable",
+				Default:     map[string]any{"key": "value"},
+			},
+			"no_default": {
+				Name:        "no_default",
+				Description: "Variable without default",
+			},
+			"no_description": {
+				Name:    "no_description",
+				Default: "value",
+			},
+			"invalid_default": {
+				Name:        "invalid_default",
+				Description: "Variable with invalid default",
+			},
+			"invalid_sensitive": {
+				Name:        "invalid_sensitive",
+				Description: "Variable with invalid sensitive",
+			},
+		}
+
+		// Verify each variable
+		if len(variables) != len(expectedVars) {
+			t.Errorf("expected %d variables, got %d", len(expectedVars), len(variables))
+		}
+
+		for _, v := range variables {
+			expected, exists := expectedVars[v.Name]
+			if !exists {
+				t.Errorf("unexpected variable %s", v.Name)
+				continue
+			}
+
+			if v.Description != expected.Description {
+				t.Errorf("variable %s: expected description %q, got %q", v.Name, expected.Description, v.Description)
+			}
+			if !reflect.DeepEqual(v.Default, expected.Default) {
+				t.Errorf("variable %s: expected default %v (%T), got %v (%T)", v.Name, expected.Default, expected.Default, v.Default, v.Default)
+			}
+			if v.Sensitive != expected.Sensitive {
+				t.Errorf("variable %s: expected sensitive %v, got %v", v.Name, expected.Sensitive, v.Sensitive)
+			}
+		}
+	})
+
+	t.Run("ProtectedVariables", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And ReadFile is mocked to return variables
+		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
+			return []byte(`
+variable "protected_var" {
+  description = "Protected variable"
+  type        = string
+}
+
+variable "normal_var" {
+  description = "Normal variable"
+  type        = string
+}`), nil
+		}
+
+		// And protected values are set
+		protectedValues := map[string]bool{
+			"protected_var": true,
+		}
+
+		// When parseVariablesFile is called
+		variables, err := generator.parseVariablesFile("test.tf", protectedValues)
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		// And only non-protected variables should be included
+		if len(variables) != 1 {
+			t.Errorf("expected 1 variable, got %d", len(variables))
+		}
+		if variables[0].Name != "normal_var" {
+			t.Errorf("expected variable normal_var, got %s", variables[0].Name)
+		}
+	})
+
+	t.Run("InvalidHCL", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And ReadFile is mocked to return invalid HCL
+		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
+			return []byte(`invalid hcl content`), nil
+		}
+
+		// When parseVariablesFile is called
+		_, err := generator.parseVariablesFile("test.tf", map[string]bool{})
+
+		// Then an error should occur
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+
+	t.Run("ReadFileError", func(t *testing.T) {
 		// Given a TerraformGenerator with mocks
 		generator, mocks := setup(t)
 
 		// And ReadFile is mocked to return an error
 		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
-			return nil, fmt.Errorf("file not found")
+			return nil, fmt.Errorf("read error")
 		}
 
-		templateValues := make(map[string]map[string]any)
+		// When parseVariablesFile is called
+		_, err := generator.parseVariablesFile("test.tf", map[string]bool{})
 
-		// When processJsonnetTemplate is called
-		err := generator.processJsonnetTemplate("/template/test.jsonnet", "test-context", templateValues)
-
-		// Then an error should be returned
+		// Then an error should occur
 		if err == nil {
-			t.Fatalf("expected an error, got nil")
-		}
-
-		// And the error should contain the expected message
-		if !strings.Contains(err.Error(), "error reading template file") {
-			t.Errorf("expected error to contain 'error reading template file', got %v", err)
-		}
-	})
-
-	t.Run("ErrorMarshallingContextToYAML", func(t *testing.T) {
-		// Given a TerraformGenerator with mocks
-		generator, mocks := setup(t)
-
-		// And ReadFile is mocked to return jsonnet content
-		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
-			return []byte(`local context = std.extVar("context");
-{
-  test_var: context.test
-}`), nil
-		}
-
-		// And YamlMarshalWithDefinedPaths is mocked to return an error
-		mocks.ConfigHandler.(*config.MockConfigHandler).YamlMarshalWithDefinedPathsFunc = func(config any) ([]byte, error) {
-			return nil, fmt.Errorf("yaml marshal error")
-		}
-
-		templateValues := make(map[string]map[string]any)
-
-		// When processJsonnetTemplate is called
-		err := generator.processJsonnetTemplate("/template/test.jsonnet", "test-context", templateValues)
-
-		// Then an error should be returned
-		if err == nil {
-			t.Fatalf("expected an error, got nil")
-		}
-
-		// And the error should contain the expected message
-		if !strings.Contains(err.Error(), "error marshalling context to YAML") {
-			t.Errorf("expected error to contain 'error marshalling context to YAML', got %v", err)
-		}
-	})
-
-	t.Run("ErrorUnmarshallingContextYAML", func(t *testing.T) {
-		// Given a TerraformGenerator with mocks
-		generator, mocks := setup(t)
-
-		// And ReadFile is mocked to return jsonnet content
-		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
-			return []byte(`local context = std.extVar("context");
-{
-  test_var: context.test
-}`), nil
-		}
-
-		// And YamlMarshalWithDefinedPaths is mocked
-		mocks.ConfigHandler.(*config.MockConfigHandler).YamlMarshalWithDefinedPathsFunc = func(config any) ([]byte, error) {
-			return []byte("test: config"), nil
-		}
-
-		// And YamlUnmarshal is mocked to return an error
-		mocks.Shims.YamlUnmarshal = func(data []byte, v any) error {
-			return fmt.Errorf("yaml unmarshal error")
-		}
-
-		templateValues := make(map[string]map[string]any)
-
-		// When processJsonnetTemplate is called
-		err := generator.processJsonnetTemplate("/template/test.jsonnet", "test-context", templateValues)
-
-		// Then an error should be returned
-		if err == nil {
-			t.Fatalf("expected an error, got nil")
-		}
-
-		// And the error should contain the expected message
-		if !strings.Contains(err.Error(), "error unmarshalling context YAML") {
-			t.Errorf("expected error to contain 'error unmarshalling context YAML', got %v", err)
-		}
-	})
-
-	t.Run("ErrorMarshallingContextToJSON", func(t *testing.T) {
-		// Given a TerraformGenerator with mocks
-		generator, mocks := setup(t)
-
-		// And ReadFile is mocked to return jsonnet content
-		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
-			return []byte(`local context = std.extVar("context");
-{
-  test_var: context.test
-}`), nil
-		}
-
-		// And YamlMarshalWithDefinedPaths is mocked
-		mocks.ConfigHandler.(*config.MockConfigHandler).YamlMarshalWithDefinedPathsFunc = func(config any) ([]byte, error) {
-			return []byte("test: config"), nil
-		}
-
-		// And YamlUnmarshal is mocked
-		mocks.Shims.YamlUnmarshal = func(data []byte, v any) error {
-			if configMap, ok := v.(*map[string]any); ok {
-				*configMap = map[string]any{"test": "config"}
-			}
-			return nil
-		}
-
-		// And JsonMarshal is mocked to return an error
-		mocks.Shims.JsonMarshal = func(v any) ([]byte, error) {
-			return nil, fmt.Errorf("json marshal error")
-		}
-
-		templateValues := make(map[string]map[string]any)
-
-		// When processJsonnetTemplate is called
-		err := generator.processJsonnetTemplate("/template/test.jsonnet", "test-context", templateValues)
-
-		// Then an error should be returned
-		if err == nil {
-			t.Fatalf("expected an error, got nil")
-		}
-
-		// And the error should contain the expected message
-		if !strings.Contains(err.Error(), "error marshalling context map to JSON") {
-			t.Errorf("expected error to contain 'error marshalling context map to JSON', got %v", err)
-		}
-	})
-
-	t.Run("ErrorEvaluatingJsonnet", func(t *testing.T) {
-		// Given a TerraformGenerator with mocks
-		generator, mocks := setup(t)
-
-		// And ReadFile is mocked to return invalid jsonnet content
-		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
-			return []byte(`invalid jsonnet syntax {`), nil
-		}
-
-		// Mock the required dependencies
-		mocks.ConfigHandler.(*config.MockConfigHandler).YamlMarshalWithDefinedPathsFunc = func(config any) ([]byte, error) {
-			return []byte("test: config"), nil
-		}
-
-		mocks.Shims.YamlUnmarshal = func(data []byte, v any) error {
-			if configMap, ok := v.(*map[string]any); ok {
-				*configMap = map[string]any{"test": "config"}
-			}
-			return nil
-		}
-
-		mocks.Shims.JsonMarshal = func(v any) ([]byte, error) {
-			return []byte(`{"test": "config", "name": "test-context"}`), nil
-		}
-
-		templateValues := make(map[string]map[string]any)
-
-		// When processJsonnetTemplate is called
-		err := generator.processJsonnetTemplate("/template/test.jsonnet", "test-context", templateValues)
-
-		// Then an error should be returned
-		if err == nil {
-			t.Fatalf("expected an error, got nil")
-		}
-
-		// And the error should contain the expected message
-		if !strings.Contains(err.Error(), "error evaluating jsonnet template") {
-			t.Errorf("expected error to contain 'error evaluating jsonnet template', got %v", err)
-		}
-	})
-
-	t.Run("ErrorUnmarshallingJsonnetResult", func(t *testing.T) {
-		// Given a TerraformGenerator with mocks
-		generator, mocks := setup(t)
-
-		// And ReadFile is mocked to return jsonnet that produces valid output
-		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
-			return []byte(`{
-  test_var: "test_value"
-}`), nil
-		}
-
-		// Mock the required dependencies
-		mocks.ConfigHandler.(*config.MockConfigHandler).YamlMarshalWithDefinedPathsFunc = func(config any) ([]byte, error) {
-			return []byte("test: config"), nil
-		}
-
-		mocks.Shims.YamlUnmarshal = func(data []byte, v any) error {
-			if configMap, ok := v.(*map[string]any); ok {
-				*configMap = map[string]any{"test": "config"}
-			}
-			return nil
-		}
-
-		mocks.Shims.JsonMarshal = func(v any) ([]byte, error) {
-			return []byte(`{"test": "config", "name": "test-context"}`), nil
-		}
-
-		// And JsonUnmarshal is mocked to return an error
-		mocks.Shims.JsonUnmarshal = func(data []byte, v any) error {
-			return fmt.Errorf("json unmarshal error")
-		}
-
-		templateValues := make(map[string]map[string]any)
-
-		// When processJsonnetTemplate is called
-		err := generator.processJsonnetTemplate("/template/test.jsonnet", "test-context", templateValues)
-
-		// Then an error should be returned
-		if err == nil {
-			t.Fatalf("expected an error, got nil")
-		}
-
-		// And the error should contain the expected message
-		if !strings.Contains(err.Error(), "jsonnet template must output valid JSON") {
-			t.Errorf("expected error to contain 'jsonnet template must output valid JSON', got %v", err)
-		}
-	})
-
-	t.Run("ErrorGettingProjectRoot", func(t *testing.T) {
-		// Given a TerraformGenerator with mocks
-		generator, mocks := setup(t)
-
-		// And Shell.GetProjectRoot is mocked to return an error
-		mocks.Shell.GetProjectRootFunc = func() (string, error) {
-			return "", fmt.Errorf("project root error")
-		}
-
-		// And ReadFile is mocked to return valid jsonnet content
-		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
-			return []byte(`{
-  test_var: "test_value"
-}`), nil
-		}
-
-		// Mock the required dependencies
-		mocks.ConfigHandler.(*config.MockConfigHandler).YamlMarshalWithDefinedPathsFunc = func(config any) ([]byte, error) {
-			return []byte("test: config"), nil
-		}
-
-		mocks.Shims.YamlUnmarshal = func(data []byte, v any) error {
-			if configMap, ok := v.(*map[string]any); ok {
-				*configMap = map[string]any{"test": "config"}
-			}
-			return nil
-		}
-
-		mocks.Shims.JsonMarshal = func(v any) ([]byte, error) {
-			return []byte(`{"test": "config", "name": "test-context"}`), nil
-		}
-
-		mocks.Shims.JsonUnmarshal = func(data []byte, v any) error {
-			if values, ok := v.(*map[string]any); ok {
-				*values = map[string]any{"test_var": "test_value"}
-			}
-			return nil
-		}
-
-		templateValues := make(map[string]map[string]any)
-
-		// When processJsonnetTemplate is called
-		err := generator.processJsonnetTemplate("/template/test.jsonnet", "test-context", templateValues)
-
-		// Then an error should be returned
-		if err == nil {
-			t.Fatalf("expected an error, got nil")
-		}
-
-		// And the error should contain the expected message
-		if !strings.Contains(err.Error(), "failed to get project root") {
-			t.Errorf("expected error to contain 'failed to get project root', got %v", err)
-		}
-	})
-
-	t.Run("ErrorCalculatingRelativePath", func(t *testing.T) {
-		// Given a TerraformGenerator with mocks
-		generator, mocks := setup(t)
-
-		// And Shell.GetProjectRoot is mocked to return expected path
-		mocks.Shell.GetProjectRootFunc = func() (string, error) {
-			return "/tmp", nil
-		}
-
-		// And ReadFile is mocked to return valid jsonnet content
-		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
-			return []byte(`{
-  test_var: "test_value"
-}`), nil
-		}
-
-		// Mock the required dependencies
-		mocks.ConfigHandler.(*config.MockConfigHandler).YamlMarshalWithDefinedPathsFunc = func(config any) ([]byte, error) {
-			return []byte("test: config"), nil
-		}
-
-		mocks.Shims.YamlUnmarshal = func(data []byte, v any) error {
-			if configMap, ok := v.(*map[string]any); ok {
-				*configMap = map[string]any{"test": "config"}
-			}
-			return nil
-		}
-
-		mocks.Shims.JsonMarshal = func(v any) ([]byte, error) {
-			return []byte(`{"test": "config", "name": "test-context"}`), nil
-		}
-
-		mocks.Shims.JsonUnmarshal = func(data []byte, v any) error {
-			if values, ok := v.(*map[string]any); ok {
-				*values = map[string]any{"test_var": "test_value"}
-			}
-			return nil
-		}
-
-		// And FilepathRel is mocked to return an error
-		mocks.Shims.FilepathRel = func(basepath, targpath string) (string, error) {
-			return "", fmt.Errorf("relative path calculation error")
-		}
-
-		templateValues := make(map[string]map[string]any)
-
-		// When processJsonnetTemplate is called
-		err := generator.processJsonnetTemplate("/template/test.jsonnet", "test-context", templateValues)
-
-		// Then an error should be returned
-		if err == nil {
-			t.Fatalf("expected an error, got nil")
-		}
-
-		// And the error should contain the expected message
-		if !strings.Contains(err.Error(), "failed to calculate relative path") {
-			t.Errorf("expected error to contain 'failed to calculate relative path', got %v", err)
-		}
-	})
-
-	t.Run("SuccessProcessingTemplate", func(t *testing.T) {
-		// Given a TerraformGenerator with mocks
-		generator, mocks := setup(t)
-
-		// And Shell.GetProjectRoot is mocked to return expected path
-		mocks.Shell.GetProjectRootFunc = func() (string, error) {
-			return "/tmp", nil
-		}
-
-		// And ReadFile is mocked to return valid jsonnet content
-		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
-			return []byte(`local context = std.extVar("context");
-{
-  test_var: context.test,
-  context_name: context.name
-}`), nil
-		}
-
-		// Mock the required dependencies
-		mocks.ConfigHandler.(*config.MockConfigHandler).YamlMarshalWithDefinedPathsFunc = func(config any) ([]byte, error) {
-			return []byte("test: config"), nil
-		}
-
-		mocks.Shims.YamlUnmarshal = func(data []byte, v any) error {
-			if configMap, ok := v.(*map[string]any); ok {
-				*configMap = map[string]any{"test": "config"}
-			}
-			return nil
-		}
-
-		mocks.Shims.JsonMarshal = func(v any) ([]byte, error) {
-			return []byte(`{"test": "config", "name": "test-context"}`), nil
-		}
-
-		mocks.Shims.JsonUnmarshal = func(data []byte, v any) error {
-			if values, ok := v.(*map[string]any); ok {
-				*values = map[string]any{
-					"test_var":     "config",
-					"context_name": "test-context",
-				}
-			}
-			return nil
-		}
-
-		templateValues := make(map[string]map[string]any)
-
-		// When processJsonnetTemplate is called
-		err := generator.processJsonnetTemplate("/tmp/contexts/_template/terraform/test.jsonnet", "test-context", templateValues)
-
-		// Then no error should occur
-		if err != nil {
-			t.Errorf("expected no error, got %v", err)
-		}
-
-		// And template values should contain the processed template
-		if len(templateValues) != 1 {
-			t.Errorf("expected 1 template value, got %d", len(templateValues))
-		}
-		if _, exists := templateValues["test"]; !exists {
-			t.Errorf("expected template values to contain 'test' key")
-		}
-
-		// And the values should match expected content
-		values := templateValues["test"]
-		if values["test_var"] != "config" {
-			t.Errorf("expected test_var to be 'config', got %v", values["test_var"])
-		}
-		if values["context_name"] != "test-context" {
-			t.Errorf("expected context_name to be 'test-context', got %v", values["context_name"])
-		}
-	})
-
-	t.Run("SuccessWithNestedPath", func(t *testing.T) {
-		// Given a TerraformGenerator with mocks
-		generator, mocks := setup(t)
-
-		// And Shell.GetProjectRoot is mocked to return expected path
-		mocks.Shell.GetProjectRootFunc = func() (string, error) {
-			return "/tmp", nil
-		}
-
-		// And ReadFile is mocked to return valid jsonnet content
-		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
-			return []byte(`{
-  nested_var: "nested_value"
-}`), nil
-		}
-
-		// Mock the required dependencies
-		mocks.ConfigHandler.(*config.MockConfigHandler).YamlMarshalWithDefinedPathsFunc = func(config any) ([]byte, error) {
-			return []byte("test: config"), nil
-		}
-
-		mocks.Shims.YamlUnmarshal = func(data []byte, v any) error {
-			if configMap, ok := v.(*map[string]any); ok {
-				*configMap = map[string]any{"test": "config"}
-			}
-			return nil
-		}
-
-		mocks.Shims.JsonMarshal = func(v any) ([]byte, error) {
-			return []byte(`{"test": "config", "name": "test-context"}`), nil
-		}
-
-		mocks.Shims.JsonUnmarshal = func(data []byte, v any) error {
-			if values, ok := v.(*map[string]any); ok {
-				*values = map[string]any{"nested_var": "nested_value"}
-			}
-			return nil
-		}
-
-		templateValues := make(map[string]map[string]any)
-
-		// When processJsonnetTemplate is called with nested path
-		err := generator.processJsonnetTemplate("/tmp/contexts/_template/terraform/nested/path/component.jsonnet", "test-context", templateValues)
-
-		// Then no error should occur
-		if err != nil {
-			t.Errorf("expected no error, got %v", err)
-		}
-
-		// And template values should contain the processed template with nested key
-		if len(templateValues) != 1 {
-			t.Errorf("expected 1 template value, got %d", len(templateValues))
-		}
-		if _, exists := templateValues["nested/path/component"]; !exists {
-			t.Errorf("expected template values to contain 'nested/path/component' key")
+			t.Error("expected error, got nil")
+		}
+		expectedError := "failed to read variables.tf: read error"
+		if err.Error() != expectedError {
+			t.Errorf("expected error %q, got %q", expectedError, err.Error())
 		}
 	})
 }
@@ -3611,32 +3836,738 @@ func TestTerraformGenerator_processJsonnetTemplate(t *testing.T) {
 // Test Helpers
 // =============================================================================
 
-// simpleDirEntry implements fs.DirEntry for testing
-type simpleDirEntry struct {
-	name  string
-	isDir bool
-}
-
-func (s *simpleDirEntry) Name() string {
-	return s.name
-}
-
-func (s *simpleDirEntry) IsDir() bool {
-	return s.isDir
-}
-
-func (s *simpleDirEntry) Type() fs.FileMode {
-	if s.isDir {
-		return fs.ModeDir
+func TestConvertToCtyValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    any
+		expected cty.Value
+	}{
+		{
+			name:     "String",
+			input:    "test",
+			expected: cty.StringVal("test"),
+		},
+		{
+			name:     "Int",
+			input:    42,
+			expected: cty.NumberIntVal(42),
+		},
+		{
+			name:     "Float64",
+			input:    42.5,
+			expected: cty.NumberFloatVal(42.5),
+		},
+		{
+			name:     "Bool",
+			input:    true,
+			expected: cty.BoolVal(true),
+		},
+		{
+			name:     "EmptyList",
+			input:    []any{},
+			expected: cty.ListValEmpty(cty.DynamicPseudoType),
+		},
+		{
+			name:     "List",
+			input:    []any{"item1", "item2"},
+			expected: cty.ListVal([]cty.Value{cty.StringVal("item1"), cty.StringVal("item2")}),
+		},
+		{
+			name:     "Map",
+			input:    map[string]any{"key": "value"},
+			expected: cty.ObjectVal(map[string]cty.Value{"key": cty.StringVal("value")}),
+		},
+		{
+			name:     "Unsupported",
+			input:    struct{}{},
+			expected: cty.NilVal,
+		},
+		{
+			name:     "Nil",
+			input:    nil,
+			expected: cty.NilVal,
+		},
 	}
-	return 0
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertToCtyValue(tt.input)
+			if !result.RawEquals(tt.expected) {
+				t.Errorf("expected %#v, got %#v", tt.expected, result)
+			}
+		})
+	}
 }
 
-func (s *simpleDirEntry) Info() (fs.FileInfo, error) {
-	return nil, nil
+func TestConvertFromCtyValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    cty.Value
+		expected any
+	}{
+		{
+			name:     "String",
+			input:    cty.StringVal("test"),
+			expected: "test",
+		},
+		{
+			name:     "Int",
+			input:    cty.NumberIntVal(42),
+			expected: int64(42),
+		},
+		{
+			name:     "Float",
+			input:    cty.NumberFloatVal(42.5),
+			expected: float64(42.5),
+		},
+		{
+			name:     "NumberBigFloat",
+			input:    cty.NumberVal(big.NewFloat(42.5)),
+			expected: float64(42.5),
+		},
+		{
+			name:     "Bool",
+			input:    cty.BoolVal(true),
+			expected: true,
+		},
+		{
+			name:     "List",
+			input:    cty.ListVal([]cty.Value{cty.StringVal("item1"), cty.StringVal("item2")}),
+			expected: []any{"item1", "item2"},
+		},
+		{
+			name:     "EmptyList",
+			input:    cty.ListValEmpty(cty.String),
+			expected: []any(nil),
+		},
+		{
+			name:     "Map",
+			input:    cty.MapVal(map[string]cty.Value{"key": cty.StringVal("value")}),
+			expected: map[string]any{"key": "value"},
+		},
+		{
+			name:     "EmptyMap",
+			input:    cty.MapValEmpty(cty.String),
+			expected: map[string]any{},
+		},
+		{
+			name:     "Object",
+			input:    cty.ObjectVal(map[string]cty.Value{"key": cty.StringVal("value")}),
+			expected: map[string]any{"key": "value"},
+		},
+		{
+			name:     "Null",
+			input:    cty.NullVal(cty.String),
+			expected: nil,
+		},
+		{
+			name:     "Unknown",
+			input:    cty.UnknownVal(cty.String),
+			expected: nil,
+		},
+		{
+			name:     "Set",
+			input:    cty.SetVal([]cty.Value{cty.StringVal("item1"), cty.StringVal("item2")}),
+			expected: []any{"item1", "item2"},
+		},
+		{
+			name:     "Tuple",
+			input:    cty.TupleVal([]cty.Value{cty.StringVal("item1"), cty.NumberIntVal(42)}),
+			expected: []any{"item1", int64(42)},
+		},
+		{
+			name:     "UnsupportedType",
+			input:    cty.DynamicVal,
+			expected: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := convertFromCtyValue(tt.input)
+			if !reflect.DeepEqual(result, tt.expected) {
+				t.Errorf("expected %#v (%T), got %#v (%T)", tt.expected, tt.expected, result, result)
+			}
+		})
+	}
 }
 
-func TestTerraformGenerator_walkTemplateDirectory(t *testing.T) {
+func TestFormatValue(t *testing.T) {
+	t.Run("EmptyArray", func(t *testing.T) {
+		result := formatValue([]any{})
+		if result != "[]" {
+			t.Errorf("expected [] got %q", result)
+		}
+	})
+
+	t.Run("EmptyMap", func(t *testing.T) {
+		result := formatValue(map[string]any{})
+		if result != "{}" {
+			t.Errorf("expected {} got %q", result)
+		}
+	})
+
+	t.Run("NilValue", func(t *testing.T) {
+		result := formatValue(nil)
+		if result != "null" {
+			t.Errorf("expected null got %q", result)
+		}
+	})
+
+	t.Run("ComplexNestedObject", func(t *testing.T) {
+		input := map[string]any{
+			"node_groups": map[string]any{
+				"default": map[string]any{
+					"instance_types": []any{"t3.medium"},
+					"min_size":       1,
+					"max_size":       3,
+					"desired_size":   2,
+				},
+			},
+		}
+		expected := `{
+  node_groups = {
+    default = {
+      desired_size = 2
+      instance_types = ["t3.medium"]
+      max_size = 3
+      min_size = 1
+    }
+  }
+}`
+		result := formatValue(input)
+		if result != expected {
+			t.Errorf("expected %q, got %q", expected, result)
+		}
+	})
+
+	t.Run("EmptyAddons", func(t *testing.T) {
+		input := map[string]any{
+			"addons": map[string]any{
+				"vpc-cni":                map[string]any{},
+				"aws-efs-csi-driver":     map[string]any{},
+				"aws-ebs-csi-driver":     map[string]any{},
+				"eks-pod-identity-agent": map[string]any{},
+				"coredns":                map[string]any{},
+				"external-dns":           map[string]any{},
+			},
+		}
+		expected := `{
+  addons = {
+    aws-ebs-csi-driver = {}
+    aws-efs-csi-driver = {}
+    coredns = {}
+    eks-pod-identity-agent = {}
+    external-dns = {}
+    vpc-cni = {}
+  }
+}`
+		result := formatValue(input)
+		if result != expected {
+			t.Errorf("expected %q, got %q", expected, result)
+		}
+	})
+}
+
+func TestWriteComponentValues(t *testing.T) {
+	t.Run("BasicComponentValues", func(t *testing.T) {
+		// Given a body and variables with component values
+		file := hclwrite.NewEmptyFile()
+		body := file.Body()
+		variables := []VariableInfo{
+			{
+				Name:        "var1",
+				Description: "Variable 1",
+				Sensitive:   true,
+				Default:     "default1",
+			},
+			{
+				Name:        "var2",
+				Description: "Variable 2",
+				Sensitive:   false,
+				Default:     "default2",
+			},
+			{
+				Name:        "var3",
+				Description: "Variable 3",
+				Default:     "default3",
+			},
+		}
+		values := map[string]any{
+			"var2": "pinned_value",
+		}
+		protectedValues := map[string]bool{}
+
+		// When writeComponentValues is called
+		writeComponentValues(body, values, protectedValues, variables)
+
+		// Then the variables should be written in order with proper handling of sensitive values
+		expected := `
+# Variable 1
+# var1 = "(sensitive)"
+
+# Variable 2
+var2 = "pinned_value"
+
+# Variable 3
+# var3 = "default3"
+`
+		if string(file.Bytes()) != expected {
+			t.Errorf("expected %q, got %q", expected, string(file.Bytes()))
+		}
+	})
+
+	t.Run("ComplexDefaultsNodeGroups", func(t *testing.T) {
+		// Given a body and variables with complex nested default for node groups
+		file := hclwrite.NewEmptyFile()
+		variable := VariableInfo{
+			Name:        "node_groups",
+			Description: "Map of EKS managed node group definitions to create.",
+			Default: map[string]any{
+				"default": map[string]any{
+					"instance_types": []any{"t3.medium"},
+					"min_size":       1,
+					"max_size":       3,
+					"desired_size":   2,
+				},
+			},
+		}
+
+		// When writeComponentValues is called
+		writeComponentValues(file.Body(), map[string]any{}, map[string]bool{}, []VariableInfo{variable})
+
+		// Then the complex default should be commented out correctly
+		expected := `
+# Map of EKS managed node group definitions to create.
+# node_groups = {
+#   default = {
+#     desired_size = 2
+#     instance_types = ["t3.medium"]
+#     max_size = 3
+#     min_size = 1
+#   }
+# }`
+		result := string(file.Bytes())
+		// Check that every line is commented
+		for _, line := range strings.Split(result, "\n") {
+			if strings.TrimSpace(line) == "" {
+				continue
+			}
+			if !strings.HasPrefix(line, "#") {
+				t.Errorf("uncommented line found: %q", line)
+			}
+		}
+		// Check that the output matches expected ignoring leading/trailing whitespace
+		if strings.TrimSpace(result) != strings.TrimSpace(expected) {
+			t.Errorf("expected\n%s\ngot\n%s", expected, result)
+		}
+	})
+
+	t.Run("ComplexDefaultsEmptyAddons", func(t *testing.T) {
+		// Given a body and variables with complex empty map defaults for addons
+		file := hclwrite.NewEmptyFile()
+		variable := VariableInfo{
+			Name:        "addons",
+			Description: "Map of EKS add-ons",
+			Default: map[string]any{
+				"vpc-cni":                map[string]any{},
+				"aws-efs-csi-driver":     map[string]any{},
+				"aws-ebs-csi-driver":     map[string]any{},
+				"eks-pod-identity-agent": map[string]any{},
+				"coredns":                map[string]any{},
+				"external-dns":           map[string]any{},
+			},
+		}
+
+		// When writeComponentValues is called
+		writeComponentValues(file.Body(), map[string]any{}, map[string]bool{}, []VariableInfo{variable})
+
+		// Then the complex empty map defaults should be commented correctly
+		expected := "\n# Map of EKS add-ons\n# addons = {\n#   aws-ebs-csi-driver = {}\n#   aws-efs-csi-driver = {}\n#   coredns = {}\n#   eks-pod-identity-agent = {}\n#   external-dns = {}\n#   vpc-cni = {}\n# }\n"
+		result := string(file.Bytes())
+		if result != expected {
+			t.Errorf("expected %q, got %q", expected, result)
+		}
+	})
+}
+
+func TestWriteDefaultValues(t *testing.T) {
+	// Given a body and variables with default values
+	file := hclwrite.NewEmptyFile()
+	body := file.Body()
+	variables := []VariableInfo{
+		{
+			Name:        "var1",
+			Description: "Variable 1",
+			Sensitive:   true,
+			Default:     "default1",
+		},
+		{
+			Name:        "var2",
+			Description: "Variable 2",
+			Sensitive:   false,
+			Default:     "default2",
+		},
+		{
+			Name:        "var3",
+			Description: "Variable 3",
+			Default:     "default3",
+		},
+	}
+
+	// When writeDefaultValues is called
+	writeDefaultValues(body, variables, nil)
+
+	// Then the variables should be written in order with proper handling of sensitive values
+	expected := `
+# Variable 1
+# var1 = "(sensitive)"
+
+# Variable 2
+# var2 = "default2"
+
+# Variable 3
+# var3 = "default3"
+`
+	if string(file.Bytes()) != expected {
+		t.Errorf("expected %q, got %q", expected, string(file.Bytes()))
+	}
+}
+
+func TestWriteVariable(t *testing.T) {
+	t.Run("SensitiveVariable", func(t *testing.T) {
+		// Given a body and variables with a sensitive variable
+		file := hclwrite.NewEmptyFile()
+		body := file.Body()
+		variables := []VariableInfo{
+			{
+				Name:        "test_var",
+				Description: "Test variable",
+				Sensitive:   true,
+			},
+		}
+
+		// When writeVariable is called
+		writeVariable(body, "test_var", "value", variables)
+
+		// Then the variable should be commented out with (sensitive)
+		expected := `# Test variable
+# test_var = "(sensitive)"
+`
+		if string(file.Bytes()) != expected {
+			t.Errorf("expected %q, got %q", expected, string(file.Bytes()))
+		}
+	})
+
+	t.Run("NonSensitiveVariable", func(t *testing.T) {
+		// Given a body and variables with a non-sensitive variable
+		file := hclwrite.NewEmptyFile()
+		body := file.Body()
+		variables := []VariableInfo{
+			{
+				Name:        "test_var",
+				Description: "Test variable",
+				Sensitive:   false,
+			},
+		}
+
+		// When writeVariable is called
+		writeVariable(body, "test_var", "value", variables)
+
+		// Then the variable should be written with its value
+		expected := `# Test variable
+test_var = "value"
+`
+		if string(file.Bytes()) != expected {
+			t.Errorf("expected %q, got %q", expected, string(file.Bytes()))
+		}
+	})
+
+	t.Run("VariableWithComment", func(t *testing.T) {
+		// Given a body and variables with a variable with comment
+		file := hclwrite.NewEmptyFile()
+		body := file.Body()
+		variables := []VariableInfo{
+			{
+				Name:        "test_var",
+				Description: "Test variable description",
+			},
+		}
+
+		// When writeVariable is called
+		writeVariable(body, "test_var", "value", variables)
+
+		// Then the variable should be written with its comment
+		expected := `# Test variable description
+test_var = "value"
+`
+		if string(file.Bytes()) != expected {
+			t.Errorf("expected %q, got %q", expected, string(file.Bytes()))
+		}
+	})
+
+	t.Run("YAMLMultilineValue", func(t *testing.T) {
+		// Given a body and variables with a YAML multiline value
+		file := hclwrite.NewEmptyFile()
+		body := file.Body()
+		variables := []VariableInfo{
+			{
+				Name:        "worker_config_patches",
+				Description: "Worker configuration patches",
+			},
+		}
+
+		// When writeVariable is called with a YAML multiline string
+		yamlValue := `machine:
+  kubelet:
+    extraMounts:
+    - destination: /var/local
+      options:
+      - rbind
+      - rw
+      source: /var/local
+      type: bind`
+		writeVariable(body, "worker_config_patches", yamlValue, variables)
+
+		// Then the variable should be written as a heredoc with valid YAML
+		actual := string(file.Bytes())
+
+		// Extract the YAML content from the heredoc
+		lines := strings.Split(actual, "\n")
+		var yamlContent strings.Builder
+		inYAML := false
+		for _, line := range lines {
+			if strings.Contains(line, "<<EOF") {
+				inYAML = true
+				continue
+			}
+			if strings.Contains(line, "EOF") {
+				inYAML = false
+				continue
+			}
+			if inYAML {
+				yamlContent.WriteString(line + "\n")
+			}
+		}
+
+		// Parse both expected and actual YAML
+		var expectedData, actualData any
+		expectedYAML := `machine:
+  kubelet:
+    extraMounts:
+    - destination: /var/local
+      options:
+      - rbind
+      - rw
+      source: /var/local
+      type: bind`
+
+		if err := yaml.UnmarshalWithOptions([]byte(expectedYAML), &expectedData); err != nil {
+			t.Fatalf("failed to parse expected YAML: %v", err)
+		}
+		if err := yaml.UnmarshalWithOptions([]byte(yamlContent.String()), &actualData); err != nil {
+			t.Fatalf("failed to parse actual YAML: %v", err)
+		}
+
+		// Compare the YAML data structures
+		var expectedBytes, actualBytes []byte
+		expectedBytes, _ = yaml.MarshalWithOptions(expectedData)
+		actualBytes, _ = yaml.MarshalWithOptions(actualData)
+		if string(expectedBytes) != string(actualBytes) {
+			t.Errorf("YAML content does not match.\nExpected:\n%s\nGot:\n%s", expectedBytes, actualBytes)
+		}
+
+		// Verify the comment and heredoc syntax
+		if !strings.Contains(actual, "# Worker configuration patches") {
+			t.Error("missing description comment")
+		}
+		if !strings.Contains(actual, "worker_config_patches = <<EOF") {
+			t.Error("missing heredoc start")
+		}
+		if !strings.Contains(actual, "EOF") {
+			t.Error("missing heredoc end")
+		}
+	})
+
+	t.Run("MultilineString", func(t *testing.T) {
+		// Given a multiline string value
+		file := hclwrite.NewEmptyFile()
+		value := `first line
+  indented line
+    more indented
+last line`
+
+		// When writeVariable is called
+		writeVariable(file.Body(), "test_var", value, nil)
+
+		// Then the content should be written as heredoc
+		content := string(file.Bytes())
+		lines := strings.Split(content, "\n")
+		var actualLines []string
+		inHeredoc := false
+		for _, line := range lines {
+			if strings.Contains(line, "<<EOF") {
+				inHeredoc = true
+				continue
+			}
+			if strings.Contains(line, "EOF") {
+				break
+			}
+			if inHeredoc {
+				actualLines = append(actualLines, line)
+			}
+		}
+		actual := strings.Join(actualLines, "\n")
+		if actual != value {
+			t.Errorf("content does not match.\nExpected:\n%s\nGot:\n%s", value, actual)
+		}
+	})
+
+	t.Run("MultilineStringWithTabs", func(t *testing.T) {
+		// Given a multiline string with tabs
+		file := hclwrite.NewEmptyFile()
+		value := `first line
+	tabbed line
+		more tabbed
+last line`
+
+		// When writeVariable is called
+		writeVariable(file.Body(), "test_var", value, nil)
+
+		// Then the content should preserve tabs
+		content := string(file.Bytes())
+		lines := strings.Split(content, "\n")
+		var actualLines []string
+		inHeredoc := false
+		for _, line := range lines {
+			if strings.Contains(line, "<<EOF") {
+				inHeredoc = true
+				continue
+			}
+			if strings.Contains(line, "EOF") {
+				break
+			}
+			if inHeredoc {
+				actualLines = append(actualLines, line)
+			}
+		}
+		actual := strings.Join(actualLines, "\n")
+		if actual != value {
+			t.Errorf("content does not match.\nExpected:\n%s\nGot:\n%s", value, actual)
+		}
+	})
+
+	t.Run("MapValue", func(t *testing.T) {
+		// Given a map value
+		file := hclwrite.NewEmptyFile()
+		value := map[string]any{
+			"string": "value",
+			"number": 42,
+			"bool":   true,
+			"nested": map[string]any{
+				"key": "value",
+			},
+		}
+
+		// When writeVariable is called
+		writeVariable(file.Body(), "test_var", value, nil)
+
+		// Then the map should be formatted correctly
+		content := string(file.Bytes())
+		assignmentPrefix := "test_var = "
+		idx := strings.Index(content, assignmentPrefix)
+		if idx == -1 {
+			t.Fatalf("assignment not found in output: %q", content)
+		}
+		actual := strings.TrimSpace(content[idx+len(assignmentPrefix):])
+		expected := `{
+  bool = true
+  nested = {
+    key = "value"
+  }
+  number = 42
+  string = "value"
+}`
+		if actual != expected {
+			t.Errorf("map content does not match.\nExpected:\n%s\nGot:\n%s", expected, actual)
+		}
+	})
+
+	t.Run("ComplexObjectNodeGroups", func(t *testing.T) {
+		// Given a complex nested object for node groups
+		file := hclwrite.NewEmptyFile()
+		value := map[string]any{
+			"node_groups": map[string]any{
+				"default": map[string]any{
+					"instance_types": []any{"t3.medium"},
+					"min_size":       1,
+					"max_size":       3,
+					"desired_size":   2,
+				},
+			},
+		}
+
+		// When writeVariable is called
+		writeVariable(file.Body(), "node_groups", value, nil)
+
+		// Then the complex object should be formatted correctly
+		expected := "node_groups = {\n  node_groups = {\n    default = {\n      desired_size = 2\n      instance_types = [\"t3.medium\"]\n      max_size = 3\n      min_size = 1\n    }\n  }\n}"
+		result := strings.TrimSpace(string(file.Bytes()))
+		if result != expected {
+			t.Errorf("expected\n%s\ngot\n%s", expected, result)
+		}
+	})
+
+	t.Run("ComplexObjectAddons", func(t *testing.T) {
+		// Given a complex object with empty maps for addons
+		file := hclwrite.NewEmptyFile()
+		value := map[string]any{
+			"addons": map[string]any{
+				"vpc-cni":                map[string]any{},
+				"aws-efs-csi-driver":     map[string]any{},
+				"aws-ebs-csi-driver":     map[string]any{},
+				"eks-pod-identity-agent": map[string]any{},
+				"coredns":                map[string]any{},
+				"external-dns":           map[string]any{},
+			},
+		}
+
+		// When writeVariable is called
+		writeVariable(file.Body(), "addons", value, nil)
+
+		// Then the addons object should be formatted correctly with sorted keys
+		expected := "addons = {\n  addons = {\n    aws-ebs-csi-driver = {}\n    aws-efs-csi-driver = {}\n    coredns = {}\n    eks-pod-identity-agent = {}\n    external-dns = {}\n    vpc-cni = {}\n  }\n}"
+		result := strings.TrimSpace(string(file.Bytes()))
+		if result != expected {
+			t.Errorf("expected\n%s\ngot\n%s", expected, result)
+		}
+	})
+
+	t.Run("ObjectAssignmentNoHeredoc", func(t *testing.T) {
+		// Given a nested object value without requiring heredoc
+		file := hclwrite.NewEmptyFile()
+		value := map[string]any{
+			"default": map[string]any{
+				"desired_size":   2,
+				"instance_types": []any{"t3.medium"},
+				"max_size":       3,
+				"min_size":       1,
+			},
+		}
+
+		// When writeVariable is called
+		writeVariable(file.Body(), "node_groups", value, nil)
+
+		// Then the object should be assigned directly without heredoc
+		expected := "node_groups = {\n  default = {\n    desired_size = 2\n    instance_types = [\"t3.medium\"]\n    max_size = 3\n    min_size = 1\n  }\n}"
+		result := strings.TrimSpace(string(file.Bytes()))
+		if result != expected {
+			t.Errorf("expected\n%s\ngot\n%s", expected, result)
+		}
+	})
+}
+
+func TestTerraformGenerator_parseOCIRef(t *testing.T) {
 	setup := func(t *testing.T) (*TerraformGenerator, *Mocks) {
 		mocks := setupMocks(t)
 		generator := NewTerraformGenerator(mocks.Injector)
@@ -3647,19 +4578,334 @@ func TestTerraformGenerator_walkTemplateDirectory(t *testing.T) {
 		return generator, mocks
 	}
 
-	t.Run("ErrorReadingDirectory", func(t *testing.T) {
+	t.Run("ValidOCIReference", func(t *testing.T) {
+		// Given a TerraformGenerator
+		generator, _ := setup(t)
+
+		// When parseOCIRef is called with valid OCI reference
+		registry, repository, tag, err := generator.parseOCIRef("oci://registry.example.com/my-repo:v1.0.0")
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		// And the components should be parsed correctly
+		if registry != "registry.example.com" {
+			t.Errorf("expected registry 'registry.example.com', got %s", registry)
+		}
+		if repository != "my-repo" {
+			t.Errorf("expected repository 'my-repo', got %s", repository)
+		}
+		if tag != "v1.0.0" {
+			t.Errorf("expected tag 'v1.0.0', got %s", tag)
+		}
+	})
+
+	t.Run("InvalidOCIPrefix", func(t *testing.T) {
+		// Given a TerraformGenerator
+		generator, _ := setup(t)
+
+		// When parseOCIRef is called with invalid prefix
+		_, _, _, err := generator.parseOCIRef("https://registry.example.com/my-repo:v1.0.0")
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+
+		// And the error should contain the expected message
+		expectedError := "invalid OCI reference format: https://registry.example.com/my-repo:v1.0.0"
+		if err.Error() != expectedError {
+			t.Errorf("expected error %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("MissingTag", func(t *testing.T) {
+		// Given a TerraformGenerator
+		generator, _ := setup(t)
+
+		// When parseOCIRef is called with missing tag
+		_, _, _, err := generator.parseOCIRef("oci://registry.example.com/my-repo")
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+
+		// And the error should contain the expected message
+		expectedError := "invalid OCI reference format, expected registry/repository:tag: oci://registry.example.com/my-repo"
+		if err.Error() != expectedError {
+			t.Errorf("expected error %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("MissingRepository", func(t *testing.T) {
+		// Given a TerraformGenerator
+		generator, _ := setup(t)
+
+		// When parseOCIRef is called with missing repository
+		_, _, _, err := generator.parseOCIRef("oci://registry.example.com:v1.0.0")
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+
+		// And the error should contain the expected message
+		expectedError := "invalid OCI reference format, expected registry/repository:tag: oci://registry.example.com:v1.0.0"
+		if err.Error() != expectedError {
+			t.Errorf("expected error %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("NestedRepositoryPath", func(t *testing.T) {
+		// Given a TerraformGenerator
+		generator, _ := setup(t)
+
+		// When parseOCIRef is called with nested repository path
+		registry, repository, tag, err := generator.parseOCIRef("oci://registry.example.com/organization/my-repo:v1.0.0")
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		// And the components should be parsed correctly
+		if registry != "registry.example.com" {
+			t.Errorf("expected registry 'registry.example.com', got %s", registry)
+		}
+		if repository != "organization/my-repo" {
+			t.Errorf("expected repository 'organization/my-repo', got %s", repository)
+		}
+		if tag != "v1.0.0" {
+			t.Errorf("expected tag 'v1.0.0', got %s", tag)
+		}
+	})
+}
+
+func TestTerraformGenerator_extractModuleFromArtifact(t *testing.T) {
+	setup := func(t *testing.T) (*TerraformGenerator, *Mocks) {
+		mocks := setupMocks(t)
+		setupTerraformGeneratorMocks(mocks) // Add terraform-specific mocks
+		generator := NewTerraformGenerator(mocks.Injector)
+		generator.shims = mocks.Shims
+
+		// Mock GetProjectRoot to return /project for tests
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return "/project", nil
+		}
+
+		if err := generator.Initialize(); err != nil {
+			t.Fatalf("failed to initialize TerraformGenerator: %v", err)
+		}
+		return generator, mocks
+	}
+
+	// Helper function to create a tar archive with test data
+	createTestTarData := func(files map[string]string, dirs []string) []byte {
+		var buf bytes.Buffer
+		tw := tar.NewWriter(&buf)
+		defer tw.Close()
+
+		// Add directories first
+		for _, dir := range dirs {
+			header := &tar.Header{
+				Name:     dir,
+				Mode:     0755,
+				Typeflag: tar.TypeDir,
+			}
+			if err := tw.WriteHeader(header); err != nil {
+				panic(err)
+			}
+		}
+
+		// Add files
+		for filename, content := range files {
+			header := &tar.Header{
+				Name: filename,
+				Mode: 0644,
+				Size: int64(len(content)),
+			}
+			if err := tw.WriteHeader(header); err != nil {
+				panic(err)
+			}
+			if _, err := tw.Write([]byte(content)); err != nil {
+				panic(err)
+			}
+		}
+
+		return buf.Bytes()
+	}
+
+	t.Run("SuccessfulExtraction", func(t *testing.T) {
 		// Given a TerraformGenerator with mocks
 		generator, mocks := setup(t)
 
-		// And ReadDir is mocked to return an error
-		mocks.Shims.ReadDir = func(path string) ([]fs.DirEntry, error) {
+		// And a tar archive with test files
+		testFiles := map[string]string{
+			"terraform/test/module/main.tf":      "module content",
+			"terraform/test/module/variables.tf": "variables content",
+			"terraform/test/module/outputs.tf":   "outputs content",
+		}
+		testDirs := []string{
+			"terraform/test/module",
+		}
+		tarData := createTestTarData(testFiles, testDirs)
+
+		// And tracking variables for mocked operations
+		var extractedFiles []string
+		var createdDirs []string
+
+		mocks.Shims.MkdirAll = func(path string, perm fs.FileMode) error {
+			createdDirs = append(createdDirs, path)
+			return nil
+		}
+		mocks.Shims.Create = func(path string) (*os.File, error) {
+			extractedFiles = append(extractedFiles, path)
+			// Return a mock file that doesn't actually write to disk
+			return &os.File{}, nil
+		}
+		mocks.Shims.Copy = func(dst io.Writer, src io.Reader) (int64, error) {
+			return 100, nil // Simulate successful copy
+		}
+		mocks.Shims.Chmod = func(name string, mode os.FileMode) error {
+			return nil // Simulate successful chmod
+		}
+
+		// When extractModuleFromArtifact is called
+		err := generator.extractModuleFromArtifact(tarData, "test/module", "test-extraction-key")
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		// And the correct files should be extracted
+		expectedFiles := map[string]bool{
+			"/project/.windsor/.oci_extracted/test-extraction-key/terraform/test/module/main.tf":      true,
+			"/project/.windsor/.oci_extracted/test-extraction-key/terraform/test/module/variables.tf": true,
+			"/project/.windsor/.oci_extracted/test-extraction-key/terraform/test/module/outputs.tf":   true,
+		}
+		if len(extractedFiles) != len(expectedFiles) {
+			t.Errorf("expected %d files extracted, got %d", len(expectedFiles), len(extractedFiles))
+		}
+		for _, extractedFile := range extractedFiles {
+			if !expectedFiles[extractedFile] {
+				t.Errorf("unexpected file extracted: %q", extractedFile)
+			}
+		}
+
+		// And the correct directory should be created
+		expectedDir := "/project/.windsor/.oci_extracted/test-extraction-key/terraform/test/module"
+		found := false
+		for _, dir := range createdDirs {
+			if dir == expectedDir {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected directory %q to be created", expectedDir)
+		}
+	})
+
+	t.Run("PathFiltering", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And a tar archive with files that should be filtered out
+		testFiles := map[string]string{
+			"terraform/test/module/main.tf":  "module content",
+			"terraform/other/module/main.tf": "other content",  // Should be filtered out
+			"docs/README.md":                 "readme content", // Should be filtered out
+		}
+		tarData := createTestTarData(testFiles, []string{})
+
+		var extractedFiles []string
+
+		mocks.Shims.MkdirAll = func(path string, perm fs.FileMode) error {
+			return nil
+		}
+		mocks.Shims.Create = func(path string) (*os.File, error) {
+			extractedFiles = append(extractedFiles, path)
+			return &os.File{}, nil
+		}
+		mocks.Shims.Copy = func(dst io.Writer, src io.Reader) (int64, error) {
+			return 100, nil
+		}
+		mocks.Shims.Chmod = func(name string, mode os.FileMode) error {
+			return nil // Simulate successful chmod
+		}
+
+		// When extractModuleFromArtifact is called
+		err := generator.extractModuleFromArtifact(tarData, "test/module", "test-extraction-key")
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		// And only matching files should be extracted
+		if len(extractedFiles) != 1 {
+			t.Errorf("expected 1 file extracted, got %d", len(extractedFiles))
+		}
+		if len(extractedFiles) > 0 && extractedFiles[0] != "/project/.windsor/.oci_extracted/test-extraction-key/terraform/test/module/main.tf" {
+			t.Errorf("expected only test/module/main.tf to be extracted, got %v", extractedFiles)
+		}
+	})
+
+	t.Run("DirectoryCreationError", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And a tar archive with directory entries
+		testDirs := []string{"terraform/test/module"}
+		tarData := createTestTarData(map[string]string{}, testDirs)
+
+		mocks.Shims.MkdirAll = func(path string, perm fs.FileMode) error {
+			return fmt.Errorf("permission denied")
+		}
+		mocks.Shims.Chmod = func(name string, mode os.FileMode) error {
+			return nil // Won't be called due to directory creation error
+		}
+
+		// When extractModuleFromArtifact is called
+		err := generator.extractModuleFromArtifact(tarData, "test/module", "test-extraction-key")
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+
+		// And the error should contain the expected message
+		if !strings.Contains(err.Error(), "failed to create directory") {
+			t.Errorf("expected error to contain 'failed to create directory', got %v", err)
+		}
+	})
+
+	t.Run("FileCreationError", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And a tar archive with file entries
+		testFiles := map[string]string{
+			"terraform/test/module/main.tf": "module content",
+		}
+		tarData := createTestTarData(testFiles, []string{})
+
+		mocks.Shims.MkdirAll = func(path string, perm fs.FileMode) error {
+			return nil
+		}
+		mocks.Shims.Create = func(path string) (*os.File, error) {
 			return nil, fmt.Errorf("permission denied")
 		}
+		mocks.Shims.Chmod = func(name string, mode os.FileMode) error {
+			return nil // Won't be called due to file creation error
+		}
 
-		templateValues := make(map[string]map[string]any)
-
-		// When walkTemplateDirectory is called
-		err := generator.walkTemplateDirectory("/template/dir", "/context/path", "test-context", false, templateValues)
+		// When extractModuleFromArtifact is called
+		err := generator.extractModuleFromArtifact(tarData, "test/module", "test-extraction-key")
 
 		// Then an error should be returned
 		if err == nil {
@@ -3667,283 +4913,542 @@ func TestTerraformGenerator_walkTemplateDirectory(t *testing.T) {
 		}
 
 		// And the error should contain the expected message
-		if !strings.Contains(err.Error(), "failed to read template directory") {
-			t.Errorf("expected error to contain 'failed to read template directory', got %v", err)
+		if !strings.Contains(err.Error(), "failed to create file") {
+			t.Errorf("expected error to contain 'failed to create file', got %v", err)
 		}
 	})
 
-	t.Run("IgnoresNonJsonnetFiles", func(t *testing.T) {
+	t.Run("FileCopyError", func(t *testing.T) {
 		// Given a TerraformGenerator with mocks
 		generator, mocks := setup(t)
 
-		// Create a simple mock for fs.DirEntry
-		mockEntry := &simpleDirEntry{name: "test.txt", isDir: false}
+		// And a tar archive with file entries
+		testFiles := map[string]string{
+			"terraform/test/module/main.tf": "module content",
+		}
+		tarData := createTestTarData(testFiles, []string{})
 
-		// And ReadDir is mocked to return a non-jsonnet file
-		mocks.Shims.ReadDir = func(path string) ([]fs.DirEntry, error) {
-			return []fs.DirEntry{mockEntry}, nil
+		mocks.Shims.MkdirAll = func(path string, perm fs.FileMode) error {
+			return nil
+		}
+		mocks.Shims.Create = func(path string) (*os.File, error) {
+			return &os.File{}, nil
+		}
+		mocks.Shims.Copy = func(dst io.Writer, src io.Reader) (int64, error) {
+			return 0, fmt.Errorf("write error")
+		}
+		mocks.Shims.Chmod = func(name string, mode os.FileMode) error {
+			return nil // Won't be called due to copy error
 		}
 
-		templateValues := make(map[string]map[string]any)
+		// When extractModuleFromArtifact is called
+		err := generator.extractModuleFromArtifact(tarData, "test/module", "test-extraction-key")
 
-		// When walkTemplateDirectory is called
-		err := generator.walkTemplateDirectory("/template/dir", "/context/path", "test-context", false, templateValues)
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
 
-		// Then no error should occur
+		// And the error should contain the expected message
+		if !strings.Contains(err.Error(), "failed to write file") {
+			t.Errorf("expected error to contain 'failed to write file', got %v", err)
+		}
+	})
+
+	t.Run("EmptyTarArchive", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, _ := setup(t)
+
+		// And an empty tar archive
+		tarData := createTestTarData(map[string]string{}, []string{})
+
+		// When extractModuleFromArtifact is called
+		err := generator.extractModuleFromArtifact(tarData, "test/module", "test-extraction-key")
+
+		// Then no error should occur (empty extraction is valid)
 		if err != nil {
 			t.Errorf("expected no error, got %v", err)
 		}
+	})
 
-		// And template values should be empty
-		if len(templateValues) != 0 {
-			t.Errorf("expected 0 template values, got %d", len(templateValues))
+	t.Run("InvalidTarData", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, _ := setup(t)
+
+		// And invalid tar data
+		invalidTarData := []byte("invalid tar data")
+
+		// When extractModuleFromArtifact is called
+		err := generator.extractModuleFromArtifact(invalidTarData, "test/module", "/project")
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+
+		// And the error should contain the expected message
+		if !strings.Contains(err.Error(), "failed to read tar header") {
+			t.Errorf("expected error to contain 'failed to read tar header', got %v", err)
 		}
 	})
 
-	t.Run("ProcessesJsonnetFiles", func(t *testing.T) {
+	t.Run("FilePermissionsPreserved", func(t *testing.T) {
 		// Given a TerraformGenerator with mocks
 		generator, mocks := setup(t)
 
-		// Create a simple mock for fs.DirEntry with jsonnet file
-		mockEntry := &simpleDirEntry{name: "test.jsonnet", isDir: false}
+		// And a tar archive with executable files
+		testFiles := map[string]string{
+			"terraform/test/module/main.tf":        "module content",
+			"terraform/test/module/scripts/run.sh": "#!/bin/bash\necho 'hello'",
+		}
+		tarData := createTestTarData(testFiles, []string{})
 
-		// And ReadDir is mocked to return a jsonnet file
-		mocks.Shims.ReadDir = func(path string) ([]fs.DirEntry, error) {
-			return []fs.DirEntry{mockEntry}, nil
+		// And mocks for file operations
+		mocks.Shims.MkdirAll = func(path string, perm fs.FileMode) error {
+			return nil
+		}
+		mocks.Shims.Create = func(path string) (*os.File, error) {
+			return &os.File{}, nil
+		}
+		mocks.Shims.Copy = func(dst io.Writer, src io.Reader) (int64, error) {
+			return 100, nil
 		}
 
-		// Mock all dependencies for processJsonnetTemplate
-		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
-			return []byte(`{
-  test_var: "test_value"
-}`), nil
-		}
-
-		mocks.ConfigHandler.(*config.MockConfigHandler).YamlMarshalWithDefinedPathsFunc = func(config any) ([]byte, error) {
-			return []byte("test: config"), nil
-		}
-
-		mocks.Shims.YamlUnmarshal = func(data []byte, v any) error {
-			if configMap, ok := v.(*map[string]any); ok {
-				*configMap = map[string]any{"test": "config"}
-			}
+		// And track chmod calls
+		chmodCalls := make(map[string]os.FileMode)
+		mocks.Shims.Chmod = func(name string, mode os.FileMode) error {
+			chmodCalls[name] = mode
 			return nil
 		}
 
-		mocks.Shims.JsonMarshal = func(v any) ([]byte, error) {
-			return []byte(`{"test": "config", "name": "test-context"}`), nil
-		}
-
-		mocks.Shims.JsonUnmarshal = func(data []byte, v any) error {
-			if values, ok := v.(*map[string]any); ok {
-				*values = map[string]any{"test_var": "test_value"}
-			}
-			return nil
-		}
-
-		mocks.Shell.GetProjectRootFunc = func() (string, error) {
-			return "/tmp", nil
-		}
-
-		templateValues := make(map[string]map[string]any)
-
-		// When walkTemplateDirectory is called
-		err := generator.walkTemplateDirectory("/tmp/contexts/_template/terraform", "/context/path", "test-context", false, templateValues)
+		// When extractModuleFromArtifact is called
+		err := generator.extractModuleFromArtifact(tarData, "test/module", "test-extraction-key")
 
 		// Then no error should occur
 		if err != nil {
 			t.Errorf("expected no error, got %v", err)
 		}
 
-		// And template values should contain the processed template
-		if len(templateValues) != 1 {
-			t.Errorf("expected 1 template value, got %d", len(templateValues))
-		}
-	})
-
-	t.Run("ErrorProcessingJsonnetTemplate", func(t *testing.T) {
-		// Given a TerraformGenerator with mocks
-		generator, mocks := setup(t)
-
-		// Create a simple mock for fs.DirEntry with jsonnet file
-		mockEntry := &simpleDirEntry{name: "test.jsonnet", isDir: false}
-
-		// And ReadDir is mocked to return a jsonnet file
-		mocks.Shims.ReadDir = func(path string) ([]fs.DirEntry, error) {
-			return []fs.DirEntry{mockEntry}, nil
+		// And chmod should have been called for all files
+		if len(chmodCalls) == 0 {
+			t.Errorf("expected chmod to be called for extracted files")
 		}
 
-		// And ReadFile is mocked to return an error for processJsonnetTemplate
-		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
-			return nil, fmt.Errorf("file read error")
-		}
-
-		templateValues := make(map[string]map[string]any)
-
-		// When walkTemplateDirectory is called
-		err := generator.walkTemplateDirectory("/template/dir", "/context/path", "test-context", false, templateValues)
-
-		// Then an error should be returned
-		if err == nil {
-			t.Fatalf("expected an error, got nil")
-		}
-
-		// And the error should contain the expected message
-		if !strings.Contains(err.Error(), "error reading template file") {
-			t.Errorf("expected error to contain 'error reading template file', got %v", err)
-		}
-	})
-
-	t.Run("RecursivelyProcessesDirectories", func(t *testing.T) {
-		// Given a TerraformGenerator with mocks
-		generator, mocks := setup(t)
-
-		callCount := 0
-		// Create mock directory entry
-		mockDirEntry := &simpleDirEntry{name: "subdir", isDir: true}
-
-		// And ReadDir is mocked to return a directory on first call, empty on second
-		mocks.Shims.ReadDir = func(path string) ([]fs.DirEntry, error) {
-			callCount++
-			if callCount == 1 {
-				return []fs.DirEntry{mockDirEntry}, nil
+		// And permissions should be preserved (the test tar data creates files with 0644)
+		for path, mode := range chmodCalls {
+			if !strings.Contains(path, "/project/.windsor/.oci_extracted/test-extraction-key/terraform/test/module/") {
+				t.Errorf("unexpected file path in chmod call: %s", path)
 			}
-			return []fs.DirEntry{}, nil // Empty subdirectory
-		}
-
-		templateValues := make(map[string]map[string]any)
-
-		// When walkTemplateDirectory is called
-		err := generator.walkTemplateDirectory("/template/dir", "/context/path", "test-context", false, templateValues)
-
-		// Then no error should occur
-		if err != nil {
-			t.Errorf("expected no error, got %v", err)
-		}
-
-		// And ReadDir should have been called twice (once for root, once for subdir)
-		if callCount != 2 {
-			t.Errorf("expected ReadDir to be called 2 times, got %d", callCount)
-		}
-	})
-
-	t.Run("ErrorInRecursiveDirectoryCall", func(t *testing.T) {
-		// Given a TerraformGenerator with mocks
-		generator, mocks := setup(t)
-
-		callCount := 0
-		// Create mock directory entry
-		mockDirEntry := &simpleDirEntry{name: "subdir", isDir: true}
-
-		// And ReadDir is mocked to return a directory on first call, error on second
-		mocks.Shims.ReadDir = func(path string) ([]fs.DirEntry, error) {
-			callCount++
-			if callCount == 1 {
-				return []fs.DirEntry{mockDirEntry}, nil
-			}
-			return nil, fmt.Errorf("subdirectory read error")
-		}
-
-		templateValues := make(map[string]map[string]any)
-
-		// When walkTemplateDirectory is called
-		err := generator.walkTemplateDirectory("/template/dir", "/context/path", "test-context", false, templateValues)
-
-		// Then an error should be returned
-		if err == nil {
-			t.Fatalf("expected an error, got nil")
-		}
-
-		// And the error should contain the expected message
-		if !strings.Contains(err.Error(), "failed to read template directory") {
-			t.Errorf("expected error to contain 'failed to read template directory', got %v", err)
-		}
-	})
-
-	t.Run("ErrorGettingConfigRoot", func(t *testing.T) {
-		// Given a TerraformGenerator with mocks
-		generator, mocks := setup(t)
-
-		// And template directory exists
-		mocks.Shims.Stat = func(path string) (fs.FileInfo, error) {
-			if strings.Contains(path, "_template") {
-				return nil, nil
-			}
-			return nil, nil
-		}
-
-		// And GetConfigRoot is mocked to return an error
-		mocks.ConfigHandler.(*config.MockConfigHandler).GetConfigRootFunc = func() (string, error) {
-			return "", fmt.Errorf("config root error")
-		}
-
-		// When processTemplates is called
-		result, err := generator.processTemplates(false)
-
-		// Then an error should be returned
-		if err == nil {
-			t.Fatalf("expected an error, got nil")
-		}
-		if result != nil {
-			t.Errorf("expected nil result, got %v", result)
-		}
-
-		// And the error should contain the expected message
-		if !strings.Contains(err.Error(), "failed to get config root") {
-			t.Errorf("expected error to contain 'failed to get config root', got %v", err)
-		}
-	})
-
-	t.Run("ContextNameFromEnvironment", func(t *testing.T) {
-		// Given a TerraformGenerator with mocks
-		generator, mocks := setup(t)
-
-		// And template directory exists
-		mocks.Shims.Stat = func(path string) (fs.FileInfo, error) {
-			if strings.Contains(path, "_template") {
-				return nil, nil
-			}
-			return nil, nil
-		}
-
-		// And GetString returns empty string (no context configured)
-		mocks.ConfigHandler.(*config.MockConfigHandler).GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "context" {
-				return ""
-			}
-			return ""
-		}
-
-		// And environment variable is set
-		originalEnv := os.Getenv("WINDSOR_CONTEXT")
-		defer func() {
-			if originalEnv == "" {
-				os.Unsetenv("WINDSOR_CONTEXT")
+			// createTestTarData creates regular files with 0644 mode
+			// but .sh files get execute permissions added (0755)
+			if strings.HasSuffix(path, ".sh") {
+				if mode != 0755 {
+					t.Errorf("expected file mode 0755 for .sh file, got %o for file %s", mode, path)
+				}
 			} else {
-				os.Setenv("WINDSOR_CONTEXT", originalEnv)
+				if mode != 0644 {
+					t.Errorf("expected file mode 0644, got %o for file %s", mode, path)
+				}
 			}
-		}()
-		os.Setenv("WINDSOR_CONTEXT", "env-context")
+		}
+	})
 
-		// And ReadDir is mocked to return empty directory
-		mocks.Shims.ReadDir = func(path string) ([]fs.DirEntry, error) {
-			return []fs.DirEntry{}, nil
+	t.Run("ChmodError", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And a tar archive with files
+		testFiles := map[string]string{
+			"terraform/test/module/main.tf": "module content",
+		}
+		tarData := createTestTarData(testFiles, []string{})
+
+		// And mocks for file operations
+		mocks.Shims.MkdirAll = func(path string, perm fs.FileMode) error {
+			return nil
+		}
+		mocks.Shims.Create = func(path string) (*os.File, error) {
+			return &os.File{}, nil
+		}
+		mocks.Shims.Copy = func(dst io.Writer, src io.Reader) (int64, error) {
+			return 100, nil
 		}
 
-		// When processTemplates is called
-		result, err := generator.processTemplates(false)
+		// And chmod returns an error
+		mocks.Shims.Chmod = func(name string, mode os.FileMode) error {
+			return fmt.Errorf("permission denied")
+		}
+
+		// When extractModuleFromArtifact is called
+		err := generator.extractModuleFromArtifact(tarData, "test/module", "test-extraction-key")
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+
+		// And the error should contain the expected message
+		if !strings.Contains(err.Error(), "failed to set file permissions") {
+			t.Errorf("expected error to contain 'failed to set file permissions', got %v", err)
+		}
+	})
+}
+
+func TestTerraformGenerator_preloadOCIArtifacts(t *testing.T) {
+	setup := func(t *testing.T) (*TerraformGenerator, *Mocks) {
+		mocks := setupMocks(t)
+		generator := NewTerraformGenerator(mocks.Injector)
+		generator.shims = mocks.Shims
+		if err := generator.Initialize(); err != nil {
+			t.Fatalf("failed to initialize TerraformGenerator: %v", err)
+		}
+		return generator, mocks
+	}
+
+	t.Run("NoOCISources", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And GetSources returns no OCI sources
+		mocks.BlueprintHandler.GetSourcesFunc = func() []blueprintv1alpha1.Source {
+			return []blueprintv1alpha1.Source{
+				{Name: "git-source", Url: "https://github.com/example/repo.git"},
+				{Name: "local-source", Url: "file:///local/path"},
+			}
+		}
+
+		// When preloadOCIArtifacts is called
+		artifacts, err := generator.preloadOCIArtifacts()
 
 		// Then no error should occur
 		if err != nil {
 			t.Errorf("expected no error, got %v", err)
 		}
 
-		// And result should be an empty map
-		if result == nil {
-			t.Errorf("expected non-nil result, got nil")
+		// And an empty map should be returned
+		if len(artifacts) != 0 {
+			t.Errorf("expected empty artifacts map, got %d items", len(artifacts))
 		}
-		if len(result) != 0 {
-			t.Errorf("expected empty result, got %v", result)
+	})
+
+	t.Run("EmptySourcesList", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And GetSources returns empty list
+		mocks.BlueprintHandler.GetSourcesFunc = func() []blueprintv1alpha1.Source {
+			return []blueprintv1alpha1.Source{}
+		}
+
+		// When preloadOCIArtifacts is called
+		artifacts, err := generator.preloadOCIArtifacts()
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		// And an empty map should be returned
+		if len(artifacts) != 0 {
+			t.Errorf("expected empty artifacts map, got %d items", len(artifacts))
+		}
+	})
+
+	t.Run("SingleOCISourceSuccess", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And GetSources returns one OCI source
+		mocks.BlueprintHandler.GetSourcesFunc = func() []blueprintv1alpha1.Source {
+			return []blueprintv1alpha1.Source{
+				{Name: "oci-source", Url: "oci://registry.example.com/my-repo:v1.0.0"},
+			}
+		}
+
+		// And terraform generator specific mocks are set up
+		setupTerraformGeneratorMocks(mocks)
+
+		// When preloadOCIArtifacts is called
+		artifacts, err := generator.preloadOCIArtifacts()
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		// And the artifacts map should contain the cached data
+		expectedKey := "registry.example.com/my-repo:v1.0.0"
+		if len(artifacts) != 1 {
+			t.Errorf("expected 1 artifact, got %d", len(artifacts))
+		}
+		expectedData := []byte("test artifact data")
+		if !bytes.Equal(artifacts[expectedKey], expectedData) {
+			t.Errorf("expected artifact data to match test data")
+		}
+	})
+
+	t.Run("MultipleOCISourcesDifferentArtifacts", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And GetSources returns multiple different OCI sources
+		mocks.BlueprintHandler.GetSourcesFunc = func() []blueprintv1alpha1.Source {
+			return []blueprintv1alpha1.Source{
+				{Name: "oci-source1", Url: "oci://registry.example.com/repo1:v1.0.0"},
+				{Name: "oci-source2", Url: "oci://registry.example.com/repo2:v2.0.0"},
+			}
+		}
+
+		// And terraform generator specific mocks are set up with counter
+		downloadCallCount := 0
+		setupTerraformGeneratorMocks(mocks)
+		// Override LayerUncompressed for counter behavior
+		mocks.Shims.LayerUncompressed = func(layer v1.Layer) (io.ReadCloser, error) {
+			downloadCallCount++
+			data := []byte(fmt.Sprintf("test artifact data %d", downloadCallCount))
+			return io.NopCloser(bytes.NewReader(data)), nil
+		}
+
+		// When preloadOCIArtifacts is called
+		artifacts, err := generator.preloadOCIArtifacts()
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		// And the artifacts map should contain both entries
+		if len(artifacts) != 2 {
+			t.Errorf("expected 2 artifacts, got %d", len(artifacts))
+		}
+
+		// And both downloads should have happened
+		if downloadCallCount != 2 {
+			t.Errorf("expected 2 download calls, got %d", downloadCallCount)
+		}
+
+		// And both artifacts should be present
+		key1 := "registry.example.com/repo1:v1.0.0"
+		key2 := "registry.example.com/repo2:v2.0.0"
+		if _, exists := artifacts[key1]; !exists {
+			t.Errorf("expected artifact %s to exist", key1)
+		}
+		if _, exists := artifacts[key2]; !exists {
+			t.Errorf("expected artifact %s to exist", key2)
+		}
+	})
+
+	t.Run("MultipleOCISourcesSameArtifact", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And GetSources returns multiple sources pointing to same OCI artifact
+		mocks.BlueprintHandler.GetSourcesFunc = func() []blueprintv1alpha1.Source {
+			return []blueprintv1alpha1.Source{
+				{Name: "oci-source1", Url: "oci://registry.example.com/my-repo:v1.0.0"},
+				{Name: "oci-source2", Url: "oci://registry.example.com/my-repo:v1.0.0"},
+				{Name: "git-source", Url: "https://github.com/example/repo.git"},
+			}
+		}
+
+		// And terraform generator specific mocks are set up with counter
+		testData := []byte("test artifact data")
+		downloadCallCount := 0
+		setupTerraformGeneratorMocks(mocks)
+		// Override LayerUncompressed for counter behavior
+		mocks.Shims.LayerUncompressed = func(layer v1.Layer) (io.ReadCloser, error) {
+			downloadCallCount++
+			return io.NopCloser(bytes.NewReader(testData)), nil
+		}
+
+		// When preloadOCIArtifacts is called
+		artifacts, err := generator.preloadOCIArtifacts()
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		// And the artifacts map should contain only one entry (deduplicated)
+		if len(artifacts) != 1 {
+			t.Errorf("expected 1 artifact, got %d", len(artifacts))
+		}
+
+		// And the download should only happen once (caching works)
+		if downloadCallCount != 1 {
+			t.Errorf("expected 1 download call, got %d", downloadCallCount)
+		}
+
+		expectedKey := "registry.example.com/my-repo:v1.0.0"
+		if !bytes.Equal(artifacts[expectedKey], testData) {
+			t.Errorf("expected artifact data to match test data")
+		}
+	})
+
+	t.Run("ErrorParsingOCIReference", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And GetSources returns an invalid OCI source (missing repository part)
+		mocks.BlueprintHandler.GetSourcesFunc = func() []blueprintv1alpha1.Source {
+			return []blueprintv1alpha1.Source{
+				{Name: "invalid-oci", Url: "oci://registry.example.com:v1.0.0"},
+			}
+		}
+
+		// When preloadOCIArtifacts is called
+		artifacts, err := generator.preloadOCIArtifacts()
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+
+		// And the error should contain the expected message
+		if !strings.Contains(err.Error(), "failed to parse OCI reference for source invalid-oci") {
+			t.Errorf("expected error to contain 'failed to parse OCI reference for source invalid-oci', got %v", err)
+		}
+
+		// And artifacts should be nil
+		if artifacts != nil {
+			t.Errorf("expected nil artifacts, got %v", artifacts)
+		}
+	})
+
+	t.Run("ErrorDownloadingOCIArtifact", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And GetSources returns a valid OCI source
+		mocks.BlueprintHandler.GetSourcesFunc = func() []blueprintv1alpha1.Source {
+			return []blueprintv1alpha1.Source{
+				{Name: "oci-source", Url: "oci://registry.example.com/my-repo:v1.0.0"},
+			}
+		}
+
+		// And terraform generator specific mocks are set up with error
+		setupTerraformGeneratorMocks(mocks)
+		// Override ParseReference to return an error
+		mocks.Shims.ParseReference = func(ref string, opts ...name.Option) (name.Reference, error) {
+			return nil, fmt.Errorf("mock download error")
+		}
+
+		// When preloadOCIArtifacts is called
+		artifacts, err := generator.preloadOCIArtifacts()
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+
+		// And the error should contain the expected message
+		if !strings.Contains(err.Error(), "failed to download OCI artifact for source oci-source") {
+			t.Errorf("expected error to contain 'failed to download OCI artifact for source oci-source', got %v", err)
+		}
+
+		// And artifacts should be nil
+		if artifacts != nil {
+			t.Errorf("expected nil artifacts, got %v", artifacts)
+		}
+	})
+
+	t.Run("ErrorFromRemoteImage", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And GetSources returns a valid OCI source
+		mocks.BlueprintHandler.GetSourcesFunc = func() []blueprintv1alpha1.Source {
+			return []blueprintv1alpha1.Source{
+				{Name: "oci-source", Url: "oci://registry.example.com/my-repo:v1.0.0"},
+			}
+		}
+
+		// And terraform generator specific mocks are set up with RemoteImage error
+		setupTerraformGeneratorMocks(mocks)
+		// Override RemoteImage to return an error
+		mocks.Shims.RemoteImage = func(ref name.Reference, options ...remote.Option) (v1.Image, error) {
+			return nil, fmt.Errorf("remote image error")
+		}
+
+		// When preloadOCIArtifacts is called
+		artifacts, err := generator.preloadOCIArtifacts()
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected an error, got nil")
+		}
+
+		// And the error should contain the expected message
+		if !strings.Contains(err.Error(), "failed to download OCI artifact for source oci-source") {
+			t.Errorf("expected error to contain 'failed to download OCI artifact for source oci-source', got %v", err)
+		}
+
+		// And artifacts should be nil
+		if artifacts != nil {
+			t.Errorf("expected nil artifacts, got %v", artifacts)
+		}
+	})
+
+	t.Run("MixedSourceTypesWithOCI", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And GetSources returns mixed source types including one OCI source
+		mocks.BlueprintHandler.GetSourcesFunc = func() []blueprintv1alpha1.Source {
+			return []blueprintv1alpha1.Source{
+				{Name: "git-source", Url: "https://github.com/example/repo.git"},
+				{Name: "oci-source", Url: "oci://registry.example.com/my-repo:v1.0.0"},
+				{Name: "local-source", Url: "file:///local/path"},
+			}
+		}
+
+		// And terraform generator specific mocks are set up
+		setupTerraformGeneratorMocks(mocks)
+
+		// When preloadOCIArtifacts is called
+		artifacts, err := generator.preloadOCIArtifacts()
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		// And only the OCI artifact should be cached (non-OCI sources ignored)
+		if len(artifacts) != 1 {
+			t.Errorf("expected 1 artifact, got %d", len(artifacts))
+		}
+
+		expectedKey := "registry.example.com/my-repo:v1.0.0"
+		expectedData := []byte("test artifact data")
+		if !bytes.Equal(artifacts[expectedKey], expectedData) {
+			t.Errorf("expected artifact data to match test data")
+		}
+	})
+
+	t.Run("MixedSourceTypesNoOCI", func(t *testing.T) {
+		// Given a TerraformGenerator with mocks
+		generator, mocks := setup(t)
+
+		// And GetSources returns mixed source types with no OCI sources
+		mocks.BlueprintHandler.GetSourcesFunc = func() []blueprintv1alpha1.Source {
+			return []blueprintv1alpha1.Source{
+				{Name: "git-source", Url: "https://github.com/example/repo.git"},
+				{Name: "local-source", Url: "file:///local/path"},
+				{Name: "http-source", Url: "https://releases.example.com/module.tar.gz"},
+			}
+		}
+
+		// When preloadOCIArtifacts is called
+		artifacts, err := generator.preloadOCIArtifacts()
+
+		// Then no error should occur (non-OCI sources should be ignored)
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		// And artifacts map should be empty (no OCI sources to process)
+		if len(artifacts) != 0 {
+			t.Errorf("expected 0 artifacts, got %d", len(artifacts))
 		}
 	})
 }


### PR DESCRIPTION
Terraform components listed in the `blueprint.yaml` can now reference sources with OCI registries. This mechanism will extract the terraform modules to a local `.windsor/.oci_extracted` folder before creating the module shims.

Bulk of the line changes are due to massive reordering of the terraform generator tests to match the style guidelines.