### PR TITLE
fix(provisioner): Ensure terraform enabled flag functions

### DIFF
--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -241,11 +241,19 @@ func (s *TerraformStack) Down(blueprint *blueprintv1alpha1.Blueprint) error {
 // =============================================================================
 
 // resolveTerraformComponents resolves terraform components from the blueprint by resolving sources and paths.
+// Components with Enabled set to false are excluded from the returned list.
 func (s *TerraformStack) resolveTerraformComponents(blueprint *blueprintv1alpha1.Blueprint, projectRoot string) []blueprintv1alpha1.TerraformComponent {
 	blueprintCopy := *blueprint
 	s.resolveComponentSources(&blueprintCopy)
 	s.resolveComponentPaths(&blueprintCopy, projectRoot)
-	return blueprintCopy.TerraformComponents
+	out := make([]blueprintv1alpha1.TerraformComponent, 0, len(blueprintCopy.TerraformComponents))
+	for _, c := range blueprintCopy.TerraformComponents {
+		if c.Enabled != nil && !c.Enabled.IsEnabled() {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
 }
 
 // resolveComponentSources resolves component source names to full URLs using blueprint sources.

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -589,6 +589,60 @@ func TestStack_Down(t *testing.T) {
 		}
 	})
 
+	t.Run("ExcludesComponentsWithEnabledFalse", func(t *testing.T) {
+		stack, mocks := setup(t)
+
+		mocks.Runtime.TerraformProvider.ClearCache()
+
+		projectRoot := os.Getenv("WINDSOR_PROJECT_ROOT")
+		contextName := mocks.Runtime.ContextName
+		enabledFalse := false
+		blueprint := createTestBlueprint()
+		blueprint.Sources = append(blueprint.Sources, blueprintv1alpha1.Source{
+			Name: "source2",
+			Url:  "https://github.com/example/example2.git",
+			Ref:  blueprintv1alpha1.Reference{Branch: "main"},
+		})
+		blueprint.TerraformComponents = []blueprintv1alpha1.TerraformComponent{
+			{
+				Source: "source1",
+				Path:   "module/path1",
+			},
+			{
+				Source:  "source2",
+				Path:    "module/path2",
+				Enabled: &blueprintv1alpha1.BoolExpression{Value: &enabledFalse, IsExpr: false},
+			},
+		}
+
+		path1Dir := filepath.Join(projectRoot, ".windsor", "contexts", contextName, "terraform", "module/path1")
+		if err := os.MkdirAll(path1Dir, 0755); err != nil {
+			t.Fatalf("Failed to create directory: %v", err)
+		}
+
+		var terraformCommands []string
+		mocks.Shell.ExecProgressFunc = func(message string, command string, args ...string) (string, error) {
+			if command == "terraform" {
+				terraformCommands = append(terraformCommands, strings.Join(args, " "))
+			}
+			return "", nil
+		}
+
+		if err := stack.Down(blueprint); err != nil {
+			t.Errorf("Expected Down to return nil, got %v", err)
+		}
+
+		for _, cmd := range terraformCommands {
+			if strings.Contains(cmd, "path2") {
+				t.Errorf("Expected no terraform commands for path2 (enabled: false), but found: %v", terraformCommands)
+				break
+			}
+		}
+		if len(terraformCommands) == 0 {
+			t.Errorf("Expected terraform commands for path1 (enabled), but got none: %v", terraformCommands)
+		}
+	})
+
 	t.Run("SkipComponentsWithDestroyFalse", func(t *testing.T) {
 		stack, mocks := setup(t)
 


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes stack execution order/selection by excluding components with `Enabled: false`, which could alter which infrastructure gets applied/destroyed if blueprints relied on previous behavior. Scope is small and covered by a new regression test.
> 
> **Overview**
> `TerraformStack.resolveTerraformComponents` now filters out blueprint `TerraformComponents` where `Enabled` is explicitly set and evaluates to false, so disabled components are not processed by `Up`/`Down`.
> 
> Adds a `stack_test.go` regression test (`ExcludesComponentsWithEnabledFalse`) asserting no Terraform commands are executed for disabled components during `Down`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b2691df03cbcdc3093c6ad3344334598a73d31e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->