### PR TITLE
feat: Add support for the GCP provider

### DIFF
--- a/api/v1alpha1/config_types.go
+++ b/api/v1alpha1/config_types.go
@@ -6,6 +6,7 @@ import (
 	"github.com/windsorcli/cli/api/v1alpha1/cluster"
 	"github.com/windsorcli/cli/api/v1alpha1/dns"
 	"github.com/windsorcli/cli/api/v1alpha1/docker"
+	"github.com/windsorcli/cli/api/v1alpha1/gcp"
 	"github.com/windsorcli/cli/api/v1alpha1/git"
 	"github.com/windsorcli/cli/api/v1alpha1/network"
 	"github.com/windsorcli/cli/api/v1alpha1/secrets"
@@ -28,6 +29,7 @@ type Context struct {
 	Secrets     *secrets.SecretsConfig     `yaml:"secrets,omitempty"`
 	AWS         *aws.AWSConfig             `yaml:"aws,omitempty"`
 	Azure       *azure.AzureConfig         `yaml:"azure,omitempty"`
+	GCP         *gcp.GCPConfig            `yaml:"gcp,omitempty"`
 	Docker      *docker.DockerConfig       `yaml:"docker,omitempty"`
 	Git         *git.GitConfig             `yaml:"git,omitempty"`
 	Terraform   *terraform.TerraformConfig `yaml:"terraform,omitempty"`
@@ -73,6 +75,12 @@ func (base *Context) Merge(overlay *Context) {
 			base.Azure = &azure.AzureConfig{}
 		}
 		base.Azure.Merge(overlay.Azure)
+	}
+	if overlay.GCP != nil {
+		if base.GCP == nil {
+			base.GCP = &gcp.GCPConfig{}
+		}
+		base.GCP.Merge(overlay.GCP)
 	}
 	if overlay.Docker != nil {
 		if base.Docker == nil {
@@ -137,6 +145,7 @@ func (c *Context) DeepCopy() *Context {
 		Secrets:     c.Secrets.Copy(),
 		AWS:         c.AWS.Copy(),
 		Azure:       c.Azure.Copy(),
+		GCP:         c.GCP.Copy(),
 		Docker:      c.Docker.Copy(),
 		Git:         c.Git.Copy(),
 		Terraform:   c.Terraform.Copy(),

--- a/api/v1alpha1/gcp/gcp_config.go
+++ b/api/v1alpha1/gcp/gcp_config.go
@@ -1,0 +1,48 @@
+package gcp
+
+// GCPConfig represents the GCP configuration
+type GCPConfig struct {
+	// Enabled indicates whether GCP integration is enabled.
+	Enabled *bool `yaml:"enabled,omitempty"`
+
+	// ProjectID is the GCP project identifier
+	ProjectID *string `yaml:"project_id,omitempty"`
+
+	// CredentialsPath specifies the path to a service account key file.
+	CredentialsPath *string `yaml:"credentials_path,omitempty"`
+
+	// QuotaProject specifies the project to use for quota and billing
+	QuotaProject *string `yaml:"quota_project,omitempty"`
+}
+
+// Merge performs a deep merge of the current GCPConfig with another GCPConfig.
+func (base *GCPConfig) Merge(overlay *GCPConfig) {
+	if overlay == nil {
+		return
+	}
+	if overlay.Enabled != nil {
+		base.Enabled = overlay.Enabled
+	}
+	if overlay.ProjectID != nil {
+		base.ProjectID = overlay.ProjectID
+	}
+	if overlay.CredentialsPath != nil {
+		base.CredentialsPath = overlay.CredentialsPath
+	}
+	if overlay.QuotaProject != nil {
+		base.QuotaProject = overlay.QuotaProject
+	}
+}
+
+// Copy creates a deep copy of the GCPConfig object
+func (c *GCPConfig) Copy() *GCPConfig {
+	if c == nil {
+		return nil
+	}
+	return &GCPConfig{
+		Enabled:         c.Enabled,
+		ProjectID:       c.ProjectID,
+		CredentialsPath: c.CredentialsPath,
+		QuotaProject:    c.QuotaProject,
+	}
+}

--- a/api/v1alpha1/gcp/gcp_config_test.go
+++ b/api/v1alpha1/gcp/gcp_config_test.go
@@ -1,0 +1,199 @@
+package gcp
+
+import (
+	"testing"
+)
+
+func TestGCPConfig_Merge(t *testing.T) {
+	t.Run("MergeWithNoNils", func(t *testing.T) {
+		base := &GCPConfig{
+			Enabled:         ptrBool(true),
+			ProjectID:       ptrString("base-project"),
+			CredentialsPath: ptrString("/base/credentials.json"),
+			QuotaProject:    ptrString("base-quota"),
+		}
+
+		overlay := &GCPConfig{
+			Enabled:         ptrBool(false),
+			ProjectID:       ptrString("overlay-project"),
+			CredentialsPath: ptrString("/overlay/credentials.json"),
+			QuotaProject:    ptrString("overlay-quota"),
+		}
+
+		base.Merge(overlay)
+
+		if base.Enabled == nil || *base.Enabled != false {
+			t.Errorf("Enabled mismatch: expected false, got %v", *base.Enabled)
+		}
+		if base.ProjectID == nil || *base.ProjectID != "overlay-project" {
+			t.Errorf("ProjectID mismatch: expected 'overlay-project', got '%s'", *base.ProjectID)
+		}
+		if base.CredentialsPath == nil || *base.CredentialsPath != "/overlay/credentials.json" {
+			t.Errorf("CredentialsPath mismatch: expected '/overlay/credentials.json', got '%s'", *base.CredentialsPath)
+		}
+		if base.QuotaProject == nil || *base.QuotaProject != "overlay-quota" {
+			t.Errorf("QuotaProject mismatch: expected 'overlay-quota', got '%s'", *base.QuotaProject)
+		}
+	})
+
+	t.Run("MergeWithAllNils", func(t *testing.T) {
+		base := &GCPConfig{
+			Enabled:         nil,
+			ProjectID:       nil,
+			CredentialsPath: nil,
+			QuotaProject:    nil,
+		}
+
+		overlay := &GCPConfig{
+			Enabled:         nil,
+			ProjectID:       nil,
+			CredentialsPath: nil,
+			QuotaProject:    nil,
+		}
+
+		base.Merge(overlay)
+
+		if base.Enabled != nil {
+			t.Errorf("Enabled mismatch: expected nil, got %v", base.Enabled)
+		}
+		if base.ProjectID != nil {
+			t.Errorf("ProjectID mismatch: expected nil, got '%s'", *base.ProjectID)
+		}
+		if base.CredentialsPath != nil {
+			t.Errorf("CredentialsPath mismatch: expected nil, got '%s'", *base.CredentialsPath)
+		}
+		if base.QuotaProject != nil {
+			t.Errorf("QuotaProject mismatch: expected nil, got '%s'", *base.QuotaProject)
+		}
+	})
+
+	t.Run("MergeWithPartialOverlay", func(t *testing.T) {
+		base := &GCPConfig{
+			Enabled:         ptrBool(true),
+			ProjectID:       ptrString("base-project"),
+			CredentialsPath: ptrString("/base/credentials.json"),
+			QuotaProject:    ptrString("base-quota"),
+		}
+
+		overlay := &GCPConfig{
+			Enabled: ptrBool(false),
+		}
+
+		base.Merge(overlay)
+
+		if base.Enabled == nil || *base.Enabled != false {
+			t.Errorf("Enabled mismatch: expected false, got %v", *base.Enabled)
+		}
+		if base.ProjectID == nil || *base.ProjectID != "base-project" {
+			t.Errorf("ProjectID mismatch: expected 'base-project', got '%s'", *base.ProjectID)
+		}
+		if base.CredentialsPath == nil || *base.CredentialsPath != "/base/credentials.json" {
+			t.Errorf("CredentialsPath mismatch: expected '/base/credentials.json', got '%s'", *base.CredentialsPath)
+		}
+		if base.QuotaProject == nil || *base.QuotaProject != "base-quota" {
+			t.Errorf("QuotaProject mismatch: expected 'base-quota', got '%s'", *base.QuotaProject)
+		}
+	})
+
+	t.Run("MergeWithNilOverlay", func(t *testing.T) {
+		base := &GCPConfig{
+			Enabled:         ptrBool(true),
+			ProjectID:       ptrString("base-project"),
+			CredentialsPath: ptrString("/base/credentials.json"),
+			QuotaProject:    ptrString("base-quota"),
+		}
+		original := base.Copy()
+
+		base.Merge(nil)
+
+		if base.Enabled == nil || *base.Enabled != *original.Enabled {
+			t.Errorf("Enabled mismatch: expected unchanged")
+		}
+		if base.ProjectID == nil || *base.ProjectID != *original.ProjectID {
+			t.Errorf("ProjectID mismatch: expected unchanged")
+		}
+		if base.CredentialsPath == nil || *base.CredentialsPath != *original.CredentialsPath {
+			t.Errorf("CredentialsPath mismatch: expected unchanged")
+		}
+		if base.QuotaProject == nil || *base.QuotaProject != *original.QuotaProject {
+			t.Errorf("QuotaProject mismatch: expected unchanged")
+		}
+	})
+}
+
+func TestGCPConfig_Copy(t *testing.T) {
+	t.Run("CopyWithNonNilValues", func(t *testing.T) {
+		original := &GCPConfig{
+			Enabled:         ptrBool(true),
+			ProjectID:       ptrString("test-project"),
+			CredentialsPath: ptrString("/test/credentials.json"),
+			QuotaProject:    ptrString("test-quota"),
+		}
+
+		copy := original.Copy()
+
+		if original.Enabled == nil || copy.Enabled == nil || *original.Enabled != *copy.Enabled {
+			t.Errorf("Enabled mismatch: expected %v, got %v", *original.Enabled, *copy.Enabled)
+		}
+		if original.ProjectID == nil || copy.ProjectID == nil || *original.ProjectID != *copy.ProjectID {
+			t.Errorf("ProjectID mismatch: expected %v, got %v", *original.ProjectID, *copy.ProjectID)
+		}
+		if original.CredentialsPath == nil || copy.CredentialsPath == nil || *original.CredentialsPath != *copy.CredentialsPath {
+			t.Errorf("CredentialsPath mismatch: expected %v, got %v", *original.CredentialsPath, *copy.CredentialsPath)
+		}
+		if original.QuotaProject == nil || copy.QuotaProject == nil || *original.QuotaProject != *copy.QuotaProject {
+			t.Errorf("QuotaProject mismatch: expected %v, got %v", *original.QuotaProject, *copy.QuotaProject)
+		}
+
+		copy.Enabled = ptrBool(false)
+		if original.Enabled == nil || *original.Enabled == *copy.Enabled {
+			t.Errorf("Original Enabled was modified: expected %v, got %v", true, *copy.Enabled)
+		}
+
+		copy.ProjectID = ptrString("modified-project")
+		if original.ProjectID == nil || *original.ProjectID == *copy.ProjectID {
+			t.Errorf("Original ProjectID was modified: expected %v, got %v", "test-project", *copy.ProjectID)
+		}
+	})
+
+	t.Run("CopyNil", func(t *testing.T) {
+		var original *GCPConfig = nil
+		mockCopy := original.Copy()
+		if mockCopy != nil {
+			t.Errorf("Mock copy should be nil, got %v", mockCopy)
+		}
+	})
+
+	t.Run("CopyWithSomeFields", func(t *testing.T) {
+		original := &GCPConfig{
+			Enabled: ptrBool(true),
+		}
+
+		copy := original.Copy()
+
+		if copy == nil {
+			t.Fatal("Expected non-nil copy")
+		}
+		if copy.Enabled == nil || *copy.Enabled != *original.Enabled {
+			t.Errorf("Expected Enabled to be copied correctly")
+		}
+		if copy.ProjectID != nil {
+			t.Error("Expected ProjectID to be nil")
+		}
+		if copy.CredentialsPath != nil {
+			t.Error("Expected CredentialsPath to be nil")
+		}
+		if copy.QuotaProject != nil {
+			t.Error("Expected QuotaProject to be nil")
+		}
+	})
+}
+
+func ptrString(s string) *string {
+	return &s
+}
+
+func ptrBool(b bool) *bool {
+	return &b
+}
+

--- a/api/v1alpha2/config/providers/gcp/gcp.go
+++ b/api/v1alpha2/config/providers/gcp/gcp.go
@@ -1,0 +1,62 @@
+package gcp
+
+// GCPConfig represents the GCP configuration
+type GCPConfig struct {
+	// Enabled indicates whether GCP integration is enabled.
+	Enabled *bool `yaml:"enabled,omitempty"`
+
+	// ProjectID is the GCP project identifier
+	ProjectID *string `yaml:"project_id,omitempty"`
+
+	// CredentialsPath specifies the path to a service account key file.
+	CredentialsPath *string `yaml:"credentials_path,omitempty"`
+
+	// QuotaProject specifies the project to use for quota and billing
+	QuotaProject *string `yaml:"quota_project,omitempty"`
+}
+
+// Merge performs a deep merge of the current GCPConfig with another GCPConfig.
+func (base *GCPConfig) Merge(overlay *GCPConfig) {
+	if overlay == nil {
+		return
+	}
+	if overlay.Enabled != nil {
+		base.Enabled = overlay.Enabled
+	}
+	if overlay.ProjectID != nil {
+		base.ProjectID = overlay.ProjectID
+	}
+	if overlay.CredentialsPath != nil {
+		base.CredentialsPath = overlay.CredentialsPath
+	}
+	if overlay.QuotaProject != nil {
+		base.QuotaProject = overlay.QuotaProject
+	}
+}
+
+// DeepCopy creates a deep copy of the GCPConfig object
+func (c *GCPConfig) DeepCopy() *GCPConfig {
+	if c == nil {
+		return nil
+	}
+	copied := &GCPConfig{}
+
+	if c.Enabled != nil {
+		enabledCopy := *c.Enabled
+		copied.Enabled = &enabledCopy
+	}
+	if c.ProjectID != nil {
+		projectCopy := *c.ProjectID
+		copied.ProjectID = &projectCopy
+	}
+	if c.CredentialsPath != nil {
+		credentialsCopy := *c.CredentialsPath
+		copied.CredentialsPath = &credentialsCopy
+	}
+	if c.QuotaProject != nil {
+		quotaCopy := *c.QuotaProject
+		copied.QuotaProject = &quotaCopy
+	}
+
+	return copied
+}

--- a/api/v1alpha2/config/providers/gcp/gcp_test.go
+++ b/api/v1alpha2/config/providers/gcp/gcp_test.go
@@ -1,0 +1,212 @@
+package gcp
+
+import (
+	"testing"
+)
+
+func TestGCPConfig_Merge(t *testing.T) {
+	t.Run("MergeWithNoNils", func(t *testing.T) {
+		base := &GCPConfig{
+			Enabled:         ptrBool(true),
+			ProjectID:       ptrString("base-project"),
+			CredentialsPath: ptrString("/base/credentials.json"),
+			QuotaProject:    ptrString("base-quota"),
+		}
+
+		overlay := &GCPConfig{
+			Enabled:         ptrBool(false),
+			ProjectID:       ptrString("overlay-project"),
+			CredentialsPath: ptrString("/overlay/credentials.json"),
+			QuotaProject:    ptrString("overlay-quota"),
+		}
+
+		base.Merge(overlay)
+
+		if base.Enabled == nil || *base.Enabled != false {
+			t.Errorf("Enabled mismatch: expected false, got %v", *base.Enabled)
+		}
+		if base.ProjectID == nil || *base.ProjectID != "overlay-project" {
+			t.Errorf("ProjectID mismatch: expected 'overlay-project', got '%s'", *base.ProjectID)
+		}
+		if base.CredentialsPath == nil || *base.CredentialsPath != "/overlay/credentials.json" {
+			t.Errorf("CredentialsPath mismatch: expected '/overlay/credentials.json', got '%s'", *base.CredentialsPath)
+		}
+		if base.QuotaProject == nil || *base.QuotaProject != "overlay-quota" {
+			t.Errorf("QuotaProject mismatch: expected 'overlay-quota', got '%s'", *base.QuotaProject)
+		}
+	})
+
+	t.Run("MergeWithAllNils", func(t *testing.T) {
+		base := &GCPConfig{
+			Enabled:         nil,
+			ProjectID:       nil,
+			CredentialsPath: nil,
+			QuotaProject:    nil,
+		}
+
+		overlay := &GCPConfig{
+			Enabled:         nil,
+			ProjectID:       nil,
+			CredentialsPath: nil,
+			QuotaProject:    nil,
+		}
+
+		base.Merge(overlay)
+
+		if base.Enabled != nil {
+			t.Errorf("Enabled mismatch: expected nil, got %v", base.Enabled)
+		}
+		if base.ProjectID != nil {
+			t.Errorf("ProjectID mismatch: expected nil, got '%s'", *base.ProjectID)
+		}
+		if base.CredentialsPath != nil {
+			t.Errorf("CredentialsPath mismatch: expected nil, got '%s'", *base.CredentialsPath)
+		}
+		if base.QuotaProject != nil {
+			t.Errorf("QuotaProject mismatch: expected nil, got '%s'", *base.QuotaProject)
+		}
+	})
+
+	t.Run("MergeWithPartialOverlay", func(t *testing.T) {
+		base := &GCPConfig{
+			Enabled:         ptrBool(true),
+			ProjectID:       ptrString("base-project"),
+			CredentialsPath: ptrString("/base/credentials.json"),
+			QuotaProject:    ptrString("base-quota"),
+		}
+
+		overlay := &GCPConfig{
+			Enabled: ptrBool(false),
+		}
+
+		base.Merge(overlay)
+
+		if base.Enabled == nil || *base.Enabled != false {
+			t.Errorf("Enabled mismatch: expected false, got %v", *base.Enabled)
+		}
+		if base.ProjectID == nil || *base.ProjectID != "base-project" {
+			t.Errorf("ProjectID mismatch: expected 'base-project', got '%s'", *base.ProjectID)
+		}
+		if base.CredentialsPath == nil || *base.CredentialsPath != "/base/credentials.json" {
+			t.Errorf("CredentialsPath mismatch: expected '/base/credentials.json', got '%s'", *base.CredentialsPath)
+		}
+		if base.QuotaProject == nil || *base.QuotaProject != "base-quota" {
+			t.Errorf("QuotaProject mismatch: expected 'base-quota', got '%s'", *base.QuotaProject)
+		}
+	})
+
+	t.Run("MergeWithNilOverlay", func(t *testing.T) {
+		base := &GCPConfig{
+			Enabled:         ptrBool(true),
+			ProjectID:       ptrString("base-project"),
+			CredentialsPath: ptrString("/base/credentials.json"),
+			QuotaProject:    ptrString("base-quota"),
+		}
+		original := base.DeepCopy()
+
+		base.Merge(nil)
+
+		if base.Enabled == nil || *base.Enabled != *original.Enabled {
+			t.Errorf("Enabled mismatch: expected unchanged")
+		}
+		if base.ProjectID == nil || *base.ProjectID != *original.ProjectID {
+			t.Errorf("ProjectID mismatch: expected unchanged")
+		}
+		if base.CredentialsPath == nil || *base.CredentialsPath != *original.CredentialsPath {
+			t.Errorf("CredentialsPath mismatch: expected unchanged")
+		}
+		if base.QuotaProject == nil || *base.QuotaProject != *original.QuotaProject {
+			t.Errorf("QuotaProject mismatch: expected unchanged")
+		}
+	})
+}
+
+func TestGCPConfig_DeepCopy(t *testing.T) {
+	t.Run("DeepCopyWithNonNilValues", func(t *testing.T) {
+		original := &GCPConfig{
+			Enabled:         ptrBool(true),
+			ProjectID:       ptrString("test-project"),
+			CredentialsPath: ptrString("/test/credentials.json"),
+			QuotaProject:    ptrString("test-quota"),
+		}
+
+		copy := original.DeepCopy()
+
+		if original.Enabled == nil || copy.Enabled == nil || *original.Enabled != *copy.Enabled {
+			t.Errorf("Enabled mismatch: expected %v, got %v", *original.Enabled, *copy.Enabled)
+		}
+		if original.ProjectID == nil || copy.ProjectID == nil || *original.ProjectID != *copy.ProjectID {
+			t.Errorf("ProjectID mismatch: expected %v, got %v", *original.ProjectID, *copy.ProjectID)
+		}
+		if original.CredentialsPath == nil || copy.CredentialsPath == nil || *original.CredentialsPath != *copy.CredentialsPath {
+			t.Errorf("CredentialsPath mismatch: expected %v, got %v", *original.CredentialsPath, *copy.CredentialsPath)
+		}
+		if original.QuotaProject == nil || copy.QuotaProject == nil || *original.QuotaProject != *copy.QuotaProject {
+			t.Errorf("QuotaProject mismatch: expected %v, got %v", *original.QuotaProject, *copy.QuotaProject)
+		}
+
+		copy.Enabled = ptrBool(false)
+		if original.Enabled == nil || *original.Enabled == *copy.Enabled {
+			t.Errorf("Original Enabled was modified: expected %v, got %v", true, *copy.Enabled)
+		}
+
+		copy.ProjectID = ptrString("modified-project")
+		if original.ProjectID == nil || *original.ProjectID == *copy.ProjectID {
+			t.Errorf("Original ProjectID was modified: expected %v, got %v", "test-project", *copy.ProjectID)
+		}
+
+		if copy.Enabled == original.Enabled {
+			t.Error("Expected Enabled pointers to be different")
+		}
+		if copy.ProjectID == original.ProjectID {
+			t.Error("Expected ProjectID pointers to be different")
+		}
+		if copy.CredentialsPath == original.CredentialsPath {
+			t.Error("Expected CredentialsPath pointers to be different")
+		}
+		if copy.QuotaProject == original.QuotaProject {
+			t.Error("Expected QuotaProject pointers to be different")
+		}
+	})
+
+	t.Run("DeepCopyNil", func(t *testing.T) {
+		var original *GCPConfig = nil
+		mockCopy := original.DeepCopy()
+		if mockCopy != nil {
+			t.Errorf("Mock copy should be nil, got %v", mockCopy)
+		}
+	})
+
+	t.Run("DeepCopyWithSomeFields", func(t *testing.T) {
+		original := &GCPConfig{
+			Enabled: ptrBool(true),
+		}
+
+		copy := original.DeepCopy()
+
+		if copy == nil {
+			t.Fatal("Expected non-nil copy")
+		}
+		if copy.Enabled == nil || *copy.Enabled != *original.Enabled {
+			t.Errorf("Expected Enabled to be copied correctly")
+		}
+		if copy.ProjectID != nil {
+			t.Error("Expected ProjectID to be nil")
+		}
+		if copy.CredentialsPath != nil {
+			t.Error("Expected CredentialsPath to be nil")
+		}
+		if copy.QuotaProject != nil {
+			t.Error("Expected QuotaProject to be nil")
+		}
+	})
+}
+
+func ptrString(s string) *string {
+	return &s
+}
+
+func ptrBool(b bool) *bool {
+	return &b
+}
+

--- a/api/v1alpha2/config/providers/providers.go
+++ b/api/v1alpha2/config/providers/providers.go
@@ -3,12 +3,14 @@ package providers
 import (
 	"github.com/windsorcli/cli/api/v1alpha2/config/providers/aws"
 	"github.com/windsorcli/cli/api/v1alpha2/config/providers/azure"
+	"github.com/windsorcli/cli/api/v1alpha2/config/providers/gcp"
 )
 
 // ProvidersConfig represents the configuration for all cloud providers
 type ProvidersConfig struct {
 	AWS   *aws.AWSConfig     `yaml:"aws,omitempty"`
 	Azure *azure.AzureConfig `yaml:"azure,omitempty"`
+	GCP   *gcp.GCPConfig     `yaml:"gcp,omitempty"`
 }
 
 // Merge performs a deep merge of the current ProvidersConfig with another ProvidersConfig.
@@ -28,6 +30,12 @@ func (base *ProvidersConfig) Merge(overlay *ProvidersConfig) {
 		}
 		base.Azure.Merge(overlay.Azure)
 	}
+	if overlay.GCP != nil {
+		if base.GCP == nil {
+			base.GCP = &gcp.GCPConfig{}
+		}
+		base.GCP.Merge(overlay.GCP)
+	}
 }
 
 // DeepCopy creates a deep copy of the ProvidersConfig object
@@ -42,6 +50,9 @@ func (c *ProvidersConfig) DeepCopy() *ProvidersConfig {
 	}
 	if c.Azure != nil {
 		copied.Azure = c.Azure.DeepCopy()
+	}
+	if c.GCP != nil {
+		copied.GCP = c.GCP.DeepCopy()
 	}
 
 	return copied

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -31,3 +31,4 @@ packages:
 - name: 1password/cli@v2.30.3
 - name: fluxcd/flux2@v2.7.5
 - name: aws/aws-cli@2.32.15
+- name: twistedpair/google-cloud-sdk@549.0.1

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -188,7 +188,7 @@ func init() {
 	initCmd.Flags().StringVar(&initArch, "vm-arch", "", "Specify the architecture for Colima")
 	initCmd.Flags().BoolVar(&initDocker, "docker", false, "Enable Docker")
 	initCmd.Flags().BoolVar(&initGitLivereload, "git-livereload", false, "Enable Git Livereload")
-	initCmd.Flags().StringVar(&initProvider, "provider", "", "Specify the provider to use [none|generic|aws|azure]")
+	initCmd.Flags().StringVar(&initProvider, "provider", "", "Specify the provider to use [none|generic|aws|azure|gcp]")
 	initCmd.Flags().StringVar(&initPlatform, "platform", "", "Deprecated: use --provider instead")
 	initCmd.Flags().StringVar(&initBlueprint, "blueprint", "", "Specify the blueprint to use")
 	initCmd.Flags().StringVar(&initEndpoint, "endpoint", "", "Specify the kubernetes API endpoint")

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -182,6 +182,7 @@ func (r *Composer) generateGitignore() error {
 		"contexts/**/.omni/",
 		"contexts/**/.aws/",
 		"contexts/**/.azure/",
+		"contexts/**/.gcp/",
 	}
 
 	projectRoot := r.Runtime.ProjectRoot

--- a/pkg/runtime/config/config_handler.go
+++ b/pkg/runtime/config/config_handler.go
@@ -740,7 +740,7 @@ func (c *configHandler) Clean() error {
 		return fmt.Errorf("error getting config root: %w", err)
 	}
 
-	dirsToDeleteFromConfigRoot := []string{".kube", ".talos", ".omni", ".aws"}
+	dirsToDeleteFromConfigRoot := []string{".kube", ".talos", ".omni", ".aws", ".gcp"}
 
 	for _, dir := range dirsToDeleteFromConfigRoot {
 		path := filepath.Join(configRoot, dir)

--- a/pkg/runtime/env/gcp_env.go
+++ b/pkg/runtime/env/gcp_env.go
@@ -1,0 +1,84 @@
+// The GcpEnvPrinter is a specialized component that manages GCP environment configuration.
+// It provides GCP-specific environment variable management and configuration,
+// The GcpEnvPrinter handles GCP configuration settings and environment setup,
+// ensuring proper gcloud CLI integration and environment setup for operations.
+
+package env
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/windsorcli/cli/pkg/runtime/config"
+	"github.com/windsorcli/cli/pkg/runtime/shell"
+)
+
+// =============================================================================
+// Types
+// =============================================================================
+
+// GcpEnvPrinter is a struct that implements GCP environment configuration
+type GcpEnvPrinter struct {
+	BaseEnvPrinter
+}
+
+// =============================================================================
+// Constructor
+// =============================================================================
+
+// NewGcpEnvPrinter creates a new GcpEnvPrinter instance
+func NewGcpEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler) *GcpEnvPrinter {
+	return &GcpEnvPrinter{
+		BaseEnvPrinter: *NewBaseEnvPrinter(shell, configHandler),
+	}
+}
+
+// =============================================================================
+// Public Methods
+// =============================================================================
+
+// GetEnvVars retrieves the environment variables for the GCP environment.
+func (e *GcpEnvPrinter) GetEnvVars() (map[string]string, error) {
+	envVars := make(map[string]string)
+
+	configRoot, err := e.configHandler.GetConfigRoot()
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving configuration root directory: %w", err)
+	}
+
+	gcpConfigDir := filepath.Join(configRoot, ".gcp")
+	gcloudConfigDir := filepath.Join(gcpConfigDir, "gcloud")
+
+	config := e.configHandler.GetConfig()
+	if config != nil && config.GCP != nil {
+		if err := e.shims.MkdirAll(gcloudConfigDir, 0755); err != nil {
+			return nil, fmt.Errorf("error creating GCP config directory: %w", err)
+		}
+		envVars["CLOUDSDK_CONFIG"] = filepath.ToSlash(gcloudConfigDir)
+
+		if config.GCP.ProjectID != nil {
+			envVars["GOOGLE_CLOUD_PROJECT"] = *config.GCP.ProjectID
+			envVars["GCLOUD_PROJECT"] = *config.GCP.ProjectID
+		}
+
+		if _, exists := e.shims.LookupEnv("GOOGLE_APPLICATION_CREDENTIALS"); !exists {
+			if config.GCP.CredentialsPath != nil {
+				envVars["GOOGLE_APPLICATION_CREDENTIALS"] = *config.GCP.CredentialsPath
+			} else {
+				serviceAccountPath := filepath.Join(gcpConfigDir, "service-accounts", "default.json")
+				if _, err := e.shims.Stat(serviceAccountPath); err == nil {
+					envVars["GOOGLE_APPLICATION_CREDENTIALS"] = filepath.ToSlash(serviceAccountPath)
+				}
+			}
+		}
+
+		if config.GCP.QuotaProject != nil {
+			envVars["GOOGLE_CLOUD_QUOTA_PROJECT"] = *config.GCP.QuotaProject
+		}
+	}
+
+	return envVars, nil
+}
+
+// Ensure GcpEnvPrinter implements the EnvPrinter interface
+var _ EnvPrinter = (*GcpEnvPrinter)(nil)

--- a/pkg/runtime/env/gcp_env_test.go
+++ b/pkg/runtime/env/gcp_env_test.go
@@ -1,0 +1,406 @@
+package env
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/windsorcli/cli/api/v1alpha1"
+	"github.com/windsorcli/cli/pkg/runtime/config"
+)
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+func setupGcpEnvMocks(t *testing.T, overrides ...*EnvTestMocks) *EnvTestMocks {
+	t.Helper()
+
+	mocks := setupEnvMocks(t, overrides...)
+
+	if _, ok := mocks.ConfigHandler.(*config.MockConfigHandler); !ok {
+		mocks.ConfigHandler = config.NewMockConfigHandler()
+	}
+
+	mockConfigHandler := mocks.ConfigHandler.(*config.MockConfigHandler)
+
+	mockConfigHandler.GetConfigRootFunc = func() (string, error) {
+		return "/mock/config/root", nil
+	}
+
+	loadedConfigs := make(map[string]*v1alpha1.Context)
+	currentContext := "test-context"
+
+	mockConfigHandler.GetContextFunc = func() string {
+		return currentContext
+	}
+
+	mockConfigHandler.SetContextFunc = func(context string) error {
+		currentContext = context
+		return nil
+	}
+
+	mockConfigHandler.LoadConfigStringFunc = func(content string) error {
+		var cfg v1alpha1.Config
+		if err := yaml.Unmarshal([]byte(content), &cfg); err != nil {
+			return err
+		}
+		for name, ctx := range cfg.Contexts {
+			if ctx != nil {
+				ctxCopy := *ctx
+				loadedConfigs[name] = &ctxCopy
+			} else {
+				loadedConfigs[name] = &v1alpha1.Context{}
+			}
+		}
+		return nil
+	}
+
+	mockConfigHandler.GetConfigFunc = func() *v1alpha1.Context {
+		if ctx, ok := loadedConfigs[currentContext]; ok {
+			return ctx
+		}
+		return &v1alpha1.Context{}
+	}
+
+	if len(overrides) == 0 || overrides[0] == nil || overrides[0].ConfigHandler == nil {
+		defaultConfigStr := `
+version: v1alpha1
+contexts:
+  test-context:
+    gcp:
+      enabled: true
+      project_id: "test-project"
+      quota_project: "billing-project"
+`
+
+		if err := mocks.ConfigHandler.LoadConfigString(defaultConfigStr); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+	}
+
+	if err := mocks.ConfigHandler.SetContext("test-context"); err != nil {
+		t.Fatalf("Failed to set context: %v", err)
+	}
+
+	mocks.Shims.Stat = func(name string) (os.FileInfo, error) {
+		return nil, os.ErrNotExist
+	}
+
+	mocks.Shims.MkdirAll = func(path string, perm os.FileMode) error {
+		return nil
+	}
+
+	return mocks
+}
+
+// =============================================================================
+// Test Public Methods
+// =============================================================================
+
+func TestGcpEnv_GetEnvVars(t *testing.T) {
+	setup := func(t *testing.T, overrides ...*EnvTestMocks) (*GcpEnvPrinter, *EnvTestMocks) {
+		t.Helper()
+		mocks := setupGcpEnvMocks(t, overrides...)
+		printer := NewGcpEnvPrinter(mocks.Shell, mocks.ConfigHandler)
+		printer.shims = mocks.Shims
+		return printer, mocks
+	}
+
+	t.Run("SuccessWithAllConfig", func(t *testing.T) {
+		printer, mocks := setup(t)
+		configRoot, err := mocks.ConfigHandler.GetConfigRoot()
+		if err != nil {
+			t.Fatalf("Failed to get config root: %v", err)
+		}
+
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		expectedGcloudConfigDir := filepath.ToSlash(filepath.Join(configRoot, ".gcp", "gcloud"))
+		if envVars["CLOUDSDK_CONFIG"] != expectedGcloudConfigDir {
+			t.Errorf("GetEnvVars returned CLOUDSDK_CONFIG=%v, want %v", envVars["CLOUDSDK_CONFIG"], expectedGcloudConfigDir)
+		}
+
+		if envVars["GOOGLE_CLOUD_PROJECT"] != "test-project" {
+			t.Errorf("GetEnvVars returned GOOGLE_CLOUD_PROJECT=%v, want test-project", envVars["GOOGLE_CLOUD_PROJECT"])
+		}
+
+		if envVars["GCLOUD_PROJECT"] != "test-project" {
+			t.Errorf("GetEnvVars returned GCLOUD_PROJECT=%v, want test-project", envVars["GCLOUD_PROJECT"])
+		}
+
+		if envVars["GOOGLE_CLOUD_QUOTA_PROJECT"] != "billing-project" {
+			t.Errorf("GetEnvVars returned GOOGLE_CLOUD_QUOTA_PROJECT=%v, want billing-project", envVars["GOOGLE_CLOUD_QUOTA_PROJECT"])
+		}
+	})
+
+	t.Run("SuccessWithMinimalConfig", func(t *testing.T) {
+		mocks := setupGcpEnvMocks(t)
+		configStr := `
+version: v1alpha1
+contexts:
+  test-context:
+    gcp:
+      enabled: true
+`
+		if err := mocks.ConfigHandler.LoadConfigString(configStr); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+		printer := NewGcpEnvPrinter(mocks.Shell, mocks.ConfigHandler)
+		printer.shims = mocks.Shims
+
+		configRoot, err := mocks.ConfigHandler.GetConfigRoot()
+		if err != nil {
+			t.Fatalf("Failed to get config root: %v", err)
+		}
+
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		expectedGcloudConfigDir := filepath.ToSlash(filepath.Join(configRoot, ".gcp", "gcloud"))
+		if envVars["CLOUDSDK_CONFIG"] != expectedGcloudConfigDir {
+			t.Errorf("GetEnvVars returned CLOUDSDK_CONFIG=%v, want %v", envVars["CLOUDSDK_CONFIG"], expectedGcloudConfigDir)
+		}
+
+		if len(envVars) != 1 {
+			t.Errorf("Expected 1 environment variable, got %d: %v", len(envVars), envVars)
+		}
+	})
+
+	t.Run("CreatesDirectoryAutomatically", func(t *testing.T) {
+		printer, mocks := setup(t)
+
+		mkdirAllCalled := false
+		mkdirAllPath := ""
+		mocks.Shims.MkdirAll = func(path string, perm os.FileMode) error {
+			mkdirAllCalled = true
+			mkdirAllPath = path
+			return nil
+		}
+
+		configRoot, err := mocks.ConfigHandler.GetConfigRoot()
+		if err != nil {
+			t.Fatalf("Failed to get config root: %v", err)
+		}
+
+		_, err = printer.GetEnvVars()
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		if !mkdirAllCalled {
+			t.Error("MkdirAll was not called")
+		}
+
+		expectedPath := filepath.Join(configRoot, ".gcp", "gcloud")
+		if mkdirAllPath != expectedPath {
+			t.Errorf("MkdirAll called with path=%v, want %v", mkdirAllPath, expectedPath)
+		}
+	})
+
+	t.Run("GetConfigRootError", func(t *testing.T) {
+		mocks := setupGcpEnvMocks(t)
+		mockConfigHandler := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockConfigHandler.GetConfigRootFunc = func() (string, error) {
+			return "", fmt.Errorf("error retrieving configuration root directory")
+		}
+		printer := NewGcpEnvPrinter(mocks.Shell, mocks.ConfigHandler)
+		printer.shims = mocks.Shims
+
+		_, err := printer.GetEnvVars()
+
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "error retrieving configuration root directory") {
+			t.Errorf("Expected error containing 'error retrieving configuration root directory', got %v", err)
+		}
+	})
+
+	t.Run("MkdirAllError", func(t *testing.T) {
+		printer, mocks := setup(t)
+
+		mocks.Shims.MkdirAll = func(path string, perm os.FileMode) error {
+			return fmt.Errorf("mock mkdirAll error")
+		}
+
+		_, err := printer.GetEnvVars()
+
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "error creating GCP config directory") {
+			t.Errorf("Expected error containing 'error creating GCP config directory', got %v", err)
+		}
+	})
+
+	t.Run("MissingConfiguration", func(t *testing.T) {
+		baseMocks := setupEnvMocks(t)
+		mocks := setupGcpEnvMocks(t, &EnvTestMocks{
+			ConfigHandler: config.NewConfigHandler(baseMocks.Shell),
+		})
+		configStr := `
+version: v1alpha1
+contexts:
+  test-context: {}
+`
+		if err := mocks.ConfigHandler.LoadConfigString(configStr); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+		mocks.ConfigHandler.SetContext("test-context")
+		printer := NewGcpEnvPrinter(mocks.Shell, mocks.ConfigHandler)
+		printer.shims = mocks.Shims
+
+		envVars, err := printer.GetEnvVars()
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if len(envVars) != 0 {
+			t.Errorf("Expected empty environment variables, got %v", envVars)
+		}
+	})
+
+	t.Run("CredentialsPathSet", func(t *testing.T) {
+		mocks := setupGcpEnvMocks(t)
+		configStr := `
+version: v1alpha1
+contexts:
+  test-context:
+    gcp:
+      enabled: true
+      credentials_path: "/path/to/credentials.json"
+`
+		if err := mocks.ConfigHandler.LoadConfigString(configStr); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+		printer := NewGcpEnvPrinter(mocks.Shell, mocks.ConfigHandler)
+		printer.shims = mocks.Shims
+
+		mocks.Shims.LookupEnv = func(key string) (string, bool) {
+			return "", false
+		}
+
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		if envVars["GOOGLE_APPLICATION_CREDENTIALS"] != "/path/to/credentials.json" {
+			t.Errorf("GetEnvVars returned GOOGLE_APPLICATION_CREDENTIALS=%v, want /path/to/credentials.json", envVars["GOOGLE_APPLICATION_CREDENTIALS"])
+		}
+	})
+
+	t.Run("ServiceAccountFileExists", func(t *testing.T) {
+		mocks := setupGcpEnvMocks(t)
+		configStr := `
+version: v1alpha1
+contexts:
+  test-context:
+    gcp:
+      enabled: true
+`
+		if err := mocks.ConfigHandler.LoadConfigString(configStr); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+		printer := NewGcpEnvPrinter(mocks.Shell, mocks.ConfigHandler)
+		printer.shims = mocks.Shims
+
+		configRoot, err := mocks.ConfigHandler.GetConfigRoot()
+		if err != nil {
+			t.Fatalf("Failed to get config root: %v", err)
+		}
+
+		serviceAccountPath := filepath.Join(configRoot, ".gcp", "service-accounts", "default.json")
+		mocks.Shims.LookupEnv = func(key string) (string, bool) {
+			return "", false
+		}
+		mocks.Shims.Stat = func(name string) (os.FileInfo, error) {
+			if name == serviceAccountPath {
+				return nil, nil
+			}
+			return nil, os.ErrNotExist
+		}
+
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		expectedPath := filepath.ToSlash(serviceAccountPath)
+		if envVars["GOOGLE_APPLICATION_CREDENTIALS"] != expectedPath {
+			t.Errorf("GetEnvVars returned GOOGLE_APPLICATION_CREDENTIALS=%v, want %v", envVars["GOOGLE_APPLICATION_CREDENTIALS"], expectedPath)
+		}
+	})
+
+	t.Run("GOOGLE_APPLICATION_CREDENTIALSAlreadySet", func(t *testing.T) {
+		mocks := setupGcpEnvMocks(t)
+		configStr := `
+version: v1alpha1
+contexts:
+  test-context:
+    gcp:
+      enabled: true
+      credentials_path: "/path/to/credentials.json"
+`
+		if err := mocks.ConfigHandler.LoadConfigString(configStr); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+		printer := NewGcpEnvPrinter(mocks.Shell, mocks.ConfigHandler)
+		printer.shims = mocks.Shims
+
+		mocks.Shims.LookupEnv = func(key string) (string, bool) {
+			if key == "GOOGLE_APPLICATION_CREDENTIALS" {
+				return "/existing/credentials.json", true
+			}
+			return "", false
+		}
+
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		if _, exists := envVars["GOOGLE_APPLICATION_CREDENTIALS"]; exists {
+			t.Error("GOOGLE_APPLICATION_CREDENTIALS should not be set when already in environment")
+		}
+	})
+
+	t.Run("OnlyProjectIDSet", func(t *testing.T) {
+		mocks := setupGcpEnvMocks(t)
+		configStr := `
+version: v1alpha1
+contexts:
+  test-context:
+    gcp:
+      enabled: true
+      project_id: "my-project"
+`
+		if err := mocks.ConfigHandler.LoadConfigString(configStr); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+		printer := NewGcpEnvPrinter(mocks.Shell, mocks.ConfigHandler)
+		printer.shims = mocks.Shims
+
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		if envVars["GOOGLE_CLOUD_PROJECT"] != "my-project" {
+			t.Errorf("GetEnvVars returned GOOGLE_CLOUD_PROJECT=%v, want my-project", envVars["GOOGLE_CLOUD_PROJECT"])
+		}
+
+		if envVars["GCLOUD_PROJECT"] != "my-project" {
+			t.Errorf("GetEnvVars returned GCLOUD_PROJECT=%v, want my-project", envVars["GCLOUD_PROJECT"])
+		}
+	})
+}


### PR DESCRIPTION
Supports GCP:
* Run `windsor init my-context --provider gcp`
* Manages environment variables in GCP contexts

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>