### PR TITLE
chore: improve AWS auth hints by removing env prefix and updating suggestions

### DIFF
--- a/pkg/runtime/tools/tools_manager.go
+++ b/pkg/runtime/tools/tools_manager.go
@@ -576,7 +576,12 @@ func (t *BaseToolsManager) awsAuthHint() string {
 	case awsProfileKeys:
 		return fmt.Sprintf("AWS access keys for %q were rejected by STS. Verify or rotate with:\n  %saws configure --profile %s", profile, prefix, profile)
 	default:
-		return fmt.Sprintf("No AWS credentials configured for context %q yet. Run:\n  %saws configure sso --profile %s", ctx, prefix, profile)
+		// Surface both SSO and access-key paths here: CI service accounts, accounts not
+		// enrolled in SSO, and operators handed programmatic keys directly all need the
+		// access-key command, and there is no signal at this point in the flow that lets
+		// us pick one automatically. SSO is listed first because it is the expected path
+		// for human operators at SSO-enrolled orgs.
+		return fmt.Sprintf("No AWS credentials configured for context %q yet. Run one of:\n  %saws configure sso --profile %s   (SSO)\n  %saws configure --profile %s       (access keys)", ctx, prefix, profile, prefix, profile)
 	}
 }
 

--- a/pkg/runtime/tools/tools_manager.go
+++ b/pkg/runtime/tools/tools_manager.go
@@ -565,7 +565,7 @@ func (t *BaseToolsManager) awsAuthHint() string {
 	}
 	configRoot, err := t.configHandler.GetConfigRoot()
 	if err != nil || configRoot == "" {
-		return fmt.Sprintf("Run 'aws configure sso --profile %s' to set up credentials.", profile)
+		return fmt.Sprintf("No AWS credentials configured for context %q yet. Run one of:\n  aws configure sso --profile %s   (SSO)\n  aws configure --profile %s       (access keys)", ctx, profile, profile)
 	}
 	awsConfigPath := filepath.Join(configRoot, ".aws", "config")
 	awsCredentialsPath := filepath.Join(configRoot, ".aws", "credentials")

