### PR TITLE
fix(workstation/network): Network configuration improvements

### DIFF
--- a/pkg/workstation/network/colima_network_test.go
+++ b/pkg/workstation/network/colima_network_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"net"
 	"os/exec"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -402,6 +403,13 @@ func TestColimaNetworkManager_ConfigureGuest(t *testing.T) {
 }
 
 func TestIsExitCode(t *testing.T) {
+	exitCmd := func(code int) *exec.Cmd {
+		if runtime.GOOS == "windows" {
+			return exec.Command("cmd", "/c", fmt.Sprintf("exit %d", code))
+		}
+		return exec.Command("sh", "-c", fmt.Sprintf("exit %d", code))
+	}
+
 	t.Run("NilError", func(t *testing.T) {
 		if isExitCode(nil, 1) {
 			t.Error("expected false for nil error")
@@ -416,7 +424,7 @@ func TestIsExitCode(t *testing.T) {
 	})
 
 	t.Run("ExitCode1", func(t *testing.T) {
-		cmd := exec.Command("sh", "-c", "exit 1")
+		cmd := exitCmd(1)
 		err := cmd.Run()
 		if err == nil {
 			t.Fatal("expected error from exit 1 command")
@@ -430,7 +438,7 @@ func TestIsExitCode(t *testing.T) {
 	})
 
 	t.Run("ExitCode2", func(t *testing.T) {
-		cmd := exec.Command("sh", "-c", "exit 2")
+		cmd := exitCmd(2)
 		err := cmd.Run()
 		if err == nil {
 			t.Fatal("expected error from exit 2 command")
@@ -444,7 +452,7 @@ func TestIsExitCode(t *testing.T) {
 	})
 
 	t.Run("WrappedExitError", func(t *testing.T) {
-		cmd := exec.Command("sh", "-c", "exit 1")
+		cmd := exitCmd(1)
 		err := cmd.Run()
 		if err == nil {
 			t.Fatal("expected error from exit 1 command")

--- a/pkg/workstation/network/linux_network_test.go
+++ b/pkg/workstation/network/linux_network_test.go
@@ -144,8 +144,8 @@ func TestLinuxNetworkManager_ConfigureHostRoute(t *testing.T) {
 	t.Run("AddRouteError", func(t *testing.T) {
 		// Given a network manager with route addition error
 		manager, mocks := setup(t)
-		mocks.Shell.ExecSilentFunc = func(command string, args ...string) (string, error) {
-			if command == "sudo" && args[0] == "ip" && args[1] == "route" && args[2] == "add" {
+		mocks.Shell.ExecSudoFunc = func(message, command string, args ...string) (string, error) {
+			if command == "ip" && args[0] == "route" && args[1] == "add" {
 				return "mock output", fmt.Errorf("mock error")
 			}
 			return "", nil
@@ -348,8 +348,8 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 		}
 
 		// And mocking drop-in directory creation error
-		mocks.Shell.ExecSilentFunc = func(command string, args ...string) (string, error) {
-			if command == "sudo" && args[0] == "mkdir" {
+		mocks.Shell.ExecSudoFunc = func(message, command string, args ...string) (string, error) {
+			if command == "mkdir" {
 				return "", fmt.Errorf("mock error creating directory")
 			}
 			return "", nil

--- a/pkg/workstation/network/windows_network_test.go
+++ b/pkg/workstation/network/windows_network_test.go
@@ -84,10 +84,8 @@ func TestWindowsNetworkManager_ConfigureHostRoute(t *testing.T) {
 		mocks.ConfigHandler.Set("vm.address", "192.168.1.2")
 
 		mocks.Shell.ExecSilentFunc = func(command string, args ...string) (string, error) {
-			if command == "powershell" && args[0] == "-Command" {
-				if args[1] == fmt.Sprintf("Get-NetRoute -DestinationPrefix %s | Where-Object { $_.NextHop -eq '%s' }", "192.168.1.0/24", "192.168.1.2") {
-					return "", fmt.Errorf("mocked shell execution error")
-				}
+			if command == "powershell" && args[0] == "-Command" && strings.Contains(args[1], "Get-NetRoute") {
+				return "", fmt.Errorf("mocked shell execution error")
 			}
 			return "", nil
 		}
@@ -114,10 +112,10 @@ func TestWindowsNetworkManager_ConfigureHostRoute(t *testing.T) {
 
 		mocks.Shell.ExecSilentFunc = func(command string, args ...string) (string, error) {
 			if command == "powershell" && args[0] == "-Command" {
-				if args[1] == fmt.Sprintf("Get-NetRoute -DestinationPrefix %s | Where-Object { $_.NextHop -eq '%s' }", "192.168.1.0/24", "192.168.1.2") {
-					return "", nil // Simulate that the route does not exist
+				if strings.Contains(args[1], "Get-NetRoute") {
+					return "", nil
 				}
-				if args[1] == fmt.Sprintf("New-NetRoute -DestinationPrefix %s -NextHop %s -RouteMetric 1", "192.168.1.0/24", "192.168.1.2") {
+				if strings.Contains(args[1], "New-NetRoute") {
 					return "", fmt.Errorf("mocked shell execution error")
 				}
 			}


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Enhances reliability and UX of network configuration across platforms.
> 
> - macOS: Parse `route -n get <prefix>` output to verify existing routes; add sudo prompts and use `ExecSudo` for route add and DNS resolver setup; tests updated to match new parsing and sudo paths
> - Linux: Use `ExecSudo` for adding routes and systemd-resolved drop-ins with clear warnings; minor command simplifications; tests updated to mock `ExecSudo`
> - Windows: Streamline route setup—explicit check via `Get-NetRoute` (with `-ErrorAction SilentlyContinue`) and always add via `New-NetRoute` if missing; show admin prompt and spinner feedback; tests relaxed to `strings.Contains` matching
> - Tests: Add cross-OS `exitCmd` helper in `colima_network_test` for exit code assertions and adjust expectations across Darwin/Linux/Windows suites
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit cb4db5055cb1ec6033262ebe920f7ca2385a37b4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->