### PR TITLE
feat(cmd): Add --wait flag to windsor apply

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 )
 
 var applyWaitFlag bool // Wait for kustomization resources to be ready after applying
@@ -51,6 +52,10 @@ var applyKustomizeCmd = &cobra.Command{
 		}
 
 		blueprint := proj.Composer.BlueprintHandler.Generate()
+		if blueprint == nil {
+			return fmt.Errorf("blueprint is not available")
+		}
+		waitBlueprint := blueprint
 
 		if len(args) == 0 {
 			if err := proj.Provisioner.ApplyKustomizeAll(blueprint); err != nil {
@@ -61,10 +66,20 @@ var applyKustomizeCmd = &cobra.Command{
 			if err := proj.Provisioner.ApplyKustomize(blueprint, componentID); err != nil {
 				return fmt.Errorf("error applying kustomize for %s: %w", componentID, err)
 			}
+			// Narrow the wait scope to only the kustomization that was applied.
+			for _, k := range blueprint.Kustomizations {
+				if k.Name == componentID {
+					kCopy := k
+					filtered := *blueprint
+					filtered.Kustomizations = []blueprintv1alpha1.Kustomization{kCopy}
+					waitBlueprint = &filtered
+					break
+				}
+			}
 		}
 
 		if applyWaitFlag {
-			if err := proj.Provisioner.Wait(blueprint); err != nil {
+			if err := proj.Provisioner.Wait(waitBlueprint); err != nil {
 				return fmt.Errorf("error waiting for kustomizations: %w", err)
 			}
 		}

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -10,9 +10,37 @@ import (
 var applyWaitFlag bool // Wait for kustomization resources to be ready after applying
 
 var applyCmd = &cobra.Command{
-	Use:   "apply",
-	Short: "Apply infrastructure changes",
-	Long:  "Apply infrastructure changes for Windsor environment components.",
+	Use:          "apply",
+	Short:        "Apply infrastructure changes",
+	Long:         "Apply infrastructure changes for Windsor environment components by running Terraform and installing the blueprint.",
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		proj, err := prepareProject(cmd)
+		if err != nil {
+			return err
+		}
+
+		blueprint := proj.Composer.BlueprintHandler.Generate()
+		if blueprint == nil {
+			return fmt.Errorf("blueprint is not available")
+		}
+
+		if err := proj.Provisioner.Up(blueprint); err != nil {
+			return fmt.Errorf("error applying terraform: %w", err)
+		}
+
+		if err := proj.Provisioner.Install(blueprint); err != nil {
+			return fmt.Errorf("error applying kustomize: %w", err)
+		}
+
+		if applyWaitFlag {
+			if err := proj.Provisioner.Wait(blueprint); err != nil {
+				return fmt.Errorf("error waiting for kustomizations: %w", err)
+			}
+		}
+
+		return nil
+	},
 }
 
 var applyTerraformCmd = &cobra.Command{
@@ -89,6 +117,7 @@ var applyKustomizeCmd = &cobra.Command{
 }
 
 func init() {
+	applyCmd.Flags().BoolVar(&applyWaitFlag, "wait", false, "Wait for kustomization resources to be ready")
 	applyKustomizeCmd.Flags().BoolVar(&applyWaitFlag, "wait", false, "Wait for kustomization resources to be ready")
 	applyCmd.AddCommand(applyTerraformCmd)
 	applyCmd.AddCommand(applyKustomizeCmd)

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -6,6 +6,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var applyWaitFlag bool // Wait for kustomization resources to be ready after applying
+
 var applyCmd = &cobra.Command{
 	Use:   "apply",
 	Short: "Apply infrastructure changes",
@@ -54,12 +56,17 @@ var applyKustomizeCmd = &cobra.Command{
 			if err := proj.Provisioner.ApplyKustomizeAll(blueprint); err != nil {
 				return fmt.Errorf("error applying kustomize: %w", err)
 			}
-			return nil
+		} else {
+			componentID := args[0]
+			if err := proj.Provisioner.ApplyKustomize(blueprint, componentID); err != nil {
+				return fmt.Errorf("error applying kustomize for %s: %w", componentID, err)
+			}
 		}
 
-		componentID := args[0]
-		if err := proj.Provisioner.ApplyKustomize(blueprint, componentID); err != nil {
-			return fmt.Errorf("error applying kustomize for %s: %w", componentID, err)
+		if applyWaitFlag {
+			if err := proj.Provisioner.Wait(blueprint); err != nil {
+				return fmt.Errorf("error waiting for kustomizations: %w", err)
+			}
 		}
 
 		return nil
@@ -67,6 +74,7 @@ var applyKustomizeCmd = &cobra.Command{
 }
 
 func init() {
+	applyKustomizeCmd.Flags().BoolVar(&applyWaitFlag, "wait", false, "Wait for kustomization resources to be ready")
 	applyCmd.AddCommand(applyTerraformCmd)
 	applyCmd.AddCommand(applyKustomizeCmd)
 	rootCmd.AddCommand(applyCmd)

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -386,30 +386,81 @@ func TestApplyKustomizeCmd(t *testing.T) {
 		}
 	})
 
-	t.Run("SuccessWithWait", func(t *testing.T) {
-		// Given a properly configured apply kustomize command with --wait
+	t.Run("SuccessWithWaitAll", func(t *testing.T) {
+		t.Cleanup(func() { applyWaitFlag = false })
+		// Given a blueprint with multiple kustomizations and --wait but no name argument
 		mocks := setupApplyTest(t)
 		testBlueprint := &blueprintv1alpha1.Blueprint{
-			Metadata:       blueprintv1alpha1.Metadata{Name: "test"},
-			Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "my-app"}},
+			Metadata: blueprintv1alpha1.Metadata{Name: "test"},
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "app-a"},
+				{Name: "app-b"},
+			},
 		}
 		mocks.BlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint { return testBlueprint }
+		var waitedBlueprint *blueprintv1alpha1.Blueprint
+		mocks.KubernetesManager.WaitForKustomizationsFunc = func(message string, bp *blueprintv1alpha1.Blueprint) error {
+			waitedBlueprint = bp
+			return nil
+		}
 		proj := newApplyKustomizeProject(mocks)
 
-		// When executing the apply kustomize command with --wait
+		// When executing apply kustomize --wait with no name
 		cmd := createTestApplyKustomizeCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
 		cmd.SetArgs([]string{"--wait"})
 		cmd.SetContext(ctx)
 		err := cmd.Execute()
 
-		// Then no error should occur
+		// Then no error should occur and the full blueprint is waited on
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
+		}
+		if len(waitedBlueprint.Kustomizations) != 2 {
+			t.Errorf("Expected wait on full blueprint (2 kustomizations), got %d", len(waitedBlueprint.Kustomizations))
+		}
+	})
+
+	t.Run("SuccessWithWaitSingle", func(t *testing.T) {
+		t.Cleanup(func() { applyWaitFlag = false })
+		// Given a blueprint with multiple kustomizations and --wait with a specific name
+		mocks := setupApplyTest(t)
+		testBlueprint := &blueprintv1alpha1.Blueprint{
+			Metadata: blueprintv1alpha1.Metadata{Name: "test"},
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "app-a"},
+				{Name: "app-b"},
+			},
+		}
+		mocks.BlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint { return testBlueprint }
+		var waitedBlueprint *blueprintv1alpha1.Blueprint
+		mocks.KubernetesManager.WaitForKustomizationsFunc = func(message string, bp *blueprintv1alpha1.Blueprint) error {
+			waitedBlueprint = bp
+			return nil
+		}
+		proj := newApplyKustomizeProject(mocks)
+
+		// When executing apply kustomize app-a --wait
+		cmd := createTestApplyKustomizeCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"app-a", "--wait"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then no error should occur and only the named kustomization is waited on
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if len(waitedBlueprint.Kustomizations) != 1 {
+			t.Errorf("Expected wait on 1 kustomization, got %d", len(waitedBlueprint.Kustomizations))
+		}
+		if waitedBlueprint.Kustomizations[0].Name != "app-a" {
+			t.Errorf("Expected wait on app-a, got %s", waitedBlueprint.Kustomizations[0].Name)
 		}
 	})
 
 	t.Run("ErrorWaitFails", func(t *testing.T) {
+		t.Cleanup(func() { applyWaitFlag = false })
 		// Given a kubernetes manager whose WaitForKustomizations fails
 		mocks := setupApplyTest(t)
 		mocks.KubernetesManager.WaitForKustomizationsFunc = func(message string, blueprint *blueprintv1alpha1.Blueprint) error {
@@ -436,6 +487,59 @@ func TestApplyKustomizeCmd(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "error waiting for kustomizations") {
 			t.Errorf("Expected wait error, got: %v", err)
+		}
+	})
+
+	t.Run("ErrorWaitFailsSingle", func(t *testing.T) {
+		t.Cleanup(func() { applyWaitFlag = false })
+		// Given a kubernetes manager whose WaitForKustomizations fails on a named kustomization
+		mocks := setupApplyTest(t)
+		mocks.KubernetesManager.WaitForKustomizationsFunc = func(message string, blueprint *blueprintv1alpha1.Blueprint) error {
+			return fmt.Errorf("wait for kustomizations failed")
+		}
+		testBlueprint := &blueprintv1alpha1.Blueprint{
+			Metadata:       blueprintv1alpha1.Metadata{Name: "test"},
+			Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "my-app"}},
+		}
+		mocks.BlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint { return testBlueprint }
+		proj := newApplyKustomizeProject(mocks)
+
+		// When executing the apply kustomize command with a name and --wait
+		cmd := createTestApplyKustomizeCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"my-app", "--wait"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then an error should occur
+		if err == nil {
+			t.Error("Expected error, got nil")
+			return
+		}
+		if !strings.Contains(err.Error(), "error waiting for kustomizations") {
+			t.Errorf("Expected wait error, got: %v", err)
+		}
+	})
+
+	t.Run("ErrorNilBlueprint", func(t *testing.T) {
+		// Given a blueprint handler that returns nil
+		mocks := setupApplyTest(t)
+		mocks.BlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint { return nil }
+		proj := newApplyKustomizeProject(mocks)
+
+		// When executing the apply kustomize command
+		cmd := createTestApplyKustomizeCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then an error should occur
+		if err == nil {
+			t.Error("Expected error, got nil")
+			return
+		}
+		if !strings.Contains(err.Error(), "blueprint is not available") {
+			t.Errorf("Expected blueprint error, got: %v", err)
 		}
 	})
 }

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -87,6 +87,7 @@ func setupApplyTest(t *testing.T, opts ...*SetupOptions) *ApplyMocks {
 
 	mockKubernetesManager := kubernetes.NewMockKubernetesManager()
 	mockKubernetesManager.ApplyBlueprintFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) error { return nil }
