### PR TITLE
feat(plan): show (new) for components without prior state

### DIFF
--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -251,8 +251,8 @@ func init() {
 func printPlanSummary(w io.Writer, tfPlans []terraforminfra.TerraformComponentPlan, k8sPlans []fluxinfra.KustomizePlan, hints []string, noColor bool) {
 	nameWidth := 20
 	for _, p := range tfPlans {
-		if len(p.ComponentID) > nameWidth {
-			nameWidth = len(p.ComponentID)
+		if n := len(terraformDisplayName(p)); n > nameWidth {
+			nameWidth = n
 		}
 	}
 	for _, p := range k8sPlans {
@@ -268,7 +268,7 @@ func printPlanSummary(w io.Writer, tfPlans []terraforminfra.TerraformComponentPl
 	if len(tfPlans) > 0 {
 		fmt.Fprintln(w, "\nTerraform")
 		for _, p := range tfPlans {
-			fmt.Fprintf(w, "  %-*s  %s\n", nameWidth, p.ComponentID, formatTerraformPlan(p, noColor))
+			fmt.Fprintf(w, "  %-*s  %s\n", nameWidth, terraformDisplayName(p), formatTerraformPlan(p, noColor))
 			if p.Err != nil {
 				lines := strings.Split(strings.TrimSpace(p.Err.Error()), "\n")
 				for _, line := range lines[1:] {
@@ -312,10 +312,12 @@ func printPlanSummary(w io.Writer, tfPlans []terraforminfra.TerraformComponentPl
 func printPlanSummaryJSON(w io.Writer, tfPlans []terraforminfra.TerraformComponentPlan, k8sPlans []fluxinfra.KustomizePlan) error {
 	type tfRow struct {
 		Component string `json:"component"`
+		Path      string `json:"path,omitempty"`
 		Add       int    `json:"add"`
 		Change    int    `json:"change"`
 		Destroy   int    `json:"destroy"`
 		NoChanges bool   `json:"no_changes"`
+		IsNew     bool   `json:"is_new"`
 		Error     string `json:"error,omitempty"`
 	}
 	type k8sRow struct {
@@ -333,7 +335,15 @@ func printPlanSummaryJSON(w io.Writer, tfPlans []terraforminfra.TerraformCompone
 
 	out := output{}
 	for _, p := range tfPlans {
-		row := tfRow{Component: p.ComponentID, Add: p.Add, Change: p.Change, Destroy: p.Destroy, NoChanges: p.NoChanges}
+		row := tfRow{
+			Component: p.ComponentID,
+			Path:      p.Path,
+			Add:       p.Add,
+			Change:    p.Change,
+			Destroy:   p.Destroy,
+			NoChanges: p.NoChanges,
+			IsNew:     p.IsNew,
+		}
 		if p.Err != nil {
 			row.Error = p.Err.Error()
 		}
@@ -391,7 +401,20 @@ func truncateFirstLine(s string) string {
 	return s
 }
 
+// terraformDisplayName returns the identifier shown to the operator for a Terraform
+// component row. The blueprint Path (e.g., "cluster/aws-eks") locates the underlying
+// module and is more informative than the short ComponentID alias (e.g., "cluster"),
+// so it's preferred when set; ComponentID is used as the fallback.
+func terraformDisplayName(p terraforminfra.TerraformComponentPlan) string {
+	if p.Path != "" {
+		return p.Path
+	}
+	return p.ComponentID
+}
+
 // formatTerraformPlan returns a concise human-readable status string for one Terraform component.
+// IsNew (no state in the configured backend) renders as "(new)" without counts because plan was
+// not run.
 func formatTerraformPlan(p terraforminfra.TerraformComponentPlan, noColor bool) string {
 	if p.Err != nil {
 		msg := truncateFirstLine(p.Err.Error())
@@ -399,6 +422,12 @@ func formatTerraformPlan(p terraforminfra.TerraformComponentPlan, noColor bool) 
 			return fmt.Sprintf("(error: %s)", msg)
 		}
 		return fmt.Sprintf("\033[31m(error: %s)\033[0m", msg)
+	}
+	if p.IsNew {
+		if noColor {
+			return "(new)"
+		}
+		return "\033[36m(new)\033[0m"
 	}
 	if p.NoChanges || (p.Add == 0 && p.Change == 0 && p.Destroy == 0) {
 		return "(no changes)"
@@ -425,13 +454,15 @@ func formatKustomizePlan(p fluxinfra.KustomizePlan, noColor bool) string {
 		return "(existing)"
 	}
 	if p.IsNew {
-		if p.Added == 0 {
-			return "(new — empty)"
-		}
+		// The kustomize-build resource count for a brand-new kustomization is
+		// rarely the count actually applied (Flux may dedupe, skip, or reconcile
+		// asynchronously), and showing "+N resources" alongside terraform's bare
+		// "(new)" is visually inconsistent. Both layers report "(new)" for the
+		// same condition: nothing exists yet.
 		if noColor {
-			return fmt.Sprintf("+%d resources  (new)", p.Added)
+			return "(new)"
 		}
-		return fmt.Sprintf("\033[32m+%d resources\033[0m  (new)", p.Added)
+		return "\033[36m(new)\033[0m"
 	}
 	if p.Added == 0 && p.Removed == 0 {
 		return "(no changes)"

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -309,6 +309,12 @@ func printPlanSummary(w io.Writer, tfPlans []terraforminfra.TerraformComponentPl
 }
 
 // printPlanSummaryJSON encodes the plan results as JSON to w.
+//
+// is_new supersedes the count fields: when is_new is true the component has no
+// state in the configured backend, terraform plan is not executed, and add/
+// change/destroy/no_changes are zero/false. Consumers detecting "pending work"
+// from this output must check is_new alongside the counts — using add+change+
+// destroy>0 alone will silently miss never-applied components.
 func printPlanSummaryJSON(w io.Writer, tfPlans []terraforminfra.TerraformComponentPlan, k8sPlans []fluxinfra.KustomizePlan) error {
 	type tfRow struct {
 		Component string `json:"component"`

--- a/cmd/plan_test.go
+++ b/cmd/plan_test.go
@@ -536,3 +536,105 @@ func TestPlanKustomizeCmd(t *testing.T) {
 		}
 	})
 }
+
+func TestFormatTerraformPlan(t *testing.T) {
+	t.Run("RendersNewWhenIsNew", func(t *testing.T) {
+		// IsNew with no error renders as "(new)" — plan was not run because
+		// the component has no state in the configured backend.
+		got := formatTerraformPlan(terraforminfra.TerraformComponentPlan{
+			ComponentID: "vpc",
+			IsNew:       true,
+		}, true)
+		if got != "(new)" {
+			t.Errorf("expected (new), got %q", got)
+		}
+	})
+
+	t.Run("ErrorTakesPrecedenceOverIsNew", func(t *testing.T) {
+		// A non-nil Err always renders as the error — IsNew is only set when
+		// classification succeeds.
+		got := formatTerraformPlan(terraforminfra.TerraformComponentPlan{
+			ComponentID: "vpc",
+			IsNew:       true,
+			Err:         fmt.Errorf("boom"),
+		}, true)
+		if !strings.Contains(got, "boom") {
+			t.Errorf("expected error message to win, got %q", got)
+		}
+	})
+
+	t.Run("RendersCountsWhenStateExists", func(t *testing.T) {
+		// IsNew=false means plan ran and counts are authoritative — render them.
+		got := formatTerraformPlan(terraforminfra.TerraformComponentPlan{
+			ComponentID: "vpc",
+			Add:         3, Change: 1, Destroy: 2,
+		}, true)
+		if !strings.Contains(got, "+3") || !strings.Contains(got, "~1") || !strings.Contains(got, "-2") {
+			t.Errorf("expected +3 ~1 -2 in output, got %q", got)
+		}
+	})
+}
+
+func TestTerraformDisplayName(t *testing.T) {
+	t.Run("PrefersPathWhenSet", func(t *testing.T) {
+		// Path locates the underlying module; ComponentID is the short alias.
+		// Showing the path tells the operator which terraform module is being
+		// invoked (e.g., cluster/aws-eks vs cluster/gke).
+		got := terraformDisplayName(terraforminfra.TerraformComponentPlan{
+			ComponentID: "cluster",
+			Path:        "cluster/aws-eks",
+		})
+		if got != "cluster/aws-eks" {
+			t.Errorf("expected cluster/aws-eks, got %q", got)
+		}
+	})
+
+	t.Run("FallsBackToComponentIDWhenPathEmpty", func(t *testing.T) {
+		// Components without an explicit Path still need to render — the
+		// ComponentID (Name fallback) is the next best identifier.
+		got := terraformDisplayName(terraforminfra.TerraformComponentPlan{
+			ComponentID: "backend",
+		})
+		if got != "backend" {
+			t.Errorf("expected backend, got %q", got)
+		}
+	})
+}
+
+func TestFormatKustomizePlan_NewParity(t *testing.T) {
+	t.Run("NewKustomizationRendersBareNew", func(t *testing.T) {
+		// Kustomize-new used to render "+N resources  (new)" but the count is
+		// derived from `kustomize build` and rarely matches what Flux actually
+		// applies. Aligning with terraform's bare "(new)" keeps the table
+		// visually consistent across layers.
+		got := formatKustomizePlan(fluxinfra.KustomizePlan{
+			Name:  "policy-base",
+			IsNew: true,
+			Added: 3,
+		}, true)
+		if got != "(new)" {
+			t.Errorf("expected (new), got %q", got)
+		}
+	})
+}
+
+func TestPrintPlanSummaryJSON_TerraformFields(t *testing.T) {
+	t.Run("EmitsIsNewFlag", func(t *testing.T) {
+		// JSON consumers need to distinguish a "new" component (no state) from
+		// a real plan with counts. Check that the flag survives serialization.
+		var buf strings.Builder
+		err := printPlanSummaryJSON(&buf, []terraforminfra.TerraformComponentPlan{
+			{ComponentID: "vpc", IsNew: true},
+			{ComponentID: "ec2", Add: 5},
+		}, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		out := buf.String()
+		if !strings.Contains(out, `"is_new": true`) {
+			t.Errorf("expected is_new: true for vpc row, got %s", out)
+		}
+	})
+}
+

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -52,15 +52,22 @@ type TerraformStack struct {
 }
 
 // TerraformComponentPlan holds the plan result for a single Terraform component.
-// Add, Change, and Destroy reflect terraform's "to add / to change / to destroy" counts.
-// NoChanges is true when terraform reports no changes. Err is non-nil when the
-// component's init or plan step failed; subsequent layers may still be attempted.
+// ComponentID is the unique identifier (Name when set, else Path). Path carries the
+// component's blueprint Path field (e.g., "cluster/aws-eks") so renderers can show
+// the underlying module location alongside or instead of the short ID. Add, Change,
+// and Destroy reflect terraform's "to add / to change / to destroy" counts.
+// NoChanges is true when terraform reports no changes. IsNew is true when no state
+// exists for the component in the configured backend — the component has never been
+// applied. Err is non-nil when the component's init or plan step failed; subsequent
+// layers may still be attempted.
 type TerraformComponentPlan struct {
 	ComponentID string
+	Path        string
 	Add         int
 	Change      int
 	Destroy     int
 	NoChanges   bool
+	IsNew       bool
 	Err         error
 }
 
@@ -892,7 +899,9 @@ func (s *TerraformStack) refreshComponentState(component *blueprintv1alpha1.Terr
 }
 
 // hasStateResources reports whether the component's state contains any resources at any
-// depth in the module tree. Used to short-circuit destroy on already-destroyed components.
+// depth in the module tree. Used by destroy to short-circuit already-destroyed components,
+// and by plan to classify never-applied components as IsNew (so plan is skipped rather than
+// running against empty state, which fails when dependent layers reference upstream state).
 func (s *TerraformStack) hasStateResources(component *blueprintv1alpha1.TerraformComponent, terraformVars map[string]string) (bool, error) {
 	terraformCommand := s.runtime.ToolsManager.GetTerraformCommand()
 	stateShowArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "show", "-json"}
@@ -994,8 +1003,14 @@ func (s *TerraformStack) resolveComponentPaths(blueprint *blueprintv1alpha1.Blue
 // planOneTerraformSummary runs terraform init and plan -no-color for a single component
 // and returns its structured result. It is shared by PlanSummary and PlanComponentSummary
 // to avoid duplicating the per-component setup, init, plan, and cleanup logic.
+//
+// Before running plan, hasStateResources is used to determine whether the configured
+// backend has any state recorded for this component. Empty state means the component
+// has never been applied — IsNew is set and plan is skipped, since plan would either
+// produce a misleading "all creates" picture or fail when `data "terraform_remote_state"`
+// references upstream layers that are also empty.
 func (s *TerraformStack) planOneTerraformSummary(component *blueprintv1alpha1.TerraformComponent) TerraformComponentPlan {
-	result := TerraformComponentPlan{ComponentID: component.GetID()}
+	result := TerraformComponentPlan{ComponentID: component.GetID(), Path: component.Path}
 
 	terraformVars, terraformArgs, cleanup, err := s.prepareComponentEnv(component)
 	if err != nil {
@@ -1007,6 +1022,16 @@ func (s *TerraformStack) planOneTerraformSummary(component *blueprintv1alpha1.Te
 
 	if err := s.runTerraformInit(component, terraformVars, terraformArgs, defaultInitFlags...); err != nil {
 		result.Err = err
+		return result
+	}
+
+	hasState, err := s.hasStateResources(component, terraformVars)
+	if err != nil {
+		result.Err = err
+		return result
+	}
+	if !hasState {
+		result.IsNew = true
 		return result
 	}
 

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -60,6 +60,12 @@ type TerraformStack struct {
 // exists for the component in the configured backend — the component has never been
 // applied. Err is non-nil when the component's init or plan step failed; subsequent
 // layers may still be attempted.
+//
+// IsNew supersedes the count fields: when IsNew is true, terraform plan is not
+// executed (it would either misreport "all creates" or fail reading dependent
+// upstream state), so Add/Change/Destroy are zero and NoChanges is false. JSON
+// consumers detecting "pending work" must check IsNew alongside the counts —
+// `IsNew || Add+Change+Destroy > 0` rather than counts alone.
 type TerraformComponentPlan struct {
 	ComponentID string
 	Path        string

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -1571,6 +1571,9 @@ func TestTerraformStack_PlanComponentSummary(t *testing.T) {
 		// Given a shell that returns a plan output with counts
 		stack, mocks := setup(t)
 		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 2 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[{"address":"aws_s3_bucket.example"}]}}}`, nil
+			}
 			if len(args) > 1 && args[1] == "plan" {
 				return "Plan: 2 to add, 1 to change, 0 to destroy.\n", nil
 			}
@@ -3159,6 +3162,9 @@ func TestStack_PlanSummary(t *testing.T) {
 		// Given a shell that returns a terraform plan line with counts
 		stack, mocks := setup(t)
 		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 2 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[{"address":"aws_s3_bucket.example"}]}}}`, nil
+			}
 			if len(args) > 1 && args[1] == "plan" {
 				return "Plan: 5 to add, 3 to change, 1 to destroy.\n", nil
 			}
@@ -3188,6 +3194,9 @@ func TestStack_PlanSummary(t *testing.T) {
 		// Given a shell that returns a "No changes." line
 		stack, mocks := setup(t)
 		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 2 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[{"address":"aws_s3_bucket.example"}]}}}`, nil
+			}
 			if len(args) > 1 && args[1] == "plan" {
 				return "No changes. Infrastructure is up-to-date.\n", nil
 			}
@@ -3260,6 +3269,9 @@ func TestStack_PlanSummary(t *testing.T) {
 		// Given a shell that returns an error on terraform plan
 		stack, mocks := setup(t)
 		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 2 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[{"address":"aws_s3_bucket.example"}]}}}`, nil
+			}
 			if len(args) > 1 && args[1] == "plan" {
 				return "", fmt.Errorf("plan failed")
 			}
@@ -3288,6 +3300,9 @@ func TestStack_PlanSummary(t *testing.T) {
 		// When PlanSummary is called, capture the env passed to terraform plan
 		var capturedEnv map[string]string
 		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 2 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[{"address":"aws_s3_bucket.example"}]}}}`, nil
+			}
 			if len(args) > 1 && args[1] == "plan" {
 				capturedEnv = env
 			}
@@ -3302,6 +3317,94 @@ func TestStack_PlanSummary(t *testing.T) {
 		}
 		if capturedEnv["TF_VAR_operation"] != "apply" {
 			t.Errorf("Expected TF_VAR_operation to be %q, got %q", "apply", capturedEnv["TF_VAR_operation"])
+		}
+	})
+
+	t.Run("MarksComponentNewWhenStateIsEmpty", func(t *testing.T) {
+		// `terraform show -json` returns "{}" when the configured backend has
+		// no state object for this component. The component has never been
+		// applied — IsNew is the truth and running plan would either show a
+		// misleading "all creates" or fail reading dependent layers via
+		// terraform_remote_state.
+		stack, mocks := setup(t)
+		var planCalled bool
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 2 && args[1] == "show" && args[2] == "-json" {
+				return "{}", nil
+			}
+			if len(args) > 1 && args[1] == "plan" {
+				planCalled = true
+			}
+			return "", nil
+		}
+
+		results := stack.PlanSummary(createTestBlueprint())
+
+		if len(results) == 0 {
+			t.Fatal("expected results")
+		}
+		for _, r := range results {
+			if !r.IsNew {
+				t.Errorf("expected IsNew=true for %q, got false", r.ComponentID)
+			}
+			if r.Err != nil {
+				t.Errorf("expected no error for %q, got %v", r.ComponentID, r.Err)
+			}
+		}
+		if planCalled {
+			t.Error("plan must not be invoked when state is empty")
+		}
+	})
+
+	t.Run("PropagatesStateProbeError", func(t *testing.T) {
+		// `terraform show -json` failures (e.g., transient backend connectivity
+		// or invalid credentials) are real errors — silently classifying as
+		// IsNew would hide them.
+		stack, mocks := setup(t)
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 2 && args[1] == "show" && args[2] == "-json" {
+				return "", fmt.Errorf("backend timeout")
+			}
+			return "", nil
+		}
+
+		results := stack.PlanSummary(createTestBlueprint())
+
+		if len(results) == 0 {
+			t.Fatal("expected results")
+		}
+		for _, r := range results {
+			if r.Err == nil {
+				t.Errorf("expected state-probe error for %q, got nil", r.ComponentID)
+			}
+			if r.IsNew {
+				t.Errorf("expected IsNew=false for %q on state-probe failure, got true", r.ComponentID)
+			}
+		}
+	})
+
+	t.Run("PopulatesPathFromComponent", func(t *testing.T) {
+		// The blueprint Path (e.g., "cluster/aws-eks") locates the underlying
+		// module and is more informative than the short ComponentID alias for
+		// renderers. PlanSummary copies it into each result so callers don't
+		// need to re-resolve components.
+		stack, mocks := setup(t)
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 2 && args[1] == "show" && args[2] == "-json" {
+				return "{}", nil
+			}
+			return "", nil
+		}
+
+		results := stack.PlanSummary(createTestBlueprint())
+
+		if len(results) == 0 {
+			t.Fatal("expected results")
+		}
+		for _, r := range results {
+			if r.Path == "" {
+				t.Errorf("expected Path to be populated for %q, got empty", r.ComponentID)
+			}
 		}
 	})
 }


### PR DESCRIPTION
Plan summary now classifies a Terraform component as IsNew when `terraform show -json` reports no resources for it in the configured backend, and renders it as `(new)` (cyan) instead of running plan. Plan was previously failing on first-run repos because dependent layers reference upstream state that doesn't exist yet — the new classification skips plan entirely for never-applied components.

Reuses the existing hasStateResources helper (also used by destroy) so both the destroy short-circuit and the plan IsNew classification share a single, consistently-tested implementation of "does this component have state?".

Also surfaces the blueprint Path (e.g. `cluster/aws-eks`) instead of the short ComponentID alias in the row label, and aligns Kustomize's new-rendering with Terraform's bare `(new)` (drops the misleading kustomize-build resource count) for visual parity across layers.

<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This change is isolated to the plan summary path and a single internal helper; nothing in the apply, destroy, or migration paths is touched.
>
> **Overview**
>
> The PR classifies a Terraform component as `IsNew` when `terraform show -json` reports no backend state, and renders `(new)` in cyan instead of running plan. This prevents plan failures on first-run repositories where `terraform_remote_state` references point at upstream layers that have never been applied. It reuses the existing `hasStateResources` helper (already used by the destroy short-circuit), so the state-detection logic is shared and consistently tested.
>
> A follow-on docs commit explicitly records the JSON contract precedence rule — `is_new` supersedes the count fields — in both `TerraformComponentPlan` and `printPlanSummaryJSON`, so downstream tooling authors have a clear signal to update consumers that used `add+change+destroy>0` as the "pending work" proxy.
>
> Reviewed by Claude for commit `f6ca1a02`.

<!-- /claude-code-review:summary -->
