### PR TITLE
refactor(pipeline): Pass context in to initialize

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -29,11 +29,6 @@ var checkCmd = &cobra.Command{
 		// Create check pipeline
 		pipeline := pipelines.NewCheckPipeline()
 
-		// Initialize the pipeline
-		if err := pipeline.Initialize(injector); err != nil {
-			return fmt.Errorf("Error initializing: %w", err)
-		}
-
 		// Create output function
 		outputFunc := func(output string) {
 			fmt.Fprintln(cmd.OutOrStdout(), output)
@@ -42,6 +37,11 @@ var checkCmd = &cobra.Command{
 		// Create execution context with operation and output function
 		ctx := context.WithValue(cmd.Context(), "operation", "tools")
 		ctx = context.WithValue(ctx, "output", outputFunc)
+
+		// Initialize the pipeline
+		if err := pipeline.Initialize(injector, ctx); err != nil {
+			return fmt.Errorf("Error initializing: %w", err)
+		}
 
 		// Execute the pipeline
 		if err := pipeline.Execute(ctx); err != nil {
@@ -64,11 +64,6 @@ var checkNodeHealthCmd = &cobra.Command{
 		// Create check pipeline
 		pipeline := pipelines.NewCheckPipeline()
 
-		// Initialize the pipeline
-		if err := pipeline.Initialize(injector); err != nil {
-			return fmt.Errorf("Error initializing: %w", err)
-		}
-
 		// Require nodes to be specified
 		if len(nodeHealthNodes) == 0 {
 			return fmt.Errorf("No nodes specified. Use --nodes flag to specify nodes to check")
@@ -90,6 +85,11 @@ var checkNodeHealthCmd = &cobra.Command{
 		ctx = context.WithValue(ctx, "timeout", nodeHealthTimeout)
 		ctx = context.WithValue(ctx, "version", nodeHealthVersion)
 		ctx = context.WithValue(ctx, "output", outputFunc)
+
+		// Initialize the pipeline
+		if err := pipeline.Initialize(injector, ctx); err != nil {
+			return fmt.Errorf("Error initializing: %w", err)
+		}
 
 		// Execute the pipeline
 		if err := pipeline.Execute(ctx); err != nil {

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -22,11 +22,6 @@ var getContextCmd = &cobra.Command{
 		// Create context pipeline
 		pipeline := pipelines.NewContextPipeline()
 
-		// Initialize the pipeline
-		if err := pipeline.Initialize(injector); err != nil {
-			return fmt.Errorf("Error initializing: %w", err)
-		}
-
 		// Create output function
 		outputFunc := func(output string) {
 			fmt.Fprintln(cmd.OutOrStdout(), output)
@@ -35,6 +30,11 @@ var getContextCmd = &cobra.Command{
 		// Create execution context with operation and output function
 		ctx := context.WithValue(cmd.Context(), "operation", "get")
 		ctx = context.WithValue(ctx, "output", outputFunc)
+
+		// Initialize the pipeline
+		if err := pipeline.Initialize(injector, ctx); err != nil {
+			return fmt.Errorf("Error initializing: %w", err)
+		}
 
 		// Execute the pipeline
 		if err := pipeline.Execute(ctx); err != nil {
@@ -58,11 +58,6 @@ var setContextCmd = &cobra.Command{
 		// Create context pipeline
 		pipeline := pipelines.NewContextPipeline()
 
-		// Initialize the pipeline
-		if err := pipeline.Initialize(injector); err != nil {
-			return fmt.Errorf("Error initializing: %w", err)
-		}
-
 		// Create output function
 		outputFunc := func(output string) {
 			fmt.Fprintln(cmd.OutOrStdout(), output)
@@ -72,6 +67,11 @@ var setContextCmd = &cobra.Command{
 		ctx := context.WithValue(cmd.Context(), "operation", "set")
 		ctx = context.WithValue(ctx, "contextName", args[0])
 		ctx = context.WithValue(ctx, "output", outputFunc)
+
+		// Initialize the pipeline
+		if err := pipeline.Initialize(injector, ctx); err != nil {
+			return fmt.Errorf("Error initializing: %w", err)
+		}
 
 		// Execute the pipeline
 		if err := pipeline.Execute(ctx); err != nil {

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -25,11 +25,6 @@ var envCmd = &cobra.Command{
 		hook, _ := cmd.Flags().GetBool("hook")
 		decrypt, _ := cmd.Flags().GetBool("decrypt")
 
-		// Initialize the pipeline with appropriate configuration
-		if err := pipeline.Initialize(injector); err != nil {
-			return fmt.Errorf("Error initializing: %w", err)
-		}
-
 		// Create execution context with flags
 		ctx := cmd.Context()
 		if decrypt {
@@ -40,6 +35,11 @@ var envCmd = &cobra.Command{
 		}
 		if hook {
 			ctx = context.WithValue(ctx, "hook", true)
+		}
+
+		// Initialize the pipeline with appropriate configuration
+		if err := pipeline.Initialize(injector, ctx); err != nil {
+			return fmt.Errorf("Error initializing: %w", err)
 		}
 
 		// Execute the pipeline

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -30,7 +30,7 @@ var execCmd = &cobra.Command{
 			envPipeline = existing.(pipelines.Pipeline)
 		} else {
 			envPipeline = pipelines.NewEnvPipeline()
-			if err := envPipeline.Initialize(injector); err != nil {
+			if err := envPipeline.Initialize(injector, cmd.Context()); err != nil {
 				return fmt.Errorf("failed to initialize env pipeline: %w", err)
 			}
 			injector.Register("envPipeline", envPipeline)
@@ -49,7 +49,7 @@ var execCmd = &cobra.Command{
 			execPipeline = existing.(pipelines.Pipeline)
 		} else {
 			execPipeline = pipelines.NewExecPipeline()
-			if err := execPipeline.Initialize(injector); err != nil {
+			if err := execPipeline.Initialize(injector, cmd.Context()); err != nil {
 				return fmt.Errorf("failed to initialize exec pipeline: %w", err)
 			}
 			injector.Register("execPipeline", execPipeline)

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -26,7 +26,7 @@ var hookCmd = &cobra.Command{
 		pipeline := pipelines.NewHookPipeline()
 
 		// Initialize the pipeline
-		if err := pipeline.Initialize(injector); err != nil {
+		if err := pipeline.Initialize(injector, cmd.Context()); err != nil {
 			return fmt.Errorf("Error initializing: %w", err)
 		}
 

--- a/pkg/pipelines/check.go
+++ b/pkg/pipelines/check.go
@@ -86,7 +86,7 @@ func NewCheckPipeline(constructors ...CheckConstructors) *CheckPipeline {
 // It sets up the config handler, shell, tools manager, and cluster client in the correct order,
 // registering each component with the dependency injector and initializing them sequentially
 // to ensure proper dependency resolution.
-func (p *CheckPipeline) Initialize(injector di.Injector) error {
+func (p *CheckPipeline) Initialize(injector di.Injector, ctx context.Context) error {
 	p.shims = p.constructors.NewShims()
 
 	if existing := injector.Resolve("shell"); existing != nil {

--- a/pkg/pipelines/check_test.go
+++ b/pkg/pipelines/check_test.go
@@ -244,7 +244,7 @@ contexts:
 `,
 		})
 
-		err := pipeline.Initialize(di.NewMockInjector())
+		err := pipeline.Initialize(di.NewMockInjector(), context.Background())
 
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
@@ -257,7 +257,7 @@ contexts:
 			return fmt.Errorf("config initialization failed")
 		}
 
-		err := pipeline.Initialize(mocks.Injector)
+		err := pipeline.Initialize(mocks.Injector, context.Background())
 
 		if err == nil {
 			t.Fatal("Expected error, got nil")
@@ -273,7 +273,7 @@ contexts:
 			return fmt.Errorf("shell initialization failed")
 		}
 
-		err := pipeline.Initialize(mocks.Injector)
+		err := pipeline.Initialize(mocks.Injector, context.Background())
 
 		if err == nil {
 			t.Fatal("Expected error, got nil")
@@ -289,7 +289,7 @@ contexts:
 			return fmt.Errorf("tools manager initialization failed")
 		}
 
-		err := pipeline.Initialize(mocks.Injector)
+		err := pipeline.Initialize(mocks.Injector, context.Background())
 
 		if err == nil {
 			t.Fatal("Expected error, got nil")
@@ -305,7 +305,7 @@ contexts:
 			return "", fmt.Errorf("project root error")
 		}
 
-		err := pipeline.Initialize(mocks.Injector)
+		err := pipeline.Initialize(mocks.Injector, context.Background())
 
 		if err == nil {
 			t.Fatal("Expected error, got nil")
@@ -361,7 +361,7 @@ contexts:
 
 		pipeline := NewCheckPipeline(constructors)
 
-		err := pipeline.Initialize(injector)
+		err := pipeline.Initialize(injector, context.Background())
 
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
@@ -391,7 +391,7 @@ func TestCheckPipeline_Execute(t *testing.T) {
 		t.Helper()
 		mocks := setupCheckMocks(t, opts...)
 		pipeline := setupCheckPipeline(t, mocks)
-		err := pipeline.Initialize(mocks.Injector)
+		err := pipeline.Initialize(mocks.Injector, context.Background())
 		if err != nil {
 			t.Fatalf("Failed to initialize pipeline: %v", err)
 		}

--- a/pkg/pipelines/context.go
+++ b/pkg/pipelines/context.go
@@ -72,7 +72,7 @@ func NewContextPipeline(constructors ...ContextConstructors) *ContextPipeline {
 // Initialize creates and registers all required components for the context pipeline.
 // It sets up the config handler and shell in the correct order, registering each component
 // with the dependency injector and initializing them sequentially to ensure proper dependency resolution.
-func (p *ContextPipeline) Initialize(injector di.Injector) error {
+func (p *ContextPipeline) Initialize(injector di.Injector, ctx context.Context) error {
 	p.shims = p.constructors.NewShims()
 
 	if existing := injector.Resolve("shell"); existing != nil {

--- a/pkg/pipelines/context_test.go
+++ b/pkg/pipelines/context_test.go
@@ -225,7 +225,7 @@ contexts:
 `,
 		})
 
-		err := pipeline.Initialize(di.NewMockInjector())
+		err := pipeline.Initialize(di.NewMockInjector(), context.Background())
 
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
@@ -243,7 +243,7 @@ contexts:
 			ConfigHandler: mockConfigHandler,
 		})
 
-		err := pipeline.Initialize(mocks.Injector)
+		err := pipeline.Initialize(mocks.Injector, context.Background())
 
 		if err == nil {
 			t.Fatal("Expected error, got nil")
@@ -259,7 +259,7 @@ contexts:
 			return fmt.Errorf("shell initialization failed")
 		}
 
-		err := pipeline.Initialize(mocks.Injector)
+		err := pipeline.Initialize(mocks.Injector, context.Background())
 
 		if err == nil {
 			t.Fatal("Expected error, got nil")
@@ -299,7 +299,7 @@ contexts:
 
 		pipeline := NewContextPipeline(constructors)
 
-		err := pipeline.Initialize(injector)
+		err := pipeline.Initialize(injector, context.Background())
 
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
@@ -323,7 +323,7 @@ func TestContextPipeline_Execute(t *testing.T) {
 		t.Helper()
 		mocks := setupContextMocks(t, opts...)
 		pipeline := setupContextPipeline(t, mocks)
-		err := pipeline.Initialize(mocks.Injector)
+		err := pipeline.Initialize(mocks.Injector, context.Background())
 		if err != nil {
 			t.Fatalf("Failed to initialize pipeline: %v", err)
 		}
@@ -438,7 +438,7 @@ func TestContextPipeline_executeGet(t *testing.T) {
 		t.Helper()
 		mocks := setupContextMocks(t, opts...)
 		pipeline := setupContextPipeline(t, mocks)
-		err := pipeline.Initialize(mocks.Injector)
+		err := pipeline.Initialize(mocks.Injector, context.Background())
 		if err != nil {
 			t.Fatalf("Failed to initialize pipeline: %v", err)
 		}
@@ -486,7 +486,7 @@ func TestContextPipeline_executeSet(t *testing.T) {
 		t.Helper()
 		mocks := setupContextMocks(t, opts...)
 		pipeline := setupContextPipeline(t, mocks)
-		err := pipeline.Initialize(mocks.Injector)
+		err := pipeline.Initialize(mocks.Injector, context.Background())
 		if err != nil {
 			t.Fatalf("Failed to initialize pipeline: %v", err)
 		}

--- a/pkg/pipelines/env.go
+++ b/pkg/pipelines/env.go
@@ -126,7 +126,7 @@ func NewEnvPipeline(constructors ...EnvConstructors) *EnvPipeline {
 // It sets up the config handler, shell, secrets providers, and environment printers
 // in the correct order, registering each component with the dependency injector
 // and initializing them sequentially to ensure proper dependency resolution.
-func (p *EnvPipeline) Initialize(injector di.Injector) error {
+func (p *EnvPipeline) Initialize(injector di.Injector, ctx context.Context) error {
 	p.shims = p.constructors.NewShims()
 
 	if existing := injector.Resolve("shell"); existing != nil {

--- a/pkg/pipelines/env_test.go
+++ b/pkg/pipelines/env_test.go
@@ -401,7 +401,7 @@ contexts:
 		})
 
 		// When initializing the pipeline
-		err := pipeline.Initialize(di.NewMockInjector())
+		err := pipeline.Initialize(di.NewMockInjector(), context.Background())
 
 		// Then no error should be returned
 		if err != nil {
@@ -423,7 +423,7 @@ contexts:
 		})
 
 		// When initializing the pipeline
-		err := pipeline.Initialize(mocks.Injector)
+		err := pipeline.Initialize(mocks.Injector, context.Background())
 
 		// Then an error should be returned
 		if err == nil {
@@ -442,7 +442,7 @@ contexts:
 		}
 
 		// When initializing the pipeline
-		err := pipeline.Initialize(mocks.Injector)
+		err := pipeline.Initialize(mocks.Injector, context.Background())
 
 		// Then an error should be returned
 		if err == nil {
@@ -467,7 +467,7 @@ contexts:
 		}
 
 		// When initializing the pipeline
-		err := pipeline.Initialize(mocks.Injector)
+		err := pipeline.Initialize(mocks.Injector, context.Background())
 
 		// Then an error should be returned
 		if err == nil {
@@ -486,7 +486,7 @@ contexts:
 		}
 
 		// When initializing the pipeline
-		err := pipeline.Initialize(mocks.Injector)
+		err := pipeline.Initialize(mocks.Injector, context.Background())
 
 		// Then an error should be returned
 		if err == nil {
@@ -509,7 +509,7 @@ contexts:
 		})
 
 		// When initializing the pipeline
-		err := pipeline.Initialize(mocks.Injector)
+		err := pipeline.Initialize(mocks.Injector, context.Background())
 
 		// Then an error should be returned
 		if err == nil {
@@ -528,7 +528,7 @@ contexts:
 		}
 
 		// When initializing the pipeline
-		err := pipeline.Initialize(mocks.Injector)
+		err := pipeline.Initialize(mocks.Injector, context.Background())
 
 		// Then no error should be returned
 		if err != nil {
@@ -544,7 +544,7 @@ contexts:
 		}
 
 		// When initializing the pipeline
-		err := pipeline.Initialize(mocks.Injector)
+		err := pipeline.Initialize(mocks.Injector, context.Background())
 
 		// Then no error should be returned and no secrets providers should exist
 		if err != nil {
@@ -560,7 +560,7 @@ contexts:
 		pipeline, _ := setup(t)
 
 		// When initializing the pipeline
-		err := pipeline.Initialize(di.NewMockInjector())
+		err := pipeline.Initialize(di.NewMockInjector(), context.Background())
 
 		// Then no error should be returned
 		if err != nil {
@@ -638,7 +638,7 @@ contexts:
 		pipeline := NewEnvPipeline(constructors)
 
 		// When initializing the pipeline
-		err := pipeline.Initialize(injector)
+		err := pipeline.Initialize(injector, context.Background())
 
 		// Then no error should be returned
 		if err != nil {
@@ -665,7 +665,7 @@ func TestPipeline_Execute(t *testing.T) {
 		t.Helper()
 		mocks := setupMocks(t, opts...)
 		pipeline := setupPipeline(t, mocks)
-		err := pipeline.Initialize(mocks.Injector)
+		err := pipeline.Initialize(mocks.Injector, context.Background())
 		if err != nil {
 			t.Fatalf("Failed to initialize pipeline: %v", err)
 		}
@@ -782,7 +782,7 @@ contexts:
 				return nil, os.ErrNotExist
 			}
 			pipeline := setupPipeline(t, mocks)
-			err := pipeline.Initialize(mocks.Injector)
+			err := pipeline.Initialize(mocks.Injector, context.Background())
 			if err != nil {
 				t.Fatalf("Failed to initialize pipeline: %v", err)
 			}
@@ -1181,7 +1181,7 @@ contexts:
 `,
 		})
 
-		err := pipeline.Initialize(mocks.Injector)
+		err := pipeline.Initialize(mocks.Injector, context.Background())
 
 		// Then all env printers should be created (aws, azure, docker, kube, talos, terraform, windsor)
 		if err != nil {
@@ -1210,7 +1210,7 @@ contexts:
 `,
 		})
 
-		err := pipeline.Initialize(mocks.Injector)
+		err := pipeline.Initialize(mocks.Injector, context.Background())
 
 		// Then only Windsor env printer should be created
 		if err != nil {

--- a/pkg/pipelines/exec_pipeline.go
+++ b/pkg/pipelines/exec_pipeline.go
@@ -59,7 +59,7 @@ func NewExecPipeline(constructors ...ExecConstructors) *ExecPipeline {
 // =============================================================================
 
 // Initialize creates and registers the shell component for command execution.
-func (p *ExecPipeline) Initialize(injector di.Injector) error {
+func (p *ExecPipeline) Initialize(injector di.Injector, ctx context.Context) error {
 	p.injector = injector
 
 	if existing := injector.Resolve("shell"); existing != nil {

--- a/pkg/pipelines/exec_pipeline_test.go
+++ b/pkg/pipelines/exec_pipeline_test.go
@@ -72,7 +72,7 @@ func TestExecPipeline_Initialize(t *testing.T) {
 		}
 
 		pipeline := NewExecPipeline(constructors)
-		err := pipeline.Initialize(injector)
+		err := pipeline.Initialize(injector, context.Background())
 
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
@@ -95,7 +95,7 @@ func TestExecPipeline_Initialize(t *testing.T) {
 		}
 
 		pipeline := NewExecPipeline(constructors)
-		err := pipeline.Initialize(injector)
+		err := pipeline.Initialize(injector, context.Background())
 
 		if err == nil {
 			t.Error("Expected error, got nil")
@@ -115,7 +115,7 @@ func TestExecPipeline_Initialize(t *testing.T) {
 		injector.Register("shell", existingShell)
 
 		pipeline := NewExecPipeline()
-		err := pipeline.Initialize(injector)
+		err := pipeline.Initialize(injector, context.Background())
 
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
@@ -148,7 +148,7 @@ func TestExecPipeline_Execute(t *testing.T) {
 		}
 
 		pipeline := NewExecPipeline(constructors)
-		err := pipeline.Initialize(injector)
+		err := pipeline.Initialize(injector, context.Background())
 		if err != nil {
 			t.Fatalf("Failed to initialize pipeline: %v", err)
 		}
@@ -183,7 +183,7 @@ func TestExecPipeline_Execute(t *testing.T) {
 		}
 
 		pipeline := NewExecPipeline(constructors)
-		err := pipeline.Initialize(injector)
+		err := pipeline.Initialize(injector, context.Background())
 		if err != nil {
 			t.Fatalf("Failed to initialize pipeline: %v", err)
 		}
@@ -213,7 +213,7 @@ func TestExecPipeline_Execute(t *testing.T) {
 		}
 
 		pipeline := NewExecPipeline(constructors)
-		err := pipeline.Initialize(injector)
+		err := pipeline.Initialize(injector, context.Background())
 		if err != nil {
 			t.Fatalf("Failed to initialize pipeline: %v", err)
 		}
@@ -249,7 +249,7 @@ func TestExecPipeline_Execute(t *testing.T) {
 		}
 
 		pipeline := NewExecPipeline(constructors)
-		err := pipeline.Initialize(injector)
+		err := pipeline.Initialize(injector, context.Background())
 		if err != nil {
 			t.Fatalf("Failed to initialize pipeline: %v", err)
 		}
@@ -289,7 +289,7 @@ func TestExecPipeline_Execute(t *testing.T) {
 		}
 
 		pipeline := NewExecPipeline(constructors)
-		err := pipeline.Initialize(injector)
+		err := pipeline.Initialize(injector, context.Background())
 		if err != nil {
 			t.Fatalf("Failed to initialize pipeline: %v", err)
 		}

--- a/pkg/pipelines/hook.go
+++ b/pkg/pipelines/hook.go
@@ -71,7 +71,7 @@ func NewHookPipeline(constructors ...HookConstructors) *HookPipeline {
 // Initialize creates and registers all required components for the hook pipeline.
 // It sets up the config handler and shell in the correct order, registering each component
 // with the dependency injector and initializing them sequentially to ensure proper dependency resolution.
-func (p *HookPipeline) Initialize(injector di.Injector) error {
+func (p *HookPipeline) Initialize(injector di.Injector, ctx context.Context) error {
 	p.shims = p.constructors.NewShims()
 
 	if existing := injector.Resolve("shell"); existing != nil {

--- a/pkg/pipelines/hook_test.go
+++ b/pkg/pipelines/hook_test.go
@@ -195,7 +195,7 @@ func TestHookPipeline_Initialize(t *testing.T) {
 		pipeline, _ := setup(t)
 
 		// When initializing the pipeline
-		err := pipeline.Initialize(di.NewMockInjector())
+		err := pipeline.Initialize(di.NewMockInjector(), context.Background())
 
 		// Then no error should be returned
 		if err != nil {
@@ -216,7 +216,7 @@ func TestHookPipeline_Initialize(t *testing.T) {
 		})
 
 		// When initializing the pipeline
-		err := pipeline.Initialize(mocks.Injector)
+		err := pipeline.Initialize(mocks.Injector, context.Background())
 
 		// Then an error should be returned
 		if err == nil {
@@ -235,7 +235,7 @@ func TestHookPipeline_Initialize(t *testing.T) {
 		}
 
 		// When initializing the pipeline
-		err := pipeline.Initialize(mocks.Injector)
+		err := pipeline.Initialize(mocks.Injector, context.Background())
 
 		// Then an error should be returned
 		if err == nil {
@@ -277,7 +277,7 @@ func TestHookPipeline_Initialize(t *testing.T) {
 		pipeline := NewHookPipeline(constructors)
 
 		// When initializing the pipeline
-		err := pipeline.Initialize(injector)
+		err := pipeline.Initialize(injector, context.Background())
 
 		// Then no error should be returned
 		if err != nil {
@@ -304,7 +304,7 @@ func TestHookPipeline_Execute(t *testing.T) {
 		t.Helper()
 		mocks := setupHookMocks(t, opts...)
 		pipeline := setupHookPipeline(t, mocks)
-		err := pipeline.Initialize(mocks.Injector)
+		err := pipeline.Initialize(mocks.Injector, context.Background())
 		if err != nil {
 			t.Fatalf("Failed to initialize pipeline: %v", err)
 		}

--- a/pkg/pipelines/mock_pipeline.go
+++ b/pkg/pipelines/mock_pipeline.go
@@ -8,7 +8,7 @@ import (
 
 // MockBasePipeline is a mock implementation of the Pipeline interface
 type MockBasePipeline struct {
-	InitializeFunc func(injector di.Injector) error
+	InitializeFunc func(injector di.Injector, ctx context.Context) error
 	ExecuteFunc    func(ctx context.Context) error
 }
 
@@ -26,9 +26,9 @@ func NewMockBasePipeline() *MockBasePipeline {
 // =============================================================================
 
 // Initialize calls the mock InitializeFunc if set, otherwise returns nil
-func (m *MockBasePipeline) Initialize(injector di.Injector) error {
+func (m *MockBasePipeline) Initialize(injector di.Injector, ctx context.Context) error {
 	if m.InitializeFunc != nil {
-		return m.InitializeFunc(injector)
+		return m.InitializeFunc(injector, ctx)
 	}
 	return nil
 }

--- a/pkg/pipelines/pipeline.go
+++ b/pkg/pipelines/pipeline.go
@@ -21,7 +21,7 @@ import (
 
 // Pipeline defines the interface for all command pipelines
 type Pipeline interface {
-	Initialize(injector di.Injector) error
+	Initialize(injector di.Injector, ctx context.Context) error
 	Execute(ctx context.Context) error
 }
 
@@ -46,7 +46,7 @@ func NewBasePipeline() *BasePipeline {
 // =============================================================================
 
 // Initialize provides a default implementation that can be overridden by specific pipelines
-func (p *BasePipeline) Initialize(injector di.Injector) error {
+func (p *BasePipeline) Initialize(injector di.Injector, ctx context.Context) error {
 	return nil
 }
 

--- a/pkg/pipelines/pipeline_test.go
+++ b/pkg/pipelines/pipeline_test.go
@@ -53,7 +53,7 @@ func TestBasePipeline_Initialize(t *testing.T) {
 		pipeline, injector := setupBasePipeline(t)
 
 		// When initializing the pipeline
-		err := pipeline.Initialize(injector)
+		err := pipeline.Initialize(injector, context.Background())
 
 		// Then no error should be returned
 		if err != nil {
@@ -68,7 +68,7 @@ func TestBasePipeline_Execute(t *testing.T) {
 		pipeline, injector := setupBasePipeline(t)
 
 		// When initializing and executing the pipeline
-		err := pipeline.Initialize(injector)
+		err := pipeline.Initialize(injector, context.Background())
 		if err != nil {
 			t.Fatalf("Initialize failed: %v", err)
 		}


### PR DESCRIPTION
Include the ctx parameter in a pipeline's Initialize. Context values may impact what a pipeline creates and initializes.