### PR TITLE
feat(runtime/env): Inject TF_VAR_operation in to terraform environment

### DIFF
--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -323,6 +323,7 @@ func (s *TerraformStack) planComponents(blueprint *blueprintv1alpha1.Blueprint, 
 		if err != nil {
 			return err
 		}
+		terraformVars["TF_VAR_operation"] = "apply"
 
 		if err := s.runTerraformInit(component, terraformVars, terraformArgs); err != nil {
 			cleanup()
@@ -380,6 +381,7 @@ func (s *TerraformStack) Plan(blueprint *blueprintv1alpha1.Blueprint, componentI
 		return err
 	}
 	defer cleanup()
+	terraformVars["TF_VAR_operation"] = "apply"
 
 	if err := s.runTerraformInit(component, terraformVars, terraformArgs); err != nil {
 		return err
@@ -416,6 +418,7 @@ func (s *TerraformStack) PlanJSON(blueprint *blueprintv1alpha1.Blueprint, compon
 		return err
 	}
 	defer cleanup()
+	terraformVars["TF_VAR_operation"] = "apply"
 
 	if err := s.runTerraformInit(component, terraformVars, terraformArgs); err != nil {
 		return err
@@ -683,6 +686,7 @@ func (s *TerraformStack) planOneTerraformSummary(component *blueprintv1alpha1.Te
 		return result
 	}
 	defer cleanup()
+	terraformVars["TF_VAR_operation"] = "apply"
 
 	if err := s.runTerraformInit(component, terraformVars, terraformArgs); err != nil {
 		result.Err = err

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -151,6 +151,7 @@ func (s *TerraformStack) Up(blueprint *blueprintv1alpha1.Blueprint, onApply ...f
 			if err != nil {
 				return err
 			}
+			terraformVars["TF_VAR_operation"] = "apply"
 
 			backendOverridePath := filepath.Join(component.FullPath, "backend_override.tf")
 			if _, err := s.shims.Stat(backendOverridePath); err == nil {
@@ -262,6 +263,7 @@ func (s *TerraformStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint) erro
 			if err != nil {
 				return err
 			}
+			terraformVars["TF_VAR_operation"] = "destroy"
 
 			backendOverridePath := filepath.Join(component.FullPath, "backend_override.tf")
 			if _, err := s.shims.Stat(backendOverridePath); err == nil {
@@ -507,6 +509,7 @@ func (s *TerraformStack) Apply(blueprint *blueprintv1alpha1.Blueprint, component
 		return err
 	}
 	defer cleanup()
+	terraformVars["TF_VAR_operation"] = "apply"
 
 	if err := s.runTerraformInit(component, terraformVars, terraformArgs); err != nil {
 		return err
@@ -552,6 +555,7 @@ func (s *TerraformStack) Destroy(blueprint *blueprintv1alpha1.Blueprint, compone
 		return err
 	}
 	defer cleanup()
+	terraformVars["TF_VAR_operation"] = "destroy"
 
 	if err := s.runTerraformInit(component, terraformVars, terraformArgs); err != nil {
 		return err

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -1333,6 +1333,31 @@ func TestStack_Plan(t *testing.T) {
 		}
 	})
 
+	t.Run("SetsTFVarOperationToApply", func(t *testing.T) {
+		// Given a stack and a blueprint with a local component
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+
+		// When Plan is called, capture the env passed to terraform plan
+		var capturedEnv map[string]string
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 1 && args[1] == "plan" {
+				capturedEnv = env
+			}
+			return "", nil
+		}
+
+		_ = stack.Plan(blueprint, "local/path")
+
+		// Then TF_VAR_operation is "apply"
+		if capturedEnv == nil {
+			t.Fatal("Expected plan to be invoked")
+		}
+		if capturedEnv["TF_VAR_operation"] != "apply" {
+			t.Errorf("Expected TF_VAR_operation to be %q, got %q", "apply", capturedEnv["TF_VAR_operation"])
+		}
+	})
+
 }
 
 func TestStack_PlanAll(t *testing.T) {
@@ -1383,6 +1408,66 @@ func TestStack_PlanAll(t *testing.T) {
 		}
 		if planCalls != 2 {
 			t.Errorf("expected 2 plan calls, got %d", planCalls)
+		}
+	})
+
+	t.Run("SetsTFVarOperationToApply", func(t *testing.T) {
+		// Given a stack and a blueprint with a local component
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+
+		// When PlanAll is called, capture the env passed to terraform plan
+		var capturedEnv map[string]string
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 1 && args[1] == "plan" {
+				capturedEnv = env
+			}
+			return "", nil
+		}
+
+		_ = stack.PlanAll(blueprint)
+
+		// Then TF_VAR_operation is "apply"
+		if capturedEnv == nil {
+			t.Fatal("Expected plan to be invoked")
+		}
+		if capturedEnv["TF_VAR_operation"] != "apply" {
+			t.Errorf("Expected TF_VAR_operation to be %q, got %q", "apply", capturedEnv["TF_VAR_operation"])
+		}
+	})
+}
+
+func TestStack_PlanJSON(t *testing.T) {
+	setup := func(t *testing.T) (*TerraformStack, *TerraformTestMocks) {
+		t.Helper()
+		mocks := setupWindsorStackMocks(t)
+		stack := NewStack(mocks.Runtime).(*TerraformStack)
+		stack.shims = mocks.Shims
+		return stack, mocks
+	}
+
+	t.Run("SetsTFVarOperationToApply", func(t *testing.T) {
+		// Given a stack and a blueprint with a local component
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+
+		// When PlanJSON is called, capture the env passed to terraform plan
+		var capturedEnv map[string]string
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 1 && args[1] == "plan" {
+				capturedEnv = env
+			}
+			return "", nil
+		}
+
+		_ = stack.PlanJSON(blueprint, "local/path")
+
+		// Then TF_VAR_operation is "apply"
+		if capturedEnv == nil {
+			t.Fatal("Expected plan to be invoked")
+		}
+		if capturedEnv["TF_VAR_operation"] != "apply" {
+			t.Errorf("Expected TF_VAR_operation to be %q, got %q", "apply", capturedEnv["TF_VAR_operation"])
 		}
 	})
 }
@@ -2047,6 +2132,31 @@ func TestStack_PlanSummary(t *testing.T) {
 			if r.Err == nil {
 				t.Errorf("expected plan error for %q, got nil", r.ComponentID)
 			}
+		}
+	})
+
+	t.Run("SetsTFVarOperationToApply", func(t *testing.T) {
+		// Given a stack and a blueprint with a local component
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+
+		// When PlanSummary is called, capture the env passed to terraform plan
+		var capturedEnv map[string]string
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 1 && args[1] == "plan" {
+				capturedEnv = env
+			}
+			return "", nil
+		}
+
+		_ = stack.PlanSummary(blueprint)
+
+		// Then TF_VAR_operation is "apply"
+		if capturedEnv == nil {
+			t.Fatal("Expected plan to be invoked")
+		}
+		if capturedEnv["TF_VAR_operation"] != "apply" {
+			t.Errorf("Expected TF_VAR_operation to be %q, got %q", "apply", capturedEnv["TF_VAR_operation"])
 		}
 	})
 }

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -510,6 +510,32 @@ func TestStack_Up(t *testing.T) {
 		}
 	})
 
