### PR TITLE
feat(provisioner/terraform): Destroy with backend migration

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -220,9 +221,11 @@ func migrateStateToLocal(proj *project.Project, blueprint *blueprintv1alpha1.Blu
 		return nil, fmt.Errorf("failed to override backend for destroy: %w", err)
 	}
 	restore := func() {
-		_ = ch.Set("terraform.backend.type", originalBackend)
+		if err := ch.Set("terraform.backend.type", originalBackend); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to restore terraform.backend.type to %q after destroy: %v\n", originalBackend, err)
+		}
 	}
-	if err := proj.Provisioner.MigrateState(blueprint); err != nil {
+	if _, err := proj.Provisioner.MigrateState(blueprint); err != nil {
 		restore()
 		return nil, fmt.Errorf("failed to migrate state to local before destroy: %w", err)
 	}

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -7,38 +7,15 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+	"github.com/windsorcli/cli/pkg/project"
 )
 
+// =============================================================================
+// Destroy Commands
+// =============================================================================
+
 var destroyConfirm string
-
-// confirmDestroy prompts the user to type confirmValue to proceed with a destructive operation.
-// It prints a description of what will be destroyed and the expected confirmation token.
-// Returns nil if the user types the correct value, or an error if input does not match or cannot be read.
-func confirmDestroy(r io.Reader, w io.Writer, description, confirmValue string) error {
-	fmt.Fprintf(w, "%s\n", description)
-	fmt.Fprintf(w, "Type %q to confirm: ", confirmValue)
-	scanner := bufio.NewScanner(r)
-	if !scanner.Scan() {
-		return fmt.Errorf("confirmation aborted")
-	}
-	if strings.TrimSpace(scanner.Text()) != confirmValue {
-		return fmt.Errorf("confirmation failed: input did not match %q", confirmValue)
-	}
-	return nil
-}
-
-// resolveDestroyConfirmation gates a destructive operation. If --confirm was supplied it must
-// match expected exactly; otherwise the user is prompted interactively. This mirrors the prompt
-// in both directions so scripted callers cannot accidentally destroy the wrong target.
-func resolveDestroyConfirmation(r io.Reader, w io.Writer, description, expected string) error {
-	if destroyConfirm != "" {
-		if destroyConfirm != expected {
-			return fmt.Errorf("confirmation failed: --confirm did not match %q", expected)
-		}
-		return nil
-	}
-	return confirmDestroy(r, w, description, expected)
-}
 
 var destroyCmd = &cobra.Command{
 	Use:   "destroy [component]",
@@ -63,6 +40,11 @@ With a component name, destroys every layer (Terraform and/or Kustomize) that co
 			if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, contextName); err != nil {
 				return err
 			}
+			restore, err := migrateStateToLocal(proj, blueprint)
+			if err != nil {
+				return err
+			}
+			defer restore()
 			if err := proj.Provisioner.DestroyAll(blueprint); err != nil {
 				return fmt.Errorf("error destroying all components: %w", err)
 			}
@@ -88,6 +70,11 @@ With a component name, destroys every layer (Terraform and/or Kustomize) that co
 			}
 		}
 		if inTerraform {
+			restore, err := migrateStateToLocal(proj, blueprint)
+			if err != nil {
+				return err
+			}
+			defer restore()
 			if err := proj.Provisioner.Destroy(blueprint, componentID); err != nil {
 				return fmt.Errorf("error destroying terraform for %s: %w", componentID, err)
 			}
@@ -118,6 +105,11 @@ var destroyTerraformCmd = &cobra.Command{
 			if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, contextName); err != nil {
 				return err
 			}
+			restore, err := migrateStateToLocal(proj, blueprint)
+			if err != nil {
+				return err
+			}
+			defer restore()
 			if err := proj.Provisioner.DestroyAllTerraform(blueprint); err != nil {
 				return fmt.Errorf("error destroying all terraform: %w", err)
 			}
@@ -129,6 +121,11 @@ var destroyTerraformCmd = &cobra.Command{
 		if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, componentID); err != nil {
 			return err
 		}
+		restore, err := migrateStateToLocal(proj, blueprint)
+		if err != nil {
+			return err
+		}
+		defer restore()
 		if err := proj.Provisioner.Destroy(blueprint, componentID); err != nil {
 			return fmt.Errorf("error destroying terraform for %s: %w", componentID, err)
 		}
@@ -173,6 +170,63 @@ var destroyKustomizeCmd = &cobra.Command{
 		}
 		return nil
 	},
+}
+
+// =============================================================================
+// Private Methods
+// =============================================================================
+
+// confirmDestroy prompts the user to type confirmValue to proceed with a destructive operation.
+// It prints a description of what will be destroyed and the expected confirmation token.
+// Returns nil if the user types the correct value, or an error if input does not match or cannot be read.
+func confirmDestroy(r io.Reader, w io.Writer, description, confirmValue string) error {
+	fmt.Fprintf(w, "%s\n", description)
+	fmt.Fprintf(w, "Type %q to confirm: ", confirmValue)
+	scanner := bufio.NewScanner(r)
+	if !scanner.Scan() {
+		return fmt.Errorf("confirmation aborted")
+	}
+	if strings.TrimSpace(scanner.Text()) != confirmValue {
+		return fmt.Errorf("confirmation failed: input did not match %q", confirmValue)
+	}
+	return nil
+}
+
+// resolveDestroyConfirmation gates a destructive operation. If --confirm was supplied it must
+// match expected exactly; otherwise the user is prompted interactively. This mirrors the prompt
+// in both directions so scripted callers cannot accidentally destroy the wrong target.
+func resolveDestroyConfirmation(r io.Reader, w io.Writer, description, expected string) error {
+	if destroyConfirm != "" {
+		if destroyConfirm != expected {
+			return fmt.Errorf("confirmation failed: --confirm did not match %q", expected)
+		}
+		return nil
+	}
+	return confirmDestroy(r, w, description, expected)
+}
+
+// migrateStateToLocal overrides the configured terraform backend to "local" in-memory and runs
+// MigrateState so each component's state is pulled from its currently configured remote backend
+// into local files. The override must remain active through the subsequent destroy pass —
+// otherwise destroy would try to read state from the remote backend again, which may be about
+// to be torn down (for example, the S3 bucket that stores its own state). Returns a restore
+// function the caller must defer; it re-applies the originally configured backend type once
+// destruction completes. Components whose state is already local (or whose directories are not
+// materialized) are no-ops, so this is safe to call on every terraform-touching destroy path.
+func migrateStateToLocal(proj *project.Project, blueprint *blueprintv1alpha1.Blueprint) (func(), error) {
+	ch := proj.Runtime.ConfigHandler
+	originalBackend := ch.GetString("terraform.backend.type", "local")
+	if err := ch.Set("terraform.backend.type", "local"); err != nil {
+		return nil, fmt.Errorf("failed to override backend for destroy: %w", err)
+	}
+	restore := func() {
+		_ = ch.Set("terraform.backend.type", originalBackend)
+	}
+	if err := proj.Provisioner.MigrateState(blueprint); err != nil {
+		restore()
+		return nil, fmt.Errorf("failed to migrate state to local before destroy: %w", err)
+	}
+	return restore, nil
 }
 
 // init registers destroy subcommands and the --confirm flag. --confirm must exactly match the