--- a/pkg/runtime/tools/tools_manager.go
+++ b/pkg/runtime/tools/tools_manager.go
@@ -544,11 +544,14 @@ func (t *BaseToolsManager) checkAWSBinary() error {
 // The lookup uses the operator's effective profile name — the value of aws.profile when set,
 // falling back to the context name — so a context like `prod` configured with
 // `aws.profile: company-prod` searches for `[profile company-prod]` and emits commands with
-// `--profile company-prod` rather than misleadingly suggesting `--profile prod`. Hints assume
-// the operator is running inside a windsor-managed shell where AWS_CONFIG_FILE /
-// AWS_SHARED_CREDENTIALS_FILE already point at the context's .aws/ directory; that is the only
-// shell where the suggested command's output will be picked up on the next run, so there is no
-// value in prefixing env vars for other shells.
+// `--profile company-prod` rather than misleadingly suggesting `--profile prod`. When the
+// current process env already advertises the context's AWS_CONFIG_FILE /
+// AWS_SHARED_CREDENTIALS_FILE (operator has sourced `windsor env`), the suggestion is a bare
+// `aws ...` command. When the env does not match — the hint was reached from a plain shell
+// — the env pair is prepended so the suggested command still writes into the context-scoped
+// .aws/ directory. Dropping the prefix unconditionally was tried and creates a silent loop on
+// a fresh machine: operators who follow the hint land their SSO tokens in ~/.aws and the next
+// windsor check re-fails against the context path with no signal explaining why.
 func (t *BaseToolsManager) awsAuthHint() string {
 	ctx := t.configHandler.GetContext()
 	profile := ctx
@@ -561,15 +564,49 @@ func (t *BaseToolsManager) awsAuthHint() string {
 		return fmt.Sprintf("Run 'aws configure sso --profile %s' to set up credentials.", profile)
 	}
 	awsConfigPath := filepath.Join(configRoot, ".aws", "config")
+	awsCredentialsPath := filepath.Join(configRoot, ".aws", "credentials")
+	prefix := ""
+	if !awsEnvPointsAtContext(awsConfigPath, awsCredentialsPath) {
+		prefix = awsEnvPrefix(configRoot)
+	}
 	state := detectAWSProfileState(awsConfigPath, profile)
 	switch state {
 	case awsProfileSSO:
-		return fmt.Sprintf("AWS SSO session for %q has likely expired. Run:\n  aws sso login --profile %s", profile, profile)
+		return fmt.Sprintf("AWS SSO session for %q has likely expired. Run:\n  %saws sso login --profile %s", profile, prefix, profile)
 	case awsProfileKeys:
-		return fmt.Sprintf("AWS access keys for %q were rejected by STS. Verify or rotate with:\n  aws configure --profile %s", profile, profile)
+		return fmt.Sprintf("AWS access keys for %q were rejected by STS. Verify or rotate with:\n  %saws configure --profile %s", profile, prefix, profile)
 	default:
-		return fmt.Sprintf("No AWS credentials configured for context %q yet. Run:\n  aws configure sso --profile %s", ctx, profile)
+		return fmt.Sprintf("No AWS credentials configured for context %q yet. Run:\n  %saws configure sso --profile %s", ctx, prefix, profile)
 	}
+}
+
+// awsEnvPointsAtContext reports whether the current process env has AWS_CONFIG_FILE and
+// AWS_SHARED_CREDENTIALS_FILE already resolving to the given context paths — i.e. the
+// operator is in a shell where `windsor env` has been sourced for this exact context. Both
+// vars must match; a partial or mismatched set means the operator is either in a plain shell
+// or has env from a different context still loaded, and in either case a bare `aws ...`
+// suggestion would write credentials to the wrong place.
+func awsEnvPointsAtContext(configPath, credentialsPath string) bool {
+	cf := os.Getenv("AWS_CONFIG_FILE")
+	sf := os.Getenv("AWS_SHARED_CREDENTIALS_FILE")
+	if cf == "" || sf == "" {
+		return false
+	}
+	return filepath.ToSlash(cf) == filepath.ToSlash(configPath) &&
+		filepath.ToSlash(sf) == filepath.ToSlash(credentialsPath)
+}
+
+// awsEnvPrefix returns the `KEY="VALUE" KEY="VALUE" ` prefix that, when prepended to an aws
+// CLI invocation, makes that invocation read from and write to the context-scoped .aws/
+// directory. Paths are double-quoted so a projectRoot containing spaces (e.g.
+// `/Users/foo/my projects/…`) still parses as a single shell token instead of splitting at
+// the space and breaking the command.
+func awsEnvPrefix(configRoot string) string {
+	awsConfigDir := filepath.Join(configRoot, ".aws")
+	return fmt.Sprintf("AWS_CONFIG_FILE=%q AWS_SHARED_CREDENTIALS_FILE=%q ",
+		filepath.ToSlash(filepath.Join(awsConfigDir, "config")),
+		filepath.ToSlash(filepath.Join(awsConfigDir, "credentials")),
+	)
 }
 
 // detectAWSProfileState parses the AWS config INI at path and classifies the profile named

--- a/pkg/runtime/tools/tools_manager.go
+++ b/pkg/runtime/tools/tools_manager.go
@@ -538,11 +538,15 @@ func (t *BaseToolsManager) checkAWSBinary() error {
 }
 
 // awsAuthHint inspects the context-scoped AWS config file and returns an actionable next-step
-// message tuned to what it finds there. The three useful states are: no profile configured yet
-// (first-time setup — point at `aws configure sso`), an SSO profile whose token has expired
-// (point at `aws sso login`), and a static-keys profile that was rejected (point at rotation).
-// The lookup uses the operator's effective profile name — the value of aws.profile when set,
-// falling back to the context name — so a context like `prod` configured with
+// message tuned to what it finds there. The three useful states are: an SSO profile whose
+// token has expired (point at `aws sso login`), a static-keys profile that was rejected
+// (point at rotation), and no profile configured yet (first-time setup — surface BOTH
+// `aws configure sso` AND `aws configure` because CI service accounts, accounts not enrolled
+// in SSO, and operators handed programmatic keys directly all need the access-key command,
+// and nothing in this code path distinguishes which kind of operator reached it; dropping
+// either path sends some fraction of them to a command that will not work for their account
+// type). The lookup uses the operator's effective profile name — the value of aws.profile
+// when set, falling back to the context name — so a context like `prod` configured with
 // `aws.profile: company-prod` searches for `[profile company-prod]` and emits commands with
 // `--profile company-prod` rather than misleadingly suggesting `--profile prod`. When the
 // current process env already advertises the context's AWS_CONFIG_FILE /
@@ -576,11 +580,6 @@ func (t *BaseToolsManager) awsAuthHint() string {
 	case awsProfileKeys:
 		return fmt.Sprintf("AWS access keys for %q were rejected by STS. Verify or rotate with:\n  %saws configure --profile %s", profile, prefix, profile)
 	default:
-		// Surface both SSO and access-key paths here: CI service accounts, accounts not
-		// enrolled in SSO, and operators handed programmatic keys directly all need the
-		// access-key command, and there is no signal at this point in the flow that lets
-		// us pick one automatically. SSO is listed first because it is the expected path
-		// for human operators at SSO-enrolled orgs.
 		return fmt.Sprintf("No AWS credentials configured for context %q yet. Run one of:\n  %saws configure sso --profile %s   (SSO)\n  %saws configure --profile %s       (access keys)", ctx, prefix, profile, prefix, profile)
 	}
 }

