### PR TITLE
fix(blueprint): Fix input injection and cleanup

### DIFF
--- a/pkg/composer/blueprint/blueprint_handler_private_test.go
+++ b/pkg/composer/blueprint/blueprint_handler_private_test.go
@@ -328,13 +328,6 @@ func TestBaseBlueprintHandler_walkAndCollectTemplates(t *testing.T) {
 			t.Errorf("Expected no error, got: %v", err)
 		}
 
-		if _, exists := templateData["schema"]; !exists {
-			t.Error("Expected 'schema' key to exist")
-		}
-		if _, exists := templateData["blueprint"]; !exists {
-			t.Error("Expected 'blueprint' key to exist")
-		}
-
 		if _, exists := templateData["_template/schema.yaml"]; !exists {
 			t.Error("Expected '_template/schema.yaml' key to exist")
 		}
@@ -5542,8 +5535,8 @@ metadata:
 		if err == nil {
 			t.Fatal("Expected error when blueprint.yaml is missing")
 		}
-		if !strings.Contains(err.Error(), "blueprint.yaml not found") {
-			t.Errorf("Expected error about missing blueprint.yaml, got: %v", err)
+		if !strings.Contains(err.Error(), "blueprint not found") {
+			t.Errorf("Expected error about missing blueprint, got: %v", err)
 		}
 	})
 

--- a/pkg/composer/blueprint/blueprint_handler_public_test.go
+++ b/pkg/composer/blueprint/blueprint_handler_public_test.go
@@ -2574,10 +2574,12 @@ metadata:
 
 		// .jsonnet files are not collected in templateData; they are processed on-demand via jsonnet() function calls during feature evaluation
 
-		if content, exists := templateData["_template/blueprint.yaml"]; exists {
+		if content, exists := templateData["blueprint"]; exists {
 			if !strings.Contains(string(content), contextName) {
 				t.Errorf("Expected blueprint content to contain context name '%s', got: %s", contextName, string(content))
 			}
+		} else {
+			t.Error("Expected composed blueprint in templateData")
 		}
 
 		if content, exists := templateData["_template/features/aws.yaml"]; exists {
@@ -2897,7 +2899,7 @@ terraform:
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
-		composedBlueprint, exists := templateData["_template/blueprint.yaml"]
+		composedBlueprint, exists := templateData["blueprint"]
 		if !exists {
 			t.Fatal("Expected composed blueprint in templateData")
 		}
@@ -2967,7 +2969,7 @@ terraform:
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
-		composedBlueprint, exists := templateData["_template/blueprint.yaml"]
+		composedBlueprint, exists := templateData["blueprint"]
 		if !exists {
 			t.Fatal("Expected composed blueprint in templateData")
 		}
@@ -3067,7 +3069,7 @@ terraform:
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
-		composedBlueprint, exists := templateData["_template/blueprint.yaml"]
+		composedBlueprint, exists := templateData["blueprint"]
 		if !exists {
 			t.Fatal("Expected composed blueprint in templateData")
 		}
@@ -3144,7 +3146,7 @@ kustomize:
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
-		composedBlueprint, exists := templateData["_template/blueprint.yaml"]
+		composedBlueprint, exists := templateData["blueprint"]
 		if !exists {
 			t.Fatal("Expected composed blueprint in templateData")
 		}
@@ -3206,7 +3208,7 @@ metadata:
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
-		if composedBlueprint, exists := templateData["_template/blueprint.yaml"]; exists {
+		if composedBlueprint, exists := templateData["blueprint"]; exists {
 			var blueprint blueprintv1alpha1.Blueprint
 			if err := yaml.Unmarshal(composedBlueprint, &blueprint); err != nil {
 				t.Fatalf("Failed to unmarshal blueprint: %v", err)


### PR DESCRIPTION
Cleaned up redundant keys on `templateData` and cleared Inputs prior to processing Features. This fixes an issue that prevented writing inputs to tfvars files.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>