### PR TITLE
fix(blueprint): Don't include "source: primary" on written blueprint

### DIFF
--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -146,7 +146,7 @@ func (p *BaseBlueprintProcessor) collectTerraformComponents(feature blueprintv1a
 			}
 			processed.Inputs = evaluated
 		}
-		if processed.Source == "" && len(sourceName) > 0 && sourceName[0] != "" {
+		if processed.Source == "" && len(sourceName) > 0 && sourceName[0] != "" && sourceName[0] != "primary" {
 			processed.Source = sourceName[0]
 		}
 
@@ -191,7 +191,7 @@ func (p *BaseBlueprintProcessor) collectKustomizations(feature blueprintv1alpha1
 			}
 			processed.Substitutions = evaluated
 		}
-		if processed.Source == "" && len(sourceName) > 0 && sourceName[0] != "" {
+		if processed.Source == "" && len(sourceName) > 0 && sourceName[0] != "" && sourceName[0] != "primary" {
 			processed.Source = sourceName[0]
 		}
 


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents default `"primary"` from being persisted into generated blueprints.
> 
> - In `processor.go`, both `collectTerraformComponents` and `collectKustomizations` now set `processed.Source` from `sourceName[0]` only when non-empty and not equal to `"primary"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3699c21d4bc8b06b61e501be0b4a3e2ac0825dda. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->