### PR TITLE
feat(composer/blueprint): Add common substitutions injection

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -897,8 +897,10 @@ func (k *Kustomization) DeepCopy() *Kustomization {
 // ToFluxKustomization converts a blueprint Kustomization to a Flux Kustomization.
 // It takes the namespace for the kustomization, the default source name to use if no source is specified,
 // and the list of sources to determine the source kind (GitRepository or OCIRepository).
+// An optional configMaps argument (blueprint-level ConfigMaps such as values-common) is added to
+// postBuild.substituteFrom so they are available to all kustomizations, matching what the provisioner applies.
 // PostBuild is constructed based on the kustomization's Substitutions field.
-func (k *Kustomization) ToFluxKustomization(namespace string, defaultSourceName string, sources []Source) kustomizev1.Kustomization {
+func (k *Kustomization) ToFluxKustomization(namespace string, defaultSourceName string, sources []Source, configMaps ...map[string]map[string]string) kustomizev1.Kustomization {
 	dependsOn := make([]kustomizev1.DependencyReference, len(k.DependsOn))
 	for idx, dep := range k.DependsOn {
 		dependsOn[idx] = kustomizev1.DependencyReference{
@@ -1000,6 +1002,20 @@ func (k *Kustomization) ToFluxKustomization(namespace string, defaultSourceName 
 					Optional: false,
 				},
 			},
+		}
+	}
+	if len(configMaps) > 0 && len(configMaps[0]) > 0 {
+		if postBuild == nil {
+			postBuild = &kustomizev1.PostBuild{
+				SubstituteFrom: make([]kustomizev1.SubstituteReference, 0),
+			}
+		}
+		for name := range configMaps[0] {
+			postBuild.SubstituteFrom = append(postBuild.SubstituteFrom, kustomizev1.SubstituteReference{
+				Kind:     "ConfigMap",
+				Name:     name,
+				Optional: false,
+			})
 		}
 	}
 

--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -291,6 +291,11 @@ type Blueprint struct {
 	// Kustomizations are kustomization configs in the blueprint.
 	Kustomizations []Kustomization `yaml:"kustomize,omitempty"`
 
+	// Substitutions are top-level key/value pairs evaluated with facet scope and injected into
+	// values-common, making them available to all kustomizations via PostBuild substitution.
+	// Values may use expression syntax (e.g. "${dns.domain}") resolved against facet config blocks.
+	Substitutions map[string]string `yaml:"substitutions,omitempty"`
+
 	// ConfigMaps are standalone ConfigMaps to be created, not tied to specific kustomizations.
 	// These ConfigMaps are referenced by all kustomizations in PostBuild substitution.
 	ConfigMaps map[string]map[string]string `yaml:"configMaps,omitempty"`
@@ -643,6 +648,7 @@ func (b *Blueprint) DeepCopy() *Blueprint {
 		Sources:             sourcesCopy,
 		TerraformComponents: terraformComponentsCopy,
 		Kustomizations:      kustomizationsCopy,
+		Substitutions:       maps.Clone(b.Substitutions),
 		ConfigMaps:          configMapsCopy,
 	}
 }
@@ -707,6 +713,13 @@ func (b *Blueprint) StrategicMerge(overlays ...*Blueprint) error {
 			if err := b.strategicMergeKustomization(overlayK); err != nil {
 				return err
 			}
+		}
+
+		if overlay.Substitutions != nil {
+			if b.Substitutions == nil {
+				b.Substitutions = make(map[string]string)
+			}
+			maps.Copy(b.Substitutions, overlay.Substitutions)
 		}
 
 		if overlay.ConfigMaps != nil {

--- a/api/v1alpha1/blueprint_types_test.go
+++ b/api/v1alpha1/blueprint_types_test.go
@@ -1289,6 +1289,57 @@ func TestBlueprint_StrategicMerge(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("MergesTopLevelSubstitutionsFromNilBase", func(t *testing.T) {
+		// Given a base blueprint with no Substitutions and an overlay with values
+		base := &Blueprint{}
+		overlay := &Blueprint{
+			Substitutions: map[string]string{
+				"private_dns": "10.0.0.1",
+				"public_dns":  "8.8.8.8",
+			},
+		}
+
+		// When strategic merging
+		base.StrategicMerge(overlay)
+
+		// Then base should have the overlay substitutions
+		if base.Substitutions == nil {
+			t.Fatal("Expected Substitutions to be initialized")
+		}
+		if base.Substitutions["private_dns"] != "10.0.0.1" {
+			t.Errorf("Expected private_dns='10.0.0.1', got '%s'", base.Substitutions["private_dns"])
+		}
+		if base.Substitutions["public_dns"] != "8.8.8.8" {
+			t.Errorf("Expected public_dns='8.8.8.8', got '%s'", base.Substitutions["public_dns"])
+		}
+	})
+
+	t.Run("OverlaySubstitutionsOverrideBase", func(t *testing.T) {
+		// Given a base blueprint with Substitutions and an overlay with overlapping key
+		base := &Blueprint{
+			Substitutions: map[string]string{
+				"private_dns": "base-value",
+				"keep_me":     "unchanged",
+			},
+		}
+		overlay := &Blueprint{
+			Substitutions: map[string]string{
+				"private_dns": "overlay-value",
+			},
+		}
+
+		// When strategic merging
+		base.StrategicMerge(overlay)
+
+		// Then overlay wins on conflicts, base keys not in overlay are preserved
+		if base.Substitutions["private_dns"] != "overlay-value" {
+			t.Errorf("Expected overlay to win, got '%s'", base.Substitutions["private_dns"])
+		}
+		if base.Substitutions["keep_me"] != "unchanged" {
+			t.Errorf("Expected base-only key to be preserved, got '%s'", base.Substitutions["keep_me"])
+		}
+	})
 }
 
 func TestBlueprint_ReplaceTerraformComponent(t *testing.T) {
@@ -3713,6 +3764,33 @@ func TestBlueprint_DeepCopy_WithNewFields(t *testing.T) {
 		}
 		if copy.Kustomizations[0].Enabled.Value == nil || *copy.Kustomizations[0].Enabled.Value {
 			t.Error("Expected Enabled to be false in copy")
+		}
+	})
+
+	t.Run("CopiesTopLevelSubstitutions", func(t *testing.T) {
+		// Given a blueprint with top-level Substitutions
+		blueprint := &Blueprint{
+			Substitutions: map[string]string{
+				"private_dns": "10.0.0.1",
+				"public_dns":  "8.8.8.8",
+			},
+		}
+
+		// When deep copying
+		copy := blueprint.DeepCopy()
+
+		// Then the copy should have the same values
+		if copy.Substitutions == nil {
+			t.Fatal("Expected Substitutions to be copied")
+		}
+		if copy.Substitutions["private_dns"] != "10.0.0.1" {
+			t.Errorf("Expected private_dns='10.0.0.1', got '%s'", copy.Substitutions["private_dns"])
+		}
+
+		// And mutating the copy must not affect the original
+		copy.Substitutions["private_dns"] = "mutated"
+		if blueprint.Substitutions["private_dns"] != "10.0.0.1" {
+			t.Error("Deep copy failed: mutating copy affected original Substitutions map")
 		}
 	})
 }

--- a/api/v1alpha1/facet_types.go
+++ b/api/v1alpha1/facet_types.go
@@ -2,7 +2,10 @@
 // +groupName=blueprints.windsorcli.dev
 package v1alpha1
 
-import "fmt"
+import (
+	"fmt"
+	"maps"
+)
 
 // =============================================================================
 // Types
@@ -64,6 +67,11 @@ type Facet struct {
 
 	// Kustomizations are kustomization configs in the facet.
 	Kustomizations []ConditionalKustomization `yaml:"kustomize,omitempty"`
+
+	// Substitutions are top-level key/value pairs evaluated with facet scope and injected into
+	// values-common, making them available to all kustomizations via PostBuild substitution.
+	// Values may use expression syntax (e.g. "${dns.domain}") resolved against facet config blocks.
+	Substitutions map[string]string `yaml:"substitutions,omitempty"`
 }
 
 // ConditionalTerraformComponent extends TerraformComponent with conditional logic support.
@@ -225,6 +233,7 @@ func (f *Facet) DeepCopy() *Facet {
 		Config:              configCopy,
 		TerraformComponents: terraformComponentsCopy,
 		Kustomizations:      kustomizationsCopy,
+		Substitutions:       maps.Clone(f.Substitutions),
 	}
 }
 

