### PR TITLE
fix(runtime/env): Ensure appropriate reset of DOCKER_HOST variable

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -49,14 +49,12 @@ var initCmd = &cobra.Command{
 
 		contextName := "local"
 		changingContext := len(args) > 0
+		tempRt := runtime.NewRuntime(rtOpts...)
+		if _, err := tempRt.Shell.WriteResetToken(); err != nil {
+			return fmt.Errorf("failed to write reset token: %w", err)
+		}
 		if changingContext {
 			contextName = args[0]
-
-			tempRt := runtime.NewRuntime(rtOpts...)
-
-			if _, err := tempRt.Shell.WriteResetToken(); err != nil {
-				return fmt.Errorf("failed to write reset token: %w", err)
-			}
 
 			if err := tempRt.ConfigHandler.SetContext(contextName); err != nil {
 				return fmt.Errorf("failed to set context: %w", err)
@@ -157,12 +155,6 @@ var initCmd = &cobra.Command{
 
 		if err := proj.Configure(flagOverrides); err != nil {
 			return err
-		}
-
-		if !changingContext {
-			if err := rt.HandleSessionReset(); err != nil {
-				return fmt.Errorf("failed to handle session reset: %w", err)
-			}
 		}
 
 		var blueprintURL []string

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1231,15 +1231,15 @@ func TestInitCmd(t *testing.T) {
 		}
 	})
 
-	t.Run("CallsHandleSessionResetWhenNoContextProvided", func(t *testing.T) {
+	t.Run("WritesResetTokenWhenNoContextProvided", func(t *testing.T) {
 		// Given a temporary directory with mocked dependencies
 		mocks := setupInitTest(t)
 
-		// And tracking whether Shell.CheckResetFlags is called (which HandleSessionReset calls)
-		var checkResetFlagsCalled bool
-		mocks.Shell.Shell.CheckResetFlagsFunc = func() (bool, error) {
-			checkResetFlagsCalled = true
-			return false, nil
+		// And tracking whether WriteResetToken is called
+		var writeResetTokenCalled bool
+		mocks.Shell.Shell.WriteResetTokenFunc = func() (string, error) {
+			writeResetTokenCalled = true
+			return "test-token", nil
 		}
 
 		// When executing the init command without a context name
@@ -1255,20 +1255,20 @@ func TestInitCmd(t *testing.T) {
 			t.Errorf("Expected success, got error: %v", err)
 		}
 
-		// And CheckResetFlags should have been called (indicating HandleSessionReset was called)
-		if !checkResetFlagsCalled {
-			t.Error("Expected CheckResetFlags to be called (via HandleSessionReset), but it was not")
+		// And WriteResetToken should have been called
+		if !writeResetTokenCalled {
+			t.Error("Expected WriteResetToken to be called when no context name is provided, but it was not")
 		}
 	})
 
-	t.Run("HandlesHandleSessionResetError", func(t *testing.T) {
+	t.Run("HandlesWriteResetTokenErrorWhenNoContextProvided", func(t *testing.T) {
 		// Given a temporary directory with mocked dependencies
 		mocks := setupInitTest(t)
 
-		// And CheckResetFlags returns an error (which HandleSessionReset will propagate)
-		expectedError := fmt.Errorf("failed to check reset flags")
-		mocks.Shell.Shell.CheckResetFlagsFunc = func() (bool, error) {
-			return false, expectedError
+		// And WriteResetToken returns an error
+		expectedError := fmt.Errorf("failed to write reset token")
+		mocks.Shell.Shell.WriteResetTokenFunc = func() (string, error) {
+			return "", expectedError
 		}
 
 		// When executing the init command
@@ -1280,13 +1280,13 @@ func TestInitCmd(t *testing.T) {
 
 		// Then an error should occur
 		if err == nil {
-			t.Error("Expected error when HandleSessionReset fails, got nil")
+			t.Error("Expected error when WriteResetToken fails, got nil")
 			return
 		}
 
 		// And the error should contain the expected message
-		if !strings.Contains(err.Error(), "failed to handle session reset") {
-			t.Errorf("Expected error message to contain 'failed to handle session reset', got: %v", err)
+		if !strings.Contains(err.Error(), "failed to write reset token") {
+			t.Errorf("Expected error message to contain 'failed to write reset token', got: %v", err)
 		}
 	})
 
@@ -1388,9 +1388,9 @@ func TestInitCmd(t *testing.T) {
 			t.Errorf("Expected success, got error: %v", err)
 		}
 
-		// And WriteResetToken should not have been called
-		if writeResetTokenCalled {
-			t.Error("Expected WriteResetToken to not be called when no context name is provided, but it was called")
+		// And WriteResetToken should have been called
+		if !writeResetTokenCalled {
+			t.Error("Expected WriteResetToken to be called when no context name is provided, but it was not")
 		}
 
 		// And SetContext should not have been called
@@ -1398,9 +1398,9 @@ func TestInitCmd(t *testing.T) {
 			t.Error("Expected SetContext to not be called when no context name is provided, but it was called")
 		}
 
-		// And HandleSessionReset SHOULD have been called (not skipped when not changing contexts)
-		if !checkResetFlagsCalled {
-			t.Error("Expected HandleSessionReset to be called when no context name is provided, but it was not")
+		// And HandleSessionReset should not have been called (reset is deferred to next env command)
+		if checkResetFlagsCalled {
+			t.Error("Expected HandleSessionReset not to be called when no context name is provided, but it was called")
 		}
 	})
 

--- a/pkg/runtime/env/virt_env.go
+++ b/pkg/runtime/env/virt_env.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
@@ -58,17 +57,7 @@ func (e *VirtEnvPrinter) GetEnvVars() (map[string]string, error) {
 	workstationRuntime := e.configHandler.GetString("workstation.runtime")
 	platform := e.configHandler.GetString("platform")
 	_, dockerHostExists := e.shims.LookupEnv("DOCKER_HOST")
-	_, managedEnvExists := e.shims.LookupEnv("WINDSOR_MANAGED_ENV")
-
-	isDockerHostManaged := false
-	if managedEnvExists {
-		managedEnvStr := e.shims.Getenv("WINDSOR_MANAGED_ENV")
-		if strings.Contains(managedEnvStr, "DOCKER_HOST") {
-			isDockerHostManaged = true
-		}
-	}
-
-	if platform != "incus" && workstationRuntime != "" && (!dockerHostExists || isDockerHostManaged) {
+	if platform != "incus" && workstationRuntime != "" && !dockerHostExists {
 		homeDir, err := e.shims.UserHomeDir()
 		if err != nil {
 			return nil, fmt.Errorf("error retrieving user home directory: %w", err)
@@ -111,7 +100,6 @@ func (e *VirtEnvPrinter) GetEnvVars() (map[string]string, error) {
 				contextName = "default"
 			}
 		}
-
 		dockerConfigContent := fmt.Sprintf(`{
 			"auths": {},
 			"currentContext": "%s",
@@ -134,6 +122,7 @@ func (e *VirtEnvPrinter) GetEnvVars() (map[string]string, error) {
 	} else if platform != "incus" && dockerHostExists {
 		if dockerHostValue, _ := e.shims.LookupEnv("DOCKER_HOST"); dockerHostValue != "" {
 			envVars["DOCKER_HOST"] = dockerHostValue
+			e.SetManagedEnv("DOCKER_HOST")
 		}
 	}
 
@@ -153,7 +142,6 @@ func (e *VirtEnvPrinter) GetEnvVars() (map[string]string, error) {
 		envVars["INCUS_SOCKET"] = filepath.ToSlash(incusSocketPath)
 		e.SetManagedEnv("INCUS_SOCKET")
 	}
-
 	return envVars, nil
 }
 

--- a/pkg/runtime/env/virt_env_test.go
+++ b/pkg/runtime/env/virt_env_test.go
@@ -551,7 +551,7 @@ contexts:
 			t.Errorf("DOCKER_HOST = %v, want %v", envVars["DOCKER_HOST"], expectedDockerHost)
 		}
 
-		// And DOCKER_HOST should NOT be marked as managed (since it was manually set)
+		// And DOCKER_HOST should be marked as managed for reset tracking
 		managedEnv := printer.GetManagedEnv()
 		isManaged := false
 		for _, env := range managedEnv {
@@ -560,12 +560,12 @@ contexts:
 				break
 			}
 		}
-		if isManaged {
-			t.Error("Expected DOCKER_HOST not to be marked as managed when manually set")
+		if !isManaged {
+			t.Error("Expected DOCKER_HOST to be marked as managed for reset tracking")
 		}
 	})
 
-	t.Run("DockerHostManagedByWindsorIsOverridden", func(t *testing.T) {
+	t.Run("DockerHostManagedByWindsorIsPreserved", func(t *testing.T) {
 		// Given a new VirtEnvPrinter with DOCKER_HOST already managed by Windsor
 		os.Unsetenv("DOCKER_HOST")
 		mocks := setupVirtEnvMocks(t)
@@ -612,18 +612,13 @@ contexts:
 			t.Fatalf("GetEnvVars returned an error: %v", err)
 		}
 
-		// And DOCKER_HOST should be set based on workstation.runtime (not the old managed value)
-		var expectedDockerHost string
-		if mocks.Shims.Goos() == "windows" {
-			expectedDockerHost = "npipe:////./pipe/docker_engine"
-		} else {
-			expectedDockerHost = fmt.Sprintf("unix://%s/.colima/windsor-test-context/docker.sock", filepath.ToSlash("/mock/home"))
-		}
+		// And DOCKER_HOST should preserve the existing managed value unless reset has cleared it
+		expectedDockerHost := "tcp://old-managed-host:2375"
 		if envVars["DOCKER_HOST"] != expectedDockerHost {
 			t.Errorf("DOCKER_HOST = %v, want %v", envVars["DOCKER_HOST"], expectedDockerHost)
 		}
 
-		// And DOCKER_HOST should be marked as managed
+		// And DOCKER_HOST should be marked as managed for reset tracking
 		managedEnv := printer.GetManagedEnv()
 		isManaged := false
 		for _, env := range managedEnv {
@@ -633,7 +628,7 @@ contexts:
 			}
 		}
 		if !isManaged {
-			t.Error("Expected DOCKER_HOST to be marked as managed when set by workstation.runtime")
+			t.Error("Expected DOCKER_HOST to be marked as managed when preserved")
 		}
 	})
 
@@ -689,7 +684,7 @@ contexts:
 			t.Errorf("DOCKER_HOST = %v, want %v", envVars["DOCKER_HOST"], expectedDockerHost)
 		}
 
-		// And DOCKER_HOST should NOT be marked as managed
+		// And DOCKER_HOST should be marked as managed for reset tracking
 		managedEnv := printer.GetManagedEnv()
 		isManaged := false
 		for _, env := range managedEnv {
@@ -698,8 +693,8 @@ contexts:
 				break
 			}
 		}
-		if isManaged {
-			t.Error("Expected DOCKER_HOST not to be marked as managed when unmanaged value is preserved")
+		if !isManaged {
+			t.Error("Expected DOCKER_HOST to be marked as managed when unmanaged value is preserved")
 		}
 	})
 


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how `DOCKER_HOST` is selected and marked as Windsor-managed, which can affect Docker connectivity and reset behavior across shells/contexts. Also alters `init` reset flow by removing immediate session reset handling, so regressions would show up as stale env until the next env command.
> 
> **Overview**
> **Improves reset tracking for Docker environment variables.** `VirtEnvPrinter.GetEnvVars` now only derives `DOCKER_HOST` from `workstation.runtime` when `DOCKER_HOST` is *not* already set, and it always records `DOCKER_HOST` as managed when it is present (including when sourced from the existing environment), simplifying and making reset behavior consistent.
> 
> **Adjusts `init` reset behavior.** `cmd/init` now always writes a reset token up-front (regardless of whether a context argument is provided) and stops calling `Runtime.HandleSessionReset` during `init`, deferring managed-env resets to later env commands; tests were updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42b19cfd4d2ef693c8adebae46c1d5f1fdf6f55d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->