+	t.Run("SetsTFVarOperationToApply", func(t *testing.T) {
+		// Given a stack and a blueprint
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+
+		// When Up is called, capture the env passed to terraform plan
+		// (TF_VAR_* are included in the plan step, not apply, since apply uses a plan file)
+		var capturedEnv map[string]string
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 1 && args[1] == "plan" {
+				capturedEnv = env
+			}
+			return "", nil
+		}
+
+		_ = stack.Up(blueprint)
+
+		// Then TF_VAR_operation is "apply"
+		if capturedEnv == nil {
+			t.Fatal("Expected plan to be invoked")
+		}
+		if capturedEnv["TF_VAR_operation"] != "apply" {
+			t.Errorf("Expected TF_VAR_operation to be %q, got %q", "apply", capturedEnv["TF_VAR_operation"])
+		}
+	})
+
 }
 
 func TestStack_DestroyAll(t *testing.T) {
@@ -836,6 +862,31 @@ func TestStack_DestroyAll(t *testing.T) {
 
 		if err := stack.DestroyAll(blueprint); err != nil {
 			t.Errorf("Expected Down to succeed with named component with source, got %v", err)
+		}
+	})
+
+	t.Run("SetsTFVarOperationToDestroy", func(t *testing.T) {
+		// Given a stack and a blueprint
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+
+		// When DestroyAll is called, capture the env passed to terraform destroy
+		var capturedEnv map[string]string
+		mocks.Shell.ExecProgressWithEnvFunc = func(message string, command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 1 && args[1] == "destroy" {
+				capturedEnv = env
+			}
+			return "", nil
+		}
+
+		_ = stack.DestroyAll(blueprint)
+
+		// Then TF_VAR_operation is "destroy"
+		if capturedEnv == nil {
+			t.Fatal("Expected destroy to be invoked")
+		}
+		if capturedEnv["TF_VAR_operation"] != "destroy" {
+			t.Errorf("Expected TF_VAR_operation to be %q, got %q", "destroy", capturedEnv["TF_VAR_operation"])
 		}
 	})
 
@@ -1572,6 +1623,32 @@ func TestStack_Apply(t *testing.T) {
 			t.Errorf("Expected no error (cleanup is best-effort), got: %v", err)
 		}
 	})
