### PR TITLE
feat(blueprint): Re-implement blueprint Write method

### DIFF
--- a/pkg/blueprint/mock_blueprint_handler.go
+++ b/pkg/blueprint/mock_blueprint_handler.go
@@ -10,6 +10,7 @@ type MockBlueprintHandler struct {
 	InitializeFunc             func() error
 	LoadConfigFunc             func() error
 	LoadDataFunc               func(data map[string]any, ociInfo ...*OCIArtifactInfo) error
+	WriteFunc                  func(overwrite ...bool) error
 	GetMetadataFunc            func() blueprintv1alpha1.Metadata
 	GetSourcesFunc             func() []blueprintv1alpha1.Source
 	GetTerraformComponentsFunc func() []blueprintv1alpha1.TerraformComponent
@@ -57,6 +58,14 @@ func (m *MockBlueprintHandler) LoadConfig() error {
 func (m *MockBlueprintHandler) LoadData(data map[string]any, ociInfo ...*OCIArtifactInfo) error {
 	if m.LoadDataFunc != nil {
 		return m.LoadDataFunc(data, ociInfo...)
+	}
+	return nil
+}
+
+// Write calls the mock WriteFunc if set, otherwise returns nil
+func (m *MockBlueprintHandler) Write(overwrite ...bool) error {
+	if m.WriteFunc != nil {
+		return m.WriteFunc(overwrite...)
 	}
 	return nil
 }

--- a/pkg/blueprint/mock_blueprint_handler_test.go
+++ b/pkg/blueprint/mock_blueprint_handler_test.go
@@ -515,3 +515,70 @@ func TestMockBlueprintHandler_Down(t *testing.T) {
 		}
 	})
 }
+
+func TestMockBlueprintHandler_Write(t *testing.T) {
+	setup := func(t *testing.T) *MockBlueprintHandler {
+		t.Helper()
+		return &MockBlueprintHandler{}
+	}
+
+	t.Run("WithFuncSet", func(t *testing.T) {
+		// Given a mock handler with Write function
+		handler := setup(t)
+		handler.WriteFunc = func(overwrite ...bool) error {
+			return nil
+		}
+		// When calling write
+		err := handler.Write()
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected error = %v, got = %v", nil, err)
+		}
+	})
+
+	t.Run("WithNoFuncSet", func(t *testing.T) {
+		// Given a mock handler with no Write function
+		handler := setup(t)
+		// When calling write
+		err := handler.Write()
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected error = %v, got = %v", nil, err)
+		}
+	})
+
+	t.Run("WithError", func(t *testing.T) {
+		// Given a mock handler with Write function that returns error
+		handler := setup(t)
+		mockErr := fmt.Errorf("mock error")
+		handler.WriteFunc = func(overwrite ...bool) error {
+			return mockErr
+		}
+		// When calling write
+		err := handler.Write()
+		// Then expected error should be returned
+		if err != mockErr {
+			t.Errorf("Expected error = %v, got = %v", mockErr, err)
+		}
+	})
+
+	t.Run("WithOverwriteParameter", func(t *testing.T) {
+		// Given a mock handler with Write function that checks parameters
+		handler := setup(t)
+		var receivedOverwrite []bool
+		handler.WriteFunc = func(overwrite ...bool) error {
+			receivedOverwrite = overwrite
+			return nil
+		}
+		// When calling write with overwrite parameter
+		err := handler.Write(true)
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected error = %v, got = %v", nil, err)
+		}
+		// And the overwrite parameter should be passed through
+		if len(receivedOverwrite) != 1 || receivedOverwrite[0] != true {
+			t.Errorf("Expected overwrite parameter [true], got %v", receivedOverwrite)
+		}
+	})
+}


### PR DESCRIPTION
- Added Write method to BaseBlueprintHandler for saving blueprint to blueprint.yaml.
- Supports overwrite functionality based on input parameter.
- Required since the blueprint generator is architecturally the wrong way