### PR TITLE
refactor(runtime): Add HandleSessionReset

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -48,8 +48,8 @@ var setContextCmd = &cobra.Command{
 		if err := runtime.NewRuntime(deps).
 			LoadShell().
 			LoadConfig().
-			WriteResetToken().
 			SetContext(args[0]).
+			WriteResetToken().
 			Do(); err != nil {
 			return fmt.Errorf("Error setting context: %w", err)
 		}


### PR DESCRIPTION
Adds the `HandleSessionReset` method to the runtime.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>