### PR TITLE
refactor(config): Remove Blueprint field from Context

### DIFF
--- a/api/v1alpha1/config_types.go
+++ b/api/v1alpha1/config_types.go
@@ -24,7 +24,6 @@ type Config struct {
 type Context struct {
 	ID          *string                    `yaml:"id,omitempty"`
 	Platform    *string                    `yaml:"platform,omitempty"`
-	Blueprint   *string                    `yaml:"blueprint,omitempty"`
 	Environment map[string]string          `yaml:"environment,omitempty"`
 	Secrets     *secrets.SecretsConfig     `yaml:"secrets,omitempty"`
 	AWS         *aws.AWSConfig             `yaml:"aws,omitempty"`
@@ -117,9 +116,6 @@ func (base *Context) Merge(overlay *Context) {
 		}
 		base.DNS.Merge(overlay.DNS)
 	}
-	if overlay.Blueprint != nil {
-		base.Blueprint = overlay.Blueprint
-	}
 }
 
 // DeepCopy creates a deep copy of the Context object
@@ -137,7 +133,6 @@ func (c *Context) DeepCopy() *Context {
 	return &Context{
 		ID:          c.ID,
 		Platform:    c.Platform,
-		Blueprint:   c.Blueprint,
 		Environment: environmentCopy,
 		Secrets:     c.Secrets.Copy(),
 		AWS:         c.AWS.Copy(),

--- a/api/v1alpha1/config_types_test.go
+++ b/api/v1alpha1/config_types_test.go
@@ -61,8 +61,7 @@ func TestConfig_Merge(t *testing.T) {
 			Network: &network.NetworkConfig{
 				CIDRBlock: ptrString("192.168.0.0/16"),
 			},
-			Platform:  ptrString("aws"),
-			Blueprint: ptrString("1.0.0"),
+			Platform: ptrString("aws"),
 		}
 
 		overlay := &Context{
@@ -108,8 +107,7 @@ func TestConfig_Merge(t *testing.T) {
 			Network: &network.NetworkConfig{
 				CIDRBlock: ptrString("10.0.0.0/8"),
 			},
-			Platform:  ptrString("azure"),
-			Blueprint: ptrString("2.0.0"),
+			Platform: ptrString("azure"),
 		}
 
 		base.Merge(overlay)
@@ -155,9 +153,6 @@ func TestConfig_Merge(t *testing.T) {
 		}
 		if base.Network.CIDRBlock == nil || *base.Network.CIDRBlock != "10.0.0.0/8" {
 			t.Errorf("Network CIDRBlock mismatch: expected '10.0.0.0/8', got '%s'", *base.Network.CIDRBlock)
-		}
-		if base.Blueprint == nil || *base.Blueprint != "2.0.0" {
-			t.Errorf("Blueprint mismatch: expected '2.0.0', got '%s'", *base.Blueprint)
 		}
 		if base.Platform == nil || *base.Platform != "azure" {
 			t.Errorf("Platform mismatch: expected 'azure', got '%s'", *base.Platform)
@@ -209,8 +204,7 @@ func TestConfig_Merge(t *testing.T) {
 			Network: &network.NetworkConfig{
 				CIDRBlock: ptrString("192.168.0.0/16"),
 			},
-			Platform:  ptrString("aws"),
-			Blueprint: ptrString("1.0.0"),
+			Platform: ptrString("aws"),
 		}
 
 		var overlay *Context = nil
@@ -257,9 +251,6 @@ func TestConfig_Merge(t *testing.T) {
 		}
 		if base.Network.CIDRBlock == nil || *base.Network.CIDRBlock != "192.168.0.0/16" {
 			t.Errorf("Network CIDRBlock mismatch: expected '192.168.0.0/16', got '%s'", *base.Network.CIDRBlock)
-		}
-		if base.Blueprint == nil || *base.Blueprint != "1.0.0" {
-			t.Errorf("Blueprint mismatch: expected '1.0.0', got '%s'", *base.Blueprint)
 		}
 		if base.Platform == nil || *base.Platform != "aws" {
 			t.Errorf("Platform mismatch: expected 'aws', got '%s'", *base.Platform)
@@ -312,8 +303,7 @@ func TestConfig_Merge(t *testing.T) {
 			Network: &network.NetworkConfig{
 				CIDRBlock: ptrString("10.0.0.0/8"),
 			},
-			Platform:  ptrString("azure"),
-			Blueprint: ptrString("2.0.0"),
+			Platform: ptrString("azure"),
 		}
 
 		base.Merge(overlay)
@@ -359,9 +349,6 @@ func TestConfig_Merge(t *testing.T) {
 		}
 		if base.Network.CIDRBlock == nil || *base.Network.CIDRBlock != "10.0.0.0/8" {
 			t.Errorf("Network CIDRBlock mismatch: expected '10.0.0.0/8', got '%s'", *base.Network.CIDRBlock)
-		}
-		if base.Blueprint == nil || *base.Blueprint != "2.0.0" {
-			t.Errorf("Blueprint mismatch: expected '2.0.0', got '%s'", *base.Blueprint)
 		}
 		if base.Platform == nil || *base.Platform != "azure" {
 			t.Errorf("Platform mismatch: expected 'azure', got '%s'", *base.Platform)
@@ -431,8 +418,7 @@ func TestConfig_Copy(t *testing.T) {
 					End:   ptrString("192.168.0.255"),
 				},
 			},
-			Platform:  ptrString("local"),
-			Blueprint: ptrString("1.0.0"),
+			Platform: ptrString("local"),
 		}
 
 		copy := original.DeepCopy()
@@ -476,9 +462,6 @@ func TestConfig_Copy(t *testing.T) {
 		}
 		if original.Network.CIDRBlock == nil || copy.Network.CIDRBlock == nil || *original.Network.CIDRBlock != *copy.Network.CIDRBlock {
 			t.Errorf("Network CIDRBlock mismatch: expected %v, got %v", *original.Network.CIDRBlock, *copy.Network.CIDRBlock)
-		}
-		if original.Blueprint == nil || copy.Blueprint == nil || *original.Blueprint != *copy.Blueprint {
-			t.Errorf("Blueprint mismatch: expected %v, got %v", *original.Blueprint, *copy.Blueprint)
 		}
 		if original.Platform == nil || copy.Platform == nil || *original.Platform != *copy.Platform {
 			t.Errorf("Platform mismatch: expected %v, got %v", *original.Platform, *copy.Platform)

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -98,7 +98,6 @@ var commonDNSConfig = dns.DNSConfig{
 }
 
 var DefaultConfig_Localhost = v1alpha1.Context{
-	Blueprint:   ptrString("full"),
 	Environment: map[string]string{},
 	Docker:      commonDockerConfig.Copy(),
 	Git:         commonGitConfig.Copy(),
@@ -135,7 +134,6 @@ var DefaultConfig_Localhost = v1alpha1.Context{
 }
 
 var DefaultConfig_Full = v1alpha1.Context{
-	Blueprint:   ptrString("full"),
 	Environment: map[string]string{},
 	Docker:      commonDockerConfig.Copy(),
 	Git:         commonGitConfig.Copy(),

--- a/pkg/config/yaml_config_handler_test.go
+++ b/pkg/config/yaml_config_handler_test.go
@@ -1735,7 +1735,6 @@ func TestYamlConfigHandler_SetDefault(t *testing.T) {
 
 		// And a default context with overlapping and additional values
 		defaultContext := v1alpha1.Context{
-			Blueprint: ptrString("full"),
 			VM: &vm.VMConfig{
 				CPU: ptrInt(4),
 			},
@@ -1774,9 +1773,6 @@ func TestYamlConfigHandler_SetDefault(t *testing.T) {
 		}
 
 		// Default values should be added where not present
-		if ctx.Blueprint == nil || *ctx.Blueprint != "full" {
-			t.Errorf("Expected Blueprint to be added from default as 'full', got %v", ctx.Blueprint)
-		}
 		if ctx.VM.CPU == nil || *ctx.VM.CPU != 4 {
 			t.Errorf("Expected VM CPU to be added from default as 4, got %v", ctx.VM.CPU)
 		}
@@ -1800,7 +1796,6 @@ func TestYamlConfigHandler_SetDefault(t *testing.T) {
 
 		// And a default context with additional values
 		defaultContext := v1alpha1.Context{
-			Blueprint: ptrString("full"),
 			Environment: map[string]string{
 				"DEFAULT_VAR": "default_value",
 			},
@@ -1829,9 +1824,6 @@ func TestYamlConfigHandler_SetDefault(t *testing.T) {
 		}
 
 		// Default values should be added where not present
-		if ctx.Blueprint == nil || *ctx.Blueprint != "full" {
-			t.Errorf("Expected Blueprint to be added from default as 'full', got %v", ctx.Blueprint)
-		}
 		if ctx.Environment["DEFAULT_VAR"] != "default_value" {
 			t.Errorf("Expected DEFAULT_VAR to be added from default as 'default_value', got '%s'", ctx.Environment["DEFAULT_VAR"])
 		}
@@ -3312,10 +3304,10 @@ contexts:
 		// Simulate SetDefault being called (like init pipeline does)
 		// Use a default config that has no VM section (like DefaultConfig_Full)
 		defaultConfig := v1alpha1.Context{
-			Blueprint: ptrString("full"),
 			Environment: map[string]string{
 				"DEFAULT_VAR": "default_value",
 			},
+			Platform: ptrString("local"),
 		}
 
 		err = handler.SetDefault(defaultConfig)
@@ -3330,9 +3322,9 @@ contexts:
 		}
 
 		// And the default values should be added
-		blueprint := handler.GetString("blueprint")
-		if blueprint != "full" {
-			t.Errorf("Expected blueprint to be added as 'full', got '%s'", blueprint)
+		platform := handler.GetString("platform")
+		if platform != "local" {
+			t.Errorf("Expected platform to be added as 'local', got '%s'", platform)
 		}
 	})
 }

--- a/pkg/pipelines/init.go
+++ b/pkg/pipelines/init.go
@@ -256,7 +256,7 @@ func (p *InitPipeline) Execute(ctx context.Context) error {
 	}
 
 	// Phase 1: template data preparation
-	templateData, err := p.prepareTemplateData()
+	templateData, err := p.prepareTemplateData(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to prepare template data: %w", err)
 	}
@@ -434,8 +434,13 @@ func (p *InitPipeline) saveConfiguration(overwrite bool) error {
 // 2: If local _template dir exists, try loading template data from it.
 // 3: If blueprint handler exists, generate default template data for current context.
 // 4: If all fail, return empty map.
-func (p *InitPipeline) prepareTemplateData() (map[string][]byte, error) {
-	blueprintValue := p.configHandler.GetString("blueprint")
+func (p *InitPipeline) prepareTemplateData(ctx context.Context) (map[string][]byte, error) {
+	var blueprintValue string
+	if blueprintCtx := ctx.Value("blueprint"); blueprintCtx != nil {
+		if blueprint, ok := blueprintCtx.(string); ok {
+			blueprintValue = blueprint
+		}
+	}
 
 	if blueprintValue != "" && strings.HasPrefix(blueprintValue, "oci://") {
 		if p.artifactBuilder == nil {

--- a/pkg/pipelines/init_test.go
+++ b/pkg/pipelines/init_test.go
@@ -835,7 +835,7 @@ func TestInitPipeline_prepareTemplateData(t *testing.T) {
 		pipeline.blueprintHandler = nil
 
 		// When prepareTemplateData is called
-		templateData, err := pipeline.prepareTemplateData()
+		templateData, err := pipeline.prepareTemplateData(context.Background())
 
 		// Then should return empty map
 		if err != nil {
@@ -853,15 +853,6 @@ func TestInitPipeline_prepareTemplateData(t *testing.T) {
 		// Given a pipeline with OCI blueprint that fails
 		pipeline := &InitPipeline{}
 
-		mockConfigHandler := config.NewMockConfigHandler()
-		mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "blueprint" {
-				return "oci://registry.example.com/blueprint:latest"
-			}
-			return ""
-		}
-		pipeline.configHandler = mockConfigHandler
-
 		// Mock artifact builder that fails
 		mockArtifactBuilder := artifact.NewMockArtifact()
 		mockArtifactBuilder.GetTemplateDataFunc = func(ociRef string) (map[string][]byte, error) {
@@ -869,8 +860,11 @@ func TestInitPipeline_prepareTemplateData(t *testing.T) {
 		}
 		pipeline.artifactBuilder = mockArtifactBuilder
 
+		// Create context with blueprint value
+		ctx := context.WithValue(context.Background(), "blueprint", "oci://registry.example.com/blueprint:latest")
+
 		// When prepareTemplateData is called
-		templateData, err := pipeline.prepareTemplateData()
+		templateData, err := pipeline.prepareTemplateData(ctx)
 
 		// Then should return error
 		if err == nil {
@@ -887,19 +881,13 @@ func TestInitPipeline_prepareTemplateData(t *testing.T) {
 	t.Run("ReturnsErrorWhenArtifactBuilderMissing", func(t *testing.T) {
 		// Given a pipeline with OCI blueprint but no artifact builder
 		pipeline := &InitPipeline{}
-
-		mockConfigHandler := config.NewMockConfigHandler()
-		mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "blueprint" {
-				return "oci://registry.example.com/blueprint:latest"
-			}
-			return ""
-		}
-		pipeline.configHandler = mockConfigHandler
 		pipeline.artifactBuilder = nil
 
+		// Create context with blueprint value
+		ctx := context.WithValue(context.Background(), "blueprint", "oci://registry.example.com/blueprint:latest")
+
 		// When prepareTemplateData is called
-		templateData, err := pipeline.prepareTemplateData()
+		templateData, err := pipeline.prepareTemplateData(ctx)
 
 		// Then should return error
 		if err == nil {
@@ -917,15 +905,6 @@ func TestInitPipeline_prepareTemplateData(t *testing.T) {
 		// Given a pipeline with OCI blueprint and artifact builder
 		pipeline := &InitPipeline{}
 
-		mockConfigHandler := config.NewMockConfigHandler()
-		mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "blueprint" {
-				return "oci://registry.example.com/blueprint:latest"
-			}
-			return ""
-		}
-		pipeline.configHandler = mockConfigHandler
-
 		mockArtifactBuilder := artifact.NewMockArtifact()
 		expectedTemplateData := map[string][]byte{
 			"blueprint.jsonnet": []byte("{ test: 'data' }"),
@@ -935,8 +914,11 @@ func TestInitPipeline_prepareTemplateData(t *testing.T) {
 		}
 		pipeline.artifactBuilder = mockArtifactBuilder
 
+		// Create context with blueprint value
+		ctx := context.WithValue(context.Background(), "blueprint", "oci://registry.example.com/blueprint:latest")
+
 		// When prepareTemplateData is called
-		templateData, err := pipeline.prepareTemplateData()
+		templateData, err := pipeline.prepareTemplateData(ctx)
 
 		// Then should use artifact builder
 		if err != nil {
@@ -970,7 +952,7 @@ func TestInitPipeline_prepareTemplateData(t *testing.T) {
 		pipeline.blueprintHandler = mockBlueprintHandler
 
 		// When prepareTemplateData is called
-		templateData, err := pipeline.prepareTemplateData()
+		templateData, err := pipeline.prepareTemplateData(context.Background())
 
 		// Then should use local template data
 		if err != nil {
@@ -1009,7 +991,7 @@ func TestInitPipeline_prepareTemplateData(t *testing.T) {
 		pipeline.blueprintHandler = mockBlueprintHandler
 
 		// When prepareTemplateData is called
-		templateData, err := pipeline.prepareTemplateData()
+		templateData, err := pipeline.prepareTemplateData(context.Background())
 
 		// Then should use default template data
 		if err != nil {


### PR DESCRIPTION
The blueprint field isn't necessarily appropriate as there's no single "blueprint" associated with a given context. We still want to pass in the `--blueprint` flag for future use.