### PR TITLE
feat(api): Add namespace and targetNamespace support to Kustomization

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -946,8 +946,10 @@ func (k *Kustomization) ToFluxKustomization(namespace string, defaultSourceName 
 	}
 
 	objectNamespace := namespace
-	if k.Namespace != "" {
+	sourceRefNamespace := ""
+	if k.Namespace != "" && k.Namespace != namespace {
 		objectNamespace = k.Namespace
+		sourceRefNamespace = namespace
 	}
 
 	sourceName := k.Source
@@ -1071,8 +1073,9 @@ func (k *Kustomization) ToFluxKustomization(namespace string, defaultSourceName 
 		},
 		Spec: kustomizev1.KustomizationSpec{
 			SourceRef: kustomizev1.CrossNamespaceSourceReference{
-				Kind: sourceKind,
-				Name: sourceName,
+				Kind:      sourceKind,
+				Name:      sourceName,
+				Namespace: sourceRefNamespace,
 			},
 			Path:            path,
 			DependsOn:       dependsOn,

--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -512,6 +512,15 @@ type Kustomization struct {
 	// Source of the kustomization.
 	Source string `yaml:"source,omitempty"`
 
+	// Namespace overrides the namespace where the Flux Kustomization object itself lives.
+	// When unset, the gitops namespace is used. DependsOn references always resolve in the
+	// gitops namespace, so cross-namespace dependencies are not currently supported.
+	Namespace string `yaml:"namespace,omitempty"`
+
+	// TargetNamespace populates spec.targetNamespace, instructing Flux to override the
+	// namespace of every resource reconciled by this kustomization.
+	TargetNamespace string `yaml:"targetNamespace,omitempty"`
+
 	// DependsOn lists dependencies of this kustomization.
 	DependsOn []string `yaml:"dependsOn,omitempty"`
 
@@ -892,28 +901,34 @@ func (k *Kustomization) DeepCopy() *Kustomization {
 	}
 
 	return &Kustomization{
-		Name:                k.Name,
-		Path:                k.Path,
-		Source:              k.Source,
-		DependsOn:           slices.Clone(k.DependsOn),
-		Interval:            k.Interval,
-		RetryInterval:       k.RetryInterval,
-		Timeout:             k.Timeout,
-		Patches:             slices.Clone(k.Patches),
-		Wait:                k.Wait,
-		Force:               k.Force,
-		Prune:               k.Prune,
-		Components:          slices.Clone(k.Components),
-		Destroy:             destroyCopy,
-		DestroyOnly:         k.DestroyOnly,
-		Enabled:             enabledCopy,
-		Substitutions:       maps.Clone(k.Substitutions),
+		Name:            k.Name,
+		Path:            k.Path,
+		Source:          k.Source,
+		Namespace:       k.Namespace,
+		TargetNamespace: k.TargetNamespace,
+		DependsOn:       slices.Clone(k.DependsOn),
+		Interval:        k.Interval,
+		RetryInterval:   k.RetryInterval,
+		Timeout:         k.Timeout,
+		Patches:         slices.Clone(k.Patches),
+		Wait:            k.Wait,
+		Force:           k.Force,
+		Prune:           k.Prune,
+		Components:      slices.Clone(k.Components),
+		Destroy:         destroyCopy,
+		DestroyOnly:     k.DestroyOnly,
+		Enabled:         enabledCopy,
+		Substitutions:   maps.Clone(k.Substitutions),
 	}
 }
 
 // ToFluxKustomization converts a blueprint Kustomization to a Flux Kustomization.
-// It takes the namespace for the kustomization, the default source name to use if no source is specified,
+// It takes the default namespace for the kustomization (overridden per-kustomization
+// by k.Namespace when set), the default source name to use if no source is specified,
 // and the list of sources to determine the source kind (GitRepository or OCIRepository).
+// k.TargetNamespace is passed through to spec.targetNamespace so Flux rewrites the
+// namespace of every reconciled resource. DependsOn references are always resolved
+// in the default namespace.
 // The mode parameter selects the default Interval: pull mode uses the short
 // poll-friendly default; push mode uses a long fallback interval on the
 // assumption that Windsor triggers reconciliation via annotation. Blueprint-
@@ -928,6 +943,11 @@ func (k *Kustomization) ToFluxKustomization(namespace string, defaultSourceName 
 			Name:      dep,
 			Namespace: namespace,
 		}
+	}
+
+	objectNamespace := namespace
+	if k.Namespace != "" {
+		objectNamespace = k.Namespace
 	}
 
 	sourceName := k.Source
@@ -1047,25 +1067,26 @@ func (k *Kustomization) ToFluxKustomization(namespace string, defaultSourceName 
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      k.Name,
-			Namespace: namespace,
+			Namespace: objectNamespace,
 		},
 		Spec: kustomizev1.KustomizationSpec{
 			SourceRef: kustomizev1.CrossNamespaceSourceReference{
 				Kind: sourceKind,
 				Name: sourceName,
 			},
-			Path:           path,
-			DependsOn:      dependsOn,
-			Interval:       interval,
-			RetryInterval:  &retryInterval,
-			Timeout:        &timeout,
-			Wait:           wait,
-			Force:          force,
-			Prune:          prune,
-			DeletionPolicy: deletionPolicy,
-			Patches:        patches,
-			Components:     k.Components,
-			PostBuild:      postBuild,
+			Path:            path,
+			DependsOn:       dependsOn,
+			Interval:        interval,
+			RetryInterval:   &retryInterval,
+			Timeout:         &timeout,
+			Wait:            wait,
+			Force:           force,
+			Prune:           prune,
+			DeletionPolicy:  deletionPolicy,
+			Patches:         patches,
+			Components:      k.Components,
+			PostBuild:       postBuild,
+			TargetNamespace: k.TargetNamespace,
 		},
 	}
 }
