### PR TITLE
feat(cmd): Add windsor show values

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,11 +58,11 @@ func commandPreflight(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// prepareProject creates and initializes a project for the given command. It reads any test
-// overrides from the command context, sets shell verbosity, checks for a trusted directory,
-// configures the project, and runs initialization. Commands that need additional steps between
-// Configure and Initialize (e.g. ValidateContextValues) should not use this helper.
-func prepareProject(cmd *cobra.Command) (*project.Project, error) {
+// configureProject creates a project for the given command and runs setup through Configure.
+// It reads any test overrides from the command context, sets shell verbosity, checks for a
+// trusted directory, and configures the project. Commands that need additional steps after
+// Configure (e.g. ComposeBlueprint, GetContextValues) call this directly.
+func configureProject(cmd *cobra.Command) (*project.Project, error) {
 	var opts []*project.Project
 	if overridesVal := cmd.Context().Value(projectOverridesKey); overridesVal != nil {
 		opts = []*project.Project{overridesVal.(*project.Project)}
@@ -73,6 +73,18 @@ func prepareProject(cmd *cobra.Command) (*project.Project, error) {
 		return nil, fmt.Errorf("not in a trusted directory. If you are in a Windsor project, run 'windsor init' to approve")
 	}
 	if err := proj.Configure(nil); err != nil {
+		return nil, err
+	}
+	return proj, nil
+}
+
+// prepareProject creates and fully initializes a project for the given command. It delegates
+// setup through Configure to configureProject, then runs Initialize. Commands that need
+// additional steps between Configure and Initialize (e.g. ValidateContextValues) should not
+// use this helper — call configureProject directly instead.
+func prepareProject(cmd *cobra.Command) (*project.Project, error) {
+	proj, err := configureProject(cmd)
+	if err != nil {
 		return nil, err
 	}
 	if err := proj.Initialize(false); err != nil {

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -11,7 +11,6 @@ import (
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	blueprintcomposer "github.com/windsorcli/cli/pkg/composer/blueprint"
 	"github.com/windsorcli/cli/pkg/constants"
-	"github.com/windsorcli/cli/pkg/project"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 )
 
@@ -133,20 +132,8 @@ func init() {
 // composition errors. Composition errors are non-fatal and allow the blueprint to be returned for
 // inspection when possible.
 func getBlueprint(cmd *cobra.Command) (*blueprintv1alpha1.Blueprint, map[string]bool, error) {
-	var opts []*project.Project
-	if overridesVal := cmd.Context().Value(projectOverridesKey); overridesVal != nil {
-		opts = []*project.Project{overridesVal.(*project.Project)}
-	}
-
-	proj := project.NewProject("", opts...)
-
-	proj.Runtime.Shell.SetVerbosity(verbose)
-
-	if err := proj.Runtime.Shell.CheckTrustedDirectory(); err != nil {
-		return nil, nil, fmt.Errorf("not in a trusted directory. If you are in a Windsor project, run 'windsor init' to approve")
-	}
-
-	if err := proj.Configure(nil); err != nil {
+	proj, err := configureProject(cmd)
+	if err != nil {
 		return nil, nil, err
 	}
 
@@ -210,20 +197,8 @@ func errKustomizationNotFound(name string) error {
 // complete set of configuration values available for use in blueprint processing. No files are written
 // or terraform modules processed. Returns values, schema (may be nil), and any error.
 func getValues(cmd *cobra.Command) (map[string]any, map[string]any, error) {
-	var opts []*project.Project
-	if overridesVal := cmd.Context().Value(projectOverridesKey); overridesVal != nil {
-		opts = []*project.Project{overridesVal.(*project.Project)}
-	}
-
-	proj := project.NewProject("", opts...)
-
-	proj.Runtime.Shell.SetVerbosity(verbose)
-
-	if err := proj.Runtime.Shell.CheckTrustedDirectory(); err != nil {
-		return nil, nil, fmt.Errorf("not in a trusted directory. If you are in a Windsor project, run 'windsor init' to approve")
-	}
-
-	if err := proj.Configure(nil); err != nil {
+	proj, err := configureProject(cmd)
+	if err != nil {
 		return nil, nil, err
 	}
 

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -12,12 +12,14 @@ import (
 	blueprintcomposer "github.com/windsorcli/cli/pkg/composer/blueprint"
 	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/project"
+	"github.com/windsorcli/cli/pkg/runtime/config"
 )
 
 var showBlueprintJSON bool
 var showBlueprintRaw bool
 var showKustomizationJSON bool
 var showKustomizationRaw bool
+var showValuesJSON bool
 
 var showCmd = &cobra.Command{
 	Use:   "show",
@@ -89,13 +91,35 @@ var showKustomizationCmd = &cobra.Command{
 	},
 }
 
+var showValuesCmd = &cobra.Command{
+	Use:          "values",
+	Short:        "Display the effective context values",
+	Long:         "Display the effective context values to stdout, combining schema defaults with values.yaml overrides. YAML output includes schema descriptions as comments. Use --json for plain JSON.",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		values, schema, err := getValues(cmd)
+		if err != nil {
+			return err
+		}
+
+		if showValuesJSON {
+			return outputResource(values, true, "values")
+		}
+
+		fmt.Print(config.RenderValuesWithDescriptions(values, schema))
+		return nil
+	},
+}
+
 func init() {
 	showBlueprintCmd.Flags().BoolVar(&showBlueprintJSON, "json", false, "Output as JSON instead of YAML")
 	showBlueprintCmd.Flags().BoolVar(&showBlueprintRaw, "raw", false, "Output unresolved deferred values as expression text instead of <deferred>")
 	showKustomizationCmd.Flags().BoolVar(&showKustomizationJSON, "json", false, "Output as JSON instead of YAML")
 	showKustomizationCmd.Flags().BoolVar(&showKustomizationRaw, "raw", false, "Output unresolved deferred values as expression text instead of <deferred>")
+	showValuesCmd.Flags().BoolVar(&showValuesJSON, "json", false, "Output as JSON instead of YAML")
 	showCmd.AddCommand(showBlueprintCmd)
 	showCmd.AddCommand(showKustomizationCmd)
+	showCmd.AddCommand(showValuesCmd)
 	rootCmd.AddCommand(showCmd)
 }
 
@@ -179,6 +203,37 @@ func findKustomization(blueprint *blueprintv1alpha1.Blueprint, name string) *blu
 // errKustomizationNotFound returns a formatted error for when a kustomization is not found.
 func errKustomizationNotFound(name string) error {
 	return fmt.Errorf("kustomization %q not found in blueprint", name)
+}
+
+// getValues configures the project and returns the effective context values and loaded schema without
+// running full initialization. It merges schema defaults with values.yaml overrides, providing the
+// complete set of configuration values available for use in blueprint processing. No files are written
+// or terraform modules processed. Returns values, schema (may be nil), and any error.
+func getValues(cmd *cobra.Command) (map[string]any, map[string]any, error) {
+	var opts []*project.Project
+	if overridesVal := cmd.Context().Value(projectOverridesKey); overridesVal != nil {
+		opts = []*project.Project{overridesVal.(*project.Project)}
+	}
+
+	proj := project.NewProject("", opts...)
+
+	proj.Runtime.Shell.SetVerbosity(verbose)
+
+	if err := proj.Runtime.Shell.CheckTrustedDirectory(); err != nil {
+		return nil, nil, fmt.Errorf("not in a trusted directory. If you are in a Windsor project, run 'windsor init' to approve")
+	}
+
+	if err := proj.Configure(nil); err != nil {
+		return nil, nil, err
+	}
+
+	values, err := proj.Runtime.ConfigHandler.GetContextValues()
+	if err != nil {
+		return nil, nil, fmt.Errorf("failed to get context values: %w", err)
+	}
+
+	schema := proj.Runtime.ConfigHandler.GetSchema()
+	return values, schema, nil
 }
 
 // buildFluxKustomization converts a blueprint Kustomization to a Flux Kustomization resource.

--- a/cmd/show_test.go
+++ b/cmd/show_test.go
@@ -442,6 +442,295 @@ func TestShowBlueprintCmd(t *testing.T) {
 	})
 }
 
+func TestShowValuesCmd(t *testing.T) {
+	createTestCmd := func() *cobra.Command {
+		showValuesJSON = false
+		cmd := &cobra.Command{
+			Use:          "values",
+			Short:        "Display the effective context values",
+			RunE:         showValuesCmd.RunE,
+			SilenceUsage: true,
+		}
+
+		showValuesCmd.Flags().VisitAll(func(flag *pflag.Flag) {
+			cmd.Flags().AddFlag(flag)
+		})
+
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
+		return cmd
+	}
+
+	setupOutput := func(t *testing.T) (*bytes.Buffer, func()) {
+		t.Helper()
+		stdout := new(bytes.Buffer)
+
+		oldStdout := os.Stdout
+		rStdout, wStdout, _ := os.Pipe()
+		os.Stdout = wStdout
+
+		done := make(chan struct{})
+		go func() {
+			io.Copy(stdout, rStdout)
+			rStdout.Close()
+			close(done)
+		}()
+
+		t.Cleanup(func() {
+			wStdout.Close()
+			<-done
+			os.Stdout = oldStdout
+		})
+
+		return stdout, func() {
+			wStdout.Close()
+			<-done
+		}
+	}
+
+	t.Run("SuccessWithYAMLAndDescriptions", func(t *testing.T) {
+		mocks := setupShowTest(t)
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"provider": "docker", "dev": true}, nil
+		}
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetSchemaFunc = func() map[string]any {
+			return map[string]any{
+				"$schema": "https://windsorcli.dev/schema/2026-02/schema",
+				"type":    "object",
+				"properties": map[string]any{
+					"provider": map[string]any{
+						"type":        "string",
+						"description": "Cloud or platform provider.",
+					},
+				},
+			}
+		}
+
+		proj := project.NewProject("", &project.Project{
+			Runtime: mocks.Runtime,
+		})
+
+		stdout, closePipes := setupOutput(t)
+
+		cmd := createTestCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{})
+		_ = cmd.Execute()
+
+		closePipes()
+
+		output := stdout.String()
+		if output == "" {
+			t.Error("Expected non-empty stdout output")
+		}
+		if !strings.Contains(output, "# Cloud or platform provider.") {
+			t.Errorf("Expected description comment in output, got:\n%s", output)
+		}
+		if !strings.Contains(output, "provider: docker") {
+			t.Errorf("Expected provider value in output, got:\n%s", output)
+		}
+	})
+
+	t.Run("SchemaOnlyFieldsRenderedCommentedOut", func(t *testing.T) {
+		mocks := setupShowTest(t)
+		// values has gateway.enabled but not gateway.driver (no default in schema)
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{
+				"gateway": map[string]any{"enabled": true},
+			}, nil
+		}
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetSchemaFunc = func() map[string]any {
+			return map[string]any{
+				"$schema": "https://windsorcli.dev/schema/2026-02/schema",
+				"type":    "object",
+				"properties": map[string]any{
+					"gateway": map[string]any{
+						"type":        "object",
+						"description": "Gateway configuration.",
+						"properties": map[string]any{
+							"enabled": map[string]any{
+								"type":        "boolean",
+								"description": "Enable gateway.",
+							},
+							"driver": map[string]any{
+								"type":        "string",
+								"description": "Gateway driver.",
+							},
+						},
+					},
+				},
+			}
+		}
+
+		proj := project.NewProject("", &project.Project{
+			Runtime: mocks.Runtime,
+		})
+
+		stdout, closePipes := setupOutput(t)
+
+		cmd := createTestCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{})
+		_ = cmd.Execute()
+
+		closePipes()
+
+		output := stdout.String()
+		if !strings.Contains(output, "enabled: true") {
+			t.Errorf("Expected enabled value in output, got:\n%s", output)
+		}
+		if !strings.Contains(output, "# Gateway driver.") {
+			t.Errorf("Expected driver description comment in output, got:\n%s", output)
+		}
+		if !strings.Contains(output, "# driver:") {
+			t.Errorf("Expected commented-out driver field in output, got:\n%s", output)
+		}
+	})
+
+	t.Run("SuccessWithYAMLNoSchema", func(t *testing.T) {
+		mocks := setupShowTest(t)
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"provider": "docker"}, nil
+		}
+
+		proj := project.NewProject("", &project.Project{
+			Runtime: mocks.Runtime,
+		})
+
+		stdout, closePipes := setupOutput(t)
+
+		cmd := createTestCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{})
+		_ = cmd.Execute()
+
+		closePipes()
+
+		output := stdout.String()
+		if output == "" {
+			t.Error("Expected non-empty stdout output")
+		}
+		if !strings.Contains(output, "provider: docker") {
+			t.Errorf("Expected provider value in output, got:\n%s", output)
+		}
+		if strings.Contains(output, "#") {
+			t.Errorf("Expected no comments when schema is absent, got:\n%s", output)
+		}
+	})
+
+	t.Run("SuccessWithJSONOutput", func(t *testing.T) {
+		mocks := setupShowTest(t)
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"provider": "aws"}, nil
+		}
+
+		proj := project.NewProject("", &project.Project{
+			Runtime: mocks.Runtime,
+		})
+
+		stdout, closePipes := setupOutput(t)
+
+		cmd := createTestCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"--json"})
+		_ = cmd.Execute()
+
+		closePipes()
+
+		output := stdout.String()
+		if output == "" {
+			t.Error("Expected non-empty stdout output")
+		}
+
+		var values map[string]any
+		if err := json.Unmarshal([]byte(output), &values); err != nil {
+			t.Errorf("Expected valid JSON output, got error: %v", err)
+		}
+		if values["provider"] != "aws" {
+			t.Errorf("Expected provider 'aws', got %v", values["provider"])
+		}
+		if strings.Contains(output, "#") {
+			t.Errorf("Expected no comments in JSON output, got:\n%s", output)
+		}
+	})
+
+	t.Run("CheckTrustedDirectoryError", func(t *testing.T) {
+		mocks := setupShowTest(t)
+		mocks.Shell.CheckTrustedDirectoryFunc = func() error {
+			return fmt.Errorf("not in trusted directory")
+		}
+
+		proj := project.NewProject("", &project.Project{
+			Runtime: mocks.Runtime,
+		})
+
+		cmd := createTestCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{})
+		err := cmd.Execute()
+
+		if err == nil {
+			t.Error("Expected error, got nil")
+			return
+		}
+		if !strings.Contains(err.Error(), "not in a trusted directory") {
+			t.Errorf("Expected trusted directory error, got: %v", err)
+		}
+	})
+
+	t.Run("GetContextValuesError", func(t *testing.T) {
+		mocks := setupShowTest(t)
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetContextValuesFunc = func() (map[string]any, error) {
+			return nil, fmt.Errorf("schema load failure")
+		}
+
+		proj := project.NewProject("", &project.Project{
+			Runtime: mocks.Runtime,
+		})
+
+		cmd := createTestCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{})
+		err := cmd.Execute()
+
+		if err == nil {
+			t.Error("Expected error, got nil")
+			return
+		}
+		if !strings.Contains(err.Error(), "failed to get context values") {
+			t.Errorf("Expected context values error, got: %v", err)
+		}
+	})
+
+	t.Run("CommandInitialization", func(t *testing.T) {
+		cmd := showValuesCmd
+
+		if cmd.Use != "values" {
+			t.Errorf("Expected Use to be 'values', got %q", cmd.Use)
+		}
+		if cmd.Short == "" {
+			t.Error("Expected non-empty Short description")
+		}
+		if cmd.Long == "" {
+			t.Error("Expected non-empty Long description")
+		}
+
+		jsonFlag := cmd.Flags().Lookup("json")
+		if jsonFlag == nil {
+			t.Error("Expected --json flag to be defined")
+		}
+		if jsonFlag.Usage == "" {
+			t.Error("Expected non-empty flag usage")
+		}
+	})
+}
+
 func TestShowKustomizationCmd(t *testing.T) {
 	createTestCmd := func() *cobra.Command {
 		showKustomizationJSON = false

--- a/integration/show_test.go
+++ b/integration/show_test.go
@@ -11,6 +11,50 @@ import (
 	"github.com/windsorcli/cli/integration/helpers"
 )
 
+func TestShowValues_DefaultFixture(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "default")
+	env = append(env, "WINDSOR_CONTEXT=default")
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"show", "values"}, env)
+	if err != nil {
+		t.Fatalf("show values: %v\nstderr: %s", err, stderr)
+	}
+	output := string(stdout)
+	// Output must be parseable as YAML (comments are stripped by the parser)
+	var values map[string]any
+	if err := yaml.Unmarshal(stdout, &values); err != nil {
+		t.Fatalf("parse values YAML: %v", err)
+	}
+	if values == nil {
+		t.Error("expected non-nil values map")
+	}
+	// Schema for the default fixture defines descriptions on provider, vm, workstation fields;
+	// at minimum the schema comment marker should appear if any described field is present.
+	if strings.Contains(output, "provider:") && !strings.Contains(output, "#") {
+		t.Errorf("expected description comments in output when schema is loaded, got:\n%s", output)
+	}
+}
+
+func TestShowValues_JSONFlag(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "default")
+	env = append(env, "WINDSOR_CONTEXT=default")
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"show", "values", "--json"}, env)
+	if err != nil {
+		t.Fatalf("show values --json: %v\nstderr: %s", err, stderr)
+	}
+	var values map[string]any
+	if err := yaml.Unmarshal(stdout, &values); err != nil {
+		t.Fatalf("parse values JSON: %v", err)
+	}
+	if values == nil {
+		t.Error("expected non-nil values map")
+	}
+	if strings.Contains(string(stdout), "#") {
+		t.Errorf("expected no comments in JSON output, got:\n%s", stdout)
+	}
+}
+
 func TestShowBlueprint_DefaultFixture(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.PrepareFixture(t, "default")

--- a/pkg/runtime/config/handler.go
+++ b/pkg/runtime/config/handler.go
@@ -48,6 +48,7 @@ type ConfigHandler interface {
 	GenerateContextID() error
 	LoadSchema(schemaPath string) error
 	LoadSchemaFromBytes(schemaContent []byte) error
+	GetSchema() map[string]any
 	GetContextValues() (map[string]any, error)
 	RegisterProvider(prefix string, provider ValueProvider)
 	ValidateContextValues() error
@@ -496,6 +497,23 @@ func (c *configHandler) Clean() error {
 // IsLoaded checks if the configuration has been loaded
 func (c *configHandler) IsLoaded() bool {
 	return c.loaded
+}
+
+// GetSchema returns a shallow copy of the loaded schema map, or nil if no schema is loaded.
+// A copy is returned so callers cannot mutate the validator's internal schema state.
+func (c *configHandler) GetSchema() map[string]any {
+	if c.schemaValidator == nil {
+		return nil
+	}
+	src := c.schemaValidator.Schema
+	if src == nil {
+		return nil
+	}
+	out := make(map[string]any, len(src))
+	for k, v := range src {
+		out[k] = v
+	}
+	return out
 }
 
 // LoadSchema loads the schema.yaml file from the specified directory.

--- a/pkg/runtime/config/mock_handler.go
+++ b/pkg/runtime/config/mock_handler.go
@@ -34,6 +34,7 @@ type MockConfigHandler struct {
 	GenerateContextIDFunc      func() error
 	LoadSchemaFunc             func(schemaPath string) error
 	LoadSchemaFromBytesFunc    func(schemaContent []byte) error
+	GetSchemaFunc              func() map[string]any
 	GetContextValuesFunc       func() (map[string]any, error)
 	RegisterProviderFunc       func(prefix string, provider ValueProvider)
 	ValidateContextValuesFunc  func() error
@@ -268,6 +269,14 @@ func (m *MockConfigHandler) LoadSchemaFromBytes(schemaContent []byte) error {
 		return m.LoadSchemaFromBytesFunc(schemaContent)
 	}
 	return fmt.Errorf("LoadSchemaFromBytesFunc not set")
+}
+
+// GetSchema calls the mock GetSchemaFunc if set, otherwise returns nil
+func (m *MockConfigHandler) GetSchema() map[string]any {
+	if m.GetSchemaFunc != nil {
+		return m.GetSchemaFunc()
+	}
+	return nil
 }
 
 // GetContextValues calls the mock GetContextValuesFunc if set, otherwise returns an error

--- a/pkg/runtime/config/values_renderer.go
+++ b/pkg/runtime/config/values_renderer.go
@@ -1,0 +1,165 @@
+package config
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/goccy/go-yaml"
+)
+
+// The ValuesRenderer produces annotated YAML for context values.
+// It walks the union of schema properties and effective values so that every
+// configurable field appears in the output. Keys present in the effective values
+// are rendered as normal YAML; schema-defined keys absent from effective values
+// are rendered as commented-out lines, making the output a complete reference template.
+
+// =============================================================================
+// Public Functions
+// =============================================================================
+
+// RenderValuesWithDescriptions renders context values as YAML annotated with schema descriptions.
+// It walks the union of schema properties and effective values so that every configurable field
+// appears in the output. Set keys render as normal YAML with description comments; unset
+// schema-defined keys render as commented-out reference lines. Top-level keys are separated
+// by blank lines. When schema is nil, values are rendered as plain YAML without comments.
+func RenderValuesWithDescriptions(values map[string]any, schema map[string]any) string {
+	return renderValuesBlock(values, schema, "")
+}
+
+// =============================================================================
+// Private Functions
+// =============================================================================
+
+// renderValuesBlock is the recursive implementation for RenderValuesWithDescriptions.
+// It accumulates output into a strings.Builder, delegating scalar and array formatting
+// to marshalKeyValue. The indent parameter tracks the current nesting depth.
+func renderValuesBlock(values map[string]any, schema map[string]any, indent string) string {
+	var sb strings.Builder
+
+	var schemaProps map[string]any
+	if schema != nil {
+		if props, ok := schema["properties"].(map[string]any); ok {
+			schemaProps = props
+		}
+	}
+
+	keys := sortedUnionKeys(values, schemaProps)
+	for i, key := range keys {
+		var val any
+		var inValues bool
+		if values != nil {
+			val, inValues = values[key]
+		}
+
+		var desc string
+		var propSchema map[string]any
+		if schemaProps != nil {
+			if raw, ok := schemaProps[key]; ok {
+				if ps, ok := raw.(map[string]any); ok {
+					propSchema = ps
+					if d, ok := ps["description"].(string); ok {
+						desc = strings.TrimSpace(d)
+					}
+				}
+			}
+		}
+
+		if inValues {
+			if desc != "" {
+				sb.WriteString(indent + "# " + desc + "\n")
+			}
+			switch v := val.(type) {
+			case map[string]any:
+				if len(v) == 0 {
+					sb.WriteString(indent + key + ": {}\n")
+				} else {
+					sb.WriteString(indent + key + ":\n")
+					sb.WriteString(renderValuesBlock(v, propSchema, indent+"  "))
+				}
+			case []any:
+				b, err := yaml.Marshal(val)
+				if err == nil {
+					sb.WriteString(indent + key + ":\n")
+					for _, line := range strings.Split(strings.TrimRight(string(b), "\n"), "\n") {
+						sb.WriteString(indent + "  " + line + "\n")
+					}
+				} else {
+					sb.WriteString(indent + key + ": []\n")
+				}
+			default:
+				_ = v
+				sb.WriteString(marshalKeyValue(key, val, indent))
+			}
+		} else {
+			// Key is defined in the schema but absent from effective values — render as a
+			// commented-out reference so users can discover it without reading the schema file.
+			propType, _ := propSchema["type"].(string)
+			if propType == "object" {
+				subContent := renderValuesBlock(nil, propSchema, indent+"  ")
+				if subContent != "" {
+					if desc != "" {
+						sb.WriteString(indent + "# " + desc + "\n")
+					}
+					sb.WriteString(indent + key + ":\n")
+					sb.WriteString(subContent)
+				} else {
+					// Object has no renderable sub-properties (e.g. additionalProperties-only) —
+					// show as a single commented-out key so the field remains discoverable.
+					if desc != "" {
+						sb.WriteString(indent + "# " + desc + "\n")
+					}
+					sb.WriteString(indent + "# " + key + ":\n")
+				}
+			} else {
+				if desc != "" {
+					sb.WriteString(indent + "# " + desc + "\n")
+				}
+				sb.WriteString(indent + "# " + key + ":\n")
+			}
+		}
+
+		if indent == "" && i < len(keys)-1 {
+			sb.WriteString("\n")
+		}
+	}
+
+	return sb.String()
+}
+
+// marshalKeyValue serializes a key-value pair as indented YAML, correctly handling
+// multi-line scalars by prefixing every output line with indent.
+func marshalKeyValue(key string, val any, indent string) string {
+	b, err := yaml.Marshal(map[string]any{key: val})
+	if err != nil {
+		return indent + key + ": " + fmt.Sprintf("%v", val) + "\n"
+	}
+	result := strings.TrimRight(string(b), "\n")
+	if indent == "" {
+		return result + "\n"
+	}
+	lines := strings.Split(result, "\n")
+	var sb strings.Builder
+	for _, line := range lines {
+		sb.WriteString(indent + line + "\n")
+	}
+	return sb.String()
+}
+
+// sortedUnionKeys returns the sorted union of keys from values and schemaProps.
+// Either argument may be nil; duplicates are deduplicated.
+func sortedUnionKeys(values, schemaProps map[string]any) []string {
+	seen := make(map[string]bool)
+	for k := range values {
+		seen[k] = true
+	}
+	for k := range schemaProps {
+		seen[k] = true
+	}
+	keys := make([]string, 0, len(seen))
+	for k := range seen {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/pkg/runtime/config/values_renderer_test.go
+++ b/pkg/runtime/config/values_renderer_test.go
@@ -1,0 +1,199 @@
+package config
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+)
+
+func TestRenderValuesWithDescriptions(t *testing.T) {
+	t.Run("ScalarWithDescription", func(t *testing.T) {
+		values := map[string]any{"provider": "docker"}
+		schema := map[string]any{
+			"properties": map[string]any{
+				"provider": map[string]any{
+					"type":        "string",
+					"description": "Cloud provider.",
+				},
+			},
+		}
+		out := RenderValuesWithDescriptions(values, schema)
+		if !strings.Contains(out, "# Cloud provider.") {
+			t.Errorf("expected description comment, got:\n%s", out)
+		}
+		if !strings.Contains(out, "provider: docker") {
+			t.Errorf("expected value line, got:\n%s", out)
+		}
+	})
+
+	t.Run("ScalarWithNoSchema", func(t *testing.T) {
+		values := map[string]any{"provider": "docker"}
+		out := RenderValuesWithDescriptions(values, nil)
+		if strings.Contains(out, "#") {
+			t.Errorf("expected no comments when schema is nil, got:\n%s", out)
+		}
+		if !strings.Contains(out, "provider: docker") {
+			t.Errorf("expected value line, got:\n%s", out)
+		}
+	})
+
+	t.Run("SchemaOnlyScalarRenderedCommentedOut", func(t *testing.T) {
+		values := map[string]any{"enabled": true}
+		schema := map[string]any{
+			"properties": map[string]any{
+				"enabled": map[string]any{"type": "boolean"},
+				"driver": map[string]any{
+					"type":        "string",
+					"description": "Gateway driver.",
+				},
+			},
+		}
+		out := RenderValuesWithDescriptions(values, schema)
+		if !strings.Contains(out, "enabled: true") {
+			t.Errorf("expected set value, got:\n%s", out)
+		}
+		if !strings.Contains(out, "# Gateway driver.") {
+			t.Errorf("expected description for unset field, got:\n%s", out)
+		}
+		if !strings.Contains(out, "# driver:") {
+			t.Errorf("expected commented-out unset field, got:\n%s", out)
+		}
+		if strings.Contains(out, "\ndriver:") {
+			t.Errorf("unset scalar should not appear as a live key, got:\n%s", out)
+		}
+	})
+
+	t.Run("NestedObjectWithMixedSetAndUnset", func(t *testing.T) {
+		values := map[string]any{
+			"gateway": map[string]any{"enabled": true},
+		}
+		schema := map[string]any{
+			"properties": map[string]any{
+				"gateway": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"enabled": map[string]any{"type": "boolean", "description": "Enable gateway."},
+						"driver":  map[string]any{"type": "string", "description": "Gateway driver."},
+					},
+				},
+			},
+		}
+		out := RenderValuesWithDescriptions(values, schema)
+		if !strings.Contains(out, "gateway:") {
+			t.Errorf("expected gateway block, got:\n%s", out)
+		}
+		if !strings.Contains(out, "enabled: true") {
+			t.Errorf("expected enabled value, got:\n%s", out)
+		}
+		if !strings.Contains(out, "# driver:") {
+			t.Errorf("expected commented-out driver, got:\n%s", out)
+		}
+	})
+
+	t.Run("SchemaOnlyObjectWithSubPropertiesShowsBlock", func(t *testing.T) {
+		values := map[string]any{}
+		schema := map[string]any{
+			"properties": map[string]any{
+				"cni": map[string]any{
+					"type":        "object",
+					"description": "CNI configuration.",
+					"properties": map[string]any{
+						"driver": map[string]any{"type": "string", "description": "CNI driver."},
+					},
+				},
+			},
+		}
+		out := RenderValuesWithDescriptions(values, schema)
+		if !strings.Contains(out, "cni:") {
+			t.Errorf("expected cni block to appear, got:\n%s", out)
+		}
+		if !strings.Contains(out, "# CNI driver.") {
+			t.Errorf("expected driver description, got:\n%s", out)
+		}
+		if !strings.Contains(out, "# driver:") {
+			t.Errorf("expected commented-out driver, got:\n%s", out)
+		}
+	})
+
+	t.Run("SchemaOnlyAdditionalPropertiesObjectRenderedAsCommentedKey", func(t *testing.T) {
+		values := map[string]any{}
+		schema := map[string]any{
+			"properties": map[string]any{
+				"registries": map[string]any{
+					"type":                 "object",
+					"description":          "Registry mirror config.",
+					"additionalProperties": map[string]any{"type": "object"},
+				},
+			},
+		}
+		out := RenderValuesWithDescriptions(values, schema)
+		if !strings.Contains(out, "# Registry mirror config.") {
+			t.Errorf("expected description comment, got:\n%s", out)
+		}
+		if !strings.Contains(out, "# registries:") {
+			t.Errorf("expected commented-out key, got:\n%s", out)
+		}
+	})
+
+	t.Run("ArrayValue", func(t *testing.T) {
+		values := map[string]any{
+			"volumes": []any{"/var/mnt/local"},
+		}
+		schema := map[string]any{
+			"properties": map[string]any{
+				"volumes": map[string]any{"type": "array", "description": "Mount paths."},
+			},
+		}
+		out := RenderValuesWithDescriptions(values, schema)
+		if !strings.Contains(out, "# Mount paths.") {
+			t.Errorf("expected array description, got:\n%s", out)
+		}
+		if !strings.Contains(out, "/var/mnt/local") {
+			t.Errorf("expected array item, got:\n%s", out)
+		}
+	})
+
+	t.Run("BooleanValue", func(t *testing.T) {
+		values := map[string]any{"dev": true}
+		out := RenderValuesWithDescriptions(values, nil)
+		if !strings.Contains(out, "dev: true") {
+			t.Errorf("expected boolean value, got:\n%s", out)
+		}
+	})
+
+	t.Run("TopLevelKeysSeparatedByBlankLines", func(t *testing.T) {
+		values := map[string]any{"a": "x", "b": "y"}
+		out := RenderValuesWithDescriptions(values, nil)
+		if !strings.Contains(out, "\n\n") {
+			t.Errorf("expected blank line between top-level keys, got:\n%s", out)
+		}
+	})
+
+	t.Run("EmptyValues", func(t *testing.T) {
+		out := RenderValuesWithDescriptions(map[string]any{}, nil)
+		if out != "" {
+			t.Errorf("expected empty output for empty values, got:\n%s", out)
+		}
+	})
+
+	t.Run("NilValues", func(t *testing.T) {
+		out := RenderValuesWithDescriptions(nil, nil)
+		if out != "" {
+			t.Errorf("expected empty output for nil values and schema, got:\n%s", out)
+		}
+	})
+
+	t.Run("MultiLineStringValue", func(t *testing.T) {
+		values := map[string]any{"script": "line1\nline2\nline3"}
+		out := RenderValuesWithDescriptions(values, nil)
+		// The output must be valid YAML — a round-trip parse must recover the original value.
+		var parsed map[string]any
+		if err := yaml.Unmarshal([]byte(out), &parsed); err != nil {
+			t.Fatalf("multi-line value produced invalid YAML: %v\noutput:\n%s", err, out)
+		}
+		if parsed["script"] != "line1\nline2\nline3" {
+			t.Errorf("expected multi-line string round-trip, got: %v", parsed["script"])
+		}
+	})
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Adds a new CLI surface and introduces a new `ConfigHandler.GetSchema()` API, which could impact any implementations/mocks and change how schema data is exposed to callers.
> 
> **Overview**
> Adds a new `windsor show values` subcommand to print the effective context values (schema defaults + `values.yaml` overrides), with `--json` support.
> 
> For YAML output, introduces `config.RenderValuesWithDescriptions()` to annotate values with schema `description` comments and to render schema-only fields as commented-out reference keys.
> 
> Refactors CLI project setup by splitting `prepareProject` into `configureProject` (Configure-only) and `prepareProject` (Configure + Initialize), and updates `show` helpers to use the shared Configure-only path. Extends `ConfigHandler`/mocks with `GetSchema()` to expose the loaded schema safely (shallow copy), and adds unit + integration tests covering the new command and renderer behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a6051063e90712928ae333d081f15a1707524ba4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->