### PR TITLE
feat(terraform): Add more auth modes for AKS

### DIFF
--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -159,6 +159,13 @@ func (s *TerraformStack) Up(blueprint *blueprintv1alpha1.Blueprint) error {
 				return fmt.Errorf("error removing backend override file for %s: %w", component.Path, err)
 			}
 		}
+
+		providersOverridePath := filepath.Join(component.FullPath, "providers_override.tf")
+		if _, err := s.shims.Stat(providersOverridePath); err == nil {
+			if err := s.shims.Remove(providersOverridePath); err != nil {
+				return fmt.Errorf("error removing providers override file for %s: %w", component.Path, err)
+			}
+		}
 	}
 
 	return nil

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -444,6 +444,32 @@ func TestStack_Up(t *testing.T) {
 			t.Errorf("Expected remove error, got: %v", err)
 		}
 	})
+
+	t.Run("ErrorRemovingProvidersOverride", func(t *testing.T) {
+		stack, mocks := setup(t)
+		projectRoot := os.Getenv("WINDSOR_PROJECT_ROOT")
+		providersOverridePath := filepath.Join(projectRoot, ".windsor", "contexts", "local", "remote", "path", "providers_override.tf")
+		if err := os.MkdirAll(filepath.Dir(providersOverridePath), 0755); err != nil {
+			t.Fatalf("Failed to create directory: %v", err)
+		}
+		if err := os.WriteFile(providersOverridePath, []byte("test"), 0644); err != nil {
+			t.Fatalf("Failed to create providers override file: %v", err)
+		}
+		mocks.Shims.Remove = func(path string) error {
+			if strings.Contains(path, "providers_override.tf") {
+				return fmt.Errorf("remove error")
+			}
+			return nil
+		}
+		blueprint := createTestBlueprint()
+		err := stack.Up(blueprint)
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "error removing providers override file") {
+			t.Errorf("Expected remove error, got: %v", err)
+		}
+	})
 }
 
 func TestStack_Down(t *testing.T) {


### PR DESCRIPTION
* When `AZURE_FEDERATED_TOKEN_FILE` is defined, AKS login mode uses `workloadidentity`
* Falls back to `azurecli` login mode when no others are provided

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>