### PR TITLE
fix(terraform): Don't pass -auto-approve by default to terraform destroy

### DIFF
--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -105,7 +105,7 @@ func (s *TerraformStack) Up(blueprint *blueprintv1alpha1.Blueprint) error {
 			return fmt.Errorf("terraform environment printer not available")
 		}
 		componentID := component.GetID()
-		terraformArgs, err := terraformEnv.GenerateTerraformArgs(componentID, component.FullPath)
+		terraformArgs, err := terraformEnv.GenerateTerraformArgs(componentID, component.FullPath, false)
 		if err != nil {
 			return fmt.Errorf("error generating terraform args for %s: %w", componentID, err)
 		}
@@ -206,7 +206,7 @@ func (s *TerraformStack) Down(blueprint *blueprintv1alpha1.Blueprint) error {
 			return fmt.Errorf("terraform environment printer not available")
 		}
 		componentID := component.GetID()
-		terraformArgs, err := terraformEnv.GenerateTerraformArgs(componentID, component.FullPath)
+		terraformArgs, err := terraformEnv.GenerateTerraformArgs(componentID, component.FullPath, false)
 		if err != nil {
 			return fmt.Errorf("error generating terraform args for %s: %w", componentID, err)
 		}

--- a/pkg/runtime/env/terraform_env_test.go
+++ b/pkg/runtime/env/terraform_env_test.go
@@ -110,7 +110,7 @@ func TestTerraformEnv_GetEnvVars(t *testing.T) {
 				filepath.ToSlash(filepath.Join(projectRoot, ".windsor", "contexts", "local", "terraform", "project/path", "terraform.tfvars")),
 				filepath.ToSlash(filepath.Join(configRoot, "terraform/project/path.tfvars")),
 				filepath.ToSlash(filepath.Join(configRoot, "terraform/project/path.tfvars.json"))),
-			"TF_CLI_ARGS_destroy": fmt.Sprintf(`-auto-approve -var-file="%s" -var-file="%s" -var-file="%s"`,
+			"TF_CLI_ARGS_destroy": fmt.Sprintf(`-var-file="%s" -var-file="%s" -var-file="%s"`,
 				filepath.ToSlash(filepath.Join(projectRoot, ".windsor", "contexts", "local", "terraform", "project/path", "terraform.tfvars")),
 				filepath.ToSlash(filepath.Join(configRoot, "terraform/project/path.tfvars")),
 				filepath.ToSlash(filepath.Join(configRoot, "terraform/project/path.tfvars.json"))),
@@ -337,7 +337,7 @@ func TestTerraformEnv_GetEnvVars(t *testing.T) {
 				filepath.ToSlash(filepath.Join(projectRoot, ".windsor", "contexts", "local", "terraform", "project/path", "terraform.tfvars")),
 				filepath.ToSlash(filepath.Join(configRoot, "terraform/project/path.tfvars")),
 				filepath.ToSlash(filepath.Join(configRoot, "terraform/project/path.tfvars.json"))),
-			"TF_CLI_ARGS_destroy": fmt.Sprintf(`-auto-approve -var-file="%s" -var-file="%s" -var-file="%s"`,
+			"TF_CLI_ARGS_destroy": fmt.Sprintf(`-var-file="%s" -var-file="%s" -var-file="%s"`,
 				filepath.ToSlash(filepath.Join(projectRoot, ".windsor", "contexts", "local", "terraform", "project/path", "terraform.tfvars")),
 				filepath.ToSlash(filepath.Join(configRoot, "terraform/project/path.tfvars")),
 				filepath.ToSlash(filepath.Join(configRoot, "terraform/project/path.tfvars.json"))),
@@ -1610,8 +1610,8 @@ func TestTerraformEnv_GenerateTerraformArgs(t *testing.T) {
 			BaseEnvPrinter: *NewBaseEnvPrinter(mocks.Shell, mocks.ConfigHandler),
 		}
 
-		// When generating terraform args without parallelism
-		args, err := printer.GenerateTerraformArgs("test/path", "test/module")
+		// When generating terraform args without parallelism for interactive regular injection
+		args, err := printer.GenerateTerraformArgs("test/path", "test/module", true)
 
 		// Then no error should be returned
 		if err != nil {
@@ -1623,8 +1623,8 @@ func TestTerraformEnv_GenerateTerraformArgs(t *testing.T) {
 			t.Errorf("Expected 1 apply arg, got %d: %v", len(args.ApplyArgs), args.ApplyArgs)
 		}
 
-		// And destroy args should contain only auto-approve
-		expectedDestroyArgs := []string{"-auto-approve"}
+		// And destroy args should not contain auto-approve for regular injection
+		expectedDestroyArgs := []string{}
 		if !reflect.DeepEqual(args.DestroyArgs, expectedDestroyArgs) {
 			t.Errorf("Expected destroy args %v, got %v", expectedDestroyArgs, args.DestroyArgs)
 		}
@@ -1665,8 +1665,8 @@ terraform:
 		}
 		printer.shims = mocks.Shims
 
-		// When generating terraform args with parallelism
-		args, err := printer.GenerateTerraformArgs("test/path", "test/module")
+		// When generating terraform args with parallelism for interactive regular injection
+		args, err := printer.GenerateTerraformArgs("test/path", "test/module", true)
 
 		// Then no error should be returned
 		if err != nil {
@@ -1729,8 +1729,8 @@ terraform:
 			BaseEnvPrinter: *NewBaseEnvPrinter(mocks.Shell, mocks.ConfigHandler),
 		}
 
-		// When generating terraform args for component without parallelism
-		args, err := printer.GenerateTerraformArgs("test/path", "test/module")
+		// When generating terraform args for component without parallelism for interactive regular injection
+		args, err := printer.GenerateTerraformArgs("test/path", "test/module", true)
 
 		// Then no error should be returned
 		if err != nil {
@@ -1758,8 +1758,8 @@ terraform:
 			BaseEnvPrinter: *NewBaseEnvPrinter(mocks.Shell, mocks.ConfigHandler),
 		}
 
-		// When generating terraform args without blueprint.yaml file
-		args, err := printer.GenerateTerraformArgs("test/path", "test/module")
+		// When generating terraform args without blueprint.yaml file for interactive regular injection
+		args, err := printer.GenerateTerraformArgs("test/path", "test/module", true)
 
 		// Then no error should be returned
 		if err != nil {
@@ -1820,7 +1820,7 @@ terraform:
 		}
 		printer.shims = mocks.Shims
 
-		args, err := printer.GenerateTerraformArgs(componentName, "test/module")
+		args, err := printer.GenerateTerraformArgs(componentName, "test/module", true)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
@@ -1854,7 +1854,7 @@ terraform:
 			BaseEnvPrinter: *NewBaseEnvPrinter(mocks.Shell, mocks.ConfigHandler),
 		}
 
-		args, err := printer.GenerateTerraformArgs("test/path", "test/module")
+		args, err := printer.GenerateTerraformArgs("test/path", "test/module", true)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
@@ -1880,7 +1880,7 @@ terraform:
 			BaseEnvPrinter: *NewBaseEnvPrinter(mocks.Shell, mocks.ConfigHandler),
 		}
 
