### PR TITLE
fix(blueprint): Correctly handle duration fields when merging and writing

### DIFF
--- a/pkg/composer/blueprint/blueprint_handler.go
+++ b/pkg/composer/blueprint/blueprint_handler.go
@@ -19,7 +19,6 @@ import (
 
 	"github.com/fluxcd/pkg/apis/kustomize"
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // The BlueprintHandler is a core component that manages infrastructure and application configurations
@@ -215,6 +214,9 @@ func (b *BaseBlueprintHandler) Write(overwrite ...bool) error {
 	}
 	for i := range cleanedBlueprint.Kustomizations {
 		cleanedBlueprint.Kustomizations[i].Patches = nil
+		cleanedBlueprint.Kustomizations[i].Interval = nil
+		cleanedBlueprint.Kustomizations[i].RetryInterval = nil
+		cleanedBlueprint.Kustomizations[i].Timeout = nil
 	}
 
 	data, err := b.shims.YamlMarshal(cleanedBlueprint)
@@ -258,13 +260,13 @@ func (b *BaseBlueprintHandler) Generate() *blueprintv1alpha1.Blueprint {
 			generated.Kustomizations[i].Path = "kustomize/" + strings.ReplaceAll(generated.Kustomizations[i].Path, "\\", "/")
 		}
 		if generated.Kustomizations[i].Interval == nil || generated.Kustomizations[i].Interval.Duration == 0 {
-			generated.Kustomizations[i].Interval = &metav1.Duration{Duration: constants.DefaultFluxKustomizationInterval}
+			generated.Kustomizations[i].Interval = &blueprintv1alpha1.DurationString{Duration: constants.DefaultFluxKustomizationInterval}
 		}
 		if generated.Kustomizations[i].RetryInterval == nil || generated.Kustomizations[i].RetryInterval.Duration == 0 {
-			generated.Kustomizations[i].RetryInterval = &metav1.Duration{Duration: constants.DefaultFluxKustomizationRetryInterval}
+			generated.Kustomizations[i].RetryInterval = &blueprintv1alpha1.DurationString{Duration: constants.DefaultFluxKustomizationRetryInterval}
 		}
 		if generated.Kustomizations[i].Timeout == nil || generated.Kustomizations[i].Timeout.Duration == 0 {
-			generated.Kustomizations[i].Timeout = &metav1.Duration{Duration: constants.DefaultFluxKustomizationTimeout}
+			generated.Kustomizations[i].Timeout = &blueprintv1alpha1.DurationString{Duration: constants.DefaultFluxKustomizationTimeout}
 		}
 		if generated.Kustomizations[i].Wait == nil {
 			defaultWait := constants.DefaultFluxKustomizationWait
@@ -892,13 +894,13 @@ func (b *BaseBlueprintHandler) getKustomizations() []blueprintv1alpha1.Kustomiza
 		}
 
 		if kustomizations[i].Interval == nil || kustomizations[i].Interval.Duration == 0 {
-			kustomizations[i].Interval = &metav1.Duration{Duration: constants.DefaultFluxKustomizationInterval}
+			kustomizations[i].Interval = &blueprintv1alpha1.DurationString{Duration: constants.DefaultFluxKustomizationInterval}
 		}
 		if kustomizations[i].RetryInterval == nil || kustomizations[i].RetryInterval.Duration == 0 {
-			kustomizations[i].RetryInterval = &metav1.Duration{Duration: constants.DefaultFluxKustomizationRetryInterval}
+			kustomizations[i].RetryInterval = &blueprintv1alpha1.DurationString{Duration: constants.DefaultFluxKustomizationRetryInterval}
 		}
 		if kustomizations[i].Timeout == nil || kustomizations[i].Timeout.Duration == 0 {
-			kustomizations[i].Timeout = &metav1.Duration{Duration: constants.DefaultFluxKustomizationTimeout}
+			kustomizations[i].Timeout = &blueprintv1alpha1.DurationString{Duration: constants.DefaultFluxKustomizationTimeout}
 		}
 		if kustomizations[i].Wait == nil {
 			defaultWait := constants.DefaultFluxKustomizationWait

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -780,17 +780,17 @@ func (k *BaseKubernetesManager) DeleteBlueprint(blueprint *blueprintv1alpha1.Blu
 
 				timeout := metav1.Duration{Duration: 30 * time.Minute}
 				if kustomization.Timeout != nil && kustomization.Timeout.Duration != 0 {
-					timeout = *kustomization.Timeout
+					timeout = metav1.Duration{Duration: kustomization.Timeout.Duration}
 				}
 
 				interval := metav1.Duration{Duration: constants.DefaultFluxKustomizationInterval}
 				if kustomization.Interval != nil && kustomization.Interval.Duration != 0 {
-					interval = *kustomization.Interval
+					interval = metav1.Duration{Duration: kustomization.Interval.Duration}
 				}
 
 				retryInterval := metav1.Duration{Duration: constants.DefaultFluxKustomizationRetryInterval}
 				if kustomization.RetryInterval != nil && kustomization.RetryInterval.Duration != 0 {
-					retryInterval = *kustomization.RetryInterval
+					retryInterval = metav1.Duration{Duration: kustomization.RetryInterval.Duration}
 				}
 
 				wait := true

--- a/pkg/provisioner/kubernetes/kubernetes_manager_private_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_private_test.go
@@ -10,7 +10,6 @@ import (
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/provisioner/kubernetes/client"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -503,7 +502,7 @@ func TestBaseKubernetesManager_calculateTotalWaitTime(t *testing.T) {
 			Kustomizations: []blueprintv1alpha1.Kustomization{
 				{
 					Name: "k1",
-					Timeout: &metav1.Duration{
+					Timeout: &blueprintv1alpha1.DurationString{
 						Duration: customTimeout,
 					},
 				},
@@ -522,7 +521,7 @@ func TestBaseKubernetesManager_calculateTotalWaitTime(t *testing.T) {
 			Kustomizations: []blueprintv1alpha1.Kustomization{
 				{
 					Name: "k1",
-					Timeout: &metav1.Duration{
+					Timeout: &blueprintv1alpha1.DurationString{
 						Duration: 0,
 					},
 				},
@@ -544,13 +543,13 @@ func TestBaseKubernetesManager_calculateTotalWaitTime(t *testing.T) {
 			Kustomizations: []blueprintv1alpha1.Kustomization{
 				{
 					Name: "k1",
-					Timeout: &metav1.Duration{
+					Timeout: &blueprintv1alpha1.DurationString{
 						Duration: timeout1,
 					},
 				},
 				{
 					Name: "k2",
-					Timeout: &metav1.Duration{
+					Timeout: &blueprintv1alpha1.DurationString{
 						Duration: timeout2,
 					},
 					DependsOn: []string{"k1"},
@@ -575,27 +574,27 @@ func TestBaseKubernetesManager_calculateTotalWaitTime(t *testing.T) {
 			Kustomizations: []blueprintv1alpha1.Kustomization{
 				{
 					Name: "k1",
-					Timeout: &metav1.Duration{
+					Timeout: &blueprintv1alpha1.DurationString{
 						Duration: timeout1,
 					},
 				},
 				{
 					Name: "k2",
-					Timeout: &metav1.Duration{
+					Timeout: &blueprintv1alpha1.DurationString{
 						Duration: timeout2,
 					},
 					DependsOn: []string{"k1"},
 				},
 				{
 					Name: "k3",
-					Timeout: &metav1.Duration{
+					Timeout: &blueprintv1alpha1.DurationString{
 						Duration: timeout3,
 					},
 					DependsOn: []string{"k2"},
 				},
 				{
 					Name: "k4",
-					Timeout: &metav1.Duration{
+					Timeout: &blueprintv1alpha1.DurationString{
 						Duration: timeout4,
 					},
 					DependsOn: []string{"k3"},
@@ -620,26 +619,26 @@ func TestBaseKubernetesManager_calculateTotalWaitTime(t *testing.T) {
 			Kustomizations: []blueprintv1alpha1.Kustomization{
 				{
 					Name: "k1",
-					Timeout: &metav1.Duration{
+					Timeout: &blueprintv1alpha1.DurationString{
 						Duration: timeout1,
 					},
 				},
 				{
 					Name: "k2",
-					Timeout: &metav1.Duration{
+					Timeout: &blueprintv1alpha1.DurationString{
 						Duration: timeout2,
 					},
 					DependsOn: []string{"k1"},
 				},
 				{
 					Name: "k3",
-					Timeout: &metav1.Duration{
+					Timeout: &blueprintv1alpha1.DurationString{
 						Duration: timeout3,
 					},
 				},
 				{
 					Name: "k4",
-					Timeout: &metav1.Duration{
+					Timeout: &blueprintv1alpha1.DurationString{
 						Duration: timeout4,
 					},
 					DependsOn: []string{"k3"},
@@ -669,27 +668,27 @@ func TestBaseKubernetesManager_calculateTotalWaitTime(t *testing.T) {
 			Kustomizations: []blueprintv1alpha1.Kustomization{
 				{
 					Name: "k1",
-					Timeout: &metav1.Duration{
+					Timeout: &blueprintv1alpha1.DurationString{
 						Duration: timeout1,
 					},
 				},
 				{
 					Name: "k2",
-					Timeout: &metav1.Duration{
+					Timeout: &blueprintv1alpha1.DurationString{
 						Duration: timeout2,
 					},
 					DependsOn: []string{"k1"},
 				},
 				{
 					Name: "k3",
-					Timeout: &metav1.Duration{
+					Timeout: &blueprintv1alpha1.DurationString{
 						Duration: timeout3,
 					},
 					DependsOn: []string{"k1"},
 				},
 				{
 					Name: "k4",
-					Timeout: &metav1.Duration{
+					Timeout: &blueprintv1alpha1.DurationString{
 						Duration: timeout4,
 					},
 					DependsOn: []string{"k2", "k3"},
@@ -719,7 +718,7 @@ func TestBaseKubernetesManager_calculateTotalWaitTime(t *testing.T) {
 				},
 				{
 					Name: "k2",
-					Timeout: &metav1.Duration{
+					Timeout: &blueprintv1alpha1.DurationString{
 						Duration: customTimeout,
 					},
 					DependsOn: []string{"k1"},

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -357,7 +357,7 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 			Kustomizations: []blueprintv1alpha1.Kustomization{
 				{
 					Name: "test-kustomization",
-					Timeout: &metav1.Duration{
+					Timeout: &blueprintv1alpha1.DurationString{
 						Duration: 200 * time.Millisecond,
 					},
 				},
@@ -393,7 +393,7 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 			Kustomizations: []blueprintv1alpha1.Kustomization{
 				{
 					Name: "test-kustomization",
-					Timeout: &metav1.Duration{
+					Timeout: &blueprintv1alpha1.DurationString{
 						Duration: 50 * time.Millisecond,
 					},
 				},
@@ -420,7 +420,7 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 			Kustomizations: []blueprintv1alpha1.Kustomization{
 				{
 					Name: "test-kustomization",
-					Timeout: &metav1.Duration{
+					Timeout: &blueprintv1alpha1.DurationString{
 						Duration: 50 * time.Millisecond,
 					},
 				},
@@ -460,7 +460,7 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 			Kustomizations: []blueprintv1alpha1.Kustomization{
 				{
 					Name: "test-kustomization",
-					Timeout: &metav1.Duration{
+					Timeout: &blueprintv1alpha1.DurationString{
 						Duration: 50 * time.Millisecond,
 					},
 				},
@@ -489,7 +489,7 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 			Kustomizations: []blueprintv1alpha1.Kustomization{
 				{
 					Name: "test-kustomization",
-					Timeout: &metav1.Duration{
+					Timeout: &blueprintv1alpha1.DurationString{
 						Duration: 50 * time.Millisecond,
 					},
 				},
@@ -525,7 +525,7 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 			Kustomizations: []blueprintv1alpha1.Kustomization{
 				{
 					Name: "test-kustomization",
-					Timeout: &metav1.Duration{
+					Timeout: &blueprintv1alpha1.DurationString{
 						Duration: 50 * time.Millisecond,
 					},
 				},
@@ -561,7 +561,7 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 			Kustomizations: []blueprintv1alpha1.Kustomization{
 				{
 					Name: "test-kustomization",
-					Timeout: &metav1.Duration{
+					Timeout: &blueprintv1alpha1.DurationString{
 						Duration: 50 * time.Millisecond,
 					},
 				},
@@ -599,13 +599,13 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 			Kustomizations: []blueprintv1alpha1.Kustomization{
 				{
 					Name: "k1",
-					Timeout: &metav1.Duration{
+					Timeout: &blueprintv1alpha1.DurationString{
 						Duration: timeout1,
 					},
 				},
 				{
 					Name: "k2",
-					Timeout: &metav1.Duration{
+					Timeout: &blueprintv1alpha1.DurationString{
 						Duration: timeout2,
 					},
 					DependsOn: []string{"k1"},


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces string-serializable durations and aligns serialization, merging, and defaulting across blueprint, composer, and provisioner.
> 
> - Adds `DurationString` with YAML marshal/unmarshal (string or `{duration: ...}`), plus helpers to convert to/from `metav1.Duration`
> - Updates `Kustomization` to use `*DurationString` for `interval`, `retryInterval`, and `timeout`; `ToFluxKustomization` now converts to `metav1.Duration`
> - Ensures defaults in `Generate()`/`getKustomizations()` use `DurationString` and that `Write()` omits these fields in `blueprint.yaml`
> - Enhances strategic merge: ignores unnamed kustomizations and copies provided duration fields
> - Adjusts Kubernetes manager to convert `DurationString` to `metav1.Duration` when creating Flux resources
> - Adds tests for duration unmarshalling (string/object forms), updates existing tests to new type, and removes now-unneeded `metav1` imports in tests
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5acdb967950551a4780b339b2af476472b91fd5f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->