### PR TITLE
feat(cmd/down): Redefine the mechanism of windsor down

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -7,17 +7,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	cleanFlag         bool
-	skipK8sFlag       bool
-	skipTerraformFlag bool
-	skipDockerFlag    bool
-)
-
 var downCmd = &cobra.Command{
 	Use:          "down",
-	Short:        "Tear down the Windsor environment",
-	Long:         "Tear down the Windsor environment by executing necessary shell commands.",
+	Short:        "Stop the local workstation environment",
+	Long:         "Stop the local workstation environment by tearing down the VM, stopping container runtimes, and cleaning up context artifacts.",
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		proj, err := prepareProject(cmd)
@@ -25,38 +18,17 @@ var downCmd = &cobra.Command{
 			return err
 		}
 
-		if !skipK8sFlag {
-			blueprint := proj.Composer.BlueprintHandler.Generate()
-			if err := proj.Provisioner.Uninstall(blueprint); err != nil {
-				return fmt.Errorf("error running blueprint cleanup: %w", err)
-			}
-		} else {
-			fmt.Fprintln(os.Stderr, "Skipping Kubernetes cleanup (--skip-k8s set)")
+		if proj.Workstation == nil {
+			fmt.Fprintln(os.Stderr, "windsor down is only applicable when a workstation is enabled; use windsor destroy to tear down live environments")
+			return nil
 		}
 
-		if !skipTerraformFlag {
-			blueprint := proj.Composer.BlueprintHandler.Generate()
-			if err := proj.Provisioner.Down(blueprint); err != nil {
-				return fmt.Errorf("error tearing down infrastructure: %w", err)
-			}
-		} else {
-			fmt.Fprintln(os.Stderr, "Skipping Terraform cleanup (--skip-tf set)")
+		if err := proj.Workstation.Down(); err != nil {
+			return fmt.Errorf("error tearing down workstation VM: %w", err)
 		}
 
-		if !skipDockerFlag {
-			if proj.Workstation != nil {
-				if err := proj.Workstation.Down(); err != nil {
-					return fmt.Errorf("error tearing down workstation: %w", err)
-				}
-			}
-		} else {
-			fmt.Fprintln(os.Stderr, "Skipping Docker container cleanup (--skip-docker set)")
-		}
-
-		if cleanFlag {
-			if err := proj.PerformCleanup(); err != nil {
-				return fmt.Errorf("error performing cleanup: %w", err)
-			}
+		if err := proj.PerformCleanup(); err != nil {
+			return fmt.Errorf("error performing cleanup: %w", err)
 		}
 
 		return nil
@@ -64,9 +36,5 @@ var downCmd = &cobra.Command{
 }
 
 func init() {
-	downCmd.Flags().BoolVar(&cleanFlag, "clean", false, "Clean up context specific artifacts")
-	downCmd.Flags().BoolVar(&skipK8sFlag, "skip-k8s", false, "Skip Kubernetes cleanup (blueprint cleanup)")
-	downCmd.Flags().BoolVar(&skipTerraformFlag, "skip-tf", false, "Skip Terraform cleanup")
-	downCmd.Flags().BoolVar(&skipDockerFlag, "skip-docker", false, "Skip Docker container cleanup")
 	rootCmd.AddCommand(downCmd)
 }

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -24,7 +24,7 @@ var downCmd = &cobra.Command{
 		}
 
 		if err := proj.Workstation.Down(); err != nil {
-			return fmt.Errorf("error tearing down workstation VM: %w", err)
+			return fmt.Errorf("error tearing down workstation: %w", err)
 		}
 
 		if err := proj.PerformCleanup(); err != nil {

--- a/cmd/down_test.go
+++ b/cmd/down_test.go
@@ -211,4 +211,29 @@ func TestDownCmd(t *testing.T) {
 			t.Errorf("Expected workstation VM error, got: %v", err)
 		}
 	})
+
+	t.Run("ErrorPerformingCleanup", func(t *testing.T) {
+		// Given a workstation where PerformCleanup fails
+		mocks := setupDownTest(t)
+		mockConfigHandler := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockConfigHandler.CleanFunc = func() error {
+			return fmt.Errorf("cleanup failed")
+		}
+		ws := workstation.NewWorkstation(mocks.Runtime.Runtime)
+		mocks.Project.Workstation = ws
+
+		// When executing the down command
+		cmd := createTestDownCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, mocks.Project)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then an error should occur
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "error performing cleanup") {
+			t.Errorf("Expected cleanup error, got: %v", err)
+		}
+	})
 }

