### PR TITLE
fix(env): Update Terraform CLI args to include -force-copy option for init command

### DIFF
--- a/pkg/env/terraform_env.go
+++ b/pkg/env/terraform_env.go
@@ -153,7 +153,7 @@ func (e *TerraformEnvPrinter) GenerateTerraformArgs(projectPath, modulePath stri
 		return nil, fmt.Errorf("error generating backend config args for env: %w", err)
 	}
 
-	initArgs := []string{"-backend=true"}
+	initArgs := []string{"-backend=true", "-force-copy"}
 	initArgs = append(initArgs, backendConfigArgs...)
 
 	planArgs := []string{fmt.Sprintf("-out=%s", tfPlanPath)}
@@ -172,7 +172,7 @@ func (e *TerraformEnvPrinter) GenerateTerraformArgs(projectPath, modulePath stri
 
 	terraformVars := make(map[string]string)
 	terraformVars["TF_DATA_DIR"] = strings.TrimSpace(tfDataDir)
-	terraformVars["TF_CLI_ARGS_init"] = strings.TrimSpace(fmt.Sprintf("-backend=true %s", strings.Join(backendConfigArgsForEnv, " ")))
+	terraformVars["TF_CLI_ARGS_init"] = strings.TrimSpace(fmt.Sprintf("-backend=true -force-copy %s", strings.Join(backendConfigArgsForEnv, " ")))
 	terraformVars["TF_CLI_ARGS_plan"] = strings.TrimSpace(fmt.Sprintf("-out=\"%s\" %s", tfPlanPath, strings.Join(varFileArgsForEnv, " ")))
 	terraformVars["TF_CLI_ARGS_apply"] = strings.TrimSpace(fmt.Sprintf("\"%s\"", tfPlanPath))
 	terraformVars["TF_CLI_ARGS_refresh"] = strings.TrimSpace(strings.Join(varFileArgsForEnv, " "))

--- a/pkg/env/terraform_env_test.go
+++ b/pkg/env/terraform_env_test.go
@@ -93,7 +93,7 @@ func TestTerraformEnv_GetEnvVars(t *testing.T) {
 
 		expectedEnvVars := map[string]string{
 			"TF_DATA_DIR":      filepath.ToSlash(filepath.Join(configRoot, ".terraform/project/path")),
-			"TF_CLI_ARGS_init": fmt.Sprintf(`-backend=true -backend-config="path=%s"`, filepath.ToSlash(filepath.Join(configRoot, ".tfstate/project/path/terraform.tfstate"))),
+			"TF_CLI_ARGS_init": fmt.Sprintf(`-backend=true -force-copy -backend-config="path=%s"`, filepath.ToSlash(filepath.Join(configRoot, ".tfstate/project/path/terraform.tfstate"))),
 			"TF_CLI_ARGS_plan": fmt.Sprintf(`-out="%s" -var-file="%s" -var-file="%s"`,
 				filepath.ToSlash(filepath.Join(configRoot, ".terraform/project/path/terraform.tfplan")),
 				filepath.ToSlash(filepath.Join(configRoot, "terraform/project/path.tfvars")),
@@ -310,7 +310,7 @@ func TestTerraformEnv_GetEnvVars(t *testing.T) {
 		// And environment variables should be set correctly
 		expectedEnvVars := map[string]string{
 			"TF_DATA_DIR":      filepath.ToSlash(filepath.Join(configRoot, ".terraform/project/path")),
-			"TF_CLI_ARGS_init": fmt.Sprintf(`-backend=true -backend-config="path=%s"`, filepath.ToSlash(filepath.Join(configRoot, ".tfstate/project/path/terraform.tfstate"))),
+			"TF_CLI_ARGS_init": fmt.Sprintf(`-backend=true -force-copy -backend-config="path=%s"`, filepath.ToSlash(filepath.Join(configRoot, ".tfstate/project/path/terraform.tfstate"))),
 			"TF_CLI_ARGS_plan": fmt.Sprintf(`-out="%s" -var-file="%s" -var-file="%s"`,
 				filepath.ToSlash(filepath.Join(configRoot, ".terraform/project/path/terraform.tfplan")),
 				filepath.ToSlash(filepath.Join(configRoot, "terraform/project/path.tfvars")),
@@ -473,7 +473,7 @@ func TestTerraformEnv_Print(t *testing.T) {
 
 		expectedEnvVars := map[string]string{
 			"TF_DATA_DIR":      filepath.Join(configRoot, ".terraform/project/path"),
-			"TF_CLI_ARGS_init": fmt.Sprintf(`-backend=true -backend-config="path=%s"`, filepath.Join(configRoot, ".tfstate/project/path/terraform.tfstate")),
+			"TF_CLI_ARGS_init": fmt.Sprintf(`-backend=true -force-copy -backend-config="path=%s"`, filepath.Join(configRoot, ".tfstate/project/path/terraform.tfstate")),
 			"TF_CLI_ARGS_plan": fmt.Sprintf(`-out="%s" -var-file="%s" -var-file="%s"`,
 				filepath.Join(configRoot, ".terraform/project/path/terraform.tfplan"),
 				filepath.Join(configRoot, "terraform/project/path.tfvars"),


### PR DESCRIPTION
Forces a state migration. We may dynamically reconfigure backends, or their reconfiguration happens at a higher level of coordination via a `windsor.yaml` configuration value.