### PR TITLE
fix(terraform): Always perform -upgrade on terraform init

### DIFF
--- a/pkg/env/terraform_env.go
+++ b/pkg/env/terraform_env.go
@@ -176,7 +176,7 @@ func (e *TerraformEnvPrinter) GenerateTerraformArgs(projectPath, modulePath stri
 		return nil, fmt.Errorf("error generating backend config args for env: %w", err)
 	}
 
-	initArgs := []string{"-backend=true", "-force-copy"}
+	initArgs := []string{"-backend=true", "-force-copy", "-upgrade"}
 	initArgs = append(initArgs, backendConfigArgs...)
 
 	planArgs := []string{fmt.Sprintf("-out=%s", tfPlanPath)}
@@ -209,7 +209,7 @@ func (e *TerraformEnvPrinter) GenerateTerraformArgs(projectPath, modulePath stri
 
 	terraformVars := make(map[string]string)
 	terraformVars["TF_DATA_DIR"] = strings.TrimSpace(tfDataDir)
-	terraformVars["TF_CLI_ARGS_init"] = strings.TrimSpace(fmt.Sprintf("-backend=true -force-copy %s", strings.Join(backendConfigArgsForEnv, " ")))
+	terraformVars["TF_CLI_ARGS_init"] = strings.TrimSpace(fmt.Sprintf("-backend=true -force-copy -upgrade %s", strings.Join(backendConfigArgsForEnv, " ")))
 	terraformVars["TF_CLI_ARGS_plan"] = strings.TrimSpace(fmt.Sprintf("-out=\"%s\" %s", tfPlanPath, strings.Join(varFileArgsForEnv, " ")))
 	terraformVars["TF_CLI_ARGS_apply"] = strings.TrimSpace(fmt.Sprintf("\"%s\"%s", tfPlanPath, parallelismArg))
 	terraformVars["TF_CLI_ARGS_refresh"] = strings.TrimSpace(strings.Join(varFileArgsForEnv, " "))

--- a/pkg/env/terraform_env_test.go
+++ b/pkg/env/terraform_env_test.go
@@ -104,7 +104,7 @@ func TestTerraformEnv_GetEnvVars(t *testing.T) {
 
 		expectedEnvVars := map[string]string{
 			"TF_DATA_DIR":      filepath.ToSlash(filepath.Join(configRoot, ".terraform/project/path")),
-			"TF_CLI_ARGS_init": fmt.Sprintf(`-backend=true -force-copy -backend-config="path=%s"`, filepath.ToSlash(filepath.Join(configRoot, ".tfstate/project/path/terraform.tfstate"))),
+			"TF_CLI_ARGS_init": fmt.Sprintf(`-backend=true -force-copy -upgrade -backend-config="path=%s"`, filepath.ToSlash(filepath.Join(configRoot, ".tfstate/project/path/terraform.tfstate"))),
 			"TF_CLI_ARGS_plan": fmt.Sprintf(`-out="%s" -var-file="%s" -var-file="%s"`,
 				filepath.ToSlash(filepath.Join(configRoot, ".terraform/project/path/terraform.tfplan")),
 				filepath.ToSlash(filepath.Join(configRoot, "terraform/project/path.tfvars")),
@@ -321,7 +321,7 @@ func TestTerraformEnv_GetEnvVars(t *testing.T) {
 		// And environment variables should be set correctly
 		expectedEnvVars := map[string]string{
 			"TF_DATA_DIR":      filepath.ToSlash(filepath.Join(configRoot, ".terraform/project/path")),
-			"TF_CLI_ARGS_init": fmt.Sprintf(`-backend=true -force-copy -backend-config="path=%s"`, filepath.ToSlash(filepath.Join(configRoot, ".tfstate/project/path/terraform.tfstate"))),
+			"TF_CLI_ARGS_init": fmt.Sprintf(`-backend=true -force-copy -upgrade -backend-config="path=%s"`, filepath.ToSlash(filepath.Join(configRoot, ".tfstate/project/path/terraform.tfstate"))),
 			"TF_CLI_ARGS_plan": fmt.Sprintf(`-out="%s" -var-file="%s" -var-file="%s"`,
 				filepath.ToSlash(filepath.Join(configRoot, ".terraform/project/path/terraform.tfplan")),
 				filepath.ToSlash(filepath.Join(configRoot, "terraform/project/path.tfvars")),
@@ -484,7 +484,7 @@ func TestTerraformEnv_Print(t *testing.T) {
 
 		expectedEnvVars := map[string]string{
 			"TF_DATA_DIR":      filepath.Join(configRoot, ".terraform/project/path"),
-			"TF_CLI_ARGS_init": fmt.Sprintf(`-backend=true -force-copy -backend-config="path=%s"`, filepath.Join(configRoot, ".tfstate/project/path/terraform.tfstate")),
+			"TF_CLI_ARGS_init": fmt.Sprintf(`-backend=true -force-copy -upgrade -backend-config="path=%s"`, filepath.Join(configRoot, ".tfstate/project/path/terraform.tfstate")),
 			"TF_CLI_ARGS_plan": fmt.Sprintf(`-out="%s" -var-file="%s" -var-file="%s"`,
 				filepath.Join(configRoot, ".terraform/project/path/terraform.tfplan"),
 				filepath.Join(configRoot, "terraform/project/path.tfvars"),


### PR DESCRIPTION
In a windsor environment, it is always expected that versions are precisely pinned. Upgrades should always take place as the current blueprint should always have consistently updated providers.