### PR TITLE
fix(config): Defaults to cluster.enabled=true

### DIFF
--- a/pkg/runtime/config/defaults.go
+++ b/pkg/runtime/config/defaults.go
@@ -19,20 +19,6 @@ import (
 	"github.com/windsorcli/cli/pkg/constants"
 )
 
-// DefaultConfig returns the default configuration for non-dev contexts
-// Uses minimal config since non-dev contexts default to provider "none"
-var DefaultConfig = v1alpha1.Context{
-	Provider:  ptrString("none"),
-	Terraform: commonTerraformConfig.Copy(),
-}
-
-// DefaultConfig_None returns a minimal default configuration for provider "none"
-// with terraform enabled but no cluster or DNS settings
-var DefaultConfig_None = v1alpha1.Context{
-	Provider:  ptrString("none"),
-	Terraform: commonTerraformConfig.Copy(),
-}
-
 var commonDockerConfig = docker.DockerConfig{
 	Enabled: ptrBool(true),
 	Registries: map[string]docker.RegistryConfig{
@@ -74,6 +60,12 @@ var commonTerraformConfig = terraform.TerraformConfig{
 	Backend: &terraform.BackendConfig{
 		Type: "local",
 	},
+}
+
+// commonClusterConfig_Minimal is a minimal cluster configuration with only enabled set to true.
+// Used for provider-specific configurations where the driver will be set by ApplyProviderDefaults.
+var commonClusterConfig_Minimal = cluster.ClusterConfig{
+	Enabled: ptrBool(true),
 }
 
 // commonClusterConfig_NoHostPorts is the base cluster configuration without hostports,
@@ -118,6 +110,15 @@ var commonClusterConfig_WithHostPorts = cluster.ClusterConfig{
 		HostPorts: []string{"8080:30080/tcp", "8443:30443/tcp", "9292:30292/tcp", "8053:30053/udp"},
 		Volumes:   []string{"${WINDSOR_PROJECT_ROOT}/.volumes:/var/local"},
 	},
+}
+
+// DefaultConfig returns the default configuration for non-dev contexts
+// Uses minimal config since non-dev contexts default to provider "none"
+// Includes cluster.enabled=true for provider-specific contexts (aws, azure)
+var DefaultConfig = v1alpha1.Context{
+	Provider:  ptrString("none"),
+	Terraform: commonTerraformConfig.Copy(),
+	Cluster:   commonClusterConfig_Minimal.Copy(),
 }
 
 var DefaultConfig_Localhost = v1alpha1.Context{

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -686,7 +686,7 @@ func (rt *Runtime) ApplyConfigDefaults(flagOverrides ...map[string]any) error {
 
 		provider := rt.ConfigHandler.GetString("provider")
 		if provider == "none" {
-			if err := rt.ConfigHandler.SetDefault(config.DefaultConfig_None); err != nil {
+			if err := rt.ConfigHandler.SetDefault(config.DefaultConfig); err != nil {
 				return fmt.Errorf("failed to set default config: %w", err)
 			}
 		} else if vmDriver == "docker-desktop" {

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1558,16 +1558,16 @@ func TestRuntime_ApplyConfigDefaults(t *testing.T) {
 		}
 
 		if setDefaultConfig.Provider == nil || *setDefaultConfig.Provider != "none" {
-			t.Error("Expected DefaultConfig_None to be set with provider 'none'")
+			t.Error("Expected DefaultConfig to be set with provider 'none'")
 		}
-		if setDefaultConfig.Cluster != nil {
-			t.Error("Expected DefaultConfig_None to have no cluster config")
+		if setDefaultConfig.Cluster == nil || setDefaultConfig.Cluster.Enabled == nil || !*setDefaultConfig.Cluster.Enabled {
+			t.Error("Expected DefaultConfig to have cluster.enabled=true")
 		}
 		if setDefaultConfig.DNS != nil {
-			t.Error("Expected DefaultConfig_None to have no DNS config")
+			t.Error("Expected DefaultConfig to have no DNS config")
 		}
 		if setDefaultConfig.Terraform == nil || setDefaultConfig.Terraform.Enabled == nil || !*setDefaultConfig.Terraform.Enabled {
-			t.Error("Expected DefaultConfig_None to have terraform enabled")
+			t.Error("Expected DefaultConfig to have terraform enabled")
 		}
 	})
 


### PR DESCRIPTION
Sets `cluster.enabled=true` by default. Fixes when `KUBECONFIG` was not set for CSP based blueprints.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>