### PR TITLE
chore(ci): Pin kubectl 1.34.3 in aqua

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -15,7 +15,7 @@ packages:
 - name: siderolabs/talos@v1.12.0
 - name: siderolabs/omni/omnictl@v1.4.6
 - name: siderolabs/omni/omni@v1.4.6
-- name: kubernetes/kubectl@v1.35.0
+- name: kubernetes/kubectl@v1.34.3 # renovate: ignore
 - name: go-task/task@v3.46.4
 - name: golang/go@go1.25.5
 - name: getsops/sops@v3.11.0


### PR DESCRIPTION
Cosign SLSA verification is failing for kubectl 1.35. Temporarily pinning in aqua.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Pins `kubernetes/kubectl` in `aqua.yaml` to `v1.34.3` and marks it with `# renovate: ignore` to prevent automated upgrades.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3354d624181ed0da7262fdc73126deadd851aa70. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->