### PR TITLE
feat(blueprint): Introduce project_root and config_path to expr interpolation

### DIFF
--- a/pkg/composer/blueprint/blueprint_handler.go
+++ b/pkg/composer/blueprint/blueprint_handler.go
@@ -1023,9 +1023,13 @@ func (b *BaseBlueprintHandler) processFeatures(templateData map[string][]byte, c
 
 	for _, feature := range features {
 		if feature.When != "" {
-			matches, err := evaluator.EvaluateExpression(feature.When, config, feature.Path)
+			result, err := evaluator.Evaluate(feature.When, config, feature.Path)
 			if err != nil {
 				return fmt.Errorf("failed to evaluate feature condition '%s': %w", feature.When, err)
+			}
+			matches, ok := result.(bool)
+			if !ok {
+				return fmt.Errorf("feature condition '%s' must evaluate to boolean, got %T", feature.When, result)
 			}
 			if !matches {
 				continue
@@ -1034,9 +1038,13 @@ func (b *BaseBlueprintHandler) processFeatures(templateData map[string][]byte, c
 
 		for _, terraformComponent := range feature.TerraformComponents {
 			if terraformComponent.When != "" {
-				matches, err := evaluator.EvaluateExpression(terraformComponent.When, config, feature.Path)
+				result, err := evaluator.Evaluate(terraformComponent.When, config, feature.Path)
 				if err != nil {
 					return fmt.Errorf("failed to evaluate terraform component condition '%s': %w", terraformComponent.When, err)
+				}
+				matches, ok := result.(bool)
+				if !ok {
+					return fmt.Errorf("terraform component condition '%s' must evaluate to boolean, got %T", terraformComponent.When, result)
 				}
 				if !matches {
 					continue
@@ -1093,9 +1101,13 @@ func (b *BaseBlueprintHandler) processFeatures(templateData map[string][]byte, c
 
 		for _, kustomization := range feature.Kustomizations {
 			if kustomization.When != "" {
-				matches, err := evaluator.EvaluateExpression(kustomization.When, config, feature.Path)
+				result, err := evaluator.Evaluate(kustomization.When, config, feature.Path)
 				if err != nil {
 					return fmt.Errorf("failed to evaluate kustomization condition '%s': %w", kustomization.When, err)
+				}
+				matches, ok := result.(bool)
+				if !ok {
+					return fmt.Errorf("kustomization condition '%s' must evaluate to boolean, got %T", kustomization.When, result)
 				}
 				if !matches {
 					continue


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a unified expression evaluator and enriches the evaluation context.
> 
> - Replaces `EvaluateExpression`/`EvaluateValue` with a single `Evaluate` that returns `any`; updates all call sites (`When` checks, defaults, interpolation, file/jsonnet helpers)
> - Injects `project_root` and `context_path` into the evaluation environment; adds tests and string interpolation cases
> - Enforces that `When` conditions for features/terraform/kustomizations evaluate to boolean; returns explicit errors otherwise
> - Updates tests to new API and behavior across evaluator, file/jsonnet loading, and helper functions
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 89595a02236545f339d96635db716c28609a657a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->