### PR TITLE
refactor(blueprint): Template and apply kustomize values and patches in memory

### DIFF
--- a/pkg/blueprint/mock_blueprint_handler.go
+++ b/pkg/blueprint/mock_blueprint_handler.go
@@ -23,7 +23,8 @@ type MockBlueprintHandler struct {
 	InstallFunc                func() error
 	GetRepositoryFunc          func() blueprintv1alpha1.Repository
 
-	DownFunc func() error
+	DownFunc                     func() error
+	SetRenderedKustomizeDataFunc func(data map[string]any)
 }
 
 // =============================================================================
@@ -129,6 +130,13 @@ func (m *MockBlueprintHandler) Down() error {
 		return m.DownFunc()
 	}
 	return nil
+}
+
+// SetRenderedKustomizeData implements BlueprintHandler interface
+func (m *MockBlueprintHandler) SetRenderedKustomizeData(data map[string]any) {
+	if m.SetRenderedKustomizeDataFunc != nil {
+		m.SetRenderedKustomizeDataFunc(data)
+	}
 }
 
 // WaitForKustomizations calls the mock WaitForKustomizationsFunc if set, otherwise returns nil

--- a/pkg/blueprint/mock_blueprint_handler_test.go
+++ b/pkg/blueprint/mock_blueprint_handler_test.go
@@ -582,3 +582,94 @@ func TestMockBlueprintHandler_Write(t *testing.T) {
 		}
 	})
 }
+
+func TestMockBlueprintHandler_SetRenderedKustomizeData(t *testing.T) {
+	setup := func(t *testing.T) *MockBlueprintHandler {
+		t.Helper()
+		return &MockBlueprintHandler{}
+	}
+
+	t.Run("WithFuncSet", func(t *testing.T) {
+		// Given a mock handler with SetRenderedKustomizeData function
+		handler := setup(t)
+		expectedData := map[string]any{
+			"key1": "value1",
+			"key2": 42,
+			"key3": []string{"item1", "item2"},
+		}
+		var receivedData map[string]any
+		handler.SetRenderedKustomizeDataFunc = func(data map[string]any) {
+			receivedData = data
+		}
+		// When setting rendered kustomize data
+		handler.SetRenderedKustomizeData(expectedData)
+		// Then the function should be called with correct data
+		if !reflect.DeepEqual(receivedData, expectedData) {
+			t.Errorf("Expected data = %v, got = %v", expectedData, receivedData)
+		}
+	})
+
+	t.Run("WithNoFuncSet", func(t *testing.T) {
+		// Given a mock handler without SetRenderedKustomizeData function
+		handler := setup(t)
+		testData := map[string]any{
+			"key1": "value1",
+			"key2": 42,
+		}
+		// When setting rendered kustomize data
+		// Then no panic should occur
+		handler.SetRenderedKustomizeData(testData)
+		// Test passes if no panic occurs
+	})
+
+	t.Run("WithEmptyData", func(t *testing.T) {
+		// Given a mock handler with SetRenderedKustomizeData function
+		handler := setup(t)
+		expectedData := map[string]any{}
+		var receivedData map[string]any
+		handler.SetRenderedKustomizeDataFunc = func(data map[string]any) {
+			receivedData = data
+		}
+		// When setting empty rendered kustomize data
+		handler.SetRenderedKustomizeData(expectedData)
+		// Then the function should be called with empty data
+		if !reflect.DeepEqual(receivedData, expectedData) {
+			t.Errorf("Expected data = %v, got = %v", expectedData, receivedData)
+		}
+	})
+
+	t.Run("WithComplexData", func(t *testing.T) {
+		// Given a mock handler with SetRenderedKustomizeData function
+		handler := setup(t)
+		expectedData := map[string]any{
+			"nested": map[string]any{
+				"level1": map[string]any{
+					"level2": []any{
+						"string1",
+						123,
+						map[string]any{"key": "value"},
+					},
+				},
+			},
+			"array": []any{
+				"item1",
+				456,
+				map[string]any{"nested": "data"},
+			},
+			"mixed": []map[string]any{
+				{"key1": "value1"},
+				{"key2": 789},
+			},
+		}
+		var receivedData map[string]any
+		handler.SetRenderedKustomizeDataFunc = func(data map[string]any) {
+			receivedData = data
+		}
+		// When setting complex rendered kustomize data
+		handler.SetRenderedKustomizeData(expectedData)
+		// Then the function should be called with correct complex data
+		if !reflect.DeepEqual(receivedData, expectedData) {
+			t.Errorf("Expected data = %v, got = %v", expectedData, receivedData)
+		}
+	})
+}

