### PR TITLE
refactor(pipeline): Use test helpers to DRY up tests

### DIFF
--- a/api/v1alpha1/config_types.go
+++ b/api/v1alpha1/config_types.go
@@ -23,6 +23,7 @@ type Config struct {
 // Context represents the context configuration
 type Context struct {
 	ID          *string                    `yaml:"id,omitempty"`
+	Platform    *string                    `yaml:"platform,omitempty"`
 	Blueprint   *string                    `yaml:"blueprint,omitempty"`
 	Environment map[string]string          `yaml:"environment,omitempty"`
 	Secrets     *secrets.SecretsConfig     `yaml:"secrets,omitempty"`
@@ -44,6 +45,9 @@ func (base *Context) Merge(overlay *Context) {
 	}
 	if overlay.ID != nil {
 		base.ID = overlay.ID
+	}
+	if overlay.Platform != nil {
+		base.Platform = overlay.Platform
 	}
 	if overlay.Environment != nil {
 		if base.Environment == nil {
@@ -132,6 +136,7 @@ func (c *Context) DeepCopy() *Context {
 	}
 	return &Context{
 		ID:          c.ID,
+		Platform:    c.Platform,
 		Blueprint:   c.Blueprint,
 		Environment: environmentCopy,
 		Secrets:     c.Secrets.Copy(),

--- a/api/v1alpha1/config_types_test.go
+++ b/api/v1alpha1/config_types_test.go
@@ -61,6 +61,7 @@ func TestConfig_Merge(t *testing.T) {
 			Network: &network.NetworkConfig{
 				CIDRBlock: ptrString("192.168.0.0/16"),
 			},
+			Platform:  ptrString("aws"),
 			Blueprint: ptrString("1.0.0"),
 		}
 
@@ -107,6 +108,7 @@ func TestConfig_Merge(t *testing.T) {
 			Network: &network.NetworkConfig{
 				CIDRBlock: ptrString("10.0.0.0/8"),
 			},
+			Platform:  ptrString("azure"),
 			Blueprint: ptrString("2.0.0"),
 		}
 
@@ -157,6 +159,9 @@ func TestConfig_Merge(t *testing.T) {
 		if base.Blueprint == nil || *base.Blueprint != "2.0.0" {
 			t.Errorf("Blueprint mismatch: expected '2.0.0', got '%s'", *base.Blueprint)
 		}
+		if base.Platform == nil || *base.Platform != "azure" {
+			t.Errorf("Platform mismatch: expected 'azure', got '%s'", *base.Platform)
+		}
 	})
 
 	t.Run("MergeWithNilOverlay", func(t *testing.T) {
@@ -204,6 +209,7 @@ func TestConfig_Merge(t *testing.T) {
 			Network: &network.NetworkConfig{
 				CIDRBlock: ptrString("192.168.0.0/16"),
 			},
+			Platform:  ptrString("aws"),
 			Blueprint: ptrString("1.0.0"),
 		}
 
@@ -255,6 +261,9 @@ func TestConfig_Merge(t *testing.T) {
 		if base.Blueprint == nil || *base.Blueprint != "1.0.0" {
 			t.Errorf("Blueprint mismatch: expected '1.0.0', got '%s'", *base.Blueprint)
 		}
+		if base.Platform == nil || *base.Platform != "aws" {
+			t.Errorf("Platform mismatch: expected 'aws', got '%s'", *base.Platform)
+		}
 	})
 
 	t.Run("MergeWithNilBase", func(t *testing.T) {
@@ -303,6 +312,7 @@ func TestConfig_Merge(t *testing.T) {
 			Network: &network.NetworkConfig{
 				CIDRBlock: ptrString("10.0.0.0/8"),
 			},
+			Platform:  ptrString("azure"),
 			Blueprint: ptrString("2.0.0"),
 		}
 
@@ -352,6 +362,9 @@ func TestConfig_Merge(t *testing.T) {
 		}
 		if base.Blueprint == nil || *base.Blueprint != "2.0.0" {
 			t.Errorf("Blueprint mismatch: expected '2.0.0', got '%s'", *base.Blueprint)
+		}
+		if base.Platform == nil || *base.Platform != "azure" {
+			t.Errorf("Platform mismatch: expected 'azure', got '%s'", *base.Platform)
 		}
 	})
 
@@ -418,6 +431,7 @@ func TestConfig_Copy(t *testing.T) {
 					End:   ptrString("192.168.0.255"),
 				},
 			},
+			Platform:  ptrString("local"),
 			Blueprint: ptrString("1.0.0"),
 		}
 
@@ -465,6 +479,9 @@ func TestConfig_Copy(t *testing.T) {
 		}
 		if original.Blueprint == nil || copy.Blueprint == nil || *original.Blueprint != *copy.Blueprint {
 			t.Errorf("Blueprint mismatch: expected %v, got %v", *original.Blueprint, *copy.Blueprint)
+		}
+		if original.Platform == nil || copy.Platform == nil || *original.Platform != *copy.Platform {
+			t.Errorf("Platform mismatch: expected %v, got %v", *original.Platform, *copy.Platform)
 		}
 	})
 

--- a/pkg/pipelines/check_test.go
+++ b/pkg/pipelines/check_test.go
@@ -3,6 +3,8 @@ package pipelines
 import (
 	"context"
 	"fmt"
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -13,124 +15,97 @@ import (
 	"github.com/windsorcli/cli/pkg/tools"
 )
 
+// mockFileInfo implements os.FileInfo for testing
+type mockFileInfo struct{}
+
+func (m *mockFileInfo) Name() string       { return "windsor.yaml" }
+func (m *mockFileInfo) Size() int64        { return 100 }
+func (m *mockFileInfo) Mode() os.FileMode  { return 0644 }
+func (m *mockFileInfo) ModTime() time.Time { return time.Now() }
+func (m *mockFileInfo) IsDir() bool        { return false }
+func (m *mockFileInfo) Sys() interface{}   { return nil }
+
 // =============================================================================
-// Test Setup
+// Test Setup Infrastructure
 // =============================================================================
 
+// CheckMocks extends the base Mocks with check-specific dependencies
 type CheckMocks struct {
-	Injector      di.Injector
-	ConfigHandler *config.MockConfigHandler
-	Shell         *shell.MockShell
+	*Mocks
 	ToolsManager  *tools.MockToolsManager
 	ClusterClient *cluster.MockClusterClient
-	Shims         *Shims
 }
 
-type CheckSetupOptions struct {
-	Injector      di.Injector
-	ConfigHandler *config.MockConfigHandler
-	ConfigStr     string
-	Shims         *Shims
-}
-
-func setupCheckMocks(t *testing.T, opts ...*CheckSetupOptions) *CheckMocks {
-	t.Helper()
-
-	var options *CheckSetupOptions
-	if len(opts) > 0 {
-		options = opts[0]
-	} else {
-		options = &CheckSetupOptions{}
-	}
-
-	var injector di.Injector
-	if options.Injector != nil {
-		injector = options.Injector
-	} else {
-		injector = di.NewMockInjector()
-	}
-
-	var configHandler *config.MockConfigHandler
-	if options.ConfigHandler != nil {
-		configHandler = options.ConfigHandler
-	} else {
-		configHandler = config.NewMockConfigHandler()
-	}
-
-	var shims *Shims
-	if options.Shims != nil {
-		shims = options.Shims
-	} else {
-		shims = setupCheckShims(t)
-	}
-
-	mockShell := shell.NewMockShell()
-	mockShell.InitializeFunc = func() error { return nil }
-	mockShell.GetProjectRootFunc = func() (string, error) { return t.TempDir(), nil }
-
-	mockToolsManager := tools.NewMockToolsManager()
-	mockToolsManager.InitializeFunc = func() error { return nil }
-	mockToolsManager.CheckFunc = func() error { return nil }
-
-	mockClusterClient := cluster.NewMockClusterClient()
-	mockClusterClient.WaitForNodesHealthyFunc = func(ctx context.Context, nodes []string, version string) error {
-		return nil
-	}
-
-	configHandler.InitializeFunc = func() error { return nil }
-	configHandler.LoadConfigFunc = func(path string) error { return nil }
-	configHandler.IsLoadedFunc = func() bool { return true }
-
-	if options.ConfigStr != "" {
-		if err := configHandler.LoadConfigString(options.ConfigStr); err != nil {
-			t.Fatalf("Failed to load config string: %v", err)
-		}
-	}
-
-	injector.Register("configHandler", configHandler)
-	injector.Register("shell", mockShell)
-	injector.Register("toolsManager", mockToolsManager)
-	injector.Register("clusterClient", mockClusterClient)
-
-	return &CheckMocks{
-		Injector:      injector,
-		ConfigHandler: configHandler,
-		Shell:         mockShell,
-		ToolsManager:  mockToolsManager,
-		ClusterClient: mockClusterClient,
-		Shims:         shims,
-	}
-}
-
+// setupCheckShims creates shims for check pipeline tests
 func setupCheckShims(t *testing.T) *Shims {
 	t.Helper()
-	return NewShims()
+	return setupShims(t)
 }
 
-func setupCheckPipeline(t *testing.T, mocks *CheckMocks) *CheckPipeline {
+// setupCheckMocks creates mocks for check pipeline tests
+func setupCheckMocks(t *testing.T, opts ...*SetupOptions) *CheckMocks {
 	t.Helper()
 
-	mocks.Injector.Register("configHandler", mocks.ConfigHandler)
-	mocks.Injector.Register("shell", mocks.Shell)
-	mocks.Injector.Register("toolsManager", mocks.ToolsManager)
-	mocks.Injector.Register("clusterClient", mocks.ClusterClient)
-	mocks.Injector.Register("shims", mocks.Shims)
+	// Create setup options, preserving any provided options
+	setupOptions := &SetupOptions{}
+	if len(opts) > 0 && opts[0] != nil {
+		setupOptions = opts[0]
+	}
 
-	return NewCheckPipeline()
-}
+	// Only create a default mock config handler if one wasn't provided
+	if setupOptions.ConfigHandler == nil {
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.InitializeFunc = func() error { return nil }
+		mockConfigHandler.IsLoadedFunc = func() bool { return true } // Default to loaded
+		setupOptions.ConfigHandler = mockConfigHandler
+	}
 
-func checkContains(str, substr string) bool {
-	return len(str) > 0 && len(substr) > 0 &&
-		(str == substr || len(str) >= len(substr) &&
-			(str[:len(substr)] == substr || str[len(str)-len(substr):] == substr ||
-				func() bool {
-					for i := 0; i <= len(str)-len(substr); i++ {
-						if str[i:i+len(substr)] == substr {
-							return true
-						}
-					}
-					return false
-				}()))
+	baseMocks := setupMocks(t, setupOptions)
+
+	// Create check-specific mocks only if they don't already exist
+	var mockToolsManager *tools.MockToolsManager
+	if existing := baseMocks.Injector.Resolve("toolsManager"); existing != nil {
+		if tm, ok := existing.(*tools.MockToolsManager); ok {
+			mockToolsManager = tm
+		} else {
+			// If existing is not a MockToolsManager, create a new one
+			mockToolsManager = tools.NewMockToolsManager()
+			mockToolsManager.InitializeFunc = func() error { return nil }
+			mockToolsManager.CheckFunc = func() error { return nil }
+			baseMocks.Injector.Register("toolsManager", mockToolsManager)
+		}
+	} else {
+		mockToolsManager = tools.NewMockToolsManager()
+		mockToolsManager.InitializeFunc = func() error { return nil }
+		mockToolsManager.CheckFunc = func() error { return nil }
+		baseMocks.Injector.Register("toolsManager", mockToolsManager)
+	}
+
+	var mockClusterClient *cluster.MockClusterClient
+	if existing := baseMocks.Injector.Resolve("clusterClient"); existing != nil {
+		if cc, ok := existing.(*cluster.MockClusterClient); ok {
+			mockClusterClient = cc
+		} else {
+			// If existing is not a MockClusterClient, create a new one
+			mockClusterClient = cluster.NewMockClusterClient()
+			mockClusterClient.WaitForNodesHealthyFunc = func(ctx context.Context, nodes []string, version string) error {
+				return nil
+			}
+			baseMocks.Injector.Register("clusterClient", mockClusterClient)
+		}
+	} else {
+		mockClusterClient = cluster.NewMockClusterClient()
+		mockClusterClient.WaitForNodesHealthyFunc = func(ctx context.Context, nodes []string, version string) error {
+			return nil
+		}
+		baseMocks.Injector.Register("clusterClient", mockClusterClient)
+	}
+
+	return &CheckMocks{
+		Mocks:         baseMocks,
+		ToolsManager:  mockToolsManager,
+		ClusterClient: mockClusterClient,
+	}
 }
 
 // =============================================================================
@@ -139,8 +114,10 @@ func checkContains(str, substr string) bool {
 
 func TestNewCheckPipeline(t *testing.T) {
 	t.Run("CreatesWithDefaults", func(t *testing.T) {
+		// Given creating a new check pipeline
 		pipeline := NewCheckPipeline()
 
+		// Then pipeline should not be nil
 		if pipeline == nil {
 			t.Fatal("Expected pipeline to not be nil")
 		}
@@ -148,560 +125,667 @@ func TestNewCheckPipeline(t *testing.T) {
 }
 
 // =============================================================================
-// Test Public Methods
+// Test Public Methods - Initialize
 // =============================================================================
 
 func TestCheckPipeline_Initialize(t *testing.T) {
-	setup := func(t *testing.T, opts ...*CheckSetupOptions) (*CheckPipeline, *CheckMocks) {
+	setup := func(t *testing.T, opts ...*SetupOptions) (*CheckPipeline, *CheckMocks) {
 		t.Helper()
+		pipeline := NewCheckPipeline()
 		mocks := setupCheckMocks(t, opts...)
-		pipeline := setupCheckPipeline(t, mocks)
 		return pipeline, mocks
 	}
 
 	t.Run("Success", func(t *testing.T) {
-		pipeline, _ := setup(t, &CheckSetupOptions{
-			ConfigStr: `
-contexts:
-  test-context:
-    tools:
-      enabled: true
-`,
-		})
+		// Given a check pipeline
+		pipeline, mocks := setup(t)
 
-		err := pipeline.Initialize(di.NewMockInjector(), context.Background())
+		// When initializing the pipeline
+		err := pipeline.Initialize(mocks.Injector, context.Background())
 
+		// Then no error should be returned
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
 	})
 
 	t.Run("ReturnsErrorWhenConfigHandlerInitializeFails", func(t *testing.T) {
-		pipeline, mocks := setup(t)
-		mocks.ConfigHandler.InitializeFunc = func() error {
+		// Given a check pipeline with failing config handler initialization
+		pipeline := NewCheckPipeline()
+
+		// Create injector and register failing config handler directly
+		injector := di.NewInjector()
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.InitializeFunc = func() error {
 			return fmt.Errorf("config initialization failed")
 		}
+		injector.Register("configHandler", mockConfigHandler)
 
-		err := pipeline.Initialize(mocks.Injector, context.Background())
+		// Create and register basic shell
+		mockShell := shell.NewMockShell()
+		mockShell.InitializeFunc = func() error { return nil }
+		mockShell.GetProjectRootFunc = func() (string, error) { return t.TempDir(), nil }
+		injector.Register("shell", mockShell)
 
+		// Register shims
+		shims := setupShims(t)
+		injector.Register("shims", shims)
+
+		// When initializing the pipeline
+		err := pipeline.Initialize(injector, context.Background())
+
+		// Then an error should be returned
 		if err == nil {
 			t.Fatal("Expected error, got nil")
 		}
-		if !checkContains(err.Error(), "failed to initialize config handler") {
+		if err.Error() != "failed to initialize config handler: config initialization failed" {
 			t.Errorf("Expected config handler error, got: %v", err)
 		}
 	})
 
 	t.Run("ReturnsErrorWhenShellInitializeFails", func(t *testing.T) {
+		// Given a check pipeline with failing shell initialization
 		pipeline, mocks := setup(t)
+
 		mocks.Shell.InitializeFunc = func() error {
 			return fmt.Errorf("shell initialization failed")
 		}
 
+		// When initializing the pipeline
 		err := pipeline.Initialize(mocks.Injector, context.Background())
 
+		// Then an error should be returned
 		if err == nil {
 			t.Fatal("Expected error, got nil")
 		}
-		if !checkContains(err.Error(), "failed to initialize shell") {
+		if err.Error() != "failed to initialize shell: shell initialization failed" {
 			t.Errorf("Expected shell error, got: %v", err)
 		}
 	})
 
 	t.Run("ReturnsErrorWhenToolsManagerInitializeFails", func(t *testing.T) {
+		// Given a check pipeline with failing tools manager initialization
 		pipeline, mocks := setup(t)
+
 		mocks.ToolsManager.InitializeFunc = func() error {
 			return fmt.Errorf("tools manager initialization failed")
 		}
 
+		// When initializing the pipeline
 		err := pipeline.Initialize(mocks.Injector, context.Background())
 
+		// Then an error should be returned
 		if err == nil {
 			t.Fatal("Expected error, got nil")
 		}
-		if !checkContains(err.Error(), "failed to initialize tools manager") {
+		if err.Error() != "failed to initialize tools manager: tools manager initialization failed" {
 			t.Errorf("Expected tools manager error, got: %v", err)
 		}
 	})
 
 	t.Run("ReturnsErrorWhenLoadConfigFails", func(t *testing.T) {
-		pipeline, mocks := setup(t)
-		mocks.Shell.GetProjectRootFunc = func() (string, error) {
-			return "", fmt.Errorf("project root error")
+		// Given a check pipeline with failing config loading
+		pipeline := NewCheckPipeline()
+
+		// Create injector and register failing config handler directly
+		injector := di.NewInjector()
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.InitializeFunc = func() error { return nil }
+		mockConfigHandler.LoadConfigFunc = func(path string) error {
+			return fmt.Errorf("config loading failed")
 		}
+		injector.Register("configHandler", mockConfigHandler)
 
-		err := pipeline.Initialize(mocks.Injector, context.Background())
+		// Create and register basic shell
+		mockShell := shell.NewMockShell()
+		mockShell.InitializeFunc = func() error { return nil }
+		mockShell.GetProjectRootFunc = func() (string, error) { return t.TempDir(), nil }
+		injector.Register("shell", mockShell)
 
+		// Register shims that simulate config file exists
+		shims := setupShims(t)
+		shims.Stat = func(name string) (os.FileInfo, error) {
+			// Simulate windsor.yaml exists
+			if strings.HasSuffix(name, "windsor.yaml") {
+				return &mockFileInfo{}, nil
+			}
+			return nil, os.ErrNotExist
+		}
+		injector.Register("shims", shims)
+
+		// When initializing the pipeline
+		err := pipeline.Initialize(injector, context.Background())
+
+		// Then an error should be returned
 		if err == nil {
 			t.Fatal("Expected error, got nil")
 		}
-		if !checkContains(err.Error(), "failed to load config") {
-			t.Errorf("Expected load config error, got: %v", err)
+		if err.Error() != "failed to load config: error loading config file: config loading failed" {
+			t.Errorf("Expected config loading error, got: %v", err)
 		}
 	})
 
 	t.Run("ReusesExistingComponentsFromDIContainer", func(t *testing.T) {
-		injector := di.NewMockInjector()
-
-		existingShell := shell.NewMockShell()
-		injector.Register("shell", existingShell)
-
-		existingConfigHandler := config.NewMockConfigHandler()
-		existingConfigHandler.InitializeFunc = func() error { return nil }
-		injector.Register("configHandler", existingConfigHandler)
-
+		// Given a check pipeline with pre-registered components
+		injector := di.NewInjector()
 		existingToolsManager := tools.NewMockToolsManager()
 		existingToolsManager.InitializeFunc = func() error { return nil }
 		injector.Register("toolsManager", existingToolsManager)
 
-		existingClusterClient := cluster.NewMockClusterClient()
-		injector.Register("clusterClient", existingClusterClient)
+		pipeline, mocks := setup(t, &SetupOptions{
+			Injector: injector,
+		})
 
-		pipeline := NewCheckPipeline()
+		// When initializing the pipeline
+		err := pipeline.Initialize(mocks.Injector, context.Background())
 
-		err := pipeline.Initialize(injector, context.Background())
-
+		// Then no error should be returned and existing components should be reused
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
 
-		if pipeline.shell != existingShell {
-			t.Error("Expected pipeline to use existing shell from DI container")
-		}
-		if pipeline.configHandler != existingConfigHandler {
-			t.Error("Expected pipeline to use existing config handler from DI container")
-		}
-		if pipeline.toolsManager != existingToolsManager {
-			t.Error("Expected pipeline to use existing tools manager from DI container")
-		}
-		if pipeline.clusterClient != existingClusterClient {
-			t.Error("Expected pipeline to use existing cluster client from DI container")
+		resolvedToolsManager := mocks.Injector.Resolve("toolsManager")
+		if resolvedToolsManager != existingToolsManager {
+			t.Error("Expected existing tools manager to be reused")
 		}
 	})
 }
 
+// =============================================================================
+// Test Public Methods - Execute
+// =============================================================================
+
 func TestCheckPipeline_Execute(t *testing.T) {
-	setup := func(t *testing.T, opts ...*CheckSetupOptions) (*CheckPipeline, *CheckMocks) {
+	setup := func(t *testing.T, opts ...*SetupOptions) (*CheckPipeline, *CheckMocks) {
 		t.Helper()
+		pipeline := NewCheckPipeline()
 		mocks := setupCheckMocks(t, opts...)
-		pipeline := setupCheckPipeline(t, mocks)
+
+		// Initialize the pipeline
 		err := pipeline.Initialize(mocks.Injector, context.Background())
 		if err != nil {
 			t.Fatalf("Failed to initialize pipeline: %v", err)
 		}
+
 		return pipeline, mocks
 	}
 
 	t.Run("ExecutesToolsCheckByDefault", func(t *testing.T) {
-		pipeline, _ := setup(t, &CheckSetupOptions{
-			ConfigStr: `
-contexts:
-  test-context:
-    tools:
-      enabled: true
-`,
-		})
+		// Given a check pipeline
+		pipeline, mocks := setup(t)
 
-		var outputMessage string
-		outputFunc := func(msg string) {
-			outputMessage = msg
+		checkCalled := false
+		mocks.ToolsManager.CheckFunc = func() error {
+			checkCalled = true
+			return nil
 		}
 
-		ctx := context.WithValue(context.Background(), "output", outputFunc)
+		// When executing the pipeline
+		err := pipeline.Execute(context.Background())
 
-		err := pipeline.Execute(ctx)
-
+		// Then no error should be returned
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
 
-		if outputMessage != "All tools are up to date." {
-			t.Errorf("Expected 'All tools are up to date.', got %q", outputMessage)
+		// And tools check should be called
+		if !checkCalled {
+			t.Error("Expected tools check to be called")
 		}
 	})
 
 	t.Run("ExecutesToolsCheckExplicitly", func(t *testing.T) {
-		pipeline, _ := setup(t, &CheckSetupOptions{
-			ConfigStr: `
-contexts:
-  test-context:
-    tools:
-      enabled: true
-`,
-		})
+		// Given a check pipeline with explicit tools operation
+		pipeline, mocks := setup(t)
 
-		var outputMessage string
-		outputFunc := func(msg string) {
-			outputMessage = msg
+		checkCalled := false
+		mocks.ToolsManager.CheckFunc = func() error {
+			checkCalled = true
+			return nil
 		}
 
 		ctx := context.WithValue(context.Background(), "operation", "tools")
-		ctx = context.WithValue(ctx, "output", outputFunc)
 
+		// When executing the pipeline
 		err := pipeline.Execute(ctx)
 
+		// Then no error should be returned
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
 
-		if outputMessage != "All tools are up to date." {
-			t.Errorf("Expected 'All tools are up to date.', got %q", outputMessage)
+		// And tools check should be called
+		if !checkCalled {
+			t.Error("Expected tools check to be called")
 		}
 	})
 
 	t.Run("ExecutesNodeHealthCheck", func(t *testing.T) {
-		pipeline, _ := setup(t, &CheckSetupOptions{
-			ConfigStr: `
-contexts:
-  test-context:
-    cluster:
-      enabled: true
-`,
-		})
+		// Given a check pipeline with node health operation
+		pipeline, mocks := setup(t)
 
-		var outputMessage string
-		outputFunc := func(msg string) {
-			outputMessage = msg
+		waitCalled := false
+		mocks.ClusterClient.WaitForNodesHealthyFunc = func(ctx context.Context, nodes []string, version string) error {
+			waitCalled = true
+			return nil
 		}
 
 		ctx := context.WithValue(context.Background(), "operation", "node-health")
-		ctx = context.WithValue(ctx, "nodes", []string{"10.0.0.1", "10.0.0.2"})
-		ctx = context.WithValue(ctx, "output", outputFunc)
+		ctx = context.WithValue(ctx, "nodes", []string{"node1", "node2"})
 
+		// When executing the pipeline
 		err := pipeline.Execute(ctx)
 
+		// Then no error should be returned
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
 
-		if outputMessage != "All 2 nodes are healthy" {
-			t.Errorf("Expected 'All 2 nodes are healthy', got %q", outputMessage)
+		// And node health check should be called
+		if !waitCalled {
+			t.Error("Expected node health check to be called")
 		}
 	})
 
 	t.Run("ExecutesNodeHealthCheckWithVersion", func(t *testing.T) {
-		pipeline, _ := setup(t, &CheckSetupOptions{
-			ConfigStr: `
-contexts:
-  test-context:
-    cluster:
-      enabled: true
-`,
-		})
+		// Given a check pipeline with node health operation and version
+		pipeline, mocks := setup(t)
 
-		var outputMessage string
-		outputFunc := func(msg string) {
-			outputMessage = msg
+		var capturedVersion string
+		mocks.ClusterClient.WaitForNodesHealthyFunc = func(ctx context.Context, nodes []string, version string) error {
+			capturedVersion = version
+			return nil
 		}
 
 		ctx := context.WithValue(context.Background(), "operation", "node-health")
-		ctx = context.WithValue(ctx, "nodes", []string{"10.0.0.1"})
-		ctx = context.WithValue(ctx, "version", "1.0.0")
-		ctx = context.WithValue(ctx, "output", outputFunc)
+		ctx = context.WithValue(ctx, "nodes", []string{"node1"})
+		ctx = context.WithValue(ctx, "version", "v1.30.0")
 
+		// When executing the pipeline
 		err := pipeline.Execute(ctx)
 
+		// Then no error should be returned
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
 
-		if outputMessage != "All 1 nodes are healthy and running version 1.0.0" {
-			t.Errorf("Expected 'All 1 nodes are healthy and running version 1.0.0', got %q", outputMessage)
+		// And node health check should be called with version
+		if capturedVersion != "v1.30.0" {
+			t.Errorf("Expected version v1.30.0, got %s", capturedVersion)
 		}
 	})
 
 	t.Run("ReturnsErrorWhenConfigNotLoaded", func(t *testing.T) {
-		pipeline, mocks := setup(t)
-		mocks.ConfigHandler.IsLoadedFunc = func() bool { return false }
+		// Given a check pipeline with config not loaded
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.InitializeFunc = func() error { return nil }
+		mockConfigHandler.IsLoadedFunc = func() bool { return false }
 
+		pipeline, _ := setup(t, &SetupOptions{
+			ConfigHandler: mockConfigHandler,
+		})
+
+		// When executing the pipeline
 		err := pipeline.Execute(context.Background())
 
+		// Then an error should be returned
 		if err == nil {
 			t.Fatal("Expected error, got nil")
 		}
-		if !checkContains(err.Error(), "Nothing to check. Have you run") {
+		expectedMsg := "Nothing to check. Have you run \033[1mwindsor init\033[0m?"
+		if err.Error() != expectedMsg {
 			t.Errorf("Expected config not loaded error, got: %v", err)
 		}
 	})
 
 	t.Run("ReturnsErrorForInvalidOperationType", func(t *testing.T) {
+		// Given a check pipeline with invalid operation type
 		pipeline, _ := setup(t)
 
 		ctx := context.WithValue(context.Background(), "operation", 123)
 
+		// When executing the pipeline
 		err := pipeline.Execute(ctx)
 
+		// Then an error should be returned
 		if err == nil {
 			t.Fatal("Expected error, got nil")
 		}
-		if !checkContains(err.Error(), "Invalid operation type") {
-			t.Errorf("Expected invalid operation type error, got: %v", err)
+		if err.Error() != "Invalid operation type" {
+			t.Errorf("Expected operation type error, got: %v", err)
 		}
 	})
 
 	t.Run("ReturnsErrorForUnknownOperation", func(t *testing.T) {
+		// Given a check pipeline with unknown operation
 		pipeline, _ := setup(t)
 
 		ctx := context.WithValue(context.Background(), "operation", "unknown")
 
+		// When executing the pipeline
 		err := pipeline.Execute(ctx)
 
+		// Then an error should be returned
 		if err == nil {
 			t.Fatal("Expected error, got nil")
 		}
-		if !checkContains(err.Error(), "Unknown operation type: unknown") {
+		if err.Error() != "Unknown operation type: unknown" {
 			t.Errorf("Expected unknown operation error, got: %v", err)
 		}
 	})
 
 	t.Run("ReturnsErrorWhenToolsCheckFails", func(t *testing.T) {
+		// Given a check pipeline with failing tools check
 		pipeline, mocks := setup(t)
+
 		mocks.ToolsManager.CheckFunc = func() error {
 			return fmt.Errorf("tools check failed")
 		}
 
+		// When executing the pipeline
 		err := pipeline.Execute(context.Background())
 
+		// Then an error should be returned
 		if err == nil {
 			t.Fatal("Expected error, got nil")
 		}
-		if !checkContains(err.Error(), "Error checking tools") {
+		if err.Error() != "Error checking tools: tools check failed" {
 			t.Errorf("Expected tools check error, got: %v", err)
 		}
 	})
 
 	t.Run("ReturnsErrorWhenNodeHealthCheckFails", func(t *testing.T) {
+		// Given a check pipeline with failing node health check
 		pipeline, mocks := setup(t)
+
 		mocks.ClusterClient.WaitForNodesHealthyFunc = func(ctx context.Context, nodes []string, version string) error {
 			return fmt.Errorf("node health check failed")
 		}
 
 		ctx := context.WithValue(context.Background(), "operation", "node-health")
-		ctx = context.WithValue(ctx, "nodes", []string{"10.0.0.1"})
+		ctx = context.WithValue(ctx, "nodes", []string{"node1"})
 
+		// When executing the pipeline
 		err := pipeline.Execute(ctx)
 
+		// Then an error should be returned
 		if err == nil {
 			t.Fatal("Expected error, got nil")
 		}
-		if !checkContains(err.Error(), "nodes failed health check") {
+		if err.Error() != "nodes failed health check: node health check failed" {
 			t.Errorf("Expected node health check error, got: %v", err)
 		}
 	})
 }
 
 // =============================================================================
-// Test Private Methods
+// Test Private Methods - executeToolsCheck
 // =============================================================================
 
 func TestCheckPipeline_executeToolsCheck(t *testing.T) {
-	setup := func(t *testing.T, opts ...*CheckSetupOptions) (*CheckPipeline, *CheckMocks) {
+	setup := func(t *testing.T) (*CheckPipeline, *CheckMocks) {
 		t.Helper()
-		mocks := setupCheckMocks(t, opts...)
-		pipeline := setupCheckPipeline(t, mocks)
-		pipeline.toolsManager = mocks.ToolsManager
+		pipeline := NewCheckPipeline()
+		mocks := setupCheckMocks(t)
+
+		// Initialize the pipeline
+		err := pipeline.Initialize(mocks.Injector, context.Background())
+		if err != nil {
+			t.Fatalf("Failed to initialize pipeline: %v", err)
+		}
+
 		return pipeline, mocks
 	}
 
 	t.Run("Success", func(t *testing.T) {
-		pipeline, _ := setup(t)
+		// Given a check pipeline
+		pipeline, mocks := setup(t)
 
-		var outputMessage string
-		outputFunc := func(msg string) {
-			outputMessage = msg
+		checkCalled := false
+		mocks.ToolsManager.CheckFunc = func() error {
+			checkCalled = true
+			return nil
 		}
 
-		ctx := context.WithValue(context.Background(), "output", outputFunc)
+		// When executing tools check
+		err := pipeline.executeToolsCheck(context.Background())
 
-		err := pipeline.executeToolsCheck(ctx)
-
+		// Then no error should be returned
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
 
-		if outputMessage != "All tools are up to date." {
-			t.Errorf("Expected 'All tools are up to date.', got %q", outputMessage)
+		// And tools check should be called
+		if !checkCalled {
+			t.Error("Expected tools check to be called")
 		}
 	})
 
 	t.Run("ReturnsErrorWhenToolsManagerCheckFails", func(t *testing.T) {
+		// Given a check pipeline with failing tools manager
 		pipeline, mocks := setup(t)
+
 		mocks.ToolsManager.CheckFunc = func() error {
 			return fmt.Errorf("tools check failed")
 		}
 
+		// When executing tools check
 		err := pipeline.executeToolsCheck(context.Background())
 
+		// Then an error should be returned
 		if err == nil {
 			t.Fatal("Expected error, got nil")
 		}
-		if !checkContains(err.Error(), "Error checking tools") {
+		if err.Error() != "Error checking tools: tools check failed" {
 			t.Errorf("Expected tools check error, got: %v", err)
 		}
 	})
 
 	t.Run("HandlesNoOutputFunction", func(t *testing.T) {
+		// Given a check pipeline with no output function
 		pipeline, _ := setup(t)
 
+		// When executing tools check
 		err := pipeline.executeToolsCheck(context.Background())
 
+		// Then no error should be returned
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
 	})
 }
 
+// =============================================================================
+// Test Private Methods - executeNodeHealthCheck
+// =============================================================================
+
 func TestCheckPipeline_executeNodeHealthCheck(t *testing.T) {
-	setup := func(t *testing.T, opts ...*CheckSetupOptions) (*CheckPipeline, *CheckMocks) {
+	setup := func(t *testing.T) (*CheckPipeline, *CheckMocks) {
 		t.Helper()
-		mocks := setupCheckMocks(t, opts...)
-		pipeline := setupCheckPipeline(t, mocks)
-		pipeline.clusterClient = mocks.ClusterClient
+		pipeline := NewCheckPipeline()
+		mocks := setupCheckMocks(t)
+
+		// Initialize the pipeline
+		err := pipeline.Initialize(mocks.Injector, context.Background())
+		if err != nil {
+			t.Fatalf("Failed to initialize pipeline: %v", err)
+		}
+
 		return pipeline, mocks
 	}
 
 	t.Run("Success", func(t *testing.T) {
-		pipeline, _ := setup(t)
+		// Given a check pipeline
+		pipeline, mocks := setup(t)
 
-		var outputMessage string
-		outputFunc := func(msg string) {
-			outputMessage = msg
+		waitCalled := false
+		mocks.ClusterClient.WaitForNodesHealthyFunc = func(ctx context.Context, nodes []string, version string) error {
+			waitCalled = true
+			return nil
 		}
 
-		ctx := context.WithValue(context.Background(), "nodes", []string{"10.0.0.1", "10.0.0.2"})
-		ctx = context.WithValue(ctx, "output", outputFunc)
+		ctx := context.WithValue(context.Background(), "nodes", []string{"node1", "node2"})
 
+		// When executing node health check
 		err := pipeline.executeNodeHealthCheck(ctx)
 
+		// Then no error should be returned
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
 
-		if outputMessage != "All 2 nodes are healthy" {
-			t.Errorf("Expected 'All 2 nodes are healthy', got %q", outputMessage)
+		// And node health check should be called
+		if !waitCalled {
+			t.Error("Expected node health check to be called")
 		}
 	})
 
 	t.Run("SuccessWithVersion", func(t *testing.T) {
-		pipeline, _ := setup(t)
+		// Given a check pipeline with version specified
+		pipeline, mocks := setup(t)
 
-		var outputMessage string
-		outputFunc := func(msg string) {
-			outputMessage = msg
+		var capturedVersion string
+		mocks.ClusterClient.WaitForNodesHealthyFunc = func(ctx context.Context, nodes []string, version string) error {
+			capturedVersion = version
+			return nil
 		}
 
-		ctx := context.WithValue(context.Background(), "nodes", []string{"10.0.0.1"})
-		ctx = context.WithValue(ctx, "version", "1.0.0")
-		ctx = context.WithValue(ctx, "output", outputFunc)
+		ctx := context.WithValue(context.Background(), "nodes", []string{"node1"})
+		ctx = context.WithValue(ctx, "version", "v1.30.0")
 
+		// When executing node health check
 		err := pipeline.executeNodeHealthCheck(ctx)
 
+		// Then no error should be returned
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
 
-		if outputMessage != "All 1 nodes are healthy and running version 1.0.0" {
-			t.Errorf("Expected 'All 1 nodes are healthy and running version 1.0.0', got %q", outputMessage)
+		// And node health check should be called with version
+		if capturedVersion != "v1.30.0" {
+			t.Errorf("Expected version v1.30.0, got %s", capturedVersion)
 		}
 	})
 
 	t.Run("SuccessWithTimeout", func(t *testing.T) {
+		// Given a check pipeline with timeout specified
 		pipeline, _ := setup(t)
 
-		ctx := context.WithValue(context.Background(), "nodes", []string{"10.0.0.1"})
-		ctx = context.WithValue(ctx, "timeout", 5*time.Second)
+		ctx := context.WithValue(context.Background(), "nodes", []string{"node1"})
+		ctx = context.WithValue(ctx, "timeout", 30*time.Second)
 
+		// When executing node health check
 		err := pipeline.executeNodeHealthCheck(ctx)
 
+		// Then no error should be returned
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
 	})
 
 	t.Run("ReturnsErrorWhenClusterClientIsNil", func(t *testing.T) {
+		// Given a check pipeline with nil cluster client
 		pipeline, _ := setup(t)
 		pipeline.clusterClient = nil
 
-		ctx := context.WithValue(context.Background(), "nodes", []string{"10.0.0.1"})
+		ctx := context.WithValue(context.Background(), "nodes", []string{"node1"})
 
+		// When executing node health check
 		err := pipeline.executeNodeHealthCheck(ctx)
 
+		// Then an error should be returned
 		if err == nil {
 			t.Fatal("Expected error, got nil")
 		}
-		if !checkContains(err.Error(), "No cluster client found") {
+		if err.Error() != "No cluster client found" {
 			t.Errorf("Expected cluster client error, got: %v", err)
 		}
 	})
 
 	t.Run("ReturnsErrorWhenNoNodesSpecified", func(t *testing.T) {
+		// Given a check pipeline with no nodes specified
 		pipeline, _ := setup(t)
 
+		// When executing node health check
 		err := pipeline.executeNodeHealthCheck(context.Background())
 
+		// Then an error should be returned
 		if err == nil {
 			t.Fatal("Expected error, got nil")
 		}
-		if !checkContains(err.Error(), "No nodes specified") {
-			t.Errorf("Expected no nodes error, got: %v", err)
+		if err.Error() != "No nodes specified. Use --nodes flag to specify nodes to check" {
+			t.Errorf("Expected nodes required error, got: %v", err)
 		}
 	})
 
 	t.Run("ReturnsErrorWhenNodesParameterIsInvalidType", func(t *testing.T) {
+		// Given a check pipeline with invalid nodes parameter type
 		pipeline, _ := setup(t)
 
 		ctx := context.WithValue(context.Background(), "nodes", "invalid")
 
+		// When executing node health check
 		err := pipeline.executeNodeHealthCheck(ctx)
 
+		// Then an error should be returned
 		if err == nil {
 			t.Fatal("Expected error, got nil")
 		}
-		if !checkContains(err.Error(), "Invalid nodes parameter type") {
-			t.Errorf("Expected invalid nodes parameter error, got: %v", err)
+		if err.Error() != "Invalid nodes parameter type" {
+			t.Errorf("Expected nodes type error, got: %v", err)
 		}
 	})
 
 	t.Run("ReturnsErrorWhenNodesSliceIsEmpty", func(t *testing.T) {
+		// Given a check pipeline with empty nodes slice
 		pipeline, _ := setup(t)
 
 		ctx := context.WithValue(context.Background(), "nodes", []string{})
 
+		// When executing node health check
 		err := pipeline.executeNodeHealthCheck(ctx)
 
+		// Then an error should be returned
 		if err == nil {
 			t.Fatal("Expected error, got nil")
 		}
-		if !checkContains(err.Error(), "No nodes specified") {
-			t.Errorf("Expected no nodes error, got: %v", err)
+		if err.Error() != "No nodes specified. Use --nodes flag to specify nodes to check" {
+			t.Errorf("Expected nodes empty error, got: %v", err)
 		}
 	})
 
 	t.Run("ReturnsErrorWhenWaitForNodesHealthyFails", func(t *testing.T) {
+		// Given a check pipeline with failing cluster client
 		pipeline, mocks := setup(t)
+
 		mocks.ClusterClient.WaitForNodesHealthyFunc = func(ctx context.Context, nodes []string, version string) error {
-			return fmt.Errorf("health check failed")
+			return fmt.Errorf("node health check failed")
 		}
 
-		ctx := context.WithValue(context.Background(), "nodes", []string{"10.0.0.1"})
+		ctx := context.WithValue(context.Background(), "nodes", []string{"node1"})
 
+		// When executing node health check
 		err := pipeline.executeNodeHealthCheck(ctx)
 
+		// Then an error should be returned
 		if err == nil {
 			t.Fatal("Expected error, got nil")
 		}
-		if !checkContains(err.Error(), "nodes failed health check") {
-			t.Errorf("Expected health check error, got: %v", err)
+		if err.Error() != "nodes failed health check: node health check failed" {
+			t.Errorf("Expected node health check error, got: %v", err)
 		}
 	})
 
 	t.Run("HandlesNoOutputFunction", func(t *testing.T) {
+		// Given a check pipeline with no output function
 		pipeline, _ := setup(t)
 
-		ctx := context.WithValue(context.Background(), "nodes", []string{"10.0.0.1"})
+		ctx := context.WithValue(context.Background(), "nodes", []string{"node1"})
 
+		// When executing node health check
 		err := pipeline.executeNodeHealthCheck(ctx)
 
+		// Then no error should be returned
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}

--- a/pkg/pipelines/env.go
+++ b/pkg/pipelines/env.go
@@ -60,8 +60,6 @@ func (p *EnvPipeline) Initialize(injector di.Injector, ctx context.Context) erro
 	}
 	p.secretsProviders = secretsProviders
 
-	// Register secrets providers in the dependency injection container
-	// so that environment printers can find them
 	for i, secretsProvider := range p.secretsProviders {
 		providerKey := fmt.Sprintf("secretsProvider_%d", i)
 		p.injector.Register(providerKey, secretsProvider)


### PR DESCRIPTION
The pipeline tests weren't following test style approaches common in our other packages. Cleans them up using setup* functions.