### PR TITLE
fix(config): Ensure proper config loading order

### DIFF
--- a/pkg/blueprint/blueprint_handler_helper_test.go
+++ b/pkg/blueprint/blueprint_handler_helper_test.go
@@ -37,6 +37,7 @@ func (m *mockConfigHandler) SetContext(context string) error                    
 func (m *mockConfigHandler) GetConfigRoot() (string, error)                      { return "/tmp", nil }
 func (m *mockConfigHandler) Clean() error                                        { return nil }
 func (m *mockConfigHandler) IsLoaded() bool                                      { return true }
+func (m *mockConfigHandler) IsContextConfigLoaded() bool                         { return true }
 func (m *mockConfigHandler) SetSecretsProvider(provider secrets.SecretsProvider) {}
 func (m *mockConfigHandler) GenerateContextID() error                            { return nil }
 func (m *mockConfigHandler) YamlMarshalWithDefinedPaths(v any) ([]byte, error)   { return nil, nil }

--- a/pkg/config/config_handler.go
+++ b/pkg/config/config_handler.go
@@ -38,6 +38,7 @@ type ConfigHandler interface {
 	GetConfigRoot() (string, error)
 	Clean() error
 	IsLoaded() bool
+	IsContextConfigLoaded() bool
 	SetSecretsProvider(provider secrets.SecretsProvider)
 	GenerateContextID() error
 	YamlMarshalWithDefinedPaths(v any) ([]byte, error)

--- a/pkg/config/mock_config_handler.go
+++ b/pkg/config/mock_config_handler.go
@@ -15,6 +15,7 @@ type MockConfigHandler struct {
 	GetStringFunc                   func(key string, defaultValue ...string) string
 	GetIntFunc                      func(key string, defaultValue ...int) int
 	GetBoolFunc                     func(key string, defaultValue ...bool) bool
+	IsContextConfigLoadedFunc       func() bool
 	GetStringSliceFunc              func(key string, defaultValue ...[]string) []string
 	GetStringMapFunc                func(key string, defaultValue ...map[string]string) map[string]string
 	SetFunc                         func(key string, value any) error
@@ -81,6 +82,14 @@ func (m *MockConfigHandler) LoadContextConfig() error {
 func (m *MockConfigHandler) IsLoaded() bool {
 	if m.IsLoadedFunc != nil {
 		return m.IsLoadedFunc()
+	}
+	return false
+}
+
+// IsContextConfigLoaded calls the mock IsContextConfigLoadedFunc if set, otherwise returns false
+func (m *MockConfigHandler) IsContextConfigLoaded() bool {
+	if m.IsContextConfigLoadedFunc != nil {
+		return m.IsContextConfigLoadedFunc()
 	}
 	return false
 }

--- a/pkg/config/mock_config_handler_test.go
+++ b/pkg/config/mock_config_handler_test.go
@@ -642,6 +642,35 @@ func TestMockConfigHandler_IsLoaded(t *testing.T) {
 	})
 }
 
+func TestMockConfigHandler_IsContextConfigLoaded(t *testing.T) {
+	t.Run("WithFuncSet", func(t *testing.T) {
+		// Given a new mock config handler with IsContextConfigLoadedFunc set
+		handler := NewMockConfigHandler()
+		handler.IsContextConfigLoadedFunc = func() bool { return true }
+
+		// When IsContextConfigLoaded is called
+		loaded := handler.IsContextConfigLoaded()
+
+		// Then the returned value should be true
+		if !loaded {
+			t.Errorf("Expected IsContextConfigLoaded to return true, got %v", loaded)
+		}
+	})
+
+	t.Run("WithNoFuncSet", func(t *testing.T) {
+		// Given a new mock config handler without IsContextConfigLoadedFunc set
+		handler := NewMockConfigHandler()
+
+		// When IsContextConfigLoaded is called
+		loaded := handler.IsContextConfigLoaded()
+
+		// Then the returned value should be false
+		if loaded {
+			t.Errorf("Expected IsContextConfigLoaded to return false, got %v", loaded)
+		}
+	})
+}
+
 func TestMockConfigHandler_LoadConfigString(t *testing.T) {
 	t.Run("WithFuncSet", func(t *testing.T) {
 		// Given a mock config handler with LoadConfigStringFunc set

--- a/pkg/config/yaml_config_handler.go
+++ b/pkg/config/yaml_config_handler.go
@@ -151,6 +151,27 @@ func (y *YamlConfigHandler) LoadContextConfig() error {
 	return nil
 }
 
+// IsContextConfigLoaded determines whether context-specific configuration has been loaded for the current context.
+// It returns true if the base configuration is loaded, the current context name is set, and a non-nil context
+// configuration exists for the current context in the configuration map. Returns false otherwise.
+func (y *YamlConfigHandler) IsContextConfigLoaded() bool {
+	if !y.BaseConfigHandler.loaded {
+		return false
+	}
+
+	contextName := y.GetContext()
+	if contextName == "" {
+		return false
+	}
+
+	if y.config.Contexts == nil {
+		return false
+	}
+
+	context, exists := y.config.Contexts[contextName]
+	return exists && context != nil
+}
+
 // SaveConfig writes configuration to root windsor.yaml and the current context's windsor.yaml.
 // Root windsor.yaml contains only the version field. The context file contains the context config
 // without the contexts wrapper. Files are created only if absent: root windsor.yaml is created if

--- a/pkg/pipelines/check_test.go
+++ b/pkg/pipelines/check_test.go
@@ -281,7 +281,7 @@ func TestCheckPipeline_Initialize(t *testing.T) {
 		if err == nil {
 			t.Fatal("Expected error, got nil")
 		}
-		if err.Error() != "failed to load config: error loading config file: config loading failed" {
+		if err.Error() != "failed to load base config: error loading config file: config loading failed" {
 			t.Errorf("Expected config loading error, got: %v", err)
 		}
 	})

--- a/pkg/pipelines/env_test.go
+++ b/pkg/pipelines/env_test.go
@@ -188,7 +188,7 @@ func TestEnvPipeline_Initialize(t *testing.T) {
 		if err == nil {
 			t.Fatal("Expected error, got nil")
 		}
-		if err.Error() != "failed to load config: error retrieving project root: project root error" {
+		if err.Error() != "failed to load base config: error retrieving project root: project root error" {
 			t.Errorf("Expected load config error, got: %v", err)
 		}
 	})

--- a/pkg/pipelines/init.go
+++ b/pkg/pipelines/init.go
@@ -84,8 +84,10 @@ func (p *InitPipeline) Initialize(injector di.Injector, ctx context.Context) err
 		return fmt.Errorf("Error setting context value: %w", err)
 	}
 
-	if err := p.setDefaultConfiguration(ctx, contextName); err != nil {
-		return err
+	if !p.configHandler.IsContextConfigLoaded() {
+		if err := p.setDefaultConfiguration(ctx, contextName); err != nil {
+			return err
+		}
 	}
 
 	if err := p.processPlatformConfiguration(ctx); err != nil {
@@ -477,8 +479,6 @@ func (p *InitPipeline) prepareTemplateData(ctx context.Context) (map[string][]by
 
 	return make(map[string][]byte), nil
 }
-
-
 
 // processTemplateData renders and processes template data for the InitPipeline.
 // Renders all templates using the template renderer, and loads blueprint data from the rendered output if present.

--- a/pkg/template/jsonnet_template.go
+++ b/pkg/template/jsonnet_template.go
@@ -115,6 +115,7 @@ func (t *JsonnetTemplate) Process(templateData map[string][]byte, renderedData m
 // Returns the resulting map or an error if any step fails.
 func (t *JsonnetTemplate) processJsonnetTemplate(templateContent string) (map[string]any, error) {
 	config := t.configHandler.GetConfig()
+
 	contextYAML, err := t.configHandler.YamlMarshalWithDefinedPaths(config)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal context to YAML: %w", err)


### PR DESCRIPTION
A default configuration was loaded on top of the local `windsor.yaml` config. This caused incorrect template values on running `windsor init`.

A few areas contributed to this. To remediate, the `--reset` logic that prevented file config loading has been removed as it is no longer the desired functionality. Furthermore, we ensure that we only load a default configuration if an existing context config has not loaded.