### PR TITLE
refactor(config): Add IsDevMode check

### DIFF
--- a/pkg/context/config/config_handler.go
+++ b/pkg/context/config/config_handler.go
@@ -35,6 +35,7 @@ type ConfigHandler interface {
 	SetDefault(context v1alpha1.Context) error
 	GetConfig() *v1alpha1.Context
 	GetContext() string
+	IsDevMode(contextName string) bool
 	SetContext(context string) error
 	GetConfigRoot() (string, error)
 	Clean() error
@@ -677,6 +678,18 @@ func (c *configHandler) GetContext() string {
 	} else {
 		return contextName
 	}
+}
+
+// IsDevMode checks if the given context name represents a dev/local environment.
+// It first checks if "dev" is explicitly set in the configuration, which takes precedence.
+// If not set, it falls back to checking if the context name equals "local" or starts with "local-".
+func (c *configHandler) IsDevMode(contextName string) bool {
+	if devValue := c.Get("dev"); devValue != nil {
+		if devBool, ok := devValue.(bool); ok {
+			return devBool
+		}
+	}
+	return contextName == "local" || strings.HasPrefix(contextName, "local-")
 }
 
 // SetContext sets the current context in the file and updates the cache

--- a/pkg/context/config/mock_config_handler.go
+++ b/pkg/context/config/mock_config_handler.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/windsorcli/cli/api/v1alpha1"
 )
@@ -23,6 +24,7 @@ type MockConfigHandler struct {
 	SetDefaultFunc          func(context v1alpha1.Context) error
 	GetConfigFunc           func() *v1alpha1.Context
 	GetContextFunc          func() string
+	IsDevModeFunc           func(contextName string) bool
 	SetContextFunc          func(context string) error
 	GetConfigRootFunc       func() (string, error)
 	CleanFunc               func() error
@@ -178,6 +180,14 @@ func (m *MockConfigHandler) GetContext() string {
 		return m.GetContextFunc()
 	}
 	return "mock-context"
+}
+
+// IsDevMode calls the mock IsDevModeFunc if set, otherwise returns default dev mode logic
+func (m *MockConfigHandler) IsDevMode(contextName string) bool {
+	if m.IsDevModeFunc != nil {
+		return m.IsDevModeFunc(contextName)
+	}
+	return contextName == "local" || strings.HasPrefix(contextName, "local-")
 }
 
 // SetContext calls the mock SetContextFunc if set, otherwise returns nil


### PR DESCRIPTION
The `IsDevMode()` provides an abstraction for checking whether we're in Dev mode, allowing us to evolve the implementation over time.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>