### PR TITLE
refactor(pipeline): Migrate check to pipeline pattern

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -7,7 +7,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/windsorcli/cli/pkg/constants"
-	ctrl "github.com/windsorcli/cli/pkg/controller"
+	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/pipelines"
 )
 
 var (
@@ -22,34 +23,31 @@ var checkCmd = &cobra.Command{
 	Long:         "Check the tool versions required by the project",
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		controller := cmd.Context().Value(controllerKey).(ctrl.Controller)
+		// Get shared dependency injector from context
+		injector := cmd.Context().Value(injectorKey).(di.Injector)
 
-		if err := controller.InitializeWithRequirements(ctrl.Requirements{
-			ConfigLoaded: true,
-			Tools:        true,
-			CommandName:  cmd.Name(),
-			Flags: map[string]bool{
-				"verbose": cmd.Flags().Changed("verbose"),
-			},
-		}); err != nil {
+		// Create check pipeline
+		pipeline := pipelines.NewCheckPipeline()
+
+		// Initialize the pipeline
+		if err := pipeline.Initialize(injector); err != nil {
 			return fmt.Errorf("Error initializing: %w", err)
 		}
 
-		// Check if projectName is set in the configuration
-		configHandler := controller.ResolveConfigHandler()
-		if !configHandler.IsLoaded() {
-			return fmt.Errorf("Nothing to check. Have you run \033[1mwindsor init\033[0m?")
+		// Create output function
+		outputFunc := func(output string) {
+			fmt.Fprintln(cmd.OutOrStdout(), output)
 		}
 
-		// Check tools
-		toolsManager := controller.ResolveToolsManager()
-		if toolsManager == nil {
-			return fmt.Errorf("No tools manager found")
+		// Create execution context with operation and output function
+		ctx := context.WithValue(cmd.Context(), "operation", "tools")
+		ctx = context.WithValue(ctx, "output", outputFunc)
+
+		// Execute the pipeline
+		if err := pipeline.Execute(ctx); err != nil {
+			return fmt.Errorf("Error executing check pipeline: %w", err)
 		}
-		if err := toolsManager.Check(); err != nil {
-			return fmt.Errorf("Error checking tools: %w", err)
-		}
-		fmt.Fprintln(cmd.OutOrStdout(), "All tools are up to date.")
+
 		return nil
 	},
 }
@@ -60,31 +58,16 @@ var checkNodeHealthCmd = &cobra.Command{
 	Long:         "Check the health status of specified cluster nodes",
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		controller := cmd.Context().Value(controllerKey).(ctrl.Controller)
+		// Get shared dependency injector from context
+		injector := cmd.Context().Value(injectorKey).(di.Injector)
 
-		if err := controller.InitializeWithRequirements(ctrl.Requirements{
-			ConfigLoaded: true,
-			Cluster:      true,
-			CommandName:  cmd.Name(),
-			Flags: map[string]bool{
-				"verbose": cmd.Flags().Changed("verbose"),
-			},
-		}); err != nil {
+		// Create check pipeline
+		pipeline := pipelines.NewCheckPipeline()
+
+		// Initialize the pipeline
+		if err := pipeline.Initialize(injector); err != nil {
 			return fmt.Errorf("Error initializing: %w", err)
 		}
-
-		// Check if projectName is set in the configuration
-		configHandler := controller.ResolveConfigHandler()
-		if !configHandler.IsLoaded() {
-			return fmt.Errorf("Nothing to check. Have you run \033[1mwindsor init\033[0m?")
-		}
-
-		// Get the cluster client
-		clusterClient := controller.ResolveClusterClient()
-		if clusterClient == nil {
-			return fmt.Errorf("No cluster client found")
-		}
-		defer clusterClient.Close()
 
 		// Require nodes to be specified
 		if len(nodeHealthNodes) == 0 {
@@ -96,21 +79,22 @@ var checkNodeHealthCmd = &cobra.Command{
 			nodeHealthTimeout = constants.DEFAULT_NODE_HEALTH_CHECK_TIMEOUT
 		}
 
-		// Create context with timeout
-		ctx, cancel := context.WithTimeout(cmd.Context(), nodeHealthTimeout)
-		defer cancel()
-
-		// Wait for nodes to be healthy (and correct version if specified)
-		if err := clusterClient.WaitForNodesHealthy(ctx, nodeHealthNodes, nodeHealthVersion); err != nil {
-			return fmt.Errorf("nodes failed health check: %w", err)
+		// Create output function
+		outputFunc := func(output string) {
+			fmt.Fprintln(cmd.OutOrStdout(), output)
 		}
 
-		// Success message
-		fmt.Fprintf(cmd.OutOrStdout(), "All %d nodes are healthy", len(nodeHealthNodes))
-		if nodeHealthVersion != "" {
-			fmt.Fprintf(cmd.OutOrStdout(), " and running version %s", nodeHealthVersion)
+		// Create execution context with operation, nodes, timeout, version, and output function
+		ctx := context.WithValue(cmd.Context(), "operation", "node-health")
+		ctx = context.WithValue(ctx, "nodes", nodeHealthNodes)
+		ctx = context.WithValue(ctx, "timeout", nodeHealthTimeout)
+		ctx = context.WithValue(ctx, "version", nodeHealthVersion)
+		ctx = context.WithValue(ctx, "output", outputFunc)
+
+		// Execute the pipeline
+		if err := pipeline.Execute(ctx); err != nil {
+			return fmt.Errorf("Error executing check pipeline: %w", err)
 		}
-		fmt.Fprintln(cmd.OutOrStdout())
 
 		return nil
 	},

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -2,51 +2,63 @@ package cmd
 
 import (
 	"bytes"
-	"context"
-	"fmt"
+	"os"
+	"strings"
 	"testing"
-	"time"
-
-	"github.com/windsorcli/cli/pkg/cluster"
-	"github.com/windsorcli/cli/pkg/controller"
-	"github.com/windsorcli/cli/pkg/tools"
 )
 
+// Helper function to check if a string contains a substring
+func checkContains(str, substr string) bool {
+	return strings.Contains(str, substr)
+}
+
 func TestCheckCmd(t *testing.T) {
-	setup := func(t *testing.T, opts ...*SetupOptions) (*Mocks, *bytes.Buffer, *bytes.Buffer) {
+	setup := func(t *testing.T, withConfig bool) (*bytes.Buffer, *bytes.Buffer) {
 		t.Helper()
 
-		// Setup mocks with default options
-		mocks := setupMocks(t, opts...)
+		// Change to a temporary directory
+		origDir, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("Failed to get working directory: %v", err)
+		}
 
-		// Setup command args and output
-		rootCmd.SetArgs([]string{"check"})
+		tmpDir := t.TempDir()
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatalf("Failed to change to temp directory: %v", err)
+		}
+
+		// Cleanup to change back to original directory
+		t.Cleanup(func() {
+			if err := os.Chdir(origDir); err != nil {
+				t.Logf("Warning: Failed to change back to original directory: %v", err)
+			}
+		})
+
+		// Create config file if requested
+		if withConfig {
+			configContent := `contexts:
+  default:
+    tools:
+      enabled: true`
+			if err := os.WriteFile("windsor.yaml", []byte(configContent), 0644); err != nil {
+				t.Fatalf("Failed to create config file: %v", err)
+			}
+		}
+
 		stdout, stderr := captureOutput(t)
 		rootCmd.SetOut(stdout)
 		rootCmd.SetErr(stderr)
+		rootCmd.SetArgs([]string{"check"})
 
-		return mocks, stdout, stderr
+		return stdout, stderr
 	}
 
 	t.Run("Success", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, stdout, stderr := setup(t, &SetupOptions{
-			ConfigStr: `
-contexts:
-  default:
-    tools:
-      enabled: true`,
-		})
-
-		// And mock tools manager that returns success
-		mockToolsManager := tools.NewMockToolsManager()
-		mockToolsManager.CheckFunc = func() error {
-			return nil
-		}
-		mocks.Injector.Register("toolsManager", mockToolsManager)
+		// Given a directory with proper configuration
+		stdout, stderr := setup(t, true)
 
 		// When executing the command
-		err := Execute(mocks.Controller)
+		err := Execute(nil)
 
 		// Then no error should occur
 		if err != nil {
@@ -64,11 +76,11 @@ contexts:
 	})
 
 	t.Run("ConfigNotLoaded", func(t *testing.T) {
-		// Given a set of mocks with no configuration
-		mocks, _, _ := setup(t)
+		// Given a directory with no configuration
+		_, _ = setup(t, false)
 
 		// When executing the command
-		err := Execute(mocks.Controller)
+		err := Execute(nil)
 
 		// Then an error should occur
 		if err == nil {
@@ -76,110 +88,46 @@ contexts:
 		}
 
 		// And error should contain init message
-		expectedError := "Nothing to check. Have you run \033[1mwindsor init\033[0m?"
+		expectedError := "Error executing check pipeline: Nothing to check. Have you run \033[1mwindsor init\033[0m?"
 		if err.Error() != expectedError {
 			t.Errorf("Expected error about init, got: %v", err)
-		}
-	})
-
-	t.Run("ToolsManagerNotFound", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, _, _ := setup(t, &SetupOptions{
-			ConfigStr: `
-contexts:
-  default:
-    tools:
-      enabled: true`,
-		})
-
-		// And mock controller that returns nil tools manager
-		mocks.Controller.ResolveToolsManagerFunc = func() tools.ToolsManager {
-			return nil
-		}
-
-		// When executing the command
-		err := Execute(mocks.Controller)
-
-		// Then an error should occur
-		if err == nil {
-			t.Error("Expected error, got nil")
-		}
-
-		// And error should contain tools manager message
-		if err.Error() != "No tools manager found" {
-			t.Errorf("Expected error about tools manager, got: %v", err)
-		}
-	})
-
-	t.Run("ToolsCheckError", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, _, _ := setup(t, &SetupOptions{
-			ConfigStr: `
-contexts:
-  default:
-    tools:
-      enabled: true`,
-		})
-
-		// And mock tools manager that returns error
-		mockToolsManager := tools.NewMockToolsManager()
-		mockToolsManager.CheckFunc = func() error {
-			return fmt.Errorf("tools check failed")
-		}
-		mocks.Injector.Register("toolsManager", mockToolsManager)
-
-		// When executing the command
-		err := Execute(mocks.Controller)
-
-		// Then an error should occur
-		if err == nil {
-			t.Error("Expected error, got nil")
-		}
-
-		// And error should contain tools check message
-		if err.Error() != "Error checking tools: tools check failed" {
-			t.Errorf("Expected error about tools check, got: %v", err)
-		}
-	})
-
-	t.Run("InitializeWithRequirementsError", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, _, _ := setup(t, &SetupOptions{
-			ConfigStr: `
-contexts:
-  default:
-    tools:
-      enabled: true`,
-		})
-
-		// And mock controller that returns error on initialization
-		mocks.Controller.InitializeWithRequirementsFunc = func(req controller.Requirements) error {
-			return fmt.Errorf("initialization failed")
-		}
-
-		// When executing the command
-		err := Execute(mocks.Controller)
-
-		// Then an error should occur
-		if err == nil {
-			t.Error("Expected error, got nil")
-		}
-
-		// And error should contain initialization message
-		if err.Error() != "Error initializing: initialization failed" {
-			t.Errorf("Expected error about initialization, got: %v", err)
 		}
 	})
 }
 
 func TestCheckNodeHealthCmd(t *testing.T) {
-	setup := func(t *testing.T, opts ...*SetupOptions) (*Mocks, *bytes.Buffer, *bytes.Buffer) {
+	setup := func(t *testing.T, withConfig bool) (*bytes.Buffer, *bytes.Buffer) {
 		t.Helper()
 
-		// Setup mocks with default options
-		mocks := setupMocks(t, opts...)
+		// Change to a temporary directory
+		origDir, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("Failed to get working directory: %v", err)
+		}
 
-		// Setup command args and output
+		tmpDir := t.TempDir()
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatalf("Failed to change to temp directory: %v", err)
+		}
+
+		// Cleanup to change back to original directory
+		t.Cleanup(func() {
+			if err := os.Chdir(origDir); err != nil {
+				t.Logf("Warning: Failed to change back to original directory: %v", err)
+			}
+		})
+
+		// Create config file if requested
+		if withConfig {
+			configContent := `contexts:
+  default:
+    cluster:
+      enabled: true`
+			if err := os.WriteFile("windsor.yaml", []byte(configContent), 0644); err != nil {
+				t.Fatalf("Failed to create config file: %v", err)
+			}
+		}
+
 		stdout, stderr := captureOutput(t)
 		rootCmd.SetOut(stdout)
 		rootCmd.SetErr(stderr)
@@ -195,156 +143,81 @@ func TestCheckNodeHealthCmd(t *testing.T) {
 		checkNodeHealthCmd.Flags().StringSliceVar(&nodeHealthNodes, "nodes", []string{}, "Nodes to check (required)")
 		checkNodeHealthCmd.Flags().StringVar(&nodeHealthVersion, "version", "", "Expected version to check against (optional)")
 
-		return mocks, stdout, stderr
+		return stdout, stderr
 	}
 
-	t.Run("Success", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, stdout, stderr := setup(t, &SetupOptions{
-			ConfigStr: `
-contexts:
-  default:
-    cluster:
-      enabled: true`,
-		})
+	t.Run("ClusterClientError", func(t *testing.T) {
+		// Given a directory with proper configuration
+		_, _ = setup(t, true)
 
-		// And mock cluster client that returns success
-		mockClusterClient := cluster.NewMockClusterClient()
-		mockClusterClient.WaitForNodesHealthyFunc = func(ctx context.Context, nodeAddresses []string, expectedVersion string) error {
-			return nil
-		}
-		mocks.Controller.ResolveClusterClientFunc = func() cluster.ClusterClient {
-			return mockClusterClient
-		}
-
-		// Setup command args
+		// Setup command args with nodes
 		rootCmd.SetArgs([]string{"check", "node-health", "--nodes", "10.0.0.1,10.0.0.2"})
 
 		// When executing the command
-		err := Execute(mocks.Controller)
+		err := Execute(nil)
 
-		// Then no error should occur
-		if err != nil {
-			t.Errorf("Expected success, got error: %v", err)
+		// Then an error should occur (because cluster client can't be initialized without proper config)
+		if err == nil {
+			t.Error("Expected error, got nil")
 		}
 
-		// And output should contain success message
-		output := stdout.String()
-		expectedOutput := "All 2 nodes are healthy\n"
-		if output != expectedOutput {
-			t.Errorf("Expected %q, got: %q", expectedOutput, output)
-		}
-		if stderr.String() != "" {
-			t.Error("Expected empty stderr")
+		// And error should contain cluster client message
+		if !checkContains(err.Error(), "Error executing check pipeline") {
+			t.Errorf("Expected error about pipeline execution, got: %v", err)
 		}
 	})
 
-	t.Run("SuccessWithVersion", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, stdout, stderr := setup(t, &SetupOptions{
-			ConfigStr: `
-contexts:
-  default:
-    cluster:
-      enabled: true`,
-		})
+	t.Run("ClusterClientErrorWithVersion", func(t *testing.T) {
+		// Given a directory with proper configuration
+		_, _ = setup(t, true)
 
-		// And mock cluster client that returns success
-		mockClusterClient := cluster.NewMockClusterClient()
-		mockClusterClient.WaitForNodesHealthyFunc = func(ctx context.Context, nodeAddresses []string, expectedVersion string) error {
-			// Verify expected version is passed correctly
-			if expectedVersion != "v1.0.0" {
-				return fmt.Errorf("unexpected version: %s", expectedVersion)
-			}
-			return nil
-		}
-		mocks.Controller.ResolveClusterClientFunc = func() cluster.ClusterClient {
-			return mockClusterClient
-		}
-
-		// Setup command args with version
-		rootCmd.SetArgs([]string{"check", "node-health", "--nodes", "10.0.0.1", "--version", "v1.0.0"})
+		// Setup command args with nodes and version
+		rootCmd.SetArgs([]string{"check", "node-health", "--nodes", "10.0.0.1", "--version", "1.0.0"})
 
 		// When executing the command
-		err := Execute(mocks.Controller)
+		err := Execute(nil)
 
-		// Then no error should occur
-		if err != nil {
-			t.Errorf("Expected success, got error: %v", err)
+		// Then an error should occur (because cluster client can't be initialized without proper config)
+		if err == nil {
+			t.Error("Expected error, got nil")
 		}
 
-		// And output should contain success message with version
-		output := stdout.String()
-		expectedOutput := "All 1 nodes are healthy and running version v1.0.0\n"
-		if output != expectedOutput {
-			t.Errorf("Expected %q, got: %q", expectedOutput, output)
-		}
-		if stderr.String() != "" {
-			t.Error("Expected empty stderr")
+		// And error should contain cluster client message
+		if !checkContains(err.Error(), "Error executing check pipeline") {
+			t.Errorf("Expected error about pipeline execution, got: %v", err)
 		}
 	})
 
-	t.Run("SuccessWithCustomTimeout", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, stdout, stderr := setup(t, &SetupOptions{
-			ConfigStr: `
-contexts:
-  default:
-    cluster:
-      enabled: true`,
-		})
+	t.Run("ClusterClientErrorWithTimeout", func(t *testing.T) {
+		// Given a directory with proper configuration
+		_, _ = setup(t, true)
 
-		// And mock cluster client that tracks timeout
-		mockClusterClient := cluster.NewMockClusterClient()
-		timeoutReceived := time.Duration(0)
-		mockClusterClient.WaitForNodesHealthyFunc = func(ctx context.Context, nodeAddresses []string, expectedVersion string) error {
-			// Extract timeout from context
-			deadline, ok := ctx.Deadline()
-			if ok {
-				timeoutReceived = time.Until(deadline)
-			}
-			return nil
-		}
-		mocks.Controller.ResolveClusterClientFunc = func() cluster.ClusterClient {
-			return mockClusterClient
-		}
-
-		// Setup command args with custom timeout
-		rootCmd.SetArgs([]string{"check", "node-health", "--nodes", "10.0.0.1", "--timeout", "2m"})
+		// Setup command args with nodes and timeout
+		rootCmd.SetArgs([]string{"check", "node-health", "--nodes", "10.0.0.1", "--timeout", "10s"})
 
 		// When executing the command
-		err := Execute(mocks.Controller)
+		err := Execute(nil)
 
-		// Then no error should occur
-		if err != nil {
-			t.Errorf("Expected success, got error: %v", err)
+		// Then an error should occur (because cluster client can't be initialized without proper config)
+		if err == nil {
+			t.Error("Expected error, got nil")
 		}
 
-		// And timeout should be approximately 2 minutes (allow some variance)
-		expectedTimeout := 2 * time.Minute
-		if timeoutReceived < expectedTimeout-10*time.Second || timeoutReceived > expectedTimeout+10*time.Second {
-			t.Errorf("Expected timeout around %v, got %v", expectedTimeout, timeoutReceived)
-		}
-
-		// And output should contain success message
-		output := stdout.String()
-		if output != "All 1 nodes are healthy\n" {
-			t.Errorf("Expected success message, got: %q", output)
-		}
-		if stderr.String() != "" {
-			t.Error("Expected empty stderr")
+		// And error should contain cluster client message
+		if !checkContains(err.Error(), "Error executing check pipeline") {
+			t.Errorf("Expected error about pipeline execution, got: %v", err)
 		}
 	})
 
 	t.Run("ConfigNotLoaded", func(t *testing.T) {
-		// Given a set of mocks with no configuration
-		mocks, _, _ := setup(t)
+		// Given a directory with no configuration
+		_, _ = setup(t, false)
 
 		// Setup command args
 		rootCmd.SetArgs([]string{"check", "node-health", "--nodes", "10.0.0.1"})
 
 		// When executing the command
-		err := Execute(mocks.Controller)
+		err := Execute(nil)
 
 		// Then an error should occur
 		if err == nil {
@@ -352,275 +225,53 @@ contexts:
 		}
 
 		// And error should contain init message
-		expectedError := "Nothing to check. Have you run \033[1mwindsor init\033[0m?"
+		expectedError := "Error executing check pipeline: Nothing to check. Have you run \033[1mwindsor init\033[0m?"
 		if err.Error() != expectedError {
 			t.Errorf("Expected error about init, got: %v", err)
 		}
 	})
 
-	t.Run("ClusterClientNotFound", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, _, _ := setup(t, &SetupOptions{
-			ConfigStr: `
-contexts:
-  default:
-    cluster:
-      enabled: true`,
-		})
-
-		// And mock controller that returns nil cluster client
-		mocks.Controller.ResolveClusterClientFunc = func() cluster.ClusterClient {
-			return nil
-		}
-
-		// Setup command args
-		rootCmd.SetArgs([]string{"check", "node-health", "--nodes", "10.0.0.1"})
-
-		// When executing the command
-		err := Execute(mocks.Controller)
-
-		// Then an error should occur
-		if err == nil {
-			t.Error("Expected error, got nil")
-		}
-
-		// And error should contain cluster client message
-		if err.Error() != "No cluster client found" {
-			t.Errorf("Expected error about cluster client, got: %v", err)
-		}
-	})
-
 	t.Run("NoNodesSpecified", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, _, _ := setup(t, &SetupOptions{
-			ConfigStr: `
-contexts:
-  default:
-    cluster:
-      enabled: true`,
-		})
-
-		// And mock cluster client
-		mockClusterClient := cluster.NewMockClusterClient()
-		mocks.Controller.ResolveClusterClientFunc = func() cluster.ClusterClient {
-			return mockClusterClient
-		}
+		// Given a directory with proper configuration
+		_, _ = setup(t, true)
 
 		// Setup command args without nodes
 		rootCmd.SetArgs([]string{"check", "node-health"})
 
 		// When executing the command
-		err := Execute(mocks.Controller)
+		err := Execute(nil)
 
 		// Then an error should occur
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}
 
-		// And error should contain nodes requirement message
+		// And error should contain nodes message
 		expectedError := "No nodes specified. Use --nodes flag to specify nodes to check"
 		if err.Error() != expectedError {
-			t.Errorf("Expected error about nodes requirement, got: %v", err)
+			t.Errorf("Expected error about nodes, got: %v", err)
 		}
 	})
 
-	t.Run("HealthCheckError", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, _, _ := setup(t, &SetupOptions{
-			ConfigStr: `
-contexts:
-  default:
-    cluster:
-      enabled: true`,
-		})
+	t.Run("EmptyNodesFlag", func(t *testing.T) {
+		// Given a directory with proper configuration
+		_, _ = setup(t, true)
 
-		// And mock cluster client that returns error
-		mockClusterClient := cluster.NewMockClusterClient()
-		mockClusterClient.WaitForNodesHealthyFunc = func(ctx context.Context, nodeAddresses []string, expectedVersion string) error {
-			return fmt.Errorf("health check failed")
-		}
-		mocks.Controller.ResolveClusterClientFunc = func() cluster.ClusterClient {
-			return mockClusterClient
-		}
-
-		// Setup command args
-		rootCmd.SetArgs([]string{"check", "node-health", "--nodes", "10.0.0.1"})
+		// Setup command args with empty nodes flag
+		rootCmd.SetArgs([]string{"check", "node-health", "--nodes", ""})
 
 		// When executing the command
-		err := Execute(mocks.Controller)
+		err := Execute(nil)
 
 		// Then an error should occur
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}
 
-		// And error should contain health check message
-		expectedError := "nodes failed health check: health check failed"
+		// And error should contain nodes message
+		expectedError := "No nodes specified. Use --nodes flag to specify nodes to check"
 		if err.Error() != expectedError {
-			t.Errorf("Expected error about health check, got: %v", err)
-		}
-	})
-
-	t.Run("InitializeWithRequirementsError", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, _, _ := setup(t, &SetupOptions{
-			ConfigStr: `
-contexts:
-  default:
-    cluster:
-      enabled: true`,
-		})
-
-		// And mock controller that returns error on initialization
-		mocks.Controller.InitializeWithRequirementsFunc = func(req controller.Requirements) error {
-			return fmt.Errorf("initialization failed")
-		}
-
-		// Setup command args
-		rootCmd.SetArgs([]string{"check", "node-health", "--nodes", "10.0.0.1"})
-
-		// When executing the command
-		err := Execute(mocks.Controller)
-
-		// Then an error should occur
-		if err == nil {
-			t.Error("Expected error, got nil")
-		}
-
-		// And error should contain initialization message
-		if err.Error() != "Error initializing: initialization failed" {
-			t.Errorf("Expected error about initialization, got: %v", err)
-		}
-	})
-
-	t.Run("MultipleNodes", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, stdout, stderr := setup(t, &SetupOptions{
-			ConfigStr: `
-contexts:
-  default:
-    cluster:
-      enabled: true`,
-		})
-
-		// And mock cluster client that validates node addresses
-		mockClusterClient := cluster.NewMockClusterClient()
-		mockClusterClient.WaitForNodesHealthyFunc = func(ctx context.Context, nodeAddresses []string, expectedVersion string) error {
-			// Verify correct node addresses are passed
-			expectedNodes := []string{"10.0.0.1", "10.0.0.2", "10.0.0.3"}
-			if len(nodeAddresses) != len(expectedNodes) {
-				return fmt.Errorf("expected %d nodes, got %d", len(expectedNodes), len(nodeAddresses))
-			}
-			for i, expected := range expectedNodes {
-				if nodeAddresses[i] != expected {
-					return fmt.Errorf("expected node %s at index %d, got %s", expected, i, nodeAddresses[i])
-				}
-			}
-			return nil
-		}
-		mocks.Controller.ResolveClusterClientFunc = func() cluster.ClusterClient {
-			return mockClusterClient
-		}
-
-		// Setup command args with multiple nodes
-		rootCmd.SetArgs([]string{"check", "node-health", "--nodes", "10.0.0.1,10.0.0.2,10.0.0.3"})
-
-		// When executing the command
-		err := Execute(mocks.Controller)
-
-		// Then no error should occur
-		if err != nil {
-			t.Errorf("Expected success, got error: %v", err)
-		}
-
-		// And output should contain success message for multiple nodes
-		output := stdout.String()
-		expectedOutput := "All 3 nodes are healthy\n"
-		if output != expectedOutput {
-			t.Errorf("Expected %q, got: %q", expectedOutput, output)
-		}
-		if stderr.String() != "" {
-			t.Error("Expected empty stderr")
-		}
-	})
-
-	t.Run("ClusterClientCloseCalledOnSuccess", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, _, _ := setup(t, &SetupOptions{
-			ConfigStr: `
-contexts:
-  default:
-    cluster:
-      enabled: true`,
-		})
-
-		// And mock cluster client that tracks close calls
-		closeCalled := false
-		mockClusterClient := cluster.NewMockClusterClient()
-		mockClusterClient.WaitForNodesHealthyFunc = func(ctx context.Context, nodeAddresses []string, expectedVersion string) error {
-			return nil
-		}
-		mockClusterClient.CloseFunc = func() {
-			closeCalled = true
-		}
-		mocks.Controller.ResolveClusterClientFunc = func() cluster.ClusterClient {
-			return mockClusterClient
-		}
-
-		// Setup command args
-		rootCmd.SetArgs([]string{"check", "node-health", "--nodes", "10.0.0.1"})
-
-		// When executing the command
-		err := Execute(mocks.Controller)
-
-		// Then no error should occur
-		if err != nil {
-			t.Errorf("Expected success, got error: %v", err)
-		}
-
-		// And Close should be called
-		if !closeCalled {
-			t.Error("Expected Close to be called on cluster client")
-		}
-	})
-
-	t.Run("ClusterClientCloseCalledOnError", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks, _, _ := setup(t, &SetupOptions{
-			ConfigStr: `
-contexts:
-  default:
-    cluster:
-      enabled: true`,
-		})
-
-		// And mock cluster client that tracks close calls and returns error
-		closeCalled := false
-		mockClusterClient := cluster.NewMockClusterClient()
-		mockClusterClient.WaitForNodesHealthyFunc = func(ctx context.Context, nodeAddresses []string, expectedVersion string) error {
-			return fmt.Errorf("health check failed")
-		}
-		mockClusterClient.CloseFunc = func() {
-			closeCalled = true
-		}
-		mocks.Controller.ResolveClusterClientFunc = func() cluster.ClusterClient {
-			return mockClusterClient
-		}
-
-		// Setup command args
-		rootCmd.SetArgs([]string{"check", "node-health", "--nodes", "10.0.0.1"})
-
-		// When executing the command
-		err := Execute(mocks.Controller)
-
-		// Then an error should occur
-		if err == nil {
-			t.Error("Expected error, got nil")
-		}
-
-		// And Close should still be called
-		if !closeCalled {
-			t.Error("Expected Close to be called on cluster client even on error")
+			t.Errorf("Expected error about nodes, got: %v", err)
 		}
 	})
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,7 @@ var verbose bool
 type contextKey string
 
 const controllerKey = contextKey("controller")
+const injectorKey = contextKey("injector")
 
 var shims = NewShims()
 
@@ -24,13 +25,18 @@ var shims = NewShims()
 // establishing the dependency injection container and controller context.
 func Execute(controllers ...controller.Controller) error {
 	var ctrl controller.Controller
+	var injector di.Injector
 	if len(controllers) > 0 {
 		ctrl = controllers[0]
+		// Extract injector from controller if possible
+		// For now, we'll create a new one since the controller interface doesn't expose the injector
+		injector = di.NewInjector()
 	} else {
-		injector := di.NewInjector()
+		injector = di.NewInjector()
 		ctrl = controller.NewController(injector)
 	}
 	ctx := context.WithValue(context.Background(), controllerKey, ctrl)
+	ctx = context.WithValue(ctx, injectorKey, injector)
 	return rootCmd.ExecuteContext(ctx)
 }
 

--- a/pkg/pipelines/check_pipeline.go
+++ b/pkg/pipelines/check_pipeline.go
@@ -1,0 +1,255 @@
+package pipelines
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/windsorcli/cli/pkg/cluster"
+	"github.com/windsorcli/cli/pkg/config"
+	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/shell"
+	"github.com/windsorcli/cli/pkg/tools"
+)
+
+// The CheckPipeline is a specialized component that manages tool version checking and node health checking functionality.
+// It provides check-specific command execution including tools verification and cluster node health validation,
+// configuration validation, and shell integration for the Windsor CLI check command.
+// The CheckPipeline handles both basic tool checking and advanced node health monitoring operations.
+
+// =============================================================================
+// Types
+// =============================================================================
+
+// CheckConstructors defines constructor functions for CheckPipeline dependencies
+type CheckConstructors struct {
+	NewConfigHandler func(di.Injector) config.ConfigHandler
+	NewShell         func(di.Injector) shell.Shell
+	NewToolsManager  func(di.Injector) tools.ToolsManager
+	NewClusterClient func(di.Injector) cluster.ClusterClient
+	NewShims         func() *Shims
+}
+
+// CheckPipeline provides tool checking and node health checking functionality
+type CheckPipeline struct {
+	BasePipeline
+
+	constructors CheckConstructors
+
+	configHandler config.ConfigHandler
+	shell         shell.Shell
+	toolsManager  tools.ToolsManager
+	clusterClient cluster.ClusterClient
+	shims         *Shims
+}
+
+// =============================================================================
+// Constructor
+// =============================================================================
+
+// NewCheckPipeline creates a new CheckPipeline instance with optional constructors
+func NewCheckPipeline(constructors ...CheckConstructors) *CheckPipeline {
+	var ctors CheckConstructors
+	if len(constructors) > 0 {
+		ctors = constructors[0]
+	} else {
+		ctors = CheckConstructors{
+			NewConfigHandler: func(injector di.Injector) config.ConfigHandler {
+				return config.NewYamlConfigHandler(injector)
+			},
+			NewShell: func(injector di.Injector) shell.Shell {
+				return shell.NewDefaultShell(injector)
+			},
+			NewToolsManager: func(injector di.Injector) tools.ToolsManager {
+				return tools.NewToolsManager(injector)
+			},
+			NewClusterClient: func(injector di.Injector) cluster.ClusterClient {
+				return cluster.NewTalosClusterClient(injector)
+			},
+			NewShims: func() *Shims {
+				return NewShims()
+			},
+		}
+	}
+
+	return &CheckPipeline{
+		BasePipeline: *NewBasePipeline(),
+		constructors: ctors,
+	}
+}
+
+// =============================================================================
+// Public Methods
+// =============================================================================
+
+// Initialize creates and registers all required components for the check pipeline.
+// It sets up the config handler, shell, tools manager, and cluster client in the correct order,
+// registering each component with the dependency injector and initializing them sequentially
+// to ensure proper dependency resolution.
+func (p *CheckPipeline) Initialize(injector di.Injector) error {
+	p.shims = p.constructors.NewShims()
+
+	if existing := injector.Resolve("shell"); existing != nil {
+		p.shell = existing.(shell.Shell)
+	} else {
+		p.shell = p.constructors.NewShell(injector)
+		injector.Register("shell", p.shell)
+	}
+	p.BasePipeline.shell = p.shell
+
+	if existing := injector.Resolve("configHandler"); existing != nil {
+		p.configHandler = existing.(config.ConfigHandler)
+	} else {
+		p.configHandler = p.constructors.NewConfigHandler(injector)
+		injector.Register("configHandler", p.configHandler)
+	}
+	p.BasePipeline.configHandler = p.configHandler
+
+	if existing := injector.Resolve("toolsManager"); existing != nil {
+		p.toolsManager = existing.(tools.ToolsManager)
+	} else {
+		p.toolsManager = p.constructors.NewToolsManager(injector)
+		injector.Register("toolsManager", p.toolsManager)
+	}
+
+	if existing := injector.Resolve("clusterClient"); existing != nil {
+		p.clusterClient = existing.(cluster.ClusterClient)
+	} else {
+		p.clusterClient = p.constructors.NewClusterClient(injector)
+		injector.Register("clusterClient", p.clusterClient)
+	}
+
+	if err := p.shell.Initialize(); err != nil {
+		return fmt.Errorf("failed to initialize shell: %w", err)
+	}
+
+	if err := p.configHandler.Initialize(); err != nil {
+		return fmt.Errorf("failed to initialize config handler: %w", err)
+	}
+
+	if err := p.loadConfig(); err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	if err := p.toolsManager.Initialize(); err != nil {
+		return fmt.Errorf("failed to initialize tools manager: %w", err)
+	}
+
+	return nil
+}
+
+// Execute performs the check operation based on the operation type specified in the context.
+// It supports both "tools" and "node-health" operations, validating configuration and
+// executing the appropriate check functionality with proper error handling and output formatting.
+func (p *CheckPipeline) Execute(ctx context.Context) error {
+	if !p.configHandler.IsLoaded() {
+		return fmt.Errorf("Nothing to check. Have you run \033[1mwindsor init\033[0m?")
+	}
+
+	operation := ctx.Value("operation")
+	if operation == nil {
+		return p.executeToolsCheck(ctx)
+	}
+
+	operationType, ok := operation.(string)
+	if !ok {
+		return fmt.Errorf("Invalid operation type")
+	}
+
+	switch operationType {
+	case "tools":
+		return p.executeToolsCheck(ctx)
+	case "node-health":
+		return p.executeNodeHealthCheck(ctx)
+	default:
+		return fmt.Errorf("Unknown operation type: %s", operationType)
+	}
+}
+
+// =============================================================================
+// Private Methods
+// =============================================================================
+
+// executeToolsCheck performs tool version checking using the tools manager.
+// It validates that all required tools are installed and meet minimum version requirements,
+// providing success output when all tools are up to date.
+func (p *CheckPipeline) executeToolsCheck(ctx context.Context) error {
+	if err := p.toolsManager.Check(); err != nil {
+		return fmt.Errorf("Error checking tools: %w", err)
+	}
+
+	outputFunc := ctx.Value("output")
+	if outputFunc != nil {
+		if fn, ok := outputFunc.(func(string)); ok {
+			fn("All tools are up to date.")
+		}
+	}
+
+	return nil
+}
+
+// executeNodeHealthCheck performs cluster node health checking using the cluster client.
+// It validates node health status and optionally checks for specific versions,
+// requiring nodes to be specified via context parameters and supporting timeout configuration.
+func (p *CheckPipeline) executeNodeHealthCheck(ctx context.Context) error {
+	if p.clusterClient == nil {
+		return fmt.Errorf("No cluster client found")
+	}
+	defer p.clusterClient.Close()
+
+	nodes := ctx.Value("nodes")
+	if nodes == nil {
+		return fmt.Errorf("No nodes specified. Use --nodes flag to specify nodes to check")
+	}
+
+	nodeAddresses, ok := nodes.([]string)
+	if !ok {
+		return fmt.Errorf("Invalid nodes parameter type")
+	}
+
+	if len(nodeAddresses) == 0 {
+		return fmt.Errorf("No nodes specified. Use --nodes flag to specify nodes to check")
+	}
+
+	timeout := ctx.Value("timeout")
+	var timeoutDuration time.Duration
+	if timeout != nil {
+		if t, ok := timeout.(time.Duration); ok {
+			timeoutDuration = t
+		}
+	}
+
+	version := ctx.Value("version")
+	var expectedVersion string
+	if version != nil {
+		if v, ok := version.(string); ok {
+			expectedVersion = v
+		}
+	}
+
+	var checkCtx context.Context
+	var cancel context.CancelFunc
+	if timeoutDuration > 0 {
+		checkCtx, cancel = context.WithTimeout(ctx, timeoutDuration)
+	} else {
+		checkCtx, cancel = context.WithCancel(ctx)
+	}
+	defer cancel()
+
+	if err := p.clusterClient.WaitForNodesHealthy(checkCtx, nodeAddresses, expectedVersion); err != nil {
+		return fmt.Errorf("nodes failed health check: %w", err)
+	}
+
+	outputFunc := ctx.Value("output")
+	if outputFunc != nil {
+		if fn, ok := outputFunc.(func(string)); ok {
+			message := fmt.Sprintf("All %d nodes are healthy", len(nodeAddresses))
+			if expectedVersion != "" {
+				message += fmt.Sprintf(" and running version %s", expectedVersion)
+			}
+			fn(message)
+		}
+	}
+
+	return nil
+}

--- a/pkg/pipelines/check_pipeline_test.go
+++ b/pkg/pipelines/check_pipeline_test.go
@@ -1,0 +1,815 @@
+package pipelines
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/windsorcli/cli/pkg/cluster"
+	"github.com/windsorcli/cli/pkg/config"
+	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/shell"
+	"github.com/windsorcli/cli/pkg/tools"
+)
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+type CheckMocks struct {
+	Injector      di.Injector
+	ConfigHandler *config.MockConfigHandler
+	Shell         *shell.MockShell
+	ToolsManager  *tools.MockToolsManager
+	ClusterClient *cluster.MockClusterClient
+	Shims         *Shims
+}
+
+type CheckSetupOptions struct {
+	Injector      di.Injector
+	ConfigHandler *config.MockConfigHandler
+	ConfigStr     string
+	Shims         *Shims
+}
+
+func setupCheckMocks(t *testing.T, opts ...*CheckSetupOptions) *CheckMocks {
+	t.Helper()
+
+	var options *CheckSetupOptions
+	if len(opts) > 0 {
+		options = opts[0]
+	} else {
+		options = &CheckSetupOptions{}
+	}
+
+	var injector di.Injector
+	if options.Injector != nil {
+		injector = options.Injector
+	} else {
+		injector = di.NewMockInjector()
+	}
+
+	var configHandler *config.MockConfigHandler
+	if options.ConfigHandler != nil {
+		configHandler = options.ConfigHandler
+	} else {
+		configHandler = config.NewMockConfigHandler()
+	}
+
+	var shims *Shims
+	if options.Shims != nil {
+		shims = options.Shims
+	} else {
+		shims = setupCheckShims(t)
+	}
+
+	mockShell := shell.NewMockShell()
+	mockShell.InitializeFunc = func() error { return nil }
+	mockShell.GetProjectRootFunc = func() (string, error) { return t.TempDir(), nil }
+
+	mockToolsManager := tools.NewMockToolsManager()
+	mockToolsManager.InitializeFunc = func() error { return nil }
+	mockToolsManager.CheckFunc = func() error { return nil }
+
+	mockClusterClient := cluster.NewMockClusterClient()
+	mockClusterClient.WaitForNodesHealthyFunc = func(ctx context.Context, nodes []string, version string) error {
+		return nil
+	}
+
+	configHandler.InitializeFunc = func() error { return nil }
+	configHandler.LoadConfigFunc = func(path string) error { return nil }
+	configHandler.IsLoadedFunc = func() bool { return true }
+
+	if options.ConfigStr != "" {
+		if err := configHandler.LoadConfigString(options.ConfigStr); err != nil {
+			t.Fatalf("Failed to load config string: %v", err)
+		}
+	}
+
+	injector.Register("configHandler", configHandler)
+	injector.Register("shell", mockShell)
+	injector.Register("toolsManager", mockToolsManager)
+	injector.Register("clusterClient", mockClusterClient)
+
+	return &CheckMocks{
+		Injector:      injector,
+		ConfigHandler: configHandler,
+		Shell:         mockShell,
+		ToolsManager:  mockToolsManager,
+		ClusterClient: mockClusterClient,
+		Shims:         shims,
+	}
+}
+
+func setupCheckShims(t *testing.T) *Shims {
+	t.Helper()
+	return NewShims()
+}
+
+func setupCheckPipeline(t *testing.T, mocks *CheckMocks) *CheckPipeline {
+	t.Helper()
+
+	constructors := CheckConstructors{
+		NewConfigHandler: func(di.Injector) config.ConfigHandler {
+			return mocks.ConfigHandler
+		},
+		NewShell: func(di.Injector) shell.Shell {
+			return mocks.Shell
+		},
+		NewToolsManager: func(di.Injector) tools.ToolsManager {
+			return mocks.ToolsManager
+		},
+		NewClusterClient: func(di.Injector) cluster.ClusterClient {
+			return mocks.ClusterClient
+		},
+		NewShims: func() *Shims {
+			return mocks.Shims
+		},
+	}
+
+	return NewCheckPipeline(constructors)
+}
+
+func checkContains(str, substr string) bool {
+	return len(str) > 0 && len(substr) > 0 &&
+		(str == substr || len(str) >= len(substr) &&
+			(str[:len(substr)] == substr || str[len(str)-len(substr):] == substr ||
+				func() bool {
+					for i := 0; i <= len(str)-len(substr); i++ {
+						if str[i:i+len(substr)] == substr {
+							return true
+						}
+					}
+					return false
+				}()))
+}
+
+// =============================================================================
+// Test Constructor
+// =============================================================================
+
+func TestNewCheckPipeline(t *testing.T) {
+	t.Run("CreatesWithDefaultConstructors", func(t *testing.T) {
+		pipeline := NewCheckPipeline()
+
+		if pipeline == nil {
+			t.Fatal("Expected pipeline to not be nil")
+		}
+
+		if pipeline.constructors.NewConfigHandler == nil {
+			t.Error("Expected NewConfigHandler constructor to be set")
+		} else {
+			handler := pipeline.constructors.NewConfigHandler(di.NewMockInjector())
+			if handler == nil {
+				t.Error("Expected NewConfigHandler to return a non-nil handler")
+			}
+		}
+
+		if pipeline.constructors.NewShell == nil {
+			t.Error("Expected NewShell constructor to be set")
+		} else {
+			shell := pipeline.constructors.NewShell(di.NewMockInjector())
+			if shell == nil {
+				t.Error("Expected NewShell to return a non-nil shell")
+			}
+		}
+
+		if pipeline.constructors.NewToolsManager == nil {
+			t.Error("Expected NewToolsManager constructor to be set")
+		} else {
+			manager := pipeline.constructors.NewToolsManager(di.NewMockInjector())
+			if manager == nil {
+				t.Error("Expected NewToolsManager to return a non-nil manager")
+			}
+		}
+
+		if pipeline.constructors.NewClusterClient == nil {
+			t.Error("Expected NewClusterClient constructor to be set")
+		} else {
+			client := pipeline.constructors.NewClusterClient(di.NewMockInjector())
+			if client == nil {
+				t.Error("Expected NewClusterClient to return a non-nil client")
+			}
+		}
+
+		if pipeline.constructors.NewShims == nil {
+			t.Error("Expected NewShims constructor to be set")
+		} else {
+			shims := pipeline.constructors.NewShims()
+			if shims == nil {
+				t.Error("Expected NewShims to return a non-nil shims")
+			}
+		}
+	})
+
+	t.Run("CreatesWithCustomConstructors", func(t *testing.T) {
+		constructors := CheckConstructors{
+			NewConfigHandler: func(di.Injector) config.ConfigHandler {
+				return config.NewMockConfigHandler()
+			},
+		}
+
+		pipeline := NewCheckPipeline(constructors)
+
+		if pipeline == nil {
+			t.Fatal("Expected pipeline to not be nil")
+		}
+
+		if pipeline.constructors.NewConfigHandler == nil {
+			t.Error("Expected NewConfigHandler constructor to be set")
+		}
+	})
+}
+
+// =============================================================================
+// Test Public Methods
+// =============================================================================
+
+func TestCheckPipeline_Initialize(t *testing.T) {
+	setup := func(t *testing.T, opts ...*CheckSetupOptions) (*CheckPipeline, *CheckMocks) {
+		t.Helper()
+		mocks := setupCheckMocks(t, opts...)
+		pipeline := setupCheckPipeline(t, mocks)
+		return pipeline, mocks
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		pipeline, _ := setup(t, &CheckSetupOptions{
+			ConfigStr: `
+contexts:
+  test-context:
+    tools:
+      enabled: true
+`,
+		})
+
+		err := pipeline.Initialize(di.NewMockInjector())
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenConfigHandlerInitializeFails", func(t *testing.T) {
+		pipeline, mocks := setup(t)
+		mocks.ConfigHandler.InitializeFunc = func() error {
+			return fmt.Errorf("config initialization failed")
+		}
+
+		err := pipeline.Initialize(mocks.Injector)
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !checkContains(err.Error(), "failed to initialize config handler") {
+			t.Errorf("Expected config handler error, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenShellInitializeFails", func(t *testing.T) {
+		pipeline, mocks := setup(t)
+		mocks.Shell.InitializeFunc = func() error {
+			return fmt.Errorf("shell initialization failed")
+		}
+
+		err := pipeline.Initialize(mocks.Injector)
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !checkContains(err.Error(), "failed to initialize shell") {
+			t.Errorf("Expected shell error, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenToolsManagerInitializeFails", func(t *testing.T) {
+		pipeline, mocks := setup(t)
+		mocks.ToolsManager.InitializeFunc = func() error {
+			return fmt.Errorf("tools manager initialization failed")
+		}
+
+		err := pipeline.Initialize(mocks.Injector)
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !checkContains(err.Error(), "failed to initialize tools manager") {
+			t.Errorf("Expected tools manager error, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenLoadConfigFails", func(t *testing.T) {
+		pipeline, mocks := setup(t)
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return "", fmt.Errorf("project root error")
+		}
+
+		err := pipeline.Initialize(mocks.Injector)
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !checkContains(err.Error(), "failed to load config") {
+			t.Errorf("Expected load config error, got: %v", err)
+		}
+	})
+
+	t.Run("ReusesExistingComponentsFromDIContainer", func(t *testing.T) {
+		injector := di.NewMockInjector()
+
+		existingShell := shell.NewMockShell()
+		existingShell.InitializeFunc = func() error { return nil }
+		existingShell.GetProjectRootFunc = func() (string, error) { return t.TempDir(), nil }
+		injector.Register("shell", existingShell)
+
+		existingConfigHandler := config.NewMockConfigHandler()
+		existingConfigHandler.InitializeFunc = func() error { return nil }
+		existingConfigHandler.LoadConfigFunc = func(path string) error { return nil }
+		existingConfigHandler.IsLoadedFunc = func() bool { return true }
+		injector.Register("configHandler", existingConfigHandler)
+
+		existingToolsManager := tools.NewMockToolsManager()
+		existingToolsManager.InitializeFunc = func() error { return nil }
+		injector.Register("toolsManager", existingToolsManager)
+
+		existingClusterClient := cluster.NewMockClusterClient()
+		injector.Register("clusterClient", existingClusterClient)
+
+		constructorsCalled := false
+		constructors := CheckConstructors{
+			NewConfigHandler: func(di.Injector) config.ConfigHandler {
+				constructorsCalled = true
+				return config.NewMockConfigHandler()
+			},
+			NewShell: func(di.Injector) shell.Shell {
+				constructorsCalled = true
+				return shell.NewMockShell()
+			},
+			NewToolsManager: func(di.Injector) tools.ToolsManager {
+				constructorsCalled = true
+				return tools.NewMockToolsManager()
+			},
+			NewClusterClient: func(di.Injector) cluster.ClusterClient {
+				constructorsCalled = true
+				return cluster.NewMockClusterClient()
+			},
+			NewShims: func() *Shims {
+				return setupCheckShims(t)
+			},
+		}
+
+		pipeline := NewCheckPipeline(constructors)
+
+		err := pipeline.Initialize(injector)
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		if constructorsCalled {
+			t.Error("Expected constructors not to be called when components exist in DI container")
+		}
+
+		if pipeline.shell != existingShell {
+			t.Error("Expected pipeline to use existing shell from DI container")
+		}
+		if pipeline.configHandler != existingConfigHandler {
+			t.Error("Expected pipeline to use existing config handler from DI container")
+		}
+		if pipeline.toolsManager != existingToolsManager {
+			t.Error("Expected pipeline to use existing tools manager from DI container")
+		}
+		if pipeline.clusterClient != existingClusterClient {
+			t.Error("Expected pipeline to use existing cluster client from DI container")
+		}
+	})
+}
+
+func TestCheckPipeline_Execute(t *testing.T) {
+	setup := func(t *testing.T, opts ...*CheckSetupOptions) (*CheckPipeline, *CheckMocks) {
+		t.Helper()
+		mocks := setupCheckMocks(t, opts...)
+		pipeline := setupCheckPipeline(t, mocks)
+		err := pipeline.Initialize(mocks.Injector)
+		if err != nil {
+			t.Fatalf("Failed to initialize pipeline: %v", err)
+		}
+		return pipeline, mocks
+	}
+
+	t.Run("ExecutesToolsCheckByDefault", func(t *testing.T) {
+		pipeline, _ := setup(t, &CheckSetupOptions{
+			ConfigStr: `
+contexts:
+  test-context:
+    tools:
+      enabled: true
+`,
+		})
+
+		var outputMessage string
+		outputFunc := func(msg string) {
+			outputMessage = msg
+		}
+
+		ctx := context.WithValue(context.Background(), "output", outputFunc)
+
+		err := pipeline.Execute(ctx)
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		if outputMessage != "All tools are up to date." {
+			t.Errorf("Expected 'All tools are up to date.', got %q", outputMessage)
+		}
+	})
+
+	t.Run("ExecutesToolsCheckExplicitly", func(t *testing.T) {
+		pipeline, _ := setup(t, &CheckSetupOptions{
+			ConfigStr: `
+contexts:
+  test-context:
+    tools:
+      enabled: true
+`,
+		})
+
+		var outputMessage string
+		outputFunc := func(msg string) {
+			outputMessage = msg
+		}
+
+		ctx := context.WithValue(context.Background(), "operation", "tools")
+		ctx = context.WithValue(ctx, "output", outputFunc)
+
+		err := pipeline.Execute(ctx)
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		if outputMessage != "All tools are up to date." {
+			t.Errorf("Expected 'All tools are up to date.', got %q", outputMessage)
+		}
+	})
+
+	t.Run("ExecutesNodeHealthCheck", func(t *testing.T) {
+		pipeline, _ := setup(t, &CheckSetupOptions{
+			ConfigStr: `
+contexts:
+  test-context:
+    cluster:
+      enabled: true
+`,
+		})
+
+		var outputMessage string
+		outputFunc := func(msg string) {
+			outputMessage = msg
+		}
+
+		ctx := context.WithValue(context.Background(), "operation", "node-health")
+		ctx = context.WithValue(ctx, "nodes", []string{"10.0.0.1", "10.0.0.2"})
+		ctx = context.WithValue(ctx, "output", outputFunc)
+
+		err := pipeline.Execute(ctx)
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		if outputMessage != "All 2 nodes are healthy" {
+			t.Errorf("Expected 'All 2 nodes are healthy', got %q", outputMessage)
+		}
+	})
+
+	t.Run("ExecutesNodeHealthCheckWithVersion", func(t *testing.T) {
+		pipeline, _ := setup(t, &CheckSetupOptions{
+			ConfigStr: `
+contexts:
+  test-context:
+    cluster:
+      enabled: true
+`,
+		})
+
+		var outputMessage string
+		outputFunc := func(msg string) {
+			outputMessage = msg
+		}
+
+		ctx := context.WithValue(context.Background(), "operation", "node-health")
+		ctx = context.WithValue(ctx, "nodes", []string{"10.0.0.1"})
+		ctx = context.WithValue(ctx, "version", "1.0.0")
+		ctx = context.WithValue(ctx, "output", outputFunc)
+
+		err := pipeline.Execute(ctx)
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		if outputMessage != "All 1 nodes are healthy and running version 1.0.0" {
+			t.Errorf("Expected 'All 1 nodes are healthy and running version 1.0.0', got %q", outputMessage)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenConfigNotLoaded", func(t *testing.T) {
+		pipeline, mocks := setup(t)
+		mocks.ConfigHandler.IsLoadedFunc = func() bool { return false }
+
+		err := pipeline.Execute(context.Background())
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !checkContains(err.Error(), "Nothing to check. Have you run") {
+			t.Errorf("Expected config not loaded error, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorForInvalidOperationType", func(t *testing.T) {
+		pipeline, _ := setup(t)
+
+		ctx := context.WithValue(context.Background(), "operation", 123)
+
+		err := pipeline.Execute(ctx)
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !checkContains(err.Error(), "Invalid operation type") {
+			t.Errorf("Expected invalid operation type error, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorForUnknownOperation", func(t *testing.T) {
+		pipeline, _ := setup(t)
+
+		ctx := context.WithValue(context.Background(), "operation", "unknown")
+
+		err := pipeline.Execute(ctx)
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !checkContains(err.Error(), "Unknown operation type: unknown") {
+			t.Errorf("Expected unknown operation error, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenToolsCheckFails", func(t *testing.T) {
+		pipeline, mocks := setup(t)
+		mocks.ToolsManager.CheckFunc = func() error {
+			return fmt.Errorf("tools check failed")
+		}
+
+		err := pipeline.Execute(context.Background())
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !checkContains(err.Error(), "Error checking tools") {
+			t.Errorf("Expected tools check error, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenNodeHealthCheckFails", func(t *testing.T) {
+		pipeline, mocks := setup(t)
+		mocks.ClusterClient.WaitForNodesHealthyFunc = func(ctx context.Context, nodes []string, version string) error {
+			return fmt.Errorf("node health check failed")
+		}
+
+		ctx := context.WithValue(context.Background(), "operation", "node-health")
+		ctx = context.WithValue(ctx, "nodes", []string{"10.0.0.1"})
+
+		err := pipeline.Execute(ctx)
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !checkContains(err.Error(), "nodes failed health check") {
+			t.Errorf("Expected node health check error, got: %v", err)
+		}
+	})
+}
+
+// =============================================================================
+// Test Private Methods
+// =============================================================================
+
+func TestCheckPipeline_executeToolsCheck(t *testing.T) {
+	setup := func(t *testing.T, opts ...*CheckSetupOptions) (*CheckPipeline, *CheckMocks) {
+		t.Helper()
+		mocks := setupCheckMocks(t, opts...)
+		pipeline := setupCheckPipeline(t, mocks)
+		pipeline.toolsManager = mocks.ToolsManager
+		return pipeline, mocks
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		pipeline, _ := setup(t)
+
+		var outputMessage string
+		outputFunc := func(msg string) {
+			outputMessage = msg
+		}
+
+		ctx := context.WithValue(context.Background(), "output", outputFunc)
+
+		err := pipeline.executeToolsCheck(ctx)
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		if outputMessage != "All tools are up to date." {
+			t.Errorf("Expected 'All tools are up to date.', got %q", outputMessage)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenToolsManagerCheckFails", func(t *testing.T) {
+		pipeline, mocks := setup(t)
+		mocks.ToolsManager.CheckFunc = func() error {
+			return fmt.Errorf("tools check failed")
+		}
+
+		err := pipeline.executeToolsCheck(context.Background())
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !checkContains(err.Error(), "Error checking tools") {
+			t.Errorf("Expected tools check error, got: %v", err)
+		}
+	})
+
+	t.Run("HandlesNoOutputFunction", func(t *testing.T) {
+		pipeline, _ := setup(t)
+
+		err := pipeline.executeToolsCheck(context.Background())
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+}
+
+func TestCheckPipeline_executeNodeHealthCheck(t *testing.T) {
+	setup := func(t *testing.T, opts ...*CheckSetupOptions) (*CheckPipeline, *CheckMocks) {
+		t.Helper()
+		mocks := setupCheckMocks(t, opts...)
+		pipeline := setupCheckPipeline(t, mocks)
+		pipeline.clusterClient = mocks.ClusterClient
+		return pipeline, mocks
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		pipeline, _ := setup(t)
+
+		var outputMessage string
+		outputFunc := func(msg string) {
+			outputMessage = msg
+		}
+
+		ctx := context.WithValue(context.Background(), "nodes", []string{"10.0.0.1", "10.0.0.2"})
+		ctx = context.WithValue(ctx, "output", outputFunc)
+
+		err := pipeline.executeNodeHealthCheck(ctx)
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		if outputMessage != "All 2 nodes are healthy" {
+			t.Errorf("Expected 'All 2 nodes are healthy', got %q", outputMessage)
+		}
+	})
+
+	t.Run("SuccessWithVersion", func(t *testing.T) {
+		pipeline, _ := setup(t)
+
+		var outputMessage string
+		outputFunc := func(msg string) {
+			outputMessage = msg
+		}
+
+		ctx := context.WithValue(context.Background(), "nodes", []string{"10.0.0.1"})
+		ctx = context.WithValue(ctx, "version", "1.0.0")
+		ctx = context.WithValue(ctx, "output", outputFunc)
+
+		err := pipeline.executeNodeHealthCheck(ctx)
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		if outputMessage != "All 1 nodes are healthy and running version 1.0.0" {
+			t.Errorf("Expected 'All 1 nodes are healthy and running version 1.0.0', got %q", outputMessage)
+		}
+	})
+
+	t.Run("SuccessWithTimeout", func(t *testing.T) {
+		pipeline, _ := setup(t)
+
+		ctx := context.WithValue(context.Background(), "nodes", []string{"10.0.0.1"})
+		ctx = context.WithValue(ctx, "timeout", 5*time.Second)
+
+		err := pipeline.executeNodeHealthCheck(ctx)
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenClusterClientIsNil", func(t *testing.T) {
+		pipeline, _ := setup(t)
+		pipeline.clusterClient = nil
+
+		ctx := context.WithValue(context.Background(), "nodes", []string{"10.0.0.1"})
+
+		err := pipeline.executeNodeHealthCheck(ctx)
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !checkContains(err.Error(), "No cluster client found") {
+			t.Errorf("Expected cluster client error, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenNoNodesSpecified", func(t *testing.T) {
+		pipeline, _ := setup(t)
+
+		err := pipeline.executeNodeHealthCheck(context.Background())
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !checkContains(err.Error(), "No nodes specified") {
+			t.Errorf("Expected no nodes error, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenNodesParameterIsInvalidType", func(t *testing.T) {
+		pipeline, _ := setup(t)
+
+		ctx := context.WithValue(context.Background(), "nodes", "invalid")
+
+		err := pipeline.executeNodeHealthCheck(ctx)
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !checkContains(err.Error(), "Invalid nodes parameter type") {
+			t.Errorf("Expected invalid nodes parameter error, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenNodesSliceIsEmpty", func(t *testing.T) {
+		pipeline, _ := setup(t)
+
+		ctx := context.WithValue(context.Background(), "nodes", []string{})
+
+		err := pipeline.executeNodeHealthCheck(ctx)
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !checkContains(err.Error(), "No nodes specified") {
+			t.Errorf("Expected no nodes error, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenWaitForNodesHealthyFails", func(t *testing.T) {
+		pipeline, mocks := setup(t)
+		mocks.ClusterClient.WaitForNodesHealthyFunc = func(ctx context.Context, nodes []string, version string) error {
+			return fmt.Errorf("health check failed")
+		}
+
+		ctx := context.WithValue(context.Background(), "nodes", []string{"10.0.0.1"})
+
+		err := pipeline.executeNodeHealthCheck(ctx)
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !checkContains(err.Error(), "nodes failed health check") {
+			t.Errorf("Expected health check error, got: %v", err)
+		}
+	})
+
+	t.Run("HandlesNoOutputFunction", func(t *testing.T) {
+		pipeline, _ := setup(t)
+
+		ctx := context.WithValue(context.Background(), "nodes", []string{"10.0.0.1"})
+
+		err := pipeline.executeNodeHealthCheck(ctx)
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+}

--- a/pkg/pipelines/mock_check_pipeline.go
+++ b/pkg/pipelines/mock_check_pipeline.go
@@ -1,0 +1,45 @@
+package pipelines
+
+import (
+	"context"
+
+	"github.com/windsorcli/cli/pkg/di"
+)
+
+// MockCheckPipeline is a mock implementation of the CheckPipeline for testing purposes.
+type MockCheckPipeline struct {
+	InitializeFunc func(di.Injector) error
+	ExecuteFunc    func(context.Context) error
+}
+
+// =============================================================================
+// Constructor
+// =============================================================================
+
+// NewMockCheckPipeline creates a new MockCheckPipeline instance.
+func NewMockCheckPipeline() *MockCheckPipeline {
+	return &MockCheckPipeline{}
+}
+
+// =============================================================================
+// Public Methods
+// =============================================================================
+
+// Initialize calls the mock InitializeFunc if set, otherwise returns nil.
+func (m *MockCheckPipeline) Initialize(injector di.Injector) error {
+	if m.InitializeFunc != nil {
+		return m.InitializeFunc(injector)
+	}
+	return nil
+}
+
+// Execute calls the mock ExecuteFunc if set, otherwise returns nil.
+func (m *MockCheckPipeline) Execute(ctx context.Context) error {
+	if m.ExecuteFunc != nil {
+		return m.ExecuteFunc(ctx)
+	}
+	return nil
+}
+
+// Ensure MockCheckPipeline implements Pipeline.
+var _ Pipeline = (*MockCheckPipeline)(nil)

--- a/pkg/pipelines/mock_check_pipeline_test.go
+++ b/pkg/pipelines/mock_check_pipeline_test.go
@@ -1,0 +1,115 @@
+package pipelines
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/windsorcli/cli/pkg/di"
+)
+
+// =============================================================================
+// Test Constructor
+// =============================================================================
+
+func TestNewMockCheckPipeline(t *testing.T) {
+	t.Run("CreatesNewMockCheckPipeline", func(t *testing.T) {
+		mock := NewMockCheckPipeline()
+
+		if mock == nil {
+			t.Fatal("Expected mock to not be nil")
+		}
+	})
+}
+
+// =============================================================================
+// Test Public Methods
+// =============================================================================
+
+func TestMockCheckPipeline_Initialize(t *testing.T) {
+	t.Run("CallsInitializeFuncWhenSet", func(t *testing.T) {
+		mock := NewMockCheckPipeline()
+		called := false
+		mock.InitializeFunc = func(di.Injector) error {
+			called = true
+			return nil
+		}
+
+		err := mock.Initialize(di.NewMockInjector())
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if !called {
+			t.Error("Expected InitializeFunc to be called")
+		}
+	})
+
+	t.Run("ReturnsErrorFromInitializeFunc", func(t *testing.T) {
+		mock := NewMockCheckPipeline()
+		expectedError := fmt.Errorf("initialize error")
+		mock.InitializeFunc = func(di.Injector) error {
+			return expectedError
+		}
+
+		err := mock.Initialize(di.NewMockInjector())
+
+		if err != expectedError {
+			t.Errorf("Expected error %v, got %v", expectedError, err)
+		}
+	})
+
+	t.Run("ReturnsNilWhenInitializeFuncNotSet", func(t *testing.T) {
+		mock := NewMockCheckPipeline()
+
+		err := mock.Initialize(di.NewMockInjector())
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+}
+
+func TestMockCheckPipeline_Execute(t *testing.T) {
+	t.Run("CallsExecuteFuncWhenSet", func(t *testing.T) {
+		mock := NewMockCheckPipeline()
+		called := false
+		mock.ExecuteFunc = func(context.Context) error {
+			called = true
+			return nil
+		}
+
+		err := mock.Execute(context.Background())
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if !called {
+			t.Error("Expected ExecuteFunc to be called")
+		}
+	})
+
+	t.Run("ReturnsErrorFromExecuteFunc", func(t *testing.T) {
+		mock := NewMockCheckPipeline()
+		expectedError := fmt.Errorf("execute error")
+		mock.ExecuteFunc = func(context.Context) error {
+			return expectedError
+		}
+
+		err := mock.Execute(context.Background())
+
+		if err != expectedError {
+			t.Errorf("Expected error %v, got %v", expectedError, err)
+		}
+	})
+
+	t.Run("ReturnsNilWhenExecuteFuncNotSet", func(t *testing.T) {
+		mock := NewMockCheckPipeline()
+
+		err := mock.Execute(context.Background())
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+}


### PR DESCRIPTION
Migrates `windsor check` to use the pipeline pattern.