### PR TITLE
fix(pipeline): Prefer existing blueprint.yaml if reset isn't set

### DIFF
--- a/pkg/blueprint/blueprint_handler.go
+++ b/pkg/blueprint/blueprint_handler.go
@@ -122,7 +122,7 @@ func (b *BaseBlueprintHandler) Initialize() error {
 }
 
 // LoadConfig reads blueprint configuration from blueprint.yaml file.
-// Only loads existing blueprint.yaml files - no templating or generation.
+// Returns an error if blueprint.yaml does not exist.
 // Template processing is now handled by the pkg/template package.
 func (b *BaseBlueprintHandler) LoadConfig() error {
 	configRoot, err := b.configHandler.GetConfigRoot()
@@ -132,12 +132,7 @@ func (b *BaseBlueprintHandler) LoadConfig() error {
 
 	yamlPath := filepath.Join(configRoot, "blueprint.yaml")
 	if _, err := b.shims.Stat(yamlPath); err != nil {
-		// No blueprint.yaml exists - use default blueprint
-		context := b.configHandler.GetContext()
-		b.blueprint = *DefaultBlueprint.DeepCopy()
-		b.blueprint.Metadata.Name = context
-		b.blueprint.Metadata.Description = fmt.Sprintf("This blueprint outlines resources in the %s context", context)
-		return nil
+		return fmt.Errorf("blueprint.yaml not found at %s", yamlPath)
 	}
 
 	yamlData, err := b.shims.ReadFile(yamlPath)

--- a/pkg/blueprint/blueprint_handler_test.go
+++ b/pkg/blueprint/blueprint_handler_test.go
@@ -640,18 +640,14 @@ func TestBlueprintHandler_LoadConfig(t *testing.T) {
 		// When loading the config
 		err := handler.LoadConfig()
 
-		// Then no error should be returned
-		if err != nil {
-			t.Errorf("Expected no error, got %v", err)
+		// Then an error should be returned since blueprint.yaml doesn't exist
+		if err == nil {
+			t.Errorf("Expected error when blueprint.yaml doesn't exist, got nil")
 		}
 
-		// And the default metadata should be set correctly
-		metadata := handler.GetMetadata()
-		if metadata.Name != "local" {
-			t.Errorf("Expected name to be 'local', got %s", metadata.Name)
-		}
-		if metadata.Description != "This blueprint outlines resources in the local context" {
-			t.Errorf("Expected description to be 'This blueprint outlines resources in the local context', got %s", metadata.Description)
+		// And the error should indicate blueprint.yaml not found
+		if !strings.Contains(err.Error(), "blueprint.yaml not found") {
+			t.Errorf("Expected error about blueprint.yaml not found, got: %v", err)
 		}
 	})
 
@@ -812,19 +808,14 @@ func TestBlueprintHandler_LoadConfig(t *testing.T) {
 		// When loading the config
 		err := handler.LoadConfig()
 
-		// Then no error should be returned
-		if err != nil {
-			t.Errorf("Expected no error for empty evaluated jsonnet, got: %v", err)
+		// Then an error should be returned since blueprint.yaml doesn't exist
+		if err == nil {
+			t.Errorf("Expected error when blueprint.yaml doesn't exist, got nil")
 		}
 
-		// And the default metadata should be set correctly
-		metadata := handler.GetMetadata()
-		if metadata.Name != "local" {
-			t.Errorf("Expected blueprint name to be 'local', got: %s", metadata.Name)
-		}
-		expectedDesc := "This blueprint outlines resources in the local context"
-		if metadata.Description != expectedDesc {
-			t.Errorf("Expected description '%s', got: %s", expectedDesc, metadata.Description)
+		// And the error should indicate blueprint.yaml not found
+		if !strings.Contains(err.Error(), "blueprint.yaml not found") {
+			t.Errorf("Expected error about blueprint.yaml not found, got: %v", err)
 		}
 	})
 


### PR DESCRIPTION
If a `blueprint.yaml` already exists for the context, and `--reset` flag isn't passed, there's no reason to load templates. Just load the file.