### PR TITLE
refactor(pipeline): Add base pipeline foundation

### DIFF
--- a/pkg/pipelines/mock_pipeline.go
+++ b/pkg/pipelines/mock_pipeline.go
@@ -1,0 +1,45 @@
+package pipelines
+
+import (
+	"context"
+
+	"github.com/windsorcli/cli/pkg/di"
+)
+
+// MockBasePipeline is a mock implementation of the Pipeline interface
+type MockBasePipeline struct {
+	InitializeFunc func(injector di.Injector) error
+	ExecuteFunc    func(ctx context.Context) error
+}
+
+// =============================================================================
+// Constructor
+// =============================================================================
+
+// NewMockBasePipeline creates a new MockBasePipeline instance
+func NewMockBasePipeline() *MockBasePipeline {
+	return &MockBasePipeline{}
+}
+
+// =============================================================================
+// Public Methods
+// =============================================================================
+
+// Initialize calls the mock InitializeFunc if set, otherwise returns nil
+func (m *MockBasePipeline) Initialize(injector di.Injector) error {
+	if m.InitializeFunc != nil {
+		return m.InitializeFunc(injector)
+	}
+	return nil
+}
+
+// Execute calls the mock ExecuteFunc if set, otherwise returns nil
+func (m *MockBasePipeline) Execute(ctx context.Context) error {
+	if m.ExecuteFunc != nil {
+		return m.ExecuteFunc(ctx)
+	}
+	return nil
+}
+
+// Ensure MockBasePipeline implements Pipeline
+var _ Pipeline = (*MockBasePipeline)(nil)