--- a/api/v1alpha1/facet_types_test.go
+++ b/api/v1alpha1/facet_types_test.go
@@ -106,6 +106,14 @@ func TestFacetDeepCopy(t *testing.T) {
 			t.Error("Deep copy failed: kustomization substitutions map was not copied")
 		}
 
+		// Verify top-level Substitutions independence (set after initial copy to test the map)
+		original.Substitutions = map[string]string{"dns": "10.0.0.1"}
+		copy2 := original.DeepCopy()
+		original.Substitutions["dns"] = "mutated"
+		if copy2.Substitutions["dns"] != "10.0.0.1" {
+			t.Error("Deep copy failed: top-level Substitutions map was not copied independently")
+		}
+
 		if len(copy.Config) != len(original.Config) {
 			t.Error("Deep copy failed: config slice length mismatch")
 		}

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -211,9 +211,11 @@ func getValues(cmd *cobra.Command) (map[string]any, map[string]any, error) {
 	return values, schema, nil
 }
 
-// buildFluxKustomization converts a blueprint Kustomization to a Flux Kustomization resource.
+// buildFluxKustomization converts a blueprint Kustomization to a Flux Kustomization resource,
+// including blueprint-level ConfigMaps (e.g. values-common) in postBuild.substituteFrom to
+// match what the kubernetes manager applies to the cluster.
 func buildFluxKustomization(blueprint *blueprintv1alpha1.Blueprint, kustomization *blueprintv1alpha1.Kustomization) kustomizev1.Kustomization {
 	defaultSourceName := blueprint.Metadata.Name
 	namespace := constants.DefaultFluxSystemNamespace
-	return kustomization.ToFluxKustomization(namespace, defaultSourceName, blueprint.Sources)
+	return kustomization.ToFluxKustomization(namespace, defaultSourceName, blueprint.Sources, blueprint.ConfigMaps)
 }

