### PR TITLE
fix(runtime/git): Normalize default git URL

### DIFF
--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -765,7 +765,7 @@ func (h *BaseBlueprintHandler) resolveRepositoryDefaults(repo blueprintv1alpha1.
 	}
 	if repo.Url == "" && h.runtime != nil && h.runtime.Shell != nil {
 		if gitURL, err := h.runtime.Shell.ExecSilent("git", "config", "--get", "remote.origin.url"); err == nil && gitURL != "" {
-			repo.Url = runtimegit.NormalizeRemoteURL(gitURL)
+			repo.Url = runtimegit.NormalizeRepositoryURL(gitURL)
 		}
 	}
 	if repo.Url != "" && repo.Ref == (blueprintv1alpha1.Reference{}) {

--- a/pkg/composer/blueprint/handler_test.go
+++ b/pkg/composer/blueprint/handler_test.go
@@ -1474,9 +1474,9 @@ func TestHandler_setRepositoryDefaults(t *testing.T) {
 		// When setting repository defaults
 		handler.setRepositoryDefaults()
 
-		// Then repository should be set with git remote URL
-		if handler.composedBlueprint.Repository.Url != "https://github.com/test/repo.git" {
-			t.Errorf("Expected URL 'https://github.com/test/repo.git', got '%s'", handler.composedBlueprint.Repository.Url)
+		// Then repository should be set with normalized host/path URL
+		if handler.composedBlueprint.Repository.Url != "github.com/test/repo" {
+			t.Errorf("Expected URL 'github.com/test/repo', got '%s'", handler.composedBlueprint.Repository.Url)
 		}
 	})
 
@@ -1501,9 +1501,9 @@ func TestHandler_setRepositoryDefaults(t *testing.T) {
 		// When setting repository defaults
 		handler.setRepositoryDefaults()
 
-		// Then repository should be normalized to SSH URL
-		if handler.composedBlueprint.Repository.Url != "ssh://git@github.com/test/repo.git" {
-			t.Errorf("Expected URL 'ssh://git@github.com/test/repo.git', got '%s'", handler.composedBlueprint.Repository.Url)
+		// Then repository should be normalized to host/path URL
+		if handler.composedBlueprint.Repository.Url != "github.com/test/repo" {
+			t.Errorf("Expected URL 'github.com/test/repo', got '%s'", handler.composedBlueprint.Repository.Url)
 		}
 	})
 
@@ -1526,8 +1526,8 @@ func TestHandler_setRepositoryDefaults(t *testing.T) {
 
 		handler.setRepositoryDefaults()
 
-		if handler.composedBlueprint.Repository.Url != "git://github.com/test/repo.git" {
-			t.Errorf("Expected URL 'git://github.com/test/repo.git', got '%s'", handler.composedBlueprint.Repository.Url)
+		if handler.composedBlueprint.Repository.Url != "github.com/test/repo" {
+			t.Errorf("Expected URL 'github.com/test/repo', got '%s'", handler.composedBlueprint.Repository.Url)
 		}
 	})
 
@@ -1574,8 +1574,8 @@ func TestHandler_setRepositoryDefaults(t *testing.T) {
 
 		handler.setRepositoryDefaults()
 
-		if handler.composedBlueprint.Repository.Url != "https://1invalid://github.com/test/repo.git" {
-			t.Errorf("Expected URL 'https://1invalid://github.com/test/repo.git', got '%s'", handler.composedBlueprint.Repository.Url)
+		if handler.composedBlueprint.Repository.Url != "github.com/test/repo" {
+			t.Errorf("Expected URL 'github.com/test/repo', got '%s'", handler.composedBlueprint.Repository.Url)
 		}
 	})
 
@@ -1598,8 +1598,8 @@ func TestHandler_setRepositoryDefaults(t *testing.T) {
 
 		handler.setRepositoryDefaults()
 
-		if handler.composedBlueprint.Repository.Url != "git+ssh://github.com/test/repo.git" {
-			t.Errorf("Expected URL 'git+ssh://github.com/test/repo.git', got '%s'", handler.composedBlueprint.Repository.Url)
+		if handler.composedBlueprint.Repository.Url != "github.com/test/repo" {
+			t.Errorf("Expected URL 'github.com/test/repo', got '%s'", handler.composedBlueprint.Repository.Url)
 		}
 	})
 

--- a/pkg/runtime/git/remote_url.go
+++ b/pkg/runtime/git/remote_url.go
@@ -5,7 +5,10 @@
 
 package git
 
-import "strings"
+import (
+	"net/url"
+	"strings"
+)
 
 // =============================================================================
 // Public Methods
@@ -24,6 +27,60 @@ func NormalizeRemoteURL(value string) string {
 		return normalized
 	}
 	return "https://" + normalized
+}
+
+// NormalizeRepositoryURL normalizes a git remote URL for blueprint repository metadata.
+// It returns host/path form (for example github.com/org/repo) when host and path can
+// be derived from the input. It strips protocol, user info, leading/trailing slashes,
+// and a trailing .git suffix from the path. If host/path cannot be derived, it falls
+// back to NormalizeRemoteURL.
+func NormalizeRepositoryURL(value string) string {
+	normalized := strings.TrimSpace(value)
+	if normalized == "" {
+		return ""
+	}
+
+	if strings.HasPrefix(normalized, "git@") && strings.Contains(normalized, ":") {
+		parts := strings.SplitN(strings.TrimPrefix(normalized, "git@"), ":", 2)
+		if len(parts) == 2 {
+			host := strings.TrimSpace(parts[0])
+			repoPath := normalizeRepositoryPath(parts[1])
+			if host != "" && repoPath != "" {
+				return host + "/" + repoPath
+			}
+		}
+		return NormalizeRemoteURL(normalized)
+	}
+
+	if strings.Contains(normalized, "://") {
+		if parsed, err := url.Parse(normalized); err == nil {
+			host := strings.TrimSpace(parsed.Host)
+			repoPath := normalizeRepositoryPath(parsed.Path)
+			if host != "" && repoPath != "" {
+				return host + "/" + repoPath
+			}
+		}
+		parts := strings.SplitN(normalized, "://", 2)
+		if len(parts) == 2 {
+			tail := strings.TrimSpace(parts[1])
+			hostPathParts := strings.SplitN(tail, "/", 2)
+			if len(hostPathParts) == 2 {
+				host := strings.TrimSpace(hostPathParts[0])
+				repoPath := normalizeRepositoryPath(hostPathParts[1])
+				if host != "" && repoPath != "" {
+					return host + "/" + repoPath
+				}
+			}
+		}
+		return NormalizeRemoteURL(normalized)
+	}
+
+	repoPath := normalizeRepositoryPath(normalized)
+	if repoPath == "" {
+		return ""
+	}
+
+	return repoPath
 }
 
 // =============================================================================
