### PR TITLE
refactor(runtime): Remove dependency injector

### DIFF
--- a/cmd/bundle_test.go
+++ b/cmd/bundle_test.go
@@ -155,9 +155,6 @@ func TestBundleCmdWithRuntime(t *testing.T) {
 		mockShell.GetProjectRootFunc = func() (string, error) {
 			return tmpDir, nil
 		}
-		mockShell.InitializeFunc = func() error {
-			return nil
-		}
 		injector.Register("shell", mockShell)
 
 		// Mock config handler
@@ -167,9 +164,6 @@ func TestBundleCmdWithRuntime(t *testing.T) {
 		}
 		mockConfigHandler.GetContextFunc = func() string {
 			return "test-context"
-		}
-		mockConfigHandler.InitializeFunc = func() error {
-			return nil
 		}
 		injector.Register("configHandler", mockConfigHandler)
 

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -8,11 +8,11 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/provisioner/cluster"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
 	"github.com/windsorcli/cli/pkg/runtime/tools"
-	"github.com/windsorcli/cli/pkg/di"
-	"github.com/windsorcli/cli/pkg/provisioner/cluster"
 )
 
 func TestCheckCmd(t *testing.T) {
@@ -69,9 +69,6 @@ func TestCheckCmd(t *testing.T) {
 		mockConfigHandler.LoadConfigFunc = func() error {
 			return nil
 		}
-		mockConfigHandler.InitializeFunc = func() error {
-			return nil
-		}
 		mockConfigHandler.GetContextFunc = func() string {
 			return "test-context"
 		}
@@ -108,9 +105,6 @@ func TestCheckCmd(t *testing.T) {
 		// Set up mocks with trusted directory but no config loaded
 		mockConfigHandler := config.NewMockConfigHandler()
 		mockConfigHandler.LoadConfigFunc = func() error {
-			return nil
-		}
-		mockConfigHandler.InitializeFunc = func() error {
 			return nil
 		}
 		mockConfigHandler.GetContextFunc = func() string {
@@ -163,9 +157,6 @@ func TestCheckCmd_ErrorScenarios(t *testing.T) {
 		mockShell.GetProjectRootFunc = func() (string, error) {
 			return "", fmt.Errorf("project root error")
 		}
-		mockShell.InitializeFunc = func() error {
-			return nil
-		}
 		injector.Register("shell", mockShell)
 
 		ctx := stdcontext.WithValue(stdcontext.Background(), injectorKey, injector)
@@ -214,9 +205,6 @@ func TestCheckCmd_ErrorScenarios(t *testing.T) {
 		mockConfigHandler.LoadConfigFunc = func() error {
 			return fmt.Errorf("config load failed")
 		}
-		mockConfigHandler.InitializeFunc = func() error {
-			return nil
-		}
 		mockConfigHandler.GetContextFunc = func() string {
 			return "test-context"
 		}
@@ -227,9 +215,6 @@ func TestCheckCmd_ErrorScenarios(t *testing.T) {
 			return t.TempDir(), nil
 		}
 		mockShell.CheckTrustedDirectoryFunc = func() error {
-			return nil
-		}
-		mockShell.InitializeFunc = func() error {
 			return nil
 		}
 		injector.Register("shell", mockShell)
@@ -254,9 +239,6 @@ func TestCheckCmd_ErrorScenarios(t *testing.T) {
 		setup(t)
 		mockConfigHandler := config.NewMockConfigHandler()
 		mockConfigHandler.LoadConfigFunc = func() error {
-			return nil
-		}
-		mockConfigHandler.InitializeFunc = func() error {
 			return nil
 		}
 		mockConfigHandler.GetContextFunc = func() string {
@@ -355,9 +337,6 @@ func TestCheckNodeHealthCmd(t *testing.T) {
 		// Set up mocks
 		mockConfigHandler := config.NewMockConfigHandler()
 		mockConfigHandler.LoadConfigFunc = func() error {
-			return nil
-		}
-		mockConfigHandler.InitializeFunc = func() error {
 			return nil
 		}
 		mockConfigHandler.GetContextFunc = func() string {
@@ -481,9 +460,6 @@ func TestCheckNodeHealthCmd_ErrorScenarios(t *testing.T) {
 		mockShell.GetProjectRootFunc = func() (string, error) {
 			return "", fmt.Errorf("project root error")
 		}
-		mockShell.InitializeFunc = func() error {
-			return nil
-		}
 		injector.Register("shell", mockShell)
 
 		ctx := stdcontext.WithValue(stdcontext.Background(), injectorKey, injector)
@@ -532,9 +508,6 @@ func TestCheckNodeHealthCmd_ErrorScenarios(t *testing.T) {
 		mockConfigHandler.LoadConfigFunc = func() error {
 			return fmt.Errorf("config load failed")
 		}
-		mockConfigHandler.InitializeFunc = func() error {
-			return nil
-		}
 		mockConfigHandler.GetContextFunc = func() string {
 			return "test-context"
 		}
@@ -545,9 +518,6 @@ func TestCheckNodeHealthCmd_ErrorScenarios(t *testing.T) {
 			return t.TempDir(), nil
 		}
 		mockShell.CheckTrustedDirectoryFunc = func() error {
-			return nil
-		}
-		mockShell.InitializeFunc = func() error {
 			return nil
 		}
 		injector.Register("shell", mockShell)
@@ -572,9 +542,6 @@ func TestCheckNodeHealthCmd_ErrorScenarios(t *testing.T) {
 		setup(t)
 		mockConfigHandler := config.NewMockConfigHandler()
 		mockConfigHandler.LoadConfigFunc = func() error {
-			return nil
-		}
-		mockConfigHandler.InitializeFunc = func() error {
 			return nil
 		}
 		mockConfigHandler.GetContextFunc = func() string {

--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -8,9 +8,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/windsorcli/cli/pkg/di"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
-	"github.com/windsorcli/cli/pkg/di"
 )
 
 func TestContextCmd(t *testing.T) {
@@ -196,9 +196,6 @@ func TestContextCmd_ErrorScenarios(t *testing.T) {
 		mockShell.GetProjectRootFunc = func() (string, error) {
 			return "", fmt.Errorf("project root error")
 		}
-		mockShell.InitializeFunc = func() error {
-			return nil
-		}
 		injector.Register("shell", mockShell)
 		ctx := context.WithValue(context.Background(), injectorKey, injector)
 		rootCmd.SetContext(ctx)
@@ -223,9 +220,6 @@ func TestContextCmd_ErrorScenarios(t *testing.T) {
 		mockConfigHandler.LoadConfigFunc = func() error {
 			return fmt.Errorf("config load failed")
 		}
-		mockConfigHandler.InitializeFunc = func() error {
-			return nil
-		}
 		mockConfigHandler.GetContextFunc = func() string {
 			return "test-context"
 		}
@@ -234,9 +228,6 @@ func TestContextCmd_ErrorScenarios(t *testing.T) {
 		mockShell := shell.NewMockShell()
 		mockShell.GetProjectRootFunc = func() (string, error) {
 			return t.TempDir(), nil
-		}
-		mockShell.InitializeFunc = func() error {
-			return nil
 		}
 		injector.Register("shell", mockShell)
 
@@ -263,9 +254,6 @@ func TestContextCmd_ErrorScenarios(t *testing.T) {
 		mockShell.GetProjectRootFunc = func() (string, error) {
 			return "", fmt.Errorf("project root error")
 		}
-		mockShell.InitializeFunc = func() error {
-			return nil
-		}
 		injector.Register("shell", mockShell)
 		ctx := context.WithValue(context.Background(), injectorKey, injector)
 		rootCmd.SetContext(ctx)
@@ -290,9 +278,6 @@ func TestContextCmd_ErrorScenarios(t *testing.T) {
 		mockConfigHandler.LoadConfigFunc = func() error {
 			return fmt.Errorf("config load failed")
 		}
-		mockConfigHandler.InitializeFunc = func() error {
-			return nil
-		}
 		mockConfigHandler.GetContextFunc = func() string {
 			return "test-context"
 		}
@@ -301,9 +286,6 @@ func TestContextCmd_ErrorScenarios(t *testing.T) {
 		mockShell := shell.NewMockShell()
 		mockShell.GetProjectRootFunc = func() (string, error) {
 			return t.TempDir(), nil
-		}
-		mockShell.InitializeFunc = func() error {
-			return nil
 		}
 		injector.Register("shell", mockShell)
 
@@ -352,9 +334,6 @@ func TestContextCmd_ErrorScenarios(t *testing.T) {
 		mockConfigHandler.LoadConfigFunc = func() error {
 			return nil
 		}
-		mockConfigHandler.InitializeFunc = func() error {
-			return nil
-		}
 		mockConfigHandler.GetContextFunc = func() string {
 			return "test-context"
 		}
@@ -369,9 +348,6 @@ func TestContextCmd_ErrorScenarios(t *testing.T) {
 		}
 		mockShell.WriteResetTokenFunc = func() (string, error) {
 			return "mock-reset-token", nil
-		}
-		mockShell.InitializeFunc = func() error {
-			return nil
 		}
 		injector.Register("shell", mockShell)
 

--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -8,10 +8,10 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/windsorcli/cli/pkg/di"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	"github.com/windsorcli/cli/pkg/runtime/env"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
-	"github.com/windsorcli/cli/pkg/di"
 )
 
 // TestEnvCmd tests the Windsor CLI 'env' command for correct environment variable output and error handling across success and decrypt scenarios.
@@ -242,9 +242,6 @@ func TestEnvCmd_ErrorScenarios(t *testing.T) {
 		mockShell.GetProjectRootFunc = func() (string, error) {
 			return "", fmt.Errorf("project root error")
 		}
-		mockShell.InitializeFunc = func() error {
-			return nil
-		}
 		injector.Register("shell", mockShell)
 		ctx := context.WithValue(context.Background(), injectorKey, injector)
 		rootCmd.SetContext(ctx)
@@ -336,9 +333,6 @@ func TestEnvCmd_ErrorScenarios(t *testing.T) {
 		mockConfigHandler.LoadConfigFunc = func() error {
 			return fmt.Errorf("config load failed")
 		}
-		mockConfigHandler.InitializeFunc = func() error {
-			return nil
-		}
 		mockConfigHandler.GetContextFunc = func() string {
 			return "test-context"
 		}
@@ -353,9 +347,6 @@ func TestEnvCmd_ErrorScenarios(t *testing.T) {
 		}
 		mockShell.CheckResetFlagsFunc = func() (bool, error) {
 			return false, nil
-		}
-		mockShell.InitializeFunc = func() error {
-			return nil
 		}
 		injector.Register("shell", mockShell)
 
@@ -498,9 +489,6 @@ func TestEnvCmd_ErrorScenarios(t *testing.T) {
 				return defaultValue[0]
 			}
 			return ""
-		}
-		mockConfigHandler.InitializeFunc = func() error {
-			return nil
 		}
 		mockConfigHandler.LoadConfigFunc = func() error {
 			return nil

--- a/cmd/exec_test.go
+++ b/cmd/exec_test.go
@@ -8,10 +8,10 @@ import (
 	"testing"
 
 	"github.com/spf13/cobra"
+	"github.com/windsorcli/cli/pkg/di"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	"github.com/windsorcli/cli/pkg/runtime/env"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
-	"github.com/windsorcli/cli/pkg/di"
 )
 
 func TestExecCmd(t *testing.T) {
@@ -158,9 +158,6 @@ func TestExecCmd_ErrorScenarios(t *testing.T) {
 		mockShell.GetProjectRootFunc = func() (string, error) {
 			return "", fmt.Errorf("project root error")
 		}
-		mockShell.InitializeFunc = func() error {
-			return nil
-		}
 		injector.Register("shell", mockShell)
 		ctx := context.WithValue(context.Background(), injectorKey, injector)
 		rootCmd.SetContext(ctx)
@@ -253,9 +250,6 @@ func TestExecCmd_ErrorScenarios(t *testing.T) {
 		mockConfigHandler.LoadConfigFunc = func() error {
 			return fmt.Errorf("config load failed")
 		}
-		mockConfigHandler.InitializeFunc = func() error {
-			return nil
-		}
 		mockConfigHandler.GetContextFunc = func() string {
 			return "test-context"
 		}
@@ -270,9 +264,6 @@ func TestExecCmd_ErrorScenarios(t *testing.T) {
 		}
 		mockShell.CheckResetFlagsFunc = func() (bool, error) {
 			return false, nil
-		}
-		mockShell.InitializeFunc = func() error {
-			return nil
 		}
 		injector.Register("shell", mockShell)
 
@@ -304,9 +295,6 @@ func TestExecCmd_ErrorScenarios(t *testing.T) {
 		verbose = false
 		mockConfigHandler := config.NewMockConfigHandler()
 		mockConfigHandler.LoadConfigFunc = func() error {
-			return nil
-		}
-		mockConfigHandler.InitializeFunc = func() error {
 			return nil
 		}
 		mockConfigHandler.GetContextFunc = func() string {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -14,12 +14,12 @@ import (
 
 	"github.com/spf13/cobra"
 	blueprintpkg "github.com/windsorcli/cli/pkg/composer/blueprint"
+	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/provisioner/kubernetes"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	envvars "github.com/windsorcli/cli/pkg/runtime/env"
 	"github.com/windsorcli/cli/pkg/runtime/secrets"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
-	"github.com/windsorcli/cli/pkg/di"
-	"github.com/windsorcli/cli/pkg/provisioner/kubernetes"
 )
 
 // =============================================================================
@@ -147,7 +147,7 @@ func setupMocks(t *testing.T, opts ...*SetupOptions) *Mocks {
 	// Create config handler
 	var configHandler config.ConfigHandler
 	if options.ConfigHandler == nil {
-		configHandler = config.NewConfigHandler(injector)
+		configHandler = config.NewConfigHandler(mockShell)
 	} else {
 		configHandler = options.ConfigHandler
 		// If it's a mock config handler, set GetConfigRootFunc to use tmpDir
@@ -162,11 +162,6 @@ func setupMocks(t *testing.T, opts ...*SetupOptions) *Mocks {
 
 	// Register config handler
 	injector.Register("configHandler", configHandler)
-
-	// Initialize config handler
-	if err := configHandler.Initialize(); err != nil {
-		t.Fatalf("Failed to initialize config handler: %v", err)
-	}
 
 	// Load config if ConfigStr is provided
 	if options.ConfigStr != "" {

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -49,7 +49,6 @@ func setupUpTest(t *testing.T, opts ...*SetupOptions) *UpMocks {
 
 	// Create mock config handler to control IsDevMode
 	mockConfigHandler := config.NewMockConfigHandler()
-	mockConfigHandler.InitializeFunc = func() error { return nil }
 	mockConfigHandler.GetContextFunc = func() string { return "test-context" }
 	mockConfigHandler.IsDevModeFunc = func(contextName string) bool { return false }
 	mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
@@ -112,7 +111,7 @@ func setupUpTest(t *testing.T, opts ...*SetupOptions) *UpMocks {
 	baseMocks.Injector.Register("kubernetesManager", mockKubernetesManager)
 
 	// Add terraform env printer (required by terraform stack)
-	terraformEnvPrinter := envvars.NewTerraformEnvPrinter(baseMocks.Injector)
+	terraformEnvPrinter := envvars.NewTerraformEnvPrinter(baseMocks.Shell, baseMocks.ConfigHandler)
 	baseMocks.Injector.Register("terraformEnv", terraformEnvPrinter)
 
 	// Add mock tools manager (required by runInit)

--- a/pkg/composer/blueprint/blueprint_handler_public_test.go
+++ b/pkg/composer/blueprint/blueprint_handler_public_test.go
@@ -412,7 +412,6 @@ contexts:
           - ${WINDSOR_PROJECT_ROOT}/.volumes:/var/local
 `
 
-	configHandler.Initialize()
 	configHandler.SetContext("mock-context")
 
 	if err := configHandler.LoadConfigString(defaultConfigStr); err != nil {
@@ -933,7 +932,7 @@ func TestBlueprintHandler_GetLocalTemplateData(t *testing.T) {
 
 		baseHandler.shims.ReadDir = func(path string) ([]os.DirEntry, error) {
 			if path == templateDir {
-			return nil, fmt.Errorf("failed to read directory")
+				return nil, fmt.Errorf("failed to read directory")
 			}
 			return nil, os.ErrNotExist
 		}

--- a/pkg/composer/terraform/module_resolver_test.go
+++ b/pkg/composer/terraform/module_resolver_test.go
@@ -79,13 +79,10 @@ func setupMocks(t *testing.T, opts ...*SetupOptions) *Mocks {
 	if len(opts) > 0 && opts[0].ConfigHandler != nil {
 		configHandler = opts[0].ConfigHandler
 	} else {
-		configHandler = config.NewConfigHandler(injector)
+		configHandler = config.NewConfigHandler(mockShell)
 	}
 	injector.Register("configHandler", configHandler)
 
-	if err := configHandler.Initialize(); err != nil {
-		t.Fatalf("Failed to initialize config handler: %v", err)
-	}
 	configHandler.SetContext("mock-context")
 
 	defaultConfigStr := `

--- a/pkg/runtime/config/config_handler_private_test.go
+++ b/pkg/runtime/config/config_handler_private_test.go
@@ -25,8 +25,7 @@ func setupPrivateTestHandler(t *testing.T) (*configHandler, string) {
 	}
 	injector.Register("shell", mockShell)
 
-	handler := NewConfigHandler(injector).(*configHandler)
-	handler.Initialize()
+	handler := NewConfigHandler(mockShell).(*configHandler)
 
 	return handler, tmpDir
 }

--- a/pkg/runtime/config/mock_config_handler.go
+++ b/pkg/runtime/config/mock_config_handler.go
@@ -9,7 +9,6 @@ import (
 
 // MockConfigHandler is a mock implementation of the ConfigHandler interface
 type MockConfigHandler struct {
-	InitializeFunc          func() error
 	LoadConfigFunc          func() error
 	LoadConfigStringFunc    func(content string) error
 	IsLoadedFunc            func() bool
@@ -46,14 +45,6 @@ func NewMockConfigHandler() *MockConfigHandler {
 // =============================================================================
 // Public Methods
 // =============================================================================
-
-// Initialize calls the mock InitializeFunc if set, otherwise returns nil
-func (m *MockConfigHandler) Initialize() error {
-	if m.InitializeFunc != nil {
-		return m.InitializeFunc()
-	}
-	return nil
-}
 
 // LoadConfig calls the mock LoadConfigFunc if set, otherwise returns nil
 func (m *MockConfigHandler) LoadConfig() error {

--- a/pkg/runtime/config/mock_config_handler_test.go
+++ b/pkg/runtime/config/mock_config_handler_test.go
@@ -48,54 +48,15 @@ func TestMockConfigHandler_NewMockConfigHandler(t *testing.T) {
 	})
 }
 
-// TestMockConfigHandler_Initialize tests the Initialize method of MockConfigHandler
-func TestMockConfigHandler_Initialize(t *testing.T) {
-	t.Run("Success", func(t *testing.T) {
-		// Given a mock config handler with InitializeFunc set
-		mockConfigHandler := setupMockConfigHandlerMocks(t)
-		mockConfigHandler.InitializeFunc = func() error {
-			return nil
-		}
-
-		// When calling Initialize
-		err := mockConfigHandler.Initialize()
-
-		// Then no error should be returned
-		if err != nil {
-			t.Errorf("Expected no error, got %v", err)
-		}
-	})
-
-	t.Run("Error", func(t *testing.T) {
-		// Given a mock config handler with InitializeFunc set to return an error
-		mockConfigHandler := setupMockConfigHandlerMocks(t)
-		expectedError := fmt.Errorf("mock initialize error")
-		mockConfigHandler.InitializeFunc = func() error {
-			return expectedError
-		}
-
-		// When calling Initialize
-		err := mockConfigHandler.Initialize()
-
-		// Then the expected error should be returned
-		if err == nil {
-			t.Error("Expected error, got nil")
-		}
-		if err.Error() != expectedError.Error() {
-			t.Errorf("Expected error %v, got %v", expectedError, err)
-		}
-	})
-
-	t.Run("NotImplemented", func(t *testing.T) {
-		// Given a mock config handler with InitializeFunc not set
+// TestMockConfigHandler tests that MockConfigHandler implements ConfigHandler interface
+func TestMockConfigHandler(t *testing.T) {
+	t.Run("ImplementsInterface", func(t *testing.T) {
+		// Given a mock config handler
 		mockConfigHandler := setupMockConfigHandlerMocks(t)
 
-		// When calling Initialize
-		err := mockConfigHandler.Initialize()
-
-		// Then no error should be returned (default implementation)
-		if err != nil {
-			t.Errorf("Expected no error, got %v", err)
+		// Then it should implement ConfigHandler
+		if mockConfigHandler == nil {
+			t.Error("Expected mock config handler to be created")
 		}
 	})
 }

--- a/pkg/runtime/env/aws_env.go
+++ b/pkg/runtime/env/aws_env.go
@@ -10,7 +10,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/runtime/config"
+	"github.com/windsorcli/cli/pkg/runtime/shell"
 )
 
 // =============================================================================
@@ -27,9 +28,9 @@ type AwsEnvPrinter struct {
 // =============================================================================
 
 // NewAwsEnvPrinter creates a new AwsEnvPrinter instance
-func NewAwsEnvPrinter(injector di.Injector) *AwsEnvPrinter {
+func NewAwsEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler) *AwsEnvPrinter {
 	return &AwsEnvPrinter{
-		BaseEnvPrinter: *NewBaseEnvPrinter(injector),
+		BaseEnvPrinter: *NewBaseEnvPrinter(shell, configHandler),
 	}
 }
 

--- a/pkg/runtime/env/aws_env_test.go
+++ b/pkg/runtime/env/aws_env_test.go
@@ -62,9 +62,7 @@ contexts:
 		ConfigHandler: mockConfigHandler,
 	})
 
-	if err := mocks.ConfigHandler.Initialize(); err != nil {
-		t.Fatalf("Failed to initialize config handler: %v", err)
-	}
+	// ConfigHandler is now fully initialized in constructor
 	if err := mocks.ConfigHandler.SetContext("test-context"); err != nil {
 		t.Fatalf("Failed to set context: %v", err)
 	}
@@ -88,10 +86,7 @@ contexts:
 func TestAwsEnv_GetEnvVars(t *testing.T) {
 	setup := func() (*AwsEnvPrinter, *Mocks) {
 		mocks := setupAwsEnvMocks(t)
-		env := NewAwsEnvPrinter(mocks.Injector)
-		if err := env.Initialize(); err != nil {
-			t.Fatalf("Failed to initialize env: %v", err)
-		}
+		env := NewAwsEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		env.shims = mocks.Shims
 		return env, mocks
 	}
@@ -150,10 +145,7 @@ contexts:
   test-context: {}
 `,
 		})
-		env := NewAwsEnvPrinter(mocks.Injector)
-		if err := env.Initialize(); err != nil {
-			t.Fatalf("Failed to initialize env: %v", err)
-		}
+		env := NewAwsEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 
 		_, err := env.GetEnvVars()
 		if err == nil {
@@ -181,10 +173,7 @@ contexts:
 			return "", fmt.Errorf("error retrieving configuration root directory")
 		}
 
-		env := NewAwsEnvPrinter(mocks.Injector)
-		if err := env.Initialize(); err != nil {
-			t.Fatalf("Failed to initialize env: %v", err)
-		}
+		env := NewAwsEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 
 		_, err := env.GetEnvVars()
 		if err == nil {

--- a/pkg/runtime/env/azure_env.go
+++ b/pkg/runtime/env/azure_env.go
@@ -9,7 +9,8 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/runtime/config"
+	"github.com/windsorcli/cli/pkg/runtime/shell"
 )
 
 // =============================================================================
@@ -26,9 +27,9 @@ type AzureEnvPrinter struct {
 // =============================================================================
 
 // NewAzureEnvPrinter creates a new AzureEnvPrinter instance
-func NewAzureEnvPrinter(injector di.Injector) *AzureEnvPrinter {
+func NewAzureEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler) *AzureEnvPrinter {
 	return &AzureEnvPrinter{
-		BaseEnvPrinter: *NewBaseEnvPrinter(injector),
+		BaseEnvPrinter: *NewBaseEnvPrinter(shell, configHandler),
 	}
 }
 

--- a/pkg/runtime/env/azure_env_test.go
+++ b/pkg/runtime/env/azure_env_test.go
@@ -55,10 +55,7 @@ func TestAzureEnv_GetEnvVars(t *testing.T) {
 	setup := func(t *testing.T, opts ...*SetupOptions) (*AzureEnvPrinter, *Mocks) {
 		t.Helper()
 		mocks := setupAzureEnvMocks(t, opts...)
-		printer := NewAzureEnvPrinter(mocks.Injector)
-		if err := printer.Initialize(); err != nil {
-			t.Fatalf("Failed to initialize env: %v", err)
-		}
+		printer := NewAzureEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		printer.shims = mocks.Shims
 		return printer, mocks
 	}
@@ -93,11 +90,7 @@ func TestAzureEnv_GetEnvVars(t *testing.T) {
 		mocks := setupAzureEnvMocks(t, &SetupOptions{
 			ConfigHandler: mockConfigHandler,
 		})
-		printer := NewAzureEnvPrinter(mocks.Injector)
-		if err := printer.Initialize(); err != nil {
-			t.Fatalf("Failed to initialize env: %v", err)
-		}
-		printer.shims = mocks.Shims
+		printer := NewAzureEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		_, err := printer.GetEnvVars()
 		if err == nil {
 			t.Error("Expected error, got nil")

--- a/pkg/runtime/env/docker_env.go
+++ b/pkg/runtime/env/docker_env.go
@@ -11,7 +11,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/runtime/config"
+	"github.com/windsorcli/cli/pkg/runtime/shell"
 )
 
 // =============================================================================
@@ -28,9 +29,9 @@ type DockerEnvPrinter struct {
 // =============================================================================
 
 // NewDockerEnvPrinter creates a new DockerEnvPrinter instance
-func NewDockerEnvPrinter(injector di.Injector) *DockerEnvPrinter {
+func NewDockerEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler) *DockerEnvPrinter {
 	return &DockerEnvPrinter{
-		BaseEnvPrinter: *NewBaseEnvPrinter(injector),
+		BaseEnvPrinter: *NewBaseEnvPrinter(shell, configHandler),
 	}
 }
 

--- a/pkg/runtime/env/docker_env_test.go
+++ b/pkg/runtime/env/docker_env_test.go
@@ -83,9 +83,8 @@ contexts:
 `,
 		})
 
-		printer := NewDockerEnvPrinter(mocks.Injector)
+		printer := NewDockerEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		printer.shims = mocks.Shims
-		printer.Initialize()
 
 		// When getting environment variables
 		envVars, err := printer.GetEnvVars()
@@ -136,9 +135,8 @@ contexts:
 `,
 		})
 
-		printer := NewDockerEnvPrinter(mocks.Injector)
+		printer := NewDockerEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		printer.shims = mocks.Shims
-		printer.Initialize()
 
 		// When getting environment variables
 		envVars, err := printer.GetEnvVars()
@@ -211,9 +209,8 @@ contexts:
 			return nil
 		}
 
-		printer := NewDockerEnvPrinter(mocks.Injector)
+		printer := NewDockerEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		printer.shims = mocks.Shims
-		printer.Initialize()
 
 		// When getting environment variables
 		envVars, err := printer.GetEnvVars()
@@ -279,9 +276,8 @@ contexts:
 `,
 		})
 
-		printer := NewDockerEnvPrinter(mocks.Injector)
+		printer := NewDockerEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		printer.shims = mocks.Shims
-		printer.Initialize()
 
 		// When getting environment variables
 		envVars, err := printer.GetEnvVars()
@@ -319,9 +315,8 @@ contexts:
 			return "", errors.New("mock user home dir error")
 		}
 
-		printer := NewDockerEnvPrinter(mocks.Injector)
+		printer := NewDockerEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		printer.shims = mocks.Shims
-		printer.Initialize()
 
 		// When getting environment variables
 		_, err := printer.GetEnvVars()
@@ -344,9 +339,8 @@ contexts:
 			return errors.New("mock mkdirAll error")
 		}
 
-		printer := NewDockerEnvPrinter(mocks.Injector)
+		printer := NewDockerEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		printer.shims = mocks.Shims
-		printer.Initialize()
 
 		// When getting environment variables
 		_, err := printer.GetEnvVars()
@@ -369,9 +363,8 @@ contexts:
 			return errors.New("mock writeFile error")
 		}
 
-		printer := NewDockerEnvPrinter(mocks.Injector)
+		printer := NewDockerEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		printer.shims = mocks.Shims
-		printer.Initialize()
 
 		// When getting environment variables
 		_, err := printer.GetEnvVars()
@@ -429,9 +422,8 @@ contexts:
 					return tc.os
 				}
 
-				printer := NewDockerEnvPrinter(mocks.Injector)
+				printer := NewDockerEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 				printer.shims = mocks.Shims
-				printer.Initialize()
 
 				// When getting environment variables
 				envVars, err := printer.GetEnvVars()
@@ -475,9 +467,8 @@ contexts:
 			return "", false
 		}
 
-		printer := NewDockerEnvPrinter(mocks.Injector)
+		printer := NewDockerEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		printer.shims = mocks.Shims
-		printer.Initialize()
 
 		// When getting environment variables
 		envVars, err := printer.GetEnvVars()
@@ -514,9 +505,8 @@ contexts:
 			return "", false
 		}
 
-		printer := NewDockerEnvPrinter(mocks.Injector)
+		printer := NewDockerEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		printer.shims = mocks.Shims
-		printer.Initialize()
 
 		// When getting environment variables
 		envVars, err := printer.GetEnvVars()
@@ -561,9 +551,8 @@ contexts:
 			return "", false
 		}
 
-		printer := NewDockerEnvPrinter(mocks.Injector)
+		printer := NewDockerEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		printer.shims = mocks.Shims
-		printer.Initialize()
 
 		// When getting environment variables
 		envVars, err := printer.GetEnvVars()
@@ -594,9 +583,8 @@ func TestDockerEnvPrinter_GetAlias(t *testing.T) {
 			return "", fmt.Errorf("not found")
 		}
 
-		printer := NewDockerEnvPrinter(mocks.Injector)
+		printer := NewDockerEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		printer.shims = mocks.Shims
-		printer.Initialize()
 
 		// When getting aliases
 		aliasMap, err := printer.GetAlias()
@@ -620,9 +608,8 @@ func TestDockerEnvPrinter_GetAlias(t *testing.T) {
 			return "", fmt.Errorf("not found")
 		}
 
-		printer := NewDockerEnvPrinter(mocks.Injector)
+		printer := NewDockerEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		printer.shims = mocks.Shims
-		printer.Initialize()
 
 		// When getting aliases
 		aliasMap, err := printer.GetAlias()
@@ -645,11 +632,8 @@ func TestDockerEnvPrinter_getRegistryURL(t *testing.T) {
 	setup := func(t *testing.T, opts ...*SetupOptions) (*DockerEnvPrinter, *Mocks) {
 		t.Helper()
 		mocks := setupDockerEnvMocks(t, opts...)
-		printer := NewDockerEnvPrinter(mocks.Injector)
+		printer := NewDockerEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		printer.shims = mocks.Shims
-		if err := printer.Initialize(); err != nil {
-			t.Fatalf("Failed to initialize printer: %v", err)
-		}
 		return printer, mocks
 	}
 

--- a/pkg/runtime/env/env.go
+++ b/pkg/runtime/env/env.go
@@ -6,12 +6,10 @@
 package env
 
 import (
-	"fmt"
 	"slices"
 
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
-	"github.com/windsorcli/cli/pkg/di"
 )
 
 // =============================================================================
@@ -20,7 +18,6 @@ import (
 
 // EnvPrinter defines the method for printing environment variables.
 type EnvPrinter interface {
-	Initialize() error
 	GetEnvVars() (map[string]string, error)
 	GetAlias() (map[string]string, error)
 	PostEnvHook(directory ...string) error
@@ -34,7 +31,6 @@ type EnvPrinter interface {
 // BaseEnvPrinter is a base implementation of the EnvPrinter interface
 type BaseEnvPrinter struct {
 	EnvPrinter
-	injector      di.Injector
 	shell         shell.Shell
 	configHandler config.ConfigHandler
 	shims         *Shims
@@ -47,32 +43,12 @@ type BaseEnvPrinter struct {
 // =============================================================================
 
 // NewBaseEnvPrinter creates a new BaseEnvPrinter instance
-func NewBaseEnvPrinter(injector di.Injector) *BaseEnvPrinter {
+func NewBaseEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler) *BaseEnvPrinter {
 	return &BaseEnvPrinter{
-		injector: injector,
-		shims:    NewShims(),
+		shell:         shell,
+		configHandler: configHandler,
+		shims:         NewShims(),
 	}
-}
-
-// =============================================================================
-// Public Methods
-// =============================================================================
-
-// Initialize resolves and assigns the shell and configHandler from the injector.
-func (e *BaseEnvPrinter) Initialize() error {
-	shell, ok := e.injector.Resolve("shell").(shell.Shell)
-	if !ok {
-		return fmt.Errorf("error resolving or casting shell to shell.Shell")
-	}
-	e.shell = shell
-
-	configInterface, ok := e.injector.Resolve("configHandler").(config.ConfigHandler)
-	if !ok {
-		return fmt.Errorf("error resolving or casting configHandler to config.ConfigHandler")
-	}
-	e.configHandler = configInterface
-
-	return nil
 }
 
 // GetEnvVars is a placeholder for retrieving environment variables.

--- a/pkg/runtime/env/kube_env.go
+++ b/pkg/runtime/env/kube_env.go
@@ -14,7 +14,8 @@ import (
 	"strings"
 
 	"github.com/windsorcli/cli/pkg/constants"
-	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/runtime/config"
+	"github.com/windsorcli/cli/pkg/runtime/shell"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -35,9 +36,9 @@ type KubeEnvPrinter struct {
 // =============================================================================
 
 // NewKubeEnvPrinter creates a new KubeEnvPrinter instance
-func NewKubeEnvPrinter(injector di.Injector) *KubeEnvPrinter {
+func NewKubeEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler) *KubeEnvPrinter {
 	return &KubeEnvPrinter{
-		BaseEnvPrinter: *NewBaseEnvPrinter(injector),
+		BaseEnvPrinter: *NewBaseEnvPrinter(shell, configHandler),
 	}
 }
 

--- a/pkg/runtime/env/kube_env_test.go
+++ b/pkg/runtime/env/kube_env_test.go
@@ -108,10 +108,7 @@ func TestKubeEnvPrinter_GetEnvVars(t *testing.T) {
 	setup := func(t *testing.T) (*KubeEnvPrinter, *Mocks) {
 		t.Helper()
 		mocks := setupKubeEnvMocks(t)
-		printer := NewKubeEnvPrinter(mocks.Injector)
-		if err := printer.Initialize(); err != nil {
-			t.Fatalf("Failed to initialize printer: %v", err)
-		}
+		printer := NewKubeEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		printer.shims = mocks.Shims
 		return printer, mocks
 	}
@@ -209,11 +206,8 @@ func TestKubeEnvPrinter_GetEnvVars(t *testing.T) {
 
 		// And a KubeEnvPrinter with the mock ConfigHandler
 		mocks := setupKubeEnvMocks(t, &SetupOptions{ConfigHandler: mockConfigHandler})
-		printer := NewKubeEnvPrinter(mocks.Injector)
+		printer := NewKubeEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		printer.shims = mocks.Shims
-		if err := printer.Initialize(); err != nil {
-			t.Fatalf("Failed to initialize printer: %v", err)
-		}
 
 		// When getting environment variables
 		envVars, err := printer.GetEnvVars()

--- a/pkg/runtime/env/talos_env.go
+++ b/pkg/runtime/env/talos_env.go
@@ -4,7 +4,8 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/runtime/config"
+	"github.com/windsorcli/cli/pkg/runtime/shell"
 )
 
 // =============================================================================
@@ -21,10 +22,10 @@ type TalosEnvPrinter struct {
 // Constructor
 // =============================================================================
 
-// NewTalosEnvPrinter creates and returns a new TalosEnvPrinter instance using the provided injector.
-func NewTalosEnvPrinter(injector di.Injector) *TalosEnvPrinter {
+// NewTalosEnvPrinter creates and returns a new TalosEnvPrinter instance.
+func NewTalosEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler) *TalosEnvPrinter {
 	return &TalosEnvPrinter{
-		BaseEnvPrinter: *NewBaseEnvPrinter(injector),
+		BaseEnvPrinter: *NewBaseEnvPrinter(shell, configHandler),
 	}
 }
 

--- a/pkg/runtime/env/talos_env_test.go
+++ b/pkg/runtime/env/talos_env_test.go
@@ -40,10 +40,7 @@ func TestTalosEnv_GetEnvVars(t *testing.T) {
 			return filepath.Join(projectRoot, "contexts", "mock-context"), nil
 		}
 
-		printer := NewTalosEnvPrinter(mocks.Injector)
-		if err := printer.Initialize(); err != nil {
-			t.Fatalf("Failed to initialize env: %v", err)
-		}
+		printer := NewTalosEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		printer.shims = mocks.Shims
 
 		return printer, mocks

--- a/pkg/runtime/env/terraform_env.go
+++ b/pkg/runtime/env/terraform_env.go
@@ -15,7 +15,8 @@ import (
 
 	"github.com/goccy/go-yaml"
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
-	"github.com/windsorcli/cli/pkg/di"
+	"github.com/windsorcli/cli/pkg/runtime/config"
+	"github.com/windsorcli/cli/pkg/runtime/shell"
 )
 
 // =============================================================================
@@ -47,9 +48,9 @@ type TerraformEnvPrinter struct {
 // =============================================================================
 
 // NewTerraformEnvPrinter creates a new TerraformEnvPrinter instance
-func NewTerraformEnvPrinter(injector di.Injector) *TerraformEnvPrinter {
+func NewTerraformEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler) *TerraformEnvPrinter {
 	return &TerraformEnvPrinter{
-		BaseEnvPrinter: *NewBaseEnvPrinter(injector),
+		BaseEnvPrinter: *NewBaseEnvPrinter(shell, configHandler),
 	}
 }
 

--- a/pkg/runtime/env/terraform_env_test.go
+++ b/pkg/runtime/env/terraform_env_test.go
@@ -69,11 +69,8 @@ func TestTerraformEnv_GetEnvVars(t *testing.T) {
 	setup := func(t *testing.T) (*TerraformEnvPrinter, *Mocks) {
 		t.Helper()
 		mocks := setupTerraformEnvMocks(t)
-		printer := NewTerraformEnvPrinter(mocks.Injector)
+		printer := NewTerraformEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		printer.shims = mocks.Shims
-		if err := printer.Initialize(); err != nil {
-			t.Fatalf("Failed to initialize printer: %v", err)
-		}
 		return printer, mocks
 	}
 
@@ -216,11 +213,8 @@ func TestTerraformEnv_GetEnvVars(t *testing.T) {
 		mocks := setupTerraformEnvMocks(t, &SetupOptions{
 			ConfigHandler: configHandler,
 		})
-		printer := NewTerraformEnvPrinter(mocks.Injector)
+		printer := NewTerraformEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		printer.shims = mocks.Shims
-		if err := printer.Initialize(); err != nil {
-			t.Fatalf("Failed to initialize printer: %v", err)
-		}
 
 		// When GetEnvVars is called
 		_, err := printer.GetEnvVars()
@@ -344,11 +338,8 @@ func TestTerraformEnv_PostEnvHook(t *testing.T) {
 	setup := func(t *testing.T) (*TerraformEnvPrinter, *Mocks) {
 		t.Helper()
 		mocks := setupTerraformEnvMocks(t)
-		printer := NewTerraformEnvPrinter(mocks.Injector)
+		printer := NewTerraformEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		printer.shims = mocks.Shims
-		if err := printer.Initialize(); err != nil {
-			t.Fatalf("Failed to initialize printer: %v", err)
-		}
 		return printer, mocks
 	}
 
@@ -439,11 +430,8 @@ func TestTerraformEnv_findRelativeTerraformProjectPath(t *testing.T) {
 	setup := func(t *testing.T) (*TerraformEnvPrinter, *Mocks) {
 		t.Helper()
 		mocks := setupTerraformEnvMocks(t)
-		printer := NewTerraformEnvPrinter(mocks.Injector)
+		printer := NewTerraformEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		printer.shims = mocks.Shims
-		if err := printer.Initialize(); err != nil {
-			t.Fatalf("Failed to initialize printer: %v", err)
-		}
 		return printer, mocks
 	}
 
@@ -593,11 +581,8 @@ func TestTerraformEnv_generateBackendOverrideTf(t *testing.T) {
 	setup := func(t *testing.T) (*TerraformEnvPrinter, *Mocks) {
 		t.Helper()
 		mocks := setupTerraformEnvMocks(t)
-		printer := NewTerraformEnvPrinter(mocks.Injector)
+		printer := NewTerraformEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		printer.shims = mocks.Shims
-		if err := printer.Initialize(); err != nil {
-			t.Fatalf("Failed to initialize printer: %v", err)
-		}
 		return printer, mocks
 	}
 
@@ -912,11 +897,8 @@ func TestTerraformEnv_generateBackendConfigArgs(t *testing.T) {
 	setup := func(t *testing.T) (*TerraformEnvPrinter, *Mocks) {
 		t.Helper()
 		mocks := setupTerraformEnvMocks(t)
-		printer := NewTerraformEnvPrinter(mocks.Injector)
+		printer := NewTerraformEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		printer.shims = mocks.Shims
-		if err := printer.Initialize(); err != nil {
-			t.Fatalf("Failed to initialize printer: %v", err)
-		}
 		return printer, mocks
 	}
 
@@ -1173,11 +1155,8 @@ func TestTerraformEnv_processBackendConfig(t *testing.T) {
 	setup := func(t *testing.T) (*TerraformEnvPrinter, *Mocks) {
 		t.Helper()
 		mocks := setupTerraformEnvMocks(t)
-		printer := NewTerraformEnvPrinter(mocks.Injector)
+		printer := NewTerraformEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		printer.shims = mocks.Shims
-		if err := printer.Initialize(); err != nil {
-			t.Fatalf("Failed to initialize printer: %v", err)
-		}
 		return printer, mocks
 	}
 
@@ -1264,11 +1243,8 @@ func TestTerraformEnv_DependencyResolution(t *testing.T) {
 	setup := func(t *testing.T) (*TerraformEnvPrinter, *Mocks) {
 		t.Helper()
 		mocks := setupTerraformEnvMocks(t)
-		printer := NewTerraformEnvPrinter(mocks.Injector)
+		printer := NewTerraformEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		printer.shims = mocks.Shims
-		if err := printer.Initialize(); err != nil {
-			t.Fatalf("Failed to initialize printer: %v", err)
-		}
 		return printer, mocks
 	}
 
@@ -1573,11 +1549,7 @@ func TestTerraformEnv_GenerateTerraformArgs(t *testing.T) {
 		mocks := setupTerraformEnvMocks(t)
 
 		printer := &TerraformEnvPrinter{
-			BaseEnvPrinter: *NewBaseEnvPrinter(mocks.Injector),
-		}
-
-		if err := printer.Initialize(); err != nil {
-			t.Fatalf("Failed to initialize printer: %v", err)
+			BaseEnvPrinter: *NewBaseEnvPrinter(mocks.Shell, mocks.ConfigHandler),
 		}
 
 		// When generating terraform args without parallelism
@@ -1630,13 +1602,9 @@ terraform:
 		}
 
 		printer := &TerraformEnvPrinter{
-			BaseEnvPrinter: *NewBaseEnvPrinter(mocks.Injector),
+			BaseEnvPrinter: *NewBaseEnvPrinter(mocks.Shell, mocks.ConfigHandler),
 		}
 		printer.shims = mocks.Shims
-
-		if err := printer.Initialize(); err != nil {
-			t.Fatalf("Failed to initialize printer: %v", err)
-		}
 
 		// When generating terraform args with parallelism
 		args, err := printer.GenerateTerraformArgs("test/path", "test/module")
@@ -1698,11 +1666,7 @@ terraform:
 		}
 
 		printer := &TerraformEnvPrinter{
-			BaseEnvPrinter: *NewBaseEnvPrinter(mocks.Injector),
-		}
-
-		if err := printer.Initialize(); err != nil {
-			t.Fatalf("Failed to initialize printer: %v", err)
+			BaseEnvPrinter: *NewBaseEnvPrinter(mocks.Shell, mocks.ConfigHandler),
 		}
 
 		// When generating terraform args for component without parallelism
@@ -1730,12 +1694,7 @@ terraform:
 		mocks := setupTerraformEnvMocks(t)
 
 		printer := &TerraformEnvPrinter{
-			BaseEnvPrinter: *NewBaseEnvPrinter(mocks.Injector),
-		}
-
-		// Initialize with the base dependencies
-		if err := printer.BaseEnvPrinter.Initialize(); err != nil {
-			t.Fatalf("Failed to initialize base printer: %v", err)
+			BaseEnvPrinter: *NewBaseEnvPrinter(mocks.Shell, mocks.ConfigHandler),
 		}
 
 		// When generating terraform args without blueprint.yaml file
@@ -1776,13 +1735,9 @@ terraform:
 		}
 
 		printer := &TerraformEnvPrinter{
-			BaseEnvPrinter: *NewBaseEnvPrinter(mocks.Injector),
+			BaseEnvPrinter: *NewBaseEnvPrinter(mocks.Shell, mocks.ConfigHandler),
 		}
 		printer.shims = mocks.Shims
-
-		if err := printer.Initialize(); err != nil {
-			t.Fatalf("Failed to initialize printer: %v", err)
-		}
 
 		// When generating terraform args
 		args, err := printer.GenerateTerraformArgs("test/path", "test/module")

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -12,12 +12,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/windsorcli/cli/pkg/di"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	"github.com/windsorcli/cli/pkg/runtime/env"
 	"github.com/windsorcli/cli/pkg/runtime/secrets"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
 	"github.com/windsorcli/cli/pkg/runtime/tools"
-	"github.com/windsorcli/cli/pkg/di"
 )
 
 // Runtime holds common execution values and core dependencies used across the Windsor CLI.
@@ -80,83 +80,78 @@ type Runtime struct {
 // If ConfigHandler is nil, it creates one using the Injector and initializes it.
 // If Shell is nil, it creates one using the Injector and initializes it.
 // Both are registered in the Injector for use by other components.
-// The context also initializes envVars and aliases maps, and automatically sets up
+// The runtime also initializes envVars and aliases maps, and automatically sets up
 // ContextName, ProjectRoot, ConfigRoot, and TemplateRoot based on the current project state.
 // Returns the Runtime with initialized dependencies or an error if initialization fails.
-func NewRuntime(ctx *Runtime) (*Runtime, error) {
-	if ctx == nil {
+func NewRuntime(rt *Runtime) (*Runtime, error) {
+	if rt == nil {
 		return nil, fmt.Errorf("execution context is required")
 	}
-	if ctx.Injector == nil {
+	if rt.Injector == nil {
 		return nil, fmt.Errorf("injector is required")
 	}
-	injector := ctx.Injector
+	injector := rt.Injector
 
-	if ctx.Shell == nil {
+	if rt.Shell == nil {
 		if existing := injector.Resolve("shell"); existing != nil {
 			if shellInstance, ok := existing.(shell.Shell); ok {
-				ctx.Shell = shellInstance
+				rt.Shell = shellInstance
 			} else {
-				shellInstance := shell.NewDefaultShell(injector)
-				ctx.Shell = shellInstance
+				shellInstance := shell.NewDefaultShell()
+				rt.Shell = shellInstance
 				injector.Register("shell", shellInstance)
 			}
 		} else {
-			shellInstance := shell.NewDefaultShell(injector)
-			ctx.Shell = shellInstance
+			shellInstance := shell.NewDefaultShell()
+			rt.Shell = shellInstance
 			injector.Register("shell", shellInstance)
 		}
-
-		if err := ctx.Shell.Initialize(); err != nil {
-			return nil, fmt.Errorf("failed to initialize shell: %w", err)
-		}
 	}
 
-	projectRoot, err := ctx.Shell.GetProjectRoot()
+	projectRoot, err := rt.Shell.GetProjectRoot()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get project root: %w", err)
 	}
-	ctx.ProjectRoot = projectRoot
-	ctx.ConfigRoot = filepath.Join(ctx.ProjectRoot, "contexts", ctx.ContextName)
-	ctx.TemplateRoot = filepath.Join(ctx.ProjectRoot, "contexts", "_template")
+	rt.ProjectRoot = projectRoot
+	rt.ConfigRoot = filepath.Join(rt.ProjectRoot, "contexts", rt.ContextName)
+	rt.TemplateRoot = filepath.Join(rt.ProjectRoot, "contexts", "_template")
 
-	if ctx.ConfigHandler == nil {
+	if rt.ConfigHandler == nil {
+		if rt.Shell == nil {
+			return nil, fmt.Errorf("shell is required to create config handler")
+		}
 		if existing := injector.Resolve("configHandler"); existing != nil {
 			if configHandler, ok := existing.(config.ConfigHandler); ok {
-				ctx.ConfigHandler = configHandler
+				rt.ConfigHandler = configHandler
 			} else {
-				ctx.ConfigHandler = config.NewConfigHandler(injector)
-				injector.Register("configHandler", ctx.ConfigHandler)
+				rt.ConfigHandler = config.NewConfigHandler(rt.Shell)
+				injector.Register("configHandler", rt.ConfigHandler)
 			}
 		} else {
-			ctx.ConfigHandler = config.NewConfigHandler(injector)
-			injector.Register("configHandler", ctx.ConfigHandler)
-		}
-
-		if err := ctx.ConfigHandler.Initialize(); err != nil {
-			return nil, fmt.Errorf("failed to initialize config handler: %w", err)
+			rt.ConfigHandler = config.NewConfigHandler(rt.Shell)
+			injector.Register("configHandler", rt.ConfigHandler)
 		}
 	}
 
-	if ctx.envVars == nil {
-		ctx.envVars = make(map[string]string)
+	if rt.envVars == nil {
+		rt.envVars = make(map[string]string)
 	}
-	if ctx.aliases == nil {
-		ctx.aliases = make(map[string]string)
+	if rt.aliases == nil {
+		rt.aliases = make(map[string]string)
 	}
 
-	projectRoot, err = ctx.Shell.GetProjectRoot()
+	projectRoot, err = rt.Shell.GetProjectRoot()
 	if err != nil {
 		return nil, fmt.Errorf("failed to get project root: %w", err)
 	}
 
-	contextName := ctx.ConfigHandler.GetContext()
-	ctx.ContextName = contextName
-	ctx.ProjectRoot = projectRoot
-	ctx.ConfigRoot = filepath.Join(projectRoot, "contexts", contextName)
-	ctx.TemplateRoot = filepath.Join(projectRoot, "contexts", "_template")
+	contextName := rt.ConfigHandler.GetContext()
+	rt.ContextName = contextName
+	rt.ProjectRoot = projectRoot
+	rt.ConfigRoot = filepath.Join(projectRoot, "contexts", contextName)
+	rt.TemplateRoot = filepath.Join(projectRoot, "contexts", "_template")
 
-	return ctx, nil
+	return rt, nil
 }
 
 // =============================================================================
@@ -167,13 +162,13 @@ func NewRuntime(ctx *Runtime) (*Runtime, error) {
 // variables if needed. It checks for WINDSOR_SESSION_TOKEN and uses the shell's CheckResetFlags
 // method to determine if a reset should occur. If reset is needed, it calls Shell.Reset() and
 // sets NO_CACHE=true. Returns an error if Shell is not initialized or if reset flag checking fails.
-func (ctx *Runtime) HandleSessionReset() error {
-	if ctx.Shell == nil {
+func (rt *Runtime) HandleSessionReset() error {
+	if rt.Shell == nil {
 		return fmt.Errorf("shell not initialized")
 	}
 
 	hasSessionToken := os.Getenv("WINDSOR_SESSION_TOKEN") != ""
-	shouldReset, err := ctx.Shell.CheckResetFlags()
+	shouldReset, err := rt.Shell.CheckResetFlags()
 	if err != nil {
 		return fmt.Errorf("failed to check reset flags: %w", err)
 	}
@@ -182,7 +177,7 @@ func (ctx *Runtime) HandleSessionReset() error {
 	}
 
 	if shouldReset {
-		ctx.Shell.Reset()
+		rt.Shell.Reset()
 		if err := os.Setenv("NO_CACHE", "true"); err != nil {
 			return fmt.Errorf("failed to set NO_CACHE: %w", err)
 		}
@@ -196,21 +191,21 @@ func (ctx *Runtime) HandleSessionReset() error {
 // secrets if requested, and aggregates all environment variables and aliases into the Runtime
 // instance. Returns an error if any required dependency is missing or if any step fails. This method
 // expects the ConfigHandler to be set before invocation.
-func (ctx *Runtime) LoadEnvironment(decrypt bool) error {
-	if ctx.ConfigHandler == nil {
+func (rt *Runtime) LoadEnvironment(decrypt bool) error {
+	if rt.ConfigHandler == nil {
 		return fmt.Errorf("config handler not loaded")
 	}
 
-	ctx.initializeEnvPrinters()
-	ctx.initializeToolsManager()
-	ctx.initializeSecretsProviders()
+	rt.initializeEnvPrinters()
+	rt.initializeToolsManager()
+	rt.initializeSecretsProviders()
 
-	if err := ctx.initializeComponents(); err != nil {
+	if err := rt.initializeComponents(); err != nil {
 		return fmt.Errorf("failed to initialize environment components: %w", err)
 	}
 
 	if decrypt {
-		if err := ctx.loadSecrets(); err != nil {
+		if err := rt.loadSecrets(); err != nil {
 			return fmt.Errorf("failed to load secrets: %w", err)
 		}
 	}
@@ -218,7 +213,7 @@ func (ctx *Runtime) LoadEnvironment(decrypt bool) error {
 	allEnvVars := make(map[string]string)
 	allAliases := make(map[string]string)
 
-	for _, printer := range ctx.getAllEnvPrinters() {
+	for _, printer := range rt.getAllEnvPrinters() {
 		if printer != nil {
 			envVars, err := printer.GetEnvVars()
 			if err != nil {
@@ -234,8 +229,8 @@ func (ctx *Runtime) LoadEnvironment(decrypt bool) error {
 		}
 	}
 
-	ctx.envVars = allEnvVars
-	ctx.aliases = allAliases
+	rt.envVars = allEnvVars
+	rt.aliases = allAliases
 
 	for key, value := range allEnvVars {
 		if err := os.Setenv(key, value); err != nil {
@@ -244,7 +239,7 @@ func (ctx *Runtime) LoadEnvironment(decrypt bool) error {
 	}
 
 	var firstError error
-	for _, printer := range ctx.getAllEnvPrinters() {
+	for _, printer := range rt.getAllEnvPrinters() {
 		if printer != nil {
 			if err := printer.PostEnvHook(); err != nil && firstError == nil {
 				firstError = err
@@ -259,18 +254,17 @@ func (ctx *Runtime) LoadEnvironment(decrypt bool) error {
 	return nil
 }
 
-
 // GetEnvVars returns a copy of the collected environment variables.
-func (ctx *Runtime) GetEnvVars() map[string]string {
+func (rt *Runtime) GetEnvVars() map[string]string {
 	result := make(map[string]string)
-	maps.Copy(result, ctx.envVars)
+	maps.Copy(result, rt.envVars)
 	return result
 }
 
 // GetAliases returns a copy of the collected aliases.
-func (ctx *Runtime) GetAliases() map[string]string {
+func (rt *Runtime) GetAliases() map[string]string {
 	result := make(map[string]string)
-	maps.Copy(result, ctx.aliases)
+	maps.Copy(result, rt.aliases)
 	return result
 }
 
@@ -278,18 +272,15 @@ func (ctx *Runtime) GetAliases() map[string]string {
 // It validates that all required tools are installed and meet minimum version requirements.
 // The tools manager must be initialized before calling this method. Returns an error if
 // the tools manager is not available or if tool checking fails.
-func (ctx *Runtime) CheckTools() error {
-	if ctx.ToolsManager == nil {
-		ctx.initializeToolsManager()
-		if ctx.ToolsManager == nil {
+func (rt *Runtime) CheckTools() error {
+	if rt.ToolsManager == nil {
+		rt.initializeToolsManager()
+		if rt.ToolsManager == nil {
 			return fmt.Errorf("tools manager not available")
-		}
-		if err := ctx.ToolsManager.Initialize(); err != nil {
-			return fmt.Errorf("failed to initialize tools manager: %w", err)
 		}
 	}
 
-	if err := ctx.ToolsManager.Check(); err != nil {
+	if err := rt.ToolsManager.Check(); err != nil {
 		return fmt.Errorf("error checking tools: %w", err)
 	}
 
@@ -299,8 +290,8 @@ func (ctx *Runtime) CheckTools() error {
 // GetBuildID retrieves the current build ID from the .windsor/.build-id file.
 // If no build ID exists, a new one is generated, persisted, and returned.
 // Returns the build ID string or an error if retrieval or persistence fails.
-func (ctx *Runtime) GetBuildID() (string, error) {
-	projectRoot := ctx.ProjectRoot
+func (rt *Runtime) GetBuildID() (string, error) {
+	projectRoot := rt.ProjectRoot
 
 	if err := os.MkdirAll(projectRoot, 0750); err != nil {
 		return "", fmt.Errorf("failed to create project root directory: %w", err)
@@ -327,11 +318,11 @@ func (ctx *Runtime) GetBuildID() (string, error) {
 	}
 
 	if buildID == "" {
-		newBuildID, err := ctx.generateBuildID()
+		newBuildID, err := rt.generateBuildID()
 		if err != nil {
 			return "", fmt.Errorf("failed to generate build ID: %w", err)
 		}
-		if err := ctx.writeBuildIDToFile(newBuildID); err != nil {
+		if err := rt.writeBuildIDToFile(newBuildID); err != nil {
 			return "", fmt.Errorf("failed to set build ID: %w", err)
 		}
 		return newBuildID, nil
@@ -342,13 +333,13 @@ func (ctx *Runtime) GetBuildID() (string, error) {
 
 // GenerateBuildID generates a new build ID and persists it to the .windsor/.build-id file,
 // overwriting any existing value. Returns the new build ID or an error if generation or persistence fails.
-func (ctx *Runtime) GenerateBuildID() (string, error) {
-	newBuildID, err := ctx.generateBuildID()
+func (rt *Runtime) GenerateBuildID() (string, error) {
+	newBuildID, err := rt.generateBuildID()
 	if err != nil {
 		return "", fmt.Errorf("failed to generate build ID: %w", err)
 	}
 
-	if err := ctx.writeBuildIDToFile(newBuildID); err != nil {
+	if err := rt.writeBuildIDToFile(newBuildID); err != nil {
 		return "", fmt.Errorf("failed to set build ID: %w", err)
 	}
 
@@ -362,70 +353,82 @@ func (ctx *Runtime) GenerateBuildID() (string, error) {
 // initializeEnvPrinters initializes environment printers based on configuration settings.
 // It creates and registers the appropriate environment printers with the dependency injector
 // based on the current configuration state.
-func (ctx *Runtime) initializeEnvPrinters() {
-	if ctx.EnvPrinters.AwsEnv == nil && ctx.ConfigHandler.GetBool("aws.enabled", false) {
-		ctx.EnvPrinters.AwsEnv = env.NewAwsEnvPrinter(ctx.Injector)
-		ctx.Injector.Register("awsEnv", ctx.EnvPrinters.AwsEnv)
+func (rt *Runtime) initializeEnvPrinters() {
+	if rt.Shell == nil || rt.ConfigHandler == nil {
+		return
 	}
-	if ctx.EnvPrinters.AzureEnv == nil && ctx.ConfigHandler.GetBool("azure.enabled", false) {
-		ctx.EnvPrinters.AzureEnv = env.NewAzureEnvPrinter(ctx.Injector)
-		ctx.Injector.Register("azureEnv", ctx.EnvPrinters.AzureEnv)
+
+	if rt.EnvPrinters.AwsEnv == nil && rt.ConfigHandler.GetBool("aws.enabled", false) {
+		rt.EnvPrinters.AwsEnv = env.NewAwsEnvPrinter(rt.Shell, rt.ConfigHandler)
+		rt.Injector.Register("awsEnv", rt.EnvPrinters.AwsEnv)
 	}
-	if ctx.EnvPrinters.DockerEnv == nil && ctx.ConfigHandler.GetBool("docker.enabled", false) {
-		if existingPrinter := ctx.Injector.Resolve("dockerEnv"); existingPrinter != nil {
+	if rt.EnvPrinters.AzureEnv == nil && rt.ConfigHandler.GetBool("azure.enabled", false) {
+		rt.EnvPrinters.AzureEnv = env.NewAzureEnvPrinter(rt.Shell, rt.ConfigHandler)
+		rt.Injector.Register("azureEnv", rt.EnvPrinters.AzureEnv)
+	}
+	if rt.EnvPrinters.DockerEnv == nil && rt.ConfigHandler.GetBool("docker.enabled", false) {
+		if existingPrinter := rt.Injector.Resolve("dockerEnv"); existingPrinter != nil {
 			if printer, ok := existingPrinter.(env.EnvPrinter); ok {
-				ctx.EnvPrinters.DockerEnv = printer
+				rt.EnvPrinters.DockerEnv = printer
 			}
 		}
-		if ctx.EnvPrinters.DockerEnv == nil {
-			ctx.EnvPrinters.DockerEnv = env.NewDockerEnvPrinter(ctx.Injector)
-			ctx.Injector.Register("dockerEnv", ctx.EnvPrinters.DockerEnv)
+		if rt.EnvPrinters.DockerEnv == nil {
+			rt.EnvPrinters.DockerEnv = env.NewDockerEnvPrinter(rt.Shell, rt.ConfigHandler)
+			rt.Injector.Register("dockerEnv", rt.EnvPrinters.DockerEnv)
 		}
 	}
-	if ctx.EnvPrinters.KubeEnv == nil && ctx.ConfigHandler.GetBool("cluster.enabled", false) {
-		if existingPrinter := ctx.Injector.Resolve("kubeEnv"); existingPrinter != nil {
+	if rt.EnvPrinters.KubeEnv == nil && rt.ConfigHandler.GetBool("cluster.enabled", false) {
+		if existingPrinter := rt.Injector.Resolve("kubeEnv"); existingPrinter != nil {
 			if printer, ok := existingPrinter.(env.EnvPrinter); ok {
-				ctx.EnvPrinters.KubeEnv = printer
+				rt.EnvPrinters.KubeEnv = printer
 			}
 		}
-		if ctx.EnvPrinters.KubeEnv == nil {
-			ctx.EnvPrinters.KubeEnv = env.NewKubeEnvPrinter(ctx.Injector)
-			ctx.Injector.Register("kubeEnv", ctx.EnvPrinters.KubeEnv)
+		if rt.EnvPrinters.KubeEnv == nil {
+			rt.EnvPrinters.KubeEnv = env.NewKubeEnvPrinter(rt.Shell, rt.ConfigHandler)
+			rt.Injector.Register("kubeEnv", rt.EnvPrinters.KubeEnv)
 		}
 	}
-	if ctx.EnvPrinters.TalosEnv == nil &&
-		(ctx.ConfigHandler.GetString("cluster.driver", "") == "talos" ||
-			ctx.ConfigHandler.GetString("cluster.driver", "") == "omni") {
-		if existingPrinter := ctx.Injector.Resolve("talosEnv"); existingPrinter != nil {
+	if rt.EnvPrinters.TalosEnv == nil &&
+		(rt.ConfigHandler.GetString("cluster.driver", "") == "talos" ||
+			rt.ConfigHandler.GetString("cluster.driver", "") == "omni") {
+		if existingPrinter := rt.Injector.Resolve("talosEnv"); existingPrinter != nil {
 			if printer, ok := existingPrinter.(env.EnvPrinter); ok {
-				ctx.EnvPrinters.TalosEnv = printer
+				rt.EnvPrinters.TalosEnv = printer
 			}
 		}
-		if ctx.EnvPrinters.TalosEnv == nil {
-			ctx.EnvPrinters.TalosEnv = env.NewTalosEnvPrinter(ctx.Injector)
-			ctx.Injector.Register("talosEnv", ctx.EnvPrinters.TalosEnv)
+		if rt.EnvPrinters.TalosEnv == nil {
+			rt.EnvPrinters.TalosEnv = env.NewTalosEnvPrinter(rt.Shell, rt.ConfigHandler)
+			rt.Injector.Register("talosEnv", rt.EnvPrinters.TalosEnv)
 		}
 	}
-	if ctx.EnvPrinters.TerraformEnv == nil && ctx.ConfigHandler.GetBool("terraform.enabled", false) {
-		if existingPrinter := ctx.Injector.Resolve("terraformEnv"); existingPrinter != nil {
+	if rt.EnvPrinters.TerraformEnv == nil && rt.ConfigHandler.GetBool("terraform.enabled", false) {
+		if existingPrinter := rt.Injector.Resolve("terraformEnv"); existingPrinter != nil {
 			if printer, ok := existingPrinter.(env.EnvPrinter); ok {
-				ctx.EnvPrinters.TerraformEnv = printer
+				rt.EnvPrinters.TerraformEnv = printer
 			}
 		}
-		if ctx.EnvPrinters.TerraformEnv == nil {
-			ctx.EnvPrinters.TerraformEnv = env.NewTerraformEnvPrinter(ctx.Injector)
-			ctx.Injector.Register("terraformEnv", ctx.EnvPrinters.TerraformEnv)
+		if rt.EnvPrinters.TerraformEnv == nil {
+			rt.EnvPrinters.TerraformEnv = env.NewTerraformEnvPrinter(rt.Shell, rt.ConfigHandler)
+			rt.Injector.Register("terraformEnv", rt.EnvPrinters.TerraformEnv)
 		}
 	}
-	if ctx.EnvPrinters.WindsorEnv == nil {
-		if existingPrinter := ctx.Injector.Resolve("windsorEnv"); existingPrinter != nil {
+	if rt.EnvPrinters.WindsorEnv == nil {
+		if existingPrinter := rt.Injector.Resolve("windsorEnv"); existingPrinter != nil {
 			if printer, ok := existingPrinter.(env.EnvPrinter); ok {
-				ctx.EnvPrinters.WindsorEnv = printer
+				rt.EnvPrinters.WindsorEnv = printer
 			}
 		}
-		if ctx.EnvPrinters.WindsorEnv == nil {
-			ctx.EnvPrinters.WindsorEnv = env.NewWindsorEnvPrinter(ctx.Injector)
-			ctx.Injector.Register("windsorEnv", ctx.EnvPrinters.WindsorEnv)
+		if rt.EnvPrinters.WindsorEnv == nil {
+			secretsProviders := []secrets.SecretsProvider{}
+			if rt.SecretsProviders.Sops != nil {
+				secretsProviders = append(secretsProviders, rt.SecretsProviders.Sops)
+			}
+			if rt.SecretsProviders.Onepassword != nil {
+				secretsProviders = append(secretsProviders, rt.SecretsProviders.Onepassword)
+			}
+			allEnvPrinters := rt.getAllEnvPrinters()
+			rt.EnvPrinters.WindsorEnv = env.NewWindsorEnvPrinter(rt.Shell, rt.ConfigHandler, secretsProviders, allEnvPrinters)
+			rt.Injector.Register("windsorEnv", rt.EnvPrinters.WindsorEnv)
 		}
 	}
 }
@@ -433,16 +436,18 @@ func (ctx *Runtime) initializeEnvPrinters() {
 // initializeToolsManager initializes the tools manager if not already set.
 // It checks the injector for an existing tools manager first, and only creates a new one if not found.
 // It creates a new ToolsManager instance and registers it with the dependency injector.
-func (ctx *Runtime) initializeToolsManager() {
-	if ctx.ToolsManager == nil {
-		if existingManager := ctx.Injector.Resolve("toolsManager"); existingManager != nil {
+func (rt *Runtime) initializeToolsManager() {
+	if rt.ToolsManager == nil {
+		if existingManager := rt.Injector.Resolve("toolsManager"); existingManager != nil {
 			if toolsManager, ok := existingManager.(tools.ToolsManager); ok {
-				ctx.ToolsManager = toolsManager
+				rt.ToolsManager = toolsManager
 				return
 			}
 		}
-		ctx.ToolsManager = tools.NewToolsManager(ctx.Injector)
-		ctx.Injector.Register("toolsManager", ctx.ToolsManager)
+		if rt.ConfigHandler != nil && rt.Shell != nil {
+			rt.ToolsManager = tools.NewToolsManager(rt.ConfigHandler, rt.Shell)
+			rt.Injector.Register("toolsManager", rt.ToolsManager)
+		}
 	}
 }
 
@@ -450,29 +455,29 @@ func (ctx *Runtime) initializeToolsManager() {
 // based on current configuration settings. The method sets up the SOPS provider if enabled with the
 // context's config root path, and sets up the 1Password provider if enabled, using a mock in test
 // scenarios. Providers are only initialized if not already present on the context.
-func (ctx *Runtime) initializeSecretsProviders() {
-	if ctx.SecretsProviders.Sops == nil && ctx.ConfigHandler.GetBool("secrets.sops.enabled", false) {
-		if existingProvider := ctx.Injector.Resolve("sopsSecretsProvider"); existingProvider != nil {
+func (rt *Runtime) initializeSecretsProviders() {
+	if rt.SecretsProviders.Sops == nil && rt.ConfigHandler.GetBool("secrets.sops.enabled", false) {
+		if existingProvider := rt.Injector.Resolve("sopsSecretsProvider"); existingProvider != nil {
 			if provider, ok := existingProvider.(secrets.SecretsProvider); ok {
-				ctx.SecretsProviders.Sops = provider
+				rt.SecretsProviders.Sops = provider
 			}
 		}
-		if ctx.SecretsProviders.Sops == nil {
-			configPath := ctx.ConfigRoot
-			ctx.SecretsProviders.Sops = secrets.NewSopsSecretsProvider(configPath, ctx.Injector)
-			ctx.Injector.Register("sopsSecretsProvider", ctx.SecretsProviders.Sops)
+		if rt.SecretsProviders.Sops == nil {
+			configPath := rt.ConfigRoot
+			rt.SecretsProviders.Sops = secrets.NewSopsSecretsProvider(configPath, rt.Injector)
+			rt.Injector.Register("sopsSecretsProvider", rt.SecretsProviders.Sops)
 		}
 	}
 
-	if ctx.SecretsProviders.Onepassword == nil && ctx.ConfigHandler.GetBool("secrets.onepassword.enabled", false) {
-		if existingProvider := ctx.Injector.Resolve("onepasswordSecretsProvider"); existingProvider != nil {
+	if rt.SecretsProviders.Onepassword == nil && rt.ConfigHandler.GetBool("secrets.onepassword.enabled", false) {
+		if existingProvider := rt.Injector.Resolve("onepasswordSecretsProvider"); existingProvider != nil {
 			if provider, ok := existingProvider.(secrets.SecretsProvider); ok {
-				ctx.SecretsProviders.Onepassword = provider
+				rt.SecretsProviders.Onepassword = provider
 			}
 		}
-		if ctx.SecretsProviders.Onepassword == nil {
-			ctx.SecretsProviders.Onepassword = secrets.NewMockSecretsProvider(ctx.Injector)
-			ctx.Injector.Register("onepasswordSecretsProvider", ctx.SecretsProviders.Onepassword)
+		if rt.SecretsProviders.Onepassword == nil {
+			rt.SecretsProviders.Onepassword = secrets.NewMockSecretsProvider(rt.Injector)
+			rt.Injector.Register("onepasswordSecretsProvider", rt.SecretsProviders.Onepassword)
 		}
 	}
 }
@@ -480,44 +485,31 @@ func (ctx *Runtime) initializeSecretsProviders() {
 // getAllEnvPrinters returns all environment printers in a consistent order.
 // This ensures that environment variables are processed in a predictable sequence
 // with WindsorEnv being processed last to take precedence.
-func (ctx *Runtime) getAllEnvPrinters() []env.EnvPrinter {
+func (rt *Runtime) getAllEnvPrinters() []env.EnvPrinter {
 	return []env.EnvPrinter{
-		ctx.EnvPrinters.AwsEnv,
-		ctx.EnvPrinters.AzureEnv,
-		ctx.EnvPrinters.DockerEnv,
-		ctx.EnvPrinters.KubeEnv,
-		ctx.EnvPrinters.TalosEnv,
-		ctx.EnvPrinters.TerraformEnv,
-		ctx.EnvPrinters.WindsorEnv,
+		rt.EnvPrinters.AwsEnv,
+		rt.EnvPrinters.AzureEnv,
+		rt.EnvPrinters.DockerEnv,
+		rt.EnvPrinters.KubeEnv,
+		rt.EnvPrinters.TalosEnv,
+		rt.EnvPrinters.TerraformEnv,
+		rt.EnvPrinters.WindsorEnv,
 	}
 }
 
 // initializeComponents initializes all environment-related components required after setup.
-// This includes initializing the tools manager (if present) and all configured environment printers.
-// Each component's Initialize method is called if the component is non-nil.
-// Returns an error if any initialization fails, otherwise returns nil.
-func (ctx *Runtime) initializeComponents() error {
-	if ctx.ToolsManager != nil {
-		if err := ctx.ToolsManager.Initialize(); err != nil {
-			return fmt.Errorf("failed to initialize tools manager: %w", err)
-		}
-	}
-	for _, printer := range ctx.getAllEnvPrinters() {
-		if printer != nil {
-			if err := printer.Initialize(); err != nil {
-				return fmt.Errorf("failed to initialize environment printer: %w", err)
-			}
-		}
-	}
+// This method is a placeholder for any future initialization logic that may be needed.
+// Returns nil as components are now fully initialized in their constructors.
+func (rt *Runtime) initializeComponents() error {
 	return nil
 }
 
 // loadSecrets loads secrets from configured secrets providers.
 // It attempts to load secrets from both SOPS and 1Password providers if they are available.
-func (ctx *Runtime) loadSecrets() error {
+func (rt *Runtime) loadSecrets() error {
 	providers := []secrets.SecretsProvider{
-		ctx.SecretsProviders.Sops,
-		ctx.SecretsProviders.Onepassword,
+		rt.SecretsProviders.Sops,
+		rt.SecretsProviders.Onepassword,
 	}
 
 	for _, provider := range providers {
@@ -533,8 +525,8 @@ func (ctx *Runtime) loadSecrets() error {
 
 // writeBuildIDToFile writes the provided build ID string to the .windsor/.build-id file in the project root.
 // Ensures the .windsor directory exists before writing. Returns an error if directory creation or file write fails.
-func (ctx *Runtime) writeBuildIDToFile(buildID string) error {
-	projectRoot := ctx.ProjectRoot
+func (rt *Runtime) writeBuildIDToFile(buildID string) error {
+	projectRoot := rt.ProjectRoot
 
 	if err := os.MkdirAll(projectRoot, 0750); err != nil {
 		return fmt.Errorf("failed to create project root directory: %w", err)
@@ -561,14 +553,14 @@ func (ctx *Runtime) writeBuildIDToFile(buildID string) error {
 // and # is a sequential counter incremented for each build on the same day. If a build ID already exists for the current day,
 // the counter is incremented; otherwise, a new build ID is generated with counter set to 1. Ensures global ordering and uniqueness.
 // Returns the build ID string or an error if generation or retrieval fails.
-func (ctx *Runtime) generateBuildID() (string, error) {
+func (rt *Runtime) generateBuildID() (string, error) {
 	now := time.Now()
 	yy := now.Year() % 100
 	mm := int(now.Month())
 	dd := now.Day()
 	datePart := fmt.Sprintf("%02d%02d%02d", yy, mm, dd)
 
-	projectRoot := ctx.ProjectRoot
+	projectRoot := rt.ProjectRoot
 
 	if err := os.MkdirAll(projectRoot, 0750); err != nil {
 		return "", fmt.Errorf("failed to create project root directory: %w", err)
@@ -595,7 +587,7 @@ func (ctx *Runtime) generateBuildID() (string, error) {
 	}
 
 	if existingBuildID != "" {
-		return ctx.incrementBuildID(existingBuildID, datePart)
+		return rt.incrementBuildID(existingBuildID, datePart)
 	}
 
 	random, err := rand.Int(rand.Reader, big.NewInt(1000))
@@ -612,7 +604,7 @@ func (ctx *Runtime) generateBuildID() (string, error) {
 // incrementBuildID parses an existing build ID and increments its counter component.
 // If the date component differs from the current date, generates a new random number and resets the counter to 1.
 // Returns the incremented or reset build ID string, or an error if the input format is invalid.
-func (ctx *Runtime) incrementBuildID(existingBuildID, currentDate string) (string, error) {
+func (rt *Runtime) incrementBuildID(existingBuildID, currentDate string) (string, error) {
 	parts := strings.Split(existingBuildID, ".")
 	if len(parts) != 3 {
 		return "", fmt.Errorf("invalid build ID format: %s", existingBuildID)
@@ -641,32 +633,32 @@ func (ctx *Runtime) incrementBuildID(existingBuildID, currentDate string) (strin
 // It determines the appropriate default configuration (localhost, full, or standard) based on the VM driver
 // and dev mode settings. For dev mode, it also sets the provider to "generic" if not already set.
 // This method should be called before loading configuration from disk to ensure defaults are applied first.
-// The context name is read from ctx.ContextName. Returns an error if any configuration operation fails.
-func (ctx *Runtime) ApplyConfigDefaults() error {
-	contextName := ctx.ContextName
+// The context name is read from rt.ContextName. Returns an error if any configuration operation fails.
+func (rt *Runtime) ApplyConfigDefaults() error {
+	contextName := rt.ContextName
 	if contextName == "" {
 		contextName = "local"
 	}
 
-	if ctx.ConfigHandler == nil {
+	if rt.ConfigHandler == nil {
 		return fmt.Errorf("config handler not available")
 	}
 
-	if !ctx.ConfigHandler.IsLoaded() {
-		existingProvider := ctx.ConfigHandler.GetString("provider")
-		contextName := ctx.ContextName
+	if !rt.ConfigHandler.IsLoaded() {
+		existingProvider := rt.ConfigHandler.GetString("provider")
+		contextName := rt.ContextName
 		if contextName == "" {
 			contextName = "local"
 		}
-		isDevMode := ctx.ConfigHandler.IsDevMode(contextName)
+		isDevMode := rt.ConfigHandler.IsDevMode(contextName)
 
 		if isDevMode {
-			if err := ctx.ConfigHandler.Set("dev", true); err != nil {
+			if err := rt.ConfigHandler.Set("dev", true); err != nil {
 				return fmt.Errorf("failed to set dev mode: %w", err)
 			}
 		}
 
-		vmDriver := ctx.ConfigHandler.GetString("vm.driver")
+		vmDriver := rt.ConfigHandler.GetString("vm.driver")
 		if isDevMode && vmDriver == "" {
 			switch runtime.GOOS {
 			case "darwin", "windows":
@@ -677,27 +669,27 @@ func (ctx *Runtime) ApplyConfigDefaults() error {
 		}
 
 		if vmDriver == "docker-desktop" {
-			if err := ctx.ConfigHandler.SetDefault(config.DefaultConfig_Localhost); err != nil {
+			if err := rt.ConfigHandler.SetDefault(config.DefaultConfig_Localhost); err != nil {
 				return fmt.Errorf("failed to set default config: %w", err)
 			}
 		} else if isDevMode {
-			if err := ctx.ConfigHandler.SetDefault(config.DefaultConfig_Full); err != nil {
+			if err := rt.ConfigHandler.SetDefault(config.DefaultConfig_Full); err != nil {
 				return fmt.Errorf("failed to set default config: %w", err)
 			}
 		} else {
-			if err := ctx.ConfigHandler.SetDefault(config.DefaultConfig); err != nil {
+			if err := rt.ConfigHandler.SetDefault(config.DefaultConfig); err != nil {
 				return fmt.Errorf("failed to set default config: %w", err)
 			}
 		}
 
-		if isDevMode && ctx.ConfigHandler.GetString("vm.driver") == "" && vmDriver != "" {
-			if err := ctx.ConfigHandler.Set("vm.driver", vmDriver); err != nil {
+		if isDevMode && rt.ConfigHandler.GetString("vm.driver") == "" && vmDriver != "" {
+			if err := rt.ConfigHandler.Set("vm.driver", vmDriver); err != nil {
 				return fmt.Errorf("failed to set vm.driver: %w", err)
 			}
 		}
 
 		if existingProvider == "" && isDevMode {
-			if err := ctx.ConfigHandler.Set("provider", "generic"); err != nil {
+			if err := rt.ConfigHandler.Set("provider", "generic"); err != nil {
 				return fmt.Errorf("failed to set provider from context name: %w", err)
 			}
 		}
@@ -711,46 +703,46 @@ func (ctx *Runtime) ApplyConfigDefaults() error {
 // For "azure", it enables Azure and sets the cluster driver to "aks".
 // For "generic", it sets the cluster driver to "talos".
 // If no provider is set but dev mode is enabled, it defaults the cluster driver to "talos".
-// The context name is read from ctx.ContextName. Returns an error if any configuration operation fails.
-func (ctx *Runtime) ApplyProviderDefaults(providerOverride string) error {
-	if ctx.ConfigHandler == nil {
+// The context name is read from rt.ContextName. Returns an error if any configuration operation fails.
+func (rt *Runtime) ApplyProviderDefaults(providerOverride string) error {
+	if rt.ConfigHandler == nil {
 		return fmt.Errorf("config handler not available")
 	}
 
-	contextName := ctx.ContextName
+	contextName := rt.ContextName
 	if contextName == "" {
 		contextName = "local"
 	}
 
 	provider := providerOverride
 	if provider == "" {
-		provider = ctx.ConfigHandler.GetString("provider")
+		provider = rt.ConfigHandler.GetString("provider")
 	}
 
 	if provider != "" {
 		switch provider {
 		case "aws":
-			if err := ctx.ConfigHandler.Set("aws.enabled", true); err != nil {
+			if err := rt.ConfigHandler.Set("aws.enabled", true); err != nil {
 				return fmt.Errorf("failed to set aws.enabled: %w", err)
 			}
-			if err := ctx.ConfigHandler.Set("cluster.driver", "eks"); err != nil {
+			if err := rt.ConfigHandler.Set("cluster.driver", "eks"); err != nil {
 				return fmt.Errorf("failed to set cluster.driver: %w", err)
 			}
 		case "azure":
-			if err := ctx.ConfigHandler.Set("azure.enabled", true); err != nil {
+			if err := rt.ConfigHandler.Set("azure.enabled", true); err != nil {
 				return fmt.Errorf("failed to set azure.enabled: %w", err)
 			}
-			if err := ctx.ConfigHandler.Set("cluster.driver", "aks"); err != nil {
+			if err := rt.ConfigHandler.Set("cluster.driver", "aks"); err != nil {
 				return fmt.Errorf("failed to set cluster.driver: %w", err)
 			}
 		case "generic":
-			if err := ctx.ConfigHandler.Set("cluster.driver", "talos"); err != nil {
+			if err := rt.ConfigHandler.Set("cluster.driver", "talos"); err != nil {
 				return fmt.Errorf("failed to set cluster.driver: %w", err)
 			}
 		}
-	} else if ctx.ConfigHandler.IsDevMode(contextName) {
-		if ctx.ConfigHandler.GetString("cluster.driver") == "" {
-			if err := ctx.ConfigHandler.Set("cluster.driver", "talos"); err != nil {
+	} else if rt.ConfigHandler.IsDevMode(contextName) {
+		if rt.ConfigHandler.GetString("cluster.driver") == "" {
+			if err := rt.ConfigHandler.Set("cluster.driver", "talos"); err != nil {
 				return fmt.Errorf("failed to set cluster.driver: %w", err)
 			}
 		}
@@ -763,21 +755,18 @@ func (ctx *Runtime) ApplyProviderDefaults(providerOverride string) error {
 // It first checks that all required tools are installed and meet version requirements,
 // then installs any missing or outdated tools. The tools manager must be available.
 // Returns an error if the tools manager is not available or if checking or installation fails.
-func (ctx *Runtime) PrepareTools() error {
-	if ctx.ToolsManager == nil {
-		ctx.initializeToolsManager()
-		if ctx.ToolsManager == nil {
+func (rt *Runtime) PrepareTools() error {
+	if rt.ToolsManager == nil {
+		rt.initializeToolsManager()
+		if rt.ToolsManager == nil {
 			return fmt.Errorf("tools manager not available")
-		}
-		if err := ctx.ToolsManager.Initialize(); err != nil {
-			return fmt.Errorf("failed to initialize tools manager: %w", err)
 		}
 	}
 
-	if err := ctx.ToolsManager.Check(); err != nil {
+	if err := rt.ToolsManager.Check(); err != nil {
 		return fmt.Errorf("error checking tools: %w", err)
 	}
-	if err := ctx.ToolsManager.Install(); err != nil {
+	if err := rt.ToolsManager.Install(); err != nil {
 		return fmt.Errorf("error installing tools: %w", err)
 	}
 

--- a/pkg/runtime/shell/mock_shell.go
+++ b/pkg/runtime/shell/mock_shell.go
@@ -2,8 +2,6 @@ package shell
 
 import (
 	"fmt"
-
-	"github.com/windsorcli/cli/pkg/di"
 )
 
 // The MockShell is a mock implementation of the Shell interface for testing purposes.
@@ -17,7 +15,6 @@ import (
 
 type MockShell struct {
 	DefaultShell
-	InitializeFunc                 func() error
 	RenderEnvVarsFunc              func(envVars map[string]string, export bool) string
 	RenderAliasesFunc              func(aliases map[string]string) string
 	GetProjectRootFunc             func() (string, error)
@@ -42,32 +39,13 @@ type MockShell struct {
 // Constructor
 // =============================================================================
 
-// NewMockShell creates a new instance of MockShell. If injector is provided, it sets the injector on MockShell.
-func NewMockShell(injectors ...di.Injector) *MockShell {
-	var injector di.Injector
-	if len(injectors) > 0 {
-		injector = injectors[0]
-	}
-
+// NewMockShell creates a new instance of MockShell
+func NewMockShell() *MockShell {
 	mockShell := &MockShell{
-		DefaultShell: DefaultShell{
-			injector: injector,
-		},
+		DefaultShell: *NewDefaultShell(),
 	}
 
 	return mockShell
-}
-
-// =============================================================================
-// Public Methods
-// =============================================================================
-
-// Initialize calls the custom InitializeFunc if provided.
-func (s *MockShell) Initialize() error {
-	if s.InitializeFunc != nil {
-		return s.InitializeFunc()
-	}
-	return nil
 }
 
 // RenderEnvVars calls the custom RenderEnvVarsFunc if provided.

--- a/pkg/runtime/shell/mock_shell_test.go
+++ b/pkg/runtime/shell/mock_shell_test.go
@@ -3,8 +3,6 @@ package shell
 import (
 	"fmt"
 	"testing"
-
-	"github.com/windsorcli/cli/pkg/di"
 )
 
 // The MockShellTest is a test suite for the MockShell implementation.
@@ -20,11 +18,8 @@ import (
 func setupMockShellMocks(t *testing.T) *MockShell {
 	t.Helper()
 
-	// Create injector
-	injector := di.NewMockInjector()
-
 	// Create mock shell
-	mockShell := NewMockShell(injector)
+	mockShell := NewMockShell()
 
 	return mockShell
 }
@@ -47,53 +42,34 @@ func TestMockShell_NewMockShell(t *testing.T) {
 }
 
 // TestMockShell_Initialize tests the Initialize method of MockShell
-func TestMockShell_Initialize(t *testing.T) {
+func TestMockShell(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		// Given a mock shell with InitializeFunc set
+		// Given a mock shell
 		mockShell := setupMockShellMocks(t)
-		mockShell.InitializeFunc = func() error {
-			return nil
-		}
 
-		// When calling Initialize
-		err := mockShell.Initialize()
-
-		// Then no error should be returned
-		if err != nil {
-			t.Errorf("Expected no error, got %v", err)
+		// Then it should be created
+		if mockShell == nil {
+			t.Error("Expected mock shell to be created")
 		}
 	})
 
-	t.Run("Error", func(t *testing.T) {
-		// Given a mock shell with InitializeFunc set to return an error
+	t.Run("Created", func(t *testing.T) {
+		// Given a mock shell
 		mockShell := setupMockShellMocks(t)
-		expectedError := fmt.Errorf("mock initialize error")
-		mockShell.InitializeFunc = func() error {
-			return expectedError
-		}
 
-		// When calling Initialize
-		err := mockShell.Initialize()
-
-		// Then the expected error should be returned
-		if err == nil {
-			t.Error("Expected error, got nil")
-		}
-		if err.Error() != expectedError.Error() {
-			t.Errorf("Expected error %v, got %v", expectedError, err)
+		// Then it should be created
+		if mockShell == nil {
+			t.Error("Expected mock shell to be created")
 		}
 	})
 
 	t.Run("NotImplemented", func(t *testing.T) {
-		// Given a mock shell with InitializeFunc not set
+		// Given a mock shell
 		mockShell := setupMockShellMocks(t)
 
-		// When calling Initialize
-		err := mockShell.Initialize()
-
-		// Then no error should be returned (default implementation)
-		if err != nil {
-			t.Errorf("Expected no error, got %v", err)
+		// Then it should be created
+		if mockShell == nil {
+			t.Error("Expected mock shell to be created")
 		}
 	})
 }

--- a/pkg/runtime/shell/secure_shell.go
+++ b/pkg/runtime/shell/secure_shell.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/windsorcli/cli/pkg/di"
 	"github.com/windsorcli/cli/pkg/runtime/shell/ssh"
 )
 
@@ -28,27 +27,12 @@ type SecureShell struct {
 // =============================================================================
 
 // NewSecureShell creates a new instance of SecureShell.
-func NewSecureShell(injector di.Injector) *SecureShell {
-	defaultShell := NewDefaultShell(injector)
+func NewSecureShell(sshClient ssh.Client) *SecureShell {
+	defaultShell := NewDefaultShell()
 	return &SecureShell{
 		DefaultShell: *defaultShell,
+		sshClient:    sshClient,
 	}
-}
-
-// =============================================================================
-// Public Methods
-// =============================================================================
-
-// Initialize initializes the SecureShell instance.
-func (s *SecureShell) Initialize() error {
-	// Get the SSH client first
-	sshClient, ok := s.injector.Resolve("sshClient").(ssh.Client)
-	if !ok {
-		return fmt.Errorf("failed to resolve SSH client")
-	}
-	s.sshClient = sshClient
-
-	return nil
 }
 
 // Exec executes a command on the remote host via SSH and returns its output as a string.
@@ -97,3 +81,4 @@ func (s *SecureShell) ExecSilent(command string, args ...string) (string, error)
 
 // Ensure SecureShell implements the Shell interface
 var _ Shell = (*SecureShell)(nil)
+

--- a/pkg/runtime/shell/secure_shell_test.go
+++ b/pkg/runtime/shell/secure_shell_test.go
@@ -6,7 +6,6 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/windsorcli/cli/pkg/di"
 	"github.com/windsorcli/cli/pkg/runtime/shell/ssh"
 )
 
@@ -80,36 +79,16 @@ func (s *MockSpinner) Stop()  {}
 // Test Public Methods
 // =============================================================================
 
-// TestSecureShell_Initialize tests the Initialize method of SecureShell
-func TestSecureShell_Initialize(t *testing.T) {
+// TestSecureShell_NewSecureShell tests the NewSecureShell constructor
+func TestSecureShell_NewSecureShell(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
-		// Given a secure shell with valid injector
+		// Given a secure shell with valid SSH client
 		mocks := setupSecureShellMocks(t)
-		shell := NewSecureShell(mocks.Injector)
+		shell := NewSecureShell(mocks.Client)
 
-		// When initializing
-		err := shell.Initialize()
-
-		// Then it should succeed
-		if err != nil {
-			t.Errorf("Expected no error, got %v", err)
-		}
-	})
-
-	t.Run("ErrorResolvingSSHClient", func(t *testing.T) {
-		// Given a secure shell with invalid injector
-		injector := di.NewMockInjector()
-		shell := NewSecureShell(injector)
-
-		// When initializing
-		err := shell.Initialize()
-
-		// Then it should return error
-		if err == nil {
-			t.Error("Expected error, got nil")
-		}
-		if !strings.Contains(err.Error(), "failed to resolve SSH client") {
-			t.Errorf("Expected error about SSH client, got %v", err)
+		// Then it should be created
+		if shell == nil {
+			t.Error("Expected shell to be created")
 		}
 	})
 }
@@ -119,10 +98,7 @@ func TestSecureShell_Exec(t *testing.T) {
 	setup := func(t *testing.T) (*SecureShell, *SecureMocks) {
 		t.Helper()
 		mocks := setupSecureShellMocks(t)
-		shell := NewSecureShell(mocks.Injector)
-		if err := shell.Initialize(); err != nil {
-			t.Fatalf("Failed to initialize secure shell: %v", err)
-		}
+		shell := NewSecureShell(mocks.Client)
 		return shell, mocks
 	}
 
@@ -235,10 +211,7 @@ func TestSecureShell_ExecProgress(t *testing.T) {
 	setup := func(t *testing.T) (*SecureShell, *SecureMocks) {
 		t.Helper()
 		mocks := setupSecureShellMocks(t)
-		shell := NewSecureShell(mocks.Injector)
-		if err := shell.Initialize(); err != nil {
-			t.Fatalf("Failed to initialize secure shell: %v", err)
-		}
+		shell := NewSecureShell(mocks.Client)
 		return shell, mocks
 	}
 
@@ -280,10 +253,7 @@ func TestSecureShell_ExecSilent(t *testing.T) {
 	setup := func(t *testing.T) (*SecureShell, *SecureMocks) {
 		t.Helper()
 		mocks := setupSecureShellMocks(t)
-		shell := NewSecureShell(mocks.Injector)
-		if err := shell.Initialize(); err != nil {
-			t.Fatalf("Failed to initialize secure shell: %v", err)
-		}
+		shell := NewSecureShell(mocks.Client)
 		return shell, mocks
 	}
 

--- a/pkg/runtime/shell/shell.go
+++ b/pkg/runtime/shell/shell.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/briandowns/spinner"
-	"github.com/windsorcli/cli/pkg/di"
 )
 
 // The Shell package is a unified interface for shell operations across different platforms.
@@ -45,7 +44,6 @@ type HookContext struct {
 
 // Shell is the interface that defines shell operations.
 type Shell interface {
-	Initialize() error
 	SetVerbosity(verbose bool)
 	RenderEnvVars(envVars map[string]string, export bool) string
 	RenderAliases(aliases map[string]string) string
@@ -70,7 +68,6 @@ type Shell interface {
 type DefaultShell struct {
 	Shell
 	projectRoot  string
-	injector     di.Injector
 	verbose      bool
 	sessionToken string
 	shims        *Shims
@@ -82,21 +79,11 @@ type DefaultShell struct {
 // =============================================================================
 
 // NewDefaultShell creates a new instance of DefaultShell
-func NewDefaultShell(injector di.Injector) *DefaultShell {
+func NewDefaultShell() *DefaultShell {
 	return &DefaultShell{
-		injector: injector,
-		shims:    NewShims(),
-		verbose:  false,
+		shims:   NewShims(),
+		verbose: false,
 	}
-}
-
-// =============================================================================
-// Public Methods
-// =============================================================================
-
-// Initialize initializes the shell
-func (s *DefaultShell) Initialize() error {
-	return nil
 }
 
 // SetVerbosity sets the verbosity flag

--- a/pkg/runtime/shell/shell_test.go
+++ b/pkg/runtime/shell/shell_test.go
@@ -222,17 +222,14 @@ func setupMocks(t *testing.T) *Mocks {
 // Test Public Methods
 // =============================================================================
 
-func TestShell_Initialize(t *testing.T) {
+func TestShell_NewDefaultShell(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		// Given a shell
-		shell := NewDefaultShell(nil)
+		shell := NewDefaultShell()
 
-		// When initializing the shell
-		err := shell.Initialize()
-
-		// Then it should succeed
-		if err != nil {
-			t.Errorf("Expected no error, got %v", err)
+		// Then it should be created
+		if shell == nil {
+			t.Error("Expected shell to be created")
 		}
 	})
 }
@@ -240,7 +237,7 @@ func TestShell_Initialize(t *testing.T) {
 func TestShell_SetVerbosity(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		// Given a shell
-		shell := NewDefaultShell(nil)
+		shell := NewDefaultShell()
 
 		// When setting verbosity to true
 		shell.SetVerbosity(true)
@@ -253,7 +250,7 @@ func TestShell_SetVerbosity(t *testing.T) {
 
 	t.Run("DisableVerbosity", func(t *testing.T) {
 		// Given a shell
-		shell := NewDefaultShell(nil)
+		shell := NewDefaultShell()
 
 		// When setting verbosity to false
 		shell.SetVerbosity(false)
@@ -273,7 +270,7 @@ func TestShell_GetProjectRoot(t *testing.T) {
 	setup := func(t *testing.T) (*DefaultShell, *Mocks) {
 		t.Helper()
 		mocks := setupMocks(t)
-		shell := NewDefaultShell(mocks.Injector)
+		shell := NewDefaultShell()
 		shell.shims = mocks.Shims
 		return shell, mocks
 	}
@@ -392,7 +389,7 @@ func TestShell_Exec(t *testing.T) {
 	setup := func(t *testing.T) (*DefaultShell, *Mocks) {
 		t.Helper()
 		mocks := setupMocks(t)
-		shell := NewDefaultShell(mocks.Injector)
+		shell := NewDefaultShell()
 		shell.shims = mocks.Shims
 		return shell, mocks
 	}
@@ -498,7 +495,7 @@ func TestShell_ExecSudo(t *testing.T) {
 	setup := func(t *testing.T) (*DefaultShell, *Mocks) {
 		t.Helper()
 		mocks := setupMocks(t)
-		shell := NewDefaultShell(mocks.Injector)
+		shell := NewDefaultShell()
 		shell.shims = mocks.Shims
 		return shell, mocks
 	}
@@ -625,7 +622,7 @@ func TestShell_ExecSudo(t *testing.T) {
 	t.Run("ErrorOnWait", func(t *testing.T) {
 		// Setup
 		shims := NewShims()
-		sh := NewDefaultShell(nil)
+		sh := NewDefaultShell()
 		sh.shims = shims
 
 		expectedOutput := "test output"
@@ -729,7 +726,7 @@ func TestShell_ExecSilent(t *testing.T) {
 	setup := func(t *testing.T) (*DefaultShell, *Mocks) {
 		t.Helper()
 		mocks := setupMocks(t)
-		shell := NewDefaultShell(mocks.Injector)
+		shell := NewDefaultShell()
 		shell.shims = mocks.Shims
 		return shell, mocks
 	}
@@ -908,7 +905,7 @@ func TestShell_GetSessionToken(t *testing.T) {
 	setup := func(t *testing.T) (*DefaultShell, *Mocks) {
 		t.Helper()
 		mocks := setupMocks(t)
-		shell := NewDefaultShell(mocks.Injector)
+		shell := NewDefaultShell()
 		shell.shims = mocks.Shims
 		return shell, mocks
 	}
@@ -980,7 +977,7 @@ func TestShell_CheckResetFlags(t *testing.T) {
 	setup := func(t *testing.T) (*DefaultShell, *Mocks) {
 		t.Helper()
 		mocks := setupMocks(t)
-		shell := NewDefaultShell(mocks.Injector)
+		shell := NewDefaultShell()
 		shell.shims = mocks.Shims
 		return shell, mocks
 	}
@@ -1113,7 +1110,7 @@ func TestShell_GenerateRandomString(t *testing.T) {
 	setup := func(t *testing.T) (*DefaultShell, *Mocks) {
 		t.Helper()
 		mocks := setupMocks(t)
-		shell := NewDefaultShell(mocks.Injector)
+		shell := NewDefaultShell()
 		shell.shims = mocks.Shims
 		return shell, mocks
 	}
@@ -1140,7 +1137,7 @@ func TestShell_InstallHook(t *testing.T) {
 	setup := func(t *testing.T) (*DefaultShell, *Mocks) {
 		t.Helper()
 		mocks := setupMocks(t)
-		shell := NewDefaultShell(mocks.Injector)
+		shell := NewDefaultShell()
 		shell.shims = mocks.Shims
 		return shell, mocks
 	}
@@ -1377,7 +1374,7 @@ func TestShell_AddCurrentDirToTrustedFile(t *testing.T) {
 	setup := func(t *testing.T) (*DefaultShell, *Mocks) {
 		t.Helper()
 		mocks := setupMocks(t)
-		shell := NewDefaultShell(mocks.Injector)
+		shell := NewDefaultShell()
 		shell.shims = mocks.Shims
 		return shell, mocks
 	}
@@ -1629,7 +1626,7 @@ func TestShell_CheckTrustedDirectory(t *testing.T) {
 	setup := func(t *testing.T) (*DefaultShell, *Mocks) {
 		t.Helper()
 		mocks := setupMocks(t)
-		shell := NewDefaultShell(mocks.Injector)
+		shell := NewDefaultShell()
 		shell.shims = mocks.Shims
 		return shell, mocks
 	}
@@ -1820,7 +1817,7 @@ func TestShell_WriteResetToken(t *testing.T) {
 	setup := func(t *testing.T) (*DefaultShell, *Mocks) {
 		t.Helper()
 		mocks := setupMocks(t)
-		shell := NewDefaultShell(mocks.Injector)
+		shell := NewDefaultShell()
 		shell.shims = mocks.Shims
 		return shell, mocks
 	}
@@ -2017,7 +2014,7 @@ func TestShell_Reset(t *testing.T) {
 	setup := func(t *testing.T) (*DefaultShell, *Mocks) {
 		t.Helper()
 		mocks := setupMocks(t)
-		shell := NewDefaultShell(mocks.Injector)
+		shell := NewDefaultShell()
 		shell.shims = mocks.Shims
 		return shell, mocks
 	}
@@ -2245,7 +2242,7 @@ func TestShell_ResetSessionToken(t *testing.T) {
 	setup := func(t *testing.T) (*DefaultShell, *Mocks) {
 		t.Helper()
 		mocks := setupMocks(t)
-		shell := NewDefaultShell(mocks.Injector)
+		shell := NewDefaultShell()
 		shell.shims = mocks.Shims
 		return shell, mocks
 	}
@@ -2312,7 +2309,7 @@ func TestShell_ExecProgress(t *testing.T) {
 	setup := func(t *testing.T) (*DefaultShell, *Mocks) {
 		t.Helper()
 		mocks := setupMocks(t)
-		shell := NewDefaultShell(mocks.Injector)
+		shell := NewDefaultShell()
 		shell.shims = mocks.Shims
 		return shell, mocks
 	}
@@ -2863,8 +2860,7 @@ func TestShell_RegisterSecret(t *testing.T) {
 	setup := func(t *testing.T) (*DefaultShell, *Mocks) {
 		t.Helper()
 		mocks := setupMocks(t)
-		shell := NewDefaultShell(mocks.Injector)
-		shell.Initialize()
+		shell := NewDefaultShell()
 		return shell, mocks
 	}
 
@@ -2942,8 +2938,7 @@ func TestShell_scrubString(t *testing.T) {
 	setup := func(t *testing.T) (*DefaultShell, *Mocks) {
 		t.Helper()
 		mocks := setupMocks(t)
-		shell := NewDefaultShell(mocks.Injector)
-		shell.Initialize()
+		shell := NewDefaultShell()
 		return shell, mocks
 	}
 
@@ -3195,7 +3190,7 @@ func TestScrubbingWriter(t *testing.T) {
 	setup := func(t *testing.T) (*DefaultShell, *bytes.Buffer) {
 		t.Helper()
 		mocks := setupMocks(t)
-		shell := NewDefaultShell(mocks.Injector)
+		shell := NewDefaultShell()
 		shell.shims = mocks.Shims
 
 		// Register a test secret

--- a/pkg/runtime/shell/unix_shell_test.go
+++ b/pkg/runtime/shell/unix_shell_test.go
@@ -23,7 +23,7 @@ func TestDefaultShell_GetProjectRoot(t *testing.T) {
 	setup := func(t *testing.T) (*DefaultShell, *Mocks) {
 		t.Helper()
 		mocks := setupMocks(t)
-		shell := NewDefaultShell(mocks.Injector)
+		shell := NewDefaultShell()
 		shell.shims = mocks.Shims
 		return shell, mocks
 	}
@@ -79,7 +79,7 @@ func TestDefaultShell_UnsetEnvs(t *testing.T) {
 	setup := func(t *testing.T) (*DefaultShell, *Mocks) {
 		t.Helper()
 		mocks := setupMocks(t)
-		shell := NewDefaultShell(mocks.Injector)
+		shell := NewDefaultShell()
 		shell.shims = mocks.Shims
 		return shell, mocks
 	}
@@ -122,7 +122,7 @@ func TestDefaultShell_UnsetAlias(t *testing.T) {
 	setup := func(t *testing.T) (*DefaultShell, *Mocks) {
 		t.Helper()
 		mocks := setupMocks(t)
-		shell := NewDefaultShell(mocks.Injector)
+		shell := NewDefaultShell()
 		shell.shims = mocks.Shims
 		return shell, mocks
 	}

--- a/pkg/runtime/shell/windows_shell_test.go
+++ b/pkg/runtime/shell/windows_shell_test.go
@@ -23,7 +23,7 @@ func TestDefaultShell_GetProjectRoot(t *testing.T) {
 	setup := func(t *testing.T) (*DefaultShell, *Mocks) {
 		t.Helper()
 		mocks := setupMocks(t)
-		shell := NewDefaultShell(mocks.Injector)
+		shell := NewDefaultShell()
 		shell.shims = mocks.Shims
 		return shell, mocks
 	}
@@ -77,7 +77,7 @@ func TestDefaultShell_UnsetEnvs(t *testing.T) {
 	setup := func(t *testing.T) (*DefaultShell, *Mocks) {
 		t.Helper()
 		mocks := setupMocks(t)
-		shell := NewDefaultShell(mocks.Injector)
+		shell := NewDefaultShell()
 		shell.shims = mocks.Shims
 		return shell, mocks
 	}
@@ -120,7 +120,7 @@ func TestDefaultShell_UnsetAlias(t *testing.T) {
 	setup := func(t *testing.T) (*DefaultShell, *Mocks) {
 		t.Helper()
 		mocks := setupMocks(t)
-		shell := NewDefaultShell(mocks.Injector)
+		shell := NewDefaultShell()
 		shell.shims = mocks.Shims
 		return shell, mocks
 	}

--- a/pkg/runtime/tools/tools_manager.go
+++ b/pkg/runtime/tools/tools_manager.go
@@ -10,10 +10,8 @@ import (
 
 	"github.com/briandowns/spinner"
 	"github.com/windsorcli/cli/pkg/constants"
-	"github.com/windsorcli/cli/pkg/di"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
-	sh "github.com/windsorcli/cli/pkg/runtime/shell"
 )
 
 // The ToolsManager is a core component that manages development tools and dependencies
@@ -26,7 +24,6 @@ import (
 // tool installations, with built-in version checking and compatibility validation.
 
 type ToolsManager interface {
-	Initialize() error
 	WriteManifest() error
 	Install() error
 	Check() error
@@ -34,7 +31,6 @@ type ToolsManager interface {
 
 // BaseToolsManager is the base implementation of the ToolsManager interface.
 type BaseToolsManager struct {
-	injector      di.Injector
 	configHandler config.ConfigHandler
 	shell         shell.Shell
 }
@@ -43,26 +39,12 @@ type BaseToolsManager struct {
 // Constructor
 // =============================================================================
 
-// Creates a new ToolsManager instance with the given injector.
-func NewToolsManager(injector di.Injector) *BaseToolsManager {
+// NewToolsManager creates a new ToolsManager instance with the given config handler and shell.
+func NewToolsManager(configHandler config.ConfigHandler, shell shell.Shell) *BaseToolsManager {
 	return &BaseToolsManager{
-		injector: injector,
+		configHandler: configHandler,
+		shell:         shell,
 	}
-}
-
-// =============================================================================
-// Public Methods
-// =============================================================================
-
-// Initialize the tools manager by resolving the config handler and shell.
-func (t *BaseToolsManager) Initialize() error {
-	configHandler := t.injector.Resolve("configHandler")
-	t.configHandler = configHandler.(config.ConfigHandler)
-
-	shell := t.injector.Resolve("shell")
-	t.shell = shell.(sh.Shell)
-
-	return nil
 }
 
 // WriteManifest writes the tools manifest to the project root.

--- a/pkg/workstation/services/service_test.go
+++ b/pkg/workstation/services/service_test.go
@@ -116,7 +116,7 @@ func setupMocks(t *testing.T, opts ...*SetupOptions) *Mocks {
 	})
 
 	// Create mock shell
-	mockShell := shell.NewMockShell(nil)
+	mockShell := shell.NewMockShell()
 	mockShell.GetProjectRootFunc = func() (string, error) {
 		return tmpDir, nil
 	}
@@ -129,11 +129,7 @@ func setupMocks(t *testing.T, opts ...*SetupOptions) *Mocks {
 		// Create minimal injector for config handler initialization
 		injector := di.NewInjector()
 		injector.Register("shell", mockShell)
-		configHandler = config.NewConfigHandler(injector)
-		// Initialize config handler
-		if err := configHandler.Initialize(); err != nil {
-			t.Fatalf("Failed to initialize config handler: %v", err)
-		}
+		configHandler = config.NewConfigHandler(mockShell)
 	}
 
 	configHandler.SetContext("mock-context")

--- a/pkg/workstation/virt/virt_test.go
+++ b/pkg/workstation/virt/virt_test.go
@@ -16,8 +16,8 @@ import (
 	"github.com/windsorcli/cli/pkg/di"
 	"github.com/windsorcli/cli/pkg/runtime"
 	"github.com/windsorcli/cli/pkg/runtime/config"
-	"github.com/windsorcli/cli/pkg/workstation/services"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
+	"github.com/windsorcli/cli/pkg/workstation/services"
 )
 
 // =============================================================================
@@ -132,11 +132,7 @@ func setupMocks(t *testing.T, opts ...*SetupOptions) *Mocks {
 		// Create minimal injector for config handler initialization
 		injector := di.NewInjector()
 		injector.Register("shell", mockShell)
-		configHandler = config.NewConfigHandler(injector)
-		// Initialize config handler
-		if err := configHandler.Initialize(); err != nil {
-			t.Fatalf("Failed to initialize config handler: %v", err)
-		}
+		configHandler = config.NewConfigHandler(mockShell)
 	} else {
 		configHandler = options.ConfigHandler
 	}


### PR DESCRIPTION
Removes the dependency injector from the runtime code in favor of explicitly passing deps to constructors.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>