### PR TITLE
chore: Make interface compliance consistent

### DIFF
--- a/pkg/composer/artifact/artifact.go
+++ b/pkg/composer/artifact/artifact.go
@@ -1336,5 +1336,9 @@ func (a *ArtifactBuilder) downloadOCIArtifact(registry, repository, tag string) 
 	return data, nil
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure ArtifactBuilder implements Artifact interface
 var _ Artifact = (*ArtifactBuilder)(nil)

--- a/pkg/composer/artifact/mock_artifact.go
+++ b/pkg/composer/artifact/mock_artifact.go
@@ -92,5 +92,9 @@ func (m *MockArtifact) GetCacheDir(registry, repository, tag string) (string, er
 	return "", nil
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure MockArtifact implements Artifact interface
 var _ Artifact = (*MockArtifact)(nil)

--- a/pkg/composer/blueprint/composer.go
+++ b/pkg/composer/blueprint/composer.go
@@ -292,4 +292,8 @@ func (c *BaseBlueprintComposer) mergeLegacySpecialVariables(mergedCommonValues m
 	}
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 var _ BlueprintComposer = (*BaseBlueprintComposer)(nil)

--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -496,4 +496,8 @@ func (h *BaseBlueprintHandler) Generate() *blueprintv1alpha1.Blueprint {
 	return h.composedBlueprint
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 var _ BlueprintHandler = (*BaseBlueprintHandler)(nil)

--- a/pkg/composer/blueprint/loader.go
+++ b/pkg/composer/blueprint/loader.go
@@ -384,4 +384,8 @@ func (l *BaseBlueprintLoader) collectTemplateData(dir string) error {
 	})
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 var _ BlueprintLoader = (*BaseBlueprintLoader)(nil)

--- a/pkg/composer/blueprint/mock_blueprint_handler.go
+++ b/pkg/composer/blueprint/mock_blueprint_handler.go
@@ -66,4 +66,8 @@ func (m *MockBlueprintHandler) Generate() *blueprintv1alpha1.Blueprint {
 	return nil
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 var _ BlueprintHandler = (*MockBlueprintHandler)(nil)

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -200,4 +200,8 @@ func (p *BaseBlueprintProcessor) evaluateSubstitutions(subs map[string]string, c
 	return result, nil
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 var _ BlueprintProcessor = (*BaseBlueprintProcessor)(nil)

--- a/pkg/composer/blueprint/writer.go
+++ b/pkg/composer/blueprint/writer.go
@@ -129,4 +129,8 @@ func (w *BaseBlueprintWriter) cleanTransientFields(blueprint *blueprintv1alpha1.
 	return cleaned
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 var _ BlueprintWriter = (*BaseBlueprintWriter)(nil)

--- a/pkg/provisioner/cluster/mock_cluster_client.go
+++ b/pkg/provisioner/cluster/mock_cluster_client.go
@@ -48,5 +48,9 @@ func (m *MockClusterClient) Close() {
 	}
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure MockClusterClient implements ClusterClient
 var _ ClusterClient = (*MockClusterClient)(nil)

--- a/pkg/provisioner/cluster/talos_cluster_client.go
+++ b/pkg/provisioner/cluster/talos_cluster_client.go
@@ -267,5 +267,9 @@ func (c *TalosClusterClient) getNodeVersion(ctx context.Context, nodeAddress str
 	return strings.TrimPrefix(versionTag, "v"), nil
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure TalosClusterClient implements ClusterClient
 var _ ClusterClient = (*TalosClusterClient)(nil)

--- a/pkg/provisioner/kubernetes/client/client.go
+++ b/pkg/provisioner/kubernetes/client/client.go
@@ -239,3 +239,10 @@ func (c *DynamicKubernetesClient) isNodeReady(node *unstructured.Unstructured) b
 
 	return false
 }
+
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
+// Ensure DynamicKubernetesClient implements the KubernetesClient interface
+var _ KubernetesClient = (*DynamicKubernetesClient)(nil)

--- a/pkg/provisioner/kubernetes/mock_kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/mock_kubernetes_manager.go
@@ -47,9 +47,6 @@ func NewMockKubernetesManager() *MockKubernetesManager {
 	return &MockKubernetesManager{}
 }
 
-// Ensure MockKubernetesManager implements KubernetesManager interface
-var _ KubernetesManager = (*MockKubernetesManager)(nil)
-
 // =============================================================================
 // Public Methods
 // =============================================================================
@@ -191,3 +188,10 @@ func (m *MockKubernetesManager) DeleteBlueprint(blueprint *blueprintv1alpha1.Blu
 	}
 	return nil
 }
+
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
+// Ensure MockKubernetesManager implements KubernetesManager interface
+var _ KubernetesManager = (*MockKubernetesManager)(nil)

--- a/pkg/provisioner/terraform/mock_stack.go
+++ b/pkg/provisioner/terraform/mock_stack.go
@@ -48,5 +48,9 @@ func (m *MockStack) Down(blueprint *blueprintv1alpha1.Blueprint) error {
 	return nil
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure MockStack implements Stack
 var _ Stack = (*MockStack)(nil)

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -384,3 +384,10 @@ func (s *TerraformStack) getTerraformEnv() *envvars.TerraformEnvPrinter {
 	}
 	return nil
 }
+
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
+// Ensure TerraformStack implements the Stack interface
+var _ Stack = (*TerraformStack)(nil)

--- a/pkg/runtime/config/config_handler.go
+++ b/pkg/runtime/config/config_handler.go
@@ -944,9 +944,6 @@ func (c *configHandler) GenerateContextID() error {
 	return c.Set("id", id)
 }
 
-// Ensure configHandler implements ConfigHandler
-var _ ConfigHandler = (*configHandler)(nil)
-
 // =============================================================================
 // Private Methods
 // =============================================================================
@@ -1261,3 +1258,10 @@ func (c *configHandler) applySystemSchemaPlugins() {
 		}
 	}
 }
+
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
+// Ensure configHandler implements ConfigHandler
+var _ ConfigHandler = (*configHandler)(nil)

--- a/pkg/runtime/config/mock_config_handler.go
+++ b/pkg/runtime/config/mock_config_handler.go
@@ -254,5 +254,9 @@ func (m *MockConfigHandler) RegisterProvider(prefix string, provider ValueProvid
 	}
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure MockConfigHandler implements ConfigHandler
 var _ ConfigHandler = (*MockConfigHandler)(nil)

--- a/pkg/runtime/env/aws_env.go
+++ b/pkg/runtime/env/aws_env.go
@@ -82,5 +82,9 @@ func (e *AwsEnvPrinter) GetEnvVars() (map[string]string, error) {
 	return envVars, nil
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure AwsEnvPrinter implements the EnvPrinter interface
 var _ EnvPrinter = (*AwsEnvPrinter)(nil)

--- a/pkg/runtime/env/docker_env.go
+++ b/pkg/runtime/env/docker_env.go
@@ -192,5 +192,9 @@ func (e *DockerEnvPrinter) getRegistryURL() (string, error) {
 	return "", nil
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure DockerEnvPrinter implements the EnvPrinter interface
 var _ EnvPrinter = (*DockerEnvPrinter)(nil)

--- a/pkg/runtime/env/gcp_env.go
+++ b/pkg/runtime/env/gcp_env.go
@@ -80,5 +80,9 @@ func (e *GcpEnvPrinter) GetEnvVars() (map[string]string, error) {
 	return envVars, nil
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure GcpEnvPrinter implements the EnvPrinter interface
 var _ EnvPrinter = (*GcpEnvPrinter)(nil)

--- a/pkg/runtime/env/kube_env.go
+++ b/pkg/runtime/env/kube_env.go
@@ -188,5 +188,9 @@ var queryPersistentVolumeClaims = func(kubeConfigPath string) (*corev1.Persisten
 	return pvcs, nil
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure KubeEnvPrinter implements the EnvPrinter interface
 var _ EnvPrinter = (*KubeEnvPrinter)(nil)

--- a/pkg/runtime/env/mock_env.go
+++ b/pkg/runtime/env/mock_env.go
@@ -110,5 +110,9 @@ func (m *MockEnvPrinter) GetManagedAlias() []string {
 	return m.BaseEnvPrinter.GetManagedAlias()
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure MockEnvPrinter implements the EnvPrinter interface
 var _ EnvPrinter = (*MockEnvPrinter)(nil)

--- a/pkg/runtime/env/talos_env.go
+++ b/pkg/runtime/env/talos_env.go
@@ -52,5 +52,9 @@ func (e *TalosEnvPrinter) GetEnvVars() (map[string]string, error) {
 	return envVars, nil
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // TalosEnvPrinter implements the EnvPrinter interface.
 var _ EnvPrinter = (*TalosEnvPrinter)(nil)

--- a/pkg/runtime/env/terraform_env.go
+++ b/pkg/runtime/env/terraform_env.go
@@ -198,5 +198,9 @@ func (e *TerraformEnvPrinter) formatArgsForEnv(args []string) string {
 	return strings.TrimSpace(strings.Join(formatted, " "))
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure TerraformEnvPrinter implements the EnvPrinter interface
 var _ EnvPrinter = (*TerraformEnvPrinter)(nil)

--- a/pkg/runtime/env/windsor_env.go
+++ b/pkg/runtime/env/windsor_env.go
@@ -313,5 +313,9 @@ func (e *WindsorEnvPrinter) incrementBuildID(existingBuildID, currentDate string
 	return fmt.Sprintf("%s.%s.%d", existingDate, existingRandom, existingCounter), nil
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure WindsorEnvPrinter implements the EnvPrinter interface
 var _ EnvPrinter = (*WindsorEnvPrinter)(nil)

--- a/pkg/runtime/evaluator/evaluator.go
+++ b/pkg/runtime/evaluator/evaluator.go
@@ -674,3 +674,11 @@ func (e *expressionEvaluator) resolvePath(path string, featurePath string) strin
 
 	return filepath.Clean(path)
 }
+
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
+// Ensure expressionEvaluator implements the ExpressionEvaluator and HelperRegistrar interfaces
+var _ ExpressionEvaluator = (*expressionEvaluator)(nil)
+var _ HelperRegistrar = (*expressionEvaluator)(nil)

--- a/pkg/runtime/evaluator/mock_evaluator.go
+++ b/pkg/runtime/evaluator/mock_evaluator.go
@@ -72,5 +72,9 @@ func (m *MockExpressionEvaluator) InterpolateString(s string, config map[string]
 	return s, nil
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure MockExpressionEvaluator implements ExpressionEvaluator.
 var _ ExpressionEvaluator = (*MockExpressionEvaluator)(nil)

--- a/pkg/runtime/evaluator/shims.go
+++ b/pkg/runtime/evaluator/shims.go
@@ -84,3 +84,9 @@ func NewShims() *Shims {
 	}
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
+// Ensure realJsonnetVM implements the JsonnetVM interface
+var _ JsonnetVM = (*realJsonnetVM)(nil)

--- a/pkg/runtime/secrets/mock_secrets_provider.go
+++ b/pkg/runtime/secrets/mock_secrets_provider.go
@@ -71,5 +71,9 @@ func (m *MockSecretsProvider) Unlock() error {
 	return nil
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure MockSecretsProvider implements SecretsProvider
 var _ SecretsProvider = (*MockSecretsProvider)(nil)

--- a/pkg/runtime/secrets/op_cli_secrets_provider.go
+++ b/pkg/runtime/secrets/op_cli_secrets_provider.go
@@ -84,5 +84,9 @@ func (s *OnePasswordCLISecretsProvider) ParseSecrets(input string) (string, erro
 	return result, nil
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure OnePasswordCLISecretsProvider implements SecretsProvider
 var _ SecretsProvider = (*OnePasswordCLISecretsProvider)(nil)

--- a/pkg/runtime/secrets/op_sdk_secrets_provider.go
+++ b/pkg/runtime/secrets/op_sdk_secrets_provider.go
@@ -129,5 +129,9 @@ func (s *OnePasswordSDKSecretsProvider) ParseSecrets(input string) (string, erro
 	return result, nil
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure OnePasswordSDKSecretsProvider implements SecretsProvider
 var _ SecretsProvider = (*OnePasswordSDKSecretsProvider)(nil)

--- a/pkg/runtime/secrets/secrets_provider.go
+++ b/pkg/runtime/secrets/secrets_provider.go
@@ -82,9 +82,6 @@ func (s *BaseSecretsProvider) ParseSecrets(input string) (string, error) {
 	panic("ParseSecrets must be implemented by concrete provider")
 }
 
-// Ensure BaseSecretsProvider implements SecretsProvider
-var _ SecretsProvider = (*BaseSecretsProvider)(nil)
-
 // =============================================================================
 // Helpers
 // =============================================================================
@@ -215,3 +212,10 @@ func parseKeys(path string) []string {
 
 	return keys
 }
+
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
+// Ensure BaseSecretsProvider implements SecretsProvider
+var _ SecretsProvider = (*BaseSecretsProvider)(nil)

--- a/pkg/runtime/secrets/sops_secrets_provider.go
+++ b/pkg/runtime/secrets/sops_secrets_provider.go
@@ -218,5 +218,9 @@ func (s *SopsSecretsProvider) ParseSecrets(input string) (string, error) {
 	return result, nil
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure SopsSecretsProvider implements the SecretsProvider interface
 var _ SecretsProvider = (*SopsSecretsProvider)(nil)

--- a/pkg/runtime/shell/mock_shell.go
+++ b/pkg/runtime/shell/mock_shell.go
@@ -197,5 +197,9 @@ func (s *MockShell) RegisterSecret(value string) {
 	}
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure MockShell implements the Shell interface
 var _ Shell = (*MockShell)(nil)

--- a/pkg/runtime/shell/secure_shell.go
+++ b/pkg/runtime/shell/secure_shell.go
@@ -126,5 +126,9 @@ func (s *SecureShell) ExecSilentWithTimeout(command string, args []string, timeo
 	return executeWithTimeout(execFn, cleanupFn, timeout)
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure SecureShell implements the Shell interface
 var _ Shell = (*SecureShell)(nil)

--- a/pkg/runtime/shell/shell.go
+++ b/pkg/runtime/shell/shell.go
@@ -754,9 +754,6 @@ func (s *DefaultShell) quoteValueForShell(value string, useDoubleQuotes bool) st
 	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
 }
 
-// Ensure DefaultShell implements the Shell interface
-var _ Shell = (*DefaultShell)(nil)
-
 // =============================================================================
 // Helper Functions
 // =============================================================================
@@ -790,3 +787,10 @@ func executeWithTimeout(execFn func() (string, error), cleanupFn func(), timeout
 func isClosedPipe(err error) bool {
 	return err != nil && (err == io.ErrClosedPipe || strings.Contains(err.Error(), "file already closed") || strings.Contains(err.Error(), "use of closed file"))
 }
+
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
+// Ensure DefaultShell implements the Shell interface
+var _ Shell = (*DefaultShell)(nil)

--- a/pkg/runtime/shell/ssh/mock_client.go
+++ b/pkg/runtime/shell/ssh/mock_client.go
@@ -176,7 +176,7 @@ func (m *MockPublicKeyAuthMethod) Method() gossh.AuthMethod {
 }
 
 // =============================================================================
-// Helpers
+// Interface Compliance
 // =============================================================================
 
 // Ensure MockClient implements the Client interface
@@ -193,3 +193,6 @@ var _ AuthMethod = (*MockAuthMethod)(nil)
 
 // Ensure MockPublicKeyAuthMethod implements the AuthMethod interface
 var _ AuthMethod = (*MockPublicKeyAuthMethod)(nil)
+
+// Ensure MockHostKeyCallback implements the HostKeyCallback interface
+var _ HostKeyCallback = (*MockHostKeyCallback)(nil)

--- a/pkg/runtime/shell/ssh/real_client.go
+++ b/pkg/runtime/shell/ssh/real_client.go
@@ -130,7 +130,7 @@ func (p *PublicKeyAuthMethod) Method() gossh.AuthMethod {
 }
 
 // =============================================================================
-// Helpers
+// Interface Compliance
 // =============================================================================
 
 // Ensure SSHClient implements the Client interface

--- a/pkg/runtime/terraform/mock_provider.go
+++ b/pkg/runtime/terraform/mock_provider.go
@@ -70,5 +70,9 @@ func (m *MockTerraformProvider) ClearCache() {
 	}
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure MockTerraformProvider implements the TerraformProvider interface
 var _ TerraformProvider = (*MockTerraformProvider)(nil)

--- a/pkg/runtime/tools/mock_tools_manager.go
+++ b/pkg/runtime/tools/mock_tools_manager.go
@@ -53,5 +53,9 @@ func (m *MockToolsManager) GetTerraformCommand() string {
 	return "terraform"
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure MockToolsManager implements ToolsManager.
 var _ ToolsManager = (*MockToolsManager)(nil)

--- a/pkg/workstation/network/colima_network.go
+++ b/pkg/workstation/network/colima_network.go
@@ -164,5 +164,9 @@ func (n *ColimaNetworkManager) getHostIP() (string, error) {
 	return "", fmt.Errorf("failed to find host IP in the same subnet as guest IP")
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure ColimaNetworkManager implements NetworkManager
 var _ NetworkManager = (*ColimaNetworkManager)(nil)

--- a/pkg/workstation/network/mock_network.go
+++ b/pkg/workstation/network/mock_network.go
@@ -69,9 +69,6 @@ func (m *MockNetworkManager) ConfigureDNS() error {
 	return nil
 }
 
-// Ensure MockNetworkManager implements the NetworkManager interface
-var _ NetworkManager = (*MockNetworkManager)(nil)
-
 // The MockNetworkInterfaceProvider is a test implementation of the NetworkInterfaceProvider interface.
 // It provides mock implementations of network interface operations for testing,
 // The MockNetworkInterfaceProvider enables controlled testing of network interface-dependent code,
@@ -117,5 +114,12 @@ func (m *MockNetworkInterfaceProvider) InterfaceAddrs(iface net.Interface) ([]ne
 	return m.InterfaceAddrsFunc(iface)
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure MockNetworkInterfaceProvider implements the NetworkInterfaceProvider interface
 var _ NetworkInterfaceProvider = (*MockNetworkInterfaceProvider)(nil)
+
+// Ensure MockNetworkManager implements the NetworkManager interface
+var _ NetworkManager = (*MockNetworkManager)(nil)

--- a/pkg/workstation/network/network.go
+++ b/pkg/workstation/network/network.go
@@ -148,5 +148,9 @@ func incrementIP(ip net.IP) net.IP {
 	return ip
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure BaseNetworkManager implements NetworkManager
 var _ NetworkManager = (*BaseNetworkManager)(nil)

--- a/pkg/workstation/network/shims.go
+++ b/pkg/workstation/network/shims.go
@@ -68,3 +68,10 @@ func (p *RealNetworkInterfaceProvider) Interfaces() ([]net.Interface, error) {
 func (p *RealNetworkInterfaceProvider) InterfaceAddrs(iface net.Interface) ([]net.Addr, error) {
 	return iface.Addrs()
 }
+
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
+// Ensure RealNetworkInterfaceProvider implements the NetworkInterfaceProvider interface
+var _ NetworkInterfaceProvider = (*RealNetworkInterfaceProvider)(nil)

--- a/pkg/workstation/services/dns_service.go
+++ b/pkg/workstation/services/dns_service.go
@@ -216,5 +216,9 @@ func (s *DNSService) WriteConfig() error {
 	return nil
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure DNSService implements Service interface
 var _ Service = (*DNSService)(nil)

--- a/pkg/workstation/services/git_livereload_service.go
+++ b/pkg/workstation/services/git_livereload_service.go
@@ -100,5 +100,9 @@ func (s *GitLivereloadService) GetComposeConfig() (*types.Config, error) {
 	}, nil
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure GitService implements Service interface
 var _ Service = (*GitLivereloadService)(nil)

--- a/pkg/workstation/services/localstack_service.go
+++ b/pkg/workstation/services/localstack_service.go
@@ -103,5 +103,9 @@ func (s *LocalstackService) SupportsWildcard() bool {
 	return true
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure LocalstackService implements Service interface
 var _ Service = (*LocalstackService)(nil)

--- a/pkg/workstation/services/mock_service.go
+++ b/pkg/workstation/services/mock_service.go
@@ -103,5 +103,9 @@ func (m *MockService) SupportsWildcard() bool {
 	return false
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure MockService implements Service interface
 var _ Service = (*MockService)(nil)

--- a/pkg/workstation/services/registry_service.go
+++ b/pkg/workstation/services/registry_service.go
@@ -192,5 +192,9 @@ func getBasename(name string) string {
 	return name
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure RegistryService implements Service interface
 var _ Service = (*RegistryService)(nil)

--- a/pkg/workstation/services/talos_service.go
+++ b/pkg/workstation/services/talos_service.go
@@ -353,5 +353,9 @@ func validateHostPort(hostPortStr string) (uint32, uint32, string, error) {
 	return hostPort, nodePort, protocol, nil
 }
 
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
 // Ensure TalosService implements Service interface
 var _ Service = (*TalosService)(nil)

--- a/pkg/workstation/virt/docker_virt.go
+++ b/pkg/workstation/virt/docker_virt.go
@@ -175,9 +175,6 @@ func (v *DockerVirt) WriteConfig() error {
 	return nil
 }
 
-// Ensure DockerVirt implements ContainerRuntime
-var _ ContainerRuntime = (*DockerVirt)(nil)
-
 // =============================================================================
 // Private Methods
 // =============================================================================
@@ -351,3 +348,10 @@ func (v *DockerVirt) supportsDockerEngineV28Plus() bool {
 	majorVersion := parts[0]
 	return majorVersion >= "28"
 }
+
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
+// Ensure DockerVirt implements ContainerRuntime
+var _ ContainerRuntime = (*DockerVirt)(nil)


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Standardizes interface compliance assertions across the codebase with consistent "Interface Compliance" sections.
> 
> - Adds or relocates `var _ <Interface> = (*<Type>)(nil)` checks in artifact, blueprint, cluster, kubernetes client/manager, terraform stack, config handler, env printers, evaluator, secrets providers, shell (including ssh), network, and workstation services files
> - Fixes missing assertions (e.g., `MockHostKeyCallback` implements `HostKeyCallback`) and removes duplicates where repositioned
> - Documentation-only/comment structure changes; no functional logic modified
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8a531579e4557a3ce1a4e87d748991a098803f0b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->