### PR TITLE
fix(cmd): Add trusted dir when running init

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -32,6 +32,10 @@ func runInit(injector di.Injector, contextName string, overwrite bool) error {
 		return fmt.Errorf("failed to initialize context: %w", err)
 	}
 
+	if err := baseCtx.Shell.AddCurrentDirToTrustedFile(); err != nil {
+		return fmt.Errorf("failed to add current directory to trusted file: %w", err)
+	}
+
 	configHandler := baseCtx.ConfigHandler
 
 	if err := configHandler.Initialize(); err != nil {


### PR DESCRIPTION
A regression dropped the functionality that adds the project to the trusted directory file when running `windsor init`. This PR reintroduces it.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>