### PR TITLE
fix(cmd/init): Fix edge case windsor init switching to local context

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -19,8 +19,7 @@ var contextGetCmd = &cobra.Command{
 	Long:         "Retrieve and display the current context from the configuration",
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		rootCmd.SetArgs(append([]string{"get", "context"}, args...))
-		return rootCmd.Execute()
+		return getContextCmd.RunE(cmd, args)
 	},
 }
 
@@ -32,8 +31,7 @@ var contextSetCmd = &cobra.Command{
 	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		rootCmd.SetArgs(append([]string{"set", "context"}, args...))
-		return rootCmd.Execute()
+		return setContextCmd.RunE(cmd, args)
 	},
 }
 
@@ -44,8 +42,7 @@ var getContextAliasCmd = &cobra.Command{
 	Long:         "Alias for 'get context'",
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		rootCmd.SetArgs(append([]string{"get", "context"}, args...))
-		return rootCmd.Execute()
+		return getContextCmd.RunE(cmd, args)
 	},
 }
 
@@ -57,8 +54,7 @@ var setContextAliasCmd = &cobra.Command{
 	Long:         "Alias for 'set context'",
 	Args:         cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		rootCmd.SetArgs(append([]string{"set", "context"}, args...))
-		return rootCmd.Execute()
+		return setContextCmd.RunE(cmd, args)
 	},
 }
 

--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -134,6 +134,35 @@ func TestContextCmd(t *testing.T) {
 		}
 	})
 
