### PR TITLE
chore: Remove unused tool dependency checks

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -109,19 +109,13 @@ const MinimumVersionColima = "0.9.0"
 
 const MinimumVersionDocker = "23.0.0"
 
-const MinimumVersionDockerCompose = "2.20.0"
-
 const MinimumVersionKubectl = "1.27.0"
 
 const MinimumVersionLima = "1.0.0"
 
-const MinimumVersionTalosctl = "1.7.0"
-
 const MinimumVersionTerraform = "1.7.0"
 
 const MinimumVersion1Password = "2.15.0"
-
-const MinimumVersionAWSCLI = "2.15.0"
 
 const MinimumVersionKubelogin = "0.1.7"
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Removes preflight checks rather than changing core runtime behavior; main risk is environments that previously relied on this CLI to flag missing/old Docker Compose will no longer get that early error.
> 
> **Overview**
> **Tool version validation is simplified** by making `checkDocker` only require the `docker` CLI (and verify its version when not running in Colima mode), removing all Docker Compose discovery/version logic and related failure modes.
> 
> **Cleans up unused dependency metadata and tests** by deleting minimum-version constants for `docker-compose`, `talosctl`, and `aws` CLI, and updating `tools_manager_test.go` to stop mocking/expecting those checks (including removing compose-specific unit tests).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f53d92ff1a250306394f4da060ecceb9119719f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->