### PR TITLE
feat(terraform): Generate kubelogin spn auth override for Azure AKS

### DIFF
--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -176,6 +176,7 @@ func (r *Composer) generateGitignore() error {
 		".windsor/",
 		".volumes/",
 		"terraform/**/backend_override.tf",
+		"terraform/**/providers_override.tf",
 		"contexts/**/.kube/",
 		"contexts/**/.talos/",
 		"contexts/**/.omni/",

--- a/pkg/composer/composer_test.go
+++ b/pkg/composer/composer_test.go
@@ -1114,7 +1114,7 @@ func TestComposer_generateGitignore(t *testing.T) {
 		}
 
 		contentStr := string(content)
-		requiredEntries := []string{".windsor/", ".volumes/", "terraform/**/backend_override.tf"}
+		requiredEntries := []string{".windsor/", ".volumes/", "terraform/**/backend_override.tf", "terraform/**/providers_override.tf"}
 		for _, entry := range requiredEntries {
 			if !strings.Contains(contentStr, entry) {
 				t.Errorf("Expected .gitignore to contain %s", entry)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -112,6 +112,16 @@ const MinimumVersion1Password = "2.15.0"
 
 const MinimumVersionAWSCLI = "2.15.0"
 
+const MinimumVersionKubelogin = "0.1.7"
+
+// DefaultAKSOIDCServerID is the standard Azure AKS OIDC server ID (application ID of the
+// Microsoft-managed enterprise application "Azure Kubernetes Service AAD Server").
+// This is the same for all AKS clusters with AKS-managed Azure AD enabled.
+const DefaultAKSOIDCServerID = "6dae42f8-4368-4678-94ff-3960e28e3630"
+
+// DefaultAKSOIDCClientID is the standard Azure AKS OIDC client ID used for all AKS clusters.
+const DefaultAKSOIDCClientID = "80faf920-1908-4b52-b5ef-a8e7bedfc67a"
+
 const DefaultNodeHealthCheckTimeout = 5 * time.Minute
 
 const DefaultNodeHealthCheckPollInterval = 10 * time.Second

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -247,6 +247,10 @@ func (s *TerraformStack) Down(blueprint *blueprintv1alpha1.Blueprint) error {
 		if err := s.shims.Remove(filepath.Join(component.FullPath, "backend_override.tf")); err != nil && !os.IsNotExist(err) {
 			return fmt.Errorf("error removing backend_override.tf from %s: %w", component.Path, err)
 		}
+
+		if err := s.shims.Remove(filepath.Join(component.FullPath, "providers_override.tf")); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("error removing providers_override.tf from %s: %w", component.Path, err)
+		}
 	}
 
 	return nil

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -697,6 +697,32 @@ func TestStack_Down(t *testing.T) {
 			t.Errorf("Expected remove error, got: %v", err)
 		}
 	})
+
+	t.Run("ErrorRemovingProvidersOverride", func(t *testing.T) {
+		stack, mocks := setup(t)
+		projectRoot := os.Getenv("WINDSOR_PROJECT_ROOT")
+		providersOverridePath := filepath.Join(projectRoot, ".windsor", "contexts", "local", "remote", "path", "providers_override.tf")
+		if err := os.MkdirAll(filepath.Dir(providersOverridePath), 0755); err != nil {
+			t.Fatalf("Failed to create directory: %v", err)
+		}
+		if err := os.WriteFile(providersOverridePath, []byte("test"), 0644); err != nil {
+			t.Fatalf("Failed to create providers override file: %v", err)
+		}
+		mocks.Shims.Remove = func(path string) error {
+			if strings.Contains(path, "providers_override.tf") {
+				return fmt.Errorf("remove error")
+			}
+			return nil
+		}
+		blueprint := createTestBlueprint()
+		err := stack.Down(blueprint)
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "error removing providers_override.tf") {
+			t.Errorf("Expected remove error, got: %v", err)
+		}
+	})
 }
 
 func TestNewShims(t *testing.T) {

--- a/pkg/runtime/env/terraform_env.go
+++ b/pkg/runtime/env/terraform_env.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/goccy/go-yaml"
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
 )
