### PR TITLE
refactor(pipeline): Migrate install command to use pipeline structure

### DIFF
--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -1,48 +1,100 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
+	"strings"
 	"testing"
 
-	blueprintpkg "github.com/windsorcli/cli/pkg/blueprint"
-	"github.com/windsorcli/cli/pkg/controller"
-	"github.com/windsorcli/cli/pkg/secrets"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/pipelines"
 )
 
-// setupInstallMocks creates mock components specifically for testing the install command
-func setupInstallMocks(t *testing.T, opts *SetupOptions) *Mocks {
-	t.Helper()
+// =============================================================================
+// Test Setup
+// =============================================================================
 
-	// Use the existing setupMocks function as a base
-	mocks := setupMocks(t, opts)
-
-	// Set up mock controller functions specific to install command
-	mocks.Controller.InitializeWithRequirementsFunc = func(req controller.Requirements) error {
-		return nil
-	}
-	mocks.Controller.ResolveAllSecretsProvidersFunc = func() []secrets.SecretsProvider {
-		return []secrets.SecretsProvider{}
-	}
-	mocks.Controller.SetEnvironmentVariablesFunc = func() error {
-		return nil
-	}
-	mocks.Controller.ResolveBlueprintHandlerFunc = func() blueprintpkg.BlueprintHandler {
-		return mocks.BlueprintHandler
-	}
-
-	return mocks
+type InstallMocks struct {
+	*Mocks
 }
 
+func setupInstallTest(t *testing.T, opts ...*SetupOptions) *InstallMocks {
+	t.Helper()
+
+	// Setup base mocks
+	baseMocks := setupMocks(t, opts...)
+
+	// Register mock env pipeline in injector (needed since install runs env pipeline first)
+	mockEnvPipeline := pipelines.NewMockBasePipeline()
+	mockEnvPipeline.InitializeFunc = func(injector di.Injector, ctx context.Context) error { return nil }
+	mockEnvPipeline.ExecuteFunc = func(ctx context.Context) error { return nil }
+	baseMocks.Injector.Register("envPipeline", mockEnvPipeline)
+
+	// Register mock install pipeline in injector
+	mockInstallPipeline := pipelines.NewMockBasePipeline()
+	mockInstallPipeline.InitializeFunc = func(injector di.Injector, ctx context.Context) error { return nil }
+	mockInstallPipeline.ExecuteFunc = func(ctx context.Context) error { return nil }
+	baseMocks.Injector.Register("installPipeline", mockInstallPipeline)
+
+	return &InstallMocks{
+		Mocks: baseMocks,
+	}
+}
+
+// =============================================================================
+// Test Cases
+// =============================================================================
+
 func TestInstallCmd(t *testing.T) {
+	createTestInstallCmd := func() *cobra.Command {
+		// Create a new command with the same RunE as installCmd
+		cmd := &cobra.Command{
+			Use:   "install",
+			Short: "Install the blueprint's cluster-level services",
+			RunE:  installCmd.RunE,
+		}
+
+		// Copy all flags from installCmd to ensure they're available
+		installCmd.Flags().VisitAll(func(flag *pflag.Flag) {
+			cmd.Flags().AddFlag(flag)
+		})
+
+		// Disable help text printing
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
+
+		return cmd
+	}
+
 	t.Run("Success", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks := setupInstallMocks(t, nil)
+		// Given a temporary directory with mocked dependencies
+		mocks := setupInstallTest(t)
 
-		// Set up command arguments
-		rootCmd.SetArgs([]string{"install"})
+		// When executing the install command
+		cmd := createTestInstallCmd()
+		ctx := context.WithValue(context.Background(), injectorKey, mocks.Injector)
+		cmd.SetArgs([]string{})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
 
-		// When executing the command
-		err := Execute(mocks.Controller)
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("Expected success, got error: %v", err)
+		}
+	})
+
+	t.Run("SuccessWithWaitFlag", func(t *testing.T) {
+		// Given a temporary directory with mocked dependencies
+		mocks := setupInstallTest(t)
+
+		// When executing the install command with wait flag
+		cmd := createTestInstallCmd()
+		ctx := context.WithValue(context.Background(), injectorKey, mocks.Injector)
+		cmd.SetArgs([]string{"--wait"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
 
 		// Then no error should occur
 		if err != nil {
@@ -50,176 +102,77 @@ func TestInstallCmd(t *testing.T) {
 		}
 	})
 
-	t.Run("InitializeWithRequirementsError", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks := setupInstallMocks(t, nil)
+	t.Run("SuccessWithVerboseContext", func(t *testing.T) {
+		// Given a temporary directory with mocked dependencies
+		mocks := setupInstallTest(t)
 
-		// Override controller to return error for InitializeWithRequirements
-		mocks.Controller.InitializeWithRequirementsFunc = func(req controller.Requirements) error {
-			return fmt.Errorf("initialize error")
-		}
-
-		// Set up command arguments
-		rootCmd.SetArgs([]string{"install"})
-
-		// When executing the command
-		err := Execute(mocks.Controller)
-
-		// Then error should occur
-		if err == nil {
-			t.Error("Expected error, got nil")
-		}
-
-		// And error should contain initialize error message
-		expectedError := "Error initializing: initialize error"
-		if err.Error() != expectedError {
-			t.Errorf("Expected error %q, got %q", expectedError, err.Error())
-		}
-	})
-
-	t.Run("LoadSecretsError", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks := setupInstallMocks(t, nil)
-
-		// Create a mock secrets provider that returns an error
-		mockSecretsProvider := secrets.NewMockSecretsProvider(mocks.Controller.ResolveInjector())
-		mockSecretsProvider.LoadSecretsFunc = func() error {
-			return fmt.Errorf("load secrets error")
-		}
-
-		// Override controller to return the mock secrets provider
-		mocks.Controller.ResolveAllSecretsProvidersFunc = func() []secrets.SecretsProvider {
-			return []secrets.SecretsProvider{mockSecretsProvider}
-		}
-
-		// Set up command arguments
-		rootCmd.SetArgs([]string{"install"})
-
-		// When executing the command
-		err := Execute(mocks.Controller)
-
-		// Then error should occur
-		if err == nil {
-			t.Error("Expected error, got nil")
-		}
-
-		// And error should contain load secrets error message
-		expectedError := "Error loading secrets: load secrets error"
-		if err.Error() != expectedError {
-			t.Errorf("Expected error %q, got %q", expectedError, err.Error())
-		}
-	})
-
-	t.Run("SetEnvironmentVariablesError", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks := setupInstallMocks(t, nil)
-
-		// Override controller to return error for SetEnvironmentVariables
-		mocks.Controller.SetEnvironmentVariablesFunc = func() error {
-			return fmt.Errorf("set env vars error")
-		}
-
-		// Set up command arguments
-		rootCmd.SetArgs([]string{"install"})
-
-		// When executing the command
-		err := Execute(mocks.Controller)
-
-		// Then error should occur
-		if err == nil {
-			t.Error("Expected error, got nil")
-		}
-
-		// And error should contain set env vars error message
-		expectedError := "Error setting environment variables: set env vars error"
-		if err.Error() != expectedError {
-			t.Errorf("Expected error %q, got %q", expectedError, err.Error())
-		}
-	})
-
-	t.Run("NoBlueprintHandler", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks := setupInstallMocks(t, nil)
-
-		// Override controller to return nil for ResolveBlueprintHandler
-		mocks.Controller.ResolveBlueprintHandlerFunc = func() blueprintpkg.BlueprintHandler {
-			return nil
-		}
-
-		// Set up command arguments
-		rootCmd.SetArgs([]string{"install"})
-
-		// When executing the command
-		err := Execute(mocks.Controller)
-
-		// Then error should occur
-		if err == nil {
-			t.Error("Expected error, got nil")
-		}
-
-		// And error should contain no blueprint handler message
-		expectedError := "No blueprint handler found"
-		if err.Error() != expectedError {
-			t.Errorf("Expected error %q, got %q", expectedError, err.Error())
-		}
-	})
-
-	t.Run("InstallError", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks := setupInstallMocks(t, nil)
-
-		// Override blueprint handler to return error for Install
-		mocks.BlueprintHandler.InstallFunc = func() error {
-			return fmt.Errorf("install error")
-		}
-
-		// Set up command arguments
-		rootCmd.SetArgs([]string{"install"})
-
-		// When executing the command
-		err := Execute(mocks.Controller)
-
-		// Then error should occur
-		if err == nil {
-			t.Error("Expected error, got nil")
-		}
-
-		// And error should contain install error message
-		expectedError := "Error installing blueprint: install error"
-		if err.Error() != expectedError {
-			t.Errorf("Expected error %q, got %q", expectedError, err.Error())
-		}
-	})
-
-	t.Run("WaitFlag_CallsWaitForKustomizations", func(t *testing.T) {
-		// Given a set of mocks with proper configuration
-		mocks := setupInstallMocks(t, nil)
-
-		// Set waitFlag = true
-		waitFlag = true
-		defer func() { waitFlag = false }()
-
-		// Set up a flag to check if WaitForKustomizations is called
-		called := false
-		mocks.BlueprintHandler.WaitForKustomizationsFunc = func(message string, names ...string) error {
-			called = true
-			return nil
-		}
-
-		// Set up command arguments
-		rootCmd.SetArgs([]string{"install"})
-
-		// When executing the command
-		err := Execute(mocks.Controller)
+		// When executing the install command with verbose context
+		cmd := createTestInstallCmd()
+		ctx := context.WithValue(context.Background(), injectorKey, mocks.Injector)
+		ctx = context.WithValue(ctx, "verbose", true)
+		cmd.SetArgs([]string{})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
 
 		// Then no error should occur
 		if err != nil {
 			t.Errorf("Expected success, got error: %v", err)
 		}
+	})
 
