### PR TITLE
fix(cmd): Include artifact system when performing windsor up

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -38,6 +38,7 @@ var upCmd = &cobra.Command{
 			Blueprint:    true,
 			Cluster:      true,
 			Generators:   true,
+			Bundler:      true,
 			Stack:        true,
 			CommandName:  cmd.Name(),
 			Flags: map[string]bool{


### PR DESCRIPTION
The new artifact system needs to be loaded when performing `windsor up`, as it calls the "init" functionality first.