### PR TITLE
refactor(template): Add the foundation template package

### DIFF
--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -41,7 +41,7 @@ func TestExecCmd(t *testing.T) {
 		ctx := context.WithValue(context.Background(), injectorKey, injector)
 		cmd.SetContext(ctx)
 
-		args := []string{"echo", "hello"}
+		args := []string{"go", "version"}
 		cmd.SetArgs(args)
 
 		err := cmd.Execute()
@@ -107,7 +107,7 @@ func TestExecCmd(t *testing.T) {
 		ctx := context.WithValue(context.Background(), injectorKey, injector)
 		cmd.SetContext(ctx)
 
-		args := []string{"echo", "hello"}
+		args := []string{"go", "version"}
 		cmd.SetArgs(args)
 
 		err := cmd.Execute()
@@ -144,7 +144,7 @@ func TestExecCmd(t *testing.T) {
 		ctx := context.WithValue(context.Background(), injectorKey, injector)
 		cmd.SetContext(ctx)
 
-		args := []string{"echo", "hello"}
+		args := []string{"go", "version"}
 		cmd.SetArgs(args)
 
 		err := cmd.Execute()
@@ -237,7 +237,7 @@ func TestExecCmd(t *testing.T) {
 		ctx := context.WithValue(context.Background(), injectorKey, injector)
 		cmd.SetContext(ctx)
 
-		args := []string{"echo", "hello"}
+		args := []string{"go", "version"}
 		cmd.SetArgs(args)
 
 		err := cmd.Execute()
@@ -326,7 +326,7 @@ func TestExecCmd(t *testing.T) {
 		ctx := context.WithValue(context.Background(), injectorKey, injector)
 		cmd.SetContext(ctx)
 
-		args := []string{"echo", "hello"}
+		args := []string{"go", "version"}
 		cmd.SetArgs(args)
 
 		err := cmd.Execute()

--- a/pkg/template/jsonnet_template.go
+++ b/pkg/template/jsonnet_template.go
@@ -1,0 +1,131 @@
+package template
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/windsorcli/cli/pkg/di"
+)
+
+// =============================================================================
+// Types
+// =============================================================================
+
+// JsonnetTemplate handles jsonnet template processing with configurable rules
+type JsonnetTemplate struct {
+	*BaseTemplate
+}
+
+// =============================================================================
+// Constructor
+// =============================================================================
+
+// NewJsonnetTemplate creates a new JsonnetTemplate instance with default rules
+func NewJsonnetTemplate(injector di.Injector) *JsonnetTemplate {
+	template := &JsonnetTemplate{
+		BaseTemplate: NewBaseTemplate(injector),
+	}
+
+	// Set up default processing rules
+	template.rules = []ProcessingRule{
+		{
+			// Blueprint rule: exact match for blueprint.jsonnet
+			PathMatcher: func(path string) bool {
+				return path == "blueprint.jsonnet"
+			},
+			KeyGenerator: func(path string) string {
+				return "blueprint"
+			},
+		},
+		{
+			// Terraform rule: files under terraform/ with .jsonnet extension
+			PathMatcher: func(path string) bool {
+				return strings.HasPrefix(path, "terraform/") && strings.HasSuffix(path, ".jsonnet")
+			},
+			KeyGenerator: func(path string) string {
+				return strings.TrimSuffix(path, ".jsonnet")
+			},
+		},
+	}
+
+	return template
+}
+
+// =============================================================================
+// Public Methods
+// =============================================================================
+
+// Initialize sets up the JsonnetTemplate dependencies
+func (t *JsonnetTemplate) Initialize() error {
+	return t.BaseTemplate.Initialize()
+}
+
+// Process processes jsonnet templates based on configured rules and adds results to renderedData
+func (t *JsonnetTemplate) Process(templateData map[string][]byte, renderedData map[string]any) error {
+	for templatePath, templateContent := range templateData {
+		// Check each rule to see if it matches this file
+		for _, rule := range t.rules {
+			if rule.PathMatcher(templatePath) {
+				values, err := t.processJsonnetTemplate(string(templateContent))
+				if err != nil {
+					return fmt.Errorf("failed to process jsonnet template %s: %w", templatePath, err)
+				}
+
+				outputKey := rule.KeyGenerator(templatePath)
+				renderedData[outputKey] = values
+				break // Only process with the first matching rule
+			}
+		}
+	}
+
+	return nil
+}
+
+// processJsonnetTemplate processes a jsonnet template with context data and returns parsed values
+func (t *JsonnetTemplate) processJsonnetTemplate(templateContent string) (map[string]any, error) {
+	config := t.configHandler.GetConfig()
+	contextYAML, err := t.configHandler.YamlMarshalWithDefinedPaths(config)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal context to YAML: %w", err)
+	}
+
+	projectRoot, err := t.shell.GetProjectRoot()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get project root: %w", err)
+	}
+
+	var contextMap map[string]any = make(map[string]any)
+	if err := t.shims.YamlUnmarshal(contextYAML, &contextMap); err != nil {
+		return nil, fmt.Errorf("failed to unmarshal context YAML: %w", err)
+	}
+
+	contextMap["name"] = t.configHandler.GetContext()
+	contextMap["projectName"] = t.shims.FilepathBase(projectRoot)
+
+	contextJSON, err := t.shims.JsonMarshal(contextMap)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal context map to JSON: %w", err)
+	}
+
+	vm := t.shims.NewJsonnetVM()
+	vm.ExtCode("context", string(contextJSON))
+
+	result, err := vm.EvaluateAnonymousSnippet("template.jsonnet", templateContent)
+	if err != nil {
+		return nil, fmt.Errorf("failed to evaluate jsonnet template: %w", err)
+	}
+
+	var values map[string]any
+	if err := t.shims.JsonUnmarshal([]byte(result), &values); err != nil {
+		return nil, fmt.Errorf("jsonnet template must output valid JSON: %w", err)
+	}
+
+	return values, nil
+}
+
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
+// Ensure JsonnetTemplate implements Template interface
+var _ Template = (*JsonnetTemplate)(nil)

--- a/pkg/template/jsonnet_template_test.go
+++ b/pkg/template/jsonnet_template_test.go
@@ -1,0 +1,805 @@
+package template
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+func setupJsonnetTemplateMocks(t *testing.T, opts ...*SetupOptions) (*Mocks, *JsonnetTemplate) {
+	t.Helper()
+	mocks := setupMocks(t, opts...)
+	template := NewJsonnetTemplate(mocks.Injector)
+	return mocks, template
+}
+
+// =============================================================================
+// Test Public Methods
+// =============================================================================
+
+func TestJsonnetTemplate_NewJsonnetTemplate(t *testing.T) {
+	t.Run("CreatesTemplateWithDefaultRules", func(t *testing.T) {
+		// Given an injector
+		mocks := setupMocks(t)
+
+		// When creating a new jsonnet template
+		template := NewJsonnetTemplate(mocks.Injector)
+
+		// Then the template should be properly initialized
+		if template == nil {
+			t.Fatal("Expected non-nil template")
+		}
+
+		// And base template should be set
+		if template.BaseTemplate == nil {
+			t.Error("Expected BaseTemplate to be set")
+		}
+
+		// And default rules should be configured (verified by testing Process method)
+	})
+}
+
+func TestJsonnetTemplate_Initialize(t *testing.T) {
+	setup := func(t *testing.T) (*JsonnetTemplate, *Mocks) {
+		t.Helper()
+		mocks, template := setupJsonnetTemplateMocks(t)
+		return template, mocks
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		// Given a jsonnet template
+		template, _ := setup(t)
+
+		// When calling Initialize
+		err := template.Initialize()
+
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected nil error, got %v", err)
+		}
+
+		// And base template dependencies should be injected
+		if template.BaseTemplate.configHandler == nil {
+			t.Error("Expected configHandler to be set after Initialize()")
+		}
+		if template.BaseTemplate.shell == nil {
+			t.Error("Expected shell to be set after Initialize()")
+		}
+	})
+
+	t.Run("HandlesBaseInitializeError", func(t *testing.T) {
+		// Given a jsonnet template with nil injector in base
+		template := NewJsonnetTemplate(nil)
+
+		// When calling Initialize
+		err := template.Initialize()
+
+		// Then no error should be returned (base template handles nil gracefully)
+		if err != nil {
+			t.Errorf("Expected nil error, got %v", err)
+		}
+	})
+}
+
+func TestJsonnetTemplate_Process(t *testing.T) {
+	setup := func(t *testing.T) (*JsonnetTemplate, *Mocks) {
+		t.Helper()
+		mocks, template := setupJsonnetTemplateMocks(t)
+		err := template.Initialize()
+		if err != nil {
+			t.Fatalf("Failed to initialize template: %v", err)
+		}
+		return template, mocks
+	}
+
+	t.Run("ProcessesBlueprintJsonnetTemplate", func(t *testing.T) {
+		// Given a jsonnet template
+		template, mocks := setup(t)
+
+		// And template data containing a blueprint.jsonnet file
+		templateData := map[string][]byte{
+			"blueprint.jsonnet": []byte(`local context = std.extVar("context"); { kind: "Blueprint", metadata: { name: context.name } }`),
+		}
+		renderedData := make(map[string]any)
+
+		// And a mock jsonnet VM that returns valid blueprint JSON
+		template.shims.NewJsonnetVM = func() JsonnetVM {
+			mockVM := &mockJsonnetVM{
+				EvaluateFunc: func(filename, snippet string) (string, error) {
+					return `{"kind": "Blueprint", "metadata": {"name": "test-context"}}`, nil
+				},
+			}
+			return mockVM
+		}
+
+		// And mock config handler returns valid YAML
+		mocks.ConfigHandler.YamlMarshalWithDefinedPathsFunc = func(v any) ([]byte, error) {
+			return []byte("contexts:\n  mock-context:\n    dns:\n      domain: mock.domain.com"), nil
+		}
+
+		// When processing the template data
+		err := template.Process(templateData, renderedData)
+
+		// Then no error should be returned
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// And the rendered data should contain the blueprint content
+		if len(renderedData) != 1 {
+			t.Errorf("Expected 1 rendered item, got %d", len(renderedData))
+		}
+
+		if _, exists := renderedData["blueprint"]; !exists {
+			t.Error("Expected blueprint to be rendered")
+		}
+	})
+
+	t.Run("ProcessesTerraformJsonnetTemplates", func(t *testing.T) {
+		// Given a jsonnet template
+		template, mocks := setup(t)
+
+		// And template data containing terraform/ .jsonnet files
+		templateData := map[string][]byte{
+			"terraform/main.jsonnet":    []byte(`local context = std.extVar("context"); { cluster_name: context.name }`),
+			"terraform/cluster.jsonnet": []byte(`local context = std.extVar("context"); { instance_type: "t3.micro" }`),
+		}
+		renderedData := make(map[string]any)
+
+		// And a mock jsonnet VM that returns valid terraform vars
+		template.shims.NewJsonnetVM = func() JsonnetVM {
+			mockVM := &mockJsonnetVM{
+				EvaluateFunc: func(filename, snippet string) (string, error) {
+					if strings.Contains(filename, "main") {
+						return `{"cluster_name": "test-cluster"}`, nil
+					}
+					return `{"instance_type": "t3.micro"}`, nil
+				},
+			}
+			return mockVM
+		}
+
+		// And mock config handler returns valid YAML
+		mocks.ConfigHandler.YamlMarshalWithDefinedPathsFunc = func(v any) ([]byte, error) {
+			return []byte("contexts:\n  mock-context:\n    dns:\n      domain: mock.domain.com"), nil
+		}
+
+		// When processing the template data
+		err := template.Process(templateData, renderedData)
+
+		// Then no error should be returned
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// And the rendered data should contain the terraform variables
+		if len(renderedData) != 2 {
+			t.Errorf("Expected 2 rendered items, got %d", len(renderedData))
+		}
+
+		if _, exists := renderedData["terraform/main"]; !exists {
+			t.Error("Expected terraform/main to be rendered")
+		}
+		if _, exists := renderedData["terraform/cluster"]; !exists {
+			t.Error("Expected terraform/cluster to be rendered")
+		}
+	})
+
+	t.Run("ProcessesBothBlueprintAndTerraformTemplates", func(t *testing.T) {
+		// Given a jsonnet template
+		template, mocks := setup(t)
+
+		// And template data containing both blueprint and terraform files
+		templateData := map[string][]byte{
+			"blueprint.jsonnet":      []byte(`{ kind: "Blueprint", metadata: { name: "test" } }`),
+			"terraform/main.jsonnet": []byte(`{ cluster_name: "test-cluster" }`),
+			"other.jsonnet":          []byte(`{ ignored: true }`),
+		}
+		renderedData := make(map[string]any)
+
+		// And a mock jsonnet VM that returns valid JSON
+		template.shims.NewJsonnetVM = func() JsonnetVM {
+			mockVM := &mockJsonnetVM{
+				EvaluateFunc: func(filename, snippet string) (string, error) {
+					if strings.Contains(filename, "blueprint") {
+						return `{"kind": "Blueprint", "metadata": {"name": "test"}}`, nil
+					}
+					return `{"cluster_name": "test-cluster"}`, nil
+				},
+			}
+			return mockVM
+		}
+
+		// And mock config handler returns valid YAML
+		mocks.ConfigHandler.YamlMarshalWithDefinedPathsFunc = func(v any) ([]byte, error) {
+			return []byte("contexts:\n  mock-context:\n    dns:\n      domain: mock.domain.com"), nil
+		}
+
+		// When processing the template data
+		err := template.Process(templateData, renderedData)
+
+		// Then no error should be returned
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// And both blueprint and terraform should be processed, but not other.jsonnet
+		if len(renderedData) != 2 {
+			t.Errorf("Expected 2 rendered items, got %d", len(renderedData))
+		}
+
+		if _, exists := renderedData["blueprint"]; !exists {
+			t.Error("Expected blueprint to be rendered")
+		}
+		if _, exists := renderedData["terraform/main"]; !exists {
+			t.Error("Expected terraform/main to be rendered")
+		}
+		if _, exists := renderedData["other"]; exists {
+			t.Error("Expected other.jsonnet to be ignored")
+		}
+	})
+
+	t.Run("IgnoresNonMatchingTemplates", func(t *testing.T) {
+		// Given a jsonnet template
+		template, _ := setup(t)
+
+		// And template data containing files that don't match any rules
+		templateData := map[string][]byte{
+			"other.jsonnet": []byte(`{"name": "test"}`),
+			"config.yaml":   []byte(`key: value`),
+			"script.js":     []byte(`console.log("hello")`),
+		}
+		renderedData := make(map[string]any)
+
+		// When processing the template data
+		err := template.Process(templateData, renderedData)
+
+		// Then no error should be returned
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// And no data should be processed
+		if len(renderedData) != 0 {
+			t.Errorf("Expected no data to be processed for non-matching templates, got %d items", len(renderedData))
+		}
+	})
+
+	t.Run("HandlesJsonnetProcessingError", func(t *testing.T) {
+		// Given a jsonnet template
+		template, mocks := setup(t)
+
+		// And template data containing a blueprint.jsonnet file
+		templateData := map[string][]byte{
+			"blueprint.jsonnet": []byte(`invalid jsonnet`),
+		}
+		renderedData := make(map[string]any)
+
+		// And a mock jsonnet VM that returns an error
+		template.shims.NewJsonnetVM = func() JsonnetVM {
+			mockVM := &mockJsonnetVM{
+				EvaluateFunc: func(filename, snippet string) (string, error) {
+					return "", fmt.Errorf("jsonnet evaluation error")
+				},
+			}
+			return mockVM
+		}
+
+		// And mock config handler returns valid YAML
+		mocks.ConfigHandler.YamlMarshalWithDefinedPathsFunc = func(v any) ([]byte, error) {
+			return []byte("contexts:\n  mock-context:\n    dns:\n      domain: mock.domain.com"), nil
+		}
+
+		// When processing the template data
+		err := template.Process(templateData, renderedData)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to process jsonnet template") {
+			t.Errorf("Expected error about jsonnet template processing, got: %v", err)
+		}
+	})
+
+	t.Run("ProcessesOnlyFirstMatchingRule", func(t *testing.T) {
+		// Given a jsonnet template
+		template, mocks := setup(t)
+
+		// And template data containing a blueprint.jsonnet file (which matches the first rule)
+		templateData := map[string][]byte{
+			"blueprint.jsonnet": []byte(`{ kind: "Blueprint" }`),
+		}
+		renderedData := make(map[string]any)
+
+		// And a mock jsonnet VM
+		template.shims.NewJsonnetVM = func() JsonnetVM {
+			mockVM := &mockJsonnetVM{
+				EvaluateFunc: func(filename, snippet string) (string, error) {
+					return `{"kind": "Blueprint"}`, nil
+				},
+			}
+			return mockVM
+		}
+
+		// And mock config handler returns valid YAML
+		mocks.ConfigHandler.YamlMarshalWithDefinedPathsFunc = func(v any) ([]byte, error) {
+			return []byte("contexts:\n  mock-context:\n    dns:\n      domain: mock.domain.com"), nil
+		}
+
+		// When processing the template data
+		err := template.Process(templateData, renderedData)
+
+		// Then no error should be returned
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// And the blueprint should be processed by the first matching rule
+		if len(renderedData) != 1 {
+			t.Errorf("Expected 1 rendered item, got %d", len(renderedData))
+		}
+		if _, exists := renderedData["blueprint"]; !exists {
+			t.Error("Expected blueprint to be rendered by blueprint rule")
+		}
+	})
+}
+
+func TestJsonnetTemplate_processJsonnetTemplate(t *testing.T) {
+	setup := func(t *testing.T) (*JsonnetTemplate, *Mocks) {
+		t.Helper()
+		mocks, template := setupJsonnetTemplateMocks(t)
+		err := template.Initialize()
+		if err != nil {
+			t.Fatalf("Failed to initialize template: %v", err)
+		}
+		return template, mocks
+	}
+
+	t.Run("ProcessesValidJsonnetTemplate", func(t *testing.T) {
+		// Given a jsonnet template
+		template, mocks := setup(t)
+
+		// And a mock jsonnet VM that returns valid JSON
+		template.shims.NewJsonnetVM = func() JsonnetVM {
+			mockVM := &mockJsonnetVM{
+				EvaluateFunc: func(filename, snippet string) (string, error) {
+					return `{"key": "value", "number": 42}`, nil
+				},
+			}
+			return mockVM
+		}
+
+		// And mock config handler returns valid YAML
+		mocks.ConfigHandler.YamlMarshalWithDefinedPathsFunc = func(v any) ([]byte, error) {
+			return []byte("contexts:\n  mock-context:\n    dns:\n      domain: mock.domain.com"), nil
+		}
+
+		templateContent := `local context = std.extVar("context"); { key: "value", number: 42 }`
+
+		// When processing the jsonnet template
+		result, err := template.processJsonnetTemplate(templateContent)
+
+		// Then no error should be returned
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// And the result should contain the expected values
+		if result["key"] != "value" {
+			t.Errorf("Expected key 'value', got: %v", result["key"])
+		}
+		if result["number"] != float64(42) {
+			t.Errorf("Expected number 42, got: %v", result["number"])
+		}
+	})
+
+	t.Run("HandlesYamlMarshalError", func(t *testing.T) {
+		// Given a jsonnet template
+		template, mocks := setup(t)
+
+		// And a config handler that returns an error when marshaling
+		mocks.ConfigHandler.YamlMarshalWithDefinedPathsFunc = func(v any) ([]byte, error) {
+			return nil, fmt.Errorf("yaml marshal error")
+		}
+
+		templateContent := `local context = std.extVar("context"); { key: "value" }`
+
+		// When processing the jsonnet template
+		_, err := template.processJsonnetTemplate(templateContent)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to marshal context to YAML") {
+			t.Errorf("Expected error about marshal failure, got: %v", err)
+		}
+	})
+
+	t.Run("HandlesProjectRootError", func(t *testing.T) {
+		// Given a jsonnet template
+		template, mocks := setup(t)
+
+		// And a shell that returns an error for project root
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return "", fmt.Errorf("project root error")
+		}
+
+		// And mock config handler returns valid YAML
+		mocks.ConfigHandler.YamlMarshalWithDefinedPathsFunc = func(v any) ([]byte, error) {
+			return []byte("contexts:\n  mock-context:\n    dns:\n      domain: mock.domain.com"), nil
+		}
+
+		templateContent := `local context = std.extVar("context"); { key: "value" }`
+
+		// When processing the jsonnet template
+		_, err := template.processJsonnetTemplate(templateContent)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to get project root") {
+			t.Errorf("Expected error about project root failure, got: %v", err)
+		}
+	})
+
+	t.Run("HandlesYamlUnmarshalError", func(t *testing.T) {
+		// Given a jsonnet template
+		template, mocks := setup(t)
+
+		// And mock config handler returns invalid YAML
+		mocks.ConfigHandler.YamlMarshalWithDefinedPathsFunc = func(v any) ([]byte, error) {
+			return []byte("invalid yaml: ["), nil
+		}
+
+		// And a mock YamlUnmarshal that returns an error
+		template.shims.YamlUnmarshal = func(data []byte, v any) error {
+			return fmt.Errorf("yaml unmarshal error")
+		}
+
+		templateContent := `local context = std.extVar("context"); { key: "value" }`
+
+		// When processing the jsonnet template
+		_, err := template.processJsonnetTemplate(templateContent)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to unmarshal context YAML") {
+			t.Errorf("Expected error about YAML unmarshal failure, got: %v", err)
+		}
+	})
+
+	t.Run("HandlesJsonMarshalError", func(t *testing.T) {
+		// Given a jsonnet template
+		template, mocks := setup(t)
+
+		// And mock config handler returns valid YAML
+		mocks.ConfigHandler.YamlMarshalWithDefinedPathsFunc = func(v any) ([]byte, error) {
+			return []byte("contexts:\n  mock-context:\n    dns:\n      domain: mock.domain.com"), nil
+		}
+
+		// And a mock JsonMarshal that returns an error
+		template.shims.JsonMarshal = func(v any) ([]byte, error) {
+			return nil, fmt.Errorf("json marshal error")
+		}
+
+		templateContent := `local context = std.extVar("context"); { key: "value" }`
+
+		// When processing the jsonnet template
+		_, err := template.processJsonnetTemplate(templateContent)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to marshal context map to JSON") {
+			t.Errorf("Expected error about JSON marshal failure, got: %v", err)
+		}
+	})
+
+	t.Run("HandlesJsonnetEvaluationError", func(t *testing.T) {
+		// Given a jsonnet template
+		template, mocks := setup(t)
+
+		// And mock config handler returns valid YAML
+		mocks.ConfigHandler.YamlMarshalWithDefinedPathsFunc = func(v any) ([]byte, error) {
+			return []byte("contexts:\n  mock-context:\n    dns:\n      domain: mock.domain.com"), nil
+		}
+
+		// And a mock jsonnet VM that returns an error
+		template.shims.NewJsonnetVM = func() JsonnetVM {
+			mockVM := &mockJsonnetVM{
+				EvaluateFunc: func(filename, snippet string) (string, error) {
+					return "", fmt.Errorf("jsonnet evaluation error")
+				},
+			}
+			return mockVM
+		}
+
+		templateContent := `invalid jsonnet syntax`
+
+		// When processing the jsonnet template
+		_, err := template.processJsonnetTemplate(templateContent)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to evaluate jsonnet template") {
+			t.Errorf("Expected error about jsonnet evaluation, got: %v", err)
+		}
+	})
+
+	t.Run("HandlesInvalidJsonResult", func(t *testing.T) {
+		// Given a jsonnet template
+		template, mocks := setup(t)
+
+		// And mock config handler returns valid YAML
+		mocks.ConfigHandler.YamlMarshalWithDefinedPathsFunc = func(v any) ([]byte, error) {
+			return []byte("contexts:\n  mock-context:\n    dns:\n      domain: mock.domain.com"), nil
+		}
+
+		// And a mock jsonnet VM that returns invalid JSON
+		template.shims.NewJsonnetVM = func() JsonnetVM {
+			mockVM := &mockJsonnetVM{
+				EvaluateFunc: func(filename, snippet string) (string, error) {
+					return `invalid json response`, nil
+				},
+			}
+			return mockVM
+		}
+
+		templateContent := `local context = std.extVar("context"); "not an object"`
+
+		// When processing the jsonnet template
+		_, err := template.processJsonnetTemplate(templateContent)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "jsonnet template must output valid JSON") {
+			t.Errorf("Expected error about invalid JSON, got: %v", err)
+		}
+	})
+
+	t.Run("HandlesContextDataInjection", func(t *testing.T) {
+		// Given a jsonnet template
+		template, mocks := setup(t)
+
+		// And mock config handler returns complex YAML with nested data
+		mocks.ConfigHandler.YamlMarshalWithDefinedPathsFunc = func(v any) ([]byte, error) {
+			return []byte(`
+contexts:
+  test-context:
+    dns:
+      domain: example.com
+    cluster:
+      name: test-cluster
+      region: us-west-2
+`), nil
+		}
+
+		// And mock shell returns a specific project root
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return "/path/to/test-project", nil
+		}
+
+		// And a mock jsonnet VM that captures the context data
+		var capturedContext string
+		template.shims.NewJsonnetVM = func() JsonnetVM {
+			mockVM := &mockJsonnetVM{
+				EvaluateFunc: func(filename, snippet string) (string, error) {
+					// Verify the template content references context
+					if !strings.Contains(snippet, "std.extVar(\"context\")") {
+						t.Errorf("Expected template to reference context variable")
+					}
+					return `{"processed": true, "contextReceived": true}`, nil
+				},
+			}
+			// Create a custom ExtCode function to capture context
+			mockVM.ExtCodeFunc = func(key, val string) {
+				if key == "context" {
+					capturedContext = val
+				}
+				// Store the call as usual
+				mockVM.ExtCalls = append(mockVM.ExtCalls, struct{ Key, Val string }{key, val})
+			}
+			return mockVM
+		}
+
+		templateContent := `local context = std.extVar("context"); { processed: true, name: context.name, projectName: context.projectName }`
+
+		// When processing the jsonnet template
+		result, err := template.processJsonnetTemplate(templateContent)
+
+		// Then no error should be returned
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// And the result should be processed
+		if result["processed"] != true {
+			t.Error("Expected template to be processed")
+		}
+
+		// And context should have been injected
+		if capturedContext == "" {
+			t.Error("Expected context to be captured")
+		}
+
+		// And context should contain expected fields
+		if !strings.Contains(capturedContext, "test-context") {
+			t.Error("Expected context to contain context name")
+		}
+		if !strings.Contains(capturedContext, "test-project") {
+			t.Error("Expected context to contain project name")
+		}
+	})
+
+	t.Run("HandlesEmptyContextMap", func(t *testing.T) {
+		// Given a jsonnet template
+		template, mocks := setup(t)
+
+		// And mock config handler returns minimal YAML
+		mocks.ConfigHandler.YamlMarshalWithDefinedPathsFunc = func(v any) ([]byte, error) {
+			return []byte("{}"), nil
+		}
+
+		// And mock config handler returns empty context
+		mocks.ConfigHandler.GetContextFunc = func() string {
+			return ""
+		}
+
+		// And a mock jsonnet VM
+		template.shims.NewJsonnetVM = func() JsonnetVM {
+			mockVM := &mockJsonnetVM{
+				EvaluateFunc: func(filename, snippet string) (string, error) {
+					return `{"minimal": true}`, nil
+				},
+			}
+			return mockVM
+		}
+
+		templateContent := `local context = std.extVar("context"); { minimal: true }`
+
+		// When processing the jsonnet template
+		result, err := template.processJsonnetTemplate(templateContent)
+
+		// Then no error should be returned
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// And the result should be processed
+		if result["minimal"] != true {
+			t.Error("Expected minimal template to be processed")
+		}
+	})
+}
+
+func TestJsonnetTemplate_RealShimsIntegration(t *testing.T) {
+	t.Run("UsesRealShimsForJsonnetVM", func(t *testing.T) {
+		// Given a jsonnet template that uses real shims (not mocked)
+		mocks := setupMocks(t)
+		template := NewJsonnetTemplate(mocks.Injector)
+		err := template.Initialize()
+		if err != nil {
+			t.Fatalf("Failed to initialize template: %v", err)
+		}
+
+		// And mock config handler returns valid YAML
+		mocks.ConfigHandler.YamlMarshalWithDefinedPathsFunc = func(v any) ([]byte, error) {
+			return []byte("contexts:\n  test-context:\n    value: test"), nil
+		}
+
+		// When processing a simple jsonnet template using real shims
+		templateContent := `local context = std.extVar("context"); { result: "success", hasContext: std.objectHas(context, "name") }`
+		result, err := template.processJsonnetTemplate(templateContent)
+
+		// Then no error should be returned
+		if err != nil {
+			t.Fatalf("Expected no error with real shims, got: %v", err)
+		}
+
+		// And the result should be processed correctly
+		if result["result"] != "success" {
+			t.Errorf("Expected result 'success', got: %v", result["result"])
+		}
+
+		// And context should be available
+		if hasContext, ok := result["hasContext"].(bool); !ok || !hasContext {
+			t.Error("Expected context to be available in jsonnet template")
+		}
+	})
+
+	t.Run("ShimsProvideBasicFunctionality", func(t *testing.T) {
+		// Given real shims
+		shims := NewShims()
+
+		// When testing basic functionality
+		// Then all function fields should be set
+		if shims.ReadFile == nil {
+			t.Error("Expected ReadFile to be set")
+		}
+		if shims.JsonMarshal == nil {
+			t.Error("Expected JsonMarshal to be set")
+		}
+		if shims.JsonUnmarshal == nil {
+			t.Error("Expected JsonUnmarshal to be set")
+		}
+		if shims.YamlMarshal == nil {
+			t.Error("Expected YamlMarshal to be set")
+		}
+		if shims.YamlUnmarshal == nil {
+			t.Error("Expected YamlUnmarshal to be set")
+		}
+		if shims.NewJsonnetVM == nil {
+			t.Error("Expected NewJsonnetVM to be set")
+		}
+		if shims.FilepathBase == nil {
+			t.Error("Expected FilepathBase to be set")
+		}
+
+		// And JsonnetVM should be creatable
+		vm := shims.NewJsonnetVM()
+		if vm == nil {
+			t.Error("Expected NewJsonnetVM to create a VM")
+		}
+
+		// And basic shim functions should work
+		testData := map[string]interface{}{"test": "value"}
+		jsonBytes, err := shims.JsonMarshal(testData)
+		if err != nil {
+			t.Errorf("Expected JsonMarshal to work, got error: %v", err)
+		}
+
+		var unmarshaledData map[string]interface{}
+		err = shims.JsonUnmarshal(jsonBytes, &unmarshaledData)
+		if err != nil {
+			t.Errorf("Expected JsonUnmarshal to work, got error: %v", err)
+		}
+		if unmarshaledData["test"] != "value" {
+			t.Errorf("Expected unmarshaled data to match, got: %v", unmarshaledData)
+		}
+
+		// And FilepathBase should work
+		baseName := shims.FilepathBase("/path/to/file.txt")
+		if baseName != "file.txt" {
+			t.Errorf("Expected base name 'file.txt', got: %v", baseName)
+		}
+	})
+}
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+type mockJsonnetVM struct {
+	EvaluateFunc func(filename, snippet string) (string, error)
+	ExtCodeFunc  func(key, val string)
+	ExtCalls     []struct{ Key, Val string }
+}
+
+func (m *mockJsonnetVM) ExtCode(key, val string) {
+	if m.ExtCodeFunc != nil {
+		m.ExtCodeFunc(key, val)
+	} else {
+		m.ExtCalls = append(m.ExtCalls, struct{ Key, Val string }{key, val})
+	}
+}
+
+func (m *mockJsonnetVM) EvaluateAnonymousSnippet(filename, snippet string) (string, error) {
+	if m.EvaluateFunc != nil {
+		return m.EvaluateFunc(filename, snippet)
+	}
+	return "", nil
+}