@@ -54,4 +111,11 @@ func hasExplicitURLScheme(value string) bool {
 // isASCIILetter reports whether a byte is an ASCII letter.
 func isASCIILetter(ch byte) bool {
 	return (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z')
+}
+
+// normalizeRepositoryPath trims separators and strips a trailing .git suffix.
+func normalizeRepositoryPath(value string) string {
+	trimmed := strings.Trim(strings.TrimSpace(value), "/")
+	trimmed = strings.TrimSuffix(trimmed, ".git")
+	return strings.Trim(trimmed, "/")
 }

--- a/pkg/runtime/git/remote_url_test.go
+++ b/pkg/runtime/git/remote_url_test.go
@@ -45,3 +45,54 @@ func TestNormalizeRemoteURL(t *testing.T) {
 		}
 	})
 }
+
+func TestNormalizeRepositoryURL(t *testing.T) {
+	t.Run("NormalizesHTTPSRemoteToHostPath", func(t *testing.T) {
+		normalized := NormalizeRepositoryURL("https://github.com/owner/repo.git")
+		if normalized != "github.com/owner/repo" {
+			t.Errorf("Expected github.com/owner/repo, got %s", normalized)
+		}
+	})
+
+	t.Run("NormalizesScpStyleSSHRemoteToHostPath", func(t *testing.T) {
+		normalized := NormalizeRepositoryURL("git@github.com:owner/repo.git")
+		if normalized != "github.com/owner/repo" {
+			t.Errorf("Expected github.com/owner/repo, got %s", normalized)
+		}
+	})
+
+	t.Run("NormalizesGitSchemeRemoteToHostPath", func(t *testing.T) {
+		normalized := NormalizeRepositoryURL("git://github.com/owner/repo.git")
+		if normalized != "github.com/owner/repo" {
+			t.Errorf("Expected github.com/owner/repo, got %s", normalized)
+		}
+	})
+
+	t.Run("NormalizesExtendedSchemeRemoteToHostPath", func(t *testing.T) {
+		normalized := NormalizeRepositoryURL("git+ssh://github.com/owner/repo.git")
+		if normalized != "github.com/owner/repo" {
+			t.Errorf("Expected github.com/owner/repo, got %s", normalized)
+		}
+	})
+
+	t.Run("NormalizesInvalidSchemePrefixUsingParsedHostPath", func(t *testing.T) {
+		normalized := NormalizeRepositoryURL("1invalid://github.com/owner/repo.git")
+		if normalized != "github.com/owner/repo" {
+			t.Errorf("Expected github.com/owner/repo, got %s", normalized)
+		}
+	})
+
+	t.Run("FallsBackForFileSchemeRemote", func(t *testing.T) {
+		normalized := NormalizeRepositoryURL("file:///tmp/repo")
+		if normalized != "file:///tmp/repo" {
+			t.Errorf("Expected file:///tmp/repo, got %s", normalized)
+		}
+	})
+
+	t.Run("PreservesBareHostPathRemoteWithoutProtocol", func(t *testing.T) {
+		normalized := NormalizeRepositoryURL("github.com/owner/repo.git")
+		if normalized != "github.com/owner/repo" {
+			t.Errorf("Expected github.com/owner/repo, got %s", normalized)
+		}
+	})
+}


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the default `repository.url` written into composed blueprints from a transport URL (e.g. `https://.../.git`) to a stripped `host/path` form, which could affect any downstream consumers expecting a full clone URL. URL parsing now has additional edge cases (schemes, scp-style SSH, invalid prefixes) covered by tests, but behavior is intentionally different.
> 
> **Overview**
> **Blueprint repository defaults now store a canonical `host/path` value** instead of a full remote URL with scheme/`.git`. When `BlueprintHandler` falls back to `git config remote.origin.url`, it now uses the new `runtimegit.NormalizeRepositoryURL` to strip protocol/userinfo, trim slashes, and remove a trailing `.git`.
> 
> Adds `NormalizeRepositoryURL` (with `net/url` parsing plus fallbacks) and corresponding tests, and updates blueprint handler tests to expect `github.com/org/repo` output across HTTPS/SSH/schemed/invalid-scheme inputs while keeping `file://` remotes unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5416c25f139038659fea36c9243571f5993c789b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->