### PR TITLE
refactor(runtime): Implement hook using runtime

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -1,0 +1,130 @@
+package runtime
+
+import (
+	"fmt"
+
+	"github.com/windsorcli/cli/pkg/artifact"
+	"github.com/windsorcli/cli/pkg/blueprint"
+	"github.com/windsorcli/cli/pkg/cluster"
+	"github.com/windsorcli/cli/pkg/config"
+	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/env"
+	"github.com/windsorcli/cli/pkg/generators"
+	"github.com/windsorcli/cli/pkg/kubernetes"
+	"github.com/windsorcli/cli/pkg/secrets"
+	"github.com/windsorcli/cli/pkg/shell"
+	"github.com/windsorcli/cli/pkg/terraform"
+	"github.com/windsorcli/cli/pkg/tools"
+	"github.com/windsorcli/cli/pkg/workstation/network"
+	"github.com/windsorcli/cli/pkg/workstation/services"
+	"github.com/windsorcli/cli/pkg/workstation/ssh"
+	"github.com/windsorcli/cli/pkg/workstation/virt"
+)
+
+// =============================================================================
+// Types
+// =============================================================================
+
+// Runtime encapsulates all core Windsor CLI runtime dependencies for injection.
+type Runtime struct {
+
+	// Core dependencies
+	shell         shell.Shell
+	configHandler config.ConfigHandler
+	toolsManager  tools.ToolsManager
+	envPrinters   struct {
+		awsEnv       env.EnvPrinter
+		azureEnv     env.EnvPrinter
+		dockerEnv    env.EnvPrinter
+		kubeEnv      env.EnvPrinter
+		talosEnv     env.EnvPrinter
+		terraformEnv env.EnvPrinter
+		windsorEnv   env.EnvPrinter
+	}
+	secretsProviders struct {
+		sops        secrets.SecretsProvider
+		onepassword secrets.SecretsProvider
+	}
+
+	// Blueprint dependencies
+	blueprintHandler blueprint.BlueprintHandler
+	artifactBuilder  artifact.Artifact
+	generators       struct {
+		gitGenerator       generators.Generator
+		terraformGenerator generators.Generator
+	}
+	terraformResolver terraform.ModuleResolver
+
+	// Cluster dependencies
+	clusterClient cluster.ClusterClient
+	k8sManager    kubernetes.KubernetesManager
+
+	// Workstation dependencies
+	workstation struct {
+		virt     virt.Virt
+		services struct {
+			dnsService           services.Service
+			gitLivereloadService services.Service
+			localstackService    services.Service
+			registryServices     map[string]services.Service
+			talosServices        map[string]services.Service
+		}
+		network network.NetworkManager
+		ssh     ssh.SSHClient
+	}
+
+	// Error
+	err error
+
+	// Injector (to be deprecated)
+	injector di.Injector
+}
+
+// =============================================================================
+// Constructor
+// =============================================================================
+
+// NewRuntime creates a new Runtime instance
+func NewRuntime(injector di.Injector) *Runtime {
+	return &Runtime{
+		injector: injector,
+	}
+}
+
+// =============================================================================
+// Public Methods
+// =============================================================================
+
+// Do serves as the final execution point in the Windsor application lifecycle.
+// It returns the cumulative error state from all preceding runtime operations, ensuring that the
+// top-level caller receives any error reported by the Windsor runtime subsystems.
+//
+// Do does not perform any additional processing; it solely propagates the stored error value,
+// which must be set by lower-level runtime methods. If no error has occurred, Do returns nil.
+func (r *Runtime) Do() error {
+	return r.err
+}
+
+// LoadShell loads the shell dependency from the injector.
+func (r *Runtime) LoadShell() *Runtime {
+	if r.err != nil {
+		return r
+	}
+	r.shell = shell.NewDefaultShell(r.injector)
+	r.injector.Register("shell", r.shell)
+	return r
+}
+
+// InstallHook installs a shell hook for the specified shell type.
+// It requires the shell to be loaded first via LoadShell().
+func (r *Runtime) InstallHook(shellType string) *Runtime {
+	if r.err != nil {
+		return r
+	}
+	if r.shell == nil {
+		r.err = fmt.Errorf("shell not loaded - call LoadShell() first")
+		return r
+	}
+	r.err = r.shell.InstallHook(shellType)
+	return r
+}

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1,0 +1,209 @@
+package runtime
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/shell"
+)
+
+// The RuntimeTest is a test suite for the Runtime struct and its chaining methods.
+// It provides comprehensive test coverage for dependency loading, error propagation,
+// and command execution in the Windsor CLI runtime system.
+// The RuntimeTest acts as a validation framework for runtime functionality,
+// ensuring reliable dependency management, proper error handling, and method chaining.
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+type Mocks struct {
+	Injector  di.Injector
+	MockShell *shell.MockShell
+}
+
+// setupMocks creates a new set of mocks for testing
+func setupMocks(t *testing.T) *Mocks {
+	t.Helper()
+
+	injector := di.NewInjector()
+	mockShell := shell.NewMockShell()
+	injector.Register("shell", mockShell)
+
+	return &Mocks{
+		Injector:  injector,
+		MockShell: mockShell,
+	}
+}
+
+// =============================================================================
+// Test Public Methods
+// =============================================================================
+
+func TestRuntime_NewRuntime(t *testing.T) {
+	t.Run("CreatesRuntimeWithInjector", func(t *testing.T) {
+		// Given an injector
+		mocks := setupMocks(t)
+
+		// When creating a new runtime
+		runtime := NewRuntime(mocks.Injector)
+
+		// Then runtime should be created successfully
+		if runtime == nil {
+			t.Error("Expected runtime to be created")
+		}
+
+		if runtime.injector != mocks.Injector {
+			t.Error("Expected injector to be set")
+		}
+	})
+}
+
+func TestRuntime_LoadShell(t *testing.T) {
+	t.Run("LoadsShellSuccessfully", func(t *testing.T) {
+		// Given a runtime with injector
+		mocks := setupMocks(t)
+		runtime := NewRuntime(mocks.Injector)
+
+		// When loading shell
+		result := runtime.LoadShell()
+
+		// Then should return the same runtime instance
+		if result != runtime {
+			t.Error("Expected LoadShell to return the same runtime instance")
+		}
+
+		// And shell should be loaded
+		if runtime.shell == nil {
+			t.Error("Expected shell to be loaded")
+		}
+
+		// And no error should be set
+		if runtime.err != nil {
+			t.Errorf("Expected no error, got %v", runtime.err)
+		}
+	})
+
+	t.Run("ReturnsEarlyOnExistingError", func(t *testing.T) {
+		// Given a runtime with an existing error
+		mocks := setupMocks(t)
+		runtime := NewRuntime(mocks.Injector)
+		runtime.err = errors.New("existing error")
+
+		// When loading shell
+		result := runtime.LoadShell()
+
+		// Then should return the same runtime instance
+		if result != runtime {
+			t.Error("Expected LoadShell to return the same runtime instance")
+		}
+
+		// And shell should not be loaded
+		if runtime.shell != nil {
+			t.Error("Expected shell to not be loaded when error exists")
+		}
+
+		// And original error should be preserved
+		if runtime.err.Error() != "existing error" {
+			t.Errorf("Expected original error to be preserved, got %v", runtime.err)
+		}
+	})
+}
+
+func TestRuntime_InstallHook(t *testing.T) {
+	t.Run("InstallsHookSuccessfully", func(t *testing.T) {
+		// Given a runtime with loaded shell
+		mocks := setupMocks(t)
+		runtime := NewRuntime(mocks.Injector).LoadShell()
+
+		// When installing hook
+		result := runtime.InstallHook("bash")
+
+		// Then should return the same runtime instance
+		if result != runtime {
+			t.Error("Expected InstallHook to return the same runtime instance")
+		}
+
+		// And no error should be set
+		if runtime.err != nil {
+			t.Errorf("Expected no error, got %v", runtime.err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenShellNotLoaded", func(t *testing.T) {
+		// Given a runtime without loaded shell
+		mocks := setupMocks(t)
+		runtime := NewRuntime(mocks.Injector)
+
+		// When installing hook
+		result := runtime.InstallHook("bash")
+
+		// Then should return the same runtime instance
+		if result != runtime {
+			t.Error("Expected InstallHook to return the same runtime instance")
+		}
+
+		// And error should be set
+		if runtime.err == nil {
+			t.Error("Expected error when shell not loaded")
+		}
+
+		expectedError := "shell not loaded - call LoadShell() first"
+		if runtime.err.Error() != expectedError {
+			t.Errorf("Expected error %q, got %q", expectedError, runtime.err.Error())
+		}
+	})
+
+	t.Run("ReturnsEarlyOnExistingError", func(t *testing.T) {
+		// Given a runtime with an existing error
+		mocks := setupMocks(t)
+		runtime := NewRuntime(mocks.Injector)
+		runtime.err = errors.New("existing error")
+
+		// When installing hook
+		result := runtime.InstallHook("bash")
+
+		// Then should return the same runtime instance
+		if result != runtime {
+			t.Error("Expected InstallHook to return the same runtime instance")
+		}
+
+		// And original error should be preserved
+		if runtime.err.Error() != "existing error" {
+			t.Errorf("Expected original error to be preserved, got %v", runtime.err)
+		}
+	})
+}
+
+func TestRuntime_Do(t *testing.T) {
+	t.Run("ReturnsNilWhenNoError", func(t *testing.T) {
+		// Given a runtime with no error
+		mocks := setupMocks(t)
+		runtime := NewRuntime(mocks.Injector)
+
+		// When calling Do
+		err := runtime.Do()
+
+		// Then should return nil
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenErrorSet", func(t *testing.T) {
+		// Given a runtime with an error
+		mocks := setupMocks(t)
+		runtime := NewRuntime(mocks.Injector)
+		expectedError := errors.New("test error")
+		runtime.err = expectedError
+
+		// When calling Do
+		err := runtime.Do()
+
+		// Then should return the error
+		if err != expectedError {
+			t.Errorf("Expected error %v, got %v", expectedError, err)
+		}
+	})
+}


### PR DESCRIPTION
The first in a series of refactors aiming to replace the pipeline architecture with a cleaner "runtime" architecture. This initial PR implements this functionality for the "hook" command. External functionality remains unchanged.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>