### PR TITLE
fix(workstation): Correctly generate service DNS entries

### DIFF
--- a/pkg/pipelines/down_test.go
+++ b/pkg/pipelines/down_test.go
@@ -8,13 +8,14 @@ import (
 	"testing"
 
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+	"github.com/windsorcli/cli/pkg/composer/blueprint"
 	"github.com/windsorcli/cli/pkg/context/config"
 	envvars "github.com/windsorcli/cli/pkg/context/env"
+	"github.com/windsorcli/cli/pkg/context/shell"
 	"github.com/windsorcli/cli/pkg/provisioner/kubernetes"
 	terraforminfra "github.com/windsorcli/cli/pkg/provisioner/terraform"
-	"github.com/windsorcli/cli/pkg/composer/blueprint"
-	"github.com/windsorcli/cli/pkg/context/shell"
 	"github.com/windsorcli/cli/pkg/workstation/network"
+	"github.com/windsorcli/cli/pkg/workstation/services"
 	"github.com/windsorcli/cli/pkg/workstation/virt"
 )
 
@@ -84,7 +85,7 @@ contexts:
 
 	// Setup network manager mock
 	mockNetworkManager := network.NewMockNetworkManager()
-	mockNetworkManager.InitializeFunc = func() error { return nil }
+	mockNetworkManager.InitializeFunc = func([]services.Service) error { return nil }
 	baseMocks.Injector.Register("networkManager", mockNetworkManager)
 
 	// Setup stack mock
