### PR TITLE
refactor(init): Load template data directly from artifact and blueprint

### DIFF
--- a/pkg/artifact/mock_artifact.go
+++ b/pkg/artifact/mock_artifact.go
@@ -17,11 +17,12 @@ import (
 
 // MockArtifact is a mock implementation of the Artifact interface
 type MockArtifact struct {
-	InitializeFunc func(injector di.Injector) error
-	AddFileFunc    func(path string, content []byte, mode os.FileMode) error
-	CreateFunc     func(outputPath string, tag string) (string, error)
-	PushFunc       func(registryBase string, repoName string, tag string) error
-	PullFunc       func(ociRefs []string) (map[string][]byte, error)
+	InitializeFunc      func(injector di.Injector) error
+	AddFileFunc         func(path string, content []byte, mode os.FileMode) error
+	CreateFunc          func(outputPath string, tag string) (string, error)
+	PushFunc            func(registryBase string, repoName string, tag string) error
+	PullFunc            func(ociRefs []string) (map[string][]byte, error)
+	GetTemplateDataFunc func(ociRef string) (map[string][]byte, error)
 }
 
 // =============================================================================
@@ -73,6 +74,14 @@ func (m *MockArtifact) Push(registryBase string, repoName string, tag string) er
 func (m *MockArtifact) Pull(ociRefs []string) (map[string][]byte, error) {
 	if m.PullFunc != nil {
 		return m.PullFunc(ociRefs)
+	}
+	return make(map[string][]byte), nil
+}
+
+// GetTemplateData calls the mock GetTemplateDataFunc if set, otherwise returns empty map and nil error
+func (m *MockArtifact) GetTemplateData(ociRef string) (map[string][]byte, error) {
+	if m.GetTemplateDataFunc != nil {
+		return m.GetTemplateDataFunc(ociRef)
 	}
 	return make(map[string][]byte), nil
 }

--- a/pkg/blueprint/blueprint_handler_test.go
+++ b/pkg/blueprint/blueprint_handler_test.go
@@ -2646,6 +2646,218 @@ func TestBlueprintHandler_GetDefaultTemplateData(t *testing.T) {
 	})
 }
 
