### PR TITLE
chore(cursor): Build out basic skills

### DIFF
--- a/.cursor/skills/windsor-architecture-patterns/SKILL.md
+++ b/.cursor/skills/windsor-architecture-patterns/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: windsor-architecture-patterns
+description: Enforce Windsor CLI architecture boundaries and dependency wiring patterns. Use when adding features or refactoring across cmd, runtime, evaluator, secrets, terraform, or composer packages, especially when deciding ownership of logic and data flow between layers.
+---
+
+# Windsor Architecture Patterns
+
+## Apply when
+- Changes touch more than one architectural layer (`cmd`, `pkg/runtime`, `pkg/composer`, API/config docs).
+- Ownership is unclear between evaluator/secrets/terraform/runtime.
+- New behavior could introduce cross-layer coupling.
+
+## Do not use when
+- The change is isolated to formatting, naming, or narrow local bug fixes within one file.
+- The task is only writing tests with no architecture decisions.
+
+## Canonical boundaries
+- `cmd/*`: parse flags, instantiate runtime/composer, call orchestration methods, return user-facing errors.
+- `pkg/runtime/runtime.go`: lifecycle orchestration and dependency wiring.
+- `pkg/runtime/evaluator/*`: provider-agnostic expression evaluation and helper registration only.
+- `pkg/runtime/secrets/*`: provider adapters and secret expression behavior.
+- `pkg/runtime/terraform/*`: terraform-specific parsing, env assembly, and provider policy decisions.
+- `pkg/composer/*`: blueprint load/process/compose/write pipeline and terraform module preparation.
+
+## Ownership rules
+- Runtime orchestrates. It should coordinate initialization order and lifecycle transitions.
+- Evaluator evaluates expressions and helper hooks. It must not hardcode provider-specific branches.
+- Secrets resolves secret references and provider-specific retrieval.
+- Terraform provider owns terraform metadata introspection and terraform env var decisions.
+- Composer blueprint handler owns blueprint pipelines and source/template composition.
+- CLI command layer owns UX/policy decisions for command behavior (for example hook/non-hook error behavior).
+
+## Proven patterns in this repo
+- Constructor injection with required dependency checks and panic-on-missing prerequisites.
+  - `pkg/runtime/runtime.go`
+  - `pkg/runtime/evaluator/evaluator.go`
+  - `pkg/composer/blueprint/handler.go`
+  - `pkg/composer/terraform/module_resolver.go`
+- Boundary companion files for isolated sub-concerns inside a package.
+  - `pkg/runtime/terraform/provider_sensitive_inputs.go`
+- Public interfaces + concrete internal implementations per package.
+  - `pkg/runtime/evaluator/evaluator.go`
+  - `pkg/runtime/secrets/secrets_provider.go`
+  - `pkg/composer/blueprint/handler.go`
+- Shims wrappers for external/system interactions to keep logic testable.
+  - `pkg/runtime/*/shims.go`
+- Explicit lifecycle sequencing in orchestration entrypoints.
+  - `cmd/env.go`
+  - `pkg/runtime/runtime.go`
+
+## Required decision checklist before coding
+1. Identify the layer that owns the behavior.
+2. Confirm whether this is orchestration, evaluation, provider adaptation, or terraform/composer-specific policy.
+3. Place new logic in the owning package; inject dependencies instead of reaching across layers.
+4. If adding a new sub-concern in a large package, isolate it in a boundary companion file.
+5. Add or update tests in the same ownership layer; include at least one boundary-focused case.
+
+## Implementation constraints
+- Do not add provider-specific syntax branching to evaluator core.
+- Do not mix parsing/introspection logic directly into orchestration methods when it can be isolated.
+- Do not introduce anonymous, hidden behavior toggles through ad-hoc type assertions.
+- Keep public APIs minimal and prefer explicit methods for mutation over exposed mutable fields.
+
+## Change map requirement for cross-cutting work
+When work spans multiple subsystems, produce and follow this map before implementation:
+- subsystem
+- reason for change
+- risk
+- verification target
+
+## Validation pass before completion
+- Boundaries remain intact and responsibilities are still single-owner.
+- Lifecycle side effects remain centralized in orchestrators.
+- No new global side effects were introduced.
+- Tests validate boundary behavior, not only happy-path output.

