### PR TITLE
feat(runtime): Migrate to terraform provider helper

### DIFF
--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	envvars "github.com/windsorcli/cli/pkg/runtime/env"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
+	terraformRuntime "github.com/windsorcli/cli/pkg/runtime/terraform"
 	"github.com/windsorcli/cli/pkg/runtime/tools"
 )
 
@@ -216,7 +217,8 @@ func setupWindsorStackMocks(t *testing.T, opts ...*SetupOptions) *TerraformTestM
 		return "terraform"
 	}
 	mocks.Runtime.ToolsManager = mockToolsManager
-	terraformEnv := envvars.NewTerraformEnvPrinter(mocks.Shell, mocks.ConfigHandler, mockToolsManager)
+	mockTerraformProvider := terraformRuntime.NewTerraformProvider(mocks.ConfigHandler, mocks.Shell, mockToolsManager, nil)
+	terraformEnv := envvars.NewTerraformEnvPrinter(mocks.Shell, mocks.ConfigHandler, mockToolsManager, mockTerraformProvider)
 	mocks.Runtime.EnvPrinters.TerraformEnv = terraformEnv
 
 	return mocks

--- a/pkg/runtime/env/terraform_env.go
+++ b/pkg/runtime/env/terraform_env.go
@@ -36,11 +36,11 @@ type TerraformEnvPrinter struct {
 // =============================================================================
 
 // NewTerraformEnvPrinter creates a new TerraformEnvPrinter instance
-func NewTerraformEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler, toolsManager tools.ToolsManager) *TerraformEnvPrinter {
+func NewTerraformEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler, toolsManager tools.ToolsManager, terraformProvider terraform.TerraformProvider) *TerraformEnvPrinter {
 	return &TerraformEnvPrinter{
 		BaseEnvPrinter:    *NewBaseEnvPrinter(shell, configHandler),
 		toolsManager:      toolsManager,
-		terraformProvider: terraform.NewTerraformProvider(configHandler, shell, toolsManager),
+		terraformProvider: terraformProvider,
 	}
 }
 

--- a/pkg/runtime/evaluator/mock_evaluator.go
+++ b/pkg/runtime/evaluator/mock_evaluator.go
@@ -1,0 +1,67 @@
+package evaluator
+
+// MockExpressionEvaluator is a mock implementation of the ExpressionEvaluator interface for testing purposes.
+// It provides a way to simulate expression evaluation without executing actual evaluation logic.
+// It allows for controlled testing of evaluator-dependent functionality by providing mock implementations
+// of all ExpressionEvaluator interface methods.
+type MockExpressionEvaluator struct {
+	SetTemplateDataFunc   func(templateData map[string][]byte)
+	RegisterFunc          func(name string, helper func(params ...any) (any, error), signature any)
+	EvaluateFunc          func(expression string, config map[string]any, featurePath string) (any, error)
+	EvaluateDefaultsFunc  func(defaults map[string]any, config map[string]any, featurePath string) (map[string]any, error)
+	InterpolateStringFunc func(s string, config map[string]any, featurePath string) (string, error)
+}
+
+// =============================================================================
+// Constructor
+// =============================================================================
+
+// NewMockExpressionEvaluator creates a new instance of MockExpressionEvaluator.
+func NewMockExpressionEvaluator() *MockExpressionEvaluator {
+	return &MockExpressionEvaluator{}
+}
+
+// =============================================================================
+// Public Methods
+// =============================================================================
+
+// SetTemplateData calls the mock SetTemplateDataFunc if set, otherwise does nothing.
+func (m *MockExpressionEvaluator) SetTemplateData(templateData map[string][]byte) {
+	if m.SetTemplateDataFunc != nil {
+		m.SetTemplateDataFunc(templateData)
+	}
+}
+
+// Register calls the mock RegisterFunc if set, otherwise does nothing.
+func (m *MockExpressionEvaluator) Register(name string, helper func(params ...any) (any, error), signature any) {
+	if m.RegisterFunc != nil {
+		m.RegisterFunc(name, helper, signature)
+	}
+}
+
+// Evaluate calls the mock EvaluateFunc if set, otherwise returns nil, nil.
+func (m *MockExpressionEvaluator) Evaluate(expression string, config map[string]any, featurePath string) (any, error) {
+	if m.EvaluateFunc != nil {
+		return m.EvaluateFunc(expression, config, featurePath)
+	}
+	return nil, nil
+}
+
+// EvaluateDefaults calls the mock EvaluateDefaultsFunc if set, otherwise returns an empty map, nil.
+func (m *MockExpressionEvaluator) EvaluateDefaults(defaults map[string]any, config map[string]any, featurePath string) (map[string]any, error) {
+	if m.EvaluateDefaultsFunc != nil {
+		return m.EvaluateDefaultsFunc(defaults, config, featurePath)
+	}
+	return make(map[string]any), nil
+}
+
+// InterpolateString calls the mock InterpolateStringFunc if set, otherwise returns the input string, nil.
+func (m *MockExpressionEvaluator) InterpolateString(s string, config map[string]any, featurePath string) (string, error) {
+	if m.InterpolateStringFunc != nil {
+		return m.InterpolateStringFunc(s, config, featurePath)
+	}
+	return s, nil
+}
+
+// Ensure MockExpressionEvaluator implements ExpressionEvaluator.
+var _ ExpressionEvaluator = (*MockExpressionEvaluator)(nil)

