### PR TITLE
fix(cmd): Deprecate --install flag

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -9,7 +9,8 @@ import (
 )
 
 var (
-	waitFlag bool // Declare the wait flag
+	waitFlag    bool // Declare the wait flag
+	installFlag bool // Deprecated: no-op, kept for backwards compatibility
 )
 
 var upCmd = &cobra.Command{
@@ -71,5 +72,7 @@ var upCmd = &cobra.Command{
 
 func init() {
 	upCmd.Flags().BoolVar(&waitFlag, "wait", false, "Wait for kustomization resources to be ready")
+	upCmd.Flags().BoolVar(&installFlag, "install", false, "")
+	_ = upCmd.Flags().MarkDeprecated("install", "the --install flag is no longer needed and will be removed in a future release")
 	rootCmd.AddCommand(upCmd)
 }

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -252,6 +252,24 @@ func TestUpCmd(t *testing.T) {
 		}
 	})
 
+	t.Run("DeprecatedInstallFlagIsNoOp", func(t *testing.T) {
+		// Given a project with a workstation configured
+		mocks := setupUpTest(t)
+		proj := newUpTestProject(mocks, true)
+
+		// When executing the up command with the deprecated --install flag
+		cmd := createTestUpCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"--install"})
+		err := cmd.Execute()
+
+		// Then no error should occur (flag is a no-op)
+		if err != nil {
+			t.Errorf("Expected success with deprecated --install flag, got error: %v", err)
+		}
+	})
+
 	t.Run("ProvisionerUpError", func(t *testing.T) {
 		// Given a terraform stack that fails during Up
 		mocks := setupUpTest(t)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Low risk: keeps existing behavior while only adding a deprecated, no-op CLI flag for backward compatibility plus a small test to ensure it doesn’t break `windsor up` invocations.
> 
> **Overview**
> `windsor up` now accepts a deprecated `--install` flag as a **no-op** (marked deprecated via Cobra) to preserve backward compatibility for older scripts.
> 
> Adds a unit test covering that `--install` does not change execution and still succeeds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 378120926250e9eba9d7185f565966063cb680ea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->