### PR TITLE
feat(cmd): Implement windsor destroy --confirm=<context>

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -9,7 +9,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var destroyForce bool
+var destroyConfirm string
 
 // confirmDestroy prompts the user to type confirmValue to proceed with a destructive operation.
 // It prints a description of what will be destroyed and the expected confirmation token.
@@ -25,6 +25,19 @@ func confirmDestroy(r io.Reader, w io.Writer, description, confirmValue string) 
 		return fmt.Errorf("confirmation failed: input did not match %q", confirmValue)
 	}
 	return nil
+}
+
+// resolveDestroyConfirmation gates a destructive operation. If --confirm was supplied it must
+// match expected exactly; otherwise the user is prompted interactively. This mirrors the prompt
+// in both directions so scripted callers cannot accidentally destroy the wrong target.
+func resolveDestroyConfirmation(r io.Reader, w io.Writer, description, expected string) error {
+	if destroyConfirm != "" {
+		if destroyConfirm != expected {
+			return fmt.Errorf("confirmation failed: --confirm did not match %q", expected)
+		}
+		return nil
+	}
+	return confirmDestroy(r, w, description, expected)
 }
 
 var destroyCmd = &cobra.Command{
@@ -45,12 +58,10 @@ With a component name, destroys every layer (Terraform and/or Kustomize) that co
 		blueprint := proj.Composer.BlueprintHandler.Generate()
 
 		if len(args) == 0 {
-			if !destroyForce {
-				contextName := proj.Runtime.ContextName
-				desc := fmt.Sprintf("This will permanently destroy all infrastructure in context %q.", contextName)
-				if err := confirmDestroy(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, contextName); err != nil {
-					return err
-				}
+			contextName := proj.Runtime.ContextName
+			desc := fmt.Sprintf("This will permanently destroy all infrastructure in context %q.", contextName)
+			if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, contextName); err != nil {
+				return err
 			}
 			if err := proj.Provisioner.DestroyAll(blueprint); err != nil {
 				return fmt.Errorf("error destroying all components: %w", err)
@@ -66,11 +77,9 @@ With a component name, destroys every layer (Terraform and/or Kustomize) that co
 			return fmt.Errorf("component %q not found in blueprint", componentID)
 		}
 
-		if !destroyForce {
-			desc := fmt.Sprintf("This will permanently destroy component %q across all layers.", componentID)
-			if err := confirmDestroy(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, componentID); err != nil {
-				return err
-			}
+		desc := fmt.Sprintf("This will permanently destroy component %q across all layers.", componentID)
+		if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, componentID); err != nil {
+			return err
 		}
 
 		if inKustomize {
@@ -104,12 +113,10 @@ var destroyTerraformCmd = &cobra.Command{
 		blueprint := proj.Composer.BlueprintHandler.Generate()
 
 		if len(args) == 0 {
-			if !destroyForce {
-				contextName := proj.Runtime.ContextName
-				desc := fmt.Sprintf("This will permanently destroy all Terraform components in context %q.", contextName)
-				if err := confirmDestroy(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, contextName); err != nil {
-					return err
-				}
+			contextName := proj.Runtime.ContextName
+			desc := fmt.Sprintf("This will permanently destroy all Terraform components in context %q.", contextName)
+			if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, contextName); err != nil {
+				return err
 			}
 			if err := proj.Provisioner.DestroyAllTerraform(blueprint); err != nil {
 				return fmt.Errorf("error destroying all terraform: %w", err)
@@ -118,11 +125,9 @@ var destroyTerraformCmd = &cobra.Command{
 		}
 
 		componentID := args[0]
-		if !destroyForce {
-			desc := fmt.Sprintf("This will permanently destroy Terraform component %q.", componentID)
-			if err := confirmDestroy(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, componentID); err != nil {
-				return err
-			}
+		desc := fmt.Sprintf("This will permanently destroy Terraform component %q.", componentID)
+		if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, componentID); err != nil {
+			return err
 		}
 		if err := proj.Provisioner.Destroy(blueprint, componentID); err != nil {
 			return fmt.Errorf("error destroying terraform for %s: %w", componentID, err)
@@ -147,12 +152,10 @@ var destroyKustomizeCmd = &cobra.Command{
 		blueprint := proj.Composer.BlueprintHandler.Generate()
 
 		if len(args) == 0 {
-			if !destroyForce {
-				contextName := proj.Runtime.ContextName
-				desc := fmt.Sprintf("This will permanently destroy all Flux kustomizations in context %q.", contextName)
-				if err := confirmDestroy(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, contextName); err != nil {
-					return err
-				}
+			contextName := proj.Runtime.ContextName
+			desc := fmt.Sprintf("This will permanently destroy all Flux kustomizations in context %q.", contextName)
+			if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, contextName); err != nil {
+				return err
 			}
 			if err := proj.Provisioner.Uninstall(blueprint); err != nil {
 				return fmt.Errorf("error destroying all kustomizations: %w", err)
@@ -161,11 +164,9 @@ var destroyKustomizeCmd = &cobra.Command{
 		}
 
 		componentID := args[0]
-		if !destroyForce {
-			desc := fmt.Sprintf("This will permanently destroy Flux kustomization %q.", componentID)
-			if err := confirmDestroy(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, componentID); err != nil {
-				return err
-			}
+		desc := fmt.Sprintf("This will permanently destroy Flux kustomization %q.", componentID)
+		if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, componentID); err != nil {
+			return err
 		}
 		if err := proj.Provisioner.DestroyKustomize(blueprint, componentID); err != nil {
 			return fmt.Errorf("error destroying kustomization %s: %w", componentID, err)
@@ -174,9 +175,11 @@ var destroyKustomizeCmd = &cobra.Command{
 	},
 }
 
-// init registers destroy subcommands and persistent flags.
+// init registers destroy subcommands and the --confirm flag. --confirm must exactly match the
+// context name (for layer-wide destroy) or component name (for targeted destroy); this is the
+// CI-safe equivalent of the interactive prompt. There is no flag that skips confirmation entirely.
 func init() {
-	destroyCmd.PersistentFlags().BoolVarP(&destroyForce, "force", "f", false, "Skip confirmation prompt")
+	destroyCmd.PersistentFlags().StringVar(&destroyConfirm, "confirm", "", "Context or component name to confirm destruction (bypasses interactive prompt)")
 	destroyCmd.AddCommand(destroyTerraformCmd)
 	destroyCmd.AddCommand(destroyKustomizeCmd)
 	rootCmd.AddCommand(destroyCmd)

--- a/cmd/destroy_test.go
+++ b/cmd/destroy_test.go
@@ -196,7 +196,7 @@ func TestConfirmDestroy(t *testing.T) {
 
 func TestDestroyCmd(t *testing.T) {
 	createTestDestroyCmd := func() *cobra.Command {
-		destroyForce = false
+		destroyConfirm = ""
 		cmd := &cobra.Command{
 			Use:  "destroy",
 			RunE: destroyCmd.RunE,
@@ -218,14 +218,14 @@ func TestDestroyCmd(t *testing.T) {
 	suppressProcessStdout(t)
 	suppressProcessStderr(t)
 
-	t.Run("SuccessDestroyAllWithForce", func(t *testing.T) {
-		// Given a destroy command with --force and no arguments
+	t.Run("SuccessDestroyAllWithConfirmFlag", func(t *testing.T) {
+		// Given --confirm matches the context name, destroy all proceeds without a prompt.
 		mocks := setupDestroyTest(t)
 		proj := newDestroyProject(mocks)
 
 		cmd := createTestDestroyCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
-		cmd.SetArgs([]string{"--force"})
+		cmd.SetArgs([]string{"--confirm=test-context"})
 		cmd.SetContext(ctx)
 		err := cmd.Execute()
 
@@ -234,8 +234,27 @@ func TestDestroyCmd(t *testing.T) {
 		}
 	})
 
+	t.Run("ErrorDestroyAllWithMismatchedConfirmFlag", func(t *testing.T) {
+		// Given --confirm does not match the context name, destroy must refuse.
+		mocks := setupDestroyTest(t)
+		proj := newDestroyProject(mocks)
+
+		cmd := createTestDestroyCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--confirm=wrong-context"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		if err == nil {
+			t.Fatal("Expected confirmation error, got nil")
+		}
+		if !strings.Contains(err.Error(), "confirmation failed") {
+			t.Errorf("Expected confirmation failed error, got: %v", err)
+		}
+	})
+
 	t.Run("SuccessDestroyAllWithConfirmation", func(t *testing.T) {
-		// Given a destroy command with correct confirmation input
+		// Given correct interactive confirmation input.
 		mocks := setupDestroyTest(t)
 		proj := newDestroyProject(mocks)
 
@@ -251,7 +270,7 @@ func TestDestroyCmd(t *testing.T) {
 	})
 
 	t.Run("ErrorDestroyAllWrongConfirmation", func(t *testing.T) {
-		// Given a destroy command with wrong confirmation input
+		// Given wrong interactive confirmation input.
 		mocks := setupDestroyTest(t)
 		proj := newDestroyProject(mocks)
 
@@ -269,14 +288,14 @@ func TestDestroyCmd(t *testing.T) {
 		}
 	})
 
-	t.Run("SuccessDestroyComponentWithForce", func(t *testing.T) {
-		// Given a blueprint with a terraform component named "cluster"
+	t.Run("SuccessDestroyComponentWithConfirmFlag", func(t *testing.T) {
+		// Given --confirm matches the component name.
 		mocks := setupDestroyTest(t)
 		proj := newDestroyProject(mocks)
 
 		cmd := createTestDestroyCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
-		cmd.SetArgs([]string{"--force", "cluster"})
+		cmd.SetArgs([]string{"--confirm=cluster", "cluster"})
 		cmd.SetContext(ctx)
 		err := cmd.Execute()
 
@@ -285,8 +304,26 @@ func TestDestroyCmd(t *testing.T) {
 		}
 	})
 
+	t.Run("ErrorDestroyComponentWithMismatchedConfirmFlag", func(t *testing.T) {
+		// Given --confirm does not match the component name.
+		mocks := setupDestroyTest(t)
+		proj := newDestroyProject(mocks)
+
+		cmd := createTestDestroyCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--confirm=other", "cluster"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		if err == nil {
+			t.Fatal("Expected confirmation error, got nil")
+		}
+		if !strings.Contains(err.Error(), "confirmation failed") {
+			t.Errorf("Expected confirmation failed error, got: %v", err)
+		}
+	})
+
 	t.Run("SuccessDestroyComponentWithConfirmation", func(t *testing.T) {
-		// Given correct component name typed as confirmation
 		mocks := setupDestroyTest(t)
 		proj := newDestroyProject(mocks)
 
@@ -303,13 +340,12 @@ func TestDestroyCmd(t *testing.T) {
 	})
 
 	t.Run("ErrorComponentNotFound", func(t *testing.T) {
-		// Given a component that does not exist in the blueprint
 		mocks := setupDestroyTest(t)
 		proj := newDestroyProject(mocks)
 
 		cmd := createTestDestroyCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
-		cmd.SetArgs([]string{"--force", "nonexistent"})
+		cmd.SetArgs([]string{"--confirm=nonexistent", "nonexistent"})
 		cmd.SetContext(ctx)
 		err := cmd.Execute()
 
@@ -330,7 +366,7 @@ func TestDestroyCmd(t *testing.T) {
 
 		cmd := createTestDestroyCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
-		cmd.SetArgs([]string{"--force"})
+		cmd.SetArgs([]string{"--confirm=test-context"})
 		cmd.SetContext(ctx)
 		err := cmd.Execute()
 
@@ -351,7 +387,7 @@ func TestDestroyCmd(t *testing.T) {
 
 		cmd := createTestDestroyCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
-		cmd.SetArgs([]string{"--force"})
+		cmd.SetArgs([]string{"--confirm=test-context"})
 		cmd.SetContext(ctx)
 		err := cmd.Execute()
 
@@ -366,7 +402,7 @@ func TestDestroyCmd(t *testing.T) {
 
 func TestDestroyTerraformCmd(t *testing.T) {
 	createTestDestroyTerraformCmd := func() *cobra.Command {
-		destroyForce = false
+		destroyConfirm = ""
 		cmd := &cobra.Command{
 			Use:  "terraform",
 			RunE: destroyTerraformCmd.RunE,
@@ -388,13 +424,13 @@ func TestDestroyTerraformCmd(t *testing.T) {
 	suppressProcessStdout(t)
 	suppressProcessStderr(t)
 
-	t.Run("SuccessAllWithForce", func(t *testing.T) {
+	t.Run("SuccessAllWithConfirmFlag", func(t *testing.T) {
 		mocks := setupDestroyTest(t)
 		proj := newDestroyProject(mocks)
 
 		cmd := createTestDestroyTerraformCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
-		cmd.SetArgs([]string{"--force"})
+		cmd.SetArgs([]string{"--confirm=test-context"})
 		cmd.SetContext(ctx)
 		err := cmd.Execute()
 
@@ -418,13 +454,13 @@ func TestDestroyTerraformCmd(t *testing.T) {
 		}
 	})
 
-	t.Run("SuccessSpecificWithForce", func(t *testing.T) {
+	t.Run("SuccessSpecificWithConfirmFlag", func(t *testing.T) {
 		mocks := setupDestroyTest(t)
 		proj := newDestroyProject(mocks)
 
 		cmd := createTestDestroyTerraformCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
-		cmd.SetArgs([]string{"--force", "cluster"})
+		cmd.SetArgs([]string{"--confirm=cluster", "cluster"})
 		cmd.SetContext(ctx)
 		err := cmd.Execute()
 
@@ -468,6 +504,24 @@ func TestDestroyTerraformCmd(t *testing.T) {
 		}
 	})
 
+	t.Run("ErrorMismatchedConfirmFlag", func(t *testing.T) {
+		mocks := setupDestroyTest(t)
+		proj := newDestroyProject(mocks)
+
+		cmd := createTestDestroyTerraformCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--confirm=other", "cluster"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		if err == nil {
+			t.Fatal("Expected confirmation error, got nil")
+		}
+		if !strings.Contains(err.Error(), "confirmation failed") {
+			t.Errorf("Expected confirmation failed error, got: %v", err)
+		}
+	})
+
 	t.Run("ErrorCheckingTrustedDirectory", func(t *testing.T) {
 		mocks := setupDestroyTest(t)
 		mocks.Shell.CheckTrustedDirectoryFunc = func() error {
@@ -477,7 +531,7 @@ func TestDestroyTerraformCmd(t *testing.T) {
 
 		cmd := createTestDestroyTerraformCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
-		cmd.SetArgs([]string{"--force", "cluster"})
+		cmd.SetArgs([]string{"--confirm=cluster", "cluster"})
 		cmd.SetContext(ctx)
 		err := cmd.Execute()
 
@@ -498,7 +552,7 @@ func TestDestroyTerraformCmd(t *testing.T) {
 
 		cmd := createTestDestroyTerraformCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
-		cmd.SetArgs([]string{"--force", "cluster"})
+		cmd.SetArgs([]string{"--confirm=cluster", "cluster"})
 		cmd.SetContext(ctx)
 		err := cmd.Execute()
 
@@ -513,7 +567,7 @@ func TestDestroyTerraformCmd(t *testing.T) {
 
 func TestDestroyKustomizeCmd(t *testing.T) {
 	createTestDestroyKustomizeCmd := func() *cobra.Command {
-		destroyForce = false
+		destroyConfirm = ""
 		cmd := &cobra.Command{
 			Use:  "kustomize",
 			RunE: destroyKustomizeCmd.RunE,
@@ -535,13 +589,13 @@ func TestDestroyKustomizeCmd(t *testing.T) {
 	suppressProcessStdout(t)
 	suppressProcessStderr(t)
 
-	t.Run("SuccessAllWithForce", func(t *testing.T) {
+	t.Run("SuccessAllWithConfirmFlag", func(t *testing.T) {
 		mocks := setupDestroyTest(t)
 		proj := newDestroyProject(mocks)
 
 		cmd := createTestDestroyKustomizeCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
-		cmd.SetArgs([]string{"--force"})
+		cmd.SetArgs([]string{"--confirm=test-context"})
 		cmd.SetContext(ctx)
 		err := cmd.Execute()
 
@@ -565,13 +619,13 @@ func TestDestroyKustomizeCmd(t *testing.T) {
 		}
 	})
 
-	t.Run("SuccessSpecificWithForce", func(t *testing.T) {
+	t.Run("SuccessSpecificWithConfirmFlag", func(t *testing.T) {
 		mocks := setupDestroyTest(t)
 		proj := newDestroyProject(mocks)
 
 		cmd := createTestDestroyKustomizeCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
-		cmd.SetArgs([]string{"--force", "my-app"})
+		cmd.SetArgs([]string{"--confirm=my-app", "my-app"})
 		cmd.SetContext(ctx)
 		err := cmd.Execute()
 
@@ -615,6 +669,24 @@ func TestDestroyKustomizeCmd(t *testing.T) {
 		}
 	})
 
+	t.Run("ErrorMismatchedConfirmFlag", func(t *testing.T) {
+		mocks := setupDestroyTest(t)
+		proj := newDestroyProject(mocks)
+
+		cmd := createTestDestroyKustomizeCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--confirm=other", "my-app"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		if err == nil {
+			t.Fatal("Expected confirmation error, got nil")
+		}
+		if !strings.Contains(err.Error(), "confirmation failed") {
+			t.Errorf("Expected confirmation failed error, got: %v", err)
+		}
+	})
+
 	t.Run("ErrorCheckingTrustedDirectory", func(t *testing.T) {
 		mocks := setupDestroyTest(t)
 		mocks.Shell.CheckTrustedDirectoryFunc = func() error {
@@ -624,7 +696,7 @@ func TestDestroyKustomizeCmd(t *testing.T) {
 
 		cmd := createTestDestroyKustomizeCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
-		cmd.SetArgs([]string{"--force", "my-app"})
+		cmd.SetArgs([]string{"--confirm=my-app", "my-app"})
 		cmd.SetContext(ctx)
 		err := cmd.Execute()
 
@@ -645,7 +717,7 @@ func TestDestroyKustomizeCmd(t *testing.T) {
 
 		cmd := createTestDestroyKustomizeCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
-		cmd.SetArgs([]string{"--force", "my-app"})
+		cmd.SetArgs([]string{"--confirm=my-app", "my-app"})
 		cmd.SetContext(ctx)
 		err := cmd.Execute()
 

--- a/integration/destroy_test.go
+++ b/integration/destroy_test.go
@@ -26,7 +26,7 @@ func TestDestroyTerraform_SucceedsWithMinimalLocalConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("apply terraform null: %v\nstderr: %s", err, stderr)
 	}
-	_, stderr, err = helpers.RunCLI(dir, []string{"destroy", "--force", "terraform", "null"}, env)
+	_, stderr, err = helpers.RunCLI(dir, []string{"destroy", "--confirm=null", "terraform", "null"}, env)
 	if err != nil {
 		t.Fatalf("destroy terraform null: %v\nstderr: %s", err, stderr)
 	}
@@ -44,7 +44,7 @@ func TestDestroyTerraform_SucceedsAllWithMinimalLocalConfig(t *testing.T) {
 	if err != nil {
 		t.Fatalf("apply terraform null: %v\nstderr: %s", err, stderr)
 	}
-	_, stderr, err = helpers.RunCLI(dir, []string{"destroy", "--force", "terraform"}, env)
+	_, stderr, err = helpers.RunCLI(dir, []string{"destroy", "--confirm=local", "terraform"}, env)
 	if err != nil {
 		t.Fatalf("destroy terraform: %v\nstderr: %s", err, stderr)
 	}
@@ -62,6 +62,23 @@ func TestDestroyTerraform_FailsWhenNotInTrustedDirectory(t *testing.T) {
 	}
 }
 
+func TestDestroy_FailsWhenConfirmFlagDoesNotMatch(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
+	if err != nil {
+		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
+	}
+	env = append(env, "WINDSOR_CONTEXT=local")
+	_, stderr, err = helpers.RunCLI(dir, []string{"destroy", "--confirm=wrong", "terraform"}, env)
+	if err == nil {
+		t.Fatal("expected failure but command succeeded")
+	}
+	if !strings.Contains(string(stderr), "confirmation failed") {
+		t.Errorf("expected stderr to mention 'confirmation failed', got: %s", stderr)
+	}
+}
+
 func TestDestroyTerraform_FailsForNonexistentComponent(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
@@ -70,7 +87,7 @@ func TestDestroyTerraform_FailsForNonexistentComponent(t *testing.T) {
 		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
 	}
 	env = append(env, "WINDSOR_CONTEXT=local")
-	_, stderr, err = helpers.RunCLI(dir, []string{"destroy", "--force", "terraform", "nonexistent"}, env)
+	_, stderr, err = helpers.RunCLI(dir, []string{"destroy", "--confirm=nonexistent", "terraform", "nonexistent"}, env)
 	if err == nil {
 		t.Fatal("expected failure but command succeeded")
 	}


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Changes the safety gating for destructive `destroy` operations by removing `--force` and adding a new `--confirm` path used in CI/scripting; a mismatch now hard-fails. Risk is moderate because it affects infra-destroy workflows and could break existing automation relying on `--force`.
> 
> **Overview**
> **Reworks `windsor destroy` confirmation flow** by removing the `--force` flag and introducing `--confirm`, which must *exactly match* the context name (for all-destroys) or component name (for targeted destroys); otherwise the command refuses to run.
> 
> Adds `resolveDestroyConfirmation` to unify interactive prompting with CI-safe confirmation, and updates unit/integration tests to cover `--confirm` success and mismatch failure cases across `destroy`, `destroy terraform`, and `destroy kustomize`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9515c7fc9b3504f05ab6412092aa53c8826c8d8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->