### PR TITLE
fix(git-livereload): Upgrade to v0.2.1

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -5,7 +5,7 @@ import "time"
 // Default git livereload settings
 const (
 	// renovate: datasource=docker depName=ghcr.io/windsorcli/git-livereload-server
-	DEFAULT_GIT_LIVE_RELOAD_IMAGE         = "ghcr.io/windsorcli/git-livereload:v0.2.0"
+	DEFAULT_GIT_LIVE_RELOAD_IMAGE         = "ghcr.io/windsorcli/git-livereload:v0.2.1"
 	DEFAULT_GIT_LIVE_RELOAD_RSYNC_INCLUDE = "kustomize"
 	DEFAULT_GIT_LIVE_RELOAD_RSYNC_EXCLUDE = ".windsor,.terraform,.volumes,.venv"
 	DEFAULT_GIT_LIVE_RELOAD_RSYNC_PROTECT = "flux-system"


### PR DESCRIPTION
Fixes an issue in which empty repositories were being served if no files were being sync'd.