--- a/.cursor/skills/windsor-go-style/SKILL.md
+++ b/.cursor/skills/windsor-go-style/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: windsor-go-style
+description: Enforce Windsor Go file organization, documentation, and package structure conventions from STYLE.md. Use when creating or editing Go implementation, test, mock, or shim files.
+---
+
+# Windsor Go Style
+
+## Apply when
+- Editing any `*.go` file in this repository
+- Creating new package files
+- Refactoring file layout or comments
+
+## Required file organization
+- Use section headers exactly:
+  - `Constants`
+  - `Types`
+  - `Interfaces`
+  - `Constructor`
+  - `Public Methods`
+  - `Private Methods`
+  - `Helpers`
+- Omit empty sections.
+- Keep sections in the required order.
+
+## Required documentation style
+- Add a 4-line class header at top of implementation files:
+  - line 1 starts with `The <Name> is a`
+  - line 2 starts with `It provides`
+  - lines 3-4 describe role/capabilities
+- Every function/method has a header comment.
+- Never place explanatory comments inside function bodies.
+
+## Package and file expectations
+- Prefer package layouts with:
+  - implementation file
+  - test file
+  - mock implementation (when needed)
+  - shims file for system calls
+- Keep naming boundary-oriented, not generic buckets (`misc`, `utils`, `helpers` as dump files).
+
+## Editing checklist
+- Confirm section headers are valid and ordered.
+- Confirm all functions have header comments.
+- Remove inline comments inside function bodies.
+- Keep naming consistent with existing package terminology.
+

--- a/.cursor/skills/windsor-large-pr-control/SKILL.md
+++ b/.cursor/skills/windsor-large-pr-control/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: windsor-large-pr-control
+description: Structure large cross-cutting changes into coherent phases with explicit dependency mapping and test checkpoints. Use when a feature touches multiple runtime subsystems.
+---
+
+# Windsor Large PR Control
+
+## Use when
+- A feature affects multiple subsystems (runtime, evaluator, secrets, terraform, cmd, docs).
+- A clean multi-PR split would require temporary churn or reversions.
+
+## Required planning output
+- Provide a change map:
+  - subsystem
+  - reason for change
+  - risk
+  - verification
+
+## Implementation phases (single PR, multiple logical commits)
+1. Contract/tests baseline for behavior intent.
+2. Core semantics changes.
+3. Lifecycle/orchestration updates.
+4. Integration wiring and persistence/security policy.
+5. Boundary cleanup and style normalization.
+6. Documentation updates.
+
+## Control rules
+- Avoid speculative refactors not required for feature correctness.
+- If refactor is required, tie it to a boundary/risk in the change map.
+- Keep each phase testable.
+- Report what changed and why after each phase.
+
+## Final review checks
+- No boundary regressions introduced.
+- No hidden global side effects.
+- Public/private visibility is intentional.
+- Files follow STYLE.md structure and comment rules.

--- a/.cursor/skills/windsor-runtime-boundaries/SKILL.md
+++ b/.cursor/skills/windsor-runtime-boundaries/SKILL.md
@@ -1,0 +1,31 @@
+---
+name: windsor-runtime-boundaries
+description: Enforce runtime/evaluator/secrets/terraform separation-of-concerns boundaries. Use when implementing or reviewing changes in pkg/runtime, pkg/composer/terraform, and related command wiring.
+---
+
+# Windsor Runtime Boundaries
+
+## Ownership rules
+- Runtime orchestrates lifecycle and wiring.
+- Evaluator is provider-agnostic and executes expressions.
+- Secrets package resolves/provider-adapts secret references.
+- Terraform provider assembles policy/output; metadata parsing lives in provider-scoped boundary files.
+
+## Do not introduce
+- Provider-specific syntax branching inside evaluator core.
+- Hidden feature toggles via anonymous type assertions.
+- Parsing/introspection logic mixed directly into orchestration paths.
+- New files that are arbitrary function dumps.
+
+## Preferred patterns
+- Constructor-injected policy where possible.
+- Named boundary companion files (example: `provider_sensitive_inputs.go`).
+- Public API kept minimal; internal state private.
+- Explicit method-based mutation instead of ad-hoc exported mutable fields.
+
+## Review checklist
+- Identify touched boundaries before edits.
+- Verify each changed symbol belongs to the file/package boundary.
+- Ensure lifecycle side effects are centralized.
+- Confirm tests cover boundary behavior, not only happy-path output.
+

