### PR TITLE
chore: Use the formal windsor schema definition

### DIFF
--- a/api/v1alpha2/config/providers/schema.yaml
+++ b/api/v1alpha2/config/providers/schema.yaml
@@ -1,4 +1,4 @@
-$schema: https://json-schema.org/draft/2020-12/schema
+$schema: https://windsorcli.dev/schema/2026-02/schema
 title: Providers Configuration Schema
 description: Schema for cloud provider configurations
 type: object

--- a/api/v1alpha2/config/secrets/schema.yaml
+++ b/api/v1alpha2/config/secrets/schema.yaml
@@ -1,4 +1,4 @@
-$schema: https://json-schema.org/draft/2020-12/schema
+$schema: https://windsorcli.dev/schema/2026-02/schema
 title: Secrets Configuration Schema
 description: Schema for secrets management configurations
 type: object

--- a/api/v1alpha2/config/terraform/schema.yaml
+++ b/api/v1alpha2/config/terraform/schema.yaml
@@ -1,4 +1,4 @@
-$schema: https://json-schema.org/draft/2020-12/schema
+$schema: https://windsorcli.dev/schema/2026-02/schema
 title: Terraform Configuration Schema
 description: Schema for Terraform configuration
 type: object

--- a/api/v1alpha2/config/workstation/schema.yaml
+++ b/api/v1alpha2/config/workstation/schema.yaml
@@ -1,4 +1,4 @@
-$schema: https://json-schema.org/draft/2020-12/schema
+$schema: https://windsorcli.dev/schema/2026-02/schema
 title: Workstation Configuration Schema
 description: Schema for local development workstation configuration
 type: object

--- a/docs/guides/templates.md
+++ b/docs/guides/templates.md
@@ -75,15 +75,16 @@ JSON Schema file that defines the expected structure and default values for conf
 - Provide default values for missing configuration keys
 - Ensure configuration consistency across contexts
 
-The schema file must be valid JSON Schema. Supported schema versions:
-- `https://json-schema.org/draft/2020-12/schema` - Standard JSON Schema Draft 2020-12
+The schema file must use the Windsor schema dialect. Supported `$schema` values:
+- `https://windsorcli.dev/schema/2026-02/schema` - Windsor schema dialect (recommended)
+- `https://json-schema.org/draft/2020-12/schema` - JSON Schema Draft 2020-12 (compatibility)
 
 **Note:** Windsor implements a subset of JSON Schema Draft 2020-12. See [Schema Reference](../reference/schema.md) for supported features.
 
 Example:
 
 ```yaml
-$schema: https://json-schema.org/draft/2020-12/schema
+$schema: https://windsorcli.dev/schema/2026-02/schema
 type: object
 properties:
   provider:

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -8,10 +8,10 @@ Blueprints can include a JSON Schema file (`_template/schema.yaml`) that defines
 
 ## Schema File Structure
 
-The schema file must be valid JSON Schema Draft 2020-12. The schema is located at `_template/schema.yaml` in blueprint templates.
+The schema file must use the Windsor schema dialect. The schema is located at `_template/schema.yaml` in blueprint templates.
 
 ```yaml
-$schema: https://json-schema.org/draft/2020-12/schema
+$schema: https://windsorcli.dev/schema/2026-02/schema
 type: object
 properties:
   # ... property definitions
@@ -90,7 +90,7 @@ The schema file must be located at `contexts/_template/schema.yaml` in your blue
 ## Example
 
 ```yaml
-$schema: https://json-schema.org/draft/2020-12/schema
+$schema: https://windsorcli.dev/schema/2026-02/schema
 type: object
 properties:
   provider:

--- a/pkg/runtime/config/schema_validator.go
+++ b/pkg/runtime/config/schema_validator.go
@@ -582,7 +582,7 @@ func (sv *SchemaValidator) validateSchemaStructure(schema map[string]any) error 
 	}
 
 	if schemaStr, ok := schemaVersion.(string); ok {
-		if schemaStr != "https://schemas.windsorcli.dev/blueprint-config/v1alpha1" &&
+		if schemaStr != "https://windsorcli.dev/schema/2026-02/schema" &&
 			schemaStr != "https://json-schema.org/draft/2020-12/schema" {
 			return fmt.Errorf("unsupported schema version: %s", schemaStr)
 		}

--- a/pkg/runtime/config/schema_validator_test.go
+++ b/pkg/runtime/config/schema_validator_test.go
@@ -25,7 +25,7 @@ func TestSchemaValidator_LoadSchema(t *testing.T) {
 
 		// And a valid schema file
 		schemaContent := `
-$schema: https://schemas.windsorcli.dev/blueprint-config/v1alpha1
+$schema: https://windsorcli.dev/schema/2026-02/schema
 title: Test Schema
 type: object
 properties:
@@ -363,7 +363,6 @@ additionalProperties: false
 		}
 	})
 }
-
 
 func TestSchemaValidator_ExtractDefaults(t *testing.T) {
 	t.Run("SuccessSimpleDefaults", func(t *testing.T) {

--- a/pkg/runtime/config/schemas/substitutions.yaml
+++ b/pkg/runtime/config/schemas/substitutions.yaml
@@ -1,4 +1,4 @@
-$schema: https://json-schema.org/draft/2020-12/schema
+$schema: https://windsorcli.dev/schema/2026-02/schema
 type: object
 properties:
   substitutions:


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a URI/dialect update across schema files, docs, and validator allowlist; behavior should remain the same aside from rejecting the old Windsor `$schema` identifier.
> 
> **Overview**
> Switches blueprint/config JSON schemas to the formal Windsor schema dialect by updating `$schema` to `https://windsorcli.dev/schema/2026-02/schema` across the bundled config schemas and `substitutions.yaml`.
> 
> Updates documentation to describe the Windsor schema dialect as the default (with Draft 2020-12 as a compatibility option), and updates the runtime `SchemaValidator` + tests to accept and test the new `$schema` URI (replacing the old `schemas.windsorcli.dev/blueprint-config/v1alpha1` identifier).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bb71dc2010e9b4c5c7feb337414e57117d2630a1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->