### PR TITLE
feat(runtime/tools): Lazy tool checks

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+	"github.com/windsorcli/cli/pkg/runtime/tools"
 )
 
 var applyWaitFlag bool // Wait for kustomization resources to be ready after applying
@@ -16,7 +17,11 @@ var applyCmd = &cobra.Command{
 	Args:         cobra.NoArgs,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		proj, err := prepareProject(cmd)
+		// `windsor apply` runs whatever is in the blueprint — terraform components and Flux
+		// kustomizations both — so the tool surface is not statically narrowable. Request
+		// AllRequirements() and let the per-tool config gates inside CheckRequirements decide
+		// what actually runs (e.g. azure.enabled controls kubelogin).
+		proj, err := prepareProject(cmd, tools.AllRequirements())
 		if err != nil {
 			return err
 		}
@@ -58,7 +63,10 @@ var applyTerraformCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		componentID := args[0]
 
-		proj, err := prepareProject(cmd)
+		// `apply terraform <project>` only invokes terraform. Secrets backends are required
+		// because terraform can dereference 1Password / SOPS-encrypted values during plan/apply;
+		// docker, colima, and kubelogin are not exercised by this codepath.
+		proj, err := prepareProject(cmd, tools.Requirements{Terraform: true, Secrets: true})
 		if err != nil {
 			return err
 		}
@@ -79,7 +87,9 @@ var applyKustomizeCmd = &cobra.Command{
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		proj, err := prepareProject(cmd)
+		// `apply kustomize` only talks to the cluster API and dereferences secrets; it does not
+		// invoke terraform or the local container runtime.
+		proj, err := prepareProject(cmd, tools.Requirements{Secrets: true, Kubelogin: true})
 		if err != nil {
 			return err
 		}

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -26,6 +26,10 @@ var applyCmd = &cobra.Command{
 			return err
 		}
 
+		if err := requireCloudAuth(cmd, proj); err != nil {
+			return err
+		}
+
 		blueprint := proj.Composer.BlueprintHandler.Generate()
 		if blueprint == nil {
 			return fmt.Errorf("blueprint is not available")
@@ -68,6 +72,10 @@ var applyTerraformCmd = &cobra.Command{
 		// docker, colima, and kubelogin are not exercised by this codepath.
 		proj, err := prepareProject(cmd, tools.Requirements{Terraform: true, Secrets: true})
 		if err != nil {
+			return err
+		}
+
+		if err := requireCloudAuth(cmd, proj); err != nil {
 			return err
 		}
 

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/windsorcli/cli/pkg/runtime"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
+	"github.com/windsorcli/cli/pkg/runtime/tools"
 )
 
 // =============================================================================
@@ -31,6 +32,7 @@ type ApplyMocks struct {
 	BlueprintHandler  *blueprint.MockBlueprintHandler
 	TerraformStack    *terraforminfra.MockStack
 	KubernetesManager *kubernetes.MockKubernetesManager
+	ToolsManager      *tools.MockToolsManager
 	Runtime           *runtime.Runtime
 	TmpDir            string
 }
@@ -105,6 +107,7 @@ func setupApplyTest(t *testing.T, opts ...*SetupOptions) *ApplyMocks {
 		BlueprintHandler:  mockBlueprintHandler,
 		TerraformStack:    mockTerraformStack,
 		KubernetesManager: mockKubernetesManager,
+		ToolsManager:      baseMocks.ToolsManager,
 		Runtime:           rt,
 		TmpDir:            tmpDir,
 	}
@@ -303,6 +306,35 @@ func TestApplyCmd(t *testing.T) {
 			t.Errorf("Expected wait error, got: %v", err)
 		}
 	})
+
+	t.Run("CheckAuthFailureBlocksTerraformApply", func(t *testing.T) {
+		// Given expired/missing cloud credentials, apply must fail at preflight rather than
+		// after several minutes of `terraform init` and `terraform apply`. This mirrors the
+		// destroy preflight bug — both paths must gate on CheckAuth.
+		mocks := setupApplyTest(t)
+		mocks.ToolsManager.CheckAuthFunc = func() error { return fmt.Errorf("aws credentials did not resolve") }
+		applyCalled := false
+		mocks.TerraformStack.UpFunc = func(*blueprintv1alpha1.Blueprint, ...func(string) error) error {
+			applyCalled = true
+			return nil
+		}
+		proj := newApplyAllProject(mocks)
+
+		cmd := makeApplyTestCmd(applyCmd)
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		if err == nil {
+			t.Fatal("Expected credential preflight error, got nil")
+		}
+		if !strings.Contains(err.Error(), "aws credentials did not resolve") {
+			t.Errorf("Expected pass-through credential error, got: %v", err)
+		}
+		if applyCalled {
+			t.Error("Provisioner.Up must not run when credential preflight fails")
+		}
+	})
 }
 
 func TestApplyTerraformCmd(t *testing.T) {
@@ -416,6 +448,35 @@ func TestApplyTerraformCmd(t *testing.T) {
 		// Then an error should occur
 		if err == nil {
 			t.Error("Expected error, got nil")
+		}
+	})
+
+	t.Run("CheckAuthFailureBlocksTerraformComponentApply", func(t *testing.T) {
+		// Given expired credentials, apply terraform <component> must fail at preflight
+		// rather than mid-init.
+		mocks := setupApplyTest(t)
+		mocks.ToolsManager.CheckAuthFunc = func() error { return fmt.Errorf("aws credentials did not resolve") }
+		applyCalled := false
+		mocks.TerraformStack.ApplyFunc = func(*blueprintv1alpha1.Blueprint, string) error {
+			applyCalled = true
+			return nil
+		}
+		proj := newApplyProject(mocks)
+
+		cmd := createTestApplyTerraformCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"cluster"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		if err == nil {
+			t.Fatal("Expected credential preflight error, got nil")
+		}
+		if !strings.Contains(err.Error(), "aws credentials did not resolve") {
+			t.Errorf("Expected pass-through credential error, got: %v", err)
+		}
+		if applyCalled {
+			t.Error("Apply must not run when credential preflight fails")
 		}
 	})
 }

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -12,6 +12,7 @@ import (
 	"github.com/windsorcli/cli/pkg/composer"
 	"github.com/windsorcli/cli/pkg/project"
 	"github.com/windsorcli/cli/pkg/runtime"
+	"github.com/windsorcli/cli/pkg/runtime/tools"
 )
 
 // =============================================================================
@@ -135,6 +136,10 @@ var bootstrapCmd = &cobra.Command{
 			return err
 		}
 
