### PR TITLE
refactor(pipeline): Migrate hook command to pipeline structure

### DIFF
--- a/cmd/hook_test.go
+++ b/cmd/hook_test.go
@@ -2,40 +2,26 @@ package cmd
 
 import (
 	"bytes"
-	"fmt"
 	"testing"
-
-	ctrl "github.com/windsorcli/cli/pkg/controller"
-	"github.com/windsorcli/cli/pkg/shell"
 )
 
 func TestHookCmd(t *testing.T) {
-	setup := func(t *testing.T, opts ...*SetupOptions) (*Mocks, *bytes.Buffer, *bytes.Buffer) {
+	setup := func(t *testing.T) (*bytes.Buffer, *bytes.Buffer) {
 		t.Helper()
-		mocks := setupMocks(t, opts...)
 		stdout, stderr := captureOutput(t)
 		rootCmd.SetOut(stdout)
 		rootCmd.SetErr(stderr)
-		return mocks, stdout, stderr
+		return stdout, stderr
 	}
 
 	t.Run("Success", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, _, stderr := setup(t)
-
-		// Mock the shell methods
-		mockShell := shell.NewMockShell()
-		mockShell.InstallHookFunc = func(shellName string) error {
-			return nil
-		}
-		mocks.Controller.ResolveShellFunc = func() shell.Shell {
-			return mockShell
-		}
+		// Given proper output capture
+		_, stderr := setup(t)
 
 		rootCmd.SetArgs([]string{"hook", "zsh"})
 
 		// When executing the command
-		err := Execute(mocks.Controller)
+		err := Execute(nil)
 
 		// Then no error should occur
 		if err != nil {
@@ -49,13 +35,13 @@ func TestHookCmd(t *testing.T) {
 	})
 
 	t.Run("NoShellName", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, _, _ := setup(t)
+		// Given proper output capture
+		setup(t)
 
 		rootCmd.SetArgs([]string{"hook"})
 
 		// When executing the command without shell name
-		err := Execute(mocks.Controller)
+		err := Execute(nil)
 
 		// Then an error should occur
 		if err == nil {
@@ -70,22 +56,13 @@ func TestHookCmd(t *testing.T) {
 	})
 
 	t.Run("UnsupportedShell", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, _, _ := setup(t)
-
-		// Mock the shell methods to return unsupported shell error
-		mockShell := shell.NewMockShell()
-		mockShell.InstallHookFunc = func(shellName string) error {
-			return fmt.Errorf("Unsupported shell: %s", shellName)
-		}
-		mocks.Controller.ResolveShellFunc = func() shell.Shell {
-			return mockShell
-		}
+		// Given proper output capture
+		setup(t)
 
 		rootCmd.SetArgs([]string{"hook", "unsupported"})
 
 		// When executing the command with unsupported shell
-		err := Execute(mocks.Controller)
+		err := Execute(nil)
 
 		// Then an error should occur
 		if err == nil {
@@ -93,65 +70,22 @@ func TestHookCmd(t *testing.T) {
 		}
 
 		// And error should contain unsupported shell message
-		expectedError := "Unsupported shell: unsupported"
-		if err.Error() != expectedError {
-			t.Errorf("Expected error %q, got %q", expectedError, err.Error())
+		if !contains(err.Error(), "Unsupported shell") {
+			t.Errorf("Expected error to contain 'Unsupported shell', got %q", err.Error())
 		}
 	})
+}
 
-	t.Run("InitializationError", func(t *testing.T) {
-		// Given a set of mocks with initialization error
-		mocks, _, _ := setup(t)
+// Helper function to check if string contains substring
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(substr) == 0 || (len(s) > len(substr) && (s[:len(substr)] == substr || s[len(s)-len(substr):] == substr || containsSubstring(s, substr))))
+}
 
-		// Mock controller to return initialization error
-		mocks.Controller.InitializeWithRequirementsFunc = func(req ctrl.Requirements) error {
-			return fmt.Errorf("initialization failed")
+func containsSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
 		}
-
-		rootCmd.SetArgs([]string{"hook", "zsh"})
-
-		// When executing the command
-		err := Execute(mocks.Controller)
-
-		// Then an error should occur
-		if err == nil {
-			t.Error("Expected error, got nil")
-		}
-
-		// And error should contain initialization message
-		expectedError := "Error initializing: initialization failed"
-		if err.Error() != expectedError {
-			t.Errorf("Expected error %q, got %q", expectedError, err.Error())
-		}
-	})
-
-	t.Run("InstallHookError", func(t *testing.T) {
-		// Given a set of mocks with install hook error
-		mocks, _, _ := setup(t)
-
-		// Mock the shell methods to return error
-		mockShell := shell.NewMockShell()
-		mockShell.InstallHookFunc = func(shellName string) error {
-			return fmt.Errorf("hook installation failed")
-		}
-		mocks.Controller.ResolveShellFunc = func() shell.Shell {
-			return mockShell
-		}
-
-		rootCmd.SetArgs([]string{"hook", "zsh"})
-
-		// When executing the command
-		err := Execute(mocks.Controller)
-
-		// Then an error should occur
-		if err == nil {
-			t.Error("Expected error, got nil")
-		}
-
-		// And error should contain install hook message
-		expectedError := "hook installation failed"
-		if err.Error() != expectedError {
-			t.Errorf("Expected error %q, got %q", expectedError, err.Error())
-		}
-	})
+	}
+	return false
 }