--- a/pkg/generators/kustomize_generator.go
+++ b/pkg/generators/kustomize_generator.go
@@ -2,31 +2,20 @@ package generators
 
 import (
 	"fmt"
-	"path/filepath"
 	"strings"
 
-	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+	"github.com/windsorcli/cli/pkg/blueprint"
 	"github.com/windsorcli/cli/pkg/di"
 )
-
-// The KustomizeGenerator is a specialized component that manages Kustomize files.
-// It provides functionality to process patch templates and values templates, generating
-// patch files and values.yaml files for kustomizations defined in the blueprint.
-// The KustomizeGenerator ensures proper file generation with templating support.
 
 // =============================================================================
 // Types
 // =============================================================================
 
-// KustomizeBlueprintHandler defines the interface for accessing blueprint data
-type KustomizeBlueprintHandler interface {
-	GetKustomizations() []blueprintv1alpha1.Kustomization
-}
-
 // KustomizeGenerator is a generator that processes and generates kustomize files
 type KustomizeGenerator struct {
 	BaseGenerator
-	blueprintHandler KustomizeBlueprintHandler
+	blueprintHandler blueprint.BlueprintHandler
 }
 
 // =============================================================================
@@ -58,7 +47,7 @@ func (g *KustomizeGenerator) Initialize() error {
 		return fmt.Errorf("blueprint handler not found in dependency injector")
 	}
 
-	handler, ok := blueprintHandler.(KustomizeBlueprintHandler)
+	handler, ok := blueprintHandler.(blueprint.BlueprintHandler)
 	if !ok {
 		return fmt.Errorf("resolved blueprint handler is not of expected type")
 	}
@@ -67,37 +56,28 @@ func (g *KustomizeGenerator) Initialize() error {
 	return nil
 }
 