--- a/pkg/runtime/evaluator/mock_evaluator_test.go
+++ b/pkg/runtime/evaluator/mock_evaluator_test.go
@@ -1,0 +1,376 @@
+package evaluator
+
+import (
+	"errors"
+	"testing"
+)
+
+// The MockExpressionEvaluatorTest is a test suite for the MockExpressionEvaluator implementation.
+// It provides comprehensive test coverage for mock evaluator operations,
+// ensuring reliable testing of evaluator-dependent functionality.
+// The MockExpressionEvaluatorTest validates the mock implementation's behavior.
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+// setupMockEvaluatorMocks creates a new set of mocks for testing MockExpressionEvaluator
+func setupMockEvaluatorMocks(t *testing.T) *MockExpressionEvaluator {
+	t.Helper()
+
+	mockEvaluator := NewMockExpressionEvaluator()
+
+	return mockEvaluator
+}
+
+// =============================================================================
+// Test Constructor
+// =============================================================================
+
+// TestMockExpressionEvaluator_NewMockExpressionEvaluator tests the constructor for MockExpressionEvaluator
+func TestMockExpressionEvaluator_NewMockExpressionEvaluator(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Given
+		mockEvaluator := setupMockEvaluatorMocks(t)
+
+		// Then the mock evaluator should be created successfully
+		if mockEvaluator == nil {
+			t.Errorf("Expected mockEvaluator, got nil")
+		}
+	})
+}
+
+// TestMockExpressionEvaluator tests that MockExpressionEvaluator implements ExpressionEvaluator interface
+func TestMockExpressionEvaluator(t *testing.T) {
+	t.Run("ImplementsInterface", func(t *testing.T) {
+		// Given a mock evaluator
+		mockEvaluator := setupMockEvaluatorMocks(t)
+
+		// Then it should implement ExpressionEvaluator
+		if mockEvaluator == nil {
+			t.Error("Expected mock evaluator to be created")
+		}
+	})
+}
+
+// =============================================================================
+// Test Public Methods
+// =============================================================================
+
+// TestMockExpressionEvaluator_SetTemplateData tests the SetTemplateData method of MockExpressionEvaluator
+func TestMockExpressionEvaluator_SetTemplateData(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Given a mock evaluator with SetTemplateDataFunc set
+		mockEvaluator := setupMockEvaluatorMocks(t)
+		called := false
+		expectedData := map[string][]byte{
+			"test.jsonnet": []byte(`{"key": "value"}`),
+		}
+		mockEvaluator.SetTemplateDataFunc = func(templateData map[string][]byte) {
+			called = true
+			if len(templateData) != len(expectedData) {
+				t.Errorf("Expected templateData length %d, got %d", len(expectedData), len(templateData))
+			}
+		}
+
+		// When SetTemplateData is called
+		mockEvaluator.SetTemplateData(expectedData)
+
+		// Then the function should be called
+		if !called {
+			t.Error("Expected SetTemplateDataFunc to be called")
+		}
+	})
+
+	t.Run("NotImplemented", func(t *testing.T) {
+		// Given a mock evaluator without SetTemplateDataFunc set
+		mockEvaluator := setupMockEvaluatorMocks(t)
+
+		// When SetTemplateData is called
+		mockEvaluator.SetTemplateData(map[string][]byte{
+			"test.jsonnet": []byte(`{"key": "value"}`),
+		})
+
+		// Then no error should occur (does nothing)
+		if mockEvaluator == nil {
+			t.Error("Expected mock evaluator to exist")
+		}
+	})
+}
+
+// TestMockExpressionEvaluator_Register tests the Register method of MockExpressionEvaluator
+func TestMockExpressionEvaluator_Register(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Given a mock evaluator with RegisterFunc set
+		mockEvaluator := setupMockEvaluatorMocks(t)
+		called := false
+		expectedName := "test_helper"
+		expectedHelper := func(params ...any) (any, error) {
+			return "result", nil
+		}
+		expectedSignature := new(func(string) any)
+		mockEvaluator.RegisterFunc = func(name string, helper func(params ...any) (any, error), signature any) {
+			called = true
+			if name != expectedName {
+				t.Errorf("Expected name %s, got %s", expectedName, name)
+			}
+		}
+
+		// When Register is called
+		mockEvaluator.Register(expectedName, expectedHelper, expectedSignature)
+
+		// Then the function should be called
+		if !called {
+			t.Error("Expected RegisterFunc to be called")
+		}
+	})
+
+	t.Run("NotImplemented", func(t *testing.T) {
+		// Given a mock evaluator without RegisterFunc set
+		mockEvaluator := setupMockEvaluatorMocks(t)
+
+		// When Register is called
+		mockEvaluator.Register("test_helper", func(params ...any) (any, error) {
+			return nil, nil
+		}, new(func(string) any))
+
+		// Then no error should occur (does nothing)
+		if mockEvaluator == nil {
+			t.Error("Expected mock evaluator to exist")
+		}
+	})
+}
+
+// TestMockExpressionEvaluator_Evaluate tests the Evaluate method of MockExpressionEvaluator
+func TestMockExpressionEvaluator_Evaluate(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Given a mock evaluator with EvaluateFunc set
+		mockEvaluator := setupMockEvaluatorMocks(t)
+		expectedResult := 42
+		expectedExpression := "value"
+		expectedConfig := map[string]any{
+			"value": 42,
+		}
+		expectedFeaturePath := "/test/feature.yaml"
+		mockEvaluator.EvaluateFunc = func(expression string, config map[string]any, featurePath string) (any, error) {
+			if expression != expectedExpression {
+				t.Errorf("Expected expression %s, got %s", expectedExpression, expression)
+			}
+			if featurePath != expectedFeaturePath {
+				t.Errorf("Expected featurePath %s, got %s", expectedFeaturePath, featurePath)
+			}
+			return expectedResult, nil
+		}
+
+		// When Evaluate is called
+		result, err := mockEvaluator.Evaluate(expectedExpression, expectedConfig, expectedFeaturePath)
+
+		// Then no error should be returned and the result should match
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if result != expectedResult {
+			t.Errorf("Expected result %v, got %v", expectedResult, result)
+		}
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		// Given a mock evaluator with EvaluateFunc set to return an error
+		mockEvaluator := setupMockEvaluatorMocks(t)
+		expectedError := errors.New("evaluation error")
+		mockEvaluator.EvaluateFunc = func(expression string, config map[string]any, featurePath string) (any, error) {
+			return nil, expectedError
+		}
+
+		// When Evaluate is called
+		result, err := mockEvaluator.Evaluate("test", map[string]any{}, "")
+
+		// Then the expected error should be returned and result should be nil
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if err.Error() != expectedError.Error() {
+			t.Errorf("Expected error %v, got %v", expectedError, err)
+		}
+		if result != nil {
+			t.Errorf("Expected nil result, got %v", result)
+		}
+	})
+
+	t.Run("NotImplemented", func(t *testing.T) {
+		// Given a mock evaluator without EvaluateFunc set
+		mockEvaluator := setupMockEvaluatorMocks(t)
+
+		// When Evaluate is called
+		result, err := mockEvaluator.Evaluate("test", map[string]any{}, "")
+
+		// Then no error should be returned and result should be nil (default implementation)
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if result != nil {
+			t.Errorf("Expected nil result, got %v", result)
+		}
+	})
+}
+
+// TestMockExpressionEvaluator_EvaluateDefaults tests the EvaluateDefaults method of MockExpressionEvaluator
+func TestMockExpressionEvaluator_EvaluateDefaults(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Given a mock evaluator with EvaluateDefaultsFunc set
+		mockEvaluator := setupMockEvaluatorMocks(t)
+		expectedResult := map[string]any{
+			"key1": "value1",
+			"key2": 42,
+		}
+		expectedDefaults := map[string]any{
+			"key1": "${value1}",
+			"key2": "${value2}",
+		}
+		expectedConfig := map[string]any{
+			"value1": "value1",
+			"value2": 42,
+		}
+		expectedFeaturePath := "/test/feature.yaml"
+		mockEvaluator.EvaluateDefaultsFunc = func(defaults map[string]any, config map[string]any, featurePath string) (map[string]any, error) {
+			if featurePath != expectedFeaturePath {
+				t.Errorf("Expected featurePath %s, got %s", expectedFeaturePath, featurePath)
+			}
+			return expectedResult, nil
+		}
+
+		// When EvaluateDefaults is called
+		result, err := mockEvaluator.EvaluateDefaults(expectedDefaults, expectedConfig, expectedFeaturePath)
+
+		// Then no error should be returned and the result should match
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if len(result) != len(expectedResult) {
+			t.Errorf("Expected result length %d, got %d", len(expectedResult), len(result))
+		}
+		if result["key1"] != expectedResult["key1"] {
+			t.Errorf("Expected result[key1] %v, got %v", expectedResult["key1"], result["key1"])
+		}
+		if result["key2"] != expectedResult["key2"] {
+			t.Errorf("Expected result[key2] %v, got %v", expectedResult["key2"], result["key2"])
+		}
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		// Given a mock evaluator with EvaluateDefaultsFunc set to return an error
+		mockEvaluator := setupMockEvaluatorMocks(t)
+		expectedError := errors.New("evaluation defaults error")
+		mockEvaluator.EvaluateDefaultsFunc = func(defaults map[string]any, config map[string]any, featurePath string) (map[string]any, error) {
+			return nil, expectedError
+		}
+
+		// When EvaluateDefaults is called
+		result, err := mockEvaluator.EvaluateDefaults(map[string]any{}, map[string]any{}, "")
+
+		// Then the expected error should be returned and result should be nil
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if err.Error() != expectedError.Error() {
+			t.Errorf("Expected error %v, got %v", expectedError, err)
+		}
+		if result != nil {
+			t.Errorf("Expected nil result, got %v", result)
+		}
+	})
+
+	t.Run("NotImplemented", func(t *testing.T) {
+		// Given a mock evaluator without EvaluateDefaultsFunc set
+		mockEvaluator := setupMockEvaluatorMocks(t)
+
+		// When EvaluateDefaults is called
+		result, err := mockEvaluator.EvaluateDefaults(map[string]any{}, map[string]any{}, "")
+
+		// Then no error should be returned and result should be an empty map (default implementation)
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if result == nil {
+			t.Error("Expected non-nil empty map, got nil")
+		}
+		if len(result) != 0 {
+			t.Errorf("Expected empty map, got map with %d entries", len(result))
+		}
+	})
+}
+
+// TestMockExpressionEvaluator_InterpolateString tests the InterpolateString method of MockExpressionEvaluator
+func TestMockExpressionEvaluator_InterpolateString(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Given a mock evaluator with InterpolateStringFunc set
+		mockEvaluator := setupMockEvaluatorMocks(t)
+		expectedResult := "interpolated value: 42"
+		expectedString := "interpolated value: ${value}"
+		expectedConfig := map[string]any{
+			"value": 42,
+		}
+		expectedFeaturePath := "/test/feature.yaml"
+		mockEvaluator.InterpolateStringFunc = func(s string, config map[string]any, featurePath string) (string, error) {
+			if s != expectedString {
+				t.Errorf("Expected string %s, got %s", expectedString, s)
+			}
+			if featurePath != expectedFeaturePath {
+				t.Errorf("Expected featurePath %s, got %s", expectedFeaturePath, featurePath)
+			}
+			return expectedResult, nil
+		}
+
+		// When InterpolateString is called
+		result, err := mockEvaluator.InterpolateString(expectedString, expectedConfig, expectedFeaturePath)
+
+		// Then no error should be returned and the result should match
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if result != expectedResult {
+			t.Errorf("Expected result %s, got %s", expectedResult, result)
+		}
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		// Given a mock evaluator with InterpolateStringFunc set to return an error
+		mockEvaluator := setupMockEvaluatorMocks(t)
+		expectedError := errors.New("interpolation error")
+		mockEvaluator.InterpolateStringFunc = func(s string, config map[string]any, featurePath string) (string, error) {
+			return "", expectedError
+		}
+
+		// When InterpolateString is called
+		result, err := mockEvaluator.InterpolateString("test", map[string]any{}, "")
+
+		// Then the expected error should be returned and result should be empty
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if err.Error() != expectedError.Error() {
+			t.Errorf("Expected error %v, got %v", expectedError, err)
+		}
+		if result != "" {
+			t.Errorf("Expected empty result, got %s", result)
+		}
+	})
+
+	t.Run("NotImplemented", func(t *testing.T) {
+		// Given a mock evaluator without InterpolateStringFunc set
+		mockEvaluator := setupMockEvaluatorMocks(t)
+		expectedString := "test string"
+
+		// When InterpolateString is called
+		result, err := mockEvaluator.InterpolateString(expectedString, map[string]any{}, "")
+
+		// Then no error should be returned and result should be the input string (default implementation)
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if result != expectedString {
+			t.Errorf("Expected result %s, got %s", expectedString, result)
+		}
+	})
+}
+

