### PR TITLE
fix(config): Generate correct defaults on windsor init

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -56,13 +56,6 @@ var initCmd = &cobra.Command{
 			return fmt.Errorf("failed to set up environment: %w", err)
 		}
 
-		ctx = context.WithValue(ctx, "quiet", false)
-		ctx = context.WithValue(ctx, "decrypt", false)
-		initPipeline, err := pipelines.WithPipeline(injector, ctx, "initPipeline")
-		if err != nil {
-			return fmt.Errorf("failed to set up init pipeline: %w", err)
-		}
-
 		configHandler := injector.Resolve("configHandler").(config.ConfigHandler)
 
 		if initBackend != "" {
@@ -128,6 +121,13 @@ var initCmd = &cobra.Command{
 					return fmt.Errorf("failed to set %s: %w", parts[0], err)
 				}
 			}
+		}
+
+		ctx = context.WithValue(ctx, "quiet", false)
+		ctx = context.WithValue(ctx, "decrypt", false)
+		initPipeline, err := pipelines.WithPipeline(injector, ctx, "initPipeline")
+		if err != nil {
+			return fmt.Errorf("failed to set up init pipeline: %w", err)
 		}
 
 		return initPipeline.Execute(ctx)

--- a/pkg/config/defaults_test.go
+++ b/pkg/config/defaults_test.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"testing"
+)
+
+func TestDefaultConfigurations_HostPorts(t *testing.T) {
+	t.Run("DefaultConfig_Localhost_HasHostPorts", func(t *testing.T) {
+		// Given the DefaultConfig_Localhost configuration (used for docker-desktop)
+		config := DefaultConfig_Localhost
+
+		// Then the workers should have hostports configured
+		if config.Cluster == nil {
+			t.Fatal("Expected cluster configuration to be present")
+		}
+
+		expectedHostPorts := []string{"8080:30080/tcp", "8443:30443/tcp", "9292:30292/tcp", "8053:30053/udp"}
+		actualHostPorts := config.Cluster.Workers.HostPorts
+
+		if len(actualHostPorts) != len(expectedHostPorts) {
+			t.Errorf("Expected %d hostports, got %d", len(expectedHostPorts), len(actualHostPorts))
+		}
+
+		for i, expected := range expectedHostPorts {
+			if i >= len(actualHostPorts) || actualHostPorts[i] != expected {
+				t.Errorf("Expected hostport %s at index %d, got %s", expected, i,
+					func() string {
+						if i < len(actualHostPorts) {
+							return actualHostPorts[i]
+						}
+						return "missing"
+					}())
+			}
+		}
+	})
+
+	t.Run("DefaultConfig_Full_HasNoHostPorts", func(t *testing.T) {
+		// Given the DefaultConfig_Full configuration (used for colima/docker)
+		config := DefaultConfig_Full
+
+		// Then the workers should have no hostports configured
+		if config.Cluster == nil {
+			t.Fatal("Expected cluster configuration to be present")
+		}
+
+		actualHostPorts := config.Cluster.Workers.HostPorts
+
+		if len(actualHostPorts) != 0 {
+			t.Errorf("Expected no hostports for DefaultConfig_Full, got %d: %v", len(actualHostPorts), actualHostPorts)
+		}
+
+		// And the controlplanes should also have no hostports
+		actualControlPlaneHostPorts := config.Cluster.ControlPlanes.HostPorts
+
+		if len(actualControlPlaneHostPorts) != 0 {
+			t.Errorf("Expected no hostports for DefaultConfig_Full controlplanes, got %d: %v", len(actualControlPlaneHostPorts), actualControlPlaneHostPorts)
+		}
+	})
+
+	t.Run("DefaultConfig_Localhost_ControlPlanes_HasNoHostPorts", func(t *testing.T) {
+		// Given the DefaultConfig_Localhost configuration
+		config := DefaultConfig_Localhost
+
+		// Then the controlplanes should have no hostports (only workers need them for docker-desktop)
+		if config.Cluster == nil {
+			t.Fatal("Expected cluster configuration to be present")
+		}
+
+		actualControlPlaneHostPorts := config.Cluster.ControlPlanes.HostPorts
+
+		if len(actualControlPlaneHostPorts) != 0 {
+			t.Errorf("Expected no hostports for DefaultConfig_Localhost controlplanes, got %d: %v", len(actualControlPlaneHostPorts), actualControlPlaneHostPorts)
+		}
+	})
+}

