### PR TITLE
feat(provisioner/cluster): Allow unknown status on talos health checks

### DIFF
--- a/pkg/provisioner/cluster/talos_cluster_client.go
+++ b/pkg/provisioner/cluster/talos_cluster_client.go
@@ -238,7 +238,7 @@ func (c *TalosClusterClient) getNodeHealthDetails(ctx context.Context, nodeAddre
 
 			isRunning := state == "Running"
 			healthUnknown := health != nil && health.GetUnknown()
-			isHealthy := isRunning && (health != nil && health.GetHealthy() || healthUnknown)
+			isHealthy := isRunning && ((health != nil && health.GetHealthy()) || healthUnknown)
 
 			if isHealthy {
 				healthyServices = append(healthyServices, serviceName)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adjusts node health gating logic during Talos provisioning; misclassification could cause nodes to be considered ready earlier or remain blocked if assumptions about `Unknown` are wrong.
> 
> **Overview**
> Updates Talos node health evaluation to **treat services reporting `Health.Unknown=true` as healthy when the service is `Running`**, while still treating a `nil` health field as unhealthy.
> 
> This changes which services are counted as healthy/unhealthy in `getNodeHealthDetails`, affecting when `WaitForNodesHealthy` considers a node ready.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b72e971665c9a7c7cdc5a1a8f2fe0a2a1cac7a73. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->