### PR TITLE
fix(cmd): Change context on init

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -152,6 +152,16 @@ var initCmd = &cobra.Command{
 			return fmt.Errorf("failed to save configuration: %w", err)
 		}
 
+		if len(args) > 0 {
+			if _, err := rt.Shell.WriteResetToken(); err != nil {
+				return fmt.Errorf("failed to write reset token: %w", err)
+			}
+
+			if err := rt.ConfigHandler.SetContext(contextName); err != nil {
+				return fmt.Errorf("failed to set context: %w", err)
+			}
+		}
+
 		fmt.Fprintln(os.Stderr, "Initialization successful")
 
 		return nil


### PR DESCRIPTION
Re-introduced functionality to ensure the context change on running `windsor init`.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>