### PR TITLE
fix(init): Ensure correct default configs when running init

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -81,6 +81,14 @@ var initCmd = &cobra.Command{
 
 		configHandler := injector.Resolve("configHandler").(config.ConfigHandler)
 
+		// Set provider in context if it's been set (either via --provider or --platform)
+		if initProvider != "" {
+			if err := configHandler.SetContextValue("provider", initProvider); err != nil {
+				return fmt.Errorf("failed to set provider: %w", err)
+			}
+		}
+
+		// Set other configuration values
 		if initBackend != "" {
 			if err := configHandler.SetContextValue("terraform.backend.type", initBackend); err != nil {
 				return fmt.Errorf("failed to set terraform.backend.type: %w", err)
@@ -129,13 +137,6 @@ var initCmd = &cobra.Command{
 		if initGitLivereload {
 			if err := configHandler.SetContextValue("git.livereload.enabled", true); err != nil {
 				return fmt.Errorf("failed to set git.livereload.enabled: %w", err)
-			}
-		}
-
-		// Set provider in context if it's been set (either via --provider or --platform)
-		if initProvider != "" {
-			if err := configHandler.SetContextValue("provider", initProvider); err != nil {
-				return fmt.Errorf("failed to set provider: %w", err)
 			}
 		}
 

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -935,9 +935,111 @@ func TestInitCmd(t *testing.T) {
 		cmd.SetContext(ctx)
 		err := cmd.Execute()
 
-		// Then no error should occur - platform should override auto-set provider
+		// Then no error should occur and platform should override auto-set provider
 		if err != nil {
-			t.Errorf("Expected success when platform overrides auto-set provider, got error: %v", err)
+			t.Errorf("Expected success, got error: %v", err)
+		}
+	})
+
+	t.Run("RunEContextNameAsProvider", func(t *testing.T) {
+		// Given a temporary directory with mocked dependencies
+		mocks := setupInitTest(t)
+
+		// When executing the init command with context name that matches a provider
+		cmd := createTestInitCmd()
+		ctx := context.WithValue(context.Background(), injectorKey, mocks.Injector)
+		cmd.SetArgs([]string{"aws"}) // No explicit provider flag
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then no error should occur and context name should be used as provider
+		if err != nil {
+			t.Errorf("Expected success, got error: %v", err)
+		}
+	})
+
+	t.Run("RunEContextNameAsProviderForAzure", func(t *testing.T) {
+		// Given a temporary directory with mocked dependencies
+		mocks := setupInitTest(t)
+
+		// When executing the init command with "azure" context name
+		cmd := createTestInitCmd()
+		ctx := context.WithValue(context.Background(), injectorKey, mocks.Injector)
+		cmd.SetArgs([]string{"azure"}) // No explicit provider flag
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then no error should occur and "azure" should be used as provider
+		if err != nil {
+			t.Errorf("Expected success, got error: %v", err)
+		}
+	})
+
+	t.Run("RunEContextNameAsProviderForMetal", func(t *testing.T) {
+		// Given a temporary directory with mocked dependencies
+		mocks := setupInitTest(t)
+
+		// When executing the init command with "metal" context name
+		cmd := createTestInitCmd()
+		ctx := context.WithValue(context.Background(), injectorKey, mocks.Injector)
+		cmd.SetArgs([]string{"metal"}) // No explicit provider flag
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then no error should occur and "metal" should be used as provider
+		if err != nil {
+			t.Errorf("Expected success, got error: %v", err)
+		}
+	})
+
+	t.Run("RunEContextNameAsProviderForLocal", func(t *testing.T) {
+		// Given a temporary directory with mocked dependencies
+		mocks := setupInitTest(t)
+
+		// When executing the init command with "local" context name
+		cmd := createTestInitCmd()
+		ctx := context.WithValue(context.Background(), injectorKey, mocks.Injector)
+		cmd.SetArgs([]string{"local"}) // No explicit provider flag
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then no error should occur and "local" should be used as provider
+		if err != nil {
+			t.Errorf("Expected success, got error: %v", err)
+		}
+	})
+
+	t.Run("RunEExplicitProviderOverridesContextName", func(t *testing.T) {
+		// Given a temporary directory with mocked dependencies
+		mocks := setupInitTest(t)
+
+		// When executing the init command with explicit provider that differs from context name
+		cmd := createTestInitCmd()
+		ctx := context.WithValue(context.Background(), injectorKey, mocks.Injector)
+		cmd.SetArgs([]string{"aws", "--provider", "azure"}) // Context name vs explicit provider
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then no error should occur and explicit provider should be used
+		if err != nil {
+			t.Errorf("Expected success, got error: %v", err)
+		}
+	})
+
+	t.Run("RunEUnknownContextNameDoesNotSetProvider", func(t *testing.T) {
+		// Given a temporary directory with mocked dependencies
+		mocks := setupInitTest(t)
+
+		// When executing the init command with unknown context name
+		cmd := createTestInitCmd()
+		ctx := context.WithValue(context.Background(), injectorKey, mocks.Injector)
+		cmd.SetArgs([]string{"unknown-context"}) // Unknown context name
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then no error should occur and no provider should be set
+		if err != nil {
+			t.Errorf("Expected success, got error: %v", err)
 		}
 	})
 

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -22,14 +22,14 @@ import (
 // DefaultConfig returns the default configuration
 var DefaultConfig = v1alpha1.Context{
 	Provider: ptrString("local"),
+	Cluster: &cluster.ClusterConfig{
+		Enabled: ptrBool(true),
+	},
 	Terraform: &terraform.TerraformConfig{
 		Enabled: ptrBool(true),
 		Backend: &terraform.BackendConfig{
 			Type: "local",
 		},
-	},
-	Cluster: &cluster.ClusterConfig{
-		Enabled: ptrBool(true),
 	},
 }
 

--- a/pkg/pipelines/pipeline.go
+++ b/pkg/pipelines/pipeline.go
@@ -277,9 +277,12 @@ func (p *BasePipeline) withGenerators() ([]generators.Generator, error) {
 	p.injector.Register("gitGenerator", gitGenerator)
 	generatorList = append(generatorList, gitGenerator)
 
-	terraformGenerator := generators.NewTerraformGenerator(p.injector)
-	p.injector.Register("terraformGenerator", terraformGenerator)
-	generatorList = append(generatorList, terraformGenerator)
+	// Only create Terraform generator if Terraform is enabled
+	if p.configHandler.GetBool("terraform.enabled", false) {
+		terraformGenerator := generators.NewTerraformGenerator(p.injector)
+		p.injector.Register("terraformGenerator", terraformGenerator)
+		generatorList = append(generatorList, terraformGenerator)
+	}
 
 	return generatorList, nil
 }


### PR DESCRIPTION
Several small bugs led to insufficient population of initial configs, especially `windsor.yaml`. Fixes the specification of `--provider`, and setting defaults.