### PR TITLE
refactor(runtime): Migrate get and set context to use runtime

### DIFF
--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -10,6 +10,15 @@ func TestContextCmd(t *testing.T) {
 	setup := func(t *testing.T) (*bytes.Buffer, *bytes.Buffer) {
 		t.Helper()
 
+		// Clear environment variables that could affect tests
+		origContext := os.Getenv("WINDSOR_CONTEXT")
+		os.Unsetenv("WINDSOR_CONTEXT")
+		t.Cleanup(func() {
+			if origContext != "" {
+				os.Setenv("WINDSOR_CONTEXT", origContext)
+			}
+		})
+
 		// Change to a temporary directory without a config file
 		origDir, err := os.Getwd()
 		if err != nil {
@@ -34,30 +43,33 @@ func TestContextCmd(t *testing.T) {
 		return stdout, stderr
 	}
 
-	t.Run("GetContextNoConfig", func(t *testing.T) {
+	t.Run("GetContext", func(t *testing.T) {
 		// Given proper output capture in a directory without config
-		_, _ = setup(t)
+		stdout, _ := setup(t)
+		// Don't set up mocks - we want to test real behavior
 
 		rootCmd.SetArgs([]string{"context", "get"})
 
 		// When executing the command
 		err := Execute()
 
-		// Then an error should occur
-		if err == nil {
-			t.Error("Expected error, got nil")
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
 		}
 
-		// And error should contain init message
-		expectedError := "Error executing context pipeline: No context is available. Have you run `windsor init`?"
-		if err.Error() != expectedError {
-			t.Errorf("Expected error %q, got %q", expectedError, err.Error())
+		// And should output default context (real behavior)
+		output := stdout.String()
+		expectedOutput := "local\n"
+		if output != expectedOutput {
+			t.Errorf("Expected output %q, got %q", expectedOutput, output)
 		}
 	})
 
 	t.Run("SetContextNoArgs", func(t *testing.T) {
 		// Given proper output capture in a directory without config
 		_, _ = setup(t)
+		setupMocks(t)
 
 		rootCmd.SetArgs([]string{"context", "set"})
 
@@ -76,51 +88,48 @@ func TestContextCmd(t *testing.T) {
 		}
 	})
 
-	t.Run("SetContextNoConfig", func(t *testing.T) {
+	t.Run("SetContext", func(t *testing.T) {
 		// Given proper output capture in a directory without config
 		_, _ = setup(t)
+		setupMocks(t)
 
 		rootCmd.SetArgs([]string{"context", "set", "new-context"})
 
 		// When executing the command
 		err := Execute()
 
-		// Then an error should occur
-		if err == nil {
-			t.Error("Expected error, got nil")
-		}
-
-		// And error should contain init message
-		expectedError := "Error executing context pipeline: No context is available. Have you run `windsor init`?"
-		if err.Error() != expectedError {
-			t.Errorf("Expected error %q, got %q", expectedError, err.Error())
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
 		}
 	})
 
-	t.Run("GetContextAliasNoConfig", func(t *testing.T) {
+	t.Run("GetContextAlias", func(t *testing.T) {
 		// Given proper output capture in a directory without config
-		_, _ = setup(t)
+		stdout, _ := setup(t)
+		// Don't set up mocks - we want to test real behavior
 
 		rootCmd.SetArgs([]string{"get-context"})
 
 		// When executing the command
 		err := Execute()
 
-		// Then an error should occur
-		if err == nil {
-			t.Error("Expected error, got nil")
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
 		}
 
-		// And error should contain init message
-		expectedError := "Error executing context pipeline: No context is available. Have you run `windsor init`?"
-		if err.Error() != expectedError {
-			t.Errorf("Expected error %q, got %q", expectedError, err.Error())
+		// And should output the current context (may be "local" or previously set context)
+		output := stdout.String()
+		if output == "" {
+			t.Error("Expected some output, got empty string")
 		}
 	})
 
 	t.Run("SetContextAliasNoArgs", func(t *testing.T) {
 		// Given proper output capture in a directory without config
 		_, _ = setup(t)
+		setupMocks(t)
 
 		rootCmd.SetArgs([]string{"set-context"})
 
@@ -139,24 +148,19 @@ func TestContextCmd(t *testing.T) {
 		}
 	})
 
-	t.Run("SetContextAliasNoConfig", func(t *testing.T) {
+	t.Run("SetContextAlias", func(t *testing.T) {
 		// Given proper output capture in a directory without config
 		_, _ = setup(t)
+		setupMocks(t)
 
 		rootCmd.SetArgs([]string{"set-context", "new-context"})
 
 		// When executing the command
 		err := Execute()
 
-		// Then an error should occur
-		if err == nil {
-			t.Error("Expected error, got nil")
-		}
-
-		// And error should contain init message
-		expectedError := "Error executing context pipeline: No context is available. Have you run `windsor init`?"
-		if err.Error() != expectedError {
-			t.Errorf("Expected error %q, got %q", expectedError, err.Error())
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
 		}
 	})
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -116,6 +116,26 @@ func (r *Runtime) LoadShell() *Runtime {
 	return r
 }
 
+// LoadConfigHandler loads and initializes the configuration handler dependency.
+func (r *Runtime) LoadConfigHandler() *Runtime {
+	if r.err != nil {
+		return r
+	}
+	if r.Shell == nil {
+		r.err = fmt.Errorf("shell not loaded - call LoadShell() first")
+		return r
+	}
+
+	if r.ConfigHandler == nil {
+		r.ConfigHandler = config.NewConfigHandler(r.Injector)
+		if err := r.ConfigHandler.Initialize(); err != nil {
+			r.err = fmt.Errorf("failed to initialize config handler: %w", err)
+			return r
+		}
+	}
+	return r
+}
+
 // InstallHook installs a shell hook for the specified shell type.
 func (r *Runtime) InstallHook(shellType string) *Runtime {
 	if r.err != nil {
@@ -126,5 +146,45 @@ func (r *Runtime) InstallHook(shellType string) *Runtime {
 		return r
 	}
 	r.err = r.Shell.InstallHook(shellType)
+	return r
+}
+
+// SetContext sets the context for the configuration handler.
+func (r *Runtime) SetContext(context string) *Runtime {
+	if r.err != nil {
+		return r
+	}
+	if r.ConfigHandler == nil {
+		r.err = fmt.Errorf("config handler not loaded - call LoadConfigHandler() first")
+		return r
+	}
+	r.err = r.ConfigHandler.SetContext(context)
+	return r
+}
+
+// PrintContext outputs the current context using the provided output function.
+func (r *Runtime) PrintContext(outputFunc func(string)) *Runtime {
+	if r.err != nil {
+		return r
+	}
+	if r.ConfigHandler == nil {
+		r.err = fmt.Errorf("config handler not loaded - call LoadConfigHandler() first")
+		return r
+	}
+	context := r.ConfigHandler.GetContext()
+	outputFunc(context)
+	return r
+}
+
+// WriteResetToken writes a session/token reset file using the shell.
+func (r *Runtime) WriteResetToken() *Runtime {
+	if r.err != nil {
+		return r
+	}
+	if r.Shell == nil {
+		r.err = fmt.Errorf("shell not loaded - call LoadShell() first")
+		return r
+	}
+	_, r.err = r.Shell.WriteResetToken()
 	return r
 }

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -2,8 +2,10 @@ package runtime
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
+	"github.com/windsorcli/cli/pkg/config"
 	"github.com/windsorcli/cli/pkg/di"
 	"github.com/windsorcli/cli/pkg/shell"
 )
@@ -25,6 +27,7 @@ func setupMocks(t *testing.T) *Dependencies {
 	return &Dependencies{
 		Injector:      di.NewInjector(),
 		Shell:         shell.NewMockShell(),
+		ConfigHandler: config.NewMockConfigHandler(),
 	}
 }
 
@@ -130,6 +133,104 @@ func TestRuntime_LoadShell(t *testing.T) {
 	})
 }
 
+func TestRuntime_LoadConfigHandler(t *testing.T) {
+	t.Run("LoadsConfigHandlerSuccessfully", func(t *testing.T) {
+		// Given a runtime with loaded shell
+		mocks := setupMocks(t)
+		runtime := NewRuntime(mocks).LoadShell()
+
+		// When loading config handler
+		result := runtime.LoadConfigHandler()
+
+		// Then should return the same runtime instance
+		if result != runtime {
+			t.Error("Expected LoadConfigHandler to return the same runtime instance")
+		}
+
+		// And config handler should be loaded
+		if runtime.ConfigHandler == nil {
+			t.Error("Expected config handler to be loaded")
+		}
+
+		// And no error should be set
+		if runtime.err != nil {
+			t.Errorf("Expected no error, got %v", runtime.err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenShellNotLoaded", func(t *testing.T) {
+		// Given a runtime without loaded shell (no pre-loaded dependencies)
+		runtime := NewRuntime()
+
+		// When loading config handler
+		result := runtime.LoadConfigHandler()
+
+		// Then should return the same runtime instance
+		if result != runtime {
+			t.Error("Expected LoadConfigHandler to return the same runtime instance")
+		}
+
+		// And error should be set
+		if runtime.err == nil {
+			t.Error("Expected error when shell not loaded")
+		}
+
+		expectedError := "shell not loaded - call LoadShell() first"
+		if runtime.err.Error() != expectedError {
+			t.Errorf("Expected error %q, got %q", expectedError, runtime.err.Error())
+		}
+	})
+
+	t.Run("ReturnsEarlyOnExistingError", func(t *testing.T) {
+		// Given a runtime with an existing error (no pre-loaded dependencies)
+		runtime := NewRuntime()
+		runtime.err = errors.New("existing error")
+
+		// When loading config handler
+		result := runtime.LoadConfigHandler()
+
+		// Then should return the same runtime instance
+		if result != runtime {
+			t.Error("Expected LoadConfigHandler to return the same runtime instance")
+		}
+
+		// And config handler should not be loaded
+		if runtime.ConfigHandler != nil {
+			t.Error("Expected config handler to not be loaded when error exists")
+		}
+
+		// And original error should be preserved
+		if runtime.err.Error() != "existing error" {
+			t.Errorf("Expected original error to be preserved, got %v", runtime.err)
+		}
+	})
+
+	t.Run("PropagatesConfigHandlerInitializationError", func(t *testing.T) {
+		// Given a runtime with an injector that cannot resolve the shell
+		runtime := NewRuntime()
+		runtime.Shell = shell.NewMockShell()
+		// Don't register the shell in the injector - this will cause initialization to fail
+
+		// When loading config handler
+		result := runtime.LoadConfigHandler()
+
+		// Then should return the same runtime instance
+		if result != runtime {
+			t.Error("Expected LoadConfigHandler to return the same runtime instance")
+		}
+
+		// And error should be set from initialization failure
+		if runtime.err == nil {
+			t.Error("Expected error from config handler initialization failure")
+		} else {
+			expectedError := "failed to initialize config handler"
+			if !strings.Contains(runtime.err.Error(), expectedError) {
+				t.Errorf("Expected error to contain %q, got %q", expectedError, runtime.err.Error())
+			}
+		}
+	})
+}
+
 func TestRuntime_InstallHook(t *testing.T) {
 	t.Run("InstallsHookSuccessfully", func(t *testing.T) {
 		// Given a runtime with loaded shell
@@ -189,6 +290,299 @@ func TestRuntime_InstallHook(t *testing.T) {
 		// And original error should be preserved
 		if runtime.err.Error() != "existing error" {
 			t.Errorf("Expected original error to be preserved, got %v", runtime.err)
+		}
+	})
+}
+
+func TestRuntime_SetContext(t *testing.T) {
+	t.Run("SetsContextSuccessfully", func(t *testing.T) {
+		// Given a runtime with loaded config handler
+		mocks := setupMocks(t)
+		runtime := NewRuntime(mocks).LoadShell().LoadConfigHandler()
+
+		// When setting context
+		result := runtime.SetContext("test-context")
+
+		// Then should return the same runtime instance
+		if result != runtime {
+			t.Error("Expected SetContext to return the same runtime instance")
+		}
+
+		// And no error should be set
+		if runtime.err != nil {
+			t.Errorf("Expected no error, got %v", runtime.err)
+		}
+
+		// And SetContext should have been called on the config handler
+		// (We can't easily track this without modifying the mock, so we just verify no error occurred)
+	})
+
+	t.Run("ReturnsErrorWhenConfigHandlerNotLoaded", func(t *testing.T) {
+		// Given a runtime without loaded config handler (no pre-loaded dependencies)
+		runtime := NewRuntime()
+
+		// When setting context
+		result := runtime.SetContext("test-context")
+
+		// Then should return the same runtime instance
+		if result != runtime {
+			t.Error("Expected SetContext to return the same runtime instance")
+		}
+
+		// And error should be set
+		if runtime.err == nil {
+			t.Error("Expected error when config handler not loaded")
+		}
+
+		expectedError := "config handler not loaded - call LoadConfigHandler() first"
+		if runtime.err.Error() != expectedError {
+			t.Errorf("Expected error %q, got %q", expectedError, runtime.err.Error())
+		}
+	})
+
+	t.Run("ReturnsEarlyOnExistingError", func(t *testing.T) {
+		// Given a runtime with an existing error (no pre-loaded dependencies)
+		runtime := NewRuntime()
+		runtime.err = errors.New("existing error")
+
+		// When setting context
+		result := runtime.SetContext("test-context")
+
+		// Then should return the same runtime instance
+		if result != runtime {
+			t.Error("Expected SetContext to return the same runtime instance")
+		}
+
+		// And original error should be preserved
+		if runtime.err.Error() != "existing error" {
+			t.Errorf("Expected original error to be preserved, got %v", runtime.err)
+		}
+	})
+
+	t.Run("PropagatesConfigHandlerError", func(t *testing.T) {
+		// Given a runtime with a mock shell that returns an error
+		mockShell := shell.NewMockShell()
+		mockShell.GetProjectRootFunc = func() (string, error) {
+			return "", errors.New("project root error")
+		}
+
+		// Create runtime with only the mock shell, no mock config handler
+		runtime := NewRuntime()
+		runtime.Shell = mockShell
+		runtime.Injector.Register("shell", mockShell)
+		runtime.LoadConfigHandler()
+
+		// When setting context
+		result := runtime.SetContext("test-context")
+
+		// Then should return the same runtime instance
+		if result != runtime {
+			t.Error("Expected SetContext to return the same runtime instance")
+		}
+
+		// And error should be propagated from config handler
+		if runtime.err == nil {
+			t.Error("Expected error to be propagated from config handler")
+		} else {
+			expectedError := "error getting project root"
+			if !strings.Contains(runtime.err.Error(), expectedError) {
+				t.Errorf("Expected error to contain %q, got %q", expectedError, runtime.err.Error())
+			}
+		}
+	})
+}
+
+func TestRuntime_PrintContext(t *testing.T) {
+	t.Run("PrintsContextSuccessfully", func(t *testing.T) {
+		// Given a runtime with loaded config handler
+		mocks := setupMocks(t)
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetContextFunc = func() string {
+			return "test-context"
+		}
+		runtime := NewRuntime(mocks).LoadShell().LoadConfigHandler()
+
+		var output string
+		outputFunc := func(s string) {
+			output = s
+		}
+
+		// When printing context
+		result := runtime.PrintContext(outputFunc)
+
+		// Then should return the same runtime instance
+		if result != runtime {
+			t.Error("Expected PrintContext to return the same runtime instance")
+		}
+
+		// And no error should be set
+		if runtime.err != nil {
+			t.Errorf("Expected no error, got %v", runtime.err)
+		}
+
+		// And output should be correct
+		if output != "test-context" {
+			t.Errorf("Expected output 'test-context', got %q", output)
+		}
+
+		// And GetContext should have been called on the config handler
+		// (We can't easily track this without modifying the mock, so we just verify the output is correct)
+	})
+
+	t.Run("ReturnsErrorWhenConfigHandlerNotLoaded", func(t *testing.T) {
+		// Given a runtime without loaded config handler (no pre-loaded dependencies)
+		runtime := NewRuntime()
+
+		var output string
+		outputFunc := func(s string) {
+			output = s
+		}
+
+		// When printing context
+		result := runtime.PrintContext(outputFunc)
+
+		// Then should return the same runtime instance
+		if result != runtime {
+			t.Error("Expected PrintContext to return the same runtime instance")
+		}
+
+		// And error should be set
+		if runtime.err == nil {
+			t.Error("Expected error when config handler not loaded")
+		}
+
+		expectedError := "config handler not loaded - call LoadConfigHandler() first"
+		if runtime.err.Error() != expectedError {
+			t.Errorf("Expected error %q, got %q", expectedError, runtime.err.Error())
+		}
+
+		// And output should not be set
+		if output != "" {
+			t.Errorf("Expected no output, got %q", output)
+		}
+	})
+
+	t.Run("ReturnsEarlyOnExistingError", func(t *testing.T) {
+		// Given a runtime with an existing error (no pre-loaded dependencies)
+		runtime := NewRuntime()
+		runtime.err = errors.New("existing error")
+
+		var output string
+		outputFunc := func(s string) {
+			output = s
+		}
+
+		// When printing context
+		result := runtime.PrintContext(outputFunc)
+
+		// Then should return the same runtime instance
+		if result != runtime {
+			t.Error("Expected PrintContext to return the same runtime instance")
+		}
+
+		// And original error should be preserved
+		if runtime.err.Error() != "existing error" {
+			t.Errorf("Expected original error to be preserved, got %v", runtime.err)
+		}
+
+		// And output should not be set
+		if output != "" {
+			t.Errorf("Expected no output, got %q", output)
+		}
+	})
+}
+
+func TestRuntime_WriteResetToken(t *testing.T) {
+	t.Run("WritesResetTokenSuccessfully", func(t *testing.T) {
+		// Given a runtime with loaded shell
+		mocks := setupMocks(t)
+		mocks.Shell.(*shell.MockShell).WriteResetTokenFunc = func() (string, error) {
+			return "/tmp/reset-token", nil
+		}
+		runtime := NewRuntime(mocks).LoadShell()
+
+		// When writing reset token
+		result := runtime.WriteResetToken()
+
+		// Then should return the same runtime instance
+		if result != runtime {
+			t.Error("Expected WriteResetToken to return the same runtime instance")
+		}
+
+		// And no error should be set
+		if runtime.err != nil {
+			t.Errorf("Expected no error, got %v", runtime.err)
+		}
+
+		// And WriteResetToken should have been called on the shell
+		// (We can't easily track this without modifying the mock, so we just verify no error occurred)
+	})
+
+	t.Run("ReturnsErrorWhenShellNotLoaded", func(t *testing.T) {
+		// Given a runtime without loaded shell (no pre-loaded dependencies)
+		runtime := NewRuntime()
+
+		// When writing reset token
+		result := runtime.WriteResetToken()
+
+		// Then should return the same runtime instance
+		if result != runtime {
+			t.Error("Expected WriteResetToken to return the same runtime instance")
+		}
+
+		// And error should be set
+		if runtime.err == nil {
+			t.Error("Expected error when shell not loaded")
+		}
+
+		expectedError := "shell not loaded - call LoadShell() first"
+		if runtime.err.Error() != expectedError {
+			t.Errorf("Expected error %q, got %q", expectedError, runtime.err.Error())
+		}
+	})
+
+	t.Run("ReturnsEarlyOnExistingError", func(t *testing.T) {
+		// Given a runtime with an existing error (no pre-loaded dependencies)
+		runtime := NewRuntime()
+		runtime.err = errors.New("existing error")
+
+		// When writing reset token
+		result := runtime.WriteResetToken()
+
+		// Then should return the same runtime instance
+		if result != runtime {
+			t.Error("Expected WriteResetToken to return the same runtime instance")
+		}
+
+		// And original error should be preserved
+		if runtime.err.Error() != "existing error" {
+			t.Errorf("Expected original error to be preserved, got %v", runtime.err)
+		}
+	})
+
+	t.Run("PropagatesShellError", func(t *testing.T) {
+		// Given a runtime with loaded shell that returns an error
+		mocks := setupMocks(t)
+		mocks.Shell.(*shell.MockShell).WriteResetTokenFunc = func() (string, error) {
+			return "", errors.New("shell error")
+		}
+		runtime := NewRuntime(mocks).LoadShell()
+
+		// When writing reset token
+		result := runtime.WriteResetToken()
+
+		// Then should return the same runtime instance
+		if result != runtime {
+			t.Error("Expected WriteResetToken to return the same runtime instance")
+		}
+
+		// And error should be propagated
+		if runtime.err == nil {
+			t.Error("Expected error to be propagated from shell")
+		} else {
+			expectedError := "shell error"
+			if runtime.err.Error() != expectedError {
+				t.Errorf("Expected error %q, got %q", expectedError, runtime.err.Error())
+			}
 		}
 	})
 }


### PR DESCRIPTION
The `windsor context` commands now leverage the runtime architecture.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>