### PR TITLE
feat(provisioner/kubernetes): Add windsor common metadata

### DIFF
--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -20,6 +20,7 @@ import (
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/provisioner/kubernetes/client"
+	"github.com/windsorcli/cli/pkg/runtime/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -58,8 +59,9 @@ type KubernetesManager interface {
 
 // BaseKubernetesManager implements KubernetesManager interface
 type BaseKubernetesManager struct {
-	shims  *Shims
-	client client.KubernetesClient
+	shims         *Shims
+	client        client.KubernetesClient
+	configHandler config.ConfigHandler
 
 	kustomizationWaitPollInterval time.Duration
 	kustomizationReconcileTimeout time.Duration
@@ -69,14 +71,19 @@ type BaseKubernetesManager struct {
 	nodeReadyPollInterval   time.Duration
 }
 
-// NewKubernetesManager creates a new instance of BaseKubernetesManager
-func NewKubernetesManager(kubernetesClient client.KubernetesClient) *BaseKubernetesManager {
+// NewKubernetesManager creates a new instance of BaseKubernetesManager.
+// The configHandler is used to retrieve context name and context ID for CommonMetadata labels.
+func NewKubernetesManager(kubernetesClient client.KubernetesClient, configHandler config.ConfigHandler) *BaseKubernetesManager {
 	if kubernetesClient == nil {
 		panic("kubernetes client is required")
+	}
+	if configHandler == nil {
+		panic("config handler is required")
 	}
 
 	manager := &BaseKubernetesManager{
 		client:                        kubernetesClient,
+		configHandler:                 configHandler,
 		shims:                         NewShims(),
 		kustomizationWaitPollInterval: 2 * time.Second,
 		kustomizationReconcileTimeout: 5 * time.Minute,
@@ -614,7 +621,9 @@ func (k *BaseKubernetesManager) GetNodeReadyStatus(ctx context.Context, nodeName
 // It creates the target namespace, applies all blueprint source repositories (Git and OCI),
 // applies all individual sources, applies any standalone ConfigMaps, and finally applies
 // all kustomizations and their associated ConfigMaps. This orchestrates a complete
-// blueprint installation following the intended order. Returns an error if any step fails.
+// blueprint installation following the intended order. CommonMetadata labels are added to all
+// kustomizations for resource provenance tracking using context info from the config handler.
+// Returns an error if any step fails.
 func (k *BaseKubernetesManager) ApplyBlueprint(blueprint *blueprintv1alpha1.Blueprint, namespace string) error {
 	if err := k.CreateNamespace(namespace); err != nil {
 		return fmt.Errorf("failed to create namespace: %w", err)
@@ -660,6 +669,13 @@ func (k *BaseKubernetesManager) ApplyBlueprint(blueprint *blueprintv1alpha1.Blue
 			}
 		}
 		fluxKustomization := kustomization.ToFluxKustomization(namespace, defaultSourceName, blueprint.Sources)
+
+		fluxKustomization.Spec.CommonMetadata = &kustomizev1.CommonMetadata{
+			Labels: map[string]string{
+				"windsorcli.dev/context":    k.configHandler.GetContext(),
+				"windsorcli.dev/context-id": k.configHandler.GetString("id"),
+			},
+		}
 
 		if len(blueprint.ConfigMaps) > 0 {
 			if fluxKustomization.Spec.PostBuild == nil {

--- a/pkg/provisioner/kubernetes/kubernetes_manager_private_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_private_test.go
@@ -18,7 +18,7 @@ func TestBaseKubernetesManager_waitForNodesReady(t *testing.T) {
 	setup := func(t *testing.T) *BaseKubernetesManager {
 		t.Helper()
 		mocks := setupKubernetesMocks(t)
-		manager := NewKubernetesManager(mocks.KubernetesClient)
+		manager := NewKubernetesManager(mocks.KubernetesClient, mocks.ConfigHandler)
 		manager.nodeReadyPollInterval = 50 * time.Millisecond
 		return manager
 	}
@@ -398,7 +398,7 @@ func TestBaseKubernetesManager_getHelmRelease(t *testing.T) {
 	setup := func(t *testing.T) *BaseKubernetesManager {
 		t.Helper()
 		mocks := setupKubernetesMocks(t)
-		manager := NewKubernetesManager(mocks.KubernetesClient)
+		manager := NewKubernetesManager(mocks.KubernetesClient, mocks.ConfigHandler)
 		return manager
 	}
 
@@ -461,7 +461,7 @@ func TestBaseKubernetesManager_calculateTotalWaitTime(t *testing.T) {
 	setup := func(t *testing.T) *BaseKubernetesManager {
 		t.Helper()
 		mocks := setupKubernetesMocks(t)
-		manager := NewKubernetesManager(mocks.KubernetesClient)
+		manager := NewKubernetesManager(mocks.KubernetesClient, mocks.ConfigHandler)
 		return manager
 	}
 

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -106,7 +106,7 @@ func NewProvisioner(rt *runtime.Runtime, blueprintHandler blueprint.BlueprintHan
 	}
 
 	if provisioner.KubernetesManager == nil {
-		provisioner.KubernetesManager = kubernetes.NewKubernetesManager(provisioner.KubernetesClient)
+		provisioner.KubernetesManager = kubernetes.NewKubernetesManager(provisioner.KubernetesClient, rt.ConfigHandler)
 	}
 
 	return provisioner


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds provenance labels to all applied Flux `Kustomization` resources and plumbs config into the manager.
> 
> - Constructor change: `NewKubernetesManager` now requires a `config.ConfigHandler`; panics if nil
> - Wiring: `Provisioner` creates the manager with `rt.ConfigHandler`
> - Blueprint apply: sets `spec.commonMetadata.labels` (`windsorcli.dev/context`, `windsorcli.dev/context-id`) on each `Kustomization`
> - Tests: updated to pass a mock `ConfigHandler` and verify new behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0d070c7df657f8d9f1265dfc3d27b6157bcdcad5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->