--- a/pkg/runtime/tools/tools_manager.go
+++ b/pkg/runtime/tools/tools_manager.go
@@ -539,17 +539,16 @@ func (t *BaseToolsManager) checkAWSBinary() error {
 
 // awsAuthHint inspects the context-scoped AWS config file and returns an actionable next-step
 // message tuned to what it finds there. The three useful states are: no profile configured yet
-// (first-time setup — offer both SSO and access-key commands), an SSO profile whose token has
-// expired (point at `aws sso login`), and a static-keys profile that was rejected (point at
-// rotation). The lookup uses the operator's effective profile name — the value of aws.profile
-// when set, falling back to the context name — so a context like `prod` configured with
+// (first-time setup — point at `aws configure sso`), an SSO profile whose token has expired
+// (point at `aws sso login`), and a static-keys profile that was rejected (point at rotation).
+// The lookup uses the operator's effective profile name — the value of aws.profile when set,
+// falling back to the context name — so a context like `prod` configured with
 // `aws.profile: company-prod` searches for `[profile company-prod]` and emits commands with
-// `--profile company-prod` rather than misleadingly suggesting `--profile prod`. Each
-// suggestion is prefixed with the context's AWS_CONFIG_FILE / AWS_SHARED_CREDENTIALS_FILE so
-// the command works in any shell — including one where `windsor env` hasn't been sourced —
-// and the resulting profile/keys land in the context folder rather than ~/.aws. Anything
-// unparseable or missing falls back to a generic hint so the error is still useful even when
-// the file is in an unexpected shape.
+// `--profile company-prod` rather than misleadingly suggesting `--profile prod`. Hints assume
+// the operator is running inside a windsor-managed shell where AWS_CONFIG_FILE /
+// AWS_SHARED_CREDENTIALS_FILE already point at the context's .aws/ directory; that is the only
+// shell where the suggested command's output will be picked up on the next run, so there is no
+// value in prefixing env vars for other shells.
 func (t *BaseToolsManager) awsAuthHint() string {
 	ctx := t.configHandler.GetContext()
 	profile := ctx
@@ -559,33 +558,18 @@ func (t *BaseToolsManager) awsAuthHint() string {
 	}
 	configRoot, err := t.configHandler.GetConfigRoot()
 	if err != nil || configRoot == "" {
-		return fmt.Sprintf("Run 'aws configure sso --profile %s' (SSO) or 'aws configure --profile %s' (access keys) to set up credentials.", profile, profile)
+		return fmt.Sprintf("Run 'aws configure sso --profile %s' to set up credentials.", profile)
 	}
 	awsConfigPath := filepath.Join(configRoot, ".aws", "config")
-	envPrefix := awsEnvPrefix(configRoot)
 	state := detectAWSProfileState(awsConfigPath, profile)
 	switch state {
 	case awsProfileSSO:
-		return fmt.Sprintf("AWS SSO session for %q has likely expired. Run:\n  %saws sso login --profile %s", profile, envPrefix, profile)
+		return fmt.Sprintf("AWS SSO session for %q has likely expired. Run:\n  aws sso login --profile %s", profile, profile)
 	case awsProfileKeys:
-		return fmt.Sprintf("AWS access keys for %q were rejected by STS. Verify or rotate with:\n  %saws configure --profile %s", profile, envPrefix, profile)
+		return fmt.Sprintf("AWS access keys for %q were rejected by STS. Verify or rotate with:\n  aws configure --profile %s", profile, profile)
 	default:
-		return fmt.Sprintf("No AWS credentials configured for context %q yet. Run one of:\n  %saws configure sso --profile %s   (SSO — recommended for teams)\n  %saws configure --profile %s       (access keys)", ctx, envPrefix, profile, envPrefix, profile)
+		return fmt.Sprintf("No AWS credentials configured for context %q yet. Run:\n  aws configure sso --profile %s", ctx, profile)
 	}
-}
-
-// awsEnvPrefix returns the `KEY="VALUE" KEY="VALUE" ` prefix that, when prepended to an aws
-// CLI invocation, makes that invocation read from and write to the context-scoped .aws/
-// directory. Paths are double-quoted so a projectRoot containing spaces (e.g.
-// `/Users/foo/my projects/…`) still parses as a single shell token instead of splitting at
-// the space and breaking the command. Pulled out of awsAuthHint so all three hint branches
-// (sso, keys, none) share one source of truth for the env-prefix shape.
-func awsEnvPrefix(configRoot string) string {
-	awsConfigDir := filepath.Join(configRoot, ".aws")
-	return fmt.Sprintf("AWS_CONFIG_FILE=%q AWS_SHARED_CREDENTIALS_FILE=%q ",
-		filepath.ToSlash(filepath.Join(awsConfigDir, "config")),
-		filepath.ToSlash(filepath.Join(awsConfigDir, "credentials")),
-	)
 }
 
 // detectAWSProfileState parses the AWS config INI at path and classifies the profile named

--- a/pkg/runtime/tools/tools_manager_test.go
+++ b/pkg/runtime/tools/tools_manager_test.go
@@ -1816,6 +1816,48 @@ sso_account_id = 123456789012
 		}
 	})
 
