### PR TITLE
fix(runtime/env): Fix DOCKER_ENV injection logic

### DIFF
--- a/pkg/runtime/env/virt_env.go
+++ b/pkg/runtime/env/virt_env.go
@@ -57,7 +57,7 @@ func (e *VirtEnvPrinter) GetEnvVars() (map[string]string, error) {
 	workstationRuntime := e.configHandler.GetString("workstation.runtime")
 	platform := e.configHandler.GetString("platform")
 	_, dockerHostExists := e.shims.LookupEnv("DOCKER_HOST")
-	if platform != "incus" && workstationRuntime != "" && !dockerHostExists {
+	if platform != "incus" && workstationRuntime != "" {
 		homeDir, err := e.shims.UserHomeDir()
 		if err != nil {
 			return nil, fmt.Errorf("error retrieving user home directory: %w", err)
@@ -73,7 +73,24 @@ func (e *VirtEnvPrinter) GetEnvVars() (map[string]string, error) {
 		var contextName string
 		configContext := e.configHandler.GetContext()
 
-		if e.shims.Goos() == "windows" {
+		if dockerHostExists {
+			if dockerHostValue, _ := e.shims.LookupEnv("DOCKER_HOST"); dockerHostValue != "" {
+				envVars["DOCKER_HOST"] = dockerHostValue
+				e.SetManagedEnv("DOCKER_HOST")
+			}
+			if e.shims.Goos() == "windows" {
+				contextName = "desktop-linux"
+			} else {
+				switch workstationRuntime {
+				case "colima":
+					contextName = fmt.Sprintf("colima-windsor-%s", configContext)
+				case "docker-desktop":
+					contextName = "desktop-linux"
+				default:
+					contextName = "default"
+				}
+			}
+		} else if e.shims.Goos() == "windows" {
 			contextName = "desktop-linux"
 			envVars["DOCKER_HOST"] = "npipe:////./pipe/docker_engine"
 			e.SetManagedEnv("DOCKER_HOST")

--- a/pkg/runtime/env/virt_env.go
+++ b/pkg/runtime/env/virt_env.go
@@ -10,6 +10,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
@@ -46,17 +47,31 @@ func NewVirtEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler) *V
 // Public Methods
 // =============================================================================
 
-// GetEnvVars sets environment variables for virtual machine and container runtimes, using DOCKER_HOST
-// from workstation.runtime or existing env, and INCUS_SOCKET for colima-incus.
-// Defaults to WINDSORCONFIG or home dir for Docker paths, ensuring config directory exists. Writes config if
-// content changes, adds DOCKER_CONFIG, REGISTRY_URL, and INCUS_SOCKET as appropriate, and returns the map.
-// Handles "colima", "docker-desktop", and "docker" workstation runtime settings, defaulting to "default" if unrecognized.
+// GetEnvVars sets environment variables for virtual machine and container runtimes. When
+// workstation.runtime is configured, it writes a Docker config file and sets DOCKER_CONFIG.
+// DOCKER_HOST is set from the runtime when it does not yet exist or was previously managed
+// by Windsor (present in WINDSOR_MANAGED_ENV); if DOCKER_HOST was set by the user it is left
+// untouched. Handles "colima", "docker-desktop", and "docker" workstation runtimes. Also sets
+// REGISTRY_URL from docker registry config, and INCUS_SOCKET for colima-incus setups.
 func (e *VirtEnvPrinter) GetEnvVars() (map[string]string, error) {
 	envVars := make(map[string]string)
 
 	workstationRuntime := e.configHandler.GetString("workstation.runtime")
 	platform := e.configHandler.GetString("platform")
+
+	isDockerHostManaged := false
+	if managedEnvStr := e.shims.Getenv("WINDSOR_MANAGED_ENV"); managedEnvStr != "" {
+		for _, key := range strings.Split(managedEnvStr, ",") {
+			if strings.TrimSpace(key) == "DOCKER_HOST" {
+				isDockerHostManaged = true
+				break
+			}
+		}
+	}
+
 	_, dockerHostExists := e.shims.LookupEnv("DOCKER_HOST")
+	shouldSetDockerHost := !dockerHostExists || isDockerHostManaged
+
 	if platform != "incus" && workstationRuntime != "" {
 		homeDir, err := e.shims.UserHomeDir()
 		if err != nil {
@@ -70,53 +85,41 @@ func (e *VirtEnvPrinter) GetEnvVars() (map[string]string, error) {
 		dockerConfigDir := filepath.Join(windsorConfigDir, "docker")
 		dockerConfigPath := filepath.Join(dockerConfigDir, "config.json")
 
-		var contextName string
 		configContext := e.configHandler.GetContext()
 
-		if dockerHostExists {
-			if dockerHostValue, _ := e.shims.LookupEnv("DOCKER_HOST"); dockerHostValue != "" {
-				envVars["DOCKER_HOST"] = dockerHostValue
-				e.SetManagedEnv("DOCKER_HOST")
-			}
-			if e.shims.Goos() == "windows" {
-				contextName = "desktop-linux"
-			} else {
-				switch workstationRuntime {
-				case "colima":
-					contextName = fmt.Sprintf("colima-windsor-%s", configContext)
-				case "docker-desktop":
-					contextName = "desktop-linux"
-				default:
-					contextName = "default"
-				}
-			}
-		} else if e.shims.Goos() == "windows" {
+		var contextName string
+		if e.shims.Goos() == "windows" {
 			contextName = "desktop-linux"
-			envVars["DOCKER_HOST"] = "npipe:////./pipe/docker_engine"
-			e.SetManagedEnv("DOCKER_HOST")
 		} else {
 			switch workstationRuntime {
 			case "colima":
 				contextName = fmt.Sprintf("colima-windsor-%s", configContext)
-				dockerHostPath := fmt.Sprintf("unix://%s/.colima/windsor-%s/docker.sock", homeDir, configContext)
-				envVars["DOCKER_HOST"] = dockerHostPath
-				e.SetManagedEnv("DOCKER_HOST")
-
 			case "docker-desktop":
 				contextName = "desktop-linux"
-				dockerHostPath := fmt.Sprintf("unix://%s/.docker/run/docker.sock", homeDir)
-				envVars["DOCKER_HOST"] = dockerHostPath
-				e.SetManagedEnv("DOCKER_HOST")
-
-			case "docker":
-				contextName = "default"
-				envVars["DOCKER_HOST"] = "unix:///var/run/docker.sock"
-				e.SetManagedEnv("DOCKER_HOST")
-
 			default:
 				contextName = "default"
 			}
 		}
+
+		if shouldSetDockerHost {
+			if e.shims.Goos() == "windows" {
+				envVars["DOCKER_HOST"] = "npipe:////./pipe/docker_engine"
+				e.SetManagedEnv("DOCKER_HOST")
+			} else {
+				switch workstationRuntime {
+				case "colima":
+					envVars["DOCKER_HOST"] = fmt.Sprintf("unix://%s/.colima/windsor-%s/docker.sock", homeDir, configContext)
+					e.SetManagedEnv("DOCKER_HOST")
+				case "docker-desktop":
+					envVars["DOCKER_HOST"] = fmt.Sprintf("unix://%s/.docker/run/docker.sock", homeDir)
+					e.SetManagedEnv("DOCKER_HOST")
+				case "docker":
+					envVars["DOCKER_HOST"] = "unix:///var/run/docker.sock"
+					e.SetManagedEnv("DOCKER_HOST")
+				}
+			}
+		}
+
 		dockerConfigContent := fmt.Sprintf(`{
 			"auths": {},
 			"currentContext": "%s",
@@ -136,11 +139,6 @@ func (e *VirtEnvPrinter) GetEnvVars() (map[string]string, error) {
 		}
 		envVars["DOCKER_CONFIG"] = filepath.ToSlash(dockerConfigDir)
 		e.SetManagedEnv("DOCKER_CONFIG")
-	} else if platform != "incus" && dockerHostExists {
-		if dockerHostValue, _ := e.shims.LookupEnv("DOCKER_HOST"); dockerHostValue != "" {
-			envVars["DOCKER_HOST"] = dockerHostValue
-			e.SetManagedEnv("DOCKER_HOST")
-		}
 	}
 
 	registryURL, _ := e.getRegistryURL()

--- a/pkg/runtime/env/virt_env_test.go
+++ b/pkg/runtime/env/virt_env_test.go
@@ -37,8 +37,6 @@ func setupVirtEnvMocks(t *testing.T, overrides ...*EnvTestMocks) *EnvTestMocks {
 version: v1alpha1
 contexts:
   test-context:
-    vm:
-      driver: colima
     docker:
       registries:
         mock-registry-url:
@@ -153,15 +151,13 @@ func TestVirtEnvPrinter_GetEnvVars(t *testing.T) {
 	})
 
 	t.Run("DockerDesktopDriver", func(t *testing.T) {
-		// Given a new VirtEnvPrinter with Docker Desktop driver on Linux
+		// Given a new VirtEnvPrinter with Docker Desktop workstation runtime on Linux
 		os.Unsetenv("DOCKER_HOST")
 		mocks := setupVirtEnvMocks(t)
 		configStr := `
 version: v1alpha1
 contexts:
   test-context:
-    vm:
-      driver: docker-desktop
     docker:
       registries:
         mock-registry-url:
@@ -245,15 +241,13 @@ contexts:
 	})
 
 	t.Run("DockerDriver", func(t *testing.T) {
-		// Given a new VirtEnvPrinter with Docker driver
+		// Given a new VirtEnvPrinter with Docker workstation runtime
 		os.Unsetenv("DOCKER_HOST")
 		mocks := setupVirtEnvMocks(t)
 		configStr := `
 version: v1alpha1
 contexts:
   test-context:
-    vm:
-      driver: docker
     docker:
       registries:
         mock-registry-url:
@@ -397,8 +391,6 @@ contexts:
 version: v1alpha1
 contexts:
   test-context:
-    vm:
-      driver: docker-desktop
     docker:
       registries:
         mock-registry-url:
@@ -432,26 +424,14 @@ contexts:
 		}
 	})
 
-	t.Run("DockerHostFromEnvironment", func(t *testing.T) {
-		// Given a new VirtEnvPrinter with DOCKER_HOST environment variable
+	t.Run("DockerHostPreservedWhenNoRuntime", func(t *testing.T) {
+		// Given a new VirtEnvPrinter with DOCKER_HOST in the environment but no workstation runtime configured
 		os.Setenv("DOCKER_HOST", "tcp://custom-docker-host:2375")
 		defer os.Unsetenv("DOCKER_HOST")
 
 		mocks := setupVirtEnvMocks(t)
-		configStr := `
-version: v1alpha1
-contexts:
-  test-context:
-    vm:
-      driver: docker-desktop
-    docker:
-      registries:
-        mock-registry-url:
-          hostport: 5000
-`
-		if err := mocks.ConfigHandler.LoadConfigString(configStr); err != nil {
-			t.Fatalf("Failed to load config: %v", err)
-		}
+		// Clear workstation.runtime so Windsor does not manage DOCKER_HOST
+		_ = mocks.ConfigHandler.Set("workstation.runtime", "")
 
 		mocks.Shims.LookupEnv = func(key string) (string, bool) {
 			if key == "DOCKER_HOST" {
@@ -471,10 +451,15 @@ contexts:
 			t.Fatalf("GetEnvVars returned an error: %v", err)
 		}
 
-		// And DOCKER_HOST should match environment value
+		// And DOCKER_HOST should be preserved from the environment (no runtime to override it)
 		expectedDockerHost := "tcp://custom-docker-host:2375"
 		if envVars["DOCKER_HOST"] != expectedDockerHost {
 			t.Errorf("DOCKER_HOST = %v, want %v", envVars["DOCKER_HOST"], expectedDockerHost)
+		}
+
+		// And DOCKER_CONFIG should not be set (no runtime configured)
+		if _, exists := envVars["DOCKER_CONFIG"]; exists {
+			t.Error("Expected DOCKER_CONFIG not to be set when workstation.runtime is empty")
 		}
 	})
 
@@ -509,15 +494,14 @@ contexts:
 		}
 	})
 
-	t.Run("DockerHostFromEnvironmentOverridesDriver", func(t *testing.T) {
-		// Given a new VirtEnvPrinter with both DOCKER_HOST and vm driver
+	t.Run("DockerHostFromEnvironmentPreservedWithDockerConfig", func(t *testing.T) {
+		// Given a new VirtEnvPrinter with workstation.runtime configured and DOCKER_HOST already in the environment
+		// (e.g. set by platform tooling on Windows or by a previous shell session)
 		mocks := setupVirtEnvMocks(t)
 		configStr := `
 version: v1alpha1
 contexts:
   test-context:
-    vm:
-      driver: docker-desktop
     docker:
       registries:
         mock-registry-url:
@@ -545,10 +529,16 @@ contexts:
 			t.Fatalf("GetEnvVars returned an error: %v", err)
 		}
 
-		// And DOCKER_HOST should match environment value, not driver value
+		// And DOCKER_HOST should be preserved from the environment (not overridden by workstation.runtime)
 		expectedDockerHost := "tcp://override-host:2375"
 		if envVars["DOCKER_HOST"] != expectedDockerHost {
 			t.Errorf("DOCKER_HOST = %v, want %v", envVars["DOCKER_HOST"], expectedDockerHost)
+		}
+
+		// And DOCKER_CONFIG should be set (always set when workstation.runtime is configured)
+		expectedDockerConfig := filepath.ToSlash("/mock/home/.config/windsor/docker")
+		if envVars["DOCKER_CONFIG"] != expectedDockerConfig {
+			t.Errorf("DOCKER_CONFIG = %v, want %v", envVars["DOCKER_CONFIG"], expectedDockerConfig)
 		}
 
 		// And DOCKER_HOST should be marked as managed for reset tracking
@@ -565,16 +555,14 @@ contexts:
 		}
 	})
 
-	t.Run("DockerHostManagedByWindsorIsPreserved", func(t *testing.T) {
-		// Given a new VirtEnvPrinter with DOCKER_HOST already managed by Windsor
+	t.Run("DockerHostManagedByWindsorIsPreservedWithDockerConfig", func(t *testing.T) {
+		// Given a new VirtEnvPrinter with DOCKER_HOST already managed by Windsor and workstation.runtime=colima
 		os.Unsetenv("DOCKER_HOST")
 		mocks := setupVirtEnvMocks(t)
 		configStr := `
 version: v1alpha1
 contexts:
   test-context:
-    vm:
-      driver: colima
     docker:
       registries:
         mock-registry-url:
@@ -612,10 +600,16 @@ contexts:
 			t.Fatalf("GetEnvVars returned an error: %v", err)
 		}
 
-		// And DOCKER_HOST should preserve the existing managed value unless reset has cleared it
+		// And DOCKER_HOST should preserve the existing managed value
 		expectedDockerHost := "tcp://old-managed-host:2375"
 		if envVars["DOCKER_HOST"] != expectedDockerHost {
 			t.Errorf("DOCKER_HOST = %v, want %v", envVars["DOCKER_HOST"], expectedDockerHost)
+		}
+
+		// And DOCKER_CONFIG should be set (always set when workstation.runtime is configured)
+		expectedDockerConfig := filepath.ToSlash("/mock/home/.config/windsor/docker")
+		if envVars["DOCKER_CONFIG"] != expectedDockerConfig {
+			t.Errorf("DOCKER_CONFIG = %v, want %v", envVars["DOCKER_CONFIG"], expectedDockerConfig)
 		}
 
 		// And DOCKER_HOST should be marked as managed for reset tracking
@@ -632,16 +626,14 @@ contexts:
 		}
 	})
 
-	t.Run("DockerHostUnmanagedIsPreserved", func(t *testing.T) {
-		// Given a new VirtEnvPrinter with DOCKER_HOST set but not managed
+	t.Run("DockerHostUnmanagedIsPreservedWithDockerConfig", func(t *testing.T) {
+		// Given a new VirtEnvPrinter with DOCKER_HOST set by external tooling and workstation.runtime=colima
 		os.Unsetenv("DOCKER_HOST")
 		mocks := setupVirtEnvMocks(t)
 		configStr := `
 version: v1alpha1
 contexts:
   test-context:
-    vm:
-      driver: colima
     docker:
       registries:
         mock-registry-url:
@@ -684,6 +676,12 @@ contexts:
 			t.Errorf("DOCKER_HOST = %v, want %v", envVars["DOCKER_HOST"], expectedDockerHost)
 		}
 
+		// And DOCKER_CONFIG should be set (always set when workstation.runtime is configured)
+		expectedDockerConfig := filepath.ToSlash("/mock/home/.config/windsor/docker")
+		if envVars["DOCKER_CONFIG"] != expectedDockerConfig {
+			t.Errorf("DOCKER_CONFIG = %v, want %v", envVars["DOCKER_CONFIG"], expectedDockerConfig)
+		}
+
 		// And DOCKER_HOST should be marked as managed for reset tracking
 		managedEnv := printer.GetManagedEnv()
 		isManaged := false
@@ -706,8 +704,6 @@ contexts:
 version: v1alpha1
 contexts:
   test-context:
-    vm:
-      driver: docker-desktop
     docker:
       registries:
         mock-registry-url:
@@ -812,16 +808,14 @@ contexts:
 		}
 	})
 
-	t.Run("DockerHostEmptyStringIsPreserved", func(t *testing.T) {
-		// Given a new VirtEnvPrinter with DOCKER_HOST set to empty string (not managed)
+	t.Run("DockerHostEmptyStringNotPropagatedDockerConfigStillSet", func(t *testing.T) {
+		// Given a new VirtEnvPrinter with workstation.runtime=colima and DOCKER_HOST set to empty string
 		os.Unsetenv("DOCKER_HOST")
 		mocks := setupVirtEnvMocks(t)
 		configStr := `
 version: v1alpha1
 contexts:
   test-context:
-    vm:
-      driver: colima
     docker:
       registries:
         mock-registry-url:
@@ -836,7 +830,7 @@ contexts:
 				return "", true // Empty string but exists
 			}
 			if key == "WINDSOR_MANAGED_ENV" {
-				return "DOCKER_CONFIG", true // DOCKER_HOST not in managed list
+				return "DOCKER_CONFIG", true
 			}
 			return "", false
 		}
@@ -858,25 +852,20 @@ contexts:
 			t.Fatalf("GetEnvVars returned an error: %v", err)
 		}
 
-		// And DOCKER_HOST should preserve the empty string value (since it exists and is not managed)
-		// Note: The code checks if DOCKER_HOST exists, and if it does and is not managed, it preserves it
-		// However, if the value is empty, it might still be preserved. Let's check the actual behavior.
-		if dockerHost, exists := envVars["DOCKER_HOST"]; exists {
-			// If DOCKER_HOST exists but is empty and not managed, it should be preserved
-			// But the code logic says: if vmDriver != "" && (!dockerHostExists || isDockerHostManaged)
-			// Since dockerHostExists is true and isDockerHostManaged is false, the condition is false
-			// So it goes to the else branch which preserves the existing value
-			if dockerHost != "" {
-				t.Errorf("DOCKER_HOST = %v, want empty string (preserved)", dockerHost)
-			}
-		} else {
-			// If DOCKER_HOST doesn't exist in envVars, that's also acceptable
-			// The code might not add it if it's empty
+		// And DOCKER_HOST should not be propagated (empty value is not set)
+		if dockerHost, exists := envVars["DOCKER_HOST"]; exists && dockerHost != "" {
+			t.Errorf("DOCKER_HOST = %v, want empty or absent", dockerHost)
+		}
+
+		// And DOCKER_CONFIG should be set (always set when workstation.runtime is configured)
+		expectedDockerConfig := filepath.ToSlash("/mock/home/.config/windsor/docker")
+		if envVars["DOCKER_CONFIG"] != expectedDockerConfig {
+			t.Errorf("DOCKER_CONFIG = %v, want %v", envVars["DOCKER_CONFIG"], expectedDockerConfig)
 		}
 	})
 
 	t.Run("IncusRuntimeSetsIncusSocket", func(t *testing.T) {
-		// Given a new VirtEnvPrinter with colima driver and provider incus
+		// Given a new VirtEnvPrinter with colima workstation runtime and incus platform
 		os.Unsetenv("DOCKER_HOST")
 		mocks := setupVirtEnvMocks(t)
 		configStr := `
@@ -885,8 +874,6 @@ contexts:
   test-context:
     platform: incus
     provider: incus
-    vm:
-      driver: colima
     docker:
       registries:
         mock-registry-url:

--- a/pkg/runtime/env/virt_env_test.go
+++ b/pkg/runtime/env/virt_env_test.go
@@ -451,10 +451,9 @@ contexts:
 			t.Fatalf("GetEnvVars returned an error: %v", err)
 		}
 
-		// And DOCKER_HOST should be preserved from the environment (no runtime to override it)
-		expectedDockerHost := "tcp://custom-docker-host:2375"
-		if envVars["DOCKER_HOST"] != expectedDockerHost {
-			t.Errorf("DOCKER_HOST = %v, want %v", envVars["DOCKER_HOST"], expectedDockerHost)
+		// And DOCKER_HOST should not be in envVars (Windsor leaves user-owned values alone)
+		if _, exists := envVars["DOCKER_HOST"]; exists {
+			t.Error("Expected DOCKER_HOST not to be in envVars when workstation.runtime is empty")
 		}
 
 		// And DOCKER_CONFIG should not be set (no runtime configured)
@@ -494,9 +493,9 @@ contexts:
 		}
 	})
 
-	t.Run("DockerHostFromEnvironmentPreservedWithDockerConfig", func(t *testing.T) {
-		// Given a new VirtEnvPrinter with workstation.runtime configured and DOCKER_HOST already in the environment
-		// (e.g. set by platform tooling on Windows or by a previous shell session)
+	t.Run("DockerHostUserOwnedNotManagedDockerConfigStillSet", func(t *testing.T) {
+		// Given a new VirtEnvPrinter with workstation.runtime configured and a user-owned DOCKER_HOST
+		// that Windsor has never managed (not in WINDSOR_MANAGED_ENV)
 		mocks := setupVirtEnvMocks(t)
 		configStr := `
 version: v1alpha1
@@ -513,7 +512,7 @@ contexts:
 
 		mocks.Shims.LookupEnv = func(key string) (string, bool) {
 			if key == "DOCKER_HOST" {
-				return "tcp://override-host:2375", true
+				return "tcp://user-owned-host:2375", true
 			}
 			return "", false
 		}
@@ -529,34 +528,30 @@ contexts:
 			t.Fatalf("GetEnvVars returned an error: %v", err)
 		}
 
-		// And DOCKER_HOST should be preserved from the environment (not overridden by workstation.runtime)
-		expectedDockerHost := "tcp://override-host:2375"
-		if envVars["DOCKER_HOST"] != expectedDockerHost {
-			t.Errorf("DOCKER_HOST = %v, want %v", envVars["DOCKER_HOST"], expectedDockerHost)
+		// And DOCKER_HOST should not be in envVars (Windsor leaves user-owned values alone)
+		if _, exists := envVars["DOCKER_HOST"]; exists {
+			t.Errorf("Expected DOCKER_HOST not to be in envVars, got %v", envVars["DOCKER_HOST"])
 		}
 
-		// And DOCKER_CONFIG should be set (always set when workstation.runtime is configured)
+		// And DOCKER_CONFIG should still be set (always set when workstation.runtime is configured)
 		expectedDockerConfig := filepath.ToSlash("/mock/home/.config/windsor/docker")
 		if envVars["DOCKER_CONFIG"] != expectedDockerConfig {
 			t.Errorf("DOCKER_CONFIG = %v, want %v", envVars["DOCKER_CONFIG"], expectedDockerConfig)
 		}
 
-		// And DOCKER_HOST should be marked as managed for reset tracking
+		// And DOCKER_HOST should not be marked as managed
 		managedEnv := printer.GetManagedEnv()
-		isManaged := false
 		for _, env := range managedEnv {
 			if env == "DOCKER_HOST" {
-				isManaged = true
+				t.Error("Expected DOCKER_HOST not to be marked as managed when user-owned")
 				break
 			}
 		}
-		if !isManaged {
-			t.Error("Expected DOCKER_HOST to be marked as managed for reset tracking")
-		}
 	})
 
-	t.Run("DockerHostManagedByWindsorIsPreservedWithDockerConfig", func(t *testing.T) {
-		// Given a new VirtEnvPrinter with DOCKER_HOST already managed by Windsor and workstation.runtime=colima
+	t.Run("DockerHostManagedByWindsorIsReinjectedWithDockerConfig", func(t *testing.T) {
+		// Given a new VirtEnvPrinter with DOCKER_HOST previously managed by Windsor
+		// (present in WINDSOR_MANAGED_ENV) and workstation.runtime=colima
 		os.Unsetenv("DOCKER_HOST")
 		mocks := setupVirtEnvMocks(t)
 		configStr := `
@@ -576,15 +571,12 @@ contexts:
 			if key == "DOCKER_HOST" {
 				return "tcp://old-managed-host:2375", true
 			}
-			if key == "WINDSOR_MANAGED_ENV" {
-				return "DOCKER_HOST DOCKER_CONFIG", true
-			}
 			return "", false
 		}
 
 		mocks.Shims.Getenv = func(key string) string {
 			if key == "WINDSOR_MANAGED_ENV" {
-				return "DOCKER_HOST DOCKER_CONFIG"
+				return "DOCKER_HOST,DOCKER_CONFIG"
 			}
 			return ""
 		}
@@ -600,8 +592,8 @@ contexts:
 			t.Fatalf("GetEnvVars returned an error: %v", err)
 		}
 
-		// And DOCKER_HOST should preserve the existing managed value
-		expectedDockerHost := "tcp://old-managed-host:2375"
+		// And DOCKER_HOST should be re-derived from workstation.runtime (Windsor re-asserts ownership)
+		expectedDockerHost := fmt.Sprintf("unix://%s/.colima/windsor-test-context/docker.sock", filepath.ToSlash("/mock/home"))
 		if envVars["DOCKER_HOST"] != expectedDockerHost {
 			t.Errorf("DOCKER_HOST = %v, want %v", envVars["DOCKER_HOST"], expectedDockerHost)
 		}
@@ -612,7 +604,7 @@ contexts:
 			t.Errorf("DOCKER_CONFIG = %v, want %v", envVars["DOCKER_CONFIG"], expectedDockerConfig)
 		}
 
-		// And DOCKER_HOST should be marked as managed for reset tracking
+		// And DOCKER_HOST should be marked as managed
 		managedEnv := printer.GetManagedEnv()
 		isManaged := false
 		for _, env := range managedEnv {
@@ -622,12 +614,13 @@ contexts:
 			}
 		}
 		if !isManaged {
-			t.Error("Expected DOCKER_HOST to be marked as managed when preserved")
+			t.Error("Expected DOCKER_HOST to be marked as managed when re-injected")
 		}
 	})
 
-	t.Run("DockerHostUnmanagedIsPreservedWithDockerConfig", func(t *testing.T) {
-		// Given a new VirtEnvPrinter with DOCKER_HOST set by external tooling and workstation.runtime=colima
+	t.Run("DockerHostUserOwnedExplicitlyNotManagedDockerConfigStillSet", func(t *testing.T) {
+		// Given a new VirtEnvPrinter with DOCKER_HOST set by external tooling, explicitly absent
+		// from WINDSOR_MANAGED_ENV, and workstation.runtime=colima
 		os.Unsetenv("DOCKER_HOST")
 		mocks := setupVirtEnvMocks(t)
 		configStr := `
@@ -647,14 +640,11 @@ contexts:
 			if key == "DOCKER_HOST" {
 				return "tcp://custom-unmanaged-host:2375", true
 			}
-			if key == "WINDSOR_MANAGED_ENV" {
-				return "DOCKER_CONFIG", true // DOCKER_HOST not in managed list
-			}
 			return "", false
 		}
 		mocks.Shims.Getenv = func(key string) string {
 			if key == "WINDSOR_MANAGED_ENV" {
-				return "DOCKER_CONFIG"
+				return "DOCKER_CONFIG" // DOCKER_HOST not in managed list
 			}
 			return ""
 		}
@@ -670,10 +660,9 @@ contexts:
 			t.Fatalf("GetEnvVars returned an error: %v", err)
 		}
 
-		// And DOCKER_HOST should preserve the unmanaged value
-		expectedDockerHost := "tcp://custom-unmanaged-host:2375"
-		if envVars["DOCKER_HOST"] != expectedDockerHost {
-			t.Errorf("DOCKER_HOST = %v, want %v", envVars["DOCKER_HOST"], expectedDockerHost)
+		// And DOCKER_HOST should not be in envVars (Windsor leaves user-owned values alone)
+		if _, exists := envVars["DOCKER_HOST"]; exists {
+			t.Errorf("Expected DOCKER_HOST not to be in envVars, got %v", envVars["DOCKER_HOST"])
 		}
 
 		// And DOCKER_CONFIG should be set (always set when workstation.runtime is configured)
@@ -682,17 +671,13 @@ contexts:
 			t.Errorf("DOCKER_CONFIG = %v, want %v", envVars["DOCKER_CONFIG"], expectedDockerConfig)
 		}
 
-		// And DOCKER_HOST should be marked as managed for reset tracking
+		// And DOCKER_HOST should not be marked as managed
 		managedEnv := printer.GetManagedEnv()
-		isManaged := false
 		for _, env := range managedEnv {
 			if env == "DOCKER_HOST" {
-				isManaged = true
+				t.Error("Expected DOCKER_HOST not to be marked as managed when user-owned")
 				break
 			}
-		}
-		if !isManaged {
-			t.Error("Expected DOCKER_HOST to be marked as managed when unmanaged value is preserved")
 		}
 	})
 

--- a/pkg/runtime/env/virt_env_test.go
+++ b/pkg/runtime/env/virt_env_test.go
@@ -581,6 +581,9 @@ contexts:
 			return ""
 		}
 
+		// Force non-Windows so the colima socket path is derived, not the named pipe
+		mocks.Shims.Goos = func() string { return "linux" }
+
 		printer := NewVirtEnvPrinter(mocks.Shell, mocks.ConfigHandler)
 		printer.shims = mocks.Shims
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes how `DOCKER_HOST` is injected, which can alter how Docker commands connect to engines across runtimes; misclassification of managed vs user-owned values could break local workflows. Scope is contained to env var generation and has expanded test coverage for edge cases.
> 
> **Overview**
> Updates `VirtEnvPrinter.GetEnvVars` to **only inject `DOCKER_HOST` when it’s missing or previously Windsor-managed** (detected via comma-separated `WINDSOR_MANAGED_ENV`), leaving user-owned `DOCKER_HOST` untouched.
> 
> When `workstation.runtime` is set, it now **always writes/sets `DOCKER_CONFIG` and Docker context** even if `DOCKER_HOST` is user-owned, and removes the old behavior that echoed existing `DOCKER_HOST` back into `envVars`. Tests were rewritten to reflect the new ownership/override rules and to cover no-runtime, user-owned, previously-managed, and empty `DOCKER_HOST` scenarios.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f57ad32fa483e80b86dbc23c07e507ed6b6fbf1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->