### PR TITLE
refactor: Leverage 'generic' provider

### DIFF
--- a/api/v1alpha1/cluster/cluster_config.go
+++ b/api/v1alpha1/cluster/cluster_config.go
@@ -3,7 +3,6 @@ package cluster
 // ClusterConfig represents the cluster configuration
 type ClusterConfig struct {
 	Enabled       *bool           `yaml:"enabled,omitempty"`
-	Platform      *string         `yaml:"platform,omitempty"`
 	Driver        *string         `yaml:"driver,omitempty"`
 	Endpoint      *string         `yaml:"endpoint,omitempty"`
 	Image         *string         `yaml:"image,omitempty"`
@@ -35,9 +34,6 @@ type NodeGroupConfig struct {
 func (base *ClusterConfig) Merge(overlay *ClusterConfig) {
 	if overlay.Enabled != nil {
 		base.Enabled = overlay.Enabled
-	}
-	if overlay.Platform != nil {
-		base.Platform = overlay.Platform
 	}
 	if overlay.Driver != nil {
 		base.Driver = overlay.Driver
@@ -140,7 +136,6 @@ func (c *ClusterConfig) Copy() *ClusterConfig {
 
 	return &ClusterConfig{
 		Enabled:  c.Enabled,
-		Platform: c.Platform,
 		Driver:   c.Driver,
 		Endpoint: c.Endpoint,
 		Image:    c.Image,

--- a/api/v1alpha1/cluster/cluster_config_test.go
+++ b/api/v1alpha1/cluster/cluster_config_test.go
@@ -22,7 +22,6 @@ func TestClusterConfig_Merge(t *testing.T) {
 		base := &ClusterConfig{
 			Enabled:  ptrBool(true),
 			Driver:   ptrString("base-driver"),
-			Platform: ptrString("base-platform"),
 			Endpoint: ptrString("base-endpoint"),
 			Image:    ptrString("base-image"),
 			ControlPlanes: struct {
@@ -74,7 +73,6 @@ func TestClusterConfig_Merge(t *testing.T) {
 		overlay := &ClusterConfig{
 			Enabled:  ptrBool(false),
 			Driver:   ptrString("overlay-driver"),
-			Platform: ptrString("overlay-platform"),
 			Endpoint: ptrString("overlay-endpoint"),
 			Image:    ptrString("overlay-image"),
 			ControlPlanes: struct {
@@ -130,9 +128,6 @@ func TestClusterConfig_Merge(t *testing.T) {
 		}
 		if base.Driver == nil || *base.Driver != "overlay-driver" {
 			t.Errorf("Driver mismatch: expected 'overlay-driver', got '%s'", *base.Driver)
-		}
-		if base.Platform == nil || *base.Platform != "overlay-platform" {
-			t.Errorf("Platform mismatch: expected 'overlay-platform', got '%s'", *base.Platform)
 		}
 		if base.Endpoint == nil || *base.Endpoint != "overlay-endpoint" {
 			t.Errorf("Endpoint mismatch: expected 'overlay-endpoint', got '%s'", *base.Endpoint)
@@ -191,7 +186,6 @@ func TestClusterConfig_Merge(t *testing.T) {
 		base := &ClusterConfig{
 			Enabled:  nil,
 			Driver:   nil,
-			Platform: nil,
 			Endpoint: nil,
 			Image:    nil,
 			ControlPlanes: struct {
@@ -233,7 +227,6 @@ func TestClusterConfig_Merge(t *testing.T) {
 		overlay := &ClusterConfig{
 			Enabled:  nil,
 			Driver:   nil,
-			Platform: nil,
 			Endpoint: nil,
 			Image:    nil,
 			ControlPlanes: struct {
@@ -279,9 +272,6 @@ func TestClusterConfig_Merge(t *testing.T) {
 		}
 		if base.Driver != nil {
 			t.Errorf("Driver mismatch: expected nil, got '%s'", *base.Driver)
-		}
-		if base.Platform != nil {
-			t.Errorf("Platform mismatch: expected nil, got '%s'", *base.Platform)
 		}
 		if base.Endpoint != nil {
 			t.Errorf("Endpoint mismatch: expected nil, got '%s'", *base.Endpoint)
@@ -336,7 +326,6 @@ func TestClusterConfig_Copy(t *testing.T) {
 		original := &ClusterConfig{
 			Enabled:  ptrBool(true),
 			Driver:   ptrString("original-driver"),
-			Platform: ptrString("original-platform"),
 			Endpoint: ptrString("original-endpoint"),
 			Image:    ptrString("original-image"),
 			ControlPlanes: struct {
@@ -392,9 +381,6 @@ func TestClusterConfig_Copy(t *testing.T) {
 		}
 		if original.Driver == nil || copy.Driver == nil || *original.Driver != *copy.Driver {
 			t.Errorf("Driver mismatch: expected %v, got %v", *original.Driver, *copy.Driver)
-		}
-		if original.Platform == nil || copy.Platform == nil || *original.Platform != *copy.Platform {
-			t.Errorf("Platform mismatch: expected %v, got %v", *original.Platform, *copy.Platform)
 		}
 		if original.Endpoint == nil || copy.Endpoint == nil || *original.Endpoint != *copy.Endpoint {
 			t.Errorf("Endpoint mismatch: expected %v, got %v", *original.Endpoint, *copy.Endpoint)

--- a/api/v1alpha2/config/workstation/cluster/cluster.go
+++ b/api/v1alpha2/config/workstation/cluster/cluster.go
@@ -3,7 +3,6 @@ package workstation
 // ClusterConfig represents the cluster configuration
 type ClusterConfig struct {
 	Enabled       *bool           `yaml:"enabled,omitempty"`
-	Platform      *string         `yaml:"platform,omitempty"`
 	Driver        *string         `yaml:"driver,omitempty"`
 	Endpoint      *string         `yaml:"endpoint,omitempty"`
 	Image         *string         `yaml:"image,omitempty"`
@@ -38,9 +37,6 @@ func (base *ClusterConfig) Merge(overlay *ClusterConfig) {
 	}
 	if overlay.Enabled != nil {
 		base.Enabled = overlay.Enabled
-	}
-	if overlay.Platform != nil {
-		base.Platform = overlay.Platform
 	}
 	if overlay.Driver != nil {
 		base.Driver = overlay.Driver
@@ -204,11 +200,6 @@ func (c *ClusterConfig) DeepCopy() *ClusterConfig {
 		enabledCopy = new(bool)
 		*enabledCopy = *c.Enabled
 	}
-	var platformCopy *string
-	if c.Platform != nil {
-		platformCopy = new(string)
-		*platformCopy = *c.Platform
-	}
 	var driverCopy *string
 	if c.Driver != nil {
 		driverCopy = new(string)
@@ -227,7 +218,6 @@ func (c *ClusterConfig) DeepCopy() *ClusterConfig {
 
 	return &ClusterConfig{
 		Enabled:  enabledCopy,
-		Platform: platformCopy,
 		Driver:   driverCopy,
 		Endpoint: endpointCopy,
 		Image:    imageCopy,

--- a/api/v1alpha2/config/workstation/cluster/cluster_test.go
+++ b/api/v1alpha2/config/workstation/cluster/cluster_test.go
@@ -28,9 +28,8 @@ func TestClusterConfig_Merge(t *testing.T) {
 		}
 
 		overlay := &ClusterConfig{
-			Enabled:  ptrBool(true),
-			Driver:   ptrString("talos"),
-			Platform: ptrString("local"),
+			Enabled: ptrBool(true),
+			Driver:  ptrString("talos"),
 		}
 
 		base.Merge(overlay)
@@ -40,9 +39,6 @@ func TestClusterConfig_Merge(t *testing.T) {
 		}
 		if *base.Driver != "talos" {
 			t.Errorf("Expected Driver to be 'talos', got %s", *base.Driver)
-		}
-		if *base.Platform != "local" {
-			t.Errorf("Expected Platform to be 'local', got %s", *base.Platform)
 		}
 	})
 
@@ -282,7 +278,6 @@ func TestClusterConfig_Merge(t *testing.T) {
 	t.Run("MergeWithAllFields", func(t *testing.T) {
 		base := &ClusterConfig{
 			Enabled:  ptrBool(false),
-			Platform: ptrString("cloud"),
 			Driver:   ptrString("kind"),
 			Endpoint: ptrString("https://old.local:6443"),
 			Image:    ptrString("kind:v1.0.0"),
@@ -290,7 +285,6 @@ func TestClusterConfig_Merge(t *testing.T) {
 
 		overlay := &ClusterConfig{
 			Enabled:  ptrBool(true),
-			Platform: ptrString("local"),
 			Driver:   ptrString("talos"),
 			Endpoint: ptrString("https://new.local:6443"),
 			Image:    ptrString("talos:v1.0.0"),
@@ -300,9 +294,6 @@ func TestClusterConfig_Merge(t *testing.T) {
 
 		if !*base.Enabled {
 			t.Errorf("Expected Enabled to be true")
-		}
-		if *base.Platform != "local" {
-			t.Errorf("Expected Platform to be 'local'")
 		}
 		if *base.Driver != "talos" {
 			t.Errorf("Expected Driver to be 'talos'")
@@ -342,7 +333,6 @@ func TestClusterConfig_Copy(t *testing.T) {
 	t.Run("CopyPopulatedConfig", func(t *testing.T) {
 		config := &ClusterConfig{
 			Enabled:  ptrBool(true),
-			Platform: ptrString("local"),
 			Driver:   ptrString("talos"),
 			Endpoint: ptrString("https://cluster.local:6443"),
 			Image:    ptrString("talos:v1.0.0"),

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -64,7 +64,7 @@ var initCmd = &cobra.Command{
 
 		// Set provider if context is "local" and no provider is specified
 		if len(args) > 0 && strings.HasPrefix(args[0], "local") && initProvider == "" {
-			initProvider = "local"
+			initProvider = "generic"
 		}
 
 		// Pass blueprint and provider to pipeline for decision logic

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -487,7 +487,7 @@ func TestInitCmd(t *testing.T) {
 
 		// If context is "local" and neither provider nor blueprint is set, set both
 		if len(args) > 0 && strings.HasPrefix(args[0], "local") && initProvider == "" && initBlueprint == "" {
-			initProvider = "local"
+			initProvider = "generic"
 			initBlueprint = constants.DEFAULT_OCI_BLUEPRINT_URL
 		}
 
@@ -502,8 +502,8 @@ func TestInitCmd(t *testing.T) {
 		}
 
 		// Then both provider and blueprint should be set correctly
-		if initProvider != "local" {
-			t.Errorf("Expected provider to be 'local', got %s", initProvider)
+		if initProvider != "generic" {
+			t.Errorf("Expected provider to be 'generic', got %s", initProvider)
 		}
 
 		if blueprintCtx := ctx.Value("blueprint"); blueprintCtx == nil {
@@ -528,7 +528,7 @@ func TestInitCmd(t *testing.T) {
 
 		// If context is "local" and neither provider nor blueprint is set, set both
 		if len(args) > 0 && strings.HasPrefix(args[0], "local") && initProvider == "" && initBlueprint == "" {
-			initProvider = "local"
+			initProvider = "generic"
 			initBlueprint = constants.DEFAULT_OCI_BLUEPRINT_URL
 		}
 
@@ -569,7 +569,7 @@ func TestInitCmd(t *testing.T) {
 
 		// If context is "local" and neither provider nor blueprint is set, set both
 		if len(args) > 0 && strings.HasPrefix(args[0], "local") && initProvider == "" && initBlueprint == "" {
-			initProvider = "local"
+			initProvider = "generic"
 			initBlueprint = constants.DEFAULT_OCI_BLUEPRINT_URL
 		}
 
@@ -606,7 +606,7 @@ func TestInitCmd(t *testing.T) {
 
 		// If context is "local" and neither provider nor blueprint is set, set both
 		if len(args) > 0 && strings.HasPrefix(args[0], "local") && initProvider == "" && initBlueprint == "" {
-			initProvider = "local"
+			initProvider = "generic"
 			initBlueprint = constants.DEFAULT_OCI_BLUEPRINT_URL
 		}
 
@@ -1003,7 +1003,7 @@ func TestInitCmd(t *testing.T) {
 		cmd.SetContext(ctx)
 		err := cmd.Execute()
 
-		// Then no error should occur and "local" should be used as provider
+		// Then no error should occur and "generic" should be used as provider
 		if err != nil {
 			t.Errorf("Expected success, got error: %v", err)
 		}

--- a/pkg/blueprint/blueprint_handler_test.go
+++ b/pkg/blueprint/blueprint_handler_test.go
@@ -326,8 +326,6 @@ func setupMocks(t *testing.T, opts ...*SetupOptions) *Mocks {
 
 		mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
 			switch key {
-			case "cluster.platform":
-				return "default"
 			case "context":
 				return currentContext
 			default:

--- a/pkg/blueprint/feature_evaluator_test.go
+++ b/pkg/blueprint/feature_evaluator_test.go
@@ -51,21 +51,21 @@ func TestEvaluateExpression(t *testing.T) {
 		},
 		{
 			name:       "SimpleInequalityExpressionTrue",
-			expression: "provider != 'local'",
+			expression: "provider != 'generic'",
 			config:     map[string]any{"provider": "aws"},
 			expected:   true,
 		},
 		{
 			name:       "SimpleInequalityExpressionFalse",
-			expression: "provider != 'local'",
-			config:     map[string]any{"provider": "local"},
+			expression: "provider != 'generic'",
+			config:     map[string]any{"provider": "generic"},
 			expected:   false,
 		},
 		{
 			name:       "LogicalAndExpressionTrue",
-			expression: "provider == 'local' && observability.enabled == true",
+			expression: "provider == 'generic' && observability.enabled == true",
 			config: map[string]any{
-				"provider": "local",
+				"provider": "generic",
 				"observability": map[string]any{
 					"enabled": true,
 				},
@@ -74,7 +74,7 @@ func TestEvaluateExpression(t *testing.T) {
 		},
 		{
 			name:       "LogicalAndExpressionFalse",
-			expression: "provider == 'local' && observability.enabled == true",
+			expression: "provider == 'generic' && observability.enabled == true",
 			config: map[string]any{
 				"provider": "aws",
 				"observability": map[string]any{
@@ -92,14 +92,14 @@ func TestEvaluateExpression(t *testing.T) {
 		{
 			name:       "LogicalOrExpressionFalse",
 			expression: "provider == 'aws' || provider == 'azure'",
-			config:     map[string]any{"provider": "local"},
+			config:     map[string]any{"provider": "generic"},
 			expected:   false,
 		},
 		{
 			name:       "ParenthesesGrouping",
-			expression: "provider == 'local' && (vm.driver != 'docker-desktop' || loadbalancer.enabled == true)",
+			expression: "provider == 'generic' && (vm.driver != 'docker-desktop' || loadbalancer.enabled == true)",
 			config: map[string]any{
-				"provider": "local",
+				"provider": "generic",
 				"vm": map[string]any{
 					"driver": "virtualbox",
 				},
@@ -186,7 +186,7 @@ func TestMatchConditions(t *testing.T) {
 		{
 			name:       "SimpleStringEqualityFalse",
 			conditions: map[string]any{"provider": "aws"},
-			config:     map[string]any{"provider": "local"},
+			config:     map[string]any{"provider": "generic"},
 			expected:   false,
 		},
 		{
@@ -212,12 +212,12 @@ func TestMatchConditions(t *testing.T) {
 		{
 			name: "MultipleConditionsAllMatch",
 			conditions: map[string]any{
-				"provider":              "local",
+				"provider":              "generic",
 				"observability.enabled": true,
 				"observability.backend": "quickwit",
 			},
 			config: map[string]any{
-				"provider": "local",
+				"provider": "generic",
 				"observability": map[string]any{
 					"enabled": true,
 					"backend": "quickwit",
@@ -228,12 +228,12 @@ func TestMatchConditions(t *testing.T) {
 		{
 			name: "MultipleConditionsOneDoesNotMatch",
 			conditions: map[string]any{
-				"provider":              "local",
+				"provider":              "generic",
 				"observability.enabled": true,
 				"observability.backend": "elk",
 			},
 			config: map[string]any{
-				"provider": "local",
+				"provider": "generic",
 				"observability": map[string]any{
 					"enabled": true,
 					"backend": "quickwit",

--- a/pkg/blueprint/schema_validator_test.go
+++ b/pkg/blueprint/schema_validator_test.go
@@ -144,7 +144,7 @@ func TestSchemaValidator_ExtractDefaults(t *testing.T) {
 			"properties": map[string]any{
 				"provider": map[string]any{
 					"type":    "string",
-					"default": "local",
+					"default": "generic",
 				},
 				"port": map[string]any{
 					"type":    "integer",
@@ -162,8 +162,8 @@ func TestSchemaValidator_ExtractDefaults(t *testing.T) {
 		}
 
 		// And defaults should be extracted
-		if defaults["provider"] != "local" {
-			t.Errorf("Expected provider default to be 'local', got: %v", defaults["provider"])
+		if defaults["provider"] != "generic" {
+			t.Errorf("Expected provider default to be 'generic', got: %v", defaults["provider"])
 		}
 
 		if defaults["port"] != float64(8080) {
@@ -232,7 +232,7 @@ func TestSchemaValidator_Validate(t *testing.T) {
 			"properties": map[string]any{
 				"provider": map[string]any{
 					"type": "string",
-					"enum": []any{"local", "aws", "azure"},
+					"enum": []any{"generic", "aws", "azure"},
 				},
 				"port": map[string]any{
 					"type":    "integer",
@@ -246,7 +246,7 @@ func TestSchemaValidator_Validate(t *testing.T) {
 
 		// And valid values
 		values := map[string]any{
-			"provider": "local",
+			"provider": "generic",
 			"port":     8080,
 		}
 
@@ -376,7 +376,7 @@ func TestSchemaValidator_Validate(t *testing.T) {
 			"properties": map[string]any{
 				"provider": map[string]any{
 					"type": "string",
-					"enum": []any{"local", "aws", "azure"},
+					"enum": []any{"generic", "aws", "azure"},
 				},
 			},
 			"additionalProperties": false,
@@ -418,7 +418,7 @@ func TestSchemaValidator_Validate(t *testing.T) {
 		validator := NewSchemaValidator(mockShell)
 
 		values := map[string]any{
-			"provider": "local",
+			"provider": "generic",
 		}
 
 		// When validating values
@@ -791,7 +791,7 @@ func TestSchemaValidator_ValidateObject_AdditionalProperties(t *testing.T) {
 
 		// And values with additional property
 		values := map[string]any{
-			"provider":   "local",
+			"provider":   "generic",
 			"extraField": "not-allowed",
 		}
 
@@ -838,7 +838,7 @@ func TestSchemaValidator_ValidateObject_AdditionalProperties(t *testing.T) {
 
 		// And values with additional property
 		values := map[string]any{
-			"provider":   "local",
+			"provider":   "generic",
 			"extraField": "allowed",
 		}
 
@@ -872,7 +872,7 @@ func TestSchemaValidator_ValidateObject_AdditionalProperties(t *testing.T) {
 
 		// And values with additional property
 		values := map[string]any{
-			"provider":   "local",
+			"provider":   "generic",
 			"extraField": "should-be-allowed",
 		}
 
@@ -1078,7 +1078,7 @@ func TestSchemaValidator_NestedValidation(t *testing.T) {
 
 		// And valid values
 		values := map[string]any{
-			"provider": "local",
+			"provider": "generic",
 		}
 
 		// When validating values
@@ -1112,7 +1112,7 @@ func TestSchemaValidator_NestedValidation(t *testing.T) {
 
 		// And valid values
 		values := map[string]any{
-			"provider": "local",
+			"provider": "generic",
 		}
 
 		// When validating values
@@ -1143,8 +1143,8 @@ type: object
 properties:
   provider:
     type: string
-    enum: [local, aws, azure, talos]
-    default: local
+    enum: [generic, aws, azure, metal]
+    default: generic
   name:
     type: string
     default: template
@@ -1227,7 +1227,7 @@ additionalProperties: false
 
 		// And should extract nested defaults properly
 		expectedDefaults := map[string]any{
-			"provider": "local",
+			"provider": "generic",
 			"name":     "template",
 			"network": map[string]any{
 				"cidr_block": "10.0.0.0/16",
@@ -1298,8 +1298,8 @@ type: object
 properties:
   provider:
     type: string
-    enum: [local, aws, azure]
-    default: local
+    enum: [generic, aws, azure]
+    default: generic
   network:
     type: object
     properties:
@@ -1347,7 +1347,7 @@ type: object
 properties:
   provider:
     type: string
-    enum: [local, aws, azure]
+    enum: [generic, aws, azure]
   network:
     type: object
     properties:

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -21,16 +21,10 @@ import (
 
 // DefaultConfig returns the default configuration
 var DefaultConfig = v1alpha1.Context{
-	Provider: ptrString("local"),
-	Cluster: &cluster.ClusterConfig{
-		Enabled: ptrBool(true),
-	},
-	Terraform: &terraform.TerraformConfig{
-		Enabled: ptrBool(true),
-		Backend: &terraform.BackendConfig{
-			Type: "local",
-		},
-	},
+	Provider:  ptrString("generic"),
+	Cluster:   commonClusterConfig.Copy(),
+	Terraform: commonTerraformConfig.Copy(),
+	DNS:       commonDNSConfig.Copy(),
 }
 
 var commonDockerConfig = docker.DockerConfig{
@@ -79,9 +73,8 @@ var commonTerraformConfig = terraform.TerraformConfig{
 // commonClusterConfig_NoHostPorts is the base cluster configuration without hostports,
 // used for VM drivers that use native networking (colima, docker)
 var commonClusterConfig_NoHostPorts = cluster.ClusterConfig{
-	Enabled:  ptrBool(true),
-	Platform: ptrString("local"),
-	Driver:   ptrString("talos"),
+	Enabled: ptrBool(true),
+	Driver:  ptrString("talos"),
 	ControlPlanes: cluster.NodeGroupConfig{
 		Count:     ptrInt(1),
 		CPU:       ptrInt(constants.DEFAULT_TALOS_CONTROL_PLANE_CPU),
@@ -102,9 +95,8 @@ var commonClusterConfig_NoHostPorts = cluster.ClusterConfig{
 // commonClusterConfig_WithHostPorts is the base cluster configuration with hostports,
 // used for VM drivers that need port forwarding (docker-desktop)
 var commonClusterConfig_WithHostPorts = cluster.ClusterConfig{
-	Enabled:  ptrBool(true),
-	Platform: ptrString("local"),
-	Driver:   ptrString("talos"),
+	Enabled: ptrBool(true),
+	Driver:  ptrString("talos"),
 	ControlPlanes: cluster.NodeGroupConfig{
 		Count:     ptrInt(1),
 		CPU:       ptrInt(constants.DEFAULT_TALOS_CONTROL_PLANE_CPU),
@@ -124,9 +116,8 @@ var commonClusterConfig_WithHostPorts = cluster.ClusterConfig{
 
 // Preserve the original commonClusterConfig for backwards compatibility with DefaultConfig
 var commonClusterConfig = cluster.ClusterConfig{
-	Enabled:  ptrBool(true),
-	Platform: ptrString("local"),
-	Driver:   ptrString("talos"),
+	Enabled: ptrBool(true),
+	Driver:  ptrString("talos"),
 	ControlPlanes: cluster.NodeGroupConfig{
 		Count:  ptrInt(1),
 		CPU:    ptrInt(constants.DEFAULT_TALOS_CONTROL_PLANE_CPU),
@@ -149,7 +140,7 @@ var commonDNSConfig = dns.DNSConfig{
 }
 
 var DefaultConfig_Localhost = v1alpha1.Context{
-	Provider:    ptrString("local"),
+	Provider:    ptrString("generic"),
 	Environment: map[string]string{},
 	Docker:      commonDockerConfig.Copy(),
 	Git:         commonGitConfig.Copy(),
@@ -168,7 +159,7 @@ var DefaultConfig_Localhost = v1alpha1.Context{
 }
 
 var DefaultConfig_Full = v1alpha1.Context{
-	Provider:    ptrString("local"),
+	Provider:    ptrString("generic"),
 	Environment: map[string]string{},
 	Docker:      commonDockerConfig.Copy(),
 	Git:         commonGitConfig.Copy(),

--- a/pkg/env/talos_env_test.go
+++ b/pkg/env/talos_env_test.go
@@ -51,9 +51,9 @@ func TestTalosEnv_GetEnvVars(t *testing.T) {
 		return printer, mocks
 	}
 
-	t.Run("TalosProvider", func(t *testing.T) {
-		// Given a new TalosOmniEnvPrinter with talos provider
-		printer, mocks := setup(t, "talos")
+	t.Run("GenericProvider", func(t *testing.T) {
+		// Given a new TalosOmniEnvPrinter with generic provider
+		printer, mocks := setup(t, "generic")
 
 		// Get the project root path
 		projectRoot, err := mocks.Shell.GetProjectRoot()
@@ -82,9 +82,9 @@ func TestTalosEnv_GetEnvVars(t *testing.T) {
 			t.Errorf("TALOSCONFIG = %v, want %v", envVars["TALOSCONFIG"], expectedTalosPath)
 		}
 
-		// And OMNICONFIG should not be set for talos provider
+		// And OMNICONFIG should not be set for generic provider
 		if _, exists := envVars["OMNICONFIG"]; exists {
-			t.Error("OMNICONFIG should not be set for talos provider")
+			t.Error("OMNICONFIG should not be set for generic provider")
 		}
 	})
 
@@ -128,7 +128,7 @@ func TestTalosEnv_GetEnvVars(t *testing.T) {
 
 	t.Run("NoConfigFiles", func(t *testing.T) {
 		// Given a new TalosOmniEnvPrinter without existing config files
-		printer, mocks := setup(t, "talos")
+		printer, mocks := setup(t, "generic")
 
 		// Get the project root path
 		projectRoot, err := mocks.Shell.GetProjectRoot()
@@ -157,7 +157,7 @@ func TestTalosEnv_GetEnvVars(t *testing.T) {
 
 	t.Run("GetProjectRootError", func(t *testing.T) {
 		// Given a new TalosOmniEnvPrinter with failing config root lookup
-		printer, _ := setup(t, "talos")
+		printer, _ := setup(t, "generic")
 
 		// Override the GetConfigRoot to return an error
 		printer.configHandler.(*config.MockConfigHandler).GetConfigRootFunc = func() (string, error) {
@@ -211,9 +211,9 @@ func TestTalosEnv_Print(t *testing.T) {
 		return printer, mocks
 	}
 
-	t.Run("TalosProviderSuccess", func(t *testing.T) {
-		// Given a new TalosOmniEnvPrinter with talos provider and existing Talos config
-		printer, mocks := setup(t, "talos")
+	t.Run("GenericProviderSuccess", func(t *testing.T) {
+		// Given a new TalosOmniEnvPrinter with generic provider and existing Talos config
+		printer, mocks := setup(t, "generic")
 
 		// Get the project root path
 		projectRoot, err := mocks.Shell.GetProjectRoot()
@@ -299,7 +299,7 @@ func TestTalosEnv_Print(t *testing.T) {
 
 	t.Run("GetProjectRootError", func(t *testing.T) {
 		// Given a new TalosOmniEnvPrinter with failing project root lookup
-		printer, mocks := setup(t, "talos")
+		printer, mocks := setup(t, "generic")
 		mocks.Shell.GetProjectRootFunc = func() (string, error) {
 			return "", errors.New("mock project root error")
 		}

--- a/pkg/pipelines/init_test.go
+++ b/pkg/pipelines/init_test.go
@@ -531,7 +531,7 @@ func TestInitPipeline_setDefaultConfiguration(t *testing.T) {
 		// When setDefaultConfiguration is called with "local" context
 		err := pipeline.setDefaultConfiguration(context.Background(), "local")
 
-		// Then should set provider to "local" and complete successfully
+		// Then should set provider to "generic" and complete successfully
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -631,12 +631,12 @@ func TestInitPipeline_setDefaultConfiguration(t *testing.T) {
 		// When setDefaultConfiguration is called with "local" context
 		err := pipeline.setDefaultConfiguration(context.Background(), "local")
 
-		// Then should set provider to "local" and complete successfully
+		// Then should set provider to "generic" and complete successfully
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
-		if setProvider != "local" {
-			t.Errorf("Expected provider to be set to 'local', got %q", setProvider)
+		if setProvider != "generic" {
+			t.Errorf("Expected provider to be set to 'generic', got %q", setProvider)
 		}
 	})
 
@@ -794,8 +794,7 @@ func TestInitPipeline_processPlatformConfiguration(t *testing.T) {
 	}{
 		{name: "HandlesAWSProvider", provider: "aws"},
 		{name: "HandlesAzureProvider", provider: "azure"},
-		{name: "HandlesMetalProvider", provider: "metal"},
-		{name: "HandlesLocalProvider", provider: "local"},
+		{name: "HandlesGenericProvider", provider: "generic"},
 		{name: "HandlesEmptyProvider", provider: ""},
 	}
 


### PR DESCRIPTION
We now support a 'generic' provider. No more 'metal' or 'talos'. This allows for falling back to defaults that assume no cloud provider is present.

Also removed the `provider` field from the cluster configuration as it's no longer relevant.