### PR TITLE
fix(runtime/secrets): More descriptive unresolvable secret error

### DIFF
--- a/pkg/runtime/secrets/op_cli_secrets_provider.go
+++ b/pkg/runtime/secrets/op_cli_secrets_provider.go
@@ -81,7 +81,7 @@ func (s *OnePasswordCLISecretsProvider) ParseSecrets(input string) (string, erro
 		}
 		value, err := s.GetSecret(fmt.Sprintf("%s.%s", secret, field))
 		if err != nil {
-			return "<ERROR: secret not found>", true
+			return fmt.Sprintf("<ERROR: failed to resolve: %s.%s: %s>", secret, field, err), true
 		}
 		return value, true
 	})


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only changes the user-facing error string returned when a 1Password secret cannot be resolved, without affecting lookup logic or security behavior.
> 
> **Overview**
> When `${{ op.<id>.<secret>.<field> }}` substitution fails in `OnePasswordCLISecretsProvider.ParseSecrets`, the placeholder now includes the *specific* `secret.field` and the underlying error instead of a generic "secret not found" message.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a02e33e1ad4188b1f4508253b9d4ef8c319920bf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->