-// Generate creates kustomize files using the provided template data.
-// Processes data keyed by "kustomize/<kustomization_name>" for patches and
-// "values/<kustomization_name>" for values.yaml files.
-// The template engine has already filtered to only include referenced files, so this
-// processes all provided data without additional filtering.
-// Returns an error if data is nil, if generation fails, or if validation fails.
+// Generate processes kustomize template data and stores it in-memory for use during install.
+// Filters data for kustomize-related keys and stores them in the blueprint handler
+// instead of writing files to disk. This allows values and patches to be composed
+// with user-defined files at install time.
+// Returns an error if data is nil or if storing the data fails.
 func (g *KustomizeGenerator) Generate(data map[string]any, overwrite ...bool) error {
 	if data == nil {
 		return fmt.Errorf("data cannot be nil")
 	}
 
-	shouldOverwrite := false
-	if len(overwrite) > 0 {
-		shouldOverwrite = overwrite[0]
-	}
-
-	configRoot, err := g.configHandler.GetConfigRoot()
-	if err != nil {
-		return fmt.Errorf("failed to get config root: %w", err)
-	}
-
+	kustomizeData := make(map[string]any)
 	for key, values := range data {
-		if strings.HasPrefix(key, "kustomize/patches/") {
-			if err := g.generatePatchFile(key, values, configRoot, shouldOverwrite); err != nil {
-				return err
+		if strings.HasPrefix(key, "kustomize/") {
+			if err := g.validateKustomizeData(key, values); err != nil {
+				return fmt.Errorf("invalid kustomize data for key %s: %w", key, err)
 			}
-		} else if key == "kustomize/values" {
-			if err := g.generateValuesFile(key, values, configRoot, shouldOverwrite); err != nil {
-				return err
-			}
+			kustomizeData[key] = values
 		}
+	}
+
+	if len(kustomizeData) > 0 {
+		g.blueprintHandler.SetRenderedKustomizeData(kustomizeData)
 	}
 
 	return nil
@@ -107,106 +87,23 @@ func (g *KustomizeGenerator) Generate(data map[string]any, overwrite ...bool) er
 // Private Methods
 // =============================================================================
 
-// generatePatchFile generates patch files for kustomizations based on the provided key and values.
-// It validates the patch path, ensures values are a map, constructs the full patch file path,
-// validates the path, validates the Kubernetes manifest, and writes the patch file. Returns an error if any step fails.
-func (g *KustomizeGenerator) generatePatchFile(key string, values any, configRoot string, overwrite bool) error {
-	patchPath := strings.TrimPrefix(key, "kustomize/patches/")
-
-	if err := g.validateKustomizationName(patchPath); err != nil {
-		return fmt.Errorf("invalid patch path %s: %w", patchPath, err)
-	}
-
-	patchesDir := filepath.Join(configRoot, "kustomize", "patches")
-	if err := g.validatePath(patchesDir, configRoot); err != nil {
-		return fmt.Errorf("invalid patches directory path %s: %w", patchesDir, err)
-	}
-
-	valuesMap, ok := values.(map[string]any)
-	if !ok {
-		return fmt.Errorf("values for patch %s must be a map, got %T", patchPath, values)
-	}
-
-	fullPatchPath := filepath.Join(patchesDir, patchPath)
-	if !strings.HasSuffix(fullPatchPath, ".yaml") && !strings.HasSuffix(fullPatchPath, ".yml") {
-		fullPatchPath = fullPatchPath + ".yaml"
-	}
-	if err := g.validatePath(fullPatchPath, configRoot); err != nil {
-		return fmt.Errorf("invalid patch file path %s: %w", fullPatchPath, err)
-	}
-
-	if err := g.validateKubernetesManifest(valuesMap); err != nil {
-		return fmt.Errorf("invalid Kubernetes manifest for %s: %w", patchPath, err)
-	}
-
-	return g.writeYamlFile(fullPatchPath, valuesMap, overwrite)
-}
-
-// generateValuesFile writes a centralized values.yaml for kustomize post-build substitution.
-// Accepts only "kustomize/values" as key. Validates that values is a map with only scalar types or one-level nested maps.
-// Merges with any existing values.yaml, overwriting keys with new values. Writes the result to values.yaml in the kustomize directory.
-// Returns error on invalid key, type, path, or file operation.
-func (g *KustomizeGenerator) generateValuesFile(key string, values any, configRoot string, overwrite bool) error {
-	if key != "kustomize/values" {
-		return fmt.Errorf("invalid values key %s, expected 'kustomize/values'", key)
-	}
-
-	valuesDir := filepath.Join(configRoot, "kustomize")
-	if err := g.validatePath(valuesDir, configRoot); err != nil {
-		return fmt.Errorf("invalid values directory path %s: %w", valuesDir, err)
-	}
-
-	valuesMap, ok := values.(map[string]any)
-	if !ok {
-		return fmt.Errorf("values must be a map, got %T", values)
-	}
-
-	if err := g.validatePostBuildValues(valuesMap, "", 0); err != nil {
-		return fmt.Errorf("invalid values for post-build substitution: %w", err)
-	}
-
-	fullValuesPath := filepath.Join(valuesDir, "values.yaml")
-	if err := g.validatePath(fullValuesPath, configRoot); err != nil {
-		return fmt.Errorf("invalid values file path %s: %w", fullValuesPath, err)
-	}
-
-	existingValues := make(map[string]any)
-	if _, err := g.shims.Stat(fullValuesPath); err == nil {
-		if data, err := g.shims.ReadFile(fullValuesPath); err == nil {
-			if err := g.shims.YamlUnmarshal(data, &existingValues); err != nil {
-				return fmt.Errorf("failed to unmarshal existing values file %s: %w", fullValuesPath, err)
-			}
+// validateKustomizeData validates kustomize template data based on the key type.
+// Validates patches as Kubernetes manifests and values for post-build substitution compatibility.
+func (g *KustomizeGenerator) validateKustomizeData(key string, values any) error {
+	if strings.HasPrefix(key, "kustomize/patches/") {
+		valuesMap, ok := values.(map[string]any)
+		if !ok {
+			return fmt.Errorf("patch values must be a map, got %T", values)
 		}
+		return g.validateKubernetesManifest(valuesMap)
 	}
 
-	for k, v := range valuesMap {
-		existingValues[k] = v
-	}
-
-	return g.writeYamlFile(fullValuesPath, existingValues, overwrite)
-}
-
-// validateKustomizationName validates that a kustomization name is safe and valid.
-// Prevents path traversal attacks and ensures names contain only valid characters.
-// Now handles full paths including subdirectories (e.g., "ingress/nginx").
-func (g *KustomizeGenerator) validateKustomizationName(name string) error {
-	if name == "" {
-		return fmt.Errorf("kustomization name cannot be empty")
-	}
-
-	if strings.Contains(name, "..") || strings.Contains(name, "\\") {
-		return fmt.Errorf("kustomization name cannot contain path traversal characters")
-	}
-
-	for _, component := range strings.Split(name, "/") {
-		if component == "" {
-			return fmt.Errorf("kustomization name cannot contain empty path components")
+	if key == "kustomize/values" {
+		valuesMap, ok := values.(map[string]any)
+		if !ok {
+			return fmt.Errorf("values must be a map, got %T", values)
 		}
-		for _, char := range component {
-			if !((char >= 'a' && char <= 'z') || (char >= 'A' && char <= 'Z') || (char >= '0' && char <= '9') || char == '-' || char == '_') {
-				return fmt.Errorf("kustomization name component '%s' contains invalid character '%c'", component, char)
-			}
-		}
+		return g.validatePostBuildValues(valuesMap, "", 0)
 	}
 
 	return nil
@@ -242,26 +139,6 @@ func (g *KustomizeGenerator) validatePostBuildValues(values map[string]any, pare
 	return nil
 }
 
-// validatePath ensures the target path is within the base path to prevent path traversal attacks.
-// Returns an error if the target path is outside the base path or contains invalid characters.
-func (g *KustomizeGenerator) validatePath(targetPath, basePath string) error {
-	absTarget, err := filepath.Abs(targetPath)
-	if err != nil {
-		return fmt.Errorf("failed to get absolute path for %s: %w", targetPath, err)
-	}
-
-	absBase, err := filepath.Abs(basePath)
-	if err != nil {
-		return fmt.Errorf("failed to get absolute path for %s: %w", basePath, err)
-	}
-
-	if !strings.HasPrefix(absTarget, absBase) {
-		return fmt.Errorf("target path %s is outside base path %s", absTarget, absBase)
-	}
-
-	return nil
-}
-
 // validateKubernetesManifest validates that the content represents a valid Kubernetes manifest.
 // Checks for required fields like apiVersion, kind, and metadata.name.
 // Returns an error if the manifest is invalid.
@@ -289,38 +166,6 @@ func (g *KustomizeGenerator) validateKubernetesManifest(content any) error {
 	name, ok := metadata["name"].(string)
 	if !ok || name == "" {
 		return fmt.Errorf("manifest missing or invalid 'metadata.name' field")
-	}
-
-	return nil
-}
-
-// writeYamlFile writes a YAML file to filePath using the provided values map.
-// filePath must be a file path. If it doesn't have a .yaml or .yml extension, .yaml will be automatically appended.
-// If overwrite is false, existing files are not replaced.
-// Returns an error on marshalling or file operation failure.
-func (g *KustomizeGenerator) writeYamlFile(filePath string, values map[string]any, overwrite bool) error {
-	if !strings.HasSuffix(filePath, ".yaml") && !strings.HasSuffix(filePath, ".yml") {
-		filePath = filePath + ".yaml"
-	}
-
-	dir := filepath.Dir(filePath)
-	if err := g.shims.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("failed to create directory %s: %w", dir, err)
-	}
-
-	if !overwrite {
-		if _, err := g.shims.Stat(filePath); err == nil {
-			return nil
-		}
-	}
-
-	yamlData, err := g.shims.MarshalYAML(values)
-	if err != nil {
-		return fmt.Errorf("failed to marshal content to YAML for %s: %w", filePath, err)
-	}
-
-	if err := g.shims.WriteFile(filePath, yamlData, 0644); err != nil {
-		return fmt.Errorf("failed to write file %s: %w", filePath, err)
 	}
 
 	return nil

--- a/pkg/pipelines/pipeline.go
+++ b/pkg/pipelines/pipeline.go
@@ -267,8 +267,9 @@ func (p *BasePipeline) withStack() stack.Stack {
 	return stack
 }
 
-// withGenerators creates and registers generators including git, terraform, and patch generators.
-// Returns a slice of initialized generators or an error if creation fails.
+// withGenerators creates and registers generator instances for git, terraform, and kustomize based on configuration.
+// It always registers the git generator. The terraform generator is registered if "terraform.enabled" is true.
+// The kustomize generator is registered if "cluster.enabled" is true. Returns a slice of initialized generators or an error.
 func (p *BasePipeline) withGenerators() ([]generators.Generator, error) {
 	var generatorList []generators.Generator
 
@@ -276,14 +277,12 @@ func (p *BasePipeline) withGenerators() ([]generators.Generator, error) {
 	p.injector.Register("gitGenerator", gitGenerator)
 	generatorList = append(generatorList, gitGenerator)
 
-	// Only create Terraform generator if Terraform is enabled
 	if p.configHandler.GetBool("terraform.enabled", false) {
 		terraformGenerator := generators.NewTerraformGenerator(p.injector)
 		p.injector.Register("terraformGenerator", terraformGenerator)
 		generatorList = append(generatorList, terraformGenerator)
 	}
 
-	// Create patch generator for Kustomize patch templating only if cluster.enabled
 	if p.configHandler.GetBool("cluster.enabled", false) {
 		kustomizeGenerator := generators.NewKustomizeGenerator(p.injector)
 		p.injector.Register("kustomizeGenerator", kustomizeGenerator)


### PR DESCRIPTION
The templating architecture is shifting. Values and patches placed in `contexts/<context>/kustomize` are now treated as overrides.

As such, `windsor init` will no longer output templated values to these folders, and instead, handle applying them in-memory. The implementation then applies user overrides on top of the base in-memory values before applying to the cluster.