### PR TITLE
feat(composer/blueprint): Inject repo info in to context config

### DIFF
--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -9,8 +9,8 @@ import (
 
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/composer/artifact"
-	runtimegit "github.com/windsorcli/cli/pkg/runtime/git"
 	"github.com/windsorcli/cli/pkg/runtime"
+	runtimegit "github.com/windsorcli/cli/pkg/runtime/git"
 )
 
 // BlueprintHandler manages the lifecycle of infrastructure blueprints.
@@ -513,6 +513,11 @@ func (h *BaseBlueprintHandler) loadNestedSources() error {
 // against the merged scope if possible. If a Terraform provider is configured, the composed components
 // are registered with the provider. Any errors during facet processing or composition are returned.
 func (h *BaseBlueprintHandler) processAndCompose() error {
+	repositoryScope := h.getRepositoryScopeValues()
+	if bp, ok := h.processor.(*BaseBlueprintProcessor); ok {
+		bp.SetExtraScope(repositoryScope)
+	}
+
 	if h.traceCollector != nil {
 		if bp, ok := h.processor.(*BaseBlueprintProcessor); ok {
 			bp.SetTraceCollector(h.traceCollector)
@@ -695,7 +700,85 @@ func (h *BaseBlueprintHandler) getConfigValues() map[string]any {
 	if err != nil {
 		return nil
 	}
+	if repositoryScope := h.getRepositoryScopeValues(); repositoryScope != nil {
+		values = MergeScopeMaps(values, repositoryScope)
+	}
 	return values
+}
+
+// getRepositoryScopeValues returns repository values for expression/config scopes, excluding secrets.
+func (h *BaseBlueprintHandler) getRepositoryScopeValues() map[string]any {
+	repo := h.getEffectiveRepository()
+	if repo.Url == "" {
+		return nil
+	}
+
+	repositoryValue := map[string]any{
+		"url": repo.Url,
+	}
+	refValue := make(map[string]any)
+	if repo.Ref.Branch != "" {
+		refValue["branch"] = repo.Ref.Branch
+	}
+	if repo.Ref.Tag != "" {
+		refValue["tag"] = repo.Ref.Tag
+	}
+	if repo.Ref.SemVer != "" {
+		refValue["semver"] = repo.Ref.SemVer
+	}
+	if repo.Ref.Name != "" {
+		refValue["name"] = repo.Ref.Name
+	}
+	if repo.Ref.Commit != "" {
+		refValue["commit"] = repo.Ref.Commit
+	}
+	if len(refValue) > 0 {
+		repositoryValue["ref"] = refValue
+	}
+
+	return map[string]any{
+		"repository": repositoryValue,
+	}
+}
+
+// getEffectiveRepository resolves repository values from blueprint/runtime defaults for scope injection.
+func (h *BaseBlueprintHandler) getEffectiveRepository() blueprintv1alpha1.Repository {
+	var repo blueprintv1alpha1.Repository
+	if h.composedBlueprint != nil && h.composedBlueprint.Repository.Url != "" {
+		repo = h.composedBlueprint.Repository
+	} else if h.userBlueprintLoader != nil && h.userBlueprintLoader.GetBlueprint() != nil {
+		repo = h.userBlueprintLoader.GetBlueprint().Repository
+	}
+	return h.resolveRepositoryDefaults(repo, false)
+}
+
+// resolveRepositoryDefaults applies URL/ref/secret defaults to repository metadata.
+// When includeSecret is false, SecretName is always removed from the returned value.
+func (h *BaseBlueprintHandler) resolveRepositoryDefaults(repo blueprintv1alpha1.Repository, includeSecret bool) blueprintv1alpha1.Repository {
+	devMode := h.runtime != nil && h.runtime.ConfigHandler != nil && h.runtime.ConfigHandler.GetBool("dev")
+	if repo.Url == "" && devMode && h.runtime != nil && h.runtime.ConfigHandler != nil {
+		domain := h.runtime.ConfigHandler.GetString("dns.domain", "test")
+		folder := h.shims.FilepathBase(h.runtime.ProjectRoot)
+		if domain != "" && folder != "" && folder != "." {
+			repo.Url = fmt.Sprintf("http://git.%s/git/%s", domain, folder)
+		}
+	}
+	if repo.Url == "" && h.runtime != nil && h.runtime.Shell != nil {
+		if gitURL, err := h.runtime.Shell.ExecSilent("git", "config", "--get", "remote.origin.url"); err == nil && gitURL != "" {
+			repo.Url = runtimegit.NormalizeRemoteURL(gitURL)
+		}
+	}
+	if repo.Url != "" && repo.Ref == (blueprintv1alpha1.Reference{}) {
+		repo.Ref = blueprintv1alpha1.Reference{Branch: "main"}
+	}
+	if repo.Url != "" && includeSecret && devMode && repo.SecretName == nil {
+		secretName := "flux-system"
+		repo.SecretName = &secretName
+	}
+	if !includeSecret {
+		repo.SecretName = nil
+	}
+	return repo
 }
 
 // setRepositoryDefaults sets default repository values on the composed blueprint when
@@ -706,42 +789,7 @@ func (h *BaseBlueprintHandler) setRepositoryDefaults() {
 	if h.composedBlueprint == nil || h.runtime == nil {
 		return
 	}
-	if h.composedBlueprint.Repository.Url != "" {
-		devMode := h.runtime.ConfigHandler != nil && h.runtime.ConfigHandler.GetBool("dev")
-		if h.composedBlueprint.Repository.Ref == (blueprintv1alpha1.Reference{}) {
-			h.composedBlueprint.Repository.Ref = blueprintv1alpha1.Reference{Branch: "main"}
-		}
-		if devMode && h.composedBlueprint.Repository.SecretName == nil {
-			secretName := "flux-system"
-			h.composedBlueprint.Repository.SecretName = &secretName
-		}
-		return
-	}
-
-	devMode := h.runtime.ConfigHandler != nil && h.runtime.ConfigHandler.GetBool("dev")
-
-	if devMode {
-		domain := h.runtime.ConfigHandler.GetString("dns.domain", "test")
-		folder := h.shims.FilepathBase(h.runtime.ProjectRoot)
-		if domain != "" && folder != "" && folder != "." {
-			h.composedBlueprint.Repository.Url = fmt.Sprintf("http://git.%s/git/%s", domain, folder)
-		}
-	}
-
-	if h.composedBlueprint.Repository.Url == "" && h.runtime.Shell != nil {
-		if gitURL, err := h.runtime.Shell.ExecSilent("git", "config", "--get", "remote.origin.url"); err == nil && gitURL != "" {
-			h.composedBlueprint.Repository.Url = runtimegit.NormalizeRemoteURL(gitURL)
-		}
-	}
-	if h.composedBlueprint.Repository.Url != "" {
-		if h.composedBlueprint.Repository.Ref == (blueprintv1alpha1.Reference{}) {
-			h.composedBlueprint.Repository.Ref = blueprintv1alpha1.Reference{Branch: "main"}
-		}
-		if devMode && h.composedBlueprint.Repository.SecretName == nil {
-			secretName := "flux-system"
-			h.composedBlueprint.Repository.SecretName = &secretName
-		}
-	}
+	h.composedBlueprint.Repository = h.resolveRepositoryDefaults(h.composedBlueprint.Repository, true)
 }
 
 // clearLocalTemplateSource clears Source on terraform components and kustomizations when Source

--- a/pkg/composer/blueprint/handler_test.go
+++ b/pkg/composer/blueprint/handler_test.go
@@ -1242,6 +1242,117 @@ func TestHandler_getConfigValues(t *testing.T) {
 			t.Errorf("Expected key='value', got '%v'", values["key"])
 		}
 	})
+
+	t.Run("MergesRepositoryScopeWithoutSecret", func(t *testing.T) {
+		mocks := setupHandlerMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"key": "value"}, nil
+		}
+		secret := "flux-system"
+		handler := NewBlueprintHandler(mocks.Runtime, mocks.ArtifactBuilder)
+		handler.userBlueprintLoader = &mockLoaderImpl{
+			getSourceNameFunc: func() string { return "user" },
+			getBlueprintFunc: func() *blueprintv1alpha1.Blueprint {
+				return &blueprintv1alpha1.Blueprint{
+					Repository: blueprintv1alpha1.Repository{
+						Url:        "https://github.com/acme/repo.git",
+						SecretName: &secret,
+					},
+				}
+			},
+		}
+
+		values := handler.getConfigValues()
+
+		if values == nil {
+			t.Fatal("Expected non-nil values")
+		}
+		repository, ok := values["repository"].(map[string]any)
+		if !ok {
+			t.Fatal("Expected repository map in config values")
+		}
+		if repository["url"] != "https://github.com/acme/repo.git" {
+			t.Errorf("Expected repository.url to be merged, got %v", repository["url"])
+		}
+		if _, hasSecret := repository["secretName"]; hasSecret {
+			t.Error("Expected repository.secretName to be excluded from scope")
+		}
+		ref, ok := repository["ref"].(map[string]any)
+		if !ok {
+			t.Fatal("Expected repository.ref map in config values")
+		}
+		if ref["branch"] != "main" {
+			t.Errorf("Expected repository.ref.branch to default to main, got %v", ref["branch"])
+		}
+	})
+}
+
+func TestHandler_getRepositoryScopeValues(t *testing.T) {
+	t.Run("ReturnsNilWhenRepositoryIsEmpty", func(t *testing.T) {
+		mocks := setupHandlerMocks(t)
+		handler := NewBlueprintHandler(mocks.Runtime, mocks.ArtifactBuilder)
+		handler.runtime.ConfigHandler = nil
+		handler.runtime.Shell = nil
+		handler.userBlueprintLoader = &mockLoaderImpl{
+			getSourceNameFunc: func() string { return "user" },
+			getBlueprintFunc: func() *blueprintv1alpha1.Blueprint {
+				return &blueprintv1alpha1.Blueprint{}
+			},
+		}
+
+		values := handler.getRepositoryScopeValues()
+		if values != nil {
+			t.Errorf("Expected nil repository scope, got %v", values)
+		}
+	})
+
+	t.Run("ReturnsRepositoryWithoutSecretName", func(t *testing.T) {
+		mocks := setupHandlerMocks(t)
+		secret := "flux-system"
+		handler := NewBlueprintHandler(mocks.Runtime, mocks.ArtifactBuilder)
+		handler.userBlueprintLoader = &mockLoaderImpl{
+			getSourceNameFunc: func() string { return "user" },
+			getBlueprintFunc: func() *blueprintv1alpha1.Blueprint {
+				return &blueprintv1alpha1.Blueprint{
+					Repository: blueprintv1alpha1.Repository{
+						Url: "https://github.com/acme/repo.git",
+						Ref: blueprintv1alpha1.Reference{
+							Branch: "develop",
+							Tag:    "v1.2.3",
+							Commit: "abc123",
+						},
+						SecretName: &secret,
+					},
+				}
+			},
+		}
+
+		values := handler.getRepositoryScopeValues()
+
+		repository, ok := values["repository"].(map[string]any)
+		if !ok {
+			t.Fatal("Expected repository map")
+		}
+		if repository["url"] != "https://github.com/acme/repo.git" {
+			t.Errorf("Expected repository.url to be set, got %v", repository["url"])
+		}
+		if _, hasSecret := repository["secretName"]; hasSecret {
+			t.Error("Expected repository.secretName to be excluded")
+		}
+		ref, ok := repository["ref"].(map[string]any)
+		if !ok {
+			t.Fatal("Expected repository.ref map")
+		}
+		if ref["branch"] != "develop" {
+			t.Errorf("Expected branch develop, got %v", ref["branch"])
+		}
+		if ref["tag"] != "v1.2.3" {
+			t.Errorf("Expected tag v1.2.3, got %v", ref["tag"])
+		}
+		if ref["commit"] != "abc123" {
+			t.Errorf("Expected commit abc123, got %v", ref["commit"])
+		}
+	})
 }
 
 // =============================================================================

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -53,6 +53,7 @@ type BaseBlueprintProcessor struct {
 	traceCollector TraceCollector
 	mu             sync.Mutex
 	deferredPaths  map[string]bool
+	extraScope     map[string]any
 }
 
 // =============================================================================
