### PR TITLE
fix(env): Include cluster vars in managed windsor env

### DIFF
--- a/pkg/runtime/env/kube_env.go
+++ b/pkg/runtime/env/kube_env.go
@@ -69,8 +69,11 @@ func (e *KubeEnvPrinter) GetEnvVars() (map[string]string, error) {
 	}
 	kubeConfigPath := filepath.Join(configRoot, ".kube", "config")
 	envVars["KUBECONFIG"] = kubeConfigPath
+	e.SetManagedEnv("KUBECONFIG")
 	envVars["KUBE_CONFIG_PATH"] = kubeConfigPath
+	e.SetManagedEnv("KUBE_CONFIG_PATH")
 	envVars["K8S_AUTH_KUBECONFIG"] = kubeConfigPath
+	e.SetManagedEnv("K8S_AUTH_KUBECONFIG")
 
 	projectRoot := os.Getenv("WINDSOR_PROJECT_ROOT")
 	if projectRoot == "" {
@@ -102,6 +105,7 @@ func (e *KubeEnvPrinter) GetEnvVars() (map[string]string, error) {
 			if len(parts) == 2 {
 				existingEnvVars[parts[0]] = parts[1]
 				envVars[parts[0]] = parts[1]
+				e.SetManagedEnv(parts[0])
 			}
 		}
 	}
@@ -145,6 +149,7 @@ func (e *KubeEnvPrinter) GetEnvVars() (map[string]string, error) {
 								return nil, fmt.Errorf("error converting volume path to absolute: %w", err)
 							}
 							envVars[envVarName] = absPath
+							e.SetManagedEnv(envVarName)
 						}
 						break
 					}

--- a/pkg/runtime/env/talos_env.go
+++ b/pkg/runtime/env/talos_env.go
@@ -64,10 +64,12 @@ func (e *TalosEnvPrinter) GetEnvVars() (map[string]string, error) {
 	if clusterDriver == "talos" {
 		talosConfigPath := filepath.Join(configRoot, ".talos", "config")
 		envVars["TALOSCONFIG"] = talosConfigPath
+		e.SetManagedEnv("TALOSCONFIG")
 	}
 	if platform == "omni" {
 		omniConfigPath := filepath.Join(configRoot, ".omni", "config")
 		envVars["OMNICONFIG"] = omniConfigPath
+		e.SetManagedEnv("OMNICONFIG")
 	}
 	return envVars, nil
 }


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adds `SetManagedEnv` calls to track which env vars Windsor manages, without changing the computed values or control flow.
> 
> **Overview**
> Ensures cluster-related environment variables are included in Windsor’s managed-env tracking.
> 
> `KubeEnvPrinter.GetEnvVars` now marks `KUBECONFIG`, `KUBE_CONFIG_PATH`, `K8S_AUTH_KUBECONFIG`, and any discovered/generated `PV_*` variables as managed, and `TalosEnvPrinter.GetEnvVars` does the same for `TALOSCONFIG` and `OMNICONFIG`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e99d5a2b8dcb02ba4904620ff060b3045c3da56. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->