### PR TITLE
fix(cmd): Set verbose correctly

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -31,6 +31,8 @@ var downCmd = &cobra.Command{
 			return err
 		}
 
+		proj.Runtime.Shell.SetVerbosity(verbose)
+
 		if err := proj.Runtime.Shell.CheckTrustedDirectory(); err != nil {
 			return fmt.Errorf("not in a trusted directory. If you are in a Windsor project, run 'windsor init' to approve")
 		}

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -34,6 +34,8 @@ var execCmd = &cobra.Command{
 			return fmt.Errorf("failed to initialize context: %w", err)
 		}
 
+		rt.Shell.SetVerbosity(verbose)
+
 		if err := rt.Shell.CheckTrustedDirectory(); err != nil {
 			return fmt.Errorf("not in a trusted directory. If you are in a Windsor project, run 'windsor init' to approve")
 		}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -24,6 +24,8 @@ var installCmd = &cobra.Command{
 			return err
 		}
 
+		proj.Runtime.Shell.SetVerbosity(verbose)
+
 		if err := proj.Runtime.Shell.CheckTrustedDirectory(); err != nil {
 			return fmt.Errorf("not in a trusted directory. If you are in a Windsor project, run 'windsor init' to approve")
 		}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -29,6 +29,8 @@ var upCmd = &cobra.Command{
 			return err
 		}
 
+		proj.Runtime.Shell.SetVerbosity(verbose)
+
 		if err := proj.Runtime.Shell.CheckTrustedDirectory(); err != nil {
 			return fmt.Errorf("not in a trusted directory. If you are in a Windsor project, run 'windsor init' to approve")
 		}


### PR DESCRIPTION
Verbose needed to be set using `shell.SetVerbosity` for several commands. Thsi functionality was dropped in the last refactor.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>