### PR TITLE
feat(cmd): Add windsor compose kustomization command

### DIFF
--- a/cmd/compose.go
+++ b/cmd/compose.go
@@ -6,10 +6,13 @@ import (
 
 	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
+	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/project"
 )
 
 var composeBlueprintJSON bool
+var composeKustomizationJSON bool
 
 var composeCmd = &cobra.Command{
 	Use:   "compose",
@@ -23,55 +26,112 @@ var composeBlueprintCmd = &cobra.Command{
 	Long:         "Output the fully compiled blueprint to stdout before cleaning/removing transient fields. Defaults to YAML output, use --json for JSON output.",
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		var opts []*project.Project
-		if overridesVal := cmd.Context().Value(projectOverridesKey); overridesVal != nil {
-			opts = []*project.Project{overridesVal.(*project.Project)}
-		}
-
-		proj, err := project.NewProject("", opts...)
+		blueprint, err := getBlueprint(cmd)
 		if err != nil {
 			return err
 		}
 
-		proj.Runtime.Shell.SetVerbosity(verbose)
+		return outputResource(blueprint, composeBlueprintJSON, "blueprint")
+	},
+}
 
-		if err := proj.Runtime.Shell.CheckTrustedDirectory(); err != nil {
-			return fmt.Errorf("not in a trusted directory. If you are in a Windsor project, run 'windsor init' to approve")
-		}
+var composeKustomizationCmd = &cobra.Command{
+	Use:          "kustomization <component-name>",
+	Short:        "Output the Flux Kustomization resource for a component",
+	Long:         "Output the Flux Kustomization resource for the specified component to stdout. Defaults to YAML output, use --json for JSON output.",
+	Args:         cobra.ExactArgs(1),
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		componentName := args[0]
 
-		if err := proj.Configure(nil); err != nil {
+		blueprint, err := getBlueprint(cmd)
+		if err != nil {
 			return err
 		}
 
-		if err := proj.Initialize(false); err != nil {
-			return err
-		}
-
-		blueprint := proj.Composer.BlueprintHandler.Generate()
-		if blueprint == nil {
-			return fmt.Errorf("failed to generate blueprint")
-		}
-
-		var output []byte
-		if composeBlueprintJSON {
-			output, err = json.MarshalIndent(blueprint, "", "  ")
-			if err != nil {
-				return fmt.Errorf("failed to marshal blueprint to JSON: %w", err)
-			}
-		} else {
-			output, err = yaml.Marshal(blueprint)
-			if err != nil {
-				return fmt.Errorf("failed to marshal blueprint to YAML: %w", err)
+		var kustomization *blueprintv1alpha1.Kustomization
+		for i := range blueprint.Kustomizations {
+			if blueprint.Kustomizations[i].Name == componentName {
+				kustomization = &blueprint.Kustomizations[i]
+				break
 			}
 		}
 
-		fmt.Print(string(output))
-		return nil
+		if kustomization == nil {
+			return fmt.Errorf("kustomization %q not found in blueprint", componentName)
+		}
+
+		defaultSourceName := blueprint.Metadata.Name
+		namespace := constants.DefaultFluxSystemNamespace
+		fluxKustomization := kustomization.ToFluxKustomization(namespace, defaultSourceName, blueprint.Sources)
+
+		return outputResource(fluxKustomization, composeKustomizationJSON, "kustomization")
 	},
 }
 
 func init() {
 	composeBlueprintCmd.Flags().BoolVar(&composeBlueprintJSON, "json", false, "Output blueprint as JSON instead of YAML")
+	composeKustomizationCmd.Flags().BoolVar(&composeKustomizationJSON, "json", false, "Output kustomization as JSON instead of YAML")
 	composeCmd.AddCommand(composeBlueprintCmd)
+	composeCmd.AddCommand(composeKustomizationCmd)
 	rootCmd.AddCommand(composeCmd)
+}
+
+// getBlueprint initializes a project and generates the composed blueprint.
+// It handles project creation, configuration, initialization, and blueprint generation.
+// Returns the generated blueprint or an error if any step fails.
+func getBlueprint(cmd *cobra.Command) (*blueprintv1alpha1.Blueprint, error) {
+	var opts []*project.Project
+	if overridesVal := cmd.Context().Value(projectOverridesKey); overridesVal != nil {
+		opts = []*project.Project{overridesVal.(*project.Project)}
+	}
+
+	proj, err := project.NewProject("", opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	proj.Runtime.Shell.SetVerbosity(verbose)
+
+	if err := proj.Runtime.Shell.CheckTrustedDirectory(); err != nil {
+		return nil, fmt.Errorf("not in a trusted directory. If you are in a Windsor project, run 'windsor init' to approve")
+	}
+
+	if err := proj.Configure(nil); err != nil {
+		return nil, err
+	}
+
+	if err := proj.Initialize(false); err != nil {
+		return nil, err
+	}
+
+	blueprint := proj.Composer.BlueprintHandler.Generate()
+	if blueprint == nil {
+		return nil, fmt.Errorf("failed to generate blueprint")
+	}
+
+	return blueprint, nil
+}
+
+// outputResource serializes the provided resource to YAML or JSON and writes it to stdout.
+// If useJSON is true, the resource is marshaled as JSON with indentation; otherwise, it's marshaled as YAML.
+// The resourceType parameter is used in error messages to identify the type of resource being output.
+func outputResource(resource any, useJSON bool, resourceType string) error {
+	var output []byte
+	var err error
+
+	if useJSON {
+		output, err = json.MarshalIndent(resource, "", "  ")
+		if err != nil {
+			return fmt.Errorf("failed to marshal %s to JSON: %w", resourceType, err)
+		}
+	} else {
+		output, err = yaml.Marshal(resource)
+		if err != nil {
+			return fmt.Errorf("failed to marshal %s to YAML: %w", resourceType, err)
+		}
+	}
+
+	fmt.Print(string(output))
+	return nil
 }

--- a/cmd/compose_test.go
+++ b/cmd/compose_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
 	"github.com/goccy/go-yaml"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -377,6 +378,292 @@ func TestComposeBlueprintCmd(t *testing.T) {
 		}
 		if cmd.Long == "" {
 			t.Error("Expected non-empty Long description")
+		}
+	})
+}
+
+func TestComposeKustomizationCmd(t *testing.T) {
+	createTestCmd := func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use:          "kustomization",
+			Short:        "Output the Flux Kustomization resource for a component",
+			RunE:         composeKustomizationCmd.RunE,
+			SilenceUsage: true,
+		}
+
+		composeKustomizationCmd.Flags().VisitAll(func(flag *pflag.Flag) {
+			cmd.Flags().AddFlag(flag)
+		})
+
+		return cmd
+	}
+
+	setupOutput := func(t *testing.T) (*bytes.Buffer, *bytes.Buffer, func()) {
+		t.Helper()
+		stdout := new(bytes.Buffer)
+		stderr := new(bytes.Buffer)
+
+		oldStdout := os.Stdout
+		oldStderr := os.Stderr
+
+		rStdout, wStdout, _ := os.Pipe()
+		rStderr, wStderr, _ := os.Pipe()
+
+		os.Stdout = wStdout
+		os.Stderr = wStderr
+
+		doneStdout := make(chan struct{})
+		doneStderr := make(chan struct{})
+
+		go func() {
+			io.Copy(stdout, rStdout)
+			rStdout.Close()
+			close(doneStdout)
+		}()
+		go func() {
+			io.Copy(stderr, rStderr)
+			rStderr.Close()
+			close(doneStderr)
+		}()
+
+		cleanup := func() {
+			wStdout.Close()
+			wStderr.Close()
+			<-doneStdout
+			<-doneStderr
+			os.Stdout = oldStdout
+			os.Stderr = oldStderr
+		}
+		t.Cleanup(cleanup)
+
+		return stdout, stderr, func() {
+			wStdout.Close()
+			wStderr.Close()
+			<-doneStdout
+			<-doneStderr
+		}
+	}
+
+	t.Run("SuccessWithYAMLOutput", func(t *testing.T) {
+		mocks := setupComposeTest(t)
+
+		comp := composer.NewComposer(mocks.Runtime)
+		comp.BlueprintHandler = mocks.BlueprintHandler
+
+		proj, err := project.NewProject("", &project.Project{
+			Runtime:  mocks.Runtime,
+			Composer: comp,
+		})
+		if err != nil {
+			t.Fatalf("Failed to create project: %v", err)
+		}
+
+		stdout, stderr, closePipes := setupOutput(t)
+
+		cmd := createTestCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"test-kustomization"})
+		err = cmd.Execute()
+
+		closePipes()
+
+		if err != nil {
+			t.Errorf("Expected success, got error: %v", err)
+		}
+
+		output := stdout.String()
+		if output == "" {
+			t.Error("Expected non-empty stdout output")
+		}
+
+		var kustomization kustomizev1.Kustomization
+		if err := yaml.Unmarshal([]byte(output), &kustomization); err != nil {
+			t.Errorf("Expected valid YAML output, got error: %v", err)
+		}
+
+		if kustomization.Name != "test-kustomization" {
+			t.Errorf("Expected kustomization name 'test-kustomization', got %q", kustomization.Name)
+		}
+
+		if kustomization.Kind != "Kustomization" {
+			t.Errorf("Expected Kind 'Kustomization', got %q", kustomization.Kind)
+		}
+
+		if kustomization.APIVersion != "kustomize.toolkit.fluxcd.io/v1" {
+			t.Errorf("Expected APIVersion 'kustomize.toolkit.fluxcd.io/v1', got %q", kustomization.APIVersion)
+		}
+
+		if stderr.String() != "" {
+			t.Error("Expected empty stderr")
+		}
+	})
+
+	t.Run("SuccessWithJSONOutput", func(t *testing.T) {
+		mocks := setupComposeTest(t)
+
+		comp := composer.NewComposer(mocks.Runtime)
+		comp.BlueprintHandler = mocks.BlueprintHandler
+
+		proj, err := project.NewProject("", &project.Project{
+			Runtime:  mocks.Runtime,
+			Composer: comp,
+		})
+		if err != nil {
+			t.Fatalf("Failed to create project: %v", err)
+		}
+
+		stdout, stderr, closePipes := setupOutput(t)
+
+		cmd := createTestCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"test-kustomization", "--json"})
+		err = cmd.Execute()
+
+		closePipes()
+
+		if err != nil {
+			t.Errorf("Expected success, got error: %v", err)
+		}
+
+		output := stdout.String()
+		if output == "" {
+			t.Error("Expected non-empty stdout output")
+		}
+
+		var kustomization kustomizev1.Kustomization
+		if err := json.Unmarshal([]byte(output), &kustomization); err != nil {
+			t.Errorf("Expected valid JSON output, got error: %v", err)
+		}
+
+		if kustomization.Name != "test-kustomization" {
+			t.Errorf("Expected kustomization name 'test-kustomization', got %q", kustomization.Name)
+		}
+
+		if !strings.Contains(output, "\"kind\"") {
+			t.Error("Expected JSON output to contain JSON structure")
+		}
+
+		if stderr.String() != "" {
+			t.Error("Expected empty stderr")
+		}
+	})
+
+	t.Run("KustomizationNotFound", func(t *testing.T) {
+		mocks := setupComposeTest(t)
+
+		comp := composer.NewComposer(mocks.Runtime)
+		comp.BlueprintHandler = mocks.BlueprintHandler
+
+		proj, err := project.NewProject("", &project.Project{
+			Runtime:  mocks.Runtime,
+			Composer: comp,
+		})
+		if err != nil {
+			t.Fatalf("Failed to create project: %v", err)
+		}
+
+		cmd := createTestCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"nonexistent-kustomization"})
+		err = cmd.Execute()
+
+		if err == nil {
+			t.Error("Expected error, got nil")
+			return
+		}
+		if !strings.Contains(err.Error(), "kustomization \"nonexistent-kustomization\" not found") {
+			t.Errorf("Expected kustomization not found error, got: %v", err)
+		}
+	})
+
+	t.Run("CheckTrustedDirectoryError", func(t *testing.T) {
+		mocks := setupComposeTest(t)
+
+		mocks.Shell.CheckTrustedDirectoryFunc = func() error {
+			return fmt.Errorf("not in trusted directory")
+		}
+
+		comp := composer.NewComposer(mocks.Runtime)
+		comp.BlueprintHandler = mocks.BlueprintHandler
+
+		proj, err := project.NewProject("", &project.Project{
+			Runtime:  mocks.Runtime,
+			Composer: comp,
+		})
+		if err != nil {
+			t.Fatalf("Failed to create project: %v", err)
+		}
+
+		cmd := createTestCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"test-kustomization"})
+		err = cmd.Execute()
+
+		if err == nil {
+			t.Error("Expected error, got nil")
+			return
+		}
+		if !strings.Contains(err.Error(), "not in a trusted directory") {
+			t.Errorf("Expected trusted directory error, got: %v", err)
+		}
+	})
+
+	t.Run("BlueprintGenerationFailure", func(t *testing.T) {
+		mocks := setupComposeTest(t)
+
+		mocks.BlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint {
+			return nil
+		}
+
+		comp := composer.NewComposer(mocks.Runtime)
+		comp.BlueprintHandler = mocks.BlueprintHandler
+
+		proj, err := project.NewProject("", &project.Project{
+			Runtime:  mocks.Runtime,
+			Composer: comp,
+		})
+		if err != nil {
+			t.Fatalf("Failed to create project: %v", err)
+		}
+
+		cmd := createTestCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"test-kustomization"})
+		err = cmd.Execute()
+
+		if err == nil {
+			t.Error("Expected error, got nil")
+			return
+		}
+		if !strings.Contains(err.Error(), "failed to generate blueprint") {
+			t.Errorf("Expected blueprint generation error, got: %v", err)
+		}
+	})
+
+	t.Run("CommandInitialization", func(t *testing.T) {
+		cmd := composeKustomizationCmd
+
+		if cmd.Use != "kustomization <component-name>" {
+			t.Errorf("Expected Use to be 'kustomization <component-name>', got %q", cmd.Use)
+		}
+		if cmd.Short == "" {
+			t.Error("Expected non-empty Short description")
+		}
+		if cmd.Long == "" {
+			t.Error("Expected non-empty Long description")
+		}
+
+		jsonFlag := cmd.Flags().Lookup("json")
+		if jsonFlag == nil {
+			t.Error("Expected --json flag to be defined")
+		}
+		if jsonFlag.Usage == "" {
+			t.Error("Expected non-empty flag usage")
 		}
 	})
 }


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a new way to render component-level Flux resources and refactors compose output logic for reuse.
> 
> - **New `compose kustomization <component-name>` subcommand**: emits a Flux `Kustomization` for a specified component in YAML or `--json`, using `constants.DefaultFluxSystemNamespace` and the blueprint name as the default source; errors if the component is not found.
> - **Refactors compose flow**: extracts `getBlueprint` and `outputResource` helpers and updates `compose blueprint` to use them.
> - **Tests**: adds comprehensive tests for the new command (YAML/JSON output, not found, trusted directory error, blueprint generation failure, flag wiring) and aligns existing blueprint compose tests with the new helpers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3c889b23db2fe8da722c305b0189b6b8b156363c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->