### PR TITLE
feat(cluster): Add --skip-services flag to node-health check

### DIFF
--- a/cmd/check.go
+++ b/cmd/check.go
@@ -12,11 +12,12 @@ import (
 )
 
 var (
-	nodeHealthTimeout time.Duration
-	nodeHealthNodes   []string
-	nodeHealthVersion string
-	k8sEndpoint       string
-	checkNodeReady    bool
+	nodeHealthTimeout      time.Duration
+	nodeHealthNodes        []string
+	nodeHealthVersion      string
+	k8sEndpoint            string
+	checkNodeReady         bool
+	nodeHealthSkipServices []string
 )
 
 var checkCmd = &cobra.Command{
@@ -111,6 +112,7 @@ var checkNodeHealthCmd = &cobra.Command{
 			K8SEndpoint:         k8sEndpointStr,
 			K8SEndpointProvided: k8sEndpoint != "" || checkNodeReady,
 			CheckNodeReady:      checkNodeReady,
+			SkipServices:        nodeHealthSkipServices,
 		}
 
 		if err := prov.CheckNodeHealth(cmd.Context(), options, outputFunc); err != nil {
@@ -132,4 +134,5 @@ func init() {
 	checkNodeHealthCmd.Flags().StringVar(&k8sEndpoint, "k8s-endpoint", "", "Perform Kubernetes API health check (use --k8s-endpoint or --k8s-endpoint=https://endpoint:6443)")
 	checkNodeHealthCmd.Flags().Lookup("k8s-endpoint").NoOptDefVal = "true"
 	checkNodeHealthCmd.Flags().BoolVar(&checkNodeReady, "ready", false, "Check Kubernetes node readiness status")
+	checkNodeHealthCmd.Flags().StringSliceVar(&nodeHealthSkipServices, "skip-services", []string{}, "Service names to ignore during health checks (e.g., dashboard)")
 }

--- a/cmd/check_test.go
+++ b/cmd/check_test.go
@@ -327,7 +327,7 @@ func TestCheckNodeHealthCmd(t *testing.T) {
 		mocks := setupMocks(t, &SetupOptions{ConfigHandler: mockConfigHandler})
 
 		mockClusterClient := cluster.NewMockClusterClient()
-		mockClusterClient.WaitForNodesHealthyFunc = func(ctx stdcontext.Context, nodeAddresses []string, expectedVersion string) error {
+		mockClusterClient.WaitForNodesHealthyFunc = func(ctx stdcontext.Context, nodeAddresses []string, expectedVersion string, skipServices []string) error {
 			return fmt.Errorf("cluster health check failed")
 		}
 
@@ -530,7 +530,7 @@ func TestCheckNodeHealthCmd_ErrorScenarios(t *testing.T) {
 		mocks := setupMocks(t, &SetupOptions{ConfigHandler: mockConfigHandler})
 
 		mockClusterClient := cluster.NewMockClusterClient()
-		mockClusterClient.WaitForNodesHealthyFunc = func(ctx stdcontext.Context, nodeAddresses []string, expectedVersion string) error {
+		mockClusterClient.WaitForNodesHealthyFunc = func(ctx stdcontext.Context, nodeAddresses []string, expectedVersion string, skipServices []string) error {
 			return fmt.Errorf("cluster health check failed")
 		}
 

--- a/pkg/provisioner/cluster/cluster_client.go
+++ b/pkg/provisioner/cluster/cluster_client.go
@@ -17,7 +17,8 @@ import (
 type ClusterClient interface {
 	// WaitForNodesHealthy waits for nodes to be healthy and optionally match a specific version
 	// Polls until all nodes are healthy (and correct version if specified) or timeout
-	WaitForNodesHealthy(ctx context.Context, nodeAddresses []string, expectedVersion string) error
+	// skipServices is a list of service names to ignore during health checks
+	WaitForNodesHealthy(ctx context.Context, nodeAddresses []string, expectedVersion string, skipServices []string) error
 
 	// Close closes any open connections.
 	Close()
@@ -53,6 +54,6 @@ func (c *BaseClusterClient) Close() {
 }
 
 // WaitForNodesHealthy implements the default polling behavior for node health and version checks
-func (c *BaseClusterClient) WaitForNodesHealthy(ctx context.Context, nodeAddresses []string, expectedVersion string) error {
+func (c *BaseClusterClient) WaitForNodesHealthy(ctx context.Context, nodeAddresses []string, expectedVersion string, skipServices []string) error {
 	return fmt.Errorf("WaitForNodesHealthy not implemented")
 }

--- a/pkg/provisioner/cluster/cluster_client_test.go
+++ b/pkg/provisioner/cluster/cluster_client_test.go
@@ -69,7 +69,7 @@ func TestBaseClusterClient_WaitForNodesHealthy(t *testing.T) {
 		expectedVersion := "v1.0.0"
 
 		// When calling WaitForNodesHealthy
-		err := client.WaitForNodesHealthy(ctx, nodeAddresses, expectedVersion)
+		err := client.WaitForNodesHealthy(ctx, nodeAddresses, expectedVersion, nil)
 
 		// Then it should return not implemented error
 		if err == nil {
@@ -90,7 +90,7 @@ func TestBaseClusterClient_WaitForNodesHealthy(t *testing.T) {
 		expectedVersion := ""
 
 		// When calling WaitForNodesHealthy with empty parameters
-		err := client.WaitForNodesHealthy(ctx, nodeAddresses, expectedVersion)
+		err := client.WaitForNodesHealthy(ctx, nodeAddresses, expectedVersion, nil)
 
 		// Then it should still return not implemented error
 		if err == nil {
@@ -112,7 +112,7 @@ func TestBaseClusterClient_WaitForNodesHealthy(t *testing.T) {
 		expectedVersion := "v1.0.0"
 
 		// When calling WaitForNodesHealthy with cancelled context
-		err := client.WaitForNodesHealthy(ctx, nodeAddresses, expectedVersion)
+		err := client.WaitForNodesHealthy(ctx, nodeAddresses, expectedVersion, nil)
 
 		// Then it should return not implemented error (not context error)
 		if err == nil {

--- a/pkg/provisioner/cluster/mock_cluster_client.go
+++ b/pkg/provisioner/cluster/mock_cluster_client.go
@@ -16,7 +16,7 @@ import (
 // MockClusterClient is a mock implementation of the ClusterClient interface
 type MockClusterClient struct {
 	BaseClusterClient
-	WaitForNodesHealthyFunc func(ctx context.Context, nodeAddresses []string, expectedVersion string) error
+	WaitForNodesHealthyFunc func(ctx context.Context, nodeAddresses []string, expectedVersion string, skipServices []string) error
 	CloseFunc               func()
 }
 
@@ -34,9 +34,9 @@ func NewMockClusterClient() *MockClusterClient {
 // =============================================================================
 
 // WaitForNodesHealthy calls the mock WaitForNodesHealthyFunc if set, otherwise returns nil
-func (m *MockClusterClient) WaitForNodesHealthy(ctx context.Context, nodeAddresses []string, expectedVersion string) error {
+func (m *MockClusterClient) WaitForNodesHealthy(ctx context.Context, nodeAddresses []string, expectedVersion string, skipServices []string) error {
 	if m.WaitForNodesHealthyFunc != nil {
-		return m.WaitForNodesHealthyFunc(ctx, nodeAddresses, expectedVersion)
+		return m.WaitForNodesHealthyFunc(ctx, nodeAddresses, expectedVersion, skipServices)
 	}
 	return nil
 }

--- a/pkg/provisioner/cluster/mock_cluster_client_test.go
+++ b/pkg/provisioner/cluster/mock_cluster_client_test.go
@@ -15,12 +15,12 @@ func TestMockClusterClient_WaitForNodesHealthy(t *testing.T) {
 		// Given a mock with configured function
 		client := NewMockClusterClient()
 		errVal := fmt.Errorf("err")
-		client.WaitForNodesHealthyFunc = func(ctx context.Context, addresses []string, version string) error {
+		client.WaitForNodesHealthyFunc = func(ctx context.Context, addresses []string, version string, skipServices []string) error {
 			return errVal
 		}
 
 		// When calling WaitForNodesHealthy
-		err := client.WaitForNodesHealthy(context.Background(), []string{"10.0.0.1"}, "v1.0.0")
+		err := client.WaitForNodesHealthy(context.Background(), []string{"10.0.0.1"}, "v1.0.0", nil)
 
 		// Then it should return the expected error
 		if err != errVal {
@@ -33,7 +33,7 @@ func TestMockClusterClient_WaitForNodesHealthy(t *testing.T) {
 		client := NewMockClusterClient()
 
 		// When calling WaitForNodesHealthy
-		err := client.WaitForNodesHealthy(context.Background(), []string{"10.0.0.1"}, "v1.0.0")
+		err := client.WaitForNodesHealthy(context.Background(), []string{"10.0.0.1"}, "v1.0.0", nil)
 
 		// Then it should return nil
 		if err != nil {

--- a/pkg/provisioner/cluster/talos_cluster_client_test.go
+++ b/pkg/provisioner/cluster/talos_cluster_client_test.go
@@ -116,7 +116,7 @@ func TestTalosClusterClient_WaitForNodesHealthy(t *testing.T) {
 		nodeAddresses := []string{"10.0.0.1", "10.0.0.2"}
 		expectedVersion := "1.0.0"
 
-		err := client.WaitForNodesHealthy(ctx, nodeAddresses, expectedVersion)
+		err := client.WaitForNodesHealthy(ctx, nodeAddresses, expectedVersion, nil)
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -130,7 +130,7 @@ func TestTalosClusterClient_WaitForNodesHealthy(t *testing.T) {
 		ctx := context.Background()
 		nodeAddresses := []string{"10.0.0.1"}
 
-		err := client.WaitForNodesHealthy(ctx, nodeAddresses, "")
+		err := client.WaitForNodesHealthy(ctx, nodeAddresses, "", nil)
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -142,7 +142,7 @@ func TestTalosClusterClient_WaitForNodesHealthy(t *testing.T) {
 		ctx := context.Background()
 		nodeAddresses := []string{"10.0.0.1"}
 
-		err := client.WaitForNodesHealthy(ctx, nodeAddresses, "")
+		err := client.WaitForNodesHealthy(ctx, nodeAddresses, "", nil)
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}
@@ -163,7 +163,7 @@ func TestTalosClusterClient_WaitForNodesHealthy(t *testing.T) {
 		ctx := context.Background()
 		nodeAddresses := []string{"10.0.0.1"}
 
-		err := client.WaitForNodesHealthy(ctx, nodeAddresses, "")
+		err := client.WaitForNodesHealthy(ctx, nodeAddresses, "", nil)
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}
@@ -198,7 +198,7 @@ func TestTalosClusterClient_WaitForNodesHealthy(t *testing.T) {
 		ctx := context.Background()
 		nodeAddresses := []string{"10.0.0.1"}
 
-		err := client.WaitForNodesHealthy(ctx, nodeAddresses, "")
+		err := client.WaitForNodesHealthy(ctx, nodeAddresses, "", nil)
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}
@@ -228,7 +228,7 @@ func TestTalosClusterClient_WaitForNodesHealthy(t *testing.T) {
 		nodeAddresses := []string{"10.0.0.1"}
 		expectedVersion := "1.0.0"
 
-		err := client.WaitForNodesHealthy(ctx, nodeAddresses, expectedVersion)
+		err := client.WaitForNodesHealthy(ctx, nodeAddresses, expectedVersion, nil)
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}
@@ -250,7 +250,7 @@ func TestTalosClusterClient_WaitForNodesHealthy(t *testing.T) {
 		nodeAddresses := []string{"10.0.0.1"}
 		expectedVersion := "1.0.0"
 
-		err := client.WaitForNodesHealthy(ctx, nodeAddresses, expectedVersion)
+		err := client.WaitForNodesHealthy(ctx, nodeAddresses, expectedVersion, nil)
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}
@@ -268,7 +268,7 @@ func TestTalosClusterClient_WaitForNodesHealthy(t *testing.T) {
 		cancel()
 		nodeAddresses := []string{"10.0.0.1"}
 
-		err := client.WaitForNodesHealthy(ctx, nodeAddresses, "")
+		err := client.WaitForNodesHealthy(ctx, nodeAddresses, "", nil)
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}
@@ -290,7 +290,7 @@ func TestTalosClusterClient_WaitForNodesHealthy(t *testing.T) {
 
 		nodeAddresses := []string{"10.0.0.1"}
 
-		err := client.WaitForNodesHealthy(ctx, nodeAddresses, "")
+		err := client.WaitForNodesHealthy(ctx, nodeAddresses, "", nil)
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -341,7 +341,7 @@ func TestTalosClusterClient_WaitForNodesHealthy(t *testing.T) {
 		ctx := context.Background()
 		nodeAddresses := []string{"10.0.0.1", "10.0.0.2"}
 
-		err := client.WaitForNodesHealthy(ctx, nodeAddresses, "")
+		err := client.WaitForNodesHealthy(ctx, nodeAddresses, "", nil)
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -389,7 +389,7 @@ func TestTalosClusterClient_WaitForNodesHealthy(t *testing.T) {
 		nodeAddresses := []string{"10.0.0.1"}
 		expectedVersion := "1.0.0"
 
-		err := client.WaitForNodesHealthy(ctx, nodeAddresses, expectedVersion)
+		err := client.WaitForNodesHealthy(ctx, nodeAddresses, expectedVersion, nil)
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}
@@ -407,7 +407,7 @@ func TestTalosClusterClient_WaitForNodesHealthy(t *testing.T) {
 		ctx := context.Background()
 		nodeAddresses := []string{}
 
-		err := client.WaitForNodesHealthy(ctx, nodeAddresses, "")
+		err := client.WaitForNodesHealthy(ctx, nodeAddresses, "", nil)
 		if err != nil {
 			t.Errorf("Expected no error for empty node addresses, got %v", err)
 		}
@@ -442,7 +442,7 @@ func TestTalosClusterClient_WaitForNodesHealthy(t *testing.T) {
 		ctx := context.Background()
 		nodeAddresses := []string{"10.0.0.1", "10.0.0.2"}
 
-		err := client.WaitForNodesHealthy(ctx, nodeAddresses, "")
+		err := client.WaitForNodesHealthy(ctx, nodeAddresses, "", nil)
 		if err == nil {
 			t.Error("Expected error when nodes are unhealthy, got nil")
 		}
@@ -475,7 +475,7 @@ func TestTalosClusterClient_WaitForNodesHealthy(t *testing.T) {
 		nodeAddresses := []string{"10.0.0.1", "10.0.0.2"}
 		expectedVersion := "1.0.0"
 
-		err := client.WaitForNodesHealthy(ctx, nodeAddresses, expectedVersion)
+		err := client.WaitForNodesHealthy(ctx, nodeAddresses, expectedVersion, nil)
 		if err == nil {
 			t.Error("Expected error when nodes have version mismatch, got nil")
 		}
@@ -634,7 +634,7 @@ func TestTalosClusterClient_getNodeHealthDetails(t *testing.T) {
 		ctx := context.Background()
 		nodeAddress := "10.0.0.1"
 
-		healthy, healthyServices, unhealthyServices, err := client.getNodeHealthDetails(ctx, nodeAddress)
+		healthy, healthyServices, unhealthyServices, err := client.getNodeHealthDetails(ctx, nodeAddress, nil)
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -658,7 +658,7 @@ func TestTalosClusterClient_getNodeHealthDetails(t *testing.T) {
 		ctx := context.Background()
 		nodeAddress := "10.0.0.1"
 
-		_, _, _, err := client.getNodeHealthDetails(ctx, nodeAddress)
+		_, _, _, err := client.getNodeHealthDetails(ctx, nodeAddress, nil)
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}
@@ -697,7 +697,7 @@ func TestTalosClusterClient_getNodeHealthDetails(t *testing.T) {
 		ctx := context.Background()
 		nodeAddress := "10.0.0.1"
 
-		healthy, healthyServices, unhealthyServices, err := client.getNodeHealthDetails(ctx, nodeAddress)
+		healthy, healthyServices, unhealthyServices, err := client.getNodeHealthDetails(ctx, nodeAddress, nil)
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -733,7 +733,7 @@ func TestTalosClusterClient_getNodeHealthDetails(t *testing.T) {
 		ctx := context.Background()
 		nodeAddress := "10.0.0.1"
 
-		healthy, healthyServices, unhealthyServices, err := client.getNodeHealthDetails(ctx, nodeAddress)
+		healthy, healthyServices, unhealthyServices, err := client.getNodeHealthDetails(ctx, nodeAddress, nil)
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -771,7 +771,7 @@ func TestTalosClusterClient_getNodeHealthDetails(t *testing.T) {
 		ctx := context.Background()
 		nodeAddress := "10.0.0.1"
 
-		healthy, healthyServices, unhealthyServices, err := client.getNodeHealthDetails(ctx, nodeAddress)
+		healthy, healthyServices, unhealthyServices, err := client.getNodeHealthDetails(ctx, nodeAddress, nil)
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -245,7 +245,7 @@ func (i *Provisioner) CheckNodeHealth(ctx context.Context, options NodeHealthChe
 			}
 			defer cancel()
 
-			if err := i.ClusterClient.WaitForNodesHealthy(checkCtx, options.Nodes, options.Version); err != nil {
+			if err := i.ClusterClient.WaitForNodesHealthy(checkCtx, options.Nodes, options.Version, options.SkipServices); err != nil {
 				if hasK8sCheck {
 					if outputFunc != nil {
 						outputFunc(fmt.Sprintf("Warning: Cluster client failed (%v), continuing with Kubernetes checks\n", err))
@@ -337,6 +337,7 @@ type NodeHealthCheckOptions struct {
 	K8SEndpoint         string
 	K8SEndpointProvided bool
 	CheckNodeReady      bool
+	SkipServices        []string
 }
 
 // Close releases resources held by provisioner components.

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -1,7 +1,7 @@
 package provisioner
 
 import (
-	stdcontext "context"
+	"context"
 	"fmt"
 	"strings"
 	"testing"
@@ -822,7 +822,7 @@ func TestProvisioner_Close(t *testing.T) {
 func TestProvisioner_CheckNodeHealth(t *testing.T) {
 	t.Run("SuccessWithNodeCheckOnly", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
-		mocks.ClusterClient.WaitForNodesHealthyFunc = func(ctx stdcontext.Context, nodeAddresses []string, expectedVersion string) error {
+		mocks.ClusterClient.WaitForNodesHealthyFunc = func(ctx context.Context, nodeAddresses []string, expectedVersion string, skipServices []string) error {
 			return nil
 		}
 		opts := &Provisioner{
@@ -840,7 +840,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 			K8SEndpointProvided: false,
 		}
 
-		err := provisioner.CheckNodeHealth(stdcontext.Background(), options, outputFunc)
+		err := provisioner.CheckNodeHealth(context.Background(), options, outputFunc)
 
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)
@@ -857,7 +857,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 
 	t.Run("SuccessWithNodeCheckAndVersion", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
-		mocks.ClusterClient.WaitForNodesHealthyFunc = func(ctx stdcontext.Context, nodeAddresses []string, expectedVersion string) error {
+		mocks.ClusterClient.WaitForNodesHealthyFunc = func(ctx context.Context, nodeAddresses []string, expectedVersion string, skipServices []string) error {
 			if expectedVersion != "v1.5.0" {
 				t.Errorf("Expected version 'v1.5.0', got: %q", expectedVersion)
 			}
@@ -879,7 +879,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 			K8SEndpointProvided: false,
 		}
 
-		err := provisioner.CheckNodeHealth(stdcontext.Background(), options, outputFunc)
+		err := provisioner.CheckNodeHealth(context.Background(), options, outputFunc)
 
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)
@@ -896,7 +896,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 
 	t.Run("SuccessWithKubernetesCheckOnly", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
-		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx stdcontext.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
+		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
 			return nil
 		}
 		opts := &Provisioner{
@@ -914,7 +914,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 			K8SEndpointProvided: true,
 		}
 
-		err := provisioner.CheckNodeHealth(stdcontext.Background(), options, outputFunc)
+		err := provisioner.CheckNodeHealth(context.Background(), options, outputFunc)
 
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)
@@ -931,10 +931,10 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 
 	t.Run("SuccessWithBothChecks", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
-		mocks.ClusterClient.WaitForNodesHealthyFunc = func(ctx stdcontext.Context, nodeAddresses []string, expectedVersion string) error {
+		mocks.ClusterClient.WaitForNodesHealthyFunc = func(ctx context.Context, nodeAddresses []string, expectedVersion string, skipServices []string) error {
 			return nil
 		}
-		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx stdcontext.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
+		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
 			return nil
 		}
 		opts := &Provisioner{
@@ -954,7 +954,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 			K8SEndpointProvided: true,
 		}
 
-		err := provisioner.CheckNodeHealth(stdcontext.Background(), options, outputFunc)
+		err := provisioner.CheckNodeHealth(context.Background(), options, outputFunc)
 
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)
@@ -963,13 +963,13 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 
 	t.Run("SuccessWithNodeReadinessCheck", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
-		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx stdcontext.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
+		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
 			if len(nodeNames) != 1 || nodeNames[0] != "10.0.0.1" {
 				t.Errorf("Expected node name '10.0.0.1', got: %v", nodeNames)
 			}
 			return nil
 		}
-		mocks.KubernetesManager.GetNodeReadyStatusFunc = func(ctx stdcontext.Context, nodeNames []string) (map[string]bool, error) {
+		mocks.KubernetesManager.GetNodeReadyStatusFunc = func(ctx context.Context, nodeNames []string) (map[string]bool, error) {
 			return map[string]bool{"10.0.0.1": true}, nil
 		}
 		opts := &Provisioner{
@@ -989,7 +989,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 			CheckNodeReady:      true,
 		}
 
-		err := provisioner.CheckNodeHealth(stdcontext.Background(), options, outputFunc)
+		err := provisioner.CheckNodeHealth(context.Background(), options, outputFunc)
 
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)
@@ -1004,7 +1004,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 			K8SEndpointProvided: false,
 		}
 
-		err := provisioner.CheckNodeHealth(stdcontext.Background(), options, nil)
+		err := provisioner.CheckNodeHealth(context.Background(), options, nil)
 
 		if err == nil {
 			t.Error("Expected error when no health checks specified")
@@ -1017,7 +1017,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 
 	t.Run("ErrorClusterClientWaitForNodesHealthy", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
-		mocks.ClusterClient.WaitForNodesHealthyFunc = func(ctx stdcontext.Context, nodeAddresses []string, expectedVersion string) error {
+		mocks.ClusterClient.WaitForNodesHealthyFunc = func(ctx context.Context, nodeAddresses []string, expectedVersion string, skipServices []string) error {
 			return fmt.Errorf("cluster health check failed")
 		}
 		opts := &Provisioner{
@@ -1030,7 +1030,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 			K8SEndpointProvided: false,
 		}
 
-		err := provisioner.CheckNodeHealth(stdcontext.Background(), options, nil)
+		err := provisioner.CheckNodeHealth(context.Background(), options, nil)
 
 		if err == nil {
 			t.Error("Expected error when cluster health check fails")
@@ -1043,10 +1043,10 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 
 	t.Run("WarningClusterClientFailureWithK8sCheck", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
-		mocks.ClusterClient.WaitForNodesHealthyFunc = func(ctx stdcontext.Context, nodeAddresses []string, expectedVersion string) error {
+		mocks.ClusterClient.WaitForNodesHealthyFunc = func(ctx context.Context, nodeAddresses []string, expectedVersion string, skipServices []string) error {
 			return fmt.Errorf("cluster health check failed")
 		}
-		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx stdcontext.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
+		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
 			return nil
 		}
 		opts := &Provisioner{
@@ -1066,7 +1066,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 			K8SEndpointProvided: true,
 		}
 
-		err := provisioner.CheckNodeHealth(stdcontext.Background(), options, outputFunc)
+		err := provisioner.CheckNodeHealth(context.Background(), options, outputFunc)
 
 		if err != nil {
 			t.Errorf("Expected no error (cluster failure should be warning), got: %v", err)
@@ -1087,7 +1087,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 
 	t.Run("ErrorKubernetesManagerWaitForKubernetesHealthy", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
-		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx stdcontext.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
+		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
 			return fmt.Errorf("kubernetes health check failed")
 		}
 		opts := &Provisioner{
@@ -1100,7 +1100,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 			K8SEndpointProvided: true,
 		}
 
-		err := provisioner.CheckNodeHealth(stdcontext.Background(), options, nil)
+		err := provisioner.CheckNodeHealth(context.Background(), options, nil)
 
 		if err == nil {
 			t.Error("Expected error when Kubernetes health check fails")
@@ -1124,7 +1124,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 			CheckNodeReady:      true,
 		}
 
-		err := provisioner.CheckNodeHealth(stdcontext.Background(), options, nil)
+		err := provisioner.CheckNodeHealth(context.Background(), options, nil)
 
 		if err == nil {
 			t.Error("Expected error when --ready flag used without --nodes")
@@ -1145,7 +1145,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 			K8SEndpointProvided: true,
 		}
 
-		err := provisioner.CheckNodeHealth(stdcontext.Background(), options, nil)
+		err := provisioner.CheckNodeHealth(context.Background(), options, nil)
 
 		if err == nil {
 			t.Error("Expected error when Kubernetes manager is nil")
@@ -1158,7 +1158,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 
 	t.Run("SuccessWithDefaultTimeout", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
-		mocks.ClusterClient.WaitForNodesHealthyFunc = func(ctx stdcontext.Context, nodeAddresses []string, expectedVersion string) error {
+		mocks.ClusterClient.WaitForNodesHealthyFunc = func(ctx context.Context, nodeAddresses []string, expectedVersion string, skipServices []string) error {
 			deadline, ok := ctx.Deadline()
 			if !ok {
 				t.Error("Expected context to have deadline")
@@ -1179,7 +1179,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 			K8SEndpointProvided: false,
 		}
 
-		err := provisioner.CheckNodeHealth(stdcontext.Background(), options, nil)
+		err := provisioner.CheckNodeHealth(context.Background(), options, nil)
 
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)
@@ -1188,7 +1188,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 
 	t.Run("SuccessWithZeroTimeout", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
-		mocks.ClusterClient.WaitForNodesHealthyFunc = func(ctx stdcontext.Context, nodeAddresses []string, expectedVersion string) error {
+		mocks.ClusterClient.WaitForNodesHealthyFunc = func(ctx context.Context, nodeAddresses []string, expectedVersion string, skipServices []string) error {
 			return nil
 		}
 		opts := &Provisioner{
@@ -1202,7 +1202,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 			K8SEndpointProvided: false,
 		}
 
-		err := provisioner.CheckNodeHealth(stdcontext.Background(), options, nil)
+		err := provisioner.CheckNodeHealth(context.Background(), options, nil)
 
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)
@@ -1211,7 +1211,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 
 	t.Run("SuccessWithK8SEndpointTrue", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
-		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx stdcontext.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
+		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
 			if endpoint != "" {
 				t.Errorf("Expected empty endpoint when K8SEndpoint is 'true', got: %q", endpoint)
 			}
@@ -1232,7 +1232,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 			K8SEndpointProvided: true,
 		}
 
-		err := provisioner.CheckNodeHealth(stdcontext.Background(), options, outputFunc)
+		err := provisioner.CheckNodeHealth(context.Background(), options, outputFunc)
 
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)
@@ -1249,10 +1249,10 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 
 	t.Run("SuccessWithNodeReadinessCheckAllReady", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
-		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx stdcontext.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
+		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
 			return nil
 		}
-		mocks.KubernetesManager.GetNodeReadyStatusFunc = func(ctx stdcontext.Context, nodeNames []string) (map[string]bool, error) {
+		mocks.KubernetesManager.GetNodeReadyStatusFunc = func(ctx context.Context, nodeNames []string) (map[string]bool, error) {
 			return map[string]bool{"10.0.0.1": true, "10.0.0.2": true}, nil
 		}
 		opts := &Provisioner{
@@ -1272,7 +1272,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 			CheckNodeReady:      true,
 		}
 
-		err := provisioner.CheckNodeHealth(stdcontext.Background(), options, outputFunc)
+		err := provisioner.CheckNodeHealth(context.Background(), options, outputFunc)
 
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)
@@ -1293,10 +1293,10 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 
 	t.Run("SuccessWithNodeReadinessCheckNotAllReady", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
-		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx stdcontext.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
+		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
 			return nil
 		}
-		mocks.KubernetesManager.GetNodeReadyStatusFunc = func(ctx stdcontext.Context, nodeNames []string) (map[string]bool, error) {
+		mocks.KubernetesManager.GetNodeReadyStatusFunc = func(ctx context.Context, nodeNames []string) (map[string]bool, error) {
 			return map[string]bool{"10.0.0.1": false}, nil
 		}
 		opts := &Provisioner{
@@ -1316,7 +1316,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 			CheckNodeReady:      true,
 		}
 
-		err := provisioner.CheckNodeHealth(stdcontext.Background(), options, outputFunc)
+		err := provisioner.CheckNodeHealth(context.Background(), options, outputFunc)
 
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)
@@ -1337,10 +1337,10 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 
 	t.Run("SuccessWithNodeReadinessCheckGetNodeReadyStatusError", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
-		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx stdcontext.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
+		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
 			return nil
 		}
-		mocks.KubernetesManager.GetNodeReadyStatusFunc = func(ctx stdcontext.Context, nodeNames []string) (map[string]bool, error) {
+		mocks.KubernetesManager.GetNodeReadyStatusFunc = func(ctx context.Context, nodeNames []string) (map[string]bool, error) {
 			return nil, fmt.Errorf("get node ready status failed")
 		}
 		opts := &Provisioner{
@@ -1360,7 +1360,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 			CheckNodeReady:      true,
 		}
 
-		err := provisioner.CheckNodeHealth(stdcontext.Background(), options, outputFunc)
+		err := provisioner.CheckNodeHealth(context.Background(), options, outputFunc)
 
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)
@@ -1381,10 +1381,10 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 
 	t.Run("SuccessWithNodeReadinessCheckPartialReadyStatus", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
-		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx stdcontext.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
+		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
 			return nil
 		}
-		mocks.KubernetesManager.GetNodeReadyStatusFunc = func(ctx stdcontext.Context, nodeNames []string) (map[string]bool, error) {
+		mocks.KubernetesManager.GetNodeReadyStatusFunc = func(ctx context.Context, nodeNames []string) (map[string]bool, error) {
 			return map[string]bool{"10.0.0.1": true}, nil
 		}
 		opts := &Provisioner{
@@ -1404,7 +1404,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 			CheckNodeReady:      true,
 		}
 
-		err := provisioner.CheckNodeHealth(stdcontext.Background(), options, outputFunc)
+		err := provisioner.CheckNodeHealth(context.Background(), options, outputFunc)
 
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)
@@ -1443,7 +1443,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 			K8SEndpointProvided: false,
 		}
 
-		err := provisioner.CheckNodeHealth(stdcontext.Background(), options, nil)
+		err := provisioner.CheckNodeHealth(context.Background(), options, nil)
 
 		if err == nil {
 			t.Error("Expected error when nodes provided but no cluster client")
@@ -1456,7 +1456,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 
 	t.Run("SuccessWithK8SEndpointEmptyString", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
-		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx stdcontext.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
+		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
 			if endpoint != "" {
 				t.Errorf("Expected empty endpoint, got: %q", endpoint)
 			}
@@ -1477,7 +1477,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 			K8SEndpointProvided: true,
 		}
 
-		err := provisioner.CheckNodeHealth(stdcontext.Background(), options, outputFunc)
+		err := provisioner.CheckNodeHealth(context.Background(), options, outputFunc)
 
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)
@@ -1494,10 +1494,10 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 
 	t.Run("SuccessWithK8SEndpointAndNodeReadinessCheckDefaultEndpoint", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
-		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx stdcontext.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
+		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
 			return nil
 		}
-		mocks.KubernetesManager.GetNodeReadyStatusFunc = func(ctx stdcontext.Context, nodeNames []string) (map[string]bool, error) {
+		mocks.KubernetesManager.GetNodeReadyStatusFunc = func(ctx context.Context, nodeNames []string) (map[string]bool, error) {
 			return map[string]bool{"10.0.0.1": true}, nil
 		}
 		opts := &Provisioner{
@@ -1517,7 +1517,7 @@ func TestProvisioner_CheckNodeHealth(t *testing.T) {
 			CheckNodeReady:      true,
 		}
 
-		err := provisioner.CheckNodeHealth(stdcontext.Background(), options, outputFunc)
+		err := provisioner.CheckNodeHealth(context.Background(), options, outputFunc)
 
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces service-skipping for node health checks and updates interfaces/implementations accordingly.
> 
> - Adds `--skip-services` flag in `cmd/check.go` and passes it via `NodeHealthCheckOptions.SkipServices`
> - Extends `NodeHealthCheckOptions` and wires through `Provisioner.CheckNodeHealth`
> - Changes `ClusterClient.WaitForNodesHealthy` signature to include `skipServices`; updates base, mock, and tests
> - Updates `TalosClusterClient` to accept `skipServices` and exclude those services in `getNodeHealthDetails`; adjusts polling logic and tests
> - Refactors tests across `cmd`, `provisioner`, and `cluster` packages to use new method signature and behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a882b031666f6b086ded6efac82b8f3f7b99d828. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->