### PR TITLE
refactor(cmd): Bundle uses context

### DIFF
--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -49,7 +49,9 @@ func NewComposer(ctx *ComposerExecutionContext) *Composer {
 		ComposerExecutionContext: ctx,
 	}
 
-	composer.ArtifactBuilder = artifact.NewArtifactBuilder()
+	if composer.ArtifactBuilder == nil {
+		composer.ArtifactBuilder = artifact.NewArtifactBuilder()
+	}
 	composer.Injector.Register("artifactBuilder", composer.ArtifactBuilder)
 
 	composer.BlueprintHandler = blueprint.NewBlueprintHandler(composer.Injector)


### PR DESCRIPTION
The `windsor bundle` command now leverages the context (runtime) construct.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>