### PR TITLE
feat(check): Include --k8s-endpoint for health checking api endpoint

### DIFF
--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -246,10 +246,10 @@ func TestCheckNodeHealthCmd(t *testing.T) {
 			t.Error("Expected error, got nil")
 		}
 
-		// And error should contain nodes message
-		expectedError := "No nodes specified. Use --nodes flag to specify nodes to check"
+		// And error should contain health checks message
+		expectedError := "No health checks specified. Use --nodes and/or --k8s-endpoint flags to specify health checks to perform"
 		if err.Error() != expectedError {
-			t.Errorf("Expected error about nodes, got: %v", err)
+			t.Errorf("Expected error about health checks, got: %v", err)
 		}
 	})
 
@@ -268,10 +268,10 @@ func TestCheckNodeHealthCmd(t *testing.T) {
 			t.Error("Expected error, got nil")
 		}
 
-		// And error should contain nodes message
-		expectedError := "No nodes specified. Use --nodes flag to specify nodes to check"
+		// And error should contain health checks message
+		expectedError := "No health checks specified. Use --nodes and/or --k8s-endpoint flags to specify health checks to perform"
 		if err.Error() != expectedError {
-			t.Errorf("Expected error about nodes, got: %v", err)
+			t.Errorf("Expected error about health checks, got: %v", err)
 		}
 	})
 }

--- a/pkg/cluster/cluster_client.go
+++ b/pkg/cluster/cluster_client.go
@@ -13,16 +13,6 @@ import (
 	"github.com/windsorcli/cli/pkg/constants"
 )
 
-// =============================================================================
-// Types
-// =============================================================================
-
-// HealthStatus represents the result of a health check.
-type HealthStatus struct {
-	Healthy bool
-	Details string
-}
-
 // ClusterClient defines the interface for cluster operations
 type ClusterClient interface {
 	// WaitForNodesHealthy waits for nodes to be healthy and optionally match a specific version

--- a/pkg/cluster/cluster_client_test.go
+++ b/pkg/cluster/cluster_client_test.go
@@ -19,13 +19,6 @@ type SetupOptions struct {
 	// Add setup options as needed
 }
 
-// setupMocks creates and configures mock objects for testing
-func setupMocks(t *testing.T, opts ...*SetupOptions) *Mocks {
-	t.Helper()
-
-	return &Mocks{}
-}
-
 // =============================================================================
 // Test Constructor
 // =============================================================================

--- a/pkg/kubernetes/mock_kubernetes_client.go
+++ b/pkg/kubernetes/mock_kubernetes_client.go
@@ -5,6 +5,8 @@
 package kubernetes
 
 import (
+	"context"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -22,6 +24,7 @@ type MockKubernetesClient struct {
 	ApplyResourceFunc  func(gvr schema.GroupVersionResource, obj *unstructured.Unstructured, opts metav1.ApplyOptions) (*unstructured.Unstructured, error)
 	DeleteResourceFunc func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error
 	PatchResourceFunc  func(gvr schema.GroupVersionResource, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*unstructured.Unstructured, error)
+	CheckHealthFunc    func(ctx context.Context, endpoint string) error
 }
 
 // =============================================================================
@@ -75,4 +78,12 @@ func (m *MockKubernetesClient) PatchResource(gvr schema.GroupVersionResource, na
 		return m.PatchResourceFunc(gvr, namespace, name, pt, data, opts)
 	}
 	return nil, nil
+}
+
+// CheckHealth implements KubernetesClient interface
+func (m *MockKubernetesClient) CheckHealth(ctx context.Context, endpoint string) error {
+	if m.CheckHealthFunc != nil {
+		return m.CheckHealthFunc(ctx, endpoint)
+	}
+	return nil
 }

--- a/pkg/kubernetes/mock_kubernetes_manager.go
+++ b/pkg/kubernetes/mock_kubernetes_manager.go
@@ -5,6 +5,8 @@
 package kubernetes
 
 import (
+	"context"
+
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
 	sourcev1 "github.com/fluxcd/source-controller/api/v1"
@@ -32,6 +34,7 @@ type MockKubernetesManager struct {
 	ApplyOCIRepositoryFunc              func(repo *sourcev1.OCIRepository) error
 	WaitForKustomizationsDeletedFunc    func(message string, names ...string) error
 	CheckGitRepositoryStatusFunc        func() error
+	WaitForKubernetesHealthyFunc        func(ctx context.Context, endpoint string) error
 }
 
 // =============================================================================
@@ -163,6 +166,14 @@ func (m *MockKubernetesManager) WaitForKustomizationsDeleted(message string, nam
 func (m *MockKubernetesManager) CheckGitRepositoryStatus() error {
 	if m.CheckGitRepositoryStatusFunc != nil {
 		return m.CheckGitRepositoryStatusFunc()
+	}
+	return nil
+}
+
+// WaitForKubernetesHealthy waits for the Kubernetes API endpoint to be healthy with polling and timeout
+func (m *MockKubernetesManager) WaitForKubernetesHealthy(ctx context.Context, endpoint string) error {
+	if m.WaitForKubernetesHealthyFunc != nil {
+		return m.WaitForKubernetesHealthyFunc(ctx, endpoint)
 	}
 	return nil
 }


### PR DESCRIPTION
It is now possible to run `windsor check node-health --k8s-endpoint` to include a k8s api endpoint health check as part of the node health checks. This will improve control flow for automated routines.