### PR TITLE
chore(runtime/terraform): Remove redundant tests

### DIFF
--- a/pkg/runtime/terraform/mock_provider_test.go
+++ b/pkg/runtime/terraform/mock_provider_test.go
@@ -180,5 +180,3 @@ func TestMockTerraformProvider_ClearCache(t *testing.T) {
 		mock.ClearCache()
 	})
 }
-
-


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Focuses test suite by removing redundant/overlapping cases in `provider_private_test.go` and `provider_public_test.go` (e.g., extra backend args/env-var quoting, sanitize edge cases, caching duplicates, optional param handling, fallback/formatting permutations).
> 
> - Retains primary coverage for backend config generation, Kubernetes sanitization basics, env var application/restoration, argument formatting, component discovery, TF args generation, and outputs retrieval
> - No changes to production code or public APIs
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5d38d5ab21c3b96ab30007aed2c24f8dbe388be5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->