--- a/pkg/template/mock_template.go
+++ b/pkg/template/mock_template.go
@@ -1,0 +1,45 @@
+package template
+
+import "github.com/windsorcli/cli/pkg/di"
+
+// MockTemplate is a mock implementation of the Template interface for testing
+type MockTemplate struct {
+	InitializeFunc func() error
+	ProcessFunc    func(templateData map[string][]byte, renderedData map[string]any) error
+}
+
+// =============================================================================
+// Constructor
+// =============================================================================
+
+// NewMockTemplate creates a new MockTemplate instance
+func NewMockTemplate(injector di.Injector) *MockTemplate {
+	return &MockTemplate{}
+}
+
+// =============================================================================
+// Public Methods
+// =============================================================================
+
+// Initialize calls the mock InitializeFunc if set, otherwise returns nil
+func (m *MockTemplate) Initialize() error {
+	if m.InitializeFunc != nil {
+		return m.InitializeFunc()
+	}
+	return nil
+}
+
+// Process calls the mock ProcessFunc if set, otherwise returns nil
+func (m *MockTemplate) Process(templateData map[string][]byte, renderedData map[string]any) error {
+	if m.ProcessFunc != nil {
+		return m.ProcessFunc(templateData, renderedData)
+	}
+	return nil
+}
+
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
+// Ensure MockTemplate implements Template interface
+var _ Template = (*MockTemplate)(nil)

