### PR TITLE
feature(cmd): Fix and deprecate --platform in exchange for --provider

### DIFF
--- a/api/v1alpha1/config_types.go
+++ b/api/v1alpha1/config_types.go
@@ -23,7 +23,7 @@ type Config struct {
 // Context represents the context configuration
 type Context struct {
 	ID          *string                    `yaml:"id,omitempty"`
-	Platform    *string                    `yaml:"platform,omitempty"`
+	Provider    *string                    `yaml:"provider,omitempty"`
 	Environment map[string]string          `yaml:"environment,omitempty"`
 	Secrets     *secrets.SecretsConfig     `yaml:"secrets,omitempty"`
 	AWS         *aws.AWSConfig             `yaml:"aws,omitempty"`
@@ -45,8 +45,8 @@ func (base *Context) Merge(overlay *Context) {
 	if overlay.ID != nil {
 		base.ID = overlay.ID
 	}
-	if overlay.Platform != nil {
-		base.Platform = overlay.Platform
+	if overlay.Provider != nil {
+		base.Provider = overlay.Provider
 	}
 	if overlay.Environment != nil {
 		if base.Environment == nil {
@@ -132,7 +132,7 @@ func (c *Context) DeepCopy() *Context {
 	}
 	return &Context{
 		ID:          c.ID,
-		Platform:    c.Platform,
+		Provider:    c.Provider,
 		Environment: environmentCopy,
 		Secrets:     c.Secrets.Copy(),
 		AWS:         c.AWS.Copy(),

--- a/api/v1alpha1/config_types_test.go
+++ b/api/v1alpha1/config_types_test.go
@@ -61,7 +61,7 @@ func TestConfig_Merge(t *testing.T) {
 			Network: &network.NetworkConfig{
 				CIDRBlock: ptrString("192.168.0.0/16"),
 			},
-			Platform: ptrString("aws"),
+			Provider: ptrString("aws"),
 		}
 
 		overlay := &Context{
@@ -107,7 +107,7 @@ func TestConfig_Merge(t *testing.T) {
 			Network: &network.NetworkConfig{
 				CIDRBlock: ptrString("10.0.0.0/8"),
 			},
-			Platform: ptrString("azure"),
+			Provider: ptrString("azure"),
 		}
 
 		base.Merge(overlay)
@@ -154,8 +154,8 @@ func TestConfig_Merge(t *testing.T) {
 		if base.Network.CIDRBlock == nil || *base.Network.CIDRBlock != "10.0.0.0/8" {
 			t.Errorf("Network CIDRBlock mismatch: expected '10.0.0.0/8', got '%s'", *base.Network.CIDRBlock)
 		}
-		if base.Platform == nil || *base.Platform != "azure" {
-			t.Errorf("Platform mismatch: expected 'azure', got '%s'", *base.Platform)
+		if base.Provider == nil || *base.Provider != "azure" {
+			t.Errorf("Provider mismatch: expected 'azure', got '%s'", *base.Provider)
 		}
 	})
 
@@ -204,7 +204,7 @@ func TestConfig_Merge(t *testing.T) {
 			Network: &network.NetworkConfig{
 				CIDRBlock: ptrString("192.168.0.0/16"),
 			},
-			Platform: ptrString("aws"),
+			Provider: ptrString("aws"),
 		}
 
 		var overlay *Context = nil
@@ -252,8 +252,8 @@ func TestConfig_Merge(t *testing.T) {
 		if base.Network.CIDRBlock == nil || *base.Network.CIDRBlock != "192.168.0.0/16" {
 			t.Errorf("Network CIDRBlock mismatch: expected '192.168.0.0/16', got '%s'", *base.Network.CIDRBlock)
 		}
-		if base.Platform == nil || *base.Platform != "aws" {
-			t.Errorf("Platform mismatch: expected 'aws', got '%s'", *base.Platform)
+		if base.Provider == nil || *base.Provider != "aws" {
+			t.Errorf("Provider mismatch: expected 'aws', got '%s'", *base.Provider)
 		}
 	})
 
@@ -303,7 +303,7 @@ func TestConfig_Merge(t *testing.T) {
 			Network: &network.NetworkConfig{
 				CIDRBlock: ptrString("10.0.0.0/8"),
 			},
-			Platform: ptrString("azure"),
+			Provider: ptrString("azure"),
 		}
 
 		base.Merge(overlay)
@@ -350,8 +350,8 @@ func TestConfig_Merge(t *testing.T) {
 		if base.Network.CIDRBlock == nil || *base.Network.CIDRBlock != "10.0.0.0/8" {
 			t.Errorf("Network CIDRBlock mismatch: expected '10.0.0.0/8', got '%s'", *base.Network.CIDRBlock)
 		}
-		if base.Platform == nil || *base.Platform != "azure" {
-			t.Errorf("Platform mismatch: expected 'azure', got '%s'", *base.Platform)
+		if base.Provider == nil || *base.Provider != "azure" {
+			t.Errorf("Provider mismatch: expected 'azure', got '%s'", *base.Provider)
 		}
 	})
 
@@ -418,7 +418,7 @@ func TestConfig_Copy(t *testing.T) {
 					End:   ptrString("192.168.0.255"),
 				},
 			},
-			Platform: ptrString("local"),
+			Provider: ptrString("local"),
 		}
 
 		copy := original.DeepCopy()
@@ -463,8 +463,8 @@ func TestConfig_Copy(t *testing.T) {
 		if original.Network.CIDRBlock == nil || copy.Network.CIDRBlock == nil || *original.Network.CIDRBlock != *copy.Network.CIDRBlock {
 			t.Errorf("Network CIDRBlock mismatch: expected %v, got %v", *original.Network.CIDRBlock, *copy.Network.CIDRBlock)
 		}
-		if original.Platform == nil || copy.Platform == nil || *original.Platform != *copy.Platform {
-			t.Errorf("Platform mismatch: expected %v, got %v", *original.Platform, *copy.Platform)
+		if original.Provider == nil || copy.Provider == nil || *original.Provider != *copy.Provider {
+			t.Errorf("Provider mismatch: expected %v, got %v", *original.Provider, *copy.Provider)
 		}
 	})
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -23,7 +24,8 @@ var (
 	initArch           string
 	initDocker         bool
 	initGitLivereload  bool
-	initPlatform       string
+	initProvider       string
+	initPlatform       string // Deprecated: use initProvider instead
 	initBlueprint      string
 	initEndpoint       string
 	initSetFlags       []string
@@ -108,9 +110,20 @@ var initCmd = &cobra.Command{
 				return fmt.Errorf("failed to set git.livereload.enabled: %w", err)
 			}
 		}
+		if initProvider != "" {
+			if err := configHandler.SetContextValue("provider", initProvider); err != nil {
+				return fmt.Errorf("failed to set provider: %w", err)
+			}
+		}
+
+		// Handle deprecated --platform flag
 		if initPlatform != "" {
-			if err := configHandler.SetContextValue("platform", initPlatform); err != nil {
-				return fmt.Errorf("failed to set platform: %w", err)
+			fmt.Fprintf(os.Stderr, "\033[33mWarning: The --platform flag is deprecated and will be removed in a future version. Please use --provider instead.\033[0m\n")
+			if initProvider != "" {
+				return fmt.Errorf("cannot specify both --provider and --platform flags. Please use --provider only")
+			}
+			if err := configHandler.SetContextValue("provider", initPlatform); err != nil {
+				return fmt.Errorf("failed to set provider: %w", err)
 			}
 		}
 
@@ -146,10 +159,14 @@ func init() {
 	initCmd.Flags().StringVar(&initArch, "vm-arch", "", "Specify the architecture for Colima")
 	initCmd.Flags().BoolVar(&initDocker, "docker", false, "Enable Docker")
 	initCmd.Flags().BoolVar(&initGitLivereload, "git-livereload", false, "Enable Git Livereload")
-	initCmd.Flags().StringVar(&initPlatform, "platform", "", "Specify the platform to use [local|metal]")
+	initCmd.Flags().StringVar(&initProvider, "provider", "", "Specify the provider to use [local|metal|aws|azure]")
+	initCmd.Flags().StringVar(&initPlatform, "platform", "", "Deprecated: use --provider instead")
 	initCmd.Flags().StringVar(&initBlueprint, "blueprint", "", "Specify the blueprint to use")
 	initCmd.Flags().StringVar(&initEndpoint, "endpoint", "", "Specify the kubernetes API endpoint")
 	initCmd.Flags().StringSliceVar(&initSetFlags, "set", []string{}, "Override configuration values. Example: --set dns.enabled=false --set cluster.endpoint=https://localhost:6443")
+
+	// Mark the platform flag as deprecated
+	initCmd.Flags().MarkDeprecated("platform", "use --provider instead")
 
 	rootCmd.AddCommand(initCmd)
 }

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -394,7 +394,7 @@ func TestInitCmd(t *testing.T) {
 		// When executing the init command with platform flag
 		cmd := createTestInitCmd()
 		ctx := context.WithValue(context.Background(), injectorKey, mocks.Injector)
-		cmd.SetArgs([]string{"--platform", "local"})
+		cmd.SetArgs([]string{"--provider", "local"})
 		cmd.SetContext(ctx)
 		err := cmd.Execute()
 

--- a/pkg/blueprint/blueprint_handler.go
+++ b/pkg/blueprint/blueprint_handler.go
@@ -365,16 +365,16 @@ func (b *BaseBlueprintHandler) GetTerraformComponents() []blueprintv1alpha1.Terr
 	return resolvedBlueprint.TerraformComponents
 }
 
-// GetDefaultTemplateData generates default template data based on the platform configuration.
-// It uses the embedded platform templates to create a map of template files that can be
+// GetDefaultTemplateData generates default template data based on the provider configuration.
+// It uses the embedded provider templates to create a map of template files that can be
 // used by the init pipeline for generating context-specific configurations.
 func (b *BaseBlueprintHandler) GetDefaultTemplateData(contextName string) (map[string][]byte, error) {
-	platform := b.configHandler.GetString("platform")
-	if platform == "" {
-		platform = b.configHandler.GetString("cluster.platform")
+	provider := b.configHandler.GetString("provider")
+	if provider == "" {
+		provider = b.configHandler.GetString("cluster.platform")
 	}
 
-	templateData, err := b.loadPlatformTemplate(platform)
+	templateData, err := b.loadPlatformTemplate(provider)
 	if err != nil || len(templateData) == 0 {
 		templateData, err = b.loadPlatformTemplate("default")
 		if err != nil {

--- a/pkg/blueprint/blueprint_handler_test.go
+++ b/pkg/blueprint/blueprint_handler_test.go
@@ -2478,13 +2478,13 @@ func TestBlueprintHandler_GetDefaultTemplateData(t *testing.T) {
 	}
 
 	t.Run("ReturnsDefaultTemplate", func(t *testing.T) {
-		// Given a blueprint handler with default platform
+		// Given a blueprint handler with default provider
 		handler, mocks := setup(t)
 
-		// Set platform to default
+		// Set provider to default
 		if mockConfigHandler, ok := mocks.ConfigHandler.(*config.MockConfigHandler); ok {
 			mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-				if key == "platform" {
+				if key == "provider" {
 					return "default"
 				}
 				return ""
@@ -2514,13 +2514,13 @@ func TestBlueprintHandler_GetDefaultTemplateData(t *testing.T) {
 	})
 
 	t.Run("ReturnsLocalTemplate", func(t *testing.T) {
-		// Given a blueprint handler with local platform
+		// Given a blueprint handler with local provider
 		handler, mocks := setup(t)
 
-		// Set platform to local
+		// Set provider to local
 		if mockConfigHandler, ok := mocks.ConfigHandler.(*config.MockConfigHandler); ok {
 			mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-				if key == "platform" {
+				if key == "provider" {
 					return "local"
 				}
 				return ""
@@ -2549,10 +2549,10 @@ func TestBlueprintHandler_GetDefaultTemplateData(t *testing.T) {
 		// Given a blueprint handler with AWS platform
 		handler, mocks := setup(t)
 
-		// Set platform to aws
+		// Set provider to aws
 		if mockConfigHandler, ok := mocks.ConfigHandler.(*config.MockConfigHandler); ok {
 			mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-				if key == "platform" {
+				if key == "provider" {
 					return "aws"
 				}
 				return ""
@@ -2577,11 +2577,11 @@ func TestBlueprintHandler_GetDefaultTemplateData(t *testing.T) {
 		}
 	})
 
-	t.Run("FallsBackToDefaultWhenPlatformEmpty", func(t *testing.T) {
-		// Given a blueprint handler with empty platform
+	t.Run("FallsBackToDefaultWhenProviderEmpty", func(t *testing.T) {
+		// Given a blueprint handler with empty provider
 		handler, mocks := setup(t)
 
-		// Set platform to empty
+		// Set provider to empty
 		if mockConfigHandler, ok := mocks.ConfigHandler.(*config.MockConfigHandler); ok {
 			mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
 				return ""
@@ -2606,14 +2606,14 @@ func TestBlueprintHandler_GetDefaultTemplateData(t *testing.T) {
 		}
 	})
 
-	t.Run("FallsBackToDefaultWhenUnknownPlatform", func(t *testing.T) {
-		// Given a blueprint handler with unknown platform
+	t.Run("FallsBackToDefaultWhenUnknownProvider", func(t *testing.T) {
+		// Given a blueprint handler with unknown provider
 		handler, mocks := setup(t)
 
-		// Set platform to unknown
+		// Set provider to unknown
 		if mockConfigHandler, ok := mocks.ConfigHandler.(*config.MockConfigHandler); ok {
 			mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-				if key == "platform" {
+				if key == "provider" {
 					return "unknown"
 				}
 				return ""

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -21,6 +21,7 @@ import (
 
 // DefaultConfig returns the default configuration
 var DefaultConfig = v1alpha1.Context{
+	Provider: ptrString("local"),
 	Terraform: &terraform.TerraformConfig{
 		Enabled: ptrBool(true),
 		Backend: &terraform.BackendConfig{
@@ -145,6 +146,7 @@ var commonDNSConfig = dns.DNSConfig{
 }
 
 var DefaultConfig_Localhost = v1alpha1.Context{
+	Provider:    ptrString("local"),
 	Environment: map[string]string{},
 	Docker:      commonDockerConfig.Copy(),
 	Git:         commonGitConfig.Copy(),
@@ -163,6 +165,7 @@ var DefaultConfig_Localhost = v1alpha1.Context{
 }
 
 var DefaultConfig_Full = v1alpha1.Context{
+	Provider:    ptrString("local"),
 	Environment: map[string]string{},
 	Docker:      commonDockerConfig.Copy(),
 	Git:         commonGitConfig.Copy(),

--- a/pkg/config/yaml_config_handler_test.go
+++ b/pkg/config/yaml_config_handler_test.go
@@ -3307,7 +3307,7 @@ contexts:
 			Environment: map[string]string{
 				"DEFAULT_VAR": "default_value",
 			},
-			Platform: ptrString("local"),
+			Provider: ptrString("local"),
 		}
 
 		err = handler.SetDefault(defaultConfig)
@@ -3322,9 +3322,9 @@ contexts:
 		}
 
 		// And the default values should be added
-		platform := handler.GetString("platform")
-		if platform != "local" {
-			t.Errorf("Expected platform to be added as 'local', got '%s'", platform)
+		provider := handler.GetString("provider")
+		if provider != "local" {
+			t.Errorf("Expected provider to be added as 'local', got '%s'", provider)
 		}
 	})
 }

--- a/pkg/pipelines/init.go
+++ b/pkg/pipelines/init.go
@@ -351,18 +351,18 @@ func (p *InitPipeline) setDefaultConfiguration(_ context.Context, contextName st
 	return nil
 }
 
-// processPlatformConfiguration applies platform-specific configuration settings based on the "platform" value in the configuration handler.
+// processPlatformConfiguration applies provider-specific configuration settings based on the "provider" value in the configuration handler.
 // For "aws", it enables AWS and sets the cluster driver to "eks".
 // For "azure", it enables Azure and sets the cluster driver to "aks".
 // For "metal" and "local", it sets the cluster driver to "talos".
 // Returns an error if any configuration operation fails.
 func (p *InitPipeline) processPlatformConfiguration(_ context.Context) error {
-	platform := p.configHandler.GetString("platform")
-	if platform == "" {
+	provider := p.configHandler.GetString("provider")
+	if provider == "" {
 		return nil
 	}
 
-	switch platform {
+	switch provider {
 	case "aws":
 		if err := p.configHandler.SetContextValue("aws.enabled", true); err != nil {
 			return fmt.Errorf("Error setting aws.enabled: %w", err)

--- a/pkg/pipelines/init_test.go
+++ b/pkg/pipelines/init_test.go
@@ -559,7 +559,7 @@ func TestInitPipeline_setDefaultConfiguration(t *testing.T) {
 			switch key {
 			case "vm.driver":
 				return vmDriver
-			case "platform":
+			case "provider":
 				return platform
 			default:
 				return ""
@@ -645,14 +645,14 @@ func TestInitPipeline_setDefaultConfiguration(t *testing.T) {
 }
 
 func TestInitPipeline_processPlatformConfiguration(t *testing.T) {
-	setup := func(t *testing.T, platform string) (*InitPipeline, *config.MockConfigHandler) {
+	setup := func(t *testing.T, provider string) (*InitPipeline, *config.MockConfigHandler) {
 		t.Helper()
 		pipeline := &InitPipeline{}
 
 		mockConfigHandler := config.NewMockConfigHandler()
 		mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "platform" {
-				return platform
+			if key == "provider" {
+				return provider
 			}
 			return ""
 		}
@@ -664,21 +664,21 @@ func TestInitPipeline_processPlatformConfiguration(t *testing.T) {
 		return pipeline, mockConfigHandler
 	}
 
-	platformTests := []struct {
+	providerTests := []struct {
 		name     string
-		platform string
+		provider string
 	}{
-		{name: "HandlesAWSPlatform", platform: "aws"},
-		{name: "HandlesAzurePlatform", platform: "azure"},
-		{name: "HandlesMetalPlatform", platform: "metal"},
-		{name: "HandlesLocalPlatform", platform: "local"},
-		{name: "HandlesEmptyPlatform", platform: ""},
+		{name: "HandlesAWSProvider", provider: "aws"},
+		{name: "HandlesAzureProvider", provider: "azure"},
+		{name: "HandlesMetalProvider", provider: "metal"},
+		{name: "HandlesLocalProvider", provider: "local"},
+		{name: "HandlesEmptyProvider", provider: ""},
 	}
 
-	for _, tt := range platformTests {
+	for _, tt := range providerTests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Given a pipeline with specific platform configuration
-			pipeline, _ := setup(t, tt.platform)
+			// Given a pipeline with specific provider configuration
+			pipeline, _ := setup(t, tt.provider)
 
 			// When processPlatformConfiguration is called
 			err := pipeline.processPlatformConfiguration(context.Background())

--- a/pkg/pipelines/pipeline.go
+++ b/pkg/pipelines/pipeline.go
@@ -665,7 +665,7 @@ func (p *BasePipeline) withServices() ([]services.Service, error) {
 		}
 	}
 
-	// Add cluster services (TalosService instances) based on cluster driver using tagged switch
+	// Add cluster services based on cluster driver
 	clusterDriver := p.configHandler.GetString("cluster.driver", "")
 	switch clusterDriver {
 	case "talos", "omni":
@@ -687,6 +687,10 @@ func (p *BasePipeline) withServices() ([]services.Service, error) {
 			p.injector.Register(fmt.Sprintf("clusterNode.%s", serviceName), workerService)
 			serviceList = append(serviceList, workerService)
 		}
+	case "eks", "aks":
+		// For managed cloud clusters (EKS, AKS), no local cluster services are needed
+		// The cluster is managed by the cloud provider
+		break
 	}
 
 	return serviceList, nil


### PR DESCRIPTION
We'll now use `provider` as the primary CSP or local platform. `--platform` is deprecated. There wil continue to be a `cluster.platform` field which is influenced by `provider`, but can be set independently.