### PR TITLE
chore(build): Strip symbol table and DWARF debug info from binary

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,9 +84,9 @@ jobs:
           echo "Testing build for version: $VERSION"
           COMMIT_SHA=${{ github.sha }}
           if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
-            GOOS=linux GOARCH=${{ matrix.arch }} go build -ldflags "-X 'github.com/${{ github.repository }}/cmd.version=$VERSION' -X 'github.com/${{ github.repository }}/cmd.commitSHA=$COMMIT_SHA'" -o /dev/null cmd/windsor/main.go
+            GOOS=linux GOARCH=${{ matrix.arch }} go build -ldflags "-s -w -X 'github.com/${{ github.repository }}/cmd.version=$VERSION' -X 'github.com/${{ github.repository }}/cmd.commitSHA=$COMMIT_SHA'" -o /dev/null cmd/windsor/main.go
           elif [ "${{ matrix.os }}" == "macos-latest" ]; then
-            GOOS=darwin GOARCH=${{ matrix.arch }} go build -ldflags "-X 'github.com/${{ github.repository }}/cmd.version=$VERSION' -X 'github.com/${{ github.repository }}/cmd.commitSHA=$COMMIT_SHA'" -o /dev/null cmd/windsor/main.go
+            GOOS=darwin GOARCH=${{ matrix.arch }} go build -ldflags "-s -w -X 'github.com/${{ github.repository }}/cmd.version=$VERSION' -X 'github.com/${{ github.repository }}/cmd.commitSHA=$COMMIT_SHA'" -o /dev/null cmd/windsor/main.go
           fi
 
       - name: Test Build Windsor CLI on Windows
@@ -97,7 +97,7 @@ jobs:
           $env:COMMIT_SHA = "${{ github.sha }}"
           $env:GOOS = "windows"
           $env:GOARCH = "${{ matrix.arch }}"
-          go build -ldflags "-X 'github.com/${{ github.repository }}/cmd.version=$env:VERSION' -X 'github.com/${{ github.repository }}/cmd.commitSHA=$env:COMMIT_SHA'" -o NUL cmd\windsor\main.go
+          go build -ldflags "-s -w -X 'github.com/${{ github.repository }}/cmd.version=$env:VERSION' -X 'github.com/${{ github.repository }}/cmd.commitSHA=$env:COMMIT_SHA'" -o NUL cmd\windsor\main.go
         shell: pwsh
 
   sast-scan:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,6 +22,7 @@ builds:
       - arm64
       - amd64
     ldflags:
+      - "-s -w"
       - "-X 'github.com/{{ .Env.GITHUB_REPOSITORY }}/pkg/constants.Version={{ .Version }}'"
       - "-X 'github.com/{{ .Env.GITHUB_REPOSITORY }}/pkg/constants.CommitSHA={{ .Env.GITHUB_SHA }}'"
       - "-X 'github.com/{{ .Env.GITHUB_REPOSITORY }}/pkg/secrets.version={{ .Version }}'"

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -17,15 +17,15 @@ tasks:
         platforms: [linux, darwin]
       - cmd: powershell -Command "New-Item -ItemType Directory -Force -Path dist"
         platforms: [windows]
-      - cmd: GOOS=linux GOARCH=amd64 go build -o dist/windsor ./cmd/windsor/main.go
+      - cmd: GOOS=linux GOARCH=amd64 go build -ldflags="-s -w" -o dist/windsor ./cmd/windsor/main.go
         platforms: [linux]
-      - cmd: GOOS=linux GOARCH=arm64 go build -o dist/windsor ./cmd/windsor/main.go
+      - cmd: GOOS=linux GOARCH=arm64 go build -ldflags="-s -w" -o dist/windsor ./cmd/windsor/main.go
         platforms: [linux]
-      - cmd: GOOS=darwin GOARCH=amd64 go build -o dist/windsor ./cmd/windsor/main.go
+      - cmd: GOOS=darwin GOARCH=amd64 go build -ldflags="-s -w" -o dist/windsor ./cmd/windsor/main.go
         platforms: [darwin]
-      - cmd: GOOS=darwin GOARCH=arm64 go build -o dist/windsor ./cmd/windsor/main.go
+      - cmd: GOOS=darwin GOARCH=arm64 go build -ldflags="-s -w" -o dist/windsor ./cmd/windsor/main.go
         platforms: [darwin]
-      - cmd: GOOS=windows GOARCH=amd64 go build -o dist/windsor.exe ./cmd/windsor/main.go
+      - cmd: GOOS=windows GOARCH=amd64 go build -ldflags="-s -w" -o dist/windsor.exe ./cmd/windsor/main.go
         platforms: [windows]
 
   clean:


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds Go linker flags `-s -w` to strip symbols and DWARF debug info in CI test builds, Taskfile builds, and GoReleaser releases.
> 
> - **Build/CI**:
>   - Update `/.github/workflows/ci.yaml` test builds (Linux/macOS/Windows) to pass `-ldflags "-s -w ..."` alongside version/commit injections.
> - **Release**:
>   - Add `"-s -w"` to `ldflags` in `/.goreleaser.yaml`.
> - **Local build**:
>   - Add `-ldflags "-s -w"` to all platform targets in `/Taskfile.yaml` `build` task.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d3e5a7583d56327fe6c3bd1c0b48fb956f263f93. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->