### PR TITLE
fix(workstation): Generate docker-compose.yaml on init

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -153,6 +153,11 @@ func (p *Project) Initialize(overwrite bool, blueprintURL ...string) error {
 		if err := p.Workstation.Prepare(); err != nil {
 			return fmt.Errorf("failed to prepare workstation: %w", err)
 		}
+		if p.Workstation.ContainerRuntime != nil {
+			if err := p.Workstation.ContainerRuntime.WriteConfig(); err != nil {
+				return fmt.Errorf("failed to write container runtime config: %w", err)
+			}
+		}
 	}
 
 	if err := p.Runtime.ConfigHandler.GenerateContextID(); err != nil {

--- a/pkg/workstation/virt/docker_virt.go
+++ b/pkg/workstation/virt/docker_virt.go
@@ -70,12 +70,6 @@ func (v *DockerVirt) Up() error {
 			return fmt.Errorf("failed to determine compose command: %w", err)
 		}
 
-		if v.configHandler.GetString("vm.driver") == "colima" {
-			if err := v.WriteConfig(); err != nil {
-				return fmt.Errorf("error regenerating docker compose config: %w", err)
-			}
-		}
-
 		projectRoot := v.runtime.ProjectRoot
 		composeFilePath := filepath.Join(projectRoot, ".windsor", "docker-compose.yaml")
 


### PR DESCRIPTION
Generates the `docker-compose.yaml` file on workstation initialization. Prevents failures on `windsor down` when the docker-compose.yaml file has been deleted.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>