--- a/cmd/destroy_test.go
+++ b/cmd/destroy_test.go
@@ -563,6 +563,123 @@ func TestDestroyTerraformCmd(t *testing.T) {
 			t.Errorf("Expected destroy error, got: %v", err)
 		}
 	})
+
+	t.Run("MigratesStateToLocalBeforeDestroyAll", func(t *testing.T) {
+		// Given a context configured for a remote backend (e.g. S3). Before tearing
+		// anything down the destroy flow must pull state back to local — otherwise
+		// destroying backend/s3 itself would try to delete the bucket while its own
+		// state file still lives inside it.
+		mocks := setupDestroyTest(t)
+		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockCH.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "terraform.backend.type" {
+				return "s3"
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
+
+		var ops []string
+		mockCH.SetFunc = func(key string, value any) error {
+			if key == "terraform.backend.type" {
+				ops = append(ops, fmt.Sprintf("set:%v", value))
+			}
+			return nil
+		}
+		mocks.TerraformStack.MigrateStateFunc = func(bp *blueprintv1alpha1.Blueprint) error {
+			ops = append(ops, "migrate")
+			return nil
+		}
+		mocks.TerraformStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint) error {
+			ops = append(ops, "destroy")
+			return nil
+		}
+
+		proj := newDestroyProject(mocks)
+		cmd := createTestDestroyTerraformCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--confirm=test-context"})
+		cmd.SetContext(ctx)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the sequence must be: override backend to local, migrate state to
+		// local, run destroy, restore the originally configured backend.
+		expected := []string{"set:local", "migrate", "destroy", "set:s3"}
+		if len(ops) != len(expected) {
+			t.Fatalf("Expected %d ops %v, got %d %v", len(expected), expected, len(ops), ops)
+		}
+		for i, want := range expected {
+			if ops[i] != want {
+				t.Errorf("op %d: got %q, want %q (full: %v)", i, ops[i], want, ops)
+			}
+		}
+	})
+
+	t.Run("MigrationFailureAbortsDestroyAndRestoresBackend", func(t *testing.T) {
+		// Given pre-destroy state migration fails (e.g. remote backend unreachable),
+		// the destroy pass must not run — otherwise we'd attempt teardown against an
+		// inconsistent or empty local state. The originally configured backend must
+		// still be restored so subsequent windsor invocations see the real config.
+		mocks := setupDestroyTest(t)
+		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockCH.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "terraform.backend.type" {
+				return "s3"
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
+
+		var ops []string
+		mockCH.SetFunc = func(key string, value any) error {
+			if key == "terraform.backend.type" {
+				ops = append(ops, fmt.Sprintf("set:%v", value))
+			}
+			return nil
+		}
+		mocks.TerraformStack.MigrateStateFunc = func(bp *blueprintv1alpha1.Blueprint) error {
+			ops = append(ops, "migrate-fail")
+			return fmt.Errorf("remote backend unreachable")
+		}
+		destroyCalled := false
+		mocks.TerraformStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint) error {
+			destroyCalled = true
+			return nil
+		}
+
+		proj := newDestroyProject(mocks)
+		cmd := createTestDestroyTerraformCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--confirm=test-context"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		if err == nil {
+			t.Fatal("Expected migration error to surface, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to migrate state to local before destroy") {
+			t.Errorf("Expected migration wrapper error, got %v", err)
+		}
+		if destroyCalled {
+			t.Error("Destroy must not run after migration failure")
+		}
+		// Backend override must be restored on the failure path.
+		expected := []string{"set:local", "migrate-fail", "set:s3"}
+		if len(ops) != len(expected) {
+			t.Fatalf("Expected %d ops %v, got %d %v", len(expected), expected, len(ops), ops)
+		}
+		for i, want := range expected {
+			if ops[i] != want {
+				t.Errorf("op %d: got %q, want %q (full: %v)", i, ops[i], want, ops)
+			}
+		}
+	})
 }
 
 func TestDestroyKustomizeCmd(t *testing.T) {

--- a/cmd/destroy_test.go
+++ b/cmd/destroy_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 	"testing"
 
@@ -588,9 +589,9 @@ func TestDestroyTerraformCmd(t *testing.T) {
 			}
 			return nil
 		}
-		mocks.TerraformStack.MigrateStateFunc = func(bp *blueprintv1alpha1.Blueprint) error {
+		mocks.TerraformStack.MigrateStateFunc = func(bp *blueprintv1alpha1.Blueprint) ([]string, error) {
 			ops = append(ops, "migrate")
-			return nil
+			return nil, nil
 		}
 		mocks.TerraformStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint) error {
 			ops = append(ops, "destroy")
@@ -643,9 +644,9 @@ func TestDestroyTerraformCmd(t *testing.T) {
 			}
 			return nil
 		}
