### PR TITLE
fix(terraform): Ensure sensitive outputs are retained

### DIFF
--- a/pkg/terraform/module_resolver.go
+++ b/pkg/terraform/module_resolver.go
@@ -198,6 +198,10 @@ func (h *BaseModuleResolver) writeShimOutputsTf(moduleDir, modulePath string) er
 						shimBlockBody.SetAttributeRaw("description", attr.Expr().BuildTokens(nil))
 					}
 
+					if attr := block.Body().GetAttribute("sensitive"); attr != nil {
+						shimBlockBody.SetAttributeRaw("sensitive", attr.Expr().BuildTokens(nil))
+					}
+
 					shimBlockBody.SetAttributeTraversal("value", hcl.Traversal{
 						hcl.TraverseRoot{Name: "module"},
 						hcl.TraverseAttr{Name: "main"},


### PR DESCRIPTION
If outputs are marked `sensitive` in a source module, this should be carried over to the module shims.