### PR TITLE
refactor(pipeline): Allow env pipeline to run in quiet mode

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -97,7 +97,7 @@ func setupMocks(t *testing.T, opts ...*SetupOptions) *Mocks {
 	mockShell.CheckResetFlagsFunc = func() (bool, error) {
 		return false, nil
 	}
-	mockShell.ResetFunc = func() {}
+	mockShell.ResetFunc = func(...bool) {}
 	injector.Register("shell", mockShell)
 
 	// Create and register mock secrets provider

--- a/pkg/env/env_test.go
+++ b/pkg/env/env_test.go
@@ -580,7 +580,7 @@ func TestBaseEnvPrinter_Reset(t *testing.T) {
 
 		// And a mock Reset function
 		resetCalled := false
-		mocks.Shell.ResetFunc = func() {
+		mocks.Shell.ResetFunc = func(...bool) {
 			resetCalled = true
 		}
 
@@ -607,7 +607,7 @@ func TestBaseEnvPrinter_Reset(t *testing.T) {
 
 		// And a mock Reset function
 		resetCalled := false
-		mocks.Shell.ResetFunc = func() {
+		mocks.Shell.ResetFunc = func(...bool) {
 			resetCalled = true
 		}
 
@@ -632,7 +632,7 @@ func TestBaseEnvPrinter_Reset(t *testing.T) {
 
 		// And a mock Reset function
 		resetCalled := false
-		mocks.Shell.ResetFunc = func() {
+		mocks.Shell.ResetFunc = func(...bool) {
 			resetCalled = true
 		}
 

--- a/pkg/pipelines/pipeline_test.go
+++ b/pkg/pipelines/pipeline_test.go
@@ -138,7 +138,7 @@ func TestBasePipeline_handleSessionReset(t *testing.T) {
 			return false, nil
 		}
 		resetCalled := false
-		mockShell.ResetFunc = func() {
+		mockShell.ResetFunc = func(...bool) {
 			resetCalled = true
 		}
 
@@ -171,7 +171,7 @@ func TestBasePipeline_handleSessionReset(t *testing.T) {
 			return true, nil
 		}
 		resetCalled := false
-		mockShell.ResetFunc = func() {
+		mockShell.ResetFunc = func(...bool) {
 			resetCalled = true
 		}
 
@@ -204,7 +204,7 @@ func TestBasePipeline_handleSessionReset(t *testing.T) {
 			return false, nil
 		}
 		resetCalled := false
-		mockShell.ResetFunc = func() {
+		mockShell.ResetFunc = func(...bool) {
 			resetCalled = true
 		}
 
@@ -256,7 +256,7 @@ func TestBasePipeline_handleSessionReset(t *testing.T) {
 		mockShell.CheckResetFlagsFunc = func() (bool, error) {
 			return true, nil
 		}
-		mockShell.ResetFunc = func() {}
+		mockShell.ResetFunc = func(...bool) {}
 
 		// When handling session reset
 		err := pipeline.handleSessionReset()

--- a/pkg/shell/mock_shell.go
+++ b/pkg/shell/mock_shell.go
@@ -34,7 +34,7 @@ type MockShell struct {
 	WriteResetTokenFunc            func() (string, error)
 	GetSessionTokenFunc            func() (string, error)
 	CheckResetFlagsFunc            func() (bool, error)
-	ResetFunc                      func()
+	ResetFunc                      func(...bool)
 	RegisterSecretFunc             func(value string)
 }
 
@@ -194,9 +194,9 @@ func (s *MockShell) CheckResetFlags() (bool, error) {
 }
 
 // Reset calls the custom ResetFunc if provided.
-func (s *MockShell) Reset() {
+func (s *MockShell) Reset(quiet ...bool) {
 	if s.ResetFunc != nil {
-		s.ResetFunc()
+		s.ResetFunc(quiet...)
 	}
 }
 

--- a/pkg/shell/mock_shell_test.go
+++ b/pkg/shell/mock_shell_test.go
@@ -1092,7 +1092,7 @@ func TestMockShell_Reset(t *testing.T) {
 		// Given a mock shell with ResetFunc set
 		mockShell := setupMockShellMocks(t)
 		called := false
-		mockShell.ResetFunc = func() {
+		mockShell.ResetFunc = func(...bool) {
 			called = true
 		}
 

--- a/pkg/shell/shell_test.go
+++ b/pkg/shell/shell_test.go
@@ -2219,12 +2219,14 @@ func TestShell_Reset(t *testing.T) {
 			shell.Reset(false)
 		})
 
-		// Then shell commands should be printed
-		if !strings.Contains(output, "unset ENV1 ENV2 ENV3") {
-			t.Errorf("Expected unset command to be printed, got: %v", output)
+		// Then shell commands should be printed (platform-specific)
+		// Unix: "unset ENV1 ENV2 ENV3" / Windows: "Remove-Item Env:ENV1"
+		if !strings.Contains(output, "unset ENV1 ENV2 ENV3") && !strings.Contains(output, "Remove-Item Env:ENV1") {
+			t.Errorf("Expected environment unset command to be printed, got: %v", output)
 		}
-		if !strings.Contains(output, "unalias ALIAS1") {
-			t.Errorf("Expected unalias command to be printed, got: %v", output)
+		// Unix: "unalias ALIAS1" / Windows: "Remove-Item Alias:ALIAS1"
+		if !strings.Contains(output, "unalias ALIAS1") && !strings.Contains(output, "Remove-Item Alias:ALIAS1") {
+			t.Errorf("Expected alias unset command to be printed, got: %v", output)
 		}
 	})
 }

--- a/pkg/shell/windows_shell_test.go
+++ b/pkg/shell/windows_shell_test.go
@@ -183,8 +183,8 @@ func TestDefaultShell_PrintAlias(t *testing.T) {
 		})
 
 		// Then the output should contain the expected alias and remove alias commands
-		expectedAliasLine := fmt.Sprintf("Set-Alias -Name ALIAS1 -Value \"command1\"\n")
-		expectedRemoveAliasLine := fmt.Sprintf("Remove-Item Alias:ALIAS2\n")
+		expectedAliasLine := "Set-Alias -Name ALIAS1 -Value \"command1\"\n"
+		expectedRemoveAliasLine := "Remove-Item Alias:ALIAS2\n"
 
 		if !strings.Contains(output, expectedAliasLine) {
 			t.Errorf("PrintAlias() output missing expected line: %v", expectedAliasLine)


### PR DESCRIPTION
Adds a `quiet` context parameter to the env pipeline. Permits using the env pipeline only for environment injection in the process in addition to shell injection.