### PR TITLE
Refactor(stack): Explicitly inject terraform vars on windsor up

### DIFF
--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -112,7 +112,7 @@ func setupMocks(t *testing.T, opts ...*SetupOptions) *Mocks {
 	mockEnvPrinter.PrintFunc = func() error {
 		return nil
 	}
-	mockEnvPrinter.PostEnvHookFunc = func() error {
+	mockEnvPrinter.PostEnvHookFunc = func(directory ...string) error {
 		return nil
 	}
 	injector.Register("envPrinter", mockEnvPrinter)
@@ -122,7 +122,7 @@ func setupMocks(t *testing.T, opts ...*SetupOptions) *Mocks {
 	mockWindsorEnvPrinter.PrintFunc = func() error {
 		return nil
 	}
-	mockWindsorEnvPrinter.PostEnvHookFunc = func() error {
+	mockWindsorEnvPrinter.PostEnvHookFunc = func(directory ...string) error {
 		return nil
 	}
 	injector.Register("windsorEnvPrinter", mockWindsorEnvPrinter)
@@ -131,7 +131,7 @@ func setupMocks(t *testing.T, opts ...*SetupOptions) *Mocks {
 	mockDockerEnvPrinter.PrintFunc = func() error {
 		return nil
 	}
-	mockDockerEnvPrinter.PostEnvHookFunc = func() error {
+	mockDockerEnvPrinter.PostEnvHookFunc = func(directory ...string) error {
 		return nil
 	}
 	injector.Register("dockerEnvPrinter", mockDockerEnvPrinter)

--- a/pkg/env/env.go
+++ b/pkg/env/env.go
@@ -24,7 +24,7 @@ type EnvPrinter interface {
 	Print() error
 	GetEnvVars() (map[string]string, error)
 	GetAlias() (map[string]string, error)
-	PostEnvHook() error
+	PostEnvHook(directory ...string) error
 	GetManagedEnv() []string
 	GetManagedAlias() []string
 	SetManagedEnv(env string)
@@ -132,7 +132,7 @@ func (e *BaseEnvPrinter) GetAlias() (map[string]string, error) {
 }
 
 // PostEnvHook simulates running any necessary commands after the environment variables have been set.
-func (e *BaseEnvPrinter) PostEnvHook() error {
+func (e *BaseEnvPrinter) PostEnvHook(directory ...string) error {
 	// Placeholder for post-processing logic
 	return nil
 }

--- a/pkg/env/mock_env.go
+++ b/pkg/env/mock_env.go
@@ -15,7 +15,7 @@ type MockEnvPrinter struct {
 	InitializeFunc      func() error
 	PrintFunc           func() error
 	PrintAliasFunc      func() error
-	PostEnvHookFunc     func() error
+	PostEnvHookFunc     func(directory ...string) error
 	GetEnvVarsFunc      func() (map[string]string, error)
 	GetAliasFunc        func() (map[string]string, error)
 	GetManagedEnvFunc   func() []string
@@ -84,9 +84,9 @@ func (m *MockEnvPrinter) GetAlias() (map[string]string, error) {
 
 // PostEnvHook simulates running any necessary commands after the environment variables have been set.
 // If a custom PostEnvHookFunc is provided, it will use that function instead.
-func (m *MockEnvPrinter) PostEnvHook() error {
+func (m *MockEnvPrinter) PostEnvHook(directory ...string) error {
 	if m.PostEnvHookFunc != nil {
-		return m.PostEnvHookFunc()
+		return m.PostEnvHookFunc(directory...)
 	}
 	// Simulate post environment setup without doing anything real
 	return nil

--- a/pkg/env/mock_env_test.go
+++ b/pkg/env/mock_env_test.go
@@ -230,7 +230,7 @@ func TestMockEnvPrinter_PostEnvHook(t *testing.T) {
 		// Given a mock environment printer with custom implementation
 		printer := NewMockEnvPrinter()
 		expectedError := fmt.Errorf("custom post env hook error")
-		printer.PostEnvHookFunc = func() error {
+		printer.PostEnvHookFunc = func(directory ...string) error {
 			return expectedError
 		}
 

--- a/pkg/env/terraform_env_test.go
+++ b/pkg/env/terraform_env_test.go
@@ -962,7 +962,7 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 		configRoot := "/mock/config/root"
 
 		// When generateBackendConfigArgs is called
-		backendConfigArgs, err := printer.generateBackendConfigArgs(projectPath, configRoot)
+		backendConfigArgs, err := printer.generateBackendConfigArgs(projectPath, configRoot, false)
 
 		// Then no error should occur and the expected arguments should be returned
 		if err != nil {
@@ -986,7 +986,7 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 		configRoot := "/mock/config/root"
 
 		// When generateBackendConfigArgs is called
-		backendConfigArgs, err := printer.generateBackendConfigArgs(projectPath, configRoot)
+		backendConfigArgs, err := printer.generateBackendConfigArgs(projectPath, configRoot, false)
 
 		// Then no error should occur and the expected arguments should be returned
 		if err != nil {
@@ -1014,7 +1014,7 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 		configRoot := "/mock/config/root"
 
 		// When generateBackendConfigArgs is called
-		backendConfigArgs, err := printer.generateBackendConfigArgs(projectPath, configRoot)
+		backendConfigArgs, err := printer.generateBackendConfigArgs(projectPath, configRoot, false)
 
 		// Then no error should occur and the expected arguments should be returned
 		if err != nil {
@@ -1043,7 +1043,7 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 		configRoot := "/mock/config/root"
 
 		// When generateBackendConfigArgs is called
-		backendConfigArgs, err := printer.generateBackendConfigArgs(projectPath, configRoot)
+		backendConfigArgs, err := printer.generateBackendConfigArgs(projectPath, configRoot, false)
 
 		// Then no error should occur and the expected arguments should be returned
 		if err != nil {
@@ -1069,7 +1069,7 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 		configRoot := "/mock/config/root"
 
 		// When generateBackendConfigArgs is called
-		backendConfigArgs, err := printer.generateBackendConfigArgs(projectPath, configRoot)
+		backendConfigArgs, err := printer.generateBackendConfigArgs(projectPath, configRoot, false)
 
 		// Then no error should occur and the expected arguments should be returned
 		if err != nil {
@@ -1102,7 +1102,7 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 		}
 
 		// When generateBackendConfigArgs is called
-		backendConfigArgs, err := printer.generateBackendConfigArgs(projectPath, configRoot)
+		backendConfigArgs, err := printer.generateBackendConfigArgs(projectPath, configRoot, false)
 
 		// Then no error should occur and backend.tfvars should be included
 		if err != nil {
@@ -1136,7 +1136,7 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 		}
 
 		// When generateBackendConfigArgs is called
-		backendConfigArgs, err := printer.generateBackendConfigArgs(projectPath, configRoot)
+		backendConfigArgs, err := printer.generateBackendConfigArgs(projectPath, configRoot, false)
 
 		// Then no error should occur and backend.tfvars should not be included
 		if err != nil {
@@ -1164,7 +1164,7 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 		configRoot := "/mock/config/root"
 
 		// When generateBackendConfigArgs is called
-		backendConfigArgs, err := printer.generateBackendConfigArgs(projectPath, configRoot)
+		backendConfigArgs, err := printer.generateBackendConfigArgs(projectPath, configRoot, false)
 
 		// Then no error should occur and the expected arguments should be returned
 		if err != nil {
@@ -1191,7 +1191,7 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 		configRoot := "/mock/config/root"
 
 		// When generateBackendConfigArgs is called
-		_, err := printer.generateBackendConfigArgs(projectPath, configRoot)
+		_, err := printer.generateBackendConfigArgs(projectPath, configRoot, false)
 
 		// Then an error should be returned
 		if err == nil {

--- a/pkg/env/terraform_env_test.go
+++ b/pkg/env/terraform_env_test.go
@@ -251,7 +251,7 @@ func TestTerraformEnv_GetEnvVars(t *testing.T) {
 		_, err := printer.GetEnvVars()
 
 		// Then appropriate error should be returned
-		expectedErrorMessage := "error checking file: mock error checking file"
+		expectedErrorMessage := "error generating terraform args: error checking file: mock error checking file"
 		if err == nil || err.Error() != expectedErrorMessage {
 			t.Errorf("Expected error %q, got %v", expectedErrorMessage, err)
 		}
@@ -512,7 +512,10 @@ func TestTerraformEnv_Print(t *testing.T) {
 			ConfigHandler: configHandler,
 		})
 		terraformEnvPrinter := NewTerraformEnvPrinter(mocks.Injector)
-		terraformEnvPrinter.Initialize()
+		terraformEnvPrinter.shims = mocks.Shims
+		if err := terraformEnvPrinter.Initialize(); err != nil {
+			t.Fatalf("Failed to initialize printer: %v", err)
+		}
 
 		// When Print is called
 		err := terraformEnvPrinter.Print()
@@ -967,7 +970,7 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 		}
 
 		expectedArgs := []string{
-			`-backend-config="path=/mock/config/root/.tfstate/project/path/terraform.tfstate"`,
+			`-backend-config=path=/mock/config/root/.tfstate/project/path/terraform.tfstate`,
 		}
 
 		if !reflect.DeepEqual(backendConfigArgs, expectedArgs) {
@@ -991,7 +994,7 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 		}
 
 		expectedArgs := []string{
-			`-backend-config="path=/mock/config/root/.tfstate/mock-prefix/project/path/terraform.tfstate"`,
+			`-backend-config=path=/mock/config/root/.tfstate/mock-prefix/project/path/terraform.tfstate`,
 		}
 
 		if !reflect.DeepEqual(backendConfigArgs, expectedArgs) {
@@ -1019,10 +1022,10 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 		}
 
 		expectedArgs := []string{
-			`-backend-config="key=mock-prefix/project/path/terraform.tfstate"`,
-			`-backend-config="bucket=mock-bucket"`,
-			`-backend-config="region=mock-region"`,
-			`-backend-config="secret_key=mock-secret-key"`,
+			`-backend-config=key=mock-prefix/project/path/terraform.tfstate`,
+			`-backend-config=bucket=mock-bucket`,
+			`-backend-config=region=mock-region`,
+			`-backend-config=secret_key=mock-secret-key`,
 		}
 
 		if !reflect.DeepEqual(backendConfigArgs, expectedArgs) {
@@ -1048,8 +1051,8 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 		}
 
 		expectedArgs := []string{
-			`-backend-config="secret_suffix=mock-prefix-project-path"`,
-			`-backend-config="namespace=mock-namespace"`,
+			`-backend-config=secret_suffix=mock-prefix-project-path`,
+			`-backend-config=namespace=mock-namespace`,
 		}
 
 		if !reflect.DeepEqual(backendConfigArgs, expectedArgs) {
@@ -1074,7 +1077,7 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 		}
 
 		expectedArgs := []string{
-			`-backend-config="path=/mock/config/root/.tfstate/mock-prefix/project/path/terraform.tfstate"`,
+			`-backend-config=path=/mock/config/root/.tfstate/mock-prefix/project/path/terraform.tfstate`,
 		}
 
 		if !reflect.DeepEqual(backendConfigArgs, expectedArgs) {
@@ -1107,8 +1110,8 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 		}
 
 		expectedArgs := []string{
-			fmt.Sprintf(`-backend-config="%s"`, filepath.ToSlash(backendTfvarsPath)),
-			`-backend-config="path=/mock/config/root/.tfstate/project/path/terraform.tfstate"`,
+			fmt.Sprintf(`-backend-config=%s`, filepath.ToSlash(backendTfvarsPath)),
+			`-backend-config=path=/mock/config/root/.tfstate/project/path/terraform.tfstate`,
 		}
 
 		if !reflect.DeepEqual(backendConfigArgs, expectedArgs) {
@@ -1141,7 +1144,7 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 		}
 
 		expectedArgs := []string{
-			`-backend-config="path=/mock/config/root/.tfstate/project/path/terraform.tfstate"`,
+			`-backend-config=path=/mock/config/root/.tfstate/project/path/terraform.tfstate`,
 		}
 
 		if !reflect.DeepEqual(backendConfigArgs, expectedArgs) {
@@ -1169,10 +1172,10 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 		}
 
 		expectedArgs := []string{
-			`-backend-config="key=mock-prefix/project/path/terraform.tfstate"`,
-			`-backend-config="container_name=mock-container"`,
-			`-backend-config="storage_account_name=mock-storage"`,
-			`-backend-config="use_azuread=true"`,
+			`-backend-config=key=mock-prefix/project/path/terraform.tfstate`,
+			`-backend-config=container_name=mock-container`,
+			`-backend-config=storage_account_name=mock-storage`,
+			`-backend-config=use_azuread=true`,
 		}
 
 		if !reflect.DeepEqual(backendConfigArgs, expectedArgs) {

--- a/pkg/pipelines/env_test.go
+++ b/pkg/pipelines/env_test.go
@@ -527,7 +527,7 @@ func TestEnvPipeline_Execute(t *testing.T) {
 
 		mockEnvPrinter := env.NewMockEnvPrinter()
 		postEnvHookCalled := false
-		mockEnvPrinter.PostEnvHookFunc = func() error {
+		mockEnvPrinter.PostEnvHookFunc = func(directory ...string) error {
 			postEnvHookCalled = true
 			return nil
 		}
@@ -597,7 +597,7 @@ func TestEnvPipeline_Execute(t *testing.T) {
 		mocks.Shell.PrintEnvVarsFunc = func(envVars map[string]string) {}
 
 		mockEnvPrinter := env.NewMockEnvPrinter()
-		mockEnvPrinter.PostEnvHookFunc = func() error {
+		mockEnvPrinter.PostEnvHookFunc = func(directory ...string) error {
 			return fmt.Errorf("post env hook error")
 		}
 		mockEnvPrinter.GetEnvVarsFunc = func() (map[string]string, error) {
@@ -631,7 +631,7 @@ func TestEnvPipeline_Execute(t *testing.T) {
 		mocks.Shell.PrintEnvVarsFunc = func(envVars map[string]string) {}
 
 		mockEnvPrinter := env.NewMockEnvPrinter()
-		mockEnvPrinter.PostEnvHookFunc = func() error {
+		mockEnvPrinter.PostEnvHookFunc = func(directory ...string) error {
 			return fmt.Errorf("post env hook error")
 		}
 		mockEnvPrinter.GetEnvVarsFunc = func() (map[string]string, error) {
@@ -765,7 +765,7 @@ func TestEnvPipeline_Execute(t *testing.T) {
 		mockEnvPrinter1.GetEnvVarsFunc = func() (map[string]string, error) {
 			return map[string]string{"VAR1": "value1"}, nil
 		}
-		mockEnvPrinter1.PostEnvHookFunc = func() error {
+		mockEnvPrinter1.PostEnvHookFunc = func(directory ...string) error {
 			return nil
 		}
 
@@ -773,7 +773,7 @@ func TestEnvPipeline_Execute(t *testing.T) {
 		mockEnvPrinter2.GetEnvVarsFunc = func() (map[string]string, error) {
 			return map[string]string{"VAR2": "value2"}, nil
 		}
-		mockEnvPrinter2.PostEnvHookFunc = func() error {
+		mockEnvPrinter2.PostEnvHookFunc = func(directory ...string) error {
 			return nil
 		}
 

--- a/pkg/pipelines/init.go
+++ b/pkg/pipelines/init.go
@@ -12,6 +12,7 @@ import (
 	"github.com/windsorcli/cli/pkg/blueprint"
 	"github.com/windsorcli/cli/pkg/config"
 	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/env"
 	"github.com/windsorcli/cli/pkg/generators"
 	"github.com/windsorcli/cli/pkg/network"
 	"github.com/windsorcli/cli/pkg/services"
@@ -99,6 +100,13 @@ func (p *InitPipeline) Initialize(injector di.Injector, ctx context.Context) err
 
 	p.blueprintHandler = p.withBlueprintHandler()
 	p.toolsManager = p.withToolsManager()
+
+	// Ensure terraform env printer is registered since the stack depends on it
+	if p.injector.Resolve("terraformEnv") == nil {
+		terraformEnv := env.NewTerraformEnvPrinter(p.injector)
+		p.injector.Register("terraformEnv", terraformEnv)
+	}
+
 	p.stack = p.withStack()
 	p.artifactBuilder = p.withArtifactBuilder()
 

--- a/pkg/stack/stack.go
+++ b/pkg/stack/stack.go
@@ -4,14 +4,13 @@ package stack
 // It provides a unified interface for initializing and managing infrastructure stacks,
 // with support for dependency injection and component lifecycle management.
 // The Stack acts as the primary orchestrator for infrastructure operations,
-// coordinating shell operations, blueprint handling, and environment configuration.
+// coordinating shell operations and blueprint handling.
 
 import (
 	"fmt"
 
 	"github.com/windsorcli/cli/pkg/blueprint"
 	"github.com/windsorcli/cli/pkg/di"
-	"github.com/windsorcli/cli/pkg/env"
 	"github.com/windsorcli/cli/pkg/shell"
 )
 
@@ -35,7 +34,6 @@ type BaseStack struct {
 	injector         di.Injector
 	blueprintHandler blueprint.BlueprintHandler
 	shell            shell.Shell
-	envPrinters      []env.EnvPrinter
 	shims            *Shims
 }
 
@@ -70,17 +68,6 @@ func (s *BaseStack) Initialize() error {
 		return fmt.Errorf("error resolving blueprintHandler")
 	}
 	s.blueprintHandler = blueprintHandler
-
-	// Resolve the envPrinters
-	envPrinterInstances, err := s.injector.ResolveAll((*env.EnvPrinter)(nil))
-	if err != nil {
-		return fmt.Errorf("error resolving envPrinters: %v", err)
-	}
-	envPrinters := make([]env.EnvPrinter, len(envPrinterInstances))
-	for i, instance := range envPrinterInstances {
-		envPrinters[i], _ = instance.(env.EnvPrinter)
-	}
-	s.envPrinters = envPrinters
 
 	return nil
 }

--- a/pkg/stack/windsor_stack_test.go
+++ b/pkg/stack/windsor_stack_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
-	"github.com/windsorcli/cli/pkg/di"
 	"github.com/windsorcli/cli/pkg/env"
 )
 
@@ -37,6 +36,13 @@ func setupWindsorStackMocks(t *testing.T, opts ...*SetupOptions) *Mocks {
 	if err := os.MkdirAll(localDir, 0755); err != nil {
 		t.Fatalf("Failed to create local directory: %v", err)
 	}
+
+	// Register and initialize terraform env printer by default
+	terraformEnv := env.NewTerraformEnvPrinter(mocks.Injector)
+	if err := terraformEnv.Initialize(); err != nil {
+		t.Fatalf("Failed to initialize terraform env printer: %v", err)
+	}
+	mocks.Injector.Register("terraformEnv", terraformEnv)
 
 	// Update shims to handle Windsor-specific paths
 	mocks.Shims.Stat = func(path string) (os.FileInfo, error) {
@@ -88,6 +94,51 @@ func TestWindsorStack_Initialize(t *testing.T) {
 			// Then no error should occur
 			t.Errorf("Expected Initialize to return nil, got %v", err)
 		}
+
+		// And the terraform env should be resolved
+		if stack.terraformEnv == nil {
+			t.Errorf("Expected terraformEnv to be resolved")
+		}
+	})
+
+	t.Run("ErrorTerraformEnvNotFound", func(t *testing.T) {
+		stack, mocks := setup(t)
+
+		// And the terraformEnv is unregistered
+		mocks.Injector.Register("terraformEnv", nil)
+
+		// When a new WindsorStack is initialized
+		err := stack.Initialize()
+
+		// Then an error should occur
+		if err == nil {
+			t.Errorf("Expected Initialize to return an error")
+		} else {
+			expectedError := "terraformEnv not found in dependency injector"
+			if !strings.Contains(err.Error(), expectedError) {
+				t.Errorf("Expected error to contain %q, got %q", expectedError, err.Error())
+			}
+		}
+	})
+
+	t.Run("ErrorResolvingTerraformEnv", func(t *testing.T) {
+		stack, mocks := setup(t)
+
+		// And a non-terraform env printer is registered with terraformEnv key
+		mocks.Injector.Register("terraformEnv", "not-a-terraform-env")
+
+		// When a new WindsorStack is initialized
+		err := stack.Initialize()
+
+		// Then an error should occur
+		if err == nil {
+			t.Errorf("Expected Initialize to return an error")
+		} else {
+			expectedError := "error resolving terraformEnv"
+			if !strings.Contains(err.Error(), expectedError) {
+				t.Errorf("Expected error to contain %q, got %q", expectedError, err.Error())
+			}
+		}
 	})
 
 	t.Run("ErrorResolvingShell", func(t *testing.T) {
@@ -119,30 +170,6 @@ func TestWindsorStack_Initialize(t *testing.T) {
 		// Then an error should occur
 		if err := stack.Initialize(); err == nil {
 			t.Errorf("Expected Initialize to return an error")
-		}
-	})
-
-	t.Run("ErrorResolvingEnvPrinters", func(t *testing.T) {
-		// Given safe mock components with a resolve all error
-		mockInjector := di.NewMockInjector()
-		mockInjector.SetResolveAllError((*env.EnvPrinter)(nil), fmt.Errorf("mock error resolving envPrinters"))
-		opts := &SetupOptions{
-			Injector: mockInjector,
-		}
-		mocks := setupWindsorStackMocks(t, opts)
-		stack := NewWindsorStack(mocks.Injector)
-
-		// When a new WindsorStack is initialized
-		err := stack.Initialize()
-
-		// Then an error should occur
-		if err == nil {
-			t.Errorf("Expected Initialize to return an error")
-		} else {
-			expectedError := "error resolving envPrinters"
-			if !strings.Contains(err.Error(), expectedError) {
-				t.Errorf("Expected error to contain %q, got %q", expectedError, err.Error())
-			}
 		}
 	})
 }
@@ -203,61 +230,14 @@ func TestWindsorStack_Up(t *testing.T) {
 		}
 	})
 
-	t.Run("ErrorChangingDirectory", func(t *testing.T) {
+	t.Run("ErrorGeneratingTerraformArgs", func(t *testing.T) {
 		stack, mocks := setup(t)
-		mocks.Shims.Chdir = func(_ string) error {
-			return fmt.Errorf("mock error changing directory")
-		}
+		mocks.ConfigHandler.SetContextValue("terraform.backend.type", "unsupported")
 
 		// And when Up is called
 		err := stack.Up()
 		// Then the expected error is contained in err
-		expectedError := "error changing to directory"
-		if !strings.Contains(err.Error(), expectedError) {
-			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
-		}
-	})
-
-	t.Run("ErrorGettingEnvVars", func(t *testing.T) {
-		stack, mocks := setup(t)
-		mocks.EnvPrinter.GetEnvVarsFunc = func() (map[string]string, error) {
-			return nil, fmt.Errorf("mock error getting environment variables")
-		}
-
-		// And when Up is called
-		err := stack.Up()
-		// Then the expected error is contained in err
-		expectedError := "error getting environment variables"
-		if !strings.Contains(err.Error(), expectedError) {
-			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
-		}
-	})
-
-	t.Run("ErrorSettingEnvVars", func(t *testing.T) {
-		stack, mocks := setup(t)
-		mocks.Shims.Setenv = func(_ string, _ string) error {
-			return fmt.Errorf("mock error setting environment variable")
-		}
-
-		// And when Up is called
-		err := stack.Up()
-		// Then the expected error is contained in err
-		expectedError := "error setting environment variable"
-		if !strings.Contains(err.Error(), expectedError) {
-			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
-		}
-	})
-
-	t.Run("ErrorRunningPostEnvHook", func(t *testing.T) {
-		stack, mocks := setup(t)
-		mocks.EnvPrinter.PostEnvHookFunc = func() error {
-			return fmt.Errorf("mock error running post environment hook")
-		}
-
-		// And when Up is called
-		err := stack.Up()
-		// Then the expected error is contained in err
-		expectedError := "error running post environment hook"
+		expectedError := "error generating terraform args"
 		if !strings.Contains(err.Error(), expectedError) {
 			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
 		}
@@ -266,7 +246,7 @@ func TestWindsorStack_Up(t *testing.T) {
 	t.Run("ErrorRunningTerraformInit", func(t *testing.T) {
 		stack, mocks := setup(t)
 		mocks.Shell.ExecProgressFunc = func(message string, command string, args ...string) (string, error) {
-			if command == "terraform" && len(args) > 0 && args[0] == "init" {
+			if command == "terraform" && len(args) > 0 && strings.HasPrefix(args[0], "-chdir=") && len(args) > 1 && args[1] == "init" {
 				return "", fmt.Errorf("mock error running terraform init")
 			}
 			return "", nil
@@ -275,7 +255,7 @@ func TestWindsorStack_Up(t *testing.T) {
 		// And when Up is called
 		err := stack.Up()
 		// Then the expected error is contained in err
-		expectedError := "error initializing Terraform"
+		expectedError := "error running terraform init for"
 		if !strings.Contains(err.Error(), expectedError) {
 			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
 		}
@@ -284,7 +264,7 @@ func TestWindsorStack_Up(t *testing.T) {
 	t.Run("ErrorRunningTerraformPlan", func(t *testing.T) {
 		stack, mocks := setup(t)
 		mocks.Shell.ExecProgressFunc = func(message string, command string, args ...string) (string, error) {
-			if command == "terraform" && len(args) > 0 && args[0] == "plan" {
+			if command == "terraform" && len(args) > 0 && strings.HasPrefix(args[0], "-chdir=") && len(args) > 1 && args[1] == "plan" {
 				return "", fmt.Errorf("mock error running terraform plan")
 			}
 			return "", nil
@@ -293,7 +273,7 @@ func TestWindsorStack_Up(t *testing.T) {
 		// And when Up is called
 		err := stack.Up()
 		// Then the expected error is contained in err
-		expectedError := "error planning Terraform changes"
+		expectedError := "error running terraform plan for"
 		if !strings.Contains(err.Error(), expectedError) {
 			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
 		}
@@ -302,7 +282,7 @@ func TestWindsorStack_Up(t *testing.T) {
 	t.Run("ErrorRunningTerraformApply", func(t *testing.T) {
 		stack, mocks := setup(t)
 		mocks.Shell.ExecProgressFunc = func(message string, command string, args ...string) (string, error) {
-			if command == "terraform" && len(args) > 0 && args[0] == "apply" {
+			if command == "terraform" && len(args) > 0 && strings.HasPrefix(args[0], "-chdir=") && len(args) > 1 && args[1] == "apply" {
 				return "", fmt.Errorf("mock error running terraform apply")
 			}
 			return "", nil
@@ -311,22 +291,7 @@ func TestWindsorStack_Up(t *testing.T) {
 		// And when Up is called
 		err := stack.Up()
 		// Then the expected error is contained in err
-		expectedError := "error applying Terraform changes"
-		if !strings.Contains(err.Error(), expectedError) {
-			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
-		}
-	})
-
-	t.Run("ErrorRemovingBackendOverride", func(t *testing.T) {
-		stack, mocks := setup(t)
-		mocks.Shims.Remove = func(_ string) error {
-			return fmt.Errorf("mock error removing backend override")
-		}
-
-		// And when Up is called
-		err := stack.Up()
-		// Then the expected error is contained in err
-		expectedError := "error removing backend_override.tf"
+		expectedError := "error running terraform apply for"
 		if !strings.Contains(err.Error(), expectedError) {
 			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
 		}
@@ -390,82 +355,30 @@ func TestWindsorStack_Down(t *testing.T) {
 
 		// And when Down is called
 		err := stack.Down()
-		if err == nil {
-			t.Fatalf("Expected an error, but got nil")
-		}
-
-		// Then the expected error is contained in err
-		expectedError := "directory"
-		if !strings.Contains(err.Error(), expectedError) {
-			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
+		// Then no error should occur since Down continues when directory doesn't exist
+		if err != nil {
+			t.Fatalf("Expected no error when directory doesn't exist, got %v", err)
 		}
 	})
 
-	t.Run("ErrorChangingDirectory", func(t *testing.T) {
+	t.Run("ErrorGeneratingTerraformArgs", func(t *testing.T) {
 		stack, mocks := setup(t)
-		mocks.Shims.Chdir = func(_ string) error {
-			return fmt.Errorf("mock error changing directory")
-		}
+		mocks.ConfigHandler.SetContextValue("terraform.backend.type", "unsupported")
 
 		// And when Down is called
 		err := stack.Down()
 		// Then the expected error is contained in err
-		expectedError := "error changing to directory"
+		expectedError := "error generating terraform args"
 		if !strings.Contains(err.Error(), expectedError) {
 			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
 		}
 	})
 
-	t.Run("ErrorGettingEnvVars", func(t *testing.T) {
-		stack, mocks := setup(t)
-		mocks.EnvPrinter.GetEnvVarsFunc = func() (map[string]string, error) {
-			return nil, fmt.Errorf("mock error getting environment variables")
-		}
-
-		// And when Down is called
-		err := stack.Down()
-		// Then the expected error is contained in err
-		expectedError := "error getting environment variables"
-		if !strings.Contains(err.Error(), expectedError) {
-			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
-		}
-	})
-
-	t.Run("ErrorSettingEnvVars", func(t *testing.T) {
-		stack, mocks := setup(t)
-		mocks.Shims.Setenv = func(_ string, _ string) error {
-			return fmt.Errorf("mock error setting environment variable")
-		}
-
-		// And when Down is called
-		err := stack.Down()
-		// Then the expected error is contained in err
-		expectedError := "error setting environment variable"
-		if !strings.Contains(err.Error(), expectedError) {
-			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
-		}
-	})
-
-	t.Run("ErrorRunningPostEnvHook", func(t *testing.T) {
-		stack, mocks := setup(t)
-		mocks.EnvPrinter.PostEnvHookFunc = func() error {
-			return fmt.Errorf("mock error running post environment hook")
-		}
-
-		// And when Down is called
-		err := stack.Down()
-		// Then the expected error is contained in err
-		expectedError := "error running post environment hook"
-		if !strings.Contains(err.Error(), expectedError) {
-			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
-		}
-	})
-
-	t.Run("ErrorRunningTerraformInit", func(t *testing.T) {
+	t.Run("ErrorRunningTerraformPlan", func(t *testing.T) {
 		stack, mocks := setup(t)
 		mocks.Shell.ExecProgressFunc = func(message string, command string, args ...string) (string, error) {
-			if command == "terraform" && len(args) > 0 && args[0] == "init" {
-				return "", fmt.Errorf("mock error running terraform init")
+			if command == "terraform" && len(args) > 0 && strings.HasPrefix(args[0], "-chdir=") && len(args) > 1 && args[1] == "plan" {
+				return "", fmt.Errorf("mock error running terraform plan")
 			}
 			return "", nil
 		}
@@ -473,25 +386,7 @@ func TestWindsorStack_Down(t *testing.T) {
 		// And when Down is called
 		err := stack.Down()
 		// Then the expected error is contained in err
-		expectedError := "error initializing Terraform"
-		if !strings.Contains(err.Error(), expectedError) {
-			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
-		}
-	})
-
-	t.Run("ErrorRunningTerraformPlanDestroy", func(t *testing.T) {
-		stack, mocks := setup(t)
-		mocks.Shell.ExecProgressFunc = func(message string, command string, args ...string) (string, error) {
-			if command == "terraform" && len(args) > 0 && args[0] == "plan" && len(args) > 1 && args[1] == "-destroy" {
-				return "", fmt.Errorf("mock error running terraform plan -destroy")
-			}
-			return "", nil
-		}
-
-		// And when Down is called
-		err := stack.Down()
-		// Then the expected error is contained in err
-		expectedError := "error planning Terraform destruction"
+		expectedError := "error running terraform plan destroy for"
 		if !strings.Contains(err.Error(), expectedError) {
 			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
 		}
@@ -500,7 +395,7 @@ func TestWindsorStack_Down(t *testing.T) {
 	t.Run("ErrorRunningTerraformDestroy", func(t *testing.T) {
 		stack, mocks := setup(t)
 		mocks.Shell.ExecProgressFunc = func(message string, command string, args ...string) (string, error) {
-			if command == "terraform" && len(args) > 0 && args[0] == "destroy" {
+			if command == "terraform" && len(args) > 0 && strings.HasPrefix(args[0], "-chdir=") && len(args) > 1 && args[1] == "destroy" {
 				return "", fmt.Errorf("mock error running terraform destroy")
 			}
 			return "", nil
@@ -509,50 +404,9 @@ func TestWindsorStack_Down(t *testing.T) {
 		// And when Down is called
 		err := stack.Down()
 		// Then the expected error is contained in err
-		expectedError := "error destroying Terraform resources"
+		expectedError := "error running terraform destroy for"
 		if !strings.Contains(err.Error(), expectedError) {
 			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
 		}
 	})
-
-	t.Run("ErrorRemovingBackendOverride", func(t *testing.T) {
-		stack, mocks := setup(t)
-		mocks.Shims.Remove = func(_ string) error {
-			return fmt.Errorf("mock error removing backend override")
-		}
-
-		// And when Down is called
-		err := stack.Down()
-		// Then the expected error is contained in err
-		expectedError := "error removing backend_override.tf"
-		if !strings.Contains(err.Error(), expectedError) {
-			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
-		}
-	})
-
-	t.Run("SkipComponentWithDestroyFalse", func(t *testing.T) {
-		stack, mocks := setup(t)
-		mocks.Blueprint.GetTerraformComponentsFunc = func() []blueprintv1alpha1.TerraformComponent {
-			return []blueprintv1alpha1.TerraformComponent{
-				{
-					Source:   "source1",
-					Path:     "module/path1",
-					FullPath: filepath.Join(os.Getenv("WINDSOR_PROJECT_ROOT"), ".windsor", ".tf_modules", "remote", "path"),
-					Destroy:  ptrBool(false),
-				},
-			}
-		}
-
-		// And when Down is called
-		err := stack.Down()
-		// Then no error should occur
-		if err != nil {
-			t.Errorf("Expected Down to return nil, got %v", err)
-		}
-	})
-}
-
-// Helper functions to create pointers for basic types
-func ptrBool(b bool) *bool {
-	return &b
 }


### PR DESCRIPTION
More explicitly injects intended variables in to the terraform commands during a `windsor up` operation. Also uses `-chdir`.