### PR TITLE
feat(cmd): Pretty print multiline strings when showing blueprint

### DIFF
--- a/cmd/show.go
+++ b/cmd/show.go
@@ -147,7 +147,7 @@ func outputResource(resource any, useJSON bool, resourceType string) error {
 			return fmt.Errorf("failed to marshal %s to JSON: %w", resourceType, err)
 		}
 	} else {
-		output, err = yaml.Marshal(resource)
+		output, err = yaml.MarshalWithOptions(resource, yaml.UseLiteralStyleIfMultiline(true))
 		if err != nil {
 			return fmt.Errorf("failed to marshal %s to YAML: %w", resourceType, err)
 		}


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Output-format-only change (YAML serialization options) with no impact on underlying blueprint generation or data handling; minor risk of diff/noise for consumers that parse the YAML output textually.
> 
> **Overview**
> Updates `cmd show` YAML output to use `yaml.MarshalWithOptions(..., yaml.UseLiteralStyleIfMultiline(true))`, causing multiline string fields in rendered `blueprint`/`kustomization` output to be emitted using YAML literal block style (more readable) instead of escaped/newline-encoded strings.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2623e46f2b01d919f86ed2f0890eed47f12b446. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->