### PR TITLE
feat(blueprint): Implement dependsOn for terraform components

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -115,6 +115,9 @@ type TerraformComponent struct {
 	// FullPath is the complete path, not serialized to YAML.
 	FullPath string `yaml:"-"`
 
+	// DependsOn lists dependencies of this terraform component.
+	DependsOn []string `yaml:"dependsOn,omitempty"`
+
 	// Values are configuration values for the module.
 	Values map[string]any `yaml:"values,omitempty"`
 
@@ -235,12 +238,15 @@ func (b *Blueprint) DeepCopy() *Blueprint {
 		valuesCopy := make(map[string]any, len(component.Values))
 		maps.Copy(valuesCopy, component.Values)
 
+		dependsOnCopy := append([]string{}, component.DependsOn...)
+
 		terraformComponentsCopy[i] = TerraformComponent{
-			Source:   component.Source,
-			Path:     component.Path,
-			FullPath: component.FullPath,
-			Values:   valuesCopy,
-			Destroy:  component.Destroy,
+			Source:    component.Source,
+			Path:      component.Path,
+			FullPath:  component.FullPath,
+			DependsOn: dependsOnCopy,
+			Values:    valuesCopy,
+			Destroy:   component.Destroy,
 		}
 	}
 
@@ -339,6 +345,10 @@ func (b *Blueprint) Merge(overlay *Blueprint) {
 
 					if overlayComponent.FullPath != "" {
 						mergedComponent.FullPath = overlayComponent.FullPath
+					}
+
+					if overlayComponent.DependsOn != nil {
+						mergedComponent.DependsOn = overlayComponent.DependsOn
 					}
 
 					if overlayComponent.Destroy != nil {

--- a/api/v1alpha1/blueprint_types_test.go
+++ b/api/v1alpha1/blueprint_types_test.go
@@ -34,11 +34,12 @@ func TestBlueprint_Merge(t *testing.T) {
 			},
 			TerraformComponents: []TerraformComponent{
 				{
-					Source:   "source1",
-					Path:     "module/path1",
-					Values:   map[string]any{"key1": "value1"},
-					FullPath: "original/full/path",
-					Destroy:  ptrBool(true),
+					Source:    "source1",
+					Path:      "module/path1",
+					Values:    map[string]any{"key1": "value1"},
+					FullPath:  "original/full/path",
+					DependsOn: []string{},
+					Destroy:   ptrBool(true),
 				},
 			},
 			Kustomizations: []Kustomization{
@@ -80,18 +81,20 @@ func TestBlueprint_Merge(t *testing.T) {
 			},
 			TerraformComponents: []TerraformComponent{
 				{
-					Source:   "source1",
-					Path:     "module/path1",
-					Values:   map[string]any{"key2": "value2"},
-					FullPath: "updated/full/path",
-					Destroy:  ptrBool(false),
+					Source:    "source1",
+					Path:      "module/path1",
+					Values:    map[string]any{"key2": "value2"},
+					FullPath:  "updated/full/path",
+					DependsOn: []string{"module/path2"},
+					Destroy:   ptrBool(false),
 				},
 				{
-					Source:   "source2",
-					Path:     "module/path2",
-					Values:   map[string]any{"key3": "value3"},
-					FullPath: "new/full/path",
-					Destroy:  ptrBool(true),
+					Source:    "source2",
+					Path:      "module/path2",
+					Values:    map[string]any{"key3": "value3"},
+					FullPath:  "new/full/path",
+					DependsOn: []string{},
+					Destroy:   ptrBool(true),
 				},
 			},
 			Kustomizations: []Kustomization{
@@ -170,6 +173,9 @@ func TestBlueprint_Merge(t *testing.T) {
 		if component1.FullPath != "updated/full/path" {
 			t.Errorf("Expected FullPath to be 'updated/full/path', but got '%s'", component1.FullPath)
 		}
+		if len(component1.DependsOn) != 1 || component1.DependsOn[0] != "module/path2" {
+			t.Errorf("Expected DependsOn to contain ['module/path2'], but got %v", component1.DependsOn)
+		}
 		if component1.Destroy == nil || *component1.Destroy != false {
 			t.Errorf("Expected Destroy to be false, but got %v", component1.Destroy)
 		}
@@ -180,6 +186,9 @@ func TestBlueprint_Merge(t *testing.T) {
 		}
 		if component2.FullPath != "new/full/path" {
 			t.Errorf("Expected FullPath to be 'new/full/path', but got '%s'", component2.FullPath)
+		}
+		if len(component2.DependsOn) != 0 {
+			t.Errorf("Expected DependsOn to be empty, but got %v", component2.DependsOn)
 		}
 		if component2.Destroy == nil || *component2.Destroy != true {
 			t.Errorf("Expected Destroy to be true, but got %v", component2.Destroy)
@@ -216,11 +225,12 @@ func TestBlueprint_Merge(t *testing.T) {
 			ApiVersion: "v1alpha1",
 			TerraformComponents: []TerraformComponent{
 				{
-					Source:   "source1",
-					Path:     "module/path1",
-					Values:   nil, // Initialize with nil
-					FullPath: "original/full/path",
-					Destroy:  ptrBool(true),
+					Source:    "source1",
+					Path:      "module/path1",
+					Values:    nil, // Initialize with nil
+					FullPath:  "original/full/path",
+					DependsOn: []string{},
+					Destroy:   ptrBool(true),
 				},
 			},
 		}
@@ -233,8 +243,9 @@ func TestBlueprint_Merge(t *testing.T) {
 					Values: map[string]any{
 						"key1": "value1",
 					},
-					FullPath: "overlay/full/path",
-					Destroy:  ptrBool(false),
+					FullPath:  "overlay/full/path",
+					DependsOn: []string{"dependency1"},
+					Destroy:   ptrBool(false),
 				},
 			},
 		}

--- a/pkg/env/shims.go
+++ b/pkg/env/shims.go
@@ -7,6 +7,7 @@ package env
 
 import (
 	"crypto/rand"
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -28,6 +29,7 @@ type Shims struct {
 	ReadDir        func(string) ([]os.DirEntry, error)
 	YamlUnmarshal  func([]byte, any) error
 	YamlMarshal    func(any) ([]byte, error)
+	JsonUnmarshal  func([]byte, any) error
 	Remove         func(string) error
 	RemoveAll      func(string) error
 	CryptoRandRead func([]byte) (int, error)
@@ -55,6 +57,7 @@ func NewShims() *Shims {
 		ReadDir:        os.ReadDir,
 		YamlUnmarshal:  yaml.Unmarshal,
 		YamlMarshal:    yaml.Marshal,
+		JsonUnmarshal:  json.Unmarshal,
 		Remove:         os.Remove,
 		RemoveAll:      os.RemoveAll,
 		CryptoRandRead: func(b []byte) (int, error) { return rand.Read(b) },

--- a/pkg/env/terraform_env_test.go
+++ b/pkg/env/terraform_env_test.go
@@ -35,11 +35,13 @@ func setupTerraformEnvMocks(t *testing.T, opts ...*SetupOptions) *Mocks {
 		return filepath.Join("mock", "project", "root", "terraform", "project", "path"), nil
 	}
 
+	// Smart Glob function that handles any terraform directory pattern
 	mocks.Shims.Glob = func(pattern string) ([]string, error) {
 		if strings.Contains(pattern, "*.tf") {
+			// Extract directory from pattern and return a main.tf file in that directory
+			dir := filepath.Dir(pattern)
 			return []string{
-				filepath.Join("real", "terraform", "project", "path", "file1.tf"),
-				filepath.Join("real", "terraform", "project", "path", "file2.tf"),
+				filepath.Join(dir, "main.tf"),
 			}, nil
 		}
 		return nil, nil

--- a/pkg/env/terraform_env_test.go
+++ b/pkg/env/terraform_env_test.go
@@ -1419,8 +1419,9 @@ func TestTerraformEnv_DependencyResolution(t *testing.T) {
 		}
 
 		// Set up the current working directory to match the "app" component
+		workingDir := filepath.Join(string(filepath.Separator), "project", "terraform", "app")
 		mocks.Shims.Getwd = func() (string, error) {
-			return "/project/terraform/app", nil
+			return workingDir, nil
 		}
 
 		// When getting environment variables for the "app" component
@@ -1486,7 +1487,7 @@ func TestTerraformEnv_DependencyResolution(t *testing.T) {
 
 		// Set up the current working directory to match one of the components
 		mocks.Shims.Getwd = func() (string, error) {
-			return "/project/terraform/a", nil
+			return filepath.Join(string(filepath.Separator), "project", "terraform", "a"), nil
 		}
 
 		// When getting environment variables
@@ -1517,7 +1518,7 @@ func TestTerraformEnv_DependencyResolution(t *testing.T) {
 
 		// Set up the current working directory to match the component
 		mocks.Shims.Getwd = func() (string, error) {
-			return "/project/terraform/app", nil
+			return filepath.Join(string(filepath.Separator), "project", "terraform", "app"), nil
 		}
 
 		// When getting environment variables
@@ -1561,7 +1562,7 @@ func TestTerraformEnv_DependencyResolution(t *testing.T) {
 
 		// Set up the current working directory to match the dependent component
 		mocks.Shims.Getwd = func() (string, error) {
-			return "/project/terraform/app/frontend", nil
+			return filepath.Join(string(filepath.Separator), "project", "terraform", "app", "frontend"), nil
 		}
 
 		// When getting environment variables
@@ -1610,7 +1611,7 @@ func TestTerraformEnv_DependencyResolution(t *testing.T) {
 
 		// Set up the current working directory to match the dependent component
 		mocks.Shims.Getwd = func() (string, error) {
-			return "/project/terraform/app", nil
+			return filepath.Join(string(filepath.Separator), "project", "terraform", "app"), nil
 		}
 
 		// When getting environment variables
@@ -1644,7 +1645,7 @@ func TestTerraformEnv_DependencyResolution(t *testing.T) {
 
 		// Set up the current working directory to not match any component
 		mocks.Shims.Getwd = func() (string, error) {
-			return "/project/terraform/nonexistent", nil
+			return filepath.FromSlash("/project/terraform/nonexistent"), nil
 		}
 
 		// When getting environment variables


### PR DESCRIPTION
Terraform components now include a `dependsOn` field. This can be configured with a list of paths to other terraform components. When specified, output variables from dependencies are injected in to the environment, allowing for variable chaining across TF components.