### PR TITLE
chore: Further standardize on platform vs. provider

### DIFF
--- a/cmd/get.go
+++ b/cmd/get.go
@@ -74,12 +74,14 @@ var getContextsCmd = &cobra.Command{
 
 		var contextInfos []contextInfo
 		for _, ctx := range contexts {
-			provider := "<none>"
+			platform := "<none>"
 			backend := "<none>"
 			ctxConfigHandler := config.NewConfigHandler(rt.Shell)
 			if err := ctxConfigHandler.LoadConfigForContext(ctx); err == nil {
-				if p := ctxConfigHandler.GetString("provider"); p != "" {
-					provider = p
+				if p := ctxConfigHandler.GetString("platform"); p != "" {
+					platform = p
+				} else if p := ctxConfigHandler.GetString("provider"); p != "" {
+					platform = p
 				}
 				if b := ctxConfigHandler.GetString("terraform.backend.type"); b != "" {
 					backend = b
@@ -88,7 +90,7 @@ var getContextsCmd = &cobra.Command{
 
 			contextInfos = append(contextInfos, contextInfo{
 				name:     ctx,
-				provider: provider,
+				provider: platform,
 				backend:  backend,
 				current:  ctx == currentContext,
 			})

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -286,8 +286,8 @@ func TestInitCmd(t *testing.T) {
 			t.Fatalf("Execute failed: %v", err)
 		}
 
-		if v, ok := setCalls["provider"]; !ok || v != "docker" {
-			t.Errorf("Expected Set(provider, docker), got provider=%v (ok=%v)", v, ok)
+		if v, ok := setCalls["platform"]; !ok || v != "docker" {
+			t.Errorf("Expected Set(platform, docker), got platform=%v (ok=%v)", v, ok)
 		}
 		if v, ok := setCalls["workstation.enabled"]; !ok || v != true {
 			t.Errorf("Expected Set(workstation.enabled, true), got workstation.enabled=%v (ok=%v)", v, ok)
@@ -300,7 +300,7 @@ func TestInitCmd(t *testing.T) {
 		}
 	})
 
-	t.Run("VmDriverDockerDesktopSetsProviderAndWorkstation", func(t *testing.T) {
+	t.Run("VmDriverDockerDesktopSetsPlatformAndWorkstation", func(t *testing.T) {
 		mocks := setupInitTest(t)
 		setCalls := make(map[string]any)
 		mockConfig := mocks.ConfigHandler.(*config.MockConfigHandler)
@@ -322,8 +322,8 @@ func TestInitCmd(t *testing.T) {
 			t.Fatalf("Execute failed: %v", err)
 		}
 
-		if v, ok := setCalls["provider"]; !ok || v != "docker" {
-			t.Errorf("Expected Set(provider, docker), got provider=%v (ok=%v)", v, ok)
+		if v, ok := setCalls["platform"]; !ok || v != "docker" {
+			t.Errorf("Expected Set(platform, docker), got platform=%v (ok=%v)", v, ok)
 		}
 		if v, ok := setCalls["workstation.enabled"]; !ok || v != true {
 			t.Errorf("Expected Set(workstation.enabled, true), got workstation.enabled=%v (ok=%v)", v, ok)
@@ -336,7 +336,7 @@ func TestInitCmd(t *testing.T) {
 		}
 	})
 
-	t.Run("VmDriverColimaIncusSetsProviderIncusAndWorkstation", func(t *testing.T) {
+	t.Run("VmDriverColimaIncusSetsPlatformIncusAndWorkstation", func(t *testing.T) {
 		mocks := setupInitTest(t)
 		setCalls := make(map[string]any)
 		mockConfig := mocks.ConfigHandler.(*config.MockConfigHandler)
@@ -358,8 +358,8 @@ func TestInitCmd(t *testing.T) {
 			t.Fatalf("Execute failed: %v", err)
 		}
 
-		if v, ok := setCalls["provider"]; !ok || v != "incus" {
-			t.Errorf("Expected Set(provider, incus), got provider=%v (ok=%v)", v, ok)
+		if v, ok := setCalls["platform"]; !ok || v != "incus" {
+			t.Errorf("Expected Set(platform, incus), got platform=%v (ok=%v)", v, ok)
 		}
 		if v, ok := setCalls["workstation.enabled"]; !ok || v != true {
 			t.Errorf("Expected Set(workstation.enabled, true), got workstation.enabled=%v (ok=%v)", v, ok)

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -430,29 +430,23 @@ func TestProject_Configure(t *testing.T) {
 		_ = NewProject("test-context", &Project{Runtime: mocks.Runtime})
 	})
 
-	t.Run("SetsDockerProviderInDevModeWhenProviderNotSet", func(t *testing.T) {
+	t.Run("SetsDockerPlatformInDevModeWhenPlatformNotSet", func(t *testing.T) {
 		mocks := setupProjectMocks(t)
 		mockConfig := mocks.ConfigHandler.(*config.MockConfigHandler)
 		mockConfig.IsDevModeFunc = func(contextName string) bool {
 			return true
 		}
 		mockConfig.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "provider" {
-				return ""
-			}
-			if key == "vm.driver" {
-				return ""
-			}
 			if key == "vm.runtime" {
 				return "docker"
 			}
 			return ""
 		}
 
-		providerSet := false
+		platformSet := false
 		mockConfig.SetFunc = func(key string, value any) error {
-			if key == "provider" && value == "docker" {
-				providerSet = true
+			if key == "platform" && value == "docker" {
+				platformSet = true
 			}
 			return nil
 		}
@@ -460,21 +454,18 @@ func TestProject_Configure(t *testing.T) {
 		proj := NewProject("test-context", &Project{Runtime: mocks.Runtime})
 		_ = proj.Configure(nil)
 
-		if !providerSet {
-			t.Error("Expected provider to be set to 'docker' in dev mode")
+		if !platformSet {
+			t.Error("Expected platform to be set to 'docker' in dev mode")
 		}
 	})
 
-	t.Run("SetsIncusProviderInDevModeWhenColimaIncus", func(t *testing.T) {
+	t.Run("SetsIncusPlatformInDevModeWhenColimaIncus", func(t *testing.T) {
 		mocks := setupProjectMocks(t)
 		mockConfig := mocks.ConfigHandler.(*config.MockConfigHandler)
 		mockConfig.IsDevModeFunc = func(contextName string) bool {
 			return true
 		}
 		mockConfig.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "provider" {
-				return ""
-			}
 			if key == "vm.driver" {
 				return "colima"
 			}
@@ -487,10 +478,10 @@ func TestProject_Configure(t *testing.T) {
 			return ""
 		}
 
-		providerSet := false
+		platformSet := false
 		mockConfig.SetFunc = func(key string, value any) error {
-			if key == "provider" && value == "incus" {
-				providerSet = true
+			if key == "platform" && value == "incus" {
+				platformSet = true
 			}
 			return nil
 		}
@@ -498,8 +489,8 @@ func TestProject_Configure(t *testing.T) {
 		proj := NewProject("test-context", &Project{Runtime: mocks.Runtime})
 		_ = proj.Configure(nil)
 
-		if !providerSet {
-			t.Error("Expected provider to be set to 'incus' in dev mode when vm.driver is colima and vm.runtime is incus")
+		if !platformSet {
+			t.Error("Expected platform to be set to 'incus' in dev mode when vm.driver is colima and vm.runtime is incus")
 		}
 	})
 
@@ -614,7 +605,7 @@ func TestProject_Configure(t *testing.T) {
 		}
 	})
 
-	t.Run("ErrorOnApplyProviderDefaultsFailure", func(t *testing.T) {
+	t.Run("ErrorOnApplyPlatformDefaultsFailure", func(t *testing.T) {
 		mocks := setupProjectMocks(t)
 		mockConfig := mocks.ConfigHandler.(*config.MockConfigHandler)
 		mockConfig.SetFunc = func(key string, value any) error {
@@ -626,10 +617,10 @@ func TestProject_Configure(t *testing.T) {
 
 		proj := NewProject("test-context", &Project{Runtime: mocks.Runtime})
 
-		err := proj.Configure(map[string]any{"provider": "aws"})
+		err := proj.Configure(map[string]any{"platform": "aws"})
 
 		if err == nil {
-			t.Error("Expected error for ApplyProviderDefaults failure")
+			t.Error("Expected error for ApplyPlatformDefaults failure")
 			return
 		}
 	})
@@ -754,14 +745,14 @@ func TestProject_Configure(t *testing.T) {
 		}
 	})
 
-	t.Run("SetsProviderToIncusAfterLoadConfigWhenColimaIncus", func(t *testing.T) {
+	t.Run("SetsPlatformToIncusAfterLoadConfigWhenColimaIncus", func(t *testing.T) {
 		mocks := setupProjectMocks(t)
 		mockConfig := mocks.ConfigHandler.(*config.MockConfigHandler)
 		mockConfig.IsDevModeFunc = func(contextName string) bool {
 			return true
 		}
 		mockConfig.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "provider" {
+			if key == "platform" {
 				return "docker"
 			}
 			if key == "vm.driver" {
@@ -776,10 +767,10 @@ func TestProject_Configure(t *testing.T) {
 			return nil
 		}
 
-		var providerSet string
+		var platformSet string
 		mockConfig.SetFunc = func(key string, value any) error {
-			if key == "provider" {
-				providerSet = value.(string)
+			if key == "platform" {
+				platformSet = value.(string)
 			}
 			return nil
 		}
@@ -787,8 +778,8 @@ func TestProject_Configure(t *testing.T) {
 		proj := NewProject("test-context", &Project{Runtime: mocks.Runtime})
 		_ = proj.Configure(nil)
 
-		if providerSet != "incus" {
-			t.Errorf("Expected provider to be set to 'incus' after LoadConfig when vm.driver is 'colima' and vm.runtime is 'incus', got: %s", providerSet)
+		if platformSet != "incus" {
+			t.Errorf("Expected platform to be set to 'incus' after LoadConfig when vm.driver is 'colima' and vm.runtime is 'incus', got: %s", platformSet)
 		}
 	})
 }

--- a/pkg/runtime/config/defaults.go
+++ b/pkg/runtime/config/defaults.go
@@ -64,7 +64,7 @@ var commonTerraformConfig = terraform.TerraformConfig{
 }
 
 // commonClusterConfig_Minimal is a minimal cluster configuration with only enabled set to true.
-// Used for provider-specific configurations where the driver will be set by ApplyProviderDefaults.
+// Used for platform-specific configurations where the driver will be set by ApplyPlatformDefaults.
 var commonClusterConfig_Minimal = cluster.ClusterConfig{
 	Enabled: ptrBool(true),
 }
@@ -107,11 +107,11 @@ var commonClusterConfig_WithHostPorts = cluster.ClusterConfig{
 	},
 }
 
-// DefaultConfig returns the default configuration for non-dev contexts
-// Uses minimal config since non-dev contexts default to provider "none"
-// Includes cluster.enabled=true for provider-specific contexts (aws, azure)
+// DefaultConfig returns the default configuration for non-dev contexts.
+// Uses minimal config since non-dev contexts default to platform "none".
+// Includes cluster.enabled=true for platform-specific contexts (aws, azure).
 var DefaultConfig = v1alpha1.Context{
-	Provider:  ptrString("none"),
+	Platform:  ptrString("none"),
 	Terraform: commonTerraformConfig.Copy(),
 	Cluster:   commonClusterConfig_Minimal.Copy(),
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -400,13 +400,16 @@ func (rt *Runtime) InitializeComponents() error {
 // ApplyConfigDefaults applies base configuration defaults if no config is currently loaded.
 // It sets "dev" mode in config if the context is a dev context, chooses a default workstation runtime
 // (optionally honoring flagOverrides["workstation.runtime"] or deprecated flagOverrides["vm.driver"]), and sets
-// provider to "docker" in dev mode if not already set, or "incus" when overrides or config specify provider incus.
+// platform to "docker" in dev mode if not already set, or "incus" when overrides or config specify incus.
 // After those, it loads a default configuration set, choosing among standard, full, localhost, or none
-// defaults depending on provider, dev mode, and workstation runtime.
+// defaults depending on platform, dev mode, and workstation runtime.
 // This must be called before loading from disk to ensure proper defaulting. Returns error on config operation failure.
 func (rt *Runtime) ApplyConfigDefaults(flagOverrides ...map[string]any) error {
 	if !rt.ConfigHandler.IsLoaded() {
-		existingProvider := rt.ConfigHandler.GetString("provider")
+		existingPlatform := rt.ConfigHandler.GetString("platform")
+		if existingPlatform == "" {
+			existingPlatform = rt.ConfigHandler.GetString("provider")
+		}
 		isDevMode := rt.ConfigHandler.IsDevMode(rt.ContextName)
 
 		if isDevMode {
@@ -458,25 +461,25 @@ func (rt *Runtime) ApplyConfigDefaults(flagOverrides ...map[string]any) error {
 			vmRuntime = rt.ConfigHandler.GetString("vm.runtime", "docker")
 		}
 
-		if existingProvider == "" && isDevMode {
-			overrideProvider := ""
+		if existingPlatform == "" && isDevMode {
+			overridePlatform := ""
 			if len(flagOverrides) > 0 && flagOverrides[0] != nil {
-				if p, ok := flagOverrides[0]["provider"].(string); ok && p != "" {
-					overrideProvider = p
+				if p, ok := flagOverrides[0]["platform"].(string); ok && p != "" {
+					overridePlatform = p
 				}
 			}
-			if overrideProvider != "" {
-				if err := rt.ConfigHandler.Set("provider", overrideProvider); err != nil {
-					return fmt.Errorf("failed to set provider from overrides: %w", err)
+			if overridePlatform != "" {
+				if err := rt.ConfigHandler.Set("platform", overridePlatform); err != nil {
+					return fmt.Errorf("failed to set platform from overrides: %w", err)
 				}
 			} else if workstationRuntime == "colima" && vmRuntime == "incus" {
 				fmt.Fprintln(os.Stderr, "\033[33mWarning: vm.runtime is deprecated; use platform: incus in your context configuration instead. Support for vm.runtime will be removed in a future version.\033[0m")
-				if err := rt.ConfigHandler.Set("provider", "incus"); err != nil {
-					return fmt.Errorf("failed to set provider to incus: %w", err)
+				if err := rt.ConfigHandler.Set("platform", "incus"); err != nil {
+					return fmt.Errorf("failed to set platform to incus: %w", err)
 				}
 			} else {
-				if err := rt.ConfigHandler.Set("provider", "docker"); err != nil {
-					return fmt.Errorf("failed to set provider from context name: %w", err)
+				if err := rt.ConfigHandler.Set("platform", "docker"); err != nil {
+					return fmt.Errorf("failed to set platform: %w", err)
 				}
 			}
 		}
@@ -487,11 +490,14 @@ func (rt *Runtime) ApplyConfigDefaults(flagOverrides ...map[string]any) error {
 			}
 		}
 
-		provider := rt.ConfigHandler.GetString("provider")
-		if provider == "none" {
+		platform := rt.ConfigHandler.GetString("platform")
+		if platform == "" {
+			platform = rt.ConfigHandler.GetString("provider")
+		}
+		if platform == "none" {
 			defaultConfig := config.DefaultConfig
-			noneProvider := "none"
-			defaultConfig.Provider = &noneProvider
+			nonePlatform := "none"
+			defaultConfig.Platform = &nonePlatform
 			if err := rt.ConfigHandler.SetDefault(defaultConfig); err != nil {
 				return fmt.Errorf("failed to set default config: %w", err)
 			}
@@ -513,21 +519,33 @@ func (rt *Runtime) ApplyConfigDefaults(flagOverrides ...map[string]any) error {
 	return nil
 }
 
-// ResolveConfig runs the full config pipeline: infer provider for dev when missing, apply pre-load
+// ResolveConfig runs the full config pipeline: infer platform for dev when missing, apply pre-load
 // defaults, load from disk, migrate vm.driver to workstation.runtime, apply flag overrides, then
-// apply dev-mode provider normalization (colima+incus). Call this once to produce final config.
-// Mutates flagOverrides when inferring provider. Returns error on config load or set failure.
+// apply dev-mode platform normalization (colima+incus). Call this once to produce final config.
+// Mutates flagOverrides when inferring platform. Returns error on config load or set failure.
 func (rt *Runtime) ResolveConfig(flagOverrides map[string]any) error {
 	if flagOverrides == nil {
 		flagOverrides = make(map[string]any)
 	}
-	if p, ok := flagOverrides["platform"]; ok {
-		flagOverrides["provider"] = p
-		delete(flagOverrides, "platform")
+	if p, ok := flagOverrides["provider"]; ok {
+		if _, hasPlatform := flagOverrides["platform"]; !hasPlatform {
+			flagOverrides["platform"] = p
+		}
+		delete(flagOverrides, "provider")
 	}
 	isDevMode := rt.ConfigHandler.IsDevMode(rt.ContextName)
 	if isDevMode {
-		if _, exists := flagOverrides["provider"]; !exists && rt.ConfigHandler.GetString("provider") == "" {
+		existingPlatform := ""
+		if _, exists := flagOverrides["platform"]; exists {
+			existingPlatform, _ = flagOverrides["platform"].(string)
+		}
+		if existingPlatform == "" {
+			existingPlatform = rt.ConfigHandler.GetString("platform")
+		}
+		if existingPlatform == "" {
+			existingPlatform = rt.ConfigHandler.GetString("provider")
+		}
+		if existingPlatform == "" {
 			workstationRuntime := ""
 			if driver, ok := flagOverrides["workstation.runtime"].(string); ok && driver != "" {
 				workstationRuntime = driver
@@ -552,20 +570,20 @@ func (rt *Runtime) ResolveConfig(flagOverrides map[string]any) error {
 			}
 			if workstationRuntime == "colima" && vmRuntime == "incus" {
 				fmt.Fprintln(os.Stderr, "\033[33mWarning: vm.runtime is deprecated; use platform: incus in your context configuration instead. Support for vm.runtime will be removed in a future version.\033[0m")
-				flagOverrides["provider"] = "incus"
+				flagOverrides["platform"] = "incus"
 			} else {
-				flagOverrides["provider"] = "docker"
+				flagOverrides["platform"] = "docker"
 			}
 		}
 	}
 	if err := rt.ApplyConfigDefaults(flagOverrides); err != nil {
 		return fmt.Errorf("failed to apply config defaults: %w", err)
 	}
-	providerOverride := ""
-	if prov, ok := flagOverrides["provider"].(string); ok {
-		providerOverride = prov
+	platformOverride := ""
+	if p, ok := flagOverrides["platform"].(string); ok {
+		platformOverride = p
 	}
-	if err := rt.ApplyProviderDefaults(providerOverride); err != nil {
+	if err := rt.ApplyPlatformDefaults(platformOverride); err != nil {
 		return err
 	}
 	if err := rt.ConfigHandler.LoadConfig(); err != nil {
@@ -592,29 +610,31 @@ func (rt *Runtime) ResolveConfig(flagOverrides map[string]any) error {
 			if err := rt.ConfigHandler.Set("platform", "incus"); err != nil {
 				return fmt.Errorf("failed to set platform to incus: %w", err)
 			}
-			_ = rt.ConfigHandler.Set("provider", "incus")
 		}
 	}
 	return nil
 }
 
-// ApplyProviderDefaults sets provider-specific configuration values based on the provider type.
+// ApplyPlatformDefaults sets platform-specific configuration values based on the platform type.
 // For "aws", it enables AWS and sets the cluster driver to "eks".
 // For "azure", it enables Azure and sets the cluster driver to "aks".
 // For "gcp", it enables GCP and sets the cluster driver to "gke".
 // For "docker", it sets the cluster driver to "talos".
 // For "metal", it sets the cluster driver to "talos".
 // For "incus", it sets the cluster driver to "talos".
-// If no provider is set but dev mode is enabled, it defaults the cluster driver to "talos".
+// If no platform is set but dev mode is enabled, it defaults the cluster driver to "talos".
 // The context name is read from rt.ContextName. Returns an error if any configuration operation fails.
-func (rt *Runtime) ApplyProviderDefaults(providerOverride string) error {
-	provider := providerOverride
-	if provider == "" {
-		provider = rt.ConfigHandler.GetString("provider")
+func (rt *Runtime) ApplyPlatformDefaults(platformOverride string) error {
+	platform := platformOverride
+	if platform == "" {
+		platform = rt.ConfigHandler.GetString("platform")
+	}
+	if platform == "" {
+		platform = rt.ConfigHandler.GetString("provider")
 	}
 
-	if provider != "" {
-		switch provider {
+	if platform != "" {
+		switch platform {
 		case "aws":
 			if err := rt.ConfigHandler.Set("aws.enabled", true); err != nil {
 				return fmt.Errorf("failed to set aws.enabled: %w", err)
@@ -750,12 +770,14 @@ func (rt *Runtime) initializeEnvPrinters() {
 	}
 }
 
-// migrateLoadedConfig normalizes in-memory config after load: platform↔provider and vm.driver→workstation.runtime when empty. Temporary migration for deprecated keys; call after LoadConfig only. Must not be called from LoadEnvironment so that provider overrides applied in ResolveConfig (e.g. from --platform) are not reset by platform synced from disk.
+// migrateLoadedConfig normalizes in-memory config after load: copies provider→platform when
+// platform is empty (legacy config migration) and vm.driver→workstation.runtime when empty.
+// Call after LoadConfig only.
 func (rt *Runtime) migrateLoadedConfig() {
-	if p := rt.ConfigHandler.GetString("platform"); p != "" {
-		_ = rt.ConfigHandler.Set("provider", p)
-	} else if p := rt.ConfigHandler.GetString("provider"); p != "" {
-		_ = rt.ConfigHandler.Set("platform", p)
+	if rt.ConfigHandler.GetString("platform") == "" {
+		if p := rt.ConfigHandler.GetString("provider"); p != "" {
+			_ = rt.ConfigHandler.Set("platform", p)
+		}
 	}
 	if rt.ConfigHandler.GetString("workstation.runtime") == "" && rt.ConfigHandler.GetString("vm.driver") != "" {
 		_ = rt.ConfigHandler.Set("workstation.runtime", rt.ConfigHandler.GetString("vm.driver"))
@@ -763,16 +785,21 @@ func (rt *Runtime) migrateLoadedConfig() {
 }
 
 // needsDockerEnv returns true when VirtEnvPrinter (DOCKER_HOST, DOCKER_CONFIG, etc.) should be used:
-// provider must be "docker" and workstation.runtime (or vm.driver) must be colima, docker-desktop, or docker.
+// platform must be "docker" (falls back to provider for legacy configs) and workstation.runtime
+// (or vm.driver) must be colima, docker-desktop, or docker.
 func (rt *Runtime) needsDockerEnv() bool {
-	if rt.ConfigHandler.GetString("provider") != "docker" {
+	platform := rt.ConfigHandler.GetString("platform")
+	if platform == "" {
+		platform = rt.ConfigHandler.GetString("provider")
+	}
+	if platform != "docker" {
 		return false
 	}
-	runtime := rt.ConfigHandler.GetString("workstation.runtime")
-	if runtime == "" {
-		runtime = rt.ConfigHandler.GetString("vm.driver")
+	wsRuntime := rt.ConfigHandler.GetString("workstation.runtime")
+	if wsRuntime == "" {
+		wsRuntime = rt.ConfigHandler.GetString("vm.driver")
 	}
-	switch runtime {
+	switch wsRuntime {
 	case "colima", "docker-desktop", "docker":
 		return true
 	default:

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1028,12 +1028,12 @@ func TestRuntime_ApplyConfigDefaults(t *testing.T) {
 			t.Error("Expected dev to be set to true")
 		}
 
-		if setCalls["provider"] != "docker" {
-			t.Error("Expected provider to be set to docker")
+		if setCalls["platform"] != "docker" {
+			t.Error("Expected platform to be set to docker")
 		}
 	})
 
-	t.Run("SetsIncusProviderInDevModeWhenColimaIncus", func(t *testing.T) {
+	t.Run("SetsIncusPlatformInDevModeWhenColimaIncus", func(t *testing.T) {
 		// Given a runtime in dev mode with colima-incus configuration
 		mocks := setupRuntimeMocks(t)
 		rt := mocks.Runtime
@@ -1071,13 +1071,13 @@ func TestRuntime_ApplyConfigDefaults(t *testing.T) {
 		// When ApplyConfigDefaults is called
 		err := rt.ApplyConfigDefaults()
 
-		// Then provider should be set to incus
+		// Then platform should be set to incus
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)
 		}
 
-		if setCalls["provider"] != "incus" {
-			t.Errorf("Expected provider to be set to incus, got: %v", setCalls["provider"])
+		if setCalls["platform"] != "incus" {
+			t.Errorf("Expected platform to be set to incus, got: %v", setCalls["platform"])
 		}
 	})
 
@@ -1385,8 +1385,8 @@ func TestRuntime_ApplyConfigDefaults(t *testing.T) {
 		}
 	})
 
-	t.Run("ErrorWhenSetProviderFails", func(t *testing.T) {
-		// Given a runtime with a config handler that fails to set provider
+	t.Run("ErrorWhenSetPlatformFails", func(t *testing.T) {
+		// Given a runtime with a config handler that fails to set platform
 		mocks := setupRuntimeMocks(t)
 		rt := mocks.Runtime
 		rt.ContextName = "local"
@@ -1407,8 +1407,8 @@ func TestRuntime_ApplyConfigDefaults(t *testing.T) {
 		}
 
 		mockConfigHandler.SetFunc = func(key string, value interface{}) error {
-			if key == "provider" {
-				return fmt.Errorf("set provider failed")
+			if key == "platform" {
+				return fmt.Errorf("set platform failed")
 			}
 			return nil
 		}
@@ -1418,11 +1418,11 @@ func TestRuntime_ApplyConfigDefaults(t *testing.T) {
 
 		// Then an error should be returned
 		if err == nil {
-			t.Error("Expected error when Set provider fails")
+			t.Error("Expected error when Set platform fails")
 		}
 
-		if !strings.Contains(err.Error(), "failed to set provider") {
-			t.Errorf("Expected error about set provider, got: %v", err)
+		if !strings.Contains(err.Error(), "failed to set platform") {
+			t.Errorf("Expected error about set platform, got: %v", err)
 		}
 	})
 
@@ -1565,7 +1565,7 @@ func TestRuntime_ApplyConfigDefaults(t *testing.T) {
 		}
 	})
 
-	t.Run("UsesDefaultConfigNoneWhenProviderIsNone", func(t *testing.T) {
+	t.Run("UsesDefaultConfigNoneWhenPlatformIsNone", func(t *testing.T) {
 		mocks := setupRuntimeMocks(t)
 		rt := mocks.Runtime
 		rt.ContextName = "test"
@@ -1578,7 +1578,7 @@ func TestRuntime_ApplyConfigDefaults(t *testing.T) {
 			return false
 		}
 		mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "provider" {
+			if key == "platform" {
 				return "none"
 			}
 			return ""
@@ -1600,8 +1600,8 @@ func TestRuntime_ApplyConfigDefaults(t *testing.T) {
 			t.Errorf("Expected no error, got: %v", err)
 		}
 
-		if setDefaultConfig.Provider == nil || *setDefaultConfig.Provider != "none" {
-			t.Error("Expected DefaultConfig to be set with provider 'none'")
+		if setDefaultConfig.Platform == nil || *setDefaultConfig.Platform != "none" {
+			t.Error("Expected DefaultConfig to be set with platform 'none'")
 		}
 		if setDefaultConfig.Cluster == nil || setDefaultConfig.Cluster.Enabled == nil || !*setDefaultConfig.Cluster.Enabled {
 			t.Error("Expected DefaultConfig to have cluster.enabled=true")
@@ -1655,7 +1655,7 @@ func TestRuntime_ApplyConfigDefaults(t *testing.T) {
 		}
 	})
 
-	t.Run("SetsProviderToIncusWhenColimaIncusInFlagOverrides", func(t *testing.T) {
+	t.Run("SetsPlatformToIncusWhenColimaIncusInFlagOverrides", func(t *testing.T) {
 		mocks := setupRuntimeMocks(t)
 		rt := mocks.Runtime
 		rt.ContextName = "local"
@@ -1668,16 +1668,13 @@ func TestRuntime_ApplyConfigDefaults(t *testing.T) {
 			return true
 		}
 		mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "provider" {
-				return ""
-			}
 			return ""
 		}
 
-		var providerSet string
+		var platformSet string
 		mockConfigHandler.SetFunc = func(key string, value interface{}) error {
-			if key == "provider" {
-				providerSet = value.(string)
+			if key == "platform" {
+				platformSet = value.(string)
 			}
 			return nil
 		}
@@ -1697,13 +1694,13 @@ func TestRuntime_ApplyConfigDefaults(t *testing.T) {
 			t.Errorf("Expected no error, got: %v", err)
 		}
 
-		if providerSet != "incus" {
-			t.Errorf("Expected provider to be set to 'incus', got: %s", providerSet)
+		if platformSet != "incus" {
+			t.Errorf("Expected platform to be set to 'incus', got: %s", platformSet)
 		}
 	})
 }
 
-func TestRuntime_ApplyProviderDefaults(t *testing.T) {
+func TestRuntime_ApplyPlatformDefaults(t *testing.T) {
 	t.Run("SetsAWSDefaults", func(t *testing.T) {
 		// Given a runtime with AWS provider
 		mocks := setupRuntimeMocks(t)
@@ -1717,8 +1714,8 @@ func TestRuntime_ApplyProviderDefaults(t *testing.T) {
 			return nil
 		}
 
-		// When ApplyProviderDefaults is called with "aws"
-		err := rt.ApplyProviderDefaults("aws")
+		// When ApplyPlatformDefaults is called with "aws"
+		err := rt.ApplyPlatformDefaults("aws")
 
 		// Then AWS defaults should be set
 		if err != nil {
@@ -1747,8 +1744,8 @@ func TestRuntime_ApplyProviderDefaults(t *testing.T) {
 			return nil
 		}
 
-		// When ApplyProviderDefaults is called with "azure"
-		err := rt.ApplyProviderDefaults("azure")
+		// When ApplyPlatformDefaults is called with "azure"
+		err := rt.ApplyPlatformDefaults("azure")
 
 		// Then Azure defaults should be set
 		if err != nil {
@@ -1777,8 +1774,8 @@ func TestRuntime_ApplyProviderDefaults(t *testing.T) {
 			return nil
 		}
 
-		// When ApplyProviderDefaults is called with "gcp"
-		err := rt.ApplyProviderDefaults("gcp")
+		// When ApplyPlatformDefaults is called with "gcp"
+		err := rt.ApplyPlatformDefaults("gcp")
 
 		// Then GCP defaults should be set
 		if err != nil {
@@ -1807,8 +1804,8 @@ func TestRuntime_ApplyProviderDefaults(t *testing.T) {
 			return nil
 		}
 
-		// When ApplyProviderDefaults is called with "docker"
-		err := rt.ApplyProviderDefaults("docker")
+		// When ApplyPlatformDefaults is called with "docker"
+		err := rt.ApplyPlatformDefaults("docker")
 
 		// Then docker defaults should be set
 		if err != nil {
@@ -1833,8 +1830,8 @@ func TestRuntime_ApplyProviderDefaults(t *testing.T) {
 			return nil
 		}
 
-		// When ApplyProviderDefaults is called with "metal"
-		err := rt.ApplyProviderDefaults("metal")
+		// When ApplyPlatformDefaults is called with "metal"
+		err := rt.ApplyPlatformDefaults("metal")
 
 		// Then metal defaults should be set
 		if err != nil {
@@ -1850,14 +1847,14 @@ func TestRuntime_ApplyProviderDefaults(t *testing.T) {
 		// Given a runtime with nil config handler
 		rt := &Runtime{}
 
-		// When ApplyProviderDefaults is called
+		// When ApplyPlatformDefaults is called
 		// Then it should panic
 		defer func() {
 			if r := recover(); r == nil {
 				t.Error("Expected panic when ConfigHandler is nil")
 			}
 		}()
-		_ = rt.ApplyProviderDefaults("aws")
+		_ = rt.ApplyPlatformDefaults("aws")
 	})
 
 	t.Run("ErrorWhenSetFails", func(t *testing.T) {
@@ -1874,8 +1871,8 @@ func TestRuntime_ApplyProviderDefaults(t *testing.T) {
 			return nil
 		}
 
-		// When ApplyProviderDefaults is called
-		err := rt.ApplyProviderDefaults("aws")
+		// When ApplyPlatformDefaults is called
+		err := rt.ApplyPlatformDefaults("aws")
 
 		// Then an error should be returned
 
@@ -1914,8 +1911,8 @@ func TestRuntime_ApplyProviderDefaults(t *testing.T) {
 			return nil
 		}
 
-		// When ApplyProviderDefaults is called with empty provider
-		err := rt.ApplyProviderDefaults("")
+		// When ApplyPlatformDefaults is called with empty provider
+		err := rt.ApplyPlatformDefaults("")
 
 		// Then dev mode defaults should be set
 
@@ -1948,8 +1945,8 @@ func TestRuntime_ApplyProviderDefaults(t *testing.T) {
 			return nil
 		}
 
-		// When ApplyProviderDefaults is called with empty provider
-		err := rt.ApplyProviderDefaults("")
+		// When ApplyPlatformDefaults is called with empty provider
+		err := rt.ApplyPlatformDefaults("")
 
 		// Then provider defaults should be set from config
 
@@ -1982,8 +1979,8 @@ func TestRuntime_ApplyProviderDefaults(t *testing.T) {
 			return nil
 		}
 
-		// When ApplyProviderDefaults is called
-		err := rt.ApplyProviderDefaults("docker")
+		// When ApplyPlatformDefaults is called
+		err := rt.ApplyPlatformDefaults("docker")
 
 		// Then an error should be returned
 
@@ -2010,8 +2007,8 @@ func TestRuntime_ApplyProviderDefaults(t *testing.T) {
 			return nil
 		}
 
-		// When ApplyProviderDefaults is called with "azure"
-		err := rt.ApplyProviderDefaults("azure")
+		// When ApplyPlatformDefaults is called with "azure"
+		err := rt.ApplyPlatformDefaults("azure")
 
 		// Then an error should be returned
 
@@ -2050,8 +2047,8 @@ func TestRuntime_ApplyProviderDefaults(t *testing.T) {
 			return nil
 		}
 
-		// When ApplyProviderDefaults is called
-		err := rt.ApplyProviderDefaults("")
+		// When ApplyPlatformDefaults is called
+		err := rt.ApplyPlatformDefaults("")
 
 		// Then an error should be returned
 


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core runtime config resolution/defaulting and flag-override behavior; while it includes fallbacks for legacy `provider`, mistakes could change inferred defaults or platform-specific settings for some contexts.
> 
> **Overview**
> Standardizes config handling to treat `platform` as the primary key across runtime config resolution: dev-mode inference/defaults, flag override normalization (`--provider` → `--platform`), and platform-specific defaults application (renaming `ApplyProviderDefaults` → `ApplyPlatformDefaults`). Legacy configs are supported by falling back to `provider` when `platform` is missing and migrating loaded config by copying `provider` → `platform`.
> 
> Updates default context config to use `Platform: "none"`, adjusts docker-env selection logic to key off `platform` (with legacy fallback), and updates CLI/tests (e.g., `get contexts` and init/project/runtime tests) to expect `platform` writes while still reading legacy `provider` when needed.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c69d0ba7f67a480c3fd0e4559b96f8fb137813a5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->