--- a/pkg/composer/blueprint/composer.go
+++ b/pkg/composer/blueprint/composer.go
@@ -240,6 +240,9 @@ func (c *BaseBlueprintComposer) dropEmptyCompositionFragments(blueprint *bluepri
 			pruneEmptyValue(blueprint.TerraformComponents[i].Inputs)
 		}
 	}
+	if blueprint.Substitutions != nil {
+		pruneEmptyValue(blueprint.Substitutions)
+	}
 	if blueprint.ConfigMaps != nil {
 		for _, m := range blueprint.ConfigMaps {
 			if m != nil {

--- a/pkg/composer/blueprint/composer.go
+++ b/pkg/composer/blueprint/composer.go
@@ -404,6 +404,10 @@ func (c *BaseBlueprintComposer) applyCommonSubstitutions(blueprint *blueprintv1a
 		}
 	}
 
+	for k, v := range blueprint.Substitutions {
+		mergedCommonValues[k] = v
+	}
+
 	if c.runtime != nil && c.runtime.ConfigHandler != nil {
 		values, err := c.runtime.ConfigHandler.GetContextValues()
 		if err == nil {

--- a/pkg/composer/blueprint/composer_test.go
+++ b/pkg/composer/blueprint/composer_test.go
@@ -1503,6 +1503,59 @@ func TestComposer_applyCommonSubstitutions(t *testing.T) {
 			t.Error("Expected ConfigMaps to be nil")
 		}
 	})
+
+	t.Run("IncludesBlueprintSubstitutionsInValuesCommon", func(t *testing.T) {
+		// Given a blueprint with top-level Substitutions (set by the processor from facets)
+		mocks := setupComposerMocks(t)
+		composer := NewBlueprintComposer(mocks.Runtime)
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Substitutions: map[string]string{
+				"private_dns": "10.0.0.1",
+				"public_dns":  "8.8.8.8",
+			},
+		}
+
+		// When applying common substitutions
+		composer.applyCommonSubstitutions(blueprint)
+
+		// Then values-common should contain the blueprint-level substitutions
+		common := blueprint.ConfigMaps["values-common"]
+		if common["private_dns"] != "10.0.0.1" {
+			t.Errorf("Expected private_dns='10.0.0.1', got '%s'", common["private_dns"])
+		}
+		if common["public_dns"] != "8.8.8.8" {
+			t.Errorf("Expected public_dns='8.8.8.8', got '%s'", common["public_dns"])
+		}
+	})
+
+	t.Run("ValuesYamlOverridesBlueprintSubstitutions", func(t *testing.T) {
+		// Given a blueprint with Substitutions and values.yaml with a conflicting key
+		mocks := setupComposerMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{
+				"substitutions": map[string]any{
+					"common": map[string]any{
+						"private_dns": "user-override",
+					},
+				},
+			}, nil
+		}
+		composer := NewBlueprintComposer(mocks.Runtime)
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Substitutions: map[string]string{
+				"private_dns": "blueprint-default",
+			},
+		}
+
+		// When applying common substitutions
+		composer.applyCommonSubstitutions(blueprint)
+
+		// Then values.yaml should win over blueprint-level substitutions
+		common := blueprint.ConfigMaps["values-common"]
+		if common["private_dns"] != "user-override" {
+			t.Errorf("Expected values.yaml to override blueprint substitutions, got '%s'", common["private_dns"])
+		}
+	})
 }
 
 func TestComposer_mergeLegacySpecialVariables(t *testing.T) {

--- a/pkg/composer/blueprint/composer_test.go
+++ b/pkg/composer/blueprint/composer_test.go
@@ -2492,6 +2492,30 @@ func TestComposer_dropEmptyCompositionFragments(t *testing.T) {
 			t.Errorf("Expected KEEP='v', got %q", common["KEEP"])
 		}
 	})