--- a/.cursor/skills/windsor-test-engineer-protocol/SKILL.md
+++ b/.cursor/skills/windsor-test-engineer-protocol/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: windsor-test-engineer-protocol
+description: Apply Windsor test workflow and test-design standards for unit and integration tests. Use when asked to write, expand, or refactor tests, especially when deciding boundary-focused expectations vs internal/private method coverage.
+---
+
+# Windsor Test Engineer Protocol
+
+## Scope
+Use this protocol when implementing or changing tests.
+
+## Test design principles
+- Prefer boundary and behavioral expectations over internal implementation details.
+- Test public contracts, state transitions, and externally visible outcomes.
+- Avoid direct private-method testing by default.
+- Allow direct private-method tests only when they provide high value for complex pure logic (for example parsers with many edge combinations).
+- Keep tests resilient to refactors that preserve behavior.
+
+## Unit vs integration intent
+- Unit tests validate package boundaries and explicit expectations with controlled dependencies.
+- Integration tests validate CLI command behavior end-to-end:
+  - command/subcommand execution
+  - parameter/flag behavior
+  - real file handling flows (including facets and related config artifacts)
+- Integration tests should exercise realistic paths and outputs rather than internal helper call patterns.
+
+## Mandatory workflow
+1. Present the full test suite structure first using `t.Run(...)` stubs.
+2. Obtain explicit user confirmation before implementing any test case.
+3. Implement exactly one `t.Run` case at a time.
+4. Run tests after each implemented case.
+5. Report results and request confirmation before the next case.
+
+## Prohibited during this protocol
+- Implementing multiple new test cases in one step.
+- Table-driven or matrix-based tests.
+- Modifying source code while executing test-engineering-only tasks.
+- Using `testify`; use standard Go `testing`.
+
+## Verification requirements
+- Show proposed test case before coding.
+- Run only relevant tests after each change.
+- Report pass/fail and next proposed case.
+
+## Coverage commands
+- `go test -coverprofile=coverage.out ./pkg/<package>`
+- `go tool cover -func=coverage.out`
+- `go test ./pkg/<package>/... -v`
+- `go test ./pkg/<package>/... -run TestName`
+

--- a/.cursorrules
+++ b/.cursorrules
@@ -1,145 +1,26 @@
-# CRITICAL TEST SUITE RULES
+# Windsor CLI Agent Rules (Concise)
 
-## CODE STYLE GUIDELINES
-Must follow Windsor CLI style guidelines in STYLE.md:
-1. Package Structure
-2. Documentation Style
-3. Testing Patterns
-4. Code Organization
+Canonical detailed guidance now lives in project skills under:
+- `.cursor/skills/windsor-go-style/`
+- `.cursor/skills/windsor-test-engineer-protocol/`
+- `.cursor/skills/windsor-runtime-boundaries/`
+- `.cursor/skills/windsor-large-pr-control/`
 
-## COMMENT PLACEMENT RULES
-CRITICAL: Function comments must ONLY be placed in function headers, NEVER inside function bodies:
+## Non-negotiable rules
 
-1. FUNCTION HEADER DOCUMENTATION
-   - All function description must be in the function header comment
-   - Use comprehensive documentation explaining purpose, parameters, and behavior
-   - Include any relevant context or usage notes in the header
+1. **Function comment placement**
+   - Function behavior documentation belongs in function header comments.
+   - Do not add explanatory comments inside function bodies.
 
-2. PROHIBITED INLINE COMMENTS
-   - NEVER place comments inside function bodies
-   - NO explanatory comments within function implementation
-   - NO step-by-step comments inside methods
+2. **Go test implementation protocol**
+   - For explicit test-engineering tasks, follow the mandatory one-`t.Run` workflow from `windsor-test-engineer-protocol`.
+   - Use standard Go `testing` package (no testify).
 
