### PR TITLE
feat(virt): Rightsize colima VM based on node requests

### DIFF
--- a/pkg/workstation/virt/colima_virt.go
+++ b/pkg/workstation/virt/colima_virt.go
@@ -365,7 +365,7 @@ func (v *ColimaVirt) validateVMResources(cpu, memory, hostMemoryReserveGB int) {
 	} else {
 		hostMemoryGB = int(hostMemoryGBUint64)
 	}
-	availableMemoryGB := hostMemoryGB - hostMemoryReserveGB
+	availableMemoryGB := int(math.Max(float64(hostMemoryGB-hostMemoryReserveGB), 0))
 
 	if memory > availableMemoryGB {
 		fmt.Fprintf(os.Stderr, "\033[33m⚠ Warning: Cluster configuration requires %dGB memory, but only %dGB available (host has %dGB, reserving %dGB for OS)\033[0m\n",


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces cluster-aware sizing for Colima VMs with safety validation and comprehensive tests.
> 
> - Update `getDefaultValues` to use `cluster.*` config when `cluster.enabled` is true, returning calculated CPU/memory plus defaults for `disk`, `hostname`, and `arch`; fallback remains half-of-host resources when cluster is disabled
> - Add `calculateVMResources` to sum control plane/worker requests, add fixed VM/service overhead, and enforce minimums
> - Add `validateVMResources` to compare against host cores/RAM (reserving 4GB) and print warnings when overcommitted; handles memory retrieval errors and large values safely
> - Extend tests: new suites for cluster-enabled defaults, resource calculation (multi-node/minimums), and validation warnings/edge cases; minor comment/doc updates
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9d69a7c911aca8d87880a817ff30ea30bc71dcad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->