### PR TITLE
fix(pipeline): Set context if provided

### DIFF
--- a/pkg/pipelines/pipeline.go
+++ b/pkg/pipelines/pipeline.go
@@ -147,6 +147,13 @@ func (p *BasePipeline) Initialize(injector di.Injector, ctx context.Context) err
 		}
 	}
 
+	// Set Windsor context if specified in execution context
+	if contextName, ok := ctx.Value("contextName").(string); ok && contextName != "" {
+		if err := p.configHandler.SetContext(contextName); err != nil {
+			return fmt.Errorf("failed to set Windsor context: %w", err)
+		}
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
The context wasn't being set during commands such as `windsor init <context>`. Now, if `contextName` is provided to a pipeline, it will be set in the base Initialize function.