### PR TITLE
docs: Update windows installation instructions

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -308,24 +308,6 @@ You can add the `windsor hook` to various shells as follows:
     eval "$(windsor hook zsh)"
     ```
 
-=== "FISH"
-    Add the following line to your `config.fish` file:
-    ```fish
-    eval (windsor hook fish)
-    ```
-
-=== "TCSH"
-    Add the following line to your `~/.tcshrc` file:
-    ```tcsh
-    eval `windsor hook tcsh`
-    ```
-
-=== "ELVISH"
-    Add the following line to your `rc.elv` file:
-    ```elvish
-    eval (windsor hook elvish)
-    ```
-
 === "POWERSHELL"
     Add the following line to your PowerShell profile script:
     ```powershell


### PR DESCRIPTION
Adds both the `choco install` option and updates the manual download to appropriately reference the .zip, not the .tar.gz.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>