@@ -106,7 +107,10 @@ func (e *TerraformEnvPrinter) GetEnvVars() (map[string]string, error) {
 
 // PostEnvHook executes operations after setting the environment variables.
 func (e *TerraformEnvPrinter) PostEnvHook(directory ...string) error {
-	return e.generateBackendOverrideTf(directory...)
+	if err := e.generateBackendOverrideTf(directory...); err != nil {
+		return err
+	}
+	return e.generateProvidersOverrideTf(directory...)
 }
 
 // GenerateTerraformArgs constructs Terraform CLI arguments and environment variables for given project and module paths.
@@ -487,6 +491,91 @@ func (e *TerraformEnvPrinter) generateBackendOverrideTf(directory ...string) err
 	err = e.shims.WriteFile(backendOverridePath, []byte(backendConfig), os.ModePerm)
 	if err != nil {
 		return fmt.Errorf("error writing backend_override.tf: %w", err)
+	}
+
+	return nil
+}
+
+// generateProvidersOverrideTf creates a providers_override.tf file when using Azure + AKS
+// to configure Kubernetes provider authentication via Entra ID using kubelogin with SPN authentication.
+// Detects SPN mode when AZURE_CLIENT_SECRET is set and validates required environment variables.
+// This enables generic Kubernetes modules to work with AKS clusters using Entra AD authentication
+// without requiring provider blocks in the modules themselves.
+func (e *TerraformEnvPrinter) generateProvidersOverrideTf(directory ...string) error {
+	var currentPath string
+	if len(directory) > 0 {
+		currentPath = filepath.Clean(directory[0])
+	} else {
+		var err error
+		currentPath, err = e.shims.Getwd()
+		if err != nil {
+			return fmt.Errorf("error getting current directory: %w", err)
+		}
+	}
+
+	projectPath, err := e.findRelativeTerraformProjectPath(directory...)
+	if err != nil {
+		return fmt.Errorf("error finding project path: %w", err)
+	}
+
+	if projectPath == "" {
+		return nil
+	}
+
+	azureEnabled := e.configHandler.GetBool("azure.enabled", false)
+	clusterDriver := e.configHandler.GetString("cluster.driver", "")
+
+	if !azureEnabled || clusterDriver != "aks" {
+		providersOverridePath := filepath.Join(currentPath, "providers_override.tf")
+		if _, err := e.shims.Stat(providersOverridePath); err == nil {
+			if err := e.shims.Remove(providersOverridePath); err != nil {
+				return fmt.Errorf("error removing providers_override.tf: %w", err)
+			}
+		}
+		return nil
+	}
+
+	config := e.configHandler.GetConfig()
+	if config == nil || config.Azure == nil {
+		return nil
+	}
+
+	azureEnv := "AzurePublicCloud"
+	if config.Azure.Environment != nil {
+		azureEnv = *config.Azure.Environment
+	}
+
+	azureClientSecret := e.shims.Getenv("AZURE_CLIENT_SECRET")
+
+	if azureClientSecret == "" {
+		providersOverridePath := filepath.Join(currentPath, "providers_override.tf")
+		if _, err := e.shims.Stat(providersOverridePath); err == nil {
+			if err := e.shims.Remove(providersOverridePath); err != nil {
+				return fmt.Errorf("error removing providers_override.tf: %w", err)
+			}
+		}
+		return nil
+	}
+
+	providerConfig := fmt.Sprintf(`provider "kubernetes" {
+  exec {
+    api_version = "client.authentication.k8s.io/v1beta1"
+    command     = "kubelogin"
+    args = [
+      "get-token",
+      "--login", "spn",
+      "--environment", "%s",
+      "--server-id", "%s",
+    ]
+  }
+}
+`, azureEnv, constants.DefaultAKSOIDCServerID)
+
+	providersOverridePath := filepath.Join(currentPath, "providers_override.tf")
+
+	err = e.shims.WriteFile(providersOverridePath, []byte(providerConfig), os.ModePerm)
+	if err != nil {
+		return fmt.Errorf("error writing providers_override.tf: %w", err)
 	}
 
 	return nil

--- a/pkg/runtime/tools/tools_manager.go
+++ b/pkg/runtime/tools/tools_manager.go
@@ -101,6 +101,14 @@ func (t *BaseToolsManager) Check() error {
 		}
 	}
 