--- a/cmd/down_test.go
+++ b/cmd/down_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/windsorcli/cli/pkg/provisioner/kubernetes"
 	terraforminfra "github.com/windsorcli/cli/pkg/provisioner/terraform"
 	"github.com/windsorcli/cli/pkg/runtime/config"
+	"github.com/windsorcli/cli/pkg/workstation"
+	"github.com/windsorcli/cli/pkg/workstation/virt"
 )
 
 // =============================================================================
@@ -77,7 +79,7 @@ func TestDownCmd(t *testing.T) {
 	createTestDownCmd := func() *cobra.Command {
 		cmd := &cobra.Command{
 			Use:   "down",
-			Short: "Tear down the Windsor environment",
+			Short: "Stop the local workstation environment",
 			RunE:  downCmd.RunE,
 		}
 
@@ -95,17 +97,18 @@ func TestDownCmd(t *testing.T) {
 	suppressProcessStdout(t)
 	suppressProcessStderr(t)
 
-	t.Run("Success", func(t *testing.T) {
-		// Given a properly configured down command
+	t.Run("NoOpWhenWorkstationDisabled", func(t *testing.T) {
+		// Given a down command with no workstation configured
 		mocks := setupDownTest(t)
 
-		// When executing the down command
+		var stderrBuf strings.Builder
 		cmd := createTestDownCmd()
+		cmd.SetErr(&stderrBuf)
 		ctx := context.WithValue(context.Background(), projectOverridesKey, mocks.Project)
 		cmd.SetContext(ctx)
 		err := cmd.Execute()
 
-		// Then no error should occur
+		// Then no error should occur and a descriptive message is printed
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -164,68 +167,11 @@ func TestDownCmd(t *testing.T) {
 		}
 	})
 
-	t.Run("SkipK8sFlag", func(t *testing.T) {
-		// Given a down command with skip-k8s flag
+	t.Run("SuccessWithWorkstation", func(t *testing.T) {
+		// Given a down command with a workstation configured (no terraform layer, no VM)
 		mocks := setupDownTest(t)
-
-		// When executing the down command with skip-k8s flag
-		cmd := createTestDownCmd()
-		cmd.SetArgs([]string{"--skip-k8s"})
-		ctx := context.WithValue(context.Background(), projectOverridesKey, mocks.Project)
-		cmd.SetContext(ctx)
-		err := cmd.Execute()
-
-		// Then no error should occur
-		if err != nil {
-			t.Errorf("Expected no error, got %v", err)
-		}
-	})
-
-	t.Run("SkipTerraformFlag", func(t *testing.T) {
-		// Given a down command with skip-tf flag
-		mocks := setupDownTest(t)
-
-		// When executing the down command with skip-tf flag
-		cmd := createTestDownCmd()
-		cmd.SetArgs([]string{"--skip-tf"})
-		ctx := context.WithValue(context.Background(), projectOverridesKey, mocks.Project)
-		cmd.SetContext(ctx)
-		err := cmd.Execute()
-
-		// Then no error should occur
-		if err != nil {
-			t.Errorf("Expected no error, got %v", err)
-		}
-	})
-
-	t.Run("SkipDockerFlag", func(t *testing.T) {
-		// Given a down command with skip-docker flag
-		mocks := setupDownTest(t)
-
-		// When executing the down command with skip-docker flag
-		cmd := createTestDownCmd()
-		cmd.SetArgs([]string{"--skip-docker"})
-		ctx := context.WithValue(context.Background(), projectOverridesKey, mocks.Project)
-		cmd.SetContext(ctx)
-		err := cmd.Execute()
-
-		// Then no error should occur
-		if err != nil {
-			t.Errorf("Expected no error, got %v", err)
-		}
-	})
-
-	t.Run("DevModeWithoutWorkstation", func(t *testing.T) {
-		// Given a down command in non-dev mode
-		mockConfigHandler := config.NewMockConfigHandler()
-		mockConfigHandler.IsDevModeFunc = func(contextName string) bool { return false }
-
-		opts := &SetupOptions{
-			ConfigHandler: mockConfigHandler,
-		}
-		mocks := setupDownTest(t, opts)
-		mocks.Runtime.Runtime.ConfigHandler = mockConfigHandler
-		mocks.Project = project.NewProject("", &project.Project{Runtime: mocks.Runtime.Runtime})
+		ws := workstation.NewWorkstation(mocks.Runtime.Runtime)
+		mocks.Project.Workstation = ws
 
 		// When executing the down command
 		cmd := createTestDownCmd()
@@ -239,54 +185,30 @@ func TestDownCmd(t *testing.T) {
 		}
 	})
 
-	t.Run("DockerFallbackWhenProviderDocker", func(t *testing.T) {
-		mockConfigHandler := config.NewMockConfigHandler()
-		mockConfigHandler.IsDevModeFunc = func(contextName string) bool { return false }
-		mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "provider" {
-				return "docker"
-			}
-			if len(defaultValue) > 0 {
-				return defaultValue[0]
-			}
-			return ""
-		}
-		mockConfigHandler.GetBoolFunc = func(key string, defaultValue ...bool) bool {
-			if len(defaultValue) > 0 {
-				return defaultValue[0]
-			}
-			return false
-		}
-		mockConfigHandler.GetContextFunc = func() string { return "test-context" }
-		mockConfigHandler.IsLoadedFunc = func() bool { return true }
-		mockConfigHandler.LoadConfigFunc = func() error { return nil }
-		mockConfigHandler.SaveConfigFunc = func(hasSetFlags ...bool) error { return nil }
-		mockConfigHandler.GenerateContextIDFunc = func() error { return nil }
+	t.Run("ErrorTearingDownWorkstationVM", func(t *testing.T) {
+		// Given a workstation whose VM teardown fails
+		mocks := setupDownTest(t)
 
-		opts := &SetupOptions{ConfigHandler: mockConfigHandler}
-		mocks := setupDownTest(t, opts)
-		mocks.Runtime.Runtime.ConfigHandler = mockConfigHandler
-		origExecSilent := mocks.Runtime.Shell.ExecSilentFunc
-		mocks.Runtime.Shell.ExecSilentFunc = func(command string, args ...string) (string, error) {
-			if command == "docker" && len(args) >= 3 && args[0] == "info" && args[1] == "--format" && args[2] == "json" {
-				return `{"ServerErrors":[]}`, nil
-			}
-			if command == "docker" && len(args) > 0 && args[0] == "compose" {
-				return "Docker Compose version 2.0.0", nil
-			}
-			if origExecSilent != nil {
-				return origExecSilent(command, args...)
-			}
-			return "", nil
-		}
-		mocks.Project = project.NewProject("", &project.Project{Runtime: mocks.Runtime.Runtime})
+		mockVirt := virt.NewMockVirt()
+		mockVirt.DownFunc = func() error { return fmt.Errorf("vm down failed") }
 
+		ws := workstation.NewWorkstation(mocks.Runtime.Runtime, &workstation.Workstation{
+			VirtualMachine: mockVirt,
+		})
+		mocks.Project.Workstation = ws
+
+		// When executing the down command
 		cmd := createTestDownCmd()
-		cmd.SetArgs([]string{"--skip-k8s", "--skip-tf", "--skip-docker=false"})
 		ctx := context.WithValue(context.Background(), projectOverridesKey, mocks.Project)
 		cmd.SetContext(ctx)
-		if err := cmd.Execute(); err != nil {
-			t.Errorf("Expected no error, got %v", err)
+		err := cmd.Execute()
+
+		// Then an error should occur
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "error tearing down workstation VM") {
+			t.Errorf("Expected workstation VM error, got: %v", err)
 		}
 	})
 }

--- a/cmd/down_test.go
+++ b/cmd/down_test.go
@@ -207,8 +207,8 @@ func TestDownCmd(t *testing.T) {
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), "error tearing down workstation VM") {
-			t.Errorf("Expected workstation VM error, got: %v", err)
+		if !strings.Contains(err.Error(), "error tearing down workstation") {
+			t.Errorf("Expected workstation error, got: %v", err)
 		}
 	})
 

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -216,26 +216,26 @@ func (p *Project) Up() (*blueprintv1alpha1.Blueprint, error) {
 	return blueprint, nil
 }
 
-// PerformCleanup removes context-specific artifacts: config state, .volumes,
-// .windsor/contexts/<context>, and .windsor/Corefile. Returns an error if any step fails.
+// PerformCleanup removes context-specific artifacts: config state and
+// contents of .windsor/contexts/<context> (preserving workstation.yaml).
+// Returns an error if any step fails.
 func (p *Project) PerformCleanup() error {
 	if err := p.configHandler.Clean(); err != nil {
 		return fmt.Errorf("error cleaning up context specific artifacts: %w", err)
 	}
 
-	volumesPath := filepath.Join(p.projectRoot, ".volumes")
-	if err := os.RemoveAll(volumesPath); err != nil {
-		return fmt.Errorf("error deleting .volumes folder: %w", err)
+	contextDir := filepath.Join(p.projectRoot, ".windsor", "contexts", p.contextName)
+	entries, err := os.ReadDir(contextDir)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("error reading .windsor/contexts/%s: %w", p.contextName, err)
 	}
-
-	tfModulesPath := filepath.Join(p.projectRoot, ".windsor", "contexts", p.contextName)
-	if err := os.RemoveAll(tfModulesPath); err != nil {
-		return fmt.Errorf("error deleting .windsor/contexts/%s folder: %w", p.contextName, err)
-	}
-
-	corefilePath := filepath.Join(p.projectRoot, ".windsor", "Corefile")
-	if err := os.RemoveAll(corefilePath); err != nil {
-		return fmt.Errorf("error deleting .windsor/Corefile: %w", err)
+	for _, entry := range entries {
+		if entry.Name() == "workstation.yaml" {
+			continue
+		}
+		if err := os.RemoveAll(filepath.Join(contextDir, entry.Name())); err != nil {
+			return fmt.Errorf("error deleting %s: %w", entry.Name(), err)
+		}
 	}
 
 	return nil

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -163,7 +163,12 @@ func (k *BaseKubernetesManager) DeleteKustomization(name, namespace string) erro
 		time.Sleep(k.kustomizationWaitPollInterval)
 	}
 
-	return fmt.Errorf("timeout waiting for kustomization %s to be deleted", name)
+	// Kustomization is stuck in Terminating — strip finalizers to unblock deletion.
+	patch := []byte(`{"metadata":{"finalizers":[]}}`)
+	if _, err := k.client.PatchResource(gvr, namespace, name, types.MergePatchType, patch, metav1.PatchOptions{FieldManager: "windsor-cli"}); err != nil && !isNotFoundError(err) {
+		return fmt.Errorf("timeout waiting for kustomization %s to be deleted, and failed to remove finalizers: %w", name, err)
+	}
+	return nil
 }
 
 // WaitForKustomizations waits for kustomizations to be ready, calculating the timeout

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -268,6 +268,7 @@ func TestBaseKubernetesManager_DeleteKustomization(t *testing.T) {
 	})
 
 	t.Run("TimeoutWaitingForDeletion", func(t *testing.T) {
+		// Given a kustomization that never disappears (stuck in Terminating)
 		manager := setup(t)
 		kubernetesClient := client.NewMockKubernetesClient()
 		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
@@ -285,12 +286,44 @@ func TestBaseKubernetesManager_DeleteKustomization(t *testing.T) {
 		manager.kustomizationReconcileTimeout = 100 * time.Millisecond
 		manager.kustomizationWaitPollInterval = 50 * time.Millisecond
 
+		// When
 		err := manager.DeleteKustomization("test-kustomization", "test-namespace")
-		if err == nil {
-			t.Error("Expected timeout error, got nil")
+
+		// Then finalizers are stripped and no error is returned
+		if err != nil {
+			t.Errorf("Expected nil after finalizer strip, got: %v", err)
 		}
-		if !strings.Contains(err.Error(), "timeout waiting for kustomization") {
-			t.Errorf("Expected timeout error, got: %v", err)
+		if !patchCalled {
+			t.Error("Expected PatchResource to be called to strip finalizers")
+		}
+	})
+
+	t.Run("FinalizerStripError", func(t *testing.T) {
+		// Given a kustomization stuck in Terminating and PatchResource fails
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			return nil
+		}
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			return &unstructured.Unstructured{}, nil
+		}
+		kubernetesClient.PatchResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*unstructured.Unstructured, error) {
+			return nil, fmt.Errorf("patch failed")
+		}
+		manager.client = kubernetesClient
+		manager.kustomizationReconcileTimeout = 100 * time.Millisecond
+		manager.kustomizationWaitPollInterval = 50 * time.Millisecond
+
+		// When
+		err := manager.DeleteKustomization("test-kustomization", "test-namespace")
+
+		// Then an error combining timeout and patch failure is returned
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to remove finalizers") {
+			t.Errorf("Expected finalizer error, got: %v", err)
 		}
 	})
 

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -276,6 +276,11 @@ func TestBaseKubernetesManager_DeleteKustomization(t *testing.T) {
 		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
 			return &unstructured.Unstructured{}, nil
 		}
+		patchCalled := false
+		kubernetesClient.PatchResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*unstructured.Unstructured, error) {
+			patchCalled = true
+			return nil, nil
+		}
 		manager.client = kubernetesClient
 		manager.kustomizationReconcileTimeout = 100 * time.Millisecond
 		manager.kustomizationWaitPollInterval = 50 * time.Millisecond

--- a/pkg/runtime/config/handler.go
+++ b/pkg/runtime/config/handler.go
@@ -35,7 +35,6 @@ type ConfigHandler interface {
 	Get(key string) any
 	SaveConfig(overwrite ...bool) error
 	SaveWorkstationState() error
-	DeleteWorkstationState() error
 	SetDefault(context v1alpha1.Context) error
 	GetConfig() *v1alpha1.Context
 	GetContext() string
@@ -306,18 +305,6 @@ func (c *configHandler) SaveWorkstationState() error {
 		c.data,
 		c.getPersistencePolicyInput(),
 	)
-}
-
-// DeleteWorkstationState removes .windsor/contexts/<context>/workstation.yaml.
-func (c *configHandler) DeleteWorkstationState() error {
-	if c.shell == nil {
-		return fmt.Errorf("shell not initialized")
-	}
-	projectRoot, err := c.shell.GetProjectRoot()
-	if err != nil {
-		return fmt.Errorf("error retrieving project root: %w", err)
-	}
-	return c.workstation.Delete(projectRoot, c.GetContext())
 }
 
 // SetDefault sets the default context configuration in the config handler's internal data.

--- a/pkg/runtime/config/handler_test.go
+++ b/pkg/runtime/config/handler_test.go
@@ -823,28 +823,6 @@ func TestConfigHandler_WorkstationStatePersistence(t *testing.T) {
 		}
 	})
 
