### PR TITLE
chore: Remove unused getMapKeys

### DIFF
--- a/pkg/composer/terraform/module_resolver.go
+++ b/pkg/composer/terraform/module_resolver.go
@@ -113,14 +113,6 @@ func (h *BaseModuleResolver) GenerateTfvars(overwrite bool) error {
 	return nil
 }
 
-func getMapKeys(m map[string]any) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	return keys
-}
-
 // =============================================================================
 // Private Methods
 // =============================================================================

--- a/pkg/runtime/evaluator/evaluator.go
+++ b/pkg/runtime/evaluator/evaluator.go
@@ -780,11 +780,3 @@ func ContainsExpression(value any) bool {
 		return false
 	}
 }
-
-func getMapKeys(m map[string]any) []string {
-	keys := make([]string, 0, len(m))
-	for k := range m {
-		keys = append(keys, k)
-	}
-	return keys
-}


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes duplicate, unused `getMapKeys` helpers from `module_resolver.go` and `evaluator.go` to reduce dead code. No functional changes to module resolution or evaluation logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7215a85ec13ade4072bd02c3fd5e7d19f5bc2240. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->