### PR TITLE
chore: update AWS configuration fields and enhance environment variable handling

### DIFF
--- a/api/v1alpha1/aws/aws_config.go
+++ b/api/v1alpha1/aws/aws_config.go
@@ -6,10 +6,13 @@ type AWSConfig struct {
 	Enabled *bool `yaml:"enabled,omitempty"`
 
 	// AWSEndpointURL specifies the custom endpoint URL for AWS services.
-	AWSEndpointURL *string `yaml:"aws_endpoint_url,omitempty"`
+	AWSEndpointURL *string `yaml:"endpoint_url,omitempty"`
 
 	// AWSProfile defines the AWS CLI profile to use for authentication.
-	AWSProfile *string `yaml:"aws_profile,omitempty"`
+	AWSProfile *string `yaml:"profile,omitempty"`
+
+	// AWSRegion is the AWS region used for API calls, exported to downstream tools as AWS_REGION.
+	AWSRegion *string `yaml:"region,omitempty"`
 
 	// S3Hostname sets the custom hostname for the S3 service.
 	S3Hostname *string `yaml:"s3_hostname,omitempty"`
@@ -37,6 +40,9 @@ func (base *AWSConfig) Merge(overlay *AWSConfig) {
 	}
 	if overlay.AWSProfile != nil {
 		base.AWSProfile = overlay.AWSProfile
+	}
+	if overlay.AWSRegion != nil {
+		base.AWSRegion = overlay.AWSRegion
 	}
 	if overlay.S3Hostname != nil {
 		base.S3Hostname = overlay.S3Hostname
@@ -71,6 +77,9 @@ func (c *AWSConfig) Copy() *AWSConfig {
 	}
 	if c.AWSProfile != nil {
 		copy.AWSProfile = c.AWSProfile
+	}
+	if c.AWSRegion != nil {
+		copy.AWSRegion = c.AWSRegion
 	}
 	if c.S3Hostname != nil {
 		copy.S3Hostname = c.S3Hostname

--- a/api/v1alpha1/aws/aws_config.go
+++ b/api/v1alpha1/aws/aws_config.go
@@ -1,10 +1,8 @@
 package aws
 
-// AWSConfig represents the AWS configuration
+// AWSConfig represents the AWS configuration. AWS integration activates whenever this block
+// is present in a context (or when platform is "aws"); there is no separate `enabled` flag.
 type AWSConfig struct {
-	// Enabled indicates whether AWS integration is enabled.
-	Enabled *bool `yaml:"enabled,omitempty"`
-
 	// AWSEndpointURL specifies the custom endpoint URL for AWS services.
 	AWSEndpointURL *string `yaml:"endpoint_url,omitempty"`
 
@@ -32,9 +30,6 @@ type LocalstackConfig struct {
 
 // Merge performs a deep merge of the current AWSConfig with another AWSConfig.
 func (base *AWSConfig) Merge(overlay *AWSConfig) {
-	if overlay.Enabled != nil {
-		base.Enabled = overlay.Enabled
-	}
 	if overlay.AWSEndpointURL != nil {
 		base.AWSEndpointURL = overlay.AWSEndpointURL
 	}
@@ -69,9 +64,6 @@ func (c *AWSConfig) Copy() *AWSConfig {
 		return nil
 	}
 	copy := &AWSConfig{}
-	if c.Enabled != nil {
-		copy.Enabled = c.Enabled
-	}
 	if c.AWSEndpointURL != nil {
 		copy.AWSEndpointURL = c.AWSEndpointURL
 	}

--- a/api/v1alpha1/aws/aws_config_test.go
+++ b/api/v1alpha1/aws/aws_config_test.go
@@ -7,7 +7,6 @@ import (
 func TestAWSConfig_Merge(t *testing.T) {
 	t.Run("MergeWithNoNils", func(t *testing.T) {
 		base := &AWSConfig{
-			Enabled:        ptrBool(true),
 			AWSEndpointURL: ptrString("https://base.aws.endpoint"),
 			AWSProfile:     ptrString("base-profile"),
 			S3Hostname:     ptrString("base-s3-hostname"),
@@ -19,7 +18,6 @@ func TestAWSConfig_Merge(t *testing.T) {
 		}
 
 		overlay := &AWSConfig{
-			Enabled:        ptrBool(false),
 			AWSEndpointURL: ptrString("https://overlay.aws.endpoint"),
 			AWSProfile:     ptrString("overlay-profile"),
 			S3Hostname:     ptrString("overlay-s3-hostname"),
@@ -32,9 +30,6 @@ func TestAWSConfig_Merge(t *testing.T) {
 
 		base.Merge(overlay)
 
-		if base.Enabled == nil || *base.Enabled != false {
-			t.Errorf("Enabled mismatch: expected false, got %v", *base.Enabled)
-		}
 		if base.AWSEndpointURL == nil || *base.AWSEndpointURL != "https://overlay.aws.endpoint" {
 			t.Errorf("AWSEndpointURL mismatch: expected 'https://overlay.aws.endpoint', got '%s'", *base.AWSEndpointURL)
 		}
@@ -57,7 +52,6 @@ func TestAWSConfig_Merge(t *testing.T) {
 
 	t.Run("MergeWithAllNils", func(t *testing.T) {
 		base := &AWSConfig{
-			Enabled:        nil,
 			AWSEndpointURL: nil,
 			AWSProfile:     nil,
 			S3Hostname:     nil,
@@ -66,7 +60,6 @@ func TestAWSConfig_Merge(t *testing.T) {
 		}
 
 		overlay := &AWSConfig{
-			Enabled:        nil,
 			AWSEndpointURL: nil,
 			AWSProfile:     nil,
 			S3Hostname:     nil,
@@ -79,9 +72,6 @@ func TestAWSConfig_Merge(t *testing.T) {
 
 		base.Merge(overlay)
 
-		if base.Enabled != nil {
-			t.Errorf("Enabled mismatch: expected nil, got %v", base.Enabled)
-		}
 		if base.AWSEndpointURL != nil {
 			t.Errorf("AWSEndpointURL mismatch: expected nil, got '%s'", *base.AWSEndpointURL)
 		}
@@ -103,7 +93,6 @@ func TestAWSConfig_Merge(t *testing.T) {
 func TestAWSConfig_Copy(t *testing.T) {
 	t.Run("CopyWithNonNilValues", func(t *testing.T) {
 		original := &AWSConfig{
-			Enabled:        ptrBool(true),
 			AWSEndpointURL: ptrString("https://original.aws.endpoint"),
 			AWSProfile:     ptrString("original-profile"),
 			S3Hostname:     ptrString("original-s3-hostname"),
@@ -116,9 +105,6 @@ func TestAWSConfig_Copy(t *testing.T) {
 
 		copy := original.Copy()
 
-		if original.Enabled == nil || copy.Enabled == nil || *original.Enabled != *copy.Enabled {
-			t.Errorf("Enabled mismatch: expected %v, got %v", *original.Enabled, *copy.Enabled)
-		}
 		if original.AWSEndpointURL == nil || copy.AWSEndpointURL == nil || *original.AWSEndpointURL != *copy.AWSEndpointURL {
 			t.Errorf("AWSEndpointURL mismatch: expected %v, got %v", *original.AWSEndpointURL, *copy.AWSEndpointURL)
 		}
@@ -144,11 +130,6 @@ func TestAWSConfig_Copy(t *testing.T) {
 		}
 
 		// Modify the copy and ensure original is unchanged
-		copy.Enabled = ptrBool(false)
-		if original.Enabled == nil || *original.Enabled == *copy.Enabled {
-			t.Errorf("Original Enabled was modified: expected %v, got %v", true, *copy.Enabled)
-		}
-
 		copy.Localstack.Services = append([]string(nil), copy.Localstack.Services...)
 		copy.Localstack.Services[0] = "dynamodb"
 		if original.Localstack.Services[0] == copy.Localstack.Services[0] {

--- a/api/v1alpha1/config_types_test.go
+++ b/api/v1alpha1/config_types_test.go
@@ -19,7 +19,6 @@ func TestConfig_Merge(t *testing.T) {
 	t.Run("MergeWithNonNilValues", func(t *testing.T) {
 		base := &Context{
 			AWS: &aws.AWSConfig{
-				Enabled:        ptrBool(true),
 				AWSEndpointURL: ptrString("https://base.aws.endpoint"),
 			},
 			Azure: &azure.AzureConfig{
@@ -162,7 +161,6 @@ func TestConfig_Merge(t *testing.T) {
 	t.Run("MergeWithNilOverlay", func(t *testing.T) {
 		base := &Context{
 			AWS: &aws.AWSConfig{
-				Enabled:        ptrBool(true),
 				AWSEndpointURL: ptrString("https://base.aws.endpoint"),
 			},
 			Azure: &azure.AzureConfig{
@@ -379,7 +377,6 @@ func TestConfig_Copy(t *testing.T) {
 				"KEY": "value",
 			},
 			AWS: &aws.AWSConfig{
-				Enabled:        ptrBool(true),
 				AWSEndpointURL: ptrString("https://original.aws.endpoint"),
 			},
 			Azure: &azure.AzureConfig{
@@ -427,8 +424,8 @@ func TestConfig_Copy(t *testing.T) {
 		if original.Environment["KEY"] != copy.Environment["KEY"] {
 			t.Errorf("Environment mismatch: expected %v, got %v", original.Environment["KEY"], copy.Environment["KEY"])
 		}
-		if original.AWS.Enabled == nil || copy.AWS.Enabled == nil || *original.AWS.Enabled != *copy.AWS.Enabled {
-			t.Errorf("AWS Enabled mismatch: expected %v, got %v", *original.AWS.Enabled, *copy.AWS.Enabled)
+		if original.AWS.AWSEndpointURL == nil || copy.AWS.AWSEndpointURL == nil || *original.AWS.AWSEndpointURL != *copy.AWS.AWSEndpointURL {
+			t.Errorf("AWS AWSEndpointURL mismatch: expected %v, got %v", *original.AWS.AWSEndpointURL, *copy.AWS.AWSEndpointURL)
 		}
 		if original.Azure.Enabled == nil || copy.Azure.Enabled == nil || *original.Azure.Enabled != *copy.Azure.Enabled {
 			t.Errorf("Azure Enabled mismatch: expected %v, got %v", *original.Azure.Enabled, *copy.Azure.Enabled)

--- a/api/v1alpha2/config/providers/aws/aws.go
+++ b/api/v1alpha2/config/providers/aws/aws.go
@@ -1,10 +1,8 @@
 package aws
 
-// AWSConfig represents the AWS configuration
+// AWSConfig represents the AWS configuration. AWS integration activates whenever this block
+// is present in a context (or when platform is "aws"); there is no separate `enabled` flag.
 type AWSConfig struct {
-	// Enabled indicates whether AWS integration is enabled.
-	Enabled *bool `yaml:"enabled,omitempty"`
-
 	// AWSEndpointURL specifies the custom endpoint URL for AWS services.
 	AWSEndpointURL *string `yaml:"endpoint_url,omitempty"`
 
@@ -23,9 +21,6 @@ type AWSConfig struct {
 
 // Merge performs a deep merge of the current AWSConfig with another AWSConfig.
 func (base *AWSConfig) Merge(overlay *AWSConfig) {
-	if overlay.Enabled != nil {
-		base.Enabled = overlay.Enabled
-	}
 	if overlay.AWSEndpointURL != nil {
 		base.AWSEndpointURL = overlay.AWSEndpointURL
 	}
@@ -50,10 +45,6 @@ func (c *AWSConfig) DeepCopy() *AWSConfig {
 	}
 	copied := &AWSConfig{}
 
-	if c.Enabled != nil {
-		enabledCopy := *c.Enabled
-		copied.Enabled = &enabledCopy
-	}
 	if c.AWSEndpointURL != nil {
 		urlCopy := *c.AWSEndpointURL
 		copied.AWSEndpointURL = &urlCopy

--- a/api/v1alpha2/config/providers/aws/aws.go
+++ b/api/v1alpha2/config/providers/aws/aws.go
@@ -6,10 +6,13 @@ type AWSConfig struct {
 	Enabled *bool `yaml:"enabled,omitempty"`
 
 	// AWSEndpointURL specifies the custom endpoint URL for AWS services.
-	AWSEndpointURL *string `yaml:"aws_endpoint_url,omitempty"`
+	AWSEndpointURL *string `yaml:"endpoint_url,omitempty"`
 
 	// AWSProfile defines the AWS CLI profile to use for authentication.
-	AWSProfile *string `yaml:"aws_profile,omitempty"`
+	AWSProfile *string `yaml:"profile,omitempty"`
+
+	// AWSRegion is the AWS region used for API calls, exported to downstream tools as AWS_REGION.
+	AWSRegion *string `yaml:"region,omitempty"`
 
 	// S3Hostname sets the custom hostname for the S3 service.
 	S3Hostname *string `yaml:"s3_hostname,omitempty"`
@@ -28,6 +31,9 @@ func (base *AWSConfig) Merge(overlay *AWSConfig) {
 	}
 	if overlay.AWSProfile != nil {
 		base.AWSProfile = overlay.AWSProfile
+	}
+	if overlay.AWSRegion != nil {
+		base.AWSRegion = overlay.AWSRegion
 	}
 	if overlay.S3Hostname != nil {
 		base.S3Hostname = overlay.S3Hostname
@@ -55,6 +61,10 @@ func (c *AWSConfig) DeepCopy() *AWSConfig {
 	if c.AWSProfile != nil {
 		profileCopy := *c.AWSProfile
 		copied.AWSProfile = &profileCopy
+	}
+	if c.AWSRegion != nil {
+		regionCopy := *c.AWSRegion
+		copied.AWSRegion = &regionCopy
 	}
 	if c.S3Hostname != nil {
 		hostnameCopy := *c.S3Hostname

--- a/api/v1alpha2/config/providers/aws/aws_test.go
+++ b/api/v1alpha2/config/providers/aws/aws_test.go
@@ -7,7 +7,6 @@ import (
 func TestAWSConfig_Merge(t *testing.T) {
 	t.Run("MergeWithNoNils", func(t *testing.T) {
 		base := &AWSConfig{
-			Enabled:        ptrBool(true),
 			AWSEndpointURL: ptrString("https://base.aws.endpoint"),
 			AWSProfile:     ptrString("base-profile"),
 			S3Hostname:     ptrString("base-s3-hostname"),
@@ -15,7 +14,6 @@ func TestAWSConfig_Merge(t *testing.T) {
 		}
 
 		overlay := &AWSConfig{
-			Enabled:        ptrBool(false),
 			AWSEndpointURL: ptrString("https://overlay.aws.endpoint"),
 			AWSProfile:     ptrString("overlay-profile"),
 			S3Hostname:     ptrString("overlay-s3-hostname"),
@@ -24,9 +22,6 @@ func TestAWSConfig_Merge(t *testing.T) {
 
 		base.Merge(overlay)
 
-		if base.Enabled == nil || *base.Enabled != false {
-			t.Errorf("Enabled mismatch: expected false, got %v", *base.Enabled)
-		}
 		if base.AWSEndpointURL == nil || *base.AWSEndpointURL != "https://overlay.aws.endpoint" {
 			t.Errorf("AWSEndpointURL mismatch: expected 'https://overlay.aws.endpoint', got '%s'", *base.AWSEndpointURL)
 		}
@@ -43,7 +38,6 @@ func TestAWSConfig_Merge(t *testing.T) {
 
 	t.Run("MergeWithAllNils", func(t *testing.T) {
 		base := &AWSConfig{
-			Enabled:        nil,
 			AWSEndpointURL: nil,
 			AWSProfile:     nil,
 			S3Hostname:     nil,
@@ -51,7 +45,6 @@ func TestAWSConfig_Merge(t *testing.T) {
 		}
 
 		overlay := &AWSConfig{
-			Enabled:        nil,
 			AWSEndpointURL: nil,
 			AWSProfile:     nil,
 			S3Hostname:     nil,
@@ -60,9 +53,6 @@ func TestAWSConfig_Merge(t *testing.T) {
 
 		base.Merge(overlay)
 
-		if base.Enabled != nil {
-			t.Errorf("Enabled mismatch: expected nil, got %v", base.Enabled)
-		}
 		if base.AWSEndpointURL != nil {
 			t.Errorf("AWSEndpointURL mismatch: expected nil, got '%s'", *base.AWSEndpointURL)
 		}
@@ -81,7 +71,6 @@ func TestAWSConfig_Merge(t *testing.T) {
 func TestAWSConfig_Copy(t *testing.T) {
 	t.Run("CopyWithNonNilValues", func(t *testing.T) {
 		original := &AWSConfig{
-			Enabled:        ptrBool(true),
 			AWSEndpointURL: ptrString("https://original.aws.endpoint"),
 			AWSProfile:     ptrString("original-profile"),
 			S3Hostname:     ptrString("original-s3-hostname"),
@@ -90,9 +79,6 @@ func TestAWSConfig_Copy(t *testing.T) {
 
 		copy := original.DeepCopy()
 
-		if original.Enabled == nil || copy.Enabled == nil || *original.Enabled != *copy.Enabled {
-			t.Errorf("Enabled mismatch: expected %v, got %v", *original.Enabled, *copy.Enabled)
-		}
 		if original.AWSEndpointURL == nil || copy.AWSEndpointURL == nil || *original.AWSEndpointURL != *copy.AWSEndpointURL {
 			t.Errorf("AWSEndpointURL mismatch: expected %v, got %v", *original.AWSEndpointURL, *copy.AWSEndpointURL)
 		}
@@ -107,9 +93,10 @@ func TestAWSConfig_Copy(t *testing.T) {
 		}
 
 		// Modify the copy and ensure original is unchanged
-		copy.Enabled = ptrBool(false)
-		if original.Enabled == nil || *original.Enabled == *copy.Enabled {
-			t.Errorf("Original Enabled was modified: expected %v, got %v", true, *copy.Enabled)
+		newProfile := "modified-profile"
+		copy.AWSProfile = &newProfile
+		if original.AWSProfile == nil || *original.AWSProfile == *copy.AWSProfile {
+			t.Errorf("Original AWSProfile was modified: expected unchanged, got %v", *copy.AWSProfile)
 		}
 	})
 
@@ -122,11 +109,7 @@ func TestAWSConfig_Copy(t *testing.T) {
 	})
 }
 
-// Helper functions to create pointers for basic types
+// Helper function to create pointers for basic types
 func ptrString(s string) *string {
 	return &s
-}
-
-func ptrBool(b bool) *bool {
-	return &b
 }

--- a/api/v1alpha2/config/providers/providers_test.go
+++ b/api/v1alpha2/config/providers/providers_test.go
@@ -7,12 +7,20 @@ import (
 	"github.com/windsorcli/cli/api/v1alpha2/config/providers/azure"
 )
 
+// awsProfileA and awsProfileB stand in for the two distinct states the merge/copy tests
+// previously expressed via aws.Enabled = true/false. The Enabled field has been removed; any
+// non-nil AWS field works as the "did the merge run" signal.
+const (
+	awsProfileA = "profile-a"
+	awsProfileB = "profile-b"
+)
+
 // TestProvidersConfig_Merge tests the Merge method of ProvidersConfig
 func TestProvidersConfig_Merge(t *testing.T) {
 	t.Run("MergeWithNilOverlay", func(t *testing.T) {
 		base := &ProvidersConfig{
 			AWS: &aws.AWSConfig{
-				Enabled: boolPtr(true),
+				AWSProfile: stringPtr(awsProfileA),
 			},
 			Azure: &azure.AzureConfig{
 				Enabled: boolPtr(false),
@@ -22,7 +30,7 @@ func TestProvidersConfig_Merge(t *testing.T) {
 
 		base.Merge(nil)
 
-		if base.AWS == nil || *base.AWS.Enabled != *original.AWS.Enabled {
+		if base.AWS == nil || *base.AWS.AWSProfile != *original.AWS.AWSProfile {
 			t.Errorf("Expected AWS config to remain unchanged")
 		}
 		if base.Azure == nil || *base.Azure.Enabled != *original.Azure.Enabled {
@@ -33,7 +41,7 @@ func TestProvidersConfig_Merge(t *testing.T) {
 	t.Run("MergeWithEmptyOverlay", func(t *testing.T) {
 		base := &ProvidersConfig{
 			AWS: &aws.AWSConfig{
-				Enabled: boolPtr(true),
+				AWSProfile: stringPtr(awsProfileA),
 			},
 			Azure: &azure.AzureConfig{
 				Enabled: boolPtr(false),
@@ -43,8 +51,8 @@ func TestProvidersConfig_Merge(t *testing.T) {
 
 		base.Merge(overlay)
 
-		if base.AWS == nil || !*base.AWS.Enabled {
-			t.Errorf("Expected AWS config to remain enabled")
+		if base.AWS == nil || *base.AWS.AWSProfile != awsProfileA {
+			t.Errorf("Expected AWS config to remain at profile %q", awsProfileA)
 		}
 		if base.Azure == nil || *base.Azure.Enabled {
 			t.Errorf("Expected Azure config to remain disabled")
@@ -54,7 +62,7 @@ func TestProvidersConfig_Merge(t *testing.T) {
 	t.Run("MergeWithPartialOverlay", func(t *testing.T) {
 		base := &ProvidersConfig{
 			AWS: &aws.AWSConfig{
-				Enabled: boolPtr(true),
+				AWSProfile: stringPtr(awsProfileA),
 			},
 			Azure: &azure.AzureConfig{
 				Enabled: boolPtr(false),
@@ -62,7 +70,7 @@ func TestProvidersConfig_Merge(t *testing.T) {
 		}
 		overlay := &ProvidersConfig{
 			AWS: &aws.AWSConfig{
-				Enabled: boolPtr(false),
+				AWSProfile: stringPtr(awsProfileB),
 			},
 			Azure: &azure.AzureConfig{
 				Enabled: boolPtr(true),
@@ -71,8 +79,8 @@ func TestProvidersConfig_Merge(t *testing.T) {
 
 		base.Merge(overlay)
 
-		if base.AWS == nil || *base.AWS.Enabled {
-			t.Errorf("Expected AWS config to be disabled after merge")
+		if base.AWS == nil || *base.AWS.AWSProfile != awsProfileB {
+			t.Errorf("Expected AWS profile to be %q after merge, got %q", awsProfileB, *base.AWS.AWSProfile)
 		}
 		if base.Azure == nil || !*base.Azure.Enabled {
 			t.Errorf("Expected Azure config to be enabled after merge")
@@ -82,7 +90,7 @@ func TestProvidersConfig_Merge(t *testing.T) {
 	t.Run("MergeWithOnlyAWS", func(t *testing.T) {
 		base := &ProvidersConfig{
 			AWS: &aws.AWSConfig{
-				Enabled: boolPtr(true),
+				AWSProfile: stringPtr(awsProfileA),
 			},
 			Azure: &azure.AzureConfig{
 				Enabled: boolPtr(false),
@@ -90,14 +98,14 @@ func TestProvidersConfig_Merge(t *testing.T) {
 		}
 		overlay := &ProvidersConfig{
 			AWS: &aws.AWSConfig{
-				Enabled: boolPtr(false),
+				AWSProfile: stringPtr(awsProfileB),
 			},
 		}
 
 		base.Merge(overlay)
 
-		if base.AWS == nil || *base.AWS.Enabled {
-			t.Errorf("Expected AWS config to be disabled after merge")
+		if base.AWS == nil || *base.AWS.AWSProfile != awsProfileB {
+			t.Errorf("Expected AWS profile to be %q after merge", awsProfileB)
 		}
 		if base.Azure == nil || *base.Azure.Enabled {
 			t.Errorf("Expected Azure config to remain disabled")
@@ -107,7 +115,7 @@ func TestProvidersConfig_Merge(t *testing.T) {
 	t.Run("MergeWithOnlyAzure", func(t *testing.T) {
 		base := &ProvidersConfig{
 			AWS: &aws.AWSConfig{
-				Enabled: boolPtr(true),
+				AWSProfile: stringPtr(awsProfileA),
 			},
 			Azure: &azure.AzureConfig{
 				Enabled: boolPtr(false),
@@ -121,8 +129,8 @@ func TestProvidersConfig_Merge(t *testing.T) {
 
 		base.Merge(overlay)
 
-		if base.AWS == nil || !*base.AWS.Enabled {
-			t.Errorf("Expected AWS config to remain enabled")
+		if base.AWS == nil || *base.AWS.AWSProfile != awsProfileA {
+			t.Errorf("Expected AWS profile to remain %q", awsProfileA)
 		}
 		if base.Azure == nil || !*base.Azure.Enabled {
 			t.Errorf("Expected Azure config to be enabled after merge")
@@ -133,7 +141,7 @@ func TestProvidersConfig_Merge(t *testing.T) {
 		base := &ProvidersConfig{}
 		overlay := &ProvidersConfig{
 			AWS: &aws.AWSConfig{
-				Enabled: boolPtr(true),
+				AWSProfile: stringPtr(awsProfileA),
 			},
 			Azure: &azure.AzureConfig{
 				Enabled: boolPtr(false),
@@ -142,8 +150,8 @@ func TestProvidersConfig_Merge(t *testing.T) {
 
 		base.Merge(overlay)
 
-		if base.AWS == nil || !*base.AWS.Enabled {
-			t.Errorf("Expected AWS config to be initialized and enabled")
+		if base.AWS == nil || *base.AWS.AWSProfile != awsProfileA {
+			t.Errorf("Expected AWS config to be initialized with profile %q", awsProfileA)
 		}
 		if base.Azure == nil || *base.Azure.Enabled {
 			t.Errorf("Expected Azure config to be initialized and disabled")
@@ -158,14 +166,14 @@ func TestProvidersConfig_Merge(t *testing.T) {
 		}
 		overlay := &ProvidersConfig{
 			AWS: &aws.AWSConfig{
-				Enabled: boolPtr(true),
+				AWSProfile: stringPtr(awsProfileA),
 			},
 		}
 
 		base.Merge(overlay)
 
-		if base.AWS == nil || !*base.AWS.Enabled {
-			t.Errorf("Expected AWS config to be initialized and enabled")
+		if base.AWS == nil || *base.AWS.AWSProfile != awsProfileA {
+			t.Errorf("Expected AWS config to be initialized with profile %q", awsProfileA)
 		}
 		if base.Azure == nil || *base.Azure.Enabled {
 			t.Errorf("Expected Azure config to remain disabled")
@@ -175,7 +183,7 @@ func TestProvidersConfig_Merge(t *testing.T) {
 	t.Run("MergeWithNilBaseAzure", func(t *testing.T) {
 		base := &ProvidersConfig{
 			AWS: &aws.AWSConfig{
-				Enabled: boolPtr(true),
+				AWSProfile: stringPtr(awsProfileA),
 			},
 		}
 		overlay := &ProvidersConfig{
@@ -186,8 +194,8 @@ func TestProvidersConfig_Merge(t *testing.T) {
 
 		base.Merge(overlay)
 
-		if base.AWS == nil || !*base.AWS.Enabled {
-			t.Errorf("Expected AWS config to remain enabled")
+		if base.AWS == nil || *base.AWS.AWSProfile != awsProfileA {
+			t.Errorf("Expected AWS profile to remain %q", awsProfileA)
 		}
 		if base.Azure == nil || *base.Azure.Enabled {
 			t.Errorf("Expected Azure config to be initialized and disabled")
@@ -224,7 +232,7 @@ func TestProvidersConfig_Copy(t *testing.T) {
 	t.Run("CopyPopulatedConfig", func(t *testing.T) {
 		config := &ProvidersConfig{
 			AWS: &aws.AWSConfig{
-				Enabled: boolPtr(true),
+				AWSProfile: stringPtr(awsProfileA),
 			},
 			Azure: &azure.AzureConfig{
 				Enabled: boolPtr(false),
@@ -239,7 +247,7 @@ func TestProvidersConfig_Copy(t *testing.T) {
 		if copied == config {
 			t.Error("Expected copy to be a new instance")
 		}
-		if copied.AWS == nil || *copied.AWS.Enabled != *config.AWS.Enabled {
+		if copied.AWS == nil || *copied.AWS.AWSProfile != *config.AWS.AWSProfile {
 			t.Errorf("Expected AWS config to be copied correctly")
 		}
 		if copied.Azure == nil || *copied.Azure.Enabled != *config.Azure.Enabled {
@@ -250,7 +258,7 @@ func TestProvidersConfig_Copy(t *testing.T) {
 	t.Run("CopyWithPartialFields", func(t *testing.T) {
 		config := &ProvidersConfig{
 			AWS: &aws.AWSConfig{
-				Enabled: boolPtr(true),
+				AWSProfile: stringPtr(awsProfileA),
 			},
 		}
 
@@ -259,7 +267,7 @@ func TestProvidersConfig_Copy(t *testing.T) {
 		if copied == nil {
 			t.Error("Expected non-nil copy")
 		}
-		if copied.AWS == nil || *copied.AWS.Enabled != *config.AWS.Enabled {
+		if copied.AWS == nil || *copied.AWS.AWSProfile != *config.AWS.AWSProfile {
 			t.Errorf("Expected AWS config to be copied correctly")
 		}
 		if copied.Azure != nil {
@@ -270,7 +278,7 @@ func TestProvidersConfig_Copy(t *testing.T) {
 	t.Run("CopyWithIndependentValues", func(t *testing.T) {
 		config := &ProvidersConfig{
 			AWS: &aws.AWSConfig{
-				Enabled: boolPtr(true),
+				AWSProfile: stringPtr(awsProfileA),
 			},
 			Azure: &azure.AzureConfig{
 				Enabled: boolPtr(false),
@@ -280,10 +288,10 @@ func TestProvidersConfig_Copy(t *testing.T) {
 		copied := config.DeepCopy()
 
 		// Modify original to verify independence
-		*config.AWS.Enabled = false
+		*config.AWS.AWSProfile = awsProfileB
 		*config.Azure.Enabled = true
 
-		if *copied.AWS.Enabled != true {
+		if *copied.AWS.AWSProfile != awsProfileA {
 			t.Error("Expected copied AWS config to remain independent")
 		}
 		if *copied.Azure.Enabled != false {
@@ -294,7 +302,7 @@ func TestProvidersConfig_Copy(t *testing.T) {
 	t.Run("CopyWithSingleField", func(t *testing.T) {
 		config := &ProvidersConfig{
 			AWS: &aws.AWSConfig{
-				Enabled: boolPtr(true),
+				AWSProfile: stringPtr(awsProfileA),
 			},
 		}
 
@@ -303,7 +311,7 @@ func TestProvidersConfig_Copy(t *testing.T) {
 		if copied == nil {
 			t.Error("Expected non-nil copy")
 		}
-		if copied.AWS == nil || *copied.AWS.Enabled != *config.AWS.Enabled {
+		if copied.AWS == nil || *copied.AWS.AWSProfile != *config.AWS.AWSProfile {
 			t.Errorf("Expected AWS config to be copied correctly")
 		}
 		if copied.Azure != nil {
@@ -314,4 +322,8 @@ func TestProvidersConfig_Copy(t *testing.T) {
 
 func boolPtr(b bool) *bool {
 	return &b
+}
+
+func stringPtr(s string) *string {
+	return &s
 }

--- a/api/v1alpha2/config/providers/schema.yaml
+++ b/api/v1alpha2/config/providers/schema.yaml
@@ -6,11 +6,8 @@ type: object
 properties:
   aws:
     type: object
-    description: AWS provider configuration
+    description: AWS provider configuration. AWS integration activates whenever this block is present in a context (or when platform is "aws"); there is no separate enabled flag.
     properties:
-      enabled:
-        type: boolean
-        description: Enable or disable AWS integration
       endpoint_url:
         type: string
         description: Custom endpoint URL for AWS services

--- a/api/v1alpha2/config/providers/schema.yaml
+++ b/api/v1alpha2/config/providers/schema.yaml
@@ -11,12 +11,15 @@ properties:
       enabled:
         type: boolean
         description: Enable or disable AWS integration
-      aws_endpoint_url:
+      endpoint_url:
         type: string
         description: Custom endpoint URL for AWS services
-      aws_profile:
+      profile:
         type: string
         description: AWS CLI profile to use for authentication
+      region:
+        type: string
+        description: AWS region for API calls, exported to tools as AWS_REGION
       s3_hostname:
         type: string
         description: Custom hostname for the S3 service

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -139,6 +139,16 @@ var bootstrapCmd = &cobra.Command{
 			return err
 		}
 
+		// Validate cloud credentials before any infrastructure-touching work runs. CheckAuth
+		// is intentionally NOT part of Initialize/PrepareTools (which fire from `windsor init`
+		// where the operator has no obligation to be authed yet); bootstrap is the first
+		// command that will exercise credentials, so failing here gives the operator the
+		// vendor's own error (expired SSO, profile not found, etc.) up front rather than
+		// minutes into a `terraform apply`.
+		if err := proj.Runtime.ToolsManager.CheckAuth(); err != nil {
+			return fmt.Errorf("error validating credentials: %w", err)
+		}
+
 		if err := proj.Runtime.SaveConfig(len(bootstrapSetFlags) > 0); err != nil {
 			return fmt.Errorf("failed to save configuration: %w", err)
 		}

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -50,6 +50,15 @@ var checkCmd = &cobra.Command{
 			return err
 		}
 
+		// CheckTools covers local CLIs and their versions; CheckAuth exercises cloud-CLI
+		// presence + credential resolution (e.g. `aws --version` + `aws sts get-caller-identity`).
+		// That pair is kept out of CheckTools so `windsor init` / `windsor env` don't touch
+		// the cloud CLI — but `windsor check` is the explicit "verify my setup" command, so
+		// running it here is the right surface.
+		if err := rt.ToolsManager.CheckAuth(); err != nil {
+			return err
+		}
+
 		return nil
 	},
 }

--- a/docs/guides/environment-injection.md
+++ b/docs/guides/environment-injection.md
@@ -12,17 +12,30 @@ You should have set up the hook during [installation](../install.md). If configu
 Several tools are presently supported by Windsor's environment management system. The following outlines what to expect for each of these tools.
 
 ### AWS CLI
-If you are using Amazon Web Services (AWS), it is assumed that your AWS config file is located in your project at `contexts/<context-name>/.aws/config`, and leverage non-sensitive, OIDC-based authentication. It's only necessary to configure a single `default` profile.
+AWS integration activates whenever a context has `platform: aws` or an `aws:` block of any kind. There is no separate `enabled` flag — its presence is the signal.
+
+Inside a Windsor shell, `AWS_CONFIG_FILE` and `AWS_SHARED_CREDENTIALS_FILE` always point at the context's own `.aws/` directory, so `aws configure` and `aws configure sso` write into the context folder rather than the operator's global `~/.aws/`. This mirrors how Windsor scopes `KUBECONFIG` and `TALOSCONFIG` per context.
+
+`AWS_PROFILE` defaults to **the context name** so that `aws configure sso --profile <context>` and `aws sso login --profile <context>` line up with what Windsor will export in subsequent shells. If your AWS profile names don't match Windsor context names (e.g. you keep `[profile company-prod]` globally but your context is `prod`), set `aws.profile` in the context to override:
+
+```yaml
+contexts:
+  prod:
+    aws:
+      profile: company-prod
+```
 
 The following environment variables are set automatically, or can be configured in your `windsor.yaml` file:
 
-| Variable         | Default Value                          | Configuration                                      |
-|------------------|----------------------------------------|----------------------------------------------------|
-| AWS_CONFIG_FILE  | `contexts/<context-name>/.aws/config`  |                                                    |
-| AWS_PROFILE      | system default                         | `contexts.<context-name>.aws.aws_profile`          |
-| AWS_ENDPOINT_URL | system default                         | `contexts.<context-name>.aws.aws_endpoint_url`     |
-| S3_HOSTNAME      | system default                         | `contexts.<context-name>.aws.s3_hostname`          |
-| MWAA_ENDPOINT    | system default                         | `contexts.<context-name>.aws.mwaa_endpoint`        |
+| Variable                    | Default Value                                | Configuration                                      |
+|-----------------------------|----------------------------------------------|----------------------------------------------------|
+| AWS_CONFIG_FILE             | `contexts/<context-name>/.aws/config`        |                                                    |
+| AWS_SHARED_CREDENTIALS_FILE | `contexts/<context-name>/.aws/credentials`   |                                                    |
+| AWS_PROFILE                 | current context name                         | `contexts.<context-name>.aws.profile`              |
+| AWS_REGION                  | profile's own `region =` line                | `contexts.<context-name>.aws.region`               |
+| AWS_ENDPOINT_URL            | system default                               | `contexts.<context-name>.aws.endpoint_url`         |
+| S3_HOSTNAME                 | system default                               | `contexts.<context-name>.aws.s3_hostname`          |
+| MWAA_ENDPOINT               | system default                               | `contexts.<context-name>.aws.mwaa_endpoint`        |
 
 ### Docker
 The Windsor CLI provides several functionalities to manage Docker environments effectively. It automatically sets the `DOCKER_HOST` environment variable based on the `workstation.runtime` configuration, ensuring compatibility with both Colima and Docker Desktop setups. The CLI also ensures the Docker configuration directory exists and writes necessary configuration files. Additionally, it adds the `DOCKER_CONFIG` environment variable pointing to the Docker configuration directory and manages aliases for Docker commands, such as `docker-compose`, if specific plugins are detected.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -39,19 +39,21 @@ Configuration details specific to the AWS cloud provider. Additionally, configur
 ```yaml
 aws:
   enabled: true
-  aws_endpoint_url: http://aws.test:4566
-  aws_profile: local
+  profile: local
+  region: us-east-2
+  endpoint_url: http://aws.test:4566
   localstack: #...
 ```
 
 | Field            | Type     | Description                                                                 |
 |------------------|----------|-----------------------------------------------------------------------------|
 | `enabled`        | `bool`   | Indicates whether AWS integration is enabled.                               |
-| `aws_endpoint_url` | `string` | Specifies the custom endpoint URL for AWS services.                        |
-| `aws_profile`    | `string` | Defines the AWS CLI profile to use for authentication.                      |
-| `s3_hostname`    | `string` | Sets the custom hostname for the S3 service.                                |
-| `mwaa_endpoint`  | `string` | Specifies the endpoint for Managed Workflows for Apache Airflow.            |
-| `localstack`     | `LocalstackConfig` | Contains the configuration for Localstack, a local AWS cloud emulator. |
+| `profile`        | `string` | AWS CLI profile to use for authentication. Defaults to the context name.     |
+| `region`         | `string` | AWS region for API calls. Emitted as `AWS_REGION` to every tool run inside the context. |
+| `endpoint_url`   | `string` | Custom endpoint URL for AWS services (for example, LocalStack).              |
+| `s3_hostname`    | `string` | Custom hostname for the S3 service.                                         |
+| `mwaa_endpoint`  | `string` | Endpoint for Managed Workflows for Apache Airflow.                          |
+| `localstack`     | `LocalstackConfig` | Configuration for Localstack, a local AWS cloud emulator.          |
 
 #### Localstack
 Configures details specific to the Localstack service container. This service is available at `aws.test:4566`.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -34,11 +34,10 @@ Windsor applies default values for various configuration options when they are n
 These defaults ensure that basic functionality is available without requiring explicit configuration. You can override any default by explicitly setting the value in your `windsor.yaml` file.
 
 ### AWS
-Configuration details specific to the AWS cloud provider. Additionally, configures a Localstack service to simulate AWS resources locally.
+Configuration details specific to the AWS cloud provider. AWS integration activates whenever this block is present in a context (or when `platform: aws` is set); there is no separate `enabled` flag. Additionally, configures a Localstack service to simulate AWS resources locally.
 
 ```yaml
 aws:
-  enabled: true
   profile: local
   region: us-east-2
   endpoint_url: http://aws.test:4566
@@ -47,8 +46,7 @@ aws:
 
 | Field            | Type     | Description                                                                 |
 |------------------|----------|-----------------------------------------------------------------------------|
-| `enabled`        | `bool`   | Indicates whether AWS integration is enabled.                               |
-| `profile`        | `string` | AWS CLI profile to use for authentication. Defaults to the context name.     |
+| `profile`        | `string` | AWS CLI profile to use for authentication. Defaults to the context name, so `aws configure sso --profile <context>` lines up with what Windsor exports. Set this when your existing profile name differs from the context name. |
 | `region`         | `string` | AWS region for API calls. Emitted as `AWS_REGION` to every tool run inside the context. |
 | `endpoint_url`   | `string` | Custom endpoint URL for AWS services (for example, LocalStack).              |
 | `s3_hostname`    | `string` | Custom hostname for the S3 service.                                         |

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -184,6 +184,8 @@ const MinimumVersionKubelogin = "0.1.7"
 
 const MinimumVersionSOPS = "3.10.0"
 
+const MinimumVersionAWS = "2.0.0"
+
 // DefaultAKSOIDCServerID is the standard Azure AKS OIDC server ID (application ID of the
 // Microsoft-managed enterprise application "Azure Kubernetes Service AAD Server").
 // This is the same for all AKS clusters with AKS-managed Azure AD enabled.

--- a/pkg/runtime/env/aws_env.go
+++ b/pkg/runtime/env/aws_env.go
@@ -7,7 +7,6 @@ package env
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/windsorcli/cli/pkg/runtime/config"
@@ -46,15 +45,15 @@ func NewAwsEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler) *Aw
 // =============================================================================
 
 // GetEnvVars retrieves the environment variables for the AWS environment.
-// AWS_CONFIG_FILE and AWS_SHARED_CREDENTIALS_FILE are only emitted when the per-context
-// .aws/config or .aws/credentials file exists and is non-empty; otherwise the AWS SDK
-// falls through to its defaults (~/.aws/config, ~/.aws/credentials), so an existing
-// SSO/profile setup keeps working without per-context duplication. AWS_PROFILE defaults
-// to the current context name so `aws configure sso` creates a profile bound to the
-// context, and subsequent aws/terraform/SDK calls pick it up without further configuration;
-// an explicit aws.profile in the context's aws block overrides the default. AWS_REGION
-// is emitted only when aws.region is set; downstream tools otherwise fall back to the
-// profile's own `region =` line.
+// AWS_CONFIG_FILE and AWS_SHARED_CREDENTIALS_FILE always point at the context's
+// .aws/config and .aws/credentials, even when those files do not yet exist, so
+// that `aws configure` (run inside a windsor-shell session) writes into the
+// context folder rather than contaminating the operator's global ~/.aws files.
+// Subsequent aws/terraform/SDK calls then read the same context-scoped files.
+// AWS_PROFILE defaults to the current context name so `aws configure sso` creates
+// a profile bound to the context; an explicit aws.profile in the context's aws
+// block overrides the default. AWS_REGION is emitted only when aws.region is set;
+// downstream tools otherwise fall back to the profile's own `region =` line.
 func (e *AwsEnvPrinter) GetEnvVars() (map[string]string, error) {
 	envVars := make(map[string]string)
 
@@ -64,23 +63,8 @@ func (e *AwsEnvPrinter) GetEnvVars() (map[string]string, error) {
 	}
 
 	awsConfigDir := filepath.Join(configRoot, ".aws")
-	awsConfigPath := filepath.Join(awsConfigDir, "config")
-	awsCredentialsPath := filepath.Join(awsConfigDir, "credentials")
-
-	if info, err := e.shims.Stat(awsConfigPath); err != nil {
-		if !os.IsNotExist(err) {
-			return nil, fmt.Errorf("error checking %s: %w", awsConfigPath, err)
-		}
-	} else if info.Size() > 0 {
-		envVars["AWS_CONFIG_FILE"] = filepath.ToSlash(awsConfigPath)
-	}
-	if info, err := e.shims.Stat(awsCredentialsPath); err != nil {
-		if !os.IsNotExist(err) {
-			return nil, fmt.Errorf("error checking %s: %w", awsCredentialsPath, err)
-		}
-	} else if info.Size() > 0 {
-		envVars["AWS_SHARED_CREDENTIALS_FILE"] = filepath.ToSlash(awsCredentialsPath)
-	}
+	envVars["AWS_CONFIG_FILE"] = filepath.ToSlash(filepath.Join(awsConfigDir, "config"))
+	envVars["AWS_SHARED_CREDENTIALS_FILE"] = filepath.ToSlash(filepath.Join(awsConfigDir, "credentials"))
 
 	contextConfigData := e.configHandler.GetConfig()
 	awsProfileOverride := ""

--- a/pkg/runtime/env/aws_env.go
+++ b/pkg/runtime/env/aws_env.go
@@ -71,14 +71,14 @@ func (e *AwsEnvPrinter) GetEnvVars() (map[string]string, error) {
 		if !os.IsNotExist(err) {
 			return nil, fmt.Errorf("error checking %s: %w", awsConfigPath, err)
 		}
-	} else if info != nil && info.Size() > 0 {
+	} else if info.Size() > 0 {
 		envVars["AWS_CONFIG_FILE"] = filepath.ToSlash(awsConfigPath)
 	}
 	if info, err := e.shims.Stat(awsCredentialsPath); err != nil {
 		if !os.IsNotExist(err) {
 			return nil, fmt.Errorf("error checking %s: %w", awsCredentialsPath, err)
 		}
-	} else if info != nil && info.Size() > 0 {
+	} else if info.Size() > 0 {
 		envVars["AWS_SHARED_CREDENTIALS_FILE"] = filepath.ToSlash(awsCredentialsPath)
 	}
 

--- a/pkg/runtime/env/aws_env.go
+++ b/pkg/runtime/env/aws_env.go
@@ -7,6 +7,7 @@ package env
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
 	"github.com/windsorcli/cli/pkg/runtime/config"
@@ -45,41 +46,66 @@ func NewAwsEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler) *Aw
 // =============================================================================
 
 // GetEnvVars retrieves the environment variables for the AWS environment.
+// AWS_CONFIG_FILE and AWS_SHARED_CREDENTIALS_FILE are only emitted when the per-context
+// .aws/config or .aws/credentials file exists and is non-empty; otherwise the AWS SDK
+// falls through to its defaults (~/.aws/config, ~/.aws/credentials), so an existing
+// SSO/profile setup keeps working without per-context duplication. AWS_PROFILE defaults
+// to the current context name so `aws configure sso` creates a profile bound to the
+// context, and subsequent aws/terraform/SDK calls pick it up without further configuration;
+// an explicit aws.profile in the context's aws block overrides the default. AWS_REGION
+// is emitted only when aws.region is set; downstream tools otherwise fall back to the
+// profile's own `region =` line.
 func (e *AwsEnvPrinter) GetEnvVars() (map[string]string, error) {
 	envVars := make(map[string]string)
 
-	// Get the context configuration
-	contextConfigData := e.configHandler.GetConfig()
-
-	// Ensure the context configuration and AWS-specific settings are available.
-	if contextConfigData == nil || contextConfigData.AWS == nil {
-		return nil, fmt.Errorf("context configuration or AWS configuration is missing")
-	}
-
-	// Determine the root directory for configuration files.
 	configRoot, err := e.configHandler.GetConfigRoot()
 	if err != nil {
 		return nil, fmt.Errorf("error retrieving configuration root directory: %w", err)
 	}
 
-	// Set AWS config folder environment variables to allow CLIs to generate auth files in the right location.
 	awsConfigDir := filepath.Join(configRoot, ".aws")
 	awsConfigPath := filepath.Join(awsConfigDir, "config")
 	awsCredentialsPath := filepath.Join(awsConfigDir, "credentials")
 
-	envVars["AWS_CONFIG_FILE"] = filepath.ToSlash(awsConfigPath)
-	envVars["AWS_SHARED_CREDENTIALS_FILE"] = filepath.ToSlash(awsCredentialsPath)
-	if contextConfigData.AWS.AWSProfile != nil {
-		envVars["AWS_PROFILE"] = *contextConfigData.AWS.AWSProfile
+	if info, err := e.shims.Stat(awsConfigPath); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("error checking %s: %w", awsConfigPath, err)
+		}
+	} else if info != nil && info.Size() > 0 {
+		envVars["AWS_CONFIG_FILE"] = filepath.ToSlash(awsConfigPath)
 	}
-	if contextConfigData.AWS.AWSEndpointURL != nil {
-		envVars["AWS_ENDPOINT_URL"] = *contextConfigData.AWS.AWSEndpointURL
+	if info, err := e.shims.Stat(awsCredentialsPath); err != nil {
+		if !os.IsNotExist(err) {
+			return nil, fmt.Errorf("error checking %s: %w", awsCredentialsPath, err)
+		}
+	} else if info != nil && info.Size() > 0 {
+		envVars["AWS_SHARED_CREDENTIALS_FILE"] = filepath.ToSlash(awsCredentialsPath)
 	}
-	if contextConfigData.AWS.S3Hostname != nil {
-		envVars["S3_HOSTNAME"] = *contextConfigData.AWS.S3Hostname
+
+	contextConfigData := e.configHandler.GetConfig()
+	awsProfileOverride := ""
+	if contextConfigData != nil && contextConfigData.AWS != nil {
+		if contextConfigData.AWS.AWSProfile != nil {
+			awsProfileOverride = *contextConfigData.AWS.AWSProfile
+		}
+		if contextConfigData.AWS.AWSRegion != nil {
+			envVars["AWS_REGION"] = *contextConfigData.AWS.AWSRegion
+		}
+		if contextConfigData.AWS.AWSEndpointURL != nil {
+			envVars["AWS_ENDPOINT_URL"] = *contextConfigData.AWS.AWSEndpointURL
+		}
+		if contextConfigData.AWS.S3Hostname != nil {
+			envVars["S3_HOSTNAME"] = *contextConfigData.AWS.S3Hostname
+		}
+		if contextConfigData.AWS.MWAAEndpoint != nil {
+			envVars["MWAA_ENDPOINT"] = *contextConfigData.AWS.MWAAEndpoint
+		}
 	}
-	if contextConfigData.AWS.MWAAEndpoint != nil {
-		envVars["MWAA_ENDPOINT"] = *contextConfigData.AWS.MWAAEndpoint
+
+	if awsProfileOverride != "" {
+		envVars["AWS_PROFILE"] = awsProfileOverride
+	} else if ctx := e.configHandler.GetContext(); ctx != "" {
+		envVars["AWS_PROFILE"] = ctx
 	}
 
 	return envVars, nil

--- a/pkg/runtime/env/aws_env_test.go
+++ b/pkg/runtime/env/aws_env_test.go
@@ -2,8 +2,6 @@ package env
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -92,15 +90,6 @@ contexts:
 		t.Fatalf("Failed to set context: %v", err)
 	}
 
-	mocks.Shims.Stat = func(name string) (os.FileInfo, error) {
-		switch name {
-		case filepath.FromSlash("/mock/config/root/.aws/config"),
-			filepath.FromSlash("/mock/config/root/.aws/credentials"):
-			return mockFileInfo{name: filepath.Base(name), size: 1}, nil
-		}
-		return nil, os.ErrNotExist
-	}
-
 	return mocks
 }
 
@@ -144,69 +133,9 @@ func TestAwsEnv_GetEnvVars(t *testing.T) {
 		}
 	})
 
-	t.Run("NonExistentConfigFileFallsThroughToSDKDefaults", func(t *testing.T) {
-		// Given an AWS env printer whose per-context .aws files don't exist
-		env, _ := setup()
-
-		env.shims.Stat = func(name string) (os.FileInfo, error) {
-			return nil, os.ErrNotExist
-		}
-
-		// When GetEnvVars is called
-		envVars, err := env.GetEnvVars()
-
-		// Then AWS_CONFIG_FILE and AWS_SHARED_CREDENTIALS_FILE must not be emitted, so the
-		// SDK falls through to ~/.aws/config and picks up an existing SSO/profile setup.
-		// The configured overrides from the aws block are still emitted.
-		if err != nil {
-			t.Errorf("GetEnvVars returned an error: %v", err)
-		}
-
-		expected := map[string]string{
-			"AWS_PROFILE":      "default",
-			"AWS_REGION":       "us-west-2",
-			"AWS_ENDPOINT_URL": "https://aws.endpoint",
-			"S3_HOSTNAME":      "s3.amazonaws.com",
-			"MWAA_ENDPOINT":    "https://mwaa.endpoint",
-		}
-
-		if !reflect.DeepEqual(envVars, expected) {
-			t.Errorf("GetEnvVars returned %v, want %v", envVars, expected)
-		}
-	})
-
-	t.Run("EmptyConfigFileFallsThroughToSDKDefaults", func(t *testing.T) {
-		// Given a per-context .aws/config that exists but is empty (leftover from init)
-		env, _ := setup()
-
-		env.shims.Stat = func(name string) (os.FileInfo, error) {
-			switch name {
-			case filepath.FromSlash("/mock/config/root/.aws/config"),
-				filepath.FromSlash("/mock/config/root/.aws/credentials"):
-				return mockFileInfo{name: filepath.Base(name), size: 0}, nil
-			}
-			return nil, os.ErrNotExist
-		}
-
-		// When GetEnvVars is called
-		envVars, err := env.GetEnvVars()
-
-		// Then AWS_CONFIG_FILE and AWS_SHARED_CREDENTIALS_FILE must not be emitted,
-		// since the empty file would point AWS CLIs at nothing and break default resolution.
-		if err != nil {
-			t.Errorf("GetEnvVars returned an error: %v", err)
-		}
-
-		if _, ok := envVars["AWS_CONFIG_FILE"]; ok {
-			t.Errorf("Expected AWS_CONFIG_FILE to be omitted for empty file, got %q", envVars["AWS_CONFIG_FILE"])
-		}
-		if _, ok := envVars["AWS_SHARED_CREDENTIALS_FILE"]; ok {
-			t.Errorf("Expected AWS_SHARED_CREDENTIALS_FILE to be omitted for empty file, got %q", envVars["AWS_SHARED_CREDENTIALS_FILE"])
-		}
-	})
-
-	t.Run("MissingAWSBlockDefaultsProfileToContext", func(t *testing.T) {
-		// Given an AWS env printer without an aws block in the context
+	t.Run("EmitsConfigPathsEvenWhenFilesAbsent", func(t *testing.T) {
+		// Given a fresh AWS-platform context where .aws/config and .aws/credentials
+		// have not been created yet (operator hasn't run `aws configure`)
 		mocks := setupAwsEnvMocks(t)
 		configStr := `
 version: v1alpha1
@@ -222,8 +151,10 @@ contexts:
 		// When GetEnvVars is called
 		envVars, err := env.GetEnvVars()
 
-		// Then static config paths emit (files exist) and AWS_PROFILE defaults to the context name,
-		// so `aws configure sso` creates a matching profile and subsequent calls resolve to it.
+		// Then AWS_CONFIG_FILE and AWS_SHARED_CREDENTIALS_FILE still point at the
+		// context-scoped paths so a subsequent `aws configure` writes into the context
+		// folder rather than ~/.aws. AWS_PROFILE defaults to the context name so the
+		// freshly-created profile section matches.
 		if err != nil {
 			t.Errorf("GetEnvVars returned an error: %v", err)
 		}

--- a/pkg/runtime/env/aws_env_test.go
+++ b/pkg/runtime/env/aws_env_test.go
@@ -76,8 +76,9 @@ version: v1alpha1
 contexts:
   test-context:
     aws:
-      aws_profile: default
-      aws_endpoint_url: https://aws.endpoint
+      profile: default
+      region: us-west-2
+      endpoint_url: https://aws.endpoint
       s3_hostname: s3.amazonaws.com
       mwaa_endpoint: https://mwaa.endpoint
 `
@@ -92,8 +93,10 @@ contexts:
 	}
 
 	mocks.Shims.Stat = func(name string) (os.FileInfo, error) {
-		if name == filepath.FromSlash("/mock/config/root/.aws/config") {
-			return nil, nil
+		switch name {
+		case filepath.FromSlash("/mock/config/root/.aws/config"),
+			filepath.FromSlash("/mock/config/root/.aws/credentials"):
+			return mockFileInfo{name: filepath.Base(name), size: 1}, nil
 		}
 		return nil, os.ErrNotExist
 	}
@@ -128,6 +131,7 @@ func TestAwsEnv_GetEnvVars(t *testing.T) {
 
 		expected := map[string]string{
 			"AWS_PROFILE":                 "default",
+			"AWS_REGION":                  "us-west-2",
 			"AWS_ENDPOINT_URL":            "https://aws.endpoint",
 			"S3_HOSTNAME":                 "s3.amazonaws.com",
 			"MWAA_ENDPOINT":               "https://mwaa.endpoint",
@@ -140,8 +144,8 @@ func TestAwsEnv_GetEnvVars(t *testing.T) {
 		}
 	})
 
-	t.Run("NonExistentConfigFile", func(t *testing.T) {
-		// Given an AWS env printer with non-existent config file
+	t.Run("NonExistentConfigFileFallsThroughToSDKDefaults", func(t *testing.T) {
+		// Given an AWS env printer whose per-context .aws files don't exist
 		env, _ := setup()
 
 		env.shims.Stat = func(name string) (os.FileInfo, error) {
@@ -151,19 +155,19 @@ func TestAwsEnv_GetEnvVars(t *testing.T) {
 		// When GetEnvVars is called
 		envVars, err := env.GetEnvVars()
 
-		// Then environment variables should be returned with AWS_CONFIG_FILE and AWS_SHARED_CREDENTIALS_FILE
-		// set even when files don't exist, to allow CLIs to generate auth files in the right location
+		// Then AWS_CONFIG_FILE and AWS_SHARED_CREDENTIALS_FILE must not be emitted, so the
+		// SDK falls through to ~/.aws/config and picks up an existing SSO/profile setup.
+		// The configured overrides from the aws block are still emitted.
 		if err != nil {
 			t.Errorf("GetEnvVars returned an error: %v", err)
 		}
 
 		expected := map[string]string{
-			"AWS_PROFILE":                 "default",
-			"AWS_ENDPOINT_URL":            "https://aws.endpoint",
-			"S3_HOSTNAME":                 "s3.amazonaws.com",
-			"MWAA_ENDPOINT":               "https://mwaa.endpoint",
-			"AWS_CONFIG_FILE":             "/mock/config/root/.aws/config",
-			"AWS_SHARED_CREDENTIALS_FILE": "/mock/config/root/.aws/credentials",
+			"AWS_PROFILE":      "default",
+			"AWS_REGION":       "us-west-2",
+			"AWS_ENDPOINT_URL": "https://aws.endpoint",
+			"S3_HOSTNAME":      "s3.amazonaws.com",
+			"MWAA_ENDPOINT":    "https://mwaa.endpoint",
 		}
 
 		if !reflect.DeepEqual(envVars, expected) {
@@ -171,8 +175,38 @@ func TestAwsEnv_GetEnvVars(t *testing.T) {
 		}
 	})
 
-	t.Run("MissingConfiguration", func(t *testing.T) {
-		// Given an AWS env printer with missing AWS configuration
+	t.Run("EmptyConfigFileFallsThroughToSDKDefaults", func(t *testing.T) {
+		// Given a per-context .aws/config that exists but is empty (leftover from init)
+		env, _ := setup()
+
+		env.shims.Stat = func(name string) (os.FileInfo, error) {
+			switch name {
+			case filepath.FromSlash("/mock/config/root/.aws/config"),
+				filepath.FromSlash("/mock/config/root/.aws/credentials"):
+				return mockFileInfo{name: filepath.Base(name), size: 0}, nil
+			}
+			return nil, os.ErrNotExist
+		}
+
+		// When GetEnvVars is called
+		envVars, err := env.GetEnvVars()
+
+		// Then AWS_CONFIG_FILE and AWS_SHARED_CREDENTIALS_FILE must not be emitted,
+		// since the empty file would point AWS CLIs at nothing and break default resolution.
+		if err != nil {
+			t.Errorf("GetEnvVars returned an error: %v", err)
+		}
+
+		if _, ok := envVars["AWS_CONFIG_FILE"]; ok {
+			t.Errorf("Expected AWS_CONFIG_FILE to be omitted for empty file, got %q", envVars["AWS_CONFIG_FILE"])
+		}
+		if _, ok := envVars["AWS_SHARED_CREDENTIALS_FILE"]; ok {
+			t.Errorf("Expected AWS_SHARED_CREDENTIALS_FILE to be omitted for empty file, got %q", envVars["AWS_SHARED_CREDENTIALS_FILE"])
+		}
+	})
+
+	t.Run("MissingAWSBlockDefaultsProfileToContext", func(t *testing.T) {
+		// Given an AWS env printer without an aws block in the context
 		mocks := setupAwsEnvMocks(t)
 		configStr := `
 version: v1alpha1
@@ -186,14 +220,50 @@ contexts:
 		env.shims = mocks.Shims
 
 		// When GetEnvVars is called
-		_, err := env.GetEnvVars()
+		envVars, err := env.GetEnvVars()
 
-		// Then an error should be returned
-		if err == nil {
-			t.Error("GetEnvVars did not return an error")
+		// Then static config paths emit (files exist) and AWS_PROFILE defaults to the context name,
+		// so `aws configure sso` creates a matching profile and subsequent calls resolve to it.
+		if err != nil {
+			t.Errorf("GetEnvVars returned an error: %v", err)
 		}
-		if err != nil && !strings.Contains(err.Error(), "context configuration or AWS configuration is missing") {
-			t.Errorf("GetEnvVars returned error %v, want error containing 'context configuration or AWS configuration is missing'", err)
+
+		expected := map[string]string{
+			"AWS_CONFIG_FILE":             "/mock/config/root/.aws/config",
+			"AWS_SHARED_CREDENTIALS_FILE": "/mock/config/root/.aws/credentials",
+			"AWS_PROFILE":                 "test-context",
+		}
+
+		if !reflect.DeepEqual(envVars, expected) {
+			t.Errorf("GetEnvVars returned %v, want %v", envVars, expected)
+		}
+	})
+
+	t.Run("ExplicitAWSProfileOverridesContextDefault", func(t *testing.T) {
+		// Given an AWS block that pins a specific profile name
+		mocks := setupAwsEnvMocks(t)
+		configStr := `
+version: v1alpha1
+contexts:
+  test-context:
+    aws:
+      profile: shared-ops
+`
+		if err := mocks.ConfigHandler.LoadConfigString(configStr); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+		env := NewAwsEnvPrinter(mocks.Shell, mocks.ConfigHandler)
+		env.shims = mocks.Shims
+
+		// When GetEnvVars is called
+		envVars, err := env.GetEnvVars()
+
+		// Then AWS_PROFILE reflects the override, not the context name
+		if err != nil {
+			t.Errorf("GetEnvVars returned an error: %v", err)
+		}
+		if got := envVars["AWS_PROFILE"]; got != "shared-ops" {
+			t.Errorf("AWS_PROFILE = %q, want %q", got, "shared-ops")
 		}
 	})
 
@@ -205,7 +275,7 @@ version: v1alpha1
 contexts:
   test-context:
     aws:
-      aws_profile: default
+      profile: default
 `
 		if err := mocks.ConfigHandler.LoadConfigString(configStr); err != nil {
 			t.Fatalf("Failed to load config: %v", err)

--- a/pkg/runtime/env/kube_env_test.go
+++ b/pkg/runtime/env/kube_env_test.go
@@ -31,10 +31,11 @@ func (m mockDirEntry) Info() (os.FileInfo, error) { return mockFileInfo{name: m.
 // mockFileInfo is a simple mock implementation of os.FileInfo
 type mockFileInfo struct {
 	name string
+	size int64
 }
 
 func (m mockFileInfo) Name() string       { return m.name }
-func (m mockFileInfo) Size() int64        { return 0 }
+func (m mockFileInfo) Size() int64        { return m.size }
 func (m mockFileInfo) Mode() os.FileMode  { return os.ModeDir }
 func (m mockFileInfo) ModTime() time.Time { return time.Time{} }
 func (m mockFileInfo) IsDir() bool        { return true }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -696,17 +696,20 @@ func (rt *Runtime) initializeEnvPrinters() {
 	if clusterDriver == "" {
 		clusterDriver = rt.ConfigHandler.GetString("cluster.driver", "")
 	}
-	awsEnabled := rt.ConfigHandler.GetBool("aws.enabled", false)
 	azureEnabled := rt.ConfigHandler.GetBool("azure.enabled", false)
 	gcpEnabled := rt.ConfigHandler.GetBool("gcp.enabled", false)
 	clusterEnabled := clusterDriver != ""
 	needsDocker := rt.needsDockerEnv()
 	configData := rt.ConfigHandler.GetConfig()
+	platform := rt.ConfigHandler.GetString("platform", "")
+	if platform == "" {
+		platform = rt.ConfigHandler.GetString("provider", "")
+	}
 	hasAWSConfig := configData != nil && configData.AWS != nil
 	hasAzureConfig := configData != nil && configData.Azure != nil
 	hasGCPConfig := configData != nil && configData.GCP != nil
 
-	if rt.EnvPrinters.AwsEnv == nil && awsEnabled && hasAWSConfig {
+	if rt.EnvPrinters.AwsEnv == nil && (hasAWSConfig || platform == "aws") {
 		rt.EnvPrinters.AwsEnv = env.NewAwsEnvPrinter(rt.Shell, rt.ConfigHandler)
 	}
 	if rt.EnvPrinters.AzureEnv == nil && azureEnabled && hasAzureConfig {

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -41,7 +41,7 @@ func setupRuntimeMocks(t *testing.T) *RuntimeTestMocks {
 		switch key {
 		case "docker.enabled", "terraform.enabled":
 			return true
-		case "aws.enabled", "azure.enabled", "gcp.enabled":
+		case "azure.enabled", "gcp.enabled":
 			return false
 		default:
 			return false
@@ -2743,7 +2743,9 @@ func TestRuntime_initializeEnvPrinters(t *testing.T) {
 	})
 
 	t.Run("DoesNotOverrideExistingPrinters", func(t *testing.T) {
-		// Given a runtime with an existing env printer
+		// Given a runtime with an existing env printer and an AWS config block that would
+		// otherwise trigger the gate (presence of an aws: block activates AWS injection now
+		// that aws.enabled has been removed).
 		mocks := setupRuntimeMocks(t)
 		rt := mocks.Runtime
 
@@ -2751,11 +2753,10 @@ func TestRuntime_initializeEnvPrinters(t *testing.T) {
 		rt.EnvPrinters.AwsEnv = existingAwsEnv
 
 		mockConfigHandler := mocks.ConfigHandler.(*config.MockConfigHandler)
-		mockConfigHandler.GetBoolFunc = func(key string, defaultValue ...bool) bool {
-			if key == "aws.enabled" {
-				return true
+		mockConfigHandler.GetConfigFunc = func() *v1alpha1.Context {
+			return &v1alpha1.Context{
+				AWS: &awsv1alpha1.AWSConfig{},
 			}
-			return false
 		}
 
 		// When initializeEnvPrinters is called

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -111,6 +111,7 @@ type MockToolsManager struct {
 	WriteManifestFunc       func() error
 	InstallFunc             func() error
 	CheckFunc               func() error
+	CheckAuthFunc           func() error
 	GetTerraformCommandFunc func() string
 }
 
@@ -131,6 +132,13 @@ func (m *MockToolsManager) Install() error {
 func (m *MockToolsManager) Check() error {
 	if m.CheckFunc != nil {
 		return m.CheckFunc()
+	}
+	return nil
+}
+
+func (m *MockToolsManager) CheckAuth() error {
+	if m.CheckAuthFunc != nil {
+		return m.CheckAuthFunc()
 	}
 	return nil
 }

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -2419,18 +2419,12 @@ func TestRuntime_initializeComponents_EdgeCases(t *testing.T) {
 }
 
 func TestRuntime_initializeEnvPrinters(t *testing.T) {
-	t.Run("InitializesAwsEnvWhenEnabled", func(t *testing.T) {
-		// Given a runtime with AWS enabled
+	t.Run("InitializesAwsEnvWhenAWSConfigPresent", func(t *testing.T) {
+		// Given a runtime with an AWS config block (aws.enabled flag is not required)
 		mocks := setupRuntimeMocks(t)
 		rt := mocks.Runtime
 
 		mockConfigHandler := mocks.ConfigHandler.(*config.MockConfigHandler)
-		mockConfigHandler.GetBoolFunc = func(key string, defaultValue ...bool) bool {
-			if key == "aws.enabled" {
-				return true
-			}
-			return false
-		}
 		mockConfigHandler.GetConfigFunc = func() *v1alpha1.Context {
 			return &v1alpha1.Context{
 				AWS: &awsv1alpha1.AWSConfig{},
@@ -2444,6 +2438,28 @@ func TestRuntime_initializeEnvPrinters(t *testing.T) {
 
 		if rt.EnvPrinters.AwsEnv == nil {
 			t.Error("Expected AwsEnv to be initialized")
+		}
+	})
+
+	t.Run("InitializesAwsEnvWhenPlatformIsAws", func(t *testing.T) {
+		// Given a runtime with platform=aws and no aws block
+		mocks := setupRuntimeMocks(t)
+		rt := mocks.Runtime
+
+		mockConfigHandler := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "platform" {
+				return "aws"
+			}
+			return ""
+		}
+
+		// When initializeEnvPrinters is called
+		rt.initializeEnvPrinters()
+
+		// Then AWS env printer should be initialized from the platform signal alone
+		if rt.EnvPrinters.AwsEnv == nil {
+			t.Error("Expected AwsEnv to be initialized when platform=aws")
 		}
 	})
 

--- a/pkg/runtime/shell/mock_shell.go
+++ b/pkg/runtime/shell/mock_shell.go
@@ -16,29 +16,30 @@ import (
 
 type MockShell struct {
 	DefaultShell
-	RenderEnvVarsFunc              func(envVars map[string]string, export bool) string
-	RenderAliasesFunc              func(aliases map[string]string) string
-	GetProjectRootFunc             func() (string, error)
-	ExecFunc                       func(command string, args ...string) (string, error)
-	ExecSilentFunc                 func(command string, args ...string) (string, error)
-	ExecSilentWithEnvFunc          func(command string, env map[string]string, args ...string) (string, error)
-	ExecSilentWithTimeoutFunc      func(command string, args []string, timeout time.Duration) (string, error)
-	ExecProgressFunc               func(message string, command string, args ...string) (string, error)
-	ExecProgressWithEnvFunc        func(message string, command string, env map[string]string, args ...string) (string, error)
-	ExecSudoFunc                   func(message string, command string, args ...string) (string, error)
-	InstallHookFunc                func(shellName string) error
-	SetVerbosityFunc               func(verbose bool)
-	IsVerboseFunc                  func() bool
-	IsGlobalFunc                   func() bool
-	AddCurrentDirToTrustedFileFunc func() error
-	CheckTrustedDirectoryFunc      func() error
-	UnsetEnvsFunc                  func(envVars []string)
-	UnsetAliasFunc                 func(aliases []string)
-	WriteResetTokenFunc            func() (string, error)
-	GetSessionTokenFunc            func() (string, error)
-	CheckResetFlagsFunc            func() (bool, error)
-	ResetFunc                      func(...bool)
-	RegisterSecretFunc             func(value string)
+	RenderEnvVarsFunc               func(envVars map[string]string, export bool) string
+	RenderAliasesFunc               func(aliases map[string]string) string
+	GetProjectRootFunc              func() (string, error)
+	ExecFunc                        func(command string, args ...string) (string, error)
+	ExecSilentFunc                  func(command string, args ...string) (string, error)
+	ExecSilentWithEnvFunc           func(command string, env map[string]string, args ...string) (string, error)
+	ExecSilentWithTimeoutFunc       func(command string, args []string, timeout time.Duration) (string, error)
+	ExecSilentWithEnvAndTimeoutFunc func(command string, env map[string]string, args []string, timeout time.Duration) (string, error)
+	ExecProgressFunc                func(message string, command string, args ...string) (string, error)
+	ExecProgressWithEnvFunc         func(message string, command string, env map[string]string, args ...string) (string, error)
+	ExecSudoFunc                    func(message string, command string, args ...string) (string, error)
+	InstallHookFunc                 func(shellName string) error
+	SetVerbosityFunc                func(verbose bool)
+	IsVerboseFunc                   func() bool
+	IsGlobalFunc                    func() bool
+	AddCurrentDirToTrustedFileFunc  func() error
+	CheckTrustedDirectoryFunc       func() error
+	UnsetEnvsFunc                   func(envVars []string)
+	UnsetAliasFunc                  func(aliases []string)
+	WriteResetTokenFunc             func() (string, error)
+	GetSessionTokenFunc             func() (string, error)
+	CheckResetFlagsFunc             func() (bool, error)
+	ResetFunc                       func(...bool)
+	RegisterSecretFunc              func(value string)
 }
 
 // =============================================================================
@@ -104,6 +105,22 @@ func (s *MockShell) ExecSilentWithEnv(command string, env map[string]string, arg
 
 // ExecSilentWithTimeout calls the custom ExecSilentWithTimeoutFunc if provided, otherwise delegates to ExecSilent.
 func (s *MockShell) ExecSilentWithTimeout(command string, args []string, timeout time.Duration) (string, error) {
+	if s.ExecSilentWithTimeoutFunc != nil {
+		return s.ExecSilentWithTimeoutFunc(command, args, timeout)
+	}
+	return s.ExecSilent(command, args...)
+}
+
+// ExecSilentWithEnvAndTimeout calls the custom ExecSilentWithEnvAndTimeoutFunc if provided.
+// Falls back to ExecSilentWithEnvFunc (then ExecSilentWithTimeoutFunc, then ExecSilent) so
+// existing tests that only stub one of the simpler variants keep working.
+func (s *MockShell) ExecSilentWithEnvAndTimeout(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+	if s.ExecSilentWithEnvAndTimeoutFunc != nil {
+		return s.ExecSilentWithEnvAndTimeoutFunc(command, env, args, timeout)
+	}
+	if s.ExecSilentWithEnvFunc != nil {
+		return s.ExecSilentWithEnvFunc(command, env, args...)
+	}
 	if s.ExecSilentWithTimeoutFunc != nil {
 		return s.ExecSilentWithTimeoutFunc(command, args, timeout)
 	}

--- a/pkg/runtime/shell/shell.go
+++ b/pkg/runtime/shell/shell.go
@@ -57,6 +57,7 @@ type Shell interface {
 	ExecSilent(command string, args ...string) (string, error)
 	ExecSilentWithEnv(command string, env map[string]string, args ...string) (string, error)
 	ExecSilentWithTimeout(command string, args []string, timeout time.Duration) (string, error)
+	ExecSilentWithEnvAndTimeout(command string, env map[string]string, args []string, timeout time.Duration) (string, error)
 	ExecSudo(message string, command string, args ...string) (string, error)
 	ExecProgress(message string, command string, args ...string) (string, error)
 	ExecProgressWithEnv(message string, command string, env map[string]string, args ...string) (string, error)
@@ -272,6 +273,51 @@ func (s *DefaultShell) ExecSilentWithTimeout(command string, args []string, time
 	if cmd.Env == nil {
 		cmd.Env = s.shims.Environ()
 	}
+
+	if err := s.shims.CmdStart(cmd); err != nil {
+		return "", fmt.Errorf("command start failed: %w", err)
+	}
+
+	var waitOnce sync.Once
+	execFn := func() (string, error) {
+		var waitErr error
+		waitOnce.Do(func() {
+			waitErr = s.shims.CmdWait(cmd)
+		})
+		if waitErr != nil {
+			return s.scrubString(stdoutBuf.String()), fmt.Errorf("command execution failed: %w\n%s", waitErr, s.scrubString(stderrBuf.String()))
+		}
+		return s.scrubString(stdoutBuf.String()), nil
+	}
+
+	cleanupFn := func() {
+		if cmd.Process != nil {
+			_ = cmd.Process.Kill()
+			waitOnce.Do(func() {
+				_ = s.shims.CmdWait(cmd)
+			})
+		}
+	}
+
+	return executeWithTimeout(execFn, cleanupFn, timeout)
+}
+
+// ExecSilentWithEnvAndTimeout combines ExecSilentWithEnv and ExecSilentWithTimeout: it merges
+// command-scoped env overrides into the inherited environment AND enforces a timeout, killing
+// the child process if it exceeds the deadline. Used by callers that need both behaviors at
+// once — e.g. CheckAuth() running `aws sts get-caller-identity` with the context-scoped
+// AWS_CONFIG_FILE/AWS_PROFILE set, where the env is required for credential resolution and
+// the timeout guards against a hung network call.
+func (s *DefaultShell) ExecSilentWithEnvAndTimeout(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd := s.shims.Command(command, args...)
+	if cmd == nil {
+		return "", fmt.Errorf("failed to create command")
+	}
+
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
+	cmd.Env = mergeEnvVars(s.shims.Environ(), env)
 
 	if err := s.shims.CmdStart(cmd); err != nil {
 		return "", fmt.Errorf("command start failed: %w", err)

--- a/pkg/runtime/shell/shell_test.go
+++ b/pkg/runtime/shell/shell_test.go
@@ -2993,6 +2993,111 @@ func TestShell_ExecSilentWithTimeout(t *testing.T) {
 	})
 }
 
+func TestShell_ExecSilentWithEnvAndTimeout(t *testing.T) {
+	setup := func(t *testing.T) (*DefaultShell, *ShellTestMocks) {
+		t.Helper()
+		mocks := setupShellMocks(t)
+		shell := NewDefaultShell()
+		shell.shims = mocks.Shims
+		return shell, mocks
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		// Given a shell with mocked command execution
+		shell, _ := setup(t)
+
+		// When executing a command with env vars and a timeout
+		out, err := shell.ExecSilentWithEnvAndTimeout("test", map[string]string{"FOO": "bar"}, []string{"arg"}, 5*time.Second)
+
+		// Then it succeeds and returns the captured output
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if out != "test\n" {
+			t.Errorf("Expected output 'test\\n', got %q", out)
+		}
+	})
+
+	t.Run("MergesEnvVars", func(t *testing.T) {
+		// Given a shell that captures cmd.Env on run
+		shell, mocks := setup(t)
+		var capturedEnv []string
+		mocks.Shims.CmdStart = func(cmd *exec.Cmd) error {
+			capturedEnv = cmd.Env
+			return nil
+		}
+		mocks.Shims.CmdWait = func(cmd *exec.Cmd) error {
+			return nil
+		}
+
+		// When executing with extra env vars
+		_, _ = shell.ExecSilentWithEnvAndTimeout("test", map[string]string{"AWS_PROFILE": "ctx"}, []string{"arg"}, 5*time.Second)
+
+		// Then the extra env var is present in the merged environment — confirming the env
+		// override actually reaches the child process rather than being silently dropped
+		found := false
+		for _, e := range capturedEnv {
+			if e == "AWS_PROFILE=ctx" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Expected AWS_PROFILE=ctx in cmd.Env, got %v", capturedEnv)
+		}
+	})
+
+	t.Run("Timeout", func(t *testing.T) {
+		// Given a CmdWait that sleeps past the timeout
+		shell, mocks := setup(t)
+		mocks.Shims.CmdStart = func(cmd *exec.Cmd) error {
+			return nil
+		}
+		mocks.Shims.CmdWait = func(cmd *exec.Cmd) error {
+			time.Sleep(200 * time.Millisecond)
+			return nil
+		}
+
+		// When executing with a short timeout
+		out, err := shell.ExecSilentWithEnvAndTimeout("test", nil, []string{"arg"}, 50*time.Millisecond)
+
+		// Then a timeout error is surfaced — the env-aware variant must inherit the same
+		// process-killing safety net as ExecSilentWithTimeout, otherwise hung commands would
+		// block bootstrap indefinitely
+		if err == nil {
+			t.Error("Expected timeout error, got nil")
+		}
+		if !strings.Contains(err.Error(), "timed out") {
+			t.Errorf("Expected timeout error, got: %v", err)
+		}
+		if out != "" {
+			t.Errorf("Expected empty output on timeout, got %q", out)
+		}
+	})
+
+	t.Run("CommandNil", func(t *testing.T) {
+		// Given a Command shim that returns nil
+		shell, mocks := setup(t)
+		mocks.Shims.Command = func(name string, args ...string) *exec.Cmd {
+			return nil
+		}
+
+		// When executing
+		output, err := shell.ExecSilentWithEnvAndTimeout("test", nil, []string{"arg"}, 5*time.Second)
+
+		// Then a command-creation error is returned
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to create command") {
+			t.Errorf("Expected error about command creation, got: %v", err)
+		}
+		if output != "" {
+			t.Errorf("Expected empty output, got %q", output)
+		}
+	})
+}
+
 func TestShell_ExecProgress(t *testing.T) {
 	setup := func(t *testing.T) (*DefaultShell, *ShellTestMocks) {
 		t.Helper()

--- a/pkg/runtime/tools/mock_tools_manager.go
+++ b/pkg/runtime/tools/mock_tools_manager.go
@@ -5,6 +5,7 @@ type MockToolsManager struct {
 	WriteManifestFunc       func() error
 	InstallFunc             func() error
 	CheckFunc               func() error
+	CheckAuthFunc           func() error
 	GetTerraformCommandFunc func() string
 }
 
@@ -41,6 +42,14 @@ func (m *MockToolsManager) Install() error {
 func (m *MockToolsManager) Check() error {
 	if m.CheckFunc != nil {
 		return m.CheckFunc()
+	}
+	return nil
+}
+
+// CheckAuth calls the mock CheckAuthFunc if set, otherwise returns nil.
+func (m *MockToolsManager) CheckAuth() error {
+	if m.CheckAuthFunc != nil {
+		return m.CheckAuthFunc()
 	}
 	return nil
 }

--- a/pkg/runtime/tools/shims.go
+++ b/pkg/runtime/tools/shims.go
@@ -8,5 +8,8 @@ import (
 // osStat is a variable that can be overridden for testing purposes, acting as a shim for os.Stat.
 var osStat = os.Stat
 
+// osReadFile is a variable that can be overridden for testing purposes, acting as a shim for os.ReadFile.
+var osReadFile = os.ReadFile
+
 // execLookPath is a variable that can be overridden for testing purposes, acting as a shim for exec.LookPath.
 var execLookPath = exec.LookPath

--- a/pkg/runtime/tools/tools_manager.go
+++ b/pkg/runtime/tools/tools_manager.go
@@ -413,6 +413,20 @@ func (t *BaseToolsManager) CheckAuth() error {
 	configData := t.configHandler.GetConfig()
 	hasAWSConfig := configData != nil && configData.AWS != nil
 	if platform == "aws" || hasAWSConfig {
+		// In a CI environment where AWS credentials are already exported via a native SDK
+		// mechanism (IRSA, ECS task role, static keys), the aws CLI binary is not required:
+		// terraform's AWS provider resolves credentials through its own SDK and never
+		// shells out. A lean CI image (e.g. a minimal GitHub Actions runner that pulls
+		// OIDC creds but never installs awscli) would otherwise fail preflight for no
+		// real reason. When ambient creds are present AND the CLI is absent, accept that
+		// we can't run sts here and defer validation to the actual terraform call — the
+		// SDK will surface its own error at that point if the web-identity token / task
+		// role is misconfigured.
+		if hasAmbientAWSCredentials() {
+			if _, err := execLookPath("aws"); err != nil {
+				return nil
+			}
+		}
 		if err := t.checkAWSBinary(); err != nil {
 			return err
 		}

--- a/pkg/runtime/tools/tools_manager.go
+++ b/pkg/runtime/tools/tools_manager.go
@@ -27,6 +27,7 @@ type ToolsManager interface {
 	WriteManifest() error
 	Install() error
 	Check() error
+	CheckAuth() error
 	GetTerraformCommand() string
 }
 
@@ -376,15 +377,12 @@ func (t *BaseToolsManager) checkKubelogin() error {
 	return nil
 }
 
-// checkAWS ensures the AWS CLI is available in PATH, meets the minimum version, and that the
-// caller identity resolves via `aws sts get-caller-identity`. The identity call is a cheap
-// read-only STS API that forces the SDK to run its full credential-resolution chain (SSO
-// session, static keys, env vars, IMDS) end-to-end; a success proves the operator's AWS setup
-// will work when terraform/SDK calls run later, while a failure surfaces the vendor's own
-// message (expired SSO, profile not found, no credentials) at check time rather than minutes
-// into a `terraform apply`. Credential resolution is agnostic to how Windsor is scoping AWS:
-// inside a Windsor shell the SDK picks up the context-scoped AWS_CONFIG_FILE/AWS_PROFILE the
-// env injection exported, outside a Windsor shell it falls back to its own defaults.
+// checkAWS verifies the AWS CLI is available in PATH and meets the minimum version. It runs
+// from Check(), which fires from every command path including `windsor init` — at that point
+// Windsor is just scaffolding files and there is no obligation for the operator to have
+// credentials yet. Credential validity is intentionally NOT checked here so that init on a
+// fresh machine or in CI doesn't fail before any AWS work has been requested; that check
+// lives in CheckAuth and runs only from bootstrap/up/apply preflights.
 func (t *BaseToolsManager) checkAWS() error {
 	if _, err := execLookPath("aws"); err != nil {
 		return fmt.Errorf("aws CLI is not available in the PATH; install it from https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html")
@@ -402,8 +400,29 @@ func (t *BaseToolsManager) checkAWS() error {
 		return fmt.Errorf("aws CLI version %s is below the minimum required version %s", version, constants.MinimumVersionAWS)
 	}
 
-	if _, err := t.shell.ExecSilentWithTimeout("aws", []string{"sts", "get-caller-identity"}, 10*time.Second); err != nil {
-		return fmt.Errorf("aws credentials did not resolve: %v; run 'aws configure' or 'aws configure sso' to set up your credentials.", err)
+	return nil
+}
+
+// CheckAuth verifies that the operator's credentials for any in-use cloud platforms actually
+// resolve. For AWS this runs `aws sts get-caller-identity` — a cheap read-only STS API that
+// forces the SDK to run its full credential-resolution chain (SSO session, static keys, env
+// vars, IMDS) end-to-end; a success proves the operator's AWS setup will work when
+// terraform/SDK calls run later, while a failure surfaces the vendor's own message (expired
+// SSO, profile not found, no credentials) at preflight time rather than minutes into a
+// `terraform apply`. CheckAuth must NOT be called from `windsor init` (which only scaffolds
+// files and has no obligation to be authed yet); it is intended for bootstrap/up/apply paths
+// where credentials are about to be exercised.
+func (t *BaseToolsManager) CheckAuth() error {
+	platform := t.configHandler.GetString("platform")
+	if platform == "" {
+		platform = t.configHandler.GetString("provider")
+	}
+	configData := t.configHandler.GetConfig()
+	hasAWSConfig := configData != nil && configData.AWS != nil
+	if platform == "aws" || hasAWSConfig {
+		if _, err := t.shell.ExecSilentWithTimeout("aws", []string{"sts", "get-caller-identity"}, 10*time.Second); err != nil {
+			return fmt.Errorf("aws credentials did not resolve: %v; run 'aws configure' or 'aws configure sso' to set up your credentials", err)
+		}
 	}
 	return nil
 }

--- a/pkg/runtime/tools/tools_manager.go
+++ b/pkg/runtime/tools/tools_manager.go
@@ -131,18 +131,11 @@ func (t *BaseToolsManager) Check() error {
 			return fmt.Errorf("kubelogin check failed: %v", err)
 		}
 	}
-
-	platform := t.configHandler.GetString("platform")
-	if platform == "" {
-		platform = t.configHandler.GetString("provider")
-	}
-	configData := t.configHandler.GetConfig()
-	hasAWSConfig := configData != nil && configData.AWS != nil
-	if platform == "aws" || hasAWSConfig {
-		if err := t.checkAWS(); err != nil {
-			return fmt.Errorf("aws check failed: %v", err)
-		}
-	}
+	// AWS tool verification lives on CheckAuth, not here. Check() fires from every command
+	// path including `windsor init` / `windsor env` — at those points the operator has no
+	// obligation to have the aws CLI installed OR to be authed. Both cloud-CLI presence and
+	// credential resolution belong to CheckAuth, which runs only from bootstrap/up/apply and
+	// from `windsor check`.
 	return nil
 }
 
@@ -399,13 +392,41 @@ func (t *BaseToolsManager) checkKubelogin() error {
 	return nil
 }
 
-// checkAWS verifies the AWS CLI is available in PATH and meets the minimum version. It runs
-// from Check(), which fires from every command path including `windsor init` — at that point
-// Windsor is just scaffolding files and there is no obligation for the operator to have
-// credentials yet. Credential validity is intentionally NOT checked here so that init on a
-// fresh machine or in CI doesn't fail before any AWS work has been requested; that check
-// lives in CheckAuth and runs only from bootstrap/up/apply preflights.
-func (t *BaseToolsManager) checkAWS() error {
+// CheckAuth verifies that the operator has the cloud CLIs for any in-use platforms AND that
+// their credentials actually resolve. For AWS it runs `aws --version` (presence + minimum
+// version) and then `aws sts get-caller-identity` — a cheap read-only STS API that forces the
+// SDK to run its full credential-resolution chain (SSO session, static keys, env vars, IMDS)
+// end-to-end. A success proves the operator's AWS setup will work when terraform/SDK calls
+// run later; a failure surfaces the vendor's own message (expired SSO, profile not found, no
+// credentials) at preflight time rather than minutes into a `terraform apply`. CheckAuth must
+// NOT be called from `windsor init` or `windsor env` (which have no obligation to be authed
+// yet); it is intended for bootstrap/up/apply paths where credentials are about to be
+// exercised, and from `windsor check` where the operator is explicitly asking to verify.
+// Error messages are tuned to the operator's current state (missing config, expired SSO
+// session, rejected static keys) so the returned hint is a copy-pasteable command rather than
+// generic advice.
+func (t *BaseToolsManager) CheckAuth() error {
+	platform := t.configHandler.GetString("platform")
+	if platform == "" {
+		platform = t.configHandler.GetString("provider")
+	}
+	configData := t.configHandler.GetConfig()
+	hasAWSConfig := configData != nil && configData.AWS != nil
+	if platform == "aws" || hasAWSConfig {
+		if err := t.checkAWSBinary(); err != nil {
+			return err
+		}
+		if _, err := t.shell.ExecSilentWithTimeout("aws", []string{"sts", "get-caller-identity"}, 10*time.Second); err != nil {
+			return fmt.Errorf("aws credentials did not resolve for context %q: %v\n%s", t.configHandler.GetContext(), err, t.awsAuthHint())
+		}
+	}
+	return nil
+}
+
+// checkAWSBinary verifies the AWS CLI is available in PATH and meets the minimum version.
+// Pulled out of CheckAuth so the binary vs. credential failure modes each have a clean
+// single-error exit point.
+func (t *BaseToolsManager) checkAWSBinary() error {
 	if _, err := execLookPath("aws"); err != nil {
 		return fmt.Errorf("aws CLI is not available in the PATH; install it from https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html")
 	}
@@ -422,32 +443,6 @@ func (t *BaseToolsManager) checkAWS() error {
 		return fmt.Errorf("aws CLI version %s is below the minimum required version %s", version, constants.MinimumVersionAWS)
 	}
 
-	return nil
-}
-
-// CheckAuth verifies that the operator's credentials for any in-use cloud platforms actually
-// resolve. For AWS this runs `aws sts get-caller-identity` — a cheap read-only STS API that
-// forces the SDK to run its full credential-resolution chain (SSO session, static keys, env
-// vars, IMDS) end-to-end; a success proves the operator's AWS setup will work when
-// terraform/SDK calls run later, while a failure surfaces the vendor's own message (expired
-// SSO, profile not found, no credentials) at preflight time rather than minutes into a
-// `terraform apply`. CheckAuth must NOT be called from `windsor init` (which only scaffolds
-// files and has no obligation to be authed yet); it is intended for bootstrap/up/apply paths
-// where credentials are about to be exercised. Error messages are tuned to the operator's
-// current state (missing config, expired SSO session, rejected static keys) so the returned
-// hint is a copy-pasteable command rather than generic advice.
-func (t *BaseToolsManager) CheckAuth() error {
-	platform := t.configHandler.GetString("platform")
-	if platform == "" {
-		platform = t.configHandler.GetString("provider")
-	}
-	configData := t.configHandler.GetConfig()
-	hasAWSConfig := configData != nil && configData.AWS != nil
-	if platform == "aws" || hasAWSConfig {
-		if _, err := t.shell.ExecSilentWithTimeout("aws", []string{"sts", "get-caller-identity"}, 10*time.Second); err != nil {
-			return fmt.Errorf("aws credentials did not resolve for context %q: %v\n%s", t.configHandler.GetContext(), err, t.awsAuthHint())
-		}
-	}
 	return nil
 }
 

--- a/pkg/runtime/tools/tools_manager.go
+++ b/pkg/runtime/tools/tools_manager.go
@@ -108,6 +108,18 @@ func (t *BaseToolsManager) Check() error {
 			return fmt.Errorf("kubelogin check failed: %v", err)
 		}
 	}
+
+	platform := t.configHandler.GetString("platform")
+	if platform == "" {
+		platform = t.configHandler.GetString("provider")
+	}
+	configData := t.configHandler.GetConfig()
+	hasAWSConfig := configData != nil && configData.AWS != nil
+	if platform == "aws" || hasAWSConfig {
+		if err := t.checkAWS(); err != nil {
+			return fmt.Errorf("aws check failed: %v", err)
+		}
+	}
 	return nil
 }
 
@@ -361,6 +373,38 @@ func (t *BaseToolsManager) checkKubelogin() error {
 		}
 	}
 
+	return nil
+}
+
+// checkAWS ensures the AWS CLI is available in PATH, meets the minimum version, and that the
+// caller identity resolves via `aws sts get-caller-identity`. The identity call is a cheap
+// read-only STS API that forces the SDK to run its full credential-resolution chain (SSO
+// session, static keys, env vars, IMDS) end-to-end; a success proves the operator's AWS setup
+// will work when terraform/SDK calls run later, while a failure surfaces the vendor's own
+// message (expired SSO, profile not found, no credentials) at check time rather than minutes
+// into a `terraform apply`. Credential resolution is agnostic to how Windsor is scoping AWS:
+// inside a Windsor shell the SDK picks up the context-scoped AWS_CONFIG_FILE/AWS_PROFILE the
+// env injection exported, outside a Windsor shell it falls back to its own defaults.
+func (t *BaseToolsManager) checkAWS() error {
+	if _, err := execLookPath("aws"); err != nil {
+		return fmt.Errorf("aws CLI is not available in the PATH; install it from https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html")
+	}
+
+	out, err := t.shell.ExecSilentWithTimeout("aws", []string{"--version"}, 5*time.Second)
+	if err != nil {
+		return fmt.Errorf("aws --version failed: %v", err)
+	}
+	version := extractVersion(out)
+	if version == "" {
+		return fmt.Errorf("failed to extract aws CLI version")
+	}
+	if compareVersion(version, constants.MinimumVersionAWS) < 0 {
+		return fmt.Errorf("aws CLI version %s is below the minimum required version %s", version, constants.MinimumVersionAWS)
+	}
+
+	if _, err := t.shell.ExecSilentWithTimeout("aws", []string{"sts", "get-caller-identity"}, 10*time.Second); err != nil {
+		return fmt.Errorf("aws credentials did not resolve: %v; run 'aws configure' or 'aws configure sso' to set up your credentials.", err)
+	}
 	return nil
 }
 

--- a/pkg/runtime/tools/tools_manager.go
+++ b/pkg/runtime/tools/tools_manager.go
@@ -421,8 +421,14 @@ func (t *BaseToolsManager) CheckAuth() error {
 		// `windsor env` / installed the windsor shell hook yet — without this, bootstrap on a
 		// fresh machine deadlocks: it can't proceed without valid credentials, but the
 		// operator can't establish credentials (`aws sso login`, `aws configure`) without the
-		// same env pointing aws at the context's .aws/config.
-		env, _ := t.awsContextEnv()
+		// same env pointing aws at the context's .aws/config. When configRoot can't be
+		// resolved the error is surfaced rather than swallowed — letting sts fall back to the
+		// ambient shell env would silently validate the wrong credentials and produce the
+		// exact false-positive CheckAuth exists to prevent.
+		env, err := t.awsContextEnv()
+		if err != nil {
+			return fmt.Errorf("cannot resolve context-scoped AWS env for credential check: %w", err)
+		}
 		if _, err := t.shell.ExecSilentWithEnvAndTimeout("aws", env, []string{"sts", "get-caller-identity"}, 10*time.Second); err != nil {
 			return fmt.Errorf("aws credentials did not resolve for context %q: %v\n%s", t.configHandler.GetContext(), err, t.awsAuthHint())
 		}

--- a/pkg/runtime/tools/tools_manager.go
+++ b/pkg/runtime/tools/tools_manager.go
@@ -439,9 +439,20 @@ func (t *BaseToolsManager) CheckAuth() error {
 // awsContextEnv returns the env vars that point the AWS CLI / SDK at the context-scoped
 // .aws/ directory and select the right profile. Mirrors AwsEnvPrinter.GetEnvVars but is
 // duplicated here intentionally — pkg/runtime/tools doesn't depend on pkg/runtime/env, and
-// the shape is small. Returns (nil, err) if the configRoot can't be resolved; callers may
-// pass nil straight through to the shell, which then falls back to the inherited env.
+// the shape is small. Returns (nil, err) if the configRoot can't be resolved.
+//
+// Returns (nil, nil) when the parent env already advertises AWS credentials via a native
+// SDK mechanism (IRSA / OIDC web identity, ECS container role, or static env keys). In
+// those environments — typically CI pods, fargate tasks, and OIDC-federated runners —
+// overriding AWS_PROFILE / AWS_CONFIG_FILE would point the aws CLI at a profile that
+// doesn't exist on the pod's filesystem, causing sts get-caller-identity to fail with
+// "profile not found" before the SDK ever consults the web-identity or container-credentials
+// provider. Passing nil through to the shell exec preserves the inherited env so the native
+// credential chain resolves normally.
 func (t *BaseToolsManager) awsContextEnv() (map[string]string, error) {
+	if hasAmbientAWSCredentials() {
+		return nil, nil
+	}
 	configRoot, err := t.configHandler.GetConfigRoot()
 	if err != nil {
 		return nil, err
@@ -458,6 +469,35 @@ func (t *BaseToolsManager) awsContextEnv() (map[string]string, error) {
 		env["AWS_PROFILE"] = ctx
 	}
 	return env, nil
+}
+
+// hasAmbientAWSCredentials reports whether the parent process environment already carries
+// AWS credentials via a native SDK mechanism that must not be overridden by context-scoped
+// profile/config vars. Triggers on:
+//
+//   - AWS_WEB_IDENTITY_TOKEN_FILE — IRSA pods on EKS, GitHub Actions OIDC, generic OIDC
+//   - AWS_CONTAINER_CREDENTIALS_RELATIVE_URI — ECS/Fargate task roles
+//   - AWS_CONTAINER_CREDENTIALS_FULL_URI — ECS Anywhere / externally hosted containers
+//   - AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY — static keys already exported
+//
+// IMDS-based EC2 is intentionally not covered: there is no env var to detect it, and an
+// operator who explicitly sets AWS_PROFILE against a missing profile on an IMDS host gets
+// the same "profile not found" error from stock aws CLI — this is baseline AWS behavior we
+// do not need to preempt.
+func hasAmbientAWSCredentials() bool {
+	if os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE") != "" {
+		return true
+	}
+	if os.Getenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI") != "" {
+		return true
+	}
+	if os.Getenv("AWS_CONTAINER_CREDENTIALS_FULL_URI") != "" {
+		return true
+	}
+	if os.Getenv("AWS_ACCESS_KEY_ID") != "" && os.Getenv("AWS_SECRET_ACCESS_KEY") != "" {
+		return true
+	}
+	return false
 }
 
 // checkAWSBinary verifies the AWS CLI is available in PATH and meets the minimum version.

--- a/pkg/runtime/tools/tools_manager.go
+++ b/pkg/runtime/tools/tools_manager.go
@@ -3,6 +3,7 @@ package tools
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -36,6 +37,27 @@ type BaseToolsManager struct {
 	configHandler config.ConfigHandler
 	shell         shell.Shell
 }
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+// awsProfileNone, awsProfileSSO, and awsProfileKeys describe what (if anything) the
+// context-scoped .aws/config has for a given profile. awsProfileNone covers "file missing,
+// unreadable, or profile not present"; callers treat it as first-time setup.
+const (
+	awsProfileNone awsProfileState = iota
+	awsProfileSSO
+	awsProfileKeys
+)
+
+// =============================================================================
+// Types
+// =============================================================================
+
+// awsProfileState classifies an entry in a context's .aws/config so CheckAuth can return a
+// hint tuned to the operator's actual state rather than generic advice.
+type awsProfileState int
 
 // =============================================================================
 // Constructor
@@ -411,7 +433,9 @@ func (t *BaseToolsManager) checkAWS() error {
 // SSO, profile not found, no credentials) at preflight time rather than minutes into a
 // `terraform apply`. CheckAuth must NOT be called from `windsor init` (which only scaffolds
 // files and has no obligation to be authed yet); it is intended for bootstrap/up/apply paths
-// where credentials are about to be exercised.
+// where credentials are about to be exercised. Error messages are tuned to the operator's
+// current state (missing config, expired SSO session, rejected static keys) so the returned
+// hint is a copy-pasteable command rather than generic advice.
 func (t *BaseToolsManager) CheckAuth() error {
 	platform := t.configHandler.GetString("platform")
 	if platform == "" {
@@ -421,10 +445,75 @@ func (t *BaseToolsManager) CheckAuth() error {
 	hasAWSConfig := configData != nil && configData.AWS != nil
 	if platform == "aws" || hasAWSConfig {
 		if _, err := t.shell.ExecSilentWithTimeout("aws", []string{"sts", "get-caller-identity"}, 10*time.Second); err != nil {
-			return fmt.Errorf("aws credentials did not resolve: %v; run 'aws configure' or 'aws configure sso' to set up your credentials", err)
+			return fmt.Errorf("aws credentials did not resolve for context %q: %v\n%s", t.configHandler.GetContext(), err, t.awsAuthHint())
 		}
 	}
 	return nil
+}
+
+// awsAuthHint inspects the context-scoped AWS config file and returns an actionable next-step
+// message tuned to what it finds there. The three useful states are: no profile configured yet
+// (first-time setup — offer both SSO and access-key commands), an SSO profile whose token has
+// expired (point at `aws sso login`), and a static-keys profile that was rejected (point at
+// rotation). Anything unparseable or missing falls back to a generic hint so the error is still
+// useful even when the file is in an unexpected shape.
+func (t *BaseToolsManager) awsAuthHint() string {
+	ctx := t.configHandler.GetContext()
+	configRoot, err := t.configHandler.GetConfigRoot()
+	if err != nil || configRoot == "" {
+		return fmt.Sprintf("Run 'aws configure sso --profile %s' (SSO) or 'aws configure --profile %s' (access keys) to set up credentials.", ctx, ctx)
+	}
+	awsConfigPath := filepath.Join(configRoot, ".aws", "config")
+	state := detectAWSProfileState(awsConfigPath, ctx)
+	switch state {
+	case awsProfileSSO:
+		return fmt.Sprintf("AWS SSO session for %q has likely expired. Run: aws sso login --profile %s", ctx, ctx)
+	case awsProfileKeys:
+		return fmt.Sprintf("AWS access keys for %q were rejected by STS. Verify or rotate with: aws configure --profile %s", ctx, ctx)
+	default:
+		return fmt.Sprintf("No AWS credentials configured for context %q yet. Run one of:\n  aws configure sso --profile %s   (SSO — recommended for teams)\n  aws configure --profile %s       (access keys)", ctx, ctx, ctx)
+	}
+}
+
+// detectAWSProfileState parses the AWS config INI at path and classifies the profile named
+// profileName. It looks for either [profile <name>] or [default] (when profileName is
+// "default"), then scans subsequent lines until the next section header for sso_session= or
+// aws_access_key_id=, returning the appropriate state. Absent file, parse errors, or an empty
+// matching section all resolve to awsProfileNone so the caller gets the first-time-setup hint
+// rather than a misleading refresh hint.
+func detectAWSProfileState(path, profileName string) awsProfileState {
+	data, err := osReadFile(path)
+	if err != nil {
+		return awsProfileNone
+	}
+	var wantedHeader string
+	if profileName == "default" {
+		wantedHeader = "[default]"
+	} else {
+		wantedHeader = "[profile " + profileName + "]"
+	}
+	inSection := false
+	for rawLine := range strings.SplitSeq(string(data), "\n") {
+		line := strings.TrimSpace(rawLine)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			inSection = line == wantedHeader
+			continue
+		}
+		if !inSection {
+			continue
+		}
+		key := strings.TrimSpace(strings.SplitN(line, "=", 2)[0])
+		switch key {
+		case "sso_session", "sso_start_url", "sso_account_id":
+			return awsProfileSSO
+		case "aws_access_key_id":
+			return awsProfileKeys
+		}
+	}
+	return awsProfileNone
 }
 
 // compareVersion is a helper function to compare two version strings.

--- a/pkg/runtime/tools/tools_manager.go
+++ b/pkg/runtime/tools/tools_manager.go
@@ -520,13 +520,15 @@ func (t *BaseToolsManager) awsAuthHint() string {
 	}
 }
 
-// awsEnvPrefix returns the `KEY=VALUE KEY=VALUE ` prefix that, when prepended to an aws CLI
-// invocation, makes that invocation read from and write to the context-scoped .aws/ directory.
-// Pulled out of awsAuthHint so all three hint branches (sso, keys, none) share one source of
-// truth for the env-prefix shape.
+// awsEnvPrefix returns the `KEY="VALUE" KEY="VALUE" ` prefix that, when prepended to an aws
+// CLI invocation, makes that invocation read from and write to the context-scoped .aws/
+// directory. Paths are double-quoted so a projectRoot containing spaces (e.g.
+// `/Users/foo/my projects/…`) still parses as a single shell token instead of splitting at
+// the space and breaking the command. Pulled out of awsAuthHint so all three hint branches
+// (sso, keys, none) share one source of truth for the env-prefix shape.
 func awsEnvPrefix(configRoot string) string {
 	awsConfigDir := filepath.Join(configRoot, ".aws")
-	return fmt.Sprintf("AWS_CONFIG_FILE=%s AWS_SHARED_CREDENTIALS_FILE=%s ",
+	return fmt.Sprintf("AWS_CONFIG_FILE=%q AWS_SHARED_CREDENTIALS_FILE=%q ",
 		filepath.ToSlash(filepath.Join(awsConfigDir, "config")),
 		filepath.ToSlash(filepath.Join(awsConfigDir, "credentials")),
 	)

--- a/pkg/runtime/tools/tools_manager.go
+++ b/pkg/runtime/tools/tools_manager.go
@@ -416,11 +416,42 @@ func (t *BaseToolsManager) CheckAuth() error {
 		if err := t.checkAWSBinary(); err != nil {
 			return err
 		}
-		if _, err := t.shell.ExecSilentWithTimeout("aws", []string{"sts", "get-caller-identity"}, 10*time.Second); err != nil {
+		// Inject the context-scoped AWS env (AWS_CONFIG_FILE, AWS_SHARED_CREDENTIALS_FILE,
+		// AWS_PROFILE) so the credential check succeeds even when the operator hasn't sourced
+		// `windsor env` / installed the windsor shell hook yet — without this, bootstrap on a
+		// fresh machine deadlocks: it can't proceed without valid credentials, but the
+		// operator can't establish credentials (`aws sso login`, `aws configure`) without the
+		// same env pointing aws at the context's .aws/config.
+		env, _ := t.awsContextEnv()
+		if _, err := t.shell.ExecSilentWithEnvAndTimeout("aws", env, []string{"sts", "get-caller-identity"}, 10*time.Second); err != nil {
 			return fmt.Errorf("aws credentials did not resolve for context %q: %v\n%s", t.configHandler.GetContext(), err, t.awsAuthHint())
 		}
 	}
 	return nil
+}
+
+// awsContextEnv returns the env vars that point the AWS CLI / SDK at the context-scoped
+// .aws/ directory and select the right profile. Mirrors AwsEnvPrinter.GetEnvVars but is
+// duplicated here intentionally — pkg/runtime/tools doesn't depend on pkg/runtime/env, and
+// the shape is small. Returns (nil, err) if the configRoot can't be resolved; callers may
+// pass nil straight through to the shell, which then falls back to the inherited env.
+func (t *BaseToolsManager) awsContextEnv() (map[string]string, error) {
+	configRoot, err := t.configHandler.GetConfigRoot()
+	if err != nil {
+		return nil, err
+	}
+	awsConfigDir := filepath.Join(configRoot, ".aws")
+	env := map[string]string{
+		"AWS_CONFIG_FILE":             filepath.ToSlash(filepath.Join(awsConfigDir, "config")),
+		"AWS_SHARED_CREDENTIALS_FILE": filepath.ToSlash(filepath.Join(awsConfigDir, "credentials")),
+	}
+	cfg := t.configHandler.GetConfig()
+	if cfg != nil && cfg.AWS != nil && cfg.AWS.AWSProfile != nil && *cfg.AWS.AWSProfile != "" {
+		env["AWS_PROFILE"] = *cfg.AWS.AWSProfile
+	} else if ctx := t.configHandler.GetContext(); ctx != "" {
+		env["AWS_PROFILE"] = ctx
+	}
+	return env, nil
 }
 
 // checkAWSBinary verifies the AWS CLI is available in PATH and meets the minimum version.
@@ -450,24 +481,49 @@ func (t *BaseToolsManager) checkAWSBinary() error {
 // message tuned to what it finds there. The three useful states are: no profile configured yet
 // (first-time setup — offer both SSO and access-key commands), an SSO profile whose token has
 // expired (point at `aws sso login`), and a static-keys profile that was rejected (point at
-// rotation). Anything unparseable or missing falls back to a generic hint so the error is still
-// useful even when the file is in an unexpected shape.
+// rotation). The lookup uses the operator's effective profile name — the value of aws.profile
+// when set, falling back to the context name — so a context like `prod` configured with
+// `aws.profile: company-prod` searches for `[profile company-prod]` and emits commands with
+// `--profile company-prod` rather than misleadingly suggesting `--profile prod`. Each
+// suggestion is prefixed with the context's AWS_CONFIG_FILE / AWS_SHARED_CREDENTIALS_FILE so
+// the command works in any shell — including one where `windsor env` hasn't been sourced —
+// and the resulting profile/keys land in the context folder rather than ~/.aws. Anything
+// unparseable or missing falls back to a generic hint so the error is still useful even when
+// the file is in an unexpected shape.
 func (t *BaseToolsManager) awsAuthHint() string {
 	ctx := t.configHandler.GetContext()
+	profile := ctx
+	cfg := t.configHandler.GetConfig()
+	if cfg != nil && cfg.AWS != nil && cfg.AWS.AWSProfile != nil && *cfg.AWS.AWSProfile != "" {
+		profile = *cfg.AWS.AWSProfile
+	}
 	configRoot, err := t.configHandler.GetConfigRoot()
 	if err != nil || configRoot == "" {
-		return fmt.Sprintf("Run 'aws configure sso --profile %s' (SSO) or 'aws configure --profile %s' (access keys) to set up credentials.", ctx, ctx)
+		return fmt.Sprintf("Run 'aws configure sso --profile %s' (SSO) or 'aws configure --profile %s' (access keys) to set up credentials.", profile, profile)
 	}
 	awsConfigPath := filepath.Join(configRoot, ".aws", "config")
-	state := detectAWSProfileState(awsConfigPath, ctx)
+	envPrefix := awsEnvPrefix(configRoot)
+	state := detectAWSProfileState(awsConfigPath, profile)
 	switch state {
 	case awsProfileSSO:
-		return fmt.Sprintf("AWS SSO session for %q has likely expired. Run: aws sso login --profile %s", ctx, ctx)
+		return fmt.Sprintf("AWS SSO session for %q has likely expired. Run:\n  %saws sso login --profile %s", profile, envPrefix, profile)
 	case awsProfileKeys:
-		return fmt.Sprintf("AWS access keys for %q were rejected by STS. Verify or rotate with: aws configure --profile %s", ctx, ctx)
+		return fmt.Sprintf("AWS access keys for %q were rejected by STS. Verify or rotate with:\n  %saws configure --profile %s", profile, envPrefix, profile)
 	default:
-		return fmt.Sprintf("No AWS credentials configured for context %q yet. Run one of:\n  aws configure sso --profile %s   (SSO — recommended for teams)\n  aws configure --profile %s       (access keys)", ctx, ctx, ctx)
+		return fmt.Sprintf("No AWS credentials configured for context %q yet. Run one of:\n  %saws configure sso --profile %s   (SSO — recommended for teams)\n  %saws configure --profile %s       (access keys)", ctx, envPrefix, profile, envPrefix, profile)
 	}
+}
+
+// awsEnvPrefix returns the `KEY=VALUE KEY=VALUE ` prefix that, when prepended to an aws CLI
+// invocation, makes that invocation read from and write to the context-scoped .aws/ directory.
+// Pulled out of awsAuthHint so all three hint branches (sso, keys, none) share one source of
+// truth for the env-prefix shape.
+func awsEnvPrefix(configRoot string) string {
+	awsConfigDir := filepath.Join(configRoot, ".aws")
+	return fmt.Sprintf("AWS_CONFIG_FILE=%s AWS_SHARED_CREDENTIALS_FILE=%s ",
+		filepath.ToSlash(filepath.Join(awsConfigDir, "config")),
+		filepath.ToSlash(filepath.Join(awsConfigDir, "credentials")),
+	)
 }
 
 // detectAWSProfileState parses the AWS config INI at path and classifies the profile named

--- a/pkg/runtime/tools/tools_manager_test.go
+++ b/pkg/runtime/tools/tools_manager_test.go
@@ -1931,6 +1931,41 @@ contexts:
 		}
 	})
 
+	t.Run("AWSPlatformAmbientCredsWithoutAwsCliIsNoOp", func(t *testing.T) {
+		// Given a lean CI image that has IRSA creds exported but no aws CLI binary —
+		// typical of a minimal GitHub Actions runner using OIDC federation where
+		// awscli was never added to the image
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: aws
+`)
+		t.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "/var/run/secrets/eks.amazonaws.com/serviceaccount/token")
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			return "", exec.ErrNotFound
+		}
+		t.Cleanup(func() { execLookPath = originalExecLookPath })
+		stsCalled := false
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			stsCalled = true
+			return "", nil
+		}
+		// When CheckAuth runs
+		err := toolsManager.CheckAuth()
+		// Then CheckAuth accepts that it can't preflight here and returns nil — terraform's
+		// AWS provider will exercise the native credential chain at apply time and surface
+		// its own error if IRSA is actually misconfigured. A hard requirement on the aws
+		// CLI in this case would be a false negative, since the CLI isn't part of the
+		// runtime credential path for terraform at all.
+		if err != nil {
+			t.Errorf("Expected CheckAuth to be a no-op under IRSA without aws CLI, got %v", err)
+		}
+		if stsCalled {
+			t.Error("sts must not be invoked when the aws CLI is absent")
+		}
+	})
+
 	t.Run("AWSConfigBlockTriggersAuthCheck", func(t *testing.T) {
 		// Given the context has an aws block (no platform set) and creds are invalid
 		mocks, toolsManager := setup(t, `

--- a/pkg/runtime/tools/tools_manager_test.go
+++ b/pkg/runtime/tools/tools_manager_test.go
@@ -1552,6 +1552,169 @@ contexts:
 		}
 	})
 
+	t.Run("AWSPlatformInjectsContextEnvForSts", func(t *testing.T) {
+		// Given platform: aws and the aws CLI is installed
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: aws
+`)
+		awsBinaryMock(t)
+		var capturedEnv map[string]string
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			if command == "aws" && len(args) == 1 && args[0] == "--version" {
+				return fmt.Sprintf("aws-cli/%s Python/3.11.8 Linux", constants.MinimumVersionAWS), nil
+			}
+			return "", fmt.Errorf("command not mocked")
+		}
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			if command == "aws" && len(args) == 2 && args[0] == "sts" && args[1] == "get-caller-identity" {
+				capturedEnv = env
+				return `{"Arn":"arn:aws:iam::123456789012:user/test"}`, nil
+			}
+			return "", fmt.Errorf("command not mocked")
+		}
+		// When CheckAuth runs
+		if err := toolsManager.CheckAuth(); err != nil {
+			t.Fatalf("Expected CheckAuth to succeed, got %v", err)
+		}
+		// Then sts received the context-scoped AWS env so it resolves against the context's
+		// .aws/config and AWS_PROFILE rather than whatever happens to be active in the parent
+		// shell — without this, CheckAuth could green-light bootstrap using stale [default]
+		// credentials that terraform apply would later fail with
+		configRoot, err := mocks.ConfigHandler.GetConfigRoot()
+		if err != nil {
+			t.Fatalf("GetConfigRoot failed: %v", err)
+		}
+		wantConfig := filepath.ToSlash(filepath.Join(configRoot, ".aws", "config"))
+		wantCreds := filepath.ToSlash(filepath.Join(configRoot, ".aws", "credentials"))
+		if capturedEnv["AWS_CONFIG_FILE"] != wantConfig {
+			t.Errorf("AWS_CONFIG_FILE = %q, want %q", capturedEnv["AWS_CONFIG_FILE"], wantConfig)
+		}
+		if capturedEnv["AWS_SHARED_CREDENTIALS_FILE"] != wantCreds {
+			t.Errorf("AWS_SHARED_CREDENTIALS_FILE = %q, want %q", capturedEnv["AWS_SHARED_CREDENTIALS_FILE"], wantCreds)
+		}
+		if capturedEnv["AWS_PROFILE"] != "test" {
+			t.Errorf("AWS_PROFILE = %q, want %q", capturedEnv["AWS_PROFILE"], "test")
+		}
+	})
+
+	t.Run("AWSPlatformWithProfileOverrideUsesAwsProfile", func(t *testing.T) {
+		// Given platform: aws and an explicit aws.profile that differs from the context name
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: aws
+    aws:
+      profile: company-prod
+`)
+		awsBinaryMock(t)
+		var capturedEnv map[string]string
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			if command == "aws" && len(args) == 1 && args[0] == "--version" {
+				return fmt.Sprintf("aws-cli/%s Python/3.11.8 Linux", constants.MinimumVersionAWS), nil
+			}
+			return "", fmt.Errorf("command not mocked")
+		}
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			capturedEnv = env
+			return `{"Arn":"arn:aws:iam::123456789012:user/x"}`, nil
+		}
+		// When CheckAuth runs
+		if err := toolsManager.CheckAuth(); err != nil {
+			t.Fatalf("Expected CheckAuth to succeed, got %v", err)
+		}
+		// Then AWS_PROFILE comes from aws.profile, not the context name — operators who
+		// alias their context to a differently-named upstream profile (e.g. company-prod)
+		// must have sts resolve against that profile, not the context label
+		if capturedEnv["AWS_PROFILE"] != "company-prod" {
+			t.Errorf("AWS_PROFILE = %q, want %q", capturedEnv["AWS_PROFILE"], "company-prod")
+		}
+	})
+
+	t.Run("AWSPlatformStsHintIncludesEnvPrefix", func(t *testing.T) {
+		// Given platform: aws, the binary check passes, sts fails, and the context's
+		// .aws/config has an SSO profile entry for the operator's context
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: aws
+`)
+		awsBinaryMock(t)
+		originalReadFile := osReadFile
+		osReadFile = func(name string) ([]byte, error) {
+			return []byte(`
+[profile test]
+sso_session = company
+sso_account_id = 123456789012
+`), nil
+		}
+		t.Cleanup(func() { osReadFile = originalReadFile })
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			return fmt.Sprintf("aws-cli/%s Python/3.11.8 Linux", constants.MinimumVersionAWS), nil
+		}
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			return "", fmt.Errorf("Token has expired")
+		}
+		// When CheckAuth runs
+		err := toolsManager.CheckAuth()
+		// Then the surfaced error includes both the AWS_CONFIG_FILE= env prefix and the
+		// `aws sso login --profile test` command — the env prefix is what makes the suggestion
+		// runnable in a plain shell where `windsor env` hasn't been sourced yet, closing the
+		// chicken-and-egg loop on a freshly provisioned machine
+		if err == nil {
+			t.Fatal("Expected CheckAuth to fail when sts errors")
+		}
+		if !strings.Contains(err.Error(), "AWS_CONFIG_FILE=") {
+			t.Errorf("Expected AWS_CONFIG_FILE= prefix in hint, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "aws sso login --profile test") {
+			t.Errorf("Expected sso-login hint with profile, got: %v", err)
+		}
+	})
+
+	t.Run("AWSPlatformStsHintHonorsAwsProfileOverride", func(t *testing.T) {
+		// Given platform: aws, an explicit aws.profile that differs from the context name,
+		// and a context-scoped .aws/config containing only the override-named SSO profile
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: aws
+    aws:
+      profile: company-prod
+`)
+		awsBinaryMock(t)
+		originalReadFile := osReadFile
+		osReadFile = func(name string) ([]byte, error) {
+			return []byte(`
+[profile company-prod]
+sso_session = company
+sso_account_id = 123456789012
+`), nil
+		}
+		t.Cleanup(func() { osReadFile = originalReadFile })
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			return fmt.Sprintf("aws-cli/%s Python/3.11.8 Linux", constants.MinimumVersionAWS), nil
+		}
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			return "", fmt.Errorf("Token has expired")
+		}
+		// When CheckAuth runs
+		err := toolsManager.CheckAuth()
+		// Then the hint suggests `aws sso login --profile company-prod` rather than
+		// --profile test — operators with aliased upstream profiles get a runnable command,
+		// not a misleading first-time-setup hint
+		if err == nil {
+			t.Fatal("Expected CheckAuth to fail when sts errors")
+		}
+		if !strings.Contains(err.Error(), "aws sso login --profile company-prod") {
+			t.Errorf("Expected sso-login hint to use aws.profile override, got: %v", err)
+		}
+		if strings.Contains(err.Error(), "--profile test") {
+			t.Errorf("Hint should not reference context name when aws.profile is set, got: %v", err)
+		}
+	})
+
 	t.Run("AWSConfigBlockTriggersAuthCheck", func(t *testing.T) {
 		// Given the context has an aws block (no platform set) and creds are invalid
 		mocks, toolsManager := setup(t, `

--- a/pkg/runtime/tools/tools_manager_test.go
+++ b/pkg/runtime/tools/tools_manager_test.go
@@ -1751,6 +1751,45 @@ contexts:
 		}
 	})
 
+	t.Run("AWSPlatformStsHintQuotesPathsWithSpaces", func(t *testing.T) {
+		// Given platform: aws and a projectRoot whose path contains a space
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: aws
+`)
+		awsBinaryMock(t)
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return "/Users/foo/my projects", nil
+		}
+		originalReadFile := osReadFile
+		osReadFile = func(name string) ([]byte, error) {
+			return []byte(`
+[profile test]
+sso_session = company
+`), nil
+		}
+		t.Cleanup(func() { osReadFile = originalReadFile })
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			return fmt.Sprintf("aws-cli/%s Python/3.11.8 Linux", constants.MinimumVersionAWS), nil
+		}
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			return "", fmt.Errorf("Token has expired")
+		}
+		// When CheckAuth runs
+		err := toolsManager.CheckAuth()
+		// Then the env-prefix quotes the path so the suggested command pastes into a shell
+		// as a single token — an unquoted path with a space would cause the shell to split
+		// at the space and treat `projects/.aws/config` as a separate command, breaking the
+		// copy-pasteable contract the hint advertises
+		if err == nil {
+			t.Fatal("Expected CheckAuth to fail when sts errors")
+		}
+		if !strings.Contains(err.Error(), `AWS_CONFIG_FILE="/Users/foo/my projects/contexts/test/.aws/config"`) {
+			t.Errorf("Expected AWS_CONFIG_FILE to be double-quoted in hint, got: %v", err)
+		}
+	})
+
 	t.Run("AWSConfigBlockTriggersAuthCheck", func(t *testing.T) {
 		// Given the context has an aws block (no platform set) and creds are invalid
 		mocks, toolsManager := setup(t, `

--- a/pkg/runtime/tools/tools_manager_test.go
+++ b/pkg/runtime/tools/tools_manager_test.go
@@ -1867,6 +1867,37 @@ contexts:
 		}
 	})
 
+	t.Run("AWSPlatformEcsAnywhereFullUriSkipsProfileInjection", func(t *testing.T) {
+		// Given an ECS-Anywhere / externally-hosted container — AWS_CONTAINER_CREDENTIALS_FULL_URI
+		// is set (rather than the RELATIVE_URI the in-cluster agent injects) because the creds
+		// endpoint lives on a non-link-local host. The SDK treats FULL_URI identically to
+		// RELATIVE_URI for credential resolution; the guard must treat it the same way too.
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: aws
+`)
+		awsBinaryMock(t)
+		t.Setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", "https://credentials.example.com/role/abc123")
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			return fmt.Sprintf("aws-cli/%s Python/3.11.8 Linux", constants.MinimumVersionAWS), nil
+		}
+		var capturedEnv map[string]string
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			capturedEnv = env
+			return `{"Arn":"arn:aws:sts::123456789012:assumed-role/ecs-anywhere-role/session"}`, nil
+		}
+		// When CheckAuth runs
+		if err := toolsManager.CheckAuth(); err != nil {
+			t.Fatalf("Expected CheckAuth to succeed under ECS-Anywhere FULL_URI, got %v", err)
+		}
+		// Then the shell receives a nil env map so the SDK resolves credentials from the
+		// externally-hosted endpoint rather than getting short-circuited by a profile lookup
+		if capturedEnv != nil {
+			t.Errorf("Expected nil env under ECS-Anywhere FULL_URI, got %v", capturedEnv)
+		}
+	})
+
 	t.Run("AWSPlatformStaticEnvKeysSkipProfileInjection", func(t *testing.T) {
 		// Given a CI environment that exports AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY
 		// directly (no profile file involved)

--- a/pkg/runtime/tools/tools_manager_test.go
+++ b/pkg/runtime/tools/tools_manager_test.go
@@ -478,6 +478,29 @@ contexts:
 		}
 	})
 
+	t.Run("AWSPlatformButAwsCliNotAvailable", func(t *testing.T) {
+		// When platform is aws and the aws CLI is not in PATH, Check must route through
+		// checkAWS and return a wrapped "aws check failed" error so operators see the
+		// platform-triggered requirement before bootstrap runs terraform.
+		configStr := `
+contexts:
+  test:
+    platform: aws
+`
+		_, toolsManager := setup(t, configStr)
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			if name == "aws" {
+				return "", exec.ErrNotFound
+			}
+			return originalExecLookPath(name)
+		}
+		err := toolsManager.Check()
+		if err == nil || !strings.Contains(err.Error(), "aws check failed") {
+			t.Errorf("Expected 'aws check failed' error, got: %v", err)
+		}
+	})
+
 	t.Run("MultipleToolFailures", func(t *testing.T) {
 		// Given multiple tools are enabled but fail checks
 		mocks, toolsManager := setup(t, defaultConfig)
@@ -1272,6 +1295,171 @@ func TestToolsManager_checkKubelogin(t *testing.T) {
 		// Then no error should be returned
 		if err != nil {
 			t.Errorf("Expected checkKubelogin to succeed with all required env vars, but got error: %v", err)
+		}
+	})
+}
+
+func TestToolsManager_checkAWS(t *testing.T) {
+	setup := func(t *testing.T) (*Mocks, *BaseToolsManager) {
+		t.Helper()
+		mocks := setupMocks(t)
+		toolsManager := NewToolsManager(mocks.ConfigHandler, mocks.Shell)
+		return mocks, toolsManager
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		// Given aws is available, meets version, and sts get-caller-identity resolves
+		mocks, toolsManager := setup(t)
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			if name == "aws" {
+				return "/usr/bin/aws", nil
+			}
+			return originalExecLookPath(name)
+		}
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			if command == "aws" && len(args) == 1 && args[0] == "--version" {
+				return fmt.Sprintf("aws-cli/%s Python/3.11.8 Darwin/24.1.0", constants.MinimumVersionAWS), nil
+			}
+			if command == "aws" && len(args) == 2 && args[0] == "sts" && args[1] == "get-caller-identity" {
+				return `{"UserId":"AIDAXXX","Account":"123456789012","Arn":"arn:aws:iam::123456789012:user/test"}`, nil
+			}
+			return "", fmt.Errorf("command not mocked: %s %v", command, args)
+		}
+		// When checking aws
+		err := toolsManager.checkAWS()
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected checkAWS to succeed, got %v", err)
+		}
+	})
+
+	t.Run("AwsNotAvailable", func(t *testing.T) {
+		// Given aws is not in PATH
+		_, toolsManager := setup(t)
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			if name == "aws" {
+				return "", exec.ErrNotFound
+			}
+			return originalExecLookPath(name)
+		}
+		// When checking aws
+		err := toolsManager.checkAWS()
+		// Then error mentions not in PATH and points to vendor install URL
+		if err == nil {
+			t.Fatal("Expected error when aws is not in PATH")
+		}
+		if !strings.Contains(err.Error(), "aws CLI is not available in the PATH") {
+			t.Errorf("Expected 'not available in the PATH' in error, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html") {
+			t.Errorf("Expected vendor install URL in error, got: %v", err)
+		}
+	})
+
+	t.Run("VersionCommandFails", func(t *testing.T) {
+		// Given aws is in PATH but `aws --version` errors
+		mocks, toolsManager := setup(t)
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			if name == "aws" {
+				return "/usr/bin/aws", nil
+			}
+			return originalExecLookPath(name)
+		}
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			if command == "aws" && len(args) == 1 && args[0] == "--version" {
+				return "", fmt.Errorf("permission denied")
+			}
+			return "", fmt.Errorf("command not mocked")
+		}
+		// When checking aws
+		err := toolsManager.checkAWS()
+		// Then the version-command error surfaces
+		if err == nil || !strings.Contains(err.Error(), "aws --version failed") {
+			t.Errorf("Expected 'aws --version failed' error, got: %v", err)
+		}
+	})
+
+	t.Run("VersionUnparseable", func(t *testing.T) {
+		// Given aws returns output without a parseable semver
+		mocks, toolsManager := setup(t)
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			if name == "aws" {
+				return "/usr/bin/aws", nil
+			}
+			return originalExecLookPath(name)
+		}
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			if command == "aws" && len(args) == 1 && args[0] == "--version" {
+				return "aws-cli banana", nil
+			}
+			return "", fmt.Errorf("command not mocked")
+		}
+		// When checking aws
+		err := toolsManager.checkAWS()
+		// Then the extraction-failure error surfaces
+		if err == nil || !strings.Contains(err.Error(), "failed to extract aws CLI version") {
+			t.Errorf("Expected 'failed to extract aws CLI version' error, got: %v", err)
+		}
+	})
+
+	t.Run("VersionTooLow", func(t *testing.T) {
+		// Given aws reports a version below the minimum
+		mocks, toolsManager := setup(t)
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			if name == "aws" {
+				return "/usr/bin/aws", nil
+			}
+			return originalExecLookPath(name)
+		}
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			if command == "aws" && len(args) == 1 && args[0] == "--version" {
+				return "aws-cli/1.2.3 Python/3.11.8 Darwin/24.1.0", nil
+			}
+			return "", fmt.Errorf("command not mocked")
+		}
+		// When checking aws
+		err := toolsManager.checkAWS()
+		// Then the version-too-low error surfaces
+		if err == nil || !strings.Contains(err.Error(), "below the minimum required version") {
+			t.Errorf("Expected version-too-low error, got: %v", err)
+		}
+	})
+
+	t.Run("StsCallerIdentityFails", func(t *testing.T) {
+		// Given aws is installed and new enough but credentials don't resolve
+		mocks, toolsManager := setup(t)
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			if name == "aws" {
+				return "/usr/bin/aws", nil
+			}
+			return originalExecLookPath(name)
+		}
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			if command == "aws" && len(args) == 1 && args[0] == "--version" {
+				return fmt.Sprintf("aws-cli/%s Python/3.11.8 Darwin/24.1.0", constants.MinimumVersionAWS), nil
+			}
+			if command == "aws" && len(args) == 2 && args[0] == "sts" && args[1] == "get-caller-identity" {
+				return "", fmt.Errorf("Unable to locate credentials")
+			}
+			return "", fmt.Errorf("command not mocked")
+		}
+		// When checking aws
+		err := toolsManager.checkAWS()
+		// Then the credential-resolution error surfaces with an actionable hint
+		if err == nil {
+			t.Fatal("Expected error when sts get-caller-identity fails")
+		}
+		if !strings.Contains(err.Error(), "aws credentials did not resolve") {
+			t.Errorf("Expected 'aws credentials did not resolve' in error, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "aws configure") {
+			t.Errorf("Expected actionable 'aws configure' hint in error, got: %v", err)
 		}
 	})
 }

--- a/pkg/runtime/tools/tools_manager_test.go
+++ b/pkg/runtime/tools/tools_manager_test.go
@@ -1526,6 +1526,103 @@ contexts:
 	})
 }
 
+func Test_detectAWSProfileState(t *testing.T) {
+	withReadFile := func(t *testing.T, contents string, readErr error) {
+		t.Helper()
+		original := osReadFile
+		osReadFile = func(name string) ([]byte, error) {
+			if readErr != nil {
+				return nil, readErr
+			}
+			return []byte(contents), nil
+		}
+		t.Cleanup(func() { osReadFile = original })
+	}
+
+	t.Run("NoFileReturnsNone", func(t *testing.T) {
+		withReadFile(t, "", os.ErrNotExist)
+		if got := detectAWSProfileState("/irrelevant", "prod"); got != awsProfileNone {
+			t.Errorf("expected awsProfileNone for missing file, got %v", got)
+		}
+	})
+
+	t.Run("ProfileWithSsoSessionReturnsSSO", func(t *testing.T) {
+		withReadFile(t, `
+[profile prod]
+sso_session = company
+sso_account_id = 123456789012
+sso_role_name = Admin
+region = us-east-1
+`, nil)
+		if got := detectAWSProfileState("/irrelevant", "prod"); got != awsProfileSSO {
+			t.Errorf("expected awsProfileSSO, got %v", got)
+		}
+	})
+
+	t.Run("ProfileWithSsoStartUrlAloneReturnsSSO", func(t *testing.T) {
+		// Legacy SSO profile form (pre-IAM-Identity-Center-sessions) uses sso_start_url
+		// directly on the profile. detectAWSProfileState treats that as SSO too so expired
+		// tokens route to the sso-login hint.
+		withReadFile(t, `
+[profile prod]
+sso_start_url = https://example.awsapps.com/start
+sso_region = us-east-1
+sso_account_id = 123456789012
+`, nil)
+		if got := detectAWSProfileState("/irrelevant", "prod"); got != awsProfileSSO {
+			t.Errorf("expected awsProfileSSO for legacy sso_start_url profile, got %v", got)
+		}
+	})
+
+	t.Run("ProfileWithAccessKeysReturnsKeys", func(t *testing.T) {
+		withReadFile(t, `
+[profile prod]
+aws_access_key_id = AKIATEST
+aws_secret_access_key = secret
+region = us-west-2
+`, nil)
+		if got := detectAWSProfileState("/irrelevant", "prod"); got != awsProfileKeys {
+			t.Errorf("expected awsProfileKeys, got %v", got)
+		}
+	})
+
+	t.Run("MissingProfileReturnsNone", func(t *testing.T) {
+		// Config file has sections for other profiles but nothing for `prod`.
+		withReadFile(t, `
+[profile dev]
+aws_access_key_id = AKIADEV
+`, nil)
+		if got := detectAWSProfileState("/irrelevant", "prod"); got != awsProfileNone {
+			t.Errorf("expected awsProfileNone when profile not present, got %v", got)
+		}
+	})
+
+	t.Run("DefaultProfileUsesDefaultHeader", func(t *testing.T) {
+		// [default] uses a different header form than [profile <name>]; detection must
+		// route to the bare header when the profile name is literally "default".
+		withReadFile(t, `
+[default]
+aws_access_key_id = AKIADEFAULT
+`, nil)
+		if got := detectAWSProfileState("/irrelevant", "default"); got != awsProfileKeys {
+			t.Errorf("expected awsProfileKeys for [default], got %v", got)
+		}
+	})
+
+	t.Run("CommentsAndBlankLinesIgnored", func(t *testing.T) {
+		withReadFile(t, `
+# header comment
+[profile prod]
+
+# inline comment
+sso_session = company
+`, nil)
+		if got := detectAWSProfileState("/irrelevant", "prod"); got != awsProfileSSO {
+			t.Errorf("expected awsProfileSSO with comments/blanks, got %v", got)
+		}
+	})
+}
+
 // =============================================================================
 // Test Helpers
 // =============================================================================

--- a/pkg/runtime/tools/tools_manager_test.go
+++ b/pkg/runtime/tools/tools_manager_test.go
@@ -1715,6 +1715,42 @@ sso_account_id = 123456789012
 		}
 	})
 
+	t.Run("AWSPlatformConfigRootFailureSurfacesError", func(t *testing.T) {
+		// Given platform: aws, the aws CLI is installed, and GetProjectRoot fails so the
+		// context-scoped AWS env cannot be computed
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: aws
+`)
+		awsBinaryMock(t)
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			return fmt.Sprintf("aws-cli/%s Python/3.11.8 Linux", constants.MinimumVersionAWS), nil
+		}
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return "", fmt.Errorf("project root not found")
+		}
+		stsCalled := false
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			stsCalled = true
+			return "", nil
+		}
+		// When CheckAuth runs
+		err := toolsManager.CheckAuth()
+		// Then the configRoot-resolution failure surfaces as an error and sts is never
+		// invoked — letting the exec fall through with a nil env would silently validate
+		// against the operator's ambient shell credentials, defeating the preflight
+		if err == nil {
+			t.Fatal("Expected CheckAuth to fail when configRoot cannot be resolved")
+		}
+		if !strings.Contains(err.Error(), "context-scoped AWS env") {
+			t.Errorf("Expected context-scoped AWS env error, got: %v", err)
+		}
+		if stsCalled {
+			t.Error("sts must not be invoked when the context-scoped env is unresolvable")
+		}
+	})
+
 	t.Run("AWSConfigBlockTriggersAuthCheck", func(t *testing.T) {
 		// Given the context has an aws block (no platform set) and creds are invalid
 		mocks, toolsManager := setup(t, `

--- a/pkg/runtime/tools/tools_manager_test.go
+++ b/pkg/runtime/tools/tools_manager_test.go
@@ -478,10 +478,12 @@ contexts:
 		}
 	})
 
-	t.Run("AWSPlatformButAwsCliNotAvailable", func(t *testing.T) {
-		// When platform is aws and the aws CLI is not in PATH, Check must route through
-		// checkAWS and return a wrapped "aws check failed" error so operators see the
-		// platform-triggered requirement before bootstrap runs terraform.
+	t.Run("AWSPlatformDoesNotTriggerAWSCheckInCheck", func(t *testing.T) {
+		// AWS CLI presence and credentials are explicitly OUT of Check(): `windsor init`
+		// and `windsor env` go through PrepareTools → Check and have no obligation to have
+		// the aws CLI installed or be authenticated. Both checks live on CheckAuth, which
+		// fires from bootstrap/up/apply preflights and from `windsor check`. This test
+		// ensures Check() stays silent even when platform is aws and the aws CLI is absent.
 		configStr := `
 contexts:
   test:
@@ -495,9 +497,8 @@ contexts:
 			}
 			return originalExecLookPath(name)
 		}
-		err := toolsManager.Check()
-		if err == nil || !strings.Contains(err.Error(), "aws check failed") {
-			t.Errorf("Expected 'aws check failed' error, got: %v", err)
+		if err := toolsManager.Check(); err != nil {
+			t.Errorf("Expected Check to succeed when aws is absent (platform: aws), got: %v", err)
 		}
 	})
 
@@ -1299,7 +1300,7 @@ func TestToolsManager_checkKubelogin(t *testing.T) {
 	})
 }
 
-func TestToolsManager_checkAWS(t *testing.T) {
+func TestToolsManager_checkAWSBinary(t *testing.T) {
 	setup := func(t *testing.T) (*Mocks, *BaseToolsManager) {
 		t.Helper()
 		mocks := setupMocks(t)
@@ -1323,12 +1324,13 @@ func TestToolsManager_checkAWS(t *testing.T) {
 			}
 			return "", fmt.Errorf("command not mocked: %s %v", command, args)
 		}
-		// When checking aws
-		err := toolsManager.checkAWS()
-		// Then no error should be returned. checkAWS must NOT invoke sts get-caller-identity
-		// — that lives in CheckAuth and is exercised at bootstrap/up preflight time only.
+		// When checking the aws binary
+		err := toolsManager.checkAWSBinary()
+		// Then no error should be returned. checkAWSBinary must NOT invoke sts — that lives
+		// in CheckAuth, which is called only from bootstrap/up/apply preflights and from
+		// `windsor check`.
 		if err != nil {
-			t.Errorf("Expected checkAWS to succeed, got %v", err)
+			t.Errorf("Expected checkAWSBinary to succeed, got %v", err)
 		}
 	})
 
@@ -1343,7 +1345,7 @@ func TestToolsManager_checkAWS(t *testing.T) {
 			return originalExecLookPath(name)
 		}
 		// When checking aws
-		err := toolsManager.checkAWS()
+		err := toolsManager.checkAWSBinary()
 		// Then error mentions not in PATH and points to vendor install URL
 		if err == nil {
 			t.Fatal("Expected error when aws is not in PATH")
@@ -1373,7 +1375,7 @@ func TestToolsManager_checkAWS(t *testing.T) {
 			return "", fmt.Errorf("command not mocked")
 		}
 		// When checking aws
-		err := toolsManager.checkAWS()
+		err := toolsManager.checkAWSBinary()
 		// Then the version-command error surfaces
 		if err == nil || !strings.Contains(err.Error(), "aws --version failed") {
 			t.Errorf("Expected 'aws --version failed' error, got: %v", err)
@@ -1397,7 +1399,7 @@ func TestToolsManager_checkAWS(t *testing.T) {
 			return "", fmt.Errorf("command not mocked")
 		}
 		// When checking aws
-		err := toolsManager.checkAWS()
+		err := toolsManager.checkAWSBinary()
 		// Then the extraction-failure error surfaces
 		if err == nil || !strings.Contains(err.Error(), "failed to extract aws CLI version") {
 			t.Errorf("Expected 'failed to extract aws CLI version' error, got: %v", err)
@@ -1421,7 +1423,7 @@ func TestToolsManager_checkAWS(t *testing.T) {
 			return "", fmt.Errorf("command not mocked")
 		}
 		// When checking aws
-		err := toolsManager.checkAWS()
+		err := toolsManager.checkAWSBinary()
 		// Then the version-too-low error surfaces
 		if err == nil || !strings.Contains(err.Error(), "below the minimum required version") {
 			t.Errorf("Expected version-too-low error, got: %v", err)
@@ -1449,14 +1451,63 @@ func TestToolsManager_CheckAuth(t *testing.T) {
 		}
 	})
 
+	// awsBinaryMock wires execLookPath and the version shell call so CheckAuth can reach the
+	// sts-get-caller-identity step. Every sub-test that exercises CheckAuth beyond the binary
+	// check uses this to get past the preliminaries.
+	awsBinaryMock := func(t *testing.T) {
+		t.Helper()
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			if name == "aws" {
+				return "/usr/bin/aws", nil
+			}
+			return originalExecLookPath(name)
+		}
+		t.Cleanup(func() { execLookPath = originalExecLookPath })
+	}
+
+	t.Run("AWSPlatformWithAwsCliMissing", func(t *testing.T) {
+		// Given platform: aws and the aws CLI is not in PATH
+		_, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: aws
+`)
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			if name == "aws" {
+				return "", exec.ErrNotFound
+			}
+			return originalExecLookPath(name)
+		}
+		t.Cleanup(func() { execLookPath = originalExecLookPath })
+
+		// When CheckAuth runs
+		err := toolsManager.CheckAuth()
+		// Then the missing-binary error surfaces with the vendor install URL — the binary
+		// check is part of CheckAuth now so bootstrap/up preflights catch a missing CLI
+		// before they try to resolve credentials.
+		if err == nil {
+			t.Fatal("Expected error when aws CLI is missing")
+		}
+		if !strings.Contains(err.Error(), "aws CLI is not available in the PATH") {
+			t.Errorf("Expected 'not available in the PATH' error, got: %v", err)
+		}
+	})
+
 	t.Run("AWSPlatformWithValidCredentials", func(t *testing.T) {
-		// Given platform: aws and sts get-caller-identity succeeds
+		// Given platform: aws, the aws CLI is installed at the minimum version, and sts
+		// get-caller-identity succeeds
 		mocks, toolsManager := setup(t, `
 contexts:
   test:
     platform: aws
 `)
+		awsBinaryMock(t)
 		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			if command == "aws" && len(args) == 1 && args[0] == "--version" {
+				return fmt.Sprintf("aws-cli/%s Python/3.11.8 Linux", constants.MinimumVersionAWS), nil
+			}
 			if command == "aws" && len(args) == 2 && args[0] == "sts" && args[1] == "get-caller-identity" {
 				return `{"Arn":"arn:aws:iam::123456789012:user/test"}`, nil
 			}
@@ -1471,13 +1522,17 @@ contexts:
 	})
 
 	t.Run("AWSPlatformWithStsFailure", func(t *testing.T) {
-		// Given platform: aws and credentials cannot be resolved
+		// Given platform: aws, the aws CLI is installed, but credentials cannot be resolved
 		mocks, toolsManager := setup(t, `
 contexts:
   test:
     platform: aws
 `)
+		awsBinaryMock(t)
 		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			if command == "aws" && len(args) == 1 && args[0] == "--version" {
+				return fmt.Sprintf("aws-cli/%s Python/3.11.8 Linux", constants.MinimumVersionAWS), nil
+			}
 			if command == "aws" && len(args) == 2 && args[0] == "sts" && args[1] == "get-caller-identity" {
 				return "", fmt.Errorf("Unable to locate credentials")
 			}
@@ -1505,10 +1560,14 @@ contexts:
     aws:
       region: us-east-1
 `)
-		called := false
+		awsBinaryMock(t)
+		stsCalled := false
 		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			if command == "aws" && len(args) == 1 && args[0] == "--version" {
+				return fmt.Sprintf("aws-cli/%s Python/3.11.8 Linux", constants.MinimumVersionAWS), nil
+			}
 			if command == "aws" && len(args) == 2 && args[0] == "sts" && args[1] == "get-caller-identity" {
-				called = true
+				stsCalled = true
 				return "", fmt.Errorf("Unable to locate credentials")
 			}
 			return "", fmt.Errorf("command not mocked")
@@ -1517,7 +1576,7 @@ contexts:
 		err := toolsManager.CheckAuth()
 		// Then sts was invoked and the error surfaced — an aws block alone is enough to gate
 		// on credentials, matching the env-printer activation rule
-		if !called {
+		if !stsCalled {
 			t.Error("Expected sts get-caller-identity to be invoked when aws block is present")
 		}
 		if err == nil {

--- a/pkg/runtime/tools/tools_manager_test.go
+++ b/pkg/runtime/tools/tools_manager_test.go
@@ -1308,7 +1308,7 @@ func TestToolsManager_checkAWS(t *testing.T) {
 	}
 
 	t.Run("Success", func(t *testing.T) {
-		// Given aws is available, meets version, and sts get-caller-identity resolves
+		// Given aws is available and meets the minimum version
 		mocks, toolsManager := setup(t)
 		originalExecLookPath := execLookPath
 		execLookPath = func(name string) (string, error) {
@@ -1321,14 +1321,12 @@ func TestToolsManager_checkAWS(t *testing.T) {
 			if command == "aws" && len(args) == 1 && args[0] == "--version" {
 				return fmt.Sprintf("aws-cli/%s Python/3.11.8 Darwin/24.1.0", constants.MinimumVersionAWS), nil
 			}
-			if command == "aws" && len(args) == 2 && args[0] == "sts" && args[1] == "get-caller-identity" {
-				return `{"UserId":"AIDAXXX","Account":"123456789012","Arn":"arn:aws:iam::123456789012:user/test"}`, nil
-			}
 			return "", fmt.Errorf("command not mocked: %s %v", command, args)
 		}
 		// When checking aws
 		err := toolsManager.checkAWS()
-		// Then no error should be returned
+		// Then no error should be returned. checkAWS must NOT invoke sts get-caller-identity
+		// — that lives in CheckAuth and is exercised at bootstrap/up preflight time only.
 		if err != nil {
 			t.Errorf("Expected checkAWS to succeed, got %v", err)
 		}
@@ -1430,28 +1428,64 @@ func TestToolsManager_checkAWS(t *testing.T) {
 		}
 	})
 
-	t.Run("StsCallerIdentityFails", func(t *testing.T) {
-		// Given aws is installed and new enough but credentials don't resolve
-		mocks, toolsManager := setup(t)
-		originalExecLookPath := execLookPath
-		execLookPath = func(name string) (string, error) {
-			if name == "aws" {
-				return "/usr/bin/aws", nil
-			}
-			return originalExecLookPath(name)
+}
+
+func TestToolsManager_CheckAuth(t *testing.T) {
+	setup := func(t *testing.T, configStr string) (*Mocks, *BaseToolsManager) {
+		t.Helper()
+		mocks := setupMocks(t, &SetupOptions{ConfigStr: configStr})
+		toolsManager := NewToolsManager(mocks.ConfigHandler, mocks.Shell)
+		return mocks, toolsManager
+	}
+
+	t.Run("NoCloudPlatformIsNoOp", func(t *testing.T) {
+		// Given a context with no AWS platform or aws block
+		_, toolsManager := setup(t, defaultConfig)
+		// When CheckAuth runs
+		err := toolsManager.CheckAuth()
+		// Then it returns nil without invoking any cloud-CLI calls
+		if err != nil {
+			t.Errorf("Expected CheckAuth to be a no-op for non-cloud contexts, got %v", err)
 		}
+	})
+
+	t.Run("AWSPlatformWithValidCredentials", func(t *testing.T) {
+		// Given platform: aws and sts get-caller-identity succeeds
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: aws
+`)
 		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
-			if command == "aws" && len(args) == 1 && args[0] == "--version" {
-				return fmt.Sprintf("aws-cli/%s Python/3.11.8 Darwin/24.1.0", constants.MinimumVersionAWS), nil
+			if command == "aws" && len(args) == 2 && args[0] == "sts" && args[1] == "get-caller-identity" {
+				return `{"Arn":"arn:aws:iam::123456789012:user/test"}`, nil
 			}
+			return "", fmt.Errorf("command not mocked: %s %v", command, args)
+		}
+		// When CheckAuth runs
+		err := toolsManager.CheckAuth()
+		// Then it succeeds
+		if err != nil {
+			t.Errorf("Expected CheckAuth to succeed when sts resolves, got %v", err)
+		}
+	})
+
+	t.Run("AWSPlatformWithStsFailure", func(t *testing.T) {
+		// Given platform: aws and credentials cannot be resolved
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: aws
+`)
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
 			if command == "aws" && len(args) == 2 && args[0] == "sts" && args[1] == "get-caller-identity" {
 				return "", fmt.Errorf("Unable to locate credentials")
 			}
 			return "", fmt.Errorf("command not mocked")
 		}
-		// When checking aws
-		err := toolsManager.checkAWS()
-		// Then the credential-resolution error surfaces with an actionable hint
+		// When CheckAuth runs
+		err := toolsManager.CheckAuth()
+		// Then it surfaces the credential-resolution error with an actionable hint
 		if err == nil {
 			t.Fatal("Expected error when sts get-caller-identity fails")
 		}
@@ -1459,7 +1493,35 @@ func TestToolsManager_checkAWS(t *testing.T) {
 			t.Errorf("Expected 'aws credentials did not resolve' in error, got: %v", err)
 		}
 		if !strings.Contains(err.Error(), "aws configure") {
-			t.Errorf("Expected actionable 'aws configure' hint in error, got: %v", err)
+			t.Errorf("Expected 'aws configure' hint in error, got: %v", err)
+		}
+	})
+
+	t.Run("AWSConfigBlockTriggersAuthCheck", func(t *testing.T) {
+		// Given the context has an aws block (no platform set) and creds are invalid
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    aws:
+      region: us-east-1
+`)
+		called := false
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			if command == "aws" && len(args) == 2 && args[0] == "sts" && args[1] == "get-caller-identity" {
+				called = true
+				return "", fmt.Errorf("Unable to locate credentials")
+			}
+			return "", fmt.Errorf("command not mocked")
+		}
+		// When CheckAuth runs
+		err := toolsManager.CheckAuth()
+		// Then sts was invoked and the error surfaced — an aws block alone is enough to gate
+		// on credentials, matching the env-printer activation rule
+		if !called {
+			t.Error("Expected sts get-caller-identity to be invoked when aws block is present")
+		}
+		if err == nil {
+			t.Error("Expected CheckAuth to surface the credential failure")
 		}
 	})
 }

--- a/pkg/runtime/tools/tools_manager_test.go
+++ b/pkg/runtime/tools/tools_manager_test.go
@@ -1435,6 +1435,16 @@ func TestToolsManager_checkAWSBinary(t *testing.T) {
 func TestToolsManager_CheckAuth(t *testing.T) {
 	setup := func(t *testing.T, configStr string) (*Mocks, *BaseToolsManager) {
 		t.Helper()
+		// Clear every env var the ambient-credentials guard consults so CheckAuth behaves
+		// identically on a dev laptop, an EKS pod, and a GitHub Actions runner. Without
+		// this, tests that assume context-env injection will intermittently skip injection
+		// on machines where a stray AWS_ACCESS_KEY_ID or AWS_WEB_IDENTITY_TOKEN_FILE
+		// happens to be exported.
+		t.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "")
+		t.Setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "")
+		t.Setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", "")
+		t.Setenv("AWS_ACCESS_KEY_ID", "")
+		t.Setenv("AWS_SECRET_ACCESS_KEY", "")
 		mocks := setupMocks(t, &SetupOptions{ConfigStr: configStr})
 		toolsManager := NewToolsManager(mocks.ConfigHandler, mocks.Shell)
 		return mocks, toolsManager
@@ -1787,6 +1797,137 @@ sso_session = company
 		}
 		if !strings.Contains(err.Error(), `AWS_CONFIG_FILE="/Users/foo/my projects/contexts/test/.aws/config"`) {
 			t.Errorf("Expected AWS_CONFIG_FILE to be double-quoted in hint, got: %v", err)
+		}
+	})
+
+	t.Run("AWSPlatformWebIdentitySkipsProfileInjection", func(t *testing.T) {
+		// Given an IRSA/OIDC environment — AWS_WEB_IDENTITY_TOKEN_FILE is set by the EKS
+		// pod-identity webhook or a GitHub Actions OIDC step — and aws CLI is installed
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: aws
+`)
+		awsBinaryMock(t)
+		t.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "/var/run/secrets/eks.amazonaws.com/serviceaccount/token")
+		t.Setenv("AWS_ROLE_ARN", "arn:aws:iam::123456789012:role/my-role")
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			return fmt.Sprintf("aws-cli/%s Python/3.11.8 Linux", constants.MinimumVersionAWS), nil
+		}
+		var capturedEnv map[string]string
+		var capturedEnvSeen bool
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			capturedEnv = env
+			capturedEnvSeen = true
+			return `{"Arn":"arn:aws:sts::123456789012:assumed-role/my-role/session"}`, nil
+		}
+		// When CheckAuth runs
+		if err := toolsManager.CheckAuth(); err != nil {
+			t.Fatalf("Expected CheckAuth to succeed under IRSA, got %v", err)
+		}
+		// Then the shell receives a nil env map — overriding AWS_PROFILE in an IRSA pod
+		// would point aws at a profile that does not exist on the pod filesystem and
+		// surface a spurious "profile not found" before the SDK's web-identity provider
+		// ever runs
+		if !capturedEnvSeen {
+			t.Fatal("Expected sts to be invoked")
+		}
+		if capturedEnv != nil {
+			t.Errorf("Expected nil env under IRSA (SDK native chain must win), got %v", capturedEnv)
+		}
+	})
+
+	t.Run("AWSPlatformEcsContainerRoleSkipsProfileInjection", func(t *testing.T) {
+		// Given an ECS task with a task role — AWS_CONTAINER_CREDENTIALS_RELATIVE_URI is
+		// injected by the ECS agent and points at the 169.254.170.2 metadata endpoint
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: aws
+`)
+		awsBinaryMock(t)
+		t.Setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "/v2/credentials/abc123")
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			return fmt.Sprintf("aws-cli/%s Python/3.11.8 Linux", constants.MinimumVersionAWS), nil
+		}
+		var capturedEnv map[string]string
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			capturedEnv = env
+			return `{"Arn":"arn:aws:sts::123456789012:assumed-role/task-role/session"}`, nil
+		}
+		// When CheckAuth runs
+		if err := toolsManager.CheckAuth(); err != nil {
+			t.Fatalf("Expected CheckAuth to succeed under ECS container role, got %v", err)
+		}
+		// Then the shell receives a nil env map so the SDK's container-credentials provider
+		// (169.254.170.2) is consulted rather than getting short-circuited by a profile
+		// lookup for a config file that doesn't exist in the task
+		if capturedEnv != nil {
+			t.Errorf("Expected nil env under ECS container role, got %v", capturedEnv)
+		}
+	})
+
+	t.Run("AWSPlatformStaticEnvKeysSkipProfileInjection", func(t *testing.T) {
+		// Given a CI environment that exports AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY
+		// directly (no profile file involved)
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: aws
+`)
+		awsBinaryMock(t)
+		t.Setenv("AWS_ACCESS_KEY_ID", "AKIATEST")
+		t.Setenv("AWS_SECRET_ACCESS_KEY", "secret")
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			return fmt.Sprintf("aws-cli/%s Python/3.11.8 Linux", constants.MinimumVersionAWS), nil
+		}
+		var capturedEnv map[string]string
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			capturedEnv = env
+			return `{"Arn":"arn:aws:iam::123456789012:user/ci"}`, nil
+		}
+		// When CheckAuth runs
+		if err := toolsManager.CheckAuth(); err != nil {
+			t.Fatalf("Expected CheckAuth to succeed with static env keys, got %v", err)
+		}
+		// Then the shell receives a nil env map — the static keys already in the parent env
+		// are the intended credentials and injecting AWS_PROFILE would route the aws CLI
+		// through a profile lookup that ignores them
+		if capturedEnv != nil {
+			t.Errorf("Expected nil env with static credentials, got %v", capturedEnv)
+		}
+	})
+
+	t.Run("AWSPlatformAccessKeyWithoutSecretStillInjects", func(t *testing.T) {
+		// Given only AWS_ACCESS_KEY_ID (no AWS_SECRET_ACCESS_KEY) — an incomplete
+		// credential export that is NOT a working native chain
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: aws
+`)
+		awsBinaryMock(t)
+		t.Setenv("AWS_ACCESS_KEY_ID", "AKIATEST")
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			return fmt.Sprintf("aws-cli/%s Python/3.11.8 Linux", constants.MinimumVersionAWS), nil
+		}
+		var capturedEnv map[string]string
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			capturedEnv = env
+			return `{"Arn":"arn:aws:iam::123456789012:user/x"}`, nil
+		}
+		// When CheckAuth runs
+		if err := toolsManager.CheckAuth(); err != nil {
+			t.Fatalf("Expected CheckAuth to succeed, got %v", err)
+		}
+		// Then context env is still injected — the guard requires BOTH halves of the static
+		// keypair before declaring the native chain ready, so a stray AWS_ACCESS_KEY_ID
+		// doesn't accidentally disable the context-scoped profile lookup
+		if capturedEnv == nil {
+			t.Fatal("Expected context env injection when static keypair is incomplete")
+		}
+		if capturedEnv["AWS_PROFILE"] != "test" {
+			t.Errorf("AWS_PROFILE = %q, want %q", capturedEnv["AWS_PROFILE"], "test")
 		}
 	})
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> The PR makes breaking YAML schema changes to a shared CLI — renaming config keys and removing `aws.enabled` — which warrants careful upgrade coordination even though the functional additions are well-implemented and tested.
>
> **Overview**
>
> This PR overhauls Windsor's AWS integration activation model: `aws.enabled` is removed in favor of presence-based activation, YAML field names are rationalized (`aws_endpoint_url` → `endpoint_url`, `aws_profile` → `profile`), and `aws.region` is added. `AwsEnvPrinter` always emits `AWS_CONFIG_FILE` and `AWS_SHARED_CREDENTIALS_FILE` pointing at the context's `.aws/` directory, with `AWS_PROFILE` defaulting to the context name. `CheckAuth` runs `aws --version` and `aws sts get-caller-identity` with context-scoped env overrides at bootstrap and `windsor check` time.
>
> `hasAmbientAWSCredentials()` detects IRSA, ECS task role (both `RELATIVE_URI` and `FULL_URI` forms), and static-key env vars. When ambient credentials are present and the aws CLI is absent, `CheckAuth` returns nil rather than failing — deferring validation to terraform's own SDK credential chain. When the CLI is present, ambient creds cause `awsContextEnv()` to pass a nil env to the sts call so the native credential provider wins. The latest commit closes the last coverage gap by adding a dedicated test for `AWS_CONTAINER_CREDENTIALS_FULL_URI`; all detection arms are now exercised.
>
> Reviewed by Claude for commit `b0f53b38`.

<!-- /claude-code-review:summary -->
