### PR TITLE
refactor(pipeline): Add resolveOrCreateDependency helper

### DIFF
--- a/pkg/artifact/artifact_test.go
+++ b/pkg/artifact/artifact_test.go
@@ -34,7 +34,7 @@ func (m *mockFileInfo) Size() int64        { return 0 }
 func (m *mockFileInfo) Mode() os.FileMode  { return 0 }
 func (m *mockFileInfo) ModTime() time.Time { return time.Time{} }
 func (m *mockFileInfo) IsDir() bool        { return m.isDir }
-func (m *mockFileInfo) Sys() interface{}   { return nil }
+func (m *mockFileInfo) Sys() any           { return nil }
 
 type ArtifactMocks struct {
 	Injector di.Injector

--- a/pkg/generators/terraform_generator_test.go
+++ b/pkg/generators/terraform_generator_test.go
@@ -2664,7 +2664,7 @@ func TestTerraformGenerator_writeTfvarsFile(t *testing.T) {
 		// And a component with values
 		component := blueprintv1alpha1.TerraformComponent{
 			Path: "module/path1",
-			Values: map[string]interface{}{
+			Values: map[string]any{
 				"test": "value",
 			},
 		}
@@ -2696,7 +2696,7 @@ func TestTerraformGenerator_writeTfvarsFile(t *testing.T) {
 		// And a component with values
 		component := blueprintv1alpha1.TerraformComponent{
 			Path: "module/path1",
-			Values: map[string]interface{}{
+			Values: map[string]any{
 				"test": "value",
 			},
 		}
@@ -2740,7 +2740,7 @@ func TestTerraformGenerator_writeTfvarsFile(t *testing.T) {
 		component := blueprintv1alpha1.TerraformComponent{
 			Path:     "module/path1",
 			FullPath: "original/full/path",
-			Values: map[string]interface{}{
+			Values: map[string]any{
 				"test": "value",
 			},
 		}
@@ -2789,7 +2789,7 @@ func TestTerraformGenerator_writeTfvarsFile(t *testing.T) {
 		component := blueprintv1alpha1.TerraformComponent{
 			Path:     "module/path1",
 			FullPath: "original/full/path",
-			Values: map[string]interface{}{
+			Values: map[string]any{
 				"test": "value",
 			},
 		}

--- a/pkg/pipelines/context.go
+++ b/pkg/pipelines/context.go
@@ -30,10 +30,6 @@ type ContextPipeline struct {
 	BasePipeline
 
 	constructors ContextConstructors
-
-	configHandler config.ConfigHandler
-	shell         shell.Shell
-	shims         *Shims
 }
 
 // =============================================================================
@@ -73,23 +69,14 @@ func NewContextPipeline(constructors ...ContextConstructors) *ContextPipeline {
 // It sets up the config handler and shell in the correct order, registering each component
 // with the dependency injector and initializing them sequentially to ensure proper dependency resolution.
 func (p *ContextPipeline) Initialize(injector di.Injector, ctx context.Context) error {
+	if err := p.BasePipeline.Initialize(injector, ctx); err != nil {
+		return err
+	}
+
 	p.shims = p.constructors.NewShims()
 
-	if existing := injector.Resolve("shell"); existing != nil {
-		p.shell = existing.(shell.Shell)
-	} else {
-		p.shell = p.constructors.NewShell(injector)
-		injector.Register("shell", p.shell)
-	}
-	p.BasePipeline.shell = p.shell
-
-	if existing := injector.Resolve("configHandler"); existing != nil {
-		p.configHandler = existing.(config.ConfigHandler)
-	} else {
-		p.configHandler = p.constructors.NewConfigHandler(injector)
-		injector.Register("configHandler", p.configHandler)
-	}
-	p.BasePipeline.configHandler = p.configHandler
+	p.shell = resolveOrCreateDependency(injector, "shell", p.constructors.NewShell)
+	p.configHandler = resolveOrCreateDependency(injector, "configHandler", p.constructors.NewConfigHandler)
 
 	if err := p.shell.Initialize(); err != nil {
 		return fmt.Errorf("failed to initialize shell: %w", err)
@@ -188,3 +175,9 @@ func (p *ContextPipeline) executeSet(ctx context.Context) error {
 
 	return nil
 }
+
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
+var _ Pipeline = (*ContextPipeline)(nil)

--- a/pkg/pipelines/exec_test.go
+++ b/pkg/pipelines/exec_test.go
@@ -21,7 +21,7 @@ func (m *mockFileInfo) Size() int64        { return 0 }
 func (m *mockFileInfo) Mode() os.FileMode  { return 0644 }
 func (m *mockFileInfo) ModTime() time.Time { return time.Time{} }
 func (m *mockFileInfo) IsDir() bool        { return false }
-func (m *mockFileInfo) Sys() interface{}   { return nil }
+func (m *mockFileInfo) Sys() any           { return nil }
 
 func TestNewExecPipeline(t *testing.T) {
 	t.Run("CreatesWithDefaultConstructors", func(t *testing.T) {


### PR DESCRIPTION
The resolveOrCreateDependency uses generics to create a simple idempotent factory for common constructor interfaces