@@ -1189,6 +1210,12 @@ func (b *Blueprint) strategicMergeKustomization(kustomization Kustomization) err
 			}
 			if kustomization.Source != "" {
 				existing.Source = kustomization.Source
+			}
+			if kustomization.Namespace != "" {
+				existing.Namespace = kustomization.Namespace
+			}
+			if kustomization.TargetNamespace != "" {
+				existing.TargetNamespace = kustomization.TargetNamespace
 			}
 			if kustomization.Destroy != nil {
 				existing.Destroy = kustomization.Destroy

--- a/api/v1alpha1/blueprint_types_test.go
+++ b/api/v1alpha1/blueprint_types_test.go
@@ -2587,6 +2587,68 @@ func TestKustomization_ToFluxKustomization(t *testing.T) {
 		}
 	})
 
+	t.Run("NamespaceFieldOverridesDefault", func(t *testing.T) {
+		// Given a kustomization that pins its own namespace
+		kustomization := &Kustomization{
+			Name:      "test-kustomization",
+			Path:      "test/path",
+			Namespace: "custom-ns",
+		}
+
+		// When converted with a different default namespace
+		result := kustomization.ToFluxKustomization("default-ns", "default-source", []Source{}, constants.GitopsModePull)
+
+		// Then the rendered Kustomization lives in the per-kustomization namespace
+		if result.Namespace != "custom-ns" {
+			t.Errorf("Expected metadata.namespace 'custom-ns', got '%s'", result.Namespace)
+		}
+		// And spec.targetNamespace stays empty when not configured
+		if result.Spec.TargetNamespace != "" {
+			t.Errorf("Expected empty spec.targetNamespace, got '%s'", result.Spec.TargetNamespace)
+		}
+	})
+
+	t.Run("DependsOnReferencesUseDefaultNamespaceEvenWhenNamespaceOverridden", func(t *testing.T) {
+		// Given a kustomization that overrides its own namespace and has dependencies
+		kustomization := &Kustomization{
+			Name:      "test-kustomization",
+			Path:      "test/path",
+			Namespace: "custom-ns",
+			DependsOn: []string{"dep1"},
+		}
+
+		// When converted
+		result := kustomization.ToFluxKustomization("default-ns", "default-source", []Source{}, constants.GitopsModePull)
+
+		// Then DependsOn references resolve in the default namespace, not the override.
+		// Cross-namespace dependencies are not currently supported and would require a
+		// richer DependsOn schema; this guards against accidentally changing that contract.
+		if len(result.Spec.DependsOn) != 1 || result.Spec.DependsOn[0].Namespace != "default-ns" {
+			t.Errorf("Expected DependsOn[0] in default-ns, got %+v", result.Spec.DependsOn)
+		}
+	})
+
+	t.Run("TargetNamespacePopulatesSpec", func(t *testing.T) {
+		// Given a kustomization that asks Flux to rewrite reconciled resource namespaces
+		kustomization := &Kustomization{
+			Name:            "test-kustomization",
+			Path:            "test/path",
+			TargetNamespace: "workload-ns",
+		}
+
+		// When converted
+		result := kustomization.ToFluxKustomization("default-ns", "default-source", []Source{}, constants.GitopsModePull)
+
+		// Then spec.targetNamespace carries through to the Flux Kustomization
+		if result.Spec.TargetNamespace != "workload-ns" {
+			t.Errorf("Expected spec.targetNamespace 'workload-ns', got '%s'", result.Spec.TargetNamespace)
+		}
+		// And the Kustomization object itself stays in the default namespace
+		if result.Namespace != "default-ns" {
+			t.Errorf("Expected metadata.namespace 'default-ns', got '%s'", result.Namespace)
+		}
+	})
+
 	t.Run("PushModeUsesLongDefaultInterval", func(t *testing.T) {
 		// Given a kustomization with no explicit Interval (leans on the default)
 		kustomization := &Kustomization{Name: "k", Path: "p"}
@@ -2883,13 +2945,15 @@ func TestKustomization_DeepCopy(t *testing.T) {
 		destroyOnly := true
 
 		kustomization := &Kustomization{
-			Name:          "test-kustomization",
-			Path:          "test/path",
-			Source:        "test-source",
-			DependsOn:     []string{"dep1", "dep2"},
-			Interval:      &interval,
-			RetryInterval: &retryInterval,
-			Timeout:       &timeout,
+			Name:            "test-kustomization",
+			Path:            "test/path",
+			Source:          "test-source",
+			Namespace:       "custom-ns",
+			TargetNamespace: "workload-ns",
+			DependsOn:       []string{"dep1", "dep2"},
+			Interval:        &interval,
+			RetryInterval:   &retryInterval,
+			Timeout:         &timeout,
 			Patches: []BlueprintPatch{
 				{
 					Patch: "test-patch",
@@ -2918,6 +2982,12 @@ func TestKustomization_DeepCopy(t *testing.T) {
 		}
 		if copy.Source != "test-source" {
 			t.Errorf("Expected source 'test-source', got '%s'", copy.Source)
+		}
+		if copy.Namespace != "custom-ns" {
+			t.Errorf("Expected namespace 'custom-ns', got '%s'", copy.Namespace)
+		}
+		if copy.TargetNamespace != "workload-ns" {
+			t.Errorf("Expected targetNamespace 'workload-ns', got '%s'", copy.TargetNamespace)
 		}
 		if len(copy.DependsOn) != 2 {
 			t.Errorf("Expected 2 dependencies, got %d", len(copy.DependsOn))
@@ -4062,4 +4132,3 @@ func TestDeepMergeMaps_EmptyOverlayDoesNotOverwritePopulated(t *testing.T) {
 		}
 	})
 }
-

--- a/api/v1alpha1/blueprint_types_test.go
+++ b/api/v1alpha1/blueprint_types_test.go
@@ -2606,6 +2606,30 @@ func TestKustomization_ToFluxKustomization(t *testing.T) {
 		if result.Spec.TargetNamespace != "" {
 			t.Errorf("Expected empty spec.targetNamespace, got '%s'", result.Spec.TargetNamespace)
 		}
+		// And spec.sourceRef.namespace is pinned to the gitops namespace so Flux
+		// resolves the source where it actually lives, not in the override namespace
+		// (an empty SourceRef.Namespace would default to the Kustomization's own
+		// namespace and produce a source-not-found reconcile error).
+		if result.Spec.SourceRef.Namespace != "default-ns" {
+			t.Errorf("Expected spec.sourceRef.namespace 'default-ns', got '%s'", result.Spec.SourceRef.Namespace)
+		}
+	})
+
+	t.Run("SourceRefNamespaceStaysEmptyWhenNamespaceNotOverridden", func(t *testing.T) {
+		// Given a kustomization that does not override its namespace
+		kustomization := &Kustomization{
+			Name: "test-kustomization",
+			Path: "test/path",
+		}
+
+		// When converted
+		result := kustomization.ToFluxKustomization("default-ns", "default-source", []Source{}, constants.GitopsModePull)
+
+		// Then SourceRef.Namespace is left empty so Flux defaults it to the
+		// Kustomization's own namespace, preserving prior serialized output.
+		if result.Spec.SourceRef.Namespace != "" {
+			t.Errorf("Expected empty spec.sourceRef.namespace, got '%s'", result.Spec.SourceRef.Namespace)
+		}
 	})
 
 	t.Run("DependsOnReferencesUseDefaultNamespaceEvenWhenNamespaceOverridden", func(t *testing.T) {


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Additive API fields on an internal struct with no existing callers using the new paths; the previous reconciliation bug is resolved.
>
> **Overview**
>
> The PR adds `namespace` and `targetNamespace` to `Kustomization`. `namespace` moves the generated Flux Kustomization object to a non-default namespace, while `targetNamespace` passes through to `spec.targetNamespace` so Flux rewrites the namespace of every reconciled resource. Both fields propagate correctly through `DeepCopy` and `strategicMergeKustomization`.
>
> The initial version of `ToFluxKustomization` left `CrossNamespaceSourceReference.Namespace` empty when `k.Namespace` overrode the object namespace, which would have caused Flux to look for the source in the wrong namespace. Commit `ef1023f5` introduces `sourceRefNamespace` and sets it to the original gitops namespace when an override is active, with a dedicated test asserting the contract. `DependsOn` references intentionally continue to resolve in the default namespace.
>
> Reviewed by Claude for commit `ef1023f5`.

<!-- /claude-code-review:summary -->