--- a/pkg/runtime/evaluator/shims.go
+++ b/pkg/runtime/evaluator/shims.go
@@ -18,6 +18,44 @@ import (
 // Types
 // =============================================================================
 
+// JsonnetVM provides an interface for Jsonnet virtual machine operations.
+// It abstracts the underlying Jsonnet VM implementation to enable testing
+// and dependency injection. The interface supports setting external code,
+// configuring importers, and evaluating Jsonnet snippets.
+type JsonnetVM interface {
+	ExtCode(key, val string)
+	Importer(importer jsonnet.Importer)
+	EvaluateAnonymousSnippet(filename, snippet string) (string, error)
+}
+
+// realJsonnetVM is the concrete implementation of JsonnetVM that wraps
+// the actual Jsonnet VM from the go-jsonnet library. It provides the
+// real functionality for Jsonnet evaluation in production code.
+type realJsonnetVM struct {
+	vm *jsonnet.VM
+}
+
+// ExtCode sets external code variables for the Jsonnet VM.
+// This allows passing external data into Jsonnet evaluation contexts,
+// enabling Jsonnet code to access runtime values and configuration.
+func (j *realJsonnetVM) ExtCode(key, val string) {
+	j.vm.ExtCode(key, val)
+}
+
+// Importer configures the file importer for the Jsonnet VM.
+// This determines how Jsonnet resolves import statements and file paths,
+// enabling support for relative imports and custom import resolution.
+func (j *realJsonnetVM) Importer(importer jsonnet.Importer) {
+	j.vm.Importer(importer)
+}
+
+// EvaluateAnonymousSnippet evaluates a Jsonnet code snippet as a string.
+// The filename parameter is used for error reporting and import resolution.
+// Returns the evaluated JSON output as a string, or an error if evaluation fails.
+func (j *realJsonnetVM) EvaluateAnonymousSnippet(filename, snippet string) (string, error) {
+	return j.vm.EvaluateAnonymousSnippet(filename, snippet)
+}
+
 // Shims provides mockable wrappers around system and runtime functions
 type Shims struct {
 	ReadFile      func(string) ([]byte, error)

--- a/pkg/runtime/terraform/mock_provider.go
+++ b/pkg/runtime/terraform/mock_provider.go
@@ -11,7 +11,6 @@ type MockTerraformProvider struct {
 	GenerateTerraformArgsFunc   func(componentID, modulePath string, interactive bool) (*TerraformArgs, error)
 	GetTerraformComponentFunc   func(componentID string) *blueprintv1alpha1.TerraformComponent
 	GetTerraformComponentsFunc  func() []blueprintv1alpha1.TerraformComponent
-	GetOutputsFunc              func(componentID string) (map[string]any, error)
 	GetTFDataDirFunc            func(componentID string) (string, error)
 	ClearCacheFunc              func()
 }
@@ -54,14 +53,6 @@ func (m *MockTerraformProvider) GetTerraformComponents() []blueprintv1alpha1.Ter
 		return m.GetTerraformComponentsFunc()
 	}
 	return []blueprintv1alpha1.TerraformComponent{}
-}
-
-// GetOutputs implements TerraformProvider.
-func (m *MockTerraformProvider) GetOutputs(componentID string) (map[string]any, error) {
-	if m.GetOutputsFunc != nil {
-		return m.GetOutputsFunc(componentID)
-	}
-	return map[string]any{}, nil
 }
 
 // GetTFDataDir implements TerraformProvider.

