### PR TITLE
fix(secrets): Prevent a secret leak scenario with --verbose

### DIFF
--- a/pkg/secrets/shims.go
+++ b/pkg/secrets/shims.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 
 	"github.com/1password/onepassword-sdk-go"
 	"github.com/getsops/sops/v3/decrypt"
@@ -26,6 +27,8 @@ type Shims struct {
 	DecryptFile          func(string, string) ([]byte, error)
 	NewOnePasswordClient func(context.Context, ...onepassword.ClientOption) (*onepassword.Client, error)
 	ResolveSecret        func(*onepassword.Client, context.Context, string) (string, error)
+	Command              func(name string, arg ...string) *exec.Cmd
+	CmdOutput            func(cmd *exec.Cmd) ([]byte, error)
 }
 
 // =============================================================================
@@ -46,6 +49,10 @@ func NewShims() *Shims {
 				return "", errors.New("client is nil")
 			}
 			return client.Secrets().Resolve(ctx, secretRef)
+		},
+		Command: exec.Command,
+		CmdOutput: func(cmd *exec.Cmd) ([]byte, error) {
+			return cmd.Output()
 		},
 	}
 }


### PR DESCRIPTION
The onepassword CLI secret provider used `shell.ExecSilent`. This function returns output when run via `--verbose`. Because the secret had not yet been retrieved, it was not yet being scrubbed.

The fix is to just use the direct `exec.Command` call, reducing any more code that could introduce such leakages and retreiving the secret directly from the command.