### PR TITLE
feat: Update providers to include 'metal' and 'docker'

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -185,7 +185,7 @@ func init() {
 	initCmd.Flags().StringVar(&initArch, "vm-arch", "", "Specify the architecture for Colima")
 	initCmd.Flags().BoolVar(&initDocker, "docker", false, "Enable Docker")
 	initCmd.Flags().BoolVar(&initGitLivereload, "git-livereload", false, "Enable Git Livereload")
-	initCmd.Flags().StringVar(&initProvider, "provider", "", "Specify the provider to use [none|generic|aws|azure|gcp]")
+	initCmd.Flags().StringVar(&initProvider, "provider", "", "Specify the provider to use [none|metal|docker|aws|azure|gcp]")
 	initCmd.Flags().StringVar(&initPlatform, "platform", "", "Deprecated: use --provider instead")
 	initCmd.Flags().StringVar(&initBlueprint, "blueprint", "", "Specify the blueprint to use")
 	initCmd.Flags().StringVar(&initEndpoint, "endpoint", "", "Specify the kubernetes API endpoint")

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -479,7 +479,7 @@ func TestInitCmd(t *testing.T) {
 
 		// If context is "local" and neither provider nor blueprint is set, set both
 		if len(args) > 0 && strings.HasPrefix(args[0], "local") && initProvider == "" && initBlueprint == "" {
-			initProvider = "generic"
+			initProvider = "docker"
 			initBlueprint = constants.DefaultOCIBlueprintURL
 		}
 
@@ -494,8 +494,8 @@ func TestInitCmd(t *testing.T) {
 		}
 
 		// Then both provider and blueprint should be set correctly
-		if initProvider != "generic" {
-			t.Errorf("Expected provider to be 'generic', got %s", initProvider)
+		if initProvider != "docker" {
+			t.Errorf("Expected provider to be 'docker', got %s", initProvider)
 		}
 
 		if blueprintCtx := ctx.Value("blueprint"); blueprintCtx == nil {
@@ -1011,7 +1011,7 @@ func TestInitCmd(t *testing.T) {
 		cmd.SetContext(ctx)
 		err := cmd.Execute()
 
-		// Then no error should occur and "generic" should be used as provider
+		// Then no error should occur and "docker" should be used as provider
 		if err != nil {
 			t.Errorf("Expected success, got error: %v", err)
 		}

--- a/docs/guides/templates.md
+++ b/docs/guides/templates.md
@@ -91,7 +91,7 @@ properties:
   provider:
     type: string
     default: "none"
-    enum: ["none", "aws", "azure", "generic"]
+    enum: ["none", "metal", "docker", "aws", "azure", "gcp"]
   observability:
     type: object
     properties:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -29,7 +29,7 @@ Windsor applies default values for various configuration options when they are n
 - **Cluster**: `cluster.enabled` defaults to `true` for all contexts. This ensures that cluster resources are available by default.
 - **Terraform**: `terraform.enabled` defaults to `true` with a `local` backend.
 - **Docker**: Docker is enabled by default with common registry configurations.
-- **Provider**: Defaults to `"none"` for non-dev contexts, `"generic"` for localhost contexts.
+- **Provider**: Defaults to `"none"` for non-dev contexts, `"docker"` for dev contexts (or `"incus"` when using colima-incus vm-driver).
 
 These defaults ensure that basic functionality is available without requiring explicit configuration. You can override any default by explicitly setting the value in your `windsor.yaml` file.
 

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -96,7 +96,7 @@ properties:
   provider:
     type: string
     default: "none"
-    enum: ["none", "aws", "azure", "generic"]
+    enum: ["none", "metal", "docker", "aws", "azure", "gcp"]
   observability:
     type: object
     properties:

--- a/pkg/runtime/config/config_handler_private_test.go
+++ b/pkg/runtime/config/config_handler_private_test.go
@@ -268,7 +268,7 @@ func TestConfigHandler_separateStaticAndDynamicFields(t *testing.T) {
 		handler, _ := setupPrivateTestHandler(t)
 
 		data := map[string]any{
-			"provider":    "generic",
+			"provider":    "docker",
 			"cluster":     map[string]any{"enabled": true},
 			"custom_key":  "custom_value",
 			"another_key": "another_value",
@@ -276,7 +276,7 @@ func TestConfigHandler_separateStaticAndDynamicFields(t *testing.T) {
 
 		staticFields, dynamicFields := handler.separateStaticAndDynamicFields(data)
 
-		if staticFields["provider"] != "generic" {
+		if staticFields["provider"] != "docker" {
 			t.Error("Expected provider in static fields")
 		}
 		if staticFields["cluster"] == nil {

--- a/pkg/runtime/config/config_handler_public_test.go
+++ b/pkg/runtime/config/config_handler_public_test.go
@@ -140,7 +140,7 @@ contexts:
 		tmpDir, _ := mocks.Shell.GetProjectRoot()
 		contextDir := filepath.Join(tmpDir, "contexts", "test-context")
 		os.MkdirAll(contextDir, 0755)
-		contextConfig := `provider: generic
+		contextConfig := `provider: docker
 cluster:
   enabled: true
   driver: talos
@@ -154,8 +154,8 @@ cluster:
 		}
 
 		provider := handler.GetString("provider")
-		if provider != "generic" {
-			t.Errorf("Expected provider='generic', got '%s'", provider)
+		if provider != "docker" {
+			t.Errorf("Expected provider='docker', got '%s'", provider)
 		}
 
 		driver := handler.GetString("cluster.driver")
@@ -1044,7 +1044,7 @@ contexts:
 		tmpDir, _ := mocks.Shell.GetProjectRoot()
 		contextDir := filepath.Join(tmpDir, "contexts", "test-context")
 		os.MkdirAll(contextDir, 0755)
-		contextConfig := `provider: generic
+		contextConfig := `provider: docker
 cluster:
   enabled: true
   driver: talos
@@ -1058,8 +1058,8 @@ cluster:
 		}
 
 		provider := handler.GetString("provider")
-		if provider != "generic" {
-			t.Errorf("Expected provider='generic', got '%s'", provider)
+		if provider != "docker" {
+			t.Errorf("Expected provider='docker', got '%s'", provider)
 		}
 
 		driver := handler.GetString("cluster.driver")
@@ -1148,7 +1148,7 @@ contexts:
 		mocks := setupConfigMocks(t)
 		handler := NewConfigHandler(mocks.Shell)
 
-		yaml := `provider: generic
+		yaml := `provider: docker
 custom_key: custom_value
 `
 
@@ -1159,8 +1159,8 @@ custom_key: custom_value
 		}
 
 		provider := handler.GetString("provider")
-		if provider != "generic" {
-			t.Errorf("Expected provider='generic', got '%s'", provider)
+		if provider != "docker" {
+			t.Errorf("Expected provider='docker', got '%s'", provider)
 		}
 
 		customKey := handler.GetString("custom_key")
@@ -2063,7 +2063,7 @@ additionalProperties: false
 		os.WriteFile(filepath.Join(schemaDir, "schema.yaml"), []byte(schemaContent), 0644)
 		handler.LoadSchema(filepath.Join(schemaDir, "schema.yaml"))
 
-		err := handler.Set("provider", "generic")
+		err := handler.Set("provider", "docker")
 
 		if err != nil {
 			t.Errorf("Expected no error for static field, got %v", err)
@@ -2312,7 +2312,7 @@ properties:
 		handler, tmpDir := setupPrivateTestHandler(t)
 		handler.SetContext("save-test")
 
-		handler.Set("provider", "generic")
+		handler.Set("provider", "docker")
 		handler.Set("cluster.enabled", true)
 		handler.Set("cluster.workers.count", 2)
 		handler.Set("custom_dynamic", "dynamic_value")
@@ -2334,7 +2334,7 @@ properties:
 
 		// Then data should be preserved
 		provider := newHandler.GetString("provider")
-		if provider != "generic" {
+		if provider != "docker" {
 			t.Errorf("Expected provider to be preserved, got '%s'", provider)
 		}
 

--- a/pkg/runtime/config/schema_validator_test.go
+++ b/pkg/runtime/config/schema_validator_test.go
@@ -142,7 +142,7 @@ type: object
 properties:
   provider:
     type: string
-    default: generic
+    default: docker
   network:
     type: object
     properties:
@@ -192,8 +192,8 @@ additionalProperties: false
 			t.Fatalf("Failed to get defaults: %v", err)
 		}
 
-		if defaults["provider"] != "generic" {
-			t.Errorf("Expected provider default 'generic', got %v", defaults["provider"])
+		if defaults["provider"] != "docker" {
+			t.Errorf("Expected provider default 'docker', got %v", defaults["provider"])
 		}
 
 		network, ok := defaults["network"].(map[string]any)
@@ -312,8 +312,8 @@ type: object
 properties:
   provider:
     type: string
-    enum: [generic, aws]
-    default: generic
+    enum: [docker, aws]
+    default: docker
 additionalProperties: true
 `
 
@@ -349,7 +349,7 @@ additionalProperties: false
 		}
 
 		values := map[string]any{
-			"provider": "generic",
+			"provider": "docker",
 			"extra":    "field",
 		}
 
@@ -359,7 +359,7 @@ additionalProperties: false
 		}
 
 		if result.Valid {
-			t.Error("Expected validation to fail - 'generic' not in overlay enum and 'extra' field not allowed")
+			t.Error("Expected validation to fail - 'docker' not in overlay enum and 'extra' field not allowed")
 		}
 	})
 }
@@ -377,7 +377,7 @@ func TestSchemaValidator_ExtractDefaults(t *testing.T) {
 			"properties": map[string]any{
 				"provider": map[string]any{
 					"type":    "string",
-					"default": "generic",
+					"default": "docker",
 				},
 				"port": map[string]any{
 					"type":    "integer",
@@ -395,8 +395,8 @@ func TestSchemaValidator_ExtractDefaults(t *testing.T) {
 		}
 
 		// And defaults should be extracted
-		if defaults["provider"] != "generic" {
-			t.Errorf("Expected provider default to be 'generic', got: %v", defaults["provider"])
+		if defaults["provider"] != "docker" {
+			t.Errorf("Expected provider default to be 'docker', got: %v", defaults["provider"])
 		}
 
 		if defaults["port"] != float64(8080) {
@@ -465,7 +465,7 @@ func TestSchemaValidator_Validate(t *testing.T) {
 			"properties": map[string]any{
 				"provider": map[string]any{
 					"type": "string",
-					"enum": []any{"generic", "aws", "azure"},
+					"enum": []any{"docker", "aws", "azure"},
 				},
 				"port": map[string]any{
 					"type":    "integer",
@@ -479,7 +479,7 @@ func TestSchemaValidator_Validate(t *testing.T) {
 
 		// And valid values
 		values := map[string]any{
-			"provider": "generic",
+			"provider": "docker",
 			"port":     8080,
 		}
 
@@ -609,7 +609,7 @@ func TestSchemaValidator_Validate(t *testing.T) {
 			"properties": map[string]any{
 				"provider": map[string]any{
 					"type": "string",
-					"enum": []any{"generic", "aws", "azure"},
+					"enum": []any{"docker", "aws", "azure"},
 				},
 			},
 			"additionalProperties": false,
@@ -651,7 +651,7 @@ func TestSchemaValidator_Validate(t *testing.T) {
 		validator := NewSchemaValidator(mockShell)
 
 		values := map[string]any{
-			"provider": "generic",
+			"provider": "docker",
 		}
 
 		// When validating values
@@ -1064,7 +1064,7 @@ func TestSchemaValidator_ValidateObject_AdditionalProperties(t *testing.T) {
 
 		// And values with additional property
 		values := map[string]any{
-			"provider":   "generic",
+			"provider":   "docker",
 			"extraField": "not-allowed",
 		}
 
@@ -1111,7 +1111,7 @@ func TestSchemaValidator_ValidateObject_AdditionalProperties(t *testing.T) {
 
 		// And values with additional property
 		values := map[string]any{
-			"provider":   "generic",
+			"provider":   "docker",
 			"extraField": "allowed",
 		}
 
@@ -1145,7 +1145,7 @@ func TestSchemaValidator_ValidateObject_AdditionalProperties(t *testing.T) {
 
 		// And values with additional property
 		values := map[string]any{
-			"provider":   "generic",
+			"provider":   "docker",
 			"extraField": "should-be-allowed",
 		}
 
@@ -1351,7 +1351,7 @@ func TestSchemaValidator_NestedValidation(t *testing.T) {
 
 		// And valid values
 		values := map[string]any{
-			"provider": "generic",
+			"provider": "docker",
 		}
 
 		// When validating values
@@ -1385,7 +1385,7 @@ func TestSchemaValidator_NestedValidation(t *testing.T) {
 
 		// And valid values
 		values := map[string]any{
-			"provider": "generic",
+			"provider": "docker",
 		}
 
 		// When validating values
@@ -1416,8 +1416,8 @@ type: object
 properties:
   provider:
     type: string
-    enum: [generic, aws, azure, metal]
-    default: generic
+    enum: [docker, metal, aws, azure]
+    default: docker
   name:
     type: string
     default: template
@@ -1500,7 +1500,7 @@ additionalProperties: false
 
 		// And should extract nested defaults properly
 		expectedDefaults := map[string]any{
-			"provider": "generic",
+			"provider": "docker",
 			"name":     "template",
 			"network": map[string]any{
 				"cidr_block": "10.0.0.0/16",
@@ -1571,8 +1571,8 @@ type: object
 properties:
   provider:
     type: string
-    enum: [generic, aws, azure]
-    default: generic
+    enum: [docker, metal, aws, azure]
+    default: docker
   network:
     type: object
     properties:
@@ -1620,7 +1620,7 @@ type: object
 properties:
   provider:
     type: string
-    enum: [generic, aws, azure]
+    enum: [docker, metal, aws, azure]
   network:
     type: object
     properties:
@@ -2647,7 +2647,7 @@ func TestSchemaValidator_mergeSchema(t *testing.T) {
 			"properties": map[string]any{
 				"provider": map[string]any{
 					"type":    "string",
-					"default": "generic",
+					"default": "docker",
 				},
 				"network": map[string]any{
 					"type": "object",

--- a/pkg/runtime/env/talos_env_test.go
+++ b/pkg/runtime/env/talos_env_test.go
@@ -46,9 +46,9 @@ func TestTalosEnv_GetEnvVars(t *testing.T) {
 		return printer, mocks
 	}
 
-	t.Run("GenericProvider", func(t *testing.T) {
-		// Given a new TalosOmniEnvPrinter with generic provider
-		printer, mocks := setup(t, "generic")
+	t.Run("DockerProvider", func(t *testing.T) {
+		// Given a new TalosOmniEnvPrinter with docker provider
+		printer, mocks := setup(t, "docker")
 
 		// Get the project root path
 		projectRoot, err := mocks.Shell.GetProjectRoot()
@@ -77,9 +77,9 @@ func TestTalosEnv_GetEnvVars(t *testing.T) {
 			t.Errorf("TALOSCONFIG = %v, want %v", envVars["TALOSCONFIG"], expectedTalosPath)
 		}
 
-		// And OMNICONFIG should not be set for generic provider
+		// And OMNICONFIG should not be set for docker provider
 		if _, exists := envVars["OMNICONFIG"]; exists {
-			t.Error("OMNICONFIG should not be set for generic provider")
+			t.Error("OMNICONFIG should not be set for docker provider")
 		}
 	})
 
@@ -123,7 +123,7 @@ func TestTalosEnv_GetEnvVars(t *testing.T) {
 
 	t.Run("NoConfigFiles", func(t *testing.T) {
 		// Given a new TalosOmniEnvPrinter without existing config files
-		printer, mocks := setup(t, "generic")
+		printer, mocks := setup(t, "docker")
 
 		// Get the project root path
 		projectRoot, err := mocks.Shell.GetProjectRoot()


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Provider model update**
> 
> - Default provider in dev/local contexts now `docker`; auto-selects `incus` when `vm.driver=colima` and `vm.runtime=incus`
> - Replace `generic` with `docker`; add `metal` across CLI flags, docs, schema enums/defaults, and config defaults
> - Update runtime/provider defaults: `docker`/`metal`/`incus` set `cluster.driver=talos`
> 
> **Code/test/doc changes**
> 
> - `init` command: `--provider` enum updated; auto-local provider set to `docker`
> - `project.Configure` and `runtime.ApplyConfigDefaults/ApplyProviderDefaults` adjusted for new defaults and selection logic
> - Extensive test updates across runtime/config/project/env to expect `docker` and handle `incus` path
> - Docs (`templates.md`, `configuration.md`, `schema.md`) updated to reflect new provider options and defaults
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9531613c9f6e56ec0b764f8ed7e23ecc34bf7c24. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->