### PR TITLE
fix(config): Set initial values when --set is passed

### DIFF
--- a/pkg/config/config_handler.go
+++ b/pkg/config/config_handler.go
@@ -317,7 +317,7 @@ func (c *configHandler) SaveConfig(overwrite ...bool) error {
 		}
 	}
 
-	if c.loaded && c.contextValues != nil && len(c.contextValues) > 0 {
+	if len(c.contextValues) > 0 {
 		if err := c.saveContextValues(); err != nil {
 			return fmt.Errorf("error saving values.yaml: %w", err)
 		}


### PR DESCRIPTION
A bug prevented the `windsor init --set ...` command/flag from setting initial values and creating the initial `values.yaml` file.