### PR TITLE
fix(test): Evaluate deferred terraform helpers

### DIFF
--- a/pkg/test/runner_test.go
+++ b/pkg/test/runner_test.go
@@ -2303,7 +2303,7 @@ func TestRegisterTerraformOutputHelperForMock(t *testing.T) {
 		}
 	})
 
-	t.Run("ReturnsDeferredErrorWhenDeferredIsFalse", func(t *testing.T) {
+	t.Run("EvaluatesImmediatelyEvenWhenDeferredIsFalse", func(t *testing.T) {
 		mockProvider := &terraform.MockTerraformProvider{
 			GetTerraformOutputsFunc: func(componentID string) (map[string]any, error) {
 				return map[string]any{"key": "value"}, nil
@@ -2315,10 +2315,10 @@ func TestRegisterTerraformOutputHelperForMock(t *testing.T) {
 		result, err := eval.Evaluate(`prefix-${terraform_output("component", "key")}-suffix`, "", false)
 
 		if err != nil {
-			t.Fatalf("Expected no error (expression preserved), got: %v", err)
+			t.Fatalf("Expected no error, got: %v", err)
 		}
-		if result != `prefix-${terraform_output("component", "key")}-suffix` {
-			t.Errorf("Expected expression to be preserved when deferred=false, got: %v", result)
+		if result != "prefix-value-suffix" {
+			t.Errorf("Expected 'prefix-value-suffix', got: %v", result)
 		}
 	})
 


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Change overview**
> 
> - Mock `terraform_output()` helper in `pkg/test/runner.go` now always evaluates immediately (ignores `deferred`), returning values or `nil` without producing `DeferredError`.
> 
> **Key updates**
> 
> - Adjusted helper docs and implementation to remove deferred handling and always fetch from mock provider.
> - Updated tests in `pkg/test/runner_test.go` to expect immediate evaluation (e.g., string interpolation resolves to `prefix-value-suffix`) and kept nil-on-miss behavior for `??` fallbacks.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd6be86ebdde1804d4dcd5db42918b0bb0fcbae5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->