### PR TITLE
refactor(blueprint): Access context values through config handler

### DIFF
--- a/pkg/config/config_handler.go
+++ b/pkg/config/config_handler.go
@@ -44,8 +44,7 @@ type ConfigHandler interface {
 	LoadSchema(schemaPath string) error
 	LoadSchemaFromBytes(schemaContent []byte) error
 	GetSchemaDefaults() (map[string]any, error)
-	// Temporary bridge method for blueprint handler during migration
-	GetSchemaValidator() *SchemaValidator
+	GetContextValues() (map[string]any, error)
 }
 
 const (
@@ -226,8 +225,8 @@ func (c *BaseConfigHandler) GetSchemaDefaults() (map[string]any, error) {
 	return c.schemaValidator.GetSchemaDefaults()
 }
 
-// GetSchemaValidator returns the internal schema validator instance
-// This is a temporary bridge method for blueprint handler during migration
-func (c *BaseConfigHandler) GetSchemaValidator() *SchemaValidator {
-	return c.schemaValidator
+// GetContextValues returns the loaded context values from values.yaml
+// This should be overridden by concrete implementations like YamlConfigHandler
+func (c *BaseConfigHandler) GetContextValues() (map[string]any, error) {
+	return nil, fmt.Errorf("GetContextValues not implemented in base config handler")
 }

--- a/pkg/config/mock_config_handler.go
+++ b/pkg/config/mock_config_handler.go
@@ -35,7 +35,7 @@ type MockConfigHandler struct {
 	LoadSchemaFunc            func(schemaPath string) error
 	LoadSchemaFromBytesFunc   func(schemaContent []byte) error
 	GetSchemaDefaultsFunc     func() (map[string]any, error)
-	GetSchemaValidatorFunc    func() *SchemaValidator
+	GetContextValuesFunc      func() (map[string]any, error)
 }
 
 // =============================================================================
@@ -273,12 +273,12 @@ func (m *MockConfigHandler) GetSchemaDefaults() (map[string]any, error) {
 	return nil, fmt.Errorf("GetSchemaDefaultsFunc not set")
 }
 
-// GetSchemaValidator calls the mock GetSchemaValidatorFunc if set, otherwise returns nil
-func (m *MockConfigHandler) GetSchemaValidator() *SchemaValidator {
-	if m.GetSchemaValidatorFunc != nil {
-		return m.GetSchemaValidatorFunc()
+// GetContextValues calls the mock GetContextValuesFunc if set, otherwise returns an error
+func (m *MockConfigHandler) GetContextValues() (map[string]any, error) {
+	if m.GetContextValuesFunc != nil {
+		return m.GetContextValuesFunc()
 	}
-	return nil
+	return nil, fmt.Errorf("GetContextValuesFunc not set")
 }
 
 // Ensure MockConfigHandler implements ConfigHandler


### PR DESCRIPTION
All context values are accessed and validated through the config handler now. This functionality has been removed from the blueprint handler, which now calls a `GetContextValues` method on config handler.