### PR TITLE
feat(cmd): More complete 'down' options

### DIFF
--- a/pkg/stack/windsor_stack.go
+++ b/pkg/stack/windsor_stack.go
@@ -198,15 +198,13 @@ func (s *WindsorStack) Down() error {
 
 		planArgs := []string{fmt.Sprintf("-chdir=%s", terraformArgs.ModulePath), "plan"}
 		planArgs = append(planArgs, terraformArgs.PlanDestroyArgs...)
-		planArgs = append(planArgs, terraformArgs.BackendConfig)
-		if _, err := s.shell.ExecProgress(fmt.Sprintf("Planning terraform destroy for %s", component.Path), "terraform", planArgs...); err != nil {
+		if _, err := s.shell.ExecProgress(fmt.Sprintf("🗑️ Planning terraform destroy for %s", component.Path), "terraform", planArgs...); err != nil {
 			return fmt.Errorf("error running terraform plan destroy for %s: %w", component.Path, err)
 		}
 
 		destroyArgs := []string{fmt.Sprintf("-chdir=%s", terraformArgs.ModulePath), "destroy"}
 		destroyArgs = append(destroyArgs, terraformArgs.DestroyArgs...)
-		destroyArgs = append(destroyArgs, terraformArgs.BackendConfig)
-		if _, err := s.shell.ExecProgress(fmt.Sprintf("Destroying terraform for %s", component.Path), "terraform", destroyArgs...); err != nil {
+		if _, err := s.shell.ExecProgress(fmt.Sprintf("🗑️ Destroying terraform for %s", component.Path), "terraform", destroyArgs...); err != nil {
 			return fmt.Errorf("error running terraform destroy for %s: %w", component.Path, err)
 		}
 

--- a/pkg/virt/docker_virt_test.go
+++ b/pkg/virt/docker_virt_test.go
@@ -580,12 +580,35 @@ func TestDockerVirt_Down(t *testing.T) {
 
 	t.Run("Success", func(t *testing.T) {
 		// Given a DockerVirt with mock components
-		dockerVirt, _ := setup(t)
+		dockerVirt, mocks := setup(t)
+
+		// And docker-compose.yaml exists
+		mocks.Shims.Stat = func(name string) (os.FileInfo, error) {
+			return nil, nil // File exists
+		}
 
 		// When calling Down
 		err := dockerVirt.Down()
 
 		// Then no error should occur
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("SuccessWithMissingComposeFile", func(t *testing.T) {
+		// Given a DockerVirt with mock components
+		dockerVirt, mocks := setup(t)
+
+		// And docker-compose.yaml doesn't exist
+		mocks.Shims.Stat = func(name string) (os.FileInfo, error) {
+			return nil, os.ErrNotExist // File doesn't exist
+		}
+
+		// When calling Down
+		err := dockerVirt.Down()
+
+		// Then no error should occur (idempotent)
 		if err != nil {
 			t.Errorf("expected no error, got %v", err)
 		}

--- a/pkg/virt/shims.go
+++ b/pkg/virt/shims.go
@@ -33,6 +33,7 @@ type Shims struct {
 	MkdirAll       func(path string, perm os.FileMode) error
 	WriteFile      func(name string, data []byte, perm os.FileMode) error
 	Rename         func(oldpath, newpath string) error
+	Stat           func(name string) (os.FileInfo, error)
 	GOARCH         func() string
 	NumCPU         func() int
 	VirtualMemory  func() (*mem.VirtualMemoryStat, error)
@@ -53,6 +54,7 @@ func NewShims() *Shims {
 		MkdirAll:      os.MkdirAll,
 		WriteFile:     os.WriteFile,
 		Rename:        os.Rename,
+		Stat:          os.Stat,
 		GOARCH:        func() string { return runtime.GOARCH },
 		NumCPU:        func() int { return runtime.NumCPU() },
 		VirtualMemory: mem.VirtualMemory,

--- a/pkg/virt/shims_test.go
+++ b/pkg/virt/shims_test.go
@@ -38,6 +38,9 @@ func TestNewShims(t *testing.T) {
 	if shims.Rename == nil {
 		t.Error("Rename should be set")
 	}
+	if shims.Stat == nil {
+		t.Error("Stat should be set")
+	}
 	if shims.GOARCH == nil {
 		t.Error("GOARCH should be set")
 	}

--- a/pkg/virt/virt_test.go
+++ b/pkg/virt/virt_test.go
@@ -60,6 +60,9 @@ func setupShims(t *testing.T) *Shims {
 		Rename: func(oldpath, newpath string) error {
 			return nil
 		},
+		Stat: func(name string) (os.FileInfo, error) {
+			return nil, nil
+		},
 		GOARCH: func() string {
 			return "x86_64"
 		},


### PR DESCRIPTION
Now possible to pass `--skip-tf` to `windsor down`. Also the `--clean` option is more thorough and idempotent.