+func TestBlueprintHandler_GetLocalTemplateData(t *testing.T) {
+	setup := func(t *testing.T) (BlueprintHandler, *Mocks) {
+		t.Helper()
+		mocks := setupMocks(t)
+		handler := NewBlueprintHandler(mocks.Injector)
+		handler.shims = mocks.Shims
+		err := handler.Initialize()
+		if err != nil {
+			t.Fatalf("Failed to initialize handler: %v", err)
+		}
+		return handler, mocks
+	}
+
+	t.Run("ReturnsEmptyMapWhenTemplateDirectoryNotExists", func(t *testing.T) {
+		// Given a blueprint handler with no template directory
+		handler, mocks := setup(t)
+
+		// Mock shell to return project root
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return "/mock/project", nil
+		}
+
+		// Mock shims to return error for template directory (doesn't exist)
+		if baseHandler, ok := handler.(*BaseBlueprintHandler); ok {
+			baseHandler.shims.Stat = func(path string) (os.FileInfo, error) {
+				return nil, os.ErrNotExist
+			}
+		}
+
+		// When getting local template data
+		result, err := handler.GetLocalTemplateData()
+
+		// Then no error should occur
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// And result should be empty map
+		if len(result) != 0 {
+			t.Errorf("Expected empty map, got: %d items", len(result))
+		}
+	})
+
+	t.Run("CollectsJsonnetFilesFromTemplateDirectory", func(t *testing.T) {
+		// Given a blueprint handler with template directory containing jsonnet files
+		handler, mocks := setup(t)
+
+		templateDir := "/mock/project/contexts/_template"
+
+		// Mock shell to return project root
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return "/mock/project", nil
+		}
+
+		// Mock shims to simulate template directory with files
+		if baseHandler, ok := handler.(*BaseBlueprintHandler); ok {
+			baseHandler.shims.Stat = func(path string) (os.FileInfo, error) {
+				if path == templateDir {
+					return mockFileInfo{name: "_template"}, nil
+				}
+				return nil, os.ErrNotExist
+			}
+
+			baseHandler.shims.ReadDir = func(path string) ([]os.DirEntry, error) {
+				if path == templateDir {
+					return []os.DirEntry{
+						&mockDirEntry{name: "blueprint.jsonnet", isDir: false},
+						&mockDirEntry{name: "config.yaml", isDir: false}, // Should be ignored
+						&mockDirEntry{name: "terraform", isDir: true},
+					}, nil
+				}
+				if path == filepath.Join(templateDir, "terraform") {
+					return []os.DirEntry{
+						&mockDirEntry{name: "cluster.jsonnet", isDir: false},
+						&mockDirEntry{name: "network.jsonnet", isDir: false},
+						&mockDirEntry{name: "README.md", isDir: false}, // Should be ignored
+					}, nil
+				}
+				return nil, fmt.Errorf("directory not found")
+			}
+
+			baseHandler.shims.ReadFile = func(path string) ([]byte, error) {
+				switch path {
+				case filepath.Join(templateDir, "blueprint.jsonnet"):
+					return []byte("{ kind: 'Blueprint' }"), nil
+				case filepath.Join(templateDir, "terraform", "cluster.jsonnet"):
+					return []byte("{ cluster_name: 'test' }"), nil
+				case filepath.Join(templateDir, "terraform", "network.jsonnet"):
+					return []byte("{ vpc_cidr: '10.0.0.0/16' }"), nil
+				default:
+					return nil, fmt.Errorf("file not found: %s", path)
+				}
+			}
+		}
+
+		// When getting local template data
+		result, err := handler.GetLocalTemplateData()
+
+		// Then no error should occur
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// And result should contain only jsonnet files
+		expectedFiles := []string{
+			"blueprint.jsonnet",
+			"terraform/cluster.jsonnet",
+			"terraform/network.jsonnet",
+		}
+
+		if len(result) != len(expectedFiles) {
+			t.Errorf("Expected %d files, got: %d", len(expectedFiles), len(result))
+		}
+
+		for _, expectedFile := range expectedFiles {
+			if _, exists := result[expectedFile]; !exists {
+				t.Errorf("Expected file %s to exist in result", expectedFile)
+			}
+		}
+
+		// Verify non-jsonnet files are ignored
+		ignoredFiles := []string{
+			"config.yaml",
+			"terraform/README.md",
+		}
+
+		for _, ignoredFile := range ignoredFiles {
+			if _, exists := result[ignoredFile]; exists {
+				t.Errorf("Expected file %s to be ignored", ignoredFile)
+			}
+		}
+
+		// Verify file contents
+		if string(result["blueprint.jsonnet"]) != "{ kind: 'Blueprint' }" {
+			t.Errorf("Expected blueprint.jsonnet content to match")
+		}
+		if string(result["terraform/cluster.jsonnet"]) != "{ cluster_name: 'test' }" {
+			t.Errorf("Expected terraform/cluster.jsonnet content to match")
+		}
+	})
+
+	t.Run("ReturnsErrorWhenGetProjectRootFails", func(t *testing.T) {
+		// Given a blueprint handler with shell that fails to get project root
+		handler, mocks := setup(t)
+
+		// Mock shell to return error
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return "", fmt.Errorf("failed to get project root")
+		}
+
+		// When getting local template data
+		result, err := handler.GetLocalTemplateData()
+
+		// Then error should occur
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+
+		if !strings.Contains(err.Error(), "failed to get project root") {
+			t.Errorf("Expected error to contain 'failed to get project root', got: %v", err)
+		}
+
+		// And result should be nil
+		if result != nil {
+			t.Error("Expected result to be nil on error")
+		}
+	})
+
+	t.Run("ReturnsErrorWhenWalkAndCollectTemplatesFails", func(t *testing.T) {
+		// Given a blueprint handler with template directory that fails to read
+		handler, mocks := setup(t)
+
+		templateDir := "/mock/project/contexts/_template"
+
+		// Mock shell to return project root
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return "/mock/project", nil
+		}
+
+		// Mock shims to simulate template directory exists but ReadDir fails
+		if baseHandler, ok := handler.(*BaseBlueprintHandler); ok {
+			baseHandler.shims.Stat = func(path string) (os.FileInfo, error) {
+				if path == templateDir {
+					return mockFileInfo{name: "_template"}, nil
+				}
+				return nil, os.ErrNotExist
+			}
+
+			baseHandler.shims.ReadDir = func(path string) ([]os.DirEntry, error) {
+				return nil, fmt.Errorf("failed to read directory")
+			}
+		}
+
+		// When getting local template data
+		result, err := handler.GetLocalTemplateData()
+
+		// Then error should occur
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+
+		if !strings.Contains(err.Error(), "failed to collect local templates") {
+			t.Errorf("Expected error to contain 'failed to collect local templates', got: %v", err)
+		}
+
+		// And result should be nil
+		if result != nil {
+			t.Error("Expected result to be nil on error")
+		}
+	})
+}
+
 func TestBlueprintHandler_ProcessContextTemplates(t *testing.T) {
 	setup := func(t *testing.T) (*BaseBlueprintHandler, *Mocks) {
 		t.Helper()

--- a/pkg/blueprint/mock_blueprint_handler.go
+++ b/pkg/blueprint/mock_blueprint_handler.go
@@ -17,6 +17,7 @@ type MockBlueprintHandler struct {
 	WaitForKustomizationsFunc   func(message string, names ...string) error
 	ProcessContextTemplatesFunc func(contextName string, reset ...bool) error
 	GetDefaultTemplateDataFunc  func(contextName string) (map[string][]byte, error)
+	GetLocalTemplateDataFunc    func() (map[string][]byte, error)
 	InstallFunc                 func() error
 	GetRepositoryFunc           func() blueprintv1alpha1.Repository
 
@@ -132,6 +133,14 @@ func (m *MockBlueprintHandler) ProcessContextTemplates(contextName string, reset
 func (m *MockBlueprintHandler) GetDefaultTemplateData(contextName string) (map[string][]byte, error) {
 	if m.GetDefaultTemplateDataFunc != nil {
 		return m.GetDefaultTemplateDataFunc(contextName)
+	}
+	return map[string][]byte{}, nil
+}
+
+// GetLocalTemplateData calls the mock GetLocalTemplateDataFunc if set, otherwise returns empty map
+func (m *MockBlueprintHandler) GetLocalTemplateData() (map[string][]byte, error) {
+	if m.GetLocalTemplateDataFunc != nil {
+		return m.GetLocalTemplateDataFunc()
 	}
 	return map[string][]byte{}, nil
 }


### PR DESCRIPTION
Removes intermediate processing in the init pipeline regarding template sources. Now can get template directly directly from an artifact or the blueprit handler.