### PR TITLE
fix(provisioner/kubernetes): Don't wait for deleteOnly kustomizations

### DIFF
--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -173,9 +173,12 @@ func (k *BaseKubernetesManager) WaitForKustomizations(message string, blueprint 
 	}
 
 	timeout := k.calculateTotalWaitTime(blueprint)
-	kustomizationNames := make([]string, len(blueprint.Kustomizations))
-	for i, kustomization := range blueprint.Kustomizations {
-		kustomizationNames[i] = kustomization.Name
+	kustomizationNames := make([]string, 0, len(blueprint.Kustomizations))
+	for _, kustomization := range blueprint.Kustomizations {
+		if kustomization.DestroyOnly != nil && *kustomization.DestroyOnly {
+			continue
+		}
+		kustomizationNames = append(kustomizationNames, kustomization.Name)
 	}
 
 	spin := spinner.New(spinner.CharSets[14], 100*time.Millisecond, spinner.WithColor("green"))


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Prevents waiting on cleanup-only kustomizations during readiness checks.
> 
> - Updates `WaitForKustomizations` to build `kustomizationNames` excluding entries with `DestroyOnly=true`
> - Adds `SkipsDestroyOnlyKustomizations` test validating that destroy-only kustomizations are not queried while regular ones are
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69062d00172dbdca6181209280f182af7bf459ec. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->