### PR TITLE
fix(blueprint): Default to setting secret name for dev

### DIFF
--- a/pkg/composer/blueprint/blueprint_handler.go
+++ b/pkg/composer/blueprint/blueprint_handler.go
@@ -1723,8 +1723,10 @@ func (b *BaseBlueprintHandler) deepMergeMaps(base, overlay map[string]any) map[s
 // setRepositoryDefaults sets or overrides the blueprint repository URL based on development mode and git configuration.
 // If development mode is enabled, the development URL is always used. Otherwise, the git remote origin URL is used if the URL is unset.
 // If a URL is set and the repository reference is empty, the branch is set to "main".
+// In dev mode, the secretName is set to "flux-system" if not already set.
 func (b *BaseBlueprintHandler) setRepositoryDefaults() error {
 	devMode := b.runtime.ConfigHandler.GetBool("dev")
+
 	if devMode {
 		url := b.getDevelopmentRepositoryURL()
 		if url != "" {
@@ -1739,6 +1741,10 @@ func (b *BaseBlueprintHandler) setRepositoryDefaults() error {
 	}
 	if b.blueprint.Repository.Url != "" && b.blueprint.Repository.Ref == (blueprintv1alpha1.Reference{}) {
 		b.blueprint.Repository.Ref = blueprintv1alpha1.Reference{Branch: "main"}
+	}
+	if devMode && b.blueprint.Repository.Url != "" && b.blueprint.Repository.SecretName == nil {
+		secretName := "flux-system"
+		b.blueprint.Repository.SecretName = &secretName
 	}
 	return nil
 }


### PR DESCRIPTION
We use a secret when authenticating with the local `git.test` repository. This secret reference was missing, causing failures in the core repository integration tests.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>