### PR TITLE
feat: Allow secrets injection in to terraform inputs

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -455,16 +455,16 @@ func (t *TerraformComponent) DeepCopy() *TerraformComponent {
 	}
 
 	return &TerraformComponent{
-		Name:         t.Name,
-		Source:       t.Source,
-		Path:         t.Path,
-		FullPath:     t.FullPath,
-		DependsOn:    dependsOnCopy,
-		Inputs:       inputsCopy,
-		Destroy:      destroyCopy,
-		Parallelism:  parallelismCopy,
-		Enabled:      enabledCopy,
-		InputOrigins: maps.Clone(t.InputOrigins),
+		Name:            t.Name,
+		Source:          t.Source,
+		Path:            t.Path,
+		FullPath:        t.FullPath,
+		DependsOn:       dependsOnCopy,
+		Inputs:          inputsCopy,
+		Destroy:         destroyCopy,
+		Parallelism:     parallelismCopy,
+		Enabled:         enabledCopy,
+		InputOrigins:    maps.Clone(t.InputOrigins),
 	}
 }
 
@@ -779,7 +779,6 @@ func (b *Blueprint) RemoveTerraformComponent(removal TerraformComponent) error {
 					delete(existing.Inputs, key)
 				}
 			}
-
 			if len(removal.DependsOn) > 0 {
 				existing.DependsOn = slices.DeleteFunc(existing.DependsOn, func(dep string) bool {
 					return slices.Contains(removal.DependsOn, dep)
@@ -861,23 +860,23 @@ func (k *Kustomization) DeepCopy() *Kustomization {
 	}
 
 	return &Kustomization{
-		Name:                k.Name,
-		Path:                k.Path,
-		Source:              k.Source,
-		DependsOn:           slices.Clone(k.DependsOn),
-		Interval:            k.Interval,
-		RetryInterval:       k.RetryInterval,
-		Timeout:             k.Timeout,
-		Patches:             slices.Clone(k.Patches),
-		Wait:                k.Wait,
-		Force:               k.Force,
-		Prune:               k.Prune,
-		Components:          slices.Clone(k.Components),
-		Cleanup:             slices.Clone(k.Cleanup),
-		Destroy:             destroyCopy,
-		DestroyOnly:         k.DestroyOnly,
-		Enabled:             enabledCopy,
-		Substitutions:       maps.Clone(k.Substitutions),
+		Name:          k.Name,
+		Path:          k.Path,
+		Source:        k.Source,
+		DependsOn:     slices.Clone(k.DependsOn),
+		Interval:      k.Interval,
+		RetryInterval: k.RetryInterval,
+		Timeout:       k.Timeout,
+		Patches:       slices.Clone(k.Patches),
+		Wait:          k.Wait,
+		Force:         k.Force,
+		Prune:         k.Prune,
+		Components:    slices.Clone(k.Components),
+		Cleanup:       slices.Clone(k.Cleanup),
+		Destroy:       destroyCopy,
+		DestroyOnly:   k.DestroyOnly,
+		Enabled:       enabledCopy,
+		Substitutions: maps.Clone(k.Substitutions),
 	}
 }
 

--- a/api/v1alpha2/config/secrets/schema.yaml
+++ b/api/v1alpha2/config/secrets/schema.yaml
@@ -4,6 +4,14 @@ description: Schema for secrets management configurations
 type: object
 
 properties:
+  sops:
+    type: object
+    description: SOPS secrets configuration
+    properties:
+      enabled:
+        type: boolean
+        description: Enable SOPS secret provider
+    additionalProperties: false
   onepassword:
     type: object
     description: OnePassword secrets configuration

--- a/api/v1alpha2/config/secrets/secrets.go
+++ b/api/v1alpha2/config/secrets/secrets.go
@@ -6,13 +6,27 @@ import (
 
 // SecretsConfig represents the Secrets configuration
 type SecretsConfig struct {
+	Sops        *SopsConfig                    `yaml:"sops,omitempty"`
 	OnePassword *onepassword.OnePasswordConfig `yaml:"onepassword,omitempty"`
+}
+
+// SopsConfig represents SOPS provider configuration.
+type SopsConfig struct {
+	Enabled *bool `yaml:"enabled,omitempty"`
 }
 
 // Merge performs a deep merge of the current SecretsConfig with another SecretsConfig.
 func (base *SecretsConfig) Merge(overlay *SecretsConfig) {
 	if overlay == nil {
 		return
+	}
+	if overlay.Sops != nil {
+		if base.Sops == nil {
+			base.Sops = &SopsConfig{}
+		}
+		if overlay.Sops.Enabled != nil {
+			base.Sops.Enabled = overlay.Sops.Enabled
+		}
 	}
 	if overlay.OnePassword != nil {
 		if base.OnePassword == nil {
@@ -28,6 +42,22 @@ func (c *SecretsConfig) DeepCopy() *SecretsConfig {
 		return nil
 	}
 	return &SecretsConfig{
+		Sops:        c.Sops.DeepCopy(),
 		OnePassword: c.OnePassword.DeepCopy(),
+	}
+}
+
+// DeepCopy creates a deep copy of the SopsConfig object.
+func (c *SopsConfig) DeepCopy() *SopsConfig {
+	if c == nil {
+		return nil
+	}
+	var enabledCopy *bool
+	if c.Enabled != nil {
+		v := *c.Enabled
+		enabledCopy = &v
+	}
+	return &SopsConfig{
+		Enabled: enabledCopy,
 	}
 }

--- a/api/v1alpha2/config/secrets/secrets.go
+++ b/api/v1alpha2/config/secrets/secrets.go
@@ -41,9 +41,17 @@ func (c *SecretsConfig) DeepCopy() *SecretsConfig {
 	if c == nil {
 		return nil
 	}
+	var sopsCopy *SopsConfig
+	if c.Sops != nil {
+		sopsCopy = c.Sops.DeepCopy()
+	}
+	var onePasswordCopy *onepassword.OnePasswordConfig
+	if c.OnePassword != nil {
+		onePasswordCopy = c.OnePassword.DeepCopy()
+	}
 	return &SecretsConfig{
-		Sops:        c.Sops.DeepCopy(),
-		OnePassword: c.OnePassword.DeepCopy(),
+		Sops:        sopsCopy,
+		OnePassword: onePasswordCopy,
 	}
 }
 

--- a/api/v1alpha2/config/secrets/secrets_test.go
+++ b/api/v1alpha2/config/secrets/secrets_test.go
@@ -113,4 +113,41 @@ func TestSecretsConfig_Copy(t *testing.T) {
 			t.Errorf("Copy is not nil, expected a nil copy")
 		}
 	})
+
+	t.Run("CopyWithNilOptionalFields", func(t *testing.T) {
+		original := &SecretsConfig{}
+
+		copy := original.DeepCopy()
+
+		if copy == nil {
+			t.Fatal("Copy should not be nil")
+		}
+		if copy.Sops != nil {
+			t.Errorf("Expected Sops to remain nil, got %v", copy.Sops)
+		}
+		if copy.OnePassword != nil {
+			t.Errorf("Expected OnePassword to remain nil, got %v", copy.OnePassword)
+		}
+	})
+
+	t.Run("CopyWithOnlySops", func(t *testing.T) {
+		enabled := true
+		original := &SecretsConfig{
+			Sops: &SopsConfig{
+				Enabled: &enabled,
+			},
+		}
+
+		copy := original.DeepCopy()
+
+		if copy == nil || copy.Sops == nil || copy.Sops.Enabled == nil {
+			t.Fatal("Expected Sops.Enabled copy to be set")
+		}
+		if copy.OnePassword != nil {
+			t.Errorf("Expected OnePassword to remain nil, got %v", copy.OnePassword)
+		}
+		if copy.Sops.Enabled == original.Sops.Enabled {
+			t.Error("Expected Sops.Enabled pointer to be deep-copied")
+		}
+	})
 }

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -77,7 +77,7 @@ var envCmd = &cobra.Command{
 		}
 
 		outputFunc := func(output string) {
-			if !decrypt && rt.Shell != nil {
+			if !decrypt && !hook && rt.Shell != nil {
 				output = rt.Shell.Scrub(output)
 			}
 			if output != "" {

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/windsorcli/cli/pkg/composer"
@@ -22,18 +21,13 @@ var envCmd = &cobra.Command{
 			verboseVal = v
 		}
 
-		if !hook && os.Getenv("NO_CACHE") == "" {
-			if err := os.Setenv("NO_CACHE", "true"); err != nil {
-				return fmt.Errorf("failed to set NO_CACHE environment variable: %w", err)
-			}
-		}
-
 		var rtOpts []*runtime.Runtime
 		if overridesVal := cmd.Root().Context().Value(runtimeOverridesKey); overridesVal != nil {
 			rtOpts = []*runtime.Runtime{overridesVal.(*runtime.Runtime)}
 		}
 
 		rt := runtime.NewRuntime(rtOpts...)
+		rt.SetSecretCacheEnabled(hook)
 
 		if err := rt.Shell.CheckTrustedDirectory(); err != nil {
 			if hook {
@@ -83,6 +77,9 @@ var envCmd = &cobra.Command{
 		}
 
 		outputFunc := func(output string) {
+			if !decrypt && rt.Shell != nil {
+				output = rt.Shell.Scrub(output)
+			}
 			if output != "" {
 				fmt.Fprint(cmd.OutOrStdout(), output)
 			}

--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -692,6 +692,35 @@ func TestEnvCmd_ErrorScenarios(t *testing.T) {
 		}
 	})
 
+	t.Run("SkipsScrubInHookModeWhenDecryptDisabled", func(t *testing.T) {
+		stdout, _ := setupOutputCapture(t)
+		mocks := setupMocks(t)
+		mocks.Shell.RenderEnvVarsFunc = func(envVars map[string]string, export bool) string {
+			return "export TF_VAR_db_password=raw-secret\n"
+		}
+		mocks.Shell.ScrubFunc = func(input string) string {
+			t.Fatal("Expected scrub to be skipped when --hook is passed")
+			return input
+		}
+		if mockWindsorEnv, ok := mocks.Runtime.EnvPrinters.WindsorEnv.(*env.MockEnvPrinter); ok {
+			mockWindsorEnv.GetEnvVarsFunc = func() (map[string]string, error) {
+				return map[string]string{"TF_VAR_db_password": "raw-secret"}, nil
+			}
+		}
+		setupTestContext(t, mocks)
+		_ = envCmd.Flags().Set("decrypt", "false")
+		_ = envCmd.Flags().Set("hook", "true")
+
+		rootCmd.SetArgs([]string{"env", "--hook"})
+		err := Execute()
+		if err != nil {
+			t.Fatalf("Expected success, got error: %v", err)
+		}
+		if !strings.Contains(stdout.String(), "export TF_VAR_db_password=raw-secret") {
+			t.Fatalf("Expected raw output in hook mode, got %q", stdout.String())
+		}
+	})
+
 	t.Run("OutputsAliasesInHookMode", func(t *testing.T) {
 		// Given mocks with aliases and hook mode
 		stdout, stderr := setupOutputCapture(t)

--- a/cmd/env_test.go
+++ b/cmd/env_test.go
@@ -116,7 +116,7 @@ func TestEnvCmd_ErrorScenarios_RequireOverride(t *testing.T) {
 			return false, fmt.Errorf("reset check failed")
 		}
 		setupTestContext(t, mocks)
-		rootCmd.SetArgs([]string{"env"})
+		rootCmd.SetArgs([]string{"env", "--decrypt=false"})
 		rootCmd.SetContext(context.WithValue(context.Background(), runtimeOverridesKey, mocks.Runtime))
 		err := Execute()
 		if err == nil {
@@ -184,7 +184,7 @@ func TestEnvCmd_SuccessScenarios(t *testing.T) {
 		rootCmd.SetContext(ctx)
 
 		// When executing the command with decrypt flag
-		rootCmd.SetArgs([]string{"env", "--decrypt"})
+		rootCmd.SetArgs([]string{"env", "--decrypt=true"})
 		err := Execute()
 
 		// Then no error should occur
@@ -548,14 +548,16 @@ func TestEnvCmd_ErrorScenarios(t *testing.T) {
 		}
 	})
 
-	t.Run("SetsNoCacheWhenNotHookAndNotSet", func(t *testing.T) {
+	t.Run("DoesNotSetNoCacheWhenNotHookAndNotSet", func(t *testing.T) {
 		// Given hook flag is not set and NO_CACHE is not set
 		setupOutputCapture(t)
 		mocks := setupMocks(t)
 		os.Unsetenv("NO_CACHE")
+		os.Setenv("WINDSOR_SESSION_TOKEN", "test-token")
 		setupTestContext(t, mocks)
 		t.Cleanup(func() {
 			os.Unsetenv("NO_CACHE")
+			os.Unsetenv("WINDSOR_SESSION_TOKEN")
 		})
 
 		// When executing the command
@@ -566,9 +568,9 @@ func TestEnvCmd_ErrorScenarios(t *testing.T) {
 		if err != nil {
 			t.Errorf("Expected success, got error: %v", err)
 		}
-		// And NO_CACHE should be set to true
-		if os.Getenv("NO_CACHE") != "true" {
-			t.Errorf("Expected NO_CACHE to be set to 'true' when hook is false and NO_CACHE is not set, got: %s", os.Getenv("NO_CACHE"))
+		// And NO_CACHE should remain unset
+		if os.Getenv("NO_CACHE") != "" {
+			t.Errorf("Expected NO_CACHE to remain unset when hook is false and NO_CACHE is not set, got: %s", os.Getenv("NO_CACHE"))
 		}
 	})
 
@@ -630,6 +632,63 @@ func TestEnvCmd_ErrorScenarios(t *testing.T) {
 		// And stderr should be empty
 		if stderr.String() != "" {
 			t.Error("Expected empty stderr")
+		}
+	})
+
+	t.Run("ScrubsRenderedOutputWithoutDecrypt", func(t *testing.T) {
+		stdout, _ := setupOutputCapture(t)
+		mocks := setupMocks(t)
+		mocks.Shell.RenderEnvVarsFunc = func(envVars map[string]string, export bool) string {
+			return "MOCK_RENDER=raw-secret\n"
+		}
+		mocks.Shell.ScrubFunc = func(input string) string {
+			return strings.ReplaceAll(input, "raw-secret", "********")
+		}
+		if mockWindsorEnv, ok := mocks.Runtime.EnvPrinters.WindsorEnv.(*env.MockEnvPrinter); ok {
+			mockWindsorEnv.GetEnvVarsFunc = func() (map[string]string, error) {
+				return map[string]string{"IRRELEVANT": "value"}, nil
+			}
+		}
+		setupTestContext(t, mocks)
+		_ = envCmd.Flags().Set("decrypt", "false")
+		_ = envCmd.Flags().Set("hook", "false")
+
+		rootCmd.SetArgs([]string{"env"})
+		err := Execute()
+		if err != nil {
+			t.Fatalf("Expected success, got error: %v", err)
+		}
+		if !strings.Contains(stdout.String(), "MOCK_RENDER=********") {
+			t.Fatalf("Expected scrubbed output, got %q", stdout.String())
+		}
+	})
+
+	t.Run("SkipsScrubWhenDecryptEnabled", func(t *testing.T) {
+		stdout, _ := setupOutputCapture(t)
+		mocks := setupMocks(t)
+		mocks.Shell.RenderEnvVarsFunc = func(envVars map[string]string, export bool) string {
+			return "MOCK_RENDER=raw-secret\n"
+		}
+		mocks.Shell.ScrubFunc = func(input string) string {
+			t.Fatal("Expected scrub to be skipped when --decrypt is passed")
+			return input
+		}
+		if mockWindsorEnv, ok := mocks.Runtime.EnvPrinters.WindsorEnv.(*env.MockEnvPrinter); ok {
+			mockWindsorEnv.GetEnvVarsFunc = func() (map[string]string, error) {
+				return map[string]string{"IRRELEVANT": "value"}, nil
+			}
+		}
+		setupTestContext(t, mocks)
+		_ = envCmd.Flags().Set("decrypt", "true")
+		_ = envCmd.Flags().Set("hook", "false")
+
+		rootCmd.SetArgs([]string{"env", "--decrypt"})
+		err := Execute()
+		if err != nil {
+			t.Fatalf("Expected success, got error: %v", err)
+		}
+		if !strings.Contains(stdout.String(), "MOCK_RENDER=raw-secret") {
+			t.Fatalf("Expected raw output with --decrypt, got %q", stdout.String())
 		}
 	})
 

--- a/docs/guides/secrets-management.md
+++ b/docs/guides/secrets-management.md
@@ -16,11 +16,19 @@ version: v1alpha1
 contexts:
   local:
     environment:
-      CRITERION_PASSWORD: {% raw %}${{ op.personal["The Criterion Channel"]["password"] }}{% endraw %}
+      CRITERION_PASSWORD: {% raw %}${op.personal["The Criterion Channel"]["password"]}{% endraw %}
 ...
 ```
 
 Where `op` represents the `onepassword` secrets provider, and `personal` is a reference to the 1Password vault where you have stored your secrets.
+
+Windsor also supports a namespaced reference form, `secret.<provider>...`, for all secrets references. The following are equivalent:
+
+```yaml
+environment:
+  STRIPE_API_KEY: {% raw %}${op.development.stripe.api_key}{% endraw %}
+  STRIPE_API_KEY_ALT: {% raw %}${secret.op.development.stripe.api_key}{% endraw %}
+```
 
 ## Supported Providers
 
@@ -34,8 +42,15 @@ version: v1alpha1
 contexts:
   local:
     environment:
-      CRITERION_PASSWORD: {% raw %}${{ sops.streaming.criterion.password }}{% endraw %}
+      CRITERION_PASSWORD: {% raw %}${sops.streaming.criterion.password}{% endraw %}
 ...
+```
+
+The namespaced syntax is also supported for SOPS:
+
+```yaml
+environment:
+  CRITERION_PASSWORD: {% raw %}${secret.sops.streaming.criterion.password}{% endraw %}
 ```
 
 ### 1Password CLI
@@ -66,11 +81,31 @@ version: v1alpha1
 contexts:
   local:
     environment:
-      LOCALSTACK_API_KEY: {% raw %}${{ op.personal.localstack.api_key }}{% endraw %}
-      STRIPE_API_KEY: {% raw %}${{ op.development.stripe.api_key }}{% endraw %}
+      LOCALSTACK_API_KEY: {% raw %}${op.personal.localstack.api_key}{% endraw %}
+      STRIPE_API_KEY: {% raw %}${op.development.stripe.api_key}{% endraw %}
 ```
 
 When you have configured 1Password in your environment, you will likely be prompted to authenticate with 1Password. This creates a session, and you will not be prompted again until that session has been expired, lasting typically 30 minutes.
+
+## Terraform Sensitive Inputs
+
+When a Terraform input value is derived from a Windsor secret reference, Windsor does not write that value to generated `terraform.tfvars`. Instead, Windsor provides the value through `TF_VAR_<name>` environment variables during Terraform execution.
+
+Secret-qualified inputs can be declared directly in Terraform component inputs:
+
+```yaml
+terraform:
+  - name: cluster
+    path: cluster
+    inputs:
+      db_password: {% raw %}${secret.op.platform.database.password}{% endraw %}
+```
+
+Secret-qualified inputs are resolved before export as `TF_VAR_*`.
+
+## Kustomize Substitutions
+
+In this phase, Kustomize substitutions remain ConfigMap-backed. Do not pass secret values through `kustomize.substitutions`, because those values are materialized in ConfigMaps.
 
 ## Caching
 Secrets from remote providers are cached in-memory in your environment to improve performance and reduce unnecessary service calls or re-authentication. If a secret has already been defined in your environment, it will not be retrieved again. If you would like to trigger a refresh of your secrets, you may either:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -221,7 +221,7 @@ You can specify environment variables in your `windsor.yaml` configuration under
 
 ```yaml
 environment:
-  API_KEY: {% raw %}${{ op.my.api-key }}{% endraw %}
+  API_KEY: {% raw %}${op.my.api-key}{% endraw %}
   DEBUG: "true"
   CUSTOM_VAR: "some-value"
 ```

--- a/docs/security/secrets.md
+++ b/docs/security/secrets.md
@@ -43,10 +43,15 @@ Any registered secret values appearing in command output are automatically repla
 - Debug or verbose output includes secret values
 - Command output is logged or captured
 
+Terraform inputs resolved from Windsor secret references are protected by routing through `TF_VAR_*` environment variables instead of generated `terraform.tfvars` assignments.
+
 ## Best Practices
 
 ### Limit Environment Injection
 Injecting secrets directly into your environment is generally discouraged outside of development environments. This practice can lead to unintentional exposure of sensitive information.
+
+### Avoid Secret Values in Kustomize Substitutions
+Kustomize substitutions are currently ConfigMap-backed. Treat all substitution values as non-secret data until Secret-backed substitution support is introduced.
 
 ### Regularly Rotate Secrets
 Regularly rotating your secrets is a critical practice for maintaining security. Using a service such as 1Password makes it simple to rotate secrets centrally.

--- a/integration/show_test.go
+++ b/integration/show_test.go
@@ -59,7 +59,7 @@ func TestShowBlueprint_RawPreservesDeferredExpressions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("show blueprint --raw: %v\nstderr: %s", err, stderr)
 	}
-	if !strings.Contains(string(stdout), `terraform_output("compute", "controlplanes")`) {
+	if !strings.Contains(string(stdout), "${cluster.endpoint ?? deferred_endpoint.endpoint}") {
 		t.Fatalf("expected raw output to include deferred expression text, got:\n%s", stdout)
 	}
 	if strings.Contains(string(stdout), "<deferred>") {

--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -643,6 +643,7 @@ func (h *BaseBlueprintHandler) processAndCompose() error {
 				if err != nil {
 					return fmt.Errorf("evaluate terraform inputs for component %q: %w", comp.GetID(), err)
 				}
+				result = normalizeDeferredValue(result)
 				evaluated[key] = result
 			}
 			h.composedBlueprint.TerraformComponents[i].Inputs = evaluated

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -685,17 +685,12 @@ func (p *BaseBlueprintProcessor) collectTerraformComponents(
 			for k, v := range evaluated {
 				origins[k] = facet.Path
 				composedPath := "terraform." + componentID + ".inputs." + k
-				if originalVal, exists := processed.Inputs[k]; exists {
-					if s, ok := originalVal.(string); ok && evaluator.ContainsExpression(s) {
-						probe, probeErr := p.evaluator.Evaluate(s, facet.Path, facetScope, false)
-						if probeErr == nil && evaluator.IsDeferredValue(probe) {
-							p.markDeferredPath(composedPath)
-							if expr, ok := evaluator.DeferredExpression(probe); ok {
-								v = expr
-							}
-						}
-					}
+				originalVal, _ := processed.Inputs[k]
+				resolvedValue, deferred := p.resolveTerraformInputDeferredState(v, originalVal, facet.Path, facetScope)
+				if deferred {
+					p.markDeferredPath(composedPath)
 				}
+				v = resolvedValue
 				v = normalizeDeferredValue(v)
 				if m := blueprintv1alpha1.ToMapStringAny(v); m != nil {
 					normalized[k] = m
@@ -772,6 +767,25 @@ func (p *BaseBlueprintProcessor) collectTerraformComponents(
 		}
 	}
 	return nil
+}
+
+// resolveTerraformInputDeferredState determines whether a terraform input should be marked deferred for display.
+func (p *BaseBlueprintProcessor) resolveTerraformInputDeferredState(value any, originalValue any, facetPath string, facetScope map[string]any) (any, bool) {
+	if evaluator.ContainsSecretValue(value) {
+		return value, true
+	}
+	s, ok := originalValue.(string)
+	if !ok || !evaluator.ContainsExpression(s) {
+		return value, false
+	}
+	probe, err := p.evaluator.Evaluate(s, facetPath, facetScope, false)
+	if err != nil || !evaluator.IsDeferredValue(probe) {
+		return value, false
+	}
+	if expr, ok := evaluator.DeferredExpression(probe); ok {
+		return expr, true
+	}
+	return value, true
 }
 
 // collectKustomizations processes all kustomizations from a facet, evaluating their conditions,
@@ -1717,6 +1731,13 @@ func normalizeDeferredValue(v any) any {
 			return nil
 		}
 		return x.Expression
+	case evaluator.SecretValue:
+		return normalizeDeferredValue(evaluator.UnwrapSecretValue(x))
+	case *evaluator.SecretValue:
+		if x == nil {
+			return nil
+		}
+		return normalizeDeferredValue(evaluator.UnwrapSecretValue(x))
 	case map[string]any:
 		out := make(map[string]any, len(x))
 		for k, val := range x {

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -1732,12 +1732,13 @@ func normalizeDeferredValue(v any) any {
 		}
 		return x.Expression
 	case evaluator.SecretValue:
-		return normalizeDeferredValue(evaluator.UnwrapSecretValue(x))
+		return evaluator.SecretValue{Value: normalizeDeferredValue(evaluator.UnwrapSecretValue(x))}
 	case *evaluator.SecretValue:
 		if x == nil {
 			return nil
 		}
-		return normalizeDeferredValue(evaluator.UnwrapSecretValue(x))
+		normalized := normalizeDeferredValue(evaluator.UnwrapSecretValue(x))
+		return &evaluator.SecretValue{Value: normalized}
 	case map[string]any:
 		out := make(map[string]any, len(x))
 		for k, val := range x {

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -4906,3 +4906,39 @@ func TestEvaluateCondition_EvaluatesAgainstScope(t *testing.T) {
 		}
 	})
 }
+
+func TestNormalizeDeferredValue(t *testing.T) {
+	t.Run("PreservesSecretWrapperForLiteralSecretValues", func(t *testing.T) {
+		normalized := normalizeDeferredValue(evaluator.SecretValue{Value: "my-password"})
+		if !evaluator.ContainsSecretValue(normalized) {
+			t.Fatal("Expected normalized value to remain secret-qualified")
+		}
+		secret, ok := normalized.(evaluator.SecretValue)
+		if !ok {
+			t.Fatalf("Expected evaluator.SecretValue, got %T", normalized)
+		}
+		if secret.Value != "my-password" {
+			t.Fatalf("Expected secret literal to be preserved, got %v", secret.Value)
+		}
+	})
+
+	t.Run("NormalizesDeferredValueInsideSecretWrapper", func(t *testing.T) {
+		normalized := normalizeDeferredValue(evaluator.SecretValue{
+			Value: evaluator.DeferredValue{Expression: "${secret.op.platform.db.password}"},
+		})
+		if !evaluator.ContainsSecretValue(normalized) {
+			t.Fatal("Expected normalized value to remain secret-qualified")
+		}
+		secret, ok := normalized.(evaluator.SecretValue)
+		if !ok {
+			t.Fatalf("Expected evaluator.SecretValue, got %T", normalized)
+		}
+		expr, ok := secret.Value.(string)
+		if !ok {
+			t.Fatalf("Expected normalized deferred expression string, got %T", secret.Value)
+		}
+		if expr != "${secret.op.platform.db.password}" {
+			t.Fatalf("Expected deferred expression to be preserved, got %q", expr)
+		}
+	})
+}

--- a/pkg/composer/terraform/module_resolver.go
+++ b/pkg/composer/terraform/module_resolver.go
@@ -532,7 +532,7 @@ func formatHeredocContent(content string) string {
 }
 
 // writeVariable writes a single variable assignment to the tfvars file body.
-// Handles descriptions, sensitive flags, multi-line strings, and object/map formatting.
+// Handles sensitive flags, multi-line strings, and object/map formatting.
 // Ensures correct HCL syntax for all supported value types.
 func writeVariable(body *hclwrite.Body, name string, value any, variables []VariableInfo) {
 	var info *VariableInfo
@@ -541,13 +541,6 @@ func writeVariable(body *hclwrite.Body, name string, value any, variables []Vari
 			info = &v
 			break
 		}
-	}
-
-	if info != nil && info.Description != "" {
-		body.AppendUnstructuredTokens(hclwrite.Tokens{
-			{Type: hclsyntax.TokenComment, Bytes: []byte("# " + info.Description)},
-		})
-		body.AppendNewline()
 	}
 
 	if info != nil && info.Sensitive {

--- a/pkg/composer/terraform/module_resolver.go
+++ b/pkg/composer/terraform/module_resolver.go
@@ -102,10 +102,7 @@ func (h *BaseModuleResolver) GenerateTfvars(overwrite bool) error {
 			if err != nil {
 				return fmt.Errorf("failed to evaluate inputs for component %s: %w", component.GetID(), err)
 			}
-			if evaluator.ContainsExpression(evaluated) {
-				continue
-			}
-			if s, ok := evaluated.(string); ok && strings.Contains(s, "${") {
+			if !shouldWriteTfvarsValue(evaluated) {
 				continue
 			}
 			nonDeferredValues[key] = evaluated
@@ -308,7 +305,6 @@ func (h *BaseModuleResolver) generateTfvarsFile(tfvarsFilePath, modulePath strin
 	if err != nil {
 		return fmt.Errorf("failed to parse variables from module: %w", err)
 	}
-
 	mergedFile := hclwrite.NewEmptyFile()
 	body := mergedFile.Body()
 
@@ -400,6 +396,20 @@ func (h *BaseModuleResolver) removeTfvarsFiles(dir string) error {
 // Helper Functions
 // =============================================================================
 
+// shouldWriteTfvarsValue reports whether an evaluated terraform input is safe to persist in tfvars.
+func shouldWriteTfvarsValue(value any) bool {
+	if evaluator.ContainsSecretValue(value) {
+		return false
+	}
+	if evaluator.ContainsExpression(value) {
+		return false
+	}
+	if s, ok := value.(string); ok && strings.Contains(s, "${") {
+		return false
+	}
+	return true
+}
+
 // addTfvarsHeader adds a Windsor CLI management header to the tfvars file body.
 // It includes a module source comment if provided, ensuring users are aware of CLI management and module provenance.
 func addTfvarsHeader(body *hclwrite.Body, source string) {
@@ -445,7 +455,7 @@ func writeComponentValues(body *hclwrite.Body, values map[string]any, protectedV
 		}
 
 		if exists {
-			writeVariable(body, info.Name, val, []VariableInfo{})
+			writeVariable(body, info.Name, val, sortedVariables)
 			continue
 		}
 

--- a/pkg/composer/terraform/module_resolver_test.go
+++ b/pkg/composer/terraform/module_resolver_test.go
@@ -2851,21 +2851,21 @@ func Test_formatValue(t *testing.T) {
 }
 
 func Test_writeVariable(t *testing.T) {
-	t.Run("WritesVariableWithDescription", func(t *testing.T) {
-		// Given a body and variable info with description
+	t.Run("DoesNotWriteDescriptionComments", func(t *testing.T) {
+		// Given a new HCL file with a variable that has a description
 		file := hclwrite.NewEmptyFile()
 		body := file.Body()
 		variables := []VariableInfo{
 			{Name: "test", Description: "Test variable"},
 		}
 
-		// When writing variable
+		// When writing the variable to the file
 		writeVariable(body, "test", "value", variables)
 
-		// Then it should include description comment
+		// Then the output should not contain a description comment
 		content := string(file.Bytes())
-		if !strings.Contains(content, "# Test variable") {
-			t.Errorf("Expected description comment, got: %s", content)
+		if strings.Contains(content, "# Test variable") {
+			t.Errorf("Expected no description comment, got: %s", content)
 		}
 	})
 
@@ -2935,6 +2935,32 @@ func Test_writeVariable(t *testing.T) {
 		content := string(file.Bytes())
 		if !strings.Contains(content, "test") {
 			t.Errorf("Expected variable assignment, got: %s", content)
+		}
+	})
+}
+
+func Test_writeComponentValues(t *testing.T) {
+	t.Run("WritesDescriptionCommentOnceForExplicitValues", func(t *testing.T) {
+		file := hclwrite.NewEmptyFile()
+		body := file.Body()
+		values := map[string]any{
+			"cluster_name": "demo-cluster",
+		}
+		variables := []VariableInfo{
+			{
+				Name:        "cluster_name",
+				Description: "The cluster name",
+			},
+		}
+
+		writeComponentValues(body, values, map[string]bool{}, variables)
+
+		content := string(file.Bytes())
+		if strings.Count(content, "# The cluster name") != 1 {
+			t.Errorf("Expected exactly one description comment, got: %s", content)
+		}
+		if !strings.Contains(content, `cluster_name = "demo-cluster"`) {
+			t.Errorf("Expected rendered value assignment, got: %s", content)
 		}
 	})
 }

--- a/pkg/composer/terraform/module_resolver_test.go
+++ b/pkg/composer/terraform/module_resolver_test.go
@@ -2384,6 +2384,100 @@ variable "cluster_name" { type = string }`
 		}
 	})
 
+	t.Run("FiltersSecretQualifiedValues", func(t *testing.T) {
+		resolver, mocks := setup(t)
+		projectRoot, _ := mocks.Shell.GetProjectRootFunc()
+		moduleDir := filepath.Join(projectRoot, ".windsor", "contexts", "local", "terraform", "test-module")
+		os.MkdirAll(moduleDir, 0755)
+		os.WriteFile(filepath.Join(moduleDir, "variables.tf"), []byte(`variable "cluster_name" { type = string }`), 0644)
+
+		mocks.BlueprintHandler.GetTerraformComponentsFunc = func() []blueprintv1alpha1.TerraformComponent {
+			return []blueprintv1alpha1.TerraformComponent{
+				{
+					Path:   "test-module",
+					Source: "git::https://github.com/test/module.git",
+					Inputs: map[string]any{
+						"cluster_name": "test-cluster",
+						"db_password":  evaluator.SecretValue{Value: "super-secret"},
+					},
+					FullPath: moduleDir,
+				},
+			}
+		}
+
+		resolver.shims.Stat = os.Stat
+		resolver.shims.ReadFile = os.ReadFile
+		resolver.shims.MkdirAll = os.MkdirAll
+		resolver.shims.WriteFile = os.WriteFile
+
+		err := resolver.GenerateTfvars(false)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		tfvarsPath := filepath.Join(moduleDir, "terraform.tfvars")
+		content, err := os.ReadFile(tfvarsPath)
+		if err != nil {
+			t.Fatalf("Expected tfvars file to be created, got error: %v", err)
+		}
+		contentStr := string(content)
+		if !strings.Contains(contentStr, "cluster_name") {
+			t.Error("Expected tfvars to contain cluster_name")
+		}
+		if strings.Contains(contentStr, "db_password") {
+			t.Error("Expected tfvars to NOT contain secret-qualified db_password")
+		}
+	})
+
+	t.Run("DoesNotPersistSensitiveLiteralValues", func(t *testing.T) {
+		resolver, mocks := setup(t)
+		projectRoot, _ := mocks.Shell.GetProjectRootFunc()
+		moduleDir := filepath.Join(projectRoot, ".windsor", "contexts", "local", "terraform", "test-module")
+		os.MkdirAll(moduleDir, 0755)
+		os.WriteFile(filepath.Join(moduleDir, "variables.tf"), []byte(`variable "cluster_name" { type = string }
+variable "db_password" {
+  type      = string
+  sensitive = true
+}`), 0644)
+
+		mocks.BlueprintHandler.GetTerraformComponentsFunc = func() []blueprintv1alpha1.TerraformComponent {
+			return []blueprintv1alpha1.TerraformComponent{
+				{
+					Path:   "test-module",
+					Source: "git::https://github.com/test/module.git",
+					Inputs: map[string]any{
+						"cluster_name": "test-cluster",
+						"db_password":  "literal-sensitive-value",
+					},
+					FullPath: moduleDir,
+				},
+			}
+		}
+
+		resolver.shims.Stat = os.Stat
+		resolver.shims.ReadFile = os.ReadFile
+		resolver.shims.MkdirAll = os.MkdirAll
+		resolver.shims.WriteFile = os.WriteFile
+
+		err := resolver.GenerateTfvars(false)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		tfvarsPath := filepath.Join(moduleDir, "terraform.tfvars")
+		content, err := os.ReadFile(tfvarsPath)
+		if err != nil {
+			t.Fatalf("Expected tfvars file to be created, got error: %v", err)
+		}
+		contentStr := string(content)
+		if !strings.Contains(contentStr, "cluster_name") {
+			t.Error("Expected tfvars to contain cluster_name")
+		}
+		if strings.Contains(contentStr, "literal-sensitive-value") {
+			t.Error("Expected tfvars to NOT persist sensitive literal value")
+		}
+	})
+
 }
 
 func TestBaseModuleResolver_evaluateInputs(t *testing.T) {

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -144,7 +144,7 @@ func (s *TerraformStack) Up(blueprint *blueprintv1alpha1.Blueprint, onApply ...f
 
 		applyArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "apply"}
 		applyArgs = append(applyArgs, terraformArgs.ApplyArgs...)
-		applyEnv := selectTerraformCommandEnv(terraformVars, true)
+		applyEnv := selectTerraformCommandEnv(terraformVars, false)
 		_, err = s.runtime.Shell.ExecProgressWithEnv(fmt.Sprintf("🌎 Applying Terraform changes in %s", component.Path), terraformCommand, applyEnv, applyArgs...)
 		if err != nil {
 			return fmt.Errorf("error running terraform apply for %s: %w", component.Path, err)

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -144,7 +144,7 @@ func (s *TerraformStack) Up(blueprint *blueprintv1alpha1.Blueprint, onApply ...f
 
 		applyArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "apply"}
 		applyArgs = append(applyArgs, terraformArgs.ApplyArgs...)
-		applyEnv := selectTerraformCommandEnv(terraformVars, false)
+		applyEnv := selectTerraformCommandEnv(terraformVars, true)
 		_, err = s.runtime.Shell.ExecProgressWithEnv(fmt.Sprintf("🌎 Applying Terraform changes in %s", component.Path), terraformCommand, applyEnv, applyArgs...)
 		if err != nil {
 			return fmt.Errorf("error running terraform apply for %s: %w", component.Path, err)

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -272,6 +272,46 @@ func TestStack_Up(t *testing.T) {
 		}
 	})
 
+	t.Run("ExcludesTFVarsFromApplyEnv", func(t *testing.T) {
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+
+		var planEnv map[string]string
+		var applyEnv map[string]string
+		mocks.Shell.ExecProgressWithEnvFunc = func(message string, command string, env map[string]string, args ...string) (string, error) {
+			if command != "terraform" || len(args) < 2 {
+				return "", nil
+			}
+			switch args[1] {
+			case "plan":
+				if planEnv == nil {
+					planEnv = env
+				}
+			case "apply":
+				if applyEnv == nil {
+					applyEnv = env
+				}
+			}
+			return "", nil
+		}
+
+		if err := stack.Up(blueprint); err != nil {
+			t.Fatalf("Expected Up to return nil, got %v", err)
+		}
+		if planEnv == nil {
+			t.Fatal("Expected terraform plan to run with env")
+		}
+		if applyEnv == nil {
+			t.Fatal("Expected terraform apply to run with env")
+		}
+		if planEnv["TF_VAR_context_path"] == "" {
+			t.Fatal("Expected TF_VAR_context_path in plan env")
+		}
+		if _, ok := applyEnv["TF_VAR_context_path"]; ok {
+			t.Fatalf("Expected TF_VAR_context_path to be omitted from apply env, got %q", applyEnv["TF_VAR_context_path"])
+		}
+	})
+
 	t.Run("InvokesOnApplyHooksAfterEachComponentWithComponentID", func(t *testing.T) {
 		stack, _ := setup(t)
 		blueprint := createTestBlueprint()

--- a/pkg/runtime/config/typed_source.go
+++ b/pkg/runtime/config/typed_source.go
@@ -66,12 +66,16 @@ func (s *typedSource) LoadRoot(
 
 	configVersion, _ := rootConfigMap["version"].(string)
 	if configVersion != "" && configVersion != "v1alpha1" {
+		v1alpha2RootValues := s.loadV1Alpha2Root(rootConfigMap)
 		if s.schemaValidator != nil {
 			if err := v1alpha2config.LoadSchemas(loadSchemaFromBytes); err != nil {
 				return nil, false, fmt.Errorf("error loading API schemas: %w", err)
 			}
+			if err := s.validateV1Alpha2Root(v1alpha2RootValues); err != nil {
+				return nil, false, fmt.Errorf("error validating v1alpha2 root config: %w", err)
+			}
 		}
-		return s.loadV1Alpha2Root(rootConfigMap), true, nil
+		return v1alpha2RootValues, true, nil
 	}
 
 	var rootConfig v1alpha1.Config
@@ -161,4 +165,16 @@ func (s *typedSource) loadV1Alpha2Root(rootConfigMap map[string]any) map[string]
 		out[key] = value
 	}
 	return out
+}
+
+// validateV1Alpha2Root validates v1alpha2 root values against loaded schemas.
+func (s *typedSource) validateV1Alpha2Root(rootValues map[string]any) error {
+	result, err := s.schemaValidator.Validate(rootValues)
+	if err != nil {
+		return err
+	}
+	if !result.Valid {
+		return fmt.Errorf("schema validation failed: %v", result.Errors)
+	}
+	return nil
 }

--- a/pkg/runtime/config/typed_source.go
+++ b/pkg/runtime/config/typed_source.go
@@ -71,6 +71,7 @@ func (s *typedSource) LoadRoot(
 				return nil, false, fmt.Errorf("error loading API schemas: %w", err)
 			}
 		}
+		return s.loadV1Alpha2Root(rootConfigMap), true, nil
 	}
 
 	var rootConfig v1alpha1.Config
@@ -144,4 +145,20 @@ func (s *typedSource) EnsureRoot(projectRoot string) error {
 	}
 
 	return nil
+}
+
+// =============================================================================
+// Private Methods
+// =============================================================================
+
+// loadV1Alpha2Root resolves root-level v1alpha2 configuration without context overlays.
+func (s *typedSource) loadV1Alpha2Root(rootConfigMap map[string]any) map[string]any {
+	out := make(map[string]any)
+	for key, value := range rootConfigMap {
+		if key == "version" || key == "contexts" {
+			continue
+		}
+		out[key] = value
+	}
+	return out
 }

--- a/pkg/runtime/config/typed_source_test.go
+++ b/pkg/runtime/config/typed_source_test.go
@@ -77,6 +77,104 @@ contexts:
 			t.Fatal("Expected error when v1alpha2 schema loading fails")
 		}
 	})
+
+	t.Run("LoadsV1Alpha2RootLevelValuesWithoutContextsBlock", func(t *testing.T) {
+		source := newTypedSource(NewShims(), nil)
+		projectRoot := t.TempDir()
+		rootConfig := `version: v1alpha2
+secrets:
+  sops:
+    enabled: true
+  onepassword:
+    vaults:
+      shared:
+        url: my.1password.com
+        name: Shared
+`
+		if err := os.WriteFile(filepath.Join(projectRoot, "windsor.yaml"), []byte(rootConfig), 0644); err != nil {
+			t.Fatalf("Expected no error writing root config, got %v", err)
+		}
+
+		contextMap, found, err := source.LoadRoot(projectRoot, "local", func([]byte) error { return nil })
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !found {
+			t.Fatal("Expected root config to be found")
+		}
+		secrets, ok := contextMap["secrets"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected secrets map, got %T", contextMap["secrets"])
+		}
+		sops, ok := secrets["sops"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected sops map, got %T", secrets["sops"])
+		}
+		if enabled, _ := sops["enabled"].(bool); !enabled {
+			t.Errorf("Expected secrets.sops.enabled=true, got %v", sops["enabled"])
+		}
+	})
+
+	t.Run("IgnoresV1Alpha2ContextsBlock", func(t *testing.T) {
+		source := newTypedSource(NewShims(), nil)
+		projectRoot := t.TempDir()
+		rootConfig := `version: v1alpha2
+secrets:
+  sops:
+    enabled: true
+  onepassword:
+    vaults:
+      shared:
+        url: my.1password.com
+        name: Shared
+contexts:
+  local:
+    secrets:
+      onepassword:
+        vaults:
+          shared:
+            name: SharedOverride
+          local:
+            url: local.1password.com
+            name: Local
+`
+		if err := os.WriteFile(filepath.Join(projectRoot, "windsor.yaml"), []byte(rootConfig), 0644); err != nil {
+			t.Fatalf("Expected no error writing root config, got %v", err)
+		}
+
+		contextMap, found, err := source.LoadRoot(projectRoot, "local", func([]byte) error { return nil })
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !found {
+			t.Fatal("Expected root config to be found")
+		}
+		secrets, ok := contextMap["secrets"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected secrets map, got %T", contextMap["secrets"])
+		}
+		onepassword, ok := secrets["onepassword"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected onepassword map, got %T", secrets["onepassword"])
+		}
+		vaults, ok := onepassword["vaults"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected vaults map, got %T", onepassword["vaults"])
+		}
+		shared, ok := vaults["shared"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected shared vault map, got %T", vaults["shared"])
+		}
+		if shared["name"] != "Shared" {
+			t.Errorf("Expected root shared name, got %v", shared["name"])
+		}
+		if shared["url"] != "my.1password.com" {
+			t.Errorf("Expected root shared url retained, got %v", shared["url"])
+		}
+		if _, ok := vaults["local"]; ok {
+			t.Error("Expected contexts block to be ignored in v1alpha2 root load")
+		}
+	})
 }
 
 func TestTypedSource_LoadContext(t *testing.T) {

--- a/pkg/runtime/config/typed_source_test.go
+++ b/pkg/runtime/config/typed_source_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/windsorcli/cli/pkg/runtime/shell"
@@ -75,6 +76,27 @@ contexts:
 		_, _, err := source.LoadRoot(projectRoot, "local", func([]byte) error { return os.ErrInvalid })
 		if err == nil {
 			t.Fatal("Expected error when v1alpha2 schema loading fails")
+		}
+	})
+
+	t.Run("ReturnsErrorWhenV1Alpha2SchemaValidationFails", func(t *testing.T) {
+		source := newTypedSource(NewShims(), NewSchemaValidator(shell.NewMockShell()))
+		projectRoot := t.TempDir()
+		rootConfig := `version: v1alpha2
+secrets:
+  sops:
+    enabled: "true"
+`
+		if err := os.WriteFile(filepath.Join(projectRoot, "windsor.yaml"), []byte(rootConfig), 0644); err != nil {
+			t.Fatalf("Expected no error writing root config, got %v", err)
+		}
+
+		_, _, err := source.LoadRoot(projectRoot, "local", source.schemaValidator.LoadSchemaFromBytes)
+		if err == nil {
+			t.Fatal("Expected validation error for malformed v1alpha2 config")
+		}
+		if !strings.Contains(err.Error(), "error validating v1alpha2 root config") {
+			t.Fatalf("Expected v1alpha2 validation error, got %v", err)
 		}
 	})
 

--- a/pkg/runtime/env/windsor_env.go
+++ b/pkg/runtime/env/windsor_env.go
@@ -249,10 +249,7 @@ func isSecretExpressionToken(token string) bool {
 		strings.HasPrefix(normalized, "sops.") {
 		return true
 	}
-	if strings.Contains(normalized, " ") || strings.Contains(normalized, "(") || strings.Contains(normalized, ")") {
-		return false
-	}
-	return strings.Contains(normalized, "secret")
+	return false
 }
 
 // shouldUseCache determines if the cache should be used based on NO_CACHE environment variable.

--- a/pkg/runtime/env/windsor_env.go
+++ b/pkg/runtime/env/windsor_env.go
@@ -36,6 +36,11 @@ var WindsorPrefixedVars = []string{
 	"WINDSOR_MANAGED_ALIAS",
 }
 
+var secretExpressionPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`\$\{\s*([^{}]+)\s*\}`),
+	regexp.MustCompile(`\$\{\{\s*([^{}]+)\s*\}\}`),
+}
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -226,14 +231,15 @@ func normalizeLegacySecretExpressions(input string) string {
 
 // containsSecretExpression reports whether input contains at least one secret expression placeholder.
 func containsSecretExpression(input string) bool {
-	re := regexp.MustCompile(`\${{?\s*(.*?)\s*}}?`)
-	matches := re.FindAllStringSubmatch(input, -1)
-	for _, match := range matches {
-		if len(match) < 2 {
-			continue
-		}
-		if isSecretExpressionToken(strings.TrimSpace(match[1])) {
-			return true
+	for _, pattern := range secretExpressionPatterns {
+		matches := pattern.FindAllStringSubmatch(input, -1)
+		for _, match := range matches {
+			if len(match) < 2 {
+				continue
+			}
+			if isSecretExpressionToken(strings.TrimSpace(match[1])) {
+				return true
+			}
 		}
 	}
 	return false

--- a/pkg/runtime/env/windsor_env.go
+++ b/pkg/runtime/env/windsor_env.go
@@ -44,26 +44,35 @@ var WindsorPrefixedVars = []string{
 type WindsorEnvPrinter struct {
 	BaseEnvPrinter
 	secretsProviders []secrets.SecretsProvider
-	allEnvPrinters   []EnvPrinter
+	secretCache      bool
+}
+
+// WindsorEnvOptions defines optional constructor settings for WindsorEnvPrinter.
+type WindsorEnvOptions struct {
+	SecretCacheEnabled bool
 }
 
 // =============================================================================
 // Constructor
 // =============================================================================
 
-// NewWindsorEnvPrinter creates a new WindsorEnvPrinter instance
-func NewWindsorEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler, secretsProviders []secrets.SecretsProvider, allEnvPrinters []EnvPrinter) *WindsorEnvPrinter {
+// NewWindsorEnvPrinter creates a new WindsorEnvPrinter instance.
+func NewWindsorEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler, secretsProviders []secrets.SecretsProvider, opts ...*WindsorEnvOptions) *WindsorEnvPrinter {
 	if shell == nil {
 		panic("shell is required")
 	}
 	if configHandler == nil {
 		panic("config handler is required")
 	}
+	options := &WindsorEnvOptions{}
+	if len(opts) > 0 && opts[0] != nil {
+		options = opts[0]
+	}
 
 	return &WindsorEnvPrinter{
 		BaseEnvPrinter:   *NewBaseEnvPrinter(shell, configHandler),
 		secretsProviders: secretsProviders,
-		allEnvPrinters:   allEnvPrinters,
+		secretCache:      options.SecretCacheEnabled,
 	}
 }
 
@@ -102,8 +111,6 @@ func (e *WindsorEnvPrinter) GetEnvVars() (map[string]string, error) {
 
 	originalEnvVars := e.configHandler.GetStringMap("environment")
 
-	re := regexp.MustCompile(`\${{\s*(.*?)\s*}}`)
-
 	_, managedEnvExists := e.shims.LookupEnv("WINDSOR_MANAGED_ENV")
 
 	for k, v := range originalEnvVars {
@@ -111,12 +118,15 @@ func (e *WindsorEnvPrinter) GetEnvVars() (map[string]string, error) {
 			e.SetManagedEnv(k)
 		}
 
-		if re.MatchString(v) {
+		if containsSecretExpression(v) {
+			existingValueHasError := false
+			useCache := e.shouldUseCache()
 			if existingValue, exists := e.shims.LookupEnv(k); exists {
+				existingValueHasError = strings.Contains(existingValue, "<ERROR")
 				if managedEnvExists {
 					e.SetManagedEnv(k)
 				}
-				if e.shouldUseCache() && !strings.Contains(existingValue, "<ERROR") {
+				if useCache && !existingValueHasError {
 					continue
 				}
 			}
@@ -127,21 +137,10 @@ func (e *WindsorEnvPrinter) GetEnvVars() (map[string]string, error) {
 		}
 	}
 
-	// Collect managed envs and aliases from all env printers
-	var allManagedEnv []string
-	var allManagedAlias []string
-
-	// Add our own managed envs and aliases
+	allManagedEnv := make([]string, 0)
+	allManagedAlias := make([]string, 0)
 	allManagedEnv = append(allManagedEnv, e.GetManagedEnv()...)
 	allManagedAlias = append(allManagedAlias, e.GetManagedAlias()...)
-
-	// Collect from other env printers
-	for _, printer := range e.allEnvPrinters {
-		if printer != nil && printer != e {
-			allManagedEnv = append(allManagedEnv, printer.GetManagedEnv()...)
-			allManagedAlias = append(allManagedAlias, printer.GetManagedAlias()...)
-		}
-	}
 
 	// Add Windsor prefixed vars to managed env (excluding BUILD_ID if not available)
 	windsorVars := make([]string, 0, len(WindsorPrefixedVars))
@@ -178,18 +177,33 @@ func (e *WindsorEnvPrinter) parseAndCheckSecrets(strValue string) string {
 		}
 	}
 
+	if strings.Contains(strValue, "${{") {
+		strValue = normalizeLegacySecretExpressions(strValue)
+		for _, secretsProvider := range e.secretsProviders {
+			parsedValue, err := secretsProvider.ParseSecrets(strValue)
+			if err == nil {
+				strValue = parsedValue
+			}
+		}
+	}
+
 	// #nosec G101 # This is just a regular expression not a secret
-	re := regexp.MustCompile(`\${{\s*(.*?)\s*}}`)
-	unparsedSecrets := re.FindAllStringSubmatch(strValue, -1)
-	if len(unparsedSecrets) > 0 {
+	re := regexp.MustCompile(`\${\s*(.*?)\s*}`)
+	matches := re.FindAllStringSubmatch(strValue, -1)
+	secretNames := make([]string, 0)
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+		secretName := strings.TrimSpace(match[1])
+		if !isSecretExpressionToken(secretName) {
+			continue
+		}
+		secretNames = append(secretNames, secretName)
+	}
+	if len(secretNames) > 0 {
 		if len(e.secretsProviders) == 0 {
 			return "<ERROR: No secrets providers configured>"
-		}
-		var secretNames []string
-		for _, match := range unparsedSecrets {
-			if len(match) > 1 {
-				secretNames = append(secretNames, match[1])
-			}
 		}
 		secrets := strings.Join(secretNames, ", ")
 		return fmt.Sprintf("<ERROR: failed to parse: %s>", secrets)
@@ -198,11 +212,55 @@ func (e *WindsorEnvPrinter) parseAndCheckSecrets(strValue string) string {
 	return strValue
 }
 
+// normalizeLegacySecretExpressions converts legacy ${{ ... }} placeholders to ${ ... } format.
+func normalizeLegacySecretExpressions(input string) string {
+	re := regexp.MustCompile(`\$\{\{\s*(.*?)\s*\}\}`)
+	return re.ReplaceAllStringFunc(input, func(match string) string {
+		submatches := re.FindStringSubmatch(match)
+		if len(submatches) < 2 {
+			return match
+		}
+		return "${" + strings.TrimSpace(submatches[1]) + "}"
+	})
+}
+
+// containsSecretExpression reports whether input contains at least one secret expression placeholder.
+func containsSecretExpression(input string) bool {
+	re := regexp.MustCompile(`\${{?\s*(.*?)\s*}}?`)
+	matches := re.FindAllStringSubmatch(input, -1)
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+		if isSecretExpressionToken(strings.TrimSpace(match[1])) {
+			return true
+		}
+	}
+	return false
+}
+
+// isSecretExpressionToken reports whether a placeholder token is a secret reference.
+func isSecretExpressionToken(token string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(token))
+	if strings.HasPrefix(normalized, "secret.") ||
+		strings.HasPrefix(normalized, "secrets.") ||
+		strings.HasPrefix(normalized, "op.") ||
+		strings.HasPrefix(normalized, "op[") ||
+		strings.HasPrefix(normalized, "sops.") {
+		return true
+	}
+	if strings.Contains(normalized, " ") || strings.Contains(normalized, "(") || strings.Contains(normalized, ")") {
+		return false
+	}
+	return strings.Contains(normalized, "secret")
+}
+
 // shouldUseCache determines if the cache should be used based on NO_CACHE environment variable.
 // Cache is enabled by default and can be disabled by setting NO_CACHE=1 or NO_CACHE=true.
 func (e *WindsorEnvPrinter) shouldUseCache() bool {
 	noCache, _ := e.shims.LookupEnv("NO_CACHE")
-	return noCache == "" || noCache == "0" || noCache == "false" || noCache == "False"
+	noCacheDisabled := noCache == "" || noCache == "0" || noCache == "false" || noCache == "False"
+	return noCacheDisabled && e.secretCache
 }
 
 // getBuildID retrieves the current build ID from the .windsor/.build-id file.

--- a/pkg/runtime/env/windsor_env.go
+++ b/pkg/runtime/env/windsor_env.go
@@ -201,7 +201,7 @@ func (e *WindsorEnvPrinter) parseAndCheckSecrets(strValue string) string {
 			continue
 		}
 		secretName := strings.TrimSpace(match[1])
-		if !isSecretExpressionToken(secretName) {
+		if !secrets.IsSecretReferenceExpression(strings.ToLower(secretName)) {
 			continue
 		}
 		secretNames = append(secretNames, secretName)
@@ -237,23 +237,10 @@ func containsSecretExpression(input string) bool {
 			if len(match) < 2 {
 				continue
 			}
-			if isSecretExpressionToken(strings.TrimSpace(match[1])) {
+			if secrets.IsSecretReferenceExpression(strings.ToLower(strings.TrimSpace(match[1]))) {
 				return true
 			}
 		}
-	}
-	return false
-}
-
-// isSecretExpressionToken reports whether a placeholder token is a secret reference.
-func isSecretExpressionToken(token string) bool {
-	normalized := strings.ToLower(strings.TrimSpace(token))
-	if strings.HasPrefix(normalized, "secret.") ||
-		strings.HasPrefix(normalized, "secrets.") ||
-		strings.HasPrefix(normalized, "op.") ||
-		strings.HasPrefix(normalized, "op[") ||
-		strings.HasPrefix(normalized, "sops.") {
-		return true
 	}
 	return false
 }

--- a/pkg/runtime/env/windsor_env_test.go
+++ b/pkg/runtime/env/windsor_env_test.go
@@ -57,7 +57,7 @@ contexts:
 	// Create and register mock secrets provider
 	mockSecretsProvider := secrets.NewMockSecretsProvider(mocks.Shell)
 	mockSecretsProvider.ParseSecretsFunc = func(input string) (string, error) {
-		if strings.Contains(input, "${{secret_name}}") {
+		if strings.Contains(input, "${secret_name}") {
 			return "parsed_secret_value", nil
 		}
 		return input, nil
@@ -86,7 +86,7 @@ func TestWindsorEnv_GetEnvVars(t *testing.T) {
 	setup := func(t *testing.T) (*WindsorEnvPrinter, *EnvTestMocks) {
 		t.Helper()
 		mocks := setupWindsorEnvMocks(t)
-		printer := NewWindsorEnvPrinter(mocks.Shell, mocks.ConfigHandler, []secrets.SecretsProvider{}, []EnvPrinter{})
+		printer := NewWindsorEnvPrinter(mocks.Shell, mocks.ConfigHandler, []secrets.SecretsProvider{})
 		printer.shims = mocks.Shims
 		return printer, mocks
 	}
@@ -127,6 +127,43 @@ func TestWindsorEnv_GetEnvVars(t *testing.T) {
 		}
 	})
 
+	t.Run("SuccessWithDoubleBrackets", func(t *testing.T) {
+		printer, mocks := setup(t)
+
+		mockSecretsProvider := secrets.NewMockSecretsProvider(mocks.Shell)
+		mockSecretsProvider.ParseSecretsFunc = func(input string) (string, error) {
+			if input == "value with ${{secrets.mySecret}}" {
+				return "value with resolved-secret", nil
+			}
+			return input, nil
+		}
+		printer.secretsProviders = []secrets.SecretsProvider{mockSecretsProvider}
+
+		result := printer.parseAndCheckSecrets("value with ${{secrets.mySecret}}")
+
+		if result != "value with resolved-secret" {
+			t.Errorf("Expected 'value with resolved-secret', got %q", result)
+		}
+	})
+
+	t.Run("LegacyDoubleBracketsWithModernProviderSyntax", func(t *testing.T) {
+		printer, mocks := setup(t)
+		mockSecretsProvider := secrets.NewMockSecretsProvider(mocks.Shell)
+		mockSecretsProvider.ParseSecretsFunc = func(input string) (string, error) {
+			if input == "value with ${secrets.mySecret}" {
+				return "value with resolved-secret", nil
+			}
+			return input, nil
+		}
+		printer.secretsProviders = []secrets.SecretsProvider{mockSecretsProvider}
+
+		result := printer.parseAndCheckSecrets("value with ${{secrets.mySecret}}")
+
+		if result != "value with resolved-secret" {
+			t.Errorf("Expected 'value with resolved-secret', got %q", result)
+		}
+	})
+
 	t.Run("ContextIDNotSet", func(t *testing.T) {
 		// Given a WindsorEnvPrinter with no context ID
 		mockConfigHandler := config.NewMockConfigHandler()
@@ -140,7 +177,7 @@ func TestWindsorEnv_GetEnvVars(t *testing.T) {
 		mocks := setupWindsorEnvMocks(t, &EnvTestMocks{
 			ConfigHandler: mockConfigHandler,
 		})
-		printer := NewWindsorEnvPrinter(mocks.Shell, mocks.ConfigHandler, []secrets.SecretsProvider{}, []EnvPrinter{})
+		printer := NewWindsorEnvPrinter(mocks.Shell, mocks.ConfigHandler, []secrets.SecretsProvider{})
 		printer.shims = mocks.Shims
 
 		// When GetEnvVars is called
@@ -182,6 +219,7 @@ func TestWindsorEnv_GetEnvVars(t *testing.T) {
 	t.Run("SecretVarWithCacheEnabled", func(t *testing.T) {
 		// Given a WindsorEnvPrinter with cache enabled
 		printer, mocks := setup(t)
+		printer.secretCache = true
 
 		t.Setenv("NO_CACHE", "0")
 		t.Setenv("SECRET_VAR", "cached_value")
@@ -201,7 +239,7 @@ version: v1alpha1
 contexts:
   mock-context:
     environment:
-      SECRET_VAR: "${{secret_name}}"
+      SECRET_VAR: "${secret_name}"
 `); err != nil {
 			t.Fatalf("LoadConfigString returned error: %v", err)
 		}
@@ -236,7 +274,7 @@ version: v1alpha1
 contexts:
   mock-context:
     environment:
-      SECRET_VAR: "${{secret_name}}"
+      SECRET_VAR: "${secret_name}"
 `); err != nil {
 			t.Fatalf("LoadConfigString returned error: %v", err)
 		}
@@ -253,9 +291,31 @@ contexts:
 		}
 	})
 
+	t.Run("PreservesNonSecretExpressions", func(t *testing.T) {
+		printer, mocks := setup(t)
+		if err := mocks.ConfigHandler.LoadConfigString(`
+version: v1alpha1
+contexts:
+  mock-context:
+    environment:
+      PROJECT_ROOT_REF: "${project_root}"
+`); err != nil {
+			t.Fatalf("LoadConfigString returned error: %v", err)
+		}
+
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars returned an error: %v", err)
+		}
+		if envVars["PROJECT_ROOT_REF"] != "${project_root}" {
+			t.Errorf("Expected PROJECT_ROOT_REF to remain unchanged, got %q", envVars["PROJECT_ROOT_REF"])
+		}
+	})
+
 	t.Run("SecretVarWithErrorInExistingValue", func(t *testing.T) {
 		// Given a WindsorEnvPrinter with error in existing value
 		printer, mocks := setup(t)
+		printer.secretCache = true
 
 		t.Setenv("NO_CACHE", "0")
 		t.Setenv("SECRET_VAR", "<e>secret error</e>")
@@ -265,7 +325,7 @@ version: v1alpha1
 contexts:
   mock-context:
     environment:
-      SECRET_VAR: "${{secret_name}}"
+      SECRET_VAR: "${secret_name}"
 `); err != nil {
 			t.Fatalf("LoadConfigString returned error: %v", err)
 		}
@@ -285,6 +345,7 @@ contexts:
 	t.Run("SecretVarWithManagedEnvExists", func(t *testing.T) {
 		// Given a WindsorEnvPrinter with managed env exists
 		printer, mocks := setup(t)
+		printer.secretCache = true
 
 		t.Setenv("NO_CACHE", "0")
 		t.Setenv("SECRET_VAR", "cached_value")
@@ -295,7 +356,7 @@ version: v1alpha1
 contexts:
   mock-context:
     environment:
-      SECRET_VAR: "${{secret_name}}"
+      SECRET_VAR: "${secret_name}"
 `); err != nil {
 			t.Fatalf("LoadConfigString returned error: %v", err)
 		}
@@ -384,7 +445,7 @@ contexts:
 			t.Fatalf("Failed to load config: %v", err)
 		}
 		mocks.ConfigHandler.SetContext("mock-context")
-		printer := NewWindsorEnvPrinter(mocks.Shell, mocks.ConfigHandler, []secrets.SecretsProvider{}, []EnvPrinter{})
+		printer := NewWindsorEnvPrinter(mocks.Shell, mocks.ConfigHandler, []secrets.SecretsProvider{})
 		printer.shims = mocks.Shims
 
 		projectRoot, err := mocks.Shell.GetProjectRoot()
@@ -755,7 +816,7 @@ func TestWindsorEnv_PostEnvHook(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		// Given a WindsorEnvPrinter
 		mocks := setupWindsorEnvMocks(t)
-		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Shell, mocks.ConfigHandler, []secrets.SecretsProvider{}, []EnvPrinter{})
+		windsorEnvPrinter := NewWindsorEnvPrinter(mocks.Shell, mocks.ConfigHandler, []secrets.SecretsProvider{})
 
 		// When PostEnvHook is called
 		err := windsorEnvPrinter.PostEnvHook()
@@ -772,7 +833,7 @@ func TestWindsorEnv_Initialize(t *testing.T) {
 	setup := func(t *testing.T) (*WindsorEnvPrinter, *EnvTestMocks) {
 		t.Helper()
 		mocks := setupWindsorEnvMocks(t)
-		printer := NewWindsorEnvPrinter(mocks.Shell, mocks.ConfigHandler, []secrets.SecretsProvider{}, []EnvPrinter{})
+		printer := NewWindsorEnvPrinter(mocks.Shell, mocks.ConfigHandler, []secrets.SecretsProvider{})
 		printer.shims = mocks.Shims
 		return printer, mocks
 	}
@@ -794,7 +855,7 @@ func TestWindsorEnv_Initialize(t *testing.T) {
 	t.Run("ResolveAllError", func(t *testing.T) {
 		// Given a WindsorEnvPrinter
 		mocks := setupWindsorEnvMocks(t)
-		printer := NewWindsorEnvPrinter(mocks.Shell, mocks.ConfigHandler, []secrets.SecretsProvider{}, []EnvPrinter{})
+		printer := NewWindsorEnvPrinter(mocks.Shell, mocks.ConfigHandler, []secrets.SecretsProvider{})
 
 		// Then printer should be created
 		if printer == nil {
@@ -808,7 +869,7 @@ func TestWindsorEnv_ParseAndCheckSecrets(t *testing.T) {
 	setup := func(t *testing.T) (*WindsorEnvPrinter, *EnvTestMocks) {
 		t.Helper()
 		mocks := setupWindsorEnvMocks(t)
-		printer := NewWindsorEnvPrinter(mocks.Shell, mocks.ConfigHandler, []secrets.SecretsProvider{}, []EnvPrinter{})
+		printer := NewWindsorEnvPrinter(mocks.Shell, mocks.ConfigHandler, []secrets.SecretsProvider{})
 		printer.shims = mocks.Shims
 		return printer, mocks
 	}
@@ -819,7 +880,7 @@ func TestWindsorEnv_ParseAndCheckSecrets(t *testing.T) {
 
 		mockSecretsProvider := secrets.NewMockSecretsProvider(mocks.Shell)
 		mockSecretsProvider.ParseSecretsFunc = func(input string) (string, error) {
-			if input == "value with ${{ secrets.mySecret }}" {
+			if input == "value with ${secrets.mySecret}" {
 				return "value with resolved-secret", nil
 			}
 			return input, nil
@@ -827,7 +888,7 @@ func TestWindsorEnv_ParseAndCheckSecrets(t *testing.T) {
 		printer.secretsProviders = []secrets.SecretsProvider{mockSecretsProvider}
 
 		// When parseAndCheckSecrets is called
-		result := printer.parseAndCheckSecrets("value with ${{ secrets.mySecret }}")
+		result := printer.parseAndCheckSecrets("value with ${secrets.mySecret}")
 
 		// Then the secret should be resolved
 		if result != "value with resolved-secret" {
@@ -846,7 +907,7 @@ func TestWindsorEnv_ParseAndCheckSecrets(t *testing.T) {
 		printer.secretsProviders = []secrets.SecretsProvider{mockSecretsProvider}
 
 		// When parseAndCheckSecrets is called
-		result := printer.parseAndCheckSecrets("value with ${{ secrets.mySecret }}")
+		result := printer.parseAndCheckSecrets("value with ${secrets.mySecret}")
 
 		// Then an error message should be returned
 		if !strings.Contains(result, "<ERROR: failed to parse") {
@@ -864,9 +925,20 @@ func TestWindsorEnv_ParseAndCheckSecrets(t *testing.T) {
 		printer.secretsProviders = []secrets.SecretsProvider{}
 
 		// When parseAndCheckSecrets is called
-		result := printer.parseAndCheckSecrets("value with ${{ secrets.mySecret }}")
+		result := printer.parseAndCheckSecrets("value with ${secrets.mySecret}")
 
 		// Then an error message should be returned
+		if result != "<ERROR: No secrets providers configured>" {
+			t.Errorf("Expected '<ERROR: No secrets providers configured>', got %q", result)
+		}
+	})
+
+	t.Run("NoSecretsProvidersWithDoubleBrackets", func(t *testing.T) {
+		printer, _ := setup(t)
+		printer.secretsProviders = []secrets.SecretsProvider{}
+
+		result := printer.parseAndCheckSecrets("value with ${{secrets.mySecret}}")
+
 		if result != "<ERROR: No secrets providers configured>" {
 			t.Errorf("Expected '<ERROR: No secrets providers configured>', got %q", result)
 		}
@@ -883,7 +955,7 @@ func TestWindsorEnv_ParseAndCheckSecrets(t *testing.T) {
 		printer.secretsProviders = []secrets.SecretsProvider{mockSecretsProvider}
 
 		// When parseAndCheckSecrets is called
-		result := printer.parseAndCheckSecrets("value with ${{ secrets.mySecret }}")
+		result := printer.parseAndCheckSecrets("value with ${secrets.mySecret}")
 
 		// Then an error message should be returned
 		if !strings.Contains(result, "<ERROR: failed to parse") {
@@ -905,7 +977,7 @@ func TestWindsorEnv_ParseAndCheckSecrets(t *testing.T) {
 		printer.secretsProviders = []secrets.SecretsProvider{mockSecretsProvider}
 
 		// When parseAndCheckSecrets is called with multiple secrets
-		result := printer.parseAndCheckSecrets("value with ${{ secrets.secretA }} and ${{ secrets.secretB }}")
+		result := printer.parseAndCheckSecrets("value with ${secrets.secretA} and ${secrets.secretB}")
 
 		// Then an error message should be returned
 		if !strings.Contains(result, "<ERROR: failed to parse") {
@@ -915,13 +987,24 @@ func TestWindsorEnv_ParseAndCheckSecrets(t *testing.T) {
 			t.Errorf("Expected error message to contain 'secrets.secretA, secrets.secretB', got %q", result)
 		}
 	})
+
+	t.Run("IgnoresNonSecretExpressions", func(t *testing.T) {
+		printer, _ := setup(t)
+		printer.secretsProviders = []secrets.SecretsProvider{}
+
+		result := printer.parseAndCheckSecrets("value with ${project_root}")
+
+		if result != "value with ${project_root}" {
+			t.Errorf("Expected non-secret expression to remain unchanged, got %q", result)
+		}
+	})
 }
 
 func TestWindsorEnv_shouldUseCache(t *testing.T) {
 	setup := func(t *testing.T) (*WindsorEnvPrinter, *EnvTestMocks) {
 		t.Helper()
 		mocks := setupWindsorEnvMocks(t)
-		printer := NewWindsorEnvPrinter(mocks.Shell, mocks.ConfigHandler, []secrets.SecretsProvider{}, []EnvPrinter{})
+		printer := NewWindsorEnvPrinter(mocks.Shell, mocks.ConfigHandler, []secrets.SecretsProvider{})
 		printer.shims = mocks.Shims
 		return printer, mocks
 	}
@@ -929,6 +1012,7 @@ func TestWindsorEnv_shouldUseCache(t *testing.T) {
 	t.Run("EmptyNoCache", func(t *testing.T) {
 		// Given NO_CACHE environment variable is not set
 		printer, mocks := setup(t)
+		printer.secretCache = true
 		mocks.Shims.LookupEnv = func(key string) (string, bool) {
 			if key == "NO_CACHE" {
 				return "", false
@@ -948,6 +1032,7 @@ func TestWindsorEnv_shouldUseCache(t *testing.T) {
 	t.Run("NoCacheZero", func(t *testing.T) {
 		// Given NO_CACHE environment variable is set to "0"
 		printer, mocks := setup(t)
+		printer.secretCache = true
 		mocks.Shims.LookupEnv = func(key string) (string, bool) {
 			if key == "NO_CACHE" {
 				return "0", true
@@ -967,6 +1052,7 @@ func TestWindsorEnv_shouldUseCache(t *testing.T) {
 	t.Run("NoCacheFalse", func(t *testing.T) {
 		// Given NO_CACHE environment variable is set to "false"
 		printer, mocks := setup(t)
+		printer.secretCache = true
 		mocks.Shims.LookupEnv = func(key string) (string, bool) {
 			if key == "NO_CACHE" {
 				return "false", true
@@ -986,6 +1072,7 @@ func TestWindsorEnv_shouldUseCache(t *testing.T) {
 	t.Run("NoCacheOne", func(t *testing.T) {
 		// Given NO_CACHE environment variable is set to "1"
 		printer, mocks := setup(t)
+		printer.secretCache = true
 		mocks.Shims.LookupEnv = func(key string) (string, bool) {
 			if key == "NO_CACHE" {
 				return "1", true
@@ -1001,6 +1088,22 @@ func TestWindsorEnv_shouldUseCache(t *testing.T) {
 			t.Error("Expected shouldUseCache to return false for NO_CACHE=1")
 		}
 	})
+
+	t.Run("DisabledWhenSecretCacheNotEnabled", func(t *testing.T) {
+		printer, mocks := setup(t)
+		mocks.Shims.LookupEnv = func(key string) (string, bool) {
+			if key == "NO_CACHE" {
+				return "", false
+			}
+			return "", false
+		}
+
+		shouldCache := printer.shouldUseCache()
+
+		if shouldCache {
+			t.Error("Expected shouldUseCache to return false when secret cache is disabled")
+		}
+	})
 }
 
 // TestWindsorEnv_getBuildID tests the getBuildID method of the WindsorEnvPrinter
@@ -1008,7 +1111,7 @@ func TestWindsorEnv_getBuildID(t *testing.T) {
 	setup := func(t *testing.T) (*WindsorEnvPrinter, *EnvTestMocks) {
 		t.Helper()
 		mocks := setupWindsorEnvMocks(t)
-		printer := NewWindsorEnvPrinter(mocks.Shell, mocks.ConfigHandler, []secrets.SecretsProvider{}, []EnvPrinter{})
+		printer := NewWindsorEnvPrinter(mocks.Shell, mocks.ConfigHandler, []secrets.SecretsProvider{})
 		printer.shims = mocks.Shims
 		return printer, mocks
 	}
@@ -1090,7 +1193,7 @@ func TestWindsorEnv_writeBuildIDToFile(t *testing.T) {
 	setup := func(t *testing.T) (*WindsorEnvPrinter, *EnvTestMocks) {
 		t.Helper()
 		mocks := setupWindsorEnvMocks(t)
-		printer := NewWindsorEnvPrinter(mocks.Shell, mocks.ConfigHandler, []secrets.SecretsProvider{}, []EnvPrinter{})
+		printer := NewWindsorEnvPrinter(mocks.Shell, mocks.ConfigHandler, []secrets.SecretsProvider{})
 		printer.shims = mocks.Shims
 		return printer, mocks
 	}
@@ -1141,7 +1244,7 @@ func TestWindsorEnv_generateBuildID(t *testing.T) {
 	setup := func(t *testing.T) (*WindsorEnvPrinter, *EnvTestMocks) {
 		t.Helper()
 		mocks := setupWindsorEnvMocks(t)
-		printer := NewWindsorEnvPrinter(mocks.Shell, mocks.ConfigHandler, []secrets.SecretsProvider{}, []EnvPrinter{})
+		printer := NewWindsorEnvPrinter(mocks.Shell, mocks.ConfigHandler, []secrets.SecretsProvider{})
 		printer.shims = mocks.Shims
 		return printer, mocks
 	}
@@ -1203,7 +1306,7 @@ func TestWindsorEnv_incrementBuildID(t *testing.T) {
 	setup := func(t *testing.T) (*WindsorEnvPrinter, *EnvTestMocks) {
 		t.Helper()
 		mocks := setupWindsorEnvMocks(t)
-		printer := NewWindsorEnvPrinter(mocks.Shell, mocks.ConfigHandler, []secrets.SecretsProvider{}, []EnvPrinter{})
+		printer := NewWindsorEnvPrinter(mocks.Shell, mocks.ConfigHandler, []secrets.SecretsProvider{})
 		printer.shims = mocks.Shims
 		return printer, mocks
 	}

--- a/pkg/runtime/env/windsor_env_test.go
+++ b/pkg/runtime/env/windsor_env_test.go
@@ -1011,6 +1011,44 @@ func TestWindsorEnv_ParseAndCheckSecrets(t *testing.T) {
 	})
 }
 
+func TestContainsSecretExpression(t *testing.T) {
+	t.Run("DetectsModernSecretExpression", func(t *testing.T) {
+		if !containsSecretExpression("value=${sops.app.db_password}") {
+			t.Fatal("Expected modern secret expression to be detected")
+		}
+	})
+
+	t.Run("DetectsLegacySecretExpression", func(t *testing.T) {
+		if !containsSecretExpression("value=${{secrets.app.db_password}}") {
+			t.Fatal("Expected legacy secret expression to be detected")
+		}
+	})
+
+	t.Run("IgnoresNonSecretExpression", func(t *testing.T) {
+		if containsSecretExpression("value=${project_root}") {
+			t.Fatal("Expected non-secret expression to be ignored")
+		}
+	})
+
+	t.Run("IgnoresUnclosedExpression", func(t *testing.T) {
+		if containsSecretExpression("value=${sops.app.db_password") {
+			t.Fatal("Expected unclosed expression to be ignored")
+		}
+	})
+
+	t.Run("IgnoresPartiallyClosedLegacyExpression", func(t *testing.T) {
+		if containsSecretExpression("value=${{sops.app.db_password}") {
+			t.Fatal("Expected partially closed legacy expression to be ignored")
+		}
+	})
+
+	t.Run("DoesNotCrossExpressionBoundaries", func(t *testing.T) {
+		if !containsSecretExpression("${sops.app.db_password} and ${project_root}") {
+			t.Fatal("Expected secret expression to be detected without crossing boundaries")
+		}
+	})
+}
+
 func TestWindsorEnv_shouldUseCache(t *testing.T) {
 	setup := func(t *testing.T) (*WindsorEnvPrinter, *EnvTestMocks) {
 		t.Helper()

--- a/pkg/runtime/env/windsor_env_test.go
+++ b/pkg/runtime/env/windsor_env_test.go
@@ -1009,6 +1009,18 @@ func TestWindsorEnv_ParseAndCheckSecrets(t *testing.T) {
 			t.Errorf("Expected expressions containing secret substring to remain unchanged, got %q", result)
 		}
 	})
+
+	t.Run("IgnoresOperatorExpressionsWithSecretPrefix", func(t *testing.T) {
+		printer, _ := setup(t)
+		printer.secretsProviders = []secrets.SecretsProvider{}
+
+		result := printer.parseAndCheckSecrets("value with ${sops.enabled ?? true} and ${op.flags.enabled && true}")
+
+		expected := "value with ${sops.enabled ?? true} and ${op.flags.enabled && true}"
+		if result != expected {
+			t.Errorf("Expected operator expressions to remain unchanged, got %q", result)
+		}
+	})
 }
 
 func TestContainsSecretExpression(t *testing.T) {
@@ -1027,6 +1039,18 @@ func TestContainsSecretExpression(t *testing.T) {
 	t.Run("IgnoresNonSecretExpression", func(t *testing.T) {
 		if containsSecretExpression("value=${project_root}") {
 			t.Fatal("Expected non-secret expression to be ignored")
+		}
+	})
+
+	t.Run("IgnoresSopsExpressionWithOperators", func(t *testing.T) {
+		if containsSecretExpression("value=${sops.enabled ?? true}") {
+			t.Fatal("Expected sops expression with operators to be ignored")
+		}
+	})
+
+	t.Run("IgnoresOpExpressionWithOperators", func(t *testing.T) {
+		if containsSecretExpression("value=${op.flags.enabled && true}") {
+			t.Fatal("Expected op expression with operators to be ignored")
 		}
 	})
 

--- a/pkg/runtime/env/windsor_env_test.go
+++ b/pkg/runtime/env/windsor_env_test.go
@@ -57,7 +57,7 @@ contexts:
 	// Create and register mock secrets provider
 	mockSecretsProvider := secrets.NewMockSecretsProvider(mocks.Shell)
 	mockSecretsProvider.ParseSecretsFunc = func(input string) (string, error) {
-		if strings.Contains(input, "${secret_name}") {
+		if strings.Contains(input, "${secrets.secret_name}") {
 			return "parsed_secret_value", nil
 		}
 		return input, nil
@@ -239,7 +239,7 @@ version: v1alpha1
 contexts:
   mock-context:
     environment:
-      SECRET_VAR: "${secret_name}"
+      SECRET_VAR: "${secrets.secret_name}"
 `); err != nil {
 			t.Fatalf("LoadConfigString returned error: %v", err)
 		}
@@ -274,7 +274,7 @@ version: v1alpha1
 contexts:
   mock-context:
     environment:
-      SECRET_VAR: "${secret_name}"
+      SECRET_VAR: "${secrets.secret_name}"
 `); err != nil {
 			t.Fatalf("LoadConfigString returned error: %v", err)
 		}
@@ -325,7 +325,7 @@ version: v1alpha1
 contexts:
   mock-context:
     environment:
-      SECRET_VAR: "${secret_name}"
+      SECRET_VAR: "${secrets.secret_name}"
 `); err != nil {
 			t.Fatalf("LoadConfigString returned error: %v", err)
 		}
@@ -356,7 +356,7 @@ version: v1alpha1
 contexts:
   mock-context:
     environment:
-      SECRET_VAR: "${secret_name}"
+      SECRET_VAR: "${secrets.secret_name}"
 `); err != nil {
 			t.Fatalf("LoadConfigString returned error: %v", err)
 		}
@@ -996,6 +996,17 @@ func TestWindsorEnv_ParseAndCheckSecrets(t *testing.T) {
 
 		if result != "value with ${project_root}" {
 			t.Errorf("Expected non-secret expression to remain unchanged, got %q", result)
+		}
+	})
+
+	t.Run("IgnoresExpressionsWithSecretSubstring", func(t *testing.T) {
+		printer, _ := setup(t)
+		printer.secretsProviders = []secrets.SecretsProvider{}
+
+		result := printer.parseAndCheckSecrets("value with ${my_secret_flag} and ${config_secret_key}")
+
+		if result != "value with ${my_secret_flag} and ${config_secret_key}" {
+			t.Errorf("Expected expressions containing secret substring to remain unchanged, got %q", result)
 		}
 	})
 }

--- a/pkg/runtime/env/windsor_env_test.go
+++ b/pkg/runtime/env/windsor_env_test.go
@@ -1036,6 +1036,12 @@ func TestContainsSecretExpression(t *testing.T) {
 		}
 	})
 
+	t.Run("DetectsBracketNotationWithSpaces", func(t *testing.T) {
+		if !containsSecretExpression(`value=${op.personal["The Criterion Channel"]["password"]}`) {
+			t.Fatal("Expected bracket notation secret expression with spaces to be detected")
+		}
+	})
+
 	t.Run("IgnoresNonSecretExpression", func(t *testing.T) {
 		if containsSecretExpression("value=${project_root}") {
 			t.Fatal("Expected non-secret expression to be ignored")

--- a/pkg/runtime/evaluator/evaluator.go
+++ b/pkg/runtime/evaluator/evaluator.go
@@ -609,6 +609,27 @@ func (e *expressionEvaluator) buildExprEnvironment(config map[string]any, facetP
 // being partially evaluated or skipped.
 func (e *expressionEvaluator) evaluateValue(value any, facetPath string, evaluateDeferred bool, scope map[string]any) (any, error) {
 	switch v := value.(type) {
+	case SecretValue:
+		evaluated, err := e.evaluateValue(v.Value, facetPath, evaluateDeferred, scope)
+		if err != nil {
+			return nil, err
+		}
+		if isSecretValue(evaluated) {
+			evaluated = UnwrapSecretValue(evaluated)
+		}
+		return SecretValue{Value: evaluated}, nil
+	case *SecretValue:
+		if v == nil {
+			return nil, nil
+		}
+		evaluated, err := e.evaluateValue(v.Value, facetPath, evaluateDeferred, scope)
+		if err != nil {
+			return nil, err
+		}
+		if isSecretValue(evaluated) {
+			evaluated = UnwrapSecretValue(evaluated)
+		}
+		return &SecretValue{Value: evaluated}, nil
 	case string:
 		evaluated, err := e.evaluate(v, facetPath, scope, evaluateDeferred)
 		if err != nil {

--- a/pkg/runtime/evaluator/evaluator.go
+++ b/pkg/runtime/evaluator/evaluator.go
@@ -288,7 +288,7 @@ func (e *expressionEvaluator) evaluate(s string, facetPath string, scope map[str
 		searchStart = 0
 	}
 	if !evaluateDeferred && deferredEncountered {
-		return DeferredValue{Expression: result}, nil
+		return DeferredValue{Expression: s}, nil
 	}
 	if secretEncountered {
 		return SecretValue{Value: result}, nil

--- a/pkg/runtime/evaluator/evaluator.go
+++ b/pkg/runtime/evaluator/evaluator.go
@@ -57,11 +57,8 @@ type expressionEvaluator struct {
 	Shims         *Shims
 	templateData  map[string][]byte
 	helpers       []func(allowDeferred bool) expr.Option
+	normalizers   []func(expression string) string
 }
-
-// =============================================================================
-// Errors
-// =============================================================================
 
 // DeferredError signals that an expression is deferred and should be preserved for later evaluation.
 // This is not an error condition but a signal that the expression cannot be evaluated at this time.
@@ -85,29 +82,9 @@ type DeferredValue struct {
 	Expression string
 }
 
-// IsDeferredValue reports whether value is a DeferredValue (value or pointer form).
-func IsDeferredValue(value any) bool {
-	switch value.(type) {
-	case DeferredValue, *DeferredValue:
-		return true
-	default:
-		return false
-	}
-}
-
-// DeferredExpression returns the preserved raw expression string when value is DeferredValue.
-func DeferredExpression(value any) (string, bool) {
-	switch v := value.(type) {
-	case DeferredValue:
-		return v.Expression, true
-	case *DeferredValue:
-		if v == nil {
-			return "", false
-		}
-		return v.Expression, true
-	default:
-		return "", false
-	}
+// SecretValue represents a value resolved from a secret reference helper.
+type SecretValue struct {
+	Value any
 }
 
 // =============================================================================
@@ -181,6 +158,14 @@ func (e *expressionEvaluator) Register(name string, helper func(params []any, de
 	})
 }
 
+// RegisterExpressionNormalizer registers a transformation function applied before expression compilation.
+func (e *expressionEvaluator) RegisterExpressionNormalizer(normalizer func(expression string) string) {
+	if normalizer == nil {
+		return
+	}
+	e.normalizers = append(e.normalizers, normalizer)
+}
+
 // Evaluate resolves Windsor expressions in the provided string s, supporting both complete and interpolated
 // (${...}) expressions, arithmetic operations, and complex object types. The evaluation will process dynamic
 // file and jsonnet loading as needed, and can defer unresolved expressions when evaluateDeferred is false.
@@ -231,6 +216,7 @@ func (e *expressionEvaluator) evaluate(s string, facetPath string, scope map[str
 	}
 	result := s
 	deferredEncountered := false
+	secretEncountered := false
 	searchStart := 0
 	for iter := 0; iter < 20; iter++ {
 		idx := strings.Index(result[searchStart:], "${")
@@ -260,27 +246,41 @@ func (e *expressionEvaluator) evaluate(s string, facetPath string, scope map[str
 		}
 		before := result[:start]
 		after := result[end+1:]
+		unwrappedValue := value
+		if isSecretValue(value) {
+			secretEncountered = true
+			unwrappedValue = UnwrapSecretValue(value)
+		}
 		singleExpr := strings.TrimSpace(before) == "" && strings.TrimSpace(after) == ""
 		if singleExpr {
-			if str, ok := value.(string); ok && ContainsExpression(str) {
+			if str, ok := unwrappedValue.(string); ok && ContainsExpression(str) {
 				if str == result {
-					return value, nil
+					if secretEncountered {
+						return SecretValue{Value: str}, nil
+					}
+					return str, nil
 				}
 				result = str
 				searchStart = 0
 				continue
 			}
-			return value, nil
+			if secretEncountered {
+				return SecretValue{Value: unwrappedValue}, nil
+			}
+			return unwrappedValue, nil
 		}
 		var replacement string
-		if value != nil {
+		if unwrappedValue != nil {
 			var err error
-			replacement, err = valueToInterpolationString(value, e.Shims.YamlMarshal)
+			replacement, err = valueToInterpolationString(unwrappedValue, e.Shims.YamlMarshal)
 			if err != nil {
 				return "", fmt.Errorf("failed to marshal expression result to YAML: %w", err)
 			}
-			if !evaluateDeferred && ContainsExpression(replacement) && isStructuredValue(value) {
-				return value, nil
+			if !evaluateDeferred && ContainsExpression(replacement) && isStructuredValue(unwrappedValue) {
+				if secretEncountered {
+					return SecretValue{Value: unwrappedValue}, nil
+				}
+				return unwrappedValue, nil
 			}
 			replacement = indentForEmbeddedYAML(before, replacement, 2)
 		}
@@ -290,6 +290,9 @@ func (e *expressionEvaluator) evaluate(s string, facetPath string, scope map[str
 	if !evaluateDeferred && deferredEncountered {
 		return DeferredValue{Expression: result}, nil
 	}
+	if secretEncountered {
+		return SecretValue{Value: result}, nil
+	}
 	return result, nil
 }
 
@@ -298,6 +301,7 @@ func (e *expressionEvaluator) evaluate(s string, facetPath string, scope map[str
 // is that scope (with runtime keys injected so helpers like file() and jsonnet() have context and paths).
 // The expression should not include ${} bookends. Returns the evaluation result or an error.
 func (e *expressionEvaluator) evaluateExpression(expression string, facetPath string, scope map[string]any, evaluateDeferred bool) (any, error) {
+	expression = e.normalizeExpression(expression)
 	var merged map[string]any
 	if scope != nil {
 		merged = make(map[string]any)
@@ -323,6 +327,14 @@ func (e *expressionEvaluator) evaluateExpression(expression string, facetPath st
 		return nil, fmt.Errorf("failed to evaluate expression '%s': %w", expression, err)
 	}
 	return result, nil
+}
+
+func (e *expressionEvaluator) normalizeExpression(expression string) string {
+	normalized := expression
+	for _, normalizer := range e.normalizers {
+		normalized = normalizer(normalized)
+	}
+	return normalized
 }
 
 // getConfig retrieves the current configuration context as a map of string keys to values.
@@ -608,9 +620,19 @@ func (e *expressionEvaluator) evaluateValue(value any, facetPath string, evaluat
 			}
 			return nil, err
 		}
-		return normalizeYamlResult(evaluated), nil
+		secretValue := false
+		if isSecretValue(evaluated) {
+			secretValue = true
+			evaluated = UnwrapSecretValue(evaluated)
+		}
+		normalized := normalizeYamlResult(evaluated)
+		if secretValue {
+			return SecretValue{Value: normalized}, nil
+		}
+		return normalized, nil
 	case map[string]any:
 		result := make(map[string]any)
+		containsSecret := false
 		for k, val := range v {
 			evaluated, err := e.evaluateValue(val, facetPath, evaluateDeferred, scope)
 			if err != nil {
@@ -629,11 +651,19 @@ func (e *expressionEvaluator) evaluateValue(value any, facetPath string, evaluat
 					continue
 				}
 			}
+			if isSecretValue(evaluated) {
+				containsSecret = true
+				evaluated = UnwrapSecretValue(evaluated)
+			}
 			result[k] = evaluated
+		}
+		if containsSecret {
+			return SecretValue{Value: result}, nil
 		}
 		return result, nil
 	case []any:
 		result := make([]any, 0, len(v))
+		containsSecret := false
 		for _, item := range v {
 			evaluated, err := e.evaluateValue(item, facetPath, evaluateDeferred, scope)
 			if err != nil {
@@ -652,7 +682,14 @@ func (e *expressionEvaluator) evaluateValue(value any, facetPath string, evaluat
 					continue
 				}
 			}
+			if isSecretValue(evaluated) {
+				containsSecret = true
+				evaluated = UnwrapSecretValue(evaluated)
+			}
 			result = append(result, evaluated)
+		}
+		if containsSecret {
+			return SecretValue{Value: result}, nil
 		}
 		return result, nil
 	default:
@@ -1518,45 +1555,4 @@ func isStructuredValue(value any) bool {
 		return true
 	}
 	return false
-}
-
-// ContainsExpression determines whether the provided value is a string that contains an unresolved expression.
-// An expression is identified by the pattern "${...}" anywhere in the string. This function returns true if
-// the value is a string containing at least one properly closed "${...}" expression pattern, and false otherwise.
-// Used to identify values containing unresolved expressions that should be skipped when evaluateDeferred is false.
-func ContainsExpression(value any) bool {
-	switch v := value.(type) {
-	case DeferredValue:
-		return ContainsExpression(v.Expression)
-	case *DeferredValue:
-		if v == nil {
-			return false
-		}
-		return ContainsExpression(v.Expression)
-	case string:
-		if !strings.Contains(v, "${") {
-			return false
-		}
-		start := strings.Index(v, "${")
-		if start == -1 {
-			return false
-		}
-		return findExpressionEnd(v, start) != -1
-	case map[string]any:
-		for _, val := range v {
-			if ContainsExpression(val) {
-				return true
-			}
-		}
-		return false
-	case []any:
-		for _, item := range v {
-			if ContainsExpression(item) {
-				return true
-			}
-		}
-		return false
-	default:
-		return false
-	}
 }

--- a/pkg/runtime/evaluator/evaluator_public_test.go
+++ b/pkg/runtime/evaluator/evaluator_public_test.go
@@ -1639,6 +1639,55 @@ func TestExpressionEvaluator_EvaluateMap(t *testing.T) {
 		}
 	})
 
+	t.Run("PreservesSecretQualificationWhenDeferredAndSecretExpressionsMix", func(t *testing.T) {
+		// Given an evaluator with deferred terraform outputs and secret helper
+		evaluator, _, _, _ := setupEvaluatorTest(t)
+		evaluator.Register("terraform_output", func(params []any, deferred bool) (any, error) {
+			if len(params) != 2 {
+				return nil, fmt.Errorf("terraform_output() requires exactly 2 arguments")
+			}
+			if deferred {
+				return "resolved-output", nil
+			}
+			component, _ := params[0].(string)
+			key, _ := params[1].(string)
+			return nil, &DeferredError{
+				Expression: fmt.Sprintf(`terraform_output("%s", "%s")`, component, key),
+				Message:    fmt.Sprintf("terraform output '%s' for component %s is deferred", key, component),
+			}
+		}, new(func(string, string) any))
+		evaluator.Register("secret", func(params []any, deferred bool) (any, error) {
+			return SecretValue{Value: "s3cr3t"}, nil
+		}, new(func(string) any))
+
+		input := `${terraform_output("cluster", "endpoint")} ${secret("secret.op.platform.db.password")}`
+
+		// When evaluating before deferred values are available
+		deferredResult, err := evaluator.Evaluate(input, "", nil, false)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		expr, ok := DeferredExpression(deferredResult)
+		if !ok {
+			t.Fatalf("Expected deferred expression, got %T", deferredResult)
+		}
+		if expr != input {
+			t.Fatalf("Expected deferred expression to preserve original secret reference, got %q", expr)
+		}
+
+		// When evaluating after deferred values become available
+		resolved, err := evaluator.Evaluate(expr, "", nil, true)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if !isSecretValue(resolved) {
+			t.Fatalf("Expected SecretValue after deferred resolution, got %T", resolved)
+		}
+		if got := UnwrapSecretValue(resolved); got != "resolved-output s3cr3t" {
+			t.Fatalf("Expected resolved output to stay secret-qualified, got %v", got)
+		}
+	})
+
 	t.Run("SkipsPartiallyInterpolatedStringsWithUnresolvedExpressions", func(t *testing.T) {
 		// Given an evaluator with terraform_output helper and mixed values
 		evaluator, _, _, _ := setupEvaluatorTest(t)

--- a/pkg/runtime/evaluator/evaluator_public_test.go
+++ b/pkg/runtime/evaluator/evaluator_public_test.go
@@ -896,6 +896,33 @@ func TestExpressionEvaluator_EvaluateMap(t *testing.T) {
 		}
 	})
 
+	t.Run("EvaluatesExpressionInsideSecretValueWrapper", func(t *testing.T) {
+		evaluator, mockConfigHandler, _, _ := setupEvaluatorTest(t)
+		mockHandler := mockConfigHandler.(*config.MockConfigHandler)
+		mockHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{
+				"db_password": "resolved-secret",
+			}, nil
+		}
+
+		values := map[string]any{
+			"wrapped_secret": SecretValue{Value: "${db_password}"},
+		}
+
+		result, err := evaluator.EvaluateMap(values, "", nil, true)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		wrapped, ok := result["wrapped_secret"].(SecretValue)
+		if !ok {
+			t.Fatalf("Expected wrapped_secret to remain SecretValue, got %T", result["wrapped_secret"])
+		}
+		if value, ok := wrapped.Value.(string); !ok || value != "resolved-secret" {
+			t.Fatalf("Expected wrapped secret value to be resolved, got %v", wrapped.Value)
+		}
+	})
+
 	t.Run("SkipsUnresolvedExpressionsWhenEvaluateDeferredIsFalse", func(t *testing.T) {
 		mockEvaluator := NewMockExpressionEvaluator()
 		mockEvaluator.EvaluateMapFunc = func(values map[string]any, facetPath string, scope map[string]any, evaluateDeferred bool) (map[string]any, error) {

--- a/pkg/runtime/evaluator/evaluator_public_test.go
+++ b/pkg/runtime/evaluator/evaluator_public_test.go
@@ -1943,3 +1943,99 @@ func TestContainsExpression(t *testing.T) {
 		}
 	})
 }
+
+func TestSecretExpressions(t *testing.T) {
+	t.Run("AppliesRegisteredExpressionNormalizer", func(t *testing.T) {
+		eval, _, _, _ := setupEvaluatorTest(t)
+		normalizerAware, ok := eval.(interface {
+			RegisterExpressionNormalizer(func(string) string)
+		})
+		if !ok {
+			t.Fatal("Expected evaluator to support expression normalizer registration")
+		}
+		normalizerAware.RegisterExpressionNormalizer(func(expression string) string {
+			if strings.TrimSpace(expression) == "secret.op.platform.db.password" {
+				return `secret("secret.op.platform.db.password")`
+			}
+			return expression
+		})
+		eval.Register("secret", func(params []any, deferred bool) (any, error) {
+			if len(params) != 1 {
+				return nil, fmt.Errorf("expected one arg")
+			}
+			ref, _ := params[0].(string)
+			return SecretValue{Value: "resolved:" + ref}, nil
+		}, new(func(string) any))
+
+		result, err := eval.Evaluate("${secret.op.platform.db.password}", "", nil, true)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if !isSecretValue(result) {
+			t.Fatalf("Expected SecretValue, got %T", result)
+		}
+		if got := UnwrapSecretValue(result); got != "resolved:secret.op.platform.db.password" {
+			t.Errorf("Expected resolved helper value, got %v", got)
+		}
+	})
+
+	t.Run("EvaluatesExplicitSecretHelperCall", func(t *testing.T) {
+		eval, _, _, _ := setupEvaluatorTest(t)
+		eval.Register("secret", func(params []any, deferred bool) (any, error) {
+			if len(params) != 1 {
+				return nil, fmt.Errorf("expected one arg")
+			}
+			ref, _ := params[0].(string)
+			return SecretValue{Value: "resolved:" + ref}, nil
+		}, new(func(string) any))
+
+		result, err := eval.Evaluate(`${secret("secret.op.platform.db.password")}`, "", nil, true)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if !isSecretValue(result) {
+			t.Fatalf("Expected SecretValue, got %T", result)
+		}
+		if got := UnwrapSecretValue(result); got != "resolved:secret.op.platform.db.password" {
+			t.Errorf("Expected resolved helper value, got %v", got)
+		}
+	})
+
+	t.Run("PropagatesSecretQualificationAcrossInterpolatedString", func(t *testing.T) {
+		eval, _, _, _ := setupEvaluatorTest(t)
+		eval.Register("secret", func(params []any, deferred bool) (any, error) {
+			return SecretValue{Value: "s3cr3t"}, nil
+		}, new(func(string) any))
+
+		result, err := eval.Evaluate(`prefix-${secret("secret.op.platform.db.password")}-suffix`, "", nil, true)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if !isSecretValue(result) {
+			t.Fatalf("Expected SecretValue, got %T", result)
+		}
+		if got := UnwrapSecretValue(result); got != "prefix-s3cr3t-suffix" {
+			t.Errorf("Expected interpolated secret result, got %v", got)
+		}
+	})
+
+	t.Run("ReadsPlainConfigPathForSecretObject", func(t *testing.T) {
+		eval, mockConfigHandler, _, _ := setupEvaluatorTest(t)
+		mockHandler := mockConfigHandler.(*config.MockConfigHandler)
+		mockHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{
+				"secret": map[string]any{
+					"value": "plain-config-value",
+				},
+			}, nil
+		}
+
+		result, err := eval.Evaluate("${secret.value}", "", nil, true)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if result != "plain-config-value" {
+			t.Errorf("Expected plain config lookup for secret.value, got %v", result)
+		}
+	})
+}

--- a/pkg/runtime/evaluator/helpers.go
+++ b/pkg/runtime/evaluator/helpers.go
@@ -1,0 +1,129 @@
+package evaluator
+
+import "strings"
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+// IsDeferredValue reports whether value is a DeferredValue (value or pointer form).
+func IsDeferredValue(value any) bool {
+	switch value.(type) {
+	case DeferredValue, *DeferredValue:
+		return true
+	default:
+		return false
+	}
+}
+
+// isSecretValue reports whether value is a SecretValue (value or pointer form).
+func isSecretValue(value any) bool {
+	switch value.(type) {
+	case SecretValue, *SecretValue:
+		return true
+	default:
+		return false
+	}
+}
+
+// UnwrapSecretValue returns the wrapped value for SecretValue, or the value unchanged.
+func UnwrapSecretValue(value any) any {
+	switch v := value.(type) {
+	case SecretValue:
+		return v.Value
+	case *SecretValue:
+		if v == nil {
+			return nil
+		}
+		return v.Value
+	default:
+		return value
+	}
+}
+
+// ContainsSecretValue reports whether value or any nested field contains SecretValue.
+func ContainsSecretValue(value any) bool {
+	switch v := value.(type) {
+	case SecretValue:
+		return true
+	case *SecretValue:
+		return v != nil
+	case map[string]any:
+		for _, item := range v {
+			if ContainsSecretValue(item) {
+				return true
+			}
+		}
+		return false
+	case []any:
+		for _, item := range v {
+			if ContainsSecretValue(item) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}
+
+// DeferredExpression returns the preserved raw expression string when value is DeferredValue.
+func DeferredExpression(value any) (string, bool) {
+	switch v := value.(type) {
+	case DeferredValue:
+		return v.Expression, true
+	case *DeferredValue:
+		if v == nil {
+			return "", false
+		}
+		return v.Expression, true
+	default:
+		return "", false
+	}
+}
+
+// ContainsExpression determines whether the provided value contains an unresolved expression.
+// An expression is identified by the pattern "${...}" in string values.
+func ContainsExpression(value any) bool {
+	switch v := value.(type) {
+	case DeferredValue:
+		return ContainsExpression(v.Expression)
+	case *DeferredValue:
+		if v == nil {
+			return false
+		}
+		return ContainsExpression(v.Expression)
+	case SecretValue:
+		return ContainsExpression(v.Value)
+	case *SecretValue:
+		if v == nil {
+			return false
+		}
+		return ContainsExpression(v.Value)
+	case string:
+		if !strings.Contains(v, "${") {
+			return false
+		}
+		start := strings.Index(v, "${")
+		if start == -1 {
+			return false
+		}
+		return findExpressionEnd(v, start) != -1
+	case map[string]any:
+		for _, val := range v {
+			if ContainsExpression(val) {
+				return true
+			}
+		}
+		return false
+	case []any:
+		for _, item := range v {
+			if ContainsExpression(item) {
+				return true
+			}
+		}
+		return false
+	default:
+		return false
+	}
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -21,6 +22,28 @@ import (
 	"github.com/windsorcli/cli/pkg/runtime/terraform"
 	"github.com/windsorcli/cli/pkg/runtime/tools"
 )
+
+// =============================================================================
+// Types
+// =============================================================================
+
+// RuntimeSecretsProviders contains runtime-level secret provider dependencies.
+type RuntimeSecretsProviders struct {
+	Sops        secretsRuntime.SecretsProvider
+	Onepassword []secretsRuntime.SecretsProvider
+}
+
+// RuntimeEnvPrinters contains runtime-level environment printer dependencies.
+type RuntimeEnvPrinters struct {
+	AwsEnv       env.EnvPrinter
+	AzureEnv     env.EnvPrinter
+	GcpEnv       env.EnvPrinter
+	DockerEnv    env.EnvPrinter
+	KubeEnv      env.EnvPrinter
+	TalosEnv     env.EnvPrinter
+	TerraformEnv env.EnvPrinter
+	WindsorEnv   env.EnvPrinter
+}
 
 // Runtime holds common execution values and core dependencies used across the Windsor CLI.
 // These fields are set during various initialization steps rather than computed on-demand.
@@ -48,22 +71,10 @@ type Runtime struct {
 	Evaluator     evaluator.ExpressionEvaluator
 
 	// SecretsProviders contains providers for Sops and 1Password secrets management
-	SecretsProviders struct {
-		Sops        secretsRuntime.SecretsProvider
-		Onepassword []secretsRuntime.SecretsProvider
-	}
+	SecretsProviders RuntimeSecretsProviders
 
 	// EnvPrinters contains environment printers for various providers and tools
-	EnvPrinters struct {
-		AwsEnv       env.EnvPrinter
-		AzureEnv     env.EnvPrinter
-		GcpEnv       env.EnvPrinter
-		DockerEnv    env.EnvPrinter
-		KubeEnv      env.EnvPrinter
-		TalosEnv     env.EnvPrinter
-		TerraformEnv env.EnvPrinter
-		WindsorEnv   env.EnvPrinter
-	}
+	EnvPrinters RuntimeEnvPrinters
 
 	// ToolsManager manages tool installation and configuration
 	ToolsManager tools.ToolsManager
@@ -76,6 +87,14 @@ type Runtime struct {
 
 	// aliases stores collected shell aliases
 	aliases map[string]string
+
+	// secretHelperRegistered tracks whether the secret helper has already been registered with the evaluator.
+	secretHelperRegistered bool
+	// secretsLoaded tracks whether configured secret providers have been loaded for this runtime lifecycle.
+	secretsLoaded bool
+
+	// secretCacheEnabled controls whether secret TF_VAR cache reuse is enabled for this runtime.
+	secretCacheEnabled bool
 }
 
 // =============================================================================
@@ -119,6 +138,7 @@ func NewRuntime(opts ...*Runtime) *Runtime {
 		if overrides.WindsorScratchPath != "" {
 			rt.WindsorScratchPath = overrides.WindsorScratchPath
 		}
+		rt.secretCacheEnabled = overrides.secretCacheEnabled
 		if overrides.ToolsManager != nil {
 			rt.ToolsManager = overrides.ToolsManager
 		}
@@ -202,6 +222,7 @@ func NewRuntime(opts ...*Runtime) *Runtime {
 	if rt.Evaluator == nil {
 		rt.Evaluator = evaluator.NewExpressionEvaluator(rt.ConfigHandler, rt.ProjectRoot, rt.TemplateRoot)
 	}
+	rt.registerSecretHelper()
 	if rt.WindsorScratchPath == "" {
 		rt.WindsorScratchPath = filepath.Join(rt.ProjectRoot, ".windsor", "contexts", rt.ContextName)
 	}
@@ -228,6 +249,7 @@ func (rt *Runtime) HandleSessionReset() error {
 	}
 	if shouldReset {
 		rt.Shell.Reset()
+		rt.secretsLoaded = false
 		if err := os.Setenv("NO_CACHE", "true"); err != nil {
 			return fmt.Errorf("failed to set NO_CACHE: %w", err)
 		}
@@ -252,7 +274,7 @@ func (rt *Runtime) LoadEnvironment(decrypt bool) error {
 		return fmt.Errorf("failed to initialize environment components: %w", err)
 	}
 
-	if decrypt {
+	if decrypt && len(rt.configuredSecretsProviders()) > 0 {
 		if err := rt.loadSecrets(); err != nil {
 			return fmt.Errorf("failed to load secrets: %w", err)
 		}
@@ -260,6 +282,8 @@ func (rt *Runtime) LoadEnvironment(decrypt bool) error {
 
 	allEnvVars := make(map[string]string)
 	allAliases := make(map[string]string)
+	managedEnv := make([]string, 0)
+	managedAlias := make([]string, 0)
 
 	for _, printer := range rt.getAllEnvPrinters() {
 		if printer != nil {
@@ -274,8 +298,12 @@ func (rt *Runtime) LoadEnvironment(decrypt bool) error {
 				return fmt.Errorf("error getting aliases: %w", err)
 			}
 			maps.Copy(allAliases, aliases)
+			managedEnv = appendUniqueStrings(managedEnv, printer.GetManagedEnv()...)
+			managedAlias = appendUniqueStrings(managedAlias, printer.GetManagedAlias()...)
 		}
 	}
+	allEnvVars["WINDSOR_MANAGED_ENV"] = strings.Join(managedEnv, ",")
+	allEnvVars["WINDSOR_MANAGED_ALIAS"] = strings.Join(managedAlias, ",")
 
 	rt.envVars = allEnvVars
 	rt.aliases = allAliases
@@ -314,6 +342,16 @@ func (rt *Runtime) GetAliases() map[string]string {
 	result := make(map[string]string)
 	maps.Copy(result, rt.aliases)
 	return result
+}
+
+// SetSecretCacheEnabled enables or disables runtime secret cache reuse behavior.
+func (rt *Runtime) SetSecretCacheEnabled(enabled bool) {
+	rt.secretCacheEnabled = enabled
+}
+
+// IsSecretCacheEnabled reports whether runtime secret cache reuse behavior is enabled.
+func (rt *Runtime) IsSecretCacheEnabled() bool {
+	return rt.secretCacheEnabled
 }
 
 // CheckTools performs tool version checking using the tools manager.
@@ -721,7 +759,10 @@ func (rt *Runtime) initializeEnvPrinters() {
 		if rt.TerraformProvider == nil {
 			rt.TerraformProvider = terraform.NewTerraformProvider(rt.ConfigHandler, rt.Shell, rt.ToolsManager, rt.Evaluator)
 		}
+		rt.TerraformProvider.SetSecretCacheEnabled(rt.secretCacheEnabled)
 		rt.EnvPrinters.TerraformEnv = env.NewTerraformEnvPrinter(rt.Shell, rt.ConfigHandler, rt.ToolsManager, rt.TerraformProvider)
+	} else if rt.TerraformProvider != nil {
+		rt.TerraformProvider.SetSecretCacheEnabled(rt.secretCacheEnabled)
 	}
 	if rt.EnvPrinters.WindsorEnv == nil {
 		secretsProviders := []secretsRuntime.SecretsProvider{}
@@ -731,8 +772,12 @@ func (rt *Runtime) initializeEnvPrinters() {
 		if rt.SecretsProviders.Onepassword != nil {
 			secretsProviders = append(secretsProviders, rt.SecretsProviders.Onepassword...)
 		}
-		allEnvPrinters := rt.getAllEnvPrinters()
-		rt.EnvPrinters.WindsorEnv = env.NewWindsorEnvPrinter(rt.Shell, rt.ConfigHandler, secretsProviders, allEnvPrinters)
+		rt.EnvPrinters.WindsorEnv = env.NewWindsorEnvPrinter(
+			rt.Shell,
+			rt.ConfigHandler,
+			secretsProviders,
+			&env.WindsorEnvOptions{SecretCacheEnabled: rt.secretCacheEnabled},
+		)
 	}
 }
 
@@ -806,7 +851,13 @@ func (rt *Runtime) initializeSecretsProviders() {
 		if vaultsValue != nil {
 			if vaultsMap, ok := vaultsValue.(map[string]any); ok {
 				rt.SecretsProviders.Onepassword = []secretsRuntime.SecretsProvider{}
-				for vaultID, vaultData := range vaultsMap {
+				vaultIDs := make([]string, 0, len(vaultsMap))
+				for vaultID := range vaultsMap {
+					vaultIDs = append(vaultIDs, vaultID)
+				}
+				sort.Strings(vaultIDs)
+				for _, vaultID := range vaultIDs {
+					vaultData := vaultsMap[vaultID]
 					if vaultMap, ok := vaultData.(map[string]any); ok {
 						vault := secretsConfigType.OnePasswordVault{
 							ID: vaultID,
@@ -833,6 +884,25 @@ func (rt *Runtime) initializeSecretsProviders() {
 			}
 		}
 	}
+	rt.registerSecretHelper()
+}
+
+// registerSecretHelper registers the secret() expression helper once for this runtime.
+func (rt *Runtime) registerSecretHelper() {
+	if rt.secretHelperRegistered || rt.Evaluator == nil {
+		return
+	}
+	secretsRuntime.RegisterSecretHelper(rt.Evaluator, rt.resolveSecretReference)
+	rt.secretHelperRegistered = true
+}
+
+// resolveSecretReference resolves a single secret reference using configured secret providers.
+func (rt *Runtime) resolveSecretReference(ref string) (string, error) {
+	rt.initializeSecretsProviders()
+	if err := rt.loadSecrets(); err != nil {
+		return "", err
+	}
+	return secretsRuntime.ResolveReference(ref, rt.configuredSecretsProviders())
 }
 
 // getAllEnvPrinters returns all environment printers in a consistent order.
@@ -856,23 +926,49 @@ func (rt *Runtime) getAllEnvPrinters() []env.EnvPrinter {
 // If a provider fails to load (e.g., file not found), it continues with other providers.
 // Returns an error only if a provider encounters a non-recoverable error (e.g., decryption failure).
 func (rt *Runtime) loadSecrets() error {
-	providers := []secretsRuntime.SecretsProvider{}
-	if rt.SecretsProviders.Sops != nil {
-		providers = append(providers, rt.SecretsProviders.Sops)
+	if rt.secretsLoaded {
+		return nil
 	}
-	if rt.SecretsProviders.Onepassword != nil {
-		providers = append(providers, rt.SecretsProviders.Onepassword...)
-	}
-
-	for _, provider := range providers {
+	for _, provider := range rt.configuredSecretsProviders() {
 		if provider != nil {
 			if err := provider.LoadSecrets(); err != nil {
 				return fmt.Errorf("failed to load secrets: %w", err)
 			}
 		}
 	}
-
+	rt.secretsLoaded = true
 	return nil
+}
+
+// configuredSecretsProviders returns all active secret providers in deterministic order.
+func (rt *Runtime) configuredSecretsProviders() []secretsRuntime.SecretsProvider {
+	providers := make([]secretsRuntime.SecretsProvider, 0)
+	if rt.SecretsProviders.Sops != nil {
+		providers = append(providers, rt.SecretsProviders.Sops)
+	}
+	if len(rt.SecretsProviders.Onepassword) > 0 {
+		providers = append(providers, rt.SecretsProviders.Onepassword...)
+	}
+	return providers
+}
+
+// appendUniqueStrings appends non-empty values to base while preserving first-seen order and avoiding duplicates.
+func appendUniqueStrings(base []string, values ...string) []string {
+	seen := make(map[string]struct{}, len(base))
+	for _, value := range base {
+		seen[value] = struct{}{}
+	}
+	for _, value := range values {
+		if value == "" {
+			continue
+		}
+		if _, exists := seen[value]; exists {
+			continue
+		}
+		seen[value] = struct{}{}
+		base = append(base, value)
+	}
+	return base
 }
 
 // writeBuildIDToFile writes the provided build ID string to the .windsor/.build-id file in the project root.

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -292,6 +292,8 @@ func (rt *Runtime) LoadEnvironment(decrypt bool) error {
 				return fmt.Errorf("error getting environment variables: %w", err)
 			}
 			maps.Copy(allEnvVars, envVars)
+			managedEnv = appendManagedValues(managedEnv, envVars["WINDSOR_MANAGED_ENV"])
+			managedAlias = appendManagedValues(managedAlias, envVars["WINDSOR_MANAGED_ALIAS"])
 
 			aliases, err := printer.GetAlias()
 			if err != nil {
@@ -969,6 +971,19 @@ func appendUniqueStrings(base []string, values ...string) []string {
 		base = append(base, value)
 	}
 	return base
+}
+
+// appendManagedValues appends comma-separated managed names while preserving first-seen order.
+func appendManagedValues(base []string, csvValues string) []string {
+	if strings.TrimSpace(csvValues) == "" {
+		return base
+	}
+	parts := strings.Split(csvValues, ",")
+	normalized := make([]string, 0, len(parts))
+	for _, part := range parts {
+		normalized = append(normalized, strings.TrimSpace(part))
+	}
+	return appendUniqueStrings(base, normalized...)
 }
 
 // writeBuildIDToFile writes the provided build ID string to the .windsor/.build-id file in the project root.

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -632,6 +632,19 @@ func TestRuntime_LoadEnvironment(t *testing.T) {
 
 		rt.SecretsProviders.Sops = mockSopsProvider
 		rt.SecretsProviders.Onepassword = []secrets.SecretsProvider{mockOnepasswordProvider}
+		if mockConfig, ok := rt.ConfigHandler.(*config.MockConfigHandler); ok {
+			mockConfig.GetStringMapFunc = func(key string, defaultValue ...map[string]string) map[string]string {
+				if key == "environment" {
+					return map[string]string{
+						"TEST_SECRET": "${op.demo.foo.bar}",
+					}
+				}
+				if len(defaultValue) > 0 {
+					return defaultValue[0]
+				}
+				return map[string]string{}
+			}
+		}
 
 		// When LoadEnvironment is called with secrets enabled
 		err := rt.LoadEnvironment(true)
@@ -653,6 +666,19 @@ func TestRuntime_LoadEnvironment(t *testing.T) {
 		}
 
 		rt.SecretsProviders.Sops = mockProvider
+		if mockConfig, ok := rt.ConfigHandler.(*config.MockConfigHandler); ok {
+			mockConfig.GetStringMapFunc = func(key string, defaultValue ...map[string]string) map[string]string {
+				if key == "environment" {
+					return map[string]string{
+						"TEST_SECRET": "${op.demo.foo.bar}",
+					}
+				}
+				if len(defaultValue) > 0 {
+					return defaultValue[0]
+				}
+				return map[string]string{}
+			}
+		}
 
 		// When LoadEnvironment is called with secrets enabled
 		err := rt.LoadEnvironment(true)
@@ -664,6 +690,61 @@ func TestRuntime_LoadEnvironment(t *testing.T) {
 
 		if !strings.Contains(err.Error(), "secrets load failed") {
 			t.Errorf("Expected secrets load error, got: %v", err)
+		}
+	})
+
+	t.Run("LoadsSecretsInDecryptModeWithoutSecretExpressionHeuristics", func(t *testing.T) {
+		mocks := setupRuntimeMocks(t)
+		rt := mocks.Runtime
+
+		loadCalls := 0
+		mockProvider := secrets.NewMockSecretsProvider(mocks.Shell)
+		mockProvider.LoadSecretsFunc = func() error {
+			loadCalls++
+			return nil
+		}
+		rt.SecretsProviders.Sops = mockProvider
+		if mockConfig, ok := rt.ConfigHandler.(*config.MockConfigHandler); ok {
+			mockConfig.GetStringMapFunc = func(key string, defaultValue ...map[string]string) map[string]string {
+				if key == "environment" {
+					return map[string]string{
+						"PROJECT_ROOT": "${project_root}",
+					}
+				}
+				if len(defaultValue) > 0 {
+					return defaultValue[0]
+				}
+				return map[string]string{}
+			}
+		}
+
+		err := rt.LoadEnvironment(true)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if loadCalls != 1 {
+			t.Fatalf("Expected LoadSecrets to be called once in decrypt mode, got %d", loadCalls)
+		}
+	})
+
+	t.Run("SkipsSecretsLoadWhenDecryptDisabled", func(t *testing.T) {
+		mocks := setupRuntimeMocks(t)
+		rt := mocks.Runtime
+
+		loadCalls := 0
+		mockProvider := secrets.NewMockSecretsProvider(mocks.Shell)
+		mockProvider.LoadSecretsFunc = func() error {
+			loadCalls++
+			return nil
+		}
+		rt.SecretsProviders.Sops = mockProvider
+
+		err := rt.LoadEnvironment(false)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if loadCalls != 0 {
+			t.Fatalf("Expected LoadSecrets to be skipped when decrypt is false, got %d", loadCalls)
 		}
 	})
 }
@@ -2106,6 +2187,48 @@ func TestRuntime_loadSecrets(t *testing.T) {
 		// Then no error should be returned
 		if err != nil {
 			t.Fatalf("Expected no error with mixed providers, got: %v", err)
+		}
+	})
+}
+
+func TestRuntime_resolveSecretReference(t *testing.T) {
+	t.Run("LoadsProvidersOnceAndResolvesReferences", func(t *testing.T) {
+		mocks := setupRuntimeMocks(t)
+		rt := mocks.Runtime
+
+		loadCalls := 0
+		parseCalls := 0
+		mockProvider := secrets.NewMockSecretsProvider(mocks.Shell)
+		mockProvider.LoadSecretsFunc = func() error {
+			loadCalls++
+			return nil
+		}
+		mockProvider.ParseSecretsFunc = func(input string) (string, error) {
+			parseCalls++
+			if input == "${op.demo.foo.bar}" {
+				return "resolved-secret", nil
+			}
+			return input, nil
+		}
+		rt.SecretsProviders.Sops = mockProvider
+		rt.SecretsProviders.Onepassword = nil
+
+		first, err := rt.resolveSecretReference("op.demo.foo.bar")
+		if err != nil {
+			t.Fatalf("Expected no error on first resolve, got: %v", err)
+		}
+		second, err := rt.resolveSecretReference("op.demo.foo.bar")
+		if err != nil {
+			t.Fatalf("Expected no error on second resolve, got: %v", err)
+		}
+		if first != "resolved-secret" || second != "resolved-secret" {
+			t.Fatalf("Expected resolved-secret results, got %q and %q", first, second)
+		}
+		if loadCalls != 1 {
+			t.Fatalf("Expected provider LoadSecrets to be called once, got %d", loadCalls)
+		}
+		if parseCalls != 2 {
+			t.Fatalf("Expected ParseSecrets to be called per resolution, got %d", parseCalls)
 		}
 	})
 }

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -747,6 +747,58 @@ func TestRuntime_LoadEnvironment(t *testing.T) {
 			t.Fatalf("Expected LoadSecrets to be skipped when decrypt is false, got %d", loadCalls)
 		}
 	})
+
+	t.Run("PreservesManagedValuesReturnedInEnvPayload", func(t *testing.T) {
+		mocks := setupRuntimeMocks(t)
+		rt := mocks.Runtime
+
+		mockEnvPrinter := env.NewMockEnvPrinter()
+		mockEnvPrinter.GetEnvVarsFunc = func() (map[string]string, error) {
+			return map[string]string{
+				"WINDSOR_CONTEXT":       "test-context",
+				"WINDSOR_PROJECT_ROOT":  "/test/project",
+				"WINDSOR_SESSION_TOKEN": "token",
+				"BUILD_ID":              "010101.001.1",
+				"WINDSOR_MANAGED_ENV":   "WINDSOR_CONTEXT,WINDSOR_PROJECT_ROOT,WINDSOR_SESSION_TOKEN,BUILD_ID",
+				"WINDSOR_MANAGED_ALIAS": "from-env-payload",
+			}, nil
+		}
+		mockEnvPrinter.GetAliasFunc = func() (map[string]string, error) {
+			return map[string]string{}, nil
+		}
+		mockEnvPrinter.GetManagedEnvFunc = func() []string {
+			return []string{"from-managed-env"}
+		}
+		mockEnvPrinter.GetManagedAliasFunc = func() []string {
+			return []string{"from-managed-alias"}
+		}
+		rt.EnvPrinters.WindsorEnv = mockEnvPrinter
+
+		err := rt.LoadEnvironment(false)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		managedEnv := rt.envVars["WINDSOR_MANAGED_ENV"]
+		for _, required := range []string{
+			"WINDSOR_CONTEXT",
+			"WINDSOR_PROJECT_ROOT",
+			"WINDSOR_SESSION_TOKEN",
+			"BUILD_ID",
+			"from-managed-env",
+		} {
+			if !strings.Contains(managedEnv, required) {
+				t.Fatalf("Expected WINDSOR_MANAGED_ENV to include %q, got %q", required, managedEnv)
+			}
+		}
+
+		managedAlias := rt.envVars["WINDSOR_MANAGED_ALIAS"]
+		for _, required := range []string{"from-env-payload", "from-managed-alias"} {
+			if !strings.Contains(managedAlias, required) {
+				t.Fatalf("Expected WINDSOR_MANAGED_ALIAS to include %q, got %q", required, managedAlias)
+			}
+		}
+	})
 }
 
 func TestRuntime_GetEnvVars(t *testing.T) {

--- a/pkg/runtime/secrets/expression_helper.go
+++ b/pkg/runtime/secrets/expression_helper.go
@@ -88,11 +88,12 @@ func normalizeSecretReferenceExpression(expression string) string {
 // IsSecretReferenceExpression reports whether expression is a plain secret reference token.
 func IsSecretReferenceExpression(expression string) bool {
 	trimmed := strings.TrimSpace(expression)
-	if !(strings.HasPrefix(trimmed, "secret.") ||
-		strings.HasPrefix(trimmed, "secrets.") ||
-		strings.HasPrefix(trimmed, "op.") ||
-		strings.HasPrefix(trimmed, "op[") ||
-		strings.HasPrefix(trimmed, "sops.")) {
+	normalized := strings.ToLower(trimmed)
+	if !(strings.HasPrefix(normalized, "secret.") ||
+		strings.HasPrefix(normalized, "secrets.") ||
+		strings.HasPrefix(normalized, "op.") ||
+		strings.HasPrefix(normalized, "op[") ||
+		strings.HasPrefix(normalized, "sops.")) {
 		return false
 	}
 	if strings.Contains(trimmed, "${") {

--- a/pkg/runtime/secrets/expression_helper.go
+++ b/pkg/runtime/secrets/expression_helper.go
@@ -1,0 +1,100 @@
+// The ExpressionHelper is a secrets expression registration and resolution component.
+// It provides evaluator helper wiring for secret() expressions and provider-backed resolution.
+// The ExpressionHelper acts as the bridge between evaluator callbacks and secrets providers.
+// It centralizes validation, deferred behavior, and reference resolution for secret expressions.
+package secrets
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/windsorcli/cli/pkg/runtime/evaluator"
+)
+
+// =============================================================================
+// Public Methods
+// =============================================================================
+
+// RegisterSecretHelper registers the secret() helper with the evaluator.
+func RegisterSecretHelper(eval evaluator.ExpressionEvaluator, resolve func(string) (string, error)) {
+	if eval == nil {
+		return
+	}
+	if normalizerAware, ok := eval.(interface {
+		RegisterExpressionNormalizer(func(string) string)
+	}); ok {
+		normalizerAware.RegisterExpressionNormalizer(normalizeSecretReferenceExpression)
+	}
+	eval.Register("secret", func(params []any, deferred bool) (any, error) {
+		return evaluateSecretHelper(params, deferred, resolve)
+	}, new(func(string) any))
+}
+
+// ResolveReference resolves a single secret reference through configured providers.
+func ResolveReference(ref string, providers []SecretsProvider) (string, error) {
+	if len(providers) == 0 {
+		return "", fmt.Errorf("no secrets providers configured")
+	}
+	initialReference := fmt.Sprintf("${%s}", ref)
+	value := initialReference
+	for _, provider := range providers {
+		if provider == nil {
+			continue
+		}
+		parsed, err := provider.ParseSecrets(value)
+		if err == nil {
+			value = parsed
+		}
+	}
+	if value == initialReference {
+		return "", fmt.Errorf("failed to resolve secret reference: %s", ref)
+	}
+	return value, nil
+}
+
+// =============================================================================
+// Private Methods
+// =============================================================================
+
+// evaluateSecretHelper executes the secret() evaluator helper and returns a secret-qualified value.
+func evaluateSecretHelper(params []any, deferred bool, resolve func(string) (string, error)) (any, error) {
+	if len(params) != 1 {
+		return nil, fmt.Errorf("secret() requires exactly 1 argument, got %d", len(params))
+	}
+	ref, ok := params[0].(string)
+	if !ok || strings.TrimSpace(ref) == "" {
+		return nil, fmt.Errorf("secret() argument must be a non-empty string, got %T", params[0])
+	}
+	if !deferred {
+		return evaluator.SecretValue{Value: fmt.Sprintf("${%s}", ref)}, nil
+	}
+	resolved, err := resolve(ref)
+	if err != nil {
+		return nil, err
+	}
+	return evaluator.SecretValue{Value: resolved}, nil
+}
+
+func normalizeSecretReferenceExpression(expression string) string {
+	trimmed := strings.TrimSpace(expression)
+	if isSecretReferenceExpression(trimmed) {
+		escaped := strings.ReplaceAll(trimmed, `\`, `\\`)
+		escaped = strings.ReplaceAll(escaped, `"`, `\"`)
+		return fmt.Sprintf(`secret("%s")`, escaped)
+	}
+	return expression
+}
+
+func isSecretReferenceExpression(expression string) bool {
+	if !(strings.HasPrefix(expression, "secret.op.") ||
+		strings.HasPrefix(expression, "secret.sops.") ||
+		strings.HasPrefix(expression, "op.") ||
+		strings.HasPrefix(expression, "op[") ||
+		strings.HasPrefix(expression, "sops.")) {
+		return false
+	}
+	if strings.Contains(expression, "${") {
+		return false
+	}
+	return !strings.ContainsAny(expression, " \t\n\r()+-*/%<>=!&|?:,")
+}

--- a/pkg/runtime/secrets/expression_helper.go
+++ b/pkg/runtime/secrets/expression_helper.go
@@ -99,5 +99,37 @@ func IsSecretReferenceExpression(expression string) bool {
 	if strings.Contains(trimmed, "${") {
 		return false
 	}
-	return !strings.ContainsAny(trimmed, " \t\n\r()+-*/%<>=!&|?:,")
+	return !containsDisallowedSecretReferenceToken(trimmed)
+}
+
+// containsDisallowedSecretReferenceToken reports whether expression contains disallowed tokens outside quoted segments.
+func containsDisallowedSecretReferenceToken(expression string) bool {
+	inSingleQuote := false
+	inDoubleQuote := false
+	escaped := false
+	for _, r := range expression {
+		if escaped {
+			escaped = false
+			continue
+		}
+		if r == '\\' && (inSingleQuote || inDoubleQuote) {
+			escaped = true
+			continue
+		}
+		if r == '\'' && !inDoubleQuote {
+			inSingleQuote = !inSingleQuote
+			continue
+		}
+		if r == '"' && !inSingleQuote {
+			inDoubleQuote = !inDoubleQuote
+			continue
+		}
+		if inSingleQuote || inDoubleQuote {
+			continue
+		}
+		if strings.ContainsRune(" \t\n\r()+-*/%<>=!&|?:,", r) {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/runtime/secrets/expression_helper.go
+++ b/pkg/runtime/secrets/expression_helper.go
@@ -77,7 +77,7 @@ func evaluateSecretHelper(params []any, deferred bool, resolve func(string) (str
 
 func normalizeSecretReferenceExpression(expression string) string {
 	trimmed := strings.TrimSpace(expression)
-	if isSecretReferenceExpression(trimmed) {
+	if IsSecretReferenceExpression(trimmed) {
 		escaped := strings.ReplaceAll(trimmed, `\`, `\\`)
 		escaped = strings.ReplaceAll(escaped, `"`, `\"`)
 		return fmt.Sprintf(`secret("%s")`, escaped)
@@ -85,16 +85,18 @@ func normalizeSecretReferenceExpression(expression string) string {
 	return expression
 }
 
-func isSecretReferenceExpression(expression string) bool {
-	if !(strings.HasPrefix(expression, "secret.op.") ||
-		strings.HasPrefix(expression, "secret.sops.") ||
-		strings.HasPrefix(expression, "op.") ||
-		strings.HasPrefix(expression, "op[") ||
-		strings.HasPrefix(expression, "sops.")) {
+// IsSecretReferenceExpression reports whether expression is a plain secret reference token.
+func IsSecretReferenceExpression(expression string) bool {
+	trimmed := strings.TrimSpace(expression)
+	if !(strings.HasPrefix(trimmed, "secret.") ||
+		strings.HasPrefix(trimmed, "secrets.") ||
+		strings.HasPrefix(trimmed, "op.") ||
+		strings.HasPrefix(trimmed, "op[") ||
+		strings.HasPrefix(trimmed, "sops.")) {
 		return false
 	}
-	if strings.Contains(expression, "${") {
+	if strings.Contains(trimmed, "${") {
 		return false
 	}
-	return !strings.ContainsAny(expression, " \t\n\r()+-*/%<>=!&|?:,")
+	return !strings.ContainsAny(trimmed, " \t\n\r()+-*/%<>=!&|?:,")
 }

--- a/pkg/runtime/secrets/expression_helper_test.go
+++ b/pkg/runtime/secrets/expression_helper_test.go
@@ -198,6 +198,7 @@ func TestIsSecretReferenceExpression(t *testing.T) {
 	t.Run("MatchesPlainReferenceForms", func(t *testing.T) {
 		candidates := []string{
 			"op.platform.db.password",
+			`op["personal"]["item"]["field"]`,
 			"OP.platform.db.password",
 			"sops.platform.db.password",
 			"secret.op.platform.db.password",

--- a/pkg/runtime/secrets/expression_helper_test.go
+++ b/pkg/runtime/secrets/expression_helper_test.go
@@ -1,0 +1,172 @@
+package secrets
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/windsorcli/cli/pkg/runtime/config"
+	"github.com/windsorcli/cli/pkg/runtime/evaluator"
+	"github.com/windsorcli/cli/pkg/runtime/shell"
+)
+
+func TestResolveReference(t *testing.T) {
+	t.Run("ReturnsResolvedValueContainingExpressionSyntax", func(t *testing.T) {
+		mockProvider := NewMockSecretsProvider(shell.NewMockShell())
+		mockProvider.ParseSecretsFunc = func(input string) (string, error) {
+			if input != "${op.vault.item.field}" {
+				t.Fatalf("expected provider input %q, got %q", "${op.vault.item.field}", input)
+			}
+			return "abc${x}", nil
+		}
+
+		value, err := ResolveReference("op.vault.item.field", []SecretsProvider{mockProvider})
+
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if value != "abc${x}" {
+			t.Fatalf("expected value %q, got %q", "abc${x}", value)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenReferenceRemainsUnresolved", func(t *testing.T) {
+		mockProvider := NewMockSecretsProvider(shell.NewMockShell())
+		mockProvider.ParseSecretsFunc = func(input string) (string, error) {
+			return input, nil
+		}
+
+		_, err := ResolveReference("op.vault.item.field", []SecretsProvider{mockProvider})
+
+		if err == nil {
+			t.Fatalf("expected unresolved reference error, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to resolve secret reference: op.vault.item.field") {
+			t.Fatalf("expected unresolved reference error, got %v", err)
+		}
+	})
+
+	t.Run("DoesNotLoadSecretsDuringReferenceResolution", func(t *testing.T) {
+		mockProvider := NewMockSecretsProvider(shell.NewMockShell())
+		loadCalls := 0
+		mockProvider.LoadSecretsFunc = func() error {
+			loadCalls++
+			return nil
+		}
+		mockProvider.ParseSecretsFunc = func(input string) (string, error) {
+			if input == "${op.vault.item.field}" {
+				return "resolved-value", nil
+			}
+			return input, nil
+		}
+
+		value, err := ResolveReference("op.vault.item.field", []SecretsProvider{mockProvider})
+
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if value != "resolved-value" {
+			t.Fatalf("expected resolved value, got %q", value)
+		}
+		if loadCalls != 0 {
+			t.Fatalf("expected ResolveReference to avoid LoadSecrets side effects, got %d calls", loadCalls)
+		}
+	})
+}
+
+func TestRegisterSecretHelper(t *testing.T) {
+	t.Run("NormalizesLegacyProviderSyntaxOutsideEvaluator", func(t *testing.T) {
+		mockConfig := config.NewMockConfigHandler()
+		mockConfig.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{}, nil
+		}
+		eval := evaluator.NewExpressionEvaluator(mockConfig, "", "")
+
+		RegisterSecretHelper(eval, func(ref string) (string, error) {
+			return "resolved:" + ref, nil
+		})
+
+		result, err := eval.Evaluate("${op.platform.db.password}", "", nil, true)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if !evaluator.ContainsSecretValue(result) {
+			t.Fatalf("expected secret-qualified value, got %T", result)
+		}
+		if got := evaluator.UnwrapSecretValue(result); got != "resolved:op.platform.db.password" {
+			t.Fatalf("expected normalized legacy secret expression result, got %v", got)
+		}
+	})
+
+	t.Run("KeepsExplicitSecretHelperCallsWorking", func(t *testing.T) {
+		mockConfig := config.NewMockConfigHandler()
+		mockConfig.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{}, nil
+		}
+		eval := evaluator.NewExpressionEvaluator(mockConfig, "", "")
+
+		RegisterSecretHelper(eval, func(ref string) (string, error) {
+			return "resolved:" + ref, nil
+		})
+
+		result, err := eval.Evaluate(`${secret("secret.op.platform.db.password")}`, "", nil, true)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if !evaluator.ContainsSecretValue(result) {
+			t.Fatalf("expected secret-qualified value, got %T", result)
+		}
+		if got := evaluator.UnwrapSecretValue(result); got != "resolved:secret.op.platform.db.password" {
+			t.Fatalf("expected explicit helper expression result, got %v", got)
+		}
+	})
+
+	t.Run("DoesNotNormalizeNonSecretExpressionsStartingWithOp", func(t *testing.T) {
+		mockConfig := config.NewMockConfigHandler()
+		mockConfig.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{
+				"op": map[string]any{
+					"flags": map[string]any{
+						"enabled": true,
+					},
+				},
+			}, nil
+		}
+		eval := evaluator.NewExpressionEvaluator(mockConfig, "", "")
+
+		RegisterSecretHelper(eval, func(ref string) (string, error) {
+			return "resolved:" + ref, nil
+		})
+
+		result, err := eval.Evaluate("${op.flags.enabled && true}", "", nil, true)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if result != true {
+			t.Fatalf("expected boolean expression result true, got %v", result)
+		}
+	})
+
+	t.Run("DoesNotNormalizeNonSecretExpressionsStartingWithSops", func(t *testing.T) {
+		mockConfig := config.NewMockConfigHandler()
+		mockConfig.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{
+				"sops": map[string]any{
+					"enabled": false,
+				},
+			}, nil
+		}
+		eval := evaluator.NewExpressionEvaluator(mockConfig, "", "")
+
+		RegisterSecretHelper(eval, func(ref string) (string, error) {
+			return "resolved:" + ref, nil
+		})
+
+		result, err := eval.Evaluate("${sops.enabled ?? true}", "", nil, true)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if result != false {
+			t.Fatalf("expected coalesce expression to return false, got %v", result)
+		}
+	})
+}

--- a/pkg/runtime/secrets/expression_helper_test.go
+++ b/pkg/runtime/secrets/expression_helper_test.go
@@ -120,6 +120,29 @@ func TestRegisterSecretHelper(t *testing.T) {
 		}
 	})
 
+	t.Run("NormalizesBracketNotationWithSpacesOutsideEvaluator", func(t *testing.T) {
+		mockConfig := config.NewMockConfigHandler()
+		mockConfig.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{}, nil
+		}
+		eval := evaluator.NewExpressionEvaluator(mockConfig, "", "")
+
+		RegisterSecretHelper(eval, func(ref string) (string, error) {
+			return "resolved:" + ref, nil
+		})
+
+		result, err := eval.Evaluate(`${op.personal["The Criterion Channel"]["password"]}`, "", nil, true)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if !evaluator.ContainsSecretValue(result) {
+			t.Fatalf("expected secret-qualified value, got %T", result)
+		}
+		if got := evaluator.UnwrapSecretValue(result); got != `resolved:op.personal["The Criterion Channel"]["password"]` {
+			t.Fatalf("expected normalized bracket provider expression result, got %v", got)
+		}
+	})
+
 	t.Run("KeepsExplicitSecretHelperCallsWorking", func(t *testing.T) {
 		mockConfig := config.NewMockConfigHandler()
 		mockConfig.GetContextValuesFunc = func() (map[string]any, error) {
@@ -199,6 +222,7 @@ func TestIsSecretReferenceExpression(t *testing.T) {
 		candidates := []string{
 			"op.platform.db.password",
 			`op["personal"]["item"]["field"]`,
+			`op.personal["The Criterion Channel"]["password"]`,
 			"OP.platform.db.password",
 			"sops.platform.db.password",
 			"secret.op.platform.db.password",

--- a/pkg/runtime/secrets/expression_helper_test.go
+++ b/pkg/runtime/secrets/expression_helper_test.go
@@ -97,6 +97,29 @@ func TestRegisterSecretHelper(t *testing.T) {
 		}
 	})
 
+	t.Run("NormalizesUppercaseProviderPrefixOutsideEvaluator", func(t *testing.T) {
+		mockConfig := config.NewMockConfigHandler()
+		mockConfig.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{}, nil
+		}
+		eval := evaluator.NewExpressionEvaluator(mockConfig, "", "")
+
+		RegisterSecretHelper(eval, func(ref string) (string, error) {
+			return "resolved:" + ref, nil
+		})
+
+		result, err := eval.Evaluate("${OP.platform.db.password}", "", nil, true)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if !evaluator.ContainsSecretValue(result) {
+			t.Fatalf("expected secret-qualified value, got %T", result)
+		}
+		if got := evaluator.UnwrapSecretValue(result); got != "resolved:OP.platform.db.password" {
+			t.Fatalf("expected normalized uppercase provider expression result, got %v", got)
+		}
+	})
+
 	t.Run("KeepsExplicitSecretHelperCallsWorking", func(t *testing.T) {
 		mockConfig := config.NewMockConfigHandler()
 		mockConfig.GetContextValuesFunc = func() (map[string]any, error) {
@@ -175,6 +198,7 @@ func TestIsSecretReferenceExpression(t *testing.T) {
 	t.Run("MatchesPlainReferenceForms", func(t *testing.T) {
 		candidates := []string{
 			"op.platform.db.password",
+			"OP.platform.db.password",
 			"sops.platform.db.password",
 			"secret.op.platform.db.password",
 			"secrets.platform.db.password",

--- a/pkg/runtime/secrets/expression_helper_test.go
+++ b/pkg/runtime/secrets/expression_helper_test.go
@@ -170,3 +170,32 @@ func TestRegisterSecretHelper(t *testing.T) {
 		}
 	})
 }
+
+func TestIsSecretReferenceExpression(t *testing.T) {
+	t.Run("MatchesPlainReferenceForms", func(t *testing.T) {
+		candidates := []string{
+			"op.platform.db.password",
+			"sops.platform.db.password",
+			"secret.op.platform.db.password",
+			"secrets.platform.db.password",
+		}
+		for _, candidate := range candidates {
+			if !IsSecretReferenceExpression(candidate) {
+				t.Fatalf("expected candidate %q to be recognized as secret reference", candidate)
+			}
+		}
+	})
+
+	t.Run("RejectsOperatorExpressions", func(t *testing.T) {
+		candidates := []string{
+			"op.flags.enabled && true",
+			"sops.enabled ?? true",
+			"secret.op.flags.enabled ? 1 : 0",
+		}
+		for _, candidate := range candidates {
+			if IsSecretReferenceExpression(candidate) {
+				t.Fatalf("expected candidate %q to be rejected", candidate)
+			}
+		}
+	})
+}

--- a/pkg/runtime/secrets/op_cli_secrets_provider.go
+++ b/pkg/runtime/secrets/op_cli_secrets_provider.go
@@ -50,6 +50,10 @@ func (s *OnePasswordCLISecretsProvider) GetSecret(key string) (string, error) {
 	if !s.unlocked {
 		return "********", nil
 	}
+	if value, ok := s.secrets[key]; ok {
+		s.shell.RegisterSecret(value)
+		return value, nil
+	}
 
 	parts := strings.SplitN(key, ".", 2)
 	if len(parts) != 2 {
@@ -64,14 +68,15 @@ func (s *OnePasswordCLISecretsProvider) GetSecret(key string) (string, error) {
 	}
 
 	value := strings.TrimSpace(string(output))
+	s.secrets[key] = value
 	s.shell.RegisterSecret(value)
 	return value, nil
 }
 
-// ParseSecrets identifies and replaces ${{ op.<id>.<secret>.<field> }} patterns in the input
+// ParseSecrets identifies and replaces ${ op.<id>.<secret>.<field> } patterns in the input
 // with corresponding secret values from 1Password, ensuring the id matches the vault ID.
 func (s *OnePasswordCLISecretsProvider) ParseSecrets(input string) (string, error) {
-	pattern := `(?i)\${{\s*op(?:\.|\[)?\s*([^}]+)\s*}}`
+	pattern := `(?i)\${\s*(?:secret\.)?op(?:\.|\[)?\s*([^}]+)\s*}`
 	result := parseSecrets(input, pattern, func(keys []string) bool {
 		return len(keys) == 3
 	}, func(keys []string) (string, bool) {

--- a/pkg/runtime/secrets/op_cli_secrets_provider_test.go
+++ b/pkg/runtime/secrets/op_cli_secrets_provider_test.go
@@ -175,7 +175,7 @@ func TestParseSecrets(t *testing.T) {
 		provider.shims = mockShims
 
 		// When ParseSecrets is called with standard notation
-		input := "This is a secret: ${{ op.test-id.test-secret.password }}"
+		input := "This is a secret: ${op.test-id.test-secret.password}"
 		expectedOutput := "This is a secret: mocked output"
 		output, err := provider.ParseSecrets(input)
 
@@ -185,6 +185,34 @@ func TestParseSecrets(t *testing.T) {
 		}
 
 		// And the output should be correctly replaced
+		if output != expectedOutput {
+			t.Errorf("Expected output to be '%s', got '%s'", expectedOutput, output)
+		}
+	})
+
+	t.Run("SupportsSecretNamespaceSyntax", func(t *testing.T) {
+		mocks := setupSecretsMocks(t)
+		vault := secretsConfigType.OnePasswordVault{
+			Name: "test-vault",
+			URL:  "test-url",
+			ID:   "test-id",
+		}
+		provider := NewOnePasswordCLISecretsProvider(vault, mocks.Shell)
+		provider.unlocked = true
+		mockShims := NewShims()
+		mockShims.Command = func(name string, args ...string) *exec.Cmd {
+			return &exec.Cmd{}
+		}
+		mockShims.CmdOutput = func(cmd *exec.Cmd) ([]byte, error) {
+			return []byte("mocked output"), nil
+		}
+		provider.shims = mockShims
+		input := "This is a secret: ${secret.op.test-id.test-secret.password}"
+		expectedOutput := "This is a secret: mocked output"
+		output, err := provider.ParseSecrets(input)
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
 		if output != expectedOutput {
 			t.Errorf("Expected output to be '%s', got '%s'", expectedOutput, output)
 		}
@@ -234,7 +262,7 @@ func TestParseSecrets(t *testing.T) {
 		provider := NewOnePasswordCLISecretsProvider(vault, mocks.Shell)
 
 		// When ParseSecrets is called with invalid format (missing field)
-		input := "This is a secret: ${{ op.test-id.test-secret }}"
+		input := "This is a secret: ${op.test-id.test-secret}"
 		expectedOutput := "This is a secret: <ERROR: invalid key path: test-id.test-secret>"
 		output, err := provider.ParseSecrets(input)
 
@@ -264,8 +292,8 @@ func TestParseSecrets(t *testing.T) {
 		provider := NewOnePasswordCLISecretsProvider(vault, mocks.Shell)
 
 		// When ParseSecrets is called with malformed JSON (missing closing brace)
-		input := "This is a secret: ${{ op.test-id.test-secret.password"
-		expectedOutput := "This is a secret: ${{ op.test-id.test-secret.password"
+		input := "This is a secret: ${op.test-id.test-secret.password"
+		expectedOutput := "This is a secret: ${op.test-id.test-secret.password"
 		output, err := provider.ParseSecrets(input)
 
 		// Then no error should be returned
@@ -294,8 +322,8 @@ func TestParseSecrets(t *testing.T) {
 		provider := NewOnePasswordCLISecretsProvider(vault, mocks.Shell)
 
 		// When ParseSecrets is called with wrong vault ID
-		input := "This is a secret: ${{ op.wrong-id.test-secret.password }}"
-		expectedOutput := "This is a secret: ${{ op.wrong-id.test-secret.password }}"
+		input := "This is a secret: ${op.wrong-id.test-secret.password}"
+		expectedOutput := "This is a secret: ${op.wrong-id.test-secret.password}"
 		output, err := provider.ParseSecrets(input)
 
 		// Then no error should be returned
@@ -335,7 +363,7 @@ func TestParseSecrets(t *testing.T) {
 		provider.shims = mockShims
 
 		// When ParseSecrets is called with a secret that doesn't exist
-		input := "This is a secret: ${{ op.test-id.nonexistent-secret.password }}"
+		input := "This is a secret: ${op.test-id.nonexistent-secret.password}"
 		expectedOutput := "This is a secret: mocked output"
 		output, err := provider.ParseSecrets(input)
 

--- a/pkg/runtime/secrets/op_sdk_secrets_provider.go
+++ b/pkg/runtime/secrets/op_sdk_secrets_provider.go
@@ -67,6 +67,10 @@ func (s *OnePasswordSDKSecretsProvider) GetSecret(key string) (string, error) {
 	if !s.unlocked {
 		return "********", nil
 	}
+	if value, ok := s.secrets[key]; ok {
+		s.shell.RegisterSecret(value)
+		return value, nil
+	}
 
 	token := os.Getenv("OP_SERVICE_ACCOUNT_TOKEN")
 	if token == "" {
@@ -109,14 +113,15 @@ func (s *OnePasswordSDKSecretsProvider) GetSecret(key string) (string, error) {
 		return "", fmt.Errorf("failed to resolve secret: %w", err)
 	}
 
+	s.secrets[key] = value
 	s.shell.RegisterSecret(value)
 	return value, nil
 }
 
-// ParseSecrets identifies and replaces ${{ op.<id>.<secret>.<field> }} patterns in the input
+// ParseSecrets identifies and replaces ${ op.<id>.<secret>.<field> } patterns in the input
 // with corresponding secret values from 1Password, ensuring the id matches the vault ID.
 func (s *OnePasswordSDKSecretsProvider) ParseSecrets(input string) (string, error) {
-	pattern := `(?i)\${{\s*op(?:\.|\[)?\s*([^}]+)\s*}}`
+	pattern := `(?i)\${\s*(?:secret\.)?op(?:\.|\[)?\s*([^}]+)\s*}`
 	result := parseSecrets(input, pattern, func(keys []string) bool {
 		return len(keys) == 3
 	}, func(keys []string) (string, bool) {

--- a/pkg/runtime/secrets/op_sdk_secrets_provider_test.go
+++ b/pkg/runtime/secrets/op_sdk_secrets_provider_test.go
@@ -385,10 +385,30 @@ func TestOnePasswordSDKSecretsProvider_ParseSecrets(t *testing.T) {
 		}
 
 		// When parsing input containing a valid 1Password secret reference
-		input := "This is a secret: ${{ op.test-id.test-secret.password }}"
+		input := "This is a secret: ${op.test-id.test-secret.password}"
 		output, err := provider.ParseSecrets(input)
 
 		// Then the secret reference should be replaced with the actual secret value
+		expectedOutput := "This is a secret: secret-value"
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if output != expectedOutput {
+			t.Errorf("Expected output to be '%s', got '%s'", expectedOutput, output)
+		}
+	})
+
+	t.Run("SupportsSecretNamespaceSyntax", func(t *testing.T) {
+		_, provider := setup(t)
+		provider.unlocked = true
+		provider.shims.NewOnePasswordClient = func(ctx context.Context, opts ...onepassword.ClientOption) (*onepassword.Client, error) {
+			return &onepassword.Client{}, nil
+		}
+		provider.shims.ResolveSecret = func(client *onepassword.Client, ctx context.Context, secretRef string) (string, error) {
+			return "secret-value", nil
+		}
+		input := "This is a secret: ${secret.op.test-id.test-secret.password}"
+		output, err := provider.ParseSecrets(input)
 		expectedOutput := "This is a secret: secret-value"
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
@@ -420,7 +440,7 @@ func TestOnePasswordSDKSecretsProvider_ParseSecrets(t *testing.T) {
 		_, provider := setup(t)
 
 		// When parsing input with an invalid secret reference format (missing field)
-		input := "This is a secret: ${{ op.test-id.test-secret }}"
+		input := "This is a secret: ${op.test-id.test-secret}"
 		output, err := provider.ParseSecrets(input)
 
 		// Then the invalid reference should be replaced with an error message
@@ -438,11 +458,11 @@ func TestOnePasswordSDKSecretsProvider_ParseSecrets(t *testing.T) {
 		_, provider := setup(t)
 
 		// When parsing input with malformed JSON syntax (missing closing brace)
-		input := "This is a secret: ${{ op.test-id.test-secret.password"
+		input := "This is a secret: ${op.test-id.test-secret.password"
 		output, err := provider.ParseSecrets(input)
 
 		// Then the malformed reference should be left unchanged
-		expectedOutput := "This is a secret: ${{ op.test-id.test-secret.password"
+		expectedOutput := "This is a secret: ${op.test-id.test-secret.password"
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -456,11 +476,11 @@ func TestOnePasswordSDKSecretsProvider_ParseSecrets(t *testing.T) {
 		_, provider := setup(t)
 
 		// When parsing input with a secret reference for a different vault ID
-		input := "This is a secret: ${{ op.wrong-id.test-secret.password }}"
+		input := "This is a secret: ${op.wrong-id.test-secret.password}"
 		output, err := provider.ParseSecrets(input)
 
 		// Then the mismatched reference should be left unchanged
-		expectedOutput := "This is a secret: ${{ op.wrong-id.test-secret.password }}"
+		expectedOutput := "This is a secret: ${op.wrong-id.test-secret.password}"
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -481,7 +501,7 @@ func TestOnePasswordSDKSecretsProvider_ParseSecrets(t *testing.T) {
 		}
 
 		// When parsing input with a reference to a nonexistent secret
-		input := "This is a secret: ${{ op.test-id.nonexistent-secret.password }}"
+		input := "This is a secret: ${op.test-id.nonexistent-secret.password}"
 		output, err := provider.ParseSecrets(input)
 
 		// Then the reference should be replaced with an error message indicating the secret was not found

--- a/pkg/runtime/secrets/secrets_provider.go
+++ b/pkg/runtime/secrets/secrets_provider.go
@@ -31,7 +31,7 @@ type SecretsProvider interface {
 	// GetSecret retrieves a secret value for the specified key
 	GetSecret(key string) (string, error)
 
-	// ParseSecrets parses a string and replaces ${{ secrets.<key> }} references with their values
+	// ParseSecrets parses a string and replaces ${ secrets.<key> } references with their values
 	ParseSecrets(input string) (string, error)
 }
 

--- a/pkg/runtime/secrets/sops_secrets_provider.go
+++ b/pkg/runtime/secrets/sops_secrets_provider.go
@@ -20,12 +20,12 @@ import (
 // Constants
 // =============================================================================
 
-// Define regex pattern for ${{ sops.<key> }} references as a constant
+// Define regex pattern for ${ sops.<key> } references as a constant
 // Allow for any amount of spaces between the brackets and the "sops.<key>"
 // We ignore the gosec G101 error here because this pattern is used for identifying secret placeholders,
 // not for storing actual secret values. The pattern itself does not contain any hardcoded credentials.
 // #nosec G101
-const sopsPattern = `(?i)\${{\s*sops\.\s*([^}\s]*?)\s*}}`
+const sopsPattern = `(?i)\${\s*(?:secret\.)?sops\.\s*([^}\s]*?)\s*}`
 
 // #nosec G101
 // This directive suppresses the gosec G101 warning, which is about hardcoded credentials.
@@ -202,7 +202,7 @@ func (s *SopsSecretsProvider) GetSecret(key string) (string, error) {
 	return "", fmt.Errorf("secret not found: %s", key)
 }
 
-// ParseSecrets parses a string and replaces ${{ sops.<key> }} references with their values
+// ParseSecrets parses a string and replaces ${ sops.<key> } references with their values
 func (s *SopsSecretsProvider) ParseSecrets(input string) (string, error) {
 	result := parseSecrets(input, sopsPattern, func(keys []string) bool {
 		for _, key := range keys {

--- a/pkg/runtime/secrets/sops_secrets_provider_test.go
+++ b/pkg/runtime/secrets/sops_secrets_provider_test.go
@@ -338,7 +338,7 @@ func TestSopsSecretsProvider_ParseSecrets(t *testing.T) {
 		provider.unlocked = true // Simulate that secrets have been unlocked
 
 		// Test with standard notation
-		input1 := "This is a secret: ${{ sops.test_key }}"
+		input1 := "This is a secret: ${sops.test_key}"
 		expectedOutput1 := "This is a secret: test_value"
 
 		output1, err := provider.ParseSecrets(input1)
@@ -352,7 +352,7 @@ func TestSopsSecretsProvider_ParseSecrets(t *testing.T) {
 		}
 
 		// Test with spaces in the notation
-		input2 := "This is a secret: ${{  sops.test_key  }}"
+		input2 := "This is a secret: ${ sops.test_key }"
 		expectedOutput2 := "This is a secret: test_value"
 
 		output2, err := provider.ParseSecrets(input2)
@@ -363,6 +363,16 @@ func TestSopsSecretsProvider_ParseSecrets(t *testing.T) {
 
 		if output2 != expectedOutput2 {
 			t.Errorf("ParseSecrets returned '%s', expected '%s'", output2, expectedOutput2)
+		}
+
+		input3 := "This is a secret: ${secret.sops.test_key}"
+		expectedOutput3 := "This is a secret: test_value"
+		output3, err := provider.ParseSecrets(input3)
+		if err != nil {
+			t.Fatalf("ParseSecrets failed with error: %v", err)
+		}
+		if output3 != expectedOutput3 {
+			t.Errorf("ParseSecrets returned '%s', expected '%s'", output3, expectedOutput3)
 		}
 	})
 
@@ -401,7 +411,7 @@ func TestSopsSecretsProvider_ParseSecrets(t *testing.T) {
 		provider.secrets["key2"] = "value2"
 		provider.unlocked = true
 
-		input := "First: ${{ sops.key1 }}, Second: ${{ sops.key2 }}"
+		input := "First: ${sops.key1}, Second: ${sops.key2}"
 		expectedOutput := "First: value1, Second: value2"
 
 		output, err := provider.ParseSecrets(input)
@@ -418,7 +428,7 @@ func TestSopsSecretsProvider_ParseSecrets(t *testing.T) {
 		provider, _ := setup(t)
 		provider.unlocked = true
 
-		input := "This is invalid: ${{ sops. }}"
+		input := "This is invalid: ${sops.}"
 		expectedOutput := "This is invalid: <ERROR: invalid secret format>"
 
 		output, err := provider.ParseSecrets(input)
@@ -435,7 +445,7 @@ func TestSopsSecretsProvider_ParseSecrets(t *testing.T) {
 		provider, _ := setup(t)
 		provider.unlocked = true
 
-		input := "This is invalid: ${{ sops.key..path }}"
+		input := "This is invalid: ${sops.key..path}"
 		expectedOutput := "This is invalid: <ERROR: invalid key path: key..path>"
 
 		output, err := provider.ParseSecrets(input)
@@ -452,7 +462,7 @@ func TestSopsSecretsProvider_ParseSecrets(t *testing.T) {
 		provider, _ := setup(t)
 		provider.unlocked = true
 
-		input := "Missing secret: ${{ sops.missing_key }}"
+		input := "Missing secret: ${sops.missing_key}"
 		expectedOutput := "Missing secret: <ERROR: secret not found: missing_key>"
 
 		output, err := provider.ParseSecrets(input)

--- a/pkg/runtime/shell/mock_shell.go
+++ b/pkg/runtime/shell/mock_shell.go
@@ -16,6 +16,7 @@ import (
 
 type MockShell struct {
 	DefaultShell
+	ScrubFunc                      func(input string) string
 	RenderEnvVarsFunc              func(envVars map[string]string, export bool) string
 	RenderAliasesFunc              func(aliases map[string]string) string
 	GetProjectRootFunc             func() (string, error)
@@ -37,6 +38,14 @@ type MockShell struct {
 	CheckResetFlagsFunc            func() (bool, error)
 	ResetFunc                      func(...bool)
 	RegisterSecretFunc             func(value string)
+}
+
+// Scrub calls the custom ScrubFunc if provided.
+func (s *MockShell) Scrub(input string) string {
+	if s.ScrubFunc != nil {
+		return s.ScrubFunc(input)
+	}
+	return input
 }
 
 // =============================================================================

--- a/pkg/runtime/shell/shell.go
+++ b/pkg/runtime/shell/shell.go
@@ -42,10 +42,25 @@ type HookContext struct {
 	SelfPath string
 }
 
+// DefaultShell is the default implementation of the Shell interface
+type DefaultShell struct {
+	Shell
+	projectRoot  string
+	verbose      bool
+	sessionToken string
+	shims        *Shims
+	secrets      []string
+}
+
+// =============================================================================
+// Interfaces
+// =============================================================================
+
 // Shell is the interface that defines shell operations.
 type Shell interface {
 	SetVerbosity(verbose bool)
 	IsVerbose() bool
+	Scrub(input string) string
 	RenderEnvVars(envVars map[string]string, export bool) string
 	RenderAliases(aliases map[string]string) string
 	GetProjectRoot() (string, error)
@@ -67,16 +82,6 @@ type Shell interface {
 	RegisterSecret(value string)
 }
 
-// DefaultShell is the default implementation of the Shell interface
-type DefaultShell struct {
-	Shell
-	projectRoot  string
-	verbose      bool
-	sessionToken string
-	shims        *Shims
-	secrets      []string
-}
-
 // =============================================================================
 // Constructor
 // =============================================================================
@@ -88,6 +93,10 @@ func NewDefaultShell() *DefaultShell {
 		verbose: false,
 	}
 }
+
+// =============================================================================
+// Public Methods
+// =============================================================================
 
 // SetVerbosity sets the verbosity flag
 func (s *DefaultShell) SetVerbosity(verbose bool) {
@@ -676,6 +685,21 @@ func (s *DefaultShell) RenderEnvVars(envVars map[string]string, export bool) str
 	}
 }
 
+// Scrub applies the registered secret scrubber to a string.
+func (s *DefaultShell) Scrub(input string) string {
+	return s.scrubString(input)
+}
+
+// PrintEnvVars is a platform-specific method that will be implemented by Unix/Windows-specific files
+// The export parameter controls whether to use OS-specific export commands or plain KEY=value format
+func (s *DefaultShell) PrintEnvVars(envVars map[string]string, export bool) {
+	if export {
+		fmt.Print(s.renderEnvVarsWithExport(envVars))
+	} else {
+		fmt.Print(s.renderEnvVarsPlain(envVars))
+	}
+}
+
 // =============================================================================
 // Private Methods
 // =============================================================================
@@ -705,16 +729,6 @@ func (s *DefaultShell) scrubString(input string) string {
 	}
 
 	return result
-}
-
-// PrintEnvVars is a platform-specific method that will be implemented by Unix/Windows-specific files
-// The export parameter controls whether to use OS-specific export commands or plain KEY=value format
-func (s *DefaultShell) PrintEnvVars(envVars map[string]string, export bool) {
-	if export {
-		fmt.Print(s.renderEnvVarsWithExport(envVars))
-	} else {
-		fmt.Print(s.renderEnvVarsPlain(envVars))
-	}
 }
 
 // renderEnvVarsPlain returns environment variables in plain KEY=value format as a string, sorted by key.

--- a/pkg/runtime/terraform/mock_provider.go
+++ b/pkg/runtime/terraform/mock_provider.go
@@ -18,6 +18,7 @@ type MockTerraformProvider struct {
 	CacheOutputsFunc            func(componentID string) error
 	GetTFDataDirFunc            func(componentID string) (string, error)
 	GetEnvVarsFunc              func(componentID string, interactive bool) (map[string]string, *TerraformArgs, error)
+	SetSecretCacheEnabledFunc   func(enabled bool)
 	FormatArgsForEnvFunc        func(args []string) string
 	ClearCacheFunc              func()
 }
@@ -114,6 +115,13 @@ func (m *MockTerraformProvider) GetEnvVars(componentID string, interactive bool)
 		return m.GetEnvVarsFunc(componentID, interactive)
 	}
 	return make(map[string]string), &TerraformArgs{}, nil
+}
+
+// SetSecretCacheEnabled implements TerraformProvider.
+func (m *MockTerraformProvider) SetSecretCacheEnabled(enabled bool) {
+	if m.SetSecretCacheEnabledFunc != nil {
+		m.SetSecretCacheEnabledFunc(enabled)
+	}
 }
 
 // FormatArgsForEnv implements TerraformProvider.

--- a/pkg/runtime/terraform/provider.go
+++ b/pkg/runtime/terraform/provider.go
@@ -458,6 +458,9 @@ func (p *terraformProvider) GetEnvVars(componentID string, interactive bool) (ma
 				return nil, nil, fmt.Errorf("error discovering sensitive terraform inputs for component %s: %w", componentID, err)
 			}
 			for key, value := range component.Inputs {
+				if deferredExpr, ok := evaluator.DeferredExpression(value); ok {
+					value = deferredExpr
+				}
 				containsSecretValue := evaluator.ContainsSecretValue(value)
 				containsExpression := evaluator.ContainsExpression(value)
 				isSensitiveInput := sensitiveInputs[key]
@@ -468,11 +471,7 @@ func (p *terraformProvider) GetEnvVars(componentID string, interactive bool) (ma
 				existingValue := p.Shims.Getenv(envKey)
 				existingFound := existingValue != ""
 				useCache := shouldUseTerraformEnvCache(p.Shims.Getenv("NO_CACHE"), secretCacheEnabled)
-				if deferredExpr, ok := evaluator.DeferredExpression(value); ok {
-					value = deferredExpr
-					containsExpression = evaluator.ContainsExpression(value)
-				}
-				if evaluator.ContainsSecretValue(value) {
+				if containsSecretValue {
 					err := p.resolveAndSetSecretEnvVar(componentID, key, envKey, value, envVars, useCache, existingValue, existingFound)
 					if err != nil {
 						return nil, nil, err
@@ -530,6 +529,7 @@ func (p *terraformProvider) GetEnvVars(componentID string, interactive bool) (ma
 					}
 					p.shell.RegisterSecret(envValue)
 					envVars[envKey] = envValue
+					continue
 				}
 			}
 		}

--- a/pkg/runtime/terraform/provider.go
+++ b/pkg/runtime/terraform/provider.go
@@ -473,24 +473,10 @@ func (p *terraformProvider) GetEnvVars(componentID string, interactive bool) (ma
 					containsExpression = evaluator.ContainsExpression(value)
 				}
 				if evaluator.ContainsSecretValue(value) {
-					if useCache && existingFound && !strings.Contains(existingValue, "<ERROR") {
-						p.shell.RegisterSecret(existingValue)
-						envVars[envKey] = existingValue
-						continue
-					}
-					evaluatedValue, shouldSet, err := p.evaluateInputValueForEnv(key, value)
+					err := p.resolveAndSetSecretEnvVar(componentID, key, envKey, value, envVars, useCache, existingValue, existingFound)
 					if err != nil {
-						return nil, nil, fmt.Errorf("error evaluating secret input '%s' for component %s: %w", key, componentID, err)
+						return nil, nil, err
 					}
-					if !shouldSet {
-						continue
-					}
-					envValue, err := p.formatTerraformEnvValue(evaluatedValue)
-					if err != nil {
-						return nil, nil, fmt.Errorf("error formatting secret input '%s' for component %s: %w", key, componentID, err)
-					}
-					p.shell.RegisterSecret(envValue)
-					envVars[envKey] = envValue
 					continue
 				}
 				if containsExpression {
@@ -506,24 +492,10 @@ func (p *terraformProvider) GetEnvVars(componentID string, interactive bool) (ma
 						continue
 					}
 					if evaluator.ContainsSecretValue(nonDeferredValue) {
-						if useCache && existingFound && !strings.Contains(existingValue, "<ERROR") {
-							p.shell.RegisterSecret(existingValue)
-							envVars[envKey] = existingValue
-							continue
-						}
-						evaluatedValue, shouldSet, err := p.evaluateInputValueForEnv(key, value)
+						err := p.resolveAndSetSecretEnvVar(componentID, key, envKey, value, envVars, useCache, existingValue, existingFound)
 						if err != nil {
-							return nil, nil, fmt.Errorf("error evaluating secret input '%s' for component %s: %w", key, componentID, err)
+							return nil, nil, err
 						}
-						if !shouldSet {
-							continue
-						}
-						envValue, err := p.formatTerraformEnvValue(evaluatedValue)
-						if err != nil {
-							return nil, nil, fmt.Errorf("error formatting secret input '%s' for component %s: %w", key, componentID, err)
-						}
-						p.shell.RegisterSecret(envValue)
-						envVars[envKey] = envValue
 						continue
 					}
 					if !evaluator.ContainsExpression(nonDeferredValue) {
@@ -1142,6 +1114,41 @@ func (p *terraformProvider) evaluateInputValueForEnv(key string, value any) (any
 		return evaluatedValue, true, nil
 	}
 	return nil, false, nil
+}
+
+// resolveAndSetSecretEnvVar resolves a secret terraform input and sets its TF_VAR value.
+func (p *terraformProvider) resolveAndSetSecretEnvVar(
+	componentID string,
+	key string,
+	envKey string,
+	value any,
+	envVars map[string]string,
+	useCache bool,
+	existingValue string,
+	existingFound bool,
+) error {
+	if useCache && existingFound && !strings.Contains(existingValue, "<ERROR") {
+		p.shell.RegisterSecret(existingValue)
+		envVars[envKey] = existingValue
+		return nil
+	}
+
+	evaluatedValue, shouldSet, err := p.evaluateInputValueForEnv(key, value)
+	if err != nil {
+		return fmt.Errorf("error evaluating secret input '%s' for component %s: %w", key, componentID, err)
+	}
+	if !shouldSet {
+		return nil
+	}
+
+	envValue, err := p.formatTerraformEnvValue(evaluatedValue)
+	if err != nil {
+		return fmt.Errorf("error formatting secret input '%s' for component %s: %w", key, componentID, err)
+	}
+
+	p.shell.RegisterSecret(envValue)
+	envVars[envKey] = envValue
+	return nil
 }
 
 // formatTerraformEnvValue renders a terraform input value as TF_VAR_* environment variable string.

--- a/pkg/runtime/terraform/provider.go
+++ b/pkg/runtime/terraform/provider.go
@@ -510,7 +510,7 @@ func (p *terraformProvider) GetEnvVars(componentID string, interactive bool) (ma
 					if err != nil {
 						continue
 					}
-					if isSensitiveInput {
+					if isSensitiveInput || evaluator.ContainsSecretValue(evaluatedValue) {
 						p.shell.RegisterSecret(envValue)
 					}
 					envVars[envKey] = envValue
@@ -1087,10 +1087,10 @@ func (p *terraformProvider) processBackendConfig(backendConfig any, addArg func(
 	return nil
 }
 
-// evaluateInputValueForEnv evaluates an input value and unwraps secret-qualified values.
+// evaluateInputValueForEnv evaluates an input value and preserves secret-qualified wrappers.
 func (p *terraformProvider) evaluateInputValueForEnv(key string, value any) (any, bool, error) {
 	if evaluator.ContainsSecretValue(value) && !evaluator.ContainsExpression(value) {
-		return evaluator.UnwrapSecretValue(value), true, nil
+		return value, true, nil
 	}
 	p.mu.RLock()
 	evalScope := p.configScope
@@ -1103,9 +1103,6 @@ func (p *terraformProvider) evaluateInputValueForEnv(key string, value any) (any
 		evaluatedValue, exists := evaluated[key]
 		if !exists {
 			return nil, false, nil
-		}
-		if evaluator.ContainsSecretValue(evaluatedValue) {
-			return evaluator.UnwrapSecretValue(evaluatedValue), true, nil
 		}
 		return evaluatedValue, true, nil
 	}

--- a/pkg/runtime/terraform/provider.go
+++ b/pkg/runtime/terraform/provider.go
@@ -27,15 +27,17 @@ import (
 
 // terraformProvider provides all terraform-specific operations with session caching.
 type terraformProvider struct {
-	configHandler config.ConfigHandler
-	shell         shell.Shell
-	toolsManager  tools.ToolsManager
-	evaluator     evaluator.ExpressionEvaluator
-	Shims         *Shims // Exported for testing
-	cache         map[string]map[string]any
-	components    []blueprintv1alpha1.TerraformComponent
-	configScope   map[string]any
-	mu            sync.RWMutex
+	configHandler  config.ConfigHandler
+	shell          shell.Shell
+	toolsManager   tools.ToolsManager
+	evaluator      evaluator.ExpressionEvaluator
+	Shims          *Shims // Exported for testing
+	cache          map[string]map[string]any
+	sensitiveInput providerSensitiveInputDiscovery
+	components     []blueprintv1alpha1.TerraformComponent
+	configScope    map[string]any
+	secretCache    bool
+	mu             sync.RWMutex
 }
 
 // terraformContext provides a scoped environment for Terraform operations with automatic cleanup.
@@ -80,6 +82,7 @@ type TerraformProvider interface {
 	CacheOutputs(componentID string) error
 	GetTFDataDir(componentID string) (string, error)
 	GetEnvVars(componentID string, interactive bool) (map[string]string, *TerraformArgs, error)
+	SetSecretCacheEnabled(enabled bool)
 	FormatArgsForEnv(args []string) string
 	ClearCache()
 }
@@ -117,6 +120,7 @@ func NewTerraformProvider(
 		Shims:         NewShims(),
 		cache:         make(map[string]map[string]any),
 	}
+	provider.sensitiveInput = newProviderSensitiveInputDiscovery(provider.Shims)
 
 	provider.registerTerraformOutputHelper(evaluator)
 
@@ -442,16 +446,54 @@ func (p *terraformProvider) GetEnvVars(componentID string, interactive bool) (ma
 	if err != nil {
 		return nil, nil, err
 	}
+	p.mu.RLock()
+	secretCacheEnabled := p.secretCache
+	p.mu.RUnlock()
 
 	if componentID != "" && p.evaluator != nil {
 		component := p.GetTerraformComponent(componentID)
 		if component != nil && component.Inputs != nil && len(component.Inputs) > 0 {
+			sensitiveInputs, err := p.sensitiveInput.GetSensitiveTerraformInputs(modulePath)
+			if err != nil {
+				return nil, nil, fmt.Errorf("error discovering sensitive terraform inputs for component %s: %w", componentID, err)
+			}
 			for key, value := range component.Inputs {
+				containsSecretValue := evaluator.ContainsSecretValue(value)
+				containsExpression := evaluator.ContainsExpression(value)
+				isSensitiveInput := sensitiveInputs[key]
+				if !isSensitiveInput && !containsSecretValue && !containsExpression {
+					continue
+				}
 				envKey := fmt.Sprintf("TF_VAR_%s", key)
+				existingValue := p.Shims.Getenv(envKey)
+				existingFound := existingValue != ""
+				useCache := shouldUseTerraformEnvCache(p.Shims.Getenv("NO_CACHE"), secretCacheEnabled)
 				if deferredExpr, ok := evaluator.DeferredExpression(value); ok {
 					value = deferredExpr
+					containsExpression = evaluator.ContainsExpression(value)
 				}
-				if evaluator.ContainsExpression(value) {
+				if evaluator.ContainsSecretValue(value) {
+					if useCache && existingFound && !strings.Contains(existingValue, "<ERROR") {
+						p.shell.RegisterSecret(existingValue)
+						envVars[envKey] = existingValue
+						continue
+					}
+					evaluatedValue, shouldSet, err := p.evaluateInputValueForEnv(key, value)
+					if err != nil {
+						return nil, nil, fmt.Errorf("error evaluating secret input '%s' for component %s: %w", key, componentID, err)
+					}
+					if !shouldSet {
+						continue
+					}
+					envValue, err := p.formatTerraformEnvValue(evaluatedValue)
+					if err != nil {
+						return nil, nil, fmt.Errorf("error formatting secret input '%s' for component %s: %w", key, componentID, err)
+					}
+					p.shell.RegisterSecret(envValue)
+					envVars[envKey] = envValue
+					continue
+				}
+				if containsExpression {
 					p.mu.RLock()
 					evalScope := p.configScope
 					p.mu.RUnlock()
@@ -463,27 +505,58 @@ func (p *terraformProvider) GetEnvVars(componentID string, interactive bool) (ma
 					if !exists {
 						continue
 					}
+					if evaluator.ContainsSecretValue(nonDeferredValue) {
+						if useCache && existingFound && !strings.Contains(existingValue, "<ERROR") {
+							p.shell.RegisterSecret(existingValue)
+							envVars[envKey] = existingValue
+							continue
+						}
+						evaluatedValue, shouldSet, err := p.evaluateInputValueForEnv(key, value)
+						if err != nil {
+							return nil, nil, fmt.Errorf("error evaluating secret input '%s' for component %s: %w", key, componentID, err)
+						}
+						if !shouldSet {
+							continue
+						}
+						envValue, err := p.formatTerraformEnvValue(evaluatedValue)
+						if err != nil {
+							return nil, nil, fmt.Errorf("error formatting secret input '%s' for component %s: %w", key, componentID, err)
+						}
+						p.shell.RegisterSecret(envValue)
+						envVars[envKey] = envValue
+						continue
+					}
 					if !evaluator.ContainsExpression(nonDeferredValue) {
 						continue
 					}
-					evaluated, err := p.evaluator.EvaluateMap(map[string]any{key: value}, "", evalScope, true)
+					evaluatedValue, shouldSet, err := p.evaluateInputValueForEnv(key, value)
 					if err != nil {
 						return nil, nil, fmt.Errorf("error evaluating input '%s' for component %s: %w", key, componentID, err)
 					}
-					evaluatedValue, exists := evaluated[key]
-					if !exists {
+					if !shouldSet {
 						continue
 					}
-					var envValue string
-					if valueStr, ok := evaluatedValue.(string); ok {
-						envValue = valueStr
-					} else {
-						valueBytes, err := p.Shims.JsonMarshal(evaluatedValue)
-						if err != nil {
-							continue
-						}
-						envValue = string(valueBytes)
+					envValue, err := p.formatTerraformEnvValue(evaluatedValue)
+					if err != nil {
+						continue
 					}
+					if isSensitiveInput {
+						p.shell.RegisterSecret(envValue)
+					}
+					envVars[envKey] = envValue
+					continue
+				}
+				if isSensitiveInput {
+					if useCache && existingFound && !strings.Contains(existingValue, "<ERROR") {
+						p.shell.RegisterSecret(existingValue)
+						envVars[envKey] = existingValue
+						continue
+					}
+					envValue, err := p.formatTerraformEnvValue(value)
+					if err != nil {
+						return nil, nil, fmt.Errorf("error formatting sensitive input '%s' for component %s: %w", key, componentID, err)
+					}
+					p.shell.RegisterSecret(envValue)
 					envVars[envKey] = envValue
 				}
 			}
@@ -491,6 +564,13 @@ func (p *terraformProvider) GetEnvVars(componentID string, interactive bool) (ma
 	}
 
 	return envVars, terraformArgs, nil
+}
+
+// SetSecretCacheEnabled enables or disables TF_VAR secret cache reuse.
+func (p *terraformProvider) SetSecretCacheEnabled(enabled bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.secretCache = enabled
 }
 
 // FormatArgsForEnv formats CLI arguments for use in environment variables.
@@ -602,6 +682,9 @@ func (p *terraformProvider) ClearCache() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.cache = make(map[string]map[string]any)
+	if p.sensitiveInput != nil {
+		p.sensitiveInput.ClearCache()
+	}
 	p.components = nil
 	p.configScope = nil
 }
@@ -1033,9 +1116,56 @@ func (p *terraformProvider) processBackendConfig(backendConfig any, addArg func(
 	return nil
 }
 
+// evaluateInputValueForEnv evaluates an input value and unwraps secret-qualified values.
+func (p *terraformProvider) evaluateInputValueForEnv(key string, value any) (any, bool, error) {
+	if evaluator.ContainsSecretValue(value) && !evaluator.ContainsExpression(value) {
+		return evaluator.UnwrapSecretValue(value), true, nil
+	}
+	p.mu.RLock()
+	evalScope := p.configScope
+	p.mu.RUnlock()
+	if evaluator.ContainsExpression(value) {
+		evaluated, err := p.evaluator.EvaluateMap(map[string]any{key: value}, "", evalScope, true)
+		if err != nil {
+			return nil, false, err
+		}
+		evaluatedValue, exists := evaluated[key]
+		if !exists {
+			return nil, false, nil
+		}
+		if evaluator.ContainsSecretValue(evaluatedValue) {
+			return evaluator.UnwrapSecretValue(evaluatedValue), true, nil
+		}
+		if evaluator.ContainsExpression(evaluatedValue) {
+			return evaluatedValue, true, nil
+		}
+		return evaluatedValue, true, nil
+	}
+	return nil, false, nil
+}
+
+// formatTerraformEnvValue renders a terraform input value as TF_VAR_* environment variable string.
+func (p *terraformProvider) formatTerraformEnvValue(value any) (string, error) {
+	value = evaluator.UnwrapSecretValue(value)
+	if valueStr, ok := value.(string); ok {
+		return valueStr, nil
+	}
+	valueBytes, err := p.Shims.JsonMarshal(value)
+	if err != nil {
+		return "", err
+	}
+	return string(valueBytes), nil
+}
+
 // =============================================================================
 // Helpers
 // =============================================================================
+
+// shouldUseTerraformEnvCache determines whether existing TF_VAR_* values may be reused.
+func shouldUseTerraformEnvCache(noCache string, cacheEnabled bool) bool {
+	noCacheDisabled := noCache == "" || noCache == "0" || noCache == "false" || noCache == "False"
+	return noCacheDisabled && cacheEnabled
+}
 
 // processMap traverses the provided configMap, applying each key-value pair to the addArg function.
 // Nested maps are handled recursively, forming compound keys with dot notation.

--- a/pkg/runtime/terraform/provider.go
+++ b/pkg/runtime/terraform/provider.go
@@ -1108,9 +1108,6 @@ func (p *terraformProvider) evaluateInputValueForEnv(key string, value any) (any
 		if evaluator.ContainsSecretValue(evaluatedValue) {
 			return evaluator.UnwrapSecretValue(evaluatedValue), true, nil
 		}
-		if evaluator.ContainsExpression(evaluatedValue) {
-			return evaluatedValue, true, nil
-		}
 		return evaluatedValue, true, nil
 	}
 	return nil, false, nil

--- a/pkg/runtime/terraform/provider.go
+++ b/pkg/runtime/terraform/provider.go
@@ -468,8 +468,7 @@ func (p *terraformProvider) GetEnvVars(componentID string, interactive bool) (ma
 					continue
 				}
 				envKey := fmt.Sprintf("TF_VAR_%s", key)
-				existingValue := p.Shims.Getenv(envKey)
-				existingFound := existingValue != ""
+				existingValue, existingFound := p.lookupEnvVar(envKey)
 				useCache := shouldUseTerraformEnvCache(p.Shims.Getenv("NO_CACHE"), secretCacheEnabled)
 				if containsSecretValue {
 					err := p.resolveAndSetSecretEnvVar(componentID, key, envKey, value, envVars, useCache, existingValue, existingFound)
@@ -1169,6 +1168,17 @@ func (p *terraformProvider) formatTerraformEnvValue(value any) (string, error) {
 func shouldUseTerraformEnvCache(noCache string, cacheEnabled bool) bool {
 	noCacheDisabled := noCache == "" || noCache == "0" || noCache == "false" || noCache == "False"
 	return noCacheDisabled && cacheEnabled
+}
+
+// lookupEnvVar returns the environment variable value and whether it exists.
+func (p *terraformProvider) lookupEnvVar(key string) (string, bool) {
+	if p.Shims.LookupEnv != nil {
+		if value, found := p.Shims.LookupEnv(key); found {
+			return value, true
+		}
+	}
+	value := p.Shims.Getenv(key)
+	return value, value != ""
 }
 
 // processMap traverses the provided configMap, applying each key-value pair to the addArg function.

--- a/pkg/runtime/terraform/provider_public_test.go
+++ b/pkg/runtime/terraform/provider_public_test.go
@@ -102,6 +102,9 @@ func setupMocks(t *testing.T, opts ...*SetupOptions) *Mocks {
 	concreteProvider.Shims.Getenv = func(key string) string {
 		return ""
 	}
+	concreteProvider.Shims.LookupEnv = func(key string) (string, bool) {
+		return "", false
+	}
 
 	concreteProvider.Shims.Setenv = func(key, value string) error {
 		return nil
@@ -2911,6 +2914,82 @@ variable "plain_value" {
 		}
 		if got := envVars["TF_VAR_db_password"]; got != "cached-secret" {
 			t.Errorf("Expected cached TF_VAR_db_password to be reused, got %q", got)
+		}
+	})
+
+	t.Run("ReusesExistingEmptyTFVarWhenCacheEnabledForSecretInput", func(t *testing.T) {
+		mocks := setupMocks(t, &SetupOptions{BackendType: "none"})
+		mocks.Provider.SetSecretCacheEnabled(true)
+		mocks.Provider.Shims.Getenv = func(key string) string {
+			if key == "NO_CACHE" {
+				return ""
+			}
+			return ""
+		}
+		mocks.Provider.Shims.LookupEnv = func(key string) (string, bool) {
+			if key == "TF_VAR_db_password" {
+				return "", true
+			}
+			return "", false
+		}
+		mocks.Provider.SetTerraformComponents([]blueprintv1alpha1.TerraformComponent{
+			{
+				Path: "cluster",
+				Inputs: map[string]any{
+					"db_password": evaluator.SecretValue{Value: "fresh-secret"},
+				},
+			},
+		})
+
+		envVars, _, err := mocks.Provider.GetEnvVars("cluster", false)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if got := envVars["TF_VAR_db_password"]; got != "" {
+			t.Errorf("Expected empty cached TF_VAR_db_password to be reused, got %q", got)
+		}
+	})
+
+	t.Run("ReusesExistingEmptyTFVarWhenCacheEnabledForSensitiveInput", func(t *testing.T) {
+		mocks := setupMocks(t, &SetupOptions{BackendType: "none"})
+		mocks.Provider.SetSecretCacheEnabled(true)
+		moduleDir := t.TempDir()
+		variablesPath := filepath.Join(moduleDir, "variables.tf")
+		if err := os.WriteFile(variablesPath, []byte(`variable "db_password" {
+  type      = string
+  sensitive = true
+}`), 0644); err != nil {
+			t.Fatalf("Expected no error writing variables.tf, got: %v", err)
+		}
+		mocks.Provider.Shims.Stat = os.Stat
+		mocks.Provider.Shims.Getenv = func(key string) string {
+			if key == "NO_CACHE" {
+				return ""
+			}
+			return ""
+		}
+		mocks.Provider.Shims.LookupEnv = func(key string) (string, bool) {
+			if key == "TF_VAR_db_password" {
+				return "", true
+			}
+			return "", false
+		}
+		mocks.Provider.SetTerraformComponents([]blueprintv1alpha1.TerraformComponent{
+			{
+				Path:     "cluster",
+				FullPath: moduleDir,
+				Inputs: map[string]any{
+					"db_password": "fresh-sensitive",
+				},
+			},
+		})
+
+		envVars, _, err := mocks.Provider.GetEnvVars("cluster", false)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if got := envVars["TF_VAR_db_password"]; got != "" {
+			t.Errorf("Expected empty cached TF_VAR_db_password to be reused, got %q", got)
 		}
 	})
 

--- a/pkg/runtime/terraform/provider_public_test.go
+++ b/pkg/runtime/terraform/provider_public_test.go
@@ -3467,6 +3467,52 @@ terraform:
 		}
 	})
 
+	t.Run("RegistersSecretForDeferredExpressionResolvedAsSecretValue", func(t *testing.T) {
+		mocks := setupMocks(t, &SetupOptions{BackendType: "none"})
+		component := blueprintv1alpha1.TerraformComponent{
+			Path: "cluster",
+			Inputs: map[string]any{
+				"db_password": `${terraform_output("comp", "key")} ${secret("secret.op.platform.db.password")}`,
+			},
+		}
+		component.FullPath = "/test/project/terraform/cluster"
+		mocks.Provider.SetTerraformComponents([]blueprintv1alpha1.TerraformComponent{component})
+
+		registeredSecrets := make([]string, 0)
+		mocks.Shell.RegisterSecretFunc = func(value string) {
+			registeredSecrets = append(registeredSecrets, value)
+		}
+
+		mockEvaluator := evaluator.NewMockExpressionEvaluator()
+		mockEvaluator.EvaluateMapFunc = func(values map[string]any, featurePath string, scope map[string]any, evaluateDeferred bool) (map[string]any, error) {
+			if evaluateDeferred {
+				return map[string]any{
+					"db_password": evaluator.SecretValue{Value: "resolved-output s3cr3t"},
+				}, nil
+			}
+			return map[string]any{
+				"db_password": evaluator.DeferredValue{
+					Expression: `${terraform_output("comp", "key")} ${secret("secret.op.platform.db.password")}`,
+				},
+			}, nil
+		}
+		mocks.Provider.evaluator = mockEvaluator
+
+		envVars, _, err := mocks.Provider.GetEnvVars("cluster", false)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if got := envVars["TF_VAR_db_password"]; got != "resolved-output s3cr3t" {
+			t.Fatalf("Expected TF_VAR_db_password to be exported, got %q", got)
+		}
+		if len(registeredSecrets) != 1 {
+			t.Fatalf("Expected one secret registration, got %d", len(registeredSecrets))
+		}
+		if registeredSecrets[0] != "resolved-output s3cr3t" {
+			t.Fatalf("Expected registered secret to match TF_VAR value, got %q", registeredSecrets[0])
+		}
+	})
+
 	t.Run("DoesNotSerializeDeferredValueWrapperIntoTFVar", func(t *testing.T) {
 		mocks := setupMocks(t, &SetupOptions{BackendType: "none"})
 		component := blueprintv1alpha1.TerraformComponent{

--- a/pkg/runtime/terraform/provider_public_test.go
+++ b/pkg/runtime/terraform/provider_public_test.go
@@ -2751,6 +2751,268 @@ terraform:
 		}
 	})
 
+	t.Run("EmitsTFVarForSecretQualifiedInputsWithoutExpressions", func(t *testing.T) {
+		mocks := setupMocks(t, &SetupOptions{BackendType: "none"})
+		mocks.Provider.SetTerraformComponents([]blueprintv1alpha1.TerraformComponent{
+			{
+				Path: "cluster",
+				Inputs: map[string]any{
+					"db_password": evaluator.SecretValue{Value: "super-secret"},
+					"plain_value": "plain",
+				},
+			},
+		})
+
+		envVars, _, err := mocks.Provider.GetEnvVars("cluster", false)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if got := envVars["TF_VAR_db_password"]; got != "super-secret" {
+			t.Errorf("Expected TF_VAR_db_password to be exported for secret input, got %q", got)
+		}
+		if _, exists := envVars["TF_VAR_plain_value"]; exists {
+			t.Error("Expected TF_VAR_plain_value to remain skipped for non-secret non-expression input")
+		}
+	})
+
+	t.Run("EmitsTFVarForSensitiveLiteralInputs", func(t *testing.T) {
+		mocks := setupMocks(t, &SetupOptions{BackendType: "none"})
+		moduleDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(moduleDir, "variables.tf"), []byte(`variable "db_password" {
+  type      = string
+  sensitive = true
+}
+variable "plain_value" {
+  type = string
+}`), 0644); err != nil {
+			t.Fatalf("Expected no error writing variables.tf, got: %v", err)
+		}
+		mocks.Provider.Shims.Stat = os.Stat
+		mocks.Provider.SetTerraformComponents([]blueprintv1alpha1.TerraformComponent{
+			{
+				Path:     "cluster",
+				FullPath: moduleDir,
+				Inputs: map[string]any{
+					"db_password": "literal-sensitive-value",
+					"plain_value": "plain",
+				},
+			},
+		})
+
+		envVars, _, err := mocks.Provider.GetEnvVars("cluster", false)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if got := envVars["TF_VAR_db_password"]; got != "literal-sensitive-value" {
+			t.Errorf("Expected TF_VAR_db_password for sensitive literal input, got %q", got)
+		}
+		if _, exists := envVars["TF_VAR_plain_value"]; exists {
+			t.Error("Expected TF_VAR_plain_value to remain skipped for non-sensitive non-expression input")
+		}
+	})
+
+	t.Run("ReturnsErrorWhenSensitiveInputDiscoveryFailsToParseModule", func(t *testing.T) {
+		mocks := setupMocks(t, &SetupOptions{BackendType: "none"})
+		moduleDir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(moduleDir, "variables.tf"), []byte(`variable "db_password" {
+  type      = string
+  sensitive = 
+}`), 0644); err != nil {
+			t.Fatalf("Expected no error writing variables.tf, got: %v", err)
+		}
+		mocks.Provider.Shims.Stat = os.Stat
+		mocks.Provider.SetTerraformComponents([]blueprintv1alpha1.TerraformComponent{
+			{
+				Path:     "cluster",
+				FullPath: moduleDir,
+				Inputs: map[string]any{
+					"db_password": "literal-sensitive-value",
+				},
+			},
+		})
+
+		_, _, err := mocks.Provider.GetEnvVars("cluster", false)
+		if err == nil {
+			t.Fatal("Expected error when sensitive input discovery cannot parse terraform file")
+		}
+		if !strings.Contains(err.Error(), "error discovering sensitive terraform inputs") {
+			t.Fatalf("Expected sensitive discovery error, got: %v", err)
+		}
+	})
+
+	t.Run("CachesSensitiveInputDiscoveryWhenModuleIsUnchanged", func(t *testing.T) {
+		mocks := setupMocks(t, &SetupOptions{BackendType: "none"})
+		moduleDir := t.TempDir()
+		variablesPath := filepath.Join(moduleDir, "variables.tf")
+		if err := os.WriteFile(variablesPath, []byte(`variable "db_password" {
+  type      = string
+  sensitive = true
+}`), 0644); err != nil {
+			t.Fatalf("Expected no error writing variables.tf, got: %v", err)
+		}
+		mocks.Provider.Shims.Stat = os.Stat
+		mocks.Provider.SetTerraformComponents([]blueprintv1alpha1.TerraformComponent{
+			{
+				Path:     "cluster",
+				FullPath: moduleDir,
+				Inputs: map[string]any{
+					"db_password": "literal-sensitive-value",
+				},
+			},
+		})
+
+		originalReadFile := mocks.Provider.Shims.ReadFile
+		readCount := 0
+		mocks.Provider.Shims.ReadFile = func(path string) ([]byte, error) {
+			if filepath.Clean(path) == filepath.Clean(variablesPath) {
+				readCount++
+			}
+			return originalReadFile(path)
+		}
+
+		_, _, err := mocks.Provider.GetEnvVars("cluster", false)
+		if err != nil {
+			t.Fatalf("Expected no error on first call, got: %v", err)
+		}
+		_, _, err = mocks.Provider.GetEnvVars("cluster", false)
+		if err != nil {
+			t.Fatalf("Expected no error on second call, got: %v", err)
+		}
+		if readCount != 1 {
+			t.Fatalf("Expected sensitive discovery to read variables file once, got %d", readCount)
+		}
+	})
+
+	t.Run("ReusesExistingTFVarWhenCacheEnabled", func(t *testing.T) {
+		mocks := setupMocks(t, &SetupOptions{BackendType: "none"})
+		mocks.Provider.SetSecretCacheEnabled(true)
+		mocks.Provider.Shims.Getenv = func(key string) string {
+			switch key {
+			case "NO_CACHE":
+				return ""
+			case "TF_VAR_db_password":
+				return "cached-secret"
+			default:
+				return ""
+			}
+		}
+		mocks.Provider.SetTerraformComponents([]blueprintv1alpha1.TerraformComponent{
+			{
+				Path: "cluster",
+				Inputs: map[string]any{
+					"db_password": evaluator.SecretValue{Value: "fresh-secret"},
+				},
+			},
+		})
+
+		envVars, _, err := mocks.Provider.GetEnvVars("cluster", false)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if got := envVars["TF_VAR_db_password"]; got != "cached-secret" {
+			t.Errorf("Expected cached TF_VAR_db_password to be reused, got %q", got)
+		}
+	})
+
+	t.Run("DoesNotReuseExistingTFVarWhenNotHookMode", func(t *testing.T) {
+		mocks := setupMocks(t, &SetupOptions{BackendType: "none"})
+		mocks.Provider.SetSecretCacheEnabled(false)
+		mocks.Provider.Shims.Getenv = func(key string) string {
+			switch key {
+			case "NO_CACHE":
+				return ""
+			case "TF_VAR_db_password":
+				return "cached-secret"
+			default:
+				return ""
+			}
+		}
+		mocks.Provider.SetTerraformComponents([]blueprintv1alpha1.TerraformComponent{
+			{
+				Path: "cluster",
+				Inputs: map[string]any{
+					"db_password": evaluator.SecretValue{Value: "fresh-secret"},
+				},
+			},
+		})
+
+		envVars, _, err := mocks.Provider.GetEnvVars("cluster", false)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if got := envVars["TF_VAR_db_password"]; got != "fresh-secret" {
+			t.Errorf("Expected TF_VAR_db_password to be recomputed outside hook mode, got %q", got)
+		}
+	})
+
+	t.Run("DoesNotReuseExistingTFVarForNonSecretExpressionInputs", func(t *testing.T) {
+		mocks := setupMocks(t, &SetupOptions{BackendType: "none"})
+		mocks.Provider.Shims.Getenv = func(key string) string {
+			switch key {
+			case "NO_CACHE":
+				return ""
+			case "TF_VAR_vpc_id":
+				return "cached-vpc-id"
+			default:
+				return ""
+			}
+		}
+		mocks.Provider.SetTerraformComponents([]blueprintv1alpha1.TerraformComponent{
+			{
+				Path: "cluster",
+				Inputs: map[string]any{
+					"vpc_id": "${terraform_output('network', 'vpc_id')}",
+				},
+			},
+		})
+		mockEvaluator := evaluator.NewMockExpressionEvaluator()
+		mockEvaluator.EvaluateMapFunc = func(values map[string]any, featurePath string, scope map[string]any, evaluateDeferred bool) (map[string]any, error) {
+			if !evaluateDeferred {
+				return map[string]any{"vpc_id": "${terraform_output('network', 'vpc_id')}"}, nil
+			}
+			return map[string]any{"vpc_id": "fresh-vpc-id"}, nil
+		}
+		mocks.Provider.evaluator = mockEvaluator
+
+		envVars, _, err := mocks.Provider.GetEnvVars("cluster", false)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if got := envVars["TF_VAR_vpc_id"]; got != "fresh-vpc-id" {
+			t.Errorf("Expected TF_VAR_vpc_id to be recomputed for non-secret expression input, got %q", got)
+		}
+	})
+
+	t.Run("DoesNotReuseExistingTFVarWhenNoCacheEnabled", func(t *testing.T) {
+		mocks := setupMocks(t, &SetupOptions{BackendType: "none"})
+		mocks.Provider.Shims.Getenv = func(key string) string {
+			switch key {
+			case "NO_CACHE":
+				return "true"
+			case "TF_VAR_db_password":
+				return "cached-secret"
+			default:
+				return ""
+			}
+		}
+		mocks.Provider.SetTerraformComponents([]blueprintv1alpha1.TerraformComponent{
+			{
+				Path: "cluster",
+				Inputs: map[string]any{
+					"db_password": evaluator.SecretValue{Value: "fresh-secret"},
+				},
+			},
+		})
+
+		envVars, _, err := mocks.Provider.GetEnvVars("cluster", false)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if got := envVars["TF_VAR_db_password"]; got != "fresh-secret" {
+			t.Errorf("Expected TF_VAR_db_password to be recomputed when NO_CACHE=true, got %q", got)
+		}
+	})
+
 	t.Run("IncludesBaseContextAndProjectRootVars", func(t *testing.T) {
 		mocks := setupMocks(t, &SetupOptions{BackendType: "none"})
 		mocks.ConfigHandler.GetContextFunc = func() string {

--- a/pkg/runtime/terraform/provider_sensitive_inputs.go
+++ b/pkg/runtime/terraform/provider_sensitive_inputs.go
@@ -1,0 +1,159 @@
+// The ProviderSensitiveInputDiscovery is a terraform provider metadata component.
+// It provides HCL parsing and cache-backed discovery of sensitive input declarations,
+// The ProviderSensitiveInputDiscovery supports TerraformProvider env rendering decisions,
+// and isolates sensitive variable introspection from broader provider orchestration flows.
+
+package terraform
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+
+	"github.com/hashicorp/hcl/v2"
+	"github.com/hashicorp/hcl/v2/hclsyntax"
+	"github.com/zclconf/go-cty/cty"
+)
+
+// =============================================================================
+// Types
+// =============================================================================
+
+type providerSensitiveInputCacheEntry struct {
+	signature string
+	inputs    map[string]bool
+}
+
+type defaultProviderSensitiveInputDiscovery struct {
+	shims *Shims
+	cache map[string]providerSensitiveInputCacheEntry
+	mu    sync.RWMutex
+}
+
+// =============================================================================
+// Interfaces
+// =============================================================================
+
+type providerSensitiveInputDiscovery interface {
+	GetSensitiveTerraformInputs(modulePath string) (map[string]bool, error)
+	ClearCache()
+}
+
+// =============================================================================
+// Constructor
+// =============================================================================
+
+// newProviderSensitiveInputDiscovery creates a sensitive terraform input discovery service for TerraformProvider.
+func newProviderSensitiveInputDiscovery(shims *Shims) providerSensitiveInputDiscovery {
+	return &defaultProviderSensitiveInputDiscovery{
+		shims: shims,
+		cache: make(map[string]providerSensitiveInputCacheEntry),
+	}
+}
+
+// =============================================================================
+// Public Methods
+// =============================================================================
+
+// GetSensitiveTerraformInputs discovers terraform variable names declared with sensitive=true.
+func (d *defaultProviderSensitiveInputDiscovery) GetSensitiveTerraformInputs(modulePath string) (map[string]bool, error) {
+	inputs := make(map[string]bool)
+	pattern := filepath.Join(modulePath, "*.tf")
+	matches, err := d.shims.Glob(pattern)
+	if err != nil {
+		return nil, fmt.Errorf("failed to find terraform files in module %s: %w", modulePath, err)
+	}
+	sort.Strings(matches)
+	signature, err := d.getSensitiveInputsSignature(matches)
+	if err != nil {
+		return nil, err
+	}
+	d.mu.RLock()
+	cached, ok := d.cache[modulePath]
+	d.mu.RUnlock()
+	if ok && cached.signature == signature {
+		return cloneProviderSensitiveInputMap(cached.inputs), nil
+	}
+
+	for _, tfFile := range matches {
+		content, err := d.shims.ReadFile(tfFile)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read terraform file %s: %w", tfFile, err)
+		}
+		parsedFile, diags := d.shims.HclParseConfig(content, tfFile, hcl.Pos{Line: 1, Column: 1})
+		if diags.HasErrors() {
+			return nil, fmt.Errorf("failed to parse terraform file %s: %s", tfFile, strings.TrimSpace(diags.Error()))
+		}
+		for _, block := range parsedFile.Body().Blocks() {
+			if block.Type() != "variable" || len(block.Labels()) == 0 {
+				continue
+			}
+			attr := block.Body().GetAttribute("sensitive")
+			if attr == nil {
+				continue
+			}
+			exprBytes := attr.Expr().BuildTokens(nil).Bytes()
+			parsedExpr, diags := hclsyntax.ParseExpression(exprBytes, "sensitive", hcl.Pos{Line: 1, Column: 1})
+			if diags.HasErrors() {
+				return nil, fmt.Errorf("failed to parse sensitive attribute in variable %s from %s: %s", block.Labels()[0], tfFile, strings.TrimSpace(diags.Error()))
+			}
+			val, diags := parsedExpr.Value(nil)
+			if diags.HasErrors() {
+				return nil, fmt.Errorf("failed to evaluate sensitive attribute in variable %s from %s: %s", block.Labels()[0], tfFile, strings.TrimSpace(diags.Error()))
+			}
+			if val.Type() != cty.Bool || !val.True() {
+				continue
+			}
+			inputs[block.Labels()[0]] = true
+		}
+	}
+
+	d.mu.Lock()
+	d.cache[modulePath] = providerSensitiveInputCacheEntry{
+		signature: signature,
+		inputs:    cloneProviderSensitiveInputMap(inputs),
+	}
+	d.mu.Unlock()
+	return inputs, nil
+}
+
+// ClearCache clears cached sensitive variable discovery results.
+func (d *defaultProviderSensitiveInputDiscovery) ClearCache() {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	d.cache = make(map[string]providerSensitiveInputCacheEntry)
+}
+
+// =============================================================================
+// Private Methods
+// =============================================================================
+
+// getSensitiveInputsSignature computes a stable cache signature from terraform file metadata.
+func (d *defaultProviderSensitiveInputDiscovery) getSensitiveInputsSignature(tfFiles []string) (string, error) {
+	var signature strings.Builder
+	for _, tfFile := range tfFiles {
+		info, err := d.shims.Stat(tfFile)
+		if err != nil {
+			return "", fmt.Errorf("failed to stat terraform file %s: %w", tfFile, err)
+		}
+		signature.WriteString(tfFile)
+		signature.WriteString("|")
+		signature.WriteString(fmt.Sprintf("%d|%d|", info.Size(), info.ModTime().UnixNano()))
+	}
+	return signature.String(), nil
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+// cloneProviderSensitiveInputMap returns a deep copy of the provided sensitivity map.
+func cloneProviderSensitiveInputMap(inputs map[string]bool) map[string]bool {
+	cloned := make(map[string]bool, len(inputs))
+	for key, value := range inputs {
+		cloned[key] = value
+	}
+	return cloned
+}

--- a/pkg/runtime/terraform/shims.go
+++ b/pkg/runtime/terraform/shims.go
@@ -27,6 +27,7 @@ type Shims struct {
 	JsonUnmarshal  func([]byte, any) error
 	JsonMarshal    func(any) ([]byte, error)
 	Getenv         func(string) string
+	LookupEnv      func(string) (string, bool)
 	Setenv         func(string, string) error
 	Unsetenv       func(string) error
 	Stat           func(string) (os.FileInfo, error)
@@ -52,6 +53,7 @@ func NewShims() *Shims {
 		JsonUnmarshal:  json.Unmarshal,
 		JsonMarshal:    json.Marshal,
 		Getenv:         os.Getenv,
+		LookupEnv:      os.LookupEnv,
 		Setenv:         os.Setenv,
 		Unsetenv:       os.Unsetenv,
 		Stat:           os.Stat,


### PR DESCRIPTION
Signed-off-by: Ryan VanGundy <85766511+rmvangun@users.noreply.github.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how secrets are detected, evaluated, cached, and injected into `TF_VAR_*`/`terraform.tfvars`, which can affect Terraform plans/applies and secret exposure if logic regresses.
> 
> **Overview**
> Adds first-class *secret-qualified* expression handling via a new evaluator `SecretValue` wrapper and a runtime-registered `secret()` helper (including expression normalization), so `${op...}`, `${sops...}`, and `${secret.<provider>...}` references can be resolved while still being treated as secrets.
> 
> Terraform input handling is updated to **avoid persisting secret/sensitive values to `terraform.tfvars`** and instead inject them through `TF_VAR_*` env vars (including module-based sensitive variable discovery), with optional cache reuse controlled by runtime settings.
> 
> `env` command behavior is adjusted to control secret cache enabling, scrub rendered output by default (unless `--decrypt` or `--hook`), and secrets/config/docs/tests are updated to the `${...}` secret syntax (legacy `${{...}}` normalized for compatibility) plus new v1alpha2 `secrets.sops.enabled` schema validation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3b252a302fb92cd3de5cc5d0bf2908aa0772978b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->