### PR TITLE
refactor(blueprint): Add LoadData function

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -80,7 +80,7 @@ type Source struct {
 	PathPrefix string `yaml:"pathPrefix,omitempty"`
 
 	// Ref details the branch, tag, or commit to use.
-	Ref Reference `yaml:"ref"`
+	Ref Reference `yaml:"ref,omitempty"`
 
 	// SecretName is the secret for source access.
 	SecretName string `yaml:"secretName,omitempty"`

--- a/pkg/blueprint/mock_blueprint_handler.go
+++ b/pkg/blueprint/mock_blueprint_handler.go
@@ -8,7 +8,8 @@ import (
 // MockBlueprintHandler is a mock implementation of BlueprintHandler interface for testing
 type MockBlueprintHandler struct {
 	InitializeFunc             func() error
-	LoadConfigFunc             func(reset ...bool) error
+	LoadConfigFunc             func() error
+	LoadDataFunc               func(data map[string]any, ociInfo ...*OCIArtifactInfo) error
 	GetMetadataFunc            func() blueprintv1alpha1.Metadata
 	GetSourcesFunc             func() []blueprintv1alpha1.Source
 	GetTerraformComponentsFunc func() []blueprintv1alpha1.TerraformComponent
@@ -45,9 +46,17 @@ func (m *MockBlueprintHandler) Initialize() error {
 }
 
 // LoadConfig calls the mock LoadConfigFunc if set, otherwise returns nil
-func (m *MockBlueprintHandler) LoadConfig(reset ...bool) error {
+func (m *MockBlueprintHandler) LoadConfig() error {
 	if m.LoadConfigFunc != nil {
-		return m.LoadConfigFunc(reset...)
+		return m.LoadConfigFunc()
+	}
+	return nil
+}
+
+// LoadData calls the mock LoadDataFunc if set, otherwise returns nil
+func (m *MockBlueprintHandler) LoadData(data map[string]any, ociInfo ...*OCIArtifactInfo) error {
+	if m.LoadDataFunc != nil {
+		return m.LoadDataFunc(data, ociInfo...)
 	}
 	return nil
 }

--- a/pkg/blueprint/mock_blueprint_handler_test.go
+++ b/pkg/blueprint/mock_blueprint_handler_test.go
@@ -57,14 +57,14 @@ func TestMockBlueprintHandler_LoadConfig(t *testing.T) {
 
 	mockLoadErr := fmt.Errorf("mock load config error")
 
-	t.Run("WithReset", func(t *testing.T) {
+	t.Run("WithError", func(t *testing.T) {
 		// Given a mock handler with load config function
 		handler := setup(t)
-		handler.LoadConfigFunc = func(reset ...bool) error {
+		handler.LoadConfigFunc = func() error {
 			return mockLoadErr
 		}
-		// When loading config with reset
-		err := handler.LoadConfig(true)
+		// When loading config
+		err := handler.LoadConfig()
 		// Then expected error should be returned
 		if err != mockLoadErr {
 			t.Errorf("Expected error = %v, got = %v", mockLoadErr, err)
@@ -335,6 +335,183 @@ func TestMockBlueprintHandler_WaitForKustomizations(t *testing.T) {
 		// Then no error should be returned
 		if err != nil {
 			t.Errorf("Expected error = %v, got = %v", nil, err)
+		}
+	})
+}
+
+func TestMockBlueprintHandler_GetDefaultTemplateData(t *testing.T) {
+	setup := func(t *testing.T) *MockBlueprintHandler {
+		t.Helper()
+		return &MockBlueprintHandler{}
+	}
+
+	t.Run("WithFuncSet", func(t *testing.T) {
+		// Given a mock handler with GetDefaultTemplateData function
+		handler := setup(t)
+		expectedData := map[string][]byte{
+			"template1": []byte("template content 1"),
+			"template2": []byte("template content 2"),
+		}
+		handler.GetDefaultTemplateDataFunc = func(contextName string) (map[string][]byte, error) {
+			return expectedData, nil
+		}
+		// When getting default template data
+		data, err := handler.GetDefaultTemplateData("test-context")
+		// Then expected data should be returned
+		if err != nil {
+			t.Errorf("Expected error = %v, got = %v", nil, err)
+		}
+		if len(data) != len(expectedData) {
+			t.Errorf("Expected data length = %v, got = %v", len(expectedData), len(data))
+		}
+		for key, expectedValue := range expectedData {
+			if value, exists := data[key]; !exists || string(value) != string(expectedValue) {
+				t.Errorf("Expected data[%s] = %s, got = %s", key, string(expectedValue), string(value))
+			}
+		}
+	})
+
+	t.Run("WithNoFuncSet", func(t *testing.T) {
+		// Given a mock handler with no GetDefaultTemplateData function
+		handler := setup(t)
+		// When getting default template data
+		data, err := handler.GetDefaultTemplateData("test-context")
+		// Then empty map and no error should be returned
+		if err != nil {
+			t.Errorf("Expected error = %v, got = %v", nil, err)
+		}
+		if data == nil || len(data) != 0 {
+			t.Errorf("Expected empty map, got = %v", data)
+		}
+	})
+
+	t.Run("WithError", func(t *testing.T) {
+		// Given a mock handler with GetDefaultTemplateData function that returns error
+		handler := setup(t)
+		mockErr := fmt.Errorf("mock error")
+		handler.GetDefaultTemplateDataFunc = func(contextName string) (map[string][]byte, error) {
+			return nil, mockErr
+		}
+		// When getting default template data
+		data, err := handler.GetDefaultTemplateData("test-context")
+		// Then expected error should be returned
+		if err != mockErr {
+			t.Errorf("Expected error = %v, got = %v", mockErr, err)
+		}
+		if data != nil {
+			t.Errorf("Expected data = %v, got = %v", nil, data)
+		}
+	})
+}
+
+func TestMockBlueprintHandler_GetLocalTemplateData(t *testing.T) {
+	setup := func(t *testing.T) *MockBlueprintHandler {
+		t.Helper()
+		return &MockBlueprintHandler{}
+	}
+
+	t.Run("WithFuncSet", func(t *testing.T) {
+		// Given a mock handler with GetLocalTemplateData function
+		handler := setup(t)
+		expectedData := map[string][]byte{
+			"local1": []byte("local content 1"),
+			"local2": []byte("local content 2"),
+		}
+		handler.GetLocalTemplateDataFunc = func() (map[string][]byte, error) {
+			return expectedData, nil
+		}
+		// When getting local template data
+		data, err := handler.GetLocalTemplateData()
+		// Then expected data should be returned
+		if err != nil {
+			t.Errorf("Expected error = %v, got = %v", nil, err)
+		}
+		if len(data) != len(expectedData) {
+			t.Errorf("Expected data length = %v, got = %v", len(expectedData), len(data))
+		}
+		for key, expectedValue := range expectedData {
+			if value, exists := data[key]; !exists || string(value) != string(expectedValue) {
+				t.Errorf("Expected data[%s] = %s, got = %s", key, string(expectedValue), string(value))
+			}
+		}
+	})
+
+	t.Run("WithNoFuncSet", func(t *testing.T) {
+		// Given a mock handler with no GetLocalTemplateData function
+		handler := setup(t)
+		// When getting local template data
+		data, err := handler.GetLocalTemplateData()
+		// Then empty map and no error should be returned
+		if err != nil {
+			t.Errorf("Expected error = %v, got = %v", nil, err)
+		}
+		if data == nil || len(data) != 0 {
+			t.Errorf("Expected empty map, got = %v", data)
+		}
+	})
+
+	t.Run("WithError", func(t *testing.T) {
+		// Given a mock handler with GetLocalTemplateData function that returns error
+		handler := setup(t)
+		mockErr := fmt.Errorf("mock error")
+		handler.GetLocalTemplateDataFunc = func() (map[string][]byte, error) {
+			return nil, mockErr
+		}
+		// When getting local template data
+		data, err := handler.GetLocalTemplateData()
+		// Then expected error should be returned
+		if err != mockErr {
+			t.Errorf("Expected error = %v, got = %v", mockErr, err)
+		}
+		if data != nil {
+			t.Errorf("Expected data = %v, got = %v", nil, data)
+		}
+	})
+}
+
+func TestMockBlueprintHandler_Down(t *testing.T) {
+	setup := func(t *testing.T) *MockBlueprintHandler {
+		t.Helper()
+		return &MockBlueprintHandler{}
+	}
+
+	t.Run("WithFuncSet", func(t *testing.T) {
+		// Given a mock handler with Down function
+		handler := setup(t)
+		handler.DownFunc = func() error {
+			return nil
+		}
+		// When calling down
+		err := handler.Down()
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected error = %v, got = %v", nil, err)
+		}
+	})
+
+	t.Run("WithNoFuncSet", func(t *testing.T) {
+		// Given a mock handler with no Down function
+		handler := setup(t)
+		// When calling down
+		err := handler.Down()
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected error = %v, got = %v", nil, err)
+		}
+	})
+
+	t.Run("WithError", func(t *testing.T) {
+		// Given a mock handler with Down function that returns error
+		handler := setup(t)
+		mockErr := fmt.Errorf("mock error")
+		handler.DownFunc = func() error {
+			return mockErr
+		}
+		// When calling down
+		err := handler.Down()
+		// Then expected error should be returned
+		if err != mockErr {
+			t.Errorf("Expected error = %v, got = %v", mockErr, err)
 		}
 	})
 }

--- a/pkg/pipelines/down_test.go
+++ b/pkg/pipelines/down_test.go
@@ -94,7 +94,7 @@ contexts:
 	// Setup blueprint handler mock
 	mockBlueprintHandler := blueprint.NewMockBlueprintHandler(baseMocks.Injector)
 	mockBlueprintHandler.InitializeFunc = func() error { return nil }
-	mockBlueprintHandler.LoadConfigFunc = func(reset ...bool) error { return nil }
+	mockBlueprintHandler.LoadConfigFunc = func() error { return nil }
 	mockBlueprintHandler.DownFunc = func() error { return nil }
 	baseMocks.Injector.Register("blueprintHandler", mockBlueprintHandler)
 
@@ -680,7 +680,7 @@ func TestDownPipeline_Execute(t *testing.T) {
 		// Given a down pipeline with failing blueprint config loading
 		pipeline := NewDownPipeline()
 		mocks := setupDownMocks(t)
-		mocks.BlueprintHandler.LoadConfigFunc = func(reset ...bool) error {
+		mocks.BlueprintHandler.LoadConfigFunc = func() error {
 			return fmt.Errorf("failed to load blueprint config")
 		}
 		err := pipeline.Initialize(mocks.Injector, context.Background())

--- a/pkg/pipelines/init.go
+++ b/pkg/pipelines/init.go
@@ -280,7 +280,7 @@ func (p *InitPipeline) Execute(ctx context.Context) error {
 	}
 
 	// Phase 3: blueprint loading
-	if err := p.blueprintHandler.LoadConfig(false); err != nil {
+	if err := p.blueprintHandler.LoadConfig(); err != nil {
 		return fmt.Errorf("Error reloading blueprint config after generation: %w", err)
 	}
 

--- a/pkg/pipelines/init_test.go
+++ b/pkg/pipelines/init_test.go
@@ -76,7 +76,7 @@ contexts:
 	// Setup blueprint handler mock
 	mockBlueprintHandler := blueprint.NewMockBlueprintHandler(baseMocks.Injector)
 	mockBlueprintHandler.InitializeFunc = func() error { return nil }
-	mockBlueprintHandler.LoadConfigFunc = func(reset ...bool) error { return nil }
+	mockBlueprintHandler.LoadConfigFunc = func() error { return nil }
 	mockBlueprintHandler.GetDefaultTemplateDataFunc = func(contextName string) (map[string][]byte, error) {
 		return make(map[string][]byte), nil
 	}
@@ -375,7 +375,7 @@ func TestInitPipeline_Execute(t *testing.T) {
 		{
 			name: "ReturnsErrorWhenBlueprintLoadConfigFails",
 			setupMock: func(mocks *InitMocks) {
-				mocks.BlueprintHandler.LoadConfigFunc = func(reset ...bool) error {
+				mocks.BlueprintHandler.LoadConfigFunc = func() error {
 					return fmt.Errorf("blueprint load config failed")
 				}
 			},


### PR DESCRIPTION
The LoadData function takes "raw" data from a template and loads it similar to LoadConfig.

OCI source info is also introduced as a parameter. This is key, as LoadData and process data can also handle augmenting a blueprint loaded from a source OCI repo, ensuring the OCI source is included on the blueprint and populating its components with proper `source` references.