### PR TITLE
refactor(generator): Generates templated tfvars to tf_modules vs. context folder

### DIFF
--- a/pkg/generators/terraform_generator_test.go
+++ b/pkg/generators/terraform_generator_test.go
@@ -815,8 +815,8 @@ func TestWriteDefaultValues(t *testing.T) {
 		},
 	}
 
-	// When writeDefaultValues is called
-	writeDefaultValues(body, variables, nil)
+	// When writeComponentValues is called with empty values
+	writeComponentValues(body, nil, map[string]bool{}, variables)
 
 	// Then the variables should be written in order with proper handling of sensitive values
 	expected := `
@@ -1567,10 +1567,10 @@ variable "instance_type" {
 			t.Errorf("expected no error with mixed provider templates, got: %v", err)
 		}
 
-		// And only AWS component tfvars files should be written
+		// And AWS component tfvars files should be written (only module files for sourced components)
 		expectedFiles := []string{
-			"/mock/context/terraform/cluster/aws-eks.tfvars",
-			"/mock/context/terraform/network/aws-vpc.tfvars",
+			"/mock/project/.windsor/.tf_modules/cluster/aws-eks/terraform.tfvars",
+			"/mock/project/.windsor/.tf_modules/network/aws-vpc/terraform.tfvars",
 		}
 
 		if len(writtenFiles) != len(expectedFiles) {


### PR DESCRIPTION
When processing templated tfvars files for a blueprint, these files are now generated as `terraform.tfvars` files directly in the `.tf_modules` folder along with the generated module shims. Now these generated input variables act as the base vars when deploying from a template. The corresponding `terraform/xyz/*.tfvars` files are now only necessary for overrides or parameterizing user-defined terraform components.