+
+	t.Run("PrunesTopLevelSubstitutionsEmptyKeysAndValues", func(t *testing.T) {
+		mocks := setupComposerMocks(t)
+		composer := NewBlueprintComposer(mocks.Runtime)
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Substitutions: map[string]string{
+				"keep":        "10.0.0.1",
+				"drop_empty":  "",
+				"":            "empty-key",
+			},
+		}
+
+		composer.dropEmptyCompositionFragments(blueprint)
+
+		if _, hasEmpty := blueprint.Substitutions[""]; hasEmpty {
+			t.Error("Expected empty key to be removed from Substitutions")
+		}
+		if _, hasDrop := blueprint.Substitutions["drop_empty"]; hasDrop {
+			t.Error("Expected key with empty value to be removed from Substitutions")
+		}
+		if blueprint.Substitutions["keep"] != "10.0.0.1" {
+			t.Errorf("Expected keep='10.0.0.1', got %q", blueprint.Substitutions["keep"])
+		}
+	})
 }
 
 // =============================================================================

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -241,6 +241,21 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 				target.Substitutions = make(map[string]string)
 			}
 			maps.Copy(target.Substitutions, evaluated)
+			facetOrd := resolvedFacetOrdinal(facet)
+			sn := ""
+			if len(sourceName) > 0 {
+				sn = sourceName[0]
+			}
+			for key, rawVal := range facet.Substitutions {
+				p.recordTrace("substitutions."+key, TraceContribution{
+					FacetPath:  facet.Path,
+					SourceName: sn,
+					Ordinal:    facetOrd,
+					Strategy:   "merge",
+					Line:       yamlNodeLine(facet.Path, "substitutions", key),
+					RawValue:   deepCopyValue(rawVal),
+				})
+			}
 			for key, isDeferred := range deferredKeys {
 				if isDeferred {
 					p.markDeferredPath("substitutions." + key)

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -232,6 +232,16 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 		if err := p.collectKustomizations(facet, sourceName, kustomizationByName, scope); err != nil {
 			return nil, nil, err
 		}
+		if len(facet.Substitutions) > 0 {
+			evaluated, _, err := p.evaluateSubstitutions(facet.Substitutions, facet.Path, scope)
+			if err != nil {
+				return nil, nil, fmt.Errorf("error evaluating substitutions for facet '%s': %w", facet.Metadata.Name, err)
+			}
+			if target.Substitutions == nil {
+				target.Substitutions = make(map[string]string)
+			}
+			maps.Copy(target.Substitutions, evaluated)
+		}
 	}
 
 	if err := p.applyCollectedComponents(target, terraformByID, kustomizationByName, scope); err != nil {

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -233,7 +233,7 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 			return nil, nil, err
 		}
 		if len(facet.Substitutions) > 0 {
-			evaluated, _, err := p.evaluateSubstitutions(facet.Substitutions, facet.Path, scope)
+			evaluated, deferredKeys, err := p.evaluateSubstitutions(facet.Substitutions, facet.Path, scope)
 			if err != nil {
 				return nil, nil, fmt.Errorf("error evaluating substitutions for facet '%s': %w", facet.Metadata.Name, err)
 			}
@@ -241,6 +241,11 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 				target.Substitutions = make(map[string]string)
 			}
 			maps.Copy(target.Substitutions, evaluated)
+			for key, isDeferred := range deferredKeys {
+				if isDeferred {
+					p.markDeferredPath("substitutions." + key)
+				}
+			}
 		}
 	}
 

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -1619,6 +1619,145 @@ func TestProcessor_ProcessFacets_Config(t *testing.T) {
 	})
 }
 
