### PR TITLE
fix(generator): Ensure proper generation of list of strings

### DIFF
--- a/pkg/generators/terraform_generator.go
+++ b/pkg/generators/terraform_generator.go
@@ -354,6 +354,15 @@ func formatValue(value any) string {
 	switch v := value.(type) {
 	case string:
 		return fmt.Sprintf("%q", v)
+	case []string:
+		if len(v) == 0 {
+			return "[]"
+		}
+		var items []string
+		for _, item := range v {
+			items = append(items, fmt.Sprintf("%q", item))
+		}
+		return fmt.Sprintf("[%s]", strings.Join(items, ", "))
 	case []any:
 		if len(v) == 0 {
 			return "[]"
@@ -407,6 +416,15 @@ func convertToCtyValue(value any) cty.Value {
 		return cty.NumberFloatVal(v)
 	case bool:
 		return cty.BoolVal(v)
+	case []string:
+		if len(v) == 0 {
+			return cty.ListValEmpty(cty.String)
+		}
+		var ctyList []cty.Value
+		for _, item := range v {
+			ctyList = append(ctyList, cty.StringVal(item))
+		}
+		return cty.ListVal(ctyList)
 	case []any:
 		if len(v) == 0 {
 			return cty.ListValEmpty(cty.DynamicPseudoType)

--- a/pkg/generators/terraform_generator_test.go
+++ b/pkg/generators/terraform_generator_test.go
@@ -478,6 +478,16 @@ func TestConvertToCtyValue(t *testing.T) {
 			expected: cty.ObjectVal(map[string]cty.Value{"key": cty.StringVal("value")}),
 		},
 		{
+			name:     "StringSliceEmpty",
+			input:    []string{},
+			expected: cty.ListValEmpty(cty.String),
+		},
+		{
+			name:     "StringSliceNonEmpty",
+			input:    []string{"a", "b"},
+			expected: cty.ListVal([]cty.Value{cty.StringVal("a"), cty.StringVal("b")}),
+		},
+		{
 			name:     "Unsupported",
 			input:    struct{}{},
 			expected: cty.NilVal,
@@ -607,6 +617,13 @@ func TestFormatValue(t *testing.T) {
 		}
 	})
 
+	t.Run("StringSliceEmpty", func(t *testing.T) {
+		result := formatValue([]string{})
+		if result != "[]" {
+			t.Errorf("expected [] got %q", result)
+		}
+	})
+
 	t.Run("NilValue", func(t *testing.T) {
 		result := formatValue(nil)
 		if result != "null" {
@@ -638,6 +655,13 @@ func TestFormatValue(t *testing.T) {
 		result := formatValue(input)
 		if result != expected {
 			t.Errorf("expected %q, got %q", expected, result)
+		}
+	})
+
+	t.Run("StringSliceNonEmpty", func(t *testing.T) {
+		result := formatValue([]string{"a", "b"})
+		if result != "[\"a\", \"b\"]" {
+			t.Errorf("expected [\"a\", \"b\"] got %q", result)
 		}
 	})
 


### PR DESCRIPTION
Generationg lists of string data was causing lists of values without quotes. This was due to changes in the source data that passes in to the generator. Explicitly handling the `[]string` case remediates this regression.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>