### PR TITLE
feat(config): Support windsor.yaml in subfolders

### DIFF
--- a/pkg/config/config_handler.go
+++ b/pkg/config/config_handler.go
@@ -21,6 +21,7 @@ type ConfigHandler interface {
 	Initialize() error
 	LoadConfig(path string) error
 	LoadConfigString(content string) error
+	LoadContextConfig() error
 	GetString(key string, defaultValue ...string) string
 	GetInt(key string, defaultValue ...int) int
 	GetBool(key string, defaultValue ...bool) bool
@@ -174,6 +175,11 @@ func (c *BaseConfigHandler) Clean() error {
 // IsLoaded checks if the configuration has been loaded
 func (c *BaseConfigHandler) IsLoaded() bool {
 	return c.loaded
+}
+
+// LoadContextConfig provides a base implementation that should be overridden by concrete implementations
+func (c *BaseConfigHandler) LoadContextConfig() error {
+	return fmt.Errorf("LoadContextConfig not implemented in base config handler")
 }
 
 // SetSecretsProvider sets the secrets provider for the config handler

--- a/pkg/config/config_handler_test.go
+++ b/pkg/config/config_handler_test.go
@@ -684,3 +684,34 @@ func TestBaseConfigHandler_SetSecretsProvider(t *testing.T) {
 		}
 	})
 }
+
+// =============================================================================
+// LoadContextConfig Tests
+// =============================================================================
+
+func TestBaseConfigHandler_LoadContextConfig(t *testing.T) {
+	setup := func(t *testing.T) *BaseConfigHandler {
+		t.Helper()
+		injector := di.NewInjector()
+		handler := NewBaseConfigHandler(injector)
+		return handler
+	}
+
+	t.Run("ReturnsNotImplementedError", func(t *testing.T) {
+		// Given a BaseConfigHandler
+		handler := setup(t)
+
+		// When LoadContextConfig is called
+		err := handler.LoadContextConfig()
+
+		// Then it should return the expected error
+		if err == nil {
+			t.Fatal("LoadContextConfig() expected error, got nil")
+		}
+
+		expectedError := "LoadContextConfig not implemented in base config handler"
+		if err.Error() != expectedError {
+			t.Errorf("LoadContextConfig() error = %v, expected '%s'", err, expectedError)
+		}
+	})
+}

--- a/pkg/config/mock_config_handler.go
+++ b/pkg/config/mock_config_handler.go
@@ -10,6 +10,7 @@ type MockConfigHandler struct {
 	InitializeFunc                  func() error
 	LoadConfigFunc                  func(path string) error
 	LoadConfigStringFunc            func(content string) error
+	LoadContextConfigFunc           func() error
 	IsLoadedFunc                    func() bool
 	GetStringFunc                   func(key string, defaultValue ...string) string
 	GetIntFunc                      func(key string, defaultValue ...int) int
@@ -64,6 +65,14 @@ func (m *MockConfigHandler) LoadConfig(path string) error {
 func (m *MockConfigHandler) LoadConfigString(content string) error {
 	if m.LoadConfigStringFunc != nil {
 		return m.LoadConfigStringFunc(content)
+	}
+	return nil
+}
+
+// LoadContextConfig calls the mock LoadContextConfigFunc if set, otherwise returns nil
+func (m *MockConfigHandler) LoadContextConfig() error {
+	if m.LoadContextConfigFunc != nil {
+		return m.LoadContextConfigFunc()
 	}
 	return nil
 }

--- a/pkg/config/mock_config_handler_test.go
+++ b/pkg/config/mock_config_handler_test.go
@@ -735,3 +735,35 @@ func TestMockConfigHandler_GenerateContextID(t *testing.T) {
 		}
 	})
 }
+
+func TestMockConfigHandler_LoadContextConfig(t *testing.T) {
+	t.Run("WithFuncSet", func(t *testing.T) {
+		// Given a MockConfigHandler with LoadContextConfigFunc set
+		mockHandler := NewMockConfigHandler()
+		expectedError := fmt.Errorf("mocked load context config error")
+		mockHandler.LoadContextConfigFunc = func() error {
+			return expectedError
+		}
+
+		// When LoadContextConfig is called
+		err := mockHandler.LoadContextConfig()
+
+		// Then it should return the mocked error
+		if err != expectedError {
+			t.Errorf("LoadContextConfig() error = %v, expected %v", err, expectedError)
+		}
+	})
+
+	t.Run("WithNoFuncSet", func(t *testing.T) {
+		// Given a MockConfigHandler with no LoadContextConfigFunc set
+		mockHandler := NewMockConfigHandler()
+
+		// When LoadContextConfig is called
+		err := mockHandler.LoadContextConfig()
+
+		// Then it should return nil
+		if err != nil {
+			t.Errorf("LoadContextConfig() error = %v, expected nil", err)
+		}
+	})
+}

--- a/pkg/pipelines/pipeline.go
+++ b/pkg/pipelines/pipeline.go
@@ -507,6 +507,10 @@ func (p *BasePipeline) loadConfig() error {
 		}
 	}
 
+	if err := p.configHandler.LoadContextConfig(); err != nil {
+		return fmt.Errorf("error loading context config: %w", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
It's now possible to override values from the project root's `windsor.yaml` by including a `windsor.yaml` containing only context config, in `contexts/<context>/windsor.yaml`.