### PR TITLE
fix(tools): Require minimum lima version for colima-incus

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -113,6 +113,10 @@ const MinimumVersionKubectl = "1.27.0"
 
 const MinimumVersionLima = "1.0.0"
 
+// MinimumVersionLimaIncus is the minimum limactl version when using colima with platform incus.
+// Lima 1.x can hang after "Terminal is not available"; 2.0.3+ is required for reliable colima+incus startup.
+const MinimumVersionLimaIncus = "2.0.3"
+
 const MinimumVersionTerraform = "1.7.0"
 
 const MinimumVersion1Password = "2.15.0"

--- a/pkg/runtime/tools/tools_manager.go
+++ b/pkg/runtime/tools/tools_manager.go
@@ -196,8 +196,12 @@ func (t *BaseToolsManager) checkColima() error {
 	if limactlVersion == "" {
 		return fmt.Errorf("failed to extract limactl version")
 	}
-	if compareVersion(limactlVersion, constants.MinimumVersionLima) < 0 {
-		return fmt.Errorf("limactl version %s is below the minimum required version %s", limactlVersion, constants.MinimumVersionLima)
+	minLima := constants.MinimumVersionLima
+	if t.configHandler.GetString("platform") == "incus" {
+		minLima = constants.MinimumVersionLimaIncus
+	}
+	if compareVersion(limactlVersion, minLima) < 0 {
+		return fmt.Errorf("limactl version %s is below the minimum required version %s (use same PATH as in core repo or upgrade limactl)", limactlVersion, minLima)
 	}
 
 	return nil


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, config-gated change to tool version checks that only affects environments running `colima` with `platform=incus`, plus a clearer error message.
> 
> **Overview**
> Updates the `colima` tool check to enforce a higher minimum `limactl` version when `platform` is set to `incus`, using a new constant `MinimumVersionLimaIncus` (2.0.3) to avoid known startup hangs.
> 
> Also improves the `limactl` version failure message to include guidance about PATH consistency/upgrading.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3aedff27ff2920135297038d0a825d972851d6a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->