-		// And WaitForKustomizations should have been called
-		if !called {
-			t.Error("Expected WaitForKustomizations to be called, but it was not")
+	t.Run("ReturnsErrorWhenEnvPipelineSetupFails", func(t *testing.T) {
+		// Given a temporary directory with mocked dependencies
+		mocks := setupInstallTest(t)
+
+		// Override env pipeline to return error during execution
+		mockEnvPipeline := pipelines.NewMockBasePipeline()
+		mockEnvPipeline.InitializeFunc = func(injector di.Injector, ctx context.Context) error { return nil }
+		mockEnvPipeline.ExecuteFunc = func(ctx context.Context) error {
+			return fmt.Errorf("env pipeline execution failed")
+		}
+		mocks.Injector.Register("envPipeline", mockEnvPipeline)
+
+		// When executing the install command
+		cmd := createTestInstallCmd()
+		ctx := context.WithValue(context.Background(), injectorKey, mocks.Injector)
+		cmd.SetArgs([]string{})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to set up environment") {
+			t.Errorf("Expected env pipeline setup error, got %q", err.Error())
+		}
+	})
+
+	t.Run("ReturnsErrorWhenInstallPipelineSetupFails", func(t *testing.T) {
+		// Given a temporary directory with mocked dependencies
+		mocks := setupInstallTest(t)
+
+		// Override install pipeline to return error during execution
+		mockInstallPipeline := pipelines.NewMockBasePipeline()
+		mockInstallPipeline.InitializeFunc = func(injector di.Injector, ctx context.Context) error { return nil }
+		mockInstallPipeline.ExecuteFunc = func(ctx context.Context) error {
+			return fmt.Errorf("install pipeline execution failed")
+		}
+		mocks.Injector.Register("installPipeline", mockInstallPipeline)
+
+		// When executing the install command
+		cmd := createTestInstallCmd()
+		ctx := context.WithValue(context.Background(), injectorKey, mocks.Injector)
+		cmd.SetArgs([]string{})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "Error executing install pipeline") {
+			t.Errorf("Expected install pipeline execution error, got %q", err.Error())
 		}
 	})
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -49,18 +49,28 @@ var upCmd = &cobra.Command{
 			return fmt.Errorf("failed to set up up pipeline: %w", err)
 		}
 
