### PR TITLE
fix(runtime/terraform): Return error when terraform_output fails

### DIFF
--- a/pkg/runtime/terraform/provider.go
+++ b/pkg/runtime/terraform/provider.go
@@ -812,7 +812,7 @@ func (p *terraformProvider) prepareTerraformContext(componentID string) (*terraf
 func (p *terraformProvider) withTerraformContext(componentID string, fn func(*terraformContext) (map[string]any, error)) (map[string]any, error) {
 	ctx, originalEnvVars, err := p.prepareTerraformContext(componentID)
 	if err != nil {
-		return make(map[string]any), nil
+		return nil, fmt.Errorf("failed to prepare terraform context for component '%s': %w", componentID, err)
 	}
 
 	cleanup := func() {

--- a/pkg/runtime/terraform/provider_public_test.go
+++ b/pkg/runtime/terraform/provider_public_test.go
@@ -289,13 +289,16 @@ func TestTerraformProvider_CacheOutputs(t *testing.T) {
 		}
 	})
 
-	t.Run("ReturnsNoErrorWhenComponentNotFound", func(t *testing.T) {
+	t.Run("ReturnsErrorWhenComponentNotFound", func(t *testing.T) {
 		mocks := setupMocks(t)
 
 		err := mocks.Provider.CacheOutputs("nonexistent-component")
 
-		if err != nil {
-			t.Errorf("Expected no error for nonexistent component (graceful fallback), got: %v", err)
+		if err == nil {
+			t.Fatal("Expected error for nonexistent component")
+		}
+		if !strings.Contains(err.Error(), "failed to prepare terraform context") {
+			t.Errorf("Expected terraform context preparation error, got: %v", err)
 		}
 	})
 }
@@ -831,12 +834,15 @@ terraform:
 		// When getting output
 		output, err := mocks.Provider.getOutput("test-component", "any-key", `terraform_output("test-component", "any-key")`, true)
 
-		// Then it should return nil without error (graceful fallback)
-		if err != nil {
-			t.Errorf("Expected no error for graceful fallback, got: %v", err)
+		// Then it should return an error
+		if err == nil {
+			t.Fatal("Expected error when context preparation fails")
+		}
+		if !strings.Contains(err.Error(), "failed to get terraform outputs") {
+			t.Errorf("Expected output retrieval error, got: %v", err)
 		}
 		if output != nil {
-			t.Errorf("Expected nil output when context prep fails, got %v", output)
+			t.Errorf("Expected nil output when error occurs, got %v", output)
 		}
 	})
 
@@ -855,12 +861,15 @@ terraform:
 		// When getting output
 		output, err := mocks.Provider.getOutput("test-component", "any-key", `terraform_output("test-component", "any-key")`, true)
 
-		// Then it should return nil without error (graceful fallback)
-		if err != nil {
-			t.Errorf("Expected no error for graceful fallback, got: %v", err)
+		// Then it should return an error
+		if err == nil {
+			t.Fatal("Expected error when backend override generation fails")
+		}
+		if !strings.Contains(err.Error(), "failed to get terraform outputs") {
+			t.Errorf("Expected output retrieval error, got: %v", err)
 		}
 		if output != nil {
-			t.Errorf("Expected nil output when context prep fails, got %v", output)
+			t.Errorf("Expected nil output when error occurs, got %v", output)
 		}
 	})
 
@@ -2408,19 +2417,21 @@ terraform:
 		}
 	})
 
-	t.Run("ReturnsEmptyMapWhenComponentNotFound", func(t *testing.T) {
+	t.Run("ReturnsErrorWhenComponentNotFound", func(t *testing.T) {
 		// Given a provider with nonexistent component
 		mocks := setupMocks(t)
 
 		// When getting terraform outputs for nonexistent component
 		outputs, err := mocks.Provider.GetTerraformOutputs("nonexistent")
-		// Then it should return empty map without error (enables ?? fallback)
-		if err != nil {
-			t.Fatalf("Expected no error for graceful fallback, got: %v", err)
+		// Then it should return an error
+		if err == nil {
+			t.Fatal("Expected error for nonexistent component")
 		}
-
-		if len(outputs) != 0 {
-			t.Errorf("Expected empty map, got: %v", outputs)
+		if !strings.Contains(err.Error(), "failed to prepare terraform context") {
+			t.Errorf("Expected terraform context preparation error, got: %v", err)
+		}
+		if outputs != nil {
+			t.Errorf("Expected nil outputs when context preparation fails, got: %v", outputs)
 		}
 	})
 


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime behavior from silent fallback to returning hard errors when Terraform context setup fails (e.g., missing component, env var/backend override setup issues), which may break callers that previously relied on nil errors/empty outputs.
> 
> **Overview**
> Stops treating Terraform context preparation failures as a *graceful fallback*: `withTerraformContext` now returns a wrapped error (and `nil` outputs) when setup fails instead of `empty map + nil`.
> 
> Updates tests to expect errors for `GetTerraformOutputs`/`CacheOutputs` on missing components and for `terraform_output` lookups when context setup (e.g., `Setenv` or backend override generation) fails.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ba86834bddfde416f2bc0b2fd6fa47e59a06291. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->