### PR TITLE
fix(blueprint): Clean blueprint before writing

### DIFF
--- a/pkg/blueprint/blueprint_handler_test.go
+++ b/pkg/blueprint/blueprint_handler_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/windsorcli/cli/pkg/di"
 	"github.com/windsorcli/cli/pkg/kubernetes"
 	"github.com/windsorcli/cli/pkg/shell"
-	"gopkg.in/yaml.v3"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -3326,6 +3325,15 @@ func TestBlueprintHandler_Write(t *testing.T) {
 		// Verify all values are cleared from the blueprint.yaml
 		if len(component.Values) != 0 {
 			t.Errorf("Expected all values to be cleared, but got %d values: %v", len(component.Values), component.Values)
+		}
+
+		// Also verify kustomizations have postBuild cleared
+		if len(writtenBlueprint.Kustomizations) > 0 {
+			for i, kustomization := range writtenBlueprint.Kustomizations {
+				if kustomization.PostBuild != nil {
+					t.Errorf("Expected PostBuild to be cleared for kustomization %d, but got %v", i, kustomization.PostBuild)
+				}
+			}
 		}
 	})
 


### PR DESCRIPTION
Prevents superfluous terraform `values` and empty kustomize `postBuild` from making it in to the written blueprint.