### PR TITLE
refactor(blueprint): Use config.yaml instead of values.yaml

### DIFF
--- a/pkg/blueprint/blueprint_handler.go
+++ b/pkg/blueprint/blueprint_handler.go
@@ -1323,7 +1323,7 @@ func (b *BaseBlueprintHandler) hasComponentValues(componentName string) bool {
 	hasUserComponent := false
 	configRoot, err := b.configHandler.GetConfigRoot()
 	if err == nil {
-		valuesPath := filepath.Join(configRoot, "kustomize", "values.yaml")
+		valuesPath := filepath.Join(configRoot, "kustomize", "config.yaml")
 		if _, err := b.shims.Stat(valuesPath); err == nil {
 			if data, err := b.shims.ReadFile(valuesPath); err == nil {
 				var values map[string]any
@@ -1357,7 +1357,7 @@ func (b *BaseBlueprintHandler) isOCISource(sourceNameOrURL string) bool {
 	return false
 }
 
-// applyValuesConfigMaps creates ConfigMaps for post-build variable substitution using rendered values data and any existing values.yaml files.
+// applyValuesConfigMaps creates ConfigMaps for post-build variable substitution using rendered values data and any existing config.yaml files.
 // It generates a ConfigMap for the "common" section and for each component section, merging rendered template values with user-defined values.
 // User-defined values take precedence over template values in case of conflicts.
 // The resulting ConfigMaps are referenced in PostBuild.SubstituteFrom for variable substitution.
@@ -1403,7 +1403,7 @@ func (b *BaseBlueprintHandler) applyValuesConfigMaps() error {
 	}
 
 	var userValues map[string]any
-	valuesPath := filepath.Join(configRoot, "kustomize", "values.yaml")
+	valuesPath := filepath.Join(configRoot, "kustomize", "config.yaml")
 	if _, err := b.shims.Stat(valuesPath); err == nil {
 		data, err := b.shims.ReadFile(valuesPath)
 		if err == nil {

--- a/pkg/blueprint/blueprint_handler_test.go
+++ b/pkg/blueprint/blueprint_handler_test.go
@@ -3577,20 +3577,20 @@ func TestBaseBlueprintHandler_applyValuesConfigMaps(t *testing.T) {
 			return []string{}
 		}
 
-		// And mock kustomize directory with global values.yaml
+		// And mock kustomize directory with global config.yaml
 		handler.shims.Stat = func(name string) (os.FileInfo, error) {
 			if name == filepath.Join("/test/config", "kustomize") {
 				return &mockFileInfo{name: "kustomize"}, nil
 			}
-			if name == filepath.Join("/test/config", "kustomize", "values.yaml") {
-				return &mockFileInfo{name: "values.yaml"}, nil
+			if name == filepath.Join("/test/config", "kustomize", "config.yaml") {
+				return &mockFileInfo{name: "config.yaml"}, nil
 			}
 			return nil, os.ErrNotExist
 		}
 
 		// And mock file read for centralized values
 		handler.shims.ReadFile = func(name string) ([]byte, error) {
-			if name == filepath.Join("/test/config", "kustomize", "values.yaml") {
+			if name == filepath.Join("/test/config", "kustomize", "config.yaml") {
 				return []byte(`common:
   domain: example.com
   port: 80
@@ -3672,20 +3672,20 @@ func TestBaseBlueprintHandler_applyValuesConfigMaps(t *testing.T) {
 			return []string{}
 		}
 
-		// And mock centralized values.yaml with component values
+		// And mock centralized config.yaml with component values
 		handler.shims.Stat = func(name string) (os.FileInfo, error) {
 			if name == filepath.Join("/test/config", "kustomize") {
 				return &mockFileInfo{name: "kustomize"}, nil
 			}
-			if name == filepath.Join("/test/config", "kustomize", "values.yaml") {
-				return &mockFileInfo{name: "values.yaml"}, nil
+			if name == filepath.Join("/test/config", "kustomize", "config.yaml") {
+				return &mockFileInfo{name: "config.yaml"}, nil
 			}
 			return nil, os.ErrNotExist
 		}
 
 		// And mock file read for centralized values
 		handler.shims.ReadFile = func(name string) ([]byte, error) {
-			if name == filepath.Join("/test/config", "kustomize", "values.yaml") {
+			if name == filepath.Join("/test/config", "kustomize", "config.yaml") {
 				return []byte(`common:
   domain: example.com
 ingress:
@@ -3831,20 +3831,20 @@ ingress:
 			return []string{}
 		}
 
-		// And mock kustomize directory and values.yaml exists
+		// And mock kustomize directory and config.yaml exists
 		handler.shims.Stat = func(name string) (os.FileInfo, error) {
 			if name == filepath.Join("/test/config", "kustomize") {
 				return &mockFileInfo{name: "kustomize"}, nil
 			}
-			if name == filepath.Join("/test/config", "kustomize", "values.yaml") {
-				return &mockFileInfo{name: "values.yaml"}, nil
+			if name == filepath.Join("/test/config", "kustomize", "config.yaml") {
+				return &mockFileInfo{name: "config.yaml"}, nil
 			}
 			return nil, os.ErrNotExist
 		}
 
 		// And mock ReadFile that fails
 		handler.shims.ReadFile = func(name string) ([]byte, error) {
-			if name == filepath.Join("/test/config", "kustomize", "values.yaml") {
+			if name == filepath.Join("/test/config", "kustomize", "config.yaml") {
 				return nil, os.ErrPermission
 			}
 			return nil, os.ErrNotExist
@@ -3899,20 +3899,20 @@ ingress:
 			return []string{}
 		}
 
-		// And mock centralized values.yaml with component values
+		// And mock centralized config.yaml with component values
 		handler.shims.Stat = func(name string) (os.FileInfo, error) {
 			if name == filepath.Join("/test/config", "kustomize") {
 				return &mockFileInfo{name: "kustomize"}, nil
 			}
-			if name == filepath.Join("/test/config", "kustomize", "values.yaml") {
-				return &mockFileInfo{name: "values.yaml"}, nil
+			if name == filepath.Join("/test/config", "kustomize", "config.yaml") {
+				return &mockFileInfo{name: "config.yaml"}, nil
 			}
 			return nil, os.ErrNotExist
 		}
 
 		// And mock file read for centralized values
 		handler.shims.ReadFile = func(name string) ([]byte, error) {
-			if name == filepath.Join("/test/config", "kustomize", "values.yaml") {
+			if name == filepath.Join("/test/config", "kustomize", "config.yaml") {
 				return []byte(`common:
   domain: example.com
 ingress:
@@ -3990,10 +3990,10 @@ func TestBaseBlueprintHandler_toFluxKustomization_WithValuesConfigMaps(t *testin
 			return "/test/config", nil
 		}
 
-		// And mock that global values.yaml exists
+		// And mock that global config.yaml exists
 		handler.shims.Stat = func(name string) (os.FileInfo, error) {
-			if name == filepath.Join("/test/config", "kustomize", "values.yaml") {
-				return &mockFileInfo{name: "values.yaml"}, nil
+			if name == filepath.Join("/test/config", "kustomize", "config.yaml") {
+				return &mockFileInfo{name: "config.yaml"}, nil
 			}
 			return nil, os.ErrNotExist
 		}
@@ -4058,17 +4058,17 @@ func TestBaseBlueprintHandler_toFluxKustomization_WithValuesConfigMaps(t *testin
 			return "/test/config", nil
 		}
 
-		// And mock that global values.yaml exists
+		// And mock that global config.yaml exists
 		handler.shims.Stat = func(name string) (os.FileInfo, error) {
-			if name == filepath.Join("/test/config", "kustomize", "values.yaml") {
-				return &mockFileInfo{name: "values.yaml"}, nil
+			if name == filepath.Join("/test/config", "kustomize", "config.yaml") {
+				return &mockFileInfo{name: "config.yaml"}, nil
 			}
 			return nil, os.ErrNotExist
 		}
 
-		// And mock the values.yaml content with ingress component
+		// And mock the config.yaml content with ingress component
 		handler.shims.ReadFile = func(name string) ([]byte, error) {
-			if name == filepath.Join("/test/config", "kustomize", "values.yaml") {
+			if name == filepath.Join("/test/config", "kustomize", "config.yaml") {
 				return []byte(`ingress:
   key: value`), nil
 			}
@@ -4142,10 +4142,10 @@ func TestBaseBlueprintHandler_toFluxKustomization_WithValuesConfigMaps(t *testin
 			return "/test/config", nil
 		}
 
-		// And mock that global values.yaml exists
+		// And mock that global config.yaml exists
 		handler.shims.Stat = func(name string) (os.FileInfo, error) {
-			if name == filepath.Join("/test/config", "kustomize", "values.yaml") {
-				return &mockFileInfo{name: "values.yaml"}, nil
+			if name == filepath.Join("/test/config", "kustomize", "config.yaml") {
+				return &mockFileInfo{name: "config.yaml"}, nil
 			}
 			return nil, os.ErrNotExist
 		}
@@ -4238,7 +4238,7 @@ func TestBaseBlueprintHandler_toFluxKustomization_WithValuesConfigMaps(t *testin
 			return "/test/config", nil
 		}
 
-		// And mock that no values.yaml files exist
+		// And mock that no config.yaml files exist
 		handler.shims.Stat = func(name string) (os.FileInfo, error) {
 			return nil, os.ErrNotExist
 		}
@@ -5526,7 +5526,7 @@ func TestBaseBlueprintHandler_hasComponentValues(t *testing.T) {
 			return "/test/config", nil
 		}
 		handler.shims.Stat = func(name string) (os.FileInfo, error) {
-			return &mockFileInfo{name: "values.yaml", isDir: false}, nil
+			return &mockFileInfo{name: "config.yaml", isDir: false}, nil
 		}
 		handler.shims.ReadFile = func(name string) ([]byte, error) {
 			return []byte(`test-component:
@@ -5563,7 +5563,7 @@ func TestBaseBlueprintHandler_hasComponentValues(t *testing.T) {
 			return "/test/config", nil
 		}
 		handler.shims.Stat = func(name string) (os.FileInfo, error) {
-			return &mockFileInfo{name: "values.yaml", isDir: false}, nil
+			return &mockFileInfo{name: "config.yaml", isDir: false}, nil
 		}
 		handler.shims.ReadFile = func(name string) ([]byte, error) {
 			return []byte(`test-component:
@@ -5641,7 +5641,7 @@ func TestBaseBlueprintHandler_hasComponentValues(t *testing.T) {
 			return "/test/config", nil
 		}
 		handler.shims.Stat = func(name string) (os.FileInfo, error) {
-			return &mockFileInfo{name: "values.yaml", isDir: false}, nil
+			return &mockFileInfo{name: "config.yaml", isDir: false}, nil
 		}
 		handler.shims.ReadFile = func(name string) ([]byte, error) {
 			return []byte("invalid yaml"), nil


### PR DESCRIPTION
`config.yaml` is more distinct from `values.yaml`. The former are injected as `postBuild` values via a configmap, the latter are used as inputs to a blueprint template.