### PR TITLE
chore(renovate): Temporarily pin kubectl

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -14,6 +14,13 @@
       "allowedVersions": "3.9.0"
     },
     {
+      "description": "Pin kubectl to v1.34.3",
+      "matchPackageNames": [
+        "kubernetes/kubectl"
+      ],
+      "allowedVersions": "1.34.3"
+    },
+    {
       "description": "Pin GitHub Actions to specific commit SHAs",
       "matchManagers": [
         "github-actions"


### PR DESCRIPTION
`kubectl` 1.35 fails SLSA verification.

Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Renovate `packageRules` entry to pin `kubernetes/kubectl` to `1.34.3`.
> 
> - Updates `.github/renovate.json` to add a rule matching `kubernetes/kubectl` with `allowedVersions: "1.34.3"`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e25820e3b913897b271107e142ba56718f769cf3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->