### PR TITLE
fix(composer): Don't prematurely evaluate deferred

### DIFF
--- a/integration/explain_test.go
+++ b/integration/explain_test.go
@@ -164,7 +164,7 @@ func TestExplain(t *testing.T) {
 		}
 	})
 
-	t.Run("DeferredTerraformOutputResolvesViaFallback", func(t *testing.T) {
+	t.Run("DeferredTerraformOutputPreservesRawExpression", func(t *testing.T) {
 		t.Parallel()
 		dir, env := helpers.PrepareFixture(t, "facet-composition")
 		env = append(env, "WINDSOR_CONTEXT=default")
@@ -173,7 +173,7 @@ func TestExplain(t *testing.T) {
 			t.Fatalf("explain failed: %v\nstderr: %s", err, stderr)
 		}
 		assertExplainOutput(t, string(stdout), explainExpectation{
-			header:             "terraform.deferred-cluster.inputs.api_endpoint = https://localhost:6443",
+			header:             "terraform.deferred-cluster.inputs.api_endpoint (deferred)",
 			sourceContains:     "option-deferred-test.yaml",
 			expressionContains: "deferred_endpoint.endpoint",
 		})

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -414,9 +414,6 @@ func (p *BaseBlueprintProcessor) evaluateGlobalScopeConfig(globalScope map[strin
 						continue
 					}
 					resolved, err := p.evaluator.Evaluate(s, "", scopeWithBlock, false)
-					if err == nil && resolved != nil && reflect.DeepEqual(resolved, v) {
-						resolved, err = p.evaluator.Evaluate(s, "", scopeWithBlock, true)
-					}
 					if err != nil || resolved == nil {
 						continue
 					}


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes config-block resolution to stop force-evaluating deferred expressions, which can alter composed blueprint values and `explain` output for users relying on early resolution.
> 
> **Overview**
> Stops the blueprint config-block resolver from retrying expression evaluation in a "force deferred" mode, so unresolved/deferred references remain as raw expressions instead of being prematurely resolved.
> 
> Updates the `explain` integration test to expect deferred Terraform-derived values to be reported as `(deferred)` with the original expression preserved rather than a resolved URL.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f5204c052704b6df9c37d3784d114da13e6c243f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->