### PR TITLE
fix: Update AWS, Azure, and GCP environment variable handling for global mode

### DIFF
--- a/pkg/runtime/env/aws_env.go
+++ b/pkg/runtime/env/aws_env.go
@@ -45,26 +45,39 @@ func NewAwsEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler) *Aw
 // =============================================================================
 
 // GetEnvVars retrieves the environment variables for the AWS environment.
-// AWS_CONFIG_FILE and AWS_SHARED_CREDENTIALS_FILE always point at the context's
-// .aws/config and .aws/credentials, even when those files do not yet exist, so
-// that `aws configure` (run inside a windsor-shell session) writes into the
-// context folder rather than contaminating the operator's global ~/.aws files.
-// Subsequent aws/terraform/SDK calls then read the same context-scoped files.
-// AWS_PROFILE defaults to the current context name so `aws configure sso` creates
-// a profile bound to the context; an explicit aws.profile in the context's aws
-// block overrides the default. AWS_REGION is emitted only when aws.region is set;
-// downstream tools otherwise fall back to the profile's own `region =` line.
+// In project mode AWS_CONFIG_FILE and AWS_SHARED_CREDENTIALS_FILE always point at
+// the context's .aws/config and .aws/credentials, even when those files do not
+// yet exist, so that `aws configure` (run inside a windsor-shell session) writes
+// into the context folder rather than contaminating the operator's global ~/.aws
+// files. Subsequent aws/terraform/SDK calls then read the same context-scoped
+// files. AWS_PROFILE defaults to the current context name so `aws configure sso`
+// creates a profile bound to the context; an explicit aws.profile in the
+// context's aws block overrides the default. AWS_REGION is emitted only when
+// aws.region is set; downstream tools otherwise fall back to the profile's own
+// `region =` line.
+//
+// In global mode (no windsor.yaml in the project tree) windsor defers on file
+// locations — AWS_CONFIG_FILE and AWS_SHARED_CREDENTIALS_FILE are not emitted so
+// the AWS SDK resolves against the operator's ambient ~/.aws/. AWS_PROFILE is
+// still emitted (from aws.profile if set, otherwise the context name) so the
+// SDK checks the profile the context actually targets; without it, calls would
+// fall through to [default] even when the right profile is logged in. The
+// non-credential project parameters (region, endpoint, s3 hostname, mwaa
+// endpoint) flow through unchanged because they describe where windsor talks to
+// AWS, not whose credentials it uses.
 func (e *AwsEnvPrinter) GetEnvVars() (map[string]string, error) {
 	envVars := make(map[string]string)
+	global := e.shell.IsGlobal()
 
-	configRoot, err := e.configHandler.GetConfigRoot()
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving configuration root directory: %w", err)
+	if !global {
+		configRoot, err := e.configHandler.GetConfigRoot()
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving configuration root directory: %w", err)
+		}
+		awsConfigDir := filepath.Join(configRoot, ".aws")
+		envVars["AWS_CONFIG_FILE"] = filepath.ToSlash(filepath.Join(awsConfigDir, "config"))
+		envVars["AWS_SHARED_CREDENTIALS_FILE"] = filepath.ToSlash(filepath.Join(awsConfigDir, "credentials"))
 	}
-
-	awsConfigDir := filepath.Join(configRoot, ".aws")
-	envVars["AWS_CONFIG_FILE"] = filepath.ToSlash(filepath.Join(awsConfigDir, "config"))
-	envVars["AWS_SHARED_CREDENTIALS_FILE"] = filepath.ToSlash(filepath.Join(awsConfigDir, "credentials"))
 
 	contextConfigData := e.configHandler.GetConfig()
 	awsProfileOverride := ""

--- a/pkg/runtime/env/aws_env_test.go
+++ b/pkg/runtime/env/aws_env_test.go
@@ -198,6 +198,76 @@ contexts:
 		}
 	})
 