-3. ALLOWED COMMENT LOCATIONS
-   - Function/method header documentation
-   - Package-level documentation
-   - Type/struct field documentation
-   - Constant/variable documentation at package level
-   - Section headers using the prescribed format
+3. **Style and organization**
+   - Follow `STYLE.md` and `windsor-go-style` for section headers, file organization, and naming.
 
-4. ENFORCEMENT
-   - Any code generation must follow this rule strictly
-   - All function bodies must be comment-free
-   - Documentation belongs in function signatures, not implementations
+4. **Architecture boundaries**
+   - Follow `windsor-runtime-boundaries` for runtime/evaluator/secrets/terraform ownership.
 
-Example CORRECT format:
-```go
-// LoadConfiguration loads and validates the application configuration from the specified path.
-// It handles environment variable substitution, validates required fields, and returns
-// a fully initialized configuration object or an error if validation fails.
-func LoadConfiguration(path string) (*Config, error) {
-    data, err := os.ReadFile(path)
-    if err != nil {
-        return nil, err
-    }
-    
-    config := &Config{}
-    if err := yaml.Unmarshal(data, config); err != nil {
-        return nil, err
-    }
-    
-    return config, config.Validate()
-}
-```
-
-Example INCORRECT format (DO NOT USE):
-```go
-func LoadConfiguration(path string) (*Config, error) {
-    // Read the configuration file
-    data, err := os.ReadFile(path)
-    if err != nil {
-        return nil, err
-    }
-    
-    // Parse the YAML content
-    config := &Config{}
-    if err := yaml.Unmarshal(data, config); err != nil {
-        return nil, err
-    }
-    
-    // Validate and return
-    return config, config.Validate()
-}
-```
-
-## MANDATORY TEST SUITE STRUCTURE
-1. TEMPLATE FIRST
-   - Must show complete test suite structure with all t.Run() stubs
-   - Must get explicit user confirmation
-   - Must not proceed without confirmation
-
-2. IMPLEMENTATION SEQUENCE
-   - Must implement one t.Run() at a time
-   - Must verify each implementation
-   - Must get user confirmation before next t.Run()
-   - Must never implement multiple tests at once
-   - Must show proposed test case before implementation
-   - Must get approval for each test case before coding
-   - Must run and verify each test before proceeding
-   - Must not use table-driven or matrix-based tests
-
-3. SOURCE CODE RULES
-   - Must not modify source code during test routines
-   - Must alert user of source code bugs
-   - Must follow Windsor CLI style guidelines
-   - Must use standard Go testing package (no testify)
-
-4. VERIFICATION CHECKLIST
-   - Must run test after each t.Run() implementation
-   - Must report test results
-   - Must get user confirmation before proceeding
-
-## VALIDATION REQUIREMENTS
-Before Implementation:
-- Confirm test suite structure is complete
-- Get user approval of structure
-- Verify no source code modifications planned
-- Get approval for first test case to implement
-
-During Implementation:
-- Show proposed test case
-- Get approval for test case
-- Implement one test at a time
-- Verify each test
-- Get user confirmation
-- Report results
-- Get approval for next test case
-
-## TEST ENGINEER CAPABILITIES
-1. Coverage Analysis
-   - Run: `go test -coverprofile=coverage.out ./pkg/[package]`
-   - Analyze: `go tool cover -func=coverage.out`
-   - Run suites: `go test ./pkg/[package]/... -v`
-   - Run individual: `go test ./pkg/[package]/... -run TestName`
-
-2. Test Management
-   - Troubleshoot failing tests
-   - Improve test coverage
-   - Ensure style compliance
-
-## AUDIO NOTIFICATIONS
-Must use `say` command with Samantha voice for:
-- Test Completion: "All tests are now passing"
-- Test Failure: "Test failure detected in [test name]"
-- Coverage Improvement: "Coverage improved to [percentage]"
-- Source Code Bug: "Source code bug detected in [function]. Please review."
-- User Input Needed: "User input required for [specific issue]"
-- Work Complete: "Test engineering work complete"
-
-## TASK TEMPLATES
-When creating new code or modifying existing code, refer to:
-1. BDD style tests: STYLE.md > Testing Patterns > BDD Style
-2. Class headers: STYLE.md > Documentation Style > Class Headers
-3. Section headers: STYLE.md > Documentation Style > Section Headers
-4. Mock implementations: STYLE.md > Code Organization > Mock Implementation
-5. Shims: STYLE.md > Code Organization > Shims
+5. **Large cross-cutting work**
+   - Follow `windsor-large-pr-control` for phased implementation and change-map reporting.

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,9 @@ integration_out.txt
 # vendor/
 
 # Cursor