--- a/pkg/template/mock_template_test.go
+++ b/pkg/template/mock_template_test.go
@@ -1,0 +1,157 @@
+package template
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/windsorcli/cli/pkg/di"
+)
+
+// =============================================================================
+// Test Public Methods
+// =============================================================================
+
+func TestMockTemplate_NewMockTemplate(t *testing.T) {
+	t.Run("CreatesTemplateWithInjector", func(t *testing.T) {
+		// Given an injector
+		injector := di.NewInjector()
+
+		// When creating a new mock template
+		template := NewMockTemplate(injector)
+
+		// Then the template should be properly initialized
+		if template == nil {
+			t.Fatal("Expected non-nil template")
+		}
+	})
+}
+
+func TestMockTemplate_Initialize(t *testing.T) {
+	setup := func(t *testing.T) *MockTemplate {
+		t.Helper()
+		injector := di.NewInjector()
+		return NewMockTemplate(injector)
+	}
+
+	t.Run("DefaultBehavior", func(t *testing.T) {
+		// Given a mock template without initialize function
+		template := setup(t)
+
+		// When calling Initialize
+		err := template.Initialize()
+
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected nil error, got %v", err)
+		}
+	})
+
+	t.Run("CustomInitializeFunc", func(t *testing.T) {
+		// Given a mock template with custom initialize function
+		template := setup(t)
+		template.InitializeFunc = func() error {
+			return fmt.Errorf("custom error")
+		}
+
+		// When calling Initialize
+		err := template.Initialize()
+
+		// Then the custom error should be returned
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if err.Error() != "custom error" {
+			t.Errorf("Expected 'custom error', got: %v", err)
+		}
+	})
+}
+
+func TestMockTemplate_Process(t *testing.T) {
+	setup := func(t *testing.T) *MockTemplate {
+		t.Helper()
+		injector := di.NewInjector()
+		return NewMockTemplate(injector)
+	}
+
+	t.Run("DefaultBehavior", func(t *testing.T) {
+		// Given a mock template without process function
+		template := setup(t)
+
+		// And template data
+		templateData := map[string][]byte{
+			"test.jsonnet": []byte(`{"key": "value"}`),
+		}
+		renderedData := make(map[string]any)
+
+		// When calling Process
+		err := template.Process(templateData, renderedData)
+
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected nil error, got %v", err)
+		}
+
+		// And rendered data should remain empty
+		if len(renderedData) != 0 {
+			t.Errorf("Expected empty rendered data, got %d items", len(renderedData))
+		}
+	})
+
+	t.Run("CustomProcessFunc", func(t *testing.T) {
+		// Given a mock template with custom process function
+		template := setup(t)
+		template.ProcessFunc = func(templateData map[string][]byte, renderedData map[string]any) error {
+			for key := range templateData {
+				renderedData[key] = "processed"
+			}
+			return nil
+		}
+
+		// And template data
+		templateData := map[string][]byte{
+			"test.jsonnet": []byte(`{"key": "value"}`),
+		}
+		renderedData := make(map[string]any)
+
+		// When calling Process
+		err := template.Process(templateData, renderedData)
+
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected nil error, got %v", err)
+		}
+
+		// And rendered data should contain the processed result
+		if len(renderedData) != 1 {
+			t.Errorf("Expected 1 rendered item, got %d", len(renderedData))
+		}
+		if renderedData["test.jsonnet"] != "processed" {
+			t.Errorf("Expected 'processed', got: %v", renderedData["test.jsonnet"])
+		}
+	})
+
+	t.Run("ProcessFuncReturnsError", func(t *testing.T) {
+		// Given a mock template with error-returning process function
+		template := setup(t)
+		template.ProcessFunc = func(templateData map[string][]byte, renderedData map[string]any) error {
+			return fmt.Errorf("process error")
+		}
+
+		// And template data
+		templateData := map[string][]byte{
+			"test.jsonnet": []byte(`{"key": "value"}`),
+		}
+		renderedData := make(map[string]any)
+
+		// When calling Process
+		err := template.Process(templateData, renderedData)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if err.Error() != "process error" {
+			t.Errorf("Expected 'process error', got: %v", err)
+		}
+	})
+}