-		// Create execution context with flags
-		ctx := cmd.Context()
-		if installFlag {
-			ctx = context.WithValue(ctx, "install", true)
-		}
-		if waitFlag {
-			ctx = context.WithValue(ctx, "wait", true)
+		// Execute the up pipeline
+		if err := upPipeline.Execute(cmd.Context()); err != nil {
+			return fmt.Errorf("Error executing up pipeline: %w", err)
 		}
 
-		// Execute the up pipeline
-		if err := upPipeline.Execute(ctx); err != nil {
-			return fmt.Errorf("Error executing up pipeline: %w", err)
+		// If install flag is set, run the install pipeline
+		if installFlag {
+			installPipeline, err := pipelines.WithPipeline(injector, cmd.Context(), "installPipeline")
+			if err != nil {
+				return fmt.Errorf("failed to set up install pipeline: %w", err)
+			}
+
+			// Create execution context with wait flag
+			installCtx := cmd.Context()
+			if waitFlag {
+				installCtx = context.WithValue(installCtx, "wait", true)
+			}
+
+			// Execute the install pipeline
+			if err := installPipeline.Execute(installCtx); err != nil {
+				return fmt.Errorf("Error executing install pipeline: %w", err)
+			}
 		}
 
 		return nil

--- a/pkg/pipelines/install.go
+++ b/pkg/pipelines/install.go
@@ -1,0 +1,101 @@
+package pipelines
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/windsorcli/cli/pkg/blueprint"
+	"github.com/windsorcli/cli/pkg/di"
+)
+
+// The InstallPipeline is a specialized component that manages blueprint installation functionality.
+// It provides install-specific command execution for blueprint installation with optional waiting
+// for kustomizations to be ready. The InstallPipeline assumes that the env pipeline has already
+// been executed to handle environment variables and secrets setup.
+
+// =============================================================================
+// Types
+// =============================================================================
+
+// InstallPipeline provides blueprint installation functionality
+type InstallPipeline struct {
+	BasePipeline
+	blueprintHandler blueprint.BlueprintHandler
+}
+
+// =============================================================================
+// Constructor
+// =============================================================================
+
+// NewInstallPipeline creates a new InstallPipeline instance
+func NewInstallPipeline() *InstallPipeline {
+	return &InstallPipeline{
+		BasePipeline: *NewBasePipeline(),
+	}
+}
+
+// =============================================================================
+// Public Methods
+// =============================================================================
+
+// Initialize sets up the install pipeline components including blueprint handler.
+// It only initializes the components needed for blueprint installation functionality
+// since environment setup is handled by the env pipeline.
+func (p *InstallPipeline) Initialize(injector di.Injector, ctx context.Context) error {
+	if err := p.BasePipeline.Initialize(injector, ctx); err != nil {
+		return err
+	}
+
+	// Set up kubernetes manager and client (required by blueprint handler)
+	kubernetesManager := p.withKubernetesManager()
+	_ = p.withKubernetesClient()
+
+	// Set up blueprint handler
+	p.blueprintHandler = p.withBlueprintHandler()
+
+	// Initialize kubernetes manager before blueprint handler
+	if kubernetesManager != nil {
+		if err := kubernetesManager.Initialize(); err != nil {
+			return fmt.Errorf("failed to initialize kubernetes manager: %w", err)
+		}
+	}
+
+	// Initialize blueprint handler
+	if p.blueprintHandler != nil {
+		if err := p.blueprintHandler.Initialize(); err != nil {
+			return fmt.Errorf("failed to initialize blueprint handler: %w", err)
+		}
+	}
+
+	return nil
+}
+
+// Execute runs the blueprint installation process for the InstallPipeline.
+// It installs the blueprint using the configured blueprint handler and, if the "wait" flag
+// is set in the context, waits for kustomizations to become ready. Returns an error if
+// configuration is not loaded, the blueprint handler is missing, installation fails, or
+// waiting for kustomizations fails.
+func (p *InstallPipeline) Execute(ctx context.Context) error {
+	if !p.configHandler.IsLoaded() {
+		return fmt.Errorf("Nothing to install. Have you run \033[1mwindsor init\033[0m?")
+	}
+
+	if p.blueprintHandler == nil {
+		return fmt.Errorf("No blueprint handler found")
+	}
+
+	if err := p.blueprintHandler.Install(); err != nil {
+		return fmt.Errorf("Error installing blueprint: %w", err)
+	}
+
+	waitFlag := ctx.Value("wait")
+	if waitFlag != nil {
+		if wait, ok := waitFlag.(bool); ok && wait {
+			if err := p.blueprintHandler.WaitForKustomizations("⏳ Waiting for kustomizations to be ready"); err != nil {
+				return fmt.Errorf("failed waiting for kustomizations: %w", err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/pkg/pipelines/install_test.go
+++ b/pkg/pipelines/install_test.go
@@ -1,0 +1,279 @@
+package pipelines
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/windsorcli/cli/pkg/blueprint"
+	"github.com/windsorcli/cli/pkg/config"
+)
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+type InstallMocks struct {
+	*Mocks
+	BlueprintHandler *blueprint.MockBlueprintHandler
+}
+
+func setupInstallMocks(t *testing.T, opts ...*SetupOptions) *InstallMocks {
+	t.Helper()
+
+	// Create setup options, preserving any provided options
+	setupOptions := &SetupOptions{}
+	if len(opts) > 0 && opts[0] != nil {
+		setupOptions = opts[0]
+	}
+
+	baseMocks := setupMocks(t, setupOptions)
+
+	// Setup blueprint handler mock
+	mockBlueprintHandler := blueprint.NewMockBlueprintHandler(baseMocks.Injector)
+	mockBlueprintHandler.InitializeFunc = func() error { return nil }
+	mockBlueprintHandler.InstallFunc = func() error { return nil }
+	mockBlueprintHandler.WaitForKustomizationsFunc = func(message string, names ...string) error { return nil }
+	baseMocks.Injector.Register("blueprintHandler", mockBlueprintHandler)
+
+	return &InstallMocks{
+		Mocks:            baseMocks,
+		BlueprintHandler: mockBlueprintHandler,
+	}
+}
+
+// =============================================================================
+// Test Constructor
+// =============================================================================
+
+func TestNewInstallPipeline(t *testing.T) {
+	t.Run("CreatesNewInstallPipeline", func(t *testing.T) {
+		// When creating a new InstallPipeline
+		pipeline := NewInstallPipeline()
+
+		// Then it should not be nil
+		if pipeline == nil {
+			t.Error("Expected pipeline to not be nil")
+		}
+
+		// And it should be of the correct type
+		if pipeline == nil {
+			t.Error("Expected pipeline to be of type *InstallPipeline")
+		}
+	})
+}
+
+// =============================================================================
+// Test Initialize
+// =============================================================================
+
+func TestInstallPipeline_Initialize(t *testing.T) {
+	setup := func(t *testing.T, opts ...*SetupOptions) (*InstallPipeline, *InstallMocks) {
+		t.Helper()
+		pipeline := NewInstallPipeline()
+		mocks := setupInstallMocks(t, opts...)
+		return pipeline, mocks
+	}
+
+	t.Run("InitializesSuccessfully", func(t *testing.T) {
+		// Given a new InstallPipeline
+		pipeline, mocks := setup(t)
+
+		// When Initialize is called
+		err := pipeline.Initialize(mocks.Injector, context.Background())
+
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		// And blueprint handler should be set
+		if pipeline.blueprintHandler == nil {
+			t.Error("Expected blueprint handler to be set")
+		}
+	})
+
+	t.Run("ReturnsErrorWhenBasePipelineInitializeFails", func(t *testing.T) {
+		// Given a pipeline with failing base initialization
+		pipeline, mocks := setup(t)
+
+		// Override shell to return error during initialization
+		mocks.Shell.InitializeFunc = func() error {
+			return fmt.Errorf("shell init failed")
+		}
+
+		// When Initialize is called
+		err := pipeline.Initialize(mocks.Injector, context.Background())
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if err.Error() != "failed to initialize shell: shell init failed" {
+			t.Errorf("Expected shell init error, got %q", err.Error())
+		}
+	})
+
+	t.Run("ReturnsErrorWhenBlueprintHandlerInitializeFails", func(t *testing.T) {
+		// Given a pipeline with failing blueprint handler initialization
+		pipeline, mocks := setup(t)
+
+		// Override blueprint handler to return error during initialization
+		mocks.BlueprintHandler.InitializeFunc = func() error {
+			return fmt.Errorf("blueprint handler init failed")
+		}
+
+		// When Initialize is called
+		err := pipeline.Initialize(mocks.Injector, context.Background())
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if err.Error() != "failed to initialize blueprint handler: blueprint handler init failed" {
+			t.Errorf("Expected blueprint handler init error, got %q", err.Error())
+		}
+	})
+}
+
+// =============================================================================
+// Test Execute
+// =============================================================================
+
+func TestInstallPipeline_Execute(t *testing.T) {
+	setup := func(t *testing.T, opts ...*SetupOptions) (*InstallPipeline, *InstallMocks) {
+		t.Helper()
+		pipeline := NewInstallPipeline()
+		mocks := setupInstallMocks(t, opts...)
+
+		err := pipeline.Initialize(mocks.Injector, context.Background())
+		if err != nil {
+			t.Fatalf("Failed to initialize pipeline: %v", err)
+		}
+
+		return pipeline, mocks
+	}
+
+	t.Run("ExecutesSuccessfully", func(t *testing.T) {
+		// Given a properly initialized InstallPipeline
+		pipeline, _ := setup(t)
+
+		// When Execute is called
+		err := pipeline.Execute(context.Background())
+
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("ExecutesWithWaitFlag", func(t *testing.T) {
+		// Given a pipeline with wait flag set
+		pipeline, mocks := setup(t)
+
+		waitCalled := false
+		mocks.BlueprintHandler.WaitForKustomizationsFunc = func(message string, names ...string) error {
+			waitCalled = true
+			return nil
+		}
+
+		ctx := context.WithValue(context.Background(), "wait", true)
+
+		// When Execute is called
+		err := pipeline.Execute(ctx)
+
+		// Then no error should be returned and wait should be called
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if !waitCalled {
+			t.Error("Expected blueprint wait to be called")
+		}
+	})
+
+	t.Run("ReturnsErrorWhenConfigNotLoaded", func(t *testing.T) {
+		// Given a mock config handler that returns not loaded
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.IsLoadedFunc = func() bool { return false }
+		mockConfigHandler.InitializeFunc = func() error { return nil }
+		mockConfigHandler.GetContextFunc = func() string { return "mock-context" }
+		mockConfigHandler.SetContextFunc = func(context string) error { return nil }
+
+		// Setup with the not-loaded config handler
+		pipeline, _ := setup(t, &SetupOptions{ConfigHandler: mockConfigHandler})
+
+		// When Execute is called
+		err := pipeline.Execute(context.Background())
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if err.Error() != "Nothing to install. Have you run \033[1mwindsor init\033[0m?" {
+			t.Errorf("Expected config not loaded error, got %q", err.Error())
+		}
+	})
+
+	t.Run("ReturnsErrorWhenNoBlueprintHandler", func(t *testing.T) {
+		// Given a pipeline with nil blueprint handler
+		pipeline, _ := setup(t)
+
+		// Set blueprint handler to nil
+		pipeline.blueprintHandler = nil
+
+		// When Execute is called
+		err := pipeline.Execute(context.Background())
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if err.Error() != "No blueprint handler found" {
+			t.Errorf("Expected no blueprint handler error, got %q", err.Error())
+		}
+	})
+
+	t.Run("ReturnsErrorWhenBlueprintInstallFails", func(t *testing.T) {
+		// Given a pipeline with failing blueprint install
+		pipeline, mocks := setup(t)
+
+		// Override blueprint handler to return error during install
+		mocks.BlueprintHandler.InstallFunc = func() error {
+			return fmt.Errorf("blueprint install failed")
+		}
+
+		// When Execute is called
+		err := pipeline.Execute(context.Background())
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if err.Error() != "Error installing blueprint: blueprint install failed" {
+			t.Errorf("Expected blueprint install error, got %q", err.Error())
+		}
+	})
+
+	t.Run("ReturnsErrorWhenBlueprintWaitFails", func(t *testing.T) {
+		// Given a pipeline with failing blueprint wait
+		pipeline, mocks := setup(t)
+
+		// Override blueprint handler to return error during wait
+		mocks.BlueprintHandler.WaitForKustomizationsFunc = func(message string, names ...string) error {
+			return fmt.Errorf("blueprint wait failed")
+		}
+
+		ctx := context.WithValue(context.Background(), "wait", true)
+
+		// When Execute is called
+		err := pipeline.Execute(ctx)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if err.Error() != "failed waiting for kustomizations: blueprint wait failed" {
+			t.Errorf("Expected blueprint wait error, got %q", err.Error())
+		}
+	})
+}

--- a/pkg/pipelines/pipeline.go
+++ b/pkg/pipelines/pipeline.go
@@ -59,6 +59,7 @@ var pipelineConstructors = map[string]PipelineConstructor{
 	"checkPipeline":   func() Pipeline { return NewCheckPipeline() },
 	"upPipeline":      func() Pipeline { return NewUpPipeline() },
 	"downPipeline":    func() Pipeline { return NewDownPipeline() },
+	"installPipeline": func() Pipeline { return NewInstallPipeline() },
 }
 
 // WithPipeline resolves or creates a pipeline instance from the DI container by name.

--- a/pkg/pipelines/pipeline_test.go
+++ b/pkg/pipelines/pipeline_test.go
@@ -164,6 +164,10 @@ contexts:
 	mockKubernetesManager := kubernetes.NewMockKubernetesManager(nil)
 	injector.Register("kubernetesManager", mockKubernetesManager)
 
+	// Create and register mock blueprint handler for stack dependency
+	mockBlueprintHandler := blueprint.NewMockBlueprintHandler(injector)
+	injector.Register("blueprintHandler", mockBlueprintHandler)
+
 	return &Mocks{
 		Injector:      injector,
 		ConfigHandler: configHandler,


### PR DESCRIPTION
Migrated the `windsor install` command to use the pipeline architecture. Also modified the `windsor up` pipeline to use this when passing the `--install` flag.