+	if t.configHandler.GetBool("azure.enabled") {
+		if err := t.checkKubelogin(); err != nil {
+			spin.Stop()
+			fmt.Fprintf(os.Stderr, "\033[31m✗ %s - Failed\033[0m\n", message)
+			return fmt.Errorf("kubelogin check failed: %v", err)
+		}
+	}
+
 	spin.Stop()
 	fmt.Fprintf(os.Stderr, "\033[32m✔\033[0m %s - \033[32mDone\033[0m\n", message)
 	return nil
@@ -222,6 +230,45 @@ func (t *BaseToolsManager) checkOnePassword() error {
 
 	if compareVersion(version, constants.MinimumVersion1Password) < 0 {
 		return fmt.Errorf("1Password CLI version %s is below the minimum required version %s", version, constants.MinimumVersion1Password)
+	}
+
+	return nil
+}
+
+// checkKubelogin ensures kubelogin is available in the system's PATH using execLookPath.
+// It checks for 'kubelogin' in the system's PATH, verifies its version, and validates
+// required environment variables for SPN authentication if AZURE_CLIENT_SECRET is set.
+// Returns nil if found and meets the minimum version requirement, else an error indicating it is not available or outdated.
+func (t *BaseToolsManager) checkKubelogin() error {
+	if _, err := execLookPath("kubelogin"); err != nil {
+		return fmt.Errorf("kubelogin is not available in the PATH")
+	}
+
+	out, err := t.shell.ExecSilent("kubelogin", "--version")
+	if err != nil {
+		return fmt.Errorf("kubelogin is not available in the PATH")
+	}
+
+	version := extractVersion(out)
+	if version == "" {
+		return fmt.Errorf("failed to extract kubelogin version")
+	}
+
+	if compareVersion(version, constants.MinimumVersionKubelogin) < 0 {
+		return fmt.Errorf("kubelogin version %s is below the minimum required version %s", version, constants.MinimumVersionKubelogin)
+	}
+
+	azureClientSecret := os.Getenv("AZURE_CLIENT_SECRET")
+	if azureClientSecret != "" {
+		azureClientID := os.Getenv("AZURE_CLIENT_ID")
+		azureTenantID := os.Getenv("AZURE_TENANT_ID")
+
+		if azureClientID == "" {
+			return fmt.Errorf("AZURE_CLIENT_SECRET is set but AZURE_CLIENT_ID is missing - both are required for SPN authentication")
+		}
+		if azureTenantID == "" {
+			return fmt.Errorf("AZURE_CLIENT_SECRET is set but AZURE_TENANT_ID is missing - both are required for SPN authentication")
+		}
 	}
 
 	return nil

--- a/pkg/runtime/tools/tools_manager_test.go
+++ b/pkg/runtime/tools/tools_manager_test.go
@@ -860,6 +860,221 @@ func TestToolsManager_checkOnePassword(t *testing.T) {
 	})
 }
 
