### PR TITLE
fix(install): Install now applies generated templates

### DIFF
--- a/pkg/blueprint/blueprint_handler_test.go
+++ b/pkg/blueprint/blueprint_handler_test.go
@@ -3672,20 +3672,20 @@ func TestBaseBlueprintHandler_applyValuesConfigMaps(t *testing.T) {
 			return []string{}
 		}
 
-		// And mock centralized config.yaml with component values
+		// And mock centralized values.yaml with component values
 		handler.shims.Stat = func(name string) (os.FileInfo, error) {
 			if name == filepath.Join("/test/config", "kustomize") {
 				return &mockFileInfo{name: "kustomize"}, nil
 			}
-			if name == filepath.Join("/test/config", "kustomize", "config.yaml") {
-				return &mockFileInfo{name: "config.yaml"}, nil
+			if name == filepath.Join("/test/config", "kustomize", "values.yaml") {
+				return &mockFileInfo{name: "values.yaml"}, nil
 			}
 			return nil, os.ErrNotExist
 		}
 
 		// And mock file read for centralized values
 		handler.shims.ReadFile = func(name string) ([]byte, error) {
-			if name == filepath.Join("/test/config", "kustomize", "config.yaml") {
+			if name == filepath.Join("/test/config", "kustomize", "values.yaml") {
 				return []byte(`common:
   domain: example.com
 ingress:
@@ -4058,17 +4058,17 @@ func TestBaseBlueprintHandler_toFluxKustomization_WithValuesConfigMaps(t *testin
 			return "/test/config", nil
 		}
 
-		// And mock that global config.yaml exists
+		// And mock that global values.yaml exists
 		handler.shims.Stat = func(name string) (os.FileInfo, error) {
-			if name == filepath.Join("/test/config", "kustomize", "config.yaml") {
-				return &mockFileInfo{name: "config.yaml"}, nil
+			if name == filepath.Join("/test/config", "kustomize", "values.yaml") {
+				return &mockFileInfo{name: "values.yaml"}, nil
 			}
 			return nil, os.ErrNotExist
 		}
 
-		// And mock the config.yaml content with ingress component
+		// And mock the values.yaml content with ingress component
 		handler.shims.ReadFile = func(name string) ([]byte, error) {
-			if name == filepath.Join("/test/config", "kustomize", "config.yaml") {
+			if name == filepath.Join("/test/config", "kustomize", "values.yaml") {
 				return []byte(`ingress:
   key: value`), nil
 			}
@@ -4142,10 +4142,10 @@ func TestBaseBlueprintHandler_toFluxKustomization_WithValuesConfigMaps(t *testin
 			return "/test/config", nil
 		}
 
-		// And mock that global config.yaml exists
+		// And mock that global values.yaml exists
 		handler.shims.Stat = func(name string) (os.FileInfo, error) {
-			if name == filepath.Join("/test/config", "kustomize", "config.yaml") {
-				return &mockFileInfo{name: "config.yaml"}, nil
+			if name == filepath.Join("/test/config", "kustomize", "values.yaml") {
+				return &mockFileInfo{name: "values.yaml"}, nil
 			}
 			return nil, os.ErrNotExist
 		}

--- a/pkg/pipelines/env_test.go
+++ b/pkg/pipelines/env_test.go
@@ -24,14 +24,6 @@ type EnvMocks struct {
 	Shims         *Shims
 }
 
-func setupEnvShims(t *testing.T) *Shims {
-	t.Helper()
-	shims := setupShims(t)
-
-	// Add any env-specific shim overrides here if needed
-	return shims
-}
-
 func setupEnvMocks(t *testing.T, opts ...*SetupOptions) *EnvMocks {
 	t.Helper()
 

--- a/pkg/pipelines/exec_test.go
+++ b/pkg/pipelines/exec_test.go
@@ -16,11 +16,6 @@ type ExecMocks struct {
 	*Mocks
 }
 
-func setupExecShims(t *testing.T) *Shims {
-	t.Helper()
-	return setupShims(t)
-}
-
 func setupExecMocks(t *testing.T, opts ...*SetupOptions) *ExecMocks {
 	t.Helper()
 

--- a/pkg/pipelines/hook_test.go
+++ b/pkg/pipelines/hook_test.go
@@ -15,12 +15,6 @@ type HookMocks struct {
 	*Mocks
 }
 
-// setupHookShims creates shims for hook pipeline tests
-func setupHookShims(t *testing.T) *Shims {
-	t.Helper()
-	return setupShims(t)
-}
-
 // setupHookMocks creates mocks for hook pipeline tests
 func setupHookMocks(t *testing.T, opts ...*SetupOptions) *HookMocks {
 	t.Helper()

--- a/pkg/pipelines/install_test.go
+++ b/pkg/pipelines/install_test.go
@@ -393,6 +393,7 @@ func TestInstallPipeline_Execute(t *testing.T) {
 		// Mock template renderer to return test data
 		mockTemplateRenderer := &MockTemplate{}
 		mockTemplateRenderer.ProcessFunc = func(templateData map[string][]byte, renderedData map[string]any) error {
+			t.Log("Template renderer Process called")
 			renderedData["kustomize/values"] = map[string]any{
 				"common": map[string]any{
 					"domain": "test.com",
@@ -400,10 +401,17 @@ func TestInstallPipeline_Execute(t *testing.T) {
 			}
 			return nil
 		}
-		pipeline.templateRenderer = mockTemplateRenderer
+		// Register the mock template renderer in the injector BEFORE initialization
+		mocks.Injector.Register("templateRenderer", mockTemplateRenderer)
+
+		// Initialize the pipeline to set up generators
+		if err := pipeline.Initialize(mocks.Injector, context.Background()); err != nil {
+			t.Fatalf("Failed to initialize pipeline: %v", err)
+		}
 
 		// Mock blueprint handler to return template data
 		mocks.BlueprintHandler.GetLocalTemplateDataFunc = func() (map[string][]byte, error) {
+			t.Log("GetLocalTemplateData called")
 			return map[string][]byte{
 				"kustomize/values.jsonnet": []byte(`{"common": {"domain": "test.com"}}`),
 			}, nil
@@ -419,7 +427,7 @@ func TestInstallPipeline_Execute(t *testing.T) {
 
 		// And template processing should be called
 		if !mockTemplateRenderer.ProcessCalled {
-			t.Error("Expected template processing to be called")
+			t.Errorf("Expected template processing to be called. Config loaded: %v, Blueprint handler: %v", pipeline.configHandler.IsLoaded(), pipeline.blueprintHandler != nil)
 		}
 	})
 
@@ -432,7 +440,13 @@ func TestInstallPipeline_Execute(t *testing.T) {
 		mockTemplateRenderer.ProcessFunc = func(templateData map[string][]byte, renderedData map[string]any) error {
 			return fmt.Errorf("template processing failed")
 		}
-		pipeline.templateRenderer = mockTemplateRenderer
+		// Register the mock template renderer in the injector BEFORE initialization
+		mocks.Injector.Register("templateRenderer", mockTemplateRenderer)
+
+		// Initialize the pipeline to set up generators
+		if err := pipeline.Initialize(mocks.Injector, context.Background()); err != nil {
+			t.Fatalf("Failed to initialize pipeline: %v", err)
+		}
 
 		// Mock blueprint handler to return template data
 		mocks.BlueprintHandler.GetLocalTemplateDataFunc = func() (map[string][]byte, error) {
@@ -467,7 +481,13 @@ func TestInstallPipeline_Execute(t *testing.T) {
 			}
 			return nil
 		}
-		pipeline.templateRenderer = mockTemplateRenderer
+		// Register the mock template renderer in the injector BEFORE initialization
+		mocks.Injector.Register("templateRenderer", mockTemplateRenderer)
+
+		// Initialize the pipeline to set up generators
+		if err := pipeline.Initialize(mocks.Injector, context.Background()); err != nil {
+			t.Fatalf("Failed to initialize pipeline: %v", err)
+		}
 
 		// Mock blueprint handler to return template data
 		mocks.BlueprintHandler.GetLocalTemplateDataFunc = func() (map[string][]byte, error) {
@@ -515,7 +535,13 @@ func TestInstallPipeline_Execute(t *testing.T) {
 			}
 			return nil
 		}
-		pipeline.templateRenderer = mockTemplateRenderer
+		// Register the mock template renderer in the injector BEFORE initialization
+		mocks.Injector.Register("templateRenderer", mockTemplateRenderer)
+
+		// Initialize the pipeline to set up generators
+		if err := pipeline.Initialize(mocks.Injector, context.Background()); err != nil {
+			t.Fatalf("Failed to initialize pipeline: %v", err)
+		}
 
 		// Mock blueprint handler to return template data
 		mocks.BlueprintHandler.GetLocalTemplateDataFunc = func() (map[string][]byte, error) {
@@ -555,7 +581,13 @@ func TestInstallPipeline_Execute(t *testing.T) {
 			// Don't add any data to renderedData
 			return nil
 		}
-		pipeline.templateRenderer = mockTemplateRenderer
+		// Register the mock template renderer in the injector BEFORE initialization
+		mocks.Injector.Register("templateRenderer", mockTemplateRenderer)
+
+		// Initialize the pipeline to set up generators
+		if err := pipeline.Initialize(mocks.Injector, context.Background()); err != nil {
+			t.Fatalf("Failed to initialize pipeline: %v", err)
+		}
 
 		// Mock blueprint handler to return template data
 		mocks.BlueprintHandler.GetLocalTemplateDataFunc = func() (map[string][]byte, error) {
@@ -607,7 +639,13 @@ func TestInstallPipeline_Execute(t *testing.T) {
 			renderedData["kustomize/values"] = expectedData["kustomize/values"]
 			return nil
 		}
-		pipeline.templateRenderer = mockTemplateRenderer
+		// Register the mock template renderer in the injector BEFORE initialization
+		mocks.Injector.Register("templateRenderer", mockTemplateRenderer)
+
+		// Initialize the pipeline to set up generators
+		if err := pipeline.Initialize(mocks.Injector, context.Background()); err != nil {
+			t.Fatalf("Failed to initialize pipeline: %v", err)
+		}
 
 		// Mock blueprint handler to return template data
 		mocks.BlueprintHandler.GetLocalTemplateDataFunc = func() (map[string][]byte, error) {
@@ -664,7 +702,13 @@ func TestInstallPipeline_Execute(t *testing.T) {
 			}
 			return nil
 		}
-		pipeline.templateRenderer = mockTemplateRenderer
+		// Register the mock template renderer in the injector BEFORE initialization
+		mocks.Injector.Register("templateRenderer", mockTemplateRenderer)
+
+		// Initialize the pipeline to set up generators
+		if err := pipeline.Initialize(mocks.Injector, context.Background()); err != nil {
+			t.Fatalf("Failed to initialize pipeline: %v", err)
+		}
 
 		// Mock blueprint handler to return template data
 		mocks.BlueprintHandler.GetLocalTemplateDataFunc = func() (map[string][]byte, error) {


### PR DESCRIPTION
Since moving to in-memory template generation, these were not available to the `windsor install` command. This PR adds templating functionality to the install pipeline.