### PR TITLE
feat(cmd): add --no-cache flag to bypass OCI artifact cache

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 	"github.com/windsorcli/cli/pkg/project"
@@ -12,6 +13,11 @@ import (
 
 // verbose is a flag for verbose output
 var verbose bool
+
+// noCache is a flag for bypassing the OCI artifact cache. When true, every
+// command's preflight sets NO_CACHE=true so ArtifactBuilder.Pull skips the
+// disk cache and re-downloads (and atomically overwrites) the cached entry.
+var noCache bool
 
 // Define a custom type for context keys
 type contextKey string
@@ -47,6 +53,10 @@ var rootCmd = &cobra.Command{
 func init() {
 	// Define the --verbose flag
 	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Enable verbose output")
+	// Define the --no-cache flag. Persistent so every command (up, apply, plan, init,
+	// bootstrap, bundle, ...) inherits it; the effect is plumbed via the NO_CACHE env
+	// var that ArtifactBuilder.Pull already honors.
+	rootCmd.PersistentFlags().BoolVar(&noCache, "no-cache", false, "Bypass the OCI artifact cache and force re-download of remote sources")
 }
 
 // commandPreflight orchestrates global CLI preflight checks and context initialization for all commands.
@@ -156,7 +166,13 @@ func silenceErrorsOnAncestors(cmd *cobra.Command) {
 }
 
 // setupGlobalContext injects global flags and context values into the command's context.
-// It sets the verbose flag in the context if enabled.
+// It sets the verbose flag in the context if enabled, and propagates --no-cache to the
+// NO_CACHE environment variable that ArtifactBuilder.Pull reads — since the artifact
+// layer is already wired to honor NO_CACHE (see pkg/composer/artifact/artifact.go),
+// setting the env var is the smallest-blast-radius path that works for every command
+// without threading a flag through the project/runtime/composer construction chain.
+// An explicit --no-cache always wins; a pre-existing NO_CACHE in the environment is
+// preserved when the flag is not set.
 func setupGlobalContext(cmd *cobra.Command) error {
 	ctx := cmd.Root().Context()
 	if ctx == nil {
@@ -164,6 +180,11 @@ func setupGlobalContext(cmd *cobra.Command) error {
 	}
 	if verbose {
 		ctx = context.WithValue(ctx, "verbose", true)
+	}
+	if noCache {
+		if err := os.Setenv("NO_CACHE", "true"); err != nil {
+			return fmt.Errorf("failed to set NO_CACHE environment variable: %w", err)
+		}
 	}
 	cmd.SetContext(ctx)
 	tui.Init(verbose)

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -564,6 +564,7 @@ func TestCommandPreflight(t *testing.T) {
 		noCache = true
 		cmd := &cobra.Command{Use: "test"}
 		rootCmd.AddCommand(cmd)
+		t.Cleanup(func() { rootCmd.RemoveCommand(cmd) })
 
 		// When running preflight
 		if err := commandPreflight(cmd, []string{}); err != nil {
@@ -594,6 +595,7 @@ func TestCommandPreflight(t *testing.T) {
 		noCache = false
 		cmd := &cobra.Command{Use: "test"}
 		rootCmd.AddCommand(cmd)
+		t.Cleanup(func() { rootCmd.RemoveCommand(cmd) })
 
 		// When running preflight
 		if err := commandPreflight(cmd, []string{}); err != nil {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -369,6 +369,19 @@ func TestRootCmd(t *testing.T) {
 			t.Errorf("Expected flag usage to be 'Enable verbose output', got %s", verboseFlag.Usage)
 		}
 
+		// And the command should have the --no-cache flag (persistent so all subcommands inherit)
+		noCacheFlag := cmd.PersistentFlags().Lookup("no-cache")
+		if noCacheFlag == nil {
+			t.Error("Expected no-cache flag to be defined")
+			return
+		}
+		if noCacheFlag.Name != "no-cache" {
+			t.Errorf("Expected flag name to be 'no-cache', got %s", noCacheFlag.Name)
+		}
+		if noCacheFlag.Shorthand != "" {
+			t.Errorf("Expected no shorthand for no-cache, got %q", noCacheFlag.Shorthand)
+		}
+
 		// Clear any previously set arguments to ensure we're testing the root command without subcommands
 		rootCmd.SetArgs([]string{})
 
@@ -431,10 +444,13 @@ func TestExecute(t *testing.T) {
 }
 
 func TestCommandPreflight(t *testing.T) {
-	// Cleanup: reset rootCmd context after all subtests complete
+	// Cleanup: reset rootCmd context and globals after all subtests complete.
+	// noCache is reset alongside verbose because both are package-level flag
+	// vars that leak across subtests if not cleared.
 	t.Cleanup(func() {
 		rootCmd.SetContext(context.Background())
 		verbose = false
+		noCache = false
 	})
 
 	// Set up mocks for all tests
@@ -527,6 +543,67 @@ func TestCommandPreflight(t *testing.T) {
 		// Then no error should occur (setupGlobalContext doesn't return errors currently)
 		if err != nil {
 			t.Errorf("Expected no error for preflight, got: %v", err)
+		}
+	})
+
+	t.Run("SetsNoCacheEnvWhenFlagTrue", func(t *testing.T) {
+		// Given the --no-cache flag is set, and NO_CACHE is unset in the environment,
+		// preflight must propagate the flag to NO_CACHE=true so ArtifactBuilder.Pull
+		// (which only reads the env var, not the flag) bypasses the disk cache.
+		original, hadOriginal := os.LookupEnv("NO_CACHE")
+		os.Unsetenv("NO_CACHE")
+		t.Cleanup(func() {
+			noCache = false
+			if hadOriginal {
+				os.Setenv("NO_CACHE", original)
+			} else {
+				os.Unsetenv("NO_CACHE")
+			}
+		})
+
+		noCache = true
+		cmd := &cobra.Command{Use: "test"}
+		rootCmd.AddCommand(cmd)
+
+		// When running preflight
+		if err := commandPreflight(cmd, []string{}); err != nil {
+			t.Fatalf("Expected no error for preflight, got: %v", err)
+		}
+
+		// Then NO_CACHE should be set to "true" so the artifact layer bypasses the cache
+		if got := os.Getenv("NO_CACHE"); got != "true" {
+			t.Errorf("Expected NO_CACHE=true after --no-cache preflight, got %q", got)
+		}
+	})
+
+	t.Run("DoesNotTouchNoCacheEnvWhenFlagFalse", func(t *testing.T) {
+		// Given --no-cache is NOT set but the operator already exported NO_CACHE in their
+		// shell, preflight must not clobber it. The flag is purely additive: explicit
+		// flag wins, but a quiet preflight leaves the operator's environment alone.
+		original, hadOriginal := os.LookupEnv("NO_CACHE")
+		os.Setenv("NO_CACHE", "preexisting")
+		t.Cleanup(func() {
+			noCache = false
+			if hadOriginal {
+				os.Setenv("NO_CACHE", original)
+			} else {
+				os.Unsetenv("NO_CACHE")
+			}
+		})
+
+		noCache = false
+		cmd := &cobra.Command{Use: "test"}
+		rootCmd.AddCommand(cmd)
+
+		// When running preflight
+		if err := commandPreflight(cmd, []string{}); err != nil {
+			t.Fatalf("Expected no error for preflight, got: %v", err)
+		}
+
+		// Then NO_CACHE should be untouched — preflight has no business overwriting an
+		// operator-supplied value when the flag is off
+		if got := os.Getenv("NO_CACHE"); got != "preexisting" {
+			t.Errorf("Expected NO_CACHE preserved at %q, got %q", "preexisting", got)
 		}
 	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This is an isolated, additive persistent flag; all previously identified concerns are now resolved.
>
> **Overview**
>
> The PR adds `--no-cache` as a persistent root flag that propagates to `NO_CACHE`, an env var already honored by `ArtifactBuilder.Pull`. Rather than threading a new parameter through the project/runtime/composer stack, `setupGlobalContext` sets the env var as a side-channel — an intentional, documented tradeoff. A pre-existing `NO_CACHE` in the caller's environment is left untouched when the flag is absent.
>
> The follow-up commit adds `t.Cleanup(func() { rootCmd.RemoveCommand(cmd) })` to both new `TestCommandPreflight` subtests, resolving the test infrastructure concern from the earlier review. Env-var state is also properly saved and restored around each subtest.
>
> Reviewed by Claude for commit `7faacbec`.

<!-- /claude-code-review:summary -->