@@ -382,7 +383,7 @@ func TestDownPipeline_Initialize(t *testing.T) {
 		mocks := setupDownMocks(t)
 
 		// Set up a failing network manager mock
-		mocks.NetworkManager.InitializeFunc = func() error {
+		mocks.NetworkManager.InitializeFunc = func([]services.Service) error {
 			return fmt.Errorf("network manager initialization failed")
 		}
 

--- a/pkg/pipelines/init.go
+++ b/pkg/pipelines/init.go
@@ -198,7 +198,7 @@ func (p *InitPipeline) Initialize(injector di.Injector, ctx context.Context) err
 	}
 
 	if p.networkManager != nil {
-		if err := p.networkManager.Initialize(); err != nil {
+		if err := p.networkManager.Initialize(p.services); err != nil {
 			return fmt.Errorf("failed to initialize network manager: %w", err)
 		}
 	}

--- a/pkg/pipelines/up.go
+++ b/pkg/pipelines/up.go
@@ -5,12 +5,13 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/windsorcli/cli/pkg/di"
 	envvars "github.com/windsorcli/cli/pkg/context/env"
-	"github.com/windsorcli/cli/pkg/context/tools"
-	terraforminfra "github.com/windsorcli/cli/pkg/provisioner/terraform"
 	"github.com/windsorcli/cli/pkg/context/shell"
+	"github.com/windsorcli/cli/pkg/context/tools"
+	"github.com/windsorcli/cli/pkg/di"
+	terraforminfra "github.com/windsorcli/cli/pkg/provisioner/terraform"
 	"github.com/windsorcli/cli/pkg/workstation/network"
+	"github.com/windsorcli/cli/pkg/workstation/services"
 	"github.com/windsorcli/cli/pkg/workstation/virt"
 )
 
@@ -105,7 +106,14 @@ func (p *UpPipeline) Initialize(injector di.Injector, ctx context.Context) error
 	}
 
 	if p.networkManager != nil {
-		if err := p.networkManager.Initialize(); err != nil {
+		resolvedServices, _ := p.injector.ResolveAll(new(services.Service))
+		serviceList := make([]services.Service, 0, len(resolvedServices))
+		for _, svc := range resolvedServices {
+			if s, ok := svc.(services.Service); ok {
+				serviceList = append(serviceList, s)
+			}
+		}
+		if err := p.networkManager.Initialize(serviceList); err != nil {
 			return fmt.Errorf("failed to initialize network manager: %w", err)
 		}
 	}

--- a/pkg/pipelines/up_test.go
+++ b/pkg/pipelines/up_test.go
@@ -8,10 +8,11 @@ import (
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/context/config"
 	envvars "github.com/windsorcli/cli/pkg/context/env"
+	"github.com/windsorcli/cli/pkg/context/shell"
 	"github.com/windsorcli/cli/pkg/context/tools"
 	terraforminfra "github.com/windsorcli/cli/pkg/provisioner/terraform"
-	"github.com/windsorcli/cli/pkg/context/shell"
 	"github.com/windsorcli/cli/pkg/workstation/network"
+	"github.com/windsorcli/cli/pkg/workstation/services"
 	"github.com/windsorcli/cli/pkg/workstation/virt"
 )
 
@@ -87,7 +88,7 @@ contexts:
 
 	// Setup network manager mock
 	mockNetworkManager := network.NewMockNetworkManager()
-	mockNetworkManager.InitializeFunc = func() error { return nil }
+	mockNetworkManager.InitializeFunc = func([]services.Service) error { return nil }
 	mockNetworkManager.ConfigureGuestFunc = func() error { return nil }
 	mockNetworkManager.ConfigureHostRouteFunc = func() error { return nil }
 	mockNetworkManager.ConfigureDNSFunc = func() error { return nil }
@@ -206,7 +207,7 @@ func TestUpPipeline_Initialize(t *testing.T) {
 		{
 			name: "ReturnsErrorWhenNetworkManagerInitializeFails",
 			setupMock: func(mocks *UpMocks) {
-				mocks.NetworkManager.InitializeFunc = func() error {
+				mocks.NetworkManager.InitializeFunc = func([]services.Service) error {
 					return fmt.Errorf("network manager failed")
 				}
 			},

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -137,7 +137,7 @@ func (p *Project) Configure(flagOverrides map[string]any) error {
 // if any step fails.
 func (p *Project) Initialize(overwrite bool) error {
 	if p.Workstation != nil && p.Workstation.NetworkManager != nil {
-		if err := p.Workstation.NetworkManager.Initialize(); err != nil {
+		if err := p.Workstation.NetworkManager.Initialize(p.Workstation.Services); err != nil {
 			return fmt.Errorf("failed to initialize network manager: %w", err)
 		}
 	}

--- a/pkg/workstation/network/colima_network.go
+++ b/pkg/workstation/network/colima_network.go
@@ -9,6 +9,7 @@ import (
 	"github.com/windsorcli/cli/pkg/di"
 	"github.com/windsorcli/cli/pkg/context/shell"
 	"github.com/windsorcli/cli/pkg/context/shell/ssh"
+	"github.com/windsorcli/cli/pkg/workstation/services"
 )
 
 // The ColimaNetworkManager is a specialized network manager for Colima-based environments.
@@ -47,8 +48,8 @@ func NewColimaNetworkManager(injector di.Injector) *ColimaNetworkManager {
 
 // Initialize sets up the ColimaNetworkManager by resolving dependencies for
 // sshClient, shell, and secureShell from the injector.
-func (n *ColimaNetworkManager) Initialize() error {
-	if err := n.BaseNetworkManager.Initialize(); err != nil {
+func (n *ColimaNetworkManager) Initialize(services []services.Service) error {
+	if err := n.BaseNetworkManager.Initialize(services); err != nil {
 		return err
 	}
 

--- a/pkg/workstation/network/colima_network_test.go
+++ b/pkg/workstation/network/colima_network_test.go
@@ -5,6 +5,8 @@ import (
 	"net"
 	"strings"
 	"testing"
+
+	"github.com/windsorcli/cli/pkg/workstation/services"
 )
 
 // =============================================================================
@@ -26,7 +28,7 @@ func TestColimaNetworkManager_Initialize(t *testing.T) {
 		mocks.Injector.Register("secureShell", "invalid")
 
 		// When initializing the network manager
-		err := manager.Initialize()
+		err := manager.Initialize([]services.Service{})
 
 		// Then an error should occur
 		if err == nil {
@@ -45,7 +47,7 @@ func TestColimaNetworkManager_Initialize(t *testing.T) {
 		mocks.Injector.Register("sshClient", "invalid")
 
 		// When initializing the network manager
-		err := manager.Initialize()
+		err := manager.Initialize([]services.Service{})
 
 		// Then an error should occur
 		if err == nil {
@@ -64,7 +66,7 @@ func TestColimaNetworkManager_Initialize(t *testing.T) {
 		mocks.Injector.Register("networkInterfaceProvider", "invalid")
 
 		// When initializing the network manager
-		err := manager.Initialize()
+		err := manager.Initialize([]services.Service{})
 
 		// Then an error should occur
 		if err == nil {
@@ -84,7 +86,7 @@ func TestColimaNetworkManager_ConfigureGuest(t *testing.T) {
 		mocks := setupMocks(t)
 		manager := NewColimaNetworkManager(mocks.Injector)
 		manager.shims = mocks.Shims
-		manager.Initialize()
+		manager.Initialize([]services.Service{})
 		return manager, mocks
 	}
 
@@ -148,7 +150,7 @@ func TestColimaNetworkManager_ConfigureGuest(t *testing.T) {
 		}
 
 		// When initializing the network manager
-		err := manager.Initialize()
+		err := manager.Initialize([]services.Service{})
 		if err != nil {
 			t.Fatalf("expected no error during initialization, got %v", err)
 		}
@@ -174,7 +176,7 @@ func TestColimaNetworkManager_ConfigureGuest(t *testing.T) {
 		}
 
 		// When initializing the network manager
-		err := manager.Initialize()
+		err := manager.Initialize([]services.Service{})
 		if err != nil {
 			t.Fatalf("expected no error during initialization, got %v", err)
 		}
@@ -203,7 +205,7 @@ func TestColimaNetworkManager_ConfigureGuest(t *testing.T) {
 		}
 
 		// When initializing the network manager
-		err := manager.Initialize()
+		err := manager.Initialize([]services.Service{})
 		if err != nil {
 			t.Fatalf("expected no error during initialization, got %v", err)
 		}
@@ -232,7 +234,7 @@ func TestColimaNetworkManager_ConfigureGuest(t *testing.T) {
 		}
 
 		// When initializing the network manager
-		err := manager.Initialize()
+		err := manager.Initialize([]services.Service{})
 		if err != nil {
 			t.Fatalf("expected no error during initialization, got %v", err)
 		}
@@ -267,7 +269,7 @@ func TestColimaNetworkManager_ConfigureGuest(t *testing.T) {
 		}
 
 		// When initializing the network manager
-		err := manager.Initialize()
+		err := manager.Initialize([]services.Service{})
 		if err != nil {
 			t.Fatalf("expected no error during initialization, got %v", err)
 		}
@@ -293,7 +295,7 @@ func TestColimaNetworkManager_ConfigureGuest(t *testing.T) {
 		}
 
 		// When initializing the network manager
-		err := manager.Initialize()
+		err := manager.Initialize([]services.Service{})
 		if err != nil {
 			t.Fatalf("expected no error during initialization, got %v", err)
 		}
@@ -322,7 +324,7 @@ func TestColimaNetworkManager_ConfigureGuest(t *testing.T) {
 		}
 
 		// When initializing the network manager
-		err := manager.Initialize()
+		err := manager.Initialize([]services.Service{})
 		if err != nil {
 			t.Fatalf("expected no error during initialization, got %v", err)
 		}
@@ -345,7 +347,7 @@ func TestColimaNetworkManager_getHostIP(t *testing.T) {
 		t.Helper()
 		mocks := setupMocks(t)
 		manager := NewColimaNetworkManager(mocks.Injector)
-		manager.Initialize()
+		manager.Initialize([]services.Service{})
 		return manager, mocks
 	}
 

--- a/pkg/workstation/network/darwin_network_test.go
+++ b/pkg/workstation/network/darwin_network_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"os"
 	"testing"
+
+	"github.com/windsorcli/cli/pkg/workstation/services"
 )
 
 // =============================================================================
@@ -19,7 +21,7 @@ func TestDarwinNetworkManager_ConfigureHostRoute(t *testing.T) {
 		mocks := setupMocks(t)
 		manager := NewBaseNetworkManager(mocks.Injector)
 		manager.shims = mocks.Shims
-		manager.Initialize()
+		manager.Initialize([]services.Service{})
 		return manager, mocks
 	}
 
@@ -167,7 +169,7 @@ func TestDarwinNetworkManager_ConfigureDNS(t *testing.T) {
 		mocks := setupMocks(t)
 		manager := NewBaseNetworkManager(mocks.Injector)
 		manager.shims = mocks.Shims
-		manager.Initialize()
+		manager.Initialize([]services.Service{})
 		return manager, mocks
 	}
 

--- a/pkg/workstation/network/linux_network_test.go
+++ b/pkg/workstation/network/linux_network_test.go
@@ -8,6 +8,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	"github.com/windsorcli/cli/pkg/workstation/services"
 )
 
 // =============================================================================
@@ -20,7 +22,7 @@ func TestLinuxNetworkManager_ConfigureHostRoute(t *testing.T) {
 		mocks := setupMocks(t)
 		manager := NewBaseNetworkManager(mocks.Injector)
 		manager.shims = mocks.Shims
-		manager.Initialize()
+		manager.Initialize([]services.Service{})
 		return manager, mocks
 	}
 
@@ -169,7 +171,7 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 		mocks := setupMocks(t)
 		manager := NewBaseNetworkManager(mocks.Injector)
 		manager.shims = mocks.Shims
-		manager.Initialize()
+		manager.Initialize([]services.Service{})
 		return manager, mocks
 	}
 

--- a/pkg/workstation/network/mock_network.go
+++ b/pkg/workstation/network/mock_network.go
@@ -1,6 +1,10 @@
 package network
 
-import "net"
+import (
+	"net"
+
+	"github.com/windsorcli/cli/pkg/workstation/services"
+)
 
 // The MockNetworkManager is a test implementation of the NetworkManager interface.
 // It provides mock implementations of network management functions for testing,
@@ -14,7 +18,7 @@ import "net"
 // MockNetworkManager is a struct that simulates a network manager for testing purposes.
 type MockNetworkManager struct {
 	NetworkManager
-	InitializeFunc         func() error
+	InitializeFunc         func([]services.Service) error
 	ConfigureHostRouteFunc func() error
 	ConfigureGuestFunc     func() error
 	ConfigureDNSFunc       func() error
@@ -34,9 +38,9 @@ func NewMockNetworkManager() *MockNetworkManager {
 // =============================================================================
 
 // Initialize calls the custom InitializeFunc if provided.
-func (m *MockNetworkManager) Initialize() error {
+func (m *MockNetworkManager) Initialize(services []services.Service) error {
 	if m.InitializeFunc != nil {
-		return m.InitializeFunc()
+		return m.InitializeFunc(services)
 	}
 	return nil
 }

--- a/pkg/workstation/network/mock_network_test.go
+++ b/pkg/workstation/network/mock_network_test.go
@@ -2,6 +2,8 @@ package network
 
 import (
 	"testing"
+
+	"github.com/windsorcli/cli/pkg/workstation/services"
 )
 
 // =============================================================================
@@ -12,12 +14,12 @@ func TestMockNetworkManager_Initialize(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		// Given a mock network manager with successful initialization
 		mockManager := NewMockNetworkManager()
-		mockManager.InitializeFunc = func() error {
+		mockManager.InitializeFunc = func([]services.Service) error {
 			return nil
 		}
 
 		// When initializing the manager
-		err := mockManager.Initialize()
+		err := mockManager.Initialize([]services.Service{})
 
 		// Then no error should occur
 		if err != nil {
@@ -30,7 +32,7 @@ func TestMockNetworkManager_Initialize(t *testing.T) {
 		mockManager := NewMockNetworkManager()
 
 		// When initializing the manager
-		err := mockManager.Initialize()
+		err := mockManager.Initialize([]services.Service{})
 
 		// Then no error should occur
 		if err != nil {

--- a/pkg/workstation/network/windows_network_test.go
+++ b/pkg/workstation/network/windows_network_test.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/windsorcli/cli/pkg/workstation/services"
 )
 
 // =============================================================================
@@ -19,7 +21,7 @@ func TestWindowsNetworkManager_ConfigureHostRoute(t *testing.T) {
 		mocks := setupMocks(t)
 		manager := NewBaseNetworkManager(mocks.Injector)
 		manager.shims = mocks.Shims
-		manager.Initialize()
+		manager.Initialize([]services.Service{})
 		return manager, mocks
 	}
 
@@ -27,14 +29,8 @@ func TestWindowsNetworkManager_ConfigureHostRoute(t *testing.T) {
 		// Given a properly configured network manager
 		manager, _ := setup(t)
 
-		// When initializing the network manager
-		err := manager.Initialize()
-		if err != nil {
-			t.Fatalf("expected no error during initialization, got %v", err)
-		}
-
 		// And configuring the host route
-		err = manager.ConfigureHostRoute()
+		err := manager.ConfigureHostRoute()
 
 		// Then no error should occur
 		if err != nil {
@@ -148,7 +144,7 @@ func TestWindowsNetworkManager_ConfigureDNS(t *testing.T) {
 		mocks := setupMocks(t)
 		manager := NewBaseNetworkManager(mocks.Injector)
 		manager.shims = mocks.Shims
-		manager.Initialize()
+		manager.Initialize([]services.Service{})
 		return manager, mocks
 	}
 

--- a/pkg/workstation/services/talos_service_test.go
+++ b/pkg/workstation/services/talos_service_test.go
@@ -638,7 +638,7 @@ func TestTalosService_SetAddress(t *testing.T) {
 		}
 
 		// When SetAddress is called for third worker
-		if err := service3.SetAddress("192.168.1.22", portAllocator); err != nil {
+		if err := service3.SetAddress("192.168.1.22", nil); err != nil {
 			t.Fatalf("Failed to set address for service3: %v", err)
 		}
 


### PR DESCRIPTION
Explicitly sets services on the network manager. This change fixes a regression in which the `Corefile` was missing service entries.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>