--- a/pkg/pipelines/hook_pipeline.go
+++ b/pkg/pipelines/hook_pipeline.go
@@ -1,0 +1,119 @@
+package pipelines
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/windsorcli/cli/pkg/config"
+	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/shell"
+)
+
+// The HookPipeline is a specialized component that manages shell hook installation functionality.
+// It provides shell hook installation command execution including shell type validation and hook script generation.
+// The HookPipeline handles shell integration for the Windsor CLI hook command.
+
+// =============================================================================
+// Types
+// =============================================================================
+
+// HookConstructors defines constructor functions for HookPipeline dependencies
+type HookConstructors struct {
+	NewConfigHandler func(di.Injector) config.ConfigHandler
+	NewShell         func(di.Injector) shell.Shell
+	NewShims         func() *Shims
+}
+
+// HookPipeline provides shell hook installation functionality
+type HookPipeline struct {
+	BasePipeline
+
+	constructors HookConstructors
+
+	configHandler config.ConfigHandler
+	shell         shell.Shell
+	shims         *Shims
+}
+
+// =============================================================================
+// Constructor
+// =============================================================================
+
+// NewHookPipeline creates a new HookPipeline instance with optional constructors
+func NewHookPipeline(constructors ...HookConstructors) *HookPipeline {
+	var ctors HookConstructors
+	if len(constructors) > 0 {
+		ctors = constructors[0]
+	} else {
+		ctors = HookConstructors{
+			NewConfigHandler: func(injector di.Injector) config.ConfigHandler {
+				return config.NewYamlConfigHandler(injector)
+			},
+			NewShell: func(injector di.Injector) shell.Shell {
+				return shell.NewDefaultShell(injector)
+			},
+			NewShims: func() *Shims {
+				return NewShims()
+			},
+		}
+	}
+
+	return &HookPipeline{
+		BasePipeline: *NewBasePipeline(),
+		constructors: ctors,
+	}
+}
+
+// =============================================================================
+// Public Methods
+// =============================================================================
+
+// Initialize creates and registers all required components for the hook pipeline.
+// It sets up the config handler and shell in the correct order, registering each component
+// with the dependency injector and initializing them sequentially to ensure proper dependency resolution.
+func (p *HookPipeline) Initialize(injector di.Injector) error {
+	p.shims = p.constructors.NewShims()
+
+	if existing := injector.Resolve("shell"); existing != nil {
+		p.shell = existing.(shell.Shell)
+	} else {
+		p.shell = p.constructors.NewShell(injector)
+		injector.Register("shell", p.shell)
+	}
+	p.BasePipeline.shell = p.shell
+
+	if existing := injector.Resolve("configHandler"); existing != nil {
+		p.configHandler = existing.(config.ConfigHandler)
+	} else {
+		p.configHandler = p.constructors.NewConfigHandler(injector)
+		injector.Register("configHandler", p.configHandler)
+	}
+	p.BasePipeline.configHandler = p.configHandler
+
+	if err := p.shell.Initialize(); err != nil {
+		return fmt.Errorf("failed to initialize shell: %w", err)
+	}
+
+	if err := p.configHandler.Initialize(); err != nil {
+		return fmt.Errorf("failed to initialize config handler: %w", err)
+	}
+
+	return nil
+}
+
+// Execute installs the shell hook for the specified shell type.
+// It validates the shell type argument and calls the shell's InstallHook method.
+// The shell type is passed through the context with the key "shellType".
+func (p *HookPipeline) Execute(ctx context.Context) error {
+	shellType := ctx.Value("shellType")
+	if shellType == nil {
+		return fmt.Errorf("No shell name provided")
+	}
+
+	shellName, ok := shellType.(string)
+	if !ok {
+		return fmt.Errorf("Invalid shell name type")
+	}
+
+	return p.shell.InstallHook(shellName)
+}

