### PR TITLE
feat(check): Check node readiness state

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -16,6 +16,7 @@ var (
 	nodeHealthNodes   []string
 	nodeHealthVersion string
 	k8sEndpoint       string
+	checkNodeReady    bool
 )
 
 var checkCmd = &cobra.Command{
@@ -81,7 +82,8 @@ var checkNodeHealthCmd = &cobra.Command{
 		ctx = context.WithValue(ctx, "timeout", nodeHealthTimeout)
 		ctx = context.WithValue(ctx, "version", nodeHealthVersion)
 		ctx = context.WithValue(ctx, "k8s-endpoint", k8sEndpoint)
-		ctx = context.WithValue(ctx, "k8s-endpoint-provided", k8sEndpoint != "")
+		ctx = context.WithValue(ctx, "k8s-endpoint-provided", k8sEndpoint != "" || checkNodeReady)
+		ctx = context.WithValue(ctx, "check-node-ready", checkNodeReady)
 		ctx = context.WithValue(ctx, "output", outputFunc)
 
 		// Set up the check pipeline
@@ -109,4 +111,5 @@ func init() {
 	checkNodeHealthCmd.Flags().StringVar(&nodeHealthVersion, "version", "", "Expected version to check against (optional)")
 	checkNodeHealthCmd.Flags().StringVar(&k8sEndpoint, "k8s-endpoint", "", "Perform Kubernetes API health check (use --k8s-endpoint or --k8s-endpoint=https://endpoint:6443)")
 	checkNodeHealthCmd.Flags().Lookup("k8s-endpoint").NoOptDefVal = "true"
+	checkNodeHealthCmd.Flags().BoolVar(&checkNodeReady, "ready", false, "Check Kubernetes node readiness status")
 }

--- a/pkg/kubernetes/kubernetes_manager.go
+++ b/pkg/kubernetes/kubernetes_manager.go
@@ -46,7 +46,8 @@ type KubernetesManager interface {
 	WaitForKustomizationsDeleted(message string, names ...string) error
 	CheckGitRepositoryStatus() error
 	GetKustomizationStatus(names []string) (map[string]bool, error)
-	WaitForKubernetesHealthy(ctx context.Context, endpoint string, nodeNames ...string) error
+	WaitForKubernetesHealthy(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error
+	GetNodeReadyStatus(ctx context.Context, nodeNames []string) (map[string]bool, error)
 }
 
 // =============================================================================
@@ -551,7 +552,7 @@ func (k *BaseKubernetesManager) GetKustomizationStatus(names []string) (map[stri
 // WaitForKubernetesHealthy waits for the Kubernetes API to be healthy and optionally checks node Ready state.
 // If nodeNames are provided, it will also verify that all specified nodes are in Ready state.
 // Returns an error if the API is unreachable or if any specified nodes are not Ready.
-func (k *BaseKubernetesManager) WaitForKubernetesHealthy(ctx context.Context, endpoint string, nodeNames ...string) error {
+func (k *BaseKubernetesManager) WaitForKubernetesHealthy(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
 	if k.client == nil {
 		return fmt.Errorf("kubernetes client not initialized")
 	}
@@ -576,7 +577,7 @@ func (k *BaseKubernetesManager) WaitForKubernetesHealthy(ctx context.Context, en
 
 			// If node names are specified, check their Ready state
 			if len(nodeNames) > 0 {
-				if err := k.waitForNodesReady(ctx, nodeNames); err != nil {
+				if err := k.waitForNodesReady(ctx, nodeNames, outputFunc); err != nil {
 					time.Sleep(pollInterval)
 					continue
 				}
@@ -589,26 +590,104 @@ func (k *BaseKubernetesManager) WaitForKubernetesHealthy(ctx context.Context, en
 	return fmt.Errorf("timeout waiting for Kubernetes API to be healthy")
 }
 
-// waitForNodesReady waits for all specified nodes to be in Ready state.
-// Returns an error if any nodes are not Ready within the context timeout.
-func (k *BaseKubernetesManager) waitForNodesReady(ctx context.Context, nodeNames []string) error {
-	readyStatus, err := k.client.GetNodeReadyStatus(ctx, nodeNames)
-	if err != nil {
-		return fmt.Errorf("failed to get node ready status: %w", err)
+// waitForNodesReady waits until all specified nodes exist and are in Ready state.
+// Returns an error if any nodes are missing or not Ready within the context deadline.
+func (k *BaseKubernetesManager) waitForNodesReady(ctx context.Context, nodeNames []string, outputFunc func(string)) error {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		deadline = time.Now().Add(5 * time.Minute)
 	}
 
+	pollInterval := 5 * time.Second
+	lastStatus := make(map[string]string)
+
+	for time.Now().Before(deadline) {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context cancelled while waiting for nodes to be ready")
+		default:
+			readyStatus, err := k.client.GetNodeReadyStatus(ctx, nodeNames)
+			if err != nil {
+				time.Sleep(pollInterval)
+				continue
+			}
+
+			var missingNodes []string
+			var notReadyNodes []string
+			var readyNodes []string
+
+			for _, nodeName := range nodeNames {
+				if ready, exists := readyStatus[nodeName]; !exists {
+					missingNodes = append(missingNodes, nodeName)
+				} else if !ready {
+					notReadyNodes = append(notReadyNodes, nodeName)
+				} else {
+					readyNodes = append(readyNodes, nodeName)
+				}
+			}
+
+			// Report status changes
+			if outputFunc != nil {
+				for _, nodeName := range nodeNames {
+					var currentStatus string
+					if ready, exists := readyStatus[nodeName]; !exists {
+						currentStatus = "NOT FOUND"
+					} else if ready {
+						currentStatus = "READY"
+					} else {
+						currentStatus = "NOT READY"
+					}
+
+					if lastStatus[nodeName] != currentStatus {
+						outputFunc(fmt.Sprintf("Node %s: %s", nodeName, currentStatus))
+						lastStatus[nodeName] = currentStatus
+					}
+				}
+			}
+
+			if len(missingNodes) == 0 && len(notReadyNodes) == 0 {
+				return nil
+			}
+
+			time.Sleep(pollInterval)
+		}
+	}
+
+	// Final check to get the current status for error reporting
+	readyStatus, err := k.client.GetNodeReadyStatus(ctx, nodeNames)
+	if err != nil {
+		return fmt.Errorf("timeout waiting for nodes to be ready: failed to get final status: %w", err)
+	}
+
+	var missingNodes []string
 	var notReadyNodes []string
+
 	for _, nodeName := range nodeNames {
-		if ready, exists := readyStatus[nodeName]; !exists || !ready {
+		if ready, exists := readyStatus[nodeName]; !exists {
+			missingNodes = append(missingNodes, nodeName)
+		} else if !ready {
 			notReadyNodes = append(notReadyNodes, nodeName)
 		}
 	}
 
-	if len(notReadyNodes) > 0 {
-		return fmt.Errorf("nodes not ready: %s", strings.Join(notReadyNodes, ", "))
+	if len(missingNodes) > 0 {
+		return fmt.Errorf("timeout waiting for nodes to appear: %s", strings.Join(missingNodes, ", "))
 	}
 
-	return nil
+	if len(notReadyNodes) > 0 {
+		return fmt.Errorf("timeout waiting for nodes to be ready: %s", strings.Join(notReadyNodes, ", "))
+	}
+
+	return fmt.Errorf("timeout waiting for nodes to be ready")
+}
+
+// GetNodeReadyStatus returns a map of node names to their Ready condition status.
+// Returns a map of node names to Ready status (true if Ready, false if NotReady), or an error if listing fails.
+func (k *BaseKubernetesManager) GetNodeReadyStatus(ctx context.Context, nodeNames []string) (map[string]bool, error) {
+	if k.client == nil {
+		return nil, fmt.Errorf("kubernetes client not initialized")
+	}
+	return k.client.GetNodeReadyStatus(ctx, nodeNames)
 }
 
 // applyWithRetry applies a resource using SSA with minimal logic

--- a/pkg/kubernetes/kubernetes_manager_test.go
+++ b/pkg/kubernetes/kubernetes_manager_test.go
@@ -1976,7 +1976,7 @@ func TestBaseKubernetesManager_WaitForKubernetesHealthy(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 
-		err := manager.WaitForKubernetesHealthy(ctx, "https://test-endpoint:6443")
+		err := manager.WaitForKubernetesHealthy(ctx, "https://test-endpoint:6443", nil)
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -1989,7 +1989,7 @@ func TestBaseKubernetesManager_WaitForKubernetesHealthy(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 		defer cancel()
 
-		err := manager.WaitForKubernetesHealthy(ctx, "https://test-endpoint:6443")
+		err := manager.WaitForKubernetesHealthy(ctx, "https://test-endpoint:6443", nil)
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}
@@ -2009,7 +2009,7 @@ func TestBaseKubernetesManager_WaitForKubernetesHealthy(t *testing.T) {
 		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		defer cancel()
 
-		err := manager.WaitForKubernetesHealthy(ctx, "https://test-endpoint:6443")
+		err := manager.WaitForKubernetesHealthy(ctx, "https://test-endpoint:6443", nil)
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}
@@ -2029,7 +2029,7 @@ func TestBaseKubernetesManager_WaitForKubernetesHealthy(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel() // Cancel immediately
 
-		err := manager.WaitForKubernetesHealthy(ctx, "https://test-endpoint:6443")
+		err := manager.WaitForKubernetesHealthy(ctx, "https://test-endpoint:6443", nil)
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}

--- a/pkg/kubernetes/mock_kubernetes_client.go
+++ b/pkg/kubernetes/mock_kubernetes_client.go
@@ -26,7 +26,6 @@ type MockKubernetesClient struct {
 	PatchResourceFunc      func(gvr schema.GroupVersionResource, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*unstructured.Unstructured, error)
 	CheckHealthFunc        func(ctx context.Context, endpoint string) error
 	GetNodeReadyStatusFunc func(ctx context.Context, nodeNames []string) (map[string]bool, error)
-	GetAllNodesFunc        func(ctx context.Context) ([]*unstructured.Unstructured, error)
 }
 
 // =============================================================================
@@ -96,12 +95,4 @@ func (m *MockKubernetesClient) GetNodeReadyStatus(ctx context.Context, nodeNames
 		return m.GetNodeReadyStatusFunc(ctx, nodeNames)
 	}
 	return make(map[string]bool), nil
-}
-
-// GetAllNodes implements KubernetesClient interface
-func (m *MockKubernetesClient) GetAllNodes(ctx context.Context) ([]*unstructured.Unstructured, error) {
-	if m.GetAllNodesFunc != nil {
-		return m.GetAllNodesFunc(ctx)
-	}
-	return []*unstructured.Unstructured{}, nil
 }

--- a/pkg/kubernetes/mock_kubernetes_client.go
+++ b/pkg/kubernetes/mock_kubernetes_client.go
@@ -19,12 +19,14 @@ import (
 
 // MockKubernetesClient is a mock implementation of KubernetesClient interface for testing
 type MockKubernetesClient struct {
-	GetResourceFunc    func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error)
-	ListResourcesFunc  func(gvr schema.GroupVersionResource, namespace string) (*unstructured.UnstructuredList, error)
-	ApplyResourceFunc  func(gvr schema.GroupVersionResource, obj *unstructured.Unstructured, opts metav1.ApplyOptions) (*unstructured.Unstructured, error)
-	DeleteResourceFunc func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error
-	PatchResourceFunc  func(gvr schema.GroupVersionResource, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*unstructured.Unstructured, error)
-	CheckHealthFunc    func(ctx context.Context, endpoint string) error
+	GetResourceFunc        func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error)
+	ListResourcesFunc      func(gvr schema.GroupVersionResource, namespace string) (*unstructured.UnstructuredList, error)
+	ApplyResourceFunc      func(gvr schema.GroupVersionResource, obj *unstructured.Unstructured, opts metav1.ApplyOptions) (*unstructured.Unstructured, error)
+	DeleteResourceFunc     func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error
+	PatchResourceFunc      func(gvr schema.GroupVersionResource, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*unstructured.Unstructured, error)
+	CheckHealthFunc        func(ctx context.Context, endpoint string) error
+	GetNodeReadyStatusFunc func(ctx context.Context, nodeNames []string) (map[string]bool, error)
+	GetAllNodesFunc        func(ctx context.Context) ([]*unstructured.Unstructured, error)
 }
 
 // =============================================================================
@@ -86,4 +88,20 @@ func (m *MockKubernetesClient) CheckHealth(ctx context.Context, endpoint string)
 		return m.CheckHealthFunc(ctx, endpoint)
 	}
 	return nil
+}
+
+// GetNodeReadyStatus implements KubernetesClient interface
+func (m *MockKubernetesClient) GetNodeReadyStatus(ctx context.Context, nodeNames []string) (map[string]bool, error) {
+	if m.GetNodeReadyStatusFunc != nil {
+		return m.GetNodeReadyStatusFunc(ctx, nodeNames)
+	}
+	return make(map[string]bool), nil
+}
+
+// GetAllNodes implements KubernetesClient interface
+func (m *MockKubernetesClient) GetAllNodes(ctx context.Context) ([]*unstructured.Unstructured, error) {
+	if m.GetAllNodesFunc != nil {
+		return m.GetAllNodesFunc(ctx)
+	}
+	return []*unstructured.Unstructured{}, nil
 }

--- a/pkg/kubernetes/mock_kubernetes_manager.go
+++ b/pkg/kubernetes/mock_kubernetes_manager.go
@@ -34,7 +34,7 @@ type MockKubernetesManager struct {
 	ApplyOCIRepositoryFunc              func(repo *sourcev1.OCIRepository) error
 	WaitForKustomizationsDeletedFunc    func(message string, names ...string) error
 	CheckGitRepositoryStatusFunc        func() error
-	WaitForKubernetesHealthyFunc        func(ctx context.Context, endpoint string) error
+	WaitForKubernetesHealthyFunc        func(ctx context.Context, endpoint string, nodeNames ...string) error
 }
 
 // =============================================================================
@@ -171,9 +171,9 @@ func (m *MockKubernetesManager) CheckGitRepositoryStatus() error {
 }
 
 // WaitForKubernetesHealthy waits for the Kubernetes API endpoint to be healthy with polling and timeout
-func (m *MockKubernetesManager) WaitForKubernetesHealthy(ctx context.Context, endpoint string) error {
+func (m *MockKubernetesManager) WaitForKubernetesHealthy(ctx context.Context, endpoint string, nodeNames ...string) error {
 	if m.WaitForKubernetesHealthyFunc != nil {
-		return m.WaitForKubernetesHealthyFunc(ctx, endpoint)
+		return m.WaitForKubernetesHealthyFunc(ctx, endpoint, nodeNames...)
 	}
 	return nil
 }

--- a/pkg/kubernetes/mock_kubernetes_manager.go
+++ b/pkg/kubernetes/mock_kubernetes_manager.go
@@ -34,7 +34,8 @@ type MockKubernetesManager struct {
 	ApplyOCIRepositoryFunc              func(repo *sourcev1.OCIRepository) error
 	WaitForKustomizationsDeletedFunc    func(message string, names ...string) error
 	CheckGitRepositoryStatusFunc        func() error
-	WaitForKubernetesHealthyFunc        func(ctx context.Context, endpoint string, nodeNames ...string) error
+	WaitForKubernetesHealthyFunc        func(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error
+	GetNodeReadyStatusFunc              func(ctx context.Context, nodeNames []string) (map[string]bool, error)
 }
 
 // =============================================================================
@@ -171,9 +172,17 @@ func (m *MockKubernetesManager) CheckGitRepositoryStatus() error {
 }
 
 // WaitForKubernetesHealthy waits for the Kubernetes API endpoint to be healthy with polling and timeout
-func (m *MockKubernetesManager) WaitForKubernetesHealthy(ctx context.Context, endpoint string, nodeNames ...string) error {
+func (m *MockKubernetesManager) WaitForKubernetesHealthy(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
 	if m.WaitForKubernetesHealthyFunc != nil {
-		return m.WaitForKubernetesHealthyFunc(ctx, endpoint, nodeNames...)
+		return m.WaitForKubernetesHealthyFunc(ctx, endpoint, outputFunc, nodeNames...)
 	}
 	return nil
+}
+
+// GetNodeReadyStatus returns a map of node names to their Ready condition status.
+func (m *MockKubernetesManager) GetNodeReadyStatus(ctx context.Context, nodeNames []string) (map[string]bool, error) {
+	if m.GetNodeReadyStatusFunc != nil {
+		return m.GetNodeReadyStatusFunc(ctx, nodeNames)
+	}
+	return make(map[string]bool), nil
 }

--- a/pkg/kubernetes/mock_kubernetes_manager_test.go
+++ b/pkg/kubernetes/mock_kubernetes_manager_test.go
@@ -420,7 +420,7 @@ func TestMockKubernetesManager_WaitForKubernetesHealthy(t *testing.T) {
 	t.Run("FuncSet", func(t *testing.T) {
 		manager := setup(t)
 		errVal := fmt.Errorf("kubernetes health check failed")
-		manager.WaitForKubernetesHealthyFunc = func(c context.Context, e string) error {
+		manager.WaitForKubernetesHealthyFunc = func(c context.Context, e string, nodeNames ...string) error {
 			if c != ctx {
 				t.Errorf("Expected context %v, got %v", ctx, c)
 			}

--- a/pkg/kubernetes/mock_kubernetes_manager_test.go
+++ b/pkg/kubernetes/mock_kubernetes_manager_test.go
@@ -420,7 +420,7 @@ func TestMockKubernetesManager_WaitForKubernetesHealthy(t *testing.T) {
 	t.Run("FuncSet", func(t *testing.T) {
 		manager := setup(t)
 		errVal := fmt.Errorf("kubernetes health check failed")
-		manager.WaitForKubernetesHealthyFunc = func(c context.Context, e string, nodeNames ...string) error {
+		manager.WaitForKubernetesHealthyFunc = func(c context.Context, e string, outputFunc func(string), nodeNames ...string) error {
 			if c != ctx {
 				t.Errorf("Expected context %v, got %v", ctx, c)
 			}
@@ -429,7 +429,7 @@ func TestMockKubernetesManager_WaitForKubernetesHealthy(t *testing.T) {
 			}
 			return errVal
 		}
-		err := manager.WaitForKubernetesHealthy(ctx, endpoint)
+		err := manager.WaitForKubernetesHealthy(ctx, endpoint, nil)
 		if err != errVal {
 			t.Errorf("Expected err, got %v", err)
 		}
@@ -437,7 +437,7 @@ func TestMockKubernetesManager_WaitForKubernetesHealthy(t *testing.T) {
 
 	t.Run("FuncNotSet", func(t *testing.T) {
 		manager := setup(t)
-		err := manager.WaitForKubernetesHealthy(ctx, endpoint)
+		err := manager.WaitForKubernetesHealthy(ctx, endpoint, nil)
 		if err != nil {
 			t.Errorf("Expected nil, got %v", err)
 		}

--- a/pkg/pipelines/check_test.go
+++ b/pkg/pipelines/check_test.go
@@ -106,13 +106,13 @@ func setupCheckMocks(t *testing.T, opts ...*SetupOptions) *CheckMocks {
 			// If existing is not a MockKubernetesManager, create a new one
 			mockKubernetesManager = kubernetes.NewMockKubernetesManager(baseMocks.Injector)
 			mockKubernetesManager.InitializeFunc = func() error { return nil }
-			mockKubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string) error { return nil }
+			mockKubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, nodeNames ...string) error { return nil }
 			baseMocks.Injector.Register("kubernetesManager", mockKubernetesManager)
 		}
 	} else {
 		mockKubernetesManager = kubernetes.NewMockKubernetesManager(baseMocks.Injector)
 		mockKubernetesManager.InitializeFunc = func() error { return nil }
-		mockKubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string) error { return nil }
+		mockKubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, nodeNames ...string) error { return nil }
 		baseMocks.Injector.Register("kubernetesManager", mockKubernetesManager)
 	}
 
@@ -757,7 +757,7 @@ func TestCheckPipeline_executeNodeHealthCheck(t *testing.T) {
 		// Given a check pipeline with only k8s endpoint specified
 		pipeline, mocks := setup(t)
 
-		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string) error {
+		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, nodeNames ...string) error {
 			return nil
 		}
 

--- a/pkg/pipelines/pipeline_test.go
+++ b/pkg/pipelines/pipeline_test.go
@@ -732,7 +732,7 @@ func TestWithPipeline(t *testing.T) {
 					// Set up kubernetes manager
 					mockKubernetesManager := kubernetes.NewMockKubernetesManager(injector)
 					mockKubernetesManager.InitializeFunc = func() error { return nil }
-					mockKubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, nodeNames ...string) error { return nil }
+					mockKubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error { return nil }
 					injector.Register("kubernetesManager", mockKubernetesManager)
 				}
 

--- a/pkg/pipelines/pipeline_test.go
+++ b/pkg/pipelines/pipeline_test.go
@@ -732,7 +732,7 @@ func TestWithPipeline(t *testing.T) {
 					// Set up kubernetes manager
 					mockKubernetesManager := kubernetes.NewMockKubernetesManager(injector)
 					mockKubernetesManager.InitializeFunc = func() error { return nil }
-					mockKubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string) error { return nil }
+					mockKubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, nodeNames ...string) error { return nil }
 					injector.Register("kubernetesManager", mockKubernetesManager)
 				}
 


### PR DESCRIPTION
The `windsor check node-health` command can now take a `--ready` flag. This will wait for kubernetes nodes listed in `--nodes` to be in a `Ready` state.