### PR TITLE
fix(cleanup): Fix kustomize paths on Windows

### DIFF
--- a/pkg/blueprint/blueprint_handler.go
+++ b/pkg/blueprint/blueprint_handler.go
@@ -497,7 +497,7 @@ func (b *BaseBlueprintHandler) destroyKustomizations(ctx context.Context, kustom
 
 			cleanupKustomization := &blueprintv1alpha1.Kustomization{
 				Name:          k.Name + "-cleanup",
-				Path:          filepath.Join(k.Path, "cleanup"),
+				Path:          strings.ReplaceAll(filepath.Join(k.Path, "cleanup"), "\\", "/"),
 				Source:        k.Source,
 				Components:    k.Cleanup,
 				Timeout:       &metav1.Duration{Duration: 30 * time.Minute},

--- a/pkg/kubernetes/kubernetes_manager.go
+++ b/pkg/kubernetes/kubernetes_manager.go
@@ -517,7 +517,7 @@ func (k *BaseKubernetesManager) GetKustomizationStatus(names []string) (map[stri
 			if condition.Type == "Ready" {
 				if condition.Status == "True" {
 					ready = true
-				} else if condition.Status == "False" && condition.Reason == "ReconciliationFailed" {
+				} else if condition.Status == "False" && (condition.Reason == "ReconciliationFailed" || condition.Reason == "ArtifactFailed") {
 					return nil, fmt.Errorf("kustomization %s failed: %s", kustomizeObj.Name, condition.Message)
 				}
 				break


### PR DESCRIPTION
Forward slashes were making it in to the paths given to the generated cleanup kustomizations on Windows. Fixed. Also fails fast for ArtifactFailed scenarios.