### PR TITLE
fix(env): Proactively inject csp specific env vars

### DIFF
--- a/pkg/runtime/env/aws_env.go
+++ b/pkg/runtime/env/aws_env.go
@@ -7,7 +7,6 @@ package env
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/windsorcli/cli/pkg/runtime/config"
@@ -63,16 +62,13 @@ func (e *AwsEnvPrinter) GetEnvVars() (map[string]string, error) {
 		return nil, fmt.Errorf("error retrieving configuration root directory: %w", err)
 	}
 
-	// Construct the path to the AWS configuration file and verify its existence.
-	awsConfigPath := filepath.Join(configRoot, ".aws", "config")
-	if _, err := e.shims.Stat(awsConfigPath); os.IsNotExist(err) {
-		awsConfigPath = ""
-	}
+	// Set AWS config folder environment variables to allow CLIs to generate auth files in the right location.
+	awsConfigDir := filepath.Join(configRoot, ".aws")
+	awsConfigPath := filepath.Join(awsConfigDir, "config")
+	awsCredentialsPath := filepath.Join(awsConfigDir, "credentials")
 
-	// Populate environment variables with AWS configuration data.
-	if awsConfigPath != "" {
-		envVars["AWS_CONFIG_FILE"] = filepath.ToSlash(awsConfigPath)
-	}
+	envVars["AWS_CONFIG_FILE"] = filepath.ToSlash(awsConfigPath)
+	envVars["AWS_SHARED_CREDENTIALS_FILE"] = filepath.ToSlash(awsCredentialsPath)
 	if contextConfigData.AWS.AWSProfile != nil {
 		envVars["AWS_PROFILE"] = *contextConfigData.AWS.AWSProfile
 	}

--- a/pkg/runtime/env/aws_env_test.go
+++ b/pkg/runtime/env/aws_env_test.go
@@ -127,11 +127,12 @@ func TestAwsEnv_GetEnvVars(t *testing.T) {
 		}
 
 		expected := map[string]string{
-			"AWS_PROFILE":      "default",
-			"AWS_ENDPOINT_URL": "https://aws.endpoint",
-			"S3_HOSTNAME":      "s3.amazonaws.com",
-			"MWAA_ENDPOINT":    "https://mwaa.endpoint",
-			"AWS_CONFIG_FILE":  "/mock/config/root/.aws/config",
+			"AWS_PROFILE":                 "default",
+			"AWS_ENDPOINT_URL":            "https://aws.endpoint",
+			"S3_HOSTNAME":                 "s3.amazonaws.com",
+			"MWAA_ENDPOINT":               "https://mwaa.endpoint",
+			"AWS_CONFIG_FILE":             "/mock/config/root/.aws/config",
+			"AWS_SHARED_CREDENTIALS_FILE": "/mock/config/root/.aws/credentials",
 		}
 
 		if !reflect.DeepEqual(envVars, expected) {
@@ -150,16 +151,19 @@ func TestAwsEnv_GetEnvVars(t *testing.T) {
 		// When GetEnvVars is called
 		envVars, err := env.GetEnvVars()
 
-		// Then environment variables should be returned without AWS_CONFIG_FILE
+		// Then environment variables should be returned with AWS_CONFIG_FILE and AWS_SHARED_CREDENTIALS_FILE
+		// set even when files don't exist, to allow CLIs to generate auth files in the right location
 		if err != nil {
 			t.Errorf("GetEnvVars returned an error: %v", err)
 		}
 
 		expected := map[string]string{
-			"AWS_PROFILE":      "default",
-			"AWS_ENDPOINT_URL": "https://aws.endpoint",
-			"S3_HOSTNAME":      "s3.amazonaws.com",
-			"MWAA_ENDPOINT":    "https://mwaa.endpoint",
+			"AWS_PROFILE":                 "default",
+			"AWS_ENDPOINT_URL":            "https://aws.endpoint",
+			"S3_HOSTNAME":                 "s3.amazonaws.com",
+			"MWAA_ENDPOINT":               "https://mwaa.endpoint",
+			"AWS_CONFIG_FILE":             "/mock/config/root/.aws/config",
+			"AWS_SHARED_CREDENTIALS_FILE": "/mock/config/root/.aws/credentials",
 		}
 
 		if !reflect.DeepEqual(envVars, expected) {

--- a/pkg/runtime/env/gcp_env.go
+++ b/pkg/runtime/env/gcp_env.go
@@ -73,9 +73,7 @@ func (e *GcpEnvPrinter) GetEnvVars() (map[string]string, error) {
 				envVars["GOOGLE_APPLICATION_CREDENTIALS"] = *config.GCP.CredentialsPath
 			} else {
 				serviceAccountPath := filepath.Join(gcpConfigDir, "service-accounts", "default.json")
-				if _, err := e.shims.Stat(serviceAccountPath); err == nil {
-					envVars["GOOGLE_APPLICATION_CREDENTIALS"] = filepath.ToSlash(serviceAccountPath)
-				}
+				envVars["GOOGLE_APPLICATION_CREDENTIALS"] = filepath.ToSlash(serviceAccountPath)
 			}
 		}
 


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Proactively injects cloud-specific env vars so CLIs write/read auth files in the expected config directories.
> 
> - **AWS**: Always set `AWS_CONFIG_FILE` and new `AWS_SHARED_CREDENTIALS_FILE` to `~/.aws/config` and `~/.aws/credentials` equivalents under the Windsor config root; keep `AWS_PROFILE`, `AWS_ENDPOINT_URL`, `S3_HOSTNAME`, `MWAA_ENDPOINT` unchanged. Removes existence checks.
> - **GCP**: When not already set and no explicit `credentials_path`, always set `GOOGLE_APPLICATION_CREDENTIALS` to `~/.gcp/service-accounts/default.json` under the config root; continue setting `CLOUDSDK_CONFIG`, project, and quota vars. Updates tests accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7a479d661b18bb0a71fca0657166c59e49bb4cfd. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->