+	t.Run("AWSPlatformStsHintQuotesPathsWithSpacesInPlainShell", func(t *testing.T) {
+		// Given platform: aws, a projectRoot whose path contains a space, and no AWS env in
+		// the current process — the hint will take the prefix-emitting branch
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: aws
+`)
+		awsBinaryMock(t)
+		t.Setenv("AWS_CONFIG_FILE", "")
+		t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "")
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return "/Users/foo/my projects", nil
+		}
+		originalReadFile := osReadFile
+		osReadFile = func(name string) ([]byte, error) {
+			return []byte(`
+[profile test]
+sso_session = company
+`), nil
+		}
+		t.Cleanup(func() { osReadFile = originalReadFile })
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			return fmt.Sprintf("aws-cli/%s Python/3.11.8 Linux", constants.MinimumVersionAWS), nil
+		}
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			return "", fmt.Errorf("Token has expired")
+		}
+		// When CheckAuth runs
+		err := toolsManager.CheckAuth()
+		// Then the emitted env-prefix double-quotes the path so the suggested command pastes
+		// into a shell as a single token — an unquoted path with a space would cause the
+		// shell to split at the space and treat `projects/.aws/config` as a separate command,
+		// breaking the copy-pasteable contract the hint advertises
+		if err == nil {
+			t.Fatal("Expected CheckAuth to fail when sts errors")
+		}
+		if !strings.Contains(err.Error(), `AWS_CONFIG_FILE="/Users/foo/my projects/contexts/test/.aws/config"`) {
+			t.Errorf("Expected AWS_CONFIG_FILE to be double-quoted in hint, got: %v", err)
+		}
+	})
+
 	t.Run("AWSPlatformConfigRootFailureSurfacesError", func(t *testing.T) {
 		// Given platform: aws, the aws CLI is installed, and GetProjectRoot fails so the
 		// context-scoped AWS env cannot be computed

--- a/pkg/runtime/tools/tools_manager_test.go
+++ b/pkg/runtime/tools/tools_manager_test.go
@@ -2124,6 +2124,32 @@ contexts:
 	})
 }
 
+func Test_awsAuthHint(t *testing.T) {
+	t.Run("ConfigRootFailureOffersBothSSOAndAccessKeys", func(t *testing.T) {
+		// Given a toolsManager whose configHandler cannot resolve configRoot — the hint's
+		// defensive fallback branch. This is reached when CheckAuth ran through awsContextEnv
+		// via ambient credentials (which short-circuits GetConfigRoot), sts still failed, and
+		// awsAuthHint is invoked for the first-and-only GetConfigRoot call which then errors.
+		mocks := setupMocks(t)
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return "", fmt.Errorf("project root not found")
+		}
+		toolsManager := NewToolsManager(mocks.ConfigHandler, mocks.Shell)
+		// When awsAuthHint runs
+		hint := toolsManager.awsAuthHint()
+		// Then the fallback surfaces BOTH setup paths — dropping access-key guidance would
+		// send CI service accounts and non-SSO operators to a command they cannot complete,
+		// contradicting the function header's contract that first-time setup always offers
+		// both since nothing in this code path distinguishes which kind of operator is here
+		if !strings.Contains(hint, "aws configure sso --profile") {
+			t.Errorf("Expected SSO setup hint in configRoot-failure fallback, got: %q", hint)
+		}
+		if !strings.Contains(hint, "aws configure --profile") {
+			t.Errorf("Expected access-key setup hint in configRoot-failure fallback, got: %q", hint)
+		}
+	})
+}
+
 func Test_detectAWSProfileState(t *testing.T) {
 	withReadFile := func(t *testing.T, contents string, readErr error) {
 		t.Helper()

--- a/pkg/runtime/tools/tools_manager_test.go
+++ b/pkg/runtime/tools/tools_manager_test.go
@@ -1734,6 +1734,46 @@ sso_account_id = 123456789012
 		}
 	})
 
+	t.Run("AWSPlatformStsHintFirstTimeOffersSSOAndAccessKeys", func(t *testing.T) {
+		// Given platform: aws, the binary check passes, sts fails, and the context's
+		// .aws/config is empty — the first-time-setup state where no profile is present
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: aws
+`)
+		awsBinaryMock(t)
+		t.Setenv("AWS_CONFIG_FILE", "")
+		t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "")
+		originalReadFile := osReadFile
+		osReadFile = func(name string) ([]byte, error) {
+			return nil, fmt.Errorf("file not found")
+		}
+		t.Cleanup(func() { osReadFile = originalReadFile })
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			return fmt.Sprintf("aws-cli/%s Python/3.11.8 Linux", constants.MinimumVersionAWS), nil
+		}
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			return "", fmt.Errorf("Unable to locate credentials")
+		}
+		// When CheckAuth runs
+		err := toolsManager.CheckAuth()
+		// Then the surfaced error presents BOTH `aws configure sso` and `aws configure`
+		// paths — CI service accounts, accounts not enrolled in SSO, and operators handed
+		// programmatic keys need the access-key command, and we cannot infer which path the
+		// operator is on at this point in the flow. Dropping either path sends some fraction
+		// of operators to a command that will not work for their account type.
+		if err == nil {
+			t.Fatal("Expected CheckAuth to fail when sts errors")
+		}
+		if !strings.Contains(err.Error(), "aws configure sso --profile test") {
+			t.Errorf("Expected SSO setup hint, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "aws configure --profile test") {
+			t.Errorf("Expected access-key setup hint, got: %v", err)
+		}
+	})
+
 	t.Run("AWSPlatformStsHintHonorsAwsProfileOverride", func(t *testing.T) {
 		// Given platform: aws, an explicit aws.profile that differs from the context name,
 		// and a context-scoped .aws/config containing only the override-named SSO profile

--- a/pkg/runtime/tools/tools_manager_test.go
+++ b/pkg/runtime/tools/tools_manager_test.go
@@ -1642,15 +1642,18 @@ contexts:
 		}
 	})
 