--- a/pkg/runtime/terraform/mock_provider_test.go
+++ b/pkg/runtime/terraform/mock_provider_test.go
@@ -153,47 +153,6 @@ func TestMockTerraformProvider_GetTerraformComponents(t *testing.T) {
 	})
 }
 
-func TestMockTerraformProvider_GetOutputs(t *testing.T) {
-	t.Run("WithFuncSet", func(t *testing.T) {
-		// Given a mock provider with GetOutputsFunc set
-		mock := &MockTerraformProvider{}
-		expectedOutputs := map[string]any{
-			"output1": "value1",
-			"output2": 42,
-		}
-		mock.GetOutputsFunc = func(componentID string) (map[string]any, error) {
-			return expectedOutputs, nil
-		}
-
-		// When GetOutputs is called
-		outputs, err := mock.GetOutputs("test/path")
-
-		// Then the expected outputs should be returned
-		if err != nil {
-			t.Errorf("Expected no error, got = %v", err)
-		}
-		if len(outputs) != len(expectedOutputs) {
-			t.Errorf("Expected %d outputs, got = %d", len(expectedOutputs), len(outputs))
-		}
-	})
-
-	t.Run("WithNoFuncSet", func(t *testing.T) {
-		// Given a mock provider with no GetOutputsFunc set
-		mock := &MockTerraformProvider{}
-
-		// When GetOutputs is called
-		outputs, err := mock.GetOutputs("test/path")
-
-		// Then empty map and no error should be returned
-		if err != nil {
-			t.Errorf("Expected no error, got = %v", err)
-		}
-		if len(outputs) != 0 {
-			t.Errorf("Expected empty map, got = %d outputs", len(outputs))
-		}
-	})
-}
-
 func TestMockTerraformProvider_ClearCache(t *testing.T) {
 	t.Run("WithFuncSet", func(t *testing.T) {
 		// Given a mock provider with ClearCacheFunc set

--- a/pkg/runtime/terraform/provider_private_test.go
+++ b/pkg/runtime/terraform/provider_private_test.go
@@ -14,7 +14,8 @@ import (
 
 func TestTerraformProvider_generateBackendConfigArgs(t *testing.T) {
 	t.Run("GeneratesLocalBackendArgs", func(t *testing.T) {
-		provider := setupProvider(t)
+		mocks := setupMocks(t)
+		provider := mocks.Provider
 		mockConfig := provider.configHandler.(*config.MockConfigHandler)
 
 		configRoot := "/test/config"
@@ -65,7 +66,8 @@ func TestTerraformProvider_generateBackendConfigArgs(t *testing.T) {
 	})
 
 	t.Run("GeneratesLocalBackendArgsWithPrefix", func(t *testing.T) {
-		provider := setupProvider(t)
+		mocks := setupMocks(t)
+		provider := mocks.Provider
 		mockConfig := provider.configHandler.(*config.MockConfigHandler)
 
 		configRoot := "/test/config"
@@ -119,7 +121,8 @@ func TestTerraformProvider_generateBackendConfigArgs(t *testing.T) {
 	})
 
 	t.Run("GeneratesLocalBackendArgsForEnvVar", func(t *testing.T) {
-		provider := setupProvider(t)
+		mocks := setupMocks(t)
+		provider := mocks.Provider
 		mockConfig := provider.configHandler.(*config.MockConfigHandler)
 
 		configRoot := "/test/config"
@@ -169,7 +172,8 @@ func TestTerraformProvider_generateBackendConfigArgs(t *testing.T) {
 	})
 
 	t.Run("IncludesBackendTfvars", func(t *testing.T) {
-		provider := setupProvider(t)
+		mocks := setupMocks(t)
+		provider := mocks.Provider
 		mockConfig := provider.configHandler.(*config.MockConfigHandler)
 
 		configRoot := "/test/config"
@@ -232,7 +236,8 @@ func TestTerraformProvider_generateBackendConfigArgs(t *testing.T) {
 	})
 
 	t.Run("PrefersNewBackendTfvarsLocation", func(t *testing.T) {
-		provider := setupProvider(t)
+		mocks := setupMocks(t)
+		provider := mocks.Provider
 		mockConfig := provider.configHandler.(*config.MockConfigHandler)
 
 		configRoot := "/test/config"
@@ -297,7 +302,8 @@ func TestTerraformProvider_generateBackendConfigArgs(t *testing.T) {
 	})
 
 	t.Run("FallsBackToOldBackendTfvarsLocation", func(t *testing.T) {
-		provider := setupProvider(t)
+		mocks := setupMocks(t)
+		provider := mocks.Provider
 		mockConfig := provider.configHandler.(*config.MockConfigHandler)
 
 		configRoot := "/test/config"
@@ -358,7 +364,8 @@ func TestTerraformProvider_generateBackendConfigArgs(t *testing.T) {
 	})
 
 	t.Run("GeneratesS3BackendArgs", func(t *testing.T) {
-		provider := setupProvider(t)
+		mocks := setupMocks(t)
+		provider := mocks.Provider
 		mockConfig := provider.configHandler.(*config.MockConfigHandler)
 
 		configRoot := "/test/config"
@@ -431,7 +438,8 @@ func TestTerraformProvider_generateBackendConfigArgs(t *testing.T) {
 	})
 
 	t.Run("GeneratesKubernetesBackendArgs", func(t *testing.T) {
-		provider := setupProvider(t)
+		mocks := setupMocks(t)
+		provider := mocks.Provider
 		mockConfig := provider.configHandler.(*config.MockConfigHandler)
 
 		configRoot := "/test/config"
@@ -501,7 +509,8 @@ func TestTerraformProvider_generateBackendConfigArgs(t *testing.T) {
 	})
 
 	t.Run("GeneratesKubernetesBackendArgsWithPrefix", func(t *testing.T) {
-		provider := setupProvider(t)
+		mocks := setupMocks(t)
+		provider := mocks.Provider
 		mockConfig := provider.configHandler.(*config.MockConfigHandler)
 
 		configRoot := "/test/config"
@@ -559,7 +568,8 @@ func TestTerraformProvider_generateBackendConfigArgs(t *testing.T) {
 	})
 
 	t.Run("GeneratesAzurermBackendArgs", func(t *testing.T) {
-		provider := setupProvider(t)
+		mocks := setupMocks(t)
+		provider := mocks.Provider
 		mockConfig := provider.configHandler.(*config.MockConfigHandler)
 
 		configRoot := "/test/config"
@@ -635,7 +645,8 @@ func TestTerraformProvider_generateBackendConfigArgs(t *testing.T) {
 	})
 
 	t.Run("ReturnsErrorForUnsupportedBackend", func(t *testing.T) {
-		provider := setupProvider(t)
+		mocks := setupMocks(t)
+		provider := mocks.Provider
 		mockConfig := provider.configHandler.(*config.MockConfigHandler)
 
 		configRoot := "/test/config"
@@ -664,7 +675,8 @@ func TestTerraformProvider_generateBackendConfigArgs(t *testing.T) {
 	})
 
 	t.Run("ReturnsErrorWhenWindsorScratchPathFails", func(t *testing.T) {
-		provider := setupProvider(t)
+		mocks := setupMocks(t)
+		provider := mocks.Provider
 		mockConfig := provider.configHandler.(*config.MockConfigHandler)
 
 		configRoot := "/test/config"
@@ -697,7 +709,8 @@ func TestTerraformProvider_generateBackendConfigArgs(t *testing.T) {
 	})
 
 	t.Run("HandlesProcessBackendConfigError", func(t *testing.T) {
-		provider := setupProvider(t)
+		mocks := setupMocks(t)
+		provider := mocks.Provider
 		mockConfig := provider.configHandler.(*config.MockConfigHandler)
 
 		configRoot := "/test/config"
@@ -1001,7 +1014,8 @@ func Test_processMap(t *testing.T) {
 
 func TestTerraformProvider_RestoreEnvVar(t *testing.T) {
 	t.Run("RestoresEnvVarWithValue", func(t *testing.T) {
-		provider := setupProvider(t)
+		mocks := setupMocks(t)
+		provider := mocks.Provider
 
 		var setKey, setValue string
 		provider.Shims.Setenv = func(key, value string) error {
@@ -1022,7 +1036,8 @@ func TestTerraformProvider_RestoreEnvVar(t *testing.T) {
 	})
 
 	t.Run("UnsetsEnvVarWhenEmpty", func(t *testing.T) {
-		provider := setupProvider(t)
+		mocks := setupMocks(t)
+		provider := mocks.Provider
 
 		var unsetKey string
 		provider.Shims.Unsetenv = func(key string) error {


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a pluggable expression evaluation layer and wires Terraform provider integration across runtime and env.
> 
> - Adds `ExpressionEvaluator` interface with helper registration (`Register`) and moves Jsonnet VM shims to `evaluator/shims.go`; updates evaluator to use `expr.AsAny` and supports custom helpers
> - Provides `MockExpressionEvaluator` for tests and comprehensive evaluator test suites
> - Updates Terraform provider: constructor now accepts an evaluator and registers `terraform_output(component, key)`; replaces public `GetOutputs`/`GetValue` with internal cached `getOutput`; adjusts mocks and tests accordingly
> - Refactors `TerraformEnvPrinter` to receive a `TerraformProvider` via DI; removes internal provider construction; updates usage in stack tests
> - Extends `Runtime` to hold `Evaluator` (as interface) and `TerraformProvider`, initializing and wiring them when Terraform is enabled
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1ad49045cbc6007c28d778238ab85f9f3d70819. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->