### PR TITLE
fix(artifact): Don't require a schema.yaml in the OCI artifact

### DIFF
--- a/pkg/artifact/artifact.go
+++ b/pkg/artifact/artifact.go
@@ -428,8 +428,6 @@ func (a *ArtifactBuilder) GetTemplateData(ociRef string) (map[string][]byte, err
 
 	if schemaContent != nil {
 		templateData["schema"] = schemaContent
-	} else {
-		return nil, fmt.Errorf("OCI artifact missing required _template/schema.yaml file")
 	}
 
 	maps.Copy(templateData, jsonnetFiles)


### PR DESCRIPTION
We were getting an error when `schema.yaml` wasn't included in a downloaded OCI artifact. Since it's not necessary, don't include it.