### PR TITLE
refactor(config): Remove projectName from config

### DIFF
--- a/api/v1alpha1/config_types.go
+++ b/api/v1alpha1/config_types.go
@@ -23,7 +23,6 @@ type Config struct {
 // Context represents the context configuration
 type Context struct {
 	ID          *string                    `yaml:"id,omitempty"`
-	ProjectName *string                    `yaml:"projectName,omitempty"`
 	Blueprint   *string                    `yaml:"blueprint,omitempty"`
 	Environment map[string]string          `yaml:"environment,omitempty"`
 	Secrets     *secrets.SecretsConfig     `yaml:"secrets,omitempty"`
@@ -45,9 +44,6 @@ func (base *Context) Merge(overlay *Context) {
 	}
 	if overlay.ID != nil {
 		base.ID = overlay.ID
-	}
-	if overlay.ProjectName != nil {
-		base.ProjectName = overlay.ProjectName
 	}
 	if overlay.Environment != nil {
 		if base.Environment == nil {
@@ -136,7 +132,6 @@ func (c *Context) DeepCopy() *Context {
 	}
 	return &Context{
 		ID:          c.ID,
-		ProjectName: c.ProjectName,
 		Blueprint:   c.Blueprint,
 		Environment: environmentCopy,
 		Secrets:     c.Secrets.Copy(),

--- a/api/v1alpha1/config_types_test.go
+++ b/api/v1alpha1/config_types_test.go
@@ -355,22 +355,6 @@ func TestConfig_Merge(t *testing.T) {
 		}
 	})
 
-	t.Run("MergeWithProjectName", func(t *testing.T) {
-		base := &Context{
-			ProjectName: ptrString("BaseProject"),
-		}
-
-		overlay := &Context{
-			ProjectName: ptrString("OverlayProject"),
-		}
-
-		base.Merge(overlay)
-
-		if base.ProjectName == nil || *base.ProjectName != "OverlayProject" {
-			t.Errorf("ProjectName mismatch: expected 'OverlayProject', got '%s'", *base.ProjectName)
-		}
-	})
-
 	t.Run("MergeWithID", func(t *testing.T) {
 		base := &Context{
 			ID: ptrString("base-id"),

--- a/pkg/blueprint/blueprint_handler.go
+++ b/pkg/blueprint/blueprint_handler.go
@@ -115,10 +115,6 @@ func (b *BaseBlueprintHandler) Initialize() error {
 	}
 	b.projectRoot = projectRoot
 
-	if err := b.configHandler.SetContextValue("projectName", filepath.Base(projectRoot)); err != nil {
-		return fmt.Errorf("error setting project name in config: %w", err)
-	}
-
 	return nil
 }
 
@@ -558,6 +554,7 @@ func (b *BaseBlueprintHandler) processJsonnetTemplate(templateFile, contextDir, 
 	}
 
 	contextMap["name"] = contextName
+	contextMap["projectName"] = filepath.Base(b.projectRoot)
 	contextJSON, err := b.shims.JsonMarshal(contextMap)
 	if err != nil {
 		return fmt.Errorf("error marshalling context map to JSON: %w", err)
@@ -604,6 +601,7 @@ func (b *BaseBlueprintHandler) generateDefaultBlueprint(contextDir, contextName 
 				return fmt.Errorf("error unmarshalling context YAML: %w", err)
 			}
 			contextMap["name"] = contextName
+			contextMap["projectName"] = filepath.Base(b.projectRoot)
 
 			// --blueprint flag controls the context.blueprint field value
 			// Only set if explicitly provided via --blueprint flag

--- a/pkg/blueprint/blueprint_handler_test.go
+++ b/pkg/blueprint/blueprint_handler_test.go
@@ -529,33 +529,6 @@ func TestBlueprintHandler_Initialize(t *testing.T) {
 		}
 	})
 
-	t.Run("ErrorSettingProjectNameInConfig", func(t *testing.T) {
-		// Given a handler with mock config handler that returns error on SetContextValue
-		mockConfigHandler := &config.MockConfigHandler{
-			SetContextValueFunc: func(key string, value any) error {
-				return fmt.Errorf("set context value error")
-			},
-		}
-
-		// Create setup options with the custom config handler
-		opts := &SetupOptions{
-			ConfigHandler: mockConfigHandler,
-		}
-		mocks := setupMocks(t, opts)
-		handler := NewBlueprintHandler(mocks.Injector)
-		handler.shims = mocks.Shims
-
-		// When calling Initialize
-		err := handler.Initialize()
-
-		// Then an error should be returned
-		if err == nil {
-			t.Error("Expected error, got nil")
-		}
-		if !strings.Contains(err.Error(), "error setting project name in config") {
-			t.Errorf("Expected project name setting error, got: %v", err)
-		}
-	})
 }
 
 func TestBlueprintHandler_LoadConfig(t *testing.T) {

--- a/pkg/config/yaml_config_handler_test.go
+++ b/pkg/config/yaml_config_handler_test.go
@@ -1688,7 +1688,7 @@ func TestYamlConfigHandler_SetDefault(t *testing.T) {
 		handler, _ := setup(t)
 		handler.context = "existing-context"
 		handler.config.Contexts = map[string]*v1alpha1.Context{
-			"existing-context": {ProjectName: ptrString("initial-project")},
+			"existing-context": {},
 		}
 
 		// And a default context configuration
@@ -1710,10 +1710,8 @@ func TestYamlConfigHandler_SetDefault(t *testing.T) {
 		}
 
 		// And the existing context should not be modified
-		if handler.config.Contexts["existing-context"] == nil ||
-			handler.config.Contexts["existing-context"].ProjectName == nil ||
-			*handler.config.Contexts["existing-context"].ProjectName != "initial-project" {
-			t.Errorf("SetDefault incorrectly overwrote existing context config. Expected ProjectName 'initial-project', got %v", handler.config.Contexts["existing-context"].ProjectName)
+		if handler.config.Contexts["existing-context"] == nil {
+			t.Errorf("SetDefault incorrectly overwrote existing context config")
 		}
 	})
 }


### PR DESCRIPTION
Removes the projectName from the config. It's only useful as an option in the blueprint templating context, and usually only by core local blueprints.