### PR TITLE
fix(runtime): Migrate deprecated config values

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -571,14 +571,14 @@ func (rt *Runtime) ResolveConfig(flagOverrides map[string]any) error {
 	if err := rt.ConfigHandler.LoadConfig(); err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
 	}
-	rt.migrateLoadedConfig()
-	if rt.ConfigHandler.GetBool("dns.enabled") && rt.ConfigHandler.GetString("dns.domain") != "" && rt.ConfigHandler.GetString("workstation.runtime") == "docker-desktop" && rt.ConfigHandler.GetString("dns.address") == "" {
-		_ = rt.ConfigHandler.Set("dns.address", "127.0.0.1")
-	}
 	for key, value := range flagOverrides {
 		if err := rt.ConfigHandler.Set(key, value); err != nil {
 			return fmt.Errorf("failed to set %s: %w", key, err)
 		}
+	}
+	rt.migrateLoadedConfig()
+	if rt.ConfigHandler.GetBool("dns.enabled") && rt.ConfigHandler.GetString("dns.domain") != "" && rt.ConfigHandler.GetString("workstation.runtime") == "docker-desktop" && rt.ConfigHandler.GetString("dns.address") == "" {
+		_ = rt.ConfigHandler.Set("dns.address", "127.0.0.1")
 	}
 	if isDevMode {
 		platform := rt.ConfigHandler.GetString("platform")


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core config resolution/persistence pipeline, so mis-ordering migrations or overrides could change provider/runtime selection across contexts; no direct security impact.
> 
> **Overview**
> **Config resolution now explicitly migrates deprecated keys after loading config.** `ResolveConfig` maps `--platform`→`provider`, applies defaults and provider-specific defaults, loads config, applies flag overrides, then calls a new `migrateLoadedConfig` to sync `platform`↔`provider` and backfill `workstation.runtime` from `vm.driver`.
> 
> **Config persistence now strips deprecated keys.** `SaveConfig` copies `provider` into `platform` only when `platform` is unset, then clears `provider` so it is never written to disk, and mirrors `workstation.runtime` to `vm.driver` before saving.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b8363cb2ca28ecfa579dbbb040a5803017a8a041. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->