### PR TITLE
fix(kubernetes): Reintroduce max wait time for all kustomizations

### DIFF
--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -101,7 +101,7 @@ func TestInstallCmd(t *testing.T) {
 
 		mockKubernetesManager := kubernetes.NewMockKubernetesManager()
 		mockKubernetesManager.ApplyBlueprintFunc = func(blueprint *blueprintv1alpha1.Blueprint, namespace string) error { return nil }
-		mockKubernetesManager.WaitForKustomizationsFunc = func(message string, names ...string) error { return nil }
+		mockKubernetesManager.WaitForKustomizationsFunc = func(message string, blueprint *blueprintv1alpha1.Blueprint) error { return nil }
 
 		// Override ConfigHandler and ProjectRoot in runtime
 		mocks.Runtime.ConfigHandler = mockConfigHandler

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -96,7 +96,7 @@ func setupUpTest(t *testing.T, opts ...*SetupOptions) *UpMocks {
 	// Add kubernetes manager mock
 	mockKubernetesManager := kubernetes.NewMockKubernetesManager()
 	mockKubernetesManager.ApplyBlueprintFunc = func(blueprint *blueprintv1alpha1.Blueprint, namespace string) error { return nil }
-	mockKubernetesManager.WaitForKustomizationsFunc = func(message string, names ...string) error { return nil }
+	mockKubernetesManager.WaitForKustomizationsFunc = func(message string, blueprint *blueprintv1alpha1.Blueprint) error { return nil }
 
 	// Create runtime with all mocked dependencies
 	rt, err := runtime.NewRuntime(&runtime.Runtime{
@@ -407,7 +407,7 @@ func TestUpCmd(t *testing.T) {
 		mocks := setupUpTest(t)
 
 		// And kubernetes manager WaitForKustomizations that fails
-		mocks.KubernetesManager.WaitForKustomizationsFunc = func(message string, names ...string) error {
+		mocks.KubernetesManager.WaitForKustomizationsFunc = func(message string, blueprint *blueprintv1alpha1.Blueprint) error {
 			return fmt.Errorf("wait for kustomizations failed")
 		}
 

--- a/pkg/provisioner/kubernetes/mock_kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/mock_kubernetes_manager.go
@@ -21,7 +21,7 @@ import (
 type MockKubernetesManager struct {
 	ApplyKustomizationFunc              func(kustomization kustomizev1.Kustomization) error
 	DeleteKustomizationFunc             func(name, namespace string) error
-	WaitForKustomizationsFunc           func(message string, names ...string) error
+	WaitForKustomizationsFunc           func(message string, blueprint *blueprintv1alpha1.Blueprint) error
 	GetKustomizationStatusFunc          func(names []string) (map[string]bool, error)
 	CreateNamespaceFunc                 func(name string) error
 	DeleteNamespaceFunc                 func(name string) error
@@ -71,9 +71,9 @@ func (m *MockKubernetesManager) DeleteKustomization(name, namespace string) erro
 }
 
 // WaitForKustomizations implements KubernetesManager interface
-func (m *MockKubernetesManager) WaitForKustomizations(message string, names ...string) error {
+func (m *MockKubernetesManager) WaitForKustomizations(message string, blueprint *blueprintv1alpha1.Blueprint) error {
 	if m.WaitForKustomizationsFunc != nil {
-		return m.WaitForKustomizationsFunc(message, names...)
+		return m.WaitForKustomizationsFunc(message, blueprint)
 	}
 	return nil
 }

--- a/pkg/provisioner/kubernetes/mock_kubernetes_manager_test.go
+++ b/pkg/provisioner/kubernetes/mock_kubernetes_manager_test.go
@@ -76,12 +76,11 @@ func TestMockKubernetesManager_WaitForKustomizations(t *testing.T) {
 		return NewMockKubernetesManager()
 	}
 	msg := "msg"
-	name := "n"
 
 	t.Run("FuncSet", func(t *testing.T) {
 		manager := setup(t)
-		manager.WaitForKustomizationsFunc = func(m string, n ...string) error { return fmt.Errorf("err") }
-		err := manager.WaitForKustomizations(msg, name)
+		manager.WaitForKustomizationsFunc = func(m string, b *blueprintv1alpha1.Blueprint) error { return fmt.Errorf("err") }
+		err := manager.WaitForKustomizations(msg, nil)
 		if err == nil || err.Error() != "err" {
 			t.Errorf("Expected error 'err', got %v", err)
 		}
@@ -89,7 +88,7 @@ func TestMockKubernetesManager_WaitForKustomizations(t *testing.T) {
 
 	t.Run("FuncNotSet", func(t *testing.T) {
 		manager := setup(t)
-		err := manager.WaitForKustomizations(msg, name)
+		err := manager.WaitForKustomizations(msg, nil)
 		if err != nil {
 			t.Errorf("Expected nil, got %v", err)
 		}

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -162,7 +162,8 @@ func (i *Provisioner) Install(blueprint *blueprintv1alpha1.Blueprint) error {
 
 // Wait waits for kustomizations from the blueprint to be ready. It initializes the kubernetes manager
 // if needed and polls the status of all kustomizations until they are ready or a timeout occurs.
-// Returns an error if the kubernetes manager is not configured, initialization fails, or waiting times out.
+// The timeout is calculated from the longest dependency chain in the blueprint. Returns an error if
+// the kubernetes manager is not configured, initialization fails, or waiting times out.
 func (i *Provisioner) Wait(blueprint *blueprintv1alpha1.Blueprint) error {
 	if blueprint == nil {
 		return fmt.Errorf("blueprint not provided")
@@ -172,12 +173,7 @@ func (i *Provisioner) Wait(blueprint *blueprintv1alpha1.Blueprint) error {
 		return fmt.Errorf("kubernetes manager not configured")
 	}
 
-	kustomizationNames := make([]string, len(blueprint.Kustomizations))
-	for i, k := range blueprint.Kustomizations {
-		kustomizationNames[i] = k.Name
-	}
-
-	if err := i.KubernetesManager.WaitForKustomizations("⏳ Waiting for kustomizations to be ready", kustomizationNames...); err != nil {
+	if err := i.KubernetesManager.WaitForKustomizations("⏳ Waiting for kustomizations to be ready", blueprint); err != nil {
 		return fmt.Errorf("failed waiting for kustomizations: %w", err)
 	}
 

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -506,7 +506,7 @@ func TestProvisioner_Install(t *testing.T) {
 func TestProvisioner_Wait(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
-		mocks.KubernetesManager.WaitForKustomizationsFunc = func(message string, names ...string) error {
+		mocks.KubernetesManager.WaitForKustomizationsFunc = func(message string, blueprint *blueprintv1alpha1.Blueprint) error {
 			return nil
 		}
 		opts := &Provisioner{
@@ -556,7 +556,7 @@ func TestProvisioner_Wait(t *testing.T) {
 
 	t.Run("ErrorWaitForKustomizations", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
-		mocks.KubernetesManager.WaitForKustomizationsFunc = func(message string, names ...string) error {
+		mocks.KubernetesManager.WaitForKustomizationsFunc = func(message string, blueprint *blueprintv1alpha1.Blueprint) error {
 			return fmt.Errorf("wait failed")
 		}
 		opts := &Provisioner{


### PR DESCRIPTION
Windsor up used to wait based on a calculation of the total combined time of the longest dependency chain of kustomizations. This PR returns this functionality, which was lost during a recent refactor. Fixes timeouts on `windsor up`.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>