+		// Bootstrap stands up everything end-to-end: terraform apply, MigrateState, install,
+		// and wait. Every tool family may be exercised, so request the full set up front and
+		// let CheckAuth (called below) validate cloud credentials separately.
+		proj.SetToolRequirements(tools.AllRequirements())
 		if err := proj.Initialize(false, blueprintURL...); err != nil {
 			return err
 		}

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -34,11 +34,21 @@ var (
 // production). Unlike `windsor init`, bootstrap does not anchor the current directory as
 // a project root — it is allowed to run in global mode, where directory trust is implicit.
 //
-// To handle the chicken-and-egg case where a configured remote backend (e.g. the kubernetes
-// backend) lives in infrastructure that terraform must create first, bootstrap temporarily
-// overrides the configured backend to "local" in-memory, runs the apply pass, then restores
-// the configured backend and calls Provisioner.MigrateState to move each component's state
-// to the real backend. The on-disk config (values.yaml) is never mutated during this window.
+// To handle the chicken-and-egg case where a configured remote backend (e.g. an S3 bucket
+// or kubernetes Secret) lives in infrastructure that terraform must create first, bootstrap
+// uses a two-phase apply when the blueprint declares a "backend" terraform component:
+//
+//  1. Override terraform.backend.type to "local" in-memory and apply only the backend
+//     component, materializing the remote state store (bucket, dynamodb table, etc.).
+//  2. Restore the configured backend type and migrate just the backend component's state
+//     to remote via MigrateComponentState. Subsequent components in the next Up pass init
+//     directly against the configured remote backend with no migration needed, since they
+//     have not been applied yet.
+//
+// When the blueprint has no backend component, bootstrap falls through to a single Up
+// pass against whatever backend type is configured (typically "local" for non-cloud
+// contexts, or a backend whose bucket exists out-of-band). The on-disk config
+// (values.yaml) is never mutated during the override window.
 var bootstrapCmd = &cobra.Command{
 	Use:          "bootstrap [context]",
 	Short:        "Bootstrap a fresh Windsor environment end-to-end",
@@ -149,9 +159,11 @@ var bootstrapCmd = &cobra.Command{
 		// where the operator has no obligation to be authed yet); bootstrap is the first
 		// command that will exercise credentials, so failing here gives the operator the
 		// vendor's own error (expired SSO, profile not found, etc.) up front rather than
-		// minutes into a `terraform apply`.
-		if err := proj.Runtime.ToolsManager.CheckAuth(); err != nil {
-			return fmt.Errorf("error validating credentials: %w", err)
+		// minutes into a `terraform apply`. Routed through requireCloudAuth so the calm
+		// output pattern (just the hint, no scary "Error:" prefix, no stacked wrappers) is
+		// consistent across all preflight call sites.
+		if err := requireCloudAuth(cmd, proj); err != nil {
+			return err
 		}
 
 		if err := proj.Runtime.SaveConfig(len(bootstrapSetFlags) > 0); err != nil {

--- a/cmd/bootstrap_test.go
+++ b/cmd/bootstrap_test.go
@@ -262,66 +262,6 @@ func TestBootstrapCmd(t *testing.T) {
 		}
 	})
 
-	t.Run("OverridesBackendToLocalThenMigratesAfterApply", func(t *testing.T) {
-		// Given a project with a kubernetes-configured backend and all provisioner steps mocked
-		mocks := setupBootstrapTest(t)
-
-		// Track the ordered sequence of backend writes, Up calls, and MigrateState calls to
-		// verify bootstrap overrides to "local" before Up and restores + migrates after.
-		var timeline []string
-		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
-		mockCH.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "terraform.backend.type" {
-				return "kubernetes"
-			}
-			if len(defaultValue) > 0 {
-				return defaultValue[0]
-			}
-			return ""
-		}
-		mockCH.SetFunc = func(key string, value any) error {
-			if key == "terraform.backend.type" {
-				timeline = append(timeline, fmt.Sprintf("set=%v", value))
-			}
-			return nil
-		}
-		mocks.TerraformStack.UpFunc = func(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(id string) error) error {
-			timeline = append(timeline, "up")
-			return nil
-		}
-		mocks.TerraformStack.MigrateStateFunc = func(blueprint *blueprintv1alpha1.Blueprint) error {
-			timeline = append(timeline, "migrate")
-			return nil
-		}
-
-		proj := newBootstrapTestProject(mocks)
-
-		cmd := createTestBootstrapCmd()
-		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
-		cmd.SetArgs([]string{})
-		cmd.SetContext(ctx)
-
-		// When executing bootstrap
-		err := cmd.Execute()
-
-		// Then the sequence is: override to local, run Up, restore to kubernetes, migrate
-		// state. A trailing "set=kubernetes" is expected from the deferred safety restore
-		// that guards against panics or future code paths that might persist config while
-		// the override is active — the defer fires idempotently on normal exit.
-		if err != nil {
-			t.Fatalf("Expected success, got %v", err)
-		}
-		expected := []string{"set=local", "up", "set=kubernetes", "migrate", "set=kubernetes"}
-		if len(timeline) != len(expected) {
-			t.Fatalf("Expected timeline %v, got %v", expected, timeline)
-		}
-		for i, step := range expected {
-			if timeline[i] != step {
-				t.Errorf("Expected timeline[%d]=%q, got %q (full: %v)", i, step, timeline[i], timeline)
-			}
-		}
-	})
-
 	t.Run("SuccessWithContextArg", func(t *testing.T) {
 		// Given a config handler that records SetContext calls
 		mocks := setupBootstrapTest(t)

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -69,6 +69,9 @@ With a component name, destroys every layer (Terraform and/or Kustomize) that co
 			if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, contextName); err != nil {
 				return err
 			}
+			if err := requireCloudAuth(cmd, proj); err != nil {
+				return err
+			}
 			if err := proj.Provisioner.DestroyAll(blueprint); err != nil {
 				return fmt.Errorf("error destroying all components: %w", err)
 			}
@@ -88,6 +91,13 @@ With a component name, destroys every layer (Terraform and/or Kustomize) that co
 			return err
 		}
 
+		// Gate auth before either teardown so a credential failure can't strand a both-layer
+		// component half-destroyed (kustomize gone, terraform state intact).
+		if inTerraform {
+			if err := requireCloudAuth(cmd, proj); err != nil {
+				return err
+			}
+		}
 		if inKustomize {
 			if err := proj.Provisioner.DestroyKustomize(blueprint, componentID); err != nil {
 				return fmt.Errorf("error destroying kustomization %s: %w", componentID, err)
@@ -125,6 +135,9 @@ var destroyTerraformCmd = &cobra.Command{
 			if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, contextName); err != nil {
 				return err
 			}
+			if err := requireCloudAuth(cmd, proj); err != nil {
+				return err
+			}
 			if err := proj.Provisioner.DestroyAllTerraform(blueprint); err != nil {
 				return fmt.Errorf("error destroying all terraform: %w", err)
 			}
@@ -134,6 +147,9 @@ var destroyTerraformCmd = &cobra.Command{
 		componentID := args[0]
 		desc := fmt.Sprintf("This will permanently destroy Terraform component %q.", componentID)
 		if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, componentID); err != nil {
+			return err
+		}
+		if err := requireCloudAuth(cmd, proj); err != nil {
 			return err
 		}
 		if err := proj.Provisioner.Destroy(blueprint, componentID); err != nil {

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/windsorcli/cli/pkg/runtime/tools"
 )
 
 var destroyConfirm string
@@ -50,7 +51,12 @@ With a component name, destroys every layer (Terraform and/or Kustomize) that co
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		proj, err := prepareProject(cmd)
+		// `destroy` (no args, or with a component name that may live in either layer) can
+		// dispatch to terraform or kustomize destroy paths depending on blueprint contents.
+		// Since the layer choice is data-driven we can't statically narrow tool requirements
+		// here without risking an under-request, so request AllRequirements() and lean on the
+		// per-tool config gates.
+		proj, err := prepareProject(cmd, tools.AllRequirements())
 		if err != nil {
 			return err
 		}
@@ -105,7 +111,8 @@ var destroyTerraformCmd = &cobra.Command{
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		proj, err := prepareProject(cmd)
+		// `destroy terraform` only invokes terraform; kustomize/k8s/docker tools are not used.
+		proj, err := prepareProject(cmd, tools.Requirements{Terraform: true, Secrets: true})
 		if err != nil {
 			return err
 		}
@@ -144,7 +151,8 @@ var destroyKustomizeCmd = &cobra.Command{
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		proj, err := prepareProject(cmd)
+		// `destroy kustomize` only talks to the cluster API; terraform/docker tools are not used.
+		proj, err := prepareProject(cmd, tools.Requirements{Secrets: true, Kubelogin: true})
 		if err != nil {
 			return err
 		}

--- a/cmd/destroy_test.go
+++ b/cmd/destroy_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/windsorcli/cli/pkg/runtime"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
+	"github.com/windsorcli/cli/pkg/runtime/tools"
 )
 
 // =============================================================================
@@ -31,6 +32,7 @@ type DestroyMocks struct {
 	BlueprintHandler  *blueprint.MockBlueprintHandler
 	TerraformStack    *terraforminfra.MockStack
 	KubernetesManager *kubernetes.MockKubernetesManager
+	ToolsManager      *tools.MockToolsManager
 	Runtime           *runtime.Runtime
 	TmpDir            string
 }
@@ -113,6 +115,7 @@ func setupDestroyTest(t *testing.T, opts ...*SetupOptions) *DestroyMocks {
 		BlueprintHandler:  mockBlueprintHandler,
 		TerraformStack:    mockTerraformStack,
 		KubernetesManager: mockKubernetesManager,
+		ToolsManager:      baseMocks.ToolsManager,
 		Runtime:           rt,
 		TmpDir:            tmpDir,
 	}
@@ -396,6 +399,89 @@ func TestDestroyCmd(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "error destroying all components") {
 			t.Errorf("Expected destroy error, got: %v", err)
+		}
+	})
+
+	t.Run("CheckAuthFailureBlocksDestroyAllBeforeStateMigration", func(t *testing.T) {
+		// Given expired/missing cloud credentials, destroy must fail at preflight rather than
+		// after several minutes of init + state migration. This is the bug: a long destroy
+		// would init every component, migrate state, then fail at the AWS provider.
+		mocks := setupDestroyTest(t)
+		mocks.ToolsManager.CheckAuthFunc = func() error { return fmt.Errorf("aws credentials did not resolve") }
+		destroyAllCalled := false
+		mocks.TerraformStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint) error {
+			destroyAllCalled = true
+			return nil
+		}
+		proj := newDestroyProject(mocks)
+
+		cmd := createTestDestroyCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--confirm=test-context"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		if err == nil {
+			t.Fatal("Expected credential preflight error, got nil")
+		}
+		if !strings.Contains(err.Error(), "aws credentials did not resolve") {
+			t.Errorf("Expected pass-through credential error, got: %v", err)
+		}
+		if destroyAllCalled {
+			t.Error("DestroyAll must not run when credential preflight fails")
+		}
+	})
+
+	t.Run("CheckAuthFailureBlocksTerraformComponentDestroy", func(t *testing.T) {
+		// Given a terraform component is targeted, the preflight must fire before migrate/destroy.
+		mocks := setupDestroyTest(t)
+		mocks.ToolsManager.CheckAuthFunc = func() error { return fmt.Errorf("aws credentials did not resolve") }
+		destroyCalled := false
+		mocks.TerraformStack.DestroyFunc = func(*blueprintv1alpha1.Blueprint, string) error {
+			destroyCalled = true
+			return nil
+		}
+		proj := newDestroyProject(mocks)
+
+		cmd := createTestDestroyCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--confirm=cluster", "cluster"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		if err == nil {
+			t.Fatal("Expected credential preflight error, got nil")
+		}
+		if !strings.Contains(err.Error(), "aws credentials did not resolve") {
+			t.Errorf("Expected pass-through credential error, got: %v", err)
+		}
+		if destroyCalled {
+			t.Error("Destroy must not run when credential preflight fails")
+		}
+	})
+
+	t.Run("CheckAuthSkippedForKustomizeOnlyComponent", func(t *testing.T) {
+		// Given a component that exists only in kustomize (not terraform), the cloud-credential
+		// preflight must NOT fire — kustomize-only paths have no obligation to be authed.
+		mocks := setupDestroyTest(t)
+		checkAuthCalled := false
+		mocks.ToolsManager.CheckAuthFunc = func() error {
+			checkAuthCalled = true
+			return fmt.Errorf("aws credentials did not resolve")
+		}
+		proj := newDestroyProject(mocks)
+
+		cmd := createTestDestroyCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--confirm=my-app", "my-app"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		if err != nil {
+			t.Errorf("Expected kustomize-only destroy to succeed without preflight, got %v", err)
+		}
+		if checkAuthCalled {
+			t.Error("CheckAuth must not be invoked for a kustomize-only component destroy")
 		}
 	})
 }

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
+	"github.com/windsorcli/cli/pkg/runtime/tools"
 )
 
 var downCmd = &cobra.Command{
@@ -13,7 +14,14 @@ var downCmd = &cobra.Command{
 	Long:         "Stop the local workstation environment by tearing down the VM, stopping container runtimes, and cleaning up context artifacts.",
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		proj, err := prepareProject(cmd)
+		// `windsor down` stops the local workstation (container runtime + colima VM if
+		// applicable) and cleans up local artifacts. Terraform and kubelogin are not
+		// exercised here. Secrets is requested because prepareProject → Initialize calls
+		// LoadEnvironment, which shells out to sops / op when those backends are configured;
+		// without this, a sops-enabled context with sops missing on PATH would surface a raw
+		// exec error instead of the registry-formatted install hint. Config gates skip the
+		// actual binary check for contexts that haven't enabled either backend.
+		proj, err := prepareProject(cmd, tools.Requirements{Docker: true, Colima: true, Secrets: true})
 		if err != nil {
 			return err
 		}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -11,6 +11,7 @@ import (
 	"github.com/windsorcli/cli/pkg/project"
 	"github.com/windsorcli/cli/pkg/runtime"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
+	"github.com/windsorcli/cli/pkg/runtime/tools"
 )
 
 // =============================================================================
@@ -152,6 +153,17 @@ var initCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
+		// `windsor init` writes config files and generates infrastructure stubs locally; it
+		// does not run terraform, start a workstation, or talk to a cluster — so docker /
+		// colima / terraform / kubelogin are deliberately NOT requested here, letting a
+		// fresh-machine init succeed before those tools are installed. Secrets is requested
+		// because Project.Initialize always calls LoadEnvironment, which shells out to
+		// sops / op when the context has those backends enabled (e.g. `init --reset` against
+		// an existing sops-enabled context); without this, the operator would get a raw
+		// "sops: command not found" instead of the registry-formatted hint. The config gates
+		// inside CheckRequirements ensure contexts that haven't enabled either backend still
+		// skip the actual binary check.
+		proj.SetToolRequirements(tools.Requirements{Secrets: true})
 		if err := proj.Initialize(initReset, blueprintURL...); err != nil {
 			return err
 		}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/windsorcli/cli/pkg/runtime/tools"
 )
 
 var installWaitFlag bool
@@ -13,7 +14,9 @@ var installCmd = &cobra.Command{
 	Short:        "Install the blueprint's cluster-level services",
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		proj, err := prepareProject(cmd)
+		// `install` applies the blueprint to the cluster (Flux + kustomizations); it does not
+		// invoke terraform or the local container runtime.
+		proj, err := prepareProject(cmd, tools.Requirements{Secrets: true, Kubelogin: true})
 		if err != nil {
 			return err
 		}

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -12,6 +12,7 @@ import (
 	"github.com/windsorcli/cli/pkg/provisioner"
 	fluxinfra "github.com/windsorcli/cli/pkg/provisioner/flux"
 	terraforminfra "github.com/windsorcli/cli/pkg/provisioner/terraform"
+	"github.com/windsorcli/cli/pkg/runtime/tools"
 	"github.com/windsorcli/cli/pkg/tui"
 )
 
@@ -26,7 +27,10 @@ var planCmd = &cobra.Command{
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		proj, err := prepareProject(cmd)
+		// `plan` (no args, or with a component name) can dispatch to terraform plan and/or
+		// flux diff depending on what the blueprint contains. Both are read-only but exercise
+		// terraform + cluster API + secrets, so request the full read-side surface.
+		proj, err := prepareProject(cmd, tools.Requirements{Terraform: true, Secrets: true, Kubelogin: true})
 		if err != nil {
 			return err
 		}
@@ -104,7 +108,8 @@ var planTerraformCmd = &cobra.Command{
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		proj, err := prepareProject(cmd)
+		// `plan terraform` only invokes terraform; cluster/k8s tools are not used.
+		proj, err := prepareProject(cmd, tools.Requirements{Terraform: true, Secrets: true})
 		if err != nil {
 			return err
 		}
@@ -165,7 +170,8 @@ var planKustomizeCmd = &cobra.Command{
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		proj, err := prepareProject(cmd)
+		// `plan kustomize` runs flux diff against the cluster; terraform/docker are not used.
+		proj, err := prepareProject(cmd, tools.Requirements{Secrets: true, Kubelogin: true})
 		if err != nil {
 			return err
 		}

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -38,6 +38,9 @@ var planCmd = &cobra.Command{
 		blueprint := proj.Composer.BlueprintHandler.Generate()
 
 		if len(args) == 0 {
+			if err := requireCloudAuth(cmd, proj); err != nil {
+				return err
+			}
 			var summary *provisioner.PlanSummary
 			if err := tui.WithProgress("Generating plan...", func() error {
 				var planErr error
@@ -59,6 +62,12 @@ var planCmd = &cobra.Command{
 
 		if !inTerraform && !inKustomize {
 			return fmt.Errorf("component %q not found in blueprint", componentID)
+		}
+
+		if inTerraform {
+			if err := requireCloudAuth(cmd, proj); err != nil {
+				return err
+			}
 		}
 
 		if planSummary || planJSON {
@@ -111,6 +120,10 @@ var planTerraformCmd = &cobra.Command{
 		// `plan terraform` only invokes terraform; cluster/k8s tools are not used.
 		proj, err := prepareProject(cmd, tools.Requirements{Terraform: true, Secrets: true})
 		if err != nil {
+			return err
+		}
+
+		if err := requireCloudAuth(cmd, proj); err != nil {
 			return err
 		}
 

--- a/cmd/plan_test.go
+++ b/cmd/plan_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/windsorcli/cli/pkg/runtime"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
+	"github.com/windsorcli/cli/pkg/runtime/tools"
 )
 
 // =============================================================================
@@ -30,6 +31,7 @@ type PlanMocks struct {
 	Shell            *shell.MockShell
 	BlueprintHandler *blueprint.MockBlueprintHandler
 	TerraformStack   *terraforminfra.MockStack
+	ToolsManager     *tools.MockToolsManager
 	Runtime          *runtime.Runtime
 	TmpDir           string
 }
@@ -99,6 +101,7 @@ func setupPlanTest(t *testing.T, opts ...*SetupOptions) *PlanMocks {
 		Shell:            baseMocks.Shell,
 		BlueprintHandler: mockBlueprintHandler,
 		TerraformStack:   mockTerraformStack,
+		ToolsManager:     baseMocks.ToolsManager,
 		Runtime:          rt,
 		TmpDir:           tmpDir,
 	}
@@ -296,6 +299,34 @@ func TestPlanTerraformCmd(t *testing.T) {
 		// Then an error should occur
 		if err == nil {
 			t.Error("Expected error, got nil")
+		}
+	})
+
+	t.Run("CheckAuthFailureBlocksPlanTerraform", func(t *testing.T) {
+		// Given expired credentials, plan terraform must fail at preflight rather than mid-init.
+		// Plan still hits provider APIs to refresh state, so the same gate applies.
+		mocks := setupPlanTest(t)
+		mocks.ToolsManager.CheckAuthFunc = func() error { return fmt.Errorf("aws credentials did not resolve") }
+		planCalled := false
+		mocks.TerraformStack.PlanAllFunc = func(*blueprintv1alpha1.Blueprint) error {
+			planCalled = true
+			return nil
+		}
+		proj := newPlanProject(mocks)
+
+		cmd := createTestPlanTerraformCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		if err == nil {
+			t.Fatal("Expected credential preflight error, got nil")
+		}
+		if !strings.Contains(err.Error(), "aws credentials did not resolve") {
+			t.Errorf("Expected pass-through credential error, got: %v", err)
+		}
+		if planCalled {
+			t.Error("PlanAll must not run when credential preflight fails")
 		}
 	})
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/windsorcli/cli/pkg/project"
+	"github.com/windsorcli/cli/pkg/runtime/tools"
 	"github.com/windsorcli/cli/pkg/tui"
 )
 
@@ -79,14 +80,19 @@ func configureProject(cmd *cobra.Command) (*project.Project, error) {
 }
 
 // prepareProject creates and fully initializes a project for the given command. It delegates
-// setup through Configure to configureProject, then runs Initialize. Commands that need
-// additional steps between Configure and Initialize (e.g. ValidateContextValues) should not
-// use this helper — call configureProject directly instead.
-func prepareProject(cmd *cobra.Command) (*project.Project, error) {
+// setup through Configure to configureProject, then runs Initialize against the supplied tool
+// requirements. Each caller declares only what tools its codepath will actually exercise so
+// commands like `down` (which only needs the container runtime) don't trip checks for
+// terraform / 1password / sops they will never invoke. Pass tools.AllRequirements() when the
+// codepath depends on the blueprint and isn't statically known. Commands that need additional
+// steps between Configure and Initialize (e.g. ValidateContextValues) should not use this
+// helper — call configureProject directly instead.
+func prepareProject(cmd *cobra.Command, reqs tools.Requirements) (*project.Project, error) {
 	proj, err := configureProject(cmd)
 	if err != nil {
 		return nil, err
 	}
+	proj.SetToolRequirements(reqs)
 	if err := proj.Initialize(false); err != nil {
 		return nil, err
 	}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -99,6 +99,42 @@ func prepareProject(cmd *cobra.Command, reqs tools.Requirements) (*project.Proje
 	return proj, nil
 }
 
+// requireCloudAuth runs the cloud-credential preflight for any platform configured for the
+// current context. It is the gate before any operation that runs terraform — apply, plan,
+// destroy, up — so credential failures (expired SSO, missing profile) surface before init
+// and state migration burn several minutes against a credential set that was never going to
+// work. CheckAuth itself is platform-aware: AWS today, with azure/gcp wired in alongside as
+// they're added. Call sites that do NOT run terraform (down, env, init, kustomize-only
+// subcommands) must not call this — there is no obligation to be authed for those paths.
+// Bootstrap calls CheckAuth directly because it runs Initialize itself before its first
+// apply pass.
+//
+// On failure: prints CheckAuth's hint to stderr verbatim (the per-platform hint already
+// names the action and ends in a copy-pasteable remediation command), silences cobra's
+// "Error:" prefix on the parent command tree, and returns the error so the process exits
+// non-zero. This is a flow-guidance moment ("run aws sso login"), not an exception, so the
+// output should read calmly without scary "Error:" framing or stacked "credentials are
+// bad" prefixes — the operator just needs the next step.
+func requireCloudAuth(cmd *cobra.Command, proj *project.Project) error {
+	if err := proj.Runtime.ToolsManager.CheckAuth(); err != nil {
+		silenceErrorsOnAncestors(cmd)
+		fmt.Fprintln(cmd.ErrOrStderr(), err.Error())
+		return err
+	}
+	return nil
+}
+
+// silenceErrorsOnAncestors walks up the cobra command tree setting SilenceErrors=true on
+// each ancestor. Cobra prints "Error: <msg>" by checking SilenceErrors on the command that
+// returned the error AND walking upward; setting it only on the leaf is not enough when
+// the error bubbles past intermediate commands (root → destroy → terraform). Walking the
+// chain mirrors what cobra does internally for the same flag.
+func silenceErrorsOnAncestors(cmd *cobra.Command) {
+	for c := cmd; c != nil; c = c.Parent() {
+		c.SilenceErrors = true
+	}
+}
+
 // setupGlobalContext injects global flags and context values into the command's context.
 // It sets the verbose flag in the context if enabled.
 func setupGlobalContext(cmd *cobra.Command) error {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -8,13 +8,16 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"strings"
 	"testing"
 
 	"github.com/spf13/cobra"
 	blueprintpkg "github.com/windsorcli/cli/pkg/composer/blueprint"
+	"github.com/windsorcli/cli/pkg/project"
 	"github.com/windsorcli/cli/pkg/runtime"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	envvars "github.com/windsorcli/cli/pkg/runtime/env"
@@ -524,6 +527,68 @@ func TestCommandPreflight(t *testing.T) {
 		// Then no error should occur (setupGlobalContext doesn't return errors currently)
 		if err != nil {
 			t.Errorf("Expected no error for preflight, got: %v", err)
+		}
+	})
+}
+
+func TestRequireCloudAuth(t *testing.T) {
+	t.Run("PrintsHintToStderrAndSilencesCobraOnFailure", func(t *testing.T) {
+		// Given CheckAuth returns the per-platform hint as the error (the awsAuthHint shape:
+		// "AWS SSO session for X has likely expired. Run: aws sso login --profile X"),
+		// requireCloudAuth must (a) print that hint to the command's stderr verbatim so the
+		// operator sees the actionable next step, (b) set SilenceErrors on the command tree
+		// so cobra does not double-print "Error: AWS SSO session..." on top — credential
+		// failures are flow-guidance moments, not exceptions, and the "Error:" framing reads
+		// as panic, and (c) still return the error so the parent command exits non-zero
+		// (preserving CI / scripted exit-code semantics).
+		mocks := setupMocks(t)
+		hint := "AWS SSO session for \"test-context\" has likely expired. Run:\n  aws sso login --profile test-context"
+		mocks.ToolsManager.CheckAuthFunc = func() error { return fmt.Errorf("%s", hint) }
+		proj := project.NewProject("", &project.Project{Runtime: mocks.Runtime})
+
+		root := &cobra.Command{Use: "windsor"}
+		leaf := &cobra.Command{Use: "destroy"}
+		root.AddCommand(leaf)
+
+		var stderr strings.Builder
+		leaf.SetErr(&stderr)
+
+		err := requireCloudAuth(leaf, proj)
+		if err == nil {
+			t.Fatal("Expected requireCloudAuth to return CheckAuth's error, got nil")
+		}
+		if !strings.Contains(stderr.String(), "aws sso login --profile test-context") {
+			t.Errorf("Expected hint printed to stderr, got: %q", stderr.String())
+		}
+		// Both leaf and root must be silenced — cobra walks the chain when deciding whether
+		// to print "Error: ...", and a missed parent re-introduces the prefix.
+		if !leaf.SilenceErrors {
+			t.Error("Expected leaf cmd's SilenceErrors to be set to suppress cobra's Error: prefix")
+		}
+		if !root.SilenceErrors {
+			t.Error("Expected root cmd's SilenceErrors to be set so cobra's chain check does not re-add Error: prefix")
+		}
+	})
+
+	t.Run("SuccessIsSilent", func(t *testing.T) {
+		// Given CheckAuth passes, requireCloudAuth must not touch stderr or fiddle with
+		// SilenceErrors — those side effects belong only on the failure path.
+		mocks := setupMocks(t)
+		// Default mock CheckAuth returns nil.
+		proj := project.NewProject("", &project.Project{Runtime: mocks.Runtime})
+
+		leaf := &cobra.Command{Use: "destroy"}
+		var stderr strings.Builder
+		leaf.SetErr(&stderr)
+
+		if err := requireCloudAuth(leaf, proj); err != nil {
+			t.Fatalf("Expected no error on success, got %v", err)
+		}
+		if stderr.String() != "" {
+			t.Errorf("Expected no stderr output on success, got: %q", stderr.String())
+		}
+		if leaf.SilenceErrors {
+			t.Error("Expected SilenceErrors to remain unset on success — only the failure path should touch it")
 		}
 	})
 }

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -84,6 +84,10 @@ var upCmd = &cobra.Command{
 			return nil
 		}
 
+		if err := requireCloudAuth(cmd, proj); err != nil {
+			return err
+		}
+
 		if _, err := proj.Up(); err != nil {
 			return err
 		}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/windsorcli/cli/pkg/project"
+	"github.com/windsorcli/cli/pkg/runtime/tools"
 )
 
 var (
@@ -59,6 +60,11 @@ var upCmd = &cobra.Command{
 			return err
 		}
 
+		// `windsor up` brings up the workstation: it starts the container runtime, applies
+		// terraform-driven workstation infrastructure, dereferences any 1Password / SOPS-backed
+		// values, and (for azure contexts) authenticates to AKS. Request the full set so any
+		// of those tools are validated up front.
+		proj.SetToolRequirements(tools.AllRequirements())
 		if err := proj.Initialize(false, blueprintURL...); err != nil {
 			return err
 		}

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -491,6 +491,34 @@ func TestUpCmd(t *testing.T) {
 			t.Errorf("Expected wait error, got: %v", err)
 		}
 	})
+
+	t.Run("CheckAuthFailureBlocksUpBeforeProjectUp", func(t *testing.T) {
+		// Given expired credentials, up must fail at preflight before kicking off the
+		// workstation/terraform path.
+		mocks := setupUpTest(t)
+		mocks.ToolsManager.CheckAuthFunc = func() error { return fmt.Errorf("aws credentials did not resolve") }
+		upCalled := false
+		mocks.TerraformStack.UpFunc = func(*blueprintv1alpha1.Blueprint, ...func(string) error) error {
+			upCalled = true
+			return nil
+		}
+		proj := newUpTestProject(mocks, true)
+
+		cmd := createTestUpCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		if err == nil {
+			t.Fatal("Expected credential preflight error, got nil")
+		}
+		if !strings.Contains(err.Error(), "aws credentials did not resolve") {
+			t.Errorf("Expected pass-through credential error, got: %v", err)
+		}
+		if upCalled {
+			t.Error("Provisioner.Up must not run when credential preflight fails")
+		}
+	})
 }
 
 func TestBuildUpFlagOverrides(t *testing.T) {

--- a/integration/apply_test.go
+++ b/integration/apply_test.go
@@ -95,3 +95,36 @@ func TestApply_AcceptsWaitFlag(t *testing.T) {
 	}
 	_ = err // may fail due to infrastructure not being available; flag must be accepted
 }
+
+// TestApplyTerraform_MissingBinary_ShowsActionableError verifies the registry-formatted
+// missing-tool error reaches the user end-to-end: when an `apply terraform` preflight
+// fails because terraform is not on PATH, stderr must include the vendor download URL
+// and the matching aqua package so the operator has a copy-pasteable next step. init
+// runs with --set terraform.enabled=true so the preflight check actually fires (without
+// that gate, the provisioner would shell out directly and surface a raw exec error
+// instead of the formatted one).
+func TestApplyTerraform_MissingBinary_ShowsActionableError(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "plan")
+
+	if _, stderr, err := helpers.RunCLI(dir, []string{"init", "local", "--set", "terraform.enabled=true"}, env); err != nil {
+		t.Fatalf("init local --set terraform.enabled=true: %v\nstderr: %s", err, stderr)
+	}
+
+	stripped := append(helpers.MinimalPATHEnv(env), "WINDSOR_CONTEXT=local")
+
+	_, stderr, err := helpers.RunCLI(dir, []string{"apply", "terraform", "null"}, stripped)
+	if err == nil {
+		t.Fatal("expected apply terraform to fail when terraform is not on PATH, but it succeeded")
+	}
+	out := string(stderr)
+	if !strings.Contains(out, "not found on PATH") {
+		t.Errorf("expected stderr to mention 'not found on PATH', got: %s", out)
+	}
+	if !strings.Contains(out, "Download:") {
+		t.Errorf("expected stderr to include a 'Download:' install hint, got: %s", out)
+	}
+	if !strings.Contains(out, "aqua g -i") {
+		t.Errorf("expected stderr to include an 'aqua g -i' install hint, got: %s", out)
+	}
+}

--- a/integration/apply_test.go
+++ b/integration/apply_test.go
@@ -102,7 +102,9 @@ func TestApply_AcceptsWaitFlag(t *testing.T) {
 // and the matching aqua package so the operator has a copy-pasteable next step. init
 // runs with --set terraform.enabled=true so the preflight check actually fires (without
 // that gate, the provisioner would shell out directly and surface a raw exec error
-// instead of the formatted one).
+// instead of the formatted one). The "null" component arg is an arbitrary positional
+// placeholder — the preflight check fails inside Initialize before the command body
+// reads componentID, so no matching component needs to exist in the plan fixture.
 func TestApplyTerraform_MissingBinary_ShowsActionableError(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")

--- a/integration/helpers/helpers.go
+++ b/integration/helpers/helpers.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -146,6 +147,22 @@ func CopyFixtureOnly(t *testing.T, name string) (workDir string, env []string) {
 	}
 	env = envForHome(t.TempDir())
 	return workDir, env
+}
+
+// MinimalPATHEnv returns env with any PATH entry replaced by a minimal PATH (/usr/bin:/bin).
+// Use this when a test asserts that a tool the host might happen to have installed (docker,
+// terraform, sops, etc.) is treated as missing — without stripping PATH the assertion would
+// pass on a clean CI runner and silently fail on a developer's laptop. The returned slice
+// is independent of the input.
+func MinimalPATHEnv(env []string) []string {
+	out := make([]string, 0, len(env)+1)
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "PATH=") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return append(out, "PATH=/usr/bin:/bin")
 }
 
 // PrepareFixture copies the named fixture into a temp dir, runs windsor init with a temp

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -305,3 +305,21 @@ func TestInit_InvalidValuesDoNotBlockShowCommand(t *testing.T) {
 		t.Fatal("expected blueprint output to be non-empty")
 	}
 }
+
+// TestInit_DoesNotRequireDocker_EvenWhenDockerEnabled pins the lazy-tool-check contract
+// for `windsor init`: scaffolding config and writing infrastructure stubs is local-only,
+// so init must succeed against a minimal PATH (no docker / colima / terraform / etc.) even
+// when the resolved config enables docker via --docker. A regression that re-eagerly checks
+// docker would block init on a fresh machine before the operator has had a chance to install
+// anything — defeating the whole purpose of `init`.
+func TestInit_DoesNotRequireDocker_EvenWhenDockerEnabled(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "default")
+
+	stripped := helpers.MinimalPATHEnv(env)
+
+	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local", "--docker"}, stripped)
+	if err != nil {
+		t.Fatalf("init local --docker should not require docker on PATH, but failed: %v\nstderr: %s", err, stderr)
+	}
+}

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -10,6 +10,7 @@ import (
 	"github.com/windsorcli/cli/pkg/provisioner"
 	"github.com/windsorcli/cli/pkg/runtime"
 	"github.com/windsorcli/cli/pkg/runtime/config"
+	"github.com/windsorcli/cli/pkg/runtime/tools"
 	"github.com/windsorcli/cli/pkg/workstation"
 )
 
@@ -17,13 +18,14 @@ import (
 // It coordinates context, provisioner, composer, and workstation managers
 // to provide a unified interface for project initialization and management.
 type Project struct {
-	Runtime       *runtime.Runtime
-	configHandler config.ConfigHandler
-	contextName   string
-	projectRoot   string
-	Provisioner   *provisioner.Provisioner
-	Composer      *composer.Composer
-	Workstation   *workstation.Workstation
+	Runtime           *runtime.Runtime
+	configHandler     config.ConfigHandler
+	contextName       string
+	projectRoot       string
+	Provisioner       *provisioner.Provisioner
+	Composer          *composer.Composer
+	Workstation       *workstation.Workstation
+	toolRequirements  *tools.Requirements
 }
 
 // NewProject creates and initializes a new Project instance with all required managers.
@@ -107,6 +109,15 @@ func NewProject(contextName string, opts ...*Project) *Project {
 	}
 }
 
+// SetToolRequirements narrows which tool families Initialize will check on this project.
+// When unset, Initialize defaults to AllRequirements — the historical "check everything"
+// behavior. Commands whose codepath is statically known (e.g. `windsor down` only stops
+// the workstation, never invokes terraform) call this with a narrower set so the operator
+// is not blocked on installing tools they will not actually use.
+func (p *Project) SetToolRequirements(reqs tools.Requirements) {
+	p.toolRequirements = &reqs
+}
+
 // Configure resolves project configuration including defaults, file loading, migration, and override processing.
 // Loads project environment variables and returns an error if resolution or environment loading fails.
 func (p *Project) Configure(flagOverrides map[string]any) error {
@@ -176,7 +187,11 @@ func (p *Project) Initialize(overwrite bool, blueprintURL ...string) error {
 		return fmt.Errorf("failed to generate infrastructure: %w", err)
 	}
 
-	if err := p.Runtime.PrepareTools(); err != nil {
+	reqs := tools.AllRequirements()
+	if p.toolRequirements != nil {
+		reqs = *p.toolRequirements
+	}
+	if err := p.Runtime.PrepareToolsFor(reqs); err != nil {
 		return err
 	}
 

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -1046,6 +1046,93 @@ func TestProject_Initialize(t *testing.T) {
 	})
 }
 
+// TestProject_SetToolRequirements pins the contract for the per-command tool-requirement
+// hand-off: an unset toolRequirements pointer means "fall back to AllRequirements" (legacy
+// behavior), while a set pointer — even when its struct value is the zero Requirements —
+// means "honor the caller's narrow set". The distinction matters because `windsor init`
+// deliberately requests a near-empty Requirements set, and the dispatcher must NOT treat
+// that as equivalent to "unset" (which would re-introduce the eager-check behavior the
+// per-command refactor was meant to fix).
+func TestProject_SetToolRequirements(t *testing.T) {
+	t.Run("UnsetDefaultsToAllRequirements", func(t *testing.T) {
+		// Given a freshly-constructed Project with no SetToolRequirements call
+		mocks := setupProjectMocks(t)
+		proj := NewProject("test-context", &Project{Runtime: mocks.Runtime, Composer: mocks.Composer})
+
+		var observed tools.Requirements
+		mockToolsManager := tools.NewMockToolsManager()
+		mockToolsManager.CheckRequirementsFunc = func(reqs tools.Requirements) error {
+			observed = reqs
+			return nil
+		}
+		proj.Runtime.ToolsManager = mockToolsManager
+
+		// When Initialize runs
+		_ = proj.Initialize(false)
+
+		// Then the tools manager receives AllRequirements — every family enabled — preserving
+		// the historical "check everything" behavior for callers that haven't migrated.
+		want := tools.AllRequirements()
+		if observed != want {
+			t.Errorf("expected unset toolRequirements to default to AllRequirements (%+v), got %+v", want, observed)
+		}
+	})
+
+	t.Run("SetEmptyMeansCheckNothing", func(t *testing.T) {
+		// Given a project where the caller has explicitly opted out of every check (the
+		// `windsor init` shape — a fresh-machine init must not block on tools the operator
+		// hasn't installed yet)
+		mocks := setupProjectMocks(t)
+		proj := NewProject("test-context", &Project{Runtime: mocks.Runtime, Composer: mocks.Composer})
+		proj.SetToolRequirements(tools.Requirements{})
+
+		var observed tools.Requirements
+		observed.Docker = true // sentinel: prove the mock callback overwrites it
+		mockToolsManager := tools.NewMockToolsManager()
+		mockToolsManager.CheckRequirementsFunc = func(reqs tools.Requirements) error {
+			observed = reqs
+			return nil
+		}
+		proj.Runtime.ToolsManager = mockToolsManager
+
+		// When Initialize runs
+		_ = proj.Initialize(false)
+
+		// Then the empty Requirements is forwarded verbatim — NOT silently replaced with
+		// AllRequirements. A regression here would silently re-enable every preflight check
+		// on init.
+		if observed != (tools.Requirements{}) {
+			t.Errorf("expected SetToolRequirements({}) to forward an empty set; got %+v", observed)
+		}
+	})
+
+	t.Run("SetNarrowForwardsExactRequest", func(t *testing.T) {
+		// Given a project with a narrow Requirements set (e.g. the `windsor down` shape)
+		mocks := setupProjectMocks(t)
+		proj := NewProject("test-context", &Project{Runtime: mocks.Runtime, Composer: mocks.Composer})
+		want := tools.Requirements{Docker: true, Colima: true, Secrets: true}
+		proj.SetToolRequirements(want)
+
+		var observed tools.Requirements
+		mockToolsManager := tools.NewMockToolsManager()
+		mockToolsManager.CheckRequirementsFunc = func(reqs tools.Requirements) error {
+			observed = reqs
+			return nil
+		}
+		proj.Runtime.ToolsManager = mockToolsManager
+
+		// When Initialize runs
+		_ = proj.Initialize(false)
+
+		// Then the tools manager receives exactly the requested set — no fields silently
+		// added (which would re-introduce eager checks) or removed (which would skip a
+		// preflight the command intended to run).
+		if observed != want {
+			t.Errorf("expected forwarded Requirements %+v, got %+v", want, observed)
+		}
+	})
+}
+
 func TestProject_PerformCleanup(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		mocks := setupProjectMocks(t)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -322,11 +322,19 @@ func (rt *Runtime) GetAliases() map[string]string {
 	return result
 }
 
-// CheckTools performs tool version checking using the tools manager.
-// It validates that all required tools are installed and meet minimum version requirements.
-// The tools manager must be initialized before calling this method. Returns an error if
-// the tools manager is not available or if tool checking fails.
+// CheckTools performs tool version checking using the tools manager against the full
+// AllRequirements set. Equivalent to CheckToolsFor(tools.AllRequirements()) and exists for
+// backward compatibility plus the explicit "verify everything" command (`windsor check`).
+// New callers should declare per-command requirements via CheckToolsFor.
 func (rt *Runtime) CheckTools() error {
+	return rt.CheckToolsFor(tools.AllRequirements())
+}
+
+// CheckToolsFor verifies only the tool families the caller has opted into via reqs. Each
+// check still respects the project's config gates (e.g. requesting Docker on a non-docker
+// context is a no-op), so over-requesting is safe — it simply runs more no-op checks. The
+// tools manager must be initialized before calling this method.
+func (rt *Runtime) CheckToolsFor(reqs tools.Requirements) error {
 	if rt.ToolsManager == nil {
 		rt.initializeToolsManager()
 		if rt.ToolsManager == nil {
@@ -334,7 +342,7 @@ func (rt *Runtime) CheckTools() error {
 		}
 	}
 
-	if err := rt.ToolsManager.Check(); err != nil {
+	if err := rt.ToolsManager.CheckRequirements(reqs); err != nil {
 		return fmt.Errorf("error checking tools: %w", err)
 	}
 
@@ -592,11 +600,18 @@ func (rt *Runtime) SaveConfig(overwrite ...bool) error {
 	return rt.ConfigHandler.SaveConfig(overwrite...)
 }
 
-// PrepareTools checks and installs required tools using the tools manager.
-// It first checks that all required tools are installed and meet version requirements,
-// then installs any missing or outdated tools. The tools manager must be available.
-// Returns an error if the tools manager is not available or if checking or installation fails.
+// PrepareTools checks and installs every tool family. Equivalent to PrepareToolsFor with
+// AllRequirements; preserved for backward compatibility. New callers should narrow their
+// requirements via PrepareToolsFor so commands like `windsor init` don't trip checks they
+// won't actually exercise.
 func (rt *Runtime) PrepareTools() error {
+	return rt.PrepareToolsFor(tools.AllRequirements())
+}
+
+// PrepareToolsFor checks the tool families requested via reqs and then installs any that
+// are missing or outdated. Each check still respects the project's config gates so
+// requesting more than a command actually needs is safe. The tools manager must be available.
+func (rt *Runtime) PrepareToolsFor(reqs tools.Requirements) error {
 	if rt.ToolsManager == nil {
 		rt.initializeToolsManager()
 		if rt.ToolsManager == nil {
@@ -604,7 +619,7 @@ func (rt *Runtime) PrepareTools() error {
 		}
 	}
 
-	if err := rt.ToolsManager.Check(); err != nil {
+	if err := rt.ToolsManager.CheckRequirements(reqs); err != nil {
 		return fmt.Errorf("error checking tools: %w", err)
 	}
 	if err := rt.ToolsManager.Install(); err != nil {

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/windsorcli/cli/pkg/runtime/env"
 	"github.com/windsorcli/cli/pkg/runtime/secrets"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
+	"github.com/windsorcli/cli/pkg/runtime/tools"
 )
 
 // =============================================================================
@@ -111,6 +112,7 @@ type MockToolsManager struct {
 	WriteManifestFunc       func() error
 	InstallFunc             func() error
 	CheckFunc               func() error
+	CheckRequirementsFunc   func(reqs tools.Requirements) error
 	CheckAuthFunc           func() error
 	GetTerraformCommandFunc func() string
 }
@@ -130,6 +132,16 @@ func (m *MockToolsManager) Install() error {
 }
 
 func (m *MockToolsManager) Check() error {
+	if m.CheckFunc != nil {
+		return m.CheckFunc()
+	}
+	return nil
+}
+
+func (m *MockToolsManager) CheckRequirements(reqs tools.Requirements) error {
+	if m.CheckRequirementsFunc != nil {
+		return m.CheckRequirementsFunc(reqs)
+	}
 	if m.CheckFunc != nil {
 		return m.CheckFunc()
 	}

--- a/pkg/runtime/tools/mock_tools_manager.go
+++ b/pkg/runtime/tools/mock_tools_manager.go
@@ -5,6 +5,7 @@ type MockToolsManager struct {
 	WriteManifestFunc       func() error
 	InstallFunc             func() error
 	CheckFunc               func() error
+	CheckRequirementsFunc   func(reqs Requirements) error
 	CheckAuthFunc           func() error
 	GetTerraformCommandFunc func() string
 }
@@ -40,6 +41,20 @@ func (m *MockToolsManager) Install() error {
 
 // Check calls the mock CheckFunc if set, otherwise returns nil.
 func (m *MockToolsManager) Check() error {
+	if m.CheckFunc != nil {
+		return m.CheckFunc()
+	}
+	return nil
+}
+
+// CheckRequirements calls the mock CheckRequirementsFunc when set, falls back to CheckFunc
+// when only the legacy hook is configured (so existing tests keep working without rewrites),
+// and otherwise returns nil. This mirrors the production aliasing where Check() routes through
+// CheckRequirements(AllRequirements()).
+func (m *MockToolsManager) CheckRequirements(reqs Requirements) error {
+	if m.CheckRequirementsFunc != nil {
+		return m.CheckRequirementsFunc(reqs)
+	}
 	if m.CheckFunc != nil {
 		return m.CheckFunc()
 	}

--- a/pkg/runtime/tools/registry.go
+++ b/pkg/runtime/tools/registry.go
@@ -1,0 +1,127 @@
+package tools
+
+import (
+	"fmt"
+
+	"github.com/windsorcli/cli/pkg/constants"
+)
+
+// The toolRegistry is a static catalog of every external CLI Windsor checks for. It exists so
+// "tool not on PATH" / "tool below minimum version" errors carry a copy-pasteable next step
+// (first-party download URL plus the matching aqua package name) instead of just naming the
+// missing binary. Entries are keyed by the actual lookup name passed to exec.LookPath so
+// check* code paths and error formatting agree on a single source of truth.
+
+// =============================================================================
+// Types
+// =============================================================================
+
+// toolInfo describes the user-facing identity of a checked tool: the display name used in
+// error messages, the minimum version Windsor will accept, the first-party install/download
+// page (vendor docs, never a third-party mirror), and the aqua package name so operators
+// already using aqua get a one-liner that fits their workflow.
+type toolInfo struct {
+	name       string
+	minVersion string
+	download   string
+	aquaPkg    string
+}
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+// toolRegistry maps the on-PATH binary name to its toolInfo. Keys MUST match the argument
+// passed to execLookPath in the corresponding check* function — missingToolError and
+// outdatedToolError look up by that key, and a mismatch silently degrades the error to a
+// generic message without install hints.
+var toolRegistry = map[string]toolInfo{
+	"docker": {
+		name:       "Docker",
+		minVersion: constants.MinimumVersionDocker,
+		download:   "https://docs.docker.com/get-docker/",
+		aquaPkg:    "docker/cli",
+	},
+	"colima": {
+		name:       "Colima",
+		minVersion: constants.MinimumVersionColima,
+		download:   "https://github.com/abiosoft/colima#installation",
+		aquaPkg:    "abiosoft/colima",
+	},
+	"limactl": {
+		name:       "Lima",
+		minVersion: constants.MinimumVersionLima,
+		download:   "https://lima-vm.io/docs/installation/",
+		aquaPkg:    "lima-vm/lima",
+	},
+	"terraform": {
+		name:       "Terraform",
+		minVersion: constants.MinimumVersionTerraform,
+		download:   "https://developer.hashicorp.com/terraform/install",
+		aquaPkg:    "hashicorp/terraform",
+	},
+	"tofu": {
+		name:       "OpenTofu",
+		minVersion: constants.MinimumVersionTerraform,
+		download:   "https://opentofu.org/docs/intro/install/",
+		aquaPkg:    "opentofu/opentofu",
+	},
+	"op": {
+		name:       "1Password CLI",
+		minVersion: constants.MinimumVersion1Password,
+		download:   "https://developer.1password.com/docs/cli/get-started",
+		aquaPkg:    "1password/cli",
+	},
+	"sops": {
+		name:       "SOPS",
+		minVersion: constants.MinimumVersionSOPS,
+		download:   "https://github.com/getsops/sops/releases",
+		aquaPkg:    "getsops/sops",
+	},
+	"kubelogin": {
+		name:       "kubelogin",
+		minVersion: constants.MinimumVersionKubelogin,
+		download:   "https://azure.github.io/kubelogin/install.html",
+		aquaPkg:    "Azure/kubelogin",
+	},
+	"aws": {
+		name:       "AWS CLI",
+		minVersion: constants.MinimumVersionAWS,
+		download:   "https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html",
+		aquaPkg:    "aws/aws-cli",
+	},
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+// missingToolError formats the standard "<tool> is required but was not found on PATH" error
+// with install guidance: the first-party download URL and the matching aqua package. Returned
+// as a fmt.Errorf so callers can wrap it. Falls back to a bare message if key is unknown,
+// which is the conservative thing to do — a typo in a check* function should still produce a
+// readable error rather than a panic.
+func missingToolError(key string) error {
+	info, ok := toolRegistry[key]
+	if !ok {
+		return fmt.Errorf("%s is required but was not found on PATH", key)
+	}
+	return fmt.Errorf("%s >= %s is required but was not found on PATH.\n  Download:    %s\n  Or via aqua: aqua g -i %s",
+		info.name, info.minVersion, info.download, info.aquaPkg)
+}
+
+// outdatedToolError formats the standard "<tool> <found> is below the minimum required version
+// <min>" error with the same install guidance as missingToolError. found is the version string
+// extracted from the tool's --version output; an empty found is rendered as "(unknown)" so the
+// message stays readable when extractVersion returns nothing.
+func outdatedToolError(key, found string) error {
+	if found == "" {
+		found = "(unknown)"
+	}
+	info, ok := toolRegistry[key]
+	if !ok {
+		return fmt.Errorf("%s version %s is below the required minimum", key, found)
+	}
+	return fmt.Errorf("%s %s is below the minimum required version %s.\n  Download:    %s\n  Or via aqua: aqua g -i %s",
+		info.name, found, info.minVersion, info.download, info.aquaPkg)
+}

--- a/pkg/runtime/tools/registry_test.go
+++ b/pkg/runtime/tools/registry_test.go
@@ -1,0 +1,107 @@
+package tools
+
+import (
+	"strings"
+	"testing"
+)
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+// TestMissingToolError pins the formatting contract: registered keys produce errors that
+// carry the display name, minimum version, vendor download URL, and aqua package; an
+// unregistered key falls back to a bare error so a programmer typo in a check* function
+// still produces a readable message instead of panicking.
+func TestMissingToolError(t *testing.T) {
+	t.Run("RegisteredKeyIncludesAllInstallHints", func(t *testing.T) {
+		// Given a key that is in the registry
+		err := missingToolError("terraform")
+
+		// Then the error includes the display name, minimum version, download URL, and
+		// aqua package — the exact four pieces operators need to resolve the failure.
+		msg := err.Error()
+		expected := []string{"Terraform", "1.7.0", "https://developer.hashicorp.com/terraform/install", "aqua g -i hashicorp/terraform", "not found on PATH"}
+		for _, want := range expected {
+			if !strings.Contains(msg, want) {
+				t.Errorf("expected error to contain %q, got: %s", want, msg)
+			}
+		}
+	})
+
+	t.Run("UnregisteredKeyFallsBackToBareMessage", func(t *testing.T) {
+		// Given a key that is NOT in the registry (simulating a programmer typo in a
+		// future check* function)
+		err := missingToolError("nonexistent-tool")
+
+		// Then the error still names the key and indicates it is required — no panic,
+		// no install-hint scaffolding pretending to exist for a tool we know nothing about.
+		msg := err.Error()
+		if !strings.Contains(msg, "nonexistent-tool") {
+			t.Errorf("expected fallback to mention the key name, got: %s", msg)
+		}
+		if strings.Contains(msg, "Download:") || strings.Contains(msg, "aqua g -i") {
+			t.Errorf("expected fallback to OMIT install hints, got: %s", msg)
+		}
+	})
+}
+
+// TestOutdatedToolError pins the format for the version-too-low case, including the
+// behavior when the version extractor returned an empty string (rendered as "(unknown)"
+// rather than producing a malformed message).
+func TestOutdatedToolError(t *testing.T) {
+	t.Run("RegisteredKeyShowsFoundAndMinimumVersions", func(t *testing.T) {
+		// Given a registered key and a found version below minimum
+		err := outdatedToolError("docker", "20.10.0")
+
+		// Then both the found version and the minimum show up alongside install hints
+		msg := err.Error()
+		expected := []string{"Docker", "20.10.0", "23.0.0", "below the minimum required version", "https://docs.docker.com/get-docker/", "aqua g -i docker/cli"}
+		for _, want := range expected {
+			if !strings.Contains(msg, want) {
+				t.Errorf("expected error to contain %q, got: %s", want, msg)
+			}
+		}
+	})
+
+	t.Run("EmptyFoundVersionRendersAsUnknown", func(t *testing.T) {
+		// Given a registered key but extractVersion returned ""
+		err := outdatedToolError("sops", "")
+
+		// Then the message stays readable instead of producing "SOPS  is below..."
+		msg := err.Error()
+		if !strings.Contains(msg, "(unknown)") {
+			t.Errorf("expected empty version to render as (unknown), got: %s", msg)
+		}
+	})
+
+	t.Run("UnregisteredKeyFallsBackToBareMessage", func(t *testing.T) {
+		// Given a key that is NOT in the registry
+		err := outdatedToolError("ghost-tool", "0.0.1")
+
+		// Then the bare fallback names the key and the found version, no install hints
+		msg := err.Error()
+		if !strings.Contains(msg, "ghost-tool") || !strings.Contains(msg, "0.0.1") {
+			t.Errorf("expected fallback to mention key + version, got: %s", msg)
+		}
+		if strings.Contains(msg, "Download:") || strings.Contains(msg, "aqua g -i") {
+			t.Errorf("expected fallback to OMIT install hints, got: %s", msg)
+		}
+	})
+}
+
+// TestToolRegistry_KeysMatchCheckFunctions guards against drift between the toolRegistry
+// keys and the strings each check* function passes to execLookPath. If a check* function
+// is added that uses an unregistered key, errors silently degrade to the bare-fallback
+// format with no install hints — that's the failure mode this test catches at CI time.
+func TestToolRegistry_KeysMatchCheckFunctions(t *testing.T) {
+	// Each entry is a binary name passed to execLookPath inside a check* function.
+	// "tofu" is included alongside "terraform" because GetTerraformCommand can return
+	// either depending on the configured driver; both must format errors identically.
+	expectedKeys := []string{"docker", "colima", "limactl", "terraform", "tofu", "op", "sops", "kubelogin", "aws"}
+	for _, key := range expectedKeys {
+		if _, ok := toolRegistry[key]; !ok {
+			t.Errorf("toolRegistry is missing %q — a check* function looks up this binary, so a missing entry would degrade its error to the bare fallback (no Download / aqua hints)", key)
+		}
+	}
+}

--- a/pkg/runtime/tools/tools_manager.go
+++ b/pkg/runtime/tools/tools_manager.go
@@ -540,7 +540,7 @@ func (t *BaseToolsManager) checkAWSBinary() error {
 		return missingToolError("aws")
 	}
 
-	out, err := t.shell.ExecSilentWithTimeout("aws", []string{"--version"}, 30*time.Second)
+	out, err := t.shell.ExecSilentWithTimeout("aws", []string{"--version"}, 10*time.Second)
 	if err != nil {
 		return fmt.Errorf("aws --version failed: %v", err)
 	}

--- a/pkg/runtime/tools/tools_manager.go
+++ b/pkg/runtime/tools/tools_manager.go
@@ -28,8 +28,36 @@ type ToolsManager interface {
 	WriteManifest() error
 	Install() error
 	Check() error
+	CheckRequirements(reqs Requirements) error
 	CheckAuth() error
 	GetTerraformCommand() string
+}
+
+// Requirements is the set of tool families a single command's codepath will actually exercise.
+// Each field is opt-in: a command requests only what it will run, and the corresponding check
+// still respects the configHandler gates (e.g. Docker=true only triggers a docker check when
+// docker.enabled is set or workstation.runtime is a docker-family driver). Over-requesting is
+// safe — checks no-op when the underlying config gate is off; under-requesting is the bug to
+// avoid because it lets a stale tool slip through to the actual command.
+type Requirements struct {
+	Docker    bool
+	Colima    bool
+	Terraform bool
+	Secrets   bool
+	Kubelogin bool
+}
+
+// AllRequirements returns a Requirements with every field true. Used by `windsor check` (the
+// explicit "verify my whole setup" command) and as the default for code paths that must
+// preserve historical Check() behavior.
+func AllRequirements() Requirements {
+	return Requirements{
+		Docker:    true,
+		Colima:    true,
+		Terraform: true,
+		Secrets:   true,
+		Kubelogin: true,
+	}
 }
 
 // BaseToolsManager is the base implementation of the ToolsManager interface.
@@ -91,51 +119,66 @@ func (t *BaseToolsManager) Install() error {
 	return nil
 }
 
-// Check verifies required tools are installed.
+// Check verifies every tool that may be required for any windsor codepath. Equivalent to
+// CheckRequirements(AllRequirements()) and exists for backward compatibility with the
+// explicit "check everything" command (`windsor check`) and any caller that has not been
+// migrated to declare per-command requirements.
 func (t *BaseToolsManager) Check() error {
+	return t.CheckRequirements(AllRequirements())
+}
+
+// CheckRequirements runs only the checks the caller has opted into via reqs, AND that the
+// configHandler still gates on. The two-layer test (command-level need × project-level
+// config) means an over-broad request from the command side is harmless — `windsor up` can
+// safely request Terraform=true even on a context where terraform.enabled is false, because
+// the config gate skips the actual binary check. Under-requesting is the failure mode worth
+// guarding against: a missed Requirements field lets a stale tool reach the actual run.
+//
+// AWS tool verification lives on CheckAuth, not here. CheckRequirements fires from many
+// command paths including `windsor init` / `windsor env` — at those points the operator has
+// no obligation to have the aws CLI installed OR to be authed. Both cloud-CLI presence and
+// credential resolution belong to CheckAuth, which runs from bootstrap and from
+// `windsor check`.
+func (t *BaseToolsManager) CheckRequirements(reqs Requirements) error {
 	rt := t.configHandler.GetString("workstation.runtime")
 	dockerEnabled := t.configHandler.GetBool("docker.enabled", false)
 	needsDocker := dockerEnabled || rt == "colima" || rt == "docker-desktop" || rt == "docker"
-	if needsDocker {
+	if reqs.Docker && needsDocker {
 		if err := t.checkDocker(); err != nil {
-			return fmt.Errorf("docker check failed: %v", err)
+			return err
 		}
 	}
 
-	if t.configHandler.GetBool("terraform.enabled") {
+	if reqs.Terraform && t.configHandler.GetBool("terraform.enabled") {
 		if err := t.checkTerraform(); err != nil {
-			return fmt.Errorf("terraform check failed: %v", err)
+			return err
 		}
 	}
 
-	if rt == "colima" {
+	if reqs.Colima && rt == "colima" {
 		if err := t.checkColima(); err != nil {
-			return fmt.Errorf("colima check failed: %v", err)
+			return err
 		}
 	}
 
-	if vaults := t.configHandler.Get("secrets.onepassword.vaults"); vaults != nil {
-		if err := t.checkOnePassword(); err != nil {
-			return fmt.Errorf("1password check failed: %v", err)
+	if reqs.Secrets {
+		if vaults := t.configHandler.Get("secrets.onepassword.vaults"); vaults != nil {
+			if err := t.checkOnePassword(); err != nil {
+				return err
+			}
+		}
+		if t.configHandler.GetBool("secrets.sops.enabled", false) {
+			if err := t.checkSops(); err != nil {
+				return err
+			}
 		}
 	}
 
-	if t.configHandler.GetBool("secrets.sops.enabled", false) {
-		if err := t.checkSops(); err != nil {
-			return fmt.Errorf("sops check failed: %v", err)
-		}
-	}
-
-	if t.configHandler.GetBool("azure.enabled") {
+	if reqs.Kubelogin && t.configHandler.GetBool("azure.enabled") {
 		if err := t.checkKubelogin(); err != nil {
-			return fmt.Errorf("kubelogin check failed: %v", err)
+			return err
 		}
 	}
-	// AWS tool verification lives on CheckAuth, not here. Check() fires from every command
-	// path including `windsor init` / `windsor env` — at those points the operator has no
-	// obligation to have the aws CLI installed OR to be authed. Both cloud-CLI presence and
-	// credential resolution belong to CheckAuth, which runs only from bootstrap/up/apply and
-	// from `windsor check`.
 	return nil
 }
 
@@ -147,7 +190,7 @@ func (t *BaseToolsManager) Check() error {
 // verifies the docker CLI version meets the minimum. Docker Compose is not required.
 func (t *BaseToolsManager) checkDocker() error {
 	if _, err := execLookPath("docker"); err != nil {
-		return fmt.Errorf("docker is not available in the PATH")
+		return missingToolError("docker")
 	}
 
 	workstationRuntime := t.configHandler.GetString("workstation.runtime")
@@ -156,11 +199,11 @@ func (t *BaseToolsManager) checkDocker() error {
 	if !isColimaMode {
 		output, err := t.shell.ExecSilentWithTimeout("docker", []string{"--version"}, 5*time.Second)
 		if err != nil {
-			return fmt.Errorf("docker version check failed: %v", err)
+			return fmt.Errorf("docker --version failed: %v", err)
 		}
 		dockerVersion := extractVersion(output)
 		if dockerVersion != "" && compareVersion(dockerVersion, constants.MinimumVersionDocker) < 0 {
-			return fmt.Errorf("docker version %s is below the minimum required version %s", dockerVersion, constants.MinimumVersionDocker)
+			return outdatedToolError("docker", dockerVersion)
 		}
 	}
 
@@ -172,7 +215,7 @@ func (t *BaseToolsManager) checkDocker() error {
 // Returns nil if both are found and meet the minimum version requirements, else an error indicating either is not available or outdated.
 func (t *BaseToolsManager) checkColima() error {
 	if _, err := execLookPath("colima"); err != nil {
-		return fmt.Errorf("colima is not available in the PATH")
+		return missingToolError("colima")
 	}
 	output, err := t.shell.ExecSilentWithTimeout("colima", []string{"version"}, 5*time.Second)
 	if err != nil {
@@ -183,11 +226,11 @@ func (t *BaseToolsManager) checkColima() error {
 		return fmt.Errorf("failed to extract colima version")
 	}
 	if compareVersion(colimaVersion, constants.MinimumVersionColima) < 0 {
-		return fmt.Errorf("colima version %s is below the minimum required version %s", colimaVersion, constants.MinimumVersionColima)
+		return outdatedToolError("colima", colimaVersion)
 	}
 
 	if _, err := execLookPath("limactl"); err != nil {
-		return fmt.Errorf("limactl is not available in the PATH")
+		return missingToolError("limactl")
 	}
 	output, err = t.shell.ExecSilentWithTimeout("limactl", []string{"--version"}, 5*time.Second)
 	if err != nil {
@@ -202,7 +245,7 @@ func (t *BaseToolsManager) checkColima() error {
 		minLima = constants.MinimumVersionLimaIncus
 	}
 	if compareVersion(limactlVersion, minLima) < 0 {
-		return fmt.Errorf("limactl version %s is below the minimum required version %s (use same PATH as in core repo or upgrade limactl)", limactlVersion, minLima)
+		return outdatedToolError("limactl", limactlVersion)
 	}
 
 	return nil
@@ -277,7 +320,7 @@ func (t *BaseToolsManager) detectTerraformDriver() string {
 func (t *BaseToolsManager) checkTerraform() error {
 	command := t.GetTerraformCommand()
 	if _, err := execLookPath(command); err != nil {
-		return fmt.Errorf("%s is not available in the PATH", command)
+		return missingToolError(command)
 	}
 	output, err := t.shell.ExecSilentWithTimeout(command, []string{"version"}, 5*time.Second)
 	if err != nil {
@@ -288,7 +331,7 @@ func (t *BaseToolsManager) checkTerraform() error {
 		return fmt.Errorf("failed to extract %s version", command)
 	}
 	if compareVersion(terraformVersion, constants.MinimumVersionTerraform) < 0 {
-		return fmt.Errorf("%s version %s is below the minimum required version %s", command, terraformVersion, constants.MinimumVersionTerraform)
+		return outdatedToolError(command, terraformVersion)
 	}
 
 	return nil
@@ -299,12 +342,12 @@ func (t *BaseToolsManager) checkTerraform() error {
 // Returns nil if found and meets the minimum version requirement, else an error indicating it is not available or outdated.
 func (t *BaseToolsManager) checkOnePassword() error {
 	if _, err := execLookPath("op"); err != nil {
-		return fmt.Errorf("1Password CLI is not available in the PATH")
+		return missingToolError("op")
 	}
 
 	out, err := t.shell.ExecSilentWithTimeout("op", []string{"--version"}, 5*time.Second)
 	if err != nil {
-		return fmt.Errorf("1Password CLI is not available in the PATH: %v", err)
+		return fmt.Errorf("1Password CLI --version failed: %v", err)
 	}
 
 	version := extractVersion(out)
@@ -313,7 +356,7 @@ func (t *BaseToolsManager) checkOnePassword() error {
 	}
 
 	if compareVersion(version, constants.MinimumVersion1Password) < 0 {
-		return fmt.Errorf("1Password CLI version %s is below the minimum required version %s", version, constants.MinimumVersion1Password)
+		return outdatedToolError("op", version)
 	}
 
 	return nil
@@ -324,12 +367,12 @@ func (t *BaseToolsManager) checkOnePassword() error {
 // Returns nil if found and meets the minimum version requirement, else an error indicating it is not available or outdated.
 func (t *BaseToolsManager) checkSops() error {
 	if _, err := execLookPath("sops"); err != nil {
-		return fmt.Errorf("SOPS CLI is not available in the PATH")
+		return missingToolError("sops")
 	}
 
 	out, err := t.shell.ExecSilentWithTimeout("sops", []string{"--version"}, 5*time.Second)
 	if err != nil {
-		return fmt.Errorf("SOPS CLI is not available in the PATH: %v", err)
+		return fmt.Errorf("sops --version failed: %v", err)
 	}
 
 	version := extractVersion(out)
@@ -338,7 +381,7 @@ func (t *BaseToolsManager) checkSops() error {
 	}
 
 	if compareVersion(version, constants.MinimumVersionSOPS) < 0 {
-		return fmt.Errorf("SOPS CLI version %s is below the minimum required version %s", version, constants.MinimumVersionSOPS)
+		return outdatedToolError("sops", version)
 	}
 
 	return nil
@@ -350,12 +393,12 @@ func (t *BaseToolsManager) checkSops() error {
 // Returns nil if found and meets the minimum version requirement, else an error indicating it is not available or outdated.
 func (t *BaseToolsManager) checkKubelogin() error {
 	if _, err := execLookPath("kubelogin"); err != nil {
-		return fmt.Errorf("kubelogin is not available in the PATH")
+		return missingToolError("kubelogin")
 	}
 
 	out, err := t.shell.ExecSilentWithTimeout("kubelogin", []string{"--version"}, 5*time.Second)
 	if err != nil {
-		return fmt.Errorf("kubelogin is not available in the PATH: %v", err)
+		return fmt.Errorf("kubelogin --version failed: %v", err)
 	}
 
 	version := extractVersion(out)
@@ -364,7 +407,7 @@ func (t *BaseToolsManager) checkKubelogin() error {
 	}
 
 	if compareVersion(version, constants.MinimumVersionKubelogin) < 0 {
-		return fmt.Errorf("kubelogin version %s is below the minimum required version %s", version, constants.MinimumVersionKubelogin)
+		return outdatedToolError("kubelogin", version)
 	}
 
 	validationRules := []struct {
@@ -519,7 +562,7 @@ func hasAmbientAWSCredentials() bool {
 // single-error exit point.
 func (t *BaseToolsManager) checkAWSBinary() error {
 	if _, err := execLookPath("aws"); err != nil {
-		return fmt.Errorf("aws CLI is not available in the PATH; install it from https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html")
+		return missingToolError("aws")
 	}
 
 	out, err := t.shell.ExecSilentWithTimeout("aws", []string{"--version"}, 5*time.Second)
@@ -531,7 +574,7 @@ func (t *BaseToolsManager) checkAWSBinary() error {
 		return fmt.Errorf("failed to extract aws CLI version")
 	}
 	if compareVersion(version, constants.MinimumVersionAWS) < 0 {
-		return fmt.Errorf("aws CLI version %s is below the minimum required version %s", version, constants.MinimumVersionAWS)
+		return outdatedToolError("aws", version)
 	}
 
 	return nil

--- a/pkg/runtime/tools/tools_manager.go
+++ b/pkg/runtime/tools/tools_manager.go
@@ -70,9 +70,8 @@ type BaseToolsManager struct {
 // Constants
 // =============================================================================
 
-// awsProfileNone, awsProfileSSO, and awsProfileKeys describe what (if anything) the
-// context-scoped .aws/config has for a given profile. awsProfileNone covers "file missing,
-// unreadable, or profile not present"; callers treat it as first-time setup.
+// awsProfile* values classify what the context-scoped .aws/config has for a profile.
+// awsProfileNone covers missing file, unreadable file, or profile not present.
 const (
 	awsProfileNone awsProfileState = iota
 	awsProfileSSO
@@ -83,8 +82,7 @@ const (
 // Types
 // =============================================================================
 
-// awsProfileState classifies an entry in a context's .aws/config so CheckAuth can return a
-// hint tuned to the operator's actual state rather than generic advice.
+// awsProfileState classifies an .aws/config profile entry so CheckAuth can tailor its hint.
 type awsProfileState int
 
 // =============================================================================
@@ -435,77 +433,65 @@ func (t *BaseToolsManager) checkKubelogin() error {
 	return nil
 }
 
-// CheckAuth verifies that the operator has the cloud CLIs for any in-use platforms AND that
-// their credentials actually resolve. For AWS it runs `aws --version` (presence + minimum
-// version) and then `aws sts get-caller-identity` — a cheap read-only STS API that forces the
-// SDK to run its full credential-resolution chain (SSO session, static keys, env vars, IMDS)
-// end-to-end. A success proves the operator's AWS setup will work when terraform/SDK calls
-// run later; a failure surfaces the vendor's own message (expired SSO, profile not found, no
-// credentials) at preflight time rather than minutes into a `terraform apply`. CheckAuth must
-// NOT be called from `windsor init` or `windsor env` (which have no obligation to be authed
-// yet); it is intended for bootstrap/up/apply paths where credentials are about to be
-// exercised, and from `windsor check` where the operator is explicitly asking to verify.
-// Error messages are tuned to the operator's current state (missing config, expired SSO
-// session, rejected static keys) so the returned hint is a copy-pasteable command rather than
-// generic advice.
+// CheckAuth verifies the operator has the cloud CLIs for in-use platforms and that their
+// credentials resolve. Called from terraform-touching command paths (bootstrap/up/apply/
+// plan/destroy) and `windsor check` — never from `init` or `env`.
 func (t *BaseToolsManager) CheckAuth() error {
-	platform := t.configHandler.GetString("platform")
-	if platform == "" {
-		platform = t.configHandler.GetString("provider")
-	}
-	configData := t.configHandler.GetConfig()
-	hasAWSConfig := configData != nil && configData.AWS != nil
-	if platform == "aws" || hasAWSConfig {
-		// In a CI environment where AWS credentials are already exported via a native SDK
-		// mechanism (IRSA, ECS task role, static keys), the aws CLI binary is not required:
-		// terraform's AWS provider resolves credentials through its own SDK and never
-		// shells out. A lean CI image (e.g. a minimal GitHub Actions runner that pulls
-		// OIDC creds but never installs awscli) would otherwise fail preflight for no
-		// real reason. When ambient creds are present AND the CLI is absent, accept that
-		// we can't run sts here and defer validation to the actual terraform call — the
-		// SDK will surface its own error at that point if the web-identity token / task
-		// role is misconfigured.
-		if hasAmbientAWSCredentials() {
-			if _, err := execLookPath("aws"); err != nil {
-				return nil
-			}
-		}
-		if err := t.checkAWSBinary(); err != nil {
+	if t.awsEnabled() {
+		if err := t.checkAWSAuth(); err != nil {
 			return err
-		}
-		// Inject the context-scoped AWS env (AWS_CONFIG_FILE, AWS_SHARED_CREDENTIALS_FILE,
-		// AWS_PROFILE) so the credential check succeeds even when the operator hasn't sourced
-		// `windsor env` / installed the windsor shell hook yet — without this, bootstrap on a
-		// fresh machine deadlocks: it can't proceed without valid credentials, but the
-		// operator can't establish credentials (`aws sso login`, `aws configure`) without the
-		// same env pointing aws at the context's .aws/config. When configRoot can't be
-		// resolved the error is surfaced rather than swallowed — letting sts fall back to the
-		// ambient shell env would silently validate the wrong credentials and produce the
-		// exact false-positive CheckAuth exists to prevent.
-		env, err := t.awsContextEnv()
-		if err != nil {
-			return fmt.Errorf("cannot resolve context-scoped AWS env for credential check: %w", err)
-		}
-		if _, err := t.shell.ExecSilentWithEnvAndTimeout("aws", env, []string{"sts", "get-caller-identity"}, 10*time.Second); err != nil {
-			return fmt.Errorf("aws credentials did not resolve for context %q: %v\n%s", t.configHandler.GetContext(), err, t.awsAuthHint())
 		}
 	}
 	return nil
 }
 
-// awsContextEnv returns the env vars that point the AWS CLI / SDK at the context-scoped
-// .aws/ directory and select the right profile. Mirrors AwsEnvPrinter.GetEnvVars but is
-// duplicated here intentionally — pkg/runtime/tools doesn't depend on pkg/runtime/env, and
-// the shape is small. Returns (nil, err) if the configRoot can't be resolved.
+// awsEnabled reports whether the current context exercises AWS — platform/provider is "aws"
+// or an aws config block is present.
+func (t *BaseToolsManager) awsEnabled() bool {
+	platform := t.configHandler.GetString("platform")
+	if platform == "" {
+		platform = t.configHandler.GetString("provider")
+	}
+	if platform == "aws" {
+		return true
+	}
+	cfg := t.configHandler.GetConfig()
+	return cfg != nil && cfg.AWS != nil
+}
+
+// checkAWSAuth verifies the AWS CLI is present at the minimum version and that
+// `aws sts get-caller-identity` resolves credentials end-to-end. When ambient SDK
+// credentials are present and the aws CLI is absent (lean CI images), defers to terraform's
+// own SDK rather than failing preflight.
 //
-// Returns (nil, nil) when the parent env already advertises AWS credentials via a native
-// SDK mechanism (IRSA / OIDC web identity, ECS container role, or static env keys). In
-// those environments — typically CI pods, fargate tasks, and OIDC-federated runners —
-// overriding AWS_PROFILE / AWS_CONFIG_FILE would point the aws CLI at a profile that
-// doesn't exist on the pod's filesystem, causing sts get-caller-identity to fail with
-// "profile not found" before the SDK ever consults the web-identity or container-credentials
-// provider. Passing nil through to the shell exec preserves the inherited env so the native
-// credential chain resolves normally.
+// The underlying STS error is intentionally discarded in favour of awsAuthHint(): the
+// raw output stacks "command execution failed" + the aws CLI's own stderr + our hint,
+// which buries the one piece of information the operator needs (the next command to run).
+// Trade-off: a network outage or IAM denial gets reported as a generic "run aws sso login"
+// hint rather than the true cause. If a debug path is needed later, route the err to a
+// verbose-only log rather than re-introducing it into the user-facing message.
+func (t *BaseToolsManager) checkAWSAuth() error {
+	if hasAmbientAWSCredentials() {
+		if _, err := execLookPath("aws"); err != nil {
+			return nil
+		}
+	}
+	if err := t.checkAWSBinary(); err != nil {
+		return err
+	}
+	env, err := t.awsContextEnv()
+	if err != nil {
+		return fmt.Errorf("cannot resolve context-scoped AWS env for credential check: %w", err)
+	}
+	if _, err := t.shell.ExecSilentWithEnvAndTimeout("aws", env, []string{"sts", "get-caller-identity"}, 10*time.Second); err != nil {
+		return fmt.Errorf("%s", t.awsAuthHint())
+	}
+	return nil
+}
+
+// awsContextEnv returns env vars pointing the AWS CLI/SDK at the context-scoped .aws/ dir
+// and selecting the right profile. Returns (nil, nil) when ambient SDK credentials are
+// present — overriding AWS_PROFILE there would mask the native credential chain.
 func (t *BaseToolsManager) awsContextEnv() (map[string]string, error) {
 	if hasAmbientAWSCredentials() {
 		return nil, nil
@@ -528,19 +514,10 @@ func (t *BaseToolsManager) awsContextEnv() (map[string]string, error) {
 	return env, nil
 }
 
-// hasAmbientAWSCredentials reports whether the parent process environment already carries
-// AWS credentials via a native SDK mechanism that must not be overridden by context-scoped
-// profile/config vars. Triggers on:
-//
-//   - AWS_WEB_IDENTITY_TOKEN_FILE — IRSA pods on EKS, GitHub Actions OIDC, generic OIDC
-//   - AWS_CONTAINER_CREDENTIALS_RELATIVE_URI — ECS/Fargate task roles
-//   - AWS_CONTAINER_CREDENTIALS_FULL_URI — ECS Anywhere / externally hosted containers
-//   - AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY — static keys already exported
-//
-// IMDS-based EC2 is intentionally not covered: there is no env var to detect it, and an
-// operator who explicitly sets AWS_PROFILE against a missing profile on an IMDS host gets
-// the same "profile not found" error from stock aws CLI — this is baseline AWS behavior we
-// do not need to preempt.
+// hasAmbientAWSCredentials reports whether the parent env already carries AWS credentials
+// via a native SDK mechanism (IRSA web identity, ECS container creds, or static keys) that
+// must not be overridden by context-scoped profile/config vars. IMDS is not covered — there
+// is no env var to detect it.
 func hasAmbientAWSCredentials() bool {
 	if os.Getenv("AWS_WEB_IDENTITY_TOKEN_FILE") != "" {
 		return true
@@ -558,14 +535,12 @@ func hasAmbientAWSCredentials() bool {
 }
 
 // checkAWSBinary verifies the AWS CLI is available in PATH and meets the minimum version.
-// Pulled out of CheckAuth so the binary vs. credential failure modes each have a clean
-// single-error exit point.
 func (t *BaseToolsManager) checkAWSBinary() error {
 	if _, err := execLookPath("aws"); err != nil {
 		return missingToolError("aws")
 	}
 
-	out, err := t.shell.ExecSilentWithTimeout("aws", []string{"--version"}, 5*time.Second)
+	out, err := t.shell.ExecSilentWithTimeout("aws", []string{"--version"}, 30*time.Second)
 	if err != nil {
 		return fmt.Errorf("aws --version failed: %v", err)
 	}
@@ -580,25 +555,11 @@ func (t *BaseToolsManager) checkAWSBinary() error {
 	return nil
 }
 
-// awsAuthHint inspects the context-scoped AWS config file and returns an actionable next-step
-// message tuned to what it finds there. The three useful states are: an SSO profile whose
-// token has expired (point at `aws sso login`), a static-keys profile that was rejected
-// (point at rotation), and no profile configured yet (first-time setup — surface BOTH
-// `aws configure sso` AND `aws configure` because CI service accounts, accounts not enrolled
-// in SSO, and operators handed programmatic keys directly all need the access-key command,
-// and nothing in this code path distinguishes which kind of operator reached it; dropping
-// either path sends some fraction of them to a command that will not work for their account
-// type). The lookup uses the operator's effective profile name — the value of aws.profile
-// when set, falling back to the context name — so a context like `prod` configured with
-// `aws.profile: company-prod` searches for `[profile company-prod]` and emits commands with
-// `--profile company-prod` rather than misleadingly suggesting `--profile prod`. When the
-// current process env already advertises the context's AWS_CONFIG_FILE /
-// AWS_SHARED_CREDENTIALS_FILE (operator has sourced `windsor env`), the suggestion is a bare
-// `aws ...` command. When the env does not match — the hint was reached from a plain shell
-// — the env pair is prepended so the suggested command still writes into the context-scoped
-// .aws/ directory. Dropping the prefix unconditionally was tried and creates a silent loop on
-// a fresh machine: operators who follow the hint land their SSO tokens in ~/.aws and the next
-// windsor check re-fails against the context path with no signal explaining why.
+// awsAuthHint returns an actionable next-step message tailored to the context's AWS config
+// state (expired SSO, rejected keys, or no profile yet). When the process env doesn't already
+// point at the context's .aws/, the suggested command is prefixed with that env so credentials
+// land in the right place. The first-time-setup branch surfaces both SSO and access-key paths
+// because we can't tell which kind of operator reached it.
 func (t *BaseToolsManager) awsAuthHint() string {
 	ctx := t.configHandler.GetContext()
 	profile := ctx
@@ -627,12 +588,9 @@ func (t *BaseToolsManager) awsAuthHint() string {
 	}
 }
 
-// awsEnvPointsAtContext reports whether the current process env has AWS_CONFIG_FILE and
-// AWS_SHARED_CREDENTIALS_FILE already resolving to the given context paths — i.e. the
-// operator is in a shell where `windsor env` has been sourced for this exact context. Both
-// vars must match; a partial or mismatched set means the operator is either in a plain shell
-// or has env from a different context still loaded, and in either case a bare `aws ...`
-// suggestion would write credentials to the wrong place.
+// awsEnvPointsAtContext reports whether AWS_CONFIG_FILE and AWS_SHARED_CREDENTIALS_FILE both
+// resolve to the given context paths. A partial or mismatched set returns false so callers
+// don't suggest bare `aws ...` commands that would write credentials to the wrong place.
 func awsEnvPointsAtContext(configPath, credentialsPath string) bool {
 	cf := os.Getenv("AWS_CONFIG_FILE")
 	sf := os.Getenv("AWS_SHARED_CREDENTIALS_FILE")
@@ -643,11 +601,8 @@ func awsEnvPointsAtContext(configPath, credentialsPath string) bool {
 		filepath.ToSlash(sf) == filepath.ToSlash(credentialsPath)
 }
 
-// awsEnvPrefix returns the `KEY="VALUE" KEY="VALUE" ` prefix that, when prepended to an aws
-// CLI invocation, makes that invocation read from and write to the context-scoped .aws/
-// directory. Paths are double-quoted so a projectRoot containing spaces (e.g.
-// `/Users/foo/my projects/…`) still parses as a single shell token instead of splitting at
-// the space and breaking the command.
+// awsEnvPrefix returns the `KEY="VALUE" KEY="VALUE" ` prefix that points an aws CLI
+// invocation at the context-scoped .aws/ directory. Paths are quoted to survive spaces.
 func awsEnvPrefix(configRoot string) string {
 	awsConfigDir := filepath.Join(configRoot, ".aws")
 	return fmt.Sprintf("AWS_CONFIG_FILE=%q AWS_SHARED_CREDENTIALS_FILE=%q ",
@@ -656,12 +611,8 @@ func awsEnvPrefix(configRoot string) string {
 	)
 }
 
-// detectAWSProfileState parses the AWS config INI at path and classifies the profile named
-// profileName. It looks for either [profile <name>] or [default] (when profileName is
-// "default"), then scans subsequent lines until the next section header for sso_session= or
-// aws_access_key_id=, returning the appropriate state. Absent file, parse errors, or an empty
-// matching section all resolve to awsProfileNone so the caller gets the first-time-setup hint
-// rather than a misleading refresh hint.
+// detectAWSProfileState classifies the named profile in the AWS config INI at path. Missing
+// file, parse errors, or an empty matching section resolve to awsProfileNone.
 func detectAWSProfileState(path, profileName string) awsProfileState {
 	data, err := osReadFile(path)
 	if err != nil {

--- a/pkg/runtime/tools/tools_manager_test.go
+++ b/pkg/runtime/tools/tools_manager_test.go
@@ -347,8 +347,8 @@ func TestToolsManager_Check(t *testing.T) {
 			return originalExecLookPath(name)
 		}
 		err := toolsManager.Check()
-		// Then an error indicating docker check failed should be returned
-		if err == nil || !strings.Contains(err.Error(), "docker check failed") {
+		// Then an error indicating docker is missing should be returned
+		if err == nil || !strings.Contains(err.Error(), "Docker") || !strings.Contains(err.Error(), "not found on PATH") {
 			t.Errorf("Expected Check to fail when docker is enabled but not available, but got: %v", err)
 		}
 	})
@@ -365,8 +365,8 @@ func TestToolsManager_Check(t *testing.T) {
 			return originalExecLookPath(name)
 		}
 		err := toolsManager.Check()
-		// Then an error indicating terraform check failed should be returned
-		if err == nil || !strings.Contains(err.Error(), "terraform check failed") {
+		// Then an error indicating terraform is missing should be returned
+		if err == nil || !strings.Contains(err.Error(), "Terraform") || !strings.Contains(err.Error(), "not found on PATH") {
 			t.Errorf("Expected Check to fail when terraform is enabled but not available, but got: %v", err)
 		}
 	})
@@ -383,8 +383,8 @@ func TestToolsManager_Check(t *testing.T) {
 			return originalExecLookPath(name)
 		}
 		err := toolsManager.Check()
-		// Then an error indicating colima check failed should be returned
-		if err == nil || !strings.Contains(err.Error(), "colima check failed") {
+		// Then an error indicating colima is missing should be returned
+		if err == nil || !strings.Contains(err.Error(), "Colima") || !strings.Contains(err.Error(), "not found on PATH") {
 			t.Errorf("Expected Check to fail when colima is enabled but not available, but got: %v", err)
 		}
 	})
@@ -420,11 +420,11 @@ contexts:
 			return originalExecSilent(name, args...)
 		}
 		err := toolsManager.Check()
-		// Then an error indicating 1Password check failed should be returned
+		// Then an error indicating 1Password CLI is missing should be returned
 		if err == nil {
 			t.Error("Expected error when 1Password is enabled but not available")
-		} else if !strings.Contains(err.Error(), "1password check failed: 1Password CLI is not available in the PATH") {
-			t.Errorf("Expected error to contain '1password check failed: 1Password CLI is not available in the PATH', got: %v", err)
+		} else if !strings.Contains(err.Error(), "1Password CLI") || !strings.Contains(err.Error(), "not found on PATH") {
+			t.Errorf("Expected error to indicate 1Password CLI is missing, got: %v", err)
 		}
 	})
 
@@ -453,11 +453,11 @@ contexts:
 			return originalExecSilent(name, args...)
 		}
 		err := toolsManager.Check()
-		// Then an error indicating SOPS check failed should be returned
+		// Then an error indicating SOPS is missing should be returned
 		if err == nil {
 			t.Error("Expected error when SOPS is enabled but not available")
-		} else if !strings.Contains(err.Error(), "sops check failed: SOPS CLI is not available in the PATH") {
-			t.Errorf("Expected error to contain 'sops check failed: SOPS CLI is not available in the PATH', got: %v", err)
+		} else if !strings.Contains(err.Error(), "SOPS") || !strings.Contains(err.Error(), "not found on PATH") {
+			t.Errorf("Expected error to indicate SOPS is missing, got: %v", err)
 		}
 	})
 
@@ -522,8 +522,199 @@ contexts:
 		// Then an error should be returned for the first failing tool
 		if err == nil {
 			t.Error("Expected error when multiple tools fail checks")
-		} else if !strings.Contains(err.Error(), "docker check failed") {
-			t.Errorf("Expected error to contain 'docker check failed', got: %v", err)
+		} else if !strings.Contains(err.Error(), "Docker") || !strings.Contains(err.Error(), "not found on PATH") {
+			t.Errorf("Expected error to indicate Docker is missing, got: %v", err)
+		}
+	})
+}
+
+// TestToolsManager_CheckRequirements asserts the per-command requirement gate: if a command
+// did NOT request a tool family, the corresponding check must not run even when the project
+// config would otherwise enable it. The opposite — requesting a family that the config does
+// not enable — is also a no-op (config gate wins). This test pins the contract Phase 5 (per
+// command Requirements) is built on; weakening it would silently re-introduce the eager-check
+// behavior the registry/Requirements split was meant to fix.
+func TestToolsManager_CheckRequirements(t *testing.T) {
+	setup := func(t *testing.T, configStr string) (*Mocks, *BaseToolsManager) {
+		t.Helper()
+		mocks := setupMocks(t, &SetupOptions{ConfigStr: configStr})
+		toolsManager := NewToolsManager(mocks.ConfigHandler, mocks.Shell)
+		return mocks, toolsManager
+	}
+
+	// configWithEverythingEnabled turns on every tool family the manager knows about so a
+	// permissive Requirements set would have many ways to fail. Each sub-test then asserts
+	// that the narrow Requirements still passes even though the underlying tools are absent.
+	configWithEverythingEnabled := `
+contexts:
+  test:
+    docker:
+      enabled: true
+    terraform:
+      enabled: true
+    secrets:
+      sops:
+        enabled: true
+      onepassword:
+        vaults:
+          v1:
+            name: V1
+            url: example.1password.com
+    azure:
+      enabled: true
+`
+
+	t.Run("EmptyRequirementsSkipsAllChecks", func(t *testing.T) {
+		// Given a config where every tool family is enabled and execLookPath fails for
+		// EVERY tool we'd otherwise check
+		_, toolsManager := setup(t, configWithEverythingEnabled)
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			return "", exec.ErrNotFound
+		}
+		t.Cleanup(func() { execLookPath = originalExecLookPath })
+
+		// When CheckRequirements runs with an empty Requirements set
+		err := toolsManager.CheckRequirements(Requirements{})
+
+		// Then no check fires and the call succeeds — this is the `windsor init` shape:
+		// it has not committed to running any tool yet, so absent tools must not block it.
+		if err != nil {
+			t.Errorf("Expected empty Requirements to skip all checks, got: %v", err)
+		}
+	})
+
+	t.Run("TerraformOnlyDoesNotCheckDocker", func(t *testing.T) {
+		// Given docker is enabled in config but terraform alone is requested
+		_, toolsManager := setup(t, configWithEverythingEnabled)
+		dockerLookedUp := false
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			if name == "docker" {
+				dockerLookedUp = true
+			}
+			if name == "terraform" || name == "tofu" {
+				return "/usr/bin/" + name, nil
+			}
+			return "", exec.ErrNotFound
+		}
+		t.Cleanup(func() { execLookPath = originalExecLookPath })
+
+		// When CheckRequirements runs with only Terraform requested
+		_ = toolsManager.CheckRequirements(Requirements{Terraform: true})
+
+		// Then the docker lookup was never invoked. This is the `apply terraform <project>`
+		// shape — terraform is the only binary that subcommand will exercise.
+		if dockerLookedUp {
+			t.Error("Expected docker to NOT be looked up when only Terraform is requested")
+		}
+	})
+
+	t.Run("DockerOnlyDoesNotCheckTerraform", func(t *testing.T) {
+		// Given terraform is enabled in config but docker alone is requested
+		_, toolsManager := setup(t, configWithEverythingEnabled)
+		terraformLookedUp := false
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			if name == "terraform" || name == "tofu" {
+				terraformLookedUp = true
+			}
+			if name == "docker" {
+				return "/usr/bin/docker", nil
+			}
+			return "", exec.ErrNotFound
+		}
+		t.Cleanup(func() { execLookPath = originalExecLookPath })
+
+		// When CheckRequirements runs with only Docker requested
+		_ = toolsManager.CheckRequirements(Requirements{Docker: true})
+
+		// Then terraform/tofu was never looked up. This is the `windsor down` shape —
+		// stopping the workstation needs the container runtime, not terraform.
+		if terraformLookedUp {
+			t.Error("Expected terraform/tofu to NOT be looked up when only Docker is requested")
+		}
+	})
+
+	t.Run("SecretsRequestedChecksBothSopsAndOnePassword", func(t *testing.T) {
+		// Given both sops and 1password are enabled in config and Secrets is requested
+		_, toolsManager := setup(t, configWithEverythingEnabled)
+		sawSops := false
+		sawOp := false
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			switch name {
+			case "sops":
+				sawSops = true
+			case "op":
+				sawOp = true
+			}
+			return "/usr/bin/" + name, nil
+		}
+		t.Cleanup(func() { execLookPath = originalExecLookPath })
+
+		// When CheckRequirements runs with Secrets requested
+		_ = toolsManager.CheckRequirements(Requirements{Secrets: true})
+
+		// Then both secrets backends were probed
+		if !sawSops {
+			t.Error("Expected sops to be looked up when Secrets is requested")
+		}
+		if !sawOp {
+			t.Error("Expected op to be looked up when Secrets is requested")
+		}
+	})
+
+	t.Run("OverRequestIsHarmlessWhenConfigGateOff", func(t *testing.T) {
+		// Given a context with every tool-config gate explicitly off (workstation.runtime
+		// pinned to "none" so the docker-needsDocker side-channel is also off)
+		mocks, toolsManager := setup(t, defaultConfig)
+		mocks.ConfigHandler.Set("docker.enabled", false)
+		mocks.ConfigHandler.Set("terraform.enabled", false)
+		mocks.ConfigHandler.Set("secrets.sops.enabled", false)
+		mocks.ConfigHandler.Set("azure.enabled", false)
+		mocks.ConfigHandler.Set("workstation.runtime", "none")
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			return "", exec.ErrNotFound
+		}
+		t.Cleanup(func() { execLookPath = originalExecLookPath })
+
+		// When CheckRequirements runs with EVERY family requested
+		err := toolsManager.CheckRequirements(AllRequirements())
+
+		// Then it succeeds because the config gates skip every actual binary check. This
+		// is the safety property that lets bootstrap/up/check pass AllRequirements() without
+		// caring which specific tools the project has opted into.
+		if err != nil {
+			t.Errorf("Expected AllRequirements with no enabled tools to succeed, got: %v", err)
+		}
+	})
+
+	t.Run("CheckEqualsCheckRequirementsAll", func(t *testing.T) {
+		// Given the docker-enabled config + a docker-missing PATH
+		mocks, toolsManager := setup(t, defaultConfig)
+		mocks.ConfigHandler.Set("docker.enabled", true)
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			if name == "docker" {
+				return "", exec.ErrNotFound
+			}
+			return originalExecLookPath(name)
+		}
+		t.Cleanup(func() { execLookPath = originalExecLookPath })
+
+		// When Check() is called and CheckRequirements(AllRequirements()) is called
+		errCheck := toolsManager.Check()
+		errAll := toolsManager.CheckRequirements(AllRequirements())
+
+		// Then both fail with the same docker-missing error — Check() is the AllRequirements
+		// alias, so any divergence is a regression.
+		if (errCheck == nil) != (errAll == nil) {
+			t.Fatalf("Check vs CheckRequirements(All) disagreed on success/failure: %v vs %v", errCheck, errAll)
+		}
+		if errCheck != nil && errCheck.Error() != errAll.Error() {
+			t.Errorf("Check vs CheckRequirements(All) returned different errors:\n  Check: %v\n  All:   %v", errCheck, errAll)
 		}
 	})
 }
@@ -559,7 +750,7 @@ func TestToolsManager_checkDocker(t *testing.T) {
 		}
 		err := toolsManager.checkDocker()
 		// Then an error indicating docker is not available should be returned
-		if err == nil || !strings.Contains(err.Error(), "docker is not available in the PATH") {
+		if err == nil || !strings.Contains(err.Error(), "Docker") || !strings.Contains(err.Error(), "not found on PATH") {
 			t.Errorf("Expected docker not available error, got %v", err)
 		}
 	})
@@ -575,7 +766,7 @@ func TestToolsManager_checkDocker(t *testing.T) {
 		}
 		err := toolsManager.checkDocker()
 		// Then an error indicating version is too low should be returned
-		if err == nil || !strings.Contains(err.Error(), "docker version 1.0.0 is below the minimum required version") {
+		if err == nil || !strings.Contains(err.Error(), "Docker 1.0.0 is below the minimum required version") {
 			t.Errorf("Expected docker version too low error, got %v", err)
 		}
 	})
@@ -664,7 +855,7 @@ func TestToolsManager_checkColima(t *testing.T) {
 		}
 		err := toolsManager.checkColima()
 		// Then an error indicating colima is not available should be returned
-		if err == nil || !strings.Contains(err.Error(), "colima is not available in the PATH") {
+		if err == nil || !strings.Contains(err.Error(), "Colima") || !strings.Contains(err.Error(), "not found on PATH") {
 			t.Errorf("Expected colima not available error, got %v", err)
 		}
 	})
@@ -702,7 +893,7 @@ func TestToolsManager_checkColima(t *testing.T) {
 		}
 		err := toolsManager.checkColima()
 		// Then an error indicating version is too low should be returned
-		if err == nil || !strings.Contains(err.Error(), "colima version 0.5.0 is below the minimum required version") {
+		if err == nil || !strings.Contains(err.Error(), "Colima 0.5.0 is below the minimum required version") {
 			t.Errorf("Expected colima version too low error, got %v", err)
 		}
 	})
@@ -725,7 +916,7 @@ func TestToolsManager_checkColima(t *testing.T) {
 		}
 		err := toolsManager.checkColima()
 		// Then an error indicating limactl is not available should be returned
-		if err == nil || !strings.Contains(err.Error(), "limactl is not available in the PATH") {
+		if err == nil || !strings.Contains(err.Error(), "Lima") || !strings.Contains(err.Error(), "not found on PATH") {
 			t.Errorf("Expected limactl not available error, got %v", err)
 		}
 	})
@@ -763,7 +954,7 @@ func TestToolsManager_checkColima(t *testing.T) {
 		}
 		err := toolsManager.checkColima()
 		// Then an error indicating version is too low should be returned
-		if err == nil || !strings.Contains(err.Error(), "limactl version 0.5.0 is below the minimum required version") {
+		if err == nil || !strings.Contains(err.Error(), "Lima 0.5.0 is below the minimum required version") {
 			t.Errorf("Expected limactl version too low error, got %v", err)
 		}
 	})
@@ -805,7 +996,7 @@ func TestToolsManager_checkTerraform(t *testing.T) {
 		// When checking terraform version
 		err := toolsManager.checkTerraform()
 		// Then an error indicating terraform or tofu is not available should be returned
-		if err == nil || (!strings.Contains(err.Error(), "terraform is not available in the PATH") && !strings.Contains(err.Error(), "tofu is not available in the PATH")) {
+		if err == nil || ((!strings.Contains(err.Error(), "Terraform") && !strings.Contains(err.Error(), "OpenTofu")) || !strings.Contains(err.Error(), "not found on PATH")) {
 			t.Errorf("Expected terraform or tofu not available error, got %v", err)
 		}
 	})
@@ -839,7 +1030,7 @@ func TestToolsManager_checkTerraform(t *testing.T) {
 		// When checking terraform version
 		err := toolsManager.checkTerraform()
 		// Then an error indicating version is too low should be returned
-		if err == nil || !strings.Contains(err.Error(), "terraform version 0.1.0 is below the minimum required version") {
+		if err == nil || !strings.Contains(err.Error(), "Terraform 0.1.0 is below the minimum required version") {
 			t.Errorf("Expected terraform version too low error, got %v", err)
 		}
 	})
@@ -877,8 +1068,8 @@ func TestToolsManager_checkOnePassword(t *testing.T) {
 		// When checking 1Password CLI version
 		err := toolsManager.checkOnePassword()
 		// Then an error indicating CLI is not available should be returned
-		if err == nil || !strings.Contains(err.Error(), "1Password CLI is not available in the PATH") {
-			t.Errorf("Expected 1Password CLI is not available in the PATH error, got %v", err)
+		if err == nil || !strings.Contains(err.Error(), "1Password CLI") || !strings.Contains(err.Error(), "not found on PATH") {
+			t.Errorf("Expected 1Password CLI not found error, got %v", err)
 		}
 	})
 
@@ -893,9 +1084,9 @@ func TestToolsManager_checkOnePassword(t *testing.T) {
 		}
 		// When checking 1Password CLI version
 		err := toolsManager.checkOnePassword()
-		// Then an error indicating CLI is not available should be returned
-		if err == nil || !strings.Contains(err.Error(), "1Password CLI is not available in the PATH") {
-			t.Errorf("Expected 1Password CLI is not available in the PATH error, got %v", err)
+		// Then an error indicating the --version invocation failed should be returned
+		if err == nil || !strings.Contains(err.Error(), "1Password CLI --version failed") {
+			t.Errorf("Expected 1Password CLI --version failed error, got %v", err)
 		}
 	})
 
@@ -927,7 +1118,7 @@ func TestToolsManager_checkOnePassword(t *testing.T) {
 		// When checking 1Password CLI version
 		err := toolsManager.checkOnePassword()
 		// Then an error indicating version is too low should be returned
-		if err == nil || !strings.Contains(err.Error(), "1Password CLI version 1.0.0 is below the minimum required version") {
+		if err == nil || !strings.Contains(err.Error(), "1Password CLI 1.0.0 is below the minimum required version") {
 			t.Errorf("Expected 1Password CLI version too low error, got %v", err)
 		}
 	})
@@ -969,8 +1160,8 @@ func TestToolsManager_checkSops(t *testing.T) {
 		// When checking SOPS CLI version
 		err := toolsManager.checkSops()
 		// Then an error indicating CLI is not available should be returned
-		if err == nil || !strings.Contains(err.Error(), "SOPS CLI is not available in the PATH") {
-			t.Errorf("Expected SOPS CLI is not available in the PATH error, got %v", err)
+		if err == nil || !strings.Contains(err.Error(), "SOPS") || !strings.Contains(err.Error(), "not found on PATH") {
+			t.Errorf("Expected SOPS not found error, got %v", err)
 		}
 	})
 
@@ -985,9 +1176,9 @@ func TestToolsManager_checkSops(t *testing.T) {
 		}
 		// When checking SOPS CLI version
 		err := toolsManager.checkSops()
-		// Then an error indicating CLI is not available should be returned
-		if err == nil || !strings.Contains(err.Error(), "SOPS CLI is not available in the PATH") {
-			t.Errorf("Expected SOPS CLI is not available in the PATH error, got %v", err)
+		// Then an error indicating the --version invocation failed should be returned
+		if err == nil || !strings.Contains(err.Error(), "sops --version failed") {
+			t.Errorf("Expected sops --version failed error, got %v", err)
 		}
 	})
 
@@ -1020,8 +1211,8 @@ func TestToolsManager_checkSops(t *testing.T) {
 		// When checking SOPS CLI version
 		err := toolsManager.checkSops()
 		// Then an error indicating version is too low should be returned
-		if err == nil || !strings.Contains(err.Error(), "SOPS CLI version 1.0.0 is below the minimum required version") {
-			t.Errorf("Expected SOPS CLI version too low error, got %v", err)
+		if err == nil || !strings.Contains(err.Error(), "SOPS 1.0.0 is below the minimum required version") {
+			t.Errorf("Expected SOPS version too low error, got %v", err)
 		}
 	})
 }
@@ -1072,7 +1263,7 @@ func TestToolsManager_checkKubelogin(t *testing.T) {
 		// When checking kubelogin version
 		err := toolsManager.checkKubelogin()
 		// Then an error indicating kubelogin is not available should be returned
-		if err == nil || !strings.Contains(err.Error(), "kubelogin is not available in the PATH") {
+		if err == nil || !strings.Contains(err.Error(), "kubelogin") || !strings.Contains(err.Error(), "not found on PATH") {
 			t.Errorf("Expected kubelogin not available error, got %v", err)
 		}
 	})
@@ -1120,7 +1311,7 @@ func TestToolsManager_checkKubelogin(t *testing.T) {
 		// When checking kubelogin version
 		err := toolsManager.checkKubelogin()
 		// Then an error indicating version is too low should be returned
-		if err == nil || !strings.Contains(err.Error(), "kubelogin version 0.1.0 is below the minimum required version") {
+		if err == nil || !strings.Contains(err.Error(), "kubelogin 0.1.0 is below the minimum required version") {
 			t.Errorf("Expected kubelogin version too low error, got %v", err)
 		}
 	})
@@ -1143,9 +1334,9 @@ func TestToolsManager_checkKubelogin(t *testing.T) {
 		}
 		// When checking kubelogin version
 		err := toolsManager.checkKubelogin()
-		// Then an error indicating kubelogin is not available should be returned
-		if err == nil || !strings.Contains(err.Error(), "kubelogin is not available in the PATH") {
-			t.Errorf("Expected kubelogin is not available in the PATH error, got %v", err)
+		// Then an error indicating the --version invocation failed should be returned
+		if err == nil || !strings.Contains(err.Error(), "kubelogin --version failed") {
+			t.Errorf("Expected kubelogin --version failed error, got %v", err)
 		}
 	})
 
@@ -1346,12 +1537,12 @@ func TestToolsManager_checkAWSBinary(t *testing.T) {
 		}
 		// When checking aws
 		err := toolsManager.checkAWSBinary()
-		// Then error mentions not in PATH and points to vendor install URL
+		// Then error mentions not on PATH and points to vendor install URL
 		if err == nil {
 			t.Fatal("Expected error when aws is not in PATH")
 		}
-		if !strings.Contains(err.Error(), "aws CLI is not available in the PATH") {
-			t.Errorf("Expected 'not available in the PATH' in error, got: %v", err)
+		if !strings.Contains(err.Error(), "AWS CLI") || !strings.Contains(err.Error(), "not found on PATH") {
+			t.Errorf("Expected 'AWS CLI ... not found on PATH' in error, got: %v", err)
 		}
 		if !strings.Contains(err.Error(), "https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html") {
 			t.Errorf("Expected vendor install URL in error, got: %v", err)
@@ -1500,8 +1691,8 @@ contexts:
 		if err == nil {
 			t.Fatal("Expected error when aws CLI is missing")
 		}
-		if !strings.Contains(err.Error(), "aws CLI is not available in the PATH") {
-			t.Errorf("Expected 'not available in the PATH' error, got: %v", err)
+		if !strings.Contains(err.Error(), "AWS CLI") || !strings.Contains(err.Error(), "not found on PATH") {
+			t.Errorf("Expected 'AWS CLI ... not found on PATH' error, got: %v", err)
 		}
 	})
 

--- a/pkg/runtime/tools/tools_manager_test.go
+++ b/pkg/runtime/tools/tools_manager_test.go
@@ -1741,15 +1741,23 @@ contexts:
 		}
 		// When CheckAuth runs
 		err := toolsManager.CheckAuth()
-		// Then it surfaces the credential-resolution error with an actionable hint
+		// Then it surfaces ONLY the actionable hint — no doubled "command execution failed"
+		// + raw aws-CLI stderr + hint stack. The hint names the actionable next step, which
+		// is the only thing the operator needs to see.
 		if err == nil {
 			t.Fatal("Expected error when sts get-caller-identity fails")
 		}
-		if !strings.Contains(err.Error(), "aws credentials did not resolve") {
-			t.Errorf("Expected 'aws credentials did not resolve' in error, got: %v", err)
+		if !strings.Contains(err.Error(), "aws configure") && !strings.Contains(err.Error(), "aws sso login") {
+			t.Errorf("Expected an aws sso/configure remediation hint in error, got: %v", err)
 		}
-		if !strings.Contains(err.Error(), "aws configure") {
-			t.Errorf("Expected 'aws configure' hint in error, got: %v", err)
+		// Guard against the noise regression: the raw shell-exec wrapper text and aws-CLI
+		// stderr must not be present in the surfaced error. If either reappears it means
+		// somebody re-introduced the %v err interpolation.
+		if strings.Contains(err.Error(), "command execution failed") {
+			t.Errorf("Expected raw shell-exec error text to be suppressed, got: %v", err)
+		}
+		if strings.Contains(err.Error(), "aws credentials did not resolve") {
+			t.Errorf("Expected the redundant 'aws credentials did not resolve' prefix to be removed, got: %v", err)
 		}
 	})
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This PR touches the tool-check dispatch path used by every command, but the changes are additive and backward-compatible: per-command `Requirements` declarations narrow which preflight checks fire while existing entry-points preserve prior behavior.
>
> **Overview**
>
> The change introduces a `Requirements` struct that lets each CLI command declare only the tool families its codepath will exercise. Narrow subcommands (`apply terraform`, `destroy kustomize`, `plan kustomize`, etc.) now skip unrelated checks; commands whose tool surface is data-driven at runtime continue to request `AllRequirements()` and rely on per-tool config gates to no-op checks the context hasn't enabled. A new `requireCloudAuth` helper consolidates the credential preflight for all terraform-touching commands, and `registry.go` centralizes tool metadata so missing-tool and outdated-tool errors carry copy-pasteable install hints.
>
> One open finding remains: `checkAWSAuth` discards the raw STS error entirely, so network outages, VPC endpoint misconfigurations, and IAM denials all surface as the SSO-refresh hint. The AWS version-check timeout, previously flagged at 30 s, has been corrected to 10 s.
>
> Reviewed by Claude for commit `cdbfa5a1`.

<!-- /claude-code-review:summary -->
