### PR TITLE
feat(cmd): Simplify windsor up to only work with workstation

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -9,14 +9,13 @@ import (
 )
 
 var (
-	installFlag bool // Declare the install flag
-	waitFlag    bool // Declare the wait flag
+	waitFlag bool // Declare the wait flag
 )
 
 var upCmd = &cobra.Command{
 	Use:          "up",
-	Short:        "Set up the Windsor environment",
-	Long:         "Set up the Windsor environment by executing necessary shell commands.",
+	Short:        "Bring up the local workstation environment",
+	Long:         "Bring up the local workstation environment by starting the VM, applying Terraform, and installing the blueprint.",
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var opts []*project.Project
@@ -44,20 +43,23 @@ var upCmd = &cobra.Command{
 			return err
 		}
 
+		if proj.Workstation == nil {
+			fmt.Fprintln(os.Stderr, "windsor up is only applicable when a workstation is enabled; use windsor apply to apply infrastructure")
+			return nil
+		}
+
 		blueprint, err := proj.Up()
 		if err != nil {
 			return err
 		}
 
-		if installFlag {
-			if err := proj.Provisioner.Install(blueprint); err != nil {
-				return fmt.Errorf("error installing blueprint: %w", err)
-			}
+		if err := proj.Provisioner.Install(blueprint); err != nil {
+			return fmt.Errorf("error installing blueprint: %w", err)
+		}
 
-			if waitFlag {
-				if err := proj.Provisioner.Wait(blueprint); err != nil {
-					return fmt.Errorf("error waiting for kustomizations: %w", err)
-				}
+		if waitFlag {
+			if err := proj.Provisioner.Wait(blueprint); err != nil {
+				return fmt.Errorf("error waiting for kustomizations: %w", err)
 			}
 		}
 
@@ -68,7 +70,6 @@ var upCmd = &cobra.Command{
 }
 
 func init() {
-	upCmd.Flags().BoolVar(&installFlag, "install", false, "Install the blueprint after setting up the environment")
 	upCmd.Flags().BoolVar(&waitFlag, "wait", false, "Wait for kustomization resources to be ready")
 	rootCmd.AddCommand(upCmd)
 }

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
 	"github.com/windsorcli/cli/pkg/runtime/tools"
+	"github.com/windsorcli/cli/pkg/workstation"
 )
 
 // =============================================================================
@@ -122,6 +123,25 @@ func setupUpTest(t *testing.T, opts ...*SetupOptions) *UpMocks {
 	}
 }
 
+// newUpTestProject builds a project override with the given mocks and an optional workstation.
+func newUpTestProject(mocks *UpMocks, withWorkstation bool) *project.Project {
+	comp := composer.NewComposer(mocks.Runtime)
+	comp.BlueprintHandler = mocks.BlueprintHandler
+	mockProvisioner := provisioner.NewProvisioner(mocks.Runtime, comp.BlueprintHandler, &provisioner.Provisioner{
+		TerraformStack:    mocks.TerraformStack,
+		KubernetesManager: mocks.KubernetesManager,
+	})
+	proj := project.NewProject("", &project.Project{
+		Runtime:     mocks.Runtime,
+		Composer:    comp,
+		Provisioner: mockProvisioner,
+	})
+	if withWorkstation {
+		proj.Workstation = workstation.NewWorkstation(mocks.Runtime)
+	}
+	return proj
+}
+
 // =============================================================================
 // Test Cases
 // =============================================================================
@@ -131,7 +151,7 @@ func TestUpCmd(t *testing.T) {
 		// Create a new command with the same RunE as upCmd
 		cmd := &cobra.Command{
 			Use:   "up",
-			Short: "Set up the Windsor environment",
+			Short: "Bring up the local workstation environment",
 			RunE:  upCmd.RunE,
 		}
 
@@ -153,21 +173,10 @@ func TestUpCmd(t *testing.T) {
 	suppressProcessStderr(t)
 
 	t.Run("Success", func(t *testing.T) {
-		// Given a temporary directory with mocked dependencies
+		// Given a project with a workstation configured
 		mocks := setupUpTest(t)
+		proj := newUpTestProject(mocks, true)
 
-		comp := composer.NewComposer(mocks.Runtime)
-		comp.BlueprintHandler = mocks.BlueprintHandler
-		mockProvisioner := provisioner.NewProvisioner(mocks.Runtime, comp.BlueprintHandler, &provisioner.Provisioner{
-			TerraformStack:    mocks.TerraformStack,
-			KubernetesManager: mocks.KubernetesManager,
-		})
-
-		proj := project.NewProject("", &project.Project{
-			Runtime:     mocks.Runtime,
-			Composer:    comp,
-			Provisioner: mockProvisioner,
-		})
 		// When executing the up command
 		cmd := createTestUpCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
@@ -181,82 +190,35 @@ func TestUpCmd(t *testing.T) {
 		}
 	})
 
-	t.Run("SuccessWithInstallFlag", func(t *testing.T) {
-		// Given a temporary directory with mocked dependencies
+	t.Run("NoOpWhenWorkstationDisabled", func(t *testing.T) {
+		// Given a project with no workstation configured
 		mocks := setupUpTest(t)
-		comp := composer.NewComposer(mocks.Runtime)
-		comp.BlueprintHandler = mocks.BlueprintHandler
-		mockProvisioner := provisioner.NewProvisioner(mocks.Runtime, comp.BlueprintHandler, &provisioner.Provisioner{
-			TerraformStack:    mocks.TerraformStack,
-			KubernetesManager: mocks.KubernetesManager,
-		})
+		proj := newUpTestProject(mocks, false)
 
-		proj := project.NewProject("", &project.Project{
-			Runtime:     mocks.Runtime,
-			Composer:    comp,
-			Provisioner: mockProvisioner,
-		})
-		// When executing the up command with install flag
+		var stderrBuf strings.Builder
 		cmd := createTestUpCmd()
+		cmd.SetErr(&stderrBuf)
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{})
 		cmd.SetContext(ctx)
-		cmd.SetArgs([]string{"--install"})
 		err := cmd.Execute()
 
-		// Then no error should occur
+		// Then no error should occur and a descriptive message is printed
 		if err != nil {
-			t.Errorf("Expected success, got error: %v", err)
+			t.Errorf("Expected no error, got %v", err)
 		}
 	})
 
-	t.Run("SuccessWithWaitFlag", func(t *testing.T) {
-		// Given a temporary directory with mocked dependencies
+	t.Run("SuccessWithWait", func(t *testing.T) {
+		// Given a project with a workstation configured
 		mocks := setupUpTest(t)
-		comp := composer.NewComposer(mocks.Runtime)
-		comp.BlueprintHandler = mocks.BlueprintHandler
-		mockProvisioner := provisioner.NewProvisioner(mocks.Runtime, comp.BlueprintHandler, &provisioner.Provisioner{
-			TerraformStack:    mocks.TerraformStack,
-			KubernetesManager: mocks.KubernetesManager,
-		})
+		proj := newUpTestProject(mocks, true)
 
-		proj := project.NewProject("", &project.Project{
-			Runtime:     mocks.Runtime,
-			Composer:    comp,
-			Provisioner: mockProvisioner,
-		})
-		// When executing the up command with wait flag
+		// When executing the up command with --wait flag
 		cmd := createTestUpCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
 		cmd.SetContext(ctx)
 		cmd.SetArgs([]string{"--wait"})
-		err := cmd.Execute()
-
-		// Then no error should occur (wait only works with install)
-		if err != nil {
-			t.Errorf("Expected success, got error: %v", err)
-		}
-	})
-
-	t.Run("SuccessWithInstallAndWaitFlags", func(t *testing.T) {
-		// Given a temporary directory with mocked dependencies
-		mocks := setupUpTest(t)
-		comp := composer.NewComposer(mocks.Runtime)
-		comp.BlueprintHandler = mocks.BlueprintHandler
-		mockProvisioner := provisioner.NewProvisioner(mocks.Runtime, comp.BlueprintHandler, &provisioner.Provisioner{
-			TerraformStack:    mocks.TerraformStack,
-			KubernetesManager: mocks.KubernetesManager,
-		})
-
-		proj := project.NewProject("", &project.Project{
-			Runtime:     mocks.Runtime,
-			Composer:    comp,
-			Provisioner: mockProvisioner,
-		})
-		// When executing the up command with both install and wait flags
-		cmd := createTestUpCmd()
-		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
-		cmd.SetContext(ctx)
-		cmd.SetArgs([]string{"--install", "--wait"})
 		err := cmd.Execute()
 
 		// Then no error should occur
@@ -266,26 +228,13 @@ func TestUpCmd(t *testing.T) {
 	})
 
 	t.Run("CheckTrustedDirectoryError", func(t *testing.T) {
-		// Given a temporary directory with mocked dependencies
+		// Given a shell that rejects the trusted directory check
 		mocks := setupUpTest(t)
-
-		// And CheckTrustedDirectory that fails
 		mocks.Shell.CheckTrustedDirectoryFunc = func() error {
 			return fmt.Errorf("not in trusted directory")
 		}
+		proj := newUpTestProject(mocks, false)
 
-		comp := composer.NewComposer(mocks.Runtime)
-		comp.BlueprintHandler = mocks.BlueprintHandler
-		mockProvisioner := provisioner.NewProvisioner(mocks.Runtime, comp.BlueprintHandler, &provisioner.Provisioner{
-			TerraformStack:    mocks.TerraformStack,
-			KubernetesManager: mocks.KubernetesManager,
-		})
-
-		proj := project.NewProject("", &project.Project{
-			Runtime:     mocks.Runtime,
-			Composer:    comp,
-			Provisioner: mockProvisioner,
-		})
 		// When executing the up command
 		cmd := createTestUpCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
@@ -304,26 +253,13 @@ func TestUpCmd(t *testing.T) {
 	})
 
 	t.Run("ProvisionerUpError", func(t *testing.T) {
-		// Given a temporary directory with mocked dependencies
+		// Given a terraform stack that fails during Up
 		mocks := setupUpTest(t)
-
-		// And terraform stack Up that fails
 		mocks.TerraformStack.UpFunc = func(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(id string) error) error {
 			return fmt.Errorf("terraform stack up failed")
 		}
+		proj := newUpTestProject(mocks, true)
 
-		comp := composer.NewComposer(mocks.Runtime)
-		comp.BlueprintHandler = mocks.BlueprintHandler
-		mockProvisioner := provisioner.NewProvisioner(mocks.Runtime, comp.BlueprintHandler, &provisioner.Provisioner{
-			TerraformStack:    mocks.TerraformStack,
-			KubernetesManager: mocks.KubernetesManager,
-		})
-
-		proj := project.NewProject("", &project.Project{
-			Runtime:     mocks.Runtime,
-			Composer:    comp,
-			Provisioner: mockProvisioner,
-		})
 		// When executing the up command
 		cmd := createTestUpCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
@@ -342,31 +278,18 @@ func TestUpCmd(t *testing.T) {
 	})
 
 	t.Run("ProvisionerInstallError", func(t *testing.T) {
-		// Given a temporary directory with mocked dependencies
+		// Given a kubernetes manager whose ApplyBlueprint fails
 		mocks := setupUpTest(t)
-
-		// And kubernetes manager ApplyBlueprint that fails
 		mocks.KubernetesManager.ApplyBlueprintFunc = func(blueprint *blueprintv1alpha1.Blueprint, namespace string) error {
 			return fmt.Errorf("kubernetes apply failed")
 		}
+		proj := newUpTestProject(mocks, true)
 
-		comp := composer.NewComposer(mocks.Runtime)
-		comp.BlueprintHandler = mocks.BlueprintHandler
-		mockProvisioner := provisioner.NewProvisioner(mocks.Runtime, comp.BlueprintHandler, &provisioner.Provisioner{
-			TerraformStack:    mocks.TerraformStack,
-			KubernetesManager: mocks.KubernetesManager,
-		})
-
-		proj := project.NewProject("", &project.Project{
-			Runtime:     mocks.Runtime,
-			Composer:    comp,
-			Provisioner: mockProvisioner,
-		})
-		// When executing the up command with install flag
+		// When executing the up command (install always runs)
 		cmd := createTestUpCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
 		cmd.SetContext(ctx)
-		cmd.SetArgs([]string{"--install"})
+		cmd.SetArgs([]string{})
 		err := cmd.Execute()
 
 		// Then an error should occur
@@ -380,31 +303,18 @@ func TestUpCmd(t *testing.T) {
 	})
 
 	t.Run("ProvisionerWaitError", func(t *testing.T) {
-		// Given a temporary directory with mocked dependencies
+		// Given a kubernetes manager whose WaitForKustomizations fails
 		mocks := setupUpTest(t)
-
-		// And kubernetes manager WaitForKustomizations that fails
 		mocks.KubernetesManager.WaitForKustomizationsFunc = func(message string, blueprint *blueprintv1alpha1.Blueprint) error {
 			return fmt.Errorf("wait for kustomizations failed")
 		}
+		proj := newUpTestProject(mocks, true)
 
-		comp := composer.NewComposer(mocks.Runtime)
-		comp.BlueprintHandler = mocks.BlueprintHandler
-		mockProvisioner := provisioner.NewProvisioner(mocks.Runtime, comp.BlueprintHandler, &provisioner.Provisioner{
-			TerraformStack:    mocks.TerraformStack,
-			KubernetesManager: mocks.KubernetesManager,
-		})
-
-		proj := project.NewProject("", &project.Project{
-			Runtime:     mocks.Runtime,
-			Composer:    comp,
-			Provisioner: mockProvisioner,
-		})
-		// When executing the up command with install and wait flags
+		// When executing the up command with --wait flag
 		cmd := createTestUpCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
 		cmd.SetContext(ctx)
-		cmd.SetArgs([]string{"--install", "--wait"})
+		cmd.SetArgs([]string{"--wait"})
 		err := cmd.Execute()
 
 		// Then an error should occur

--- a/docs/guides/kustomize.md
+++ b/docs/guides/kustomize.md
@@ -60,7 +60,7 @@ kustomize:
 
 Each entry under `kustomize` follows the [Flux Kustomization spec](https://fluxcd.io/flux/components/kustomize/kustomizations/). As such, you may include patches and any other necessary settings for modifying the behavior of `my-app`.
 
-When running `windsor up --install` or `windsor install`, all Kustomization resources are applied to your cluster. This involves creating [GitRepository](https://fluxcd.io/flux/components/source/gitrepositories/) resources from the corresponding `repository` and `sources`, as well as [Kustomizations](https://fluxcd.io/flux/components/kustomize/kustomizations/).
+When running `windsor up` or `windsor install`, all Kustomization resources are applied to your cluster. This involves creating [GitRepository](https://fluxcd.io/flux/components/source/gitrepositories/) resources from the corresponding `repository` and `sources`, as well as [Kustomizations](https://fluxcd.io/flux/components/kustomize/kustomizations/).
 
 You can observe these resources on your cluster by running the following commands,
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -67,7 +67,7 @@ windsor context get
 Start the local environment and install the default local blueprint, run:
 
 ```sh
-windsor up --install
+windsor up
 ```
 
 This command will start appropriate docker containers, run kubernetes nodes and support services with docker compose, and bootstrap your cluster using Terraform. It can take up to 5 minutes to fully launch, so be patient!

--- a/integration/fixtures/up/contexts/_template/blueprint.yaml
+++ b/integration/fixtures/up/contexts/_template/blueprint.yaml
@@ -1,0 +1,4 @@
+kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: up

--- a/integration/fixtures/up/windsor.yaml
+++ b/integration/fixtures/up/windsor.yaml
@@ -1,0 +1,3 @@
+version: v1alpha1
+contexts:
+  staging: {}

--- a/integration/up_test.go
+++ b/integration/up_test.go
@@ -1,0 +1,64 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/windsorcli/cli/integration/helpers"
+)
+
+// =============================================================================
+// Integration Tests
+// =============================================================================
+
+// TestUp_NoOpWhenWorkstationDisabled verifies that windsor up exits successfully
+// and prints a descriptive message when no workstation is configured.
+func TestUp_NoOpWhenWorkstationDisabled(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "up")
+	_, stderr, err := helpers.RunCLI(dir, []string{"init", "staging"}, env)
+	if err != nil {
+		t.Fatalf("init staging: %v\nstderr: %s", err, stderr)
+	}
+	env = append(env, "WINDSOR_CONTEXT=staging")
+	_, stderr, err = helpers.RunCLI(dir, []string{"up"}, env)
+	if err != nil {
+		t.Fatalf("expected no-op success when workstation is disabled, got error: %v\nstderr: %s", err, stderr)
+	}
+	if !strings.Contains(string(stderr), "workstation") {
+		t.Errorf("expected stderr to mention 'workstation', got: %s", stderr)
+	}
+}
+
+// TestUp_FailsWhenNotInTrustedDirectory verifies that windsor up rejects runs
+// outside a trusted directory.
+func TestUp_FailsWhenNotInTrustedDirectory(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "up")
+	_, stderr, err := helpers.RunCLI(dir, []string{"up"}, env)
+	if err == nil {
+		t.Fatal("expected failure but command succeeded")
+	}
+	if !strings.Contains(string(stderr), "trusted") {
+		t.Errorf("expected stderr to mention 'trusted', got: %s", stderr)
+	}
+}
+
+// TestUp_AcceptsWaitFlag verifies that --wait is a recognised flag and does not
+// cause an "unknown flag" error in the no-op path.
+func TestUp_AcceptsWaitFlag(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "up")
+	_, stderr, err := helpers.RunCLI(dir, []string{"init", "staging"}, env)
+	if err != nil {
+		t.Fatalf("init staging: %v\nstderr: %s", err, stderr)
+	}
+	env = append(env, "WINDSOR_CONTEXT=staging")
+	_, stderr, err = helpers.RunCLI(dir, []string{"up", "--wait"}, env)
+	if err != nil {
+		t.Fatalf("expected --wait to be accepted, got error: %v\nstderr: %s", err, stderr)
+	}
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes `windsor up` CLI semantics by removing `--install`, always running blueprint install, and turning non-workstation contexts into a no-op, which may break existing scripts and workflows. Impact is limited to the local environment bring-up path and related docs/tests.
> 
> **Overview**
> **`windsor up` is simplified to a workstation-only workflow.** The command now exits successfully with a message when no workstation is enabled, instead of proceeding with infrastructure-only setup.
> 
> `--install` is removed and blueprint installation now always runs after `proj.Up()`, while `--wait` remains as an optional post-install wait. Unit tests and docs are updated accordingly, and new integration fixtures/tests cover the no-op behavior, trusted-directory failure, and `--wait` flag acceptance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 212feb5a98cd8bce6a6417e892c678b441755c3f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->