--- a/pkg/pipelines/init_test.go
+++ b/pkg/pipelines/init_test.go
@@ -376,10 +376,11 @@ func TestInitPipeline_Execute(t *testing.T) {
 		mockConfigHandler.SetDefaultFunc = func(defaultConfig v1alpha1.Context) error { return nil }
 
 		setupOptions := &SetupOptions{ConfigHandler: mockConfigHandler}
-		pipeline, _ := setup(t, setupOptions)
+		pipeline := NewInitPipeline()
+		mocks := setupInitMocks(t, setupOptions)
 
-		// When Execute is called
-		err := pipeline.Execute(context.Background())
+		// When Initialize is called
+		err := pipeline.Initialize(mocks.Injector, context.Background())
 
 		// Then should return context ID generation error
 		if err == nil {
@@ -511,10 +512,11 @@ func TestInitPipeline_Execute(t *testing.T) {
 				mockConfigHandler.SetDefaultFunc = func(defaultConfig v1alpha1.Context) error { return nil }
 
 				setupOptions := &SetupOptions{ConfigHandler: mockConfigHandler}
-				pipeline, _ := setup(t, setupOptions)
+				pipeline := NewInitPipeline()
+				mocks := setupInitMocks(t, setupOptions)
 
-				// When executing the pipeline
-				err := pipeline.Execute(context.Background())
+				// When initializing the pipeline
+				err := pipeline.Initialize(mocks.Injector, context.Background())
 
 				// Then an error should be returned
 				if err == nil {

--- a/pkg/pipelines/init_test.go
+++ b/pkg/pipelines/init_test.go
@@ -1114,3 +1114,141 @@ func TestInitPipeline_prepareTemplateData(t *testing.T) {
 		}
 	})
 }
+
+func TestInitPipeline_setDefaultConfiguration_HostPortsValidation(t *testing.T) {
+	setup := func(t *testing.T, vmDriver string) (*InitPipeline, *config.MockConfigHandler, *v1alpha1.Context) {
+		t.Helper()
+		pipeline := &InitPipeline{}
+
+		mockConfigHandler := config.NewMockConfigHandler()
+
+		// Track which default config was set
+		var setDefaultConfig v1alpha1.Context
+
+		mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "vm.driver" {
+				return vmDriver
+			}
+			return ""
+		}
+		mockConfigHandler.SetDefaultFunc = func(defaultConfig v1alpha1.Context) error {
+			setDefaultConfig = defaultConfig
+			return nil
+		}
+		mockConfigHandler.SetContextValueFunc = func(key string, value interface{}) error {
+			return nil
+		}
+
+		pipeline.configHandler = mockConfigHandler
+
+		return pipeline, mockConfigHandler, &setDefaultConfig
+	}
+
+	t.Run("ColimaDriver_UsesConfigWithoutHostPorts", func(t *testing.T) {
+		// Given a pipeline with colima driver
+		pipeline, _, setConfigPtr := setup(t, "colima")
+
+		// When setDefaultConfiguration is called
+		err := pipeline.setDefaultConfiguration(context.Background(), "test")
+
+		// Then no error should occur
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// And the default config should be DefaultConfig_Full (no hostports)
+		setConfig := *setConfigPtr
+		if setConfig.Cluster == nil {
+			t.Fatal("Expected cluster configuration to be present")
+		}
+
+		// Verify no hostports for workers
+		if len(setConfig.Cluster.Workers.HostPorts) != 0 {
+			t.Errorf("Expected no hostports for colima driver, got %d: %v",
+				len(setConfig.Cluster.Workers.HostPorts), setConfig.Cluster.Workers.HostPorts)
+		}
+
+		// Verify no hostports for controlplanes
+		if len(setConfig.Cluster.ControlPlanes.HostPorts) != 0 {
+			t.Errorf("Expected no hostports for colima driver controlplanes, got %d: %v",
+				len(setConfig.Cluster.ControlPlanes.HostPorts), setConfig.Cluster.ControlPlanes.HostPorts)
+		}
+	})
+
+	t.Run("DockerDriver_UsesConfigWithoutHostPorts", func(t *testing.T) {
+		// Given a pipeline with docker driver
+		pipeline, _, setConfigPtr := setup(t, "docker")
+
+		// When setDefaultConfiguration is called
+		err := pipeline.setDefaultConfiguration(context.Background(), "test")
+
+		// Then no error should occur
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// And the default config should be DefaultConfig_Full (no hostports)
+		setConfig := *setConfigPtr
+		if setConfig.Cluster == nil {
+			t.Fatal("Expected cluster configuration to be present")
+		}
+
+		// Verify no hostports for workers
+		if len(setConfig.Cluster.Workers.HostPorts) != 0 {
+			t.Errorf("Expected no hostports for docker driver, got %d: %v",
+				len(setConfig.Cluster.Workers.HostPorts), setConfig.Cluster.Workers.HostPorts)
+		}
+
+		// Verify no hostports for controlplanes
+		if len(setConfig.Cluster.ControlPlanes.HostPorts) != 0 {
+			t.Errorf("Expected no hostports for docker driver controlplanes, got %d: %v",
+				len(setConfig.Cluster.ControlPlanes.HostPorts), setConfig.Cluster.ControlPlanes.HostPorts)
+		}
+	})
+
+	t.Run("DockerDesktopDriver_UsesConfigWithHostPorts", func(t *testing.T) {
+		// Given a pipeline with docker-desktop driver
+		pipeline, _, setConfigPtr := setup(t, "docker-desktop")
+
+		// When setDefaultConfiguration is called
+		err := pipeline.setDefaultConfiguration(context.Background(), "test")
+
+		// Then no error should occur
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// And the default config should be DefaultConfig_Localhost (with hostports)
+		setConfig := *setConfigPtr
+		if setConfig.Cluster == nil {
+			t.Fatal("Expected cluster configuration to be present")
+		}
+
+		// Verify hostports are present for workers
+		expectedHostPorts := []string{"8080:30080/tcp", "8443:30443/tcp", "9292:30292/tcp", "8053:30053/udp"}
+		actualHostPorts := setConfig.Cluster.Workers.HostPorts
+
+		if len(actualHostPorts) != len(expectedHostPorts) {
+			t.Errorf("Expected %d hostports for docker-desktop driver, got %d",
+				len(expectedHostPorts), len(actualHostPorts))
+		}
+
+		for i, expected := range expectedHostPorts {
+			if i >= len(actualHostPorts) || actualHostPorts[i] != expected {
+				t.Errorf("Expected hostport %s at index %d, got %s", expected, i,
+					func() string {
+						if i < len(actualHostPorts) {
+							return actualHostPorts[i]
+						}
+						return "missing"
+					}())
+			}
+		}
+
+		// Verify no hostports for controlplanes (only workers need them)
+		if len(setConfig.Cluster.ControlPlanes.HostPorts) != 0 {
+			t.Errorf("Expected no hostports for docker-desktop driver controlplanes, got %d: %v",
+				len(setConfig.Cluster.ControlPlanes.HostPorts), setConfig.Cluster.ControlPlanes.HostPorts)
+		}
+	})
+}


### PR DESCRIPTION
- Specifying the `colima` driver no longer includes hostport configurations
- Post-processed nodes added to the config no longer make it in to the default `windsor.yaml`