### PR TITLE
feat(cmd): Add windsor compose blueprint

### DIFF
--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -1,0 +1,77 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/goccy/go-yaml"
+	"github.com/spf13/cobra"
+	"github.com/windsorcli/cli/pkg/project"
+)
+
+var composeBlueprintJSON bool
+
+var composeCmd = &cobra.Command{
+	Use:   "compose",
+	Short: "Compose and output resources to stdout",
+	Long:  "Compose and output resources to stdout",
+}
+
+var composeBlueprintCmd = &cobra.Command{
+	Use:          "blueprint",
+	Short:        "Output the fully compiled blueprint",
+	Long:         "Output the fully compiled blueprint to stdout before cleaning/removing transient fields. Defaults to YAML output, use --json for JSON output.",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		var opts []*project.Project
+		if overridesVal := cmd.Context().Value(projectOverridesKey); overridesVal != nil {
+			opts = []*project.Project{overridesVal.(*project.Project)}
+		}
+
+		proj, err := project.NewProject("", opts...)
+		if err != nil {
+			return err
+		}
+
+		proj.Runtime.Shell.SetVerbosity(verbose)
+
+		if err := proj.Runtime.Shell.CheckTrustedDirectory(); err != nil {
+			return fmt.Errorf("not in a trusted directory. If you are in a Windsor project, run 'windsor init' to approve")
+		}
+
+		if err := proj.Configure(nil); err != nil {
+			return err
+		}
+
+		if err := proj.Initialize(false); err != nil {
+			return err
+		}
+
+		blueprint := proj.Composer.BlueprintHandler.Generate()
+		if blueprint == nil {
+			return fmt.Errorf("failed to generate blueprint")
+		}
+
+		var output []byte
+		if composeBlueprintJSON {
+			output, err = json.MarshalIndent(blueprint, "", "  ")
+			if err != nil {
+				return fmt.Errorf("failed to marshal blueprint to JSON: %w", err)
+			}
+		} else {
+			output, err = yaml.Marshal(blueprint)
+			if err != nil {
+				return fmt.Errorf("failed to marshal blueprint to YAML: %w", err)
+			}
+		}
+
+		fmt.Print(string(output))
+		return nil
+	},
+}
+
+func init() {
+	composeBlueprintCmd.Flags().BoolVar(&composeBlueprintJSON, "json", false, "Output blueprint as JSON instead of YAML")
+	composeCmd.AddCommand(composeBlueprintCmd)
+	rootCmd.AddCommand(composeCmd)
+}