+func TestProcessor_ProcessFacets_Substitutions(t *testing.T) {
+	t.Run("CollectsStaticFacetSubstitutionsIntoTarget", func(t *testing.T) {
+		// Given a facet with top-level substitutions
+		mocks := setupProcessorMocks(t)
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "dns"},
+				Substitutions: map[string]string{
+					"private_dns": "10.0.0.1",
+					"public_dns":  "8.8.8.8",
+				},
+			},
+		}
+
+		// When processing facets
+		_, _, err := processor.ProcessFacets(target, facets)
+
+		// Then target.Substitutions should contain the facet values
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if target.Substitutions == nil {
+			t.Fatal("Expected target.Substitutions to be initialized")
+		}
+		if target.Substitutions["private_dns"] != "10.0.0.1" {
+			t.Errorf("Expected private_dns='10.0.0.1', got '%s'", target.Substitutions["private_dns"])
+		}
+		if target.Substitutions["public_dns"] != "8.8.8.8" {
+			t.Errorf("Expected public_dns='8.8.8.8', got '%s'", target.Substitutions["public_dns"])
+		}
+	})
+
+	t.Run("EvaluatesFacetSubstitutionExpressionsWithConfigScope", func(t *testing.T) {
+		// Given a facet with config block and substitution expression referencing it
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "dns"},
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{
+						Name: "dns",
+						Body: map[string]any{
+							"value": map[string]any{
+								"private": "10.0.0.1",
+								"public":  "8.8.8.8",
+							},
+						},
+					},
+				},
+				Substitutions: map[string]string{
+					"private_dns": "${dns.private}",
+					"public_dns":  "${dns.public}",
+				},
+			},
+		}
+
+		// When processing facets
+		_, _, err := processor.ProcessFacets(target, facets)
+
+		// Then substitution expressions should be evaluated against config scope
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if target.Substitutions["private_dns"] != "10.0.0.1" {
+			t.Errorf("Expected private_dns='10.0.0.1', got '%s'", target.Substitutions["private_dns"])
+		}
+		if target.Substitutions["public_dns"] != "8.8.8.8" {
+			t.Errorf("Expected public_dns='8.8.8.8', got '%s'", target.Substitutions["public_dns"])
+		}
+	})
+
+	t.Run("LaterOrdinalFacetSubstitutionsOverrideEarlier", func(t *testing.T) {
+		// Given two facets with overlapping substitution keys, higher ordinal wins
+		mocks := setupProcessorMocks(t)
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		lowOrdinal := 100
+		highOrdinal := 200
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata:      blueprintv1alpha1.Metadata{Name: "base"},
+				Ordinal:       &lowOrdinal,
+				Substitutions: map[string]string{"private_dns": "base-value"},
+			},
+			{
+				Metadata:      blueprintv1alpha1.Metadata{Name: "override"},
+				Ordinal:       &highOrdinal,
+				Substitutions: map[string]string{"private_dns": "override-value"},
+			},
+		}
+
+		// When processing facets
+		_, _, err := processor.ProcessFacets(target, facets)
+
+		// Then the higher-ordinal facet's value should win
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if target.Substitutions["private_dns"] != "override-value" {
+			t.Errorf("Expected private_dns='override-value', got '%s'", target.Substitutions["private_dns"])
+		}
+	})
+
+	t.Run("ExcludesFacetSubstitutionsWhenFacetConditionFalse", func(t *testing.T) {
+		// Given a facet with a false when condition
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"enabled": false}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata:      blueprintv1alpha1.Metadata{Name: "conditional"},
+				When:          "enabled == true",
+				Substitutions: map[string]string{"private_dns": "10.0.0.1"},
+			},
+		}
+
+		// When processing facets
+		_, _, err := processor.ProcessFacets(target, facets)
+
+		// Then substitutions from excluded facet should not appear
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if target.Substitutions != nil && target.Substitutions["private_dns"] != "" {
+			t.Errorf("Expected private_dns to be absent, got '%s'", target.Substitutions["private_dns"])
+		}
+	})
+}
+
 func TestProcessor_mergeHelpers(t *testing.T) {
 	t.Run("deepMergeMapMergesNestedMaps", func(t *testing.T) {
 		base := map[string]any{"a": 1, "b": map[string]any{"x": 10}}

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -1756,6 +1756,41 @@ func TestProcessor_ProcessFacets_Substitutions(t *testing.T) {
 			t.Errorf("Expected private_dns to be absent, got '%s'", target.Substitutions["private_dns"])
 		}
 	})
+
+	t.Run("RecordsTraceForEachSubstitutionKey", func(t *testing.T) {
+		// Given a facet with static substitutions and a trace collector attached
+		mocks := setupProcessorMocks(t)
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		tc := NewTraceCollector()
+		processor.SetTraceCollector(tc)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "dns"},
+				Substitutions: map[string]string{
+					"private_dns": "10.0.0.1",
+					"public_dns":  "8.8.8.8",
+				},
+			},
+		}
+
+		// When processing facets
+		_, _, err := processor.ProcessFacets(target, facets)
+		tc.Finalize(target, nil, "")
+
+		// Then the trace collector should have a contribution for each substitution key
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		tracePrivate, errPrivate := tc.GetTrace("substitutions.private_dns")
+		if errPrivate != nil || tracePrivate == nil {
+			t.Errorf("Expected trace for substitutions.private_dns, got err=%v trace=%v", errPrivate, tracePrivate)
+		}
+		tracePublic, errPublic := tc.GetTrace("substitutions.public_dns")
+		if errPublic != nil || tracePublic == nil {
+			t.Errorf("Expected trace for substitutions.public_dns, got err=%v trace=%v", errPublic, tracePublic)
+		}
+	})
 }
 
 func TestProcessor_mergeHelpers(t *testing.T) {

--- a/pkg/composer/blueprint/render.go
+++ b/pkg/composer/blueprint/render.go
@@ -65,6 +65,11 @@ func applyDeferredPathsToBlueprint(bp *blueprintv1alpha1.Blueprint, deferredPath
 			}
 		}
 	}