+	mockKubernetesManager.WaitForKustomizationsFunc = func(message string, blueprint *blueprintv1alpha1.Blueprint) error { return nil }
 
 	rt := runtime.NewRuntime(&runtime.Runtime{
 		Shell:         baseMocks.Shell,
@@ -382,6 +383,59 @@ func TestApplyKustomizeCmd(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "error applying kustomize") {
 			t.Errorf("Expected apply error, got: %v", err)
+		}
+	})
+
+	t.Run("SuccessWithWait", func(t *testing.T) {
+		// Given a properly configured apply kustomize command with --wait
+		mocks := setupApplyTest(t)
+		testBlueprint := &blueprintv1alpha1.Blueprint{
+			Metadata:       blueprintv1alpha1.Metadata{Name: "test"},
+			Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "my-app"}},
+		}
+		mocks.BlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint { return testBlueprint }
+		proj := newApplyKustomizeProject(mocks)
+
+		// When executing the apply kustomize command with --wait
+		cmd := createTestApplyKustomizeCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--wait"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("ErrorWaitFails", func(t *testing.T) {
+		// Given a kubernetes manager whose WaitForKustomizations fails
+		mocks := setupApplyTest(t)
+		mocks.KubernetesManager.WaitForKustomizationsFunc = func(message string, blueprint *blueprintv1alpha1.Blueprint) error {
+			return fmt.Errorf("wait for kustomizations failed")
+		}
+		testBlueprint := &blueprintv1alpha1.Blueprint{
+			Metadata:       blueprintv1alpha1.Metadata{Name: "test"},
+			Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "my-app"}},
+		}
+		mocks.BlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint { return testBlueprint }
+		proj := newApplyKustomizeProject(mocks)
+
+		// When executing the apply kustomize command with --wait
+		cmd := createTestApplyKustomizeCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--wait"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then an error should occur
+		if err == nil {
+			t.Error("Expected error, got nil")
+			return
+		}
+		if !strings.Contains(err.Error(), "error waiting for kustomizations") {
+			t.Errorf("Expected wait error, got: %v", err)
 		}
 	})
 }

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -110,54 +110,185 @@ func setupApplyTest(t *testing.T, opts ...*SetupOptions) *ApplyMocks {
 	}
 }
 