--- a/pkg/template/shims.go
+++ b/pkg/template/shims.go
@@ -1,0 +1,80 @@
+package template
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+
+	"github.com/goccy/go-yaml"
+	"github.com/google/go-jsonnet"
+)
+
+// The shims package is a system call abstraction layer for the template package
+// It provides mockable wrappers around system and runtime functions
+// It serves as a testing aid by allowing system calls to be intercepted
+// It enables dependency injection and test isolation for system-level operations
+
+// =============================================================================
+// Types
+// =============================================================================
+
+// JsonnetVM provides an interface for Jsonnet virtual machine operations
+type JsonnetVM interface {
+	ExtCode(key, val string)
+	EvaluateAnonymousSnippet(filename, snippet string) (string, error)
+}
+
+// RealJsonnetVM is the real implementation of JsonnetVM
+type RealJsonnetVM struct {
+	vm *jsonnet.VM
+}
+
+// ExtCode sets external code for the Jsonnet VM
+func (j *RealJsonnetVM) ExtCode(key, val string) {
+	j.vm.ExtCode(key, val)
+}
+
+// EvaluateAnonymousSnippet evaluates a Jsonnet snippet
+func (j *RealJsonnetVM) EvaluateAnonymousSnippet(filename, snippet string) (string, error) {
+	return j.vm.EvaluateAnonymousSnippet(filename, snippet)
+}
+
+// Shims provides mockable wrappers around system and runtime functions
+type Shims struct {
+	ReadFile      func(name string) ([]byte, error)
+	ReadDir       func(name string) ([]os.DirEntry, error)
+	Stat          func(name string) (os.FileInfo, error)
+	WriteFile     func(name string, data []byte, perm os.FileMode) error
+	MkdirAll      func(path string, perm os.FileMode) error
+	Getenv        func(key string) string
+	YamlUnmarshal func(data []byte, v any) error
+	YamlMarshal   func(v any) ([]byte, error)
+	JsonMarshal   func(v any) ([]byte, error)
+	JsonUnmarshal func(data []byte, v any) error
+	NewJsonnetVM  func() JsonnetVM
+	FilepathBase  func(path string) string
+}
+
+// =============================================================================
+// Constructor
+// =============================================================================
+
+// NewShims creates a new Shims instance with default implementations
+func NewShims() *Shims {
+	return &Shims{
+		ReadFile:      os.ReadFile,
+		ReadDir:       os.ReadDir,
+		Stat:          os.Stat,
+		WriteFile:     os.WriteFile,
+		MkdirAll:      os.MkdirAll,
+		Getenv:        os.Getenv,
+		YamlUnmarshal: yaml.Unmarshal,
+		YamlMarshal:   yaml.Marshal,
+		JsonMarshal:   json.Marshal,
+		JsonUnmarshal: json.Unmarshal,
+		NewJsonnetVM: func() JsonnetVM {
+			return &RealJsonnetVM{vm: jsonnet.MakeVM()}
+		},
+		FilepathBase: filepath.Base,
+	}
+}