@@ -73,8 +74,8 @@ func NewBlueprintProcessor(rt *runtime.Runtime) *BaseBlueprintProcessor {
 	}
 
 	return &BaseBlueprintProcessor{
-		runtime:   rt,
-		evaluator: rt.Evaluator,
+		runtime:       rt,
+		evaluator:     rt.Evaluator,
 		deferredPaths: make(map[string]bool),
 	}
 }
@@ -88,6 +89,20 @@ func NewBlueprintProcessor(rt *runtime.Runtime) *BaseBlueprintProcessor {
 // Set to nil to disable trace collection.
 func (p *BaseBlueprintProcessor) SetTraceCollector(tc TraceCollector) {
 	p.traceCollector = tc
+}
+
+// SetExtraScope sets additional scope values that are merged over context values during facet processing.
+func (p *BaseBlueprintProcessor) SetExtraScope(scope map[string]any) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if scope == nil {
+		p.extraScope = nil
+		return
+	}
+	p.extraScope = make(map[string]any, len(scope))
+	for k, v := range scope {
+		p.extraScope[k] = v
+	}
 }
 
 // GetDeferredPaths returns a copy of deferred composed paths discovered during the last ProcessFacets call.
@@ -131,6 +146,9 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 		if vals, err := p.runtime.ConfigHandler.GetContextValues(); err == nil {
 			contextScope = vals
 		}