-		args, err := printer.GenerateTerraformArgs("test/path", "test/module")
+		args, err := printer.GenerateTerraformArgs("test/path", "test/module", true)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
@@ -1905,7 +1905,7 @@ terraform:
 			BaseEnvPrinter: *NewBaseEnvPrinter(mocks.Shell, mockConfigHandler),
 		}
 
-		_, err := printer.GenerateTerraformArgs("test/path", "test/module")
+		_, err := printer.GenerateTerraformArgs("test/path", "test/module", true)
 		if err == nil {
 			t.Error("Expected error when GetWindsorScratchPath fails")
 		}
@@ -1941,8 +1941,8 @@ terraform:
 		}
 		printer.shims = mocks.Shims
 
-		// When generating terraform args
-		args, err := printer.GenerateTerraformArgs("test/path", "test/module")
+		// When generating terraform args for interactive regular injection
+		args, err := printer.GenerateTerraformArgs("test/path", "test/module", true)
 
 		// Then no error should be returned
 		if err != nil {


### PR DESCRIPTION
The `-auto-approve` flag shouldn't be passed by default to the `terraform destroy` command unless running a stack. This prevents unexpected behavior when users are executing terraform commands directly.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds an `interactive` flag to `GenerateTerraformArgs` to omit `-auto-approve` for interactive/env injection while retaining it for stack operations; updates callers and tests accordingly.
> 
> - **Terraform env args**:
>   - `GenerateTerraformArgs(projectPath, modulePath, interactive)` adds `interactive` flag.
>   - Conditionally include `-auto-approve` in destroy args only when `interactive == false`.
>   - `GetEnvVars` and output-capture paths call with `interactive=true` (no auto-approve in `TF_CLI_ARGS_destroy`).
> - **Stack execution**:
>   - `stack.Up/Down` call `GenerateTerraformArgs(..., false)` to retain non-interactive `-auto-approve` for stack destroys.
> - **Tests**:
>   - Update all invocations to pass the new `interactive` param.
>   - Adjust expectations to remove `-auto-approve` from `TF_CLI_ARGS_destroy` in interactive scenarios.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 708d0e47f75f7c1993a98841ea3e39743b1dbf75. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->