### PR TITLE
ci(release): Pin latest core semver on release

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -174,6 +174,19 @@ jobs:
           fi
         shell: bash
 
+      - name: Fetch latest core version
+        id: core_version
+        run: |
+          # Fetch the latest release tag from windsorcli/core
+          LATEST_TAG=$(curl -s "https://api.github.com/repos/windsorcli/core/releases/latest" | jq -r '.tag_name')
+          if [ "$LATEST_TAG" = "null" ] || [ -z "$LATEST_TAG" ]; then
+            echo "Warning: Could not fetch latest core version, using fallback"
+            LATEST_TAG="latest"
+          fi
+          echo "Found latest core version: $LATEST_TAG"
+          echo "PINNED_BLUEPRINT_URL=oci://ghcr.io/windsorcli/core:$LATEST_TAG" >> $GITHUB_ENV
+        shell: bash
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@9c156ee8a17a598857849441385a2041ef570552 # v6.3.0
         with:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,6 +25,7 @@ builds:
       - "-X 'github.com/{{ .Env.GITHUB_REPOSITORY }}/cmd.version={{ .Version }}'"
       - "-X 'github.com/{{ .Env.GITHUB_REPOSITORY }}/pkg/secrets.version={{ .Version }}'"
       - "-X 'github.com/{{ .Env.GITHUB_REPOSITORY }}/cmd.commitSHA={{ .Env.GITHUB_SHA }}'"
+      - "-X 'github.com/{{ .Env.GITHUB_REPOSITORY }}/pkg/constants.PinnedBlueprintURL={{ .Env.PINNED_BLUEPRINT_URL }}'"
 
 # Archive configuration
 archives:

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -100,5 +100,18 @@ const (
 
 // Default OCI blueprint settings
 const (
-	DEFAULT_OCI_BLUEPRINT_URL = "oci://ghcr.io/windsorcli/core:v0.5.0"
+	DEFAULT_OCI_BLUEPRINT_URL = "oci://ghcr.io/windsorcli/core:latest"
 )
+
+// Build-time variable for pinned blueprint URL (set via ldflags)
+var PinnedBlueprintURL = ""
+
+// GetEffectiveBlueprintURL returns the pinned blueprint URL if set at build time,
+// otherwise returns the default blueprint URL. This allows for different behavior
+// between development builds (using :latest) and release builds (using pinned versions).
+func GetEffectiveBlueprintURL() string {
+	if PinnedBlueprintURL != "" {
+		return PinnedBlueprintURL
+	}
+	return DEFAULT_OCI_BLUEPRINT_URL
+}

--- a/pkg/pipelines/init.go
+++ b/pkg/pipelines/init.go
@@ -460,7 +460,8 @@ func (p *InitPipeline) prepareTemplateData(ctx context.Context) (map[string][]by
 	}
 
 	if p.artifactBuilder != nil {
-		ociInfo, err := artifact.ParseOCIReference(constants.DEFAULT_OCI_BLUEPRINT_URL)
+		effectiveBlueprintURL := constants.GetEffectiveBlueprintURL()
+		ociInfo, err := artifact.ParseOCIReference(effectiveBlueprintURL)
 		if err != nil {
 			return nil, fmt.Errorf("failed to parse default blueprint reference: %w", err)
 		}
@@ -468,7 +469,7 @@ func (p *InitPipeline) prepareTemplateData(ctx context.Context) (map[string][]by
 		if err != nil {
 			return nil, fmt.Errorf("failed to get template data from default blueprint: %w", err)
 		}
-		p.fallbackBlueprintURL = constants.DEFAULT_OCI_BLUEPRINT_URL
+		p.fallbackBlueprintURL = effectiveBlueprintURL
 		return templateData, nil
 	}
 

--- a/pkg/template/jsonnet_template.go
+++ b/pkg/template/jsonnet_template.go
@@ -114,7 +114,7 @@ func (t *JsonnetTemplate) processJsonnetTemplate(templateContent string) (map[st
 	vm := t.shims.NewJsonnetVM()
 	vm.ExtCode("helpers", t.buildHelperLibrary())
 	vm.ExtCode("context", string(contextJSON))
-	vm.ExtCode("ociUrl", fmt.Sprintf("%q", constants.DEFAULT_OCI_BLUEPRINT_URL))
+	vm.ExtCode("ociUrl", fmt.Sprintf("%q", constants.GetEffectiveBlueprintURL()))
 
 	result, err := vm.EvaluateAnonymousSnippet("template.jsonnet", templateContent)
 	if err != nil {


### PR DESCRIPTION
Pinned releases now automatically pin themselves to the latest semver from the core repository. This mechanism assumes that significant changes to core will always be released before releasing a new version of the CLI. Furthermore, pinned combinations should be tested via integration tests.