### PR TITLE
fix(runtime): Don't proactively create a build-id unless command is run

### DIFF
--- a/pkg/runtime/env/windsor_env.go
+++ b/pkg/runtime/env/windsor_env.go
@@ -199,8 +199,9 @@ func (e *WindsorEnvPrinter) shouldUseCache() bool {
 }
 
 // getBuildID retrieves the current build ID from the .windsor/.build-id file.
-// If no build ID exists, a new one is generated, persisted, and returned.
-// Returns the build ID string or an error if retrieval or persistence fails.
+// This is a read-only operation - it never creates a build ID.
+// Returns the build ID string if it exists, or empty string if it doesn't exist.
+// Returns an error only if file read fails (not if file doesn't exist).
 func (e *WindsorEnvPrinter) getBuildID() (string, error) {
 	projectRoot, err := e.shell.GetProjectRoot()
 	if err != nil {
@@ -208,30 +209,17 @@ func (e *WindsorEnvPrinter) getBuildID() (string, error) {
 	}
 
 	buildIDPath := filepath.Join(projectRoot, ".windsor", ".build-id")
-	var buildID string
 
 	if _, err := e.shims.Stat(buildIDPath); os.IsNotExist(err) {
-		buildID = ""
-	} else {
-		data, err := e.shims.ReadFile(buildIDPath)
-		if err != nil {
-			return "", fmt.Errorf("failed to read build ID file: %w", err)
-		}
-		buildID = strings.TrimSpace(string(data))
+		return "", nil
 	}
 
-	if buildID == "" {
-		newBuildID, err := e.generateBuildID()
-		if err != nil {
-			return "", fmt.Errorf("failed to generate build ID: %w", err)
-		}
-		if err := e.writeBuildIDToFile(newBuildID); err != nil {
-			return "", fmt.Errorf("failed to set build ID: %w", err)
-		}
-		return newBuildID, nil
+	data, err := e.shims.ReadFile(buildIDPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to read build ID file: %w", err)
 	}
 
-	return buildID, nil
+	return strings.TrimSpace(string(data)), nil
 }
 
 // writeBuildIDToFile writes the provided build ID string to the .windsor/.build-id file in the project root.

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -2063,7 +2063,7 @@ func TestRuntime_PrepareTools(t *testing.T) {
 }
 
 func TestRuntime_GetBuildID(t *testing.T) {
-	t.Run("CreatesNewBuildIDWhenNoneExists", func(t *testing.T) {
+	t.Run("ReturnsEmptyStringWhenNoBuildIDExists", func(t *testing.T) {
 		// Given a runtime with no existing build ID
 		mocks := setupRuntimeMocks(t)
 		rt := mocks.Runtime
@@ -2074,14 +2074,14 @@ func TestRuntime_GetBuildID(t *testing.T) {
 		// When GetBuildID is called
 		buildID, err := rt.GetBuildID()
 
-		// Then a new build ID should be created
+		// Then an empty string should be returned (read-only behavior)
 
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)
 		}
 
-		if buildID == "" {
-			t.Error("Expected build ID to be generated")
+		if buildID != "" {
+			t.Errorf("Expected empty string when no build ID exists, got: %s", buildID)
 		}
 	})
 


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Behavior change: read-only build ID retrieval**
> 
> - Make `getBuildID` (env) and `Runtime.GetBuildID` read-only: return empty string if `.windsor/.build-id` is missing; only error on read failures
> - Update `WindsorEnvPrinter.GetEnvVars` to set `BUILD_ID` only when present and include it in `WINDSOR_MANAGED_ENV` conditionally
> 
> **Tests**
> 
> - Adjust tests to expect empty string when build ID file is absent and no auto-generation
> - Remove/replace cases expecting automatic creation; add coverage for non-existent file path and read failures
> - Update base env var count assertions to exclude unset `BUILD_ID`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit efa2ca81889005e2f939f3e0063cf6e2bdf874ed. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->