### PR TITLE
fix(cmd): Don't show usage on error

### DIFF
--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -30,6 +30,7 @@ Examples:
 
   # Bundle using metadata.yaml for name/version
   windsor bundle`,
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get shared dependency injector from context
 		injector := cmd.Context().Value(injectorKey).(di.Injector)

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -45,10 +45,11 @@ var getContextCmd = &cobra.Command{
 
 // setContextCmd represents the set command
 var setContextCmd = &cobra.Command{
-	Use:   "set [context]",
-	Short: "Set the current context",
-	Long:  "Set the current context in the configuration and save it",
-	Args:  cobra.ExactArgs(1), // Ensure exactly one argument is provided
+	Use:          "set [context]",
+	Short:        "Set the current context",
+	Long:         "Set the current context in the configuration and save it",
+	Args:         cobra.ExactArgs(1), // Ensure exactly one argument is provided
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Get shared dependency injector from context
 		injector := cmd.Context().Value(injectorKey).(di.Injector)
@@ -80,9 +81,10 @@ var setContextCmd = &cobra.Command{
 
 // getContextAliasCmd is an alias for the get command
 var getContextAliasCmd = &cobra.Command{
-	Use:   "get-context",
-	Short: "Alias for 'context get'",
-	Long:  "Alias for 'context get'",
+	Use:          "get-context",
+	Short:        "Alias for 'context get'",
+	Long:         "Alias for 'context get'",
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		rootCmd.SetArgs(append([]string{"context", "get"}, args...))
 		return rootCmd.Execute()
@@ -91,10 +93,11 @@ var getContextAliasCmd = &cobra.Command{
 
 // setContextAliasCmd is an alias for the set command
 var setContextAliasCmd = &cobra.Command{
-	Use:   "set-context [context]",
-	Short: "Alias for 'context set'",
-	Long:  "Alias for 'context set'",
-	Args:  cobra.ExactArgs(1), // Ensure exactly one argument is provided
+	Use:          "set-context [context]",
+	Short:        "Alias for 'context set'",
+	SilenceUsage: true,
+	Long:         "Alias for 'context set'",
+	Args:         cobra.ExactArgs(1), // Ensure exactly one argument is provided
 	RunE: func(cmd *cobra.Command, args []string) error {
 		rootCmd.SetArgs(append([]string{"context", "set"}, args...))
 		return rootCmd.Execute()

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -11,10 +11,11 @@ import (
 
 // execCmd represents the exec command
 var execCmd = &cobra.Command{
-	Use:   "exec [command] [args...]",
-	Short: "Execute a command with environment variables",
-	Long:  "Execute a command with environment variables loaded from configuration and secrets",
-	Args:  cobra.MinimumNArgs(1),
+	Use:          "exec [command] [args...]",
+	Short:        "Execute a command with environment variables",
+	Long:         "Execute a command with environment variables loaded from configuration and secrets",
+	Args:         cobra.MinimumNArgs(1),
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Safety check for arguments
 		if len(args) == 0 {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -32,10 +32,11 @@ var (
 )
 
 var initCmd = &cobra.Command{
-	Use:   "init [context]",
-	Short: "Initialize the application environment",
-	Long:  "Initialize the application environment with the specified context configuration",
-	Args:  cobra.MaximumNArgs(1),
+	Use:          "init [context]",
+	Short:        "Initialize the application environment",
+	Long:         "Initialize the application environment with the specified context configuration",
+	Args:         cobra.MaximumNArgs(1),
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		injector := cmd.Context().Value(injectorKey).(di.Injector)
 		ctx := cmd.Context()

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -18,9 +18,10 @@ var Goos = runtime.GOOS
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Display the current version",
-	Long:  "Display the current version of the application",
+	Use:          "version",
+	Short:        "Display the current version",
+	Long:         "Display the current version of the application",
+	SilenceUsage: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		platform := fmt.Sprintf("%s/%s", Goos, runtime.GOARCH)
 		cmd.Printf("Version: %s\nCommit SHA: %s\nPlatform: %s\n", version, commitSHA, platform)


### PR DESCRIPTION
It's not necessary and often distracting to show usage info when a command fails. This PR disables it.