### PR TITLE
refactor(terraform): Add standard module resolver

### DIFF
--- a/pkg/terraform/standard_module_resolver.go
+++ b/pkg/terraform/standard_module_resolver.go
@@ -1,0 +1,278 @@
+package terraform
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/windsorcli/cli/pkg/blueprint"
+	"github.com/windsorcli/cli/pkg/config"
+	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/generators"
+	"github.com/windsorcli/cli/pkg/shell"
+)
+
+// The StandardModuleResolver is a terraform module resolver for standard source types.
+// It provides functionality to process git repositories, local paths, and other standard terraform module sources.
+// The StandardModuleResolver acts as a specialized resolver within the terraform module system,
+// handling module initialization, shim generation, and configuration for non-OCI terraform sources.
+
+// =============================================================================
+// Types
+// =============================================================================
+
+// StandardModuleResolver handles standard terraform module sources (git, local paths, etc.)
+type StandardModuleResolver struct {
+	*BaseModuleResolver
+	configHandler config.ConfigHandler
+	reset         bool
+}
+
+// =============================================================================
+// Constructor
+// =============================================================================
+
+// NewStandardModuleResolver creates a new standard module resolver
+func NewStandardModuleResolver(injector di.Injector) *StandardModuleResolver {
+	base := NewBaseModuleResolver(injector)
+	return &StandardModuleResolver{
+		BaseModuleResolver: base,
+		reset:              false,
+	}
+}
+
+// Initialize sets up the StandardModuleResolver by resolving and assigning required dependencies.
+// It initializes the base resolver, then resolves and assigns the blueprint handler, shell, and config handler
+// from the dependency injector. Returns an error if any dependency cannot be resolved.
+func (h *StandardModuleResolver) Initialize() error {
+	if err := h.BaseModuleResolver.Initialize(); err != nil {
+		return err
+	}
+
+	blueprintHandlerInterface := h.injector.Resolve("blueprintHandler")
+	var ok bool
+	h.blueprintHandler, ok = blueprintHandlerInterface.(blueprint.BlueprintHandler)
+	if !ok {
+		return fmt.Errorf("failed to resolve blueprint handler")
+	}
+
+	shellInterface := h.injector.Resolve("shell")
+	h.shell, ok = shellInterface.(shell.Shell)
+	if !ok {
+		return fmt.Errorf("failed to resolve shell")
+	}
+
+	configHandlerInterface := h.injector.Resolve("configHandler")
+	h.configHandler, ok = configHandlerInterface.(config.ConfigHandler)
+	if !ok {
+		return fmt.Errorf("failed to resolve config handler")
+	}
+
+	return nil
+}
+
+// =============================================================================
+// Public Methods
+// =============================================================================
+
+// ProcessModules processes all standard terraform modules from the blueprint.
+// It iterates over each terraform component, determines if the resolver should handle the source,
+// creates the module directory, writes shim files (main.tf, variables.tf, outputs.tf), initializes
+// the module with terraform, and determines the correct module path for shimming. Errors are returned
+// if any step fails, ensuring that only valid and initialized modules are processed.
+func (h *StandardModuleResolver) ProcessModules() error {
+	if h.blueprintHandler == nil {
+		return fmt.Errorf("blueprint handler not initialized")
+	}
+
+	components := h.blueprintHandler.GetTerraformComponents()
+
+	for _, component := range components {
+		if component.Source == "" {
+			continue
+		}
+
+		if !h.shouldHandle(component.Source) {
+			continue
+		}
+
+		moduleDir := component.FullPath
+		if err := h.shims.MkdirAll(moduleDir, 0755); err != nil {
+			return fmt.Errorf("failed to create module directory for %s: %w", component.Path, err)
+		}
+
+		if err := h.writeShimMainTf(moduleDir, component.Source); err != nil {
+			return fmt.Errorf("failed to write main.tf for %s: %w", component.Path, err)
+		}
+
+		if err := h.shims.Chdir(moduleDir); err != nil {
+			return fmt.Errorf("failed to change to module directory for %s: %w", component.Path, err)
+		}
+
+		contextPath, err := h.configHandler.GetConfigRoot()
+		if err != nil {
+			return fmt.Errorf("failed to get config root for %s: %w", component.Path, err)
+		}
+
+		tfDataDir := filepath.Join(contextPath, ".terraform", component.Path)
+		if err := h.shims.Setenv("TF_DATA_DIR", tfDataDir); err != nil {
+			return fmt.Errorf("failed to set TF_DATA_DIR for %s: %w", component.Path, err)
+		}
+
+		output, err := h.shell.ExecProgress(
+			fmt.Sprintf("📥 Loading component %s", component.Path),
+			"terraform",
+			"init",
+			"--backend=false",
+			"-input=false",
+			"-upgrade",
+			"-json",
+		)
+		if err != nil {
+			return fmt.Errorf("failed to initialize terraform for %s: %w", component.Path, err)
+		}
+
+		detectedPath := ""
+		for line := range strings.SplitSeq(output, "\n") {
+			if line == "" {
+				continue
+			}
+			var initOutput generators.TerraformInitOutput
+			if err := h.shims.JsonUnmarshal([]byte(line), &initOutput); err != nil {
+				continue
+			}
+			if initOutput.Type == "log" {
+				msg := initOutput.Message
+				startIdx := strings.Index(msg, "- main in")
+				if startIdx == -1 {
+					continue
+				}
+
+				pathStart := startIdx + len("- main in")
+				if pathStart >= len(msg) {
+					continue
+				}
+
+				path := strings.TrimSpace(msg[pathStart:])
+				if path == "" {
+					continue
+				}
+
+				if _, err := h.shims.Stat(path); err == nil {
+					detectedPath = path
+					break
+				}
+			}
+		}
+
+		modulePath := filepath.Join(contextPath, ".terraform", component.Path, "modules", "main", "terraform", component.Path)
+		if detectedPath != "" {
+			if detectedPath != modulePath {
+				fmt.Printf("\033[33mWarning: Using detected module path %s instead of standard path %s\033[0m\n", detectedPath, modulePath)
+			}
+			modulePath = detectedPath
+		}
+
+		if err := h.writeShimVariablesTf(moduleDir, modulePath, component.Source); err != nil {
+			return fmt.Errorf("failed to write variables.tf for %s: %w", component.Path, err)
+		}
+
+		if err := h.writeShimOutputsTf(moduleDir, modulePath); err != nil {
+			return fmt.Errorf("failed to write outputs.tf for %s: %w", component.Path, err)
+		}
+	}
+
+	return nil
+}
+
+// =============================================================================
+// Private Methods
+// =============================================================================
+
+// shouldHandle determines if this resolver should handle the given source by checking
+// if the source matches valid terraform module source patterns. This includes local paths,
+// terraform registry modules, git repositories, HTTP URLs, and cloud storage buckets.
+// It does not handle OCI sources or perform any blueprint handler lookups.
+func (h *StandardModuleResolver) shouldHandle(source string) bool {
+	if source == "" {
+		return false
+	}
+
+	if strings.HasPrefix(source, "./") || strings.HasPrefix(source, "../") {
+		return true
+	}
+
+	if h.isTerraformRegistryModule(source) {
+		return true
+	}
+
+	if strings.HasPrefix(source, "github.com/") {
+		return true
+	}
+
+	if strings.HasPrefix(source, "git@github.com:") {
+		return true
+	}
+
+	if strings.HasPrefix(source, "bitbucket.org/") {
+		return true
+	}
+
+	if strings.HasPrefix(source, "git::") {
+		return true
+	}
+
+	if strings.HasPrefix(source, "hg::") {
+		return true
+	}
+
+	if strings.HasPrefix(source, "https://") || strings.HasPrefix(source, "http://") {
+		return true
+	}
+
+	if strings.HasPrefix(source, "s3::") {
+		return true
+	}
+
+	if strings.HasPrefix(source, "gcs::") {
+		return true
+	}
+
+	if strings.HasPrefix(source, "git@") && strings.Contains(source, ":") {
+		return true
+	}
+
+	return false
+}
+
+// isTerraformRegistryModule checks if the source is a Terraform Registry module by validating
+// the format namespace/name/provider and ensuring each component contains only valid characters.
+// Registry modules must have exactly three slash-separated parts, with each part containing
+// only alphanumeric characters, hyphens, and underscores.
+func (h *StandardModuleResolver) isTerraformRegistryModule(source string) bool {
+	parts := strings.Split(source, "/")
+	if len(parts) != 3 {
+		return false
+	}
+
+	for _, part := range parts {
+		if part == "" {
+			return false
+		}
+		for _, char := range part {
+			if !((char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') ||
+				(char >= '0' && char <= '9') || char == '-' || char == '_') {
+				return false
+			}
+		}
+	}
+
+	return true
+}
+
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
+// Ensure StandardModuleResolver implements ModuleResolver
+var _ ModuleResolver = (*StandardModuleResolver)(nil)

--- a/pkg/terraform/standard_module_resolver_test.go
+++ b/pkg/terraform/standard_module_resolver_test.go
@@ -1,0 +1,925 @@
+package terraform
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+
+	"encoding/json"
+
+	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+	"github.com/windsorcli/cli/pkg/blueprint"
+	"github.com/windsorcli/cli/pkg/config"
+	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/generators"
+	"github.com/windsorcli/cli/pkg/shell"
+)
+
+// The StandardModuleResolverTest is a test suite for the StandardModuleResolver implementation
+// It provides comprehensive coverage for standard terraform module source processing and validation
+// The StandardModuleResolverTest ensures proper handling of git repositories, local paths, and registry modules
+// enabling reliable terraform module resolution and shim generation for standard sources
+
+// =============================================================================
+// Test Public Methods
+// =============================================================================
+
+func TestStandardModuleResolver_NewStandardModuleResolver(t *testing.T) {
+	t.Run("CreatesStandardModuleResolver", func(t *testing.T) {
+		injector := di.NewInjector()
+		resolver := NewStandardModuleResolver(injector)
+		if resolver == nil {
+			t.Fatal("Expected non-nil standard module resolver")
+		}
+		if resolver.BaseModuleResolver == nil {
+			t.Error("Expected BaseModuleResolver to be set")
+		}
+		if resolver.reset {
+			t.Error("Expected reset to be false by default")
+		}
+	})
+}
+
+func TestStandardModuleResolver_Initialize(t *testing.T) {
+	setup := func(t *testing.T) (*StandardModuleResolver, *Mocks) {
+		t.Helper()
+		mocks := setupMocks(t, &SetupOptions{})
+		resolver := NewStandardModuleResolver(mocks.Injector)
+		return resolver, mocks
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		// Given a standard module resolver with valid dependencies
+		resolver, _ := setup(t)
+
+		// When Initialize is called
+		err := resolver.Initialize()
+
+		// Then no error is returned and all handlers are set
+		if err != nil {
+			t.Errorf("Expected nil error, got %v", err)
+		}
+		if resolver.blueprintHandler == nil {
+			t.Error("Expected blueprintHandler to be set after Initialize()")
+		}
+		if resolver.shell == nil {
+			t.Error("Expected shell to be set after Initialize()")
+		}
+		if resolver.configHandler == nil {
+			t.Error("Expected configHandler to be set after Initialize()")
+		}
+	})
+
+	t.Run("HandlesBaseInitializeError", func(t *testing.T) {
+		// Given a resolver with an injector missing shell dependency
+		injector := di.NewInjector()
+		resolver := NewStandardModuleResolver(injector)
+
+		// When Initialize is called
+		err := resolver.Initialize()
+
+		// Then an error is returned indicating shell resolution failure
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if err == nil || !strings.Contains(err.Error(), "failed to resolve shell") {
+			t.Errorf("Expected shell resolution error, got: %v", err)
+		}
+	})
+
+	t.Run("HandlesMissingBlueprintHandler", func(t *testing.T) {
+		// Given a resolver with blueprintHandler explicitly set to nil in injector
+		resolver, mocks := setup(t)
+		mocks.Injector.Register("blueprintHandler", nil)
+
+		// When Initialize is called
+		err := resolver.Initialize()
+
+		// Then an error is returned indicating blueprint handler resolution failure
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if err == nil || !strings.Contains(err.Error(), "failed to resolve blueprint handler") {
+			t.Errorf("Expected blueprint handler resolution error, got: %v", err)
+		}
+	})
+
+	t.Run("HandlesMissingConfigHandler", func(t *testing.T) {
+		// Given a resolver with configHandler explicitly set to nil in injector
+		resolver, mocks := setup(t)
+		mocks.Injector.Register("configHandler", nil)
+
+		// When Initialize is called
+		err := resolver.Initialize()
+
+		// Then an error is returned indicating config handler resolution failure
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if err == nil || !strings.Contains(err.Error(), "failed to resolve config handler") {
+			t.Errorf("Expected config handler resolution error, got: %v", err)
+		}
+	})
+
+	t.Run("HandlesShellTypeAssertionError", func(t *testing.T) {
+		// Given a resolver with shell registered as an invalid type
+		resolver, mocks := setup(t)
+		mocks.Injector.Register("shell", "invalid-shell-type")
+
+		// When Initialize is called
+		err := resolver.Initialize()
+
+		// Then an error is returned indicating shell type assertion failure
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to resolve shell") {
+			t.Errorf("Expected shell type assertion error, got: %v", err)
+		}
+	})
+
+	t.Run("HandlesBlueprintHandlerTypeAssertionError", func(t *testing.T) {
+		// Given a resolver with blueprintHandler registered as an invalid type
+		resolver, mocks := setup(t)
+		mocks.Injector.Register("blueprintHandler", "invalid-blueprint-handler-type")
+
+		// When Initialize is called
+		err := resolver.Initialize()
+
+		// Then an error is returned indicating blueprint handler type assertion failure
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to resolve blueprint handler") {
+			t.Errorf("Expected blueprint handler type assertion error, got: %v", err)
+		}
+	})
+
+	t.Run("HandlesConfigHandlerTypeAssertionError", func(t *testing.T) {
+		// Given a resolver with configHandler registered as an invalid type
+		resolver, mocks := setup(t)
+		mocks.Injector.Register("configHandler", "invalid-config-handler-type")
+
+		// When Initialize is called
+		err := resolver.Initialize()
+
+		// Then an error is returned indicating config handler type assertion failure
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to resolve config handler") {
+			t.Errorf("Expected config handler type assertion error, got: %v", err)
+		}
+	})
+
+	t.Run("HandlesNilShellResolution", func(t *testing.T) {
+		// Given a resolver with shell registered as nil interface
+		resolver, mocks := setup(t)
+		mocks.Injector.Register("shell", (*shell.Shell)(nil))
+
+		// When Initialize is called
+		err := resolver.Initialize()
+
+		// Then an error is returned indicating shell resolution failure
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to resolve shell") {
+			t.Errorf("Expected shell resolution error, got: %v", err)
+		}
+	})
+
+	t.Run("HandlesNilBlueprintHandlerResolution", func(t *testing.T) {
+		// Given a resolver with blueprintHandler registered as nil interface
+		resolver, mocks := setup(t)
+		mocks.Injector.Register("blueprintHandler", (*blueprint.BlueprintHandler)(nil))
+
+		// When Initialize is called
+		err := resolver.Initialize()
+
+		// Then an error is returned indicating blueprint handler resolution failure
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to resolve blueprint handler") {
+			t.Errorf("Expected blueprint handler resolution error, got: %v", err)
+		}
+	})
+
+	t.Run("HandlesNilConfigHandlerResolution", func(t *testing.T) {
+		// Given a resolver with configHandler registered as nil interface
+		resolver, mocks := setup(t)
+		mocks.Injector.Register("configHandler", (*config.ConfigHandler)(nil))
+
+		// When Initialize is called
+		err := resolver.Initialize()
+
+		// Then an error is returned indicating config handler resolution failure
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to resolve config handler") {
+			t.Errorf("Expected config handler resolution error, got: %v", err)
+		}
+	})
+}
+
+func TestStandardModuleResolver_ProcessModules(t *testing.T) {
+	setup := func(t *testing.T) (*StandardModuleResolver, *Mocks) {
+		t.Helper()
+		mocks := setupMocks(t, &SetupOptions{})
+		resolver := NewStandardModuleResolver(mocks.Injector)
+		err := resolver.Initialize()
+		if err != nil {
+			t.Fatalf("Failed to initialize resolver: %v", err)
+		}
+		resolver.shims = mocks.Shims
+		return resolver, mocks
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		// Given a resolver with proper JSON unmarshaling for complete path coverage
+		resolver, mocks := setup(t)
+
+		// Use real JSON unmarshaling to exercise the parsing logic
+		resolver.shims.JsonUnmarshal = func(data []byte, v any) error {
+			return json.Unmarshal(data, v)
+		}
+
+		mocks.Shell.ExecProgressFunc = func(msg, cmd string, args ...string) (string, error) {
+			if cmd == "terraform" && len(args) > 0 && args[0] == "init" {
+				// Return terraform init output with detected path different from standard
+				return `{"@level":"info","@message":"Initializing modules...","@module":"terraform.ui","@timestamp":"2025-01-09T16:25:03Z","type":"log","message":"- main in /detected/module/path"}`, nil
+			}
+			return "", nil
+		}
+
+		// When processing modules
+		err := resolver.ProcessModules()
+
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected nil error, got %v", err)
+		}
+	})
+
+	t.Run("HandlesNilBlueprintHandler", func(t *testing.T) {
+		// Given a resolver with nil blueprint handler
+		resolver, _ := setup(t)
+		resolver.blueprintHandler = nil
+
+		// When ProcessModules is called
+		err := resolver.ProcessModules()
+
+		// Then an error is returned indicating blueprint handler not initialized
+		if err == nil || !strings.Contains(err.Error(), "blueprint handler not initialized") {
+			t.Errorf("Expected blueprint handler error, got: %v", err)
+		}
+	})
+
+	t.Run("HandlesMkdirAllError", func(t *testing.T) {
+		// Given a resolver with MkdirAll shim returning error
+		resolver, _ := setup(t)
+		resolver.shims.MkdirAll = func(path string, perm os.FileMode) error {
+			return errors.New("mkdir error")
+		}
+
+		// When ProcessModules is called
+		err := resolver.ProcessModules()
+
+		// Then an error is returned indicating failure to create module directory
+		if err == nil || !strings.Contains(err.Error(), "failed to create module directory") {
+			t.Errorf("Expected mkdir error, got: %v", err)
+		}
+	})
+
+	t.Run("HandlesChdirError", func(t *testing.T) {
+		// Given a resolver with Chdir shim returning error
+		resolver, _ := setup(t)
+		resolver.shims.Chdir = func(path string) error {
+			return errors.New("chdir error")
+		}
+
+		// When ProcessModules is called
+		err := resolver.ProcessModules()
+
+		// Then an error is returned indicating failure to change to module directory
+		if err == nil || !strings.Contains(err.Error(), "failed to change to module directory") {
+			t.Errorf("Expected chdir error, got: %v", err)
+		}
+	})
+
+	t.Run("HandlesGetConfigRootError", func(t *testing.T) {
+		// Given a resolver with config handler GetConfigRoot returning error
+		resolver, mocks := setup(t)
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.GetConfigRootFunc = func() (string, error) {
+			return "", errors.New("config root error")
+		}
+		mocks.Injector.Register("configHandler", mockConfigHandler)
+		resolver.configHandler = mockConfigHandler
+
+		// When ProcessModules is called
+		err := resolver.ProcessModules()
+
+		// Then an error is returned indicating failure to get config root
+		if err == nil || !strings.Contains(err.Error(), "failed to get config root") {
+			t.Errorf("Expected config root error, got: %v", err)
+		}
+	})
+
+	t.Run("HandlesSetenvError", func(t *testing.T) {
+		// Given a resolver with Setenv shim returning error for TF_DATA_DIR
+		resolver, mocks := setup(t)
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.GetConfigRootFunc = func() (string, error) {
+			return "/mock/config/root", nil
+		}
+		mocks.Injector.Register("configHandler", mockConfigHandler)
+		resolver.configHandler = mockConfigHandler
+		resolver.shims.Setenv = func(key, value string) error {
+			if key == "TF_DATA_DIR" {
+				return errors.New("setenv error")
+			}
+			return nil
+		}
+
+		// When ProcessModules is called
+		err := resolver.ProcessModules()
+
+		// Then an error is returned indicating failure to set TF_DATA_DIR
+		if err == nil || !strings.Contains(err.Error(), "failed to set TF_DATA_DIR") {
+			t.Errorf("Expected setenv error, got: %v", err)
+		}
+	})
+
+	t.Run("HandlesTerraformInitError", func(t *testing.T) {
+		// Given a resolver with Shell.ExecProgressFunc returning error for terraform init
+		resolver, mocks := setup(t)
+		mocks.Shell.ExecProgressFunc = func(msg, cmd string, args ...string) (string, error) {
+			if cmd == "terraform" && len(args) > 0 && args[0] == "init" {
+				return "", errors.New("terraform init error")
+			}
+			return "", nil
+		}
+
+		// When ProcessModules is called
+		err := resolver.ProcessModules()
+
+		// Then an error is returned indicating failure to initialize terraform
+		if err == nil || !strings.Contains(err.Error(), "failed to initialize terraform") {
+			t.Errorf("Expected terraform init error, got: %v", err)
+		}
+	})
+
+	t.Run("HandlesWriteShimMainTfError", func(t *testing.T) {
+		// Given a resolver with WriteFile shim returning error for main.tf
+		resolver, _ := setup(t)
+		resolver.shims.WriteFile = func(path string, data []byte, perm os.FileMode) error {
+			if strings.HasSuffix(path, "main.tf") {
+				return errors.New("write main.tf error")
+			}
+			return nil
+		}
+
+		// When ProcessModules is called
+		err := resolver.ProcessModules()
+
+		// Then an error is returned indicating failure to write main.tf
+		if err == nil || !strings.Contains(err.Error(), "failed to write main.tf") {
+			t.Errorf("Expected write main.tf error, got: %v", err)
+		}
+	})
+
+	t.Run("HandlesWriteShimVariablesTfError", func(t *testing.T) {
+		// Given a resolver with WriteFile shim returning error for variables.tf
+		resolver, _ := setup(t)
+		resolver.shims.WriteFile = func(path string, data []byte, perm os.FileMode) error {
+			if strings.HasSuffix(path, "variables.tf") {
+				return errors.New("write variables.tf error")
+			}
+			return nil
+		}
+
+		// When ProcessModules is called
+		err := resolver.ProcessModules()
+
+		// Then an error is returned indicating failure to write variables.tf
+		if err == nil || !strings.Contains(err.Error(), "failed to write variables.tf") {
+			t.Errorf("Expected write variables.tf error, got: %v", err)
+		}
+	})
+
+	t.Run("HandlesWriteShimOutputsTfError", func(t *testing.T) {
+		// Given a resolver with WriteFile shim returning error for outputs.tf
+		resolver, _ := setup(t)
+		resolver.shims.WriteFile = func(path string, data []byte, perm os.FileMode) error {
+			if strings.HasSuffix(path, "outputs.tf") {
+				return errors.New("write outputs.tf error")
+			}
+			return nil
+		}
+
+		// When ProcessModules is called
+		err := resolver.ProcessModules()
+
+		// Then an error is returned indicating failure to write outputs.tf
+		if err == nil || !strings.Contains(err.Error(), "failed to write outputs.tf") {
+			t.Errorf("Expected write outputs.tf error, got: %v", err)
+		}
+	})
+
+	// Edge cases for component filtering
+	t.Run("HandlesEmptySourceComponents", func(t *testing.T) {
+		// Given a resolver with a component having empty source
+		resolver, mocks := setup(t)
+		mocks.BlueprintHandler.GetTerraformComponentsFunc = func() []blueprintv1alpha1.TerraformComponent {
+			return []blueprintv1alpha1.TerraformComponent{{
+				Path:     "test-module",
+				Source:   "",
+				FullPath: "/mock/project/terraform/test-module",
+			}}
+		}
+
+		// When ProcessModules is called
+		err := resolver.ProcessModules()
+
+		// Then no error is returned (component is skipped)
+		if err != nil {
+			t.Errorf("Expected nil error, got %v", err)
+		}
+	})
+
+	t.Run("HandlesNonStandardSources", func(t *testing.T) {
+		// Given a resolver with a component having non-standard source
+		resolver, mocks := setup(t)
+		mocks.BlueprintHandler.GetTerraformComponentsFunc = func() []blueprintv1alpha1.TerraformComponent {
+			return []blueprintv1alpha1.TerraformComponent{{
+				Path:     "test-module",
+				Source:   "oci://registry.example.com/module:latest",
+				FullPath: "/mock/project/terraform/test-module",
+			}}
+		}
+
+		// When ProcessModules is called
+		err := resolver.ProcessModules()
+
+		// Then no error is returned (component is skipped)
+		if err != nil {
+			t.Errorf("Expected nil error, got %v", err)
+		}
+	})
+
+	// Terraform init output parsing edge cases
+	t.Run("HandlesTerraformInitOutputParsing", func(t *testing.T) {
+		// Given a resolver with custom JsonUnmarshal and Stat shims for output parsing edge cases
+		resolver, mocks := setup(t)
+		resolver.shims.JsonUnmarshal = func(data []byte, v any) error {
+			if initOutput, ok := v.(*generators.TerraformInitOutput); ok {
+				jsonStr := string(data)
+				if strings.Contains(jsonStr, `"empty_line"`) {
+					return nil
+				}
+				if strings.Contains(jsonStr, `"invalid_json"`) {
+					return errors.New("invalid JSON")
+				}
+				if strings.Contains(jsonStr, `"non_log_type"`) {
+					initOutput.Type = "info"
+					return nil
+				}
+				if strings.Contains(jsonStr, `"no_main_in"`) {
+					initOutput.Type = "log"
+					initOutput.Message = "some other message"
+					return nil
+				}
+				if strings.Contains(jsonStr, `"main_in_at_end"`) {
+					initOutput.Type = "log"
+					initOutput.Message = "- main in"
+					return nil
+				}
+				if strings.Contains(jsonStr, `"empty_path"`) {
+					initOutput.Type = "log"
+					initOutput.Message = "- main in   "
+					return nil
+				}
+				if strings.Contains(jsonStr, `"nonexistent_path"`) {
+					initOutput.Type = "log"
+					initOutput.Message = "- main in /nonexistent/path"
+					return nil
+				}
+				if strings.Contains(jsonStr, `"valid_path"`) {
+					initOutput.Type = "log"
+					initOutput.Message = "- main in /valid/path"
+					return nil
+				}
+			}
+			return nil
+		}
+
+		// And Stat shim only succeeds for /valid/path
+		resolver.shims.Stat = func(path string) (os.FileInfo, error) {
+			if path == "/valid/path" {
+				return nil, nil
+			}
+			return nil, os.ErrNotExist
+		}
+
+		// And Shell.ExecProgressFunc returns all edge case lines
+		mocks.Shell.ExecProgressFunc = func(msg, cmd string, args ...string) (string, error) {
+			if cmd == "terraform" && len(args) > 0 && args[0] == "init" {
+				return `
+{"empty_line":""}
+invalid json line
+{"non_log_type":"info"}
+{"no_main_in":"log"}
+{"main_in_at_end":"log"}
+{"empty_path":"log"}
+{"nonexistent_path":"log"}
+{"valid_path":"log"}`, nil
+			}
+			return "", nil
+		}
+
+		// When ProcessModules is called
+		err := resolver.ProcessModules()
+
+		// Then no error is returned (all output parsing edge cases handled)
+		if err != nil {
+			t.Errorf("Expected nil error, got %v", err)
+		}
+	})
+}
+
+func TestStandardModuleResolver_shouldHandle(t *testing.T) {
+	setup := func(t *testing.T) *StandardModuleResolver {
+		t.Helper()
+		mocks := setupMocks(t, &SetupOptions{})
+		resolver := NewStandardModuleResolver(mocks.Injector)
+		err := resolver.Initialize()
+		if err != nil {
+			t.Fatalf("Failed to initialize resolver: %v", err)
+		}
+		resolver.shims = mocks.Shims
+		return resolver
+	}
+
+	t.Run("HandlesLocalPaths", func(t *testing.T) {
+		// Given a standard module resolver
+		resolver := setup(t)
+
+		// When checking if it should handle local paths
+		// Then it should handle relative local module paths
+		if !resolver.shouldHandle("./local/module") {
+			t.Error("Expected ./local/module to be handled")
+		}
+		if !resolver.shouldHandle("../parent/module") {
+			t.Error("Expected ../parent/module to be handled")
+		}
+	})
+
+	t.Run("HandlesTerraformRegistryModules", func(t *testing.T) {
+		// Given a standard module resolver
+		resolver := setup(t)
+
+		// When checking if it should handle terraform registry modules
+		// Then it should handle registry module sources
+		if !resolver.shouldHandle("terraform-aws-modules/vpc/aws") {
+			t.Error("Expected terraform-aws-modules/vpc/aws to be handled")
+		}
+		if !resolver.shouldHandle("hashicorp/consul/aws") {
+			t.Error("Expected hashicorp/consul/aws to be handled")
+		}
+	})
+
+	t.Run("HandlesGitSources", func(t *testing.T) {
+		// Given a standard module resolver
+		resolver := setup(t)
+
+		// When checking if it should handle git sources
+		// Then it should handle various git source formats
+		if !resolver.shouldHandle("github.com/terraform-aws-modules/terraform-aws-vpc") {
+			t.Error("Expected github.com/terraform-aws-modules/terraform-aws-vpc to be handled")
+		}
+		if !resolver.shouldHandle("git@github.com:terraform-aws-modules/terraform-aws-vpc.git") {
+			t.Error("Expected git@github.com:terraform-aws-modules/terraform-aws-vpc.git to be handled")
+		}
+		if !resolver.shouldHandle("git::https://github.com/terraform-aws-modules/terraform-aws-vpc.git") {
+			t.Error("Expected git::https://github.com/terraform-aws-modules/terraform-aws-vpc.git to be handled")
+		}
+	})
+
+	t.Run("HandlesHTTPSources", func(t *testing.T) {
+		// Given a standard module resolver
+		resolver := setup(t)
+
+		// When checking if it should handle HTTP(S) sources
+		// Then it should handle HTTP and HTTPS module sources
+		if !resolver.shouldHandle("https://github.com/terraform-aws-modules/terraform-aws-vpc") {
+			t.Error("Expected https://github.com/terraform-aws-modules/terraform-aws-vpc to be handled")
+		}
+		if !resolver.shouldHandle("http://example.com/module.zip") {
+			t.Error("Expected http://example.com/module.zip to be handled")
+		}
+	})
+
+	t.Run("HandlesCloudStorageSources", func(t *testing.T) {
+		// Given a standard module resolver
+		resolver := setup(t)
+
+		// When checking if it should handle cloud storage sources
+		// Then it should handle S3 and GCS module sources
+		if !resolver.shouldHandle("s3::https://s3.amazonaws.com/bucket/module.zip") {
+			t.Error("Expected s3::https://s3.amazonaws.com/bucket/module.zip to be handled")
+		}
+		if !resolver.shouldHandle("gcs::https://storage.googleapis.com/bucket/module.zip") {
+			t.Error("Expected gcs::https://storage.googleapis.com/bucket/module.zip to be handled")
+		}
+	})
+
+	t.Run("RejectsEmptySource", func(t *testing.T) {
+		// Given a standard module resolver
+		resolver := setup(t)
+
+		// When checking if it should handle an empty source
+		// Then it should not handle empty sources
+		if resolver.shouldHandle("") {
+			t.Error("Expected empty source to not be handled")
+		}
+	})
+
+	t.Run("RejectsOCISources", func(t *testing.T) {
+		// Given a standard module resolver
+		resolver := setup(t)
+
+		// When checking if it should handle OCI sources
+		// Then it should not handle OCI sources
+		if resolver.shouldHandle("oci://registry.example.com/module:latest") {
+			t.Error("Expected oci://registry.example.com/module:latest to not be handled")
+		}
+	})
+
+	t.Run("HandlesMercurialSources", func(t *testing.T) {
+		// Given a resolver
+		resolver := setup(t)
+
+		// When checking if it should handle mercurial sources
+		testCases := []string{
+			"hg::https://bitbucket.org/user/repo",
+			"hg::ssh://hg@bitbucket.org/user/repo",
+		}
+
+		for _, source := range testCases {
+			// Then it should handle mercurial sources
+			if !resolver.shouldHandle(source) {
+				t.Errorf("Expected %s to be handled", source)
+			}
+		}
+	})
+
+	t.Run("HandlesAdditionalGitSources", func(t *testing.T) {
+		// Given a resolver
+		resolver := setup(t)
+
+		// When checking if it should handle additional git sources
+		testCases := []string{
+			"git@gitlab.com:user/repo.git",
+			"git@bitbucket.org:user/repo.git",
+			"git@custom-server.com:user/repo.git",
+		}
+
+		for _, source := range testCases {
+			// Then it should handle git sources
+			if !resolver.shouldHandle(source) {
+				t.Errorf("Expected %s to be handled", source)
+			}
+		}
+	})
+
+	t.Run("HandlesBitbucketSources", func(t *testing.T) {
+		// Given a resolver
+		resolver := setup(t)
+
+		// When checking if it should handle bitbucket sources
+		testCases := []string{
+			"bitbucket.org/user/repo",
+			"bitbucket.org/user/repo.git",
+		}
+
+		for _, source := range testCases {
+			// Then it should handle bitbucket sources
+			if !resolver.shouldHandle(source) {
+				t.Errorf("Expected %s to be handled", source)
+			}
+		}
+	})
+
+	t.Run("RejectsUnsupportedSources", func(t *testing.T) {
+		// Given a resolver
+		resolver := setup(t)
+
+		// When checking if it should handle unsupported sources
+		testCases := []string{
+			"ftp://example.com/module.zip",
+			"file:///local/path",
+			"registry.terraform.io/hashicorp/aws", // 4 parts
+			"invalid-source",
+		}
+
+		for _, source := range testCases {
+			// Then it should not handle unsupported sources
+			if resolver.shouldHandle(source) {
+				t.Errorf("Expected %s to not be handled", source)
+			}
+		}
+	})
+
+	t.Run("HandlesGitSSHWithoutColon", func(t *testing.T) {
+		// Given a resolver
+		resolver := setup(t)
+
+		// When checking git@ sources without colon (should not be handled)
+		testCases := []string{
+			"git@github.com",
+			"git@gitlab.com",
+		}
+
+		for _, source := range testCases {
+			// Then it should not handle git sources without colon
+			if resolver.shouldHandle(source) {
+				t.Errorf("Expected %s to not be handled", source)
+			}
+		}
+	})
+}
+
+func TestStandardModuleResolver_isTerraformRegistryModule(t *testing.T) {
+	setup := func(t *testing.T) *StandardModuleResolver {
+		t.Helper()
+		mocks := setupMocks(t, &SetupOptions{})
+		resolver := NewStandardModuleResolver(mocks.Injector)
+		err := resolver.Initialize()
+		if err != nil {
+			t.Fatalf("Failed to initialize resolver: %v", err)
+		}
+		resolver.shims = mocks.Shims
+		return resolver
+	}
+
+	t.Run("ValidRegistryModules", func(t *testing.T) {
+		resolver := setup(t)
+		if !resolver.isTerraformRegistryModule("terraform-aws-modules/vpc/aws") {
+			t.Error("Expected terraform-aws-modules/vpc/aws to be valid")
+		}
+		if !resolver.isTerraformRegistryModule("hashicorp/consul/aws") {
+			t.Error("Expected hashicorp/consul/aws to be valid")
+		}
+		if !resolver.isTerraformRegistryModule("my-org/my-module/my-provider") {
+			t.Error("Expected my-org/my-module/my-provider to be valid")
+		}
+	})
+
+	t.Run("InvalidRegistryModules", func(t *testing.T) {
+		resolver := setup(t)
+		if resolver.isTerraformRegistryModule("invalid") {
+			t.Error("Expected invalid to not be valid")
+		}
+		if resolver.isTerraformRegistryModule("too/many/parts/here") {
+			t.Error("Expected too/many/parts/here to not be valid")
+		}
+		if resolver.isTerraformRegistryModule("only/two") {
+			t.Error("Expected only/two to not be valid")
+		}
+		if resolver.isTerraformRegistryModule("empty//provider") {
+			t.Error("Expected empty//provider to not be valid")
+		}
+		if resolver.isTerraformRegistryModule("invalid@chars/provider") {
+			t.Error("Expected invalid@chars/provider to not be valid")
+		}
+	})
+
+	t.Run("HandlesSpecialCharacters", func(t *testing.T) {
+		resolver := setup(t)
+		if !resolver.isTerraformRegistryModule("my-org/my_module/my-provider") {
+			t.Error("Expected my-org/my_module/my-provider to be valid")
+		}
+		if !resolver.isTerraformRegistryModule("org123/module456/provider789") {
+			t.Error("Expected org123/module456/provider789 to be valid")
+		}
+	})
+
+	t.Run("HandlesEdgeCases", func(t *testing.T) {
+		// Given a resolver
+		resolver := setup(t)
+
+		// When checking edge cases for registry modules
+		validCases := []string{
+			"a/b/c",                   // minimal valid case
+			"A/B/C",                   // uppercase
+			"a-b/c_d/e-f",             // mixed separators
+			"123/456/789",             // all numbers
+			"_test/_module/_provider", // starting with underscore
+			"test-/module_/provider-", // ending with separator
+		}
+
+		for _, testCase := range validCases {
+			if !resolver.isTerraformRegistryModule(testCase) {
+				t.Errorf("Expected %s to be valid registry module", testCase)
+			}
+		}
+	})
+
+	t.Run("RejectsInvalidCharacters", func(t *testing.T) {
+		// Given a resolver
+		resolver := setup(t)
+
+		// When checking invalid characters for registry modules
+		invalidCases := []string{
+			"org/module/provider@version", // @ character
+			"org/module/provider.git",     // . character
+			"org/module/provider+extra",   // + character
+			"org/module/provider space",   // space character
+			"org/module/provider!",        // ! character
+			"org/module/provider#hash",    // # character
+			"org/module/provider%",        // % character
+			"org/module/provider&",        // & character
+			"org/module/provider*",        // * character
+			"org/module/provider(",        // ( character
+			"org/module/provider)",        // ) character
+			"org/module/provider=",        // = character
+			"org/module/provider[",        // [ character
+			"org/module/provider]",        // ] character
+			"org/module/provider{",        // { character
+			"org/module/provider}",        // } character
+			"org/module/provider|",        // | character
+			"org/module/provider\\",       // \ character
+			"org/module/provider:",        // : character
+			"org/module/provider;",        // ; character
+			"org/module/provider\"",       // " character
+			"org/module/provider'",        // ' character
+			"org/module/provider<",        // < character
+			"org/module/provider>",        // > character
+			"org/module/provider,",        // , character
+			"org/module/provider?",        // ? character
+			"org/module/provider/",        // trailing slash
+		}
+
+		for _, testCase := range invalidCases {
+			if resolver.isTerraformRegistryModule(testCase) {
+				t.Errorf("Expected %s to not be valid registry module", testCase)
+			}
+		}
+	})
+
+	t.Run("RejectsUnicodeCharacters", func(t *testing.T) {
+		// Given a resolver
+		resolver := setup(t)
+
+		// When checking unicode characters for registry modules
+		unicodeCases := []string{
+			"org/module/provider™",        // trademark symbol
+			"org/module/provider©",        // copyright symbol
+			"org/module/provider®",        // registered trademark
+			"org/module/provider€",        // euro symbol
+			"org/module/provider中文",       // Chinese characters
+			"org/module/provider日本語",      // Japanese characters
+			"org/module/provider한국어",      // Korean characters
+			"org/module/provider العربية", // Arabic characters
+			"org/module/provider русский", // Russian characters
+			"org/module/provider ñ",       // accented character
+			"org/module/provider ç",       // cedilla
+			"org/module/provider ü",       // umlaut
+		}
+
+		for _, testCase := range unicodeCases {
+			if resolver.isTerraformRegistryModule(testCase) {
+				t.Errorf("Expected %s to not be valid registry module", testCase)
+			}
+		}
+	})
+
+	t.Run("HandlesBoundaryConditions", func(t *testing.T) {
+		// Given a resolver
+		resolver := setup(t)
+
+		// When checking boundary conditions
+		boundaryCases := []string{
+			"",          // empty string
+			"/",         // single slash
+			"//",        // double slash
+			"a//c",      // empty middle part
+			"/b/c",      // empty first part
+			"a/b/",      // empty last part
+			"a/b/c/d",   // too many parts
+			"a",         // single part
+			"a/b",       // two parts
+			"a/b/c/d/e", // five parts
+		}
+
+		for _, testCase := range boundaryCases {
+			if resolver.isTerraformRegistryModule(testCase) {
+				t.Errorf("Expected %s to not be valid registry module", testCase)
+			}
+		}
+	})
+}


### PR DESCRIPTION
Adds a standard terraform module resolver. This module performs a basic `terraform init` to pull down any standard terraform remote module to the local filesystem.