+	for key := range bp.Substitutions {
+		if deferredPaths["substitutions."+key] {
+			bp.Substitutions[key] = deferredPlaceholder
+		}
+	}
 	for i := range bp.Kustomizations {
 		name := bp.Kustomizations[i].Name
 		if deferredPaths["kustomize."+name+".path"] {

--- a/pkg/composer/blueprint/render_test.go
+++ b/pkg/composer/blueprint/render_test.go
@@ -1,0 +1,74 @@
+package blueprint
+
+import (
+	"testing"
+
+	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+)
+
+// =============================================================================
+// Test Public Methods
+// =============================================================================
+
+func TestRenderDeferredPlaceholders(t *testing.T) {
+	t.Run("ReturnsResourceUnchangedWhenRawMode", func(t *testing.T) {
+		bp := &blueprintv1alpha1.Blueprint{
+			Substitutions: map[string]string{"key": "${unresolved}"},
+		}
+		result := RenderDeferredPlaceholders(bp, true, map[string]bool{"substitutions.key": true})
+		got := result.(*blueprintv1alpha1.Blueprint)
+		if got.Substitutions["key"] != "${unresolved}" {
+			t.Errorf("Expected raw value preserved, got '%s'", got.Substitutions["key"])
+		}
+	})
+
+	t.Run("ReturnsResourceUnchangedWhenNoDeferredPaths", func(t *testing.T) {
+		bp := &blueprintv1alpha1.Blueprint{
+			Substitutions: map[string]string{"key": "${unresolved}"},
+		}
+		result := RenderDeferredPlaceholders(bp, false, nil)
+		got := result.(*blueprintv1alpha1.Blueprint)
+		if got.Substitutions["key"] != "${unresolved}" {
+			t.Errorf("Expected value unchanged with empty deferred paths, got '%s'", got.Substitutions["key"])
+		}
+	})
+
+	t.Run("RewritesDeferredTopLevelSubstitutionToPlaceholder", func(t *testing.T) {
+		// Given a blueprint with a deferred top-level substitution
+		bp := &blueprintv1alpha1.Blueprint{
+			Substitutions: map[string]string{
+				"private_dns": "${dns.private}",
+				"public_dns":  "8.8.8.8",
+			},
+		}
+		deferredPaths := map[string]bool{"substitutions.private_dns": true}
+
+		// When rendering deferred placeholders
+		result := RenderDeferredPlaceholders(bp, false, deferredPaths)
+
+		// Then the deferred key becomes <deferred> and the resolved key is unchanged
+		got := result.(*blueprintv1alpha1.Blueprint)
+		if got.Substitutions["private_dns"] != deferredPlaceholder {
+			t.Errorf("Expected deferred substitution to be '%s', got '%s'", deferredPlaceholder, got.Substitutions["private_dns"])
+		}
+		if got.Substitutions["public_dns"] != "8.8.8.8" {
+			t.Errorf("Expected resolved substitution to be unchanged, got '%s'", got.Substitutions["public_dns"])
+		}
+	})
+
+	t.Run("DoesNotMutateOriginalBlueprint", func(t *testing.T) {
+		// Given a blueprint with a deferred substitution
+		bp := &blueprintv1alpha1.Blueprint{
+			Substitutions: map[string]string{"private_dns": "${dns.private}"},
+		}
+		deferredPaths := map[string]bool{"substitutions.private_dns": true}
+
+		// When rendering
+		RenderDeferredPlaceholders(bp, false, deferredPaths)
+
+		// Then the original blueprint is not mutated
+		if bp.Substitutions["private_dns"] != "${dns.private}" {
+			t.Errorf("Original blueprint was mutated: got '%s'", bp.Substitutions["private_dns"])
+		}
+	})
+}

--- a/pkg/composer/blueprint/trace.go
+++ b/pkg/composer/blueprint/trace.go
@@ -25,6 +25,7 @@ const (
 	ExplainPathKindKustomizeSubstitution
 	ExplainPathKindKustomizeComponents
 	ExplainPathKindConfigMap
+	ExplainPathKindSubstitution
 )
 
 // =============================================================================
@@ -278,6 +279,12 @@ func (c *DefaultTraceCollector) GetTrace(pathStr string) (*ExplainTrace, error) 
 		trace.Value = val
 		trace.Contributions = []ExplainContribution{{SourceName: "composition (runtime config)", Effective: true}}
 
+	case ExplainPathKindSubstitution:
+		if bp.Substitutions != nil {
+			trace.Value = bp.Substitutions[p.Key]
+		}
+		trace.Contributions = c.buildContributions("substitutions." + p.Key)
+
 	default:
 		return nil, errors.New("unknown path kind")
 	}
@@ -298,6 +305,8 @@ func (p ExplainPath) String() string {
 		return fmt.Sprintf("kustomize.%s.components", p.Segment)
 	case ExplainPathKindConfigMap:
 		return fmt.Sprintf("configMaps.%s.%s", p.Segment, p.Key)
+	case ExplainPathKindSubstitution:
+		return fmt.Sprintf("substitutions.%s", p.Key)
 	default:
 		return ""
 	}
@@ -352,8 +361,16 @@ func ParseExplainPath(path string) (ExplainPath, error) {
 			Segment: parts[1],
 			Key:     strings.Join(parts[2:], "."),
 		}, nil
+	case "substitutions":
+		if len(parts) < 2 {
+			return ExplainPath{}, fmt.Errorf("invalid substitutions path %q: expected substitutions.<key>", path)
+		}
+		return ExplainPath{
+			Kind: ExplainPathKindSubstitution,
+			Key:  strings.Join(parts[1:], "."),
+		}, nil
 	default:
-		return ExplainPath{}, fmt.Errorf("invalid path %q: must start with terraform., kustomize., or configMaps.", path)
+		return ExplainPath{}, fmt.Errorf("invalid path %q: must start with terraform., kustomize., configMaps., or substitutions.", path)
 	}
 }
 

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -738,28 +738,13 @@ func (k *BaseKubernetesManager) ApplyBlueprint(blueprint *blueprintv1alpha1.Blue
 				return fmt.Errorf("failed to create ConfigMap for kustomization %s: %w", kustomization.Name, err)
 			}
 		}
