### PR TITLE
chore(ci): Add govulncheck

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -134,6 +134,12 @@ jobs:
           GOTOOLCHAIN: 'auto'
           GOFLAGS: '-buildvcs=false'
 
+      - name: Run Govulncheck Security Scanner
+        run: govulncheck ./...
+        env:
+          GOTOOLCHAIN: 'auto'
+          GOFLAGS: '-buildvcs=false'
+
   release:
     runs-on: windows-latest
     needs: [build-and-test, sast-scan]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,6 +160,12 @@ jobs:
           GOTOOLCHAIN: 'auto'
           GOFLAGS: '-buildvcs=false'
 
+      - name: Run Govulncheck Security Scanner
+        run: govulncheck ./...
+        env:
+          GOTOOLCHAIN: 'auto'
+          GOFLAGS: '-buildvcs=false'
+
   docs-check:
     runs-on: ubuntu-latest
     steps:

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -54,7 +54,9 @@ tasks:
     desc: Scan for security vulnerabilities
     cmds:
       - go install github.com/securego/gosec/v2/cmd/gosec@latest
+      - go install golang.org/x/vuln/cmd/govulncheck@latest
       - gosec ./...
+      - govulncheck ./...
 
   run:
     desc: Run the Windsor CLI

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -124,7 +124,9 @@ tasks:
     desc: Scan for security vulnerabilities
     cmds:
       - go install github.com/securego/gosec/v2/cmd/gosec@latest
+      - go install golang.org/x/vuln/cmd/govulncheck@latest
       - gosec ./...
+      - govulncheck ./...
 
   docs:gen:commands:
     desc: Regenerate docs/reference/commands/ from the cobra command tree. CI fails on any diff.

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -31,3 +31,4 @@ packages:
 - name: aws/aws-cli@2.32.33
 - name: twistedpair/google-cloud-sdk@551.0.0
 - name: opentofu/opentofu@v1.11.1
+- name: golang/vuln/govulncheck@v1.1.4

--- a/aqua.yaml
+++ b/aqua.yaml
@@ -29,3 +29,4 @@ packages:
 - name: fluxcd/flux2@v2.9.2
 - name: aws/aws-cli@2.36.15
 - name: twistedpair/google-cloud-sdk@562.0.0
+- name: golang/vuln/govulncheck@v1.1.4

--- a/go.mod
+++ b/go.mod
@@ -128,7 +128,7 @@ require (
 	golang.org/x/tools v0.48.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20260504160031-60b97b32f348 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20260504160031-60b97b32f348 // indirect
-	google.golang.org/grpc v1.81.0 // indirect
+	google.golang.org/grpc v1.82.1 // indirect
 	google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af // indirect
 	gopkg.in/evanphx/json-patch.v4 v4.13.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -364,8 +364,8 @@ google.golang.org/genproto/googleapis/api v0.0.0-20260504160031-60b97b32f348 h1:
 google.golang.org/genproto/googleapis/api v0.0.0-20260504160031-60b97b32f348/go.mod h1:Yzdzr5OOZFgSsEV2D/Xi9NL3bszpXFAg0hFJiRohcD8=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260504160031-60b97b32f348 h1:pfIbyB44sWzHiCpRqIen67ZQnVXSfIxWrqUMk1qwODE=
 google.golang.org/genproto/googleapis/rpc v0.0.0-20260504160031-60b97b32f348/go.mod h1:4Hqkh8ycfw05ld/3BWL7rJOSfebL2Q+DVDeRgYgxUU8=
-google.golang.org/grpc v1.81.0 h1:W3G9N3KQf3BU+YuCtGKJk0CmxQNbAISICD/9AORxLIw=
-google.golang.org/grpc v1.81.0/go.mod h1:xGH9GfzOyMTGIOXBJmXt+BX/V0kcdQbdcuwQ/zNw42I=
+google.golang.org/grpc v1.82.1 h1:NnAxzGRA0677vCa4BUkOAnO5+FfQqVl9iUXeD0IqcGE=
+google.golang.org/grpc v1.82.1/go.mod h1:yzTZ1TB1Z3SG+LIYaI+WiE8D5+PZ3ArnrSp8zF3+/ZA=
 google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af h1:+5/Sw3GsDNlEmu7TfklWKPdQ0Ykja5VEmq2i817+jbI=
 google.golang.org/protobuf v1.36.12-0.20260120151049-f2248ac996af/go.mod h1:HTf+CrKn2C3g5S8VImy6tdcUvCska2kB7j23XfzDpco=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces vulnerability scanning with `govulncheck` across CI and local workflows.
> 
> - CI (`.github/workflows/ci.yaml`): adds `govulncheck ./...` step to the `sast-scan` job
> - Taskfile (`Taskfile.yaml`): updates `scan` task to install and run `govulncheck`
> - Aqua (`aqua.yaml`): adds `golang/vuln/govulncheck@v1.1.4` to managed tools
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2be7fad22c8c14d7f3a5f4887736b0e675ba6c67. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->