+	}
+	if p.extraScope != nil {
+		contextScope = MergeScopeMaps(contextScope, p.extraScope)
 	}
 
 	sortedFacets := make([]blueprintv1alpha1.Facet, len(facets))

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -257,6 +257,38 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 		}
 	})
 
+	t.Run("IncludesFacetWhenConditionUsesExtraScope", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"enabled": false}, nil
+		}
+		processor.SetExtraScope(map[string]any{"enabled": true})
+
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "extra-scope"},
+				When:     "enabled == true",
+				TerraformComponents: []blueprintv1alpha1.ConditionalTerraformComponent{
+					{TerraformComponent: blueprintv1alpha1.TerraformComponent{Path: "extra"}},
+				},
+			},
+		}
+
+		target := &blueprintv1alpha1.Blueprint{}
+		_, _, err := processor.ProcessFacets(target, facets)
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if len(target.TerraformComponents) != 1 {
+			t.Fatalf("Expected 1 terraform component, got %d", len(target.TerraformComponents))
+		}
+		if target.TerraformComponents[0].Path != "extra" {
+			t.Errorf("Expected path='extra', got %s", target.TerraformComponents[0].Path)
+		}
+	})
+
 	t.Run("ExcludesFacetWhenConditionFalse", func(t *testing.T) {
 		// Given a facet with false condition
 		mocks := setupProcessorMocks(t)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the expression/config scope used during facet processing by injecting repository metadata (with defaults), which can alter which facets/components are included and how inputs evaluate across blueprints.
> 
> **Overview**
> Adds repository metadata (URL and resolved `ref` fields) into the scope used for blueprint facet `when` evaluation and config merging, while *explicitly excluding* `repository.secretName` from any injected scope.
> 
> Refactors repository defaulting into `resolveRepositoryDefaults` and introduces `getRepositoryScopeValues`/`SetExtraScope` so the handler can inject repo info into the processor and config values early; updates tests to cover scope merging, default `main` branch behavior, and secret exclusion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7e52f78de5bb1f3716c55cf29fbe2566586e67a2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->