### PR TITLE
chore: Improve TUI and plan/apply flow messages and prompts

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -57,7 +57,10 @@ var configureNetworkCmd = &cobra.Command{
 			fmt.Fprintln(os.Stderr, "network: n/a")
 			return nil
 		}
-		return proj.Workstation.ConfigureNetwork(dnsAddr, true)
+		if err := proj.Workstation.ConfigureNetwork(dnsAddr, true); err != nil {
+			return err
+		}
+		return proj.Workstation.FlushDNS()
 	},
 }
 

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -9,8 +9,10 @@ import (
 
 	"github.com/spf13/cobra"
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+	"github.com/windsorcli/cli/pkg/provisioner"
 	fluxinfra "github.com/windsorcli/cli/pkg/provisioner/flux"
 	terraforminfra "github.com/windsorcli/cli/pkg/provisioner/terraform"
+	"github.com/windsorcli/cli/pkg/tui"
 )
 
 var planNoColor bool
@@ -32,8 +34,12 @@ var planCmd = &cobra.Command{
 		blueprint := proj.Composer.BlueprintHandler.Generate()
 
 		if len(args) == 0 {
-			summary, err := proj.Provisioner.PlanAll(blueprint)
-			if err != nil {
+			var summary *provisioner.PlanSummary
+			if err := tui.WithProgress("Generating plan...", func() error {
+				var planErr error
+				summary, planErr = proj.Provisioner.PlanAll(blueprint)
+				return planErr
+			}); err != nil {
 				return fmt.Errorf("error running plan: %w", err)
 			}
 			if planJSON {
@@ -76,6 +82,7 @@ var planCmd = &cobra.Command{
 		}
 
 		if inTerraform {
+			fmt.Fprintf(os.Stderr, "\n%s\n", tui.SectionHeader("Terraform: "+componentID))
 			if err := proj.Provisioner.Plan(blueprint, componentID); err != nil {
 				return fmt.Errorf("error planning terraform for %s: %w", componentID, err)
 			}
@@ -142,6 +149,7 @@ var planTerraformCmd = &cobra.Command{
 			return nil
 		}
 
+		fmt.Fprintf(os.Stderr, "\n%s\n", tui.SectionHeader("Terraform: "+componentID))
 		if err := proj.Provisioner.Plan(blueprint, componentID); err != nil {
 			return fmt.Errorf("error planning terraform for %s: %w", componentID, err)
 		}

--- a/pkg/composer/terraform/oci_module_resolver.go
+++ b/pkg/composer/terraform/oci_module_resolver.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
-	"github.com/windsorcli/cli/pkg/tui"
 	"github.com/windsorcli/cli/pkg/composer/artifact"
 	"github.com/windsorcli/cli/pkg/composer/blueprint"
 	"github.com/windsorcli/cli/pkg/runtime"
@@ -115,7 +114,7 @@ func (h *OCIModuleResolver) processComponent(component blueprintv1alpha1.Terrafo
 		return fmt.Errorf("failed to clear shim directory: %w", err)
 	}
 
-	extractedPath, err := h.extractOCIModule(component.Source, component.Path, ociArtifacts)
+	extractedPath, err := h.extractOCIModule(component.Source, ociArtifacts)
 	if err != nil {
 		return fmt.Errorf("failed to extract OCI module: %w", err)
 	}
@@ -144,39 +143,32 @@ func (h *OCIModuleResolver) processComponent(component blueprintv1alpha1.Terrafo
 // It parses the resolved OCI source, determines the cache key, and uses the artifact package
 // to extract the module path from the cached artifact. Returns the full path to the extracted module
 // or an error if extraction fails.
-func (h *OCIModuleResolver) extractOCIModule(resolvedSource, componentPath string, ociArtifacts map[string]string) (string, error) {
-	var extractedPath string
-	if err := tui.WithProgress(fmt.Sprintf("Loading component %s", componentPath), func() error {
-		if !strings.HasPrefix(resolvedSource, "oci://") {
-			return fmt.Errorf("invalid resolved OCI source format: %s", resolvedSource)
-		}
+func (h *OCIModuleResolver) extractOCIModule(resolvedSource string, ociArtifacts map[string]string) (string, error) {
+	if !strings.HasPrefix(resolvedSource, "oci://") {
+		return "", fmt.Errorf("invalid resolved OCI source format: %s", resolvedSource)
+	}
 
-		pathSeparatorIdx := strings.Index(resolvedSource[6:], "//")
-		if pathSeparatorIdx == -1 {
-			return fmt.Errorf("invalid resolved OCI source format, missing path separator: %s", resolvedSource)
-		}
+	pathSeparatorIdx := strings.Index(resolvedSource[6:], "//")
+	if pathSeparatorIdx == -1 {
+		return "", fmt.Errorf("invalid resolved OCI source format, missing path separator: %s", resolvedSource)
+	}
 
-		baseURL := resolvedSource[:6+pathSeparatorIdx]      // oci://registry/repo:tag
-		modulePath := resolvedSource[6+pathSeparatorIdx+2:] // terraform/path/to/module
+	baseURL := resolvedSource[:6+pathSeparatorIdx]      // oci://registry/repo:tag
+	modulePath := resolvedSource[6+pathSeparatorIdx+2:] // terraform/path/to/module
 
-		registry, repository, tag, err := h.artifactBuilder.ParseOCIRef(baseURL)
-		if err != nil {
-			return fmt.Errorf("failed to parse OCI reference: %w", err)
-		}
+	registry, repository, tag, err := h.artifactBuilder.ParseOCIRef(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse OCI reference: %w", err)
+	}
 
-		cacheKey := fmt.Sprintf("%s/%s:%s", registry, repository, tag)
-		_, exists := ociArtifacts[cacheKey]
-		if !exists {
-			return fmt.Errorf("OCI artifact %s not found in cache", cacheKey)
-		}
+	cacheKey := fmt.Sprintf("%s/%s:%s", registry, repository, tag)
+	if _, exists := ociArtifacts[cacheKey]; !exists {
+		return "", fmt.Errorf("OCI artifact %s not found in cache", cacheKey)
+	}
 
-		extractedPath, err = h.artifactBuilder.ExtractModulePath(registry, repository, tag, modulePath)
-		if err != nil {
-			return fmt.Errorf("failed to extract module path: %w", err)
-		}
-		return nil
-	}); err != nil {
-		return "", err
+	extractedPath, err := h.artifactBuilder.ExtractModulePath(registry, repository, tag, modulePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to extract module path: %w", err)
 	}
 	return extractedPath, nil
 }

--- a/pkg/composer/terraform/oci_module_resolver_private_test.go
+++ b/pkg/composer/terraform/oci_module_resolver_private_test.go
@@ -167,7 +167,6 @@ func TestOCIModuleResolver_extractOCIModule(t *testing.T) {
 		// Given a resolver with valid OCI source and cached artifact
 		resolver := setup(t)
 		resolvedSource := "oci://registry.example.com/module:latest//terraform/test-module"
-		componentPath := "test-module"
 		ociArtifacts := map[string]string{
 			"registry.example.com/module:latest": "/test/project/.windsor/cache/oci/registry.example.com_module_latest",
 		}
@@ -189,7 +188,7 @@ func TestOCIModuleResolver_extractOCIModule(t *testing.T) {
 		resolver.BaseModuleResolver.runtime.ProjectRoot = "/test/project"
 
 		// When extracting OCI module
-		path, err := resolver.extractOCIModule(resolvedSource, componentPath, ociArtifacts)
+		path, err := resolver.extractOCIModule(resolvedSource, ociArtifacts)
 
 		// Then it should return the extracted path
 		if err != nil {
@@ -204,7 +203,6 @@ func TestOCIModuleResolver_extractOCIModule(t *testing.T) {
 		// Given a resolver with existing extracted module
 		resolver := setup(t)
 		resolvedSource := "oci://registry.example.com/module:latest//terraform/test-module"
-		componentPath := "test-module"
 		ociArtifacts := map[string]string{
 			"registry.example.com/module:latest": "/test/project/.windsor/cache/oci/registry.example.com_module_latest",
 		}
@@ -230,7 +228,7 @@ func TestOCIModuleResolver_extractOCIModule(t *testing.T) {
 		resolver.BaseModuleResolver.runtime.ProjectRoot = "/test/project"
 
 		// When extracting OCI module
-		path, err := resolver.extractOCIModule(resolvedSource, componentPath, ociArtifacts)
+		path, err := resolver.extractOCIModule(resolvedSource, ociArtifacts)
 
 		// Then it should return the cached path without extraction
 		if err != nil {
@@ -251,28 +249,24 @@ func TestOCIModuleResolver_extractOCIModule(t *testing.T) {
 		errorCases := []struct {
 			name           string
 			resolvedSource string
-			componentPath  string
 			ociArtifacts   map[string]string
 			expectedError  string
 		}{
 			{
 				name:           "InvalidOCISourceFormat",
 				resolvedSource: "invalid://source",
-				componentPath:  "test-module",
 				ociArtifacts:   map[string]string{},
 				expectedError:  "invalid resolved OCI source format",
 			},
 			{
 				name:           "MissingPathSeparator",
 				resolvedSource: "oci://registry.example.com/module:latest",
-				componentPath:  "test-module",
 				ociArtifacts:   map[string]string{},
 				expectedError:  "missing path separator",
 			},
 			{
 				name:           "ArtifactNotFoundInCache",
 				resolvedSource: "oci://registry.example.com/module:latest//terraform/test-module",
-				componentPath:  "test-module",
 				ociArtifacts:   map[string]string{},
 				expectedError:  "not found in cache",
 			},
@@ -300,7 +294,7 @@ func TestOCIModuleResolver_extractOCIModule(t *testing.T) {
 				}
 			}
 			// When extracting OCI module with error conditions
-			_, err := resolver.extractOCIModule(tc.resolvedSource, tc.componentPath, tc.ociArtifacts)
+			_, err := resolver.extractOCIModule(tc.resolvedSource, tc.ociArtifacts)
 
 			// Then it should return appropriate errors
 			if err == nil {
@@ -316,7 +310,6 @@ func TestOCIModuleResolver_extractOCIModule(t *testing.T) {
 		// Given a resolver with GetProjectRoot error
 		resolver := setup(t)
 		resolvedSource := "oci://registry.example.com/module:latest//terraform/test-module"
-		componentPath := "test-module"
 		ociArtifacts := map[string]string{
 			"registry.example.com/module:latest": "/test/project/.windsor/cache/oci/registry.example.com_module_latest",
 		}
@@ -339,7 +332,7 @@ func TestOCIModuleResolver_extractOCIModule(t *testing.T) {
 		resolver.BaseModuleResolver.runtime.ProjectRoot = ""
 
 		// When extracting OCI module
-		_, err := resolver.extractOCIModule(resolvedSource, componentPath, ociArtifacts)
+		_, err := resolver.extractOCIModule(resolvedSource, ociArtifacts)
 
 		// Then it should return an error
 		if err == nil {
@@ -354,7 +347,6 @@ func TestOCIModuleResolver_extractOCIModule(t *testing.T) {
 		// Given a resolver with invalid OCI reference format
 		resolver := setup(t)
 		resolvedSource := "oci://invalid-format//terraform/test-module"
-		componentPath := "test-module"
 		ociArtifacts := map[string]string{}
 
 		// Set up ParseOCIRef mock to return error
@@ -363,7 +355,7 @@ func TestOCIModuleResolver_extractOCIModule(t *testing.T) {
 		}
 
 		// When extracting OCI module
-		_, err := resolver.extractOCIModule(resolvedSource, componentPath, ociArtifacts)
+		_, err := resolver.extractOCIModule(resolvedSource, ociArtifacts)
 
 		// Then it should return an error
 		if err == nil {
@@ -378,7 +370,6 @@ func TestOCIModuleResolver_extractOCIModule(t *testing.T) {
 		// Given a resolver with extraction error
 		resolver := setup(t)
 		resolvedSource := "oci://registry.example.com/module:latest//terraform/test-module"
-		componentPath := "test-module"
 		ociArtifacts := map[string]string{
 			"registry.example.com/module:latest": "/test/project/.windsor/cache/oci/registry.example.com_module_latest",
 		}
@@ -398,7 +389,7 @@ func TestOCIModuleResolver_extractOCIModule(t *testing.T) {
 		}
 
 		// When extracting OCI module
-		_, err := resolver.extractOCIModule(resolvedSource, componentPath, ociArtifacts)
+		_, err := resolver.extractOCIModule(resolvedSource, ociArtifacts)
 
 		// Then it should return an error
 		if err == nil {

--- a/pkg/composer/terraform/standard_module_resolver.go
+++ b/pkg/composer/terraform/standard_module_resolver.go
@@ -148,8 +148,7 @@ func (h *StandardModuleResolver) ProcessModules() error {
 		}
 
 		terraformCommand := h.runtime.ToolsManager.GetTerraformCommand()
-		output, err := h.runtime.Shell.ExecProgress(
-			fmt.Sprintf("Loading component %s", componentID),
+		output, err := h.runtime.Shell.ExecSilent(
 			terraformCommand,
 			"init",
 			"--backend=false",

--- a/pkg/composer/terraform/standard_module_resolver_test.go
+++ b/pkg/composer/terraform/standard_module_resolver_test.go
@@ -81,7 +81,7 @@ func TestStandardModuleResolver_ProcessModules(t *testing.T) {
 			return json.Unmarshal(data, v)
 		}
 
-		mocks.Shell.ExecProgressFunc = func(msg, cmd string, args ...string) (string, error) {
+		mocks.Shell.ExecSilentFunc = func(cmd string, args ...string) (string, error) {
 			if cmd == "terraform" && len(args) > 0 && args[0] == "init" {
 				// Return terraform init output with detected path different from standard
 				return `{"@level":"info","@message":"Initializing modules...","@module":"terraform.ui","@timestamp":"2025-01-09T16:25:03Z","type":"log","message":"- main in /detected/module/path"}`, nil
@@ -186,7 +186,7 @@ func TestStandardModuleResolver_ProcessModules(t *testing.T) {
 		// Given a resolver with Shell.ExecProgressFunc returning error for terraform init
 		resolver, mocks := setup(t)
 		resolver.BaseModuleResolver.runtime.ConfigRoot = "/test/config"
-		mocks.Shell.ExecProgressFunc = func(msg, cmd string, args ...string) (string, error) {
+		mocks.Shell.ExecSilentFunc = func(cmd string, args ...string) (string, error) {
 			if cmd == "terraform" && len(args) > 0 && args[0] == "init" {
 				return "", errors.New("terraform init error")
 			}
@@ -239,7 +239,7 @@ func TestStandardModuleResolver_ProcessModules(t *testing.T) {
 			return json.Unmarshal(data, v)
 		}
 
-		mocks.Shell.ExecProgressFunc = func(msg, cmd string, args ...string) (string, error) {
+		mocks.Shell.ExecSilentFunc = func(cmd string, args ...string) (string, error) {
 			if cmd == "terraform" && len(args) > 0 && args[0] == "init" {
 				return `{"@level":"info","@message":"Initializing modules...","@module":"terraform.ui","@timestamp":"2025-01-09T16:25:03Z","type":"log","message":"- main in /path/to/module"}`, nil
 			}
@@ -276,7 +276,7 @@ func TestStandardModuleResolver_ProcessModules(t *testing.T) {
 			return json.Unmarshal(data, v)
 		}
 
-		mocks.Shell.ExecProgressFunc = func(msg, cmd string, args ...string) (string, error) {
+		mocks.Shell.ExecSilentFunc = func(cmd string, args ...string) (string, error) {
 			if cmd == "terraform" && len(args) > 0 && args[0] == "init" {
 				return `{"@level":"info","@message":"Initializing modules...","@module":"terraform.ui","@timestamp":"2025-01-09T16:25:03Z","type":"log","message":"- main in /path/to/module"}`, nil
 			}
@@ -462,7 +462,7 @@ func TestStandardModuleResolver_ProcessModules(t *testing.T) {
 		}
 
 		// And Shell.ExecProgressFunc returns all edge case lines
-		mocks.Shell.ExecProgressFunc = func(msg, cmd string, args ...string) (string, error) {
+		mocks.Shell.ExecSilentFunc = func(cmd string, args ...string) (string, error) {
 			if cmd == "terraform" && len(args) > 0 && args[0] == "init" {
 				return `invalid json line
 {"@type":"info","@message":"some info message","non_log_type":true}
@@ -509,7 +509,7 @@ func TestStandardModuleResolver_ProcessModules(t *testing.T) {
 			return json.Unmarshal(data, v)
 		}
 
-		mocks.Shell.ExecProgressFunc = func(msg, cmd string, args ...string) (string, error) {
+		mocks.Shell.ExecSilentFunc = func(cmd string, args ...string) (string, error) {
 			if cmd == "terraform" && len(args) > 0 && args[0] == "init" {
 				return `{"@type":"log","@message":"- main in /first/path"}
 {"@type":"log","@message":"- main in /second/path"}`, nil
@@ -551,7 +551,7 @@ func TestStandardModuleResolver_ProcessModules(t *testing.T) {
 			return nil, os.ErrNotExist
 		}
 
-		mocks.Shell.ExecProgressFunc = func(msg, cmd string, args ...string) (string, error) {
+		mocks.Shell.ExecSilentFunc = func(cmd string, args ...string) (string, error) {
 			if cmd == "terraform" && len(args) > 0 && args[0] == "init" {
 				return `invalid json line
 {"@type":"log","@message":"- main in /valid/path"}`, nil
@@ -584,7 +584,7 @@ func TestStandardModuleResolver_ProcessModules(t *testing.T) {
 			return nil, os.ErrNotExist
 		}
 
-		mocks.Shell.ExecProgressFunc = func(msg, cmd string, args ...string) (string, error) {
+		mocks.Shell.ExecSilentFunc = func(cmd string, args ...string) (string, error) {
 			if cmd == "terraform" && len(args) > 0 && args[0] == "init" {
 				return `
 

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -205,6 +205,9 @@ func (p *Project) Up() (*blueprintv1alpha1.Blueprint, error) {
 			return nil, err
 		}
 		onApply = p.Workstation.MakeApplyHook()
+		if postApply := p.Workstation.MakePostApplyHook(); postApply != nil {
+			p.Provisioner.OnTerraformPostApply(postApply)
+		}
 	}
 	if onApply != nil {
 		if err := p.Provisioner.Up(blueprint, onApply); err != nil {

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -228,8 +228,18 @@ func (p *Project) PerformCleanup() error {
 	}
 
 	contextDir := filepath.Join(p.projectRoot, ".windsor", "contexts", p.contextName)
+	info, err := os.Stat(contextDir)
+	if os.IsNotExist(err) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("error reading .windsor/contexts/%s: %w", p.contextName, err)
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("error reading .windsor/contexts/%s: not a directory", p.contextName)
+	}
 	entries, err := os.ReadDir(contextDir)
-	if err != nil && !os.IsNotExist(err) {
+	if err != nil {
 		return fmt.Errorf("error reading .windsor/contexts/%s: %w", p.contextName, err)
 	}
 	for _, entry := range entries {

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -2,6 +2,7 @@ package project
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -1085,6 +1086,66 @@ func TestProject_PerformCleanup(t *testing.T) {
 
 		if !strings.Contains(err.Error(), "error cleaning up context specific artifacts") {
 			t.Errorf("Expected specific error message, got: %v", err)
+		}
+	})
+
+	t.Run("ErrorReadingContextDir", func(t *testing.T) {
+		// Given a path where a regular file occupies the context directory slot
+		mocks := setupProjectMocks(t)
+		proj := NewProject("test-context", &Project{Runtime: mocks.Runtime})
+
+		parent := filepath.Join(mocks.Runtime.ProjectRoot, ".windsor", "contexts")
+		if err := os.MkdirAll(parent, 0755); err != nil {
+			t.Fatalf("Failed to create parent dir: %v", err)
+		}
+		// Place a regular file where the context directory would be
+		contextPath := filepath.Join(parent, "test-context")
+		if err := os.WriteFile(contextPath, []byte("not a dir"), 0644); err != nil {
+			t.Fatalf("Failed to write file at context path: %v", err)
+		}
+
+		// When
+		err := proj.PerformCleanup()
+
+		// Then the error mentions the context directory
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "error reading .windsor/contexts/test-context") {
+			t.Errorf("Expected context-dir read error, got: %v", err)
+		}
+	})
+
+	t.Run("PreservesWorkstationYaml", func(t *testing.T) {
+		// Given a context dir containing workstation.yaml alongside other artifacts
+		mocks := setupProjectMocks(t)
+		proj := NewProject("test-context", &Project{Runtime: mocks.Runtime})
+
+		contextDir := filepath.Join(mocks.Runtime.ProjectRoot, ".windsor", "contexts", "test-context")
+		if err := os.MkdirAll(contextDir, 0755); err != nil {
+			t.Fatalf("Failed to create context dir: %v", err)
+		}
+		wsFile := filepath.Join(contextDir, "workstation.yaml")
+		if err := os.WriteFile(wsFile, []byte("state: preserved"), 0644); err != nil {
+			t.Fatalf("Failed to write workstation.yaml: %v", err)
+		}
+		otherFile := filepath.Join(contextDir, "ephemeral.txt")
+		if err := os.WriteFile(otherFile, []byte("ephemeral"), 0644); err != nil {
+			t.Fatalf("Failed to write ephemeral.txt: %v", err)
+		}
+
+		// When
+		err := proj.PerformCleanup()
+
+		// Then
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+		if _, statErr := os.Stat(wsFile); os.IsNotExist(statErr) {
+			t.Error("Expected workstation.yaml to be preserved, but it was deleted")
+		}
+		if _, statErr := os.Stat(otherFile); !os.IsNotExist(statErr) {
+			t.Error("Expected ephemeral.txt to be deleted, but it still exists")
 		}
 	})
 }

--- a/pkg/provisioner/flux/stack.go
+++ b/pkg/provisioner/flux/stack.go
@@ -21,6 +21,7 @@ import (
 	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/provisioner/kubernetes"
 	"github.com/windsorcli/cli/pkg/runtime"
+	"github.com/windsorcli/cli/pkg/tui"
 	sigsyaml "sigs.k8s.io/yaml"
 )
 
@@ -362,10 +363,7 @@ func (s *FluxStack) planOne(blueprint *blueprintv1alpha1.Blueprint, k blueprintv
 	localPath := filepath.Join(sourceRoot, fluxK.Spec.Path)
 
 	if exists {
-		return s.runFluxDiff(
-			fmt.Sprintf("📋 Planning kustomize changes for %s", k.Name),
-			"diff", "kustomization", k.Name, "--namespace", namespace, "--path", localPath,
-		)
+		return s.runFluxDiff(k.Name, "diff", "kustomization", k.Name, "--namespace", namespace, "--path", localPath)
 	}
 
 	return s.runFromScratch(k, fluxK.Spec.Components, localPath, sourceRoot)
@@ -406,12 +404,10 @@ func (s *FluxStack) resolveSourceRoot(blueprint *blueprintv1alpha1.Blueprint, k 
 // mirrors what flux would generate at reconcile time: if localPath is a Component, it is
 // listed under components: (not resources:), matching flux's own wrapping behaviour.
 func (s *FluxStack) runFromScratch(k blueprintv1alpha1.Kustomization, components []string, localPath, sourceRoot string) error {
-	label := fmt.Sprintf("📋 Planning kustomize changes for %s", k.Name)
-
 	baseIsComponent := s.isKustomizeComponent(localPath)
 
 	if !baseIsComponent && len(components) == 0 {
-		return s.runKustomizeBuild(label, localPath)
+		return s.runKustomizeBuild(k.Name, localPath)
 	}
 
 	planDir := filepath.Join(sourceRoot, ".windsor", "plan", k.Name)
@@ -424,7 +420,7 @@ func (s *FluxStack) runFromScratch(k blueprintv1alpha1.Kustomization, components
 		return err
 	}
 
-	return s.runKustomizeBuild(label, planDir)
+	return s.runKustomizeBuild(k.Name, planDir)
 }
 
 // writeSyntheticKustomization writes a synthetic kustomization.yaml into planDir that mirrors
@@ -478,8 +474,8 @@ func (s *FluxStack) isKustomizeComponent(path string) bool {
 // runKustomizeBuild executes "kustomize build <path>" to render all kubernetes manifests
 // for a kustomization that does not yet exist in the cluster. Unlike flux diff/build,
 // kustomize build requires no cluster access and always emits rendered YAML to stdout.
-func (s *FluxStack) runKustomizeBuild(label, path string) error {
-	fmt.Fprintf(os.Stderr, "%s\n", label)
+func (s *FluxStack) runKustomizeBuild(name, path string) error {
+	fmt.Fprintf(os.Stderr, "\n%s\n", tui.SectionHeader("Kustomize: "+name))
 	stdout, stderr, err := s.shims.ExecCommand("kustomize", "build", path)
 	if err != nil {
 		if stderr != "" {
@@ -489,6 +485,8 @@ func (s *FluxStack) runKustomizeBuild(label, path string) error {
 	}
 	if stdout != "" {
 		fmt.Print(stdout)
+	} else {
+		fmt.Fprintln(os.Stderr, "No changes.")
 	}
 	return nil
 }
@@ -497,10 +495,10 @@ func (s *FluxStack) runKustomizeBuild(label, path string) error {
 // stdout and stderr separately and sets NO_COLOR=1 to prevent flux from writing
 // progress indicators directly to the terminal TTY.
 // flux diff exits 0 (no changes) or 1 (changes exist) — both are treated as success.
-// On exit 0 output is suppressed. On exit 1 the diff (stdout) is printed.
+// On exit 0 "No changes." is printed. On exit 1 the diff (stdout) is printed.
 // Any other exit code is returned as an error with stderr details.
-func (s *FluxStack) runFluxDiff(label string, args ...string) error {
-	fmt.Fprintf(os.Stderr, "%s\n", label)
+func (s *FluxStack) runFluxDiff(name string, args ...string) error {
+	fmt.Fprintf(os.Stderr, "\n%s\n", tui.SectionHeader("Kustomize: "+name))
 	stdout, stderr, err := s.shims.ExecCommand("flux", args...)
 	if err != nil {
 		var exitErr *exec.ExitError
@@ -515,6 +513,7 @@ func (s *FluxStack) runFluxDiff(label string, args ...string) error {
 		}
 		return err
 	}
+	fmt.Fprintln(os.Stderr, "No changes.")
 	return nil
 }
 

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -1200,7 +1200,6 @@ func (k *BaseKubernetesManager) deployCleanupSemaphore() error {
 		return fmt.Errorf("failed to create cleanup semaphore: %w", err)
 	}
 
-	fmt.Fprintf(os.Stderr, "\033[32m✔\033[0m Cleanup authorization deployed\n")
 	return nil
 }
 

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -43,9 +43,10 @@ type Provisioner struct {
 	configRoot    string
 	runtime       *runtime.Runtime
 
-	TerraformStack    terraforminfra.Stack
-	FluxStack         fluxinfra.Stack
-	onTerraformApply  []func(id string) error
+	TerraformStack         terraforminfra.Stack
+	FluxStack              fluxinfra.Stack
+	onTerraformApply       []func(id string) error
+	onTerraformPostApply   []func(id string) error
 	KubernetesManager kubernetes.KubernetesManager
 	KubernetesClient  k8sclient.KubernetesClient
 	ClusterClient     cluster.ClusterClient
@@ -122,10 +123,18 @@ func NewProvisioner(rt *runtime.Runtime, blueprintHandler blueprint.BlueprintHan
 // Public Methods
 // =============================================================================
 
-// OnTerraformApply registers a hook to run after each Terraform component apply.
+// OnTerraformApply registers a hook to run after each Terraform component apply, inside the progress spinner.
 func (i *Provisioner) OnTerraformApply(fn func(id string) error) {
 	if fn != nil {
 		i.onTerraformApply = append(i.onTerraformApply, fn)
+	}
+}
+
+// OnTerraformPostApply registers a hook to run after each Terraform component's Done line is printed.
+// Use this for operations that must not run inside the progress spinner (e.g. interactive sudo prompts).
+func (i *Provisioner) OnTerraformPostApply(fn func(id string) error) {
+	if fn != nil {
+		i.onTerraformPostApply = append(i.onTerraformPostApply, fn)
 	}
 }
 
@@ -144,6 +153,9 @@ func (i *Provisioner) Up(blueprint *blueprintv1alpha1.Blueprint, onApply ...func
 	}
 	hooks := append([]func(id string) error{}, i.onTerraformApply...)
 	hooks = append(hooks, onApply...)
+	if len(i.onTerraformPostApply) > 0 {
+		i.TerraformStack.PostApply(i.onTerraformPostApply...)
+	}
 	if err := i.TerraformStack.Up(blueprint, hooks...); err != nil {
 		return fmt.Errorf("failed to run terraform up: %w", err)
 	}

--- a/pkg/provisioner/terraform/mock_stack.go
+++ b/pkg/provisioner/terraform/mock_stack.go
@@ -16,6 +16,7 @@ import (
 // MockStack is a mock implementation of the Stack interface for testing.
 type MockStack struct {
 	UpFunc                   func(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(id string) error) error
+	PostApplyFunc            func(fns ...func(id string) error)
 	DestroyAllFunc           func(blueprint *blueprintv1alpha1.Blueprint) error
 	PlanFunc                 func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
 	PlanAllFunc              func(blueprint *blueprintv1alpha1.Blueprint) error
@@ -46,6 +47,13 @@ func (m *MockStack) Up(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(i
 		return m.UpFunc(blueprint, onApply...)
 	}
 	return nil
+}
+
+// PostApply is a mock implementation of the PostApply method.
+func (m *MockStack) PostApply(fns ...func(id string) error) {
+	if m.PostApplyFunc != nil {
+		m.PostApplyFunc(fns...)
+	}
 }
 
 // DestroyAll is a mock implementation of the DestroyAll method.

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -28,6 +28,7 @@ import (
 // Both the Stack struct and MockStack implement this interface.
 type Stack interface {
 	Up(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(id string) error) error
+	PostApply(fns ...func(id string) error)
 	DestroyAll(blueprint *blueprintv1alpha1.Blueprint) error
 	Plan(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
 	PlanAll(blueprint *blueprintv1alpha1.Blueprint) error
@@ -62,6 +63,7 @@ type TerraformStack struct {
 	runtime      *runtime.Runtime
 	shims        *Shims
 	terraformEnv *envvars.TerraformEnvPrinter
+	postApply    []func(id string) error
 }
 
 // =============================================================================
@@ -95,15 +97,26 @@ func NewStack(rt *runtime.Runtime, opts ...*TerraformStack) Stack {
 	return stack
 }
 
+// PostApply registers hooks to run after each component's WithProgress block completes (i.e. after Done is
+// printed). Hooks are consumed and cleared at the start of the next Up call so they are not retained.
+func (s *TerraformStack) PostApply(fns ...func(id string) error) {
+	s.postApply = append(s.postApply, fns...)
+}
+
 // Up creates a new stack of components by initializing and applying Terraform configurations.
 // It processes components in order, generating terraform arguments, running Terraform init,
 // plan, and apply operations. Backend override files are cleaned up after all components complete,
 // ensuring they remain available for terraform_output() calls between component executions.
-// Optional onApply hooks run after each component apply, in order; they are not retained after Up returns.
+// Optional onApply hooks run after each component apply inside the progress spinner, in order.
+// PostApply hooks run after each component's Done line is printed; they are not retained after Up returns.
 func (s *TerraformStack) Up(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(id string) error) error {
 	if blueprint == nil {
 		return fmt.Errorf("blueprint not provided")
 	}
+
+	// Consume and clear postApply hooks so they are not retained across calls.
+	postApply := s.postApply
+	s.postApply = nil
 
 	currentDir, err := s.shims.Getwd()
 	if err != nil {
@@ -182,6 +195,16 @@ func (s *TerraformStack) Up(blueprint *blueprintv1alpha1.Blueprint, onApply ...f
 			return nil
 		}); err != nil {
 			return err
+		}
+
+		// Run post-apply hooks after Done is printed, before the next component's spinner starts.
+		componentID := component.GetID()
+		for _, fn := range postApply {
+			if fn != nil {
+				if err := fn(componentID); err != nil {
+					return fmt.Errorf("post-apply hook %s: %w", componentID, err)
+				}
+			}
 		}
 	}
 
@@ -292,35 +315,32 @@ func (s *TerraformStack) planComponents(blueprint *blueprintv1alpha1.Blueprint, 
 	for i := range components {
 		component := &components[i]
 
-		if err := tui.WithProgress(fmt.Sprintf("Planning %s", component.Path), func() error {
-			terraformVars, terraformArgs, cleanup, err := s.prepareComponentEnv(component)
-			if err != nil {
-				return err
-			}
+		fmt.Fprintf(os.Stderr, "\n%s\n", tui.SectionHeader("Terraform: "+component.Path))
 
-			if err := s.runTerraformInit(component, terraformVars, terraformArgs); err != nil {
-				cleanup()
-				return err
-			}
-
-			terraformCommand := s.runtime.ToolsManager.GetTerraformCommand()
-			planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan"}
-			if jsonMode {
-				planArgs = append(planArgs, "-json", "-no-color")
-			}
-			planArgs = append(planArgs, terraformArgs.PlanArgs...)
-			planEnv := selectTerraformCommandEnv(terraformVars, true)
-			planOutput, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, planEnv, planArgs...)
-			cleanup()
-			if err != nil {
-				return fmt.Errorf("error running terraform plan for %s: %w", component.Path, err)
-			}
-			if planOutput != "" {
-				fmt.Fprint(os.Stdout, planOutput)
-			}
-			return nil
-		}); err != nil {
+		terraformVars, terraformArgs, cleanup, err := s.prepareComponentEnv(component)
+		if err != nil {
 			return err
+		}
+
+		if err := s.runTerraformInit(component, terraformVars, terraformArgs); err != nil {
+			cleanup()
+			return err
+		}
+
+		terraformCommand := s.runtime.ToolsManager.GetTerraformCommand()
+		planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan"}
+		if jsonMode {
+			planArgs = append(planArgs, "-json", "-no-color")
+		}
+		planArgs = append(planArgs, terraformArgs.PlanArgs...)
+		planEnv := selectTerraformCommandEnv(terraformVars, true)
+		planOutput, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, planEnv, planArgs...)
+		cleanup()
+		if err != nil {
+			return fmt.Errorf("error running terraform plan for %s: %w", component.Path, err)
+		}
+		if planOutput != "" {
+			fmt.Fprint(os.Stdout, planOutput)
 		}
 	}
 

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -379,7 +379,7 @@ func TestStack_Up(t *testing.T) {
 
 	t.Run("ErrorRunningTerraformApply", func(t *testing.T) {
 		stack, mocks := setup(t)
-		mocks.Shell.ExecProgressFunc = func(message string, command string, args ...string) (string, error) {
+		mocks.Shell.ExecProgressWithEnvFunc = func(message string, command string, env map[string]string, args ...string) (string, error) {
 			if command == "terraform" && len(args) > 0 && strings.HasPrefix(args[0], "-chdir=") && len(args) > 1 && args[1] == "apply" {
 				return "", fmt.Errorf("mock error running terraform apply")
 			}
@@ -708,7 +708,7 @@ func TestStack_DestroyAll(t *testing.T) {
 
 	t.Run("ErrorRunningTerraformDestroy", func(t *testing.T) {
 		stack, mocks := setup(t)
-		mocks.Shell.ExecProgressFunc = func(message string, command string, args ...string) (string, error) {
+		mocks.Shell.ExecProgressWithEnvFunc = func(message string, command string, env map[string]string, args ...string) (string, error) {
 			if command == "terraform" && len(args) > 0 && strings.HasPrefix(args[0], "-chdir=") && len(args) > 1 && args[1] == "destroy" {
 				return "", fmt.Errorf("mock error running terraform destroy")
 			}
@@ -1507,7 +1507,7 @@ func TestStack_Apply(t *testing.T) {
 	t.Run("ErrorRunningTerraformApply", func(t *testing.T) {
 		// Given a stack whose shell fails on terraform apply
 		stack, mocks := setup(t)
-		mocks.Shell.ExecProgressFunc = func(message string, command string, args ...string) (string, error) {
+		mocks.Shell.ExecProgressWithEnvFunc = func(message string, command string, env map[string]string, args ...string) (string, error) {
 			if command == "terraform" && len(args) > 1 && args[1] == "apply" {
 				return "", fmt.Errorf("mock error running terraform apply")
 			}

--- a/pkg/runtime/shell/mock_shell.go
+++ b/pkg/runtime/shell/mock_shell.go
@@ -25,6 +25,7 @@ type MockShell struct {
 	ExecSilentWithTimeoutFunc      func(command string, args []string, timeout time.Duration) (string, error)
 	ExecProgressFunc               func(message string, command string, args ...string) (string, error)
 	ExecProgressWithEnvFunc        func(message string, command string, env map[string]string, args ...string) (string, error)
+	ExecInteractiveWithEnvFunc     func(message string, command string, env map[string]string, args ...string) error
 	ExecSudoFunc                   func(message string, command string, args ...string) (string, error)
 	InstallHookFunc                func(shellName string) error
 	SetVerbosityFunc               func(verbose bool)
@@ -127,6 +128,14 @@ func (s *MockShell) ExecProgressWithEnv(message string, command string, env map[
 		return s.ExecProgressFunc(message, command, args...)
 	}
 	return "", nil
+}
+
+// ExecInteractiveWithEnv calls the custom ExecInteractiveWithEnvFunc if provided.
+func (s *MockShell) ExecInteractiveWithEnv(message string, command string, env map[string]string, args ...string) error {
+	if s.ExecInteractiveWithEnvFunc != nil {
+		return s.ExecInteractiveWithEnvFunc(message, command, env, args...)
+	}
+	return nil
 }
 
 // ExecSudo calls the custom ExecSudoFunc if provided.

--- a/pkg/runtime/shell/mock_shell.go
+++ b/pkg/runtime/shell/mock_shell.go
@@ -25,7 +25,6 @@ type MockShell struct {
 	ExecSilentWithTimeoutFunc      func(command string, args []string, timeout time.Duration) (string, error)
 	ExecProgressFunc               func(message string, command string, args ...string) (string, error)
 	ExecProgressWithEnvFunc        func(message string, command string, env map[string]string, args ...string) (string, error)
-	ExecInteractiveWithEnvFunc     func(message string, command string, env map[string]string, args ...string) error
 	ExecSudoFunc                   func(message string, command string, args ...string) (string, error)
 	InstallHookFunc                func(shellName string) error
 	SetVerbosityFunc               func(verbose bool)
@@ -128,14 +127,6 @@ func (s *MockShell) ExecProgressWithEnv(message string, command string, env map[
 		return s.ExecProgressFunc(message, command, args...)
 	}
 	return "", nil
-}
-
-// ExecInteractiveWithEnv calls the custom ExecInteractiveWithEnvFunc if provided.
-func (s *MockShell) ExecInteractiveWithEnv(message string, command string, env map[string]string, args ...string) error {
-	if s.ExecInteractiveWithEnvFunc != nil {
-		return s.ExecInteractiveWithEnvFunc(message, command, env, args...)
-	}
-	return nil
 }
 
 // ExecSudo calls the custom ExecSudoFunc if provided.

--- a/pkg/runtime/shell/shell.go
+++ b/pkg/runtime/shell/shell.go
@@ -303,7 +303,9 @@ func (s *DefaultShell) ExecProgressWithEnv(message string, command string, env m
 		return "", fmt.Errorf("failed to create command")
 	}
 	cmd.Env = mergeEnvVars(s.shims.Environ(), env)
-	cmd.Stdin = os.Stdin
+	if command == "sudo" {
+		cmd.Stdin = os.Stdin
+	}
 
 	stdoutPipe, err := s.shims.StdoutPipe(cmd)
 	if err != nil {

--- a/pkg/runtime/shell/shell.go
+++ b/pkg/runtime/shell/shell.go
@@ -56,7 +56,6 @@ type Shell interface {
 	ExecSudo(message string, command string, args ...string) (string, error)
 	ExecProgress(message string, command string, args ...string) (string, error)
 	ExecProgressWithEnv(message string, command string, env map[string]string, args ...string) (string, error)
-	ExecInteractiveWithEnv(message string, command string, env map[string]string, args ...string) error
 	InstallHook(shellName string) error
 	AddCurrentDirToTrustedFile() error
 	CheckTrustedDirectory() error

--- a/pkg/runtime/shell/shell.go
+++ b/pkg/runtime/shell/shell.go
@@ -56,6 +56,7 @@ type Shell interface {
 	ExecSudo(message string, command string, args ...string) (string, error)
 	ExecProgress(message string, command string, args ...string) (string, error)
 	ExecProgressWithEnv(message string, command string, env map[string]string, args ...string) (string, error)
+	ExecInteractiveWithEnv(message string, command string, env map[string]string, args ...string) error
 	InstallHook(shellName string) error
 	AddCurrentDirToTrustedFile() error
 	CheckTrustedDirectory() error
@@ -302,6 +303,7 @@ func (s *DefaultShell) ExecProgressWithEnv(message string, command string, env m
 		return "", fmt.Errorf("failed to create command")
 	}
 	cmd.Env = mergeEnvVars(s.shims.Environ(), env)
+	cmd.Stdin = os.Stdin
 
 	stdoutPipe, err := s.shims.StdoutPipe(cmd)
 	if err != nil {

--- a/pkg/runtime/shell/unix_shell.go
+++ b/pkg/runtime/shell/unix_shell.go
@@ -9,6 +9,8 @@ import (
 	"os"
 	"sort"
 	"strings"
+
+	"github.com/windsorcli/cli/pkg/tui"
 )
 
 // The UnixShell is a platform-specific implementation of shell operations for Unix-like systems.
@@ -61,6 +63,55 @@ func (s *DefaultShell) RenderAliases(aliases map[string]string) string {
 	return result.String()
 }
 
+// ExecInteractiveWithEnv runs the command with the spinner paused and /dev/tty connected for
+// stdin and stderr, so that interactive prompts from sub-processes (e.g. sudo called by a
+// terraform local-exec provisioner) appear on the terminal and can receive keyboard input.
+// stdout is suppressed. No new session is created, so the command inherits Windsor's controlling
+// terminal; sudo inside any child process can therefore open /dev/tty successfully.
+// Falls back to os.Stdin/os.Stderr when /dev/tty is unavailable (e.g. CI).
+func (s *DefaultShell) ExecInteractiveWithEnv(message string, command string, env map[string]string, args ...string) error {
+	cmd := s.shims.Command(command, args...)
+	if cmd == nil {
+		return fmt.Errorf("failed to create command")
+	}
+	cmd.Env = mergeEnvVars(s.shims.Environ(), env)
+
+	if s.verbose {
+		fmt.Fprintln(os.Stderr, message)
+		cmd.Stdin = os.Stdin
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		if err := s.shims.CmdStart(cmd); err != nil {
+			return fmt.Errorf("command start failed: %w", err)
+		}
+		return s.shims.CmdWait(cmd)
+	}
+
+	// Open /dev/tty directly so that sudo (running inside a terraform local-exec provisioner
+	// several layers down) can display its password prompt and read input. /dev/tty always
+	// refers to the controlling terminal of the calling process — as long as we do NOT create
+	// a new session (no Setsid), the command inherits Windsor's controlling terminal, and any
+	// child that opens /dev/tty gets the same real user terminal.
+	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	if err != nil {
+		cmd.Stdin = os.Stdin
+		cmd.Stderr = os.Stderr
+	} else {
+		defer tty.Close()
+		cmd.Stdin = tty
+		cmd.Stderr = tty
+	}
+	cmd.Stdout = nil // suppress terraform output in non-verbose mode
+
+	if err := s.shims.CmdStart(cmd); err != nil {
+		return fmt.Errorf("command start failed: %w", err)
+	}
+	if err := s.shims.CmdWait(cmd); err != nil {
+		return fmt.Errorf("command execution failed: %w", err)
+	}
+	return nil
+}
+
 // ExecSudo runs a command with 'sudo', ensuring elevated privileges. It handles password prompts by
 // connecting to the terminal and captures the command's output. If verbose mode is enabled or no TTY
 // is available (CI/CD environments), it uses direct execution. Otherwise, it connects to /dev/tty for
@@ -78,6 +129,14 @@ func (s *DefaultShell) ExecSudo(message string, command string, args ...string) 
 		return s.Exec(command, args...)
 	}
 
+	// Pause spinner while interactive sudo owns the TTY, preventing prompt overwrite.
+	// Use a static progress line only when the caller provided a sudo-specific message.
+	// Do not resume here; this avoids spinner redraw flicker before Done and between chained sudo calls.
+	if message != "" {
+		tui.PauseWithMessage()
+	} else {
+		tui.Pause()
+	}
 	cmd := s.shims.Command(command, args...)
 	if cmd == nil {
 		return "", fmt.Errorf("failed to create command")
@@ -114,7 +173,6 @@ func (s *DefaultShell) ExecSudo(message string, command string, args ...string) 
 		}
 		return stdoutBuf.String(), fmt.Errorf("command execution failed: %w", err)
 	}
-
 	if message != "" {
 		fmt.Fprintf(os.Stderr, "\033[32m✔\033[0m %s - \033[32mDone\033[0m\n", message)
 	}
@@ -147,3 +205,4 @@ func (s *DefaultShell) renderEnvVarsWithExport(envVars map[string]string) string
 	}
 	return result.String()
 }
+

--- a/pkg/runtime/shell/unix_shell.go
+++ b/pkg/runtime/shell/unix_shell.go
@@ -63,54 +63,6 @@ func (s *DefaultShell) RenderAliases(aliases map[string]string) string {
 	return result.String()
 }
 
-// ExecInteractiveWithEnv runs the command with the spinner paused and /dev/tty connected for
-// stdin and stderr, so that interactive prompts from sub-processes (e.g. sudo called by a
-// terraform local-exec provisioner) appear on the terminal and can receive keyboard input.
-// stdout is suppressed. No new session is created, so the command inherits Windsor's controlling
-// terminal; sudo inside any child process can therefore open /dev/tty successfully.
-// Falls back to os.Stdin/os.Stderr when /dev/tty is unavailable (e.g. CI).
-func (s *DefaultShell) ExecInteractiveWithEnv(message string, command string, env map[string]string, args ...string) error {
-	cmd := s.shims.Command(command, args...)
-	if cmd == nil {
-		return fmt.Errorf("failed to create command")
-	}
-	cmd.Env = mergeEnvVars(s.shims.Environ(), env)
-
-	if s.verbose {
-		fmt.Fprintln(os.Stderr, message)
-		cmd.Stdin = os.Stdin
-		cmd.Stdout = os.Stdout
-		cmd.Stderr = os.Stderr
-		if err := s.shims.CmdStart(cmd); err != nil {
-			return fmt.Errorf("command start failed: %w", err)
-		}
-		return s.shims.CmdWait(cmd)
-	}
-
-	// Open /dev/tty directly so that sudo (running inside a terraform local-exec provisioner
-	// several layers down) can display its password prompt and read input. /dev/tty always
-	// refers to the controlling terminal of the calling process — as long as we do NOT create
-	// a new session (no Setsid), the command inherits Windsor's controlling terminal, and any
-	// child that opens /dev/tty gets the same real user terminal.
-	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
-	if err != nil {
-		cmd.Stdin = os.Stdin
-		cmd.Stderr = os.Stderr
-	} else {
-		defer tty.Close()
-		cmd.Stdin = tty
-		cmd.Stderr = tty
-	}
-	cmd.Stdout = nil // suppress terraform output in non-verbose mode
-
-	if err := s.shims.CmdStart(cmd); err != nil {
-		return fmt.Errorf("command start failed: %w", err)
-	}
-	if err := s.shims.CmdWait(cmd); err != nil {
-		return fmt.Errorf("command execution failed: %w", err)
-	}
-	return nil
-}
 
 // ExecSudo runs a command with 'sudo', ensuring elevated privileges. It handles password prompts by
 // connecting to the terminal and captures the command's output. If verbose mode is enabled or no TTY

--- a/pkg/runtime/shell/windows_shell.go
+++ b/pkg/runtime/shell/windows_shell.go
@@ -88,6 +88,26 @@ func (s *DefaultShell) ExecSudo(message string, command string, args ...string) 
 	return s.Exec(command, args...)
 }
 
+// ExecInteractiveWithEnv on Windows runs the command with stdin/stdout/stderr connected to the
+// terminal directly. Windows has no PTY concern equivalent to the Unix sudo/isatty issue.
+func (s *DefaultShell) ExecInteractiveWithEnv(message string, command string, env map[string]string, args ...string) error {
+	if s.verbose {
+		fmt.Fprintln(os.Stderr, message)
+	}
+	cmd := s.shims.Command(command, args...)
+	if cmd == nil {
+		return fmt.Errorf("failed to create command")
+	}
+	cmd.Env = mergeEnvVars(s.shims.Environ(), env)
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := s.shims.CmdStart(cmd); err != nil {
+		return fmt.Errorf("command start failed: %w", err)
+	}
+	return s.shims.CmdWait(cmd)
+}
+
 // =============================================================================
 // Private Methods
 // =============================================================================

--- a/pkg/runtime/shell/windows_shell.go
+++ b/pkg/runtime/shell/windows_shell.go
@@ -88,25 +88,6 @@ func (s *DefaultShell) ExecSudo(message string, command string, args ...string) 
 	return s.Exec(command, args...)
 }
 
-// ExecInteractiveWithEnv on Windows runs the command with stdin/stdout/stderr connected to the
-// terminal directly. Windows has no PTY concern equivalent to the Unix sudo/isatty issue.
-func (s *DefaultShell) ExecInteractiveWithEnv(message string, command string, env map[string]string, args ...string) error {
-	if s.verbose {
-		fmt.Fprintln(os.Stderr, message)
-	}
-	cmd := s.shims.Command(command, args...)
-	if cmd == nil {
-		return fmt.Errorf("failed to create command")
-	}
-	cmd.Env = mergeEnvVars(s.shims.Environ(), env)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := s.shims.CmdStart(cmd); err != nil {
-		return fmt.Errorf("command start failed: %w", err)
-	}
-	return s.shims.CmdWait(cmd)
-}
 
 // =============================================================================
 // Private Methods

--- a/pkg/tui/mock_tui.go
+++ b/pkg/tui/mock_tui.go
@@ -6,6 +6,8 @@ type MockSpinner struct {
 	UpdateFunc func(message string)
 	DoneFunc   func()
 	FailFunc   func()
+	PauseFunc  func()
+	ResumeFunc func()
 }
 
 // =============================================================================
@@ -46,6 +48,20 @@ func (m *MockSpinner) Done() {
 func (m *MockSpinner) Fail() {
 	if m.FailFunc != nil {
 		m.FailFunc()
+	}
+}
+
+// Pause calls PauseFunc if set, otherwise does nothing.
+func (m *MockSpinner) Pause() {
+	if m.PauseFunc != nil {
+		m.PauseFunc()
+	}
+}
+
+// Resume calls ResumeFunc if set, otherwise does nothing.
+func (m *MockSpinner) Resume() {
+	if m.ResumeFunc != nil {
+		m.ResumeFunc()
 	}
 }
 

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -226,10 +226,8 @@ func (s *termSpinner) pause(printMessage bool) {
 
 // Resume restarts the spinner animation using the previously set message.
 func (s *termSpinner) Resume() {
-	if s.spin != nil {
-		if s.paused > 0 {
-			s.paused--
-		}
+	if s.spin != nil && s.paused > 0 {
+		s.paused--
 		if s.paused == 0 {
 			s.spin.Start()
 		}

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -3,6 +3,7 @@ package tui
 import (
 	"fmt"
 	"os"
+	"strings"
 	"sync/atomic"
 	"time"
 
@@ -20,8 +21,10 @@ import (
 
 // termSpinner is the default terminal Spinner implementation backed by an animated spinner.
 type termSpinner struct {
-	spin    *spinner.Spinner
-	message string
+	spin              *spinner.Spinner
+	message           string
+	paused            int
+	pauseCursorSaved  bool
 }
 
 // verboseSpinner is the Spinner implementation used in verbose mode.
@@ -37,6 +40,8 @@ type Spinner interface {
 	Update(message string)
 	Done()
 	Fail()
+	Pause()
+	Resume()
 }
 
 // =============================================================================
@@ -87,6 +92,17 @@ func Done() {
 	Active.Done()
 }
 
+// SectionHeader returns a fixed-width section label padded with ─ characters.
+// Example: SectionHeader("Kustomize: gitops") → "── Kustomize: gitops ──────────────────────────────────────"
+func SectionHeader(label string) string {
+	s := fmt.Sprintf("── %s ", label)
+	const width = 62
+	if n := width - len(s); n > 0 {
+		s += strings.Repeat("─", n)
+	}
+	return s
+}
+
 // Fail stops the active spinner and prints a failure line.
 // When called inside a WithProgress block, it is a no-op.
 func Fail() {
@@ -95,6 +111,23 @@ func Fail() {
 	}
 	Active.Fail()
 }
+
+// Pause stops the spinner animation without printing Done or Fail.
+// Use before handing the terminal to an interactive subprocess; call Resume after it exits.
+func Pause() { Active.Pause() }
+
+// PauseWithMessage stops the spinner animation and prints a static progress line once.
+// Use this for interactive prompts where the current progress context should stay visible.
+func PauseWithMessage() {
+	if term, ok := Active.(*termSpinner); ok {
+		term.pause(true)
+		return
+	}
+	Active.Pause()
+}
+
+// Resume restarts the spinner animation after a Pause.
+func Resume() { Active.Resume() }
 
 // WithProgress runs fn with a progress spinner showing message.
 // Increments the nesting depth so that any Start/Done/Fail calls inside fn
@@ -124,10 +157,12 @@ func WithProgress(message string, fn func() error) error {
 
 // Start stops any existing spinner and begins a new one with the given message.
 func (s *termSpinner) Start(message string) {
-	if s.spin != nil {
+	if s.spin != nil && s.spin.Active() {
 		s.spin.Stop()
 	}
 	s.message = message
+	s.paused = 0
+	s.pauseCursorSaved = false
 	s.spin = spinner.New(spinner.CharSets[14], 100*time.Millisecond, spinner.WithColor("green"), spinner.WithWriter(os.Stderr))
 	s.spin.Suffix = " " + message
 	s.spin.Start()
@@ -142,20 +177,58 @@ func (s *termSpinner) Update(message string) {
 
 // Done stops the spinner and prints a green success line to stderr.
 func (s *termSpinner) Done() {
-	if s.spin != nil {
+	if s.spin != nil && s.spin.Active() {
 		s.spin.Stop()
-		s.spin = nil
+	}
+	s.spin = nil
+	s.paused = 0
+	if s.pauseCursorSaved {
+		fmt.Fprint(os.Stderr, "\033[u\033[2K\r")
+		s.pauseCursorSaved = false
 	}
 	fmt.Fprintf(os.Stderr, "\033[32m✔\033[0m %s - \033[32mDone\033[0m\n", s.message)
 }
 
 // Fail stops the spinner and prints a red failure line to stderr.
 func (s *termSpinner) Fail() {
-	if s.spin != nil {
+	if s.spin != nil && s.spin.Active() {
 		s.spin.Stop()
-		s.spin = nil
 	}
+	s.spin = nil
+	s.paused = 0
 	fmt.Fprintf(os.Stderr, "\033[31m✗ %s - Failed\033[0m\n", s.message)
+}
+
+// Pause stops the spinner animation without printing Done or Fail, preserving the message for Resume.
+func (s *termSpinner) Pause() {
+	s.pause(false)
+}
+
+// pause stops the spinner animation and optionally prints a static progress line.
+func (s *termSpinner) pause(printMessage bool) {
+	if s.spin != nil {
+		if s.paused == 0 {
+			fmt.Fprint(os.Stderr, "\033[s")
+			s.pauseCursorSaved = true
+			s.spin.Stop()
+			if printMessage {
+				fmt.Fprintf(os.Stderr, "… %s\n", s.message)
+			}
+		}
+		s.paused++
+	}
+}
+
+// Resume restarts the spinner animation using the previously set message.
+func (s *termSpinner) Resume() {
+	if s.spin != nil {
+		if s.paused > 0 {
+			s.paused--
+		}
+		if s.paused == 0 {
+			s.spin.Start()
+		}
+	}
 }
 
 // Start prints the message directly to stderr without animation.
@@ -173,3 +246,10 @@ func (s *verboseSpinner) Done() {}
 
 // Fail is a no-op in verbose mode since errors are surfaced through return values.
 func (s *verboseSpinner) Fail() {}
+
+// Pause is a no-op in verbose mode since there is no animation to stop.
+func (s *verboseSpinner) Pause() {}
+
+// Resume is a no-op in verbose mode since there is no animation to restart.
+func (s *verboseSpinner) Resume() {}
+

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 	"sync/atomic"
+	"unicode/utf8"
 	"time"
 
 	"github.com/briandowns/spinner"
@@ -97,7 +98,7 @@ func Done() {
 func SectionHeader(label string) string {
 	s := fmt.Sprintf("── %s ", label)
 	const width = 62
-	if n := width - len(s); n > 0 {
+	if n := width - utf8.RuneCountInString(s); n > 0 {
 		s += strings.Repeat("─", n)
 	}
 	return s

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -197,6 +197,10 @@ func (s *termSpinner) Fail() {
 	}
 	s.spin = nil
 	s.paused = 0
+	if s.pauseCursorSaved {
+		fmt.Fprint(os.Stderr, "\033[u\033[2K\r")
+		s.pauseCursorSaved = false
+	}
 	fmt.Fprintf(os.Stderr, "\033[31m✗ %s - Failed\033[0m\n", s.message)
 }
 

--- a/pkg/tui/tui_test.go
+++ b/pkg/tui/tui_test.go
@@ -320,6 +320,25 @@ func TestTermSpinner_Fail(t *testing.T) {
 			t.Error("expected spin to be nil after Fail")
 		}
 	})
+
+	t.Run("ClearsPauseWithMessageLine", func(t *testing.T) {
+		// Given a termSpinner that has printed a static progress line via PauseWithMessage
+		s := &termSpinner{}
+		captureStderr(t, func() { s.Start("deploying") })
+		captureStderr(t, func() { s.pause(true) }) // simulate PauseWithMessage
+
+		// When Fail is called
+		out := captureStderr(t, s.Fail)
+
+		// Then the cursor-restore and line-clear sequence is emitted before the failure line
+		if !strings.Contains(out, "\033[u\033[2K\r") {
+			t.Errorf("expected cursor restore/clear sequence in output, got %q", out)
+		}
+		// And pauseCursorSaved is reset
+		if s.pauseCursorSaved {
+			t.Error("expected pauseCursorSaved to be false after Fail")
+		}
+	})
 }
 
 // Tests for termSpinner Pause behavior

--- a/pkg/tui/tui_test.go
+++ b/pkg/tui/tui_test.go
@@ -400,6 +400,43 @@ func TestTermSpinner_Pause(t *testing.T) {
 	})
 }
 
+// Tests for termSpinner Resume behavior
+func TestTermSpinner_Resume(t *testing.T) {
+	t.Run("ResumeAfterPauseDecrementsCounter", func(t *testing.T) {
+		// Given a paused termSpinner
+		s := &termSpinner{}
+		captureStderr(t, func() { s.Start("deploying") })
+		captureStderr(t, s.Pause)
+		t.Cleanup(func() { captureStderr(t, s.Done) })
+
+		// When Resume is called
+		captureStderr(t, s.Resume)
+
+		// Then paused counter is back to zero
+		if s.paused != 0 {
+			t.Errorf("expected paused=0 after Resume, got %d", s.paused)
+		}
+	})
+
+	t.Run("UnpairedResumeDoesNotDecrementBelowZero", func(t *testing.T) {
+		// Given a running termSpinner that has never been paused
+		s := &termSpinner{}
+		captureStderr(t, func() { s.Start("deploying") })
+		t.Cleanup(func() { captureStderr(t, s.Done) })
+
+		// When Resume is called without a prior Pause
+		captureStderr(t, s.Resume)
+
+		// Then paused stays at zero and spin is still non-nil
+		if s.paused != 0 {
+			t.Errorf("expected paused=0, got %d", s.paused)
+		}
+		if s.spin == nil {
+			t.Error("expected spin to still be non-nil after unpaired Resume")
+		}
+	})
+}
+
 // Tests for verboseSpinner output behavior
 func TestVerboseSpinner_Start(t *testing.T) {
 	t.Run("PrintsMessage", func(t *testing.T) {

--- a/pkg/tui/tui_test.go
+++ b/pkg/tui/tui_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strings"
 	"testing"
 )
 
@@ -274,6 +275,20 @@ func TestTermSpinner_Done(t *testing.T) {
 			t.Errorf("expected %q, got %q", want, out)
 		}
 	})
+
+	t.Run("PrintsSuccessLineWhenPaused", func(t *testing.T) {
+		// Given a termSpinner paused by an interactive prompt
+		s := &termSpinner{message: "Applying workstation/docker", paused: 1}
+
+		// When Done is called
+		out := captureStderr(t, s.Done)
+
+		// Then the full success line is written consistently, even after pause
+		want := "\033[32m✔\033[0m Applying workstation/docker - \033[32mDone\033[0m\n"
+		if out != want {
+			t.Errorf("expected %q, got %q", want, out)
+		}
+	})
 }
 
 // Tests for termSpinner Fail output
@@ -303,6 +318,65 @@ func TestTermSpinner_Fail(t *testing.T) {
 		// Then spin is nil and the spinner was stopped
 		if s.spin != nil {
 			t.Error("expected spin to be nil after Fail")
+		}
+	})
+}
+
+// Tests for termSpinner Pause behavior
+func TestTermSpinner_Pause(t *testing.T) {
+	t.Run("PauseDoesNotPrintMessage", func(t *testing.T) {
+		// Given a termSpinner with an active spinner
+		s := &termSpinner{}
+		captureStderr(t, func() { s.Start("Applying workstation/docker") })
+		t.Cleanup(func() { captureStderr(t, s.Done) })
+
+		// When Pause is called
+		out := captureStderr(t, s.Pause)
+
+		// Then no progress message text is emitted
+		if strings.Contains(out, "Applying workstation/docker") {
+			t.Errorf("expected no progress message text, got %q", out)
+		}
+	})
+
+	t.Run("NestedPauseDoesNotPrintMessage", func(t *testing.T) {
+		// Given a termSpinner with an active spinner
+		s := &termSpinner{}
+		captureStderr(t, func() { s.Start("Applying workstation/docker") })
+		t.Cleanup(func() { captureStderr(t, s.Done) })
+
+		// When Pause is called twice before a matching Resume
+		out := captureStderr(t, func() {
+			s.Pause()
+			s.Pause()
+		})
+
+		// Then no progress message text is emitted
+		if strings.Contains(out, "Applying workstation/docker") {
+			t.Errorf("expected no progress message text, got %q", out)
+		}
+	})
+
+	t.Run("PauseWithMessagePrintsOnce", func(t *testing.T) {
+		// Given an active term spinner installed as Active
+		s := &termSpinner{}
+		original := Active
+		Active = s
+		t.Cleanup(func() {
+			Active = original
+			captureStderr(t, s.Done)
+		})
+		captureStderr(t, func() { s.Start("Applying workstation/docker") })
+
+		// When PauseWithMessage is called twice
+		out := captureStderr(t, func() {
+			PauseWithMessage()
+			PauseWithMessage()
+		})
+
+		// Then PauseWithMessage emits one static progress line only once
+		if got := strings.Count(out, "Applying workstation/docker"); got != 1 {
+			t.Errorf("expected one paused progress line, got %d output %q", got, out)
 		}
 	})
 }

--- a/pkg/workstation/network/darwin_network.go
+++ b/pkg/workstation/network/darwin_network.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/windsorcli/cli/pkg/tui"
 )
 
 // The DarwinNetworkManager is a platform-specific network manager for macOS.
@@ -57,7 +59,10 @@ func (n *BaseNetworkManager) ConfigureHostRoute() error {
 		return nil
 	}
 
-	fmt.Fprintf(os.Stderr, "\n\033[33m⚠\033[0m Network configuration may require elevated privileges\n")
+	tui.Pause()
+	if os.Geteuid() != 0 && !n.sudoCached() {
+		fmt.Fprintf(os.Stderr, "\033[33m⚠\033[0m Network configuration may require elevated privileges\n")
+	}
 	output, err = n.shell.ExecSudo(
 		"Adding host route",
 		"route",
@@ -95,7 +100,11 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 		return nil
 	}
 
-	fmt.Fprintf(os.Stderr, "\n\033[33m⚠\033[0m DNS configuration may require elevated privileges\n")
+	n.dnsChanged = true
+	tui.Pause()
+	if os.Geteuid() != 0 && !n.sudoCached() {
+		fmt.Fprintf(os.Stderr, "\033[33m⚠\033[0m DNS configuration may require elevated privileges\n")
+	}
 
 	if _, err := n.shims.Stat(resolverDir); os.IsNotExist(err) {
 		if _, err := n.shell.ExecSudo(
@@ -114,7 +123,7 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 	}
 
 	if _, err := n.shell.ExecSudo(
-		fmt.Sprintf("Configuring DNS resolver at %s", resolverFile),
+		"",
 		"mv",
 		tempResolverFile,
 		resolverFile,
@@ -122,7 +131,7 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 		return fmt.Errorf("Error moving resolver file: %w", err)
 	}
 	if _, err := n.shell.ExecSudo(
-		"Setting resolver file readable for next-run check",
+		"",
 		"chmod",
 		"0644",
 		resolverFile,
@@ -130,8 +139,17 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 		return fmt.Errorf("Error setting resolver file mode: %w", err)
 	}
 
+	return nil
+}
+
+// FlushDNS flushes the macOS DNS cache by running dscacheutil and restarting mDNSResponder.
+func (n *BaseNetworkManager) FlushDNS() error {
+	tui.Pause()
+	if os.Geteuid() != 0 && !n.sudoCached() {
+		fmt.Fprintf(os.Stderr, "\033[33m⚠\033[0m DNS cache flush may require elevated privileges\n")
+	}
 	if _, err := n.shell.ExecSudo(
-		"Flushing DNS cache",
+		"",
 		"dscacheutil",
 		"-flushcache",
 	); err != nil {
@@ -139,7 +157,7 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 	}
 
 	if _, err := n.shell.ExecSudo(
-		"Restarting mDNSResponder",
+		"",
 		"killall",
 		"-HUP",
 		"mDNSResponder",
@@ -153,6 +171,12 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 // =============================================================================
 // Private Methods
 // =============================================================================
+
+// sudoCached reports whether sudo credentials are currently cached, i.e., sudo -n true succeeds without a password prompt.
+func (n *BaseNetworkManager) sudoCached() bool {
+	_, err := n.shell.ExecSilent("sudo", "-n", "true")
+	return err == nil
+}
 
 // resolverAlreadyConfigured reports whether the resolver file content already has a nameserver line for desiredIP.
 // Used to skip writing and sudo when the effective config matches. Parses lines and checks the first nameserver line.

--- a/pkg/workstation/network/darwin_network_test.go
+++ b/pkg/workstation/network/darwin_network_test.go
@@ -367,58 +367,6 @@ func TestDarwinNetworkManager_ConfigureDNS(t *testing.T) {
 		}
 	})
 
-	t.Run("FlushDNSCacheError", func(t *testing.T) {
-		// Given a network manager with DNS cache flush error
-		manager, mocks := setup(t)
-		mocks.ConfigHandler.Set("dns.domain", "example.com")
-		mocks.ConfigHandler.Set("workstation.dns.address", "1.2.3.4")
-
-		mocks.Shell.ExecSudoFunc = func(message string, command string, args ...string) (string, error) {
-			if command == "dscacheutil" && args[0] == "-flushcache" {
-				return "", fmt.Errorf("mock error flushing DNS cache")
-			}
-			return "", nil
-		}
-
-		// And configuring DNS
-		err := manager.ConfigureDNS()
-
-		// Then an error should occur
-		if err == nil {
-			t.Fatalf("expected error, got nil")
-		}
-		expectedError := "Error flushing DNS cache: mock error flushing DNS cache"
-		if err.Error() != expectedError {
-			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
-		}
-	})
-
-	t.Run("RestartMDNSResponderError", func(t *testing.T) {
-		// Given a network manager with mDNSResponder restart error
-		manager, mocks := setup(t)
-		mocks.ConfigHandler.Set("dns.domain", "example.com")
-		mocks.ConfigHandler.Set("workstation.dns.address", "1.2.3.4")
-
-		mocks.Shell.ExecSudoFunc = func(message string, command string, args ...string) (string, error) {
-			if command == "killall" && args[0] == "-HUP" {
-				return "", fmt.Errorf("mock error restarting mDNSResponder")
-			}
-			return "", nil
-		}
-
-		// And configuring DNS
-		err := manager.ConfigureDNS()
-
-		// Then an error should occur
-		if err == nil {
-			t.Fatalf("expected error, got nil")
-		}
-		expectedError := "Error restarting mDNSResponder: mock error restarting mDNSResponder"
-		if err.Error() != expectedError {
-			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
-		}
-	})
-
 	t.Run("IsLocalhostScenario", func(t *testing.T) {
 		// Given a network manager in localhost mode
 		manager, mocks := setup(t)
@@ -431,6 +379,75 @@ func TestDarwinNetworkManager_ConfigureDNS(t *testing.T) {
 		// Then no error should occur
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+}
+
+func TestDarwinNetworkManager_FlushDNS(t *testing.T) {
+	setup := func(t *testing.T) (*BaseNetworkManager, *NetworkTestMocks) {
+		t.Helper()
+		mocks := setupNetworkMocks(t)
+		manager := NewBaseNetworkManager(mocks.Runtime)
+		manager.shims = mocks.Shims
+		return manager, mocks
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		// Given a network manager
+		manager, _ := setup(t)
+
+		// When flushing the DNS cache
+		err := manager.FlushDNS()
+
+		// Then no error should occur
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("FlushCacheError", func(t *testing.T) {
+		// Given a network manager where dscacheutil fails
+		manager, mocks := setup(t)
+		mocks.Shell.ExecSudoFunc = func(message string, command string, args ...string) (string, error) {
+			if command == "dscacheutil" {
+				return "", fmt.Errorf("mock error flushing DNS cache")
+			}
+			return "", nil
+		}
+
+		// When flushing the DNS cache
+		err := manager.FlushDNS()
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		expectedError := "Error flushing DNS cache: mock error flushing DNS cache"
+		if err.Error() != expectedError {
+			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("RestartMDNSResponderError", func(t *testing.T) {
+		// Given a network manager where killall mDNSResponder fails
+		manager, mocks := setup(t)
+		mocks.Shell.ExecSudoFunc = func(message string, command string, args ...string) (string, error) {
+			if command == "killall" {
+				return "", fmt.Errorf("mock error restarting mDNSResponder")
+			}
+			return "", nil
+		}
+
+		// When flushing the DNS cache
+		err := manager.FlushDNS()
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		expectedError := "Error restarting mDNSResponder: mock error restarting mDNSResponder"
+		if err.Error() != expectedError {
+			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
 		}
 	})
 }

--- a/pkg/workstation/network/linux_network.go
+++ b/pkg/workstation/network/linux_network.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"os"
 	"strings"
+
+	"github.com/windsorcli/cli/pkg/tui"
 )
 
 // The LinuxNetworkManager is a platform-specific network manager for Linux systems.
@@ -49,6 +51,7 @@ func (n *BaseNetworkManager) ConfigureHostRoute() error {
 	}
 
 	if os.Geteuid() != 0 {
+		tui.Pause()
 		fmt.Fprintf(os.Stderr, "\n\033[33m⚠\033[0m Network configuration may require elevated privileges\n")
 	}
 	output, err = n.shell.ExecSudo(
@@ -97,6 +100,7 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 
 	n.dnsChanged = true
 	if os.Geteuid() != 0 {
+		tui.Pause()
 		fmt.Fprintf(os.Stderr, "\n\033[33m⚠\033[0m DNS configuration may require elevated privileges\n")
 	}
 

--- a/pkg/workstation/network/linux_network.go
+++ b/pkg/workstation/network/linux_network.go
@@ -48,7 +48,9 @@ func (n *BaseNetworkManager) ConfigureHostRoute() error {
 		return nil
 	}
 
-	fmt.Fprintf(os.Stderr, "\n\033[33m⚠\033[0m Network configuration may require elevated privileges\n")
+	if os.Geteuid() != 0 {
+		fmt.Fprintf(os.Stderr, "\n\033[33m⚠\033[0m Network configuration may require elevated privileges\n")
+	}
 	output, err = n.shell.ExecSudo(
 		"Adding host route",
 		"ip",
@@ -93,7 +95,10 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 		return nil
 	}
 
-	fmt.Fprintf(os.Stderr, "\n\033[33m⚠\033[0m DNS configuration may require elevated privileges\n")
+	n.dnsChanged = true
+	if os.Geteuid() != 0 {
+		fmt.Fprintf(os.Stderr, "\n\033[33m⚠\033[0m DNS configuration may require elevated privileges\n")
+	}
 
 	_, err = n.shell.ExecSudo(
 		"Creating DNS configuration directory",
@@ -131,6 +136,11 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 // =============================================================================
 // Private Methods
 // =============================================================================
+
+// FlushDNS is a no-op on Linux; DNS cache is cleared by restarting systemd-resolved during ConfigureDNS.
+func (n *BaseNetworkManager) FlushDNS() error {
+	return nil
+}
 
 // needsPrivilegeForResolver reports whether sudo is required to apply the desired DNS resolver IP
 // for the configured domain. It returns true when systemd-resolved is in use and the current

--- a/pkg/workstation/network/linux_network_test.go
+++ b/pkg/workstation/network/linux_network_test.go
@@ -448,3 +448,26 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 		}
 	})
 }
+
+func TestLinuxNetworkManager_FlushDNS(t *testing.T) {
+	setup := func(t *testing.T) (*BaseNetworkManager, *NetworkTestMocks) {
+		t.Helper()
+		mocks := setupNetworkMocks(t)
+		manager := NewBaseNetworkManager(mocks.Runtime)
+		manager.shims = mocks.Shims
+		return manager, mocks
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		// Given a network manager
+		manager, _ := setup(t)
+
+		// When flushing the DNS cache
+		err := manager.FlushDNS()
+
+		// Then no error should occur (FlushDNS is a no-op on Linux)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+}

--- a/pkg/workstation/network/mock_network.go
+++ b/pkg/workstation/network/mock_network.go
@@ -19,7 +19,9 @@ type MockNetworkManager struct {
 	ConfigureHostRouteFunc func() error
 	ConfigureGuestFunc     func() error
 	ConfigureDNSFunc       func() error
+	FlushDNSFunc           func() error
 	NeedsPrivilegeFunc     func() bool
+	DNSChangedFunc         func() bool
 }
 
 // =============================================================================
@@ -59,10 +61,26 @@ func (m *MockNetworkManager) ConfigureDNS() error {
 	return nil
 }
 
+// FlushDNS calls the custom FlushDNSFunc if provided.
+func (m *MockNetworkManager) FlushDNS() error {
+	if m.FlushDNSFunc != nil {
+		return m.FlushDNSFunc()
+	}
+	return nil
+}
+
 // NeedsPrivilege calls the custom NeedsPrivilegeFunc if provided.
 func (m *MockNetworkManager) NeedsPrivilege() bool {
 	if m.NeedsPrivilegeFunc != nil {
 		return m.NeedsPrivilegeFunc()
+	}
+	return false
+}
+
+// DNSChanged calls the custom DNSChangedFunc if provided.
+func (m *MockNetworkManager) DNSChanged() bool {
+	if m.DNSChangedFunc != nil {
+		return m.DNSChangedFunc()
 	}
 	return false
 }

--- a/pkg/workstation/network/network.go
+++ b/pkg/workstation/network/network.go
@@ -21,7 +21,9 @@ type NetworkManager interface {
 	ConfigureHostRoute() error
 	ConfigureGuest() error
 	ConfigureDNS() error
+	FlushDNS() error
 	NeedsPrivilege() bool
+	DNSChanged() bool
 }
 
 // BaseNetworkManager is a concrete implementation of NetworkManager.
@@ -30,6 +32,7 @@ type BaseNetworkManager struct {
 	configHandler            config.ConfigHandler
 	shims                    *Shims
 	networkInterfaceProvider NetworkInterfaceProvider
+	dnsChanged               bool
 }
 
 // =============================================================================
@@ -62,6 +65,11 @@ func NewBaseNetworkManager(rt *runtime.Runtime) *BaseNetworkManager {
 // ConfigureGuest sets up the guest VM network. Base implementation is a no-op; Colima overrides and reads guest address from config.
 func (n *BaseNetworkManager) ConfigureGuest() error {
 	return nil
+}
+
+// DNSChanged reports whether ConfigureDNS wrote a new configuration during this run.
+func (n *BaseNetworkManager) DNSChanged() bool {
+	return n.dnsChanged
 }
 
 // NeedsPrivilege returns true when network configuration will require elevated privileges (sudo or administrator).

--- a/pkg/workstation/network/windows_network.go
+++ b/pkg/workstation/network/windows_network.go
@@ -106,6 +106,7 @@ if ($existingRule) {
 	}
 
 	if strings.TrimSpace(output) == "False" || output == "" {
+		n.dnsChanged = true
 		fmt.Fprintf(os.Stderr, "\n\033[33m⚠\033[0m DNS configuration requires elevated privileges\n")
 
 		addOrUpdateScript := fmt.Sprintf(`
@@ -138,6 +139,14 @@ if ($?) {
 // =============================================================================
 // Private Methods
 // =============================================================================
+
+// FlushDNS clears the Windows DNS client cache via PowerShell.
+func (n *BaseNetworkManager) FlushDNS() error {
+	if _, err := n.shell.ExecSilent("powershell", "-Command", "Clear-DnsClientCache"); err != nil {
+		return fmt.Errorf("Error flushing DNS cache: %w", err)
+	}
+	return nil
+}
 
 // needsPrivilegeForResolver reports whether the NRPT rule for the configured DNS domain is missing
 // or has a different name server than desiredIP. Returns false on any error or when domain is unset.

--- a/pkg/workstation/workstation.go
+++ b/pkg/workstation/workstation.go
@@ -204,7 +204,11 @@ func (w *Workstation) EnsureNetworkPrivilege() error {
 		return nil
 	}
 	if term.IsTerminal(int(os.Stdin.Fd())) || stdruntime.GOOS == "windows" { // #nosec G115 -- file descriptors are small, safe to cast to int
-		fmt.Fprintln(os.Stderr, "Network configuration may require elevated privileges")
+		if os.Geteuid() != 0 {
+			if _, err := w.shell.ExecSilent("sudo", "-n", "true"); err != nil {
+				fmt.Fprintf(os.Stderr, "\033[33m⚠\033[0m Network configuration may require elevated privileges\n")
+			}
+		}
 		if _, err := w.shell.ExecSudo("", "true"); err != nil {
 			return fmt.Errorf("privileged access required: %w", err)
 		}

--- a/pkg/workstation/workstation.go
+++ b/pkg/workstation/workstation.go
@@ -174,6 +174,11 @@ func (w *Workstation) Up() error {
 				if err := w.NetworkManager.ConfigureDNS(); err != nil {
 					return fmt.Errorf("error configuring DNS: %w", err)
 				}
+				if w.NetworkManager.DNSChanged() {
+					if err := w.FlushDNS(); err != nil {
+						return fmt.Errorf("error flushing DNS cache: %w", err)
+					}
+				}
 			}
 		}
 	}
@@ -303,8 +308,43 @@ func (w *Workstation) MakeApplyHook() func(componentID string) error {
 	}
 }
 
-// Down stops the workstation environment: container runtime, then VM and networking.
+// FlushDNS flushes the DNS cache when DNS is enabled and fully configured.
+// It is a no-op when the network manager is absent or DNS domain/address are not set.
+func (w *Workstation) FlushDNS() error {
+	if w.NetworkManager == nil {
+		return nil
+	}
+	dnsEnabled := w.configHandler.Get("dns.enabled")
+	dnsDomain := w.configHandler.GetString("dns.domain")
+	dnsAddress := w.configHandler.GetString("workstation.dns.address")
+	if (dnsEnabled == nil || dnsEnabled == true) && dnsDomain != "" && dnsAddress != "" {
+		return w.NetworkManager.FlushDNS()
+	}
+	return nil
+}
+
+// MakePostApplyHook returns a callback for the provisioner's postApply when DeferHostGuestSetup is true.
+// The callback flushes the DNS cache after the "workstation" Terraform component's Done line is printed,
+// so the elevated-privilege prompt appears after the spinner completes rather than during it.
+// Returns nil when DeferHostGuestSetup is false.
+func (w *Workstation) MakePostApplyHook() func(componentID string) error {
+	if !w.DeferHostGuestSetup {
+		return nil
+	}
+	return func(componentID string) error {
+		if componentID != "workstation" {
+			return nil
+		}
+		if w.NetworkManager == nil || !w.NetworkManager.DNSChanged() {
+			return nil
+		}
+		return w.FlushDNS()
+	}
+}
+
+// Down stops the workstation environment: container runtime, then VM.
 // Gracefully shuts down the container runtime and virtual machine if present.
+// Workstation state is preserved so that windsor up can resume cleanly.
 func (w *Workstation) Down() error {
 	platform := w.configHandler.GetString("platform")
 

--- a/pkg/workstation/workstation_test.go
+++ b/pkg/workstation/workstation_test.go
@@ -666,6 +666,212 @@ func TestWorkstation_Up(t *testing.T) {
 		}
 	})
 
+	t.Run("FlushesAfterConfigureDNSWhenChanged", func(t *testing.T) {
+		// Given a workstation without DeferHostGuestSetup where DNS is configured and changed
+		mocks := setupWorkstationMocks(t)
+		mocks.ConfigHandler.Set("dns.domain", "test.example")
+		mocks.ConfigHandler.Set("workstation.dns.address", "10.5.0.2")
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetFunc = func(key string) any {
+			if key == "dns.enabled" {
+				return nil
+			}
+			return nil
+		}
+		flushCalled := false
+		mocks.NetworkManager.DNSChangedFunc = func() bool { return true }
+		mocks.NetworkManager.FlushDNSFunc = func() error {
+			flushCalled = true
+			return nil
+		}
+		workstation := NewWorkstation(mocks.Runtime, &Workstation{
+			VirtualMachine:   mocks.VirtualMachine,
+			ContainerRuntime: mocks.ContainerRuntime,
+			NetworkManager:   mocks.NetworkManager,
+		})
+		workstation.DeferHostGuestSetup = false
+
+		// When calling Up()
+		err := workstation.Up()
+
+		// Then no error occurs and FlushDNS was called
+		if err != nil {
+			t.Errorf("Expected success, got error: %v", err)
+		}
+		if !flushCalled {
+			t.Error("Expected FlushDNS to be called after ConfigureDNS changed the resolver")
+		}
+	})
+
+	t.Run("SkipsFlushAfterConfigureDNSWhenUnchanged", func(t *testing.T) {
+		// Given a workstation without DeferHostGuestSetup where DNS is configured but unchanged
+		mocks := setupWorkstationMocks(t)
+		mocks.ConfigHandler.Set("dns.domain", "test.example")
+		mocks.ConfigHandler.Set("workstation.dns.address", "10.5.0.2")
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetFunc = func(key string) any {
+			if key == "dns.enabled" {
+				return nil
+			}
+			return nil
+		}
+		flushCalled := false
+		mocks.NetworkManager.DNSChangedFunc = func() bool { return false }
+		mocks.NetworkManager.FlushDNSFunc = func() error {
+			flushCalled = true
+			return nil
+		}
+		workstation := NewWorkstation(mocks.Runtime, &Workstation{
+			VirtualMachine:   mocks.VirtualMachine,
+			ContainerRuntime: mocks.ContainerRuntime,
+			NetworkManager:   mocks.NetworkManager,
+		})
+		workstation.DeferHostGuestSetup = false
+
+		// When calling Up()
+		err := workstation.Up()
+
+		// Then no error occurs and FlushDNS was not called
+		if err != nil {
+			t.Errorf("Expected success, got error: %v", err)
+		}
+		if flushCalled {
+			t.Error("Expected FlushDNS not to be called when DNS was not changed")
+		}
+	})
+
+	t.Run("PropagatesFlushDNSError", func(t *testing.T) {
+		// Given a workstation without DeferHostGuestSetup where FlushDNS fails
+		mocks := setupWorkstationMocks(t)
+		mocks.ConfigHandler.Set("dns.domain", "test.example")
+		mocks.ConfigHandler.Set("workstation.dns.address", "10.5.0.2")
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetFunc = func(key string) any {
+			if key == "dns.enabled" {
+				return nil
+			}
+			return nil
+		}
+		mocks.NetworkManager.DNSChangedFunc = func() bool { return true }
+		mocks.NetworkManager.FlushDNSFunc = func() error {
+			return fmt.Errorf("flush failed")
+		}
+		workstation := NewWorkstation(mocks.Runtime, &Workstation{
+			VirtualMachine:   mocks.VirtualMachine,
+			ContainerRuntime: mocks.ContainerRuntime,
+			NetworkManager:   mocks.NetworkManager,
+		})
+		workstation.DeferHostGuestSetup = false
+
+		// When calling Up()
+		err := workstation.Up()
+
+		// Then the error is propagated
+		if err == nil {
+			t.Error("Expected error for FlushDNS failure")
+		}
+		if !strings.Contains(err.Error(), "error flushing DNS cache") {
+			t.Errorf("Expected flush DNS error, got: %v", err)
+		}
+	})
+
+}
+
+func TestWorkstation_FlushDNS(t *testing.T) {
+	t.Run("CallsFlushDNSWhenDNSConfigured", func(t *testing.T) {
+		// Given a workstation with DNS domain and address configured
+		mocks := setupWorkstationMocks(t)
+		mocks.ConfigHandler.Set("dns.domain", "test.example")
+		mocks.ConfigHandler.Set("workstation.dns.address", "10.5.0.2")
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetFunc = func(key string) any {
+			if key == "dns.enabled" {
+				return nil
+			}
+			return "mock-value"
+		}
+		flushCalled := false
+		mocks.NetworkManager.FlushDNSFunc = func() error {
+			flushCalled = true
+			return nil
+		}
+		workstation := NewWorkstation(mocks.Runtime, &Workstation{
+			NetworkManager: mocks.NetworkManager,
+		})
+
+		// When FlushDNS is called
+		err := workstation.FlushDNS()
+
+		// Then no error occurs and FlushDNS was called on the network manager
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if !flushCalled {
+			t.Error("expected NetworkManager.FlushDNS to be called")
+		}
+	})
+
+	t.Run("SkipsFlushWhenDNSDomainNotSet", func(t *testing.T) {
+		// Given a workstation with no DNS domain
+		mocks := setupWorkstationMocks(t)
+		mocks.ConfigHandler.Set("workstation.dns.address", "10.5.0.2")
+		flushCalled := false
+		mocks.NetworkManager.FlushDNSFunc = func() error {
+			flushCalled = true
+			return nil
+		}
+		workstation := NewWorkstation(mocks.Runtime, &Workstation{
+			NetworkManager: mocks.NetworkManager,
+		})
+
+		// When FlushDNS is called
+		err := workstation.FlushDNS()
+
+		// Then no error occurs and FlushDNS was not called
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if flushCalled {
+			t.Error("expected NetworkManager.FlushDNS not to be called when domain is empty")
+		}
+	})
+
+	t.Run("PropagatesNetworkManagerError", func(t *testing.T) {
+		// Given a workstation where NetworkManager.FlushDNS returns an error
+		mocks := setupWorkstationMocks(t)
+		mocks.ConfigHandler.Set("dns.domain", "test.example")
+		mocks.ConfigHandler.Set("workstation.dns.address", "10.5.0.2")
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetFunc = func(key string) any {
+			if key == "dns.enabled" {
+				return nil
+			}
+			return "mock-value"
+		}
+		mocks.NetworkManager.FlushDNSFunc = func() error {
+			return fmt.Errorf("flush failed")
+		}
+		workstation := NewWorkstation(mocks.Runtime, &Workstation{
+			NetworkManager: mocks.NetworkManager,
+		})
+
+		// When FlushDNS is called
+		err := workstation.FlushDNS()
+
+		// Then the error is propagated
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+
+	t.Run("NoopWhenNetworkManagerNil", func(t *testing.T) {
+		// Given a workstation with no network manager
+		mocks := setupWorkstationMocks(t)
+		workstation := NewWorkstation(mocks.Runtime)
+
+		// When FlushDNS is called
+		err := workstation.FlushDNS()
+
+		// Then no error occurs
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
 }
 
 func TestWorkstation_PrepareForUp(t *testing.T) {
@@ -893,6 +1099,115 @@ func TestWorkstation_MakeApplyHook(t *testing.T) {
 		}
 		if !configureNetworkCalled {
 			t.Error("Expected ConfigureNetwork to be called for workstation component")
+		}
+	})
+}
+
+func TestWorkstation_MakePostApplyHook(t *testing.T) {
+	t.Run("ReturnsNilWhenDeferHostGuestSetupFalse", func(t *testing.T) {
+		mocks := setupWorkstationMocks(t)
+		ws := NewWorkstation(mocks.Runtime)
+		ws.DeferHostGuestSetup = false
+
+		hook := ws.MakePostApplyHook()
+
+		if hook != nil {
+			t.Error("Expected nil hook when DeferHostGuestSetup is false")
+		}
+	})
+
+	t.Run("CallbackIgnoresNonWorkstationComponent", func(t *testing.T) {
+		mocks := setupWorkstationMocks(t)
+		mocks.ConfigHandler.Set("dns.domain", "test.example")
+		mocks.ConfigHandler.Set("workstation.dns.address", "10.5.0.2")
+		flushCalled := false
+		mocks.NetworkManager.FlushDNSFunc = func() error {
+			flushCalled = true
+			return nil
+		}
+		ws := NewWorkstation(mocks.Runtime, &Workstation{
+			NetworkManager: mocks.NetworkManager,
+		})
+		ws.DeferHostGuestSetup = true
+
+		hook := ws.MakePostApplyHook()
+		if hook == nil {
+			t.Fatal("Expected non-nil hook when DeferHostGuestSetup is true")
+		}
+
+		err := hook("other-component")
+
+		if err != nil {
+			t.Errorf("Expected no error for non-workstation component, got: %v", err)
+		}
+		if flushCalled {
+			t.Error("Expected FlushDNS not to be called for non-workstation component")
+		}
+	})
+
+	t.Run("CallbackFlushDNSForWorkstationComponent", func(t *testing.T) {
+		mocks := setupWorkstationMocks(t)
+		mocks.ConfigHandler.Set("dns.domain", "test.example")
+		mocks.ConfigHandler.Set("workstation.dns.address", "10.5.0.2")
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetFunc = func(key string) any {
+			if key == "dns.enabled" {
+				return nil
+			}
+			return "mock-value"
+		}
+		flushCalled := false
+		mocks.NetworkManager.DNSChangedFunc = func() bool { return true }
+		mocks.NetworkManager.FlushDNSFunc = func() error {
+			flushCalled = true
+			return nil
+		}
+		ws := NewWorkstation(mocks.Runtime, &Workstation{
+			NetworkManager: mocks.NetworkManager,
+		})
+		ws.DeferHostGuestSetup = true
+
+		hook := ws.MakePostApplyHook()
+		if hook == nil {
+			t.Fatal("Expected non-nil hook when DeferHostGuestSetup is true")
+		}
+
+		err := hook("workstation")
+
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+		if !flushCalled {
+			t.Error("Expected FlushDNS to be called for workstation component")
+		}
+	})
+
+	t.Run("CallbackSkipsFlushDNSWhenDNSUnchanged", func(t *testing.T) {
+		mocks := setupWorkstationMocks(t)
+		mocks.ConfigHandler.Set("dns.domain", "test.example")
+		mocks.ConfigHandler.Set("workstation.dns.address", "10.5.0.2")
+		flushCalled := false
+		mocks.NetworkManager.DNSChangedFunc = func() bool { return false }
+		mocks.NetworkManager.FlushDNSFunc = func() error {
+			flushCalled = true
+			return nil
+		}
+		ws := NewWorkstation(mocks.Runtime, &Workstation{
+			NetworkManager: mocks.NetworkManager,
+		})
+		ws.DeferHostGuestSetup = true
+
+		hook := ws.MakePostApplyHook()
+		if hook == nil {
+			t.Fatal("Expected non-nil hook when DeferHostGuestSetup is true")
+		}
+
+		err := hook("workstation")
+
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+		if flushCalled {
+			t.Error("Expected FlushDNS not to be called when DNS was not changed")
 		}
 	})
 }


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk due to changes in Terraform apply hook timing and new DNS-flush behavior that runs privileged commands outside progress spinners, which could affect workstation networking flows across platforms.
> 
> **Overview**
> Improves CLI UX around planning and privileged operations by adding spinner `Pause`/`Resume`, fixed-width `SectionHeader`s, and more consistent “no changes” output for Flux/Kustomize and Terraform streaming plans.
> 
> Adds a new Terraform **post-apply hook** mechanism (`Provisioner.OnTerraformPostApply` + `TerraformStack.PostApply`) so workstation DNS cache flushing can run *after* a component finishes (avoiding interactive `sudo` prompts fighting the spinner). Workstation networking now tracks when DNS config actually changed (`NetworkManager.DNSChanged`) and conditionally calls new per-OS `FlushDNS` implementations (macOS/Windows real flush; Linux no-op).
> 
> Also tightens cleanup behavior by validating `.windsor/contexts/<context>` exists and is a directory before deleting entries, and tweaks module resolvers to reduce noisy progress output (`StandardModuleResolver` uses `ExecSilent`; OCI resolver drops spinner-wrapped extraction).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b814b8337d656089e26c5e13b17c4966914178c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->