-	t.Run("DeletesContextScopedWorkstationState", func(t *testing.T) {
-		mocks := setupConfigMocks(t)
-		tmpDir, _ := mocks.Shell.GetProjectRoot()
-
-		handler := NewConfigHandler(mocks.Shell)
-		if err := handler.SetContext("ctx-a"); err != nil {
-			t.Fatalf("Expected no error setting context, got %v", err)
-		}
-
-		contextPath := filepath.Join(tmpDir, ".windsor", "contexts", "ctx-a", "workstation.yaml")
-		os.MkdirAll(filepath.Dir(contextPath), 0755)
-		os.WriteFile(contextPath, []byte("workstation:\n  runtime: colima\n"), 0644)
-
-		if err := handler.DeleteWorkstationState(); err != nil {
-			t.Fatalf("Expected no error deleting workstation state, got %v", err)
-		}
-
-		if _, err := os.Stat(contextPath); !os.IsNotExist(err) {
-			t.Errorf("Expected context-scoped workstation state to be removed, stat err=%v", err)
-		}
-	})
-
 	t.Run("SaveConfigAndSaveWorkstationStateRespectOwnershipBoundaries", func(t *testing.T) {
 		handler, tmpDir := setupPrivateTestHandler(t)
 		if err := handler.SetContext("local-dev"); err != nil {

--- a/pkg/runtime/config/mock_handler.go
+++ b/pkg/runtime/config/mock_handler.go
@@ -21,9 +21,8 @@ type MockConfigHandler struct {
 	GetStringMapFunc           func(key string, defaultValue ...map[string]string) map[string]string
 	SetFunc                    func(key string, value any) error
 	SaveConfigFunc             func(overwrite ...bool) error
-	SaveWorkstationStateFunc   func() error
-	DeleteWorkstationStateFunc func() error
-	GetFunc                    func(key string) any
+	SaveWorkstationStateFunc func() error
+	GetFunc                  func(key string) any
 	SetDefaultFunc             func(context v1alpha1.Context) error
 	GetConfigFunc              func() *v1alpha1.Context
 	GetContextFunc             func() string
@@ -168,14 +167,6 @@ func (m *MockConfigHandler) SaveConfig(overwrite ...bool) error {
 func (m *MockConfigHandler) SaveWorkstationState() error {
 	if m.SaveWorkstationStateFunc != nil {
 		return m.SaveWorkstationStateFunc()
-	}
-	return nil
-}
-
-// DeleteWorkstationState calls the mock DeleteWorkstationStateFunc if set, otherwise returns nil
-func (m *MockConfigHandler) DeleteWorkstationState() error {
-	if m.DeleteWorkstationStateFunc != nil {
-		return m.DeleteWorkstationStateFunc()
 	}
 	return nil
 }

--- a/pkg/workstation/virt/colima_virt_test.go
+++ b/pkg/workstation/virt/colima_virt_test.go
@@ -83,7 +83,6 @@ version: v1alpha1
 contexts:
   mock-context:
     vm:
-      driver: colima
       cpu: 2
       memory: 4
       disk: 60

--- a/pkg/workstation/virt/docker_virt.go
+++ b/pkg/workstation/virt/docker_virt.go
@@ -70,7 +70,7 @@ func (v *DockerVirt) WriteConfig() error {
 // Anonymous volumes are removed with containers via rm -v. No global Docker cleanup is performed.
 // Best-effort: errors are logged to stderr but do not cause Down to return an error. Shows a progress spinner.
 func (v *DockerVirt) Down() error {
-	return tui.WithProgress("Cleaning up residual Docker resources", func() error {
+	return tui.WithProgress("Cleaning up Docker resources", func() error {
 		contextName := v.configHandler.GetContext()
 		projectLabelValue := DockerComposeProjectPrefix + contextName
 		netName := WindsorNetworkPrefix + contextName

--- a/pkg/workstation/workstation.go
+++ b/pkg/workstation/workstation.go
@@ -316,10 +316,6 @@ func (w *Workstation) Down() error {
 		}
 	}
 
-	if err := w.DeleteState(); err != nil {
-		return fmt.Errorf("Error deleting workstation state: %w", err)
-	}
-
 	return nil
 }
 

--- a/pkg/workstation/workstation.go
+++ b/pkg/workstation/workstation.go
@@ -325,8 +325,3 @@ func (w *Workstation) WriteState() error {
 	return w.configHandler.SaveWorkstationState()
 }
 
-// DeleteState delegates to ConfigHandler.DeleteWorkstationState to remove .windsor/contexts/<context>/workstation.yaml.
-func (w *Workstation) DeleteState() error {
-	return w.configHandler.DeleteWorkstationState()
-}
-

--- a/pkg/workstation/workstation_test.go
+++ b/pkg/workstation/workstation_test.go
@@ -1004,7 +1004,8 @@ func TestWorkstation_Down(t *testing.T) {
 		}
 	})
 
-	t.Run("DeletesStateAfterStoppingServices", func(t *testing.T) {
+	t.Run("PreservesWorkstationState", func(t *testing.T) {
+		// Given
 		mocks := setupWorkstationMocks(t)
 		deleteStateCalled := false
 		mockConfig := mocks.ConfigHandler.(*config.MockConfigHandler)
@@ -1013,40 +1014,22 @@ func TestWorkstation_Down(t *testing.T) {
 			return nil
 		}
 		workstation := NewWorkstation(mocks.Runtime, &Workstation{
-			ContainerRuntime: mocks.ContainerRuntime,
 			VirtualMachine:   mocks.VirtualMachine,
+			ContainerRuntime: mocks.ContainerRuntime,
 		})
 
+		// When
 		err := workstation.Down()
 
+		// Then
 		if err != nil {
 			t.Errorf("Expected success, got error: %v", err)
 		}
-		if !deleteStateCalled {
-			t.Error("Expected DeleteWorkstationState to be called")
+		if deleteStateCalled {
+			t.Error("Expected DeleteWorkstationState NOT to be called; workstation state must survive windsor down")
 		}
 	})
 
-	t.Run("DeleteStateError", func(t *testing.T) {
-		mocks := setupWorkstationMocks(t)
-		mockConfig := mocks.ConfigHandler.(*config.MockConfigHandler)
-		mockConfig.DeleteWorkstationStateFunc = func() error {
-			return fmt.Errorf("delete state failed")
-		}
-		workstation := NewWorkstation(mocks.Runtime, &Workstation{
-			ContainerRuntime: mocks.ContainerRuntime,
-			VirtualMachine:   mocks.VirtualMachine,
-		})
-
-		err := workstation.Down()
-
-		if err == nil {
-			t.Error("Expected error for DeleteState failure")
-		}
-		if !strings.Contains(err.Error(), "Error deleting workstation state") {
-			t.Errorf("Expected specific error message, got: %v", err)
-		}
-	})
 }
 
 // =============================================================================

--- a/pkg/workstation/workstation_test.go
+++ b/pkg/workstation/workstation_test.go
@@ -1004,31 +1004,6 @@ func TestWorkstation_Down(t *testing.T) {
 		}
 	})
 
-	t.Run("PreservesWorkstationState", func(t *testing.T) {
-		// Given
-		mocks := setupWorkstationMocks(t)
-		deleteStateCalled := false
-		mockConfig := mocks.ConfigHandler.(*config.MockConfigHandler)
-		mockConfig.DeleteWorkstationStateFunc = func() error {
-			deleteStateCalled = true
-			return nil
-		}
-		workstation := NewWorkstation(mocks.Runtime, &Workstation{
-			VirtualMachine:   mocks.VirtualMachine,
-			ContainerRuntime: mocks.ContainerRuntime,
-		})
-
-		// When
-		err := workstation.Down()
-
-		// Then
-		if err != nil {
-			t.Errorf("Expected success, got error: %v", err)
-		}
-		if deleteStateCalled {
-			t.Error("Expected DeleteWorkstationState NOT to be called; workstation state must survive windsor down")
-		}
-	})
 
 }
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes `windsor down` semantics to only operate on local workstations, always running cleanup and no longer supporting skip flags, which may surprise existing workflows. Also alters Kubernetes deletion behavior by force-removing Flux Kustomization finalizers on timeout, which can have cluster-side implications if misapplied.
> 
> **Overview**
> Redefines `windsor down` to be *workstation-only*: it now no-ops with a message when no workstation is configured, and otherwise always runs `Workstation.Down()` followed by `Project.PerformCleanup()` (removing the prior Kubernetes/Terraform/Docker teardown paths and all skip/clean flags).
> 
> Adjusts cleanup/state handling by preserving `.windsor/contexts/<context>/workstation.yaml` during cleanup, removing the `ConfigHandler.DeleteWorkstationState` API and the workstation state deletion step in `Workstation.Down()`.
> 
> Improves Kubernetes teardown resilience by, on kustomization deletion timeout, attempting to strip finalizers via a merge patch instead of immediately failing; tests were updated accordingly, along with minor messaging tweaks (e.g., DockerVirt progress text).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3b4f30e76493ef73c260822226fbf310800ba36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->