### PR TITLE
refactor(config): Initialize windsor.yaml to context folder

### DIFF
--- a/pkg/config/config_handler.go
+++ b/pkg/config/config_handler.go
@@ -30,7 +30,7 @@ type ConfigHandler interface {
 	Set(key string, value any) error
 	SetContextValue(key string, value any) error
 	Get(key string) any
-	SaveConfig(path string, overwrite ...bool) error
+	SaveConfig(overwrite ...bool) error
 	SetDefault(context v1alpha1.Context) error
 	GetConfig() *v1alpha1.Context
 	GetContext() string

--- a/pkg/config/mock_config_handler.go
+++ b/pkg/config/mock_config_handler.go
@@ -19,7 +19,7 @@ type MockConfigHandler struct {
 	GetStringMapFunc                func(key string, defaultValue ...map[string]string) map[string]string
 	SetFunc                         func(key string, value any) error
 	SetContextValueFunc             func(key string, value any) error
-	SaveConfigFunc                  func(path string, overwrite ...bool) error
+	SaveConfigFunc                  func(overwrite ...bool) error
 	GetFunc                         func(key string) any
 	SetDefaultFunc                  func(context v1alpha1.Context) error
 	GetConfigFunc                   func() *v1alpha1.Context
@@ -164,10 +164,10 @@ func (m *MockConfigHandler) Get(key string) any {
 	return "mock-value"
 }
 
-// SaveConfig calls the mock SaveConfigFunc if set, otherwise returns nil
-func (m *MockConfigHandler) SaveConfig(path string, overwrite ...bool) error {
+// SaveConfig calls the SaveConfigFunc if set, otherwise returns nil
+func (m *MockConfigHandler) SaveConfig(overwrite ...bool) error {
 	if m.SaveConfigFunc != nil {
-		return m.SaveConfigFunc(path, overwrite...)
+		return m.SaveConfigFunc(overwrite...)
 	}
 	return nil
 }

--- a/pkg/config/mock_config_handler_test.go
+++ b/pkg/config/mock_config_handler_test.go
@@ -348,10 +348,10 @@ func TestMockConfigHandler_SaveConfig(t *testing.T) {
 	t.Run("WithPath", func(t *testing.T) {
 		// Given a mock config handler with SaveConfigFunc set to return an error
 		handler := NewMockConfigHandler()
-		handler.SaveConfigFunc = func(path string, overwrite ...bool) error { return mockSaveErr }
+		handler.SaveConfigFunc = func(overwrite ...bool) error { return mockSaveErr }
 
-		// When SaveConfig is called with a path
-		err := handler.SaveConfig("some/path")
+		// When SaveConfig is called
+		err := handler.SaveConfig()
 
 		// Then the error should match the expected mock error
 		if err != mockSaveErr {
@@ -363,12 +363,12 @@ func TestMockConfigHandler_SaveConfig(t *testing.T) {
 		// Given a mock config handler without SaveConfigFunc set
 		handler := NewMockConfigHandler()
 
-		// When SaveConfig is called with a path
-		err := handler.SaveConfig("some/path")
+		// When SaveConfig is called
+		err := handler.SaveConfig()
 
 		// Then no error should be returned
 		if err != nil {
-			t.Errorf("Expected error = %v, got = %v", nil, err)
+			t.Errorf("Expected SaveConfig to return nil, got %v", err)
 		}
 	})
 }

--- a/pkg/config/yaml_config_handler_test.go
+++ b/pkg/config/yaml_config_handler_test.go
@@ -243,299 +243,114 @@ func TestYamlConfigHandler_SaveConfig(t *testing.T) {
 	}
 
 	t.Run("Success", func(t *testing.T) {
-		// Given a set of safe mocks and a YamlConfigHandler
+		// Given a YamlConfigHandler with a mocked shell
 		handler, mocks := setup(t)
 
-		// And a mocked shell that returns a project root
+		tempDir := t.TempDir()
 		mocks.Shell.GetProjectRootFunc = func() (string, error) {
-			return "/mock/project/root", nil
+			return tempDir, nil
 		}
 
-		// And a key-value pair to save
-		handler.Set("saveKey", "saveValue")
+		// And a context is set
+		handler.context = "test-context"
 
-		// And a valid config path
-		tempDir := t.TempDir()
-		configPath := filepath.Join(tempDir, "save_config.yaml")
-
-		// When SaveConfig is called with the valid path
-		err := handler.SaveConfig(configPath)
-
-		// Then no error should be returned
-		if err != nil {
-			t.Errorf("Expected error = %v, got = %v", nil, err)
-		}
-
-		// And the config file should exist at the specified path
-		if _, err := handler.shims.Stat(configPath); os.IsNotExist(err) {
-			t.Fatalf("Config file was not created at %s", configPath)
-		}
-	})
-
-	t.Run("WithEmptyPath", func(t *testing.T) {
-		// Given a set of safe mocks and a YamlConfigHandler
-		handler, _ := setup(t)
-
-		// And a key-value pair to save
-		handler.Set("saveKey", "saveValue")
-
-		// When SaveConfig is called with an empty path
-		err := handler.SaveConfig("")
-
-		// Then an error should be returned
-		if err == nil {
-			t.Fatalf("SaveConfig() expected error, got nil")
-		}
-
-		// And the error message should be as expected
-		expectedError := "path cannot be empty"
-		if err.Error() != expectedError {
-			t.Fatalf("SaveConfig() error = %v, expected '%s'", err, expectedError)
-		}
-	})
-
-	t.Run("UsePredefinedPath", func(t *testing.T) {
-		// Given a set of safe mocks and a YamlConfigHandler
-		handler, _ := setup(t)
-
-		// And a predefined path is set
-		handler.path = filepath.Join(t.TempDir(), "config.yaml")
-
-		// When SaveConfig is called with an empty path
-		err := handler.SaveConfig("")
-
-		// Then no error should be returned
-		if err != nil {
-			t.Errorf("Expected error = %v, got = %v", nil, err)
-		}
-
-		// And the config file should exist at the predefined path
-		if _, err := handler.shims.Stat(handler.path); os.IsNotExist(err) {
-			t.Fatalf("Config file was not created at %s", handler.path)
-		}
-	})
-
-	t.Run("CreateDirectoriesError", func(t *testing.T) {
-		// Given a set of safe mocks and a YamlConfigHandler
-		handler, _ := setup(t)
-
-		// And a predefined path is set
-		handler.path = filepath.Join(t.TempDir(), "config.yaml")
-
-		// And a mocked osMkdirAll that returns an error
-		handler.shims.MkdirAll = func(path string, perm os.FileMode) error {
-			return fmt.Errorf("mocked error creating directories")
-		}
+		// And some configuration data
+		handler.Set("contexts.test-context.provider", "local")
 
 		// When SaveConfig is called
-		err := handler.SaveConfig(handler.path)
-
-		// Then an error should be returned
-		if err == nil {
-			t.Fatalf("SaveConfig() expected error, got nil")
-		}
-
-		// And the error message should be as expected
-		expectedErrorMessage := "error creating directories: mocked error creating directories"
-		if err.Error() != expectedErrorMessage {
-			t.Errorf("Unexpected error message. Got: %s, Expected: %s", err.Error(), expectedErrorMessage)
-		}
-	})
-
-	t.Run("MarshallingError", func(t *testing.T) {
-		// Given a set of safe mocks and a YamlConfigHandler
-		handler, _ := setup(t)
-
-		// And a mocked yamlMarshal that returns an error
-		handler.shims.YamlMarshal = func(v any) ([]byte, error) {
-			return nil, fmt.Errorf("mock marshalling error")
-		}
-
-		// And a sample config
-		handler.config = v1alpha1.Config{}
-
-		// When SaveConfig is called
-		err := handler.SaveConfig("test.yaml")
-
-		// Then an error should be returned
-		if err == nil {
-			t.Fatalf("Expected error, got nil")
-		}
-
-		// And the error message should be as expected
-		expectedErrorMessage := "error marshalling yaml: mock marshalling error"
-		if err.Error() != expectedErrorMessage {
-			t.Errorf("Unexpected error message. Got: %s, Expected: %s", err.Error(), expectedErrorMessage)
-		}
-	})
-
-	t.Run("WriteFileError", func(t *testing.T) {
-		// Given a set of safe mocks and a YamlConfigHandler
-		handler, _ := setup(t)
-
-		// And a key-value pair to save
-		handler.Set("saveKey", "saveValue")
-
-		// And a mocked osWriteFile that returns an error
-		handler.shims.WriteFile = func(filename string, data []byte, perm os.FileMode) error {
-			return fmt.Errorf("mocked error writing file")
-		}
-
-		// And a valid config path
-		tempDir := t.TempDir()
-		configPath := filepath.Join(tempDir, "save_config.yaml")
-
-		// When SaveConfig is called
-		err := handler.SaveConfig(configPath)
-
-		// Then an error should be returned
-		if err == nil {
-			t.Fatalf("SaveConfig() expected error, got nil")
-		}
-
-		// And the error message should be as expected
-		expectedError := "error writing config file: mocked error writing file"
-		if err.Error() != expectedError {
-			t.Fatalf("SaveConfig() error = %v, expected '%s'", err, expectedError)
-		}
-	})
-
-	t.Run("UsesExistingPath", func(t *testing.T) {
-		// Given a set of safe mocks and a YamlConfigHandler
-		handler, _ := setup(t)
-
-		// And a temporary directory and expected path
-		tempDir := t.TempDir()
-		expectedPath := filepath.Join(tempDir, "config.yaml")
-
-		// And a path is set and a key-value pair to save
-		handler.path = expectedPath
-		handler.Set("key", "value")
-
-		// When SaveConfig is called with an empty path
-		err := handler.SaveConfig("")
-
-		// Then no error should be returned
-		if err != nil {
-			t.Fatalf("SaveConfig() unexpected error: %v", err)
-		}
-	})
-
-	t.Run("OverwriteFalseWithExistingFile", func(t *testing.T) {
-		// Given a set of safe mocks and a YamlConfigHandler
-		handler, _ := setup(t)
-
-		// And a valid config path with existing file
-		tempDir := t.TempDir()
-		configPath := filepath.Join(tempDir, "existing_config.yaml")
-
-		// Create an existing file
-		existingContent := "existing: content"
-		if err := os.WriteFile(configPath, []byte(existingContent), 0644); err != nil {
-			t.Fatalf("Failed to create existing file: %v", err)
-		}
-
-		// And a key-value pair to save
-		handler.Set("saveKey", "newValue")
-
-		// Use real file system for this test
-		handler.shims = NewShims()
-
-		// When SaveConfig is called with overwrite=false
-		err := handler.SaveConfig(configPath, false)
+		err := handler.SaveConfig()
 
 		// Then no error should be returned
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
 
-		// And the existing file should not be modified
-		content, err := os.ReadFile(configPath)
-		if err != nil {
-			t.Fatalf("Failed to read file: %v", err)
+		// And the root windsor.yaml should exist with only version
+		rootConfigPath := filepath.Join(tempDir, "windsor.yaml")
+		if _, err := handler.shims.Stat(rootConfigPath); os.IsNotExist(err) {
+			t.Fatalf("Root config file was not created at %s", rootConfigPath)
 		}
-		if string(content) != existingContent {
-			t.Errorf("Expected file to remain unchanged, got %s", string(content))
+
+		// And the context config should exist
+		contextConfigPath := filepath.Join(tempDir, "contexts", "test-context", "windsor.yaml")
+		if _, err := handler.shims.Stat(contextConfigPath); os.IsNotExist(err) {
+			t.Fatalf("Context config file was not created at %s", contextConfigPath)
 		}
 	})
 
-	t.Run("OverwriteTrueWithExistingFile", func(t *testing.T) {
-		// Given a set of safe mocks and a YamlConfigHandler
-		handler, _ := setup(t)
+	t.Run("WithOverwriteFalse", func(t *testing.T) {
+		// Given a YamlConfigHandler with existing config files
+		handler, mocks := setup(t)
 
-		// And a valid config path with existing file
 		tempDir := t.TempDir()
-		configPath := filepath.Join(tempDir, "existing_config.yaml")
-
-		// Create an existing file
-		existingContent := "existing: content"
-		if err := os.WriteFile(configPath, []byte(existingContent), 0644); err != nil {
-			t.Fatalf("Failed to create existing file: %v", err)
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return tempDir, nil
 		}
 
-		// And a key-value pair to save
-		handler.Set("saveKey", "newValue")
+		handler.context = "test-context"
 
-		// Use real file system for this test
-		handler.shims = NewShims()
+		// Create existing files
+		rootConfigPath := filepath.Join(tempDir, "windsor.yaml")
+		os.WriteFile(rootConfigPath, []byte("existing content"), 0644)
 
-		// When SaveConfig is called with overwrite=true
-		err := handler.SaveConfig(configPath, true)
+		contextDir := filepath.Join(tempDir, "contexts", "test-context")
+		os.MkdirAll(contextDir, 0755)
+		contextConfigPath := filepath.Join(contextDir, "windsor.yaml")
+		os.WriteFile(contextConfigPath, []byte("existing context content"), 0644)
+
+		// When SaveConfig is called with overwrite false
+		err := handler.SaveConfig(false)
 
 		// Then no error should be returned
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
 
-		// And the file should be overwritten with new content
-		content, err := os.ReadFile(configPath)
-		if err != nil {
-			t.Fatalf("Failed to read file: %v", err)
+		// And the files should still contain the original content
+		rootContent, _ := os.ReadFile(rootConfigPath)
+		if string(rootContent) != "existing content" {
+			t.Errorf("Root config file was overwritten when it shouldn't have been")
 		}
-		if string(content) == existingContent {
-			t.Error("Expected file to be overwritten, but it remained unchanged")
+
+		contextContent, _ := os.ReadFile(contextConfigPath)
+		if string(contextContent) != "existing context content" {
+			t.Errorf("Context config file was overwritten when it shouldn't have been")
 		}
 	})
 
-	t.Run("OmitsNullValues", func(t *testing.T) {
-		// Given a set of safe mocks and a YamlConfigHandler
+	t.Run("ShellNotInitialized", func(t *testing.T) {
+		// Given a YamlConfigHandler without initialized shell
 		handler, _ := setup(t)
+		handler.shell = nil
 
-		// And a context and config with null values
-		handler.context = "local"
-		handler.config = v1alpha1.Config{
-			Contexts: map[string]*v1alpha1.Context{
-				"default": {
-					Environment: map[string]string{
-						"name":  "John Doe",
-						"email": "john.doe@example.com",
-					},
-					AWS: &aws.AWSConfig{
-						AWSEndpointURL: nil,
-					},
-				},
-			},
+		// When SaveConfig is called
+		err := handler.SaveConfig()
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatal("Expected error, got nil")
 		}
+		if err.Error() != "shell not initialized" {
+			t.Errorf("Expected 'shell not initialized' error, got %v", err)
+		}
+	})
 
-		// And a mocked writeFile to capture written data
-		var writtenData []byte
-		handler.shims.WriteFile = func(filename string, data []byte, perm os.FileMode) error {
-			writtenData = data
-			return nil
+	t.Run("GetProjectRootError", func(t *testing.T) {
+		// Given a YamlConfigHandler with shell that fails to get project root
+		handler, mocks := setup(t)
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return "", fmt.Errorf("project root failed")
 		}
 
 		// When SaveConfig is called
-		err := handler.SaveConfig("mocked_path.yaml")
+		err := handler.SaveConfig()
 
-		// Then no error should be returned
-		if err != nil {
-			t.Fatalf("SaveConfig() unexpected error: %v", err)
+		// Then an error should be returned
+		if err == nil {
+			t.Fatal("Expected error, got nil")
 		}
-
-		// And the YAML data should match the expected content
-		expectedContent := "version: v1alpha1\ncontexts:\n  default:\n    environment:\n      email: john.doe@example.com\n      name: John Doe\n    aws: {}\n"
-		if string(writtenData) != expectedContent {
-			t.Errorf("Config file content = %v, expected %v", string(writtenData), expectedContent)
+		if !strings.Contains(err.Error(), "error retrieving project root") {
+			t.Errorf("Expected 'error retrieving project root' in error, got %v", err)
 		}
 	})
 }


### PR DESCRIPTION
When performing a `windsor init`, the `windsor.yaml` that's written to the `contexts/` folder will contain all the context configuration. Context specific content will no longer write to the root `windsor.yaml` during initialization.

Also, no longer overwrites the `windsor.yaml` files when passing `--reset`. Windsor configs should remain static, allowing overwriting of other configuration values only.