--- a/cmd/compose_test.go
+++ b/cmd/compose_test.go
@@ -1,0 +1,382 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+	"github.com/windsorcli/cli/pkg/composer"
+	"github.com/windsorcli/cli/pkg/composer/blueprint"
+	"github.com/windsorcli/cli/pkg/project"
+	"github.com/windsorcli/cli/pkg/runtime"
+	"github.com/windsorcli/cli/pkg/runtime/config"
+	"github.com/windsorcli/cli/pkg/runtime/shell"
+)
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+type ComposeMocks struct {
+	ConfigHandler    config.ConfigHandler
+	Shell            *shell.MockShell
+	Shims            *Shims
+	BlueprintHandler *blueprint.MockBlueprintHandler
+	Runtime          *runtime.Runtime
+	TmpDir           string
+}
+
+func setupComposeTest(t *testing.T, opts ...*SetupOptions) *ComposeMocks {
+	t.Helper()
+
+	mockConfigHandler := config.NewMockConfigHandler()
+	mockConfigHandler.GetContextFunc = func() string { return "test-context" }
+	mockConfigHandler.IsDevModeFunc = func(contextName string) bool { return false }
+	mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+		if len(defaultValue) > 0 {
+			return defaultValue[0]
+		}
+		return ""
+	}
+	mockConfigHandler.GetBoolFunc = func(key string, defaultValue ...bool) bool {
+		if len(defaultValue) > 0 {
+			return defaultValue[0]
+		}
+		return false
+	}
+	mockConfigHandler.IsLoadedFunc = func() bool { return true }
+	mockConfigHandler.LoadConfigFunc = func() error { return nil }
+	mockConfigHandler.SaveConfigFunc = func(hasSetFlags ...bool) error { return nil }
+	mockConfigHandler.GenerateContextIDFunc = func() error { return nil }
+
+	testOpts := &SetupOptions{}
+	if len(opts) > 0 && opts[0] != nil {
+		testOpts = opts[0]
+	}
+	testOpts.ConfigHandler = mockConfigHandler
+	baseMocks := setupMocks(t, testOpts)
+	tmpDir := baseMocks.TmpDir
+	mockConfigHandler.GetConfigRootFunc = func() (string, error) { return tmpDir + "/contexts/test-context", nil }
+
+	baseMocks.Shell.CheckTrustedDirectoryFunc = func() error { return nil }
+
+	testBlueprint := &blueprintv1alpha1.Blueprint{
+		Kind:       "Blueprint",
+		ApiVersion: "blueprints.windsorcli.dev/v1alpha1",
+		Metadata: blueprintv1alpha1.Metadata{
+			Name:        "test-blueprint",
+			Description: "Test blueprint for compose command",
+		},
+		TerraformComponents: []blueprintv1alpha1.TerraformComponent{
+			{
+				Name: "test-component",
+				Path: "test/path",
+			},
+		},
+		Kustomizations: []blueprintv1alpha1.Kustomization{
+			{
+				Name: "test-kustomization",
+			},
+		},
+	}
+
+	mockBlueprintHandler := blueprint.NewMockBlueprintHandler()
+	mockBlueprintHandler.LoadBlueprintFunc = func(...string) error { return nil }
+	mockBlueprintHandler.WriteFunc = func(overwrite ...bool) error { return nil }
+	mockBlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint { return testBlueprint }
+
+	rt, err := runtime.NewRuntime(&runtime.Runtime{
+		Shell:         baseMocks.Shell,
+		ConfigHandler: baseMocks.ConfigHandler,
+		ProjectRoot:   tmpDir,
+		ToolsManager:  baseMocks.ToolsManager,
+	})
+	if err != nil {
+		t.Fatalf("Failed to create runtime: %v", err)
+	}
+
+	return &ComposeMocks{
+		ConfigHandler:    baseMocks.ConfigHandler,
+		Shell:            baseMocks.Shell,
+		Shims:            baseMocks.Shims,
+		BlueprintHandler: mockBlueprintHandler,
+		Runtime:          rt,
+		TmpDir:           tmpDir,
+	}
+}
+
+// =============================================================================
+// Test Cases
+// =============================================================================
+
+func TestComposeBlueprintCmd(t *testing.T) {
+	createTestCmd := func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use:          "blueprint",
+			Short:        "Output the fully compiled blueprint",
+			RunE:         composeBlueprintCmd.RunE,
+			SilenceUsage: true,
+		}
+
+		composeBlueprintCmd.Flags().VisitAll(func(flag *pflag.Flag) {
+			cmd.Flags().AddFlag(flag)
+		})
+
+		return cmd
+	}
+
+	setupOutput := func(t *testing.T) (*bytes.Buffer, *bytes.Buffer, func()) {
+		t.Helper()
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+
+		oldStdout := os.Stdout
+		oldStderr := os.Stderr
+
+		rStdout, wStdout, _ := os.Pipe()
+		rStderr, wStderr, _ := os.Pipe()
+
+		os.Stdout = wStdout
+		os.Stderr = wStderr
+
+		doneStdout := make(chan struct{})
+		doneStderr := make(chan struct{})
+
+		go func() {
+			io.Copy(stdout, rStdout)
+			rStdout.Close()
+			close(doneStdout)
+		}()
+		go func() {
+			io.Copy(stderr, rStderr)
+			rStderr.Close()
+			close(doneStderr)
+		}()
+
+		cleanup := func() {
+			wStdout.Close()
+			wStderr.Close()
+			<-doneStdout
+			<-doneStderr
+			os.Stdout = oldStdout
+			os.Stderr = oldStderr
+		}
+		t.Cleanup(cleanup)
+
+		return stdout, stderr, func() {
+			wStdout.Close()
+			wStderr.Close()
+			<-doneStdout
+			<-doneStderr
+		}
+	}
+
+	t.Run("SuccessWithYAMLOutput", func(t *testing.T) {
+		mocks := setupComposeTest(t)
+
+		comp := composer.NewComposer(mocks.Runtime)
+		comp.BlueprintHandler = mocks.BlueprintHandler
+
+		proj, err := project.NewProject("", &project.Project{
+			Runtime:  mocks.Runtime,
+			Composer: comp,
+		})
+		if err != nil {
+			t.Fatalf("Failed to create project: %v", err)
+		}
+
+		stdout, stderr, closePipes := setupOutput(t)
+
+		cmd := createTestCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{})
+		err = cmd.Execute()
+
+		closePipes()
+
+		if err != nil {
+			t.Errorf("Expected success, got error: %v", err)
+		}
+
+		output := stdout.String()
+		if output == "" {
+			t.Error("Expected non-empty stdout output")
+		}
+
+		var bp blueprintv1alpha1.Blueprint
+		if err := yaml.Unmarshal([]byte(output), &bp); err != nil {
+			t.Errorf("Expected valid YAML output, got error: %v", err)
+		}
+
+		if bp.Metadata.Name != "test-blueprint" {
+			t.Errorf("Expected blueprint name 'test-blueprint', got %q", bp.Metadata.Name)
+		}
+
+		if stderr.String() != "" {
+			t.Error("Expected empty stderr")
+		}
+	})
+
+	t.Run("SuccessWithJSONOutput", func(t *testing.T) {
+		mocks := setupComposeTest(t)
+
+		comp := composer.NewComposer(mocks.Runtime)
+		comp.BlueprintHandler = mocks.BlueprintHandler
+
+		proj, err := project.NewProject("", &project.Project{
+			Runtime:  mocks.Runtime,
+			Composer: comp,
+		})
+		if err != nil {
+			t.Fatalf("Failed to create project: %v", err)
+		}
+
+		stdout, stderr, closePipes := setupOutput(t)
+
+		cmd := createTestCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"--json"})
+		err = cmd.Execute()
+
+		closePipes()
+
+		if err != nil {
+			t.Errorf("Expected success, got error: %v", err)
+		}
+
+		output := stdout.String()
+		if output == "" {
+			t.Error("Expected non-empty stdout output")
+		}
+
+		var bp blueprintv1alpha1.Blueprint
+		if err := json.Unmarshal([]byte(output), &bp); err != nil {
+			t.Errorf("Expected valid JSON output, got error: %v", err)
+		}
+
+		if bp.Metadata.Name != "test-blueprint" {
+			t.Errorf("Expected blueprint name 'test-blueprint', got %q", bp.Metadata.Name)
+		}
+
+		if !strings.Contains(output, "\"Kind\"") {
+			t.Error("Expected JSON output to contain JSON structure")
+		}
+
+		if stderr.String() != "" {
+			t.Error("Expected empty stderr")
+		}
+	})
+
+	t.Run("CheckTrustedDirectoryError", func(t *testing.T) {
+		mocks := setupComposeTest(t)
+
+		mocks.Shell.CheckTrustedDirectoryFunc = func() error {
+			return fmt.Errorf("not in trusted directory")
+		}
+
+		comp := composer.NewComposer(mocks.Runtime)
+		comp.BlueprintHandler = mocks.BlueprintHandler
+
+		proj, err := project.NewProject("", &project.Project{
+			Runtime:  mocks.Runtime,
+			Composer: comp,
+		})
+		if err != nil {
+			t.Fatalf("Failed to create project: %v", err)
+		}
+
+		cmd := createTestCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{})
+		err = cmd.Execute()
+
+		if err == nil {
+			t.Error("Expected error, got nil")
+			return
+		}
+		if !strings.Contains(err.Error(), "not in a trusted directory") {
+			t.Errorf("Expected trusted directory error, got: %v", err)
+		}
+	})
+
+	t.Run("BlueprintGenerationFailure", func(t *testing.T) {
+		mocks := setupComposeTest(t)
+
+		mocks.BlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint {
+			return nil
+		}
+
+		comp := composer.NewComposer(mocks.Runtime)
+		comp.BlueprintHandler = mocks.BlueprintHandler
+
+		proj, err := project.NewProject("", &project.Project{
+			Runtime:  mocks.Runtime,
+			Composer: comp,
+		})
+		if err != nil {
+			t.Fatalf("Failed to create project: %v", err)
+		}
+
+		cmd := createTestCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{})
+		err = cmd.Execute()
+
+		if err == nil {
+			t.Error("Expected error, got nil")
+			return
+		}
+		if !strings.Contains(err.Error(), "failed to generate blueprint") {
+			t.Errorf("Expected blueprint generation error, got: %v", err)
+		}
+	})
+
+	t.Run("CommandInitialization", func(t *testing.T) {
+		cmd := composeBlueprintCmd
+
+		if cmd.Use != "blueprint" {
+			t.Errorf("Expected Use to be 'blueprint', got %q", cmd.Use)
+		}
+		if cmd.Short == "" {
+			t.Error("Expected non-empty Short description")
+		}
+		if cmd.Long == "" {
+			t.Error("Expected non-empty Long description")
+		}
+
+		jsonFlag := cmd.Flags().Lookup("json")
+		if jsonFlag == nil {
+			t.Error("Expected --json flag to be defined")
+		}
+		if jsonFlag.Usage == "" {
+			t.Error("Expected non-empty flag usage")
+		}
+	})
+
+	t.Run("ComposeCommandInitialization", func(t *testing.T) {
+		cmd := composeCmd
+
+		if cmd.Use != "compose" {
+			t.Errorf("Expected Use to be 'compose', got %q", cmd.Use)
+		}
+		if cmd.Short == "" {
+			t.Error("Expected non-empty Short description")
+		}
+		if cmd.Long == "" {
+			t.Error("Expected non-empty Long description")
+		}
+	})
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds a new CLI entrypoint to inspect compiled blueprints.
> 
> - Introduces `compose` command with `blueprint` subcommand to output the fully compiled `Blueprint` to stdout
> - Supports YAML by default and JSON via `--json`; uses `yaml.Marshal`/`json.MarshalIndent`
> - Integrates with project runtime: sets shell verbosity, checks trusted directory, runs `Configure` and `Initialize`
> - Returns an error if blueprint generation fails
> - Comprehensive tests for YAML/JSON output, trusted-directory error, generation failure, and command/flag initialization
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 890405e5eb492a19f1acad221cdd75f89419516b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->