### PR TITLE
feat(composer): Inject repository.name on config

### DIFF
--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -716,8 +716,8 @@ func (h *BaseBlueprintHandler) getRepositoryScopeValues() map[string]any {
 	}
 
 	var blueprintName string
-	if h.composedBlueprint != nil {
-		blueprintName = h.composedBlueprint.Metadata.Name
+	if h.runtime != nil {
+		blueprintName = h.runtime.ContextName
 	}
 
 	repositoryValue := map[string]any{


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: only augments the injected `repository` scope map used for config/expression evaluation, with no behavior change unless templates reference the new `repository.name` field.
> 
> **Overview**
> Adds `repository.name` to the scope values injected into config/expression evaluation (alongside `repository.url` and `repository.ref.*`), deriving the name from `runtime.ContextName` so downstream templates can reference the Flux `GitRepository` resource name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 96b2208c734714bee35305b533b5be904ca8ef19. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->