-		fluxKustomization := kustomization.ToFluxKustomization(namespace, defaultSourceName, blueprint.Sources)
+		fluxKustomization := kustomization.ToFluxKustomization(namespace, defaultSourceName, blueprint.Sources, blueprint.ConfigMaps)
 
 		fluxKustomization.Spec.CommonMetadata = &kustomizev1.CommonMetadata{
 			Labels: map[string]string{
 				"windsorcli.dev/context":    k.configHandler.GetContext(),
 				"windsorcli.dev/context-id": k.configHandler.GetString("id"),
 			},
-		}
-
-		if len(blueprint.ConfigMaps) > 0 {
-			if fluxKustomization.Spec.PostBuild == nil {
-				fluxKustomization.Spec.PostBuild = &kustomizev1.PostBuild{
-					SubstituteFrom: make([]kustomizev1.SubstituteReference, 0),
-				}
-			}
-			for configMapName := range blueprint.ConfigMaps {
-				fluxKustomization.Spec.PostBuild.SubstituteFrom = append(fluxKustomization.Spec.PostBuild.SubstituteFrom, kustomizev1.SubstituteReference{
-					Kind:     "ConfigMap",
-					Name:     configMapName,
-					Optional: false,
-				})
-			}
 		}
 
 		if err := k.ApplyKustomization(fluxKustomization); err != nil {
@@ -1025,7 +1010,7 @@ func (k *BaseKubernetesManager) processDestroyOnlyKustomizations(kustomizations 
 			}
 		}
 
