### PR TITLE
fix(blueprint): Deep merge substitutions in kustomizations

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -994,6 +994,12 @@ func (b *Blueprint) strategicMergeKustomization(kustomization Kustomization) err
 			if len(kustomization.Patches) > 0 {
 				existing.Patches = append(existing.Patches, kustomization.Patches...)
 			}
+			if len(kustomization.Substitutions) > 0 {
+				if existing.Substitutions == nil {
+					existing.Substitutions = make(map[string]string)
+				}
+				maps.Copy(existing.Substitutions, kustomization.Substitutions)
+			}
 			b.Kustomizations[i] = existing
 			return b.sortKustomize()
 		}


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves merge behavior for kustomization substitutions.
> 
> - Update `strategicMergeKustomization` to deep-merge `Kustomization.Substitutions` (preserves existing keys, overwrites conflicts, initializes when nil)
> - Add unit tests in `blueprint_types_test.go` covering merge, overwrite precedence, and nil-map initialization for `substitutions`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 45948432eb19129fe846fa1ff35320c963b2f1bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->