-		mocks.TerraformStack.MigrateStateFunc = func(bp *blueprintv1alpha1.Blueprint) error {
+		mocks.TerraformStack.MigrateStateFunc = func(bp *blueprintv1alpha1.Blueprint) ([]string, error) {
 			ops = append(ops, "migrate-fail")
-			return fmt.Errorf("remote backend unreachable")
+			return nil, fmt.Errorf("remote backend unreachable")
 		}
 		destroyCalled := false
 		mocks.TerraformStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint) error {
@@ -678,6 +679,63 @@ func TestDestroyTerraformCmd(t *testing.T) {
 			if ops[i] != want {
 				t.Errorf("op %d: got %q, want %q (full: %v)", i, ops[i], want, ops)
 			}
+		}
+	})
+
+	t.Run("RestoreFailureEmitsStderrWarning", func(t *testing.T) {
+		// Given the restore path's ch.Set fails (rare but possible), the error used
+		// to be silently discarded — leaving the in-memory backend type stuck on
+		// "local" for any code that ran after destroy in the same process. Destroy
+		// itself has already succeeded, so we don't want to fail the command, but
+		// the problem must be observable on stderr rather than invisible.
+		mocks := setupDestroyTest(t)
+		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockCH.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "terraform.backend.type" {
+				return "s3"
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
+		mockCH.SetFunc = func(key string, value any) error {
+			if key == "terraform.backend.type" && value == "s3" {
+				return fmt.Errorf("mock restore failure")
+			}
+			return nil
+		}
+
+		// Capture stderr so we can assert on the warning text.
+		r, w, pipeErr := os.Pipe()
+		if pipeErr != nil {
+			t.Fatalf("Pipe failed: %v", pipeErr)
+		}
+		origStderr := os.Stderr
+		os.Stderr = w
+		defer func() { os.Stderr = origStderr }()
+
+		proj := newDestroyProject(mocks)
+		cmd := createTestDestroyTerraformCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--confirm=test-context"})
+		cmd.SetContext(ctx)
+		execErr := cmd.Execute()
+
+		// Flush the write side so the pipe reader can finish.
+		w.Close()
+		stderrBytes, _ := io.ReadAll(r)
+		stderrOutput := string(stderrBytes)
+
+		// Destroy itself should still succeed — the restore failure is post-destroy.
+		if execErr != nil {
+			t.Fatalf("Expected destroy to succeed despite restore failure, got %v", execErr)
+		}
+		if !strings.Contains(stderrOutput, "failed to restore terraform.backend.type") {
+			t.Errorf("Expected stderr warning about restore failure, got: %q", stderrOutput)
+		}
+		if !strings.Contains(stderrOutput, "mock restore failure") {
+			t.Errorf("Expected stderr warning to include underlying cause, got: %q", stderrOutput)
 		}
 	})
 }

