### PR TITLE
refactor(pipeline): Migrate windsor context to pipeline architecture

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -1,10 +1,12 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
-	ctrl "github.com/windsorcli/cli/pkg/controller"
+	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/pipelines"
 )
 
 // getContextCmd represents the get command
@@ -14,34 +16,31 @@ var getContextCmd = &cobra.Command{
 	Long:         "Retrieve and display the current context from the configuration",
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		controller := cmd.Context().Value(controllerKey).(ctrl.Controller)
+		// Create dependency injector
+		injector := di.NewInjector()
 
-		// Initialize environment components
-		if err := controller.InitializeWithRequirements(ctrl.Requirements{
-			Env:         true,
-			CommandName: cmd.Name(),
-		}); err != nil {
-			return fmt.Errorf("Error initializing environment components: %w", err)
+		// Create context pipeline
+		pipeline := pipelines.NewContextPipeline()
+
+		// Initialize the pipeline
+		if err := pipeline.Initialize(injector); err != nil {
+			return fmt.Errorf("Error initializing: %w", err)
 		}
 
-		// Resolve config handler
-		configHandler := controller.ResolveConfigHandler()
-
-		// Check if config is loaded
-		if !configHandler.IsLoaded() {
-			return fmt.Errorf("No context is available. Have you run `windsor init`?")
+		// Create output function
+		outputFunc := func(output string) {
+			fmt.Fprintln(cmd.OutOrStdout(), output)
 		}
 
-		// Set the environment variables internally in the process
-		if err := controller.SetEnvironmentVariables(); err != nil {
-			return fmt.Errorf("Error setting environment variables: %w", err)
+		// Create execution context with operation and output function
+		ctx := context.WithValue(cmd.Context(), "operation", "get")
+		ctx = context.WithValue(ctx, "output", outputFunc)
+
+		// Execute the pipeline
+		if err := pipeline.Execute(ctx); err != nil {
+			return fmt.Errorf("Error executing context pipeline: %w", err)
 		}
 
-		// Get the current context
-		currentContext := configHandler.GetContext()
-
-		// Print the current context
-		fmt.Fprintln(cmd.OutOrStdout(), currentContext)
 		return nil
 	},
 }
@@ -53,39 +52,32 @@ var setContextCmd = &cobra.Command{
 	Long:  "Set the current context in the configuration and save it",
 	Args:  cobra.ExactArgs(1), // Ensure exactly one argument is provided
 	RunE: func(cmd *cobra.Command, args []string) error {
-		controller := cmd.Context().Value(controllerKey).(ctrl.Controller)
+		// Create dependency injector
+		injector := di.NewInjector()
 
-		// Initialize environment components
-		if err := controller.InitializeWithRequirements(ctrl.Requirements{
-			ConfigLoaded: true,
-			Env:          true,
-			CommandName:  cmd.Name(),
-		}); err != nil {
-			return fmt.Errorf("Error initializing environment components: %w", err)
+		// Create context pipeline
+		pipeline := pipelines.NewContextPipeline()
+
+		// Initialize the pipeline
+		if err := pipeline.Initialize(injector); err != nil {
+			return fmt.Errorf("Error initializing: %w", err)
 		}
 
-		// Set the environment variables internally in the process
-		if err := controller.SetEnvironmentVariables(); err != nil {
-			return fmt.Errorf("Error setting environment variables: %w", err)
+		// Create output function
+		outputFunc := func(output string) {
+			fmt.Fprintln(cmd.OutOrStdout(), output)
 		}
 
-		// Resolve config handler
-		configHandler := controller.ResolveConfigHandler()
+		// Create execution context with operation, context name, and output function
+		ctx := context.WithValue(cmd.Context(), "operation", "set")
+		ctx = context.WithValue(ctx, "contextName", args[0])
+		ctx = context.WithValue(ctx, "output", outputFunc)
 
-		// Write a reset token to reset the session
-		shell := controller.ResolveShell()
-		if _, err := shell.WriteResetToken(); err != nil {
-			return fmt.Errorf("Error writing reset token: %w", err)
+		// Execute the pipeline
+		if err := pipeline.Execute(ctx); err != nil {
+			return fmt.Errorf("Error executing context pipeline: %w", err)
 		}
 
-		// Set the context
-		contextName := args[0]
-		if err := configHandler.SetContext(contextName); err != nil {
-			return fmt.Errorf("Error setting context: %w", err)
-		}
-
-		// Print the context
-		fmt.Fprintln(cmd.OutOrStdout(), "Context set to:", contextName)
 		return nil
 	},
 }

--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -2,67 +2,46 @@ package cmd
 
 import (
 	"bytes"
-	"fmt"
+	"os"
 	"testing"
-
-	"github.com/windsorcli/cli/pkg/config"
-	"github.com/windsorcli/cli/pkg/controller"
-	"github.com/windsorcli/cli/pkg/shell"
 )
 
 func TestContextCmd(t *testing.T) {
-	setup := func(t *testing.T, opts ...*SetupOptions) (*Mocks, *bytes.Buffer, *bytes.Buffer) {
+	setup := func(t *testing.T) (*bytes.Buffer, *bytes.Buffer) {
 		t.Helper()
 
-		// Setup mocks with default options
-		mocks := setupMocks(t, opts...)
+		// Change to a temporary directory without a config file
+		origDir, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("Failed to get working directory: %v", err)
+		}
 
-		// Setup command args and output
+		tmpDir := t.TempDir()
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatalf("Failed to change to temp directory: %v", err)
+		}
+
+		// Cleanup to change back to original directory
+		t.Cleanup(func() {
+			if err := os.Chdir(origDir); err != nil {
+				t.Logf("Warning: Failed to change back to original directory: %v", err)
+			}
+		})
+
 		stdout, stderr := captureOutput(t)
 		rootCmd.SetOut(stdout)
 		rootCmd.SetErr(stderr)
-
-		return mocks, stdout, stderr
+		return stdout, stderr
 	}
 
-	t.Run("GetContext", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, stdout, stderr := setup(t, &SetupOptions{
-			ConfigStr: `
-contexts:
-  default:
-    tools:
-      enabled: true`,
-		})
-
-		rootCmd.SetArgs([]string{"context", "get"})
-
-		// When executing the command
-		err := Execute(mocks.Controller)
-
-		// Then no error should occur
-		if err != nil {
-			t.Errorf("Expected success, got error: %v", err)
-		}
-
-		// And output should contain current context
-		output := stdout.String()
-		if output != "default\n" {
-			t.Errorf("Expected 'default', got: %q", output)
-		}
-		if stderr.String() != "" {
-			t.Error("Expected empty stderr")
-		}
-	})
-
 	t.Run("GetContextNoConfig", func(t *testing.T) {
-		// Given a set of mocks with no configuration
-		mocks, _, _ := setup(t)
+		// Given proper output capture in a directory without config
+		_, _ = setup(t)
 
 		rootCmd.SetArgs([]string{"context", "get"})
 
 		// When executing the command
-		err := Execute(mocks.Controller)
+		err := Execute(nil)
 
 		// Then an error should occur
 		if err == nil {
@@ -70,65 +49,20 @@ contexts:
 		}
 
 		// And error should contain init message
-		expectedError := "No context is available. Have you run `windsor init`?"
+		expectedError := "Error executing context pipeline: No context is available. Have you run `windsor init`?"
 		if err.Error() != expectedError {
 			t.Errorf("Expected error %q, got %q", expectedError, err.Error())
 		}
 	})
 
-	t.Run("SetContext", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, stdout, stderr := setup(t, &SetupOptions{
-			ConfigStr: `
-contexts:
-  default:
-    tools:
-      enabled: true`,
-		})
-
-		// Mock the shell methods
-		mockShell := shell.NewMockShell()
-		mockShell.WriteResetTokenFunc = func() (string, error) {
-			return "mock-token", nil
-		}
-		mocks.Controller.ResolveShellFunc = func() shell.Shell {
-			return mockShell
-		}
-
-		rootCmd.SetArgs([]string{"context", "set", "new-context"})
-
-		// When executing the command
-		err := Execute(mocks.Controller)
-
-		// Then no error should occur
-		if err != nil {
-			t.Errorf("Expected success, got error: %v", err)
-		}
-
-		// And output should contain success message
-		output := stdout.String()
-		if output != "Context set to: new-context\n" {
-			t.Errorf("Expected 'Context set to: new-context', got: %q", output)
-		}
-		if stderr.String() != "" {
-			t.Error("Expected empty stderr")
-		}
-	})
-
 	t.Run("SetContextNoArgs", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, _, _ := setup(t, &SetupOptions{
-			ConfigStr: `
-contexts:
-  default:
-    tools:
-      enabled: true`,
-		})
+		// Given proper output capture in a directory without config
+		_, _ = setup(t)
 
 		rootCmd.SetArgs([]string{"context", "set"})
 
 		// When executing the command
-		err := Execute(mocks.Controller)
+		err := Execute(nil)
 
 		// Then an error should occur
 		if err == nil {
@@ -143,18 +77,13 @@ contexts:
 	})
 
 	t.Run("SetContextNoConfig", func(t *testing.T) {
-		// Given a set of mocks with no configuration
-		mocks, _, _ := setup(t)
-
-		// Mock initialization to return error
-		mocks.Controller.InitializeWithRequirementsFunc = func(req controller.Requirements) error {
-			return fmt.Errorf("No context is available. Have you run `windsor init`?")
-		}
+		// Given proper output capture in a directory without config
+		_, _ = setup(t)
 
 		rootCmd.SetArgs([]string{"context", "set", "new-context"})
 
 		// When executing the command
-		err := Execute(mocks.Controller)
+		err := Execute(nil)
 
 		// Then an error should occur
 		if err == nil {
@@ -162,204 +91,41 @@ contexts:
 		}
 
 		// And error should contain init message
-		expectedError := "Error initializing environment components: No context is available. Have you run `windsor init`?"
+		expectedError := "Error executing context pipeline: No context is available. Have you run `windsor init`?"
 		if err.Error() != expectedError {
 			t.Errorf("Expected error %q, got %q", expectedError, err.Error())
 		}
 	})
 
-	t.Run("GetContextEnvError", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, _, _ := setup(t, &SetupOptions{
-			ConfigStr: `
-contexts:
-  default:
-    tools:
-      enabled: true`,
-		})
-
-		// Mock SetEnvironmentVariables to return error
-		mocks.Controller.SetEnvironmentVariablesFunc = func() error {
-			return fmt.Errorf("env error")
-		}
-
-		rootCmd.SetArgs([]string{"context", "get"})
-
-		// When executing the command
-		err := Execute(mocks.Controller)
-
-		// Then an error should occur
-		if err == nil {
-			t.Error("Expected error, got nil")
-		}
-
-		// And error should contain env error message
-		expectedError := "Error setting environment variables: env error"
-		if err.Error() != expectedError {
-			t.Errorf("Expected error %q, got %q", expectedError, err.Error())
-		}
-	})
-
-	t.Run("SetContextEnvError", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, _, _ := setup(t, &SetupOptions{
-			ConfigStr: `
-contexts:
-  default:
-    tools:
-      enabled: true`,
-		})
-
-		// Mock SetEnvironmentVariables to return error
-		mocks.Controller.SetEnvironmentVariablesFunc = func() error {
-			return fmt.Errorf("env error")
-		}
-
-		rootCmd.SetArgs([]string{"context", "set", "new-context"})
-
-		// When executing the command
-		err := Execute(mocks.Controller)
-
-		// Then an error should occur
-		if err == nil {
-			t.Error("Expected error, got nil")
-		}
-
-		// And error should contain env error message
-		expectedError := "Error setting environment variables: env error"
-		if err.Error() != expectedError {
-			t.Errorf("Expected error %q, got %q", expectedError, err.Error())
-		}
-	})
-
-	t.Run("SetContextError", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, _, _ := setup(t, &SetupOptions{
-			ConfigStr: `
-contexts:
-  default:
-    tools:
-      enabled: true`,
-		})
-
-		// Mock the shell methods
-		mockShell := shell.NewMockShell()
-		mockShell.WriteResetTokenFunc = func() (string, error) {
-			return "mock-token", nil
-		}
-		mocks.Controller.ResolveShellFunc = func() shell.Shell {
-			return mockShell
-		}
-
-		// Mock config handler to return error on SetContext
-		mockConfigHandler := config.NewMockConfigHandler()
-		mockConfigHandler.SetContextFunc = func(context string) error {
-			return fmt.Errorf("set context error")
-		}
-		mocks.Controller.ResolveConfigHandlerFunc = func() config.ConfigHandler {
-			return mockConfigHandler
-		}
-
-		rootCmd.SetArgs([]string{"context", "set", "new-context"})
-
-		// When executing the command
-		err := Execute(mocks.Controller)
-
-		// Then an error should occur
-		if err == nil {
-			t.Error("Expected error, got nil")
-		}
-
-		// And error should contain set context error message
-		expectedError := "Error setting context: set context error"
-		if err.Error() != expectedError {
-			t.Errorf("Expected error %q, got %q", expectedError, err.Error())
-		}
-	})
-
-	t.Run("GetContextAlias", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, stdout, stderr := setup(t, &SetupOptions{
-			ConfigStr: `
-contexts:
-  default:
-    tools:
-      enabled: true`,
-		})
+	t.Run("GetContextAliasNoConfig", func(t *testing.T) {
+		// Given proper output capture in a directory without config
+		_, _ = setup(t)
 
 		rootCmd.SetArgs([]string{"get-context"})
 
 		// When executing the command
-		err := Execute(mocks.Controller)
+		err := Execute(nil)
 
-		// Then no error should occur
-		if err != nil {
-			t.Errorf("Expected success, got error: %v", err)
+		// Then an error should occur
+		if err == nil {
+			t.Error("Expected error, got nil")
 		}
 
-		// And output should contain current context
-		output := stdout.String()
-		if output != "default\n" {
-			t.Errorf("Expected 'default', got: %q", output)
-		}
-		if stderr.String() != "" {
-			t.Error("Expected empty stderr")
-		}
-	})
-
-	t.Run("SetContextAlias", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, stdout, stderr := setup(t, &SetupOptions{
-			ConfigStr: `
-contexts:
-  default:
-    tools:
-      enabled: true`,
-		})
-
-		// Mock the shell methods
-		mockShell := shell.NewMockShell()
-		mockShell.WriteResetTokenFunc = func() (string, error) {
-			return "mock-token", nil
-		}
-		mocks.Controller.ResolveShellFunc = func() shell.Shell {
-			return mockShell
-		}
-
-		rootCmd.SetArgs([]string{"set-context", "new-context"})
-
-		// When executing the command
-		err := Execute(mocks.Controller)
-
-		// Then no error should occur
-		if err != nil {
-			t.Errorf("Expected success, got error: %v", err)
-		}
-
-		// And output should contain success message
-		output := stdout.String()
-		if output != "Context set to: new-context\n" {
-			t.Errorf("Expected 'Context set to: new-context', got: %q", output)
-		}
-		if stderr.String() != "" {
-			t.Error("Expected empty stderr")
+		// And error should contain init message
+		expectedError := "Error executing context pipeline: No context is available. Have you run `windsor init`?"
+		if err.Error() != expectedError {
+			t.Errorf("Expected error %q, got %q", expectedError, err.Error())
 		}
 	})
 
 	t.Run("SetContextAliasNoArgs", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, _, _ := setup(t, &SetupOptions{
-			ConfigStr: `
-contexts:
-  default:
-    tools:
-      enabled: true`,
-		})
+		// Given proper output capture in a directory without config
+		_, _ = setup(t)
 
 		rootCmd.SetArgs([]string{"set-context"})
 
 		// When executing the command
-		err := Execute(mocks.Controller)
+		err := Execute(nil)
 
 		// Then an error should occur
 		if err == nil {
@@ -373,73 +139,22 @@ contexts:
 		}
 	})
 
-	t.Run("SetContextResetTokenError", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, _, _ := setup(t, &SetupOptions{
-			ConfigStr: `
-contexts:
-  default:
-    tools:
-      enabled: true`,
-		})
-
-		// Mock the shell methods to return error
-		mockShell := shell.NewMockShell()
-		mockShell.WriteResetTokenFunc = func() (string, error) {
-			return "", fmt.Errorf("reset token error")
-		}
-		mocks.Controller.ResolveShellFunc = func() shell.Shell {
-			return mockShell
-		}
-
-		rootCmd.SetArgs([]string{"context", "set", "new-context"})
-
-		// When executing the command
-		err := Execute(mocks.Controller)
-
-		// Then an error should occur
-		if err == nil {
-			t.Error("Expected error, got nil")
-		}
-
-		// And error should contain reset token error message
-		expectedError := "Error writing reset token: reset token error"
-		if err.Error() != expectedError {
-			t.Errorf("Expected error %q, got %q", expectedError, err.Error())
-		}
-	})
-
-	t.Run("SetContextAliasResetTokenError", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, _, _ := setup(t, &SetupOptions{
-			ConfigStr: `
-contexts:
-  default:
-    tools:
-      enabled: true`,
-		})
-
-		// Mock the shell methods to return error
-		mockShell := shell.NewMockShell()
-		mockShell.WriteResetTokenFunc = func() (string, error) {
-			return "", fmt.Errorf("reset token error")
-		}
-		mocks.Controller.ResolveShellFunc = func() shell.Shell {
-			return mockShell
-		}
+	t.Run("SetContextAliasNoConfig", func(t *testing.T) {
+		// Given proper output capture in a directory without config
+		_, _ = setup(t)
 
 		rootCmd.SetArgs([]string{"set-context", "new-context"})
 
 		// When executing the command
-		err := Execute(mocks.Controller)
+		err := Execute(nil)
 
 		// Then an error should occur
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}
 
-		// And error should contain reset token error message
-		expectedError := "Error writing reset token: reset token error"
+		// And error should contain init message
+		expectedError := "Error executing context pipeline: No context is available. Have you run `windsor init`?"
 		if err.Error() != expectedError {
 			t.Errorf("Expected error %q, got %q", expectedError, err.Error())
 		}

--- a/pkg/pipelines/context_pipeline.go
+++ b/pkg/pipelines/context_pipeline.go
@@ -1,0 +1,190 @@
+package pipelines
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/windsorcli/cli/pkg/config"
+	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/shell"
+)
+
+// The ContextPipeline is a specialized component that manages context operations functionality.
+// It provides context-specific command execution including context getting and setting operations,
+// configuration validation, and shell integration for the Windsor CLI context command.
+// The ContextPipeline handles context management operations with proper initialization and validation.
+
+// =============================================================================
+// Types
+// =============================================================================
+
+// ContextConstructors defines constructor functions for ContextPipeline dependencies
+type ContextConstructors struct {
+	NewConfigHandler func(di.Injector) config.ConfigHandler
+	NewShell         func(di.Injector) shell.Shell
+	NewShims         func() *Shims
+}
+
+// ContextPipeline provides context management functionality
+type ContextPipeline struct {
+	BasePipeline
+
+	constructors ContextConstructors
+
+	configHandler config.ConfigHandler
+	shell         shell.Shell
+	shims         *Shims
+}
+
+// =============================================================================
+// Constructor
+// =============================================================================
+
+// NewContextPipeline creates a new ContextPipeline instance with optional constructors
+func NewContextPipeline(constructors ...ContextConstructors) *ContextPipeline {
+	var ctors ContextConstructors
+	if len(constructors) > 0 {
+		ctors = constructors[0]
+	} else {
+		ctors = ContextConstructors{
+			NewConfigHandler: func(injector di.Injector) config.ConfigHandler {
+				return config.NewYamlConfigHandler(injector)
+			},
+			NewShell: func(injector di.Injector) shell.Shell {
+				return shell.NewDefaultShell(injector)
+			},
+			NewShims: func() *Shims {
+				return NewShims()
+			},
+		}
+	}
+
+	return &ContextPipeline{
+		BasePipeline: *NewBasePipeline(),
+		constructors: ctors,
+	}
+}
+
+// =============================================================================
+// Public Methods
+// =============================================================================
+
+// Initialize creates and registers all required components for the context pipeline.
+// It sets up the config handler and shell in the correct order, registering each component
+// with the dependency injector and initializing them sequentially to ensure proper dependency resolution.
+func (p *ContextPipeline) Initialize(injector di.Injector) error {
+	p.shims = p.constructors.NewShims()
+
+	if existing := injector.Resolve("shell"); existing != nil {
+		p.shell = existing.(shell.Shell)
+	} else {
+		p.shell = p.constructors.NewShell(injector)
+		injector.Register("shell", p.shell)
+	}
+	p.BasePipeline.shell = p.shell
+
+	if existing := injector.Resolve("configHandler"); existing != nil {
+		p.configHandler = existing.(config.ConfigHandler)
+	} else {
+		p.configHandler = p.constructors.NewConfigHandler(injector)
+		injector.Register("configHandler", p.configHandler)
+	}
+	p.BasePipeline.configHandler = p.configHandler
+
+	if err := p.shell.Initialize(); err != nil {
+		return fmt.Errorf("failed to initialize shell: %w", err)
+	}
+
+	if err := p.configHandler.Initialize(); err != nil {
+		return fmt.Errorf("failed to initialize config handler: %w", err)
+	}
+
+	if err := p.loadConfig(); err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	return nil
+}
+
+// Execute runs the context management logic based on the operation type.
+// It supports both "get" and "set" operations specified through the context.
+// For "get" operations, it returns the current context.
+// For "set" operations, it sets the context and writes a reset token.
+func (p *ContextPipeline) Execute(ctx context.Context) error {
+	operation := ctx.Value("operation")
+	if operation == nil {
+		return fmt.Errorf("no operation specified")
+	}
+
+	operationStr, ok := operation.(string)
+	if !ok {
+		return fmt.Errorf("invalid operation type")
+	}
+
+	switch operationStr {
+	case "get":
+		return p.executeGet(ctx)
+	case "set":
+		return p.executeSet(ctx)
+	default:
+		return fmt.Errorf("unsupported operation: %s", operationStr)
+	}
+}
+
+// =============================================================================
+// Private Methods
+// =============================================================================
+
+// executeGet handles the context get operation by checking if config is loaded
+// and returning the current context name.
+func (p *ContextPipeline) executeGet(ctx context.Context) error {
+	if !p.configHandler.IsLoaded() {
+		return fmt.Errorf("No context is available. Have you run `windsor init`?")
+	}
+
+	currentContext := p.configHandler.GetContext()
+
+	output := ctx.Value("output")
+	if output != nil {
+		if outputFunc, ok := output.(func(string)); ok {
+			outputFunc(currentContext)
+		}
+	}
+
+	return nil
+}
+
+// executeSet handles the context set operation by validating the context name,
+// setting the context, and writing a reset token.
+func (p *ContextPipeline) executeSet(ctx context.Context) error {
+	contextName := ctx.Value("contextName")
+	if contextName == nil {
+		return fmt.Errorf("no context name provided")
+	}
+
+	contextNameStr, ok := contextName.(string)
+	if !ok {
+		return fmt.Errorf("invalid context name type")
+	}
+
+	if !p.configHandler.IsLoaded() {
+		return fmt.Errorf("No context is available. Have you run `windsor init`?")
+	}
+
+	if _, err := p.shell.WriteResetToken(); err != nil {
+		return fmt.Errorf("Error writing reset token: %w", err)
+	}
+
+	if err := p.configHandler.SetContext(contextNameStr); err != nil {
+		return fmt.Errorf("Error setting context: %w", err)
+	}
+
+	output := ctx.Value("output")
+	if output != nil {
+		if outputFunc, ok := output.(func(string)); ok {
+			outputFunc(fmt.Sprintf("Context set to: %s", contextNameStr))
+		}
+	}
+
+	return nil
+}

--- a/pkg/pipelines/context_pipeline_test.go
+++ b/pkg/pipelines/context_pipeline_test.go
@@ -1,0 +1,605 @@
+package pipelines
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/windsorcli/cli/pkg/config"
+	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/shell"
+)
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+type ContextMocks struct {
+	Injector      di.Injector
+	ConfigHandler *config.MockConfigHandler
+	Shell         *shell.MockShell
+	Shims         *Shims
+}
+
+type ContextSetupOptions struct {
+	Injector      di.Injector
+	ConfigHandler config.ConfigHandler
+	ConfigStr     string
+}
+
+func setupContextShims(t *testing.T) *Shims {
+	t.Helper()
+	shims := NewShims()
+
+	shims.Stat = func(name string) (os.FileInfo, error) {
+		return nil, os.ErrNotExist
+	}
+
+	shims.Getenv = func(key string) string {
+		return ""
+	}
+
+	shims.Setenv = func(key, value string) error {
+		return nil
+	}
+
+	return shims
+}
+
+func setupContextMocks(t *testing.T, opts ...*ContextSetupOptions) *ContextMocks {
+	t.Helper()
+
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Failed to get working directory: %v", err)
+	}
+
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("Failed to change to temp directory: %v", err)
+	}
+
+	os.Setenv("WINDSOR_PROJECT_ROOT", tmpDir)
+
+	var options *ContextSetupOptions
+	if len(opts) > 0 {
+		options = opts[0]
+	}
+	if options == nil {
+		options = &ContextSetupOptions{}
+	}
+
+	var injector di.Injector
+	if options.Injector == nil {
+		injector = di.NewInjector()
+	} else {
+		injector = options.Injector
+	}
+
+	mockShell := shell.NewMockShell()
+	mockShell.GetProjectRootFunc = func() (string, error) {
+		return tmpDir, nil
+	}
+	mockShell.InitializeFunc = func() error {
+		return nil
+	}
+	mockShell.WriteResetTokenFunc = func() (string, error) {
+		return "reset-token", nil
+	}
+	injector.Register("shell", mockShell)
+
+	var configHandler *config.MockConfigHandler
+	if options.ConfigHandler == nil {
+		configHandler = config.NewMockConfigHandler()
+	} else {
+		if mockHandler, ok := options.ConfigHandler.(*config.MockConfigHandler); ok {
+			configHandler = mockHandler
+		} else {
+			configHandler = config.NewMockConfigHandler()
+		}
+	}
+	injector.Register("configHandler", configHandler)
+
+	if options.ConfigStr != "" {
+		if err := configHandler.LoadConfigString(options.ConfigStr); err != nil {
+			t.Fatalf("Failed to load config string: %v", err)
+		}
+	}
+	configHandler.Initialize()
+
+	shims := setupContextShims(t)
+
+	t.Cleanup(func() {
+		os.Unsetenv("WINDSOR_PROJECT_ROOT")
+		if err := os.Chdir(origDir); err != nil {
+			t.Logf("Warning: Failed to change back to original directory: %v", err)
+		}
+	})
+
+	return &ContextMocks{
+		Injector:      injector,
+		ConfigHandler: configHandler,
+		Shell:         mockShell,
+		Shims:         shims,
+	}
+}
+
+func setupContextPipeline(t *testing.T, mocks *ContextMocks) *ContextPipeline {
+	t.Helper()
+
+	constructors := ContextConstructors{
+		NewConfigHandler: func(di.Injector) config.ConfigHandler {
+			return mocks.ConfigHandler
+		},
+		NewShell: func(di.Injector) shell.Shell {
+			return mocks.Shell
+		},
+		NewShims: func() *Shims {
+			return mocks.Shims
+		},
+	}
+
+	return NewContextPipeline(constructors)
+}
+
+// =============================================================================
+// Test Constructor
+// =============================================================================
+
+func TestNewContextPipeline(t *testing.T) {
+	t.Run("CreatesWithDefaultConstructors", func(t *testing.T) {
+		pipeline := NewContextPipeline()
+
+		if pipeline == nil {
+			t.Fatal("Expected pipeline to not be nil")
+		}
+
+		injector := di.NewMockInjector()
+
+		if pipeline.constructors.NewConfigHandler == nil {
+			t.Error("Expected NewConfigHandler constructor to be set")
+		} else {
+			configHandler := pipeline.constructors.NewConfigHandler(injector)
+			if configHandler == nil {
+				t.Error("Expected NewConfigHandler to return a non-nil config handler")
+			}
+		}
+
+		if pipeline.constructors.NewShell == nil {
+			t.Error("Expected NewShell constructor to be set")
+		} else {
+			shell := pipeline.constructors.NewShell(injector)
+			if shell == nil {
+				t.Error("Expected NewShell to return a non-nil shell")
+			}
+		}
+
+		if pipeline.constructors.NewShims == nil {
+			t.Error("Expected NewShims constructor to be set")
+		} else {
+			shims := pipeline.constructors.NewShims()
+			if shims == nil {
+				t.Error("Expected NewShims to return a non-nil shims")
+			}
+		}
+	})
+
+	t.Run("CreatesWithCustomConstructors", func(t *testing.T) {
+		constructors := ContextConstructors{
+			NewConfigHandler: func(di.Injector) config.ConfigHandler {
+				return config.NewMockConfigHandler()
+			},
+		}
+
+		pipeline := NewContextPipeline(constructors)
+
+		if pipeline == nil {
+			t.Fatal("Expected pipeline to not be nil")
+		}
+
+		if pipeline.constructors.NewConfigHandler == nil {
+			t.Error("Expected NewConfigHandler constructor to be set")
+		}
+	})
+}
+
+// =============================================================================
+// Test Public Methods
+// =============================================================================
+
+func TestContextPipeline_Initialize(t *testing.T) {
+	setup := func(t *testing.T, opts ...*ContextSetupOptions) (*ContextPipeline, *ContextMocks) {
+		t.Helper()
+		mocks := setupContextMocks(t, opts...)
+		pipeline := setupContextPipeline(t, mocks)
+		return pipeline, mocks
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		pipeline, _ := setup(t, &ContextSetupOptions{
+			ConfigStr: `
+contexts:
+  test-context:
+    name: "Test Context"
+`,
+		})
+
+		err := pipeline.Initialize(di.NewMockInjector())
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenConfigHandlerInitializeFails", func(t *testing.T) {
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.InitializeFunc = func() error {
+			return fmt.Errorf("config initialization failed")
+		}
+
+		pipeline, mocks := setup(t, &ContextSetupOptions{
+			Injector:      di.NewMockInjector(),
+			ConfigHandler: mockConfigHandler,
+		})
+
+		err := pipeline.Initialize(mocks.Injector)
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !contextContains(err.Error(), "failed to initialize config handler") {
+			t.Errorf("Expected config handler error, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenShellInitializeFails", func(t *testing.T) {
+		pipeline, mocks := setup(t)
+		mocks.Shell.InitializeFunc = func() error {
+			return fmt.Errorf("shell initialization failed")
+		}
+
+		err := pipeline.Initialize(mocks.Injector)
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !contextContains(err.Error(), "failed to initialize shell") {
+			t.Errorf("Expected shell error, got: %v", err)
+		}
+	})
+
+	t.Run("ReusesExistingComponentsFromDIContainer", func(t *testing.T) {
+		injector := di.NewMockInjector()
+
+		existingShell := shell.NewMockShell()
+		existingShell.InitializeFunc = func() error { return nil }
+		existingShell.GetProjectRootFunc = func() (string, error) { return t.TempDir(), nil }
+		injector.Register("shell", existingShell)
+
+		existingConfigHandler := config.NewMockConfigHandler()
+		existingConfigHandler.InitializeFunc = func() error { return nil }
+		existingConfigHandler.LoadConfigFunc = func(path string) error { return nil }
+		injector.Register("configHandler", existingConfigHandler)
+
+		constructorsCalled := false
+		constructors := ContextConstructors{
+			NewConfigHandler: func(di.Injector) config.ConfigHandler {
+				constructorsCalled = true
+				return config.NewMockConfigHandler()
+			},
+			NewShell: func(di.Injector) shell.Shell {
+				constructorsCalled = true
+				return shell.NewMockShell()
+			},
+			NewShims: func() *Shims {
+				return setupContextShims(t)
+			},
+		}
+
+		pipeline := NewContextPipeline(constructors)
+
+		err := pipeline.Initialize(injector)
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		if constructorsCalled {
+			t.Error("Expected constructors not to be called when components exist in DI container")
+		}
+
+		if pipeline.shell != existingShell {
+			t.Error("Expected pipeline to use existing shell from DI container")
+		}
+		if pipeline.configHandler != existingConfigHandler {
+			t.Error("Expected pipeline to use existing config handler from DI container")
+		}
+	})
+}
+
+func TestContextPipeline_Execute(t *testing.T) {
+	setup := func(t *testing.T, opts ...*ContextSetupOptions) (*ContextPipeline, *ContextMocks) {
+		t.Helper()
+		mocks := setupContextMocks(t, opts...)
+		pipeline := setupContextPipeline(t, mocks)
+		err := pipeline.Initialize(mocks.Injector)
+		if err != nil {
+			t.Fatalf("Failed to initialize pipeline: %v", err)
+		}
+		return pipeline, mocks
+	}
+
+	t.Run("ReturnsErrorWhenNoOperationSpecified", func(t *testing.T) {
+		pipeline, _ := setup(t)
+
+		err := pipeline.Execute(context.Background())
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if err.Error() != "no operation specified" {
+			t.Errorf("Expected 'no operation specified', got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenInvalidOperationType", func(t *testing.T) {
+		pipeline, _ := setup(t)
+
+		ctx := context.WithValue(context.Background(), "operation", 123)
+		err := pipeline.Execute(ctx)
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if err.Error() != "invalid operation type" {
+			t.Errorf("Expected 'invalid operation type', got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenUnsupportedOperation", func(t *testing.T) {
+		pipeline, _ := setup(t)
+
+		ctx := context.WithValue(context.Background(), "operation", "unsupported")
+		err := pipeline.Execute(ctx)
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if err.Error() != "unsupported operation: unsupported" {
+			t.Errorf("Expected 'unsupported operation: unsupported', got: %v", err)
+		}
+	})
+
+	t.Run("ExecutesGetOperationSuccessfully", func(t *testing.T) {
+		pipeline, mocks := setup(t, &ContextSetupOptions{
+			ConfigStr: `
+contexts:
+  test-context:
+    name: "Test Context"
+`,
+		})
+
+		mocks.ConfigHandler.IsLoadedFunc = func() bool { return true }
+		mocks.ConfigHandler.GetContextFunc = func() string { return "test-context" }
+
+		var capturedOutput string
+		outputFunc := func(output string) {
+			capturedOutput = output
+		}
+
+		ctx := context.WithValue(context.Background(), "operation", "get")
+		ctx = context.WithValue(ctx, "output", outputFunc)
+		err := pipeline.Execute(ctx)
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if capturedOutput != "test-context" {
+			t.Errorf("Expected 'test-context', got: %v", capturedOutput)
+		}
+	})
+
+	t.Run("ExecutesSetOperationSuccessfully", func(t *testing.T) {
+		pipeline, mocks := setup(t, &ContextSetupOptions{
+			ConfigStr: `
+contexts:
+  test-context:
+    name: "Test Context"
+  new-context:
+    name: "New Context"
+`,
+		})
+
+		mocks.ConfigHandler.IsLoadedFunc = func() bool { return true }
+		mocks.ConfigHandler.SetContextFunc = func(context string) error { return nil }
+
+		var capturedOutput string
+		outputFunc := func(output string) {
+			capturedOutput = output
+		}
+
+		ctx := context.WithValue(context.Background(), "operation", "set")
+		ctx = context.WithValue(ctx, "contextName", "new-context")
+		ctx = context.WithValue(ctx, "output", outputFunc)
+		err := pipeline.Execute(ctx)
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if capturedOutput != "Context set to: new-context" {
+			t.Errorf("Expected 'Context set to: new-context', got: %v", capturedOutput)
+		}
+	})
+}
+
+func TestContextPipeline_executeGet(t *testing.T) {
+	setup := func(t *testing.T, opts ...*ContextSetupOptions) (*ContextPipeline, *ContextMocks) {
+		t.Helper()
+		mocks := setupContextMocks(t, opts...)
+		pipeline := setupContextPipeline(t, mocks)
+		err := pipeline.Initialize(mocks.Injector)
+		if err != nil {
+			t.Fatalf("Failed to initialize pipeline: %v", err)
+		}
+		return pipeline, mocks
+	}
+
+	t.Run("ReturnsErrorWhenConfigNotLoaded", func(t *testing.T) {
+		pipeline, mocks := setup(t)
+		mocks.ConfigHandler.IsLoadedFunc = func() bool { return false }
+
+		err := pipeline.executeGet(context.Background())
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if err.Error() != "No context is available. Have you run `windsor init`?" {
+			t.Errorf("Expected context not available error, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsCurrentContextSuccessfully", func(t *testing.T) {
+		pipeline, mocks := setup(t)
+		mocks.ConfigHandler.IsLoadedFunc = func() bool { return true }
+		mocks.ConfigHandler.GetContextFunc = func() string { return "current-context" }
+
+		var capturedOutput string
+		outputFunc := func(output string) {
+			capturedOutput = output
+		}
+
+		ctx := context.WithValue(context.Background(), "output", outputFunc)
+		err := pipeline.executeGet(ctx)
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if capturedOutput != "current-context" {
+			t.Errorf("Expected 'current-context', got: %v", capturedOutput)
+		}
+	})
+}
+
+func TestContextPipeline_executeSet(t *testing.T) {
+	setup := func(t *testing.T, opts ...*ContextSetupOptions) (*ContextPipeline, *ContextMocks) {
+		t.Helper()
+		mocks := setupContextMocks(t, opts...)
+		pipeline := setupContextPipeline(t, mocks)
+		err := pipeline.Initialize(mocks.Injector)
+		if err != nil {
+			t.Fatalf("Failed to initialize pipeline: %v", err)
+		}
+		return pipeline, mocks
+	}
+
+	t.Run("ReturnsErrorWhenNoContextNameProvided", func(t *testing.T) {
+		pipeline, _ := setup(t)
+
+		err := pipeline.executeSet(context.Background())
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if err.Error() != "no context name provided" {
+			t.Errorf("Expected 'no context name provided', got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenInvalidContextNameType", func(t *testing.T) {
+		pipeline, _ := setup(t)
+
+		ctx := context.WithValue(context.Background(), "contextName", 123)
+		err := pipeline.executeSet(ctx)
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if err.Error() != "invalid context name type" {
+			t.Errorf("Expected 'invalid context name type', got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenConfigNotLoaded", func(t *testing.T) {
+		pipeline, mocks := setup(t)
+		mocks.ConfigHandler.IsLoadedFunc = func() bool { return false }
+
+		ctx := context.WithValue(context.Background(), "contextName", "test-context")
+		err := pipeline.executeSet(ctx)
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if err.Error() != "No context is available. Have you run `windsor init`?" {
+			t.Errorf("Expected context not available error, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenWriteResetTokenFails", func(t *testing.T) {
+		pipeline, mocks := setup(t)
+		mocks.ConfigHandler.IsLoadedFunc = func() bool { return true }
+		mocks.Shell.WriteResetTokenFunc = func() (string, error) {
+			return "", fmt.Errorf("write reset token failed")
+		}
+
+		ctx := context.WithValue(context.Background(), "contextName", "test-context")
+		err := pipeline.executeSet(ctx)
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !contextContains(err.Error(), "Error writing reset token") {
+			t.Errorf("Expected reset token error, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenSetContextFails", func(t *testing.T) {
+		pipeline, mocks := setup(t)
+		mocks.ConfigHandler.IsLoadedFunc = func() bool { return true }
+		mocks.ConfigHandler.SetContextFunc = func(context string) error {
+			return fmt.Errorf("set context failed")
+		}
+
+		ctx := context.WithValue(context.Background(), "contextName", "test-context")
+		err := pipeline.executeSet(ctx)
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !contextContains(err.Error(), "Error setting context") {
+			t.Errorf("Expected set context error, got: %v", err)
+		}
+	})
+
+	t.Run("SetsContextSuccessfully", func(t *testing.T) {
+		pipeline, mocks := setup(t)
+		mocks.ConfigHandler.IsLoadedFunc = func() bool { return true }
+		mocks.ConfigHandler.SetContextFunc = func(context string) error { return nil }
+
+		var capturedOutput string
+		outputFunc := func(output string) {
+			capturedOutput = output
+		}
+
+		ctx := context.WithValue(context.Background(), "contextName", "new-context")
+		ctx = context.WithValue(ctx, "output", outputFunc)
+		err := pipeline.executeSet(ctx)
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if capturedOutput != "Context set to: new-context" {
+			t.Errorf("Expected 'Context set to: new-context', got: %v", capturedOutput)
+		}
+	})
+}
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+func contextContains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || (len(s) > len(substr) &&
+		(s[:len(substr)] == substr || s[len(s)-len(substr):] == substr ||
+			contextContains(s[1:len(s)-1], substr))))
+}

--- a/pkg/pipelines/mock_context_pipeline.go
+++ b/pkg/pipelines/mock_context_pipeline.go
@@ -1,0 +1,45 @@
+package pipelines
+
+import (
+	"context"
+
+	"github.com/windsorcli/cli/pkg/di"
+)
+
+// MockContextPipeline is a mock implementation of the ContextPipeline
+type MockContextPipeline struct {
+	InitializeFunc func(injector di.Injector) error
+	ExecuteFunc    func(ctx context.Context) error
+}
+
+// =============================================================================
+// Constructor
+// =============================================================================
+
+// NewMockContextPipeline creates a new MockContextPipeline instance
+func NewMockContextPipeline() *MockContextPipeline {
+	return &MockContextPipeline{}
+}
+
+// =============================================================================
+// Public Methods
+// =============================================================================
+
+// Initialize calls the mock InitializeFunc if set, otherwise returns nil
+func (m *MockContextPipeline) Initialize(injector di.Injector) error {
+	if m.InitializeFunc != nil {
+		return m.InitializeFunc(injector)
+	}
+	return nil
+}
+
+// Execute calls the mock ExecuteFunc if set, otherwise returns nil
+func (m *MockContextPipeline) Execute(ctx context.Context) error {
+	if m.ExecuteFunc != nil {
+		return m.ExecuteFunc(ctx)
+	}
+	return nil
+}
+
+// Ensure MockContextPipeline implements Pipeline
+var _ Pipeline = (*MockContextPipeline)(nil)

--- a/pkg/pipelines/mock_context_pipeline_test.go
+++ b/pkg/pipelines/mock_context_pipeline_test.go
@@ -1,0 +1,123 @@
+package pipelines
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/windsorcli/cli/pkg/di"
+)
+
+// =============================================================================
+// Test Constructor
+// =============================================================================
+
+func TestNewMockContextPipeline(t *testing.T) {
+	t.Run("CreatesMockContextPipeline", func(t *testing.T) {
+		mock := NewMockContextPipeline()
+
+		if mock == nil {
+			t.Fatal("Expected mock to not be nil")
+		}
+	})
+}
+
+// =============================================================================
+// Test Public Methods
+// =============================================================================
+
+func TestMockContextPipeline_Initialize(t *testing.T) {
+	t.Run("InitializeReturnsNilByDefault", func(t *testing.T) {
+		mock := NewMockContextPipeline()
+
+		injector := di.NewInjector()
+		err := mock.Initialize(injector)
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("InitializeCallsInitializeFunc", func(t *testing.T) {
+		mock := NewMockContextPipeline()
+		called := false
+		mock.InitializeFunc = func(injector di.Injector) error {
+			called = true
+			return nil
+		}
+
+		injector := di.NewInjector()
+		err := mock.Initialize(injector)
+
+		if !called {
+			t.Error("Expected InitializeFunc to be called")
+		}
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("InitializeReturnsErrorFromInitializeFunc", func(t *testing.T) {
+		mock := NewMockContextPipeline()
+		expectedError := fmt.Errorf("test error")
+		mock.InitializeFunc = func(injector di.Injector) error {
+			return expectedError
+		}
+
+		injector := di.NewInjector()
+		err := mock.Initialize(injector)
+
+		if err != expectedError {
+			t.Errorf("Expected error %v, got %v", expectedError, err)
+		}
+	})
+}
+
+func TestMockContextPipeline_Execute(t *testing.T) {
+	t.Run("ExecuteReturnsNilByDefault", func(t *testing.T) {
+		mock := NewMockContextPipeline()
+
+		ctx := context.Background()
+		err := mock.Execute(ctx)
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("ExecuteCallsExecuteFunc", func(t *testing.T) {
+		mock := NewMockContextPipeline()
+		called := false
+		mock.ExecuteFunc = func(ctx context.Context) error {
+			called = true
+			return nil
+		}
+
+		ctx := context.Background()
+		err := mock.Execute(ctx)
+
+		if !called {
+			t.Error("Expected ExecuteFunc to be called")
+		}
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("ExecuteReturnsErrorFromExecuteFunc", func(t *testing.T) {
+		mock := NewMockContextPipeline()
+		expectedError := fmt.Errorf("test error")
+		mock.ExecuteFunc = func(ctx context.Context) error {
+			return expectedError
+		}
+
+		ctx := context.Background()
+		err := mock.Execute(ctx)
+
+		if err != expectedError {
+			t.Errorf("Expected error %v, got %v", expectedError, err)
+		}
+	})
+}


### PR DESCRIPTION
Refactors the `windsor context` command to follow the pipeline architectural pattern.