### PR TITLE
refactor(project): Adds the project component for top level orchestration

### DIFF
--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -10,8 +10,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"github.com/windsorcli/cli/pkg/composer/blueprint"
-	"github.com/windsorcli/cli/pkg/context/config"
 	"github.com/windsorcli/cli/pkg/constants"
+	"github.com/windsorcli/cli/pkg/context/config"
+	"github.com/windsorcli/cli/pkg/context/tools"
 	"github.com/windsorcli/cli/pkg/di"
 )
 
@@ -67,6 +68,13 @@ func setupInitTest(t *testing.T, opts ...*SetupOptions) *InitMocks {
 	mockBlueprintHandler.LoadBlueprintFunc = func() error { return nil }
 	mockBlueprintHandler.WriteFunc = func(overwrite ...bool) error { return nil }
 	baseMocks.Injector.Register("blueprintHandler", mockBlueprintHandler)
+
+	// Add mock tools manager (required by runInit)
+	mockToolsManager := tools.NewMockToolsManager()
+	mockToolsManager.InitializeFunc = func() error { return nil }
+	mockToolsManager.CheckFunc = func() error { return nil }
+	mockToolsManager.InstallFunc = func() error { return nil }
+	baseMocks.Injector.Register("toolsManager", mockToolsManager)
 
 	return &InitMocks{
 		Injector:         baseMocks.Injector,

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -1,13 +1,11 @@
 package cmd
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/spf13/cobra"
 	"github.com/windsorcli/cli/pkg/di"
-	"github.com/windsorcli/cli/pkg/pipelines"
-	"github.com/windsorcli/cli/pkg/runtime"
+	"github.com/windsorcli/cli/pkg/project"
 )
 
 var (
@@ -21,72 +19,48 @@ var upCmd = &cobra.Command{
 	Long:         "Set up the Windsor environment by executing necessary shell commands.",
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// Get shared dependency injector from context
 		injector := cmd.Context().Value(injectorKey).(di.Injector)
 
-		// First, set up environment variables using runtime
-		deps := &runtime.Dependencies{
-			Injector: injector,
-		}
-		if err := runtime.NewRuntime(deps).
-			LoadShell().
-			CheckTrustedDirectory().
-			LoadConfig().
-			LoadSecretsProviders().
-			LoadEnvVars(runtime.EnvVarsOptions{
-				Decrypt: true,
-				Verbose: verbose,
-			}).
-			ExecutePostEnvHook(verbose).
-			Do(); err != nil {
-			return fmt.Errorf("failed to set up environment: %w", err)
-		}
-
-		// Then, run the init pipeline to initialize the environment
-		var initPipeline pipelines.Pipeline
-		initPipeline, err := pipelines.WithPipeline(injector, cmd.Context(), "initPipeline")
+		proj, err := project.NewProject(injector, "")
 		if err != nil {
-			return fmt.Errorf("failed to set up init pipeline: %w", err)
-		}
-		if err := initPipeline.Execute(cmd.Context()); err != nil {
-			return fmt.Errorf("failed to initialize environment: %w", err)
+			return err
 		}
 
-		// Finally, run the up pipeline for infrastructure setup
-		upPipeline, err := pipelines.WithPipeline(injector, cmd.Context(), "upPipeline")
-		if err != nil {
-			return fmt.Errorf("failed to set up up pipeline: %w", err)
+		if err := proj.Context.Shell.CheckTrustedDirectory(); err != nil {
+			return fmt.Errorf("not in a trusted directory. If you are in a Windsor project, run 'windsor init' to approve")
 		}
 
-		// Create execution context with flags
-		ctx := cmd.Context()
+		if err := proj.Configure(nil); err != nil {
+			return err
+		}
+
+		if err := proj.Initialize(false); err != nil {
+			if !verbose {
+				return nil
+			}
+			return err
+		}
+
+		if proj.Workstation != nil {
+			if err := proj.Workstation.Up(); err != nil {
+				return fmt.Errorf("error starting workstation: %w", err)
+			}
+		}
+
+		blueprint := proj.Composer.BlueprintHandler.Generate()
+		if err := proj.Provisioner.Up(blueprint); err != nil {
+			return fmt.Errorf("error starting infrastructure: %w", err)
+		}
+
 		if installFlag {
-			ctx = context.WithValue(ctx, "install", true)
-		}
-		if waitFlag {
-			ctx = context.WithValue(ctx, "wait", true)
-		}
-
-		// Execute the up pipeline
-		if err := upPipeline.Execute(ctx); err != nil {
-			return fmt.Errorf("Error executing up pipeline: %w", err)
-		}
-
-		// Run install pipeline if requested
-		if installFlag {
-			installPipeline, err := pipelines.WithPipeline(injector, cmd.Context(), "installPipeline")
-			if err != nil {
-				return fmt.Errorf("failed to set up install pipeline: %w", err)
+			if err := proj.Provisioner.Install(blueprint); err != nil {
+				return fmt.Errorf("error installing blueprint: %w", err)
 			}
 
-			// Create installation context with wait flag if needed
-			installCtx := cmd.Context()
 			if waitFlag {
-				installCtx = context.WithValue(installCtx, "wait", true)
-			}
-
-			if err := installPipeline.Execute(installCtx); err != nil {
-				return fmt.Errorf("Error executing install pipeline: %w", err)
+				if err := proj.Provisioner.Wait(blueprint); err != nil {
+					return fmt.Errorf("error waiting for kustomizations: %w", err)
+				}
 			}
 		}
 

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,0 +1,165 @@
+package project
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/windsorcli/cli/pkg/composer"
+	"github.com/windsorcli/cli/pkg/context"
+	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/provisioner"
+	"github.com/windsorcli/cli/pkg/workstation"
+)
+
+// Project orchestrates the setup and initialization of a Windsor project.
+// It coordinates context, provisioner, composer, and workstation managers
+// to provide a unified interface for project initialization and management.
+type Project struct {
+	Context     *context.ExecutionContext
+	Provisioner *provisioner.Provisioner
+	Composer    *composer.Composer
+	Workstation *workstation.Workstation
+}
+
+// NewProject creates and initializes a new Project instance with all required managers.
+// It sets up the execution context, applies config defaults, and creates provisioner,
+// composer, and workstation managers. The workstation is only created if the project
+// is in dev mode. If an existing context is provided, it will be reused; otherwise,
+// a new context will be created. Returns the initialized Project or an error if any step fails.
+// After creation, call Configure() to apply flag overrides if needed.
+func NewProject(injector di.Injector, contextName string, existingCtx ...*context.ExecutionContext) (*Project, error) {
+	var baseCtx *context.ExecutionContext
+	var err error
+
+	if len(existingCtx) > 0 && existingCtx[0] != nil {
+		baseCtx = existingCtx[0]
+	} else {
+		baseCtx = &context.ExecutionContext{
+			Injector: injector,
+		}
+		baseCtx, err = context.NewContext(baseCtx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to initialize context: %w", err)
+		}
+	}
+
+	if contextName == "" {
+		contextName = baseCtx.ConfigHandler.GetContext()
+		if contextName == "" {
+			contextName = "local"
+		}
+	}
+
+	baseCtx.ContextName = contextName
+	baseCtx.ConfigRoot = filepath.Join(baseCtx.ProjectRoot, "contexts", contextName)
+
+	if err := baseCtx.ApplyConfigDefaults(); err != nil {
+		return nil, err
+	}
+
+	provCtx := &provisioner.ProvisionerExecutionContext{
+		ExecutionContext: *baseCtx,
+	}
+	prov := provisioner.NewProvisioner(provCtx)
+
+	composerCtx := &composer.ComposerExecutionContext{
+		ExecutionContext: *baseCtx,
+	}
+	comp := composer.NewComposer(composerCtx)
+
+	var ws *workstation.Workstation
+	if baseCtx.ConfigHandler.IsDevMode(baseCtx.ContextName) {
+		workstationCtx := &workstation.WorkstationExecutionContext{
+			ExecutionContext: *baseCtx,
+		}
+		ws, err = workstation.NewWorkstation(workstationCtx, baseCtx.Injector)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create workstation: %w", err)
+		}
+	}
+
+	return &Project{
+		Context:     baseCtx,
+		Provisioner: prov,
+		Composer:    comp,
+		Workstation: ws,
+	}, nil
+}
+
+// Configure loads configuration from disk and applies flag-based overrides.
+// This should be called after NewProject if command flags need to override
+// configuration values. Returns an error if loading or applying overrides fails.
+func (p *Project) Configure(flagOverrides map[string]any) error {
+	contextName := p.Context.ContextName
+	if contextName == "" {
+		contextName = "local"
+	}
+
+	if p.Context.ConfigHandler.IsDevMode(contextName) {
+		if flagOverrides == nil {
+			flagOverrides = make(map[string]any)
+		}
+		if _, exists := flagOverrides["provider"]; !exists {
+			if p.Context.ConfigHandler.GetString("provider") == "" {
+				flagOverrides["provider"] = "generic"
+			}
+		}
+	}
+
+	providerOverride := ""
+	if flagOverrides != nil {
+		if prov, ok := flagOverrides["provider"].(string); ok {
+			providerOverride = prov
+		}
+	}
+
+	if err := p.Context.ApplyProviderDefaults(providerOverride); err != nil {
+		return err
+	}
+
+	if err := p.Context.ConfigHandler.LoadConfig(); err != nil {
+		return fmt.Errorf("failed to load config: %w", err)
+	}
+
+	for key, value := range flagOverrides {
+		if err := p.Context.ConfigHandler.Set(key, value); err != nil {
+			return fmt.Errorf("failed to set %s: %w", key, err)
+		}
+	}
+
+	return nil
+}
+
+// Initialize runs the complete initialization sequence for the project.
+// It initializes network, prepares context, generates infrastructure, prepares tools,
+// and bootstraps the environment. The overwrite parameter controls whether
+// infrastructure generation should overwrite existing files. Returns an error
+// if any step fails.
+func (p *Project) Initialize(overwrite bool) error {
+	if p.Workstation != nil && p.Workstation.NetworkManager != nil {
+		if err := p.Workstation.NetworkManager.Initialize(); err != nil {
+			return fmt.Errorf("failed to initialize network manager: %w", err)
+		}
+	}
+
+	if err := p.Context.ConfigHandler.GenerateContextID(); err != nil {
+		return fmt.Errorf("failed to generate context ID: %w", err)
+	}
+	if err := p.Context.ConfigHandler.SaveConfig(overwrite); err != nil {
+		return fmt.Errorf("failed to save config: %w", err)
+	}
+
+	if err := p.Composer.Generate(overwrite); err != nil {
+		return fmt.Errorf("failed to generate infrastructure: %w", err)
+	}
+
+	if err := p.Context.PrepareTools(); err != nil {
+		return err
+	}
+
+	if err := p.Context.LoadEnvironment(true); err != nil {
+		return fmt.Errorf("failed to load environment: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -1,0 +1,571 @@
+package project
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/windsorcli/cli/pkg/composer"
+	"github.com/windsorcli/cli/pkg/context"
+	"github.com/windsorcli/cli/pkg/context/config"
+	"github.com/windsorcli/cli/pkg/context/shell"
+	"github.com/windsorcli/cli/pkg/context/tools"
+	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/provisioner"
+	"github.com/windsorcli/cli/pkg/workstation"
+)
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+type Mocks struct {
+	Injector      di.Injector
+	ConfigHandler config.ConfigHandler
+	Shell         shell.Shell
+	Workstation   *workstation.Workstation
+	Composer      *composer.Composer
+	Provisioner   *provisioner.Provisioner
+}
+
+func setupMocks(t *testing.T) *Mocks {
+	t.Helper()
+
+	tmpDir := t.TempDir()
+	configRoot := filepath.Join(tmpDir, "contexts", "test-context")
+
+	injector := di.NewInjector()
+	configHandler := config.NewMockConfigHandler()
+	mockShell := shell.NewMockShell()
+
+	configHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+		switch key {
+		case "cluster.driver":
+			return "talos"
+		case "provider":
+			return ""
+		default:
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
+	}
+
+	configHandler.GetBoolFunc = func(key string, defaultValue ...bool) bool {
+		return false
+	}
+
+	configHandler.GetContextFunc = func() string {
+		return "test-context"
+	}
+
+	configHandler.IsDevModeFunc = func(contextName string) bool {
+		return false
+	}
+
+	configHandler.LoadConfigFunc = func() error {
+		return nil
+	}
+
+	configHandler.SetFunc = func(key string, value any) error {
+		return nil
+	}
+
+	configHandler.GenerateContextIDFunc = func() error {
+		return nil
+	}
+
+	configHandler.SaveConfigFunc = func(hasSetFlags ...bool) error {
+		return nil
+	}
+
+	mockShell.GetProjectRootFunc = func() (string, error) {
+		return tmpDir, nil
+	}
+
+	mockShell.GetSessionTokenFunc = func() (string, error) {
+		return "test-session-token", nil
+	}
+
+	configHandler.GetConfigRootFunc = func() (string, error) {
+		return configRoot, nil
+	}
+
+	mockToolsManager := tools.NewMockToolsManager()
+	mockToolsManager.CheckFunc = func() error {
+		return nil
+	}
+
+	injector.Register("shell", mockShell)
+	injector.Register("configHandler", configHandler)
+	injector.Register("toolsManager", mockToolsManager)
+
+	baseCtx := &context.ExecutionContext{
+		Injector: injector,
+	}
+
+	ctx, err := context.NewContext(baseCtx)
+	if err != nil {
+		t.Fatalf("Failed to create context: %v", err)
+	}
+
+	provCtx := &provisioner.ProvisionerExecutionContext{
+		ExecutionContext: *ctx,
+	}
+	prov := provisioner.NewProvisioner(provCtx)
+
+	composerCtx := &composer.ComposerExecutionContext{
+		ExecutionContext: *ctx,
+	}
+	comp := composer.NewComposer(composerCtx)
+
+	return &Mocks{
+		Injector:      injector,
+		ConfigHandler: configHandler,
+		Shell:         mockShell,
+		Provisioner:   prov,
+		Composer:      comp,
+	}
+}
+
+// =============================================================================
+// Test Constructor
+// =============================================================================
+
+func TestNewProject(t *testing.T) {
+	t.Run("CreatesProjectWithDependencies", func(t *testing.T) {
+		mocks := setupMocks(t)
+
+		proj, err := NewProject(mocks.Injector, "test-context")
+
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		if proj == nil {
+			t.Fatal("Expected Project to be created")
+		}
+
+		if proj.Context == nil {
+			t.Error("Expected Context to be set")
+		}
+
+		if proj.Provisioner == nil {
+			t.Error("Expected Provisioner to be set")
+		}
+
+		if proj.Composer == nil {
+			t.Error("Expected Composer to be set")
+		}
+
+		if proj.Context.ContextName != "test-context" {
+			t.Errorf("Expected ContextName to be 'test-context', got: %s", proj.Context.ContextName)
+		}
+	})
+
+	t.Run("UsesProvidedContextName", func(t *testing.T) {
+		mocks := setupMocks(t)
+
+		proj, err := NewProject(mocks.Injector, "custom-context")
+
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		if proj.Context.ContextName != "custom-context" {
+			t.Errorf("Expected ContextName to be 'custom-context', got: %s", proj.Context.ContextName)
+		}
+	})
+
+	t.Run("UsesConfigContextWhenContextNameEmpty", func(t *testing.T) {
+		mocks := setupMocks(t)
+
+		proj, err := NewProject(mocks.Injector, "")
+
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		if proj.Context.ContextName != "test-context" {
+			t.Errorf("Expected ContextName to be 'test-context', got: %s", proj.Context.ContextName)
+		}
+	})
+
+	t.Run("UsesLocalWhenContextNameAndConfigContextEmpty", func(t *testing.T) {
+		mocks := setupMocks(t)
+		mockConfig := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockConfig.GetContextFunc = func() string {
+			return ""
+		}
+
+		proj, err := NewProject(mocks.Injector, "")
+
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		if proj.Context.ContextName != "local" {
+			t.Errorf("Expected ContextName to be 'local', got: %s", proj.Context.ContextName)
+		}
+	})
+
+	t.Run("CreatesWorkstationWhenDevMode", func(t *testing.T) {
+		mocks := setupMocks(t)
+		mockConfig := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockConfig.IsDevModeFunc = func(contextName string) bool {
+			return true
+		}
+
+		proj, err := NewProject(mocks.Injector, "test-context")
+
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		if proj.Workstation == nil {
+			t.Error("Expected Workstation to be created in dev mode")
+		}
+	})
+
+	t.Run("SkipsWorkstationWhenNotDevMode", func(t *testing.T) {
+		mocks := setupMocks(t)
+		mockConfig := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockConfig.IsDevModeFunc = func(contextName string) bool {
+			return false
+		}
+
+		proj, err := NewProject(mocks.Injector, "test-context")
+
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		if proj.Workstation != nil {
+			t.Error("Expected Workstation to be nil when not in dev mode")
+		}
+	})
+
+	t.Run("ErrorOnContextInitializationFailure", func(t *testing.T) {
+		var injector di.Injector
+
+		proj, err := NewProject(injector, "test-context")
+
+		if err == nil {
+			t.Error("Expected error for context initialization failure")
+			return
+		}
+
+		if proj != nil {
+			t.Error("Expected Project to be nil on error")
+		}
+
+		if !strings.Contains(err.Error(), "failed to initialize context") {
+			t.Errorf("Expected specific error message, got: %v", err)
+		}
+	})
+
+}
+
+// =============================================================================
+// Test Public Methods
+// =============================================================================
+
+func TestProject_Configure(t *testing.T) {
+	t.Run("SuccessWithNilFlagOverrides", func(t *testing.T) {
+		mocks := setupMocks(t)
+		proj, err := NewProject(mocks.Injector, "test-context")
+		if err != nil {
+			t.Fatalf("Failed to create project: %v", err)
+		}
+
+		err = proj.Configure(nil)
+
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("SuccessWithEmptyFlagOverrides", func(t *testing.T) {
+		mocks := setupMocks(t)
+		proj, err := NewProject(mocks.Injector, "test-context")
+		if err != nil {
+			t.Fatalf("Failed to create project: %v", err)
+		}
+
+		err = proj.Configure(make(map[string]any))
+
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("SuccessWithFlagOverrides", func(t *testing.T) {
+		mocks := setupMocks(t)
+		proj, err := NewProject(mocks.Injector, "test-context")
+		if err != nil {
+			t.Fatalf("Failed to create project: %v", err)
+		}
+
+		flagOverrides := map[string]any{
+			"provider": "aws",
+			"key":      "value",
+		}
+
+		err = proj.Configure(flagOverrides)
+
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("SetsGenericProviderInDevModeWhenProviderNotSet", func(t *testing.T) {
+		mocks := setupMocks(t)
+		mockConfig := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockConfig.IsDevModeFunc = func(contextName string) bool {
+			return true
+		}
+		mockConfig.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "provider" {
+				return ""
+			}
+			return ""
+		}
+
+		proj, err := NewProject(mocks.Injector, "test-context")
+		if err != nil {
+			t.Fatalf("Failed to create project: %v", err)
+		}
+
+		providerSet := false
+		mockConfig.SetFunc = func(key string, value any) error {
+			if key == "provider" && value == "generic" {
+				providerSet = true
+			}
+			return nil
+		}
+
+		err = proj.Configure(nil)
+
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+
+		if !providerSet {
+			t.Error("Expected provider to be set to 'generic' in dev mode")
+		}
+	})
+
+	t.Run("SkipsGenericProviderWhenProviderAlreadySet", func(t *testing.T) {
+		mocks := setupMocks(t)
+		mockConfig := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockConfig.IsDevModeFunc = func(contextName string) bool {
+			return true
+		}
+		mockConfig.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "provider" {
+				return "aws"
+			}
+			return ""
+		}
+
+		proj, err := NewProject(mocks.Injector, "test-context")
+		if err != nil {
+			t.Fatalf("Failed to create project: %v", err)
+		}
+
+		genericSet := false
+		mockConfig.SetFunc = func(key string, value any) error {
+			if key == "provider" && value == "generic" {
+				genericSet = true
+			}
+			return nil
+		}
+
+		err = proj.Configure(nil)
+
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+
+		if genericSet {
+			t.Error("Expected provider not to be set to 'generic' when already set")
+		}
+	})
+
+	t.Run("ErrorOnApplyProviderDefaultsFailure", func(t *testing.T) {
+		mocks := setupMocks(t)
+		proj, err := NewProject(mocks.Injector, "test-context")
+		if err != nil {
+			t.Fatalf("Failed to create project: %v", err)
+		}
+
+		mockConfig := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockConfig.SetFunc = func(key string, value any) error {
+			if key == "cluster.driver" {
+				return fmt.Errorf("set cluster.driver failed")
+			}
+			return nil
+		}
+
+		err = proj.Configure(map[string]any{"provider": "aws"})
+
+		if err == nil {
+			t.Error("Expected error for ApplyProviderDefaults failure")
+			return
+		}
+	})
+
+	t.Run("ErrorOnLoadConfigFailure", func(t *testing.T) {
+		mocks := setupMocks(t)
+		proj, err := NewProject(mocks.Injector, "test-context")
+		if err != nil {
+			t.Fatalf("Failed to create project: %v", err)
+		}
+
+		mockConfig := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockConfig.LoadConfigFunc = func() error {
+			return fmt.Errorf("load config failed")
+		}
+
+		err = proj.Configure(nil)
+
+		if err == nil {
+			t.Error("Expected error for LoadConfig failure")
+			return
+		}
+
+		if !strings.Contains(err.Error(), "failed to load config") {
+			t.Errorf("Expected specific error message, got: %v", err)
+		}
+	})
+
+	t.Run("ErrorOnSetFailure", func(t *testing.T) {
+		mocks := setupMocks(t)
+		proj, err := NewProject(mocks.Injector, "test-context")
+		if err != nil {
+			t.Fatalf("Failed to create project: %v", err)
+		}
+
+		mockConfig := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockConfig.SetFunc = func(key string, value any) error {
+			return fmt.Errorf("set failed")
+		}
+
+		err = proj.Configure(map[string]any{"key": "value"})
+
+		if err == nil {
+			t.Error("Expected error for Set failure")
+			return
+		}
+
+		if !strings.Contains(err.Error(), "failed to set") {
+			t.Errorf("Expected specific error message, got: %v", err)
+		}
+	})
+}
+
+func TestProject_Initialize(t *testing.T) {
+	t.Run("SuccessWithoutWorkstation", func(t *testing.T) {
+		mocks := setupMocks(t)
+		proj, err := NewProject(mocks.Injector, "test-context")
+		if err != nil {
+			t.Fatalf("Failed to create project: %v", err)
+		}
+
+		err = proj.Initialize(false)
+
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("SuccessWithWorkstation", func(t *testing.T) {
+		mocks := setupMocks(t)
+		mockConfig := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockConfig.IsDevModeFunc = func(contextName string) bool {
+			return true
+		}
+
+		proj, err := NewProject(mocks.Injector, "test-context")
+		if err != nil {
+			t.Fatalf("Failed to create project: %v", err)
+		}
+
+		if proj.Workstation == nil {
+			t.Fatal("Expected workstation to be created")
+		}
+
+		proj.Workstation.NetworkManager = nil
+
+		err = proj.Initialize(false)
+
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("SuccessWithOverwriteTrue", func(t *testing.T) {
+		mocks := setupMocks(t)
+		proj, err := NewProject(mocks.Injector, "test-context")
+		if err != nil {
+			t.Fatalf("Failed to create project: %v", err)
+		}
+
+		err = proj.Initialize(true)
+
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("ErrorOnGenerateContextIDFailure", func(t *testing.T) {
+		mocks := setupMocks(t)
+		proj, err := NewProject(mocks.Injector, "test-context")
+		if err != nil {
+			t.Fatalf("Failed to create project: %v", err)
+		}
+
+		mockConfig := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockConfig.GenerateContextIDFunc = func() error {
+			return fmt.Errorf("generate context ID failed")
+		}
+
+		err = proj.Initialize(false)
+
+		if err == nil {
+			t.Error("Expected error for GenerateContextID failure")
+			return
+		}
+
+		if !strings.Contains(err.Error(), "failed to generate context ID") {
+			t.Errorf("Expected specific error message, got: %v", err)
+		}
+	})
+
+	t.Run("ErrorOnSaveConfigFailure", func(t *testing.T) {
+		mocks := setupMocks(t)
+		proj, err := NewProject(mocks.Injector, "test-context")
+		if err != nil {
+			t.Fatalf("Failed to create project: %v", err)
+		}
+
+		mockConfig := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockConfig.SaveConfigFunc = func(hasSetFlags ...bool) error {
+			return fmt.Errorf("save config failed")
+		}
+
+		err = proj.Initialize(false)
+
+		if err == nil {
+			t.Error("Expected error for SaveConfig failure")
+			return
+		}
+
+		if !strings.Contains(err.Error(), "failed to save config") {
+			t.Errorf("Expected specific error message, got: %v", err)
+		}
+	})
+
+}


### PR DESCRIPTION
There is a need for some reusable high-level orchestration. In particular, both configuration and initialization must take place for several commands, and requires coordination between a several high-level objects.

This refactor also involved creating a few high level convenience methods on `pkg/context`. Test coverage was also expanded broadly on `pkg/context`.

Improves some steps in the "up" pipeline including the blueprint installation, workstation configurations.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>