--- a/pkg/pipelines/hook_pipeline_test.go
+++ b/pkg/pipelines/hook_pipeline_test.go
@@ -1,0 +1,435 @@
+package pipelines
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/windsorcli/cli/pkg/config"
+	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/shell"
+)
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+type HookMocks struct {
+	Injector      di.Injector
+	ConfigHandler *config.MockConfigHandler
+	Shell         *shell.MockShell
+	Shims         *Shims
+}
+
+type HookSetupOptions struct {
+	Injector      di.Injector
+	ConfigHandler *config.MockConfigHandler
+	Shell         *shell.MockShell
+}
+
+func setupHookMocks(t *testing.T, opts ...*HookSetupOptions) *HookMocks {
+	t.Helper()
+
+	var options *HookSetupOptions
+	if len(opts) > 0 {
+		options = opts[0]
+	} else {
+		options = &HookSetupOptions{}
+	}
+
+	var injector di.Injector
+	if options.Injector != nil {
+		injector = options.Injector
+	} else {
+		injector = di.NewMockInjector()
+	}
+
+	var configHandler *config.MockConfigHandler
+	if options.ConfigHandler != nil {
+		configHandler = options.ConfigHandler
+	} else {
+		configHandler = config.NewMockConfigHandler()
+		configHandler.InitializeFunc = func() error { return nil }
+		configHandler.GetContextFunc = func() string { return "test-context" }
+		configHandler.GetConfigRootFunc = func() (string, error) { return t.TempDir(), nil }
+	}
+
+	var mockShell *shell.MockShell
+	if options.Shell != nil {
+		mockShell = options.Shell
+	} else {
+		mockShell = shell.NewMockShell()
+		mockShell.InitializeFunc = func() error { return nil }
+		mockShell.GetProjectRootFunc = func() (string, error) { return t.TempDir(), nil }
+		mockShell.InstallHookFunc = func(shellName string) error { return nil }
+	}
+
+	shims := setupShims(t)
+
+	return &HookMocks{
+		Injector:      injector,
+		ConfigHandler: configHandler,
+		Shell:         mockShell,
+		Shims:         shims,
+	}
+}
+
+func setupShims(t *testing.T) *Shims {
+	t.Helper()
+	return &Shims{
+		Stat: func(name string) (os.FileInfo, error) {
+			return nil, os.ErrNotExist
+		},
+		Getenv: func(key string) string {
+			return ""
+		},
+		Setenv: func(key, value string) error {
+			return nil
+		},
+	}
+}
+
+func setupHookPipeline(t *testing.T, mocks *HookMocks) *HookPipeline {
+	t.Helper()
+
+	constructors := HookConstructors{
+		NewConfigHandler: func(di.Injector) config.ConfigHandler {
+			return mocks.ConfigHandler
+		},
+		NewShell: func(di.Injector) shell.Shell {
+			return mocks.Shell
+		},
+		NewShims: func() *Shims {
+			return mocks.Shims
+		},
+	}
+
+	return NewHookPipeline(constructors)
+}
+
+// =============================================================================
+// Test Constructor
+// =============================================================================
+
+func TestNewHookPipeline(t *testing.T) {
+	t.Run("CreatesWithDefaultConstructors", func(t *testing.T) {
+		// Given no constructors provided
+		// When creating a new hook pipeline
+		pipeline := NewHookPipeline()
+
+		// Then pipeline should be created successfully
+		if pipeline == nil {
+			t.Fatal("Expected pipeline to not be nil")
+		}
+
+		// And all default constructors should be set and functional
+		injector := di.NewMockInjector()
+
+		if pipeline.constructors.NewConfigHandler == nil {
+			t.Error("Expected NewConfigHandler constructor to be set")
+		} else {
+			configHandler := pipeline.constructors.NewConfigHandler(injector)
+			if configHandler == nil {
+				t.Error("Expected NewConfigHandler to return a non-nil config handler")
+			}
+		}
+
+		if pipeline.constructors.NewShell == nil {
+			t.Error("Expected NewShell constructor to be set")
+		} else {
+			shell := pipeline.constructors.NewShell(injector)
+			if shell == nil {
+				t.Error("Expected NewShell to return a non-nil shell")
+			}
+		}
+
+		if pipeline.constructors.NewShims == nil {
+			t.Error("Expected NewShims constructor to be set")
+		} else {
+			shims := pipeline.constructors.NewShims()
+			if shims == nil {
+				t.Error("Expected NewShims to return a non-nil shims")
+			}
+		}
+	})
+
+	t.Run("CreatesWithCustomConstructors", func(t *testing.T) {
+		// Given custom constructors
+		constructors := HookConstructors{
+			NewConfigHandler: func(di.Injector) config.ConfigHandler {
+				return config.NewMockConfigHandler()
+			},
+		}
+
+		// When creating a new hook pipeline
+		pipeline := NewHookPipeline(constructors)
+
+		// Then pipeline should be created successfully
+		if pipeline == nil {
+			t.Fatal("Expected pipeline to not be nil")
+		}
+
+		// And custom constructor should be used
+		if pipeline.constructors.NewConfigHandler == nil {
+			t.Error("Expected NewConfigHandler constructor to be set")
+		}
+	})
+}
+
+// =============================================================================
+// Test Public Methods
+// =============================================================================
+
+func TestHookPipeline_Initialize(t *testing.T) {
+	setup := func(t *testing.T, opts ...*HookSetupOptions) (*HookPipeline, *HookMocks) {
+		t.Helper()
+		mocks := setupHookMocks(t, opts...)
+		pipeline := setupHookPipeline(t, mocks)
+		return pipeline, mocks
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		// Given a properly configured pipeline
+		pipeline, _ := setup(t)
+
+		// When initializing the pipeline
+		err := pipeline.Initialize(di.NewMockInjector())
+
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenConfigHandlerInitializeFails", func(t *testing.T) {
+		// Given a config handler that fails to initialize
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.InitializeFunc = func() error {
+			return fmt.Errorf("config initialization failed")
+		}
+
+		pipeline, mocks := setup(t, &HookSetupOptions{
+			Injector:      di.NewMockInjector(),
+			ConfigHandler: mockConfigHandler,
+		})
+
+		// When initializing the pipeline
+		err := pipeline.Initialize(mocks.Injector)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to initialize config handler") {
+			t.Errorf("Expected config handler error, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenShellInitializeFails", func(t *testing.T) {
+		// Given a shell that fails to initialize
+		pipeline, mocks := setup(t)
+		mocks.Shell.InitializeFunc = func() error {
+			return fmt.Errorf("shell initialization failed")
+		}
+
+		// When initializing the pipeline
+		err := pipeline.Initialize(mocks.Injector)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to initialize shell") {
+			t.Errorf("Expected shell error, got: %v", err)
+		}
+	})
+
+	t.Run("ReusesExistingComponentsFromDIContainer", func(t *testing.T) {
+		// Given a DI container with pre-existing shell and config handler
+		injector := di.NewMockInjector()
+
+		existingShell := shell.NewMockShell()
+		existingShell.InitializeFunc = func() error { return nil }
+		injector.Register("shell", existingShell)
+
+		existingConfigHandler := config.NewMockConfigHandler()
+		existingConfigHandler.InitializeFunc = func() error { return nil }
+		injector.Register("configHandler", existingConfigHandler)
+
+		// And a pipeline with custom constructors that should NOT be called
+		constructorsCalled := false
+		constructors := HookConstructors{
+			NewConfigHandler: func(di.Injector) config.ConfigHandler {
+				constructorsCalled = true
+				return config.NewMockConfigHandler()
+			},
+			NewShell: func(di.Injector) shell.Shell {
+				constructorsCalled = true
+				return shell.NewMockShell()
+			},
+			NewShims: func() *Shims {
+				return setupShims(t)
+			},
+		}
+
+		pipeline := NewHookPipeline(constructors)
+
+		// When initializing the pipeline
+		err := pipeline.Initialize(injector)
+
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		// And the existing components should be reused (constructors not called)
+		if constructorsCalled {
+			t.Error("Expected constructors not to be called when components exist in DI container")
+		}
+
+		// And the pipeline should use the existing components
+		if pipeline.shell != existingShell {
+			t.Error("Expected pipeline to use existing shell from DI container")
+		}
+		if pipeline.configHandler != existingConfigHandler {
+			t.Error("Expected pipeline to use existing config handler from DI container")
+		}
+	})
+}
+
+func TestHookPipeline_Execute(t *testing.T) {
+	setup := func(t *testing.T, opts ...*HookSetupOptions) (*HookPipeline, *HookMocks) {
+		t.Helper()
+		mocks := setupHookMocks(t, opts...)
+		pipeline := setupHookPipeline(t, mocks)
+		err := pipeline.Initialize(mocks.Injector)
+		if err != nil {
+			t.Fatalf("Failed to initialize pipeline: %v", err)
+		}
+		return pipeline, mocks
+	}
+
+	t.Run("ExecutesSuccessfully", func(t *testing.T) {
+		// Given a properly initialized pipeline
+		pipeline, mocks := setup(t)
+
+		// And a shell that successfully installs hooks
+		hookInstalled := false
+		mocks.Shell.InstallHookFunc = func(shellName string) error {
+			hookInstalled = true
+			if shellName != "zsh" {
+				t.Errorf("Expected shell name 'zsh', got '%s'", shellName)
+			}
+			return nil
+		}
+
+		// When executing the pipeline with a shell type
+		ctx := context.WithValue(context.Background(), "shellType", "zsh")
+		err := pipeline.Execute(ctx)
+
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		// And the hook should be installed
+		if !hookInstalled {
+			t.Error("Expected hook to be installed")
+		}
+	})
+
+	t.Run("ReturnsErrorWhenNoShellTypeProvided", func(t *testing.T) {
+		// Given a properly initialized pipeline
+		pipeline, _ := setup(t)
+
+		// When executing the pipeline without a shell type
+		ctx := context.Background()
+		err := pipeline.Execute(ctx)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "No shell name provided") {
+			t.Errorf("Expected shell name error, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenShellTypeIsInvalidType", func(t *testing.T) {
+		// Given a properly initialized pipeline
+		pipeline, _ := setup(t)
+
+		// When executing the pipeline with an invalid shell type
+		ctx := context.WithValue(context.Background(), "shellType", 123)
+		err := pipeline.Execute(ctx)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "Invalid shell name type") {
+			t.Errorf("Expected shell name type error, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenInstallHookFails", func(t *testing.T) {
+		// Given a properly initialized pipeline
+		pipeline, mocks := setup(t)
+
+		// And a shell that fails to install hooks
+		mocks.Shell.InstallHookFunc = func(shellName string) error {
+			return fmt.Errorf("hook installation failed")
+		}
+
+		// When executing the pipeline with a shell type
+		ctx := context.WithValue(context.Background(), "shellType", "bash")
+		err := pipeline.Execute(ctx)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "hook installation failed") {
+			t.Errorf("Expected hook installation error, got: %v", err)
+		}
+	})
+
+	t.Run("HandlesAllSupportedShellTypes", func(t *testing.T) {
+		// Given a properly initialized pipeline
+		pipeline, mocks := setup(t)
+
+		// And a list of supported shell types
+		supportedShells := []string{"zsh", "bash", "fish", "tcsh", "elvish", "powershell"}
+
+		for _, shellType := range supportedShells {
+			t.Run(fmt.Sprintf("Shell_%s", shellType), func(t *testing.T) {
+				// And a shell that tracks the installed shell type
+				var installedShellType string
+				mocks.Shell.InstallHookFunc = func(shellName string) error {
+					installedShellType = shellName
+					return nil
+				}
+
+				// When executing the pipeline with the shell type
+				ctx := context.WithValue(context.Background(), "shellType", shellType)
+				err := pipeline.Execute(ctx)
+
+				// Then no error should be returned
+				if err != nil {
+					t.Errorf("Expected no error for shell %s, got %v", shellType, err)
+				}
+
+				// And the correct shell type should be passed to InstallHook
+				if installedShellType != shellType {
+					t.Errorf("Expected shell type '%s', got '%s'", shellType, installedShellType)
+				}
+			})
+		}
+	})
+}
+
+// =============================================================================
+// Test Helpers
+// =============================================================================


### PR DESCRIPTION
Migrated `cmd/hook.go` from the controller architecture to the new pipeline architecture, following the same pattern established by the env command.