### PR TITLE
refactor(config): Consolidate values.yaml and windsor.yaml configs under config handler

### DIFF
--- a/pkg/config/config_handler.go
+++ b/pkg/config/config_handler.go
@@ -65,6 +65,7 @@ type BaseConfigHandler struct {
 	loaded           bool
 	shims            *Shims
 	schemaValidator  *SchemaValidator
+	contextValues    map[string]any
 }
 
 // =============================================================================
@@ -74,8 +75,9 @@ type BaseConfigHandler struct {
 // NewBaseConfigHandler creates a new BaseConfigHandler instance
 func NewBaseConfigHandler(injector di.Injector) *BaseConfigHandler {
 	return &BaseConfigHandler{
-		injector: injector,
-		shims:    NewShims(),
+		injector:      injector,
+		shims:         NewShims(),
+		contextValues: make(map[string]any),
 	}
 }
 

--- a/pkg/pipelines/init.go
+++ b/pkg/pipelines/init.go
@@ -293,8 +293,12 @@ func (p *InitPipeline) Execute(ctx context.Context) error {
 		return err
 	}
 
-	// Save the configuration to windsor.yaml files
-	if err := p.configHandler.SaveConfig(); err != nil {
+	hasSetFlags := false
+	if setFlagsValue := ctx.Value("hasSetFlags"); setFlagsValue != nil {
+		hasSetFlags = setFlagsValue.(bool)
+	}
+
+	if err := p.configHandler.SaveConfig(hasSetFlags); err != nil {
 		return fmt.Errorf("failed to save configuration: %w", err)
 	}
 

--- a/pkg/pipelines/pipeline_test.go
+++ b/pkg/pipelines/pipeline_test.go
@@ -160,6 +160,26 @@ contexts:
 		}
 	}
 
+	// Create context directory and config file to ensure loaded flag is set
+	contextDir := filepath.Join(tmpDir, "contexts", "mock-context")
+	if err := os.MkdirAll(contextDir, 0755); err != nil {
+		t.Fatalf("Failed to create context directory: %v", err)
+	}
+	contextConfigPath := filepath.Join(contextDir, "windsor.yaml")
+	contextConfigYAML := `
+dns:
+  domain: mock.domain.com
+network:
+  cidr_block: 10.0.0.0/24`
+	if err := os.WriteFile(contextConfigPath, []byte(contextConfigYAML), 0644); err != nil {
+		t.Fatalf("Failed to write context config: %v", err)
+	}
+
+	// Load context config to set loaded flag
+	if err := configHandler.LoadContextConfig(); err != nil {
+		t.Fatalf("Failed to load context config: %v", err)
+	}
+
 	// Register shims
 	shims := setupShims(t)
 	injector.Register("shims", shims)


### PR DESCRIPTION
The `values.yaml` functionality has now been migrated in to the config handler. This is an intermediate PR. Subsequent PRs will leverage the config handler interface exclusively when acccessing configuration values.