### PR TITLE
fix(pipeline): Ensure 'install' deploys kustomizations

### DIFF
--- a/pkg/blueprint/templates/aws.jsonnet
+++ b/pkg/blueprint/templates/aws.jsonnet
@@ -31,11 +31,8 @@ local terraformConfig = [
   }
 ];
 
-// Determine the blueprint, defaulting to an empty string if not defined
-local blueprint = if std.objectHas(context, "blueprint") then context.blueprint else "";
-
 // Kustomize configuration
-local kustomizeConfig = if blueprint == "full" then [
+local kustomizeConfig = [
   {
     name: "telemetry-base",
     source: "core",
@@ -151,7 +148,7 @@ local kustomizeConfig = if blueprint == "full" then [
       "grafana/flux"
     ],
   }
-] else [];
+];
 
 // Blueprint metadata
 local blueprintMetadata = {

--- a/pkg/blueprint/templates/azure.jsonnet
+++ b/pkg/blueprint/templates/azure.jsonnet
@@ -26,11 +26,8 @@ local terraformConfig = [
   }
 ];
 
-// Determine the blueprint, defaulting to an empty string if not defined
-local blueprint = if std.objectHas(context, "blueprint") then context.blueprint else "";
-
 // Kustomize configuration
-local kustomizeConfig = if blueprint == "full" then [
+local kustomizeConfig = [
   {
     name: "telemetry-base",
     source: "core",
@@ -149,7 +146,7 @@ local kustomizeConfig = if blueprint == "full" then [
       "grafana/flux"
     ],
   }
-] else [];
+];
 
 // Blueprint metadata
 local blueprintMetadata = {

--- a/pkg/blueprint/templates/local.jsonnet
+++ b/pkg/blueprint/templates/local.jsonnet
@@ -198,11 +198,8 @@ local terraformConfig = [
   }
 ];
 
-// Determine the blueprint, defaulting to an empty string if not defined
-local blueprint = if std.objectHas(context, "blueprint") then context.blueprint else "";
-
 // Kustomize configuration
-local kustomizeConfig = if blueprint == "full" then [
+local kustomizeConfig = [
   {
     name: "telemetry-base",
     source: "core",
@@ -379,7 +376,7 @@ local kustomizeConfig = if blueprint == "full" then [
       "grafana/flux"
     ],
   }
-] else [];
+];
 
 // Blueprint metadata
 local blueprintMetadata = {

--- a/pkg/blueprint/templates/metal.jsonnet
+++ b/pkg/blueprint/templates/metal.jsonnet
@@ -180,11 +180,8 @@ local terraformConfig = [
   }
 ];
 
-// Determine the blueprint, defaulting to an empty string if not defined
-local blueprint = if std.objectHas(context, "blueprint") then context.blueprint else "";
-
 // Kustomize configuration
-local kustomizeConfig = if blueprint == "full" then [
+local kustomizeConfig = [
   {
     name: "telemetry-base",
     source: "core",
@@ -346,7 +343,7 @@ local kustomizeConfig = if blueprint == "full" then [
       "grafana/flux"
     ],
   }
-] else [];
+];
 
 // Blueprint metadata
 local blueprintMetadata = {

--- a/pkg/pipelines/install.go
+++ b/pkg/pipelines/install.go
@@ -84,6 +84,10 @@ func (p *InstallPipeline) Execute(ctx context.Context) error {
 		return fmt.Errorf("No blueprint handler found")
 	}
 
+	if err := p.blueprintHandler.LoadConfig(); err != nil {
+		return fmt.Errorf("Error loading blueprint config: %w", err)
+	}
+
 	if err := p.blueprintHandler.Install(); err != nil {
 		return fmt.Errorf("Error installing blueprint: %w", err)
 	}


### PR DESCRIPTION
The `windsor install` command failed to install kustomizations. This was due to both embedded blueprint formatting and the lack of running the `blueprint.LoadConfig` command during init.