### PR TITLE
fix(cmd): Don't check trusted directory when injecting env on init

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -61,7 +61,6 @@ var initCmd = &cobra.Command{
 		}
 		if err := runtime.NewRuntime(deps).
 			LoadShell().
-			CheckTrustedDirectory().
 			LoadConfig().
 			LoadSecretsProviders().
 			LoadEnvVars(runtime.EnvVarsOptions{


### PR DESCRIPTION
When running `windsor init`, there's no need to check if a directory is trusted. The `init` command implicitly trusts a folder.