### PR TITLE
chore(cmd): Clean up tests

### DIFF
--- a/cmd/build_id.go
+++ b/cmd/build_id.go
@@ -25,8 +25,14 @@ Examples:
   BUILD_ID=$(windsor build-id --new) && docker build -t myapp:$BUILD_ID .`,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		var rtOpts []*runtime.Runtime
+		if overridesVal := cmd.Context().Value(runtimeOverridesKey); overridesVal != nil {
+			if rt, ok := overridesVal.(*runtime.Runtime); ok {
+				rtOpts = []*runtime.Runtime{rt}
+			}
+		}
 
-		rt, err := runtime.NewRuntime()
+		rt, err := runtime.NewRuntime(rtOpts...)
 		if err != nil {
 			return fmt.Errorf("failed to initialize context: %w", err)
 		}

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -5,6 +5,7 @@ import (
 	stdcontext "context"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -22,31 +23,18 @@ func TestCheckCmd(t *testing.T) {
 	setup := func(t *testing.T, withConfig bool) (*bytes.Buffer, *bytes.Buffer) {
 		t.Helper()
 
-		// Change to a temporary directory
-		origDir, err := os.Getwd()
-		if err != nil {
-			t.Fatalf("Failed to get working directory: %v", err)
-		}
+		// Use setupMocks to get a temp dir without os.Chdir()
+		mocks := setupMocks(t)
+		tmpDir := mocks.TmpDir
 
-		tmpDir := t.TempDir()
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatalf("Failed to change to temp directory: %v", err)
-		}
-
-		// Cleanup to change back to original directory
-		t.Cleanup(func() {
-			if err := os.Chdir(origDir); err != nil {
-				t.Logf("Warning: Failed to change back to original directory: %v", err)
-			}
-		})
-
-		// Create config file if requested
+		// Create config file if requested (using full path to avoid chdir)
 		if withConfig {
 			configContent := `contexts:
   default:
     tools:
       enabled: true`
-			if err := os.WriteFile("windsor.yaml", []byte(configContent), 0644); err != nil {
+			configPath := filepath.Join(tmpDir, "windsor.yaml")
+			if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
 				t.Fatalf("Failed to create config file: %v", err)
 			}
 		}

--- a/cmd/down_test.go
+++ b/cmd/down_test.go
@@ -12,6 +12,37 @@ import (
 	"github.com/windsorcli/cli/pkg/runtime/config"
 )
 
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+type DownMocks struct {
+	ConfigHandler config.ConfigHandler
+	Runtime       *Mocks
+	Project       *project.Project
+}
+
+func setupDownTest(t *testing.T, opts ...*SetupOptions) *DownMocks {
+	t.Helper()
+
+	baseMocks := setupMocks(t, opts...)
+
+	proj, err := project.NewProject("", &project.Project{Runtime: baseMocks.Runtime})
+	if err != nil {
+		t.Fatalf("Failed to create project: %v", err)
+	}
+
+	return &DownMocks{
+		ConfigHandler: baseMocks.ConfigHandler,
+		Runtime:       baseMocks,
+		Project:       proj,
+	}
+}
+
+// =============================================================================
+// Test Cases
+// =============================================================================
+
 func TestDownCmd(t *testing.T) {
 	createTestDownCmd := func() *cobra.Command {
 		cmd := &cobra.Command{
@@ -30,49 +61,46 @@ func TestDownCmd(t *testing.T) {
 	}
 
 	t.Run("Success", func(t *testing.T) {
-		mocks := setupMocks(t)
+		// Given a properly configured down command
+		mocks := setupDownTest(t)
 
-		proj, err := project.NewProject("", &project.Project{Runtime: mocks.Runtime})
-		if err != nil {
-			t.Fatalf("Failed to create project: %v", err)
-		}
-
+		// When executing the down command
 		cmd := createTestDownCmd()
-		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		ctx := context.WithValue(context.Background(), projectOverridesKey, mocks.Project)
 		cmd.SetContext(ctx)
-		err = cmd.Execute()
+		err := cmd.Execute()
 
+		// Then no error should occur
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
 	})
 
 	t.Run("ErrorCheckingTrustedDirectory", func(t *testing.T) {
-		mocks := setupMocks(t)
-
-		mocks.Shell.CheckTrustedDirectoryFunc = func() error {
+		// Given a down command with untrusted directory
+		mocks := setupDownTest(t)
+		mocks.Runtime.Shell.CheckTrustedDirectoryFunc = func() error {
 			return fmt.Errorf("not in trusted directory")
 		}
 
-		proj, err := project.NewProject("", &project.Project{Runtime: mocks.Runtime})
-		if err != nil {
-			t.Fatalf("Failed to create project: %v", err)
-		}
-
+		// When executing the down command
 		cmd := createTestDownCmd()
-		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		ctx := context.WithValue(context.Background(), projectOverridesKey, mocks.Project)
 		cmd.SetContext(ctx)
-		err = cmd.Execute()
+		err := cmd.Execute()
 
+		// Then an error should occur
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}
+		// And error should contain trusted directory message
 		if !strings.Contains(err.Error(), "not in a trusted directory") {
 			t.Errorf("Expected trusted directory error, got: %v", err)
 		}
 	})
 
 	t.Run("ErrorLoadingConfig", func(t *testing.T) {
+		// Given a down command with config load failure
 		mockConfigHandler := config.NewMockConfigHandler()
 		mockConfigHandler.LoadConfigFunc = func() error {
 			return fmt.Errorf("config load failed")
@@ -81,108 +109,96 @@ func TestDownCmd(t *testing.T) {
 		opts := &SetupOptions{
 			ConfigHandler: mockConfigHandler,
 		}
-		mocks := setupMocks(t, opts)
+		mocks := setupDownTest(t, opts)
+		mocks.Runtime.Runtime.ConfigHandler = mockConfigHandler
+		mocks.Project, _ = project.NewProject("", &project.Project{Runtime: mocks.Runtime.Runtime})
 
-		// Override ConfigHandler in runtime
-		mocks.Runtime.ConfigHandler = mockConfigHandler
-
-		proj, err := project.NewProject("", &project.Project{Runtime: mocks.Runtime})
-		if err != nil {
-			t.Fatalf("Failed to create project: %v", err)
-		}
-
+		// When executing the down command
 		cmd := createTestDownCmd()
-		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		ctx := context.WithValue(context.Background(), projectOverridesKey, mocks.Project)
 		cmd.SetContext(ctx)
-		err = cmd.Execute()
+		err := cmd.Execute()
 
+		// Then an error should occur
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}
+		// And error should contain config load message
 		if !strings.Contains(err.Error(), "failed to load config") {
 			t.Errorf("Expected config load error, got: %v", err)
 		}
 	})
 
 	t.Run("SkipK8sFlag", func(t *testing.T) {
-		mocks := setupMocks(t)
+		// Given a down command with skip-k8s flag
+		mocks := setupDownTest(t)
 
-		proj, err := project.NewProject("", &project.Project{Runtime: mocks.Runtime})
-		if err != nil {
-			t.Fatalf("Failed to create project: %v", err)
-		}
-
+		// When executing the down command with skip-k8s flag
 		cmd := createTestDownCmd()
 		cmd.SetArgs([]string{"--skip-k8s"})
-		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		ctx := context.WithValue(context.Background(), projectOverridesKey, mocks.Project)
 		cmd.SetContext(ctx)
-		err = cmd.Execute()
+		err := cmd.Execute()
 
+		// Then no error should occur
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
 	})
 
 	t.Run("SkipTerraformFlag", func(t *testing.T) {
-		mocks := setupMocks(t)
+		// Given a down command with skip-tf flag
+		mocks := setupDownTest(t)
 
-		proj, err := project.NewProject("", &project.Project{Runtime: mocks.Runtime})
-		if err != nil {
-			t.Fatalf("Failed to create project: %v", err)
-		}
-
+		// When executing the down command with skip-tf flag
 		cmd := createTestDownCmd()
 		cmd.SetArgs([]string{"--skip-tf"})
-		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		ctx := context.WithValue(context.Background(), projectOverridesKey, mocks.Project)
 		cmd.SetContext(ctx)
-		err = cmd.Execute()
+		err := cmd.Execute()
 
+		// Then no error should occur
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
 	})
 
 	t.Run("SkipDockerFlag", func(t *testing.T) {
-		mocks := setupMocks(t)
+		// Given a down command with skip-docker flag
+		mocks := setupDownTest(t)
 
-		proj, err := project.NewProject("", &project.Project{Runtime: mocks.Runtime})
-		if err != nil {
-			t.Fatalf("Failed to create project: %v", err)
-		}
-
+		// When executing the down command with skip-docker flag
 		cmd := createTestDownCmd()
 		cmd.SetArgs([]string{"--skip-docker"})
-		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		ctx := context.WithValue(context.Background(), projectOverridesKey, mocks.Project)
 		cmd.SetContext(ctx)
-		err = cmd.Execute()
+		err := cmd.Execute()
 
+		// Then no error should occur
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
 	})
 
 	t.Run("DevModeWithoutWorkstation", func(t *testing.T) {
+		// Given a down command in non-dev mode
 		mockConfigHandler := config.NewMockConfigHandler()
 		mockConfigHandler.IsDevModeFunc = func(contextName string) bool { return false }
 
 		opts := &SetupOptions{
 			ConfigHandler: mockConfigHandler,
 		}
-		mocks := setupMocks(t, opts)
+		mocks := setupDownTest(t, opts)
+		mocks.Runtime.Runtime.ConfigHandler = mockConfigHandler
+		mocks.Project, _ = project.NewProject("", &project.Project{Runtime: mocks.Runtime.Runtime})
 
-		// Override ConfigHandler in runtime
-		mocks.Runtime.ConfigHandler = mockConfigHandler
-
-		proj, err := project.NewProject("", &project.Project{Runtime: mocks.Runtime})
-		if err != nil {
-			t.Fatalf("Failed to create project: %v", err)
-		}
-
+		// When executing the down command
 		cmd := createTestDownCmd()
-		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		ctx := context.WithValue(context.Background(), projectOverridesKey, mocks.Project)
 		cmd.SetContext(ctx)
-		err = cmd.Execute()
+		err := cmd.Execute()
 
+		// Then no error should occur
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -24,7 +24,9 @@ var execCmd = &cobra.Command{
 
 		var rtOpts []*runtime.Runtime
 		if overridesVal := cmd.Context().Value(runtimeOverridesKey); overridesVal != nil {
-			rtOpts = []*runtime.Runtime{overridesVal.(*runtime.Runtime)}
+			if rt, ok := overridesVal.(*runtime.Runtime); ok {
+				rtOpts = []*runtime.Runtime{rt}
+			}
 		}
 
 		rt, err := runtime.NewRuntime(rtOpts...)

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -14,9 +14,14 @@ var hookCmd = &cobra.Command{
 	SilenceUsage: true,
 	Args:         cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		var rtOpts []*runtime.Runtime
+		if overridesVal := cmd.Context().Value(runtimeOverridesKey); overridesVal != nil {
+			if rt, ok := overridesVal.(*runtime.Runtime); ok {
+				rtOpts = []*runtime.Runtime{rt}
+			}
+		}
 
-
-		rt, err := runtime.NewRuntime()
+		rt, err := runtime.NewRuntime(rtOpts...)
 		if err != nil {
 			return fmt.Errorf("failed to initialize context: %w", err)
 		}

--- a/cmd/hook_test.go
+++ b/cmd/hook_test.go
@@ -19,10 +19,10 @@ func TestHookCmd(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		// Given proper output capture and mock setup
 		_, stderr := setup(t)
-		setupMocks(t)
+		mocks := setupMocks(t)
 
-		// Set up command context with injector
-		ctx := context.Background()
+		// Set up command context with runtime override
+		ctx := context.WithValue(context.Background(), runtimeOverridesKey, mocks.Runtime)
 		rootCmd.SetContext(ctx)
 
 		rootCmd.SetArgs([]string{"hook", "zsh"})
@@ -75,8 +75,8 @@ func TestHookCmd(t *testing.T) {
 			return nil
 		}
 
-		// Set up command context with injector
-		ctx := context.Background()
+		// Set up command context with runtime override
+		ctx := context.WithValue(context.Background(), runtimeOverridesKey, mocks.Runtime)
 		rootCmd.SetContext(ctx)
 
 		rootCmd.SetArgs([]string{"hook", "unsupported"})

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -49,12 +48,6 @@ func setupInitTest(t *testing.T, opts ...*SetupOptions) *InitMocks {
 	initBlueprint = ""
 	initEndpoint = ""
 	initSetFlags = []string{}
-
-	// Set up temporary directory and change to it
-	tmpDir := t.TempDir()
-	oldDir, _ := os.Getwd()
-	os.Chdir(tmpDir)
-	t.Cleanup(func() { os.Chdir(oldDir) })
 
 	// Get base mocks
 	baseMocks := setupMocks(t, opts...)

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -37,12 +37,8 @@ func TestInstallCmd(t *testing.T) {
 	}
 
 	t.Run("Success", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		oldDir, _ := os.Getwd()
-		os.Chdir(tmpDir)
-		t.Cleanup(func() { os.Chdir(oldDir) })
-
 		mocks := setupMocks(t)
+		tmpDir := mocks.TmpDir
 
 		mockConfigHandler := config.NewMockConfigHandler()
 		mockConfigHandler.GetContextFunc = func() string { return "test-context" }
@@ -89,12 +85,8 @@ func TestInstallCmd(t *testing.T) {
 	})
 
 	t.Run("SuccessWithWaitFlag", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		oldDir, _ := os.Getwd()
-		os.Chdir(tmpDir)
-		t.Cleanup(func() { os.Chdir(oldDir) })
-
 		mocks := setupMocks(t)
+		tmpDir := mocks.TmpDir
 
 		mockConfigHandler := config.NewMockConfigHandler()
 		mockConfigHandler.GetContextFunc = func() string { return "test-context" }
@@ -142,12 +134,8 @@ func TestInstallCmd(t *testing.T) {
 	})
 
 	t.Run("ErrorCheckingTrustedDirectory", func(t *testing.T) {
-		tmpDir := t.TempDir()
-		oldDir, _ := os.Getwd()
-		os.Chdir(tmpDir)
-		t.Cleanup(func() { os.Chdir(oldDir) })
-
 		mocks := setupMocks(t)
+		tmpDir := mocks.TmpDir
 		mocks.Shell.CheckTrustedDirectoryFunc = func() error {
 			return fmt.Errorf("not in trusted directory")
 		}

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -34,10 +34,14 @@ Examples:
 		if len(args) == 0 {
 			return fmt.Errorf("registry is required: windsor push registry/repo[:tag]")
 		}
+		var rtOpts []*runtime.Runtime
+		if overridesVal := cmd.Context().Value(runtimeOverridesKey); overridesVal != nil {
+			if rt, ok := overridesVal.(*runtime.Runtime); ok {
+				rtOpts = []*runtime.Runtime{rt}
+			}
+		}
 
-
-
-		rt, err := runtime.NewRuntime()
+		rt, err := runtime.NewRuntime(rtOpts...)
 		if err != nil {
 			return fmt.Errorf("failed to initialize context: %w", err)
 		}

--- a/cmd/shims_test.go
+++ b/cmd/shims_test.go
@@ -1,8 +1,3 @@
-// The shims_test package provides test utilities for the shims package
-// It contains mock implementations of system call wrappers
-// It enables testing of system-level operations
-// It facilitates dependency injection and test isolation
-
 package cmd
 
 import (

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 
@@ -41,12 +40,6 @@ type UpMocks struct {
 func setupUpTest(t *testing.T, opts ...*SetupOptions) *UpMocks {
 	t.Helper()
 
-	// Set up temporary directory and change to it
-	tmpDir := t.TempDir()
-	oldDir, _ := os.Getwd()
-	os.Chdir(tmpDir)
-	t.Cleanup(func() { os.Chdir(oldDir) })
-
 	// Create mock config handler to control IsDevMode
 	mockConfigHandler := config.NewMockConfigHandler()
 	mockConfigHandler.GetContextFunc = func() string { return "test-context" }
@@ -72,7 +65,6 @@ func setupUpTest(t *testing.T, opts ...*SetupOptions) *UpMocks {
 	mockConfigHandler.LoadConfigFunc = func() error { return nil }
 	mockConfigHandler.SaveConfigFunc = func(hasSetFlags ...bool) error { return nil }
 	mockConfigHandler.GenerateContextIDFunc = func() error { return nil }
-	mockConfigHandler.GetConfigRootFunc = func() (string, error) { return tmpDir + "/contexts/test-context", nil }
 
 	// Get base mocks with mock config handler
 	testOpts := &SetupOptions{}
@@ -81,6 +73,8 @@ func setupUpTest(t *testing.T, opts ...*SetupOptions) *UpMocks {
 	}
 	testOpts.ConfigHandler = mockConfigHandler
 	baseMocks := setupMocks(t, testOpts)
+	tmpDir := baseMocks.TmpDir
+	mockConfigHandler.GetConfigRootFunc = func() (string, error) { return tmpDir + "/contexts/test-context", nil }
 
 	// Add up-specific shell mock behaviors
 	baseMocks.Shell.CheckTrustedDirectoryFunc = func() error { return nil }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -138,13 +138,17 @@ func NewRuntime(opts ...*Runtime) (*Runtime, error) {
 		rt.Shell = shell.NewDefaultShell()
 	}
 
-	projectRoot, err := rt.Shell.GetProjectRoot()
-	if err != nil {
-		return nil, fmt.Errorf("failed to get project root: %w", err)
+	if rt.ProjectRoot == "" {
+		projectRoot, err := rt.Shell.GetProjectRoot()
+		if err != nil {
+			return nil, fmt.Errorf("failed to get project root: %w", err)
+		}
+		rt.ProjectRoot = projectRoot
 	}
-	rt.ProjectRoot = projectRoot
 
 	if rt.ConfigHandler == nil {
+		// Only create real config handler if we have a real shell
+		// In tests, ConfigHandler should always be provided via overrides
 		rt.ConfigHandler = config.NewConfigHandler(rt.Shell)
 	}
 
@@ -161,14 +165,6 @@ func NewRuntime(opts ...*Runtime) (*Runtime, error) {
 	}
 	if rt.ContextName == "" {
 		rt.ContextName = "local"
-	}
-
-	if rt.ProjectRoot == "" {
-		projectRoot, err = rt.Shell.GetProjectRoot()
-		if err != nil {
-			return nil, fmt.Errorf("failed to get project root: %w", err)
-		}
-		rt.ProjectRoot = projectRoot
 	}
 
 	if rt.ConfigRoot == "" {

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -293,14 +293,10 @@ func TestRuntime_NewRuntime(t *testing.T) {
 	})
 
 	t.Run("ErrorWhenGetProjectRootFailsOnSecondCall", func(t *testing.T) {
-		// Given a shell that fails to get project root on second call
+		// Given a shell that fails to get project root
+		// Note: With the optimization, GetProjectRoot is only called once when ProjectRoot is empty
 		mockShell := shell.NewMockShell()
-		callCount := 0
 		mockShell.GetProjectRootFunc = func() (string, error) {
-			callCount++
-			if callCount == 1 {
-				return "", nil
-			}
 			return "", fmt.Errorf("failed to get project root")
 		}
 
@@ -321,12 +317,11 @@ func TestRuntime_NewRuntime(t *testing.T) {
 		_, err := NewRuntime(rtOpts...)
 
 		// Then an error should be returned
-
 		if err == nil {
-			t.Error("Expected error when GetProjectRoot fails on second call")
+			t.Error("Expected error when GetProjectRoot fails")
 		}
 
-		if !strings.Contains(err.Error(), "failed to get project root") {
+		if err != nil && !strings.Contains(err.Error(), "failed to get project root") {
 			t.Errorf("Expected error about getting project root, got: %v", err)
 		}
 	})
@@ -421,8 +416,8 @@ func TestRuntime_NewRuntime(t *testing.T) {
 			t.Errorf("Expected ContextName to be 'custom-context', got: %s", rt.ContextName)
 		}
 
-		if rt.ProjectRoot != "/test/project" {
-			t.Errorf("Expected ProjectRoot to be '/test/project' (from GetProjectRoot), got: %s", rt.ProjectRoot)
+		if rt.ProjectRoot != "/custom/project" {
+			t.Errorf("Expected ProjectRoot to be '/custom/project' (from override), got: %s", rt.ProjectRoot)
 		}
 
 		if rt.ConfigRoot != "/custom/config" {


### PR DESCRIPTION
Cleans up and optimizes spects of the command tests. Makes them more conformal.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>