### PR TITLE
fx(generator): Properly overwrites tfvars when --reset is passed

### DIFF
--- a/pkg/generators/terraform_generator.go
+++ b/pkg/generators/terraform_generator.go
@@ -95,6 +95,12 @@ func (g *TerraformGenerator) Write(overwrite ...bool) error {
 // TerraformComponents and determines the variables.tf location based on component source presence (remote or local).
 // Module resolution is now handled by the pkg/terraform package.
 func (g *TerraformGenerator) Generate(data map[string]any, overwrite ...bool) error {
+	// Set reset flag from overwrite parameter
+	shouldOverwrite := false
+	if len(overwrite) > 0 {
+		shouldOverwrite = overwrite[0]
+	}
+	g.reset = shouldOverwrite
 
 	contextPath, err := g.configHandler.GetConfigRoot()
 	if err != nil {


### PR DESCRIPTION
The `windsor init --reset` flag was not overwiting `tfvars` files. Added the correct logic to handle this.