+	t.Run("GlobalModeDefersToAmbientAWSConfig", func(t *testing.T) {
+		// Given an AWS-platform context running in global mode (no project root —
+		// operator is invoking windsor outside of a windsor.yaml-anchored tree)
+		mocks := setupAwsEnvMocks(t)
+		mocks.Shell.IsGlobalFunc = func() bool { return true }
+		env := NewAwsEnvPrinter(mocks.Shell, mocks.ConfigHandler)
+		env.shims = mocks.Shims
+
+		// When GetEnvVars is called
+		envVars, err := env.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars returned an error: %v", err)
+		}
+
+		// Then AWS_CONFIG_FILE and AWS_SHARED_CREDENTIALS_FILE are NOT emitted, so
+		// the AWS CLI/SDK fall through to the operator's ambient ~/.aws/. AWS_PROFILE
+		// is still emitted because aws.profile is set explicitly in the context — the
+		// user asked for that profile, even in global mode. Region/endpoint and the
+		// other project-level identifiers continue to flow through.
+		if _, ok := envVars["AWS_CONFIG_FILE"]; ok {
+			t.Errorf("AWS_CONFIG_FILE should not be set in global mode, got %q", envVars["AWS_CONFIG_FILE"])
+		}
+		if _, ok := envVars["AWS_SHARED_CREDENTIALS_FILE"]; ok {
+			t.Errorf("AWS_SHARED_CREDENTIALS_FILE should not be set in global mode, got %q", envVars["AWS_SHARED_CREDENTIALS_FILE"])
+		}
+		if got := envVars["AWS_PROFILE"]; got != "default" {
+			t.Errorf("AWS_PROFILE = %q, want %q (explicit aws.profile override)", got, "default")
+		}
+		if got := envVars["AWS_REGION"]; got != "us-west-2" {
+			t.Errorf("AWS_REGION = %q, want %q", got, "us-west-2")
+		}
+	})
+
+	t.Run("GlobalModeFallsBackToContextNameForAWSProfile", func(t *testing.T) {
+		// Given a context with no aws.profile override, running in global mode
+		mocks := setupAwsEnvMocks(t)
+		configStr := `
+version: v1alpha1
+contexts:
+  test-context: {}
+`
+		if err := mocks.ConfigHandler.LoadConfigString(configStr); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+		mocks.Shell.IsGlobalFunc = func() bool { return true }
+		env := NewAwsEnvPrinter(mocks.Shell, mocks.ConfigHandler)
+		env.shims = mocks.Shims
+
+		// When GetEnvVars is called
+		envVars, err := env.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars returned an error: %v", err)
+		}
+
+		// Then AWS_PROFILE defaults to the context name so the AWS SDK resolves
+		// the right profile in the operator's ambient ~/.aws/config — without it,
+		// calls fall through to [default] even when the matching profile is logged
+		// in. AWS_CONFIG_FILE / AWS_SHARED_CREDENTIALS_FILE remain unset so the
+		// SDK uses the user-managed config locations.
+		if got := envVars["AWS_PROFILE"]; got != "test-context" {
+			t.Errorf("AWS_PROFILE = %q, want %q", got, "test-context")
+		}
+		if _, ok := envVars["AWS_CONFIG_FILE"]; ok {
+			t.Errorf("AWS_CONFIG_FILE should not be set in global mode, got %q", envVars["AWS_CONFIG_FILE"])
+		}
+		if _, ok := envVars["AWS_SHARED_CREDENTIALS_FILE"]; ok {
+			t.Errorf("AWS_SHARED_CREDENTIALS_FILE should not be set in global mode, got %q", envVars["AWS_SHARED_CREDENTIALS_FILE"])
+		}
+	})
+
 	t.Run("GetConfigRootError", func(t *testing.T) {
 		// Given a printer with a config handler that fails to get config root
 		mocks := setupAwsEnvMocks(t)

--- a/pkg/runtime/env/azure_env.go
+++ b/pkg/runtime/env/azure_env.go
@@ -45,21 +45,27 @@ func NewAzureEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler) *
 // =============================================================================
 
 // GetEnvVars retrieves the environment variables for the Azure environment.
+// In global mode (no windsor.yaml in the project tree) AZURE_CONFIG_DIR is not
+// emitted so the az CLI defers to the operator's ambient ~/.azure config; the
+// project-level identifiers (ARM_SUBSCRIPTION_ID, ARM_TENANT_ID, ARM_ENVIRONMENT)
+// are still emitted because they describe which Azure account/tenant the
+// context targets, not whose credentials are used.
 func (e *AzureEnvPrinter) GetEnvVars() (map[string]string, error) {
 	envVars := make(map[string]string)
-
-	configRoot, err := e.configHandler.GetConfigRoot()
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving configuration root directory: %w", err)
-	}
-
-	azureConfigDir := filepath.Join(configRoot, ".azure")
+	global := e.shell.IsGlobal()
 
 	// Get the current context configuration
 	config := e.configHandler.GetConfig()
 	if config != nil && config.Azure != nil {
-		envVars["AZURE_CONFIG_DIR"] = filepath.ToSlash(azureConfigDir)
-		envVars["AZURE_CORE_LOGIN_EXPERIENCE_V2"] = "false"
+		if !global {
+			configRoot, err := e.configHandler.GetConfigRoot()
+			if err != nil {
+				return nil, fmt.Errorf("error retrieving configuration root directory: %w", err)
+			}
+			azureConfigDir := filepath.Join(configRoot, ".azure")
+			envVars["AZURE_CONFIG_DIR"] = filepath.ToSlash(azureConfigDir)
+			envVars["AZURE_CORE_LOGIN_EXPERIENCE_V2"] = "false"
+		}
 
 		if config.Azure.SubscriptionID != nil {
 			envVars["ARM_SUBSCRIPTION_ID"] = *config.Azure.SubscriptionID

--- a/pkg/runtime/env/azure_env_test.go
+++ b/pkg/runtime/env/azure_env_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/windsorcli/cli/api/v1alpha1"
+	"github.com/windsorcli/cli/api/v1alpha1/azure"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 )
 
@@ -105,9 +107,16 @@ func TestAzureEnv_GetEnvVars(t *testing.T) {
 
 	t.Run("GetConfigRootError", func(t *testing.T) {
 		// Given a printer with a config handler that fails to get config root
+		// AND an azure block in context config (so the config-root resolution path
+		// is exercised — without azure config, GetEnvVars short-circuits before
+		// touching the config root).
+		subID := "test-subscription"
 		mockConfigHandler := &config.MockConfigHandler{}
 		mockConfigHandler.GetConfigRootFunc = func() (string, error) {
 			return "", fmt.Errorf("error retrieving configuration root directory")
+		}
+		mockConfigHandler.GetConfigFunc = func() *v1alpha1.Context {
+			return &v1alpha1.Context{Azure: &azure.AzureConfig{SubscriptionID: &subID}}
 		}
 		mocks := setupAzureEnvMocks(t, &EnvTestMocks{
 			ConfigHandler: mockConfigHandler,
@@ -123,6 +132,36 @@ func TestAzureEnv_GetEnvVars(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "error retrieving configuration root directory") {
 			t.Errorf("Expected error containing 'error retrieving configuration root directory', got %v", err)
+		}
+	})
+
+	t.Run("GlobalModeDefersToAmbientAzureConfig", func(t *testing.T) {
+		// Given an Azure-platform context running in global mode
+		printer, mocks := setup(t)
+		mocks.Shell.IsGlobalFunc = func() bool { return true }
+
+		// When GetEnvVars is called
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars returned an error: %v", err)
+		}
+
+		// Then AZURE_CONFIG_DIR and AZURE_CORE_LOGIN_EXPERIENCE_V2 are NOT emitted —
+		// the az CLI defers to the operator's ambient ~/.azure config. The project-
+		// level identifiers (subscription, tenant, environment) still flow through
+		// because they describe which Azure account the context targets, not whose
+		// credentials are used.
+		if _, ok := envVars["AZURE_CONFIG_DIR"]; ok {
+			t.Errorf("AZURE_CONFIG_DIR should not be set in global mode, got %q", envVars["AZURE_CONFIG_DIR"])
+		}
+		if _, ok := envVars["AZURE_CORE_LOGIN_EXPERIENCE_V2"]; ok {
+			t.Errorf("AZURE_CORE_LOGIN_EXPERIENCE_V2 should not be set in global mode")
+		}
+		if got := envVars["ARM_SUBSCRIPTION_ID"]; got != "test-subscription" {
+			t.Errorf("ARM_SUBSCRIPTION_ID = %q, want %q", got, "test-subscription")
+		}
+		if got := envVars["ARM_TENANT_ID"]; got != "test-tenant" {
+			t.Errorf("ARM_TENANT_ID = %q, want %q", got, "test-tenant")
 		}
 	})
 

--- a/pkg/runtime/env/gcp_env.go
+++ b/pkg/runtime/env/gcp_env.go
@@ -45,36 +45,48 @@ func NewGcpEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler) *Gc
 // =============================================================================
 
 // GetEnvVars retrieves the environment variables for the GCP environment.
+// In global mode (no windsor.yaml in the project tree) windsor defers to the
+// operator's ambient gcloud setup: CLOUDSDK_CONFIG is not emitted, the
+// context-scoped gcloud directory is not created, and GOOGLE_APPLICATION_CREDENTIALS
+// is only emitted when gcp.credentials_path is set explicitly. The project
+// identifiers (GOOGLE_CLOUD_PROJECT, GCLOUD_PROJECT, GOOGLE_CLOUD_QUOTA_PROJECT)
+// are still emitted because they describe which GCP project the context
+// targets, not whose credentials are used.
 func (e *GcpEnvPrinter) GetEnvVars() (map[string]string, error) {
 	envVars := make(map[string]string)
-
-	configRoot, err := e.configHandler.GetConfigRoot()
-	if err != nil {
-		return nil, fmt.Errorf("error retrieving configuration root directory: %w", err)
-	}
-
-	gcpConfigDir := filepath.Join(configRoot, ".gcp")
-	gcloudConfigDir := filepath.Join(gcpConfigDir, "gcloud")
+	global := e.shell.IsGlobal()
 
 	config := e.configHandler.GetConfig()
 	if config != nil && config.GCP != nil {
-		if err := e.shims.MkdirAll(gcloudConfigDir, 0755); err != nil {
-			return nil, fmt.Errorf("error creating GCP config directory: %w", err)
+		if !global {
+			configRoot, err := e.configHandler.GetConfigRoot()
+			if err != nil {
+				return nil, fmt.Errorf("error retrieving configuration root directory: %w", err)
+			}
+			gcpConfigDir := filepath.Join(configRoot, ".gcp")
+			gcloudConfigDir := filepath.Join(gcpConfigDir, "gcloud")
+			if err := e.shims.MkdirAll(gcloudConfigDir, 0755); err != nil {
+				return nil, fmt.Errorf("error creating GCP config directory: %w", err)
+			}
+			envVars["CLOUDSDK_CONFIG"] = filepath.ToSlash(gcloudConfigDir)
+
+			if _, exists := e.shims.LookupEnv("GOOGLE_APPLICATION_CREDENTIALS"); !exists {
+				if config.GCP.CredentialsPath != nil {
+					envVars["GOOGLE_APPLICATION_CREDENTIALS"] = *config.GCP.CredentialsPath
+				} else {
+					serviceAccountPath := filepath.Join(gcpConfigDir, "service-accounts", "default.json")
+					envVars["GOOGLE_APPLICATION_CREDENTIALS"] = filepath.ToSlash(serviceAccountPath)
+				}
+			}
+		} else if config.GCP.CredentialsPath != nil {
+			if _, exists := e.shims.LookupEnv("GOOGLE_APPLICATION_CREDENTIALS"); !exists {
+				envVars["GOOGLE_APPLICATION_CREDENTIALS"] = *config.GCP.CredentialsPath
+			}
 		}
-		envVars["CLOUDSDK_CONFIG"] = filepath.ToSlash(gcloudConfigDir)
 
 		if config.GCP.ProjectID != nil {
 			envVars["GOOGLE_CLOUD_PROJECT"] = *config.GCP.ProjectID
 			envVars["GCLOUD_PROJECT"] = *config.GCP.ProjectID
-		}
-
-		if _, exists := e.shims.LookupEnv("GOOGLE_APPLICATION_CREDENTIALS"); !exists {
-			if config.GCP.CredentialsPath != nil {
-				envVars["GOOGLE_APPLICATION_CREDENTIALS"] = *config.GCP.CredentialsPath
-			} else {
-				serviceAccountPath := filepath.Join(gcpConfigDir, "service-accounts", "default.json")
-				envVars["GOOGLE_APPLICATION_CREDENTIALS"] = filepath.ToSlash(serviceAccountPath)
-			}
 		}
 
 		if config.GCP.QuotaProject != nil {

--- a/pkg/runtime/env/gcp_env_test.go
+++ b/pkg/runtime/env/gcp_env_test.go
@@ -259,6 +259,82 @@ contexts:
 		}
 	})
 
+	t.Run("GlobalModeDefersToAmbientGcloudConfig", func(t *testing.T) {
+		// Given a GCP context running in global mode
+		printer, mocks := setup(t)
+		mocks.Shims.LookupEnv = func(key string) (string, bool) {
+			return "", false
+		}
+		mocks.Shell.IsGlobalFunc = func() bool { return true }
+
+		mkdirCalled := false
+		mocks.Shims.MkdirAll = func(path string, perm os.FileMode) error {
+			mkdirCalled = true
+			return nil
+		}
+
+		// When GetEnvVars is called
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars returned an error: %v", err)
+		}
+
+		// Then CLOUDSDK_CONFIG and GOOGLE_APPLICATION_CREDENTIALS (the defaulted
+		// context-scoped service-account path) are NOT emitted, and no context-
+		// scoped gcloud directory is created. Project identifiers still flow.
+		if mkdirCalled {
+			t.Error("MkdirAll should not be called in global mode (no context-scoped dir to create)")
+		}
+		if _, ok := envVars["CLOUDSDK_CONFIG"]; ok {
+			t.Errorf("CLOUDSDK_CONFIG should not be set in global mode, got %q", envVars["CLOUDSDK_CONFIG"])
+		}
+		if _, ok := envVars["GOOGLE_APPLICATION_CREDENTIALS"]; ok {
+			t.Errorf("GOOGLE_APPLICATION_CREDENTIALS should not be set in global mode without explicit credentials_path, got %q", envVars["GOOGLE_APPLICATION_CREDENTIALS"])
+		}
+		if got := envVars["GOOGLE_CLOUD_PROJECT"]; got != "test-project" {
+			t.Errorf("GOOGLE_CLOUD_PROJECT = %q, want %q", got, "test-project")
+		}
+		if got := envVars["GOOGLE_CLOUD_QUOTA_PROJECT"]; got != "billing-project" {
+			t.Errorf("GOOGLE_CLOUD_QUOTA_PROJECT = %q, want %q", got, "billing-project")
+		}
+	})
+
+	t.Run("GlobalModeHonorsExplicitCredentialsPath", func(t *testing.T) {
+		// Given a GCP context with an explicit credentials_path, running in global mode
+		mocks := setupGcpEnvMocks(t)
+		configStr := `
+version: v1alpha1
+contexts:
+  test-context:
+    gcp:
+      enabled: true
+      project_id: "test-project"
+      credentials_path: "/explicit/sa.json"
+`
+		if err := mocks.ConfigHandler.LoadConfigString(configStr); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+		mocks.Shell.IsGlobalFunc = func() bool { return true }
+		mocks.Shims.LookupEnv = func(key string) (string, bool) { return "", false }
+		printer := NewGcpEnvPrinter(mocks.Shell, mocks.ConfigHandler)
+		printer.shims = mocks.Shims
+
+		// When GetEnvVars is called
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars returned an error: %v", err)
+		}
+
+		// Then GOOGLE_APPLICATION_CREDENTIALS reflects the explicit path — the user
+		// asked for that file specifically, so global mode honors it.
+		if got := envVars["GOOGLE_APPLICATION_CREDENTIALS"]; got != "/explicit/sa.json" {
+			t.Errorf("GOOGLE_APPLICATION_CREDENTIALS = %q, want %q", got, "/explicit/sa.json")
+		}
+		if _, ok := envVars["CLOUDSDK_CONFIG"]; ok {
+			t.Error("CLOUDSDK_CONFIG should still be unset in global mode even with explicit credentials_path")
+		}
+	})
+
 	t.Run("MissingConfiguration", func(t *testing.T) {
 		baseMocks := setupEnvMocks(t)
 		mocks := setupGcpEnvMocks(t, &EnvTestMocks{

--- a/pkg/runtime/tools/tools_manager.go
+++ b/pkg/runtime/tools/tools_manager.go
@@ -489,27 +489,36 @@ func (t *BaseToolsManager) checkAWSAuth() error {
 	return nil
 }
 
-// awsContextEnv returns env vars pointing the AWS CLI/SDK at the context-scoped .aws/ dir
-// and selecting the right profile. Returns (nil, nil) when ambient SDK credentials are
-// present — overriding AWS_PROFILE there would mask the native credential chain.
+// awsContextEnv returns env vars pointing the AWS CLI/SDK at the right profile (and in
+// project mode, the context-scoped .aws/ dir). Returns (nil, nil) when ambient SDK
+// credentials are present — overriding AWS_PROFILE there would mask the native credential
+// chain. In global mode AWS_CONFIG_FILE / AWS_SHARED_CREDENTIALS_FILE are not emitted so
+// the SDK resolves against the operator's ambient ~/.aws/, but AWS_PROFILE is still
+// emitted (from aws.profile if set, otherwise the context name) so sts checks the profile
+// the operator actually meant — without it sts would fall through to [default] and fail
+// even though the right profile is logged in.
 func (t *BaseToolsManager) awsContextEnv() (map[string]string, error) {
 	if hasAmbientAWSCredentials() {
 		return nil, nil
 	}
-	configRoot, err := t.configHandler.GetConfigRoot()
-	if err != nil {
-		return nil, err
-	}
-	awsConfigDir := filepath.Join(configRoot, ".aws")
-	env := map[string]string{
-		"AWS_CONFIG_FILE":             filepath.ToSlash(filepath.Join(awsConfigDir, "config")),
-		"AWS_SHARED_CREDENTIALS_FILE": filepath.ToSlash(filepath.Join(awsConfigDir, "credentials")),
+	env := map[string]string{}
+	if !t.shell.IsGlobal() {
+		configRoot, err := t.configHandler.GetConfigRoot()
+		if err != nil {
+			return nil, err
+		}
+		awsConfigDir := filepath.Join(configRoot, ".aws")
+		env["AWS_CONFIG_FILE"] = filepath.ToSlash(filepath.Join(awsConfigDir, "config"))
+		env["AWS_SHARED_CREDENTIALS_FILE"] = filepath.ToSlash(filepath.Join(awsConfigDir, "credentials"))
 	}
 	cfg := t.configHandler.GetConfig()
 	if cfg != nil && cfg.AWS != nil && cfg.AWS.AWSProfile != nil && *cfg.AWS.AWSProfile != "" {
 		env["AWS_PROFILE"] = *cfg.AWS.AWSProfile
 	} else if ctx := t.configHandler.GetContext(); ctx != "" {
 		env["AWS_PROFILE"] = ctx
+	}
+	if len(env) == 0 {
+		return nil, nil
 	}
 	return env, nil
 }
@@ -556,9 +565,12 @@ func (t *BaseToolsManager) checkAWSBinary() error {
 }
 
 // awsAuthHint returns an actionable next-step message tailored to the context's AWS config
-// state (expired SSO, rejected keys, or no profile yet). When the process env doesn't already
-// point at the context's .aws/, the suggested command is prefixed with that env so credentials
-// land in the right place. The first-time-setup branch surfaces both SSO and access-key paths
+// state (expired SSO, rejected keys, or no profile yet). In project mode windsor scopes
+// AWS config to the context's .aws/, so when the process env doesn't already point there
+// the suggested command is prefixed with that env so credentials land in the right place.
+// In global mode windsor defers to the operator's ambient ~/.aws/ (or AWS_CONFIG_FILE
+// override), so no env prefix is suggested and profile-state detection reads from the
+// ambient config. The first-time-setup branch surfaces both SSO and access-key paths
 // because we can't tell which kind of operator reached it.
 func (t *BaseToolsManager) awsAuthHint() string {
 	ctx := t.configHandler.GetContext()
@@ -566,6 +578,17 @@ func (t *BaseToolsManager) awsAuthHint() string {
 	cfg := t.configHandler.GetConfig()
 	if cfg != nil && cfg.AWS != nil && cfg.AWS.AWSProfile != nil && *cfg.AWS.AWSProfile != "" {
 		profile = *cfg.AWS.AWSProfile
+	}
+	if t.shell.IsGlobal() {
+		state := detectAWSProfileState(ambientAWSConfigPath(), profile)
+		switch state {
+		case awsProfileSSO:
+			return fmt.Sprintf("AWS SSO session for %q has likely expired. Run:\n  aws sso login --profile %s", profile, profile)
+		case awsProfileKeys:
+			return fmt.Sprintf("AWS access keys for %q were rejected by STS. Verify or rotate with:\n  aws configure --profile %s", profile, profile)
+		default:
+			return fmt.Sprintf("No AWS credentials configured for profile %q yet. Run one of:\n  aws configure sso --profile %s   (SSO)\n  aws configure --profile %s       (access keys)", profile, profile, profile)
+		}
 	}
 	configRoot, err := t.configHandler.GetConfigRoot()
 	if err != nil || configRoot == "" {
@@ -586,6 +609,23 @@ func (t *BaseToolsManager) awsAuthHint() string {
 	default:
 		return fmt.Sprintf("No AWS credentials configured for context %q yet. Run one of:\n  %saws configure sso --profile %s   (SSO)\n  %saws configure --profile %s       (access keys)", ctx, prefix, profile, prefix, profile)
 	}
+}
+
+// ambientAWSConfigPath returns the path the AWS CLI would read for profile config when
+// no windsor-scoped overrides are in play: AWS_CONFIG_FILE if set, otherwise
+// $HOME/.aws/config. Used by the global-mode auth hint to inspect the user's existing
+// profile state. Returns "" if the home directory cannot be resolved and AWS_CONFIG_FILE
+// is unset, in which case profile-state detection falls through to the first-time-setup
+// branch — the right outcome when we genuinely can't tell what's there.
+func ambientAWSConfigPath() string {
+	if cf := os.Getenv("AWS_CONFIG_FILE"); cf != "" {
+		return cf
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".aws", "config")
 }
 
 // awsEnvPointsAtContext reports whether AWS_CONFIG_FILE and AWS_SHARED_CREDENTIALS_FILE both

--- a/pkg/runtime/tools/tools_manager_test.go
+++ b/pkg/runtime/tools/tools_manager_test.go
@@ -2398,6 +2398,77 @@ contexts:
 	})
 }
 
+func Test_awsContextEnv(t *testing.T) {
+	clearAmbientAWS := func(t *testing.T) {
+		t.Helper()
+		t.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "")
+		t.Setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "")
+		t.Setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", "")
+		t.Setenv("AWS_ACCESS_KEY_ID", "")
+		t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+	}
+
+	t.Run("GlobalModeWithoutContextOrProfileReturnsNil", func(t *testing.T) {
+		// Given a tools manager in global mode with no aws.profile override AND no context
+		// name. This degenerate state is only reachable through a configHandler that
+		// returns "" from GetContext — the production handler always falls back to "local",
+		// so this path cannot be hit in production. The test pins the contract: when there
+		// is nothing to override, return (nil, nil) so the caller passes no env to STS
+		// and STS resolves against the ambient environment, the same effective behavior
+		// as when ambient SDK credentials are detected at the top of awsContextEnv.
+		clearAmbientAWS(t)
+		mockConfig := &config.MockConfigHandler{
+			GetContextFunc: func() string { return "" },
+		}
+		mockShell := sh.NewMockShell()
+		mockShell.IsGlobalFunc = func() bool { return true }
+		toolsManager := NewToolsManager(mockConfig, mockShell)
+
+		// When awsContextEnv is invoked
+		env, err := toolsManager.awsContextEnv()
+
+		// Then (nil, nil) is returned — STS gets no override
+		if err != nil {
+			t.Fatalf("awsContextEnv returned error: %v", err)
+		}
+		if env != nil {
+			t.Errorf("expected nil env when no profile and no context in global mode, got %v", env)
+		}
+	})
+
+	t.Run("GlobalModeFallsBackToContextNameWhenNoProfile", func(t *testing.T) {
+		// Given a tools manager in global mode with no aws.profile override but a non-empty
+		// context name — the production-reachable path, since configHandler.GetContext()
+		// falls back to "local" even when nothing else is set. This pins that the (nil, nil)
+		// degenerate branch is unreachable when GetContext() honors its "local" fallback,
+		// so AWS_PROFILE is always populated and STS does not silently drop to [default].
+		clearAmbientAWS(t)
+		mockConfig := &config.MockConfigHandler{
+			GetContextFunc: func() string { return "local" },
+		}
+		mockShell := sh.NewMockShell()
+		mockShell.IsGlobalFunc = func() bool { return true }
+		toolsManager := NewToolsManager(mockConfig, mockShell)
+
+		// When awsContextEnv is invoked
+		env, err := toolsManager.awsContextEnv()
+
+		// Then AWS_PROFILE is set from the context name and config-file paths are omitted
+		if err != nil {
+			t.Fatalf("awsContextEnv returned error: %v", err)
+		}
+		if got := env["AWS_PROFILE"]; got != "local" {
+			t.Errorf("AWS_PROFILE = %q, want %q", got, "local")
+		}
+		if _, ok := env["AWS_CONFIG_FILE"]; ok {
+			t.Errorf("AWS_CONFIG_FILE should not be set in global mode, got %q", env["AWS_CONFIG_FILE"])
+		}
+		if _, ok := env["AWS_SHARED_CREDENTIALS_FILE"]; ok {
+			t.Errorf("AWS_SHARED_CREDENTIALS_FILE should not be set in global mode, got %q", env["AWS_SHARED_CREDENTIALS_FILE"])
+		}
+	})
+}
+
 func Test_awsAuthHint(t *testing.T) {
 	t.Run("GlobalModeOmitsEnvPrefixAndReadsAmbientConfig", func(t *testing.T) {
 		// Given a toolsManager in global mode with an SSO profile in the ambient

--- a/pkg/runtime/tools/tools_manager_test.go
+++ b/pkg/runtime/tools/tools_manager_test.go
@@ -2290,6 +2290,81 @@ contexts:
 		}
 	})
 
+	t.Run("GlobalModeDefersStsToAmbientAWSConfigButKeepsProfile", func(t *testing.T) {
+		// Given platform: aws and the shell reports global mode (no windsor.yaml in
+		// the project tree — operator is invoking windsor outside of a project)
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: aws
+`)
+		mocks.Shell.IsGlobalFunc = func() bool { return true }
+		awsBinaryMock(t)
+		var capturedEnv map[string]string
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			return fmt.Sprintf("aws-cli/%s Python/3.11.8 Linux", constants.MinimumVersionAWS), nil
+		}
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			capturedEnv = env
+			return `{"Arn":"arn:aws:iam::123456789012:user/x"}`, nil
+		}
+		// When CheckAuth runs
+		if err := toolsManager.CheckAuth(); err != nil {
+			t.Fatalf("Expected CheckAuth to succeed, got %v", err)
+		}
+		// Then AWS_CONFIG_FILE / AWS_SHARED_CREDENTIALS_FILE are NOT injected (the
+		// SDK resolves from the operator's ambient ~/.aws/), but AWS_PROFILE IS
+		// injected from the context name so sts checks the profile the context
+		// targets — without it sts would fall through to [default] and fail even
+		// when the right profile is logged in.
+		if _, ok := capturedEnv["AWS_CONFIG_FILE"]; ok {
+			t.Errorf("AWS_CONFIG_FILE should not be set in global mode, got %q", capturedEnv["AWS_CONFIG_FILE"])
+		}
+		if _, ok := capturedEnv["AWS_SHARED_CREDENTIALS_FILE"]; ok {
+			t.Errorf("AWS_SHARED_CREDENTIALS_FILE should not be set in global mode, got %q", capturedEnv["AWS_SHARED_CREDENTIALS_FILE"])
+		}
+		if capturedEnv["AWS_PROFILE"] != "test" {
+			t.Errorf("AWS_PROFILE = %q, want %q (context name fallback)", capturedEnv["AWS_PROFILE"], "test")
+		}
+	})
+
+	t.Run("GlobalModeWithExplicitProfileStillInjectsAWSProfile", func(t *testing.T) {
+		// Given platform: aws, global mode, and an explicit aws.profile override
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: aws
+    aws:
+      profile: company-prod
+`)
+		mocks.Shell.IsGlobalFunc = func() bool { return true }
+		awsBinaryMock(t)
+		var capturedEnv map[string]string
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			return fmt.Sprintf("aws-cli/%s Python/3.11.8 Linux", constants.MinimumVersionAWS), nil
+		}
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			capturedEnv = env
+			return `{"Arn":"arn:aws:iam::123456789012:user/x"}`, nil
+		}
+		// When CheckAuth runs
+		if err := toolsManager.CheckAuth(); err != nil {
+			t.Fatalf("Expected CheckAuth to succeed, got %v", err)
+		}
+		// Then AWS_PROFILE is set (the operator explicitly asked for that profile,
+		// even in global mode) but config-file paths are NOT — sts resolves the
+		// profile against the ambient ~/.aws/config.
+		if capturedEnv["AWS_PROFILE"] != "company-prod" {
+			t.Errorf("AWS_PROFILE = %q, want %q", capturedEnv["AWS_PROFILE"], "company-prod")
+		}
+		if _, ok := capturedEnv["AWS_CONFIG_FILE"]; ok {
+			t.Errorf("AWS_CONFIG_FILE should not be set in global mode, got %q", capturedEnv["AWS_CONFIG_FILE"])
+		}
+		if _, ok := capturedEnv["AWS_SHARED_CREDENTIALS_FILE"]; ok {
+			t.Errorf("AWS_SHARED_CREDENTIALS_FILE should not be set in global mode, got %q", capturedEnv["AWS_SHARED_CREDENTIALS_FILE"])
+		}
+	})
+
 	t.Run("AWSConfigBlockTriggersAuthCheck", func(t *testing.T) {
 		// Given the context has an aws block (no platform set) and creds are invalid
 		mocks, toolsManager := setup(t, `
@@ -2324,6 +2399,34 @@ contexts:
 }
 
 func Test_awsAuthHint(t *testing.T) {
+	t.Run("GlobalModeOmitsEnvPrefixAndReadsAmbientConfig", func(t *testing.T) {
+		// Given a toolsManager in global mode with an SSO profile in the ambient
+		// ~/.aws/config (which detectAWSProfileState reads via osReadFile)
+		mocks := setupMocks(t)
+		mocks.Shell.IsGlobalFunc = func() bool { return true }
+		originalReadFile := osReadFile
+		osReadFile = func(name string) ([]byte, error) {
+			return []byte(`
+[profile test]
+sso_session = company
+sso_account_id = 123456789012
+`), nil
+		}
+		t.Cleanup(func() { osReadFile = originalReadFile })
+		toolsManager := NewToolsManager(mocks.ConfigHandler, mocks.Shell)
+		// When awsAuthHint runs
+		hint := toolsManager.awsAuthHint()
+		// Then the hint suggests `aws sso login` against the operator's existing config
+		// (no AWS_CONFIG_FILE prefix), because in global mode windsor is deferring to
+		// the ambient ~/.aws/ rather than scoping config to a context directory.
+		if !strings.Contains(hint, "aws sso login --profile test") {
+			t.Errorf("Expected ambient SSO login hint in global mode, got: %q", hint)
+		}
+		if strings.Contains(hint, "AWS_CONFIG_FILE=") {
+			t.Errorf("Expected no AWS_CONFIG_FILE prefix in global mode, got: %q", hint)
+		}
+	})
+
 	t.Run("ConfigRootFailureOffersBothSSOAndAccessKeys", func(t *testing.T) {
 		// Given a toolsManager whose configHandler cannot resolve configRoot — the hint's
 		// defensive fallback branch. This is reached when CheckAuth ran through awsContextEnv


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> The change touches three cloud-provider env printers and the AWS tools manager, but the logic is additive — global mode is a new code path with no impact on existing project-mode behavior.
>
> **Overview**
>
> This PR introduces global-mode awareness to the AWS, Azure, and GCP environment printers and to the AWS STS auth check. When windsor is invoked outside a project tree (`shell.IsGlobal() == true`), it stops injecting config-dir-scoped file paths (`AWS_CONFIG_FILE`, `AWS_SHARED_CREDENTIALS_FILE`, `AZURE_CONFIG_DIR`, `CLOUDSDK_CONFIG`) and defers to the operator's ambient toolchain config instead. `AWS_PROFILE` is still injected so the SDK checks the intended profile rather than falling through to `[default]`.
>
> The follow-up commit adds unit tests for the two boundary cases in `awsContextEnv`: the degenerate path where neither a profile nor a context name is configured (returns `nil, nil`, effectively treating the call as ambient-credential), and the production-reachable path where `GetContext()` falls back to `"local"` (injects `AWS_PROFILE` and omits the config-file paths). All prior open review threads are resolved.
>
> Reviewed by Claude for commit `e02bb2f`.

<!-- /claude-code-review:summary -->