-.cursor/
+.cursor/*
+!.cursor/skills/
+!.cursor/skills/**
 
 # Go workspace file
 go.work

--- a/STYLE.md
+++ b/STYLE.md
@@ -1,74 +1,31 @@
-# Windsor CLI Code Style Guide
+# Windsor CLI Style Guide (Concise)
 
-## Package Structure
+Detailed execution playbooks are now defined in project skills:
+- `.cursor/skills/windsor-go-style/`
+- `.cursor/skills/windsor-test-engineer-protocol/`
+- `.cursor/skills/windsor-runtime-boundaries/`
+- `.cursor/skills/windsor-large-pr-control/`
 
-A typical package should contain:
-1. Main implementation file (`{name}.go`)
-2. Test file (`{name}_test.go`)
-3. Mock implementation (`mock_{name}.go`)
-4. Test mocks (`mock_{name}_test.go`)
-5. Shims file (`shims.go`) for testable system calls
+This file defines the durable style contract for contributors and reviewers.
 
-## File Organization
+## 1) Package Structure
 
-### Main Implementation File
-1. Package declaration and imports
-2. Interface definition with detailed documentation
-3. Base struct definition
-4. Class header comment block
-5. Section headers using `// =============================================================================`
-6. Methods organized by visibility (public/private)
+Prefer packages with:
+1. implementation file
+2. test file
+3. mock implementation file (when useful)
+4. shims file for system-call abstraction
 
-### Test File
-1. Test setup section with Mocks struct and SetupOptions
-2. Global setupMocks function
-3. Test functions using t.Run for BDD style
-4. Local setup functions within each test
-5. BDD style comments (Given/When/Then)
+## 2) File Organization
 
-### Mock Implementation
-1. Mock struct with function fields
-2. Constructor
-3. Interface implementation methods
-4. Interface compliance check
-
-### Shims
-1. System call variables that can be overridden in tests
-2. Minimal implementation, just variable declarations
-
-## Documentation Style
-
-### Class Headers
-Every package-level file MUST begin with a class header in the following exact format:
-```go
-// The [ClassName] is a [brief description]
-// It provides [detailed explanation]
-// [role in application]
-// [key features/capabilities]
-```
-
-Each line MUST start with "// " and MUST NOT be empty. The first line MUST start with "The [ClassName] is a".
-The second line MUST start with "It provides". The third and fourth lines describe role and features.
-
-Example:
-```go
-// The ConfigHandler is a core component that manages configuration state and context.
-// It provides a unified interface for loading, saving, and accessing configuration data,
-// The ConfigHandler acts as the central configuration orchestrator for the application,
-// coordinating context switching, secret management, and configuration persistence.
-```
-
-### Section Headers
-Section headers MUST follow this exact format with no variations:
+Section headers must use:
 ```go
 // =============================================================================
 // [SECTION NAME]
 // =============================================================================
 ```
 
-The following are the ONLY allowed section names, in this exact order when present:
-
-For implementation files (*.go, mock_*.go):
+Implementation files may include (in order, only when non-empty):
 1. Constants
 2. Types
 3. Interfaces
@@ -77,382 +34,41 @@ For implementation files (*.go, mock_*.go):
 6. Private Methods
 7. Helpers
 
-For test files (*_test.go ONLY):
+Test files may include (in order, only when non-empty):
 1. Test Setup
 2. Test Constructor
 3. Test Public Methods
 4. Test Private Methods
 5. Test Helpers
 
-IMPORTANT:
-- Only include section headers for sections that contain code
-- Empty sections MUST be omitted entirely
-- The equals signs must be exactly 77 characters long
-- There must be exactly one blank line before and after each section header
-- Sections must appear in the order specified above when present
+## 3) Documentation Style
 
-Example for implementation file with only types and constructor:
-```go
-// =============================================================================
-// Types
-// =============================================================================
+### Class header
+Implementation files should include a 4-line class header at the top:
+- line 1 starts with `The <Name> is a`
+- line 2 starts with `It provides`
+- lines 3-4 explain role and capabilities
 
-type Config struct {
-    // fields
-}
+### Function comments
+- Every function/method has a header comment.
+- No explanatory comments inside function bodies.
+- Keep behavior/context in the function header.
 
-// =============================================================================
-// Constructor
-// =============================================================================
+## 4) Testing Style
 
-func NewConfig() *Config {
-    return &Config{}
-}
-```
+- Use Go standard `testing` package.
+- Prefer BDD `t.Run` scenario naming and Given/When/Then flow.
+- For strict test-engineering workflows, follow `.cursor/skills/windsor-test-engineer-protocol/`.
 
-Example for test file with only setup and methods:
-```go
-// =============================================================================
-// Test Setup
-// =============================================================================
+## 5) Code Organization Principles
 
-type Mocks struct {
-    // fields
-}
+- Split files by functional boundaries, not arbitrary helper collections.
+- Keep interfaces focused and minimal.
+- Keep implementation details private unless required by external package consumers.
+- Prefer explicit constructor/method APIs over hidden side channels.
 
-// =============================================================================
-// Test Methods
-// =============================================================================
+## 6) Shims
 
-func TestConfig_Load(t *testing.T) {
-    // test implementation
-}
-```
-
-### Method Documentation
-- Brief description at the top of each method
-- No inline comments within method bodies
-- Focus on what and why, not how
-
-Example from config_handler.go:
-```go
-// Initialize sets up the config handler by resolving and storing the shell dependency.
-func (c *BaseConfigHandler) Initialize() error {
-    // Implementation...
-}
-```
-
-## Testing Patterns
-
-### Test Structure
-
-Tests should follow a BDD (Behavior-Driven Development) style with Given/When/Then comments:
-
-```go
-t.Run("Scenario", func(t *testing.T) {
-    // Given [context]
-    mocks, obj := setup(t)
-    
-    // When [action]
-    err := obj.DoSomething()
-    
-    // Then [result]
-    if err != nil {
-        t.Errorf("Expected success, got error: %v", err)
-    }
-})
-```
-
-### Mock Setup
-
-The base setupMocks function provides common mock behaviors. To extend it for specific test needs:
-
-```go
-// setupDockerMocks extends the base setupMocks function with Docker-specific mock behaviors.
-// It sets up mock configurations for Docker commands, container inspection, and service configuration.
-func setupDockerMocks(t *testing.T, opts ...*SetupOptions) (*Mocks, string) {
-    t.Helper()
-
-    // Store original directory and create temp dir
-    origDir, err := os.Getwd()
-    if err != nil {
-        t.Fatalf("Failed to get working directory: %v", err)
-    }
-
-    tmpDir := t.TempDir()
-    if err := os.Chdir(tmpDir); err != nil {
-        t.Fatalf("Failed to change to temp directory: %v", err)
-    }
-
-    // Set project root environment variable
-    os.Setenv("WINDSOR_PROJECT_ROOT", tmpDir)
-
-    // Get base mocks
-    mocks := setupMocks(t, opts...)
-
-    // Add Docker-specific mock behaviors
-    mocks.MockConfigHandler.GetBoolFunc = func(key string, defaultValue ...bool) bool {
-        if key == "docker.enabled" {
-            return true
-        }
-        return false
-    }
-
-    // Register cleanup to restore original state
-    t.Cleanup(func() {
-        os.Unsetenv("WINDSOR_PROJECT_ROOT")
-        if err := os.Chdir(origDir); err != nil {
-            t.Logf("Warning: Failed to change back to original directory: %v", err)
-        }
-    })
-
-    return mocks, tmpDir
-}
-```
-
-Key points for extending setupMocks:
-1. Call the base setupMocks function first
-2. Add domain-specific mock behaviors
-3. Handle cleanup of any additional resources
-4. Return both mocks and any additional context needed
-
-### Baseline Configuration
-1. Use ConfigStr in SetupOptions to set baseline configuration
-2. Default config should be minimal but functional
-3. Test-specific config should extend default config
-4. Config should be in YAML format
-5. Config should be loaded after handler initialization
-
-Example:
-```go
-// Default config in setupMocks
-defaultConfigStr := `
-contexts:
-  mock-context:
-    dns:
-      domain: mock.domain.com
-    network:
-      cidr_block: 10.0.0.0/24`
-
-// Test-specific config
-testConfig := `
-contexts:
-  mock-context:
-    dns:
-      enabled: true
-      address: 10.0.0.53
-    docker:
-      enabled: true
-      compose_file: docker-compose.yml`
-
-mocks := setupMocks(t, &SetupOptions{
-    ConfigStr: testConfig,
-})
-```
-
-### BDD Style
-```go
-t.Run("Scenario", func(t *testing.T) {
-    // Given [context]
-    mocks, obj := setup(t)
-    
-    // When [action]
-    err := obj.DoSomething()
-    
-    // Then [result]
-    if err != nil {
-        t.Errorf("Expected success, got error: %v", err)
-    }
-})
-```
-
-## Code Organization
-
-### Interface Definition
-1. Clear, focused interface
-2. Detailed documentation
-3. Minimal method set
-
-Example from config_handler.go:
-```go
-type ConfigHandler interface {
-    Initialize() error
-    LoadConfig(path string) error
-    LoadConfigString(content string) error
-    GetString(key string, defaultValue ...string) string
-    GetInt(key string, defaultValue ...int) int
-    GetBool(key string, defaultValue ...bool) bool
-    GetStringSlice(key string, defaultValue ...[]string) []string
-    GetStringMap(key string, defaultValue ...map[string]string) map[string]string
-    Set(key string, value any) error
-    SetContextValue(key string, value any) error
-    Get(key string) any
-    SaveConfig(path string, overwrite ...bool) error
-    SetDefault(context v1alpha1.Context) error
-    GetConfig() *v1alpha1.Context
-    GetContext() string
-    SetContext(context string) error
-    GetConfigRoot() (string, error)
-    Clean() error
-    IsLoaded() bool
-}
-```
-
-### Base Implementation
-1. Struct with dependencies
-2. Constructor function
-3. Interface implementation
-4. Clear separation of concerns
-
-Example from config_handler.go:
-```go
-// BaseConfigHandler is a base implementation of the ConfigHandler interface
-type BaseConfigHandler struct {
-    injector         di.Injector
-    shell            shell.Shell
-    config           v1alpha1.Config
-    context          string
-    secretsProviders []secrets.SecretsProvider
-    loaded           bool
-}
-
-// =============================================================================
-// Constructor
-// =============================================================================
-
-// NewBaseConfigHandler creates a new BaseConfigHandler instance
-func NewBaseConfigHandler(injector di.Injector) *BaseConfigHandler {
-    return &BaseConfigHandler{injector: injector}
-}
-```
-
-### Mock Implementation
-1. Function fields for each interface method
-2. Default implementations
-3. Interface compliance check
-4. Minimal implementation
-5. No internal comments - mock implementations should be self-documenting through their structure
-
-Example from mock_config_handler.go:
-```go
-// MockConfigHandler is a mock implementation of the ConfigHandler interface
-type MockConfigHandler struct {
-    InitializeFunc       func() error
-    LoadConfigFunc       func(path string) error
-    LoadConfigStringFunc func(content string) error
-    IsLoadedFunc         func() bool
-    // ... other function fields
-}
-
-// =============================================================================
-// Constructor
-// =============================================================================
-
-// NewMockConfigHandler is a constructor for MockConfigHandler
-func NewMockConfigHandler() *MockConfigHandler {
-    return &MockConfigHandler{}
-}
-
-// =============================================================================
-// Public Methods
-// =============================================================================
-
-// Initialize calls the mock InitializeFunc if set, otherwise returns nil
-func (m *MockConfigHandler) Initialize() error {
-    if m.InitializeFunc != nil {
-        return m.InitializeFunc()
-    }
-    return nil
-}
-
-// Ensure MockConfigHandler implements ConfigHandler
-var _ ConfigHandler = (*MockConfigHandler)(nil)
-```
-
-### Shims
-1. Create a `shims.go` file in each package that needs system call abstraction
-2. Define a `Shims` struct with function fields for each system call
-3. Implement a `NewShims()` constructor that provides default implementations
-4. Use the Shims struct in your implementation for dependency injection
-5. Override specific functions in tests as needed
-
-Example from shims.go:
-```go
-package virt
-
-import (
-    "encoding/json"
-    "io"
-    "os"
-    "runtime"
-
-    "github.com/goccy/go-yaml"
-    "github.com/shirou/gopsutil/mem"
-)
-
-// The shims package is a system call abstraction layer
-// It provides mockable wrappers around system and runtime functions
-// It serves as a testing aid by allowing system calls to be intercepted
-// It enables dependency injection and test isolation for system-level operations
-
-// =============================================================================
-// Types
-// =============================================================================
-
-// YAMLEncoder is an interface for encoding YAML data.
-type YAMLEncoder interface {
-    Encode(v any) error
-    Close() error
-}
-
-// Shims provides mockable wrappers around system and runtime functions
-type Shims struct {
-    Setenv         func(key, value string) error
-    UnmarshalJSON  func(data []byte, v any) error
-    UserHomeDir    func() (string, error)
-    MkdirAll       func(path string, perm os.FileMode) error
-    WriteFile      func(name string, data []byte, perm os.FileMode) error
-    Rename         func(oldpath, newpath string) error
-    GOARCH         func() string
-    NumCPU         func() int
-    VirtualMemory  func() (*mem.VirtualMemoryStat, error)
-    MarshalYAML    func(v any) ([]byte, error)
-    NewYAMLEncoder func(w io.Writer, opts ...yaml.EncodeOption) YAMLEncoder
-}
-
-// =============================================================================
-// Helpers
-// =============================================================================
-
-// NewShims creates a new Shims instance with default implementations
-func NewShims() *Shims {
-    return &Shims{
-        Setenv:        os.Setenv,
-        UnmarshalJSON: json.Unmarshal,
-        UserHomeDir:   os.UserHomeDir,
-        MkdirAll:      os.MkdirAll,
-        WriteFile:     os.WriteFile,
-        Rename:        os.Rename,
-        GOARCH:        func() string { return runtime.GOARCH },
-        NumCPU:        func() int { return runtime.NumCPU() },
-        VirtualMemory: mem.VirtualMemory,
-        MarshalYAML:   yaml.Marshal,
-        NewYAMLEncoder: func(w io.Writer, opts ...yaml.EncodeOption) YAMLEncoder {
-            return yaml.NewEncoder(w, opts...)
-        },
-    }
-}
-```
-
-## Best Practices
-
-1. Use shims for system calls
-2. Keep methods focused and small
-3. Document at the package and type level
-4. Use BDD style in tests
-5. Maintain clear separation between interface and implementation
-6. Use dependency injection
-7. Keep test setup clean and reusable
-8. Use section headers for code organization
-9. Document public APIs thoroughly
-10. Keep implementation details private 
+- Use shims for OS/runtime/system interactions.
+- Keep shims simple and dependency-injectable for tests.
+- Override shim functions in tests rather than monkey-patching behavior elsewhere.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk because changes are limited to editor guidance/docs and `.gitignore` patterns, with no runtime code paths affected. The main risk is accidental repo noise if Cursor files outside `.cursor/skills/` are now ignored as intended.
> 
> **Overview**
> Adds a set of Cursor *project skills* under `.cursor/skills/` covering Go style conventions, test-engineering workflow, runtime/terraform boundary rules, large-PR planning, and overall architecture ownership.
> 
> Refactors `.cursorrules` and `STYLE.md` into concise entrypoints that defer detailed guidance to those skills, and updates `.gitignore` to ignore most `.cursor` content while explicitly keeping `.cursor/skills/` tracked.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4a301866bdc8cdad52f273f404f95008f8168cd0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->