### PR TITLE
fix(provisioner/kubernetes): Suspend kustomizations prior to deletion

### DIFF
--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -404,10 +404,14 @@ func (k *BaseKubernetesManager) SuspendHelmRelease(name, namespace string) error
 	return err
 }
 
-// getKustomizationsToDelete returns a list of kustomization names that should be deleted based on their destroy settings.
+// getKustomizationsToDelete returns a list of regular kustomization names that should be suspended and deleted.
+// Excludes destroy-only kustomizations since they need to reconcile during deletion to perform cleanup work.
 func (k *BaseKubernetesManager) getKustomizationsToDelete(blueprint *blueprintv1alpha1.Blueprint) []string {
 	var names []string
 	for _, kustomization := range blueprint.Kustomizations {
+		if kustomization.DestroyOnly != nil && *kustomization.DestroyOnly {
+			continue
+		}
 		destroy := kustomization.Destroy.ToBool()
 		if destroy != nil && !*destroy {
 			continue

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -4765,7 +4765,7 @@ func TestBaseKubernetesManager_getKustomizationsToDelete(t *testing.T) {
 		}
 	})
 
-	t.Run("IncludesDestroyOnly", func(t *testing.T) {
+	t.Run("ExcludesDestroyOnly", func(t *testing.T) {
 		manager := setup(t)
 		destroyOnly := true
 		blueprint := &blueprintv1alpha1.Blueprint{
@@ -4776,8 +4776,11 @@ func TestBaseKubernetesManager_getKustomizationsToDelete(t *testing.T) {
 		}
 
 		names := manager.getKustomizationsToDelete(blueprint)
-		if len(names) != 2 {
-			t.Errorf("Expected 2 kustomizations (includes destroy-only), got %d", len(names))
+		if len(names) != 1 {
+			t.Errorf("Expected 1 kustomization (excludes destroy-only), got %d", len(names))
+		}
+		if len(names) > 0 && names[0] != "regular-kust" {
+			t.Errorf("Expected [regular-kust], got %v", names)
 		}
 	})
 }


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements pre-delete suspension to avoid Flux reconciliation during teardown and validates the flow with targeted tests.
> 
> - Adds `getKustomizationsToDelete` (filters out `DestroyOnly` and `destroy:false`) and `suspendKustomizations` (reverse order, merge-patch `spec.suspend=true`, accumulate non-404 errors)
> - Integrates suspension into `DeleteBlueprint` before processing destroy-only and regular deletions
> - Provides user feedback via spinners and summarized results during suspension
> - Adds unit and integration tests in `kubernetes_manager_public_test.go` covering selection, order, error handling, and end-to-end suspend-before-delete behavior
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 0f7ace348f4bd1e877be8817109cc595cdaa7a22. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->