+
+	t.Run("SetsTFVarOperationToApply", func(t *testing.T) {
+		// Given a stack and a blueprint with a local component
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+
+		// When Apply is called, capture the env passed to terraform plan
+		// (TF_VAR_* are included in the plan step, not apply, since apply uses a plan file)
+		var capturedEnv map[string]string
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 1 && args[1] == "plan" {
+				capturedEnv = env
+			}
+			return "", nil
+		}
+
+		_ = stack.Apply(blueprint, "local/path")
+
+		// Then TF_VAR_operation is "apply"
+		if capturedEnv == nil {
+			t.Fatal("Expected plan to be invoked")
+		}
+		if capturedEnv["TF_VAR_operation"] != "apply" {
+			t.Errorf("Expected TF_VAR_operation to be %q, got %q", "apply", capturedEnv["TF_VAR_operation"])
+		}
+	})
 }
 
 func TestStack_Destroy(t *testing.T) {
@@ -1797,6 +1874,31 @@ func TestStack_Destroy(t *testing.T) {
 		}
 		if !found {
 			t.Errorf("Expected refresh command to include -var-file=secrets.tfvars, got args: %v", refreshArgs)
+		}
+	})
+
+	t.Run("SetsTFVarOperationToDestroy", func(t *testing.T) {
+		// Given a stack and a blueprint with a local component
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+
+		// When Destroy is called, capture the env passed to terraform destroy
+		var capturedEnv map[string]string
+		mocks.Shell.ExecProgressWithEnvFunc = func(message string, command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 1 && args[1] == "destroy" {
+				capturedEnv = env
+			}
+			return "", nil
+		}
+
+		_ = stack.Destroy(blueprint, "local/path")
+
+		// Then TF_VAR_operation is "destroy"
+		if capturedEnv == nil {
+			t.Fatal("Expected destroy to be invoked")
+		}
+		if capturedEnv["TF_VAR_operation"] != "destroy" {
+			t.Errorf("Expected TF_VAR_operation to be %q, got %q", "destroy", capturedEnv["TF_VAR_operation"])
 		}
 	})
 }

--- a/pkg/runtime/env/terraform_env.go
+++ b/pkg/runtime/env/terraform_env.go
@@ -134,6 +134,7 @@ func (e *TerraformEnvPrinter) getEmptyEnvVars() map[string]string {
 		"TF_VAR_context_path",
 		"TF_VAR_context_id",
 		"TF_VAR_os_type",
+		"TF_VAR_operation",
 	}
 	if managedEnv := e.shims.Getenv("WINDSOR_MANAGED_ENV"); managedEnv != "" {
 		for _, key := range strings.Split(managedEnv, ",") {

--- a/pkg/runtime/env/terraform_env_test.go
+++ b/pkg/runtime/env/terraform_env_test.go
@@ -344,6 +344,35 @@ func TestTerraformEnv_GetEnvVars(t *testing.T) {
 		}
 	})
 
+	t.Run("ResetsTFVarOperationWhenNoProjectPathFound", func(t *testing.T) {
+		// Given a TerraformEnvPrinter outside a terraform project with TF_VAR_operation set
+		printer, mocks := setup(t)
+
+		mocks.Shims.LookupEnv = func(key string) (string, bool) {
+			if key == "TF_VAR_operation" {
+				return "apply", true
+			}
+			return "", false
+		}
+
+		mockProvider := setupMockTerraformProvider(mocks)
+		mockProvider.FindRelativeProjectPathFunc = func(directory ...string) (string, error) {
+			return "", nil
+		}
+		printer = setupTerraformEnvPrinter(t, mocks, mockProvider)
+
+		// When GetEnvVars is called
+		envVars, err := printer.GetEnvVars()
+
+		// Then TF_VAR_operation is reset to empty string
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if val, exists := envVars["TF_VAR_operation"]; !exists || val != "" {
+			t.Errorf("Expected TF_VAR_operation to be reset to empty string, got %q (exists=%v)", val, exists)
+		}
+	})
+
 	t.Run("ResetManagedDynamicTFVarsWhenNoProjectPathFound", func(t *testing.T) {
 		printer, mocks := setup(t)
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Touches Terraform execution paths by injecting a new `TF_VAR_operation` env var into all plan/apply/destroy flows; incorrect propagation could affect module behavior during provisioning.
> 
> **Overview**
> Adds a new Terraform environment variable, `TF_VAR_operation`, and sets it explicitly to `apply` or `destroy` across stack operations (`Up`, `Plan*`, `Apply`, `Destroy*`, and plan summaries) so modules can branch on the current operation.
> 
> Updates `TerraformEnvPrinter` to treat `TF_VAR_operation` as a managed TF var that is cleared when not in a Terraform project, and adds targeted tests asserting the env var is set/reset appropriately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e5e563b5a27475739b40b53a25e7d1c09001a7c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->