### PR TITLE
refactor(pipeline): Use blueprint handler's write in init pipeline

### DIFF
--- a/pkg/blueprint/blueprint_handler_test.go
+++ b/pkg/blueprint/blueprint_handler_test.go
@@ -13,6 +13,7 @@ import (
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+	"github.com/windsorcli/cli/pkg/artifact"
 	"github.com/windsorcli/cli/pkg/config"
 	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/di"
@@ -3009,7 +3010,7 @@ func TestBlueprintHandler_LoadData(t *testing.T) {
 		}
 
 		// And OCI artifact info
-		ociInfo := &OCIArtifactInfo{
+		ociInfo := &artifact.OCIArtifactInfo{
 			Name: "my-blueprint",
 			URL:  "oci://registry.example.com/my-blueprint:v1.0.0",
 		}

--- a/pkg/blueprint/mock_blueprint_handler.go
+++ b/pkg/blueprint/mock_blueprint_handler.go
@@ -2,6 +2,7 @@ package blueprint
 
 import (
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+	"github.com/windsorcli/cli/pkg/artifact"
 	"github.com/windsorcli/cli/pkg/di"
 )
 
@@ -9,7 +10,7 @@ import (
 type MockBlueprintHandler struct {
 	InitializeFunc             func() error
 	LoadConfigFunc             func() error
-	LoadDataFunc               func(data map[string]any, ociInfo ...*OCIArtifactInfo) error
+	LoadDataFunc               func(data map[string]any, ociInfo ...*artifact.OCIArtifactInfo) error
 	WriteFunc                  func(overwrite ...bool) error
 	GetMetadataFunc            func() blueprintv1alpha1.Metadata
 	GetSourcesFunc             func() []blueprintv1alpha1.Source
@@ -55,7 +56,7 @@ func (m *MockBlueprintHandler) LoadConfig() error {
 }
 
 // LoadData calls the mock LoadDataFunc if set, otherwise returns nil
-func (m *MockBlueprintHandler) LoadData(data map[string]any, ociInfo ...*OCIArtifactInfo) error {
+func (m *MockBlueprintHandler) LoadData(data map[string]any, ociInfo ...*artifact.OCIArtifactInfo) error {
 	if m.LoadDataFunc != nil {
 		return m.LoadDataFunc(data, ociInfo...)
 	}

--- a/pkg/pipelines/pipeline.go
+++ b/pkg/pipelines/pipeline.go
@@ -260,7 +260,7 @@ func (p *BasePipeline) withStack() stack.Stack {
 	return stack
 }
 
-// withGenerators creates and registers generators including git, terraform, and blueprint generators.
+// withGenerators creates and registers generators including git and terraform generators.
 // Returns a slice of initialized generators or an error if creation fails.
 func (p *BasePipeline) withGenerators() ([]generators.Generator, error) {
 	var generatorList []generators.Generator
@@ -272,10 +272,6 @@ func (p *BasePipeline) withGenerators() ([]generators.Generator, error) {
 	terraformGenerator := generators.NewTerraformGenerator(p.injector)
 	p.injector.Register("terraformGenerator", terraformGenerator)
 	generatorList = append(generatorList, terraformGenerator)
-
-	blueprintGenerator := generators.NewBlueprintGenerator(p.injector)
-	p.injector.Register("blueprintGenerator", blueprintGenerator)
-	generatorList = append(generatorList, blueprintGenerator)
 
 	return generatorList, nil
 }


### PR DESCRIPTION
Migrates to use blueprint handler's `Write` function, deprecating the blueprint generator. Also leverages `blueprint.LoadData` to load post-rendered data directly.