-		fluxKustomization := kustomization.ToFluxKustomization(namespace, defaultSourceName, blueprint.Sources)
+		fluxKustomization := kustomization.ToFluxKustomization(namespace, defaultSourceName, blueprint.Sources, blueprint.ConfigMaps)
 
 		fluxKustomization.Spec.CommonMetadata = &kustomizev1.CommonMetadata{
 			Labels: map[string]string{
@@ -1041,21 +1026,6 @@ func (k *BaseKubernetesManager) processDestroyOnlyKustomizations(kustomizations 
 			}
 		}
 		fluxKustomization.Spec.DependsOn = filteredDependsOn
-
-		if len(blueprint.ConfigMaps) > 0 {
-			if fluxKustomization.Spec.PostBuild == nil {
-				fluxKustomization.Spec.PostBuild = &kustomizev1.PostBuild{
-					SubstituteFrom: make([]kustomizev1.SubstituteReference, 0),
-				}
-			}
-			for configMapName := range blueprint.ConfigMaps {
-				fluxKustomization.Spec.PostBuild.SubstituteFrom = append(fluxKustomization.Spec.PostBuild.SubstituteFrom, kustomizev1.SubstituteReference{
-					Kind:     "ConfigMap",
-					Name:     configMapName,
-					Optional: false,
-				})
-			}
-		}
 
 		tui.Start(fmt.Sprintf("Applying destroy-only kustomization %s", kustomization.Name))
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes blueprint composition and Flux `Kustomization` generation by introducing and merging top-level substitutions and automatically wiring additional ConfigMaps into `postBuild.substituteFrom`, which can affect rendered manifests and override precedence.
> 
> **Overview**
> **Adds top-level `substitutions` support** on both `Facet` and `Blueprint`, including deep copy + strategic merge semantics (overlay keys override base).
> 
> During facet processing, facet `substitutions` are now evaluated against facet config scope, merged into the composed blueprint, traced per key (with deferred-path tracking), and rendered with `<deferred>` placeholders when needed.
> 
> Composer now injects composed blueprint `Substitutions` into the generated `values-common` ConfigMap (with runtime `values.yaml` overrides taking precedence) and prunes empty keys/values.
> 
> Flux `Kustomization` generation (`ToFluxKustomization`) now optionally includes blueprint-level ConfigMaps in `spec.postBuild.substituteFrom`; callers (`kubernetes_manager` and `cmd/show`) pass `blueprint.ConfigMaps`, and the previous provisioner-side postBuild mutation is removed. Trace `Explain` also gains `substitutions.<key>` path support.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87be156a76b52e8bbf626b45f512f4167f350fdd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->