--- a/pkg/provisioner/terraform/mock_stack.go
+++ b/pkg/provisioner/terraform/mock_stack.go
@@ -16,7 +16,7 @@ import (
 // MockStack is a mock implementation of the Stack interface for testing.
 type MockStack struct {
 	UpFunc                   func(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(id string) error) error
-	MigrateStateFunc         func(blueprint *blueprintv1alpha1.Blueprint) error
+	MigrateStateFunc         func(blueprint *blueprintv1alpha1.Blueprint) ([]string, error)
 	PostApplyFunc            func(fns ...func(id string) error)
 	DestroyAllFunc           func(blueprint *blueprintv1alpha1.Blueprint) error
 	PlanFunc                 func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
@@ -51,11 +51,11 @@ func (m *MockStack) Up(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(i
 }
 
 // MigrateState is a mock implementation of the MigrateState method.
-func (m *MockStack) MigrateState(blueprint *blueprintv1alpha1.Blueprint) error {
+func (m *MockStack) MigrateState(blueprint *blueprintv1alpha1.Blueprint) ([]string, error) {
 	if m.MigrateStateFunc != nil {
 		return m.MigrateStateFunc(blueprint)
 	}
-	return nil
+	return nil, nil
 }
 
 // PostApply is a mock implementation of the PostApply method.

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -28,7 +28,7 @@ import (
 // Both the Stack struct and MockStack implement this interface.
 type Stack interface {
 	Up(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(id string) error) error
-	MigrateState(blueprint *blueprintv1alpha1.Blueprint) error
+	MigrateState(blueprint *blueprintv1alpha1.Blueprint) ([]string, error)
 	PostApply(fns ...func(id string) error)
 	DestroyAll(blueprint *blueprintv1alpha1.Blueprint) error
 	Plan(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
@@ -229,19 +229,26 @@ func (s *TerraformStack) Up(blueprint *blueprintv1alpha1.Blueprint, onApply ...f
 // change (e.g. at the end of bootstrap, after the initial local-state applies, once the configured
 // remote backend exists and is reachable, or before destroy, after overriding the backend to
 // local in-memory so state is pulled back out of the remote backend for teardown). A component
-// whose state is already on the configured backend is a no-op. Components whose directories
-// have not been materialized on disk are skipped — they have no state to migrate and forcing
-// an error would block pre-destroy migration when the blueprint lists components that were
-// never applied. On the first failure MigrateState returns; any components not yet migrated
-// retain their existing state, so the call is safe to retry once the underlying issue is resolved.
-func (s *TerraformStack) MigrateState(blueprint *blueprintv1alpha1.Blueprint) error {
+// whose state is already on the configured backend is a no-op.
+//
+// Components whose directories are not materialized on disk are skipped — there is literally no
+// state to migrate — and their IDs are returned in the skipped slice so callers can decide what
+// to do about it. Bootstrap, which calls MigrateState only after a successful Up that itself
+// errors on missing dirs, should treat a non-empty skipped list as a hard error (state/config
+// would be left inconsistent). Pre-destroy migration should discard the list, because the
+// blueprint may legitimately list components that were never applied or were torn down
+// out-of-band. Returning the signal rather than branching internally keeps both contracts
+// visible at the call site. On the first terraform failure MigrateState returns; any components
+// not yet migrated retain their existing state, so the call is safe to retry once the
+// underlying issue is resolved.
+func (s *TerraformStack) MigrateState(blueprint *blueprintv1alpha1.Blueprint) ([]string, error) {
 	if blueprint == nil {
-		return fmt.Errorf("blueprint not provided")
+		return nil, fmt.Errorf("blueprint not provided")
 	}
 
 	currentDir, err := s.shims.Getwd()
 	if err != nil {
-		return fmt.Errorf("error getting current directory: %v", err)
+		return nil, fmt.Errorf("error getting current directory: %v", err)
 	}
 	defer func() {
 		_ = s.shims.Chdir(currentDir)
@@ -249,7 +256,7 @@ func (s *TerraformStack) MigrateState(blueprint *blueprintv1alpha1.Blueprint) er
 
 	projectRoot := s.runtime.ProjectRoot
 	if projectRoot == "" {
-		return fmt.Errorf("error getting project root: project root is empty")
+		return nil, fmt.Errorf("error getting project root: project root is empty")
 	}
 	components := s.resolveTerraformComponents(blueprint, projectRoot)
 
@@ -260,11 +267,13 @@ func (s *TerraformStack) MigrateState(blueprint *blueprintv1alpha1.Blueprint) er
 		}
 	}()
 
+	var skipped []string
 	// Migration is a fast post-apply bookkeeping step per component; users don't need a
 	// spinner line for each one. A single top-level progress message covers the whole pass.
-	return tui.WithProgress("Migrating terraform state", func() error {
+	err = tui.WithProgress("Migrating terraform state", func() error {
 		for _, component := range components {
 			if _, err := s.shims.Stat(component.FullPath); os.IsNotExist(err) {
+				skipped = append(skipped, component.GetID())
 				continue
 			}
 
@@ -287,6 +296,10 @@ func (s *TerraformStack) MigrateState(blueprint *blueprintv1alpha1.Blueprint) er
 		}
 		return nil
 	})
+	if err != nil {
+		return nil, err
+	}
+	return skipped, nil
 }
 
 // DestroyAll destroys all Terraform components in the stack in reverse dependency order.

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -227,8 +227,12 @@ func (s *TerraformStack) Up(blueprint *blueprintv1alpha1.Blueprint, onApply ...f
 // directory to the configured target. It runs terraform init with -migrate-state -force-copy per
 // component; no plan or apply is executed. Intended to be called after a backend configuration
 // change (e.g. at the end of bootstrap, after the initial local-state applies, once the configured
-// remote backend exists and is reachable). A component whose state is already on the configured
-// backend is a no-op. On the first failure MigrateState returns; any components not yet migrated
+// remote backend exists and is reachable, or before destroy, after overriding the backend to
+// local in-memory so state is pulled back out of the remote backend for teardown). A component
+// whose state is already on the configured backend is a no-op. Components whose directories
+// have not been materialized on disk are skipped — they have no state to migrate and forcing
+// an error would block pre-destroy migration when the blueprint lists components that were
+// never applied. On the first failure MigrateState returns; any components not yet migrated
 // retain their existing state, so the call is safe to retry once the underlying issue is resolved.
 func (s *TerraformStack) MigrateState(blueprint *blueprintv1alpha1.Blueprint) error {
 	if blueprint == nil {
@@ -261,7 +265,7 @@ func (s *TerraformStack) MigrateState(blueprint *blueprintv1alpha1.Blueprint) er
 	return tui.WithProgress("Migrating terraform state", func() error {
 		for _, component := range components {
 			if _, err := s.shims.Stat(component.FullPath); os.IsNotExist(err) {
-				return fmt.Errorf("directory %s does not exist", component.FullPath)
+				continue
 			}
 
 			terraformVars, terraformArgs, err := s.setupTerraformEnvironment(component)
@@ -285,11 +289,13 @@ func (s *TerraformStack) MigrateState(blueprint *blueprintv1alpha1.Blueprint) er
 	})
 }
 
-// DestroyAll destroys all Terraform components in the stack by executing Terraform destroy operations in reverse dependency order.
-// For each component, DestroyAll generates Terraform arguments, sets required environment variables, unsets conflicting TF_CLI_ARGS_* variables,
-// creates backend override files, runs Terraform refresh, plan (with destroy flag), and destroy commands. Backend override files are
-// cleaned up after all components complete. Components with Destroy set to false are skipped. Directory state is restored after execution.
-// Errors are returned on any operation failure. The blueprint parameter is required to resolve terraform components.
+// DestroyAll destroys all Terraform components in the stack in reverse dependency order.
+// For each component, it runs a destroy-prep apply (init, plan, apply with TF_VAR_operation=destroy)
+// followed by the actual destroy (refresh, plan -destroy, destroy) in a single progress span.
+// This ensures modules can update state before teardown (e.g., remove protection flags).
+// Components with Destroy set to false are skipped. Backend override files are cleaned up after.
+// Directory state is restored on return. Returns an error on any failure.
+// The blueprint parameter is required to resolve components.
 func (s *TerraformStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint) error {
 	if blueprint == nil {
 		return fmt.Errorf("blueprint not provided")
@@ -331,17 +337,22 @@ func (s *TerraformStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint) erro
 			continue
 		}
 
+		terraformVars, terraformArgs, err := s.setupTerraformEnvironment(component)
+		if err != nil {
+			return err
+		}
+
+		backendOverridePath := filepath.Join(component.FullPath, "backend_override.tf")
+		if _, err := s.shims.Stat(backendOverridePath); err == nil {
+			backendOverridePaths = append(backendOverridePaths, backendOverridePath)
+		}
+
 		if err := tui.WithProgress(fmt.Sprintf("Destroying %s", component.Path), func() error {
-			terraformVars, terraformArgs, err := s.setupTerraformEnvironment(component)
-			if err != nil {
+			if err := s.applyComponentForDestroy(&component, terraformVars, terraformArgs); err != nil {
 				return err
 			}
-			terraformVars["TF_VAR_operation"] = "destroy"
 
-			backendOverridePath := filepath.Join(component.FullPath, "backend_override.tf")
-			if _, err := s.shims.Stat(backendOverridePath); err == nil {
-				backendOverridePaths = append(backendOverridePaths, backendOverridePath)
-			}
+			terraformVars["TF_VAR_operation"] = "destroy"
 
 			terraformCommand := s.runtime.ToolsManager.GetTerraformCommand()
 			refreshArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "refresh"}
@@ -352,14 +363,14 @@ func (s *TerraformStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint) erro
 			planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan"}
 			planArgs = append(planArgs, terraformArgs.PlanDestroyArgs...)
 			planEnv := selectTerraformCommandEnv(terraformVars, true)
-			if _, err := s.runtime.Shell.ExecProgressWithEnv(fmt.Sprintf("Planning terraform destroy for %s", component.Path), terraformCommand, planEnv, planArgs...); err != nil {
+			if _, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, planEnv, planArgs...); err != nil {
 				return fmt.Errorf("error running terraform plan destroy for %s: %w", component.Path, err)
 			}
 
 			destroyArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "destroy"}
 			destroyArgs = append(destroyArgs, terraformArgs.DestroyArgs...)
 			destroyEnv := selectTerraformCommandEnv(terraformVars, true)
-			if _, err := s.runtime.Shell.ExecProgressWithEnv(fmt.Sprintf("Destroying terraform for %s", component.Path), terraformCommand, destroyEnv, destroyArgs...); err != nil {
+			if _, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, destroyEnv, destroyArgs...); err != nil {
 				return fmt.Errorf("error running terraform destroy for %s: %w", component.Path, err)
 			}
 			return nil
@@ -612,8 +623,13 @@ func (s *TerraformStack) Apply(blueprint *blueprintv1alpha1.Blueprint, component
 	})
 }
 
-// Destroy runs terraform init, plan -destroy, and destroy for a single component identified by componentID.
-// Returns an error if the blueprint is nil, the component is not found, or any terraform operation fails.
+// Destroy runs a destroy-prep apply followed by terraform refresh, plan -destroy, and destroy
+// for a single component. The prep-apply cycle runs terraform init, plan, and apply with
+// TF_VAR_operation=destroy so the module can flip any destroy-prep flags (for example,
+// force_destroy on S3 buckets, deletion_protection off on RDS, lifecycle rules cleared)
+// into state before the destroy pass. Modules that don't consume var.operation see the
+// prep-apply as a no-op. Returns an error if the blueprint is nil, the component is not
+// found, or any terraform operation fails.
 func (s *TerraformStack) Destroy(blueprint *blueprintv1alpha1.Blueprint, componentID string) error {
 	if blueprint == nil {
 		return fmt.Errorf("blueprint not provided")
@@ -627,9 +643,8 @@ func (s *TerraformStack) Destroy(blueprint *blueprintv1alpha1.Blueprint, compone
 		return err
 	}
 	defer cleanup()
-	terraformVars["TF_VAR_operation"] = "destroy"
 
-	if err := s.runTerraformInit(component, terraformVars, terraformArgs, defaultInitFlags...); err != nil {
+	if err := s.applyComponentForDestroy(component, terraformVars, terraformArgs); err != nil {
 		return err
 	}
 
@@ -661,6 +676,41 @@ func (s *TerraformStack) Destroy(blueprint *blueprintv1alpha1.Blueprint, compone
 // =============================================================================
 // Private Methods
 // =============================================================================
+
+// applyComponentForDestroy runs terraform init, plan, and apply for a single component with
+// TF_VAR_operation=destroy. This is the destroy-prep phase of the destroy routine: it lets
+// the module flip any destroy-prep flags (force_destroy on S3 buckets, deletion_protection
+// off on RDS, lifecycle rules cleared, and so on) into state before the destroy pass runs.
+// Modules that don't consume var.operation see this as a no-op. Every step runs silently
+// so the caller's outer "Destroying <path>" progress span is the only label the user sees;
+// surfacing a separate "Preparing" spinner here would leak implementation detail into the
+// UI and make the destroy look like two operations. The caller owns directory save/restore
+// and backend override cleanup; this helper performs only the per-component terraform work.
+func (s *TerraformStack) applyComponentForDestroy(component *blueprintv1alpha1.TerraformComponent, terraformVars map[string]string, terraformArgs *envvars.TerraformArgs) error {
+	terraformVars["TF_VAR_operation"] = "destroy"
+
+	if err := s.runTerraformInit(component, terraformVars, terraformArgs, defaultInitFlags...); err != nil {
+		return err
+	}
+
+	terraformCommand := s.runtime.ToolsManager.GetTerraformCommand()
+
+	planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan"}
+	planArgs = append(planArgs, terraformArgs.PlanArgs...)
+	planEnv := selectTerraformCommandEnv(terraformVars, true)
+	if _, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, planEnv, planArgs...); err != nil {
+		return fmt.Errorf("error running destroy-prep plan for %s: %w", component.Path, err)
+	}
+
+	applyArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "apply"}
+	applyArgs = append(applyArgs, terraformArgs.ApplyArgs...)
+	applyEnv := selectTerraformCommandEnv(terraformVars, false)
+	if _, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, applyEnv, applyArgs...); err != nil {
+		return fmt.Errorf("error running destroy-prep apply for %s: %w", component.Path, err)
+	}
+
+	return nil
+}
 
 // resolveTerraformComponents resolves terraform components from the blueprint by resolving sources and paths.
 // Components with Enabled set to false are excluded from the returned list.

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -549,7 +549,7 @@ func TestStack_MigrateState(t *testing.T) {
 
 	t.Run("ReturnsErrorForNilBlueprint", func(t *testing.T) {
 		stack, _ := setup(t)
-		if err := stack.MigrateState(nil); err == nil {
+		if _, err := stack.MigrateState(nil); err == nil {
 			t.Fatal("Expected error for nil blueprint")
 		}
 	})
@@ -573,8 +573,12 @@ func TestStack_MigrateState(t *testing.T) {
 		}
 
 		// When MigrateState runs
-		if err := stack.MigrateState(blueprint); err != nil {
+		skipped, err := stack.MigrateState(blueprint)
+		if err != nil {
 			t.Fatalf("Expected MigrateState to succeed, got %v", err)
+		}
+		if len(skipped) != 0 {
+			t.Errorf("Expected no skipped components when all dirs exist, got %v", skipped)
 		}
 
 		// Then terraform init -migrate-state fired once per component and no plan/apply ran.
@@ -604,7 +608,7 @@ func TestStack_MigrateState(t *testing.T) {
 		}
 
 		// When MigrateState runs
-		if err := stack.MigrateState(blueprint); err != nil {
+		if _, err := stack.MigrateState(blueprint); err != nil {
 			t.Fatalf("Expected MigrateState to succeed, got %v", err)
 		}
 
@@ -625,7 +629,7 @@ func TestStack_MigrateState(t *testing.T) {
 			return "", nil
 		}
 
-		err := stack.MigrateState(blueprint)
+		_, err := stack.MigrateState(blueprint)
 		if err == nil {
 			t.Fatal("Expected MigrateState to return an error when init fails")
 		}
@@ -637,12 +641,14 @@ func TestStack_MigrateState(t *testing.T) {
 		}
 	})
 
-	t.Run("SkipsComponentsWithMissingDirectories", func(t *testing.T) {
+	t.Run("SkipsComponentsWithMissingDirectoriesAndReportsThem", func(t *testing.T) {
 		// Given a stat shim that reports every component directory as missing — the
 		// blueprint may list components that were never applied (or were already
 		// torn down manually), and MigrateState is called before destroy precisely
-		// when some of that state may be absent. Erroring out here would block the
-		// whole destroy flow.
+		// when some of that state may be absent. The skipped components must be
+		// returned to the caller so bootstrap (which calls MigrateState after Up
+		// has materialized all dirs) can treat a non-empty skip as an anomaly,
+		// while pre-destroy migration can discard the list and proceed.
 		stack, mocks := setup(t)
 		blueprint := createTestBlueprint()
 
@@ -659,13 +665,18 @@ func TestStack_MigrateState(t *testing.T) {
 		}
 
 		// When MigrateState runs
-		if err := stack.MigrateState(blueprint); err != nil {
+		skipped, err := stack.MigrateState(blueprint)
+		if err != nil {
 			t.Fatalf("Expected no error when every component dir is missing, got %v", err)
 		}
 
-		// Then no terraform init was invoked — the missing components were skipped.
+		// Then no terraform init was invoked — the missing components were skipped —
+		// and both component IDs appear in the returned skip list.
 		if initsSeen != 0 {
 			t.Errorf("Expected 0 init invocations when all dirs are missing, got %d", initsSeen)
+		}
+		if len(skipped) != 2 {
+			t.Fatalf("Expected 2 skipped component IDs, got %d: %v", len(skipped), skipped)
 		}
 	})
 }

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -636,6 +636,38 @@ func TestStack_MigrateState(t *testing.T) {
 			t.Errorf("Expected error to wrap the underlying cause, got: %v", err)
 		}
 	})
+
+	t.Run("SkipsComponentsWithMissingDirectories", func(t *testing.T) {
+		// Given a stat shim that reports every component directory as missing — the
+		// blueprint may list components that were never applied (or were already
+		// torn down manually), and MigrateState is called before destroy precisely
+		// when some of that state may be absent. Erroring out here would block the
+		// whole destroy flow.
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+
+		mocks.Shims.Stat = func(path string) (os.FileInfo, error) {
+			return nil, os.ErrNotExist
+		}
+
+		var initsSeen int
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == "init" {
+				initsSeen++
+			}
+			return "", nil
+		}
+
+		// When MigrateState runs
+		if err := stack.MigrateState(blueprint); err != nil {
+			t.Fatalf("Expected no error when every component dir is missing, got %v", err)
+		}
+
+		// Then no terraform init was invoked — the missing components were skipped.
+		if initsSeen != 0 {
+			t.Errorf("Expected 0 init invocations when all dirs are missing, got %d", initsSeen)
+		}
+	})
 }
 
 func TestStack_DestroyAll(t *testing.T) {
@@ -695,10 +727,19 @@ func TestStack_DestroyAll(t *testing.T) {
 	})
 
 	t.Run("ErrorRunningTerraformPlan", func(t *testing.T) {
+		// Given a stack whose shell fails on the destroy-phase terraform plan.
+		// Both the prep-apply plan and the destroy-phase plan run via ExecSilentWithEnv;
+		// this test matches the second occurrence (plan -destroy, identified by
+		// PlanDestroyArgs being appended), so the first prep-apply plan succeeds and we
+		// still exercise the destroy-phase error path.
 		stack, mocks := setup(t)
-		mocks.Shell.ExecProgressFunc = func(message string, command string, args ...string) (string, error) {
+		planCalls := 0
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
 			if command == "terraform" && len(args) > 0 && strings.HasPrefix(args[0], "-chdir=") && len(args) > 1 && args[1] == "plan" {
-				return "", fmt.Errorf("mock error running terraform plan")
+				planCalls++
+				if planCalls >= 2 {
+					return "", fmt.Errorf("mock error running terraform plan")
+				}
 			}
 			return "", nil
 		}
@@ -706,6 +747,9 @@ func TestStack_DestroyAll(t *testing.T) {
 		blueprint := createTestBlueprint()
 		err := stack.DestroyAll(blueprint)
 		expectedError := "error running terraform plan destroy for"
+		if err == nil {
+			t.Fatalf("Expected plan-destroy error, got nil")
+		}
 		if !strings.Contains(err.Error(), expectedError) {
 			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
 		}
@@ -743,7 +787,7 @@ func TestStack_DestroyAll(t *testing.T) {
 		}
 
 		var terraformCommands []string
-		mocks.Shell.ExecProgressFunc = func(message string, command string, args ...string) (string, error) {
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
 			if command == "terraform" {
 				terraformCommands = append(terraformCommands, strings.Join(args, " "))
 			}
@@ -800,7 +844,7 @@ func TestStack_DestroyAll(t *testing.T) {
 		}
 
 		var terraformCommands []string
-		mocks.Shell.ExecProgressFunc = func(message string, command string, args ...string) (string, error) {
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
 			if command == "terraform" {
 				cmdStr := strings.Join(args, " ")
 				terraformCommands = append(terraformCommands, cmdStr)
@@ -833,8 +877,10 @@ func TestStack_DestroyAll(t *testing.T) {
 	})
 
 	t.Run("ErrorRunningTerraformDestroy", func(t *testing.T) {
+		// DestroyAll runs every terraform subcommand via ExecSilentWithEnv so the outer
+		// "Destroying <path>" progress span is the only label the user sees.
 		stack, mocks := setup(t)
-		mocks.Shell.ExecProgressWithEnvFunc = func(message string, command string, env map[string]string, args ...string) (string, error) {
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
 			if command == "terraform" && len(args) > 0 && strings.HasPrefix(args[0], "-chdir=") && len(args) > 1 && args[1] == "destroy" {
 				return "", fmt.Errorf("mock error running terraform destroy")
 			}
@@ -844,6 +890,9 @@ func TestStack_DestroyAll(t *testing.T) {
 		blueprint := createTestBlueprint()
 		err := stack.DestroyAll(blueprint)
 		expectedError := "error running terraform destroy for"
+		if err == nil {
+			t.Fatalf("Expected destroy error, got nil")
+		}
 		if !strings.Contains(err.Error(), expectedError) {
 			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
 		}
@@ -970,9 +1019,10 @@ func TestStack_DestroyAll(t *testing.T) {
 		stack, mocks := setup(t)
 		blueprint := createTestBlueprint()
 
-		// When DestroyAll is called, capture the env passed to terraform destroy
+		// When DestroyAll is called, capture the env passed to terraform destroy.
+		// All destroy-phase subcommands run via ExecSilentWithEnv now.
 		var capturedEnv map[string]string
-		mocks.Shell.ExecProgressWithEnvFunc = func(message string, command string, env map[string]string, args ...string) (string, error) {
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
 			if len(args) > 1 && args[1] == "destroy" {
 				capturedEnv = env
 			}
@@ -987,6 +1037,99 @@ func TestStack_DestroyAll(t *testing.T) {
 		}
 		if capturedEnv["TF_VAR_operation"] != "destroy" {
 			t.Errorf("Expected TF_VAR_operation to be %q, got %q", "destroy", capturedEnv["TF_VAR_operation"])
+		}
+	})
+
+	t.Run("RunsPrepThenDestroyPerComponentInReverseOrder", func(t *testing.T) {
+		// Given a stack that records the per-component terraform steps in order
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+
+		type step struct {
+			component  string
+			subcommand string
+			operation  string
+		}
+		var sequence []step
+		componentOf := func(args []string) string {
+			if len(args) == 0 {
+				return ""
+			}
+			switch {
+			case strings.Contains(args[0], "remote/path"):
+				return "remote/path"
+			case strings.Contains(args[0], "local/path"):
+				return "local/path"
+			}
+			return ""
+		}
+		record := func(env map[string]string, args []string) {
+			if len(args) <= 1 {
+				return
+			}
+			sequence = append(sequence, step{
+				component:  componentOf(args),
+				subcommand: args[1],
+				operation:  env["TF_VAR_operation"],
+			})
+		}
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" {
+				record(env, args)
+			}
+			return "", nil
+		}
+		mocks.Shell.ExecProgressWithEnvFunc = func(message string, command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" {
+				record(env, args)
+			}
+			return "", nil
+		}
+
+		// When destroying all components
+		if err := stack.DestroyAll(blueprint); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then components are walked in reverse dependency order, and each component is
+		// taken fully through prep-apply then destroy before the next one begins. This
+		// matches terraform destroy semantics end-to-end: a dependent is torn down
+		// (including its prep) before its dependency is touched. TF_VAR_operation=destroy
+		// is forwarded to the commands that include TF_VAR_* in their env (plan, refresh,
+		// destroy); init and apply intentionally don't forward TF_VAR_* and rely on the
+		// process env set by windsor env.
+		type ordered struct {
+			component  string
+			subcommand string
+		}
+		expected := []ordered{
+			{component: "local/path", subcommand: "init"},
+			{component: "local/path", subcommand: "plan"},
+			{component: "local/path", subcommand: "apply"},
+			{component: "local/path", subcommand: "refresh"},
+			{component: "local/path", subcommand: "plan"},
+			{component: "local/path", subcommand: "destroy"},
+			{component: "remote/path", subcommand: "init"},
+			{component: "remote/path", subcommand: "plan"},
+			{component: "remote/path", subcommand: "apply"},
+			{component: "remote/path", subcommand: "refresh"},
+			{component: "remote/path", subcommand: "plan"},
+			{component: "remote/path", subcommand: "destroy"},
+		}
+		if len(sequence) != len(expected) {
+			t.Fatalf("Expected %d steps, got %d: %+v", len(expected), len(sequence), sequence)
+		}
+		for i, want := range expected {
+			got := ordered{component: sequence[i].component, subcommand: sequence[i].subcommand}
+			if got != want {
+				t.Errorf("step %d: got %+v, want %+v", i, got, want)
+			}
+			switch sequence[i].subcommand {
+			case "plan", "refresh", "destroy":
+				if sequence[i].operation != "destroy" {
+					t.Errorf("step %d (%s %s): TF_VAR_operation = %q, want %q", i, sequence[i].component, sequence[i].subcommand, sequence[i].operation, "destroy")
+				}
+			}
 		}
 	})
 
@@ -1984,12 +2127,12 @@ func TestStack_Destroy(t *testing.T) {
 		}
 	})
 
-	t.Run("ErrorRunningTerraformPlanDestroy", func(t *testing.T) {
-		// Given a stack whose shell fails on terraform plan -destroy
+	t.Run("ErrorRunningDestroyPrepPlan", func(t *testing.T) {
+		// Given a stack whose shell fails on the first terraform plan (the destroy-prep plan)
 		stack, mocks := setup(t)
 		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
 			if command == "terraform" && len(args) > 1 && args[1] == "plan" {
-				return "", fmt.Errorf("mock error running terraform plan destroy")
+				return "", fmt.Errorf("mock error running destroy-prep plan")
 			}
 			return "", nil
 		}
@@ -1998,7 +2141,31 @@ func TestStack_Destroy(t *testing.T) {
 		// When destroying
 		err := stack.Destroy(blueprint, "local/path")
 
-		// Then an error should occur
+		// Then the prep-plan error path should be reported
+		if !strings.Contains(err.Error(), "error running destroy-prep plan for") {
+			t.Fatalf("Expected error to contain %q, got %q", "error running destroy-prep plan for", err.Error())
+		}
+	})
+
+	t.Run("ErrorRunningTerraformPlanDestroy", func(t *testing.T) {
+		// Given a stack whose shell fails on the second terraform plan (the destroy-pass plan -destroy)
+		stack, mocks := setup(t)
+		planCalls := 0
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" && len(args) > 1 && args[1] == "plan" {
+				planCalls++
+				if planCalls >= 2 {
+					return "", fmt.Errorf("mock error running terraform plan destroy")
+				}
+			}
+			return "", nil
+		}
+		blueprint := createTestBlueprint()
+
+		// When destroying
+		err := stack.Destroy(blueprint, "local/path")
+
+		// Then the destroy-pass plan error path should be reported
 		if !strings.Contains(err.Error(), "error running terraform plan destroy for") {
 			t.Fatalf("Expected error to contain %q, got %q", "error running terraform plan destroy for", err.Error())
 		}
@@ -2084,6 +2251,63 @@ func TestStack_Destroy(t *testing.T) {
 		}
 		if capturedEnv["TF_VAR_operation"] != "destroy" {
 			t.Errorf("Expected TF_VAR_operation to be %q, got %q", "destroy", capturedEnv["TF_VAR_operation"])
+		}
+	})
+
+	t.Run("RunsPrepApplyBeforeDestroy", func(t *testing.T) {
+		// Given a stack that records the ordered sequence of terraform subcommands with their TF_VAR_operation
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+
+		type step struct {
+			subcommand string
+			operation  string
+		}
+		var sequence []step
+		record := func(env map[string]string, args []string) {
+			if len(args) <= 1 {
+				return
+			}
+			sequence = append(sequence, step{subcommand: args[1], operation: env["TF_VAR_operation"]})
+		}
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" {
+				record(env, args)
+			}
+			return "", nil
+		}
+		mocks.Shell.ExecProgressWithEnvFunc = func(message string, command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" {
+				record(env, args)
+			}
+			return "", nil
+		}
+
+		// When destroying a single component
+		if err := stack.Destroy(blueprint, "local/path"); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the sequence starts with a full apply pass (init, plan, apply) followed by the
+		// destroy pass (refresh, plan, destroy). TF_VAR_operation=destroy is forwarded to the
+		// commands that include TF_VAR_* in their env (plan, refresh, destroy); init and apply
+		// intentionally don't forward TF_VAR_* and rely on the process env set by windsor env.
+		expected := []string{"init", "plan", "apply", "refresh", "plan", "destroy"}
+		if len(sequence) < len(expected) {
+			t.Fatalf("Expected at least %d terraform steps, got %d: %+v", len(expected), len(sequence), sequence)
+		}
+		for i, want := range expected {
+			if sequence[i].subcommand != want {
+				t.Errorf("step %d: subcommand = %q, want %q (full sequence: %+v)", i, sequence[i].subcommand, want, sequence)
+			}
+		}
+		for i, s := range sequence[:len(expected)] {
+			switch s.subcommand {
+			case "plan", "refresh", "destroy":
+				if s.operation != "destroy" {
+					t.Errorf("step %d (%s): TF_VAR_operation = %q, want %q", i, s.subcommand, s.operation, "destroy")
+				}
+			}
 		}
 	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **High Risk**
>
> The `Stack.MigrateState` signature change is not propagated to the `Provisioner` wrapper, producing compile errors at `provisioner.go:209` and `cmd/destroy.go:228` that will block the build against main.
>
> **Overview**
>
> This PR inserts a pre-destroy backend migration step into every terraform-touching destroy path. Before tearing anything down, it overrides the configured backend to `"local"` in memory, calls `MigrateState` to pull state out of remote storage into local files, then defers restoration of the original backend type. This solves the case where the S3 bucket holding remote state is itself a component being torn down.
>
> A new "destroy-prep" apply phase runs `init`/`plan`/`apply` with `TF_VAR_operation=destroy` before the actual destroy pass, allowing modules to flip protection flags into state first. The `destroyTerraformCmd` paths have thorough new tests; the equivalent paths in the base `destroyCmd` do not.
>
> Reviewed by Claude for commit `c3bd4c7`.

<!-- /claude-code-review:summary -->
