### PR TITLE
fix(blueprint): Wait for kustomizations to complete and their resources to terminate

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -173,6 +173,10 @@ type Kustomization struct {
 
 	// PostBuild is a post-build step to run after the kustomization is applied.
 	PostBuild *PostBuild `yaml:"postBuild,omitempty"`
+
+	// Destroy determines if the kustomization should be destroyed during down operations.
+	// Defaults to true if not specified.
+	Destroy *bool `yaml:"destroy,omitempty"`
 }
 
 // PostBuild is a post-build step to run after the kustomization is applied.
@@ -414,5 +418,6 @@ func (k *Kustomization) DeepCopy() *Kustomization {
 		Components:    slices.Clone(k.Components),
 		Cleanup:       slices.Clone(k.Cleanup),
 		PostBuild:     postBuildCopy,
+		Destroy:       k.Destroy,
 	}
 }

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -13,6 +13,7 @@ var (
 	cleanFlag         bool
 	skipK8sFlag       bool
 	skipTerraformFlag bool
+	skipDockerFlag    bool
 )
 
 var downCmd = &cobra.Command{
@@ -63,6 +64,9 @@ var downCmd = &cobra.Command{
 		if skipTerraformFlag {
 			ctx = context.WithValue(ctx, "skipTerraform", true)
 		}
+		if skipDockerFlag {
+			ctx = context.WithValue(ctx, "skipDocker", true)
+		}
 
 		// Execute the down pipeline
 		if err := downPipeline.Execute(ctx); err != nil {
@@ -77,5 +81,6 @@ func init() {
 	downCmd.Flags().BoolVar(&cleanFlag, "clean", false, "Clean up context specific artifacts")
 	downCmd.Flags().BoolVar(&skipK8sFlag, "skip-k8s", false, "Skip Kubernetes cleanup (blueprint cleanup)")
 	downCmd.Flags().BoolVar(&skipTerraformFlag, "skip-tf", false, "Skip Terraform cleanup")
+	downCmd.Flags().BoolVar(&skipDockerFlag, "skip-docker", false, "Skip Docker container cleanup")
 	rootCmd.AddCommand(downCmd)
 }

--- a/pkg/blueprint/blueprint_handler.go
+++ b/pkg/blueprint/blueprint_handler.go
@@ -1,11 +1,14 @@
 package blueprint
 
 import (
+	"context"
 	"fmt"
 	"os"
+	"os/signal"
 	"path/filepath"
 	"slices"
 	"strings"
+	"syscall"
 	"time"
 
 	_ "embed"
@@ -174,7 +177,10 @@ func (b *BaseBlueprintHandler) Write(overwrite ...bool) error {
 		return fmt.Errorf("error creating directory: %w", err)
 	}
 
-	cleanedBlueprint := b.createCleanedBlueprint()
+	cleanedBlueprint := b.blueprint.DeepCopy()
+	for i := range cleanedBlueprint.TerraformComponents {
+		cleanedBlueprint.TerraformComponents[i].Values = map[string]any{}
+	}
 
 	data, err := b.shims.YamlMarshal(cleanedBlueprint)
 	if err != nil {
@@ -263,7 +269,7 @@ func (b *BaseBlueprintHandler) Install() error {
 	spin.Start()
 	defer spin.Stop()
 
-	if err := b.createManagedNamespace(constants.DEFAULT_FLUX_SYSTEM_NAMESPACE); err != nil {
+	if err := b.kubernetesManager.CreateNamespace(constants.DEFAULT_FLUX_SYSTEM_NAMESPACE); err != nil {
 		spin.Stop()
 		fmt.Fprintf(os.Stderr, "✗%s - \033[31mFailed\033[0m\n", spin.Suffix)
 		return fmt.Errorf("failed to create namespace: %w", err)
@@ -385,16 +391,11 @@ func (b *BaseBlueprintHandler) GetLocalTemplateData() (map[string][]byte, error)
 	return templateData, nil
 }
 
-// Down orchestrates the teardown of all kustomizations and associated resources, skipping "not found" errors.
-// Sequence:
-// 1. Suspend all kustomizations and associated helmreleases to prevent reconciliation (ignoring not found errors)
-// 2. Apply cleanup kustomizations if defined for resource cleanup tasks
-// 3. Wait for cleanup kustomizations to complete
-// 4. Delete main kustomizations in reverse dependency order, skipping not found errors
-// 5. Delete cleanup kustomizations and their namespace, skipping not found errors
-//
-// Dependency resolution is handled via topological sorting to ensure correct deletion order.
-// A dedicated cleanup namespace is managed for cleanup kustomizations when required.
+// Down manages the teardown of kustomizations and related resources, ignoring "not found" errors.
+// It suspends kustomizations and helmreleases, applies cleanup kustomizations, waits for completion,
+// deletes main kustomizations in reverse dependency order, and removes cleanup kustomizations and namespaces.
+// The function filters kustomizations for destruction, sorts them by dependencies, and performs cleanup if specified.
+// Dependency resolution is achieved through topological sorting for correct deletion order.
 func (b *BaseBlueprintHandler) Down() error {
 	allKustomizations := b.getKustomizations()
 	if len(allKustomizations) == 0 {
@@ -412,11 +413,35 @@ func (b *BaseBlueprintHandler) Down() error {
 		return nil
 	}
 
-	spin := spinner.New(spinner.CharSets[14], 100*time.Millisecond, spinner.WithColor("green"))
-	spin.Suffix = " 🗑️  Tearing down blueprint resources"
-	spin.Start()
-	defer spin.Stop()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
+	sigChan := make(chan os.Signal, 1)
+	signal.Notify(sigChan, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		<-sigChan
+		fmt.Fprintf(os.Stderr, "\nReceived interrupt signal, cancelling operations...\n")
+		cancel()
+	}()
+
+	if err := b.destroyKustomizations(ctx, kustomizations); err != nil {
+		if ctx.Err() == context.Canceled {
+			return fmt.Errorf("operation cancelled by user: %w", err)
+		}
+		return err
+	}
+
+	return nil
+}
+
+// =============================================================================
+// Private Methods
+// =============================================================================
+
+// destroyKustomizations removes kustomizations and performs cleanup tasks.
+// It sorts kustomizations by dependencies, applies cleanup kustomizations if defined,
+// ensures readiness, and deletes them, followed by the main kustomizations.
+func (b *BaseBlueprintHandler) destroyKustomizations(ctx context.Context, kustomizations []blueprintv1alpha1.Kustomization) error {
 	deps := make(map[string][]string)
 	for _, k := range kustomizations {
 		deps[k.Name] = k.DependsOn
@@ -447,55 +472,29 @@ func (b *BaseBlueprintHandler) Down() error {
 		nameToK[k.Name] = k
 	}
 
-	needsCleanupNamespace := false
-	for _, k := range kustomizations {
-		if len(k.Cleanup) > 0 {
-			needsCleanupNamespace = true
-			break
-		}
-	}
-
-	if needsCleanupNamespace {
-		if err := b.createManagedNamespace("system-cleanup"); err != nil {
-			spin.Stop()
-			fmt.Fprintf(os.Stderr, "✗%s - \033[31mFailed\033[0m\n", spin.Suffix)
-			return fmt.Errorf("failed to create system-cleanup namespace: %w", err)
-		}
-	}
-
 	for _, name := range sorted {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+		}
+
 		k := nameToK[name]
 
-		if err := b.kubernetesManager.SuspendKustomization(k.Name, constants.DEFAULT_FLUX_SYSTEM_NAMESPACE); err != nil {
-			if !isNotFoundError(err) {
-				spin.Stop()
-				fmt.Fprintf(os.Stderr, "✗%s - \033[31mFailed\033[0m\n", spin.Suffix)
-				return fmt.Errorf("failed to suspend kustomization %s: %w", k.Name, err)
-			}
-		}
-
-		helmReleases, err := b.kubernetesManager.GetHelmReleasesForKustomization(k.Name, constants.DEFAULT_FLUX_SYSTEM_NAMESPACE)
-		if err != nil {
-			spin.Stop()
-			fmt.Fprintf(os.Stderr, "✗%s - \033[31mFailed\033[0m\n", spin.Suffix)
-			return fmt.Errorf("failed to get helmreleases for kustomization %s: %w", k.Name, err)
-		}
-
-		for _, hr := range helmReleases {
-			if err := b.kubernetesManager.SuspendHelmRelease(hr.Name, hr.Namespace); err != nil {
-				if !isNotFoundError(err) {
-					spin.Stop()
-					fmt.Fprintf(os.Stderr, "✗%s - \033[31mFailed\033[0m\n", spin.Suffix)
-					return fmt.Errorf("failed to suspend helmrelease %s in namespace %s: %w", hr.Name, hr.Namespace, err)
-				}
-			}
-		}
-	}
-
-	var cleanupNames []string
-	for _, name := range sorted {
-		k := nameToK[name]
 		if len(k.Cleanup) > 0 {
+			status, err := b.kubernetesManager.GetKustomizationStatus([]string{k.Name})
+			if err != nil {
+				return fmt.Errorf("failed to check if kustomization %s exists: %w", k.Name, err)
+			}
+
+			if !status[k.Name] {
+				continue
+			}
+
+			cleanupSpin := spinner.New(spinner.CharSets[14], 100*time.Millisecond, spinner.WithColor("green"))
+			cleanupSpin.Suffix = fmt.Sprintf(" 🧹 Applying cleanup kustomization for %s", k.Name)
+			cleanupSpin.Start()
+
 			cleanupKustomization := &blueprintv1alpha1.Kustomization{
 				Name:          k.Name + "-cleanup",
 				Path:          filepath.Join(k.Path, "cleanup"),
@@ -510,81 +509,73 @@ func (b *BaseBlueprintHandler) Down() error {
 					SubstituteFrom: []blueprintv1alpha1.SubstituteReference{},
 				},
 			}
+
 			if err := b.kubernetesManager.ApplyKustomization(b.toKubernetesKustomization(*cleanupKustomization, constants.DEFAULT_FLUX_SYSTEM_NAMESPACE)); err != nil {
-				spin.Stop()
-				fmt.Fprintf(os.Stderr, "✗%s - \033[31mFailed\033[0m\n", spin.Suffix)
 				return fmt.Errorf("failed to apply cleanup kustomization for %s: %w", k.Name, err)
 			}
-			cleanupNames = append(cleanupNames, cleanupKustomization.Name)
-		}
-	}
 
-	if len(cleanupNames) > 0 {
-		if err := b.kubernetesManager.WaitForKustomizations("⌛️ Waiting for cleanup kustomizations to complete", cleanupNames...); err != nil {
-			spin.Stop()
-			fmt.Fprintf(os.Stderr, "✗%s - \033[31mFailed\033[0m\n", spin.Suffix)
-			return fmt.Errorf("failed waiting for cleanup kustomizations to complete: %w", err)
-		}
-	}
+			timeout := b.shims.TimeAfter(30 * time.Second)
+			ticker := b.shims.NewTicker(2 * time.Second)
+			defer b.shims.TickerStop(ticker)
 
-	for _, name := range sorted {
-		k := nameToK[name]
+			cleanupReady := false
+			attempts := 0
+			maxAttempts := 15
+
+			for !cleanupReady && attempts < maxAttempts {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-timeout:
+					attempts = maxAttempts
+				case <-ticker.C:
+					attempts++
+					ready, err := b.kubernetesManager.GetKustomizationStatus([]string{cleanupKustomization.Name})
+					if err != nil {
+						continue
+					}
+					if ready[cleanupKustomization.Name] {
+						cleanupReady = true
+					}
+				}
+			}
+
+			cleanupSpin.Stop()
+
+			if !cleanupReady {
+				fmt.Fprintf(os.Stderr, "Warning: Cleanup kustomization %s did not become ready within 30 seconds, proceeding anyway\n", cleanupKustomization.Name)
+			}
+			fmt.Fprintf(os.Stderr, "\033[32m✔\033[0m 🧹 Applying cleanup kustomization for %s - \033[32mDone\033[0m\n", k.Name)
+
+			cleanupDeleteSpin := spinner.New(spinner.CharSets[14], 100*time.Millisecond, spinner.WithColor("green"))
+			cleanupDeleteSpin.Suffix = fmt.Sprintf(" 🗑️  Deleting cleanup kustomization %s", cleanupKustomization.Name)
+			cleanupDeleteSpin.Start()
+			if err := b.kubernetesManager.DeleteKustomization(cleanupKustomization.Name, constants.DEFAULT_FLUX_SYSTEM_NAMESPACE); err != nil {
+				return fmt.Errorf("failed to delete cleanup kustomization %s: %w", cleanupKustomization.Name, err)
+			}
+
+			cleanupDeleteSpin.Stop()
+			fmt.Fprintf(os.Stderr, "\033[32m✔\033[0m 🗑️  Deleting cleanup kustomization %s - \033[32mDone\033[0m\n", cleanupKustomization.Name)
+		}
+
+		deleteSpin := spinner.New(spinner.CharSets[14], 100*time.Millisecond, spinner.WithColor("green"))
+		deleteSpin.Suffix = fmt.Sprintf(" 🗑️  Deleting kustomization %s", k.Name)
+		deleteSpin.Start()
 		if err := b.kubernetesManager.DeleteKustomization(k.Name, constants.DEFAULT_FLUX_SYSTEM_NAMESPACE); err != nil {
-			spin.Stop()
-			fmt.Fprintf(os.Stderr, "✗%s - \033[31mFailed\033[0m\n", spin.Suffix)
 			return fmt.Errorf("failed to delete kustomization %s: %w", k.Name, err)
 		}
-	}
 
-	spin.Stop()
-	fmt.Fprintf(os.Stderr, "\033[32m✔\033[0m%s - \033[32mDone\033[0m\n", spin.Suffix)
-
-	if err := b.kubernetesManager.WaitForKustomizationsDeleted("⌛️ Waiting for kustomizations to be deleted", sorted...); err != nil {
-		spin.Stop()
-		fmt.Fprintf(os.Stderr, "✗%s - \033[31mFailed\033[0m\n", spin.Suffix)
-		return fmt.Errorf("failed waiting for kustomizations to be deleted: %w", err)
-	}
-
-	if len(cleanupNames) > 0 {
-		for _, cname := range cleanupNames {
-			if err := b.kubernetesManager.DeleteKustomization(cname, constants.DEFAULT_FLUX_SYSTEM_NAMESPACE); err != nil {
-				spin.Stop()
-				fmt.Fprintf(os.Stderr, "✗%s - \033[31mFailed\033[0m\n", spin.Suffix)
-				return fmt.Errorf("failed to delete cleanup kustomization %s: %w", cname, err)
-			}
-		}
-
-		if err := b.kubernetesManager.WaitForKustomizationsDeleted("⌛️ Waiting for cleanup kustomizations to be deleted", cleanupNames...); err != nil {
-			spin.Stop()
-			fmt.Fprintf(os.Stderr, "✗%s - \033[31mFailed\033[0m\n", spin.Suffix)
-			return fmt.Errorf("failed waiting for cleanup kustomizations to be deleted: %w", err)
-		}
-
-		if err := b.deleteNamespace("system-cleanup"); err != nil {
-			spin.Stop()
-			fmt.Fprintf(os.Stderr, "✗%s - \033[31mFailed\033[0m\n", spin.Suffix)
-			return fmt.Errorf("failed to delete system-cleanup namespace: %w", err)
-		}
+		deleteSpin.Stop()
+		fmt.Fprintf(os.Stderr, "\033[32m✔\033[0m 🗑️  Deleting kustomization %s - \033[32mDone\033[0m\n", k.Name)
 	}
 
 	return nil
 }
 
-// =============================================================================
-// Private Methods
-// =============================================================================
-
-// createCleanedBlueprint returns a deep copy of the blueprint with all Terraform component Values fields removed.
-// All Values maps are cleared, as these should not be persisted in the final blueprint.yaml.
-func (b *BaseBlueprintHandler) createCleanedBlueprint() *blueprintv1alpha1.Blueprint {
-	cleaned := b.blueprint.DeepCopy()
-	for i := range cleaned.TerraformComponents {
-		cleaned.TerraformComponents[i].Values = map[string]any{}
-	}
-	return cleaned
-}
-
-// walkAndCollectTemplates recursively walks through template directories and collects .jsonnet files.
+// walkAndCollectTemplates traverses template directories to gather .jsonnet files.
+// It updates the provided templateData map with the relative paths and content of
+// the .jsonnet files found. The function handles directory recursion and file reading
+// errors, returning an error if any operation fails.
 func (b *BaseBlueprintHandler) walkAndCollectTemplates(templateDir, templateRoot string, templateData map[string][]byte) error {
 	entries, err := b.shims.ReadDir(templateDir)
 	if err != nil {
@@ -1099,14 +1090,6 @@ func (b *BaseBlueprintHandler) calculateMaxWaitTime() time.Duration {
 	return maxPathTime
 }
 
-func (b *BaseBlueprintHandler) createManagedNamespace(name string) error {
-	return b.kubernetesManager.CreateNamespace(name)
-}
-
-func (b *BaseBlueprintHandler) deleteNamespace(name string) error {
-	return b.kubernetesManager.DeleteNamespace(name)
-}
-
 // toKubernetesKustomization converts a blueprint kustomization to a Flux kustomization
 // It handles conversion of dependsOn, patches, and postBuild configurations
 // It maps blueprint fields to their Flux kustomization equivalents
@@ -1197,41 +1180,20 @@ func (b *BaseBlueprintHandler) toKubernetesKustomization(k blueprintv1alpha1.Kus
 	}
 }
 
-// isOCISource determines whether a given source name or resolved URL corresponds to an OCI repository
-// source by examining the URL prefix of the blueprint's main repository and any additional sources,
-// or by checking if the input is already a resolved OCI URL.
+// isOCISource returns true if the provided sourceNameOrURL is an OCI repository reference.
+// It checks if the input is a resolved OCI URL, matches the blueprint's main repository with an OCI URL,
+// or matches any additional source with an OCI URL.
 func (b *BaseBlueprintHandler) isOCISource(sourceNameOrURL string) bool {
-	// Check if it's already a resolved OCI URL
 	if strings.HasPrefix(sourceNameOrURL, "oci://") {
 		return true
 	}
-
-	// Check if it's a source name that maps to an OCI URL
 	if sourceNameOrURL == b.blueprint.Metadata.Name && strings.HasPrefix(b.blueprint.Repository.Url, "oci://") {
 		return true
 	}
-
 	for _, source := range b.blueprint.Sources {
 		if source.Name == sourceNameOrURL && strings.HasPrefix(source.Url, "oci://") {
 			return true
 		}
 	}
-
 	return false
-}
-
-// isNotFoundError checks if an error is a Kubernetes resource not found error
-// This is used during cleanup to ignore errors when resources don't exist
-func isNotFoundError(err error) bool {
-	if err == nil {
-		return false
-	}
-
-	errMsg := strings.ToLower(err.Error())
-	// Check for resource not found errors, but not namespace not found errors
-	return (strings.Contains(errMsg, "resource not found") ||
-		strings.Contains(errMsg, "could not find the requested resource") ||
-		strings.Contains(errMsg, "the server could not find the requested resource") ||
-		strings.Contains(errMsg, "\" not found")) &&
-		!strings.Contains(errMsg, "namespace not found")
 }

--- a/pkg/kubernetes/kubernetes_client.go
+++ b/pkg/kubernetes/kubernetes_client.go
@@ -137,16 +137,11 @@ func (c *DynamicKubernetesClient) GetNodeReadyStatus(ctx context.Context, nodeNa
 		Resource: "nodes",
 	}
 
-	var nodes *unstructured.UnstructuredList
-	var err error
-
-	// Get all nodes and filter by name if specific nodes are requested
-	nodes, err = c.client.Resource(nodeGVR).List(ctx, metav1.ListOptions{})
+	nodes, err := c.client.Resource(nodeGVR).List(ctx, metav1.ListOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("failed to list nodes: %w", err)
 	}
 
-	// Filter nodes if specific node names are requested
 	if len(nodeNames) > 0 {
 		var filteredNodes []unstructured.Unstructured
 		nodeNameSet := make(map[string]bool)
@@ -160,12 +155,7 @@ func (c *DynamicKubernetesClient) GetNodeReadyStatus(ctx context.Context, nodeNa
 			}
 		}
 
-		// Replace the items with filtered ones
 		nodes.Items = filteredNodes
-	}
-
-	if err != nil {
-		return nil, fmt.Errorf("failed to list nodes: %w", err)
 	}
 
 	readyStatus := make(map[string]bool)

--- a/pkg/kubernetes/mock_kubernetes_manager.go
+++ b/pkg/kubernetes/mock_kubernetes_manager.go
@@ -32,7 +32,6 @@ type MockKubernetesManager struct {
 	SuspendHelmReleaseFunc              func(name, namespace string) error
 	ApplyGitRepositoryFunc              func(repo *sourcev1.GitRepository) error
 	ApplyOCIRepositoryFunc              func(repo *sourcev1.OCIRepository) error
-	WaitForKustomizationsDeletedFunc    func(message string, names ...string) error
 	CheckGitRepositoryStatusFunc        func() error
 	WaitForKubernetesHealthyFunc        func(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error
 	GetNodeReadyStatusFunc              func(ctx context.Context, nodeNames []string) (map[string]bool, error)
@@ -155,13 +154,7 @@ func (m *MockKubernetesManager) ApplyOCIRepository(repo *sourcev1.OCIRepository)
 	return nil
 }
 
-// WaitForKustomizationsDeleted waits for the specified kustomizations to be deleted.
-func (m *MockKubernetesManager) WaitForKustomizationsDeleted(message string, names ...string) error {
-	if m.WaitForKustomizationsDeletedFunc != nil {
-		return m.WaitForKustomizationsDeletedFunc(message, names...)
-	}
-	return nil
-}
+// WaitForKustomizationDeletionProcessed waits for the specified kustomization deletion to be processed.
 
 // CheckGitRepositoryStatus checks the status of all GitRepository resources
 func (m *MockKubernetesManager) CheckGitRepositoryStatus() error {

--- a/pkg/kubernetes/mock_kubernetes_manager_test.go
+++ b/pkg/kubernetes/mock_kubernetes_manager_test.go
@@ -334,32 +334,6 @@ func TestMockKubernetesManager_ApplyGitRepository(t *testing.T) {
 	})
 }
 
-func TestMockKubernetesManager_WaitForKustomizationsDeleted(t *testing.T) {
-	setup := func(t *testing.T) *MockKubernetesManager {
-		t.Helper()
-		return NewMockKubernetesManager(nil)
-	}
-	msg := "msg"
-	name := "n"
-
-	t.Run("FuncSet", func(t *testing.T) {
-		manager := setup(t)
-		manager.WaitForKustomizationsDeletedFunc = func(m string, n ...string) error { return fmt.Errorf("err") }
-		err := manager.WaitForKustomizationsDeleted(msg, name)
-		if err == nil || err.Error() != "err" {
-			t.Errorf("Expected error 'err', got %v", err)
-		}
-	})
-
-	t.Run("FuncNotSet", func(t *testing.T) {
-		manager := setup(t)
-		err := manager.WaitForKustomizationsDeleted(msg, name)
-		if err != nil {
-			t.Errorf("Expected nil, got %v", err)
-		}
-	})
-}
-
 func TestMockKubernetesManager_CheckGitRepositoryStatus(t *testing.T) {
 	setup := func(t *testing.T) *MockKubernetesManager {
 		t.Helper()

--- a/pkg/pipelines/down.go
+++ b/pkg/pipelines/down.go
@@ -163,13 +163,16 @@ func (p *DownPipeline) Execute(ctx context.Context) error {
 
 	// Tear down the container runtime if enabled
 	containerRuntimeEnabled := p.configHandler.GetBool("docker.enabled")
-	if containerRuntimeEnabled {
+	skipDockerFlag := ctx.Value("skipDocker")
+	if containerRuntimeEnabled && (skipDockerFlag == nil || !skipDockerFlag.(bool)) {
 		if p.containerRuntime == nil {
 			return fmt.Errorf("No container runtime found")
 		}
 		if err := p.containerRuntime.Down(); err != nil {
 			return fmt.Errorf("Error running container runtime Down command: %w", err)
 		}
+	} else if skipDockerFlag != nil && skipDockerFlag.(bool) {
+		fmt.Fprintln(os.Stderr, "Skipping Docker container cleanup (--skip-docker set)")
 	}
 
 	// Clean up context specific artifacts if --clean flag is set


### PR DESCRIPTION
We were previously not properly waiting for resources to terminate as expected. This change will both wait for cleanup kustomizations to complete, and wait for termination of resources when kustomizations are deleted.