### PR TITLE
refactor(cmd): Factor out runtime and pipeline from down

### DIFF
--- a/pkg/workstation/workstation.go
+++ b/pkg/workstation/workstation.go
@@ -202,12 +202,18 @@ func (w *Workstation) Up() error {
 // step fails, it returns an error describing the issue.
 func (w *Workstation) Down() error {
 	if w.ContainerRuntime != nil {
+		if err := w.ContainerRuntime.Initialize(); err != nil {
+			return fmt.Errorf("failed to initialize container runtime: %w", err)
+		}
 		if err := w.ContainerRuntime.Down(); err != nil {
 			return fmt.Errorf("Error running container runtime Down command: %w", err)
 		}
 	}
 
 	if w.VirtualMachine != nil {
+		if err := w.VirtualMachine.Initialize(); err != nil {
+			return fmt.Errorf("failed to initialize virtual machine: %w", err)
+		}
 		if err := w.VirtualMachine.Down(); err != nil {
 			return fmt.Errorf("Error running virtual machine Down command: %w", err)
 		}


### PR DESCRIPTION
We no longer need pipeline or runtime constructs in the down command. These have been factored out to use newer components.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>