### PR TITLE
refactor(runtime): Load blueprint in runtime

### DIFF
--- a/pkg/blueprint/mock_blueprint_handler.go
+++ b/pkg/blueprint/mock_blueprint_handler.go
@@ -9,6 +9,7 @@ import (
 // MockBlueprintHandler is a mock implementation of BlueprintHandler interface for testing
 type MockBlueprintHandler struct {
 	InitializeFunc             func() error
+	LoadBlueprintFunc          func() error
 	LoadConfigFunc             func() error
 	LoadDataFunc               func(data map[string]any, ociInfo ...*artifact.OCIArtifactInfo) error
 	WriteFunc                  func(overwrite ...bool) error
@@ -44,6 +45,14 @@ func NewMockBlueprintHandler(injector di.Injector) *MockBlueprintHandler {
 func (m *MockBlueprintHandler) Initialize() error {
 	if m.InitializeFunc != nil {
 		return m.InitializeFunc()
+	}
+	return nil
+}
+
+// LoadBlueprint calls the mock LoadBlueprintFunc if set, otherwise returns nil
+func (m *MockBlueprintHandler) LoadBlueprint() error {
+	if m.LoadBlueprintFunc != nil {
+		return m.LoadBlueprintFunc()
 	}
 	return nil
 }


### PR DESCRIPTION
The runtime now supports loading a blueprint. The blueprint loaded includes a full blueprint, including loading from artifact and local templating

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>