### PR TITLE
fix(livereload): Include kustomize/ folder and don't ignore data/

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -6,8 +6,8 @@ import "time"
 const (
 	// renovate: datasource=docker depName=ghcr.io/windsorcli/git-livereload-server
 	DEFAULT_GIT_LIVE_RELOAD_IMAGE         = "ghcr.io/windsorcli/git-livereload:v0.2.0"
-	DEFAULT_GIT_LIVE_RELOAD_RSYNC_INCLUDE = ""
-	DEFAULT_GIT_LIVE_RELOAD_RSYNC_EXCLUDE = ".windsor,.terraform,data,.volumes,.venv"
+	DEFAULT_GIT_LIVE_RELOAD_RSYNC_INCLUDE = "kustomize"
+	DEFAULT_GIT_LIVE_RELOAD_RSYNC_EXCLUDE = ".windsor,.terraform,.volumes,.venv"
 	DEFAULT_GIT_LIVE_RELOAD_RSYNC_PROTECT = "flux-system"
 	DEFAULT_GIT_LIVE_RELOAD_USERNAME      = "local"
 	DEFAULT_GIT_LIVE_RELOAD_PASSWORD      = "local"

--- a/pkg/services/git_livereload_service_test.go
+++ b/pkg/services/git_livereload_service_test.go
@@ -164,17 +164,19 @@ func TestGitLivereloadService_GetComposeConfig(t *testing.T) {
 			t.Fatalf("GetComposeConfig() error = %v", err)
 		}
 
-		// Then verify the configuration doesn't contain RSYNC_INCLUDE when it's empty
+		// Then verify the configuration contains the expected service with default RSYNC_INCLUDE
 		expectedName := "git"
 		serviceFound := false
-		rsyncIncludePresent := false
+		rsyncIncludeFound := false
 
 		for _, service := range composeConfig.Services {
 			if service.Name == expectedName {
 				serviceFound = true
-				// Check if RSYNC_INCLUDE environment variable is NOT set when empty
-				if _, exists := service.Environment["RSYNC_INCLUDE"]; exists {
-					rsyncIncludePresent = true
+				// Check if RSYNC_INCLUDE environment variable is set to default value
+				if rsyncInclude, exists := service.Environment["RSYNC_INCLUDE"]; exists && rsyncInclude != nil {
+					if *rsyncInclude == "kustomize" {
+						rsyncIncludeFound = true
+					}
 				}
 				break
 			}
@@ -183,8 +185,8 @@ func TestGitLivereloadService_GetComposeConfig(t *testing.T) {
 		if !serviceFound {
 			t.Errorf("expected service with name %q to be in the list of configurations", expectedName)
 		}
-		if rsyncIncludePresent {
-			t.Errorf("expected RSYNC_INCLUDE environment variable to NOT be set when rsync_include is empty")
+		if !rsyncIncludeFound {
+			t.Errorf("expected RSYNC_INCLUDE environment variable to be set to default value 'kustomize'")
 		}
 	})
 }


### PR DESCRIPTION
Updated constants that enumerate default settings for git-livereload. Now we wish to only include the `kustomize/` folder.