### PR TITLE
fix(composer): Restores contextual patches and substitutions functionality

### DIFF
--- a/pkg/composer/blueprint/composer_test.go
+++ b/pkg/composer/blueprint/composer_test.go
@@ -1713,6 +1713,9 @@ patches:
 		if patch.Target != nil {
 			t.Error("Expected target to be nil when kind is missing")
 		}
+		if patch.Patch != string(patchData) {
+			t.Error("Expected patch content to be full YAML when falling back to strategic merge")
+		}
 	})
 
 	t.Run("ReturnsNilForEmptyData", func(t *testing.T) {


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores context-aware patching and per-kustomization substitutions in blueprint composition.
> 
> - Adds discovery of context patches in `patches/<kustomization>/`, supporting strategic merge and JSON 6902 via `parsePatch`
> - Applies per-kustomization substitutions from `values.yaml` into `ConfigMaps` (`values-<name>`), merging with `values-common` and `Kustomization.Substitutions`
> - Wires features into `Compose`; introduces `Shims` for fs/YAML ops
> - Extensive tests added for patch discovery, parsing, and substitutions (including edge cases)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 673773a329a78a6780b0c8bf8f70f7a8f168b30e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->