### PR TITLE
feat(composer/blueprint): Resolve deferred in substitutions

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -13,6 +13,7 @@ var applyCmd = &cobra.Command{
 	Use:          "apply",
 	Short:        "Apply infrastructure changes",
 	Long:         "Apply infrastructure changes for Windsor environment components by running Terraform and installing the blueprint.",
+	Args:         cobra.NoArgs,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		proj, err := prepareProject(cmd)
@@ -28,6 +29,10 @@ var applyCmd = &cobra.Command{
 		if err := proj.Provisioner.Up(blueprint); err != nil {
 			return fmt.Errorf("error applying terraform: %w", err)
 		}
+
+		// Re-generate with deferred substitutions resolved now that terraform
+		// outputs are available from the Up step above.
+		blueprint = proj.Composer.BlueprintHandler.GenerateResolved()
 
 		if err := proj.Provisioner.Install(blueprint); err != nil {
 			return fmt.Errorf("error applying kustomize: %w", err)

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -190,6 +190,24 @@ func TestApplyCmd(t *testing.T) {
 		}
 	})
 
+	t.Run("ErrorUnexpectedArgs", func(t *testing.T) {
+		// Given a bare apply command with an unexpected positional argument
+		mocks := setupApplyTest(t)
+		proj := newApplyAllProject(mocks)
+
+		// When executing the apply command with a stray argument
+		cmd := createTestApplyCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"workstation"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then an error should occur indicating no args are accepted
+		if err == nil {
+			t.Error("Expected error for unexpected argument, got nil")
+		}
+	})
+
 	t.Run("ErrorNilBlueprint", func(t *testing.T) {
 		// Given a blueprint handler that returns nil
 		mocks := setupApplyTest(t)

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -18,7 +18,7 @@ var installCmd = &cobra.Command{
 			return err
 		}
 
-		blueprint := proj.Composer.BlueprintHandler.Generate()
+		blueprint := proj.Composer.BlueprintHandler.GenerateResolved()
 		if err := proj.Provisioner.Install(blueprint); err != nil {
 			return fmt.Errorf("error installing blueprint: %w", err)
 		}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -49,10 +49,13 @@ var upCmd = &cobra.Command{
 			return nil
 		}
 
-		blueprint, err := proj.Up()
-		if err != nil {
+		if _, err := proj.Up(); err != nil {
 			return err
 		}
+
+		// Re-generate with deferred substitutions resolved now that terraform
+		// outputs are available from the Up step above.
+		blueprint := proj.Composer.BlueprintHandler.GenerateResolved()
 
 		if err := proj.Provisioner.Install(blueprint); err != nil {
 			return fmt.Errorf("error installing blueprint: %w", err)

--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -201,16 +201,22 @@ func (h *BaseBlueprintHandler) Generate() *blueprintv1alpha1.Blueprint {
 	return h.composedBlueprint
 }
 
-// GenerateResolved returns the composed blueprint with deferred substitutions resolved.
-// This is the JIT entry point for consumers that need fully evaluated values (e.g. the
-// provisioner writing ConfigMaps to the cluster). Callers that only display the blueprint
-// (e.g. windsor show) should use Generate() instead to preserve deferred placeholders.
+// GenerateResolved returns a deep copy of the composed blueprint with deferred substitutions
+// resolved. This is the JIT entry point for consumers that need fully evaluated values (e.g.
+// the provisioner writing ConfigMaps to the cluster). The copy ensures the base composedBlueprint
+// is never mutated, so subsequent Generate() or GenerateResolved() calls start from the original
+// deferred expressions. Callers that only display the blueprint (e.g. windsor show) should use
+// Generate() instead to preserve deferred placeholders.
 func (h *BaseBlueprintHandler) GenerateResolved() *blueprintv1alpha1.Blueprint {
 	bp := h.Generate()
-	if bp != nil {
-		h.resolveDeferredSubstitutions()
+	if bp == nil {
+		return nil
 	}
-	return bp
+	resolved := bp.DeepCopy()
+	h.composedBlueprint = resolved
+	h.resolveDeferredSubstitutions()
+	h.composedBlueprint = bp
+	return resolved
 }
 
 // GetDeferredPaths returns composed paths whose values were deferred during expression evaluation.

--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -21,6 +21,7 @@ type BlueprintHandler interface {
 	GetTerraformComponents() []blueprintv1alpha1.TerraformComponent
 	GetLocalTemplateData() (map[string][]byte, error)
 	Generate() *blueprintv1alpha1.Blueprint
+	GenerateResolved() *blueprintv1alpha1.Blueprint
 	Explain(path string) (*ExplainTrace, error)
 	GetDeferredPaths() map[string]bool
 }
@@ -42,6 +43,7 @@ type BaseBlueprintHandler struct {
 	sourceBlueprintLoaders map[string]BlueprintLoader
 	userBlueprintLoader    BlueprintLoader
 	composedBlueprint      *blueprintv1alpha1.Blueprint
+	composedScope          map[string]any
 	deferredPathsMu        sync.Mutex
 	deferredPaths          map[string]bool
 	traceCollector         TraceCollector
@@ -199,6 +201,18 @@ func (h *BaseBlueprintHandler) Generate() *blueprintv1alpha1.Blueprint {
 	return h.composedBlueprint
 }
 
+// GenerateResolved returns the composed blueprint with deferred substitutions resolved.
+// This is the JIT entry point for consumers that need fully evaluated values (e.g. the
+// provisioner writing ConfigMaps to the cluster). Callers that only display the blueprint
+// (e.g. windsor show) should use Generate() instead to preserve deferred placeholders.
+func (h *BaseBlueprintHandler) GenerateResolved() *blueprintv1alpha1.Blueprint {
+	bp := h.Generate()
+	if bp != nil {
+		h.resolveDeferredSubstitutions()
+	}
+	return bp
+}
+
 // GetDeferredPaths returns composed paths whose values were deferred during expression evaluation.
 func (h *BaseBlueprintHandler) GetDeferredPaths() map[string]bool {
 	h.deferredPathsMu.Lock()
@@ -216,6 +230,75 @@ func (h *BaseBlueprintHandler) GetDeferredPaths() map[string]bool {
 // =============================================================================
 // Private Methods
 // =============================================================================
+
+// resolveDeferredSubstitutions re-evaluates deferred substitutions with evaluateDeferred=true
+// so that helpers like terraform_output() resolve using outputs available at generate time
+// (after terraform apply). Only substitutions marked as deferred during composition are
+// re-evaluated; already-resolved substitutions are left untouched. Covers global substitutions,
+// blueprint-level ConfigMaps, and per-kustomization substitutions.
+func (h *BaseBlueprintHandler) resolveDeferredSubstitutions() {
+	if h.runtime == nil || h.runtime.Evaluator == nil || h.composedBlueprint == nil {
+		return
+	}
+
+	deferred := h.GetDeferredPaths()
+	if len(deferred) == 0 {
+		return
+	}
+
+	bp := h.composedBlueprint
+
+	for key, value := range bp.Substitutions {
+		if !deferred["substitutions."+key] {
+			continue
+		}
+		if str := h.resolveDeferred(value); str != nil {
+			bp.Substitutions[key] = *str
+		}
+	}
+
+	for name, configMap := range bp.ConfigMaps {
+		for key, value := range configMap {
+			if !deferred["substitutions."+key] {
+				continue
+			}
+			if str := h.resolveDeferred(value); str != nil {
+				bp.ConfigMaps[name][key] = *str
+			}
+		}
+	}
+
+	for i := range bp.Kustomizations {
+		k := &bp.Kustomizations[i]
+		for key, value := range k.Substitutions {
+			if !deferred["kustomize."+k.Name+".substitutions."+key] {
+				continue
+			}
+			if str := h.resolveDeferred(value); str != nil {
+				k.Substitutions[key] = *str
+			}
+		}
+	}
+}
+
+// resolveDeferred evaluates a single expression with evaluateDeferred=true using the composed
+// scope. Returns a pointer to the resolved string, or nil if evaluation fails (leaving the
+// original value unchanged for the next Generate() call to retry).
+func (h *BaseBlueprintHandler) resolveDeferred(expr string) *string {
+	resolved, err := h.runtime.Evaluator.Evaluate(expr, "", h.composedScope, true)
+	if err != nil {
+		return nil
+	}
+	var s string
+	if resolved == nil {
+		s = ""
+	} else if str, ok := resolved.(string); ok {
+		s = str
+	} else {
+		s = fmt.Sprintf("%v", resolved)
+	}
+	return &s
+}
 
 // getMergedTemplateData returns template file contents from all loaded blueprint sources merged
 // into a single map. Used by the evaluator when resolving yaml() and similar file-based
@@ -620,6 +703,7 @@ func (h *BaseBlueprintHandler) processAndCompose() error {
 	}
 	composedBp, composeErr := h.composer.Compose(loaders, initLoaderNames, userPath, mergedScope)
 	h.composedBlueprint = composedBp
+	h.composedScope = mergedScope
 
 	if h.traceCollector != nil {
 		h.traceCollector.Finalize(h.composedBlueprint, mergedScope, h.runtime.TemplateRoot)

--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -259,7 +259,7 @@ func (h *BaseBlueprintHandler) resolveDeferredSubstitutions() {
 
 	for name, configMap := range bp.ConfigMaps {
 		for key, value := range configMap {
-			if !deferred["substitutions."+key] {
+			if !deferred["configmaps."+name+"."+key] {
 				continue
 			}
 			if str := h.resolveDeferred(value); str != nil {
@@ -298,6 +298,33 @@ func (h *BaseBlueprintHandler) resolveDeferred(expr string) *string {
 		s = fmt.Sprintf("%v", resolved)
 	}
 	return &s
+}
+
+// deriveConfigMapDeferredPaths propagates deferred status to ConfigMap entries that inherited
+// values from deferred substitutions. The composer copies blueprint.Substitutions into
+// values-common and kustomization substitutions into per-kustomization ConfigMaps; this
+// method marks the corresponding "configmaps.<name>.<key>" paths as deferred so that
+// resolveDeferredSubstitutions and applyDeferredPathsToBlueprint handle them correctly.
+func (h *BaseBlueprintHandler) deriveConfigMapDeferredPaths() {
+	bp := h.composedBlueprint
+	if bp == nil || len(bp.ConfigMaps) == 0 {
+		return
+	}
+
+	h.deferredPathsMu.Lock()
+	defer h.deferredPathsMu.Unlock()
+
+	for name, configMap := range bp.ConfigMaps {
+		for key, value := range configMap {
+			if value != deferredPlaceholder {
+				continue
+			}
+			if h.deferredPaths == nil {
+				h.deferredPaths = make(map[string]bool)
+			}
+			h.deferredPaths["configmaps."+name+"."+key] = true
+		}
+	}
 }
 
 // getMergedTemplateData returns template file contents from all loaded blueprint sources merged
@@ -712,6 +739,8 @@ func (h *BaseBlueprintHandler) processAndCompose() error {
 	if composeErr != nil {
 		return composeErr
 	}
+
+	h.deriveConfigMapDeferredPaths()
 
 	if h.runtime.Evaluator != nil {
 		for i := range h.composedBlueprint.TerraformComponents {

--- a/pkg/composer/blueprint/handler_test.go
+++ b/pkg/composer/blueprint/handler_test.go
@@ -1934,3 +1934,70 @@ func TestHandler_processAndCompose(t *testing.T) {
 		}
 	})
 }
+
+func TestHandler_deriveConfigMapDeferredPaths(t *testing.T) {
+	t.Run("MarksConfigMapEntriesContainingDeferredPlaceholder", func(t *testing.T) {
+		// Given a handler with a composed blueprint containing deferred ConfigMap values
+		handler := &BaseBlueprintHandler{
+			deferredPaths: map[string]bool{
+				"substitutions.MY_KEY": true,
+			},
+			composedBlueprint: &blueprintv1alpha1.Blueprint{
+				ConfigMaps: map[string]map[string]string{
+					"values-common": {
+						"MY_KEY":       "<deferred>",
+						"RESOLVED_KEY": "resolved-value",
+					},
+					"values-my-app": {
+						"APP_KEY": "<deferred>",
+					},
+				},
+			},
+		}
+
+		// When deriving ConfigMap deferred paths
+		handler.deriveConfigMapDeferredPaths()
+
+		// Then deferred entries are marked with the configmaps prefix
+		paths := handler.GetDeferredPaths()
+		if !paths["configmaps.values-common.MY_KEY"] {
+			t.Error("Expected configmaps.values-common.MY_KEY to be marked deferred")
+		}
+		if paths["configmaps.values-common.RESOLVED_KEY"] {
+			t.Error("Expected configmaps.values-common.RESOLVED_KEY not to be marked deferred")
+		}
+		if !paths["configmaps.values-my-app.APP_KEY"] {
+			t.Error("Expected configmaps.values-my-app.APP_KEY to be marked deferred")
+		}
+	})
+
+	t.Run("NoOpWhenNilBlueprint", func(t *testing.T) {
+		// Given a handler with no composed blueprint
+		handler := &BaseBlueprintHandler{}
+
+		// When deriving ConfigMap deferred paths
+		handler.deriveConfigMapDeferredPaths()
+
+		// Then no paths are added
+		paths := handler.GetDeferredPaths()
+		if len(paths) != 0 {
+			t.Errorf("Expected empty deferred paths, got %v", paths)
+		}
+	})
+
+	t.Run("NoOpWhenNoConfigMaps", func(t *testing.T) {
+		// Given a handler with a composed blueprint but no ConfigMaps
+		handler := &BaseBlueprintHandler{
+			composedBlueprint: &blueprintv1alpha1.Blueprint{},
+		}
+
+		// When deriving ConfigMap deferred paths
+		handler.deriveConfigMapDeferredPaths()
+
+		// Then no paths are added
+		paths := handler.GetDeferredPaths()
+		if len(paths) != 0 {
+			t.Errorf("Expected empty deferred paths, got %v", paths)
+		}
+	})
+}

--- a/pkg/composer/blueprint/handler_test.go
+++ b/pkg/composer/blueprint/handler_test.go
@@ -1190,6 +1190,49 @@ func TestHandler_Generate(t *testing.T) {
 	})
 }
 
+func TestHandler_GenerateResolved(t *testing.T) {
+	t.Run("DoesNotMutateComposedBlueprint", func(t *testing.T) {
+		// Given a handler with a deferred substitution
+		mocks := setupHandlerMocks(t)
+		handler := NewBlueprintHandler(mocks.Runtime, mocks.ArtifactBuilder)
+		handler.composedBlueprint = &blueprintv1alpha1.Blueprint{
+			Substitutions: map[string]string{
+				"MY_KEY": "<deferred>",
+			},
+		}
+		handler.deferredPaths = map[string]bool{
+			"substitutions.MY_KEY": true,
+		}
+
+		// When calling GenerateResolved
+		resolved := handler.GenerateResolved()
+
+		// Then the returned blueprint is a separate object
+		if resolved == handler.composedBlueprint {
+			t.Error("Expected GenerateResolved to return a deep copy, not the same pointer")
+		}
+
+		// And the original composedBlueprint retains the deferred placeholder
+		if handler.composedBlueprint.Substitutions["MY_KEY"] != "<deferred>" {
+			t.Errorf("Expected composedBlueprint to retain '<deferred>', got '%s'", handler.composedBlueprint.Substitutions["MY_KEY"])
+		}
+	})
+
+	t.Run("ReturnsNilWhenNoBlueprint", func(t *testing.T) {
+		// Given a handler with no composed blueprint
+		mocks := setupHandlerMocks(t)
+		handler := NewBlueprintHandler(mocks.Runtime, mocks.ArtifactBuilder)
+
+		// When calling GenerateResolved
+		result := handler.GenerateResolved()
+
+		// Then should return nil
+		if result != nil {
+			t.Error("Expected nil when no blueprint")
+		}
+	})
+}
+
 func TestHandler_getConfigValues(t *testing.T) {
 	t.Run("ReturnsNilWhenConfigHandlerNil", func(t *testing.T) {
 		// Given a handler with nil ConfigHandler

--- a/pkg/composer/blueprint/mock_blueprint_handler.go
+++ b/pkg/composer/blueprint/mock_blueprint_handler.go
@@ -11,6 +11,7 @@ type MockBlueprintHandler struct {
 	GetTerraformComponentsFunc func() []blueprintv1alpha1.TerraformComponent
 	GetLocalTemplateDataFunc   func() (map[string][]byte, error)
 	GenerateFunc               func() *blueprintv1alpha1.Blueprint
+	GenerateResolvedFunc       func() *blueprintv1alpha1.Blueprint
 	ExplainFunc                func(string) (*ExplainTrace, error)
 	GetDeferredPathsFunc       func() map[string]bool
 }
@@ -66,6 +67,14 @@ func (m *MockBlueprintHandler) Generate() *blueprintv1alpha1.Blueprint {
 		return m.GenerateFunc()
 	}
 	return nil
+}
+
+// GenerateResolved calls the mock GenerateResolvedFunc if set, otherwise falls back to Generate.
+func (m *MockBlueprintHandler) GenerateResolved() *blueprintv1alpha1.Blueprint {
+	if m.GenerateResolvedFunc != nil {
+		return m.GenerateResolvedFunc()
+	}
+	return m.Generate()
 }
 
 // Explain calls the mock ExplainFunc if set, otherwise returns nil.

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -1619,6 +1619,66 @@ func TestProcessor_ProcessFacets_Config(t *testing.T) {
 	})
 }
 
+func TestProcessor_ProcessFacets_ConfigDeferredValues(t *testing.T) {
+	t.Run("DeferredConfigBlockValuePreservesExpressionInSubstitution", func(t *testing.T) {
+		// Given a config block with a deferred helper and a substitution that
+		// references the config block value. During composition the helper is
+		// deferred, so the config block stores the raw expression string in scope
+		// and the substitution is also marked as deferred for JIT resolution.
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{}, nil
+		}
+
+		realEval := evaluator.NewExpressionEvaluator(mocks.ConfigHandler, mocks.Runtime.ProjectRoot, mocks.Runtime.ConfigRoot)
+		realEval.Register("deferred_helper", func(params []any, deferred bool) (any, error) {
+			if !deferred {
+				return nil, &evaluator.DeferredError{
+					Expression: fmt.Sprintf("deferred_helper(%q)", params[0]),
+					Message:    "deferred",
+				}
+			}
+			return "mirror.test", nil
+		}, new(func(string) any))
+
+		mocks.Evaluator.EvaluateFunc = realEval.Evaluate
+		mocks.Evaluator.EvaluateMapFunc = realEval.EvaluateMap
+
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "test-facet"},
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{
+						Name: "mirror_effective",
+						Body: map[string]any{
+							"value": map[string]any{
+								"address": "${(deferred_helper('workstation') ?? 'mirror') + ':5000'}",
+							},
+						},
+					},
+				},
+				Substitutions: map[string]string{
+					"helm_registry": "${mirror_effective.address != '' ? 'oci://' + mirror_effective.address + '/charts' : ''}",
+				},
+			},
+		}
+
+		_, _, err := processor.ProcessFacets(target, facets)
+		if err != nil {
+			t.Fatalf("ProcessFacets failed: %v", err)
+		}
+
+		// Then helm_registry should be marked as deferred for JIT resolution
+		helmReg := target.Substitutions["helm_registry"]
+		deferred := processor.GetDeferredPaths()
+		if !deferred["substitutions.helm_registry"] {
+			t.Errorf("Expected helm_registry to be marked as deferred, got deferred paths: %v (value: %q)", deferred, helmReg)
+		}
+	})
+}
+
 func TestProcessor_ProcessFacets_Substitutions(t *testing.T) {
 	t.Run("CollectsStaticFacetSubstitutionsIntoTarget", func(t *testing.T) {
 		// Given a facet with top-level substitutions

--- a/pkg/composer/blueprint/render.go
+++ b/pkg/composer/blueprint/render.go
@@ -70,6 +70,13 @@ func applyDeferredPathsToBlueprint(bp *blueprintv1alpha1.Blueprint, deferredPath
 			bp.Substitutions[key] = deferredPlaceholder
 		}
 	}
+	for name, configMap := range bp.ConfigMaps {
+		for key := range configMap {
+			if deferredPaths["configmaps."+name+"."+key] {
+				bp.ConfigMaps[name][key] = deferredPlaceholder
+			}
+		}
+	}
 	for i := range bp.Kustomizations {
 		name := bp.Kustomizations[i].Name
 		if deferredPaths["kustomize."+name+".path"] {

--- a/pkg/composer/blueprint/render_test.go
+++ b/pkg/composer/blueprint/render_test.go
@@ -56,6 +56,31 @@ func TestRenderDeferredPlaceholders(t *testing.T) {
 		}
 	})
 
+	t.Run("RewritesDeferredConfigMapEntryToPlaceholder", func(t *testing.T) {
+		// Given a blueprint with a deferred ConfigMap entry
+		bp := &blueprintv1alpha1.Blueprint{
+			ConfigMaps: map[string]map[string]string{
+				"values-common": {
+					"DEFERRED_KEY": "${terraform_output(\"x\")}",
+					"RESOLVED_KEY": "resolved-value",
+				},
+			},
+		}
+		deferredPaths := map[string]bool{"configmaps.values-common.DEFERRED_KEY": true}
+
+		// When rendering deferred placeholders
+		result := RenderDeferredPlaceholders(bp, false, deferredPaths)
+
+		// Then the deferred key becomes <deferred> and the resolved key is unchanged
+		got := result.(*blueprintv1alpha1.Blueprint)
+		if got.ConfigMaps["values-common"]["DEFERRED_KEY"] != deferredPlaceholder {
+			t.Errorf("Expected deferred ConfigMap entry to be '%s', got '%s'", deferredPlaceholder, got.ConfigMaps["values-common"]["DEFERRED_KEY"])
+		}
+		if got.ConfigMaps["values-common"]["RESOLVED_KEY"] != "resolved-value" {
+			t.Errorf("Expected resolved ConfigMap entry unchanged, got '%s'", got.ConfigMaps["values-common"]["RESOLVED_KEY"])
+		}
+	})
+
 	t.Run("DoesNotMutateOriginalBlueprint", func(t *testing.T) {
 		// Given a blueprint with a deferred substitution
 		bp := &blueprintv1alpha1.Blueprint{

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -514,29 +514,29 @@ func (s *TerraformStack) Apply(blueprint *blueprintv1alpha1.Blueprint, component
 	defer cleanup()
 	terraformVars["TF_VAR_operation"] = "apply"
 
-	if err := s.runTerraformInit(component, terraformVars, terraformArgs); err != nil {
-		return err
-	}
+	return tui.WithProgress(fmt.Sprintf("Applying %s", component.Path), func() error {
+		if err := s.runTerraformInit(component, terraformVars, terraformArgs); err != nil {
+			return err
+		}
 
-	terraformCommand := s.runtime.ToolsManager.GetTerraformCommand()
-	planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan"}
-	planArgs = append(planArgs, terraformArgs.PlanArgs...)
-	planEnv := selectTerraformCommandEnv(terraformVars, true)
-	_, err = s.runtime.Shell.ExecSilentWithEnv(terraformCommand, planEnv, planArgs...)
-	if err != nil {
-		return fmt.Errorf("error running terraform plan for %s: %w", component.Path, err)
-	}
+		terraformCommand := s.runtime.ToolsManager.GetTerraformCommand()
+		planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan"}
+		planArgs = append(planArgs, terraformArgs.PlanArgs...)
+		planEnv := selectTerraformCommandEnv(terraformVars, true)
+		if _, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, planEnv, planArgs...); err != nil {
+			return fmt.Errorf("error running terraform plan for %s: %w", component.Path, err)
+		}
 
-	applyArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "apply"}
-	applyArgs = append(applyArgs, terraformArgs.ApplyArgs...)
-	applyEnv := selectTerraformCommandEnv(terraformVars, false)
-	if _, err := s.runtime.Shell.ExecProgressWithEnv(fmt.Sprintf("Applying Terraform changes in %s", component.Path), terraformCommand, applyEnv, applyArgs...); err != nil {
-		return fmt.Errorf("error running terraform apply for %s: %w", component.Path, err)
-	}
+		applyArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "apply"}
+		applyArgs = append(applyArgs, terraformArgs.ApplyArgs...)
+		applyEnv := selectTerraformCommandEnv(terraformVars, false)
+		if _, err := s.runtime.Shell.ExecProgressWithEnv(fmt.Sprintf("Applying Terraform changes in %s", component.Path), terraformCommand, applyEnv, applyArgs...); err != nil {
+			return fmt.Errorf("error running terraform apply for %s: %w", component.Path, err)
+		}
+		_ = s.runtime.TerraformProvider.CacheOutputs(component.GetID())
 
-	_ = s.runtime.TerraformProvider.CacheOutputs(component.GetID())
-
-	return nil
+		return nil
+	})
 }
 
 // Destroy runs terraform init, plan -destroy, and destroy for a single component identified by componentID.

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -530,12 +530,8 @@ func (s *TerraformStack) Apply(blueprint *blueprintv1alpha1.Blueprint, component
 	applyArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "apply"}
 	applyArgs = append(applyArgs, terraformArgs.ApplyArgs...)
 	applyEnv := selectTerraformCommandEnv(terraformVars, false)
-	applyOutput, err := s.runtime.Shell.ExecProgressWithEnv(fmt.Sprintf("Applying Terraform changes in %s", component.Path), terraformCommand, applyEnv, applyArgs...)
-	if err != nil {
+	if _, err := s.runtime.Shell.ExecProgressWithEnv(fmt.Sprintf("Applying Terraform changes in %s", component.Path), terraformCommand, applyEnv, applyArgs...); err != nil {
 		return fmt.Errorf("error running terraform apply for %s: %w", component.Path, err)
-	}
-	if applyOutput != "" {
-		fmt.Fprint(os.Stdout, applyOutput)
 	}
 
 	_ = s.runtime.TerraformProvider.CacheOutputs(component.GetID())

--- a/pkg/runtime/config/values_source.go
+++ b/pkg/runtime/config/values_source.go
@@ -95,39 +95,18 @@ func (s *valuesSource) Save(
 		valuesExists = true
 	}
 
-	if !valuesExists || overwrite {
-		partition := s.policy.Partition(data, input)
-		marshaled, err := s.shims.YamlMarshal(partition.Values)
-		if err != nil {
-			return fmt.Errorf("error marshalling values.yaml: %w", err)
-		}
-
-		if err := s.shims.WriteFile(valuesPath, marshaled, 0644); err != nil {
-			return fmt.Errorf("error writing values.yaml: %w", err)
-		}
-
+	if valuesExists && !overwrite {
 		return nil
 	}
 
-	fileData, err := s.shims.ReadFile(valuesPath)
+	partition := s.policy.Partition(data, input)
+	marshaled, err := s.shims.YamlMarshal(partition.Values)
 	if err != nil {
-		return nil
+		return fmt.Errorf("error marshalling values.yaml: %w", err)
 	}
 
-	var existing map[string]any
-	if err := s.shims.YamlUnmarshal(fileData, &existing); err != nil {
-		return nil
-	}
-
-	cleaned := s.policy.Partition(existing, input).Values
-	if len(cleaned) != len(existing) {
-		marshaled, err := s.shims.YamlMarshal(cleaned)
-		if err != nil {
-			return nil
-		}
-		if err := s.shims.WriteFile(valuesPath, marshaled, 0644); err != nil {
-			return fmt.Errorf("error writing cleaned values.yaml: %w", err)
-		}
+	if err := s.shims.WriteFile(valuesPath, marshaled, 0644); err != nil {
+		return fmt.Errorf("error writing values.yaml: %w", err)
 	}
 
 	return nil

--- a/pkg/runtime/config/values_source_test.go
+++ b/pkg/runtime/config/values_source_test.go
@@ -84,7 +84,7 @@ func TestValuesSource_Save(t *testing.T) {
 		}
 	})
 
-	t.Run("CleansWorkstationManagedKeysFromExistingWhenNotOverwrite", func(t *testing.T) {
+	t.Run("LeavesExistingValuesUntouchedWhenNotOverwrite", func(t *testing.T) {
 		source := newValuesSource(NewShims(), nil, newPersistencePolicy())
 		projectRoot := t.TempDir()
 		contextName := "local"
@@ -98,7 +98,7 @@ func TestValuesSource_Save(t *testing.T) {
 		}
 
 		if err := source.Save(projectRoot, contextName, map[string]any{"cluster": map[string]any{"driver": "talos"}}, false, persistencePolicyInput{IsDevMode: true}); err != nil {
-			t.Fatalf("Expected no error cleaning existing values file, got %v", err)
+			t.Fatalf("Expected no error, got %v", err)
 		}
 
 		valuesPath := filepath.Join(contextDir, "values.yaml")
@@ -106,15 +106,8 @@ func TestValuesSource_Save(t *testing.T) {
 		if err != nil {
 			t.Fatalf("Expected values.yaml to be readable, got %v", err)
 		}
-		valuesStr := string(content)
-		if contains(valuesStr, "platform:") {
-			t.Errorf("Expected platform to be removed during cleaning, got %s", valuesStr)
-		}
-		if contains(valuesStr, "workstation:") {
-			t.Errorf("Expected workstation to be removed during cleaning, got %s", valuesStr)
-		}
-		if contains(valuesStr, "provider:") {
-			t.Errorf("Expected provider to be removed during cleaning, got %s", valuesStr)
+		if string(content) != initial {
+			t.Errorf("Expected values.yaml to be unchanged, got %s", string(content))
 		}
 	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> This PR touches the blueprint generation pipeline and the terraform apply path, both of which are in the critical path for every `windsor up` and `windsor apply` run.
>
> **Overview**
>
> The change introduces a `GenerateResolved()` method on `BlueprintHandler` that re-evaluates deferred expressions (e.g. `terraform_output()`) against the composed scope after terraform has run, then passes the fully-resolved blueprint to the provisioner for kustomize installation. The `install` and `apply` commands are updated to call `GenerateResolved()` so they pick up JIT-evaluated values. A separate cleanup removes stale-key management from `values_source.Save`, simplifying the overwrite logic.
>
> All three issues identified in the previous review have been resolved: `GenerateResolved()` now deep-copies the blueprint before mutating it and restores the original afterward; the ConfigMap deferred-resolution loop now uses the correct `configmaps.<name>.<key>` path prefix; and terraform apply output is handled by the `tui.WithProgress` wrapper rather than a dropped return value. The new `deriveConfigMapDeferredPaths()` helper correctly propagates deferred status from ConfigMap entries to the path registry so JIT resolution covers them.
>
> Reviewed by Claude for commit `fd945c69`.

<!-- /claude-code-review:summary -->