-	t.Run("AWSPlatformStsHintSuggestsSsoLogin", func(t *testing.T) {
-		// Given platform: aws, the binary check passes, sts fails, and the context's
-		// .aws/config has an SSO profile entry for the operator's context
+	t.Run("AWSPlatformStsHintPrefixesEnvWhenShellNotSourced", func(t *testing.T) {
+		// Given platform: aws, the binary check passes, sts fails, the context's .aws/config
+		// has an SSO profile entry, and the process env does NOT have AWS_CONFIG_FILE
+		// pointing at the context (plain shell — `windsor env` has not been sourced)
 		mocks, toolsManager := setup(t, `
 contexts:
   test:
     platform: aws
 `)
 		awsBinaryMock(t)
+		t.Setenv("AWS_CONFIG_FILE", "")
+		t.Setenv("AWS_SHARED_CREDENTIALS_FILE", "")
 		originalReadFile := osReadFile
 		osReadFile = func(name string) ([]byte, error) {
 			return []byte(`
@@ -1668,9 +1671,58 @@ sso_account_id = 123456789012
 		}
 		// When CheckAuth runs
 		err := toolsManager.CheckAuth()
-		// Then the surfaced error points the operator at `aws sso login --profile test`
-		// without any env-var prefix — hints assume the operator is in a windsor-managed
-		// shell where AWS_CONFIG_FILE already resolves, so the bare command is what pastes
+		// Then the surfaced error prepends AWS_CONFIG_FILE= / AWS_SHARED_CREDENTIALS_FILE= so
+		// the suggested `aws sso login` writes its token into the context path even though
+		// the operator's shell has no windsor env loaded — without the prefix the token would
+		// land in ~/.aws and the next windsor check would silently re-fail
+		if err == nil {
+			t.Fatal("Expected CheckAuth to fail when sts errors")
+		}
+		if !strings.Contains(err.Error(), "AWS_CONFIG_FILE=") {
+			t.Errorf("Expected AWS_CONFIG_FILE= prefix when shell env is not sourced, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "aws sso login --profile test") {
+			t.Errorf("Expected sso-login hint with profile, got: %v", err)
+		}
+	})
+
+	t.Run("AWSPlatformStsHintDropsEnvPrefixWhenShellIsSourced", func(t *testing.T) {
+		// Given platform: aws, the binary check passes, sts fails, the context's .aws/config
+		// has an SSO profile entry, and the process env's AWS_CONFIG_FILE /
+		// AWS_SHARED_CREDENTIALS_FILE already point at the context's .aws/ paths — the
+		// operator has sourced `windsor env` for this context
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: aws
+`)
+		awsBinaryMock(t)
+		configRoot, err := mocks.ConfigHandler.GetConfigRoot()
+		if err != nil {
+			t.Fatalf("GetConfigRoot failed: %v", err)
+		}
+		t.Setenv("AWS_CONFIG_FILE", filepath.ToSlash(filepath.Join(configRoot, ".aws", "config")))
+		t.Setenv("AWS_SHARED_CREDENTIALS_FILE", filepath.ToSlash(filepath.Join(configRoot, ".aws", "credentials")))
+		originalReadFile := osReadFile
+		osReadFile = func(name string) ([]byte, error) {
+			return []byte(`
+[profile test]
+sso_session = company
+sso_account_id = 123456789012
+`), nil
+		}
+		t.Cleanup(func() { osReadFile = originalReadFile })
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			return fmt.Sprintf("aws-cli/%s Python/3.11.8 Linux", constants.MinimumVersionAWS), nil
+		}
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			return "", fmt.Errorf("Token has expired")
+		}
+		// When CheckAuth runs
+		err = toolsManager.CheckAuth()
+		// Then the hint emits a bare `aws sso login --profile test` with no env prefix —
+		// the operator's shell will resolve AWS_CONFIG_FILE from its own env, so prefixing
+		// would just be noise in the common case (they're in a windsor-managed shell)
 		if err == nil {
 			t.Fatal("Expected CheckAuth to fail when sts errors")
 		}
@@ -1678,7 +1730,7 @@ sso_account_id = 123456789012
 			t.Errorf("Expected sso-login hint with profile, got: %v", err)
 		}
 		if strings.Contains(err.Error(), "AWS_CONFIG_FILE=") {
-			t.Errorf("Hint should not include AWS_CONFIG_FILE= env prefix, got: %v", err)
+			t.Errorf("Hint should omit AWS_CONFIG_FILE= prefix when shell env already points at context, got: %v", err)
 		}
 	})
 

