### PR TITLE
feat(pipeline): Show DNS configuration warning on "windsor up"

### DIFF
--- a/pkg/pipelines/up.go
+++ b/pkg/pipelines/up.go
@@ -188,6 +188,8 @@ func (p *UpPipeline) Execute(ctx context.Context) error {
 
 	// Configure DNS settings
 	if dnsEnabled := p.configHandler.GetBool("dns.enabled"); dnsEnabled {
+		fmt.Fprintf(os.Stderr, "→ ⚠️  DNS configuration may require administrative privileges\n")
+
 		if err := p.networkManager.ConfigureDNS(); err != nil {
 			return fmt.Errorf("Error configuring DNS: %w", err)
 		}


### PR DESCRIPTION
Sometimes `windsor up` asks for `sudo` permissions or requires administrative privileges in order to configure DNS. The user needs to be notified if local DNS configuration is enabled.