### PR TITLE
fix(evaluator): Allow empty strings in Evaluate

### DIFF
--- a/pkg/runtime/evaluator/evaluator.go
+++ b/pkg/runtime/evaluator/evaluator.go
@@ -107,12 +107,9 @@ func (e *expressionEvaluator) Register(name string, helper func(params []any, de
 // file and jsonnet loading as needed, and can defer unresolved expressions when evaluateDeferred is false.
 // The featurePath parameter is used for relative expression resolution, and evaluateDeferred controls
 // whether to process unresolved expressions immediately. Returns the fully evaluated value, or an error if
-// evaluation fails or the input is malformed. If s is empty, an error is returned. If no evaluation is triggered,
-// or if the result is nil (such as from an undefined variable), the original string s is returned as-is.
+// evaluation fails or the input is malformed. Empty strings are returned as-is. If no evaluation is
+// triggered, or if the result is nil (such as from an undefined variable), the original string s is returned as-is.
 func (e *expressionEvaluator) Evaluate(s string, featurePath string, evaluateDeferred bool) (any, error) {
-	if s == "" {
-		return nil, fmt.Errorf("expression cannot be empty")
-	}
 	if strings.Contains(s, "${") {
 		result := s
 		for strings.Contains(result, "${") {
@@ -123,6 +120,9 @@ func (e *expressionEvaluator) Evaluate(s string, featurePath string, evaluateDef
 			}
 			end += start
 			expr := result[start+2 : end]
+			if expr == "" {
+				return nil, fmt.Errorf("expression cannot be empty")
+			}
 			value, err := e.evaluateExpression(expr, featurePath, evaluateDeferred)
 			if err != nil {
 				return "", fmt.Errorf("failed to evaluate expression '${%s}': %w", expr, err)

--- a/pkg/runtime/evaluator/evaluator_public_test.go
+++ b/pkg/runtime/evaluator/evaluator_public_test.go
@@ -190,16 +190,37 @@ func TestExpressionEvaluator_Evaluate(t *testing.T) {
 		}
 	})
 
+	t.Run("ReturnsEmptyStringAsIs", func(t *testing.T) {
+		// Given an evaluator
+		evaluator, _, _, _ := setupEvaluatorTest(t)
+
+		// When evaluating an empty string
+		result, err := evaluator.Evaluate("", "", false)
+
+		// Then it should be returned as-is
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		if result != "" {
+			t.Errorf("Expected empty string, got %v", result)
+		}
+	})
+
 	t.Run("ReturnsErrorForEmptyExpression", func(t *testing.T) {
 		// Given an evaluator
 		evaluator, _, _, _ := setupEvaluatorTest(t)
 
 		// When evaluating an empty expression
-		_, err := evaluator.Evaluate("", "", false)
+		_, err := evaluator.Evaluate("${}", "", false)
 
 		// Then an error should be returned
 		if err == nil {
 			t.Fatal("Expected error for empty expression, got nil")
+		}
+
+		if !strings.Contains(err.Error(), "expression cannot be empty") {
+			t.Errorf("Expected error message to contain 'expression cannot be empty', got: %v", err)
 		}
 	})
 
@@ -854,6 +875,30 @@ func TestExpressionEvaluator_EvaluateMap(t *testing.T) {
 			t.Errorf("Expected normal to be 'value', got %v", result["normal"])
 		}
 	})
+
+	t.Run("HandlesEmptyStringValues", func(t *testing.T) {
+		evaluator, _, _, _ := setupEvaluatorTest(t)
+
+		values := map[string]any{
+			"empty":    "",
+			"nonEmpty": "value",
+		}
+
+		result, err := evaluator.EvaluateMap(values, "", false)
+
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		if result["empty"] != "" {
+			t.Errorf("Expected empty to be empty string, got %v", result["empty"])
+		}
+
+		if result["nonEmpty"] != "value" {
+			t.Errorf("Expected nonEmpty to be 'value', got %v", result["nonEmpty"])
+		}
+	})
+
 }
 
 func TestContainsExpression(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Behavior changes**
> 
> - `Evaluate` returns empty strings as-is (no error, no evaluation) and still returns the original string when no evaluation occurs or result is nil.
> - Adds explicit validation for empty `${}` expressions, returning `"expression cannot be empty"`.
> 
> **Tests**
> 
> - Adds `ReturnsEmptyStringAsIs` and `HandlesEmptyStringValues` for `Evaluate`/`EvaluateMap`.
> - Updates empty-expression test to use `${}` and assert the new error message.
> 
> **Docs**
> 
> - Clarifies `Evaluate` comment to reflect new empty-string behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3dc2d9d848d0a29ba0f80318223ddff244a91dc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->