### PR TITLE
fix(config): Enable cluster by default

### DIFF
--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -28,6 +28,9 @@ var DefaultConfig = v1alpha1.Context{
 			Type: "local",
 		},
 	},
+	Cluster: &cluster.ClusterConfig{
+		Enabled: ptrBool(true),
+	},
 }
 
 var commonDockerConfig = docker.DockerConfig{


### PR DESCRIPTION
The `cluster: enabled` setting should be true by default. By not including it, failures occurred due to the lack of `KUBECONFIG` environment variables.