+	t.Run("SetContextMissingContextPrintsSingleError", func(t *testing.T) {
+		_, stderr := setup(t)
+		mocks := setupMocks(t)
+		tmpDir := mocks.TmpDir
+
+		contextsDir := filepath.Join(tmpDir, "contexts")
+		if err := os.MkdirAll(contextsDir, 0755); err != nil {
+			t.Fatalf("Failed to create contexts directory: %v", err)
+		}
+
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return tmpDir, nil
+		}
+
+		ctx := context.WithValue(context.Background(), runtimeOverridesKey, mocks.Runtime)
+		rootCmd.SetContext(ctx)
+		rootCmd.SetArgs([]string{"context", "set", "missing-context"})
+
+		err := Execute()
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+
+		expected := "Error: context \"missing-context\" not found. Run 'windsor init missing-context' to create it"
+		if occurrences := strings.Count(stderr.String(), expected); occurrences != 1 {
+			t.Errorf("Expected one error occurrence, got %d. stderr: %q", occurrences, stderr.String())
+		}
+	})
+
 	t.Run("GetContextAlias", func(t *testing.T) {
 		// Given proper output capture in a directory without config
 		stdout, _ := setup(t)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -69,7 +69,7 @@ var initCmd = &cobra.Command{
 
 		if !changingContext {
 			currentContext := rt.ConfigHandler.GetContext()
-			if currentContext != "" && currentContext != "local" {
+			if currentContext != "" {
 				contextName = currentContext
 			}
 		}

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -1404,6 +1404,31 @@ func TestInitCmd(t *testing.T) {
 		}
 	})
 
+	t.Run("UsesConfigHandlerContextWhenNoContextNameProvided", func(t *testing.T) {
+		mocks := setupInitTest(t)
+		mockConfigHandler := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockConfigHandler.GetContextFunc = func() string { return "chatbot" }
+		var loadBlueprintArgs []string
+		mocks.BlueprintHandler.LoadBlueprintFunc = func(urls ...string) error {
+			loadBlueprintArgs = append([]string{}, urls...)
+			return nil
+		}
+
+		cmd := createTestInitCmd()
+		ctx := context.WithValue(context.Background(), runtimeOverridesKey, mocks.Runtime)
+		ctx = context.WithValue(ctx, composerOverridesKey, mocks.Composer)
+		cmd.SetArgs([]string{})
+		cmd.SetContext(ctx)
+		execErr := cmd.Execute()
+
+		if execErr != nil {
+			t.Errorf("Expected success, got error: %v", execErr)
+		}
+		if len(loadBlueprintArgs) != 0 {
+			t.Errorf("Expected no default blueprint for persisted non-local context, got: %v", loadBlueprintArgs)
+		}
+	})
+
 	t.Run("HandlesSetContextError", func(t *testing.T) {
 		// Given a temporary directory with mocked dependencies
 		mocks := setupInitTest(t)

--- a/pkg/runtime/config/handler.go
+++ b/pkg/runtime/config/handler.go
@@ -365,25 +365,32 @@ func (c *configHandler) GetConfig() *v1alpha1.Context {
 func (c *configHandler) GetContext() string {
 	contextName := "local"
 
+	if c.shell != nil {
+		projectRoot, err := c.shell.GetProjectRoot()
+		if err != nil {
+			envContext := c.shims.Getenv("WINDSOR_CONTEXT")
+			if envContext != "" {
+				return envContext
+			}
+			return contextName
+		}
+
+		contextFilePath := filepath.Join(projectRoot, windsorDirName, contextFileName)
+		data, err := c.shims.ReadFile(contextFilePath)
+		if err == nil {
+			fileContext := strings.TrimSpace(string(data))
+			if fileContext != "" {
+				return fileContext
+			}
+		}
+	}
+
 	envContext := c.shims.Getenv("WINDSOR_CONTEXT")
 	if envContext != "" {
 		return envContext
-	} else if c.shell != nil {
-		projectRoot, err := c.shell.GetProjectRoot()
-		if err != nil {
-			return contextName
-		} else {
-			contextFilePath := filepath.Join(projectRoot, windsorDirName, contextFileName)
-			data, err := c.shims.ReadFile(contextFilePath)
-			if err != nil {
-				return contextName
-			} else {
-				return strings.TrimSpace(string(data))
-			}
-		}
-	} else {
-		return contextName
 	}
+
+	return contextName
 }
 
 // IsDevMode checks if the given context name represents a dev/local environment.

--- a/pkg/runtime/config/handler_test.go
+++ b/pkg/runtime/config/handler_test.go
@@ -1481,6 +1481,39 @@ func TestConfigHandler_GetContext(t *testing.T) {
 		}
 	})
 
+	t.Run("PrefersContextFileOverEnvironmentContext", func(t *testing.T) {
+		mocks := setupConfigMocks(t)
+		tmpDir, _ := mocks.Shell.GetProjectRoot()
+
+		os.Setenv("WINDSOR_CONTEXT", "env-context")
+
+		handler := NewConfigHandler(mocks.Shell)
+
+		contextFilePath := filepath.Join(tmpDir, ".windsor", "context")
+		os.MkdirAll(filepath.Dir(contextFilePath), 0755)
+		os.WriteFile(contextFilePath, []byte("file-context"), 0644)
+
+		context := handler.GetContext()
+
+		if context != "file-context" {
+			t.Errorf("Expected 'file-context', got '%s'", context)
+		}
+	})
+
+	t.Run("UsesEnvironmentContextWhenContextFileDoesNotExist", func(t *testing.T) {
+		mocks := setupConfigMocks(t)
+
+		os.Setenv("WINDSOR_CONTEXT", "env-context")
+
+		handler := NewConfigHandler(mocks.Shell)
+
+		context := handler.GetContext()
+
+		if context != "env-context" {
+			t.Errorf("Expected 'env-context', got '%s'", context)
+		}
+	})
+
 	t.Run("ReadsContextFromFile", func(t *testing.T) {
 		mocks := setupConfigMocks(t)
 		tmpDir, _ := mocks.Shell.GetProjectRoot()


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how the active context is resolved (now prefers `.windsor/context` over `WINDSOR_CONTEXT`) and how `windsor init` selects a context when none is provided, which can affect which environment is initialized in existing projects.
> 
> **Overview**
> Fixes several context-selection edge cases by **routing legacy `windsor context (get|set)` and `get-context`/`set-context` directly to the new `get context`/`set context` handlers** instead of re-invoking `rootCmd`, avoiding duplicated execution/error output.
> 
> Updates runtime context resolution so `ConfigHandler.GetContext()` **prefers a non-empty `.windsor/context` value** and only falls back to `WINDSOR_CONTEXT` (or `local`) when the file is missing/empty or project root can’t be determined.
> 
> Adjusts `windsor init` so that when no context arg is provided it **uses whatever context is already persisted in config (including `local`)**, and adds tests covering the missing-context error output and the non-local persisted-context init behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b33ec9aa768a8e35840e7d6e1cd89100bf3123c9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->