--- a/pkg/runtime/tools/tools_manager_test.go
+++ b/pkg/runtime/tools/tools_manager_test.go
@@ -1642,7 +1642,7 @@ contexts:
 		}
 	})
 
-	t.Run("AWSPlatformStsHintIncludesEnvPrefix", func(t *testing.T) {
+	t.Run("AWSPlatformStsHintSuggestsSsoLogin", func(t *testing.T) {
 		// Given platform: aws, the binary check passes, sts fails, and the context's
 		// .aws/config has an SSO profile entry for the operator's context
 		mocks, toolsManager := setup(t, `
@@ -1668,18 +1668,17 @@ sso_account_id = 123456789012
 		}
 		// When CheckAuth runs
 		err := toolsManager.CheckAuth()
-		// Then the surfaced error includes both the AWS_CONFIG_FILE= env prefix and the
-		// `aws sso login --profile test` command — the env prefix is what makes the suggestion
-		// runnable in a plain shell where `windsor env` hasn't been sourced yet, closing the
-		// chicken-and-egg loop on a freshly provisioned machine
+		// Then the surfaced error points the operator at `aws sso login --profile test`
+		// without any env-var prefix — hints assume the operator is in a windsor-managed
+		// shell where AWS_CONFIG_FILE already resolves, so the bare command is what pastes
 		if err == nil {
 			t.Fatal("Expected CheckAuth to fail when sts errors")
 		}
-		if !strings.Contains(err.Error(), "AWS_CONFIG_FILE=") {
-			t.Errorf("Expected AWS_CONFIG_FILE= prefix in hint, got: %v", err)
-		}
 		if !strings.Contains(err.Error(), "aws sso login --profile test") {
 			t.Errorf("Expected sso-login hint with profile, got: %v", err)
+		}
+		if strings.Contains(err.Error(), "AWS_CONFIG_FILE=") {
+			t.Errorf("Hint should not include AWS_CONFIG_FILE= env prefix, got: %v", err)
 		}
 	})
 
@@ -1758,45 +1757,6 @@ contexts:
 		}
 		if stsCalled {
 			t.Error("sts must not be invoked when the context-scoped env is unresolvable")
-		}
-	})
-
-	t.Run("AWSPlatformStsHintQuotesPathsWithSpaces", func(t *testing.T) {
-		// Given platform: aws and a projectRoot whose path contains a space
-		mocks, toolsManager := setup(t, `
-contexts:
-  test:
-    platform: aws
-`)
-		awsBinaryMock(t)
-		mocks.Shell.GetProjectRootFunc = func() (string, error) {
-			return "/Users/foo/my projects", nil
-		}
-		originalReadFile := osReadFile
-		osReadFile = func(name string) ([]byte, error) {
-			return []byte(`
-[profile test]
-sso_session = company
-`), nil
-		}
-		t.Cleanup(func() { osReadFile = originalReadFile })
-		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
-			return fmt.Sprintf("aws-cli/%s Python/3.11.8 Linux", constants.MinimumVersionAWS), nil
-		}
-		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
-			return "", fmt.Errorf("Token has expired")
-		}
-		// When CheckAuth runs
-		err := toolsManager.CheckAuth()
-		// Then the env-prefix quotes the path so the suggested command pastes into a shell
-		// as a single token — an unquoted path with a space would cause the shell to split
-		// at the space and treat `projects/.aws/config` as a separate command, breaking the
-		// copy-pasteable contract the hint advertises
-		if err == nil {
-			t.Fatal("Expected CheckAuth to fail when sts errors")
-		}
-		if !strings.Contains(err.Error(), `AWS_CONFIG_FILE="/Users/foo/my projects/contexts/test/.aws/config"`) {
-			t.Errorf("Expected AWS_CONFIG_FILE to be double-quoted in hint, got: %v", err)
 		}
 	})
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Isolated UX hint logic with no security surface; the worst-case failure of the new conditional is an unnecessary env-var prefix in the suggested command, not a silent auth failure.
>
> **Overview**
>
> The PR adds `awsEnvPointsAtContext`, which checks whether the process environment's `AWS_CONFIG_FILE` and `AWS_SHARED_CREDENTIALS_FILE` already point at the context's `.aws/` directory. When they match, `awsAuthHint` omits the env-var prefix — the operator's sourced shell handles routing. When they do not match (plain shell), the prefix is retained, closing the silent-failure loop the prior review described.
>
> The early-return when `GetConfigRoot` fails is corrected to offer both `aws configure sso` and `aws configure` paths, consistent with the `default` branch and the function header's contract. A new `Test_awsAuthHint` suite verifies this fallback directly, and the surrounding integration tests are extended to cover the sourced-vs-plain-shell distinction explicitly.
>
> Reviewed by Claude for commit `adb4892`.

<!-- /claude-code-review:summary -->