-// newApplyProject wires mocks into a project for apply tests.
-func newApplyProject(mocks *ApplyMocks) *project.Project {
+// newApplyProjectWith wires mocks into a project using the given provisioner overrides.
+func newApplyProjectWith(mocks *ApplyMocks, overrides *provisioner.Provisioner) *project.Project {
 	comp := composer.NewComposer(mocks.Runtime)
 	comp.BlueprintHandler = mocks.BlueprintHandler
-	mockProvisioner := provisioner.NewProvisioner(mocks.Runtime, comp.BlueprintHandler, &provisioner.Provisioner{
-		TerraformStack: mocks.TerraformStack,
-	})
 	return project.NewProject("", &project.Project{
 		Runtime:     mocks.Runtime,
 		Composer:    comp,
-		Provisioner: mockProvisioner,
+		Provisioner: provisioner.NewProvisioner(mocks.Runtime, comp.BlueprintHandler, overrides),
 	})
 }
 
-// newApplyKustomizeProject wires mocks into a project for apply kustomize tests.
+func newApplyProject(mocks *ApplyMocks) *project.Project {
+	return newApplyProjectWith(mocks, &provisioner.Provisioner{TerraformStack: mocks.TerraformStack})
+}
+
 func newApplyKustomizeProject(mocks *ApplyMocks) *project.Project {
-	comp := composer.NewComposer(mocks.Runtime)
-	comp.BlueprintHandler = mocks.BlueprintHandler
-	mockProvisioner := provisioner.NewProvisioner(mocks.Runtime, comp.BlueprintHandler, &provisioner.Provisioner{
-		KubernetesManager: mocks.KubernetesManager,
-	})
-	return project.NewProject("", &project.Project{
-		Runtime:     mocks.Runtime,
-		Composer:    comp,
-		Provisioner: mockProvisioner,
-	})
+	return newApplyProjectWith(mocks, &provisioner.Provisioner{KubernetesManager: mocks.KubernetesManager})
+}
+
+func newApplyAllProject(mocks *ApplyMocks) *project.Project {
+	return newApplyProjectWith(mocks, &provisioner.Provisioner{TerraformStack: mocks.TerraformStack, KubernetesManager: mocks.KubernetesManager})
+}
+
+// makeApplyTestCmd clones source into a fresh isolated command for use in unit tests.
+func makeApplyTestCmd(source *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{Use: source.Use, RunE: source.RunE, Args: source.Args}
+	source.Flags().VisitAll(func(flag *pflag.Flag) { cmd.Flags().AddFlag(flag) })
+	cmd.SilenceUsage = true
+	cmd.SilenceErrors = true
+	cmd.SetOut(io.Discard)
+	cmd.SetErr(io.Discard)
+	return cmd
 }
 
 // =============================================================================
 // Test Cases
 // =============================================================================
 
-func TestApplyTerraformCmd(t *testing.T) {
-	createTestApplyTerraformCmd := func() *cobra.Command {
-		cmd := &cobra.Command{
-			Use:  "terraform",
-			RunE: applyTerraformCmd.RunE,
+func TestApplyCmd(t *testing.T) {
+	createTestApplyCmd := func() *cobra.Command { return makeApplyTestCmd(applyCmd) }
+
+	suppressProcessStdout(t)
+	suppressProcessStderr(t)
+
+	t.Run("Success", func(t *testing.T) {
+		// Given a properly configured apply command
+		mocks := setupApplyTest(t)
+		proj := newApplyAllProject(mocks)
+
+		// When executing the bare apply command
+		cmd := createTestApplyCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
 		}
-		applyTerraformCmd.Flags().VisitAll(func(flag *pflag.Flag) {
-			cmd.Flags().AddFlag(flag)
-		})
-		cmd.Args = applyTerraformCmd.Args
-		cmd.SilenceUsage = true
-		cmd.SilenceErrors = true
-		cmd.SetOut(io.Discard)
-		cmd.SetErr(io.Discard)
-		return cmd
-	}
+	})
+
+	t.Run("SuccessWithWait", func(t *testing.T) {
+		t.Cleanup(func() { applyWaitFlag = false })
+		// Given a properly configured apply command with --wait
+		mocks := setupApplyTest(t)
+		proj := newApplyAllProject(mocks)
+
+		// When executing the bare apply command with --wait
+		cmd := createTestApplyCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--wait"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("ErrorNilBlueprint", func(t *testing.T) {
+		// Given a blueprint handler that returns nil
+		mocks := setupApplyTest(t)
+		mocks.BlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint { return nil }
+		proj := newApplyAllProject(mocks)
+
+		// When executing the bare apply command
+		cmd := createTestApplyCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then an error should occur
+		if err == nil {
+			t.Error("Expected error, got nil")
+			return
+		}
+		if !strings.Contains(err.Error(), "blueprint is not available") {
+			t.Errorf("Expected blueprint error, got: %v", err)
+		}
+	})
+
+	t.Run("ErrorTerraformFails", func(t *testing.T) {
+		// Given a terraform stack whose Up fails
+		mocks := setupApplyTest(t)
+		mocks.TerraformStack.UpFunc = func(bp *blueprintv1alpha1.Blueprint, onApply ...func(id string) error) error {
+			return fmt.Errorf("terraform up failed")
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When executing the bare apply command
+		cmd := createTestApplyCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then an error should occur
+		if err == nil {
+			t.Error("Expected error, got nil")
+			return
+		}
+		if !strings.Contains(err.Error(), "error applying terraform") {
+			t.Errorf("Expected terraform error, got: %v", err)
+		}
+	})
+
+	t.Run("ErrorKustomizeFails", func(t *testing.T) {
+		// Given a kubernetes manager whose ApplyBlueprint fails
+		mocks := setupApplyTest(t)
+		mocks.KubernetesManager.ApplyBlueprintFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) error {
+			return fmt.Errorf("kustomize apply failed")
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When executing the bare apply command
+		cmd := createTestApplyCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then an error should occur
+		if err == nil {
+			t.Error("Expected error, got nil")
+			return
+		}
+		if !strings.Contains(err.Error(), "error applying kustomize") {
+			t.Errorf("Expected kustomize error, got: %v", err)
+		}
+	})
+
+	t.Run("ErrorWaitFails", func(t *testing.T) {
+		t.Cleanup(func() { applyWaitFlag = false })
+		// Given a kubernetes manager whose WaitForKustomizations fails
+		mocks := setupApplyTest(t)
+		mocks.KubernetesManager.WaitForKustomizationsFunc = func(message string, bp *blueprintv1alpha1.Blueprint) error {
+			return fmt.Errorf("wait failed")
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When executing the bare apply command with --wait
+		cmd := createTestApplyCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--wait"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then an error should occur
+		if err == nil {
+			t.Error("Expected error, got nil")
+			return
+		}
+		if !strings.Contains(err.Error(), "error waiting for kustomizations") {
+			t.Errorf("Expected wait error, got: %v", err)
+		}
+	})
+}
+
+func TestApplyTerraformCmd(t *testing.T) {
+	createTestApplyTerraformCmd := func() *cobra.Command { return makeApplyTestCmd(applyTerraformCmd) }
 
 	suppressProcessStdout(t)
 	suppressProcessStderr(t)
@@ -272,21 +403,7 @@ func TestApplyTerraformCmd(t *testing.T) {
 }
 
 func TestApplyKustomizeCmd(t *testing.T) {
-	createTestApplyKustomizeCmd := func() *cobra.Command {
-		cmd := &cobra.Command{
-			Use:  "kustomize",
-			RunE: applyKustomizeCmd.RunE,
-		}
-		applyKustomizeCmd.Flags().VisitAll(func(flag *pflag.Flag) {
-			cmd.Flags().AddFlag(flag)
-		})
-		cmd.Args = applyKustomizeCmd.Args
-		cmd.SilenceUsage = true
-		cmd.SilenceErrors = true
-		cmd.SetOut(io.Discard)
-		cmd.SetErr(io.Discard)
-		return cmd
-	}
+	createTestApplyKustomizeCmd := func() *cobra.Command { return makeApplyTestCmd(applyKustomizeCmd) }
 
 	suppressProcessStdout(t)
 	suppressProcessStderr(t)

--- a/integration/apply_test.go
+++ b/integration/apply_test.go
@@ -65,3 +65,18 @@ func TestApplyTerraform_FailsForNonexistentComponent(t *testing.T) {
 		t.Errorf("expected stderr to mention the component or an error, got: %s", stderr)
 	}
 }
+
+func TestApplyKustomize_AcceptsWaitFlag(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
+	if err != nil {
+		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
+	}
+	env = append(env, "WINDSOR_CONTEXT=local")
+	_, stderr, err = helpers.RunCLI(dir, []string{"apply", "kustomize", "--wait"}, env)
+	if strings.Contains(string(stderr), "unknown flag") {
+		t.Errorf("--wait should be a recognised flag, got: %s", stderr)
+	}
+	_ = err // failure is expected without a live cluster; the flag must be accepted
+}

--- a/integration/apply_test.go
+++ b/integration/apply_test.go
@@ -80,3 +80,18 @@ func TestApplyKustomize_AcceptsWaitFlag(t *testing.T) {
 	}
 	_ = err // failure is expected without a live cluster; the flag must be accepted
 }
+
+func TestApply_AcceptsWaitFlag(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
+	if err != nil {
+		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
+	}
+	env = append(env, "WINDSOR_CONTEXT=local")
+	_, stderr, err = helpers.RunCLI(dir, []string{"apply", "--wait"}, env)
+	if strings.Contains(string(stderr), "unknown flag") {
+		t.Errorf("--wait should be a recognised flag on apply, got: %s", stderr)
+	}
+	_ = err // may fail due to infrastructure not being available; flag must be accepted
+}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the core `apply` execution flow to run Terraform + kustomize and optionally block on Flux kustomization readiness, which can affect CLI behavior and runtime in real environments. Risk is limited by small scope and added unit/integration coverage, but touches infrastructure orchestration paths.
> 
> **Overview**
> **`windsor apply` now performs a full apply and can optionally wait for readiness.** The top-level `apply` command has been upgraded to run Terraform (`Provisioner.Up`), install the blueprint (`Provisioner.Install`), and when `--wait` is set, call `Provisioner.Wait` to block until Flux kustomizations report ready.
> 
> **`apply kustomize` gains `--wait` and waits only on what it applied.** When applying a single kustomization by name, the wait scope is narrowed to that kustomization by filtering `blueprint.Kustomizations` before calling `Wait`.
> 
> Tests were expanded/refactored to cover the new apply flow, nil-blueprint errors, wait success/failure paths, and integration checks that `--wait` is accepted on both `apply` and `apply kustomize`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3fa20cb234ed04fba1deee7d537e435463f1a39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->