--- a/pkg/template/template.go
+++ b/pkg/template/template.go
@@ -1,0 +1,71 @@
+package template
+
+import (
+	"github.com/windsorcli/cli/pkg/config"
+	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/shell"
+)
+
+// =============================================================================
+// Interfaces
+// =============================================================================
+
+// Template defines the interface for template processors
+type Template interface {
+	Initialize() error
+	Process(templateData map[string][]byte, renderedData map[string]any) error
+}
+
+// =============================================================================
+// Processing Rules
+// =============================================================================
+
+// ProcessingRule defines how to match and process template files
+type ProcessingRule struct {
+	// PathMatcher determines if a file path should be processed by this rule
+	PathMatcher func(string) bool
+	// KeyGenerator generates the output key from the input path
+	KeyGenerator func(string) string
+}
+
+// =============================================================================
+// Types
+// =============================================================================
+
+// BaseTemplate provides common functionality for template implementations
+type BaseTemplate struct {
+	injector      di.Injector
+	configHandler config.ConfigHandler
+	shell         shell.Shell
+	rules         []ProcessingRule
+	shims         *Shims
+}
+
+// =============================================================================
+// Constructor
+// =============================================================================
+
+// NewBaseTemplate creates a new BaseTemplate instance
+func NewBaseTemplate(injector di.Injector) *BaseTemplate {
+	return &BaseTemplate{
+		injector: injector,
+		shims:    NewShims(),
+	}
+}
+
+// =============================================================================
+// Public Methods
+// =============================================================================
+
+// Initialize sets up the BaseTemplate dependencies
+func (t *BaseTemplate) Initialize() error {
+	if t.injector != nil {
+		if configHandler := t.injector.Resolve("configHandler"); configHandler != nil {
+			t.configHandler = configHandler.(config.ConfigHandler)
+		}
+		if shellService := t.injector.Resolve("shell"); shellService != nil {
+			t.shell = shellService.(shell.Shell)
+		}
+	}
+	return nil
+}

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -1,7 +1,6 @@
 package template
 
 import (
-	"os"
 	"testing"
 
 	"github.com/windsorcli/cli/pkg/config"
@@ -25,13 +24,6 @@ type SetupOptions struct {
 
 func setupMocks(t *testing.T, opts ...*SetupOptions) *Mocks {
 	t.Helper()
-
-	tmpDir := t.TempDir()
-	if err := os.Chdir(tmpDir); err != nil {
-		t.Fatalf("Failed to change to temp directory: %v", err)
-	}
-
-	os.Setenv("WINDSOR_PROJECT_ROOT", tmpDir)
 
 	injector := di.NewInjector()
 	mockShell := shell.NewMockShell()
@@ -68,11 +60,6 @@ contexts:
 			t.Fatalf("Failed to load config string: %v", err)
 		}
 	}
-
-	t.Cleanup(func() {
-		os.Unsetenv("WINDSOR_PROJECT_ROOT")
-		os.Chdir(tmpDir)
-	})
 
 	return &Mocks{
 		Injector:      injector,

--- a/pkg/template/template_test.go
+++ b/pkg/template/template_test.go
@@ -1,0 +1,165 @@
+package template
+
+import (
+	"os"
+	"testing"
+
+	"github.com/windsorcli/cli/pkg/config"
+	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/shell"
+)
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+type Mocks struct {
+	Injector      di.Injector
+	Shell         *shell.MockShell
+	ConfigHandler *config.MockConfigHandler
+}
+
+type SetupOptions struct {
+	ConfigStr string
+}
+
+func setupMocks(t *testing.T, opts ...*SetupOptions) *Mocks {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatalf("Failed to change to temp directory: %v", err)
+	}
+
+	os.Setenv("WINDSOR_PROJECT_ROOT", tmpDir)
+
+	injector := di.NewInjector()
+	mockShell := shell.NewMockShell()
+	mockShell.GetProjectRootFunc = func() (string, error) {
+		return "/mock/project", nil
+	}
+
+	mockConfigHandler := config.NewMockConfigHandler()
+	mockConfigHandler.GetContextFunc = func() string {
+		return "mock-context"
+	}
+	mockConfigHandler.YamlMarshalWithDefinedPathsFunc = func(v any) ([]byte, error) {
+		return []byte("contexts:\n  mock-context:\n    dns:\n      domain: mock.domain.com"), nil
+	}
+
+	injector.Register("shell", mockShell)
+	injector.Register("configHandler", mockConfigHandler)
+
+	defaultConfigStr := `
+contexts:
+  mock-context:
+    dns:
+      domain: mock.domain.com
+`
+
+	mockConfigHandler.Initialize()
+	mockConfigHandler.SetContext("mock-context")
+
+	if err := mockConfigHandler.LoadConfigString(defaultConfigStr); err != nil {
+		t.Fatalf("Failed to load default config string: %v", err)
+	}
+	if len(opts) > 0 && opts[0].ConfigStr != "" {
+		if err := mockConfigHandler.LoadConfigString(opts[0].ConfigStr); err != nil {
+			t.Fatalf("Failed to load config string: %v", err)
+		}
+	}
+
+	t.Cleanup(func() {
+		os.Unsetenv("WINDSOR_PROJECT_ROOT")
+		os.Chdir(tmpDir)
+	})
+
+	return &Mocks{
+		Injector:      injector,
+		Shell:         mockShell,
+		ConfigHandler: mockConfigHandler,
+	}
+}
+
+// =============================================================================
+// Test Public Methods
+// =============================================================================
+
+func TestBaseTemplate_NewBaseTemplate(t *testing.T) {
+	t.Run("CreatesTemplateWithInjector", func(t *testing.T) {
+		// Given an injector
+		mocks := setupMocks(t)
+
+		// When creating a new base template
+		template := NewBaseTemplate(mocks.Injector)
+
+		// Then the template should be properly initialized
+		if template == nil {
+			t.Fatal("Expected non-nil template")
+		}
+
+		// And basic fields should be set
+		if template.injector == nil {
+			t.Error("Expected injector to be set")
+		}
+
+		// And dependency fields should be nil until Initialize() is called
+		if template.configHandler != nil {
+			t.Error("Expected configHandler to be nil before Initialize()")
+		}
+		if template.shell != nil {
+			t.Error("Expected shell to be nil before Initialize()")
+		}
+	})
+}
+
+func TestBaseTemplate_Initialize(t *testing.T) {
+	setup := func(t *testing.T) (*BaseTemplate, *Mocks) {
+		t.Helper()
+		mocks := setupMocks(t)
+		template := NewBaseTemplate(mocks.Injector)
+		return template, mocks
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		// Given a template
+		template, _ := setup(t)
+
+		// When calling Initialize
+		err := template.Initialize()
+
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected nil error, got %v", err)
+		}
+
+		// And dependencies should be injected
+		if template.configHandler == nil {
+			t.Error("Expected configHandler to be set after Initialize()")
+		}
+		if template.shell == nil {
+			t.Error("Expected shell to be set after Initialize()")
+		}
+	})
+
+	t.Run("HandlesNilInjector", func(t *testing.T) {
+		// Given a template with nil injector
+		template := NewBaseTemplate(nil)
+
+		// When calling Initialize
+		err := template.Initialize()
+
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected nil error, got %v", err)
+		}
+
+		// And dependencies should remain nil
+		if template.configHandler != nil {
+			t.Error("Expected configHandler to remain nil")
+		}
+		if template.shell != nil {
+			t.Error("Expected shell to remain nil")
+		}
+	})
+}


### PR DESCRIPTION
Adds a new `pkg/template` class. This handles processing templates passed in on a map of relative folder paths. They output the templated data as post-rendered paths, for later processing by generators.