+// Tests for kubelogin version validation
+func TestToolsManager_checkKubelogin(t *testing.T) {
+	setup := func(t *testing.T) (*Mocks, *BaseToolsManager) {
+		t.Helper()
+		mocks := setupMocks(t)
+		toolsManager := NewToolsManager(mocks.ConfigHandler, mocks.Shell)
+		return mocks, toolsManager
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		// Given kubelogin is available with correct version
+		mocks, toolsManager := setup(t)
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			if name == "kubelogin" {
+				return "/usr/bin/kubelogin", nil
+			}
+			return originalExecLookPath(name)
+		}
+		mocks.Shell.ExecSilentFunc = func(name string, args ...string) (string, error) {
+			if name == "kubelogin" && args[0] == "--version" {
+				return fmt.Sprintf("kubelogin version %s", constants.MinimumVersionKubelogin), nil
+			}
+			return "", fmt.Errorf("command not found")
+		}
+		// When checking kubelogin version
+		err := toolsManager.checkKubelogin()
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected checkKubelogin to succeed, but got error: %v", err)
+		}
+	})
+
+	t.Run("KubeloginNotAvailable", func(t *testing.T) {
+		// Given kubelogin is not found in PATH
+		_, toolsManager := setup(t)
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			if name == "kubelogin" {
+				return "", exec.ErrNotFound
+			}
+			return originalExecLookPath(name)
+		}
+		// When checking kubelogin version
+		err := toolsManager.checkKubelogin()
+		// Then an error indicating kubelogin is not available should be returned
+		if err == nil || !strings.Contains(err.Error(), "kubelogin is not available in the PATH") {
+			t.Errorf("Expected kubelogin not available error, got %v", err)
+		}
+	})
+
+	t.Run("KubeloginVersionInvalidResponse", func(t *testing.T) {
+		// Given kubelogin version response is invalid
+		mocks, toolsManager := setup(t)
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			if name == "kubelogin" {
+				return "/usr/bin/kubelogin", nil
+			}
+			return originalExecLookPath(name)
+		}
+		mocks.Shell.ExecSilentFunc = func(name string, args ...string) (string, error) {
+			if name == "kubelogin" && args[0] == "--version" {
+				return "Invalid version response", nil
+			}
+			return "", fmt.Errorf("command not found")
+		}
+		// When checking kubelogin version
+		err := toolsManager.checkKubelogin()
+		// Then an error indicating version extraction failed should be returned
+		if err == nil || !strings.Contains(err.Error(), "failed to extract kubelogin version") {
+			t.Errorf("Expected failed to extract kubelogin version error, got %v", err)
+		}
+	})
+
+	t.Run("KubeloginVersionTooLow", func(t *testing.T) {
+		// Given kubelogin version is below minimum required version
+		mocks, toolsManager := setup(t)
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			if name == "kubelogin" {
+				return "/usr/bin/kubelogin", nil
+			}
+			return originalExecLookPath(name)
+		}
+		mocks.Shell.ExecSilentFunc = func(name string, args ...string) (string, error) {
+			if name == "kubelogin" && args[0] == "--version" {
+				return "kubelogin version 0.1.0", nil
+			}
+			return "", fmt.Errorf("command not found")
+		}
+		// When checking kubelogin version
+		err := toolsManager.checkKubelogin()
+		// Then an error indicating version is too low should be returned
+		if err == nil || !strings.Contains(err.Error(), "kubelogin version 0.1.0 is below the minimum required version") {
+			t.Errorf("Expected kubelogin version too low error, got %v", err)
+		}
+	})
+
+	t.Run("KubeloginCommandError", func(t *testing.T) {
+		// Given kubelogin command execution fails
+		mocks, toolsManager := setup(t)
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			if name == "kubelogin" {
+				return "/usr/bin/kubelogin", nil
+			}
+			return originalExecLookPath(name)
+		}
+		mocks.Shell.ExecSilentFunc = func(name string, args ...string) (string, error) {
+			if name == "kubelogin" && args[0] == "--version" {
+				return "", fmt.Errorf("kubelogin is not available in the PATH")
+			}
+			return "", fmt.Errorf("command not found")
+		}
+		// When checking kubelogin version
+		err := toolsManager.checkKubelogin()
+		// Then an error indicating kubelogin is not available should be returned
+		if err == nil || !strings.Contains(err.Error(), "kubelogin is not available in the PATH") {
+			t.Errorf("Expected kubelogin is not available in the PATH error, got %v", err)
+		}
+	})
+
+	t.Run("AZURE_CLIENT_SECRETSetButAZURE_CLIENT_IDMissing", func(t *testing.T) {
+		// Given AZURE_CLIENT_SECRET is set but AZURE_CLIENT_ID is missing
+		mocks, toolsManager := setup(t)
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			if name == "kubelogin" {
+				return "/usr/bin/kubelogin", nil
+			}
+			return originalExecLookPath(name)
+		}
+		mocks.Shell.ExecSilentFunc = func(name string, args ...string) (string, error) {
+			if name == "kubelogin" && args[0] == "--version" {
+				return fmt.Sprintf("kubelogin version %s", constants.MinimumVersionKubelogin), nil
+			}
+			return "", fmt.Errorf("command not found")
+		}
+		os.Setenv("AZURE_CLIENT_SECRET", "test-secret")
+		defer os.Unsetenv("AZURE_CLIENT_SECRET")
+		os.Unsetenv("AZURE_CLIENT_ID")
+		os.Unsetenv("AZURE_TENANT_ID")
+		// When checking kubelogin
+		err := toolsManager.checkKubelogin()
+		// Then an error indicating AZURE_CLIENT_ID is missing should be returned
+		if err == nil || !strings.Contains(err.Error(), "AZURE_CLIENT_SECRET is set but AZURE_CLIENT_ID is missing") {
+			t.Errorf("Expected AZURE_CLIENT_ID missing error, got %v", err)
+		}
+	})
+
+	t.Run("AZURE_CLIENT_SECRETSetButAZURE_TENANT_IDMissing", func(t *testing.T) {
+		// Given AZURE_CLIENT_SECRET is set but AZURE_TENANT_ID is missing
+		mocks, toolsManager := setup(t)
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			if name == "kubelogin" {
+				return "/usr/bin/kubelogin", nil
+			}
+			return originalExecLookPath(name)
+		}
+		mocks.Shell.ExecSilentFunc = func(name string, args ...string) (string, error) {
+			if name == "kubelogin" && args[0] == "--version" {
+				return fmt.Sprintf("kubelogin version %s", constants.MinimumVersionKubelogin), nil
+			}
+			return "", fmt.Errorf("command not found")
+		}
+		os.Setenv("AZURE_CLIENT_SECRET", "test-secret")
+		os.Setenv("AZURE_CLIENT_ID", "test-client-id")
+		defer func() {
+			os.Unsetenv("AZURE_CLIENT_SECRET")
+			os.Unsetenv("AZURE_CLIENT_ID")
+		}()
+		os.Unsetenv("AZURE_TENANT_ID")
+		// When checking kubelogin
+		err := toolsManager.checkKubelogin()
+		// Then an error indicating AZURE_TENANT_ID is missing should be returned
+		if err == nil || !strings.Contains(err.Error(), "AZURE_CLIENT_SECRET is set but AZURE_TENANT_ID is missing") {
+			t.Errorf("Expected AZURE_TENANT_ID missing error, got %v", err)
+		}
+	})
+
+	t.Run("AZURE_CLIENT_SECRETSetWithAllRequiredVars", func(t *testing.T) {
+		// Given AZURE_CLIENT_SECRET is set with all required environment variables
+		mocks, toolsManager := setup(t)
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			if name == "kubelogin" {
+				return "/usr/bin/kubelogin", nil
+			}
+			return originalExecLookPath(name)
+		}
+		mocks.Shell.ExecSilentFunc = func(name string, args ...string) (string, error) {
+			if name == "kubelogin" && args[0] == "--version" {
+				return fmt.Sprintf("kubelogin version %s", constants.MinimumVersionKubelogin), nil
+			}
+			return "", fmt.Errorf("command not found")
+		}
+		os.Setenv("AZURE_CLIENT_SECRET", "test-secret")
+		os.Setenv("AZURE_CLIENT_ID", "test-client-id")
+		os.Setenv("AZURE_TENANT_ID", "test-tenant-id")
+		defer func() {
+			os.Unsetenv("AZURE_CLIENT_SECRET")
+			os.Unsetenv("AZURE_CLIENT_ID")
+			os.Unsetenv("AZURE_TENANT_ID")
+		}()
+		// When checking kubelogin
+		err := toolsManager.checkKubelogin()
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected checkKubelogin to succeed with all required env vars, but got error: %v", err)
+		}
+	})
+}
+
 // =============================================================================
 // Test Helpers
 // =============================================================================


### PR DESCRIPTION
For Azure AKS, service principals are expected to use kubelogin to authenticate with an AKS cluster when accessing the cluster using Entra AD. Now, a `provider_override.tf` file gets generated when using AKS that includes appropriate values for properly using non-interactive kubelogin to authenticate with the cluster.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>