### PR TITLE
chore(blueprint): Remove Authors field

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -44,16 +44,13 @@ type PartialBlueprint struct {
 	Kustomizations      []map[string]any     `yaml:"kustomize"`
 }
 
-// Metadata describes a blueprint, including name and authors.
+// Metadata describes a blueprint.
 type Metadata struct {
 	// Name is the blueprint's unique identifier.
 	Name string `yaml:"name"`
 
 	// Description is a brief overview of the blueprint.
 	Description string `yaml:"description,omitempty"`
-
-	// Authors are the creators or maintainers of the blueprint.
-	Authors []string `yaml:"authors,omitempty"`
 }
 
 // Repository contains source code repository info.
@@ -223,7 +220,6 @@ func (b *Blueprint) DeepCopy() *Blueprint {
 	metadataCopy := Metadata{
 		Name:        b.Metadata.Name,
 		Description: b.Metadata.Description,
-		Authors:     append([]string{}, b.Metadata.Authors...),
 	}
 
 	repositoryCopy := Repository{
@@ -307,9 +303,6 @@ func (b *Blueprint) Merge(overlay *Blueprint) {
 	}
 	if overlay.Metadata.Description != "" {
 		b.Metadata.Description = overlay.Metadata.Description
-	}
-	if len(overlay.Metadata.Authors) > 0 {
-		b.Metadata.Authors = overlay.Metadata.Authors
 	}
 
 	if overlay.Repository.Url != "" {

--- a/api/v1alpha1/blueprint_types_test.go
+++ b/api/v1alpha1/blueprint_types_test.go
@@ -14,7 +14,6 @@ func TestBlueprint_Merge(t *testing.T) {
 			Metadata: Metadata{
 				Name:        "original",
 				Description: "original description",
-				Authors:     []string{"author1"},
 			},
 			Repository: Repository{
 				Url: "http://example.com/repo1",
@@ -61,7 +60,6 @@ func TestBlueprint_Merge(t *testing.T) {
 			Metadata: Metadata{
 				Name:        "updated",
 				Description: "updated description",
-				Authors:     []string{"author2"},
 			},
 			Repository: Repository{
 				Url: "http://example.com/repo2",
@@ -119,9 +117,6 @@ func TestBlueprint_Merge(t *testing.T) {
 		}
 		if dst.Metadata.Description != "updated description" {
 			t.Errorf("Expected Metadata.Description to be 'updated description', but got '%s'", dst.Metadata.Description)
-		}
-		if !reflect.DeepEqual(dst.Metadata.Authors, []string{"author2"}) {
-			t.Errorf("Expected Metadata.Authors to be ['author2'], but got %v", dst.Metadata.Authors)
 		}
 
 		expectedSources := map[string]Source{
@@ -714,7 +709,6 @@ func TestBlueprint_Merge(t *testing.T) {
 			Metadata: Metadata{
 				Name:        "original",
 				Description: "original description",
-				Authors:     []string{"author1"},
 			},
 			Repository: Repository{
 				Url: "http://example.com/repo1",
@@ -790,7 +784,6 @@ func TestBlueprint_Merge(t *testing.T) {
 			Metadata: Metadata{
 				Name:        "original",
 				Description: "original description",
-				Authors:     []string{"author1"},
 			},
 			Repository: Repository{
 				Url: "http://example.com/repo1",

--- a/pkg/blueprint/blueprint_handler_test.go
+++ b/pkg/blueprint/blueprint_handler_test.go
@@ -3484,10 +3484,6 @@ func TestBlueprintHandler_LoadData(t *testing.T) {
 		if metadata.Description != "A test blueprint from data" {
 			t.Errorf("Expected description to be 'A test blueprint from data', got %s", metadata.Description)
 		}
-		if len(metadata.Authors) != 1 || metadata.Authors[0] != "John Doe" {
-			t.Errorf("Expected authors to be ['John Doe'], got %v", metadata.Authors)
-		}
-
 		// And the sources should be loaded
 		sources := handler.GetSources()
 		if len(sources) != 1 {
@@ -3669,7 +3665,6 @@ func TestBlueprintHandler_Write(t *testing.T) {
 			Metadata: blueprintv1alpha1.Metadata{
 				Name:        "test-blueprint",
 				Description: "A test blueprint",
-				Authors:     []string{"test-author"},
 			},
 			Repository: blueprintv1alpha1.Repository{
 				Url: "https://github.com/example/repo",

--- a/pkg/blueprint/defaults.go
+++ b/pkg/blueprint/defaults.go
@@ -8,7 +8,6 @@ var DefaultBlueprint = blueprintv1alpha1.Blueprint{
 	Metadata: blueprintv1alpha1.Metadata{
 		Name:        "default",
 		Description: "A default blueprint",
-		Authors:     []string{},
 	},
 	Sources:             []blueprintv1alpha1.Source{},
 	TerraformComponents: []blueprintv1alpha1.TerraformComponent{},


### PR DESCRIPTION
The Authors field isn't valuable here and is better represented within OCI metadata.