--- a/pkg/pipelines/mock_pipeline_test.go
+++ b/pkg/pipelines/mock_pipeline_test.go
@@ -1,0 +1,145 @@
+package pipelines
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/windsorcli/cli/pkg/di"
+)
+
+// =============================================================================
+// Test Constructor
+// =============================================================================
+
+func TestNewMockBasePipeline(t *testing.T) {
+	t.Run("CreatesMockBasePipeline", func(t *testing.T) {
+		// Given a new mock base pipeline is created
+		mock := NewMockBasePipeline()
+
+		// Then the mock should be created successfully
+		if mock == nil {
+			t.Fatal("Expected mock to not be nil")
+		}
+	})
+}
+
+// =============================================================================
+// Test Public Methods
+// =============================================================================
+
+func TestMockBasePipeline_Initialize(t *testing.T) {
+	t.Run("InitializeReturnsNilByDefault", func(t *testing.T) {
+		// Given a mock base pipeline with no InitializeFunc set
+		mock := NewMockBasePipeline()
+
+		// When initializing the mock
+		injector := di.NewInjector()
+		err := mock.Initialize(injector)
+
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("InitializeCallsInitializeFunc", func(t *testing.T) {
+		// Given a mock base pipeline with InitializeFunc set
+		mock := NewMockBasePipeline()
+		called := false
+		mock.InitializeFunc = func(injector di.Injector) error {
+			called = true
+			return nil
+		}
+
+		// When initializing the mock
+		injector := di.NewInjector()
+		err := mock.Initialize(injector)
+
+		// Then InitializeFunc should be called
+		if !called {
+			t.Error("Expected InitializeFunc to be called")
+		}
+
+		// And no error should be returned
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("InitializeReturnsErrorFromInitializeFunc", func(t *testing.T) {
+		// Given a mock base pipeline with InitializeFunc that returns an error
+		mock := NewMockBasePipeline()
+		expectedError := fmt.Errorf("test error")
+		mock.InitializeFunc = func(injector di.Injector) error {
+			return expectedError
+		}
+
+		// When initializing the mock
+		injector := di.NewInjector()
+		err := mock.Initialize(injector)
+
+		// Then the error should be returned
+		if err != expectedError {
+			t.Errorf("Expected error %v, got %v", expectedError, err)
+		}
+	})
+}
+
+func TestMockBasePipeline_Execute(t *testing.T) {
+	t.Run("ExecuteReturnsNilByDefault", func(t *testing.T) {
+		// Given a mock base pipeline with no ExecuteFunc set
+		mock := NewMockBasePipeline()
+
+		// When executing the mock
+		ctx := context.Background()
+		err := mock.Execute(ctx)
+
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("ExecuteCallsExecuteFunc", func(t *testing.T) {
+		// Given a mock base pipeline with ExecuteFunc set
+		mock := NewMockBasePipeline()
+		called := false
+		mock.ExecuteFunc = func(ctx context.Context) error {
+			called = true
+			return nil
+		}
+
+		// When executing the mock
+		ctx := context.Background()
+		err := mock.Execute(ctx)
+
+		// Then ExecuteFunc should be called
+		if !called {
+			t.Error("Expected ExecuteFunc to be called")
+		}
+
+		// And no error should be returned
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("ExecuteReturnsErrorFromExecuteFunc", func(t *testing.T) {
+		// Given a mock base pipeline with ExecuteFunc that returns an error
+		mock := NewMockBasePipeline()
+		expectedError := fmt.Errorf("test error")
+		mock.ExecuteFunc = func(ctx context.Context) error {
+			return expectedError
+		}
+
+		// When executing the mock
+		ctx := context.Background()
+		err := mock.Execute(ctx)
+
+		// Then the error should be returned
+		if err != expectedError {
+			t.Errorf("Expected error %v, got %v", expectedError, err)
+		}
+	})
+}

--- a/pkg/pipelines/pipeline.go
+++ b/pkg/pipelines/pipeline.go
@@ -1,0 +1,124 @@
+package pipelines
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+
+	"github.com/windsorcli/cli/pkg/config"
+	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/shell"
+)
+
+// The BasePipeline is a foundational component that provides common pipeline functionality for command execution.
+// It provides a unified interface for pipeline execution with dependency injection support,
+// serving as the base implementation for all command-specific pipelines in the Windsor CLI system.
+// The BasePipeline facilitates standardized command execution patterns with constructor-based dependency injection.
+
+// =============================================================================
+// Types
+// =============================================================================
+
+// Pipeline defines the interface for all command pipelines
+type Pipeline interface {
+	Initialize(injector di.Injector) error
+	Execute(ctx context.Context) error
+}
+
+// BasePipeline provides common pipeline functionality including config loading
+// Specific pipelines should embed this and add their own constructor dependencies
+type BasePipeline struct {
+	shell         shell.Shell
+	configHandler config.ConfigHandler
+}
+
+// =============================================================================
+// Constructor
+// =============================================================================
+
+// NewBasePipeline creates a new BasePipeline instance
+func NewBasePipeline() *BasePipeline {
+	return &BasePipeline{}
+}
+
+// =============================================================================
+// Public Methods
+// =============================================================================
+
+// Initialize provides a default implementation that can be overridden by specific pipelines
+func (p *BasePipeline) Initialize(injector di.Injector) error {
+	return nil
+}
+
+// Execute provides a default implementation that can be overridden by specific pipelines
+func (p *BasePipeline) Execute(ctx context.Context) error {
+	return nil
+}
+
+// =============================================================================
+// Protected Methods
+// =============================================================================
+
+// handleSessionReset checks session state and performs reset if needed.
+// This is a common pattern used by multiple commands (env, exec, context, init).
+func (p *BasePipeline) handleSessionReset() error {
+	if p.shell == nil {
+		return nil
+	}
+
+	hasSessionToken := osGetenv("WINDSOR_SESSION_TOKEN") != ""
+
+	shouldReset, err := p.shell.CheckResetFlags()
+	if err != nil {
+		return err
+	}
+
+	if !hasSessionToken {
+		shouldReset = true
+	}
+
+	if shouldReset {
+		p.shell.Reset()
+
+		if err := osSetenv("NO_CACHE", "true"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// loadConfig loads the windsor.yaml config file from the project root into the config handler.
+// This is a common operation that most pipelines will need, so it's provided in the base pipeline.
+func (p *BasePipeline) loadConfig() error {
+	if p.shell == nil {
+		return fmt.Errorf("shell not initialized")
+	}
+	if p.configHandler == nil {
+		return fmt.Errorf("config handler not initialized")
+	}
+
+	projectRoot, err := p.shell.GetProjectRoot()
+	if err != nil {
+		return fmt.Errorf("error retrieving project root: %w", err)
+	}
+
+	yamlPath := filepath.Join(projectRoot, "windsor.yaml")
+	ymlPath := filepath.Join(projectRoot, "windsor.yml")
+
+	var cliConfigPath string
+	shims := NewShims()
+	if _, err := shims.Stat(yamlPath); err == nil {
+		cliConfigPath = yamlPath
+	} else if _, err := shims.Stat(ymlPath); err == nil {
+		cliConfigPath = ymlPath
+	}
+
+	if cliConfigPath != "" {
+		if err := p.configHandler.LoadConfig(cliConfigPath); err != nil {
+			return fmt.Errorf("error loading config file: %w", err)
+		}
+	}
+
+	return nil
+}

--- a/pkg/pipelines/pipeline_test.go
+++ b/pkg/pipelines/pipeline_test.go
@@ -1,0 +1,439 @@
+package pipelines
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/windsorcli/cli/pkg/config"
+	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/shell"
+)
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+func setupBasePipeline(t *testing.T) (*BasePipeline, di.Injector) {
+	t.Helper()
+
+	injector := di.NewInjector()
+	pipeline := NewBasePipeline()
+
+	return pipeline, injector
+}
+
+// =============================================================================
+// Test Constructor
+// =============================================================================
+
+func TestNewBasePipeline(t *testing.T) {
+	t.Run("CreatesBasePipeline", func(t *testing.T) {
+		// Given a new base pipeline is created
+		// When creating a new base pipeline
+		pipeline := NewBasePipeline()
+
+		// Then the pipeline should be created successfully
+		if pipeline == nil {
+			t.Fatal("Expected pipeline to not be nil")
+		}
+	})
+}
+
+// =============================================================================
+// Test Public Methods
+// =============================================================================
+
+func TestBasePipeline_Initialize(t *testing.T) {
+	t.Run("InitializeReturnsNilByDefault", func(t *testing.T) {
+		// Given a base pipeline
+		pipeline, injector := setupBasePipeline(t)
+
+		// When initializing the pipeline
+		err := pipeline.Initialize(injector)
+
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+}
+
+func TestBasePipeline_Execute(t *testing.T) {
+	t.Run("ExecuteReturnsNilByDefault", func(t *testing.T) {
+		// Given a base pipeline
+		pipeline, injector := setupBasePipeline(t)
+
+		// When initializing and executing the pipeline
+		err := pipeline.Initialize(injector)
+		if err != nil {
+			t.Fatalf("Initialize failed: %v", err)
+		}
+
+		ctx := context.Background()
+		err = pipeline.Execute(ctx)
+
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+}
+
+// =============================================================================
+// Test Protected Methods
+// =============================================================================
+
+func TestBasePipeline_handleSessionReset(t *testing.T) {
+	setup := func(t *testing.T) (*BasePipeline, *shell.MockShell) {
+		t.Helper()
+		pipeline := NewBasePipeline()
+		mockShell := shell.NewMockShell()
+		pipeline.shell = mockShell
+
+		origOsGetenv := osGetenv
+		origOsSetenv := osSetenv
+		t.Cleanup(func() {
+			osGetenv = origOsGetenv
+			osSetenv = origOsSetenv
+		})
+
+		osGetenv = func(key string) string {
+			return ""
+		}
+		osSetenv = func(key, value string) error {
+			return nil
+		}
+
+		return pipeline, mockShell
+	}
+
+	t.Run("ReturnsNilWhenShellIsNil", func(t *testing.T) {
+		// Given a pipeline with nil shell
+		pipeline := &BasePipeline{}
+
+		// When handling session reset
+		err := pipeline.handleSessionReset()
+
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("ResetsWhenNoSessionToken", func(t *testing.T) {
+		// Given a pipeline with no session token
+		pipeline, mockShell := setup(t)
+
+		osGetenv = func(key string) string {
+			return ""
+		}
+		osSetenv = func(key, value string) error {
+			return nil
+		}
+		mockShell.CheckResetFlagsFunc = func() (bool, error) {
+			return false, nil
+		}
+		resetCalled := false
+		mockShell.ResetFunc = func() {
+			resetCalled = true
+		}
+
+		// When handling session reset
+		err := pipeline.handleSessionReset()
+
+		// Then reset should be called
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if !resetCalled {
+			t.Error("Expected shell reset to be called")
+		}
+	})
+
+	t.Run("ResetsWhenResetFlagsTrue", func(t *testing.T) {
+		// Given a pipeline with reset flags true
+		pipeline, mockShell := setup(t)
+
+		osGetenv = func(key string) string {
+			if key == "WINDSOR_SESSION_TOKEN" {
+				return "test-token"
+			}
+			return ""
+		}
+		osSetenv = func(key, value string) error {
+			return nil
+		}
+		mockShell.CheckResetFlagsFunc = func() (bool, error) {
+			return true, nil
+		}
+		resetCalled := false
+		mockShell.ResetFunc = func() {
+			resetCalled = true
+		}
+
+		// When handling session reset
+		err := pipeline.handleSessionReset()
+
+		// Then reset should be called
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if !resetCalled {
+			t.Error("Expected shell reset to be called")
+		}
+	})
+
+	t.Run("DoesNotResetWhenSessionTokenExistsAndResetFlagsFalse", func(t *testing.T) {
+		// Given a pipeline with session token and reset flags false
+		pipeline, mockShell := setup(t)
+
+		osGetenv = func(key string) string {
+			if key == "WINDSOR_SESSION_TOKEN" {
+				return "test-token"
+			}
+			return ""
+		}
+		osSetenv = func(key, value string) error {
+			return nil
+		}
+		mockShell.CheckResetFlagsFunc = func() (bool, error) {
+			return false, nil
+		}
+		resetCalled := false
+		mockShell.ResetFunc = func() {
+			resetCalled = true
+		}
+
+		// When handling session reset
+		err := pipeline.handleSessionReset()
+
+		// Then reset should not be called
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if resetCalled {
+			t.Error("Expected shell reset to not be called")
+		}
+	})
+
+	t.Run("ReturnsErrorWhenCheckResetFlagsFails", func(t *testing.T) {
+		// Given a pipeline where check reset flags fails
+		pipeline, mockShell := setup(t)
+
+		osGetenv = func(key string) string {
+			return ""
+		}
+		mockShell.CheckResetFlagsFunc = func() (bool, error) {
+			return false, fmt.Errorf("check reset flags error")
+		}
+
+		// When handling session reset
+		err := pipeline.handleSessionReset()
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if err.Error() != "check reset flags error" {
+			t.Errorf("Expected check reset flags error, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenSetenvFails", func(t *testing.T) {
+		// Given a pipeline where setenv fails
+		pipeline, mockShell := setup(t)
+
+		osGetenv = func(key string) string {
+			return ""
+		}
+		osSetenv = func(key, value string) error {
+			return fmt.Errorf("setenv error")
+		}
+		mockShell.CheckResetFlagsFunc = func() (bool, error) {
+			return true, nil
+		}
+		mockShell.ResetFunc = func() {}
+
+		// When handling session reset
+		err := pipeline.handleSessionReset()
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if err.Error() != "setenv error" {
+			t.Errorf("Expected setenv error, got: %v", err)
+		}
+	})
+}
+
+func TestBasePipeline_loadConfig(t *testing.T) {
+	t.Run("ReturnsErrorWhenShellIsNil", func(t *testing.T) {
+		// Given a BasePipeline with nil shell
+		pipeline := NewBasePipeline()
+
+		// When loadConfig is called
+		err := pipeline.loadConfig()
+
+		// Then an error should be returned
+		if err == nil {
+			t.Error("Expected error when shell is nil")
+		}
+		if err.Error() != "shell not initialized" {
+			t.Errorf("Expected 'shell not initialized' error, got %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenConfigHandlerIsNil", func(t *testing.T) {
+		// Given a BasePipeline with shell but nil config handler
+		pipeline := NewBasePipeline()
+		pipeline.shell = shell.NewMockShell()
+
+		// When loadConfig is called
+		err := pipeline.loadConfig()
+
+		// Then an error should be returned
+		if err == nil {
+			t.Error("Expected error when config handler is nil")
+		}
+		if err.Error() != "config handler not initialized" {
+			t.Errorf("Expected 'config handler not initialized' error, got %v", err)
+		}
+	})
+
+	t.Run("LoadsConfigSuccessfully", func(t *testing.T) {
+		// Given a BasePipeline with shell and config handler
+		pipeline := NewBasePipeline()
+
+		mockShell := shell.NewMockShell()
+		projectRoot := t.TempDir()
+		mockShell.GetProjectRootFunc = func() (string, error) {
+			return projectRoot, nil
+		}
+		pipeline.shell = mockShell
+
+		mockConfigHandler := config.NewMockConfigHandler()
+		loadConfigCalled := false
+		mockConfigHandler.LoadConfigFunc = func(path string) error {
+			loadConfigCalled = true
+			expectedPath := filepath.Join(projectRoot, "windsor.yaml")
+			if path != expectedPath {
+				t.Errorf("Expected config path %q, got %q", expectedPath, path)
+			}
+			return nil
+		}
+		pipeline.configHandler = mockConfigHandler
+
+		// Create a test config file
+		configPath := filepath.Join(projectRoot, "windsor.yaml")
+		if err := os.WriteFile(configPath, []byte("test: config"), 0644); err != nil {
+			t.Fatalf("Failed to create test config file: %v", err)
+		}
+
+		// When loadConfig is called
+		err := pipeline.loadConfig()
+
+		// Then no error should be returned and config should be loaded
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if !loadConfigCalled {
+			t.Error("Expected loadConfig to be called on config handler")
+		}
+	})
+
+	t.Run("ReturnsErrorWhenGetProjectRootFails", func(t *testing.T) {
+		// Given a BasePipeline with failing shell
+		pipeline := NewBasePipeline()
+
+		mockShell := shell.NewMockShell()
+		mockShell.GetProjectRootFunc = func() (string, error) {
+			return "", fmt.Errorf("project root error")
+		}
+		pipeline.shell = mockShell
+
+		mockConfigHandler := config.NewMockConfigHandler()
+		pipeline.configHandler = mockConfigHandler
+
+		// When loadConfig is called
+		err := pipeline.loadConfig()
+
+		// Then an error should be returned
+		if err == nil {
+			t.Error("Expected error when GetProjectRoot fails")
+		}
+		if !strings.Contains(err.Error(), "error retrieving project root") {
+			t.Errorf("Expected 'error retrieving project root' in error, got %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenLoadConfigFails", func(t *testing.T) {
+		// Given a BasePipeline with config handler that fails to load
+		pipeline := NewBasePipeline()
+
+		mockShell := shell.NewMockShell()
+		projectRoot := t.TempDir()
+		mockShell.GetProjectRootFunc = func() (string, error) {
+			return projectRoot, nil
+		}
+		pipeline.shell = mockShell
+
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.LoadConfigFunc = func(path string) error {
+			return fmt.Errorf("load config error")
+		}
+		pipeline.configHandler = mockConfigHandler
+
+		// Create a test config file
+		configPath := filepath.Join(projectRoot, "windsor.yaml")
+		if err := os.WriteFile(configPath, []byte("test: config"), 0644); err != nil {
+			t.Fatalf("Failed to create test config file: %v", err)
+		}
+
+		// When loadConfig is called
+		err := pipeline.loadConfig()
+
+		// Then an error should be returned
+		if err == nil {
+			t.Error("Expected error when loadConfig fails")
+		}
+		if !strings.Contains(err.Error(), "error loading config file") {
+			t.Errorf("Expected 'error loading config file' in error, got %v", err)
+		}
+	})
+
+	t.Run("SkipsLoadingWhenNoConfigFileExists", func(t *testing.T) {
+		// Given a BasePipeline with no config file
+		pipeline := NewBasePipeline()
+
+		mockShell := shell.NewMockShell()
+		projectRoot := t.TempDir()
+		mockShell.GetProjectRootFunc = func() (string, error) {
+			return projectRoot, nil
+		}
+		pipeline.shell = mockShell
+
+		mockConfigHandler := config.NewMockConfigHandler()
+		loadConfigCalled := false
+		mockConfigHandler.LoadConfigFunc = func(path string) error {
+			loadConfigCalled = true
+			return nil
+		}
+		pipeline.configHandler = mockConfigHandler
+
+		// When loadConfig is called (no config file exists)
+		err := pipeline.loadConfig()
+
+		// Then no error should be returned and loadConfig should not be called
+		if err != nil {
+			t.Errorf("Expected no error when no config file exists, got %v", err)
+		}
+		if loadConfigCalled {
+			t.Error("Expected loadConfig not to be called when no config file exists")
+		}
+	})
+}

--- a/pkg/pipelines/shims.go
+++ b/pkg/pipelines/shims.go
@@ -1,0 +1,33 @@
+package pipelines
+
+import "os"
+
+// osStat retrieves the file info for a given path
+var osStat = os.Stat
+
+// osGetenv retrieves an environment variable
+var osGetenv = os.Getenv
+
+// osSetenv sets an environment variable
+var osSetenv = os.Setenv
+
+// Shims provides a testable interface for system operations used by pipelines.
+// This struct-based approach allows for better isolation during testing by enabling
+// dependency injection of mock implementations for file system and environment operations.
+// Each pipeline can use its own Shims instance with customized behavior for testing scenarios.
+type Shims struct {
+	Stat   func(name string) (os.FileInfo, error)
+	Getenv func(key string) string
+	Setenv func(key, value string) error
+}
+
+// NewShims creates a new Shims instance with default system call implementations.
+// The returned instance provides direct access to os package functions and can be
+// used in production environments or as a base for creating test-specific variants.
+func NewShims() *Shims {
+	return &Shims{
+		Stat:   os.Stat,
+		Getenv: os.Getenv,
+		Setenv: os.Setenv,
+	}
+}


### PR DESCRIPTION
The controller has become unwieldy and also is the wrong architecture for a CLI or pipeline utility. The base pipeline begins our migration away from the controller towards a dedicated pipeline approach. 