### PR TITLE
feat(facets): Add requires blocks

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -226,6 +226,7 @@ jobs:
           STICKY_MARKER: "<!-- claude-code-review:summary -->"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          allowed_bots: github-actions
           prompt: |
             Run the `review-pr` skill against this pull request and publish
             findings as a GitHub pull request review with **inline, line-anchored

--- a/api/v1alpha1/facet_types.go
+++ b/api/v1alpha1/facet_types.go
@@ -5,6 +5,7 @@ package v1alpha1
 import (
 	"fmt"
 	"maps"
+	"slices"
 )
 
 // =============================================================================
@@ -30,6 +31,22 @@ type ConfigBlock struct {
 	Ordinal *int `yaml:"ordinal,omitempty"`
 	// Body holds the canonical content as map[string]any{"value": <content>} for merge and evaluation. Not YAML-marshaled directly.
 	Body map[string]any `yaml:"-"`
+}
+
+// RequirementBlock declares a set of scope paths that must resolve to present,
+// non-empty values for the parent facet's activation to be well-formed. When is
+// optional and gates the block; if empty, the paths are required whenever the
+// parent facet is active. Message is optional context surfaced in the
+// aggregated error alongside the missing paths.
+type RequirementBlock struct {
+	// When is an expression gating this block. Empty means always required while the parent facet is active.
+	When string `yaml:"when,omitempty"`
+
+	// Paths are dotted scope keys whose values must be present and non-empty.
+	Paths []string `yaml:"paths"`
+
+	// Message is optional author-supplied context surfaced under this block's heading in the aggregated error.
+	Message string `yaml:"message,omitempty"`
 }
 
 // Facet represents a conditional blueprint fragment that can be merged into a base blueprint.
@@ -61,6 +78,11 @@ type Facet struct {
 	// Config is a list of named configuration blocks evaluated in blueprint context and exposed at scope root.
 	// Terraform inputs and kustomize substitutions reference <name>.<key> (e.g. talos.controlplanes), like context (cluster.*, network.*).
 	Config []ConfigBlock `yaml:"config,omitempty"`
+
+	// Requires lists input requirement blocks. When the facet is active and a block's optional When holds,
+	// every path must resolve to a present, non-empty value in the merged scope. Unsatisfied paths across
+	// every active facet are aggregated into a single user-facing error.
+	Requires []RequirementBlock `yaml:"requires,omitempty"`
 
 	// TerraformComponents are Terraform modules in the facet.
 	TerraformComponents []ConditionalTerraformComponent `yaml:"terraform,omitempty"`
@@ -178,6 +200,18 @@ func (c *ConfigBlock) MarshalYAML() (any, error) {
 	return out, nil
 }
 
+// DeepCopy creates a deep copy of the RequirementBlock object.
+func (r *RequirementBlock) DeepCopy() *RequirementBlock {
+	if r == nil {
+		return nil
+	}
+	return &RequirementBlock{
+		When:    r.When,
+		Paths:   slices.Clone(r.Paths),
+		Message: r.Message,
+	}
+}
+
 // DeepCopy creates a deep copy of the ConfigBlock object.
 func (c *ConfigBlock) DeepCopy() *ConfigBlock {
 	if c == nil {
@@ -217,6 +251,11 @@ func (f *Facet) DeepCopy() *Facet {
 		configCopy[i] = *block.DeepCopy()
 	}
 
+	requiresCopy := make([]RequirementBlock, len(f.Requires))
+	for i, block := range f.Requires {
+		requiresCopy[i] = *block.DeepCopy()
+	}
+
 	var ordinalCopy *int
 	if f.Ordinal != nil {
 		o := *f.Ordinal
@@ -231,6 +270,7 @@ func (f *Facet) DeepCopy() *Facet {
 		Ordinal:             ordinalCopy,
 		When:                f.When,
 		Config:              configCopy,
+		Requires:            requiresCopy,
 		TerraformComponents: terraformComponentsCopy,
 		Kustomizations:      kustomizationsCopy,
 		Substitutions:       maps.Clone(f.Substitutions),

--- a/api/v1alpha1/facet_types.go
+++ b/api/v1alpha1/facet_types.go
@@ -232,6 +232,22 @@ func (c *ConfigBlock) MarshalYAML() (any, error) {
 	return out, nil
 }
 
+// UnmarshalYAML enforces that paths is present and non-empty. A block with no paths would silently
+// disable requirement checking and defeat the feature's purpose, so the most likely cause (a typo
+// like `pahts:`) is surfaced as a parse-time error instead of a downstream surprise.
+func (r *RequirementBlock) UnmarshalYAML(unmarshal func(any) error) error {
+	type rawRequirementBlock RequirementBlock
+	var raw rawRequirementBlock
+	if err := unmarshal(&raw); err != nil {
+		return err
+	}
+	if len(raw.Paths) == 0 {
+		return fmt.Errorf("requirement block: paths is required and must contain at least one entry")
+	}
+	*r = RequirementBlock(raw)
+	return nil
+}
+
 // DeepCopy creates a deep copy of the RequirementBlock object.
 func (r *RequirementBlock) DeepCopy() *RequirementBlock {
 	if r == nil {

--- a/api/v1alpha1/facet_types.go
+++ b/api/v1alpha1/facet_types.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"maps"
 	"slices"
+
+	"github.com/goccy/go-yaml"
 )
 
 // =============================================================================
@@ -29,6 +31,11 @@ type ConfigBlock struct {
 	// Ordinal overrides the facet ordinal for this block's merge precedence. When nil, the facet's ordinal is used.
 	// Higher ordinal means higher precedence when merging (wins on conflict).
 	Ordinal *int `yaml:"ordinal,omitempty"`
+	// Requires lists requirement blocks scoped to this config block. When the parent facet is active and this
+	// block's optional When holds, every block in Requires is evaluated under the AND of facet.When,
+	// block.When, and each Requires entry's own When. Missing paths are aggregated alongside facet- and
+	// component-level misses in the user-facing error.
+	Requires []RequirementBlock `yaml:"requires,omitempty"`
 	// Body holds the canonical content as map[string]any{"value": <content>} for merge and evaluation. Not YAML-marshaled directly.
 	Body map[string]any `yaml:"-"`
 }
@@ -118,6 +125,11 @@ type ConditionalTerraformComponent struct {
 	// Ordinal overrides the facet ordinal for this component's merge precedence. When nil, the facet's ordinal is used.
 	// Higher ordinal means higher precedence when merging (processed later, wins on conflict).
 	Ordinal *int `yaml:"ordinal,omitempty"`
+
+	// Requires lists requirement blocks scoped to this terraform component. Evaluated only when the
+	// parent facet is active and this component's When holds; missing paths are aggregated under the
+	// effective condition (facet.When && component.When && block.When).
+	Requires []RequirementBlock `yaml:"requires,omitempty"`
 }
 
 // ConditionalKustomization extends Kustomization with conditional logic support.
@@ -139,6 +151,11 @@ type ConditionalKustomization struct {
 	// Ordinal overrides the facet ordinal for this kustomization's merge precedence. When nil, the facet's ordinal is used.
 	// Higher ordinal means higher precedence when merging (processed later, wins on conflict).
 	Ordinal *int `yaml:"ordinal,omitempty"`
+
+	// Requires lists requirement blocks scoped to this kustomization. Evaluated only when the parent
+	// facet is active and this kustomization's When holds; missing paths are aggregated under the
+	// effective condition (facet.When && kustomization.When && block.When).
+	Requires []RequirementBlock `yaml:"requires,omitempty"`
 }
 
 // =============================================================================
@@ -173,6 +190,15 @@ func (c *ConfigBlock) UnmarshalYAML(unmarshal func(any) error) error {
 			c.Ordinal = &i
 		}
 	}
+	if r, ok := raw["requires"]; ok && r != nil {
+		b, err := yaml.Marshal(r)
+		if err != nil {
+			return fmt.Errorf("config block %q: marshal requires: %w", c.Name, err)
+		}
+		if err := yaml.Unmarshal(b, &c.Requires); err != nil {
+			return fmt.Errorf("config block %q: parse requires: %w", c.Name, err)
+		}
+	}
 	if _, hasValue := raw["value"]; !hasValue {
 		return fmt.Errorf("config block %q: value is required", c.Name)
 	}
@@ -194,6 +220,9 @@ func (c *ConfigBlock) MarshalYAML() (any, error) {
 	}
 	if c.Ordinal != nil {
 		out["ordinal"] = *c.Ordinal
+	}
+	if len(c.Requires) > 0 {
+		out["requires"] = c.Requires
 	}
 	if c.Body != nil {
 		if v, ok := c.Body["value"]; ok {
@@ -225,7 +254,21 @@ func (c *ConfigBlock) DeepCopy() *ConfigBlock {
 		o := *c.Ordinal
 		ordinalCopy = &o
 	}
-	return &ConfigBlock{Name: c.Name, When: c.When, Strategy: c.Strategy, Ordinal: ordinalCopy, Body: deepCopyMapStringAny(c.Body)}
+	var requiresCopy []RequirementBlock
+	if len(c.Requires) > 0 {
+		requiresCopy = make([]RequirementBlock, len(c.Requires))
+		for i, block := range c.Requires {
+			requiresCopy[i] = *block.DeepCopy()
+		}
+	}
+	return &ConfigBlock{
+		Name:     c.Name,
+		When:     c.When,
+		Strategy: c.Strategy,
+		Ordinal:  ordinalCopy,
+		Requires: requiresCopy,
+		Body:     deepCopyMapStringAny(c.Body),
+	}
 }
 
 // DeepCopy creates a deep copy of the Facet object.
@@ -293,11 +336,20 @@ func (c *ConditionalTerraformComponent) DeepCopy() *ConditionalTerraformComponen
 		ordinalCopy = &o
 	}
 
+	var requiresCopy []RequirementBlock
+	if len(c.Requires) > 0 {
+		requiresCopy = make([]RequirementBlock, len(c.Requires))
+		for i, block := range c.Requires {
+			requiresCopy[i] = *block.DeepCopy()
+		}
+	}
+
 	return &ConditionalTerraformComponent{
 		TerraformComponent: *c.TerraformComponent.DeepCopy(),
 		When:               c.When,
 		Strategy:           c.Strategy,
 		Ordinal:            ordinalCopy,
+		Requires:           requiresCopy,
 	}
 }
 
@@ -313,11 +365,20 @@ func (c *ConditionalKustomization) DeepCopy() *ConditionalKustomization {
 		ordinalCopy = &o
 	}
 
+	var requiresCopy []RequirementBlock
+	if len(c.Requires) > 0 {
+		requiresCopy = make([]RequirementBlock, len(c.Requires))
+		for i, block := range c.Requires {
+			requiresCopy[i] = *block.DeepCopy()
+		}
+	}
+
 	return &ConditionalKustomization{
 		Kustomization: *c.Kustomization.DeepCopy(),
 		When:          c.When,
 		Strategy:      c.Strategy,
 		Ordinal:       ordinalCopy,
+		Requires:      requiresCopy,
 	}
 }
 

--- a/api/v1alpha1/facet_types.go
+++ b/api/v1alpha1/facet_types.go
@@ -5,6 +5,7 @@ package v1alpha1
 import (
 	"fmt"
 	"maps"
+	"slices"
 )
 
 // =============================================================================
@@ -30,6 +31,22 @@ type ConfigBlock struct {
 	Ordinal *int `yaml:"ordinal,omitempty"`
 	// Body holds the canonical content as map[string]any{"value": <content>} for merge and evaluation. Not YAML-marshaled directly.
 	Body map[string]any `yaml:"-"`
+}
+
+// RequirementBlock declares a set of scope paths that must resolve to present,
+// non-empty values for the parent facet's activation to be well-formed. When is
+// optional and gates the block; if empty, the paths are required whenever the
+// parent facet is active. Message is optional context surfaced in the
+// aggregated error alongside the missing paths.
+type RequirementBlock struct {
+	// When is an expression gating this block. Empty means always required while the parent facet is active.
+	When string `yaml:"when,omitempty"`
+
+	// Paths are dotted scope keys whose values must be present and non-empty.
+	Paths []string `yaml:"paths"`
+
+	// Message is optional author-supplied context surfaced under this block's heading in the aggregated error.
+	Message string `yaml:"message,omitempty"`
 }
 
 // Facet represents a conditional blueprint fragment that can be merged into a base blueprint.
@@ -64,6 +81,11 @@ type Facet struct {
 	// Config is a list of named configuration blocks evaluated in blueprint context and exposed at scope root.
 	// Terraform inputs and kustomize substitutions reference <name>.<key> (e.g. talos.controlplanes), like context (cluster.*, network.*).
 	Config []ConfigBlock `yaml:"config,omitempty"`
+
+	// Requires lists input requirement blocks. When the facet is active and a block's optional When holds,
+	// every path must resolve to a present, non-empty value in the merged scope. Unsatisfied paths across
+	// every active facet are aggregated into a single user-facing error.
+	Requires []RequirementBlock `yaml:"requires,omitempty"`
 
 	// TerraformComponents are Terraform modules in the facet.
 	TerraformComponents []ConditionalTerraformComponent `yaml:"terraform,omitempty"`
@@ -181,6 +203,18 @@ func (c *ConfigBlock) MarshalYAML() (any, error) {
 	return out, nil
 }
 
+// DeepCopy creates a deep copy of the RequirementBlock object.
+func (r *RequirementBlock) DeepCopy() *RequirementBlock {
+	if r == nil {
+		return nil
+	}
+	return &RequirementBlock{
+		When:    r.When,
+		Paths:   slices.Clone(r.Paths),
+		Message: r.Message,
+	}
+}
+
 // DeepCopy creates a deep copy of the ConfigBlock object.
 func (c *ConfigBlock) DeepCopy() *ConfigBlock {
 	if c == nil {
@@ -220,6 +254,11 @@ func (f *Facet) DeepCopy() *Facet {
 		configCopy[i] = *block.DeepCopy()
 	}
 
+	requiresCopy := make([]RequirementBlock, len(f.Requires))
+	for i, block := range f.Requires {
+		requiresCopy[i] = *block.DeepCopy()
+	}
+
 	var ordinalCopy *int
 	if f.Ordinal != nil {
 		o := *f.Ordinal
@@ -235,6 +274,7 @@ func (f *Facet) DeepCopy() *Facet {
 		When:                f.When,
 		Backend:             f.Backend,
 		Config:              configCopy,
+		Requires:            requiresCopy,
 		TerraformComponents: terraformComponentsCopy,
 		Kustomizations:      kustomizationsCopy,
 		Substitutions:       maps.Clone(f.Substitutions),

--- a/api/v1alpha1/facet_types_test.go
+++ b/api/v1alpha1/facet_types_test.go
@@ -128,6 +128,71 @@ func TestFacetDeepCopy(t *testing.T) {
 			t.Error("Deep copy failed: config block body nested map was not copied")
 		}
 	})
+
+	t.Run("PreservesRequiresIndependently", func(t *testing.T) {
+		original := &Facet{
+			Metadata: Metadata{Name: "test-facet"},
+			Requires: []RequirementBlock{
+				{Paths: []string{"cluster.name", "dns.domain"}},
+				{
+					When:    "provider == 'aws'",
+					Paths:   []string{"aws.region"},
+					Message: "Set aws.region",
+				},
+			},
+		}
+
+		copy := original.DeepCopy()
+
+		if len(copy.Requires) != len(original.Requires) {
+			t.Fatalf("Expected %d requirement blocks, got %d", len(original.Requires), len(copy.Requires))
+		}
+
+		original.Requires[0].Paths[0] = "modified"
+		if copy.Requires[0].Paths[0] == "modified" {
+			t.Error("Deep copy failed: requires paths slice was not copied")
+		}
+
+		original.Requires[1].Message = "modified"
+		if copy.Requires[1].Message == "modified" {
+			t.Error("Deep copy failed: requires message was not copied")
+		}
+	})
+}
+
+func TestRequirementBlockDeepCopy(t *testing.T) {
+	t.Run("ReturnsNilForNilBlock", func(t *testing.T) {
+		var r *RequirementBlock
+		result := r.DeepCopy()
+		if result != nil {
+			t.Errorf("Expected nil, got %v", result)
+		}
+	})
+
+	t.Run("CreatesDeepCopyOfRequirementBlock", func(t *testing.T) {
+		original := &RequirementBlock{
+			When:    "provider == 'aws'",
+			Paths:   []string{"aws.region", "aws.account_id"},
+			Message: "Set these in values.yaml",
+		}
+
+		copy := original.DeepCopy()
+
+		if copy.When != original.When {
+			t.Errorf("Expected When %q, got %q", original.When, copy.When)
+		}
+		if copy.Message != original.Message {
+			t.Errorf("Expected Message %q, got %q", original.Message, copy.Message)
+		}
+		if len(copy.Paths) != len(original.Paths) {
+			t.Fatalf("Expected %d paths, got %d", len(original.Paths), len(copy.Paths))
+		}
+
+		original.Paths[0] = "modified"
+		if copy.Paths[0] == "modified" {
+			t.Error("Deep copy failed: paths slice was not copied")
+		}
+	})
 }
 
 func TestConditionalTerraformComponentDeepCopy(t *testing.T) {
@@ -377,6 +442,96 @@ controlplanes: ${cluster.controlplanes}
 		}
 		if block.Body != nil {
 			t.Error("Expected Body to be nil when unmarshal fails")
+		}
+	})
+
+	t.Run("FacetUnmarshalsRequires", func(t *testing.T) {
+		facetYAML := []byte(`kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: requires-facet
+when: provider == 'aws'
+requires:
+  - paths:
+      - cluster.name
+      - dns.domain
+  - when: cluster.workers.count > 0
+    paths:
+      - aws.subnets.private
+  - when: observability.enabled
+    paths:
+      - observability.endpoint
+      - observability.token
+    message: |
+      Observability is enabled but its endpoint/token are not set.
+      See https://docs.windsorcli.dev/observability for setup details.
+`)
+		var facet Facet
+		err := yaml.Unmarshal(facetYAML, &facet)
+		if err != nil {
+			t.Fatalf("Failed to unmarshal facet with requires: %v", err)
+		}
+		if len(facet.Requires) != 3 {
+			t.Fatalf("Expected 3 requirement blocks, got %d", len(facet.Requires))
+		}
+
+		first := facet.Requires[0]
+		if first.When != "" {
+			t.Errorf("Expected first block When empty, got %q", first.When)
+		}
+		if len(first.Paths) != 2 || first.Paths[0] != "cluster.name" || first.Paths[1] != "dns.domain" {
+			t.Errorf("Unexpected first block paths: %v", first.Paths)
+		}
+		if first.Message != "" {
+			t.Errorf("Expected first block Message empty, got %q", first.Message)
+		}
+
+		second := facet.Requires[1]
+		if second.When != "cluster.workers.count > 0" {
+			t.Errorf("Unexpected second block When: %q", second.When)
+		}
+		if len(second.Paths) != 1 || second.Paths[0] != "aws.subnets.private" {
+			t.Errorf("Unexpected second block paths: %v", second.Paths)
+		}
+
+		third := facet.Requires[2]
+		if third.When != "observability.enabled" {
+			t.Errorf("Unexpected third block When: %q", third.When)
+		}
+		if len(third.Paths) != 2 {
+			t.Fatalf("Expected 2 paths in third block, got %d", len(third.Paths))
+		}
+		if !strings.Contains(third.Message, "endpoint/token are not set") {
+			t.Errorf("Expected message to contain context, got %q", third.Message)
+		}
+	})
+
+	t.Run("FacetMarshalsRequires", func(t *testing.T) {
+		facet := Facet{
+			Kind:       "Facet",
+			ApiVersion: "blueprints.windsorcli.dev/v1alpha1",
+			Metadata:   Metadata{Name: "test"},
+			Requires: []RequirementBlock{
+				{Paths: []string{"cluster.name"}},
+				{When: "provider == 'aws'", Paths: []string{"aws.region"}, Message: "Set aws.region"},
+			},
+		}
+		out, err := yaml.Marshal(&facet)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		s := string(out)
+		if !strings.Contains(s, "requires:") {
+			t.Error("Expected marshaled YAML to contain requires:")
+		}
+		if !strings.Contains(s, "cluster.name") {
+			t.Error("Expected marshaled YAML to contain cluster.name path")
+		}
+		if !strings.Contains(s, "when: provider == 'aws'") {
+			t.Error("Expected marshaled YAML to contain when: provider == 'aws'")
+		}
+		if !strings.Contains(s, "Set aws.region") {
+			t.Error("Expected marshaled YAML to contain message text")
 		}
 	})
 

--- a/api/v1alpha1/facet_types_test.go
+++ b/api/v1alpha1/facet_types_test.go
@@ -141,6 +141,71 @@ func TestFacetDeepCopy(t *testing.T) {
 			t.Errorf("Expected copy.Backend=\"cluster\", got %q", copy.Backend)
 		}
 	})
+
+	t.Run("PreservesRequiresIndependently", func(t *testing.T) {
+		original := &Facet{
+			Metadata: Metadata{Name: "test-facet"},
+			Requires: []RequirementBlock{
+				{Paths: []string{"cluster.name", "dns.domain"}},
+				{
+					When:    "provider == 'aws'",
+					Paths:   []string{"aws.region"},
+					Message: "Set aws.region",
+				},
+			},
+		}
+
+		copy := original.DeepCopy()
+
+		if len(copy.Requires) != len(original.Requires) {
+			t.Fatalf("Expected %d requirement blocks, got %d", len(original.Requires), len(copy.Requires))
+		}
+
+		original.Requires[0].Paths[0] = "modified"
+		if copy.Requires[0].Paths[0] == "modified" {
+			t.Error("Deep copy failed: requires paths slice was not copied")
+		}
+
+		original.Requires[1].Message = "modified"
+		if copy.Requires[1].Message == "modified" {
+			t.Error("Deep copy failed: requires message was not copied")
+		}
+	})
+}
+
+func TestRequirementBlockDeepCopy(t *testing.T) {
+	t.Run("ReturnsNilForNilBlock", func(t *testing.T) {
+		var r *RequirementBlock
+		result := r.DeepCopy()
+		if result != nil {
+			t.Errorf("Expected nil, got %v", result)
+		}
+	})
+
+	t.Run("CreatesDeepCopyOfRequirementBlock", func(t *testing.T) {
+		original := &RequirementBlock{
+			When:    "provider == 'aws'",
+			Paths:   []string{"aws.region", "aws.account_id"},
+			Message: "Set these in values.yaml",
+		}
+
+		copy := original.DeepCopy()
+
+		if copy.When != original.When {
+			t.Errorf("Expected When %q, got %q", original.When, copy.When)
+		}
+		if copy.Message != original.Message {
+			t.Errorf("Expected Message %q, got %q", original.Message, copy.Message)
+		}
+		if len(copy.Paths) != len(original.Paths) {
+			t.Fatalf("Expected %d paths, got %d", len(original.Paths), len(copy.Paths))
+		}
+
+		original.Paths[0] = "modified"
+		if copy.Paths[0] == "modified" {
+			t.Error("Deep copy failed: paths slice was not copied")
+		}
+	})
 }
 
 func TestConditionalTerraformComponentDeepCopy(t *testing.T) {
@@ -427,6 +492,96 @@ controlplanes: ${cluster.controlplanes}
 		}
 		if block.Body != nil {
 			t.Error("Expected Body to be nil when unmarshal fails")
+		}
+	})
+
+	t.Run("FacetUnmarshalsRequires", func(t *testing.T) {
+		facetYAML := []byte(`kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: requires-facet
+when: provider == 'aws'
+requires:
+  - paths:
+      - cluster.name
+      - dns.domain
+  - when: cluster.workers.count > 0
+    paths:
+      - aws.subnets.private
+  - when: observability.enabled
+    paths:
+      - observability.endpoint
+      - observability.token
+    message: |
+      Observability is enabled but its endpoint/token are not set.
+      See https://docs.windsorcli.dev/observability for setup details.
+`)
+		var facet Facet
+		err := yaml.Unmarshal(facetYAML, &facet)
+		if err != nil {
+			t.Fatalf("Failed to unmarshal facet with requires: %v", err)
+		}
+		if len(facet.Requires) != 3 {
+			t.Fatalf("Expected 3 requirement blocks, got %d", len(facet.Requires))
+		}
+
+		first := facet.Requires[0]
+		if first.When != "" {
+			t.Errorf("Expected first block When empty, got %q", first.When)
+		}
+		if len(first.Paths) != 2 || first.Paths[0] != "cluster.name" || first.Paths[1] != "dns.domain" {
+			t.Errorf("Unexpected first block paths: %v", first.Paths)
+		}
+		if first.Message != "" {
+			t.Errorf("Expected first block Message empty, got %q", first.Message)
+		}
+
+		second := facet.Requires[1]
+		if second.When != "cluster.workers.count > 0" {
+			t.Errorf("Unexpected second block When: %q", second.When)
+		}
+		if len(second.Paths) != 1 || second.Paths[0] != "aws.subnets.private" {
+			t.Errorf("Unexpected second block paths: %v", second.Paths)
+		}
+
+		third := facet.Requires[2]
+		if third.When != "observability.enabled" {
+			t.Errorf("Unexpected third block When: %q", third.When)
+		}
+		if len(third.Paths) != 2 {
+			t.Fatalf("Expected 2 paths in third block, got %d", len(third.Paths))
+		}
+		if !strings.Contains(third.Message, "endpoint/token are not set") {
+			t.Errorf("Expected message to contain context, got %q", third.Message)
+		}
+	})
+
+	t.Run("FacetMarshalsRequires", func(t *testing.T) {
+		facet := Facet{
+			Kind:       "Facet",
+			ApiVersion: "blueprints.windsorcli.dev/v1alpha1",
+			Metadata:   Metadata{Name: "test"},
+			Requires: []RequirementBlock{
+				{Paths: []string{"cluster.name"}},
+				{When: "provider == 'aws'", Paths: []string{"aws.region"}, Message: "Set aws.region"},
+			},
+		}
+		out, err := yaml.Marshal(&facet)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		s := string(out)
+		if !strings.Contains(s, "requires:") {
+			t.Error("Expected marshaled YAML to contain requires:")
+		}
+		if !strings.Contains(s, "cluster.name") {
+			t.Error("Expected marshaled YAML to contain cluster.name path")
+		}
+		if !strings.Contains(s, "when: provider == 'aws'") {
+			t.Error("Expected marshaled YAML to contain when: provider == 'aws'")
+		}
+		if !strings.Contains(s, "Set aws.region") {
+			t.Error("Expected marshaled YAML to contain message text")
 		}
 	})
 

--- a/api/v1alpha1/facet_types_test.go
+++ b/api/v1alpha1/facet_types_test.go
@@ -208,6 +208,51 @@ func TestRequirementBlockDeepCopy(t *testing.T) {
 	})
 }
 
+func TestRequirementBlockUnmarshalYAML(t *testing.T) {
+	t.Run("ErrorsWhenPathsKeyMissing", func(t *testing.T) {
+		// Models a typo such as `pahts:` — the field is absent entirely, which would
+		// otherwise produce a silently-disabled requirement.
+		var f Facet
+		err := yaml.Unmarshal([]byte(`requires:
+  - when: provider == 'aws'
+    message: missing the paths key entirely
+`), &f)
+		if err == nil {
+			t.Fatal("Expected error when paths is missing, got nil")
+		}
+		if !strings.Contains(err.Error(), "paths is required") {
+			t.Errorf("Expected error to mention 'paths is required', got: %v", err)
+		}
+	})
+
+	t.Run("ErrorsWhenPathsListEmpty", func(t *testing.T) {
+		var f Facet
+		err := yaml.Unmarshal([]byte(`requires:
+  - paths: []
+`), &f)
+		if err == nil {
+			t.Fatal("Expected error when paths is empty, got nil")
+		}
+		if !strings.Contains(err.Error(), "paths is required") {
+			t.Errorf("Expected error to mention 'paths is required', got: %v", err)
+		}
+	})
+
+	t.Run("AcceptsValidBlock", func(t *testing.T) {
+		var f Facet
+		err := yaml.Unmarshal([]byte(`requires:
+  - paths:
+      - cluster.name
+`), &f)
+		if err != nil {
+			t.Fatalf("Expected no error for valid block, got: %v", err)
+		}
+		if len(f.Requires) != 1 || len(f.Requires[0].Paths) != 1 || f.Requires[0].Paths[0] != "cluster.name" {
+			t.Errorf("Expected one requires entry with paths=[cluster.name], got: %+v", f.Requires)
+		}
+	})
+}
+
 func TestConditionalTerraformComponentDeepCopy(t *testing.T) {
 	t.Run("ReturnsNilForNilComponent", func(t *testing.T) {
 		var c *ConditionalTerraformComponent

--- a/api/v1alpha1/facet_types_test.go
+++ b/api/v1alpha1/facet_types_test.go
@@ -250,6 +250,33 @@ func TestConditionalTerraformComponentDeepCopy(t *testing.T) {
 			t.Error("Deep copy failed: inputs map was not copied")
 		}
 	})
+
+	t.Run("PreservesRequiresIndependently", func(t *testing.T) {
+		original := &ConditionalTerraformComponent{
+			TerraformComponent: TerraformComponent{Path: "network/aws-vpc"},
+			When:               "platform == 'aws'",
+			Requires: []RequirementBlock{
+				{Paths: []string{"aws.region"}},
+				{When: "cni_effective.driver == 'cilium'", Paths: []string{"aws.cilium.role_arn"}, Message: "Set the cilium role arn."},
+			},
+		}
+
+		copy := original.DeepCopy()
+
+		if len(copy.Requires) != len(original.Requires) {
+			t.Fatalf("Expected %d requirement blocks, got %d", len(original.Requires), len(copy.Requires))
+		}
+
+		original.Requires[0].Paths[0] = "modified"
+		if copy.Requires[0].Paths[0] == "modified" {
+			t.Error("Deep copy failed: requires paths slice was not copied")
+		}
+
+		original.Requires[1].Message = "modified"
+		if copy.Requires[1].Message == "modified" {
+			t.Error("Deep copy failed: requires message was not copied")
+		}
+	})
 }
 
 func TestConditionalKustomizationDeepCopy(t *testing.T) {
@@ -300,6 +327,63 @@ func TestConditionalKustomizationDeepCopy(t *testing.T) {
 		original.Substitutions["host"] = "modified"
 		if copy.Substitutions["host"] == "modified" {
 			t.Error("Deep copy failed: substitutions map was not copied")
+		}
+	})
+
+	t.Run("PreservesRequiresIndependently", func(t *testing.T) {
+		original := &ConditionalKustomization{
+			Kustomization: Kustomization{Name: "ingress"},
+			When:          "ingress.enabled == true",
+			Requires: []RequirementBlock{
+				{Paths: []string{"ingress.class"}},
+				{When: "ingress.tls == true", Paths: []string{"ingress.tls_secret"}, Message: "Set the TLS secret name."},
+			},
+		}
+
+		copy := original.DeepCopy()
+
+		if len(copy.Requires) != len(original.Requires) {
+			t.Fatalf("Expected %d requirement blocks, got %d", len(original.Requires), len(copy.Requires))
+		}
+
+		original.Requires[0].Paths[0] = "modified"
+		if copy.Requires[0].Paths[0] == "modified" {
+			t.Error("Deep copy failed: requires paths slice was not copied")
+		}
+
+		original.Requires[1].Message = "modified"
+		if copy.Requires[1].Message == "modified" {
+			t.Error("Deep copy failed: requires message was not copied")
+		}
+	})
+}
+
+func TestConfigBlockDeepCopy(t *testing.T) {
+	t.Run("PreservesRequiresIndependently", func(t *testing.T) {
+		original := &ConfigBlock{
+			Name: "talos",
+			When: "platform == 'docker'",
+			Body: map[string]any{"value": "x"},
+			Requires: []RequirementBlock{
+				{Paths: []string{"talos.endpoint"}},
+				{When: "talos.tls == true", Paths: []string{"talos.ca_cert"}, Message: "Set the CA cert path."},
+			},
+		}
+
+		copy := original.DeepCopy()
+
+		if len(copy.Requires) != len(original.Requires) {
+			t.Fatalf("Expected %d requirement blocks, got %d", len(original.Requires), len(copy.Requires))
+		}
+
+		original.Requires[0].Paths[0] = "modified"
+		if copy.Requires[0].Paths[0] == "modified" {
+			t.Error("Deep copy failed: requires paths slice was not copied")
+		}
+
+		original.Requires[1].Message = "modified"
+		if copy.Requires[1].Message == "modified" {
+			t.Error("Deep copy failed: requires message was not copied")
 		}
 	})
 }
@@ -626,6 +710,111 @@ kustomize:
 			t.Error("Expected Timeout to be set, got nil")
 		} else if k.Timeout.Duration != 10*time.Minute {
 			t.Errorf("Expected Timeout duration 10m, got %v", k.Timeout.Duration)
+		}
+	})
+
+	t.Run("ConfigBlockUnmarshalsAndMarshalsRequires", func(t *testing.T) {
+		y := []byte(`name: talos
+when: platform == 'docker'
+requires:
+  - paths:
+      - talos.endpoint
+  - when: talos.tls == true
+    paths:
+      - talos.ca_cert
+    message: |
+      Set the CA cert path.
+value:
+  controlplanes: ${cluster.controlplanes}
+`)
+		var block ConfigBlock
+		if err := yaml.Unmarshal(y, &block); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if len(block.Requires) != 2 {
+			t.Fatalf("Expected 2 requirement blocks, got %d", len(block.Requires))
+		}
+		if block.Requires[0].When != "" || block.Requires[0].Paths[0] != "talos.endpoint" {
+			t.Errorf("Unexpected first block: %+v", block.Requires[0])
+		}
+		if block.Requires[1].When != "talos.tls == true" || block.Requires[1].Paths[0] != "talos.ca_cert" {
+			t.Errorf("Unexpected second block: %+v", block.Requires[1])
+		}
+		if !strings.Contains(block.Requires[1].Message, "Set the CA cert path.") {
+			t.Errorf("Unexpected second block message: %q", block.Requires[1].Message)
+		}
+
+		out, err := yaml.Marshal(&block)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+		outStr := string(out)
+		if !strings.Contains(outStr, "requires:") {
+			t.Errorf("Expected marshaled YAML to contain requires: %s", outStr)
+		}
+		if !strings.Contains(outStr, "talos.endpoint") || !strings.Contains(outStr, "talos.ca_cert") {
+			t.Errorf("Expected marshaled YAML to contain both required paths: %s", outStr)
+		}
+	})
+
+	t.Run("ConditionalTerraformComponentUnmarshalsRequires", func(t *testing.T) {
+		y := []byte(`kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: aws
+when: platform == 'aws'
+terraform:
+  - path: cluster/aws-cilium
+    when: cni_effective.driver == 'cilium'
+    requires:
+      - paths:
+          - aws.cilium.role_arn
+        message: |
+          Set the cilium role arn.
+`)
+		var facet Facet
+		if err := yaml.Unmarshal(y, &facet); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if len(facet.TerraformComponents) != 1 {
+			t.Fatalf("Expected 1 terraform component, got %d", len(facet.TerraformComponents))
+		}
+		comp := facet.TerraformComponents[0]
+		if len(comp.Requires) != 1 {
+			t.Fatalf("Expected 1 requirement block on terraform component, got %d", len(comp.Requires))
+		}
+		if comp.Requires[0].Paths[0] != "aws.cilium.role_arn" {
+			t.Errorf("Unexpected required path: %v", comp.Requires[0].Paths)
+		}
+	})
+
+	t.Run("ConditionalKustomizationUnmarshalsRequires", func(t *testing.T) {
+		y := []byte(`kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: gateway
+when: gateway.enabled == true
+kustomize:
+  - name: gateway
+    path: gateway
+    when: gateway.driver == 'envoy'
+    requires:
+      - paths:
+          - gateway.cert_arn
+`)
+		var facet Facet
+		if err := yaml.Unmarshal(y, &facet); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+		if len(facet.Kustomizations) != 1 {
+			t.Fatalf("Expected 1 kustomization, got %d", len(facet.Kustomizations))
+		}
+		k := facet.Kustomizations[0]
+		if len(k.Requires) != 1 {
+			t.Fatalf("Expected 1 requirement block on kustomization, got %d", len(k.Requires))
+		}
+		if k.Requires[0].Paths[0] != "gateway.cert_arn" {
+			t.Errorf("Unexpected required path: %v", k.Requires[0].Paths)
 		}
 	})
 }

--- a/docs/reference/facets.md
+++ b/docs/reference/facets.md
@@ -44,6 +44,7 @@ kustomize:
 | `ordinal`   | `integer` (optional)              | Order in which this facet is applied relative to others. Higher ordinal = higher precedence when merging. When omitted, derived from the facet file basename (see [Default ordinal from filename](#default-ordinal-from-filename)). |
 | `when`      | `string`                          | Expression that determines if the facet should be applied. Evaluated against configuration values. If empty or evaluates to `true`, the facet is applied. |
 | `config`    | `[]ConfigBlock`                   | Named configuration blocks evaluated in blueprint context; referenced as `<name>.<key>` (e.g. `talos.controlplanes`) from terraform inputs and kustomize substitutions, same style as context (`cluster.*`, `network.*`). |
+| `requires`  | `[]RequirementBlock`              | Input requirement blocks. When the facet is active and a block's optional `when` holds, every path must resolve to a present, non-empty value. Unsatisfied paths are aggregated into a single user-facing error. See [Requires](#requires). |
 | `terraform` | `[]ConditionalTerraformComponent` | Terraform components to include when the facet matches.                  |
 | `kustomize` | `[]ConditionalKustomization`       | Kustomizations to include when the facet matches.                         |
 
@@ -96,6 +97,65 @@ terraform:
 ```
 
 Evaluation order: facets are processed by ordinal (ascending), then by name. First, each facet's config block **structure** (name, when, body keys) is merged into a global scope (same block name merges block bodies recursively); config body expressions are **not** evaluated yet. After all facets are merged, config body expressions are evaluated once in blueprint context (very late). Then terraform and kustomize components are collected; their inputs and substitutions can reference the evaluated `<name>.<key>` (e.g. `talos.controlplanes`).
+
+## Requires
+
+A facet can declare the inputs it needs via `requires`. Each entry is a **block** that scopes a set of `paths` under an optional `when` condition with an optional `message`. The check runs once the facet's own `when` is true; if any required path is missing, the facet is deferred and may be re-evaluated in a later round (so requirements satisfied by another facet's config block work naturally). After the convergence loop, every still-unsatisfied path across every active facet is collected into a single error.
+
+```yaml
+when: provider == 'aws'
+requires:
+  # Always required while this facet is active.
+  - paths:
+      - cluster.name
+      - dns.domain
+
+  # Conditionally required.
+  - when: cluster.workers.count > 0
+    paths:
+      - aws.subnets.private
+
+  # Conditionally required, with author-supplied context.
+  - when: observability.enabled
+    paths:
+      - observability.endpoint
+      - observability.token
+    message: |
+      Observability is enabled but its endpoint/token are not set.
+      See https://docs.windsorcli.dev/observability for setup details.
+```
+
+Block fields:
+
+| Field     | Type       | Required | Notes                                                                                       |
+|-----------|------------|----------|---------------------------------------------------------------------------------------------|
+| `when`    | `string`   | no       | Expression gating the block. Empty means always required while the parent facet is active.  |
+| `paths`   | `[]string` | yes      | Dotted scope keys (e.g. `aws.region`, `cluster.workers.count`).                              |
+| `message` | `string`   | no       | Optional context surfaced under the heading in the aggregated error.                         |
+
+A path is **satisfied** when it resolves to a non-nil, non-empty value. Empty string, empty slice, and empty map count as **missing**; `false` and `0` count as **present**. `requires` checks presence — *that the user has declared a value* — not truthiness. If you mean "only required when the feature is on," put that in the block's `when`.
+
+The aggregated error groups missing paths by their effective condition (the AND of facet `when` and block `when`) — never by facet — and never uses the word "facet" in user-facing output. Example output:
+
+```
+Required configuration is missing:
+
+  Required:
+    - cluster.name
+    - dns.domain
+
+  Because provider == 'aws':
+    - aws.region
+    - aws.account_id
+
+  Because observability.enabled:
+    Observability is enabled but its endpoint/token are not set.
+    See https://docs.windsorcli.dev/observability for setup details.
+      - observability.endpoint
+      - observability.token
+
+5 missing values. Set these in values.yaml and re-run.
+```
 
 ## Conditional Logic
 

--- a/docs/reference/facets.md
+++ b/docs/reference/facets.md
@@ -103,7 +103,7 @@ Evaluation order: facets are processed by ordinal (ascending), then by name. Fir
 A facet can declare the inputs it needs via `requires`. Each entry is a **block** that scopes a set of `paths` under an optional `when` condition with an optional `message`. The check runs once the facet's own `when` is true; if any required path is missing, the facet is deferred and may be re-evaluated in a later round (so requirements satisfied by another facet's config block work naturally). After the convergence loop, every still-unsatisfied path across every active facet is collected into a single error.
 
 ```yaml
-when: provider == 'aws'
+when: platform == 'aws'
 requires:
   # Always required while this facet is active.
   - paths:
@@ -144,7 +144,7 @@ Required configuration is missing:
     - cluster.name
     - dns.domain
 
-  Because provider == 'aws':
+  Because platform == 'aws':
     - aws.region
     - aws.account_id
 

--- a/docs/reference/facets.md
+++ b/docs/reference/facets.md
@@ -74,6 +74,7 @@ Facets can define **config** blocks to build generic configuration (e.g. Talos n
 - **name** – Exposed at scope root; expressions use `name.key` (e.g. `talos.controlplanes`).
 - **when** (optional) – Expression; if present and false, the block is skipped.
 - **body** – Remaining keys (e.g. `controlplanes`, `workers`, `patchVars`); values may contain `${}` expressions.
+- **requires** (optional) – Input requirements evaluated only when this block's `when` holds; see [RequirementBlock](#requirementblock).
 
 Config blocks are evaluated in blueprint context only (no facet config in scope). References from terraform or kustomize use `<name>.<key>`.
 
@@ -98,64 +99,19 @@ terraform:
 
 Evaluation order: facets are processed by ordinal (ascending), then by name. First, each facet's config block **structure** (name, when, body keys) is merged into a global scope (same block name merges block bodies recursively); config body expressions are **not** evaluated yet. After all facets are merged, config body expressions are evaluated once in blueprint context (very late). Then terraform and kustomize components are collected; their inputs and substitutions can reference the evaluated `<name>.<key>` (e.g. `talos.controlplanes`).
 
-## Requires
+## RequirementBlock
 
-A facet can declare the inputs it needs via `requires`. Each entry is a **block** that scopes a set of `paths` under an optional `when` condition with an optional `message`. The check runs once the facet's own `when` is true; if any required path is missing, the facet is deferred and may be re-evaluated in a later round (so requirements satisfied by another facet's config block work naturally). After the convergence loop, every still-unsatisfied path across every active facet is collected into a single error.
+A `requires` field may appear on `Facet`, `ConfigBlock`, `ConditionalTerraformComponent`, and `ConditionalKustomization`. Each entry is a `RequirementBlock`:
 
-```yaml
-when: platform == 'aws'
-requires:
-  # Always required while this facet is active.
-  - paths:
-      - cluster.name
-      - dns.domain
+| Field     | Type       | Required | Description                                                                                       |
+|-----------|------------|----------|---------------------------------------------------------------------------------------------------|
+| `when`    | `string`   | no       | Expression gating the block. Empty means always required while the parent facet/component is active. |
+| `paths`   | `[]string` | yes      | Dotted scope keys (e.g. `aws.region`, `cluster.workers.count`) that must resolve to a present, non-empty value. |
+| `message` | `string`   | no       | Optional author context surfaced under the condition heading in the aggregated error.              |
 
-  # Conditionally required.
-  - when: cluster.workers.count > 0
-    paths:
-      - aws.subnets.private
+Presence semantics: `nil`, `""`, empty slice, and empty map count as **missing**; `false` and `0` count as **present**. The check verifies that the user has declared a value, not that the value is truthy.
 
-  # Conditionally required, with author-supplied context.
-  - when: observability.enabled
-    paths:
-      - observability.endpoint
-      - observability.token
-    message: |
-      Observability is enabled but its endpoint/token are not set.
-      See https://docs.windsorcli.dev/observability for setup details.
-```
-
-Block fields:
-
-| Field     | Type       | Required | Notes                                                                                       |
-|-----------|------------|----------|---------------------------------------------------------------------------------------------|
-| `when`    | `string`   | no       | Expression gating the block. Empty means always required while the parent facet is active.  |
-| `paths`   | `[]string` | yes      | Dotted scope keys (e.g. `aws.region`, `cluster.workers.count`).                              |
-| `message` | `string`   | no       | Optional context surfaced under the heading in the aggregated error.                         |
-
-A path is **satisfied** when it resolves to a non-nil, non-empty value. Empty string, empty slice, and empty map count as **missing**; `false` and `0` count as **present**. `requires` checks presence — *that the user has declared a value* — not truthiness. If you mean "only required when the feature is on," put that in the block's `when`.
-
-The aggregated error groups missing paths by their effective condition (the AND of facet `when` and block `when`) — never by facet — and never uses the word "facet" in user-facing output. Example output:
-
-```
-Required configuration is missing:
-
-  Required:
-    - cluster.name
-    - dns.domain
-
-  Because platform == 'aws':
-    - aws.region
-    - aws.account_id
-
-  Because observability.enabled:
-    Observability is enabled but its endpoint/token are not set.
-    See https://docs.windsorcli.dev/observability for setup details.
-      - observability.endpoint
-      - observability.token
-
-5 missing values. Set these in values.yaml and re-run.
-```
+For composition rules, deferral semantics, and worked examples, see the conceptual guide: [Blueprint facets — Requires](https://docs.windsorcli.dev/blueprints/facets#requires).
 
 ## Conditional Logic
 
@@ -209,6 +165,7 @@ Extends `TerraformComponent` with conditional logic and merge strategy support.
 | `when`     | `string`            | Expression that determines if this component should be applied. If empty, the component is always applied when the parent facet matches. |
 | `ordinal`  | `integer` (optional)| Overrides the facet ordinal for this component's merge precedence. When omitted, the facet's ordinal is used. Higher ordinal wins when merging. |
 | `strategy` | `string`            | Merge strategy: `merge` (default), `replace`, or `remove`. Only available in facets.  |
+| `requires` | `[]RequirementBlock`| Input requirements evaluated only when this component's `when` holds; missing paths are bucketed under the AND of facet, component, and block `when`. See [RequirementBlock](#requirementblock). |
 
 ### Merge Strategies
 
@@ -257,6 +214,7 @@ Extends `Kustomization` with conditional logic and merge strategy support.
 | `when`         | `string`            | Expression that determines if this kustomization should be applied. If empty, the kustomization is always applied when the parent facet matches. |
 | `ordinal`      | `integer` (optional) | Overrides the facet ordinal for this kustomization's merge precedence. When omitted, the facet's ordinal is used. Higher ordinal wins when merging. |
 | `strategy`     | `string`            | Merge strategy: `merge` (default), `replace`, or `remove`. Only available in facets.  |
+| `requires`     | `[]RequirementBlock`| Input requirements evaluated only when this kustomization's `when` holds; missing paths are bucketed under the AND of facet, kustomization, and block `when`. See [RequirementBlock](#requirementblock). |
 
 ### Merge Strategies
 

--- a/integration/composer_test.go
+++ b/integration/composer_test.go
@@ -62,3 +62,55 @@ func TestWindsorTest_DerivedConfigFixture(t *testing.T) {
 		t.Errorf("expected PASS or ✓ in output: %s", out)
 	}
 }
+
+// TestShowBlueprint_FacetRequires_Satisfied verifies the success path: when every required
+// path resolves to a present, non-empty value, ProcessFacets returns no error and the
+// blueprint renders normally.
+func TestShowBlueprint_FacetRequires_Satisfied(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "facet-requires")
+	env = append(env, "WINDSOR_CONTEXT=ok")
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"show", "blueprint"}, env)
+	if err != nil {
+		t.Fatalf("show blueprint: %v\nstderr: %s", err, stderr)
+	}
+	var bp map[string]any
+	if err := yaml.Unmarshal(stdout, &bp); err != nil {
+		t.Fatalf("parse blueprint YAML: %v\nstdout: %s", err, stdout)
+	}
+	if bp["kind"] != "Blueprint" {
+		t.Errorf("expected kind Blueprint, got %v", bp["kind"])
+	}
+}
+
+// TestShowBlueprint_FacetRequires_MissingProducesAggregatedError verifies the failure path:
+// when required paths are missing, the command fails and stderr contains the aggregated error
+// — every missing path, the block-level message, and the count summary — grouped under the
+// effective condition heading rather than per-facet.
+func TestShowBlueprint_FacetRequires_MissingProducesAggregatedError(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "facet-requires")
+	env = append(env, "WINDSOR_CONTEXT=missing")
+	_, stderr, err := helpers.RunCLI(dir, []string{"show", "blueprint"}, env)
+	if err == nil {
+		t.Fatalf("expected show blueprint to fail with missing requirements, got nil error\nstderr: %s", stderr)
+	}
+	out := string(stderr)
+	if !strings.Contains(out, "Required configuration is missing") {
+		t.Errorf("expected aggregated error header, got: %s", out)
+	}
+	for _, path := range []string{"dns.domain", "aws.region", "aws.account_id"} {
+		if !strings.Contains(out, path) {
+			t.Errorf("expected stderr to list %q, got: %s", path, out)
+		}
+	}
+	if !strings.Contains(out, "AWS provider needs region and account_id set.") {
+		t.Errorf("expected block message in stderr, got: %s", out)
+	}
+	if !strings.Contains(out, "Because (provider ?? '') == 'aws':") {
+		t.Errorf("expected condition heading in stderr, got: %s", out)
+	}
+	if !strings.Contains(out, "3 missing values") {
+		t.Errorf("expected count summary in stderr, got: %s", out)
+	}
+}

--- a/integration/composer_test.go
+++ b/integration/composer_test.go
@@ -96,10 +96,10 @@ func TestShowBlueprint_FacetRequires_MissingProducesAggregatedError(t *testing.T
 		t.Fatalf("expected show blueprint to fail with missing requirements, got nil error\nstderr: %s", stderr)
 	}
 	out := string(stderr)
-	if !strings.Contains(out, "Required configuration is missing") {
-		t.Errorf("expected aggregated error header, got: %s", out)
+	if !strings.Contains(out, "the following required values are not set in values.yaml:") {
+		t.Errorf("expected aggregated error lead, got: %s", out)
 	}
-	for _, path := range []string{"dns.domain", "aws.region", "aws.account_id"} {
+	for _, path := range []string{"- dns.domain", "- aws.region", "- aws.account_id"} {
 		if !strings.Contains(out, path) {
 			t.Errorf("expected stderr to list %q, got: %s", path, out)
 		}
@@ -107,11 +107,16 @@ func TestShowBlueprint_FacetRequires_MissingProducesAggregatedError(t *testing.T
 	if !strings.Contains(out, "AWS platform needs region and account_id set.") {
 		t.Errorf("expected block message in stderr, got: %s", out)
 	}
-	if !strings.Contains(out, "Because (platform ?? '') == 'aws':") {
-		t.Errorf("expected condition heading in stderr, got: %s", out)
+	if !strings.Contains(out, "\nNotes:\n") {
+		t.Errorf("expected Notes section in stderr, got: %s", out)
 	}
-	if !strings.Contains(out, "3 missing values") {
-		t.Errorf("expected count summary in stderr, got: %s", out)
+	if strings.Contains(out, "Because") || strings.Contains(out, "platform ?? '')") {
+		t.Errorf("expected no condition expression in output, got: %s", out)
+	}
+	for _, frame := range []string{"failed to load blueprint data", "failed to compose blueprint", "failed to process facets for"} {
+		if strings.Contains(out, frame) {
+			t.Errorf("expected wrapped chain frame %q to be absent (RequirementsError should be passed through unwrapped), got: %s", frame, out)
+		}
 	}
 }
 
@@ -147,17 +152,22 @@ func TestShowBlueprint_FacetComponentRequires_MissingProducesComposedConditionEr
 		t.Fatalf("expected show blueprint to fail with missing component requirements, got nil error\nstderr: %s", stderr)
 	}
 	out := string(stderr)
-	if !strings.Contains(out, "Required configuration is missing") {
-		t.Errorf("expected aggregated error header, got: %s", out)
+	if !strings.Contains(out, "the following required values are not set in values.yaml:") {
+		t.Errorf("expected aggregated error lead, got: %s", out)
 	}
-	if !strings.Contains(out, "aws.cilium_role_arn") {
-		t.Errorf("expected stderr to list aws.cilium_role_arn, got: %s", out)
-	}
-	if !strings.Contains(out, "Because (platform ?? '') == 'aws' && (cni.driver ?? '') == 'cilium':") {
-		t.Errorf("expected composed condition heading (facet && component), got: %s", out)
+	if !strings.Contains(out, "- aws.cilium_role_arn") {
+		t.Errorf("expected stderr to list aws.cilium_role_arn as a bullet, got: %s", out)
 	}
 	if !strings.Contains(out, "The cilium terraform component needs an IAM role ARN.") {
 		t.Errorf("expected block message in stderr, got: %s", out)
+	}
+	if strings.Contains(out, "Because") || strings.Contains(out, "cni.driver") {
+		t.Errorf("expected no condition expression in output, got: %s", out)
+	}
+	for _, frame := range []string{"failed to load blueprint data", "failed to compose blueprint", "failed to process facets for"} {
+		if strings.Contains(out, frame) {
+			t.Errorf("expected wrapped chain frame %q to be absent (RequirementsError should be passed through unwrapped), got: %s", frame, out)
+		}
 	}
 }
 

--- a/integration/composer_test.go
+++ b/integration/composer_test.go
@@ -104,10 +104,10 @@ func TestShowBlueprint_FacetRequires_MissingProducesAggregatedError(t *testing.T
 			t.Errorf("expected stderr to list %q, got: %s", path, out)
 		}
 	}
-	if !strings.Contains(out, "AWS provider needs region and account_id set.") {
+	if !strings.Contains(out, "AWS platform needs region and account_id set.") {
 		t.Errorf("expected block message in stderr, got: %s", out)
 	}
-	if !strings.Contains(out, "Because (provider ?? '') == 'aws':") {
+	if !strings.Contains(out, "Because (platform ?? '') == 'aws':") {
 		t.Errorf("expected condition heading in stderr, got: %s", out)
 	}
 	if !strings.Contains(out, "3 missing values") {

--- a/integration/composer_test.go
+++ b/integration/composer_test.go
@@ -114,3 +114,70 @@ func TestShowBlueprint_FacetRequires_MissingProducesAggregatedError(t *testing.T
 		t.Errorf("expected count summary in stderr, got: %s", out)
 	}
 }
+
+// TestShowBlueprint_FacetComponentRequires_Satisfied verifies the happy path for per-component
+// requires: when the component's When is true and the required inputs are present, show blueprint
+// succeeds and emits a Blueprint document.
+func TestShowBlueprint_FacetComponentRequires_Satisfied(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "facet-component-requires")
+	env = append(env, "WINDSOR_CONTEXT=ok")
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"show", "blueprint"}, env)
+	if err != nil {
+		t.Fatalf("show blueprint: %v\nstderr: %s", err, stderr)
+	}
+	var bp map[string]any
+	if err := yaml.Unmarshal(stdout, &bp); err != nil {
+		t.Fatalf("parse blueprint YAML: %v\nstdout: %s", err, stdout)
+	}
+	if bp["kind"] != "Blueprint" {
+		t.Errorf("expected kind Blueprint, got %v", bp["kind"])
+	}
+}
+
+// TestShowBlueprint_FacetComponentRequires_MissingProducesComposedConditionError verifies the
+// failure path: when a per-component required path is missing, the error groups the miss under the
+// AND of facet.When and component.When, not just the facet condition.
+func TestShowBlueprint_FacetComponentRequires_MissingProducesComposedConditionError(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "facet-component-requires")
+	env = append(env, "WINDSOR_CONTEXT=missing")
+	_, stderr, err := helpers.RunCLI(dir, []string{"show", "blueprint"}, env)
+	if err == nil {
+		t.Fatalf("expected show blueprint to fail with missing component requirements, got nil error\nstderr: %s", stderr)
+	}
+	out := string(stderr)
+	if !strings.Contains(out, "Required configuration is missing") {
+		t.Errorf("expected aggregated error header, got: %s", out)
+	}
+	if !strings.Contains(out, "aws.cilium_role_arn") {
+		t.Errorf("expected stderr to list aws.cilium_role_arn, got: %s", out)
+	}
+	if !strings.Contains(out, "Because (platform ?? '') == 'aws' && (cni.driver ?? '') == 'cilium':") {
+		t.Errorf("expected composed condition heading (facet && component), got: %s", out)
+	}
+	if !strings.Contains(out, "The cilium terraform component needs an IAM role ARN.") {
+		t.Errorf("expected block message in stderr, got: %s", out)
+	}
+}
+
+// TestShowBlueprint_FacetComponentRequires_ComponentExcludedSkipsRequires verifies that a
+// per-component require does not fire when the component's own When evaluates to false. The
+// fixture sets cni.driver to a non-cilium value, so the cilium terraform component is excluded
+// and its missing aws.cilium_role_arn is not surfaced.
+func TestShowBlueprint_FacetComponentRequires_ComponentExcludedSkipsRequires(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "facet-component-requires")
+	env = append(env, "WINDSOR_CONTEXT=skipped")
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"show", "blueprint"}, env)
+	if err != nil {
+		t.Fatalf("show blueprint: %v\nstderr: %s", err, stderr)
+	}
+	var bp map[string]any
+	if err := yaml.Unmarshal(stdout, &bp); err != nil {
+		t.Fatalf("parse blueprint YAML: %v\nstdout: %s", err, stdout)
+	}
+	if bp["kind"] != "Blueprint" {
+		t.Errorf("expected kind Blueprint, got %v", bp["kind"])
+	}
+}

--- a/integration/fixtures/facet-component-requires/contexts/_template/blueprint.yaml
+++ b/integration/fixtures/facet-component-requires/contexts/_template/blueprint.yaml
@@ -1,0 +1,5 @@
+kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: facet-component-requires
+  description: Per-component facet requires integration fixture

--- a/integration/fixtures/facet-component-requires/contexts/_template/facets/aws-platform.yaml
+++ b/integration/fixtures/facet-component-requires/contexts/_template/facets/aws-platform.yaml
@@ -1,0 +1,20 @@
+kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: aws-platform
+  description: Active on aws; the cilium terraform component requires aws.cilium_role_arn only when cni.driver is cilium.
+when: (platform ?? '') == 'aws'
+requires:
+  - paths:
+      - aws.region
+terraform:
+  - path: cluster/aws-cilium
+    when: (cni.driver ?? '') == 'cilium'
+    requires:
+      - paths:
+          - aws.cilium_role_arn
+        message: |
+          The cilium terraform component needs an IAM role ARN.
+          See https://docs.windsorcli.dev/aws-cilium for setup.
+    inputs:
+      role_arn: ${aws.cilium_role_arn}

--- a/integration/fixtures/facet-component-requires/contexts/missing/values.yaml
+++ b/integration/fixtures/facet-component-requires/contexts/missing/values.yaml
@@ -1,0 +1,5 @@
+platform: aws
+cni:
+  driver: cilium
+aws:
+  region: us-east-1

--- a/integration/fixtures/facet-component-requires/contexts/ok/values.yaml
+++ b/integration/fixtures/facet-component-requires/contexts/ok/values.yaml
@@ -1,0 +1,6 @@
+platform: aws
+cni:
+  driver: cilium
+aws:
+  region: us-east-1
+  cilium_role_arn: arn:aws:iam::123456789012:role/cilium

--- a/integration/fixtures/facet-component-requires/contexts/skipped/values.yaml
+++ b/integration/fixtures/facet-component-requires/contexts/skipped/values.yaml
@@ -1,0 +1,5 @@
+platform: aws
+cni:
+  driver: calico
+aws:
+  region: us-east-1

--- a/integration/fixtures/facet-component-requires/windsor.yaml
+++ b/integration/fixtures/facet-component-requires/windsor.yaml
@@ -1,0 +1,6 @@
+version: v1alpha1
+contexts:
+  default: {}
+  ok: {}
+  missing: {}
+  skipped: {}

--- a/integration/fixtures/facet-requires/contexts/_template/blueprint.yaml
+++ b/integration/fixtures/facet-requires/contexts/_template/blueprint.yaml
@@ -1,0 +1,5 @@
+kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: facet-requires
+  description: Facet requires integration fixture

--- a/integration/fixtures/facet-requires/contexts/_template/facets/consumer.yaml
+++ b/integration/fixtures/facet-requires/contexts/_template/facets/consumer.yaml
@@ -1,0 +1,15 @@
+kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: consumer
+  description: Activates on aws provider; requires region, account, and dns domain.
+when: (provider ?? '') == 'aws'
+requires:
+  - paths:
+      - dns.domain
+  - paths:
+      - aws.region
+      - aws.account_id
+    message: |
+      AWS provider needs region and account_id set.
+      See https://docs.windsorcli.dev/aws for details.

--- a/integration/fixtures/facet-requires/contexts/_template/facets/consumer.yaml
+++ b/integration/fixtures/facet-requires/contexts/_template/facets/consumer.yaml
@@ -2,8 +2,8 @@ kind: Facet
 apiVersion: blueprints.windsorcli.dev/v1alpha1
 metadata:
   name: consumer
-  description: Activates on aws provider; requires region, account, and dns domain.
-when: (provider ?? '') == 'aws'
+  description: Activates on aws platform; requires region, account, and dns domain.
+when: (platform ?? '') == 'aws'
 requires:
   - paths:
       - dns.domain
@@ -11,5 +11,5 @@ requires:
       - aws.region
       - aws.account_id
     message: |
-      AWS provider needs region and account_id set.
+      AWS platform needs region and account_id set.
       See https://docs.windsorcli.dev/aws for details.

--- a/integration/fixtures/facet-requires/contexts/_template/tests/requires.test.yaml
+++ b/integration/fixtures/facet-requires/contexts/_template/tests/requires.test.yaml
@@ -1,0 +1,29 @@
+# Facet requires tests for the declarative `windsor test` harness.
+# Exercises the `consumer` facet (active when platform == 'aws') across the
+# three states an author cares about: requirements satisfied, requirements
+# missing while the facet is active, and the facet not active at all.
+
+cases:
+
+  # All required paths are present — composition succeeds.
+  - name: satisfied
+    values:
+      platform: aws
+      dns:
+        domain: example.com
+      aws:
+        region: us-east-1
+        account_id: "123456789012"
+
+  # Facet is active (platform == 'aws') but required paths are missing —
+  # composition must fail.
+  - name: missing_required_paths_fails
+    values:
+      platform: aws
+    expectError: true
+
+  # Facet's own `when` evaluates false — requires are not checked even
+  # though required paths are absent.
+  - name: facet_not_active_skips_requires
+    values:
+      platform: docker

--- a/integration/fixtures/facet-requires/contexts/missing/values.yaml
+++ b/integration/fixtures/facet-requires/contexts/missing/values.yaml
@@ -1,0 +1,1 @@
+provider: aws

--- a/integration/fixtures/facet-requires/contexts/missing/values.yaml
+++ b/integration/fixtures/facet-requires/contexts/missing/values.yaml
@@ -1,1 +1,1 @@
-provider: aws
+platform: aws

--- a/integration/fixtures/facet-requires/contexts/ok/values.yaml
+++ b/integration/fixtures/facet-requires/contexts/ok/values.yaml
@@ -1,0 +1,6 @@
+provider: aws
+dns:
+  domain: example.com
+aws:
+  region: us-east-1
+  account_id: "123456789012"

--- a/integration/fixtures/facet-requires/contexts/ok/values.yaml
+++ b/integration/fixtures/facet-requires/contexts/ok/values.yaml
@@ -1,4 +1,4 @@
-provider: aws
+platform: aws
 dns:
   domain: example.com
 aws:

--- a/integration/fixtures/facet-requires/windsor.yaml
+++ b/integration/fixtures/facet-requires/windsor.yaml
@@ -1,0 +1,5 @@
+version: v1alpha1
+contexts:
+  default: {}
+  ok: {}
+  missing: {}

--- a/integration/test_test.go
+++ b/integration/test_test.go
@@ -23,3 +23,21 @@ func TestWindsorTest_DefaultFixture(t *testing.T) {
 		t.Errorf("expected PASS or ✓ in output: %s", out)
 	}
 }
+
+// TestWindsorTest_FacetRequiresFixture exercises the declarative test harness against the
+// facet-requires fixture's requires.test.yaml. The three cases cover the states a facet
+// author cares about: requirements satisfied, requirements missing while the facet is
+// active, and the facet not active at all.
+func TestWindsorTest_FacetRequiresFixture(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "facet-requires")
+	env = append(env, "WINDSOR_CONTEXT=ok")
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"test"}, env)
+	if err != nil {
+		t.Fatalf("windsor test: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
+	}
+	out := string(stdout) + string(stderr)
+	if !strings.Contains(out, "PASS") && !strings.Contains(out, "✓") {
+		t.Errorf("expected PASS or ✓ in output: %s", out)
+	}
+}

--- a/pkg/composer/blueprint/errors.go
+++ b/pkg/composer/blueprint/errors.go
@@ -1,0 +1,15 @@
+package blueprint
+
+// RequirementsError signals that one or more required facet inputs are not set. It carries the
+// formatted operator-facing message produced by formatRequirementsError. Pipeline callers that
+// would otherwise wrap blueprint errors with internal context (project's "failed to load
+// blueprint data", handler's "failed to compose blueprint" and "failed to process facets for
+// 'X'") detect this type via errors.As and pass it through unwrapped, so the operator sees the
+// prose alone instead of a chain of internal frame names.
+type RequirementsError struct {
+	Message string
+}
+
+func (e *RequirementsError) Error() string {
+	return e.Message
+}

--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -138,6 +138,10 @@ func (h *BaseBlueprintHandler) LoadBlueprint(blueprintURL ...string) error {
 	}
 
 	if err := h.processAndCompose(); err != nil {
+		var reqErr *RequirementsError
+		if errors.As(err, &reqErr) {
+			return err
+		}
 		return fmt.Errorf("failed to compose blueprint: %w", err)
 	}
 
@@ -722,7 +726,12 @@ func (h *BaseBlueprintHandler) processAndCompose() error {
 			scope, _, err := h.processLoader(l)
 			if err != nil {
 				mu.Lock()
-				errs = append(errs, fmt.Errorf("failed to process facets for '%s': %w", name, err))
+				var reqErr *RequirementsError
+				if errors.As(err, &reqErr) {
+					errs = append(errs, err)
+				} else {
+					errs = append(errs, fmt.Errorf("failed to process facets for '%s': %w", name, err))
+				}
 				mu.Unlock()
 				return
 			}

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"slices"
 	"sort"
+	"strings"
 	"sync"
 
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
@@ -54,6 +55,23 @@ type BaseBlueprintProcessor struct {
 	mu             sync.Mutex
 	deferredPaths  map[string]bool
 	extraScope     map[string]any
+}
+
+// requirementBlockMiss records the unsatisfied paths and the effective condition under which a
+// single requirement block applied during a ProcessFacets pass. Condition is the AND of the parent
+// facet's When and the block's When; an empty Condition means the paths were unconditionally
+// required. Message is the optional author-supplied context for this block.
+type requirementBlockMiss struct {
+	Condition string
+	Message   string
+	Paths     []string
+}
+
+// facetRequirementMisses aggregates a single facet's unsatisfied requirement blocks for the
+// final-round error report.
+type facetRequirementMisses struct {
+	FacetName string
+	Misses    []requirementBlockMiss
 }
 
 // =============================================================================
@@ -169,12 +187,14 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 	var configBlockOrder []string
 	includedFacets := make([]blueprintv1alpha1.Facet, 0, len(sortedFacets))
 	prevIncludedSet := make(map[string]bool)
+	pendingRequirements := make(map[string]facetRequirementMisses)
 	const maxFacetRounds = 10
 	for range make([]struct{}, maxFacetRounds) {
 		includedFacets = includedFacets[:0]
 		globalScope = nil
 		cfgEntries = nil
 		configBlockOrder = nil
+		pendingRequirements = make(map[string]facetRequirementMisses)
 		passScope := scope
 		if passScope == nil && contextScope != nil {
 			passScope = maps.Clone(contextScope)
@@ -188,6 +208,17 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 				return nil, nil, err
 			}
 			if !shouldInclude {
+				continue
+			}
+			misses, err := p.evaluateRequirements(facet, passScope)
+			if err != nil {
+				return nil, nil, err
+			}
+			if len(misses) > 0 {
+				pendingRequirements[facet.Metadata.Name] = facetRequirementMisses{
+					FacetName: facet.Metadata.Name,
+					Misses:    misses,
+				}
 				continue
 			}
 			includedFacets = append(includedFacets, facet)
@@ -223,6 +254,10 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 			}
 		}
 		prevIncludedSet = currSet
+	}
+
+	if len(pendingRequirements) > 0 {
+		return nil, nil, formatRequirementsError(pendingRequirements)
 	}
 
 	for _, facet := range includedFacets {
@@ -1574,6 +1609,49 @@ func (p *BaseBlueprintProcessor) evaluateIntegerExpression(expr string, facetPat
 	return &result, nil
 }
 
+// evaluateRequirements walks the facet's Requires blocks against scope and returns the unsatisfied
+// blocks. A block is skipped when its When evaluates to false; otherwise every path must resolve to
+// a present, non-empty value (nil/""/empty slice/empty map count as missing; false and 0 are
+// present). The returned slice is empty when all blocks are satisfied. An error is returned only
+// when a block's When fails to evaluate.
+func (p *BaseBlueprintProcessor) evaluateRequirements(facet blueprintv1alpha1.Facet, scope map[string]any) ([]requirementBlockMiss, error) {
+	if len(facet.Requires) == 0 {
+		return nil, nil
+	}
+	var misses []requirementBlockMiss
+	for _, block := range facet.Requires {
+		if len(block.Paths) == 0 {
+			continue
+		}
+		applies := true
+		if block.When != "" {
+			ok, err := p.evaluateCondition(block.When, facet.Path, scope)
+			if err != nil {
+				return nil, fmt.Errorf("error evaluating requirement when '%s' in facet '%s': %w", block.When, facet.Metadata.Name, err)
+			}
+			applies = ok
+		}
+		if !applies {
+			continue
+		}
+		var missing []string
+		for _, path := range block.Paths {
+			if !isPresentAtPath(scope, path) {
+				missing = append(missing, path)
+			}
+		}
+		if len(missing) == 0 {
+			continue
+		}
+		misses = append(misses, requirementBlockMiss{
+			Condition: combineConditions(facet.When, block.When),
+			Message:   block.Message,
+			Paths:     missing,
+		})
+	}
+	return misses, nil
+}
+
 // =============================================================================
 // Helpers
 // =============================================================================
@@ -1812,6 +1890,146 @@ func accumulateMapKeys[K comparable, V any](m1, m2 map[K]V) map[K]V {
 		result[k] = zero
 	}
 	return result
+}
+
+// lookupPath resolves a dotted-path key (e.g. "cluster.workers.count") in a nested scope. Returns
+// (value, true) when every segment is found; returns (nil, false) when any segment is missing or
+// when an intermediate segment is not a map.
+func lookupPath(scope map[string]any, path string) (any, bool) {
+	if path == "" {
+		return nil, false
+	}
+	segments := strings.Split(path, ".")
+	var current any = scope
+	for _, seg := range segments {
+		m, ok := asMapStringAny(current)
+		if !ok {
+			return nil, false
+		}
+		v, exists := m[seg]
+		if !exists {
+			return nil, false
+		}
+		current = v
+	}
+	return current, true
+}
+
+// isPresentAtPath reports whether the dotted path resolves to a non-nil, non-empty value in scope.
+// Empty string, empty slice, and empty map are treated as missing; false and 0 are present.
+func isPresentAtPath(scope map[string]any, path string) bool {
+	val, ok := lookupPath(scope, path)
+	if !ok || val == nil {
+		return false
+	}
+	if s, ok := val.(string); ok {
+		return s != ""
+	}
+	rv := reflect.ValueOf(val)
+	switch rv.Kind() {
+	case reflect.Map, reflect.Slice, reflect.Array:
+		return rv.Len() > 0
+	}
+	return true
+}
+
+// combineConditions joins facet-level and block-level when expressions into a single condition
+// string used as a grouping key in the aggregated requirements error. Empty parts are dropped;
+// both empty yields "", meaning the requirement was unconditional.
+func combineConditions(facetWhen, blockWhen string) string {
+	fw := strings.TrimSpace(facetWhen)
+	bw := strings.TrimSpace(blockWhen)
+	switch {
+	case fw == "" && bw == "":
+		return ""
+	case fw == "":
+		return bw
+	case bw == "":
+		return fw
+	default:
+		return fw + " && " + bw
+	}
+}
+
+// formatRequirementsError renders the user-facing aggregated error for unsatisfied facet
+// requirements. Missing paths are bucketed by (effective condition, message); same-key buckets
+// merge while preserving authoring order of paths. Buckets are emitted unconditional-first, then
+// alphabetically by condition. The word "facet" is intentionally absent from the rendered output.
+func formatRequirementsError(pending map[string]facetRequirementMisses) error {
+	type bucketKey struct {
+		Condition string
+		Message   string
+	}
+	type bucket struct {
+		Key   bucketKey
+		Paths []string
+	}
+	bucketIndex := make(map[bucketKey]int)
+	var buckets []*bucket
+
+	names := make([]string, 0, len(pending))
+	for name := range pending {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		for _, miss := range pending[name].Misses {
+			key := bucketKey{Condition: miss.Condition, Message: miss.Message}
+			idx, exists := bucketIndex[key]
+			if !exists {
+				bucketIndex[key] = len(buckets)
+				buckets = append(buckets, &bucket{Key: key, Paths: slices.Clone(miss.Paths)})
+				continue
+			}
+			for _, p := range miss.Paths {
+				if !slices.Contains(buckets[idx].Paths, p) {
+					buckets[idx].Paths = append(buckets[idx].Paths, p)
+				}
+			}
+		}
+	}
+
+	sort.SliceStable(buckets, func(i, j int) bool {
+		ci, cj := buckets[i].Key.Condition, buckets[j].Key.Condition
+		if ci == "" && cj != "" {
+			return true
+		}
+		if cj == "" && ci != "" {
+			return false
+		}
+		return ci < cj
+	})
+
+	var b strings.Builder
+	b.WriteString("Required configuration is missing:\n\n")
+	total := 0
+	for _, bk := range buckets {
+		if bk.Key.Condition == "" {
+			b.WriteString("  Required:\n")
+		} else {
+			fmt.Fprintf(&b, "  Because %s:\n", bk.Key.Condition)
+		}
+		pathIndent := "    "
+		if bk.Key.Message != "" {
+			for _, line := range strings.Split(strings.TrimRight(bk.Key.Message, "\n"), "\n") {
+				b.WriteString("    ")
+				b.WriteString(line)
+				b.WriteByte('\n')
+			}
+			pathIndent = "      "
+		}
+		for _, p := range bk.Paths {
+			fmt.Fprintf(&b, "%s- %s\n", pathIndent, p)
+			total++
+		}
+		b.WriteByte('\n')
+	}
+	noun := "values"
+	if total == 1 {
+		noun = "value"
+	}
+	fmt.Fprintf(&b, "%d missing %s. Set these in values.yaml and re-run.", total, noun)
+	return fmt.Errorf("%s", b.String())
 }
 
 // =============================================================================

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"slices"
 	"sort"
+	"strings"
 	"sync"
 
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
@@ -54,6 +55,23 @@ type BaseBlueprintProcessor struct {
 	mu             sync.Mutex
 	deferredPaths  map[string]bool
 	extraScope     map[string]any
+}
+
+// requirementBlockMiss records the unsatisfied paths and the effective condition under which a
+// single requirement block applied during a ProcessFacets pass. Condition is the AND of the parent
+// facet's When and the block's When; an empty Condition means the paths were unconditionally
+// required. Message is the optional author-supplied context for this block.
+type requirementBlockMiss struct {
+	Condition string
+	Message   string
+	Paths     []string
+}
+
+// facetRequirementMisses aggregates a single facet's unsatisfied requirement blocks for the
+// final-round error report.
+type facetRequirementMisses struct {
+	FacetName string
+	Misses    []requirementBlockMiss
 }
 
 // =============================================================================
@@ -169,12 +187,14 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 	var configBlockOrder []string
 	includedFacets := make([]blueprintv1alpha1.Facet, 0, len(sortedFacets))
 	prevIncludedSet := make(map[string]bool)
+	pendingRequirements := make(map[string]facetRequirementMisses)
 	const maxFacetRounds = 10
 	for range make([]struct{}, maxFacetRounds) {
 		includedFacets = includedFacets[:0]
 		globalScope = nil
 		cfgEntries = nil
 		configBlockOrder = nil
+		pendingRequirements = make(map[string]facetRequirementMisses)
 		passScope := scope
 		if passScope == nil && contextScope != nil {
 			passScope = maps.Clone(contextScope)
@@ -188,6 +208,17 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 				return nil, nil, err
 			}
 			if !shouldInclude {
+				continue
+			}
+			misses, err := p.evaluateRequirements(facet, passScope)
+			if err != nil {
+				return nil, nil, err
+			}
+			if len(misses) > 0 {
+				pendingRequirements[facet.Metadata.Name] = facetRequirementMisses{
+					FacetName: facet.Metadata.Name,
+					Misses:    misses,
+				}
 				continue
 			}
 			includedFacets = append(includedFacets, facet)
@@ -223,6 +254,10 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 			}
 		}
 		prevIncludedSet = currSet
+	}
+
+	if len(pendingRequirements) > 0 {
+		return nil, nil, formatRequirementsError(pendingRequirements)
 	}
 
 	for _, facet := range includedFacets {
@@ -1578,6 +1613,49 @@ func (p *BaseBlueprintProcessor) evaluateIntegerExpression(expr string, facetPat
 	return &result, nil
 }
 
+// evaluateRequirements walks the facet's Requires blocks against scope and returns the unsatisfied
+// blocks. A block is skipped when its When evaluates to false; otherwise every path must resolve to
+// a present, non-empty value (nil/""/empty slice/empty map count as missing; false and 0 are
+// present). The returned slice is empty when all blocks are satisfied. An error is returned only
+// when a block's When fails to evaluate.
+func (p *BaseBlueprintProcessor) evaluateRequirements(facet blueprintv1alpha1.Facet, scope map[string]any) ([]requirementBlockMiss, error) {
+	if len(facet.Requires) == 0 {
+		return nil, nil
+	}
+	var misses []requirementBlockMiss
+	for _, block := range facet.Requires {
+		if len(block.Paths) == 0 {
+			continue
+		}
+		applies := true
+		if block.When != "" {
+			ok, err := p.evaluateCondition(block.When, facet.Path, scope)
+			if err != nil {
+				return nil, fmt.Errorf("error evaluating requirement when '%s' in facet '%s': %w", block.When, facet.Metadata.Name, err)
+			}
+			applies = ok
+		}
+		if !applies {
+			continue
+		}
+		var missing []string
+		for _, path := range block.Paths {
+			if !isPresentAtPath(scope, path) {
+				missing = append(missing, path)
+			}
+		}
+		if len(missing) == 0 {
+			continue
+		}
+		misses = append(misses, requirementBlockMiss{
+			Condition: combineConditions(facet.When, block.When),
+			Message:   block.Message,
+			Paths:     missing,
+		})
+	}
+	return misses, nil
+}
+
 // =============================================================================
 // Helpers
 // =============================================================================
@@ -1816,6 +1894,146 @@ func accumulateMapKeys[K comparable, V any](m1, m2 map[K]V) map[K]V {
 		result[k] = zero
 	}
 	return result
+}
+
+// lookupPath resolves a dotted-path key (e.g. "cluster.workers.count") in a nested scope. Returns
+// (value, true) when every segment is found; returns (nil, false) when any segment is missing or
+// when an intermediate segment is not a map.
+func lookupPath(scope map[string]any, path string) (any, bool) {
+	if path == "" {
+		return nil, false
+	}
+	segments := strings.Split(path, ".")
+	var current any = scope
+	for _, seg := range segments {
+		m, ok := asMapStringAny(current)
+		if !ok {
+			return nil, false
+		}
+		v, exists := m[seg]
+		if !exists {
+			return nil, false
+		}
+		current = v
+	}
+	return current, true
+}
+
+// isPresentAtPath reports whether the dotted path resolves to a non-nil, non-empty value in scope.
+// Empty string, empty slice, and empty map are treated as missing; false and 0 are present.
+func isPresentAtPath(scope map[string]any, path string) bool {
+	val, ok := lookupPath(scope, path)
+	if !ok || val == nil {
+		return false
+	}
+	if s, ok := val.(string); ok {
+		return s != ""
+	}
+	rv := reflect.ValueOf(val)
+	switch rv.Kind() {
+	case reflect.Map, reflect.Slice, reflect.Array:
+		return rv.Len() > 0
+	}
+	return true
+}
+
+// combineConditions joins facet-level and block-level when expressions into a single condition
+// string used as a grouping key in the aggregated requirements error. Empty parts are dropped;
+// both empty yields "", meaning the requirement was unconditional.
+func combineConditions(facetWhen, blockWhen string) string {
+	fw := strings.TrimSpace(facetWhen)
+	bw := strings.TrimSpace(blockWhen)
+	switch {
+	case fw == "" && bw == "":
+		return ""
+	case fw == "":
+		return bw
+	case bw == "":
+		return fw
+	default:
+		return fw + " && " + bw
+	}
+}
+
+// formatRequirementsError renders the user-facing aggregated error for unsatisfied facet
+// requirements. Missing paths are bucketed by (effective condition, message); same-key buckets
+// merge while preserving authoring order of paths. Buckets are emitted unconditional-first, then
+// alphabetically by condition. The word "facet" is intentionally absent from the rendered output.
+func formatRequirementsError(pending map[string]facetRequirementMisses) error {
+	type bucketKey struct {
+		Condition string
+		Message   string
+	}
+	type bucket struct {
+		Key   bucketKey
+		Paths []string
+	}
+	bucketIndex := make(map[bucketKey]int)
+	var buckets []*bucket
+
+	names := make([]string, 0, len(pending))
+	for name := range pending {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		for _, miss := range pending[name].Misses {
+			key := bucketKey{Condition: miss.Condition, Message: miss.Message}
+			idx, exists := bucketIndex[key]
+			if !exists {
+				bucketIndex[key] = len(buckets)
+				buckets = append(buckets, &bucket{Key: key, Paths: slices.Clone(miss.Paths)})
+				continue
+			}
+			for _, p := range miss.Paths {
+				if !slices.Contains(buckets[idx].Paths, p) {
+					buckets[idx].Paths = append(buckets[idx].Paths, p)
+				}
+			}
+		}
+	}
+
+	sort.SliceStable(buckets, func(i, j int) bool {
+		ci, cj := buckets[i].Key.Condition, buckets[j].Key.Condition
+		if ci == "" && cj != "" {
+			return true
+		}
+		if cj == "" && ci != "" {
+			return false
+		}
+		return ci < cj
+	})
+
+	var b strings.Builder
+	b.WriteString("Required configuration is missing:\n\n")
+	total := 0
+	for _, bk := range buckets {
+		if bk.Key.Condition == "" {
+			b.WriteString("  Required:\n")
+		} else {
+			fmt.Fprintf(&b, "  Because %s:\n", bk.Key.Condition)
+		}
+		pathIndent := "    "
+		if bk.Key.Message != "" {
+			for _, line := range strings.Split(strings.TrimRight(bk.Key.Message, "\n"), "\n") {
+				b.WriteString("    ")
+				b.WriteString(line)
+				b.WriteByte('\n')
+			}
+			pathIndent = "      "
+		}
+		for _, p := range bk.Paths {
+			fmt.Fprintf(&b, "%s- %s\n", pathIndent, p)
+			total++
+		}
+		b.WriteByte('\n')
+	}
+	noun := "values"
+	if total == 1 {
+		noun = "value"
+	}
+	fmt.Fprintf(&b, "%d missing %s. Set these in values.yaml and re-run.", total, noun)
+	return fmt.Errorf("%s", b.String())
 }
 
 // =============================================================================

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -1,6 +1,7 @@
 package blueprint
 
 import (
+	"errors"
 	"fmt"
 	"maps"
 	"reflect"
@@ -2100,7 +2101,7 @@ func formatRequirementsError(pending map[string]facetRequirementMisses) error {
 		noun = "value"
 	}
 	fmt.Fprintf(&b, "%d missing %s. Set these in values.yaml and re-run.", total, noun)
-	return fmt.Errorf("%s", b.String())
+	return errors.New(b.String())
 }
 
 // =============================================================================

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -459,13 +459,9 @@ func (p *BaseBlueprintProcessor) mergeFacetScopeIntoGlobal(facet blueprintv1alph
 		}
 		cb := incoming[name]
 		cb.Body = map[string]any{"value": body}
-		for i := 0; i < len(order); i++ {
-			if order[i] == name {
-				order = append(order[:i], order[i+1:]...)
-				break
-			}
+		if !slices.Contains(order, name) {
+			order = append(order, name)
 		}
-		order = append(order, name)
 	}
 	if len(incoming) == 0 {
 		return globalScope, existing, order, nil

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -458,9 +458,13 @@ func (p *BaseBlueprintProcessor) mergeFacetScopeIntoGlobal(facet blueprintv1alph
 		}
 		cb := incoming[name]
 		cb.Body = map[string]any{"value": body}
-		if !slices.Contains(order, name) {
-			order = append(order, name)
+		for i := 0; i < len(order); i++ {
+			if order[i] == name {
+				order = append(order[:i], order[i+1:]...)
+				break
+			}
 		}
+		order = append(order, name)
 	}
 	if len(incoming) == 0 {
 		return globalScope, existing, order, nil

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -1,7 +1,6 @@
 package blueprint
 
 import (
-	"errors"
 	"fmt"
 	"maps"
 	"reflect"
@@ -2020,20 +2019,27 @@ func combineConditions(parts ...string) string {
 }
 
 // formatRequirementsError renders the user-facing aggregated error for unsatisfied facet
-// requirements. Missing paths are bucketed by (effective condition, message); same-key buckets
-// merge while preserving authoring order of paths. Buckets are emitted unconditional-first, then
-// alphabetically by condition. The word "facet" is intentionally absent from the rendered output.
+// requirements. Paths are listed alphabetically, deduplicated across facets, with any
+// author-supplied messages attached underneath. Conditions are deliberately not surfaced —
+// the message field is the right place for an author to explain why a value is needed; raw
+// when-expressions leak engine detail and confuse operators. The word "facet" is intentionally
+// absent from the rendered output.
 func formatRequirementsError(pending map[string]facetRequirementMisses) error {
-	type bucketKey struct {
-		Condition string
-		Message   string
+	pathMessages := make(map[string][]string)
+	var pathOrder []string
+	addMessage := func(path, msg string) {
+		if _, exists := pathMessages[path]; !exists {
+			pathOrder = append(pathOrder, path)
+			pathMessages[path] = nil
+		}
+		if msg == "" {
+			return
+		}
+		if slices.Contains(pathMessages[path], msg) {
+			return
+		}
+		pathMessages[path] = append(pathMessages[path], msg)
 	}
-	type bucket struct {
-		Key   bucketKey
-		Paths []string
-	}
-	bucketIndex := make(map[bucketKey]int)
-	var buckets []*bucket
 
 	names := make([]string, 0, len(pending))
 	for name := range pending {
@@ -2042,62 +2048,46 @@ func formatRequirementsError(pending map[string]facetRequirementMisses) error {
 	sort.Strings(names)
 	for _, name := range names {
 		for _, miss := range pending[name].Misses {
-			key := bucketKey{Condition: miss.Condition, Message: miss.Message}
-			idx, exists := bucketIndex[key]
-			if !exists {
-				bucketIndex[key] = len(buckets)
-				buckets = append(buckets, &bucket{Key: key, Paths: slices.Clone(miss.Paths)})
-				continue
-			}
 			for _, p := range miss.Paths {
-				if !slices.Contains(buckets[idx].Paths, p) {
-					buckets[idx].Paths = append(buckets[idx].Paths, p)
-				}
+				addMessage(p, miss.Message)
 			}
 		}
 	}
 
-	sort.SliceStable(buckets, func(i, j int) bool {
-		ci, cj := buckets[i].Key.Condition, buckets[j].Key.Condition
-		if ci == "" && cj != "" {
-			return true
-		}
-		if cj == "" && ci != "" {
-			return false
-		}
-		return ci < cj
-	})
+	sort.Strings(pathOrder)
 
 	var b strings.Builder
-	b.WriteString("Required configuration is missing:\n\n")
-	total := 0
-	for _, bk := range buckets {
-		if bk.Key.Condition == "" {
-			b.WriteString("  Required:\n")
-		} else {
-			fmt.Fprintf(&b, "  Because %s:\n", bk.Key.Condition)
+	b.WriteString("the following required values are not set in values.yaml:\n\n")
+	for _, path := range pathOrder {
+		fmt.Fprintf(&b, "  - %s\n", path)
+	}
+
+	hasNotes := false
+	for _, msgs := range pathMessages {
+		if len(msgs) > 0 {
+			hasNotes = true
+			break
 		}
-		pathIndent := "    "
-		if bk.Key.Message != "" {
-			for _, line := range strings.Split(strings.TrimRight(bk.Key.Message, "\n"), "\n") {
-				b.WriteString("    ")
-				b.WriteString(line)
-				b.WriteByte('\n')
+	}
+	if hasNotes {
+		b.WriteString("\nNotes:\n\n")
+		for _, path := range pathOrder {
+			msgs := pathMessages[path]
+			if len(msgs) == 0 {
+				continue
 			}
-			pathIndent = "      "
+			fmt.Fprintf(&b, "  %s:\n", path)
+			for _, msg := range msgs {
+				for _, line := range strings.Split(strings.TrimRight(msg, "\n"), "\n") {
+					b.WriteString("    ")
+					b.WriteString(line)
+					b.WriteByte('\n')
+				}
+			}
+			b.WriteByte('\n')
 		}
-		for _, p := range bk.Paths {
-			fmt.Fprintf(&b, "%s- %s\n", pathIndent, p)
-			total++
-		}
-		b.WriteByte('\n')
 	}
-	noun := "values"
-	if total == 1 {
-		noun = "value"
-	}
-	fmt.Fprintf(&b, "%d missing %s. Set these in values.yaml and re-run.", total, noun)
-	return errors.New(b.String())
+	return &RequirementsError{Message: strings.TrimRight(b.String(), "\n")}
 }
 
 // =============================================================================

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -1613,25 +1613,101 @@ func (p *BaseBlueprintProcessor) evaluateIntegerExpression(expr string, facetPat
 	return &result, nil
 }
 
-// evaluateRequirements walks the facet's Requires blocks against scope and returns the unsatisfied
-// blocks. A block is skipped when its When evaluates to false; otherwise every path must resolve to
-// a present, non-empty value (nil/""/empty slice/empty map count as missing; false and 0 are
-// present). The returned slice is empty when all blocks are satisfied. An error is returned only
-// when a block's When fails to evaluate.
+// evaluateRequirements walks the facet's Requires blocks and the Requires blocks of every config
+// block, terraform component, and kustomization whose When holds, returning the unsatisfied entries.
+// A requirement block is skipped when its own When evaluates to false; otherwise every path must
+// resolve to a present, non-empty value (nil/""/empty slice/empty map count as missing; false and 0
+// are present). Component-level Requires are skipped entirely when the component's When is false,
+// so the component's needs only bind when it would actually be included. The miss's Condition is
+// the AND of facet.When, component.When (when applicable), and block.When; the formatter buckets
+// misses by Condition so each effective scope renders as its own "Because" section. An error is
+// returned only when a When expression fails to evaluate.
 func (p *BaseBlueprintProcessor) evaluateRequirements(facet blueprintv1alpha1.Facet, scope map[string]any) ([]requirementBlockMiss, error) {
-	if len(facet.Requires) == 0 {
+	var misses []requirementBlockMiss
+
+	facetMisses, err := p.evaluateRequirementBlocks(facet.Requires, scope, facet.Path, facet.Metadata.Name, facet.When)
+	if err != nil {
+		return nil, err
+	}
+	misses = append(misses, facetMisses...)
+
+	for _, cb := range facet.Config {
+		if len(cb.Requires) == 0 {
+			continue
+		}
+		include, err := p.shouldIncludeComponent(cb.When, facet.Path, scope)
+		if err != nil {
+			return nil, fmt.Errorf("error evaluating config block when '%s' in facet '%s': %w", cb.When, facet.Metadata.Name, err)
+		}
+		if !include {
+			continue
+		}
+		m, err := p.evaluateRequirementBlocks(cb.Requires, scope, facet.Path, facet.Metadata.Name, facet.When, cb.When)
+		if err != nil {
+			return nil, err
+		}
+		misses = append(misses, m...)
+	}
+
+	for _, tc := range facet.TerraformComponents {
+		if len(tc.Requires) == 0 {
+			continue
+		}
+		include, err := p.shouldIncludeComponent(tc.When, facet.Path, scope)
+		if err != nil {
+			return nil, fmt.Errorf("error evaluating terraform component when '%s' in facet '%s': %w", tc.When, facet.Metadata.Name, err)
+		}
+		if !include {
+			continue
+		}
+		m, err := p.evaluateRequirementBlocks(tc.Requires, scope, facet.Path, facet.Metadata.Name, facet.When, tc.When)
+		if err != nil {
+			return nil, err
+		}
+		misses = append(misses, m...)
+	}
+
+	for _, k := range facet.Kustomizations {
+		if len(k.Requires) == 0 {
+			continue
+		}
+		include, err := p.shouldIncludeComponent(k.When, facet.Path, scope)
+		if err != nil {
+			return nil, fmt.Errorf("error evaluating kustomization when '%s' in facet '%s': %w", k.When, facet.Metadata.Name, err)
+		}
+		if !include {
+			continue
+		}
+		m, err := p.evaluateRequirementBlocks(k.Requires, scope, facet.Path, facet.Metadata.Name, facet.When, k.When)
+		if err != nil {
+			return nil, err
+		}
+		misses = append(misses, m...)
+	}
+
+	return misses, nil
+}
+
+// evaluateRequirementBlocks walks blocks against scope and returns the unsatisfied entries.
+// parentWhens are the chain of parent-level when expressions (facet.When, optionally
+// component.When) that are composed with each block's own When into the miss's effective condition.
+// A block is skipped when its own When evaluates to false. Empty parts in parentWhens are dropped
+// by combineConditions, so callers may pass an unset When (e.g. an empty facet.When) without
+// special-casing.
+func (p *BaseBlueprintProcessor) evaluateRequirementBlocks(blocks []blueprintv1alpha1.RequirementBlock, scope map[string]any, facetPath, facetName string, parentWhens ...string) ([]requirementBlockMiss, error) {
+	if len(blocks) == 0 {
 		return nil, nil
 	}
 	var misses []requirementBlockMiss
-	for _, block := range facet.Requires {
+	for _, block := range blocks {
 		if len(block.Paths) == 0 {
 			continue
 		}
 		applies := true
 		if block.When != "" {
-			ok, err := p.evaluateCondition(block.When, facet.Path, scope)
+			ok, err := p.evaluateCondition(block.When, facetPath, scope)
 			if err != nil {
-				return nil, fmt.Errorf("error evaluating requirement when '%s' in facet '%s': %w", block.When, facet.Metadata.Name, err)
+				return nil, fmt.Errorf("error evaluating requirement when '%s' in facet '%s': %w", block.When, facetName, err)
 			}
 			applies = ok
 		}
@@ -1648,7 +1724,7 @@ func (p *BaseBlueprintProcessor) evaluateRequirements(facet blueprintv1alpha1.Fa
 			continue
 		}
 		misses = append(misses, requirementBlockMiss{
-			Condition: combineConditions(facet.When, block.When),
+			Condition: combineConditions(append(parentWhens, block.When)...),
 			Message:   block.Message,
 			Paths:     missing,
 		})
@@ -1937,22 +2013,17 @@ func isPresentAtPath(scope map[string]any, path string) bool {
 	return true
 }
 
-// combineConditions joins facet-level and block-level when expressions into a single condition
-// string used as a grouping key in the aggregated requirements error. Empty parts are dropped;
-// both empty yields "", meaning the requirement was unconditional.
-func combineConditions(facetWhen, blockWhen string) string {
-	fw := strings.TrimSpace(facetWhen)
-	bw := strings.TrimSpace(blockWhen)
-	switch {
-	case fw == "" && bw == "":
-		return ""
-	case fw == "":
-		return bw
-	case bw == "":
-		return fw
-	default:
-		return fw + " && " + bw
+// combineConditions joins one or more when expressions into a single condition string used as a
+// grouping key in the aggregated requirements error. Empty parts are trimmed and dropped; all
+// empty (or no parts) yields "", meaning the requirement was unconditional.
+func combineConditions(parts ...string) string {
+	var nonEmpty []string
+	for _, p := range parts {
+		if trimmed := strings.TrimSpace(p); trimmed != "" {
+			nonEmpty = append(nonEmpty, trimmed)
+		}
 	}
+	return strings.Join(nonEmpty, " && ")
 }
 
 // formatRequirementsError renders the user-facing aggregated error for unsatisfied facet

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -68,10 +68,9 @@ type requirementBlockMiss struct {
 }
 
 // facetRequirementMisses aggregates a single facet's unsatisfied requirement blocks for the
-// final-round error report.
+// final-round error report. The facet name is carried by the outer map key in pendingRequirements.
 type facetRequirementMisses struct {
-	FacetName string
-	Misses    []requirementBlockMiss
+	Misses []requirementBlockMiss
 }
 
 // =============================================================================
@@ -215,10 +214,7 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 				return nil, nil, err
 			}
 			if len(misses) > 0 {
-				pendingRequirements[facet.Metadata.Name] = facetRequirementMisses{
-					FacetName: facet.Metadata.Name,
-					Misses:    misses,
-				}
+				pendingRequirements[facet.Metadata.Name] = facetRequirementMisses{Misses: misses}
 				continue
 			}
 			includedFacets = append(includedFacets, facet)

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -5172,3 +5172,353 @@ func TestEvaluateCondition_EvaluatesAgainstScope(t *testing.T) {
 		}
 	})
 }
+
+// =============================================================================
+// Test Public Methods
+// =============================================================================
+
+func TestProcessor_ProcessFacets_Requires(t *testing.T) {
+	t.Run("SatisfiedByContextValues", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{
+				"cluster": map[string]any{"name": "mycluster"},
+				"dns":     map[string]any{"domain": "example.com"},
+			}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "consumer"},
+				Requires: []blueprintv1alpha1.RequirementBlock{
+					{Paths: []string{"cluster.name", "dns.domain"}},
+				},
+			},
+		}
+		if _, _, err := processor.ProcessFacets(target, facets); err != nil {
+			t.Fatalf("Expected no error when requirements are satisfied, got %v", err)
+		}
+	})
+
+	t.Run("ConditionalBlockSkippedWhenFalse", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"provider": "docker"}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "aws-only"},
+				Requires: []blueprintv1alpha1.RequirementBlock{
+					{When: "provider == 'aws'", Paths: []string{"aws.region"}},
+				},
+			},
+		}
+		if _, _, err := processor.ProcessFacets(target, facets); err != nil {
+			t.Fatalf("Expected no error; aws block should be skipped, got %v", err)
+		}
+	})
+
+	t.Run("UnsatisfiedRequirementProducesAggregatedError", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"provider": "aws"}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "provider-aws"},
+				When:     "provider == 'aws'",
+				Requires: []blueprintv1alpha1.RequirementBlock{
+					{Paths: []string{"aws.region", "aws.account_id"}},
+				},
+			},
+		}
+		_, _, err := processor.ProcessFacets(target, facets)
+		if err == nil {
+			t.Fatal("Expected error for unsatisfied requirements, got nil")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "Required configuration is missing") {
+			t.Errorf("Expected aggregated header, got: %s", msg)
+		}
+		if !strings.Contains(msg, "aws.region") || !strings.Contains(msg, "aws.account_id") {
+			t.Errorf("Expected both paths listed, got: %s", msg)
+		}
+		if !strings.Contains(msg, "Because provider == 'aws':") {
+			t.Errorf("Expected condition heading, got: %s", msg)
+		}
+		if strings.Contains(msg, "facet") {
+			t.Errorf("Expected error to not mention 'facet', got: %s", msg)
+		}
+	})
+
+	t.Run("EmptyValueIsTreatedAsMissing", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{
+				"dns":  map[string]any{"domain": ""},
+				"tags": []any{},
+			}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "consumer"},
+				Requires: []blueprintv1alpha1.RequirementBlock{
+					{Paths: []string{"dns.domain", "tags"}},
+				},
+			},
+		}
+		_, _, err := processor.ProcessFacets(target, facets)
+		if err == nil {
+			t.Fatal("Expected error for empty values, got nil")
+		}
+		if !strings.Contains(err.Error(), "dns.domain") || !strings.Contains(err.Error(), "tags") {
+			t.Errorf("Expected both empty paths reported, got: %s", err.Error())
+		}
+	})
+
+	t.Run("FalseAndZeroAreTreatedAsPresent", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{
+				"feature":  map[string]any{"enabled": false},
+				"replicas": 0,
+			}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "consumer"},
+				Requires: []blueprintv1alpha1.RequirementBlock{
+					{Paths: []string{"feature.enabled", "replicas"}},
+				},
+			},
+		}
+		if _, _, err := processor.ProcessFacets(target, facets); err != nil {
+			t.Fatalf("Expected false/0 to satisfy requirement, got error: %v", err)
+		}
+	})
+
+	t.Run("CrossFacetConfigBlockSatisfiesAfterDeferral", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"provider": "incus", "cluster": map[string]any{"name": "demo"}}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "consumer"},
+				Ordinal:  intPtr(200),
+				Requires: []blueprintv1alpha1.RequirementBlock{
+					{Paths: []string{"talos.cluster_name"}},
+				},
+			},
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "config-talos"},
+				Ordinal:  intPtr(100),
+				When:     "provider == 'incus'",
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "talos", Body: map[string]any{"value": map[string]any{"cluster_name": "${cluster.name}"}}},
+				},
+			},
+		}
+		if _, _, err := processor.ProcessFacets(target, facets); err != nil {
+			t.Fatalf("Expected requirement to be satisfied via config block in later round, got: %v", err)
+		}
+	})
+
+	t.Run("MessageRendersUnderConditionHeading", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"observability": map[string]any{"enabled": true}}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "obs"},
+				Requires: []blueprintv1alpha1.RequirementBlock{
+					{
+						When:    "observability.enabled",
+						Paths:   []string{"observability.endpoint", "observability.token"},
+						Message: "See docs/observability for setup.",
+					},
+				},
+			},
+		}
+		_, _, err := processor.ProcessFacets(target, facets)
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "Because observability.enabled:") {
+			t.Errorf("Expected condition heading, got: %s", msg)
+		}
+		if !strings.Contains(msg, "See docs/observability for setup.") {
+			t.Errorf("Expected message text in error, got: %s", msg)
+		}
+		if !strings.Contains(msg, "observability.endpoint") || !strings.Contains(msg, "observability.token") {
+			t.Errorf("Expected both paths in error, got: %s", msg)
+		}
+	})
+
+	t.Run("AggregatesAcrossMultipleFacets", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"provider": "aws"}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "facet-a"},
+				Requires: []blueprintv1alpha1.RequirementBlock{
+					{Paths: []string{"cluster.name"}},
+				},
+			},
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "facet-b"},
+				When:     "provider == 'aws'",
+				Requires: []blueprintv1alpha1.RequirementBlock{
+					{Paths: []string{"aws.region"}},
+				},
+			},
+		}
+		_, _, err := processor.ProcessFacets(target, facets)
+		if err == nil {
+			t.Fatal("Expected aggregated error, got nil")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "Required:") {
+			t.Errorf("Expected unconditional 'Required:' heading, got: %s", msg)
+		}
+		if !strings.Contains(msg, "Because provider == 'aws':") {
+			t.Errorf("Expected conditional heading, got: %s", msg)
+		}
+		if !strings.Contains(msg, "cluster.name") || !strings.Contains(msg, "aws.region") {
+			t.Errorf("Expected both paths, got: %s", msg)
+		}
+		if !strings.Contains(msg, "2 missing values") {
+			t.Errorf("Expected '2 missing values' summary, got: %s", msg)
+		}
+	})
+
+	t.Run("SelfReferenceNeverSatisfied", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"provider": "incus", "cluster": map[string]any{"name": "demo"}}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "self-referencing"},
+				When:     "provider == 'incus'",
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "self", Body: map[string]any{"value": map[string]any{"k": "${cluster.name}"}}},
+				},
+				Requires: []blueprintv1alpha1.RequirementBlock{
+					{Paths: []string{"self.k"}},
+				},
+			},
+		}
+		_, _, err := processor.ProcessFacets(target, facets)
+		if err == nil {
+			t.Fatal("Expected error for self-referenced requirement, got nil")
+		}
+		if !strings.Contains(err.Error(), "self.k") {
+			t.Errorf("Expected self.k path in error, got: %s", err.Error())
+		}
+	})
+}
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+func TestFormatRequirementsError(t *testing.T) {
+	t.Run("UnconditionalBucketRendersFirst", func(t *testing.T) {
+		pending := map[string]facetRequirementMisses{
+			"a": {FacetName: "a", Misses: []requirementBlockMiss{
+				{Condition: "", Paths: []string{"cluster.name"}},
+			}},
+			"b": {FacetName: "b", Misses: []requirementBlockMiss{
+				{Condition: "provider == 'aws'", Paths: []string{"aws.region"}},
+			}},
+		}
+		msg := formatRequirementsError(pending).Error()
+		idxRequired := strings.Index(msg, "Required:")
+		idxBecause := strings.Index(msg, "Because provider == 'aws':")
+		if idxRequired < 0 || idxBecause < 0 {
+			t.Fatalf("Missing headings in: %s", msg)
+		}
+		if idxRequired > idxBecause {
+			t.Error("Expected 'Required:' to appear before conditional heading")
+		}
+	})
+
+	t.Run("MergesSameConditionAcrossFacets", func(t *testing.T) {
+		pending := map[string]facetRequirementMisses{
+			"a": {FacetName: "a", Misses: []requirementBlockMiss{
+				{Condition: "provider == 'aws'", Paths: []string{"aws.region"}},
+			}},
+			"b": {FacetName: "b", Misses: []requirementBlockMiss{
+				{Condition: "provider == 'aws'", Paths: []string{"aws.account_id"}},
+			}},
+		}
+		msg := formatRequirementsError(pending).Error()
+		if c := strings.Count(msg, "Because provider == 'aws':"); c != 1 {
+			t.Errorf("Expected one merged heading, got %d. Msg: %s", c, msg)
+		}
+		if !strings.Contains(msg, "aws.region") || !strings.Contains(msg, "aws.account_id") {
+			t.Error("Expected both paths under merged heading")
+		}
+	})
+
+	t.Run("MessageIndentedAboveDeeperPaths", func(t *testing.T) {
+		pending := map[string]facetRequirementMisses{
+			"obs": {FacetName: "obs", Misses: []requirementBlockMiss{
+				{Condition: "observability.enabled", Message: "See docs/obs.", Paths: []string{"observability.token"}},
+			}},
+		}
+		msg := formatRequirementsError(pending).Error()
+		if !strings.Contains(msg, "    See docs/obs.\n") {
+			t.Errorf("Expected message indented at 4 spaces, got: %s", msg)
+		}
+		if !strings.Contains(msg, "      - observability.token") {
+			t.Errorf("Expected path indented at 6 spaces under message, got: %s", msg)
+		}
+	})
+
+	t.Run("FooterUsesSingularForOneMissing", func(t *testing.T) {
+		pending := map[string]facetRequirementMisses{
+			"a": {FacetName: "a", Misses: []requirementBlockMiss{
+				{Paths: []string{"cluster.name"}},
+			}},
+		}
+		msg := formatRequirementsError(pending).Error()
+		if !strings.Contains(msg, "1 missing value.") {
+			t.Errorf("Expected singular footer, got: %s", msg)
+		}
+	})
+
+	t.Run("ErrorDoesNotMentionFacet", func(t *testing.T) {
+		pending := map[string]facetRequirementMisses{
+			"facet-name-here": {FacetName: "facet-name-here", Misses: []requirementBlockMiss{
+				{Paths: []string{"cluster.name"}},
+			}},
+		}
+		msg := formatRequirementsError(pending).Error()
+		if strings.Contains(msg, "facet") {
+			t.Errorf("Expected error not to mention 'facet', got: %s", msg)
+		}
+	})
+}

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -5312,7 +5312,7 @@ func TestProcessor_ProcessFacets_Requires(t *testing.T) {
 	t.Run("ConditionalBlockSkippedWhenFalse", func(t *testing.T) {
 		mocks := setupProcessorMocks(t)
 		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
-			return map[string]any{"provider": "docker"}, nil
+			return map[string]any{"platform": "docker"}, nil
 		}
 		processor := NewBlueprintProcessor(mocks.Runtime)
 		target := &blueprintv1alpha1.Blueprint{}
@@ -5320,7 +5320,7 @@ func TestProcessor_ProcessFacets_Requires(t *testing.T) {
 			{
 				Metadata: blueprintv1alpha1.Metadata{Name: "aws-only"},
 				Requires: []blueprintv1alpha1.RequirementBlock{
-					{When: "provider == 'aws'", Paths: []string{"aws.region"}},
+					{When: "platform == 'aws'", Paths: []string{"aws.region"}},
 				},
 			},
 		}
@@ -5332,14 +5332,14 @@ func TestProcessor_ProcessFacets_Requires(t *testing.T) {
 	t.Run("UnsatisfiedRequirementProducesAggregatedError", func(t *testing.T) {
 		mocks := setupProcessorMocks(t)
 		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
-			return map[string]any{"provider": "aws"}, nil
+			return map[string]any{"platform": "aws"}, nil
 		}
 		processor := NewBlueprintProcessor(mocks.Runtime)
 		target := &blueprintv1alpha1.Blueprint{}
 		facets := []blueprintv1alpha1.Facet{
 			{
-				Metadata: blueprintv1alpha1.Metadata{Name: "provider-aws"},
-				When:     "provider == 'aws'",
+				Metadata: blueprintv1alpha1.Metadata{Name: "platform-aws"},
+				When:     "platform == 'aws'",
 				Requires: []blueprintv1alpha1.RequirementBlock{
 					{Paths: []string{"aws.region", "aws.account_id"}},
 				},
@@ -5356,7 +5356,7 @@ func TestProcessor_ProcessFacets_Requires(t *testing.T) {
 		if !strings.Contains(msg, "aws.region") || !strings.Contains(msg, "aws.account_id") {
 			t.Errorf("Expected both paths listed, got: %s", msg)
 		}
-		if !strings.Contains(msg, "Because provider == 'aws':") {
+		if !strings.Contains(msg, "Because platform == 'aws':") {
 			t.Errorf("Expected condition heading, got: %s", msg)
 		}
 		if strings.Contains(msg, "facet") {
@@ -5417,7 +5417,7 @@ func TestProcessor_ProcessFacets_Requires(t *testing.T) {
 	t.Run("CrossFacetConfigBlockSatisfiesAfterDeferral", func(t *testing.T) {
 		mocks := setupProcessorMocks(t)
 		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
-			return map[string]any{"provider": "incus", "cluster": map[string]any{"name": "demo"}}, nil
+			return map[string]any{"platform": "incus", "cluster": map[string]any{"name": "demo"}}, nil
 		}
 		processor := NewBlueprintProcessor(mocks.Runtime)
 		target := &blueprintv1alpha1.Blueprint{}
@@ -5432,7 +5432,7 @@ func TestProcessor_ProcessFacets_Requires(t *testing.T) {
 			{
 				Metadata: blueprintv1alpha1.Metadata{Name: "config-talos"},
 				Ordinal:  intPtr(100),
-				When:     "provider == 'incus'",
+				When:     "platform == 'incus'",
 				Config: []blueprintv1alpha1.ConfigBlock{
 					{Name: "talos", Body: map[string]any{"value": map[string]any{"cluster_name": "${cluster.name}"}}},
 				},
@@ -5481,7 +5481,7 @@ func TestProcessor_ProcessFacets_Requires(t *testing.T) {
 	t.Run("AggregatesAcrossMultipleFacets", func(t *testing.T) {
 		mocks := setupProcessorMocks(t)
 		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
-			return map[string]any{"provider": "aws"}, nil
+			return map[string]any{"platform": "aws"}, nil
 		}
 		processor := NewBlueprintProcessor(mocks.Runtime)
 		target := &blueprintv1alpha1.Blueprint{}
@@ -5494,7 +5494,7 @@ func TestProcessor_ProcessFacets_Requires(t *testing.T) {
 			},
 			{
 				Metadata: blueprintv1alpha1.Metadata{Name: "facet-b"},
-				When:     "provider == 'aws'",
+				When:     "platform == 'aws'",
 				Requires: []blueprintv1alpha1.RequirementBlock{
 					{Paths: []string{"aws.region"}},
 				},
@@ -5508,7 +5508,7 @@ func TestProcessor_ProcessFacets_Requires(t *testing.T) {
 		if !strings.Contains(msg, "Required:") {
 			t.Errorf("Expected unconditional 'Required:' heading, got: %s", msg)
 		}
-		if !strings.Contains(msg, "Because provider == 'aws':") {
+		if !strings.Contains(msg, "Because platform == 'aws':") {
 			t.Errorf("Expected conditional heading, got: %s", msg)
 		}
 		if !strings.Contains(msg, "cluster.name") || !strings.Contains(msg, "aws.region") {
@@ -5522,14 +5522,14 @@ func TestProcessor_ProcessFacets_Requires(t *testing.T) {
 	t.Run("SelfReferenceNeverSatisfied", func(t *testing.T) {
 		mocks := setupProcessorMocks(t)
 		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
-			return map[string]any{"provider": "incus", "cluster": map[string]any{"name": "demo"}}, nil
+			return map[string]any{"platform": "incus", "cluster": map[string]any{"name": "demo"}}, nil
 		}
 		processor := NewBlueprintProcessor(mocks.Runtime)
 		target := &blueprintv1alpha1.Blueprint{}
 		facets := []blueprintv1alpha1.Facet{
 			{
 				Metadata: blueprintv1alpha1.Metadata{Name: "self-referencing"},
-				When:     "provider == 'incus'",
+				When:     "platform == 'incus'",
 				Config: []blueprintv1alpha1.ConfigBlock{
 					{Name: "self", Body: map[string]any{"value": map[string]any{"k": "${cluster.name}"}}},
 				},
@@ -5559,12 +5559,12 @@ func TestFormatRequirementsError(t *testing.T) {
 				{Condition: "", Paths: []string{"cluster.name"}},
 			}},
 			"b": {FacetName: "b", Misses: []requirementBlockMiss{
-				{Condition: "provider == 'aws'", Paths: []string{"aws.region"}},
+				{Condition: "platform == 'aws'", Paths: []string{"aws.region"}},
 			}},
 		}
 		msg := formatRequirementsError(pending).Error()
 		idxRequired := strings.Index(msg, "Required:")
-		idxBecause := strings.Index(msg, "Because provider == 'aws':")
+		idxBecause := strings.Index(msg, "Because platform == 'aws':")
 		if idxRequired < 0 || idxBecause < 0 {
 			t.Fatalf("Missing headings in: %s", msg)
 		}
@@ -5576,14 +5576,14 @@ func TestFormatRequirementsError(t *testing.T) {
 	t.Run("MergesSameConditionAcrossFacets", func(t *testing.T) {
 		pending := map[string]facetRequirementMisses{
 			"a": {FacetName: "a", Misses: []requirementBlockMiss{
-				{Condition: "provider == 'aws'", Paths: []string{"aws.region"}},
+				{Condition: "platform == 'aws'", Paths: []string{"aws.region"}},
 			}},
 			"b": {FacetName: "b", Misses: []requirementBlockMiss{
-				{Condition: "provider == 'aws'", Paths: []string{"aws.account_id"}},
+				{Condition: "platform == 'aws'", Paths: []string{"aws.account_id"}},
 			}},
 		}
 		msg := formatRequirementsError(pending).Error()
-		if c := strings.Count(msg, "Because provider == 'aws':"); c != 1 {
+		if c := strings.Count(msg, "Because platform == 'aws':"); c != 1 {
 			t.Errorf("Expected one merged heading, got %d. Msg: %s", c, msg)
 		}
 		if !strings.Contains(msg, "aws.region") || !strings.Contains(msg, "aws.account_id") {

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -5411,14 +5411,14 @@ func TestProcessor_ProcessFacets_Requires(t *testing.T) {
 			t.Fatal("Expected error for unsatisfied requirements, got nil")
 		}
 		msg := err.Error()
-		if !strings.Contains(msg, "Required configuration is missing") {
-			t.Errorf("Expected aggregated header, got: %s", msg)
+		if !strings.Contains(msg, "the following required values are not set in values.yaml:") {
+			t.Errorf("Expected lead instruction, got: %s", msg)
 		}
-		if !strings.Contains(msg, "aws.region") || !strings.Contains(msg, "aws.account_id") {
-			t.Errorf("Expected both paths listed, got: %s", msg)
+		if !strings.Contains(msg, "- aws.account_id\n  - aws.region") {
+			t.Errorf("Expected both paths listed alphabetically as bullets, got: %s", msg)
 		}
-		if !strings.Contains(msg, "Because platform == 'aws':") {
-			t.Errorf("Expected condition heading, got: %s", msg)
+		if strings.Contains(msg, "Because") || strings.Contains(msg, "platform == 'aws'") {
+			t.Errorf("Expected error to not surface condition expression, got: %s", msg)
 		}
 		if strings.Contains(msg, "facet") {
 			t.Errorf("Expected error to not mention 'facet', got: %s", msg)
@@ -5504,7 +5504,7 @@ func TestProcessor_ProcessFacets_Requires(t *testing.T) {
 		}
 	})
 
-	t.Run("MessageRendersUnderConditionHeading", func(t *testing.T) {
+	t.Run("MessageRendersInNotesSection", func(t *testing.T) {
 		mocks := setupProcessorMocks(t)
 		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
 			return map[string]any{"observability": map[string]any{"enabled": true}}, nil
@@ -5528,14 +5528,17 @@ func TestProcessor_ProcessFacets_Requires(t *testing.T) {
 			t.Fatal("Expected error, got nil")
 		}
 		msg := err.Error()
-		if !strings.Contains(msg, "Because observability.enabled:") {
-			t.Errorf("Expected condition heading, got: %s", msg)
+		if strings.Contains(msg, "Because") {
+			t.Errorf("Expected no 'Because' heading in new format, got: %s", msg)
 		}
-		if !strings.Contains(msg, "See docs/observability for setup.") {
-			t.Errorf("Expected message text in error, got: %s", msg)
+		if !strings.Contains(msg, "\nNotes:\n") {
+			t.Errorf("Expected 'Notes:' section, got: %s", msg)
 		}
-		if !strings.Contains(msg, "observability.endpoint") || !strings.Contains(msg, "observability.token") {
-			t.Errorf("Expected both paths in error, got: %s", msg)
+		if !strings.Contains(msg, "  observability.endpoint:\n    See docs/observability for setup.") {
+			t.Errorf("Expected message in Notes under first path, got: %s", msg)
+		}
+		if !strings.Contains(msg, "  observability.token:\n    See docs/observability for setup.") {
+			t.Errorf("Expected message in Notes under second path, got: %s", msg)
 		}
 	})
 
@@ -5566,17 +5569,11 @@ func TestProcessor_ProcessFacets_Requires(t *testing.T) {
 			t.Fatal("Expected aggregated error, got nil")
 		}
 		msg := err.Error()
-		if !strings.Contains(msg, "Required:") {
-			t.Errorf("Expected unconditional 'Required:' heading, got: %s", msg)
+		if !strings.Contains(msg, "- aws.region") || !strings.Contains(msg, "- cluster.name") {
+			t.Errorf("Expected both paths as bullets, got: %s", msg)
 		}
-		if !strings.Contains(msg, "Because platform == 'aws':") {
-			t.Errorf("Expected conditional heading, got: %s", msg)
-		}
-		if !strings.Contains(msg, "cluster.name") || !strings.Contains(msg, "aws.region") {
-			t.Errorf("Expected both paths, got: %s", msg)
-		}
-		if !strings.Contains(msg, "2 missing values") {
-			t.Errorf("Expected '2 missing values' summary, got: %s", msg)
+		if strings.Contains(msg, "platform == 'aws'") {
+			t.Errorf("Expected no condition expression in output, got: %s", msg)
 		}
 	})
 
@@ -5614,68 +5611,65 @@ func TestProcessor_ProcessFacets_Requires(t *testing.T) {
 // =============================================================================
 
 func TestFormatRequirementsError(t *testing.T) {
-	t.Run("UnconditionalBucketRendersFirst", func(t *testing.T) {
+	t.Run("PathsListedAlphabetically", func(t *testing.T) {
 		pending := map[string]facetRequirementMisses{
 			"a": {Misses: []requirementBlockMiss{
-				{Condition: "", Paths: []string{"cluster.name"}},
+				{Paths: []string{"cluster.name"}},
 			}},
 			"b": {Misses: []requirementBlockMiss{
-				{Condition: "platform == 'aws'", Paths: []string{"aws.region"}},
+				{Paths: []string{"aws.region"}},
 			}},
 		}
 		msg := formatRequirementsError(pending).Error()
-		idxRequired := strings.Index(msg, "Required:")
-		idxBecause := strings.Index(msg, "Because platform == 'aws':")
-		if idxRequired < 0 || idxBecause < 0 {
-			t.Fatalf("Missing headings in: %s", msg)
+		idxAws := strings.Index(msg, "- aws.region")
+		idxCluster := strings.Index(msg, "- cluster.name")
+		if idxAws < 0 || idxCluster < 0 {
+			t.Fatalf("Missing bullets in: %s", msg)
 		}
-		if idxRequired > idxBecause {
-			t.Error("Expected 'Required:' to appear before conditional heading")
+		if idxAws > idxCluster {
+			t.Error("Expected aws.region to appear before cluster.name (alphabetical)")
 		}
 	})
 
-	t.Run("MergesSameConditionAcrossFacets", func(t *testing.T) {
+	t.Run("DuplicatePathAcrossFacetsRendersOnce", func(t *testing.T) {
 		pending := map[string]facetRequirementMisses{
 			"a": {Misses: []requirementBlockMiss{
-				{Condition: "platform == 'aws'", Paths: []string{"aws.region"}},
+				{Paths: []string{"aws.region"}},
 			}},
 			"b": {Misses: []requirementBlockMiss{
-				{Condition: "platform == 'aws'", Paths: []string{"aws.account_id"}},
+				{Paths: []string{"aws.region"}},
 			}},
 		}
 		msg := formatRequirementsError(pending).Error()
-		if c := strings.Count(msg, "Because platform == 'aws':"); c != 1 {
-			t.Errorf("Expected one merged heading, got %d. Msg: %s", c, msg)
-		}
-		if !strings.Contains(msg, "aws.region") || !strings.Contains(msg, "aws.account_id") {
-			t.Error("Expected both paths under merged heading")
+		if c := strings.Count(msg, "- aws.region"); c != 1 {
+			t.Errorf("Expected one bullet for aws.region (deduplicated), got %d. Msg: %s", c, msg)
 		}
 	})
 
-	t.Run("MessageIndentedAboveDeeperPaths", func(t *testing.T) {
+	t.Run("NotesSectionRendersAuthorMessage", func(t *testing.T) {
 		pending := map[string]facetRequirementMisses{
 			"obs": {Misses: []requirementBlockMiss{
-				{Condition: "observability.enabled", Message: "See docs/obs.", Paths: []string{"observability.token"}},
+				{Message: "See docs/obs.", Paths: []string{"observability.token"}},
 			}},
 		}
 		msg := formatRequirementsError(pending).Error()
-		if !strings.Contains(msg, "    See docs/obs.\n") {
-			t.Errorf("Expected message indented at 4 spaces, got: %s", msg)
+		if !strings.Contains(msg, "\nNotes:\n") {
+			t.Errorf("Expected 'Notes:' section, got: %s", msg)
 		}
-		if !strings.Contains(msg, "      - observability.token") {
-			t.Errorf("Expected path indented at 6 spaces under message, got: %s", msg)
+		if !strings.Contains(msg, "  observability.token:\n    See docs/obs.") {
+			t.Errorf("Expected '<path>:' header with indented message, got: %s", msg)
 		}
 	})
 
-	t.Run("FooterUsesSingularForOneMissing", func(t *testing.T) {
+	t.Run("NotesSectionOmittedWhenNoMessages", func(t *testing.T) {
 		pending := map[string]facetRequirementMisses{
 			"a": {Misses: []requirementBlockMiss{
 				{Paths: []string{"cluster.name"}},
 			}},
 		}
 		msg := formatRequirementsError(pending).Error()
-		if !strings.Contains(msg, "1 missing value.") {
-			t.Errorf("Expected singular footer, got: %s", msg)
+		if strings.Contains(msg, "Notes:") {
+			t.Errorf("Expected no 'Notes:' section when no messages, got: %s", msg)
 		}
 	})
 
@@ -5790,8 +5784,8 @@ func TestProcessor_ProcessFacets_ComponentRequires(t *testing.T) {
 		if !strings.Contains(msg, "aws.cilium_role_arn") {
 			t.Errorf("Expected missing path listed, got: %s", msg)
 		}
-		if !strings.Contains(msg, "Because platform == 'aws' && cni.driver == 'cilium':") {
-			t.Errorf("Expected composed condition heading, got: %s", msg)
+		if strings.Contains(msg, "Because") || strings.Contains(msg, "platform == 'aws'") {
+			t.Errorf("Expected no condition expression in output, got: %s", msg)
 		}
 	})
 
@@ -5852,8 +5846,8 @@ func TestProcessor_ProcessFacets_ComponentRequires(t *testing.T) {
 		if !strings.Contains(msg, "gateway.cert_arn") {
 			t.Errorf("Expected missing path listed, got: %s", msg)
 		}
-		if !strings.Contains(msg, "Because gateway.enabled == true && gateway.driver == 'envoy':") {
-			t.Errorf("Expected composed condition heading, got: %s", msg)
+		if strings.Contains(msg, "Because") || strings.Contains(msg, "gateway.enabled") {
+			t.Errorf("Expected no condition expression in output, got: %s", msg)
 		}
 	})
 
@@ -5915,8 +5909,8 @@ func TestProcessor_ProcessFacets_ComponentRequires(t *testing.T) {
 		if !strings.Contains(msg, "talos.ca_cert") {
 			t.Errorf("Expected missing path listed, got: %s", msg)
 		}
-		if !strings.Contains(msg, "Because cluster.driver == 'talos' && talos.tls == true:") {
-			t.Errorf("Expected composed condition heading, got: %s", msg)
+		if strings.Contains(msg, "Because") || strings.Contains(msg, "cluster.driver") {
+			t.Errorf("Expected no condition expression in output, got: %s", msg)
 		}
 	})
 
@@ -5982,14 +5976,11 @@ func TestProcessor_ProcessFacets_ComponentRequires(t *testing.T) {
 			t.Fatal("Expected aggregated error")
 		}
 		msg := err.Error()
-		if !strings.Contains(msg, "Because platform == 'aws' && cni.driver == 'cilium':") {
-			t.Errorf("Expected cilium bucket, got: %s", msg)
+		if !strings.Contains(msg, "- aws.cilium_role_arn") || !strings.Contains(msg, "- aws.public_zone_id") {
+			t.Errorf("Expected both paths as bullets, got: %s", msg)
 		}
-		if !strings.Contains(msg, "Because platform == 'aws' && dns.public_domain != '':") {
-			t.Errorf("Expected dns bucket, got: %s", msg)
-		}
-		if !strings.Contains(msg, "aws.cilium_role_arn") || !strings.Contains(msg, "aws.public_zone_id") {
-			t.Errorf("Expected both paths listed, got: %s", msg)
+		if strings.Contains(msg, "Because") || strings.Contains(msg, "cni.driver") {
+			t.Errorf("Expected no condition expression in output, got: %s", msg)
 		}
 	})
 
@@ -6021,14 +6012,11 @@ func TestProcessor_ProcessFacets_ComponentRequires(t *testing.T) {
 			t.Fatal("Expected aggregated error")
 		}
 		msg := err.Error()
-		if !strings.Contains(msg, "Because platform == 'aws':") {
-			t.Errorf("Expected facet-level bucket, got: %s", msg)
+		if !strings.Contains(msg, "- aws.cilium_role_arn") || !strings.Contains(msg, "- aws.region") {
+			t.Errorf("Expected both paths as bullets, got: %s", msg)
 		}
-		if !strings.Contains(msg, "Because platform == 'aws' && cni.driver == 'cilium':") {
-			t.Errorf("Expected component-level bucket, got: %s", msg)
-		}
-		if !strings.Contains(msg, "aws.region") || !strings.Contains(msg, "aws.cilium_role_arn") {
-			t.Errorf("Expected both paths listed, got: %s", msg)
+		if strings.Contains(msg, "Because") || strings.Contains(msg, "platform == 'aws'") {
+			t.Errorf("Expected no condition expression in output, got: %s", msg)
 		}
 	})
 

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -1617,67 +1617,6 @@ func TestProcessor_ProcessFacets_Config(t *testing.T) {
 			t.Errorf("Expected tags to contain evaluated list (${tag1}/${tag2}), got %q", tagsStr)
 		}
 	})
-
-	t.Run("FirstWriterDefinesIterationOrderForCrossBlockReads", func(t *testing.T) {
-		// Mirrors the platform-base / platform-hyperv reproduction in core:
-		// facet-a writes network.cidr_block with a self-referential default;
-		// facet-b has higher ordinal, extends the same network block with
-		// gateway, and writes hyperv_effective.nat_host_address which calls
-		// cidrhost(network.cidr_block, 1). Iteration position for the network
-		// block must stay anchored to facet-a (its first writer). If position
-		// were driven by last writer, facet-b would push network to the end
-		// of the iteration order, hyperv_effective would evaluate first, and
-		// cidrhost would receive the unevaluated template string and error
-		// with "invalid CIDR address".
-		mocks := setupProcessorMocks(t)
-		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
-			return map[string]any{}, nil
-		}
-		processor := NewBlueprintProcessor(mocks.Runtime)
-		target := &blueprintv1alpha1.Blueprint{}
-		lowOrdinal := 100
-		highOrdinal := 200
-		facets := []blueprintv1alpha1.Facet{
-			{
-				Metadata: blueprintv1alpha1.Metadata{Name: "platform-base"},
-				Ordinal:  &lowOrdinal,
-				Config: []blueprintv1alpha1.ConfigBlock{
-					{Name: "network", Body: map[string]any{"value": map[string]any{"cidr_block": "${network.cidr_block ?? '10.5.0.0/16'}"}}},
-				},
-			},
-			{
-				Metadata: blueprintv1alpha1.Metadata{Name: "platform-hyperv"},
-				Ordinal:  &highOrdinal,
-				Config: []blueprintv1alpha1.ConfigBlock{
-					{Name: "hyperv_effective", Body: map[string]any{"value": map[string]any{
-						"nat_host_address": "${cidrhost(network.cidr_block ?? '10.5.0.0/16', 1)}",
-					}}},
-					{Name: "network", Body: map[string]any{"value": map[string]any{"gateway": "10.5.0.1"}}},
-				},
-			},
-		}
-		scope, _, err := processor.ProcessFacets(target, facets)
-		if err != nil {
-			t.Fatalf("ProcessFacets failed: %v", err)
-		}
-		hyperv, ok := scope["hyperv_effective"].(map[string]any)
-		if !ok {
-			t.Fatalf("Expected scope hyperv_effective to be map, got %T", scope["hyperv_effective"])
-		}
-		if hyperv["nat_host_address"] != "10.5.0.1" {
-			t.Errorf("Expected hyperv_effective.nat_host_address='10.5.0.1' (network evaluated before hyperv_effective), got %v", hyperv["nat_host_address"])
-		}
-		network, ok := scope["network"].(map[string]any)
-		if !ok {
-			t.Fatalf("Expected scope network to be map, got %T", scope["network"])
-		}
-		if network["cidr_block"] != "10.5.0.0/16" {
-			t.Errorf("Expected network.cidr_block='10.5.0.0/16', got %v", network["cidr_block"])
-		}
-		if network["gateway"] != "10.5.0.1" {
-			t.Errorf("Expected network.gateway='10.5.0.1' (merged from platform-hyperv), got %v", network["gateway"])
-		}
-	})
 }
 
 func TestProcessor_ProcessFacets_ConfigDeferredValues(t *testing.T) {

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -1617,6 +1617,67 @@ func TestProcessor_ProcessFacets_Config(t *testing.T) {
 			t.Errorf("Expected tags to contain evaluated list (${tag1}/${tag2}), got %q", tagsStr)
 		}
 	})
+
+	t.Run("FirstWriterDefinesIterationOrderForCrossBlockReads", func(t *testing.T) {
+		// Mirrors the platform-base / platform-hyperv reproduction in core:
+		// facet-a writes network.cidr_block with a self-referential default;
+		// facet-b has higher ordinal, extends the same network block with
+		// gateway, and writes hyperv_effective.nat_host_address which calls
+		// cidrhost(network.cidr_block, 1). Iteration position for the network
+		// block must stay anchored to facet-a (its first writer). If position
+		// were driven by last writer, facet-b would push network to the end
+		// of the iteration order, hyperv_effective would evaluate first, and
+		// cidrhost would receive the unevaluated template string and error
+		// with "invalid CIDR address".
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		lowOrdinal := 100
+		highOrdinal := 200
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "platform-base"},
+				Ordinal:  &lowOrdinal,
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "network", Body: map[string]any{"value": map[string]any{"cidr_block": "${network.cidr_block ?? '10.5.0.0/16'}"}}},
+				},
+			},
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "platform-hyperv"},
+				Ordinal:  &highOrdinal,
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "hyperv_effective", Body: map[string]any{"value": map[string]any{
+						"nat_host_address": "${cidrhost(network.cidr_block ?? '10.5.0.0/16', 1)}",
+					}}},
+					{Name: "network", Body: map[string]any{"value": map[string]any{"gateway": "10.5.0.1"}}},
+				},
+			},
+		}
+		scope, _, err := processor.ProcessFacets(target, facets)
+		if err != nil {
+			t.Fatalf("ProcessFacets failed: %v", err)
+		}
+		hyperv, ok := scope["hyperv_effective"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected scope hyperv_effective to be map, got %T", scope["hyperv_effective"])
+		}
+		if hyperv["nat_host_address"] != "10.5.0.1" {
+			t.Errorf("Expected hyperv_effective.nat_host_address='10.5.0.1' (network evaluated before hyperv_effective), got %v", hyperv["nat_host_address"])
+		}
+		network, ok := scope["network"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected scope network to be map, got %T", scope["network"])
+		}
+		if network["cidr_block"] != "10.5.0.0/16" {
+			t.Errorf("Expected network.cidr_block='10.5.0.0/16', got %v", network["cidr_block"])
+		}
+		if network["gateway"] != "10.5.0.1" {
+			t.Errorf("Expected network.gateway='10.5.0.1' (merged from platform-hyperv), got %v", network["gateway"])
+		}
+	})
 }
 
 func TestProcessor_ProcessFacets_ConfigDeferredValues(t *testing.T) {

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -5630,3 +5630,436 @@ func TestFormatRequirementsError(t *testing.T) {
 		}
 	})
 }
+
+func TestCombineConditions(t *testing.T) {
+	t.Run("NoPartsYieldsEmpty", func(t *testing.T) {
+		if got := combineConditions(); got != "" {
+			t.Errorf("Expected empty, got %q", got)
+		}
+	})
+
+	t.Run("AllEmptyYieldsEmpty", func(t *testing.T) {
+		if got := combineConditions("", "  ", ""); got != "" {
+			t.Errorf("Expected empty, got %q", got)
+		}
+	})
+
+	t.Run("SingleNonEmptyReturnsItTrimmed", func(t *testing.T) {
+		if got := combineConditions("", "platform == 'aws'", ""); got != "platform == 'aws'" {
+			t.Errorf("Unexpected: %q", got)
+		}
+	})
+
+	t.Run("MultipleNonEmptyJoinedWithAnd", func(t *testing.T) {
+		got := combineConditions("platform == 'aws'", "cluster.driver == 'eks'", "dns.public_domain != ''")
+		want := "platform == 'aws' && cluster.driver == 'eks' && dns.public_domain != ''"
+		if got != want {
+			t.Errorf("Got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("MixedEmptyAndNonEmptyDropsEmpties", func(t *testing.T) {
+		got := combineConditions("platform == 'aws'", "", "cni.driver == 'cilium'")
+		want := "platform == 'aws' && cni.driver == 'cilium'"
+		if got != want {
+			t.Errorf("Got %q, want %q", got, want)
+		}
+	})
+}
+
+func TestProcessor_ProcessFacets_ComponentRequires(t *testing.T) {
+	t.Run("TerraformComponentRequiresSatisfied", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{
+				"platform": "aws",
+				"aws":      map[string]any{"cilium_role_arn": "arn:aws:iam::123:role/cilium"},
+				"cni":      map[string]any{"driver": "cilium"},
+			}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "platform-aws"},
+				When:     "platform == 'aws'",
+				TerraformComponents: []blueprintv1alpha1.ConditionalTerraformComponent{
+					{
+						TerraformComponent: blueprintv1alpha1.TerraformComponent{Path: "cluster/aws-cilium"},
+						When:               "cni.driver == 'cilium'",
+						Requires: []blueprintv1alpha1.RequirementBlock{
+							{Paths: []string{"aws.cilium_role_arn"}},
+						},
+					},
+				},
+			},
+		}
+		if _, _, err := processor.ProcessFacets(target, facets); err != nil {
+			t.Fatalf("Expected no error when component requires are satisfied, got %v", err)
+		}
+	})
+
+	t.Run("TerraformComponentRequiresUnsatisfiedProducesError", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"platform": "aws", "cni": map[string]any{"driver": "cilium"}}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "platform-aws"},
+				When:     "platform == 'aws'",
+				TerraformComponents: []blueprintv1alpha1.ConditionalTerraformComponent{
+					{
+						TerraformComponent: blueprintv1alpha1.TerraformComponent{Path: "cluster/aws-cilium"},
+						When:               "cni.driver == 'cilium'",
+						Requires: []blueprintv1alpha1.RequirementBlock{
+							{Paths: []string{"aws.cilium_role_arn"}},
+						},
+					},
+				},
+			},
+		}
+		_, _, err := processor.ProcessFacets(target, facets)
+		if err == nil {
+			t.Fatal("Expected error for unsatisfied component requirement")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "aws.cilium_role_arn") {
+			t.Errorf("Expected missing path listed, got: %s", msg)
+		}
+		if !strings.Contains(msg, "Because platform == 'aws' && cni.driver == 'cilium':") {
+			t.Errorf("Expected composed condition heading, got: %s", msg)
+		}
+	})
+
+	t.Run("TerraformComponentRequiresSkippedWhenComponentExcluded", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"platform": "aws", "cni": map[string]any{"driver": "calico"}}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "platform-aws"},
+				When:     "platform == 'aws'",
+				TerraformComponents: []blueprintv1alpha1.ConditionalTerraformComponent{
+					{
+						TerraformComponent: blueprintv1alpha1.TerraformComponent{Path: "cluster/aws-cilium"},
+						When:               "cni.driver == 'cilium'",
+						Requires: []blueprintv1alpha1.RequirementBlock{
+							{Paths: []string{"aws.cilium_role_arn"}},
+						},
+					},
+				},
+			},
+		}
+		if _, _, err := processor.ProcessFacets(target, facets); err != nil {
+			t.Fatalf("Expected no error when component is excluded by When, got %v", err)
+		}
+	})
+
+	t.Run("KustomizationRequiresUnsatisfiedProducesError", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"gateway": map[string]any{"enabled": true, "driver": "envoy"}}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "gateway"},
+				When:     "gateway.enabled == true",
+				Kustomizations: []blueprintv1alpha1.ConditionalKustomization{
+					{
+						Kustomization: blueprintv1alpha1.Kustomization{Name: "gateway", Path: "gateway"},
+						When:          "gateway.driver == 'envoy'",
+						Requires: []blueprintv1alpha1.RequirementBlock{
+							{Paths: []string{"gateway.cert_arn"}},
+						},
+					},
+				},
+			},
+		}
+		_, _, err := processor.ProcessFacets(target, facets)
+		if err == nil {
+			t.Fatal("Expected error for unsatisfied kustomization requirement")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "gateway.cert_arn") {
+			t.Errorf("Expected missing path listed, got: %s", msg)
+		}
+		if !strings.Contains(msg, "Because gateway.enabled == true && gateway.driver == 'envoy':") {
+			t.Errorf("Expected composed condition heading, got: %s", msg)
+		}
+	})
+
+	t.Run("KustomizationRequiresSkippedWhenExcluded", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"gateway": map[string]any{"enabled": true, "driver": "cilium"}}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "gateway"},
+				When:     "gateway.enabled == true",
+				Kustomizations: []blueprintv1alpha1.ConditionalKustomization{
+					{
+						Kustomization: blueprintv1alpha1.Kustomization{Name: "gateway", Path: "gateway"},
+						When:          "gateway.driver == 'envoy'",
+						Requires: []blueprintv1alpha1.RequirementBlock{
+							{Paths: []string{"gateway.cert_arn"}},
+						},
+					},
+				},
+			},
+		}
+		if _, _, err := processor.ProcessFacets(target, facets); err != nil {
+			t.Fatalf("Expected no error when kustomization is excluded by When, got %v", err)
+		}
+	})
+
+	t.Run("ConfigBlockRequiresUnsatisfiedProducesError", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"cluster": map[string]any{"driver": "talos"}, "talos": map[string]any{"tls": true}}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "config-talos"},
+				When:     "cluster.driver == 'talos'",
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{
+						Name: "talos",
+						When: "talos.tls == true",
+						Body: map[string]any{"value": "x"},
+						Requires: []blueprintv1alpha1.RequirementBlock{
+							{Paths: []string{"talos.ca_cert"}},
+						},
+					},
+				},
+			},
+		}
+		_, _, err := processor.ProcessFacets(target, facets)
+		if err == nil {
+			t.Fatal("Expected error for unsatisfied config-block requirement")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "talos.ca_cert") {
+			t.Errorf("Expected missing path listed, got: %s", msg)
+		}
+		if !strings.Contains(msg, "Because cluster.driver == 'talos' && talos.tls == true:") {
+			t.Errorf("Expected composed condition heading, got: %s", msg)
+		}
+	})
+
+	t.Run("ConfigBlockRequiresSkippedWhenExcluded", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"cluster": map[string]any{"driver": "talos"}, "talos": map[string]any{"tls": false}}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "config-talos"},
+				When:     "cluster.driver == 'talos'",
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{
+						Name: "talos",
+						When: "talos.tls == true",
+						Body: map[string]any{"value": "x"},
+						Requires: []blueprintv1alpha1.RequirementBlock{
+							{Paths: []string{"talos.ca_cert"}},
+						},
+					},
+				},
+			},
+		}
+		if _, _, err := processor.ProcessFacets(target, facets); err != nil {
+			t.Fatalf("Expected no error when config block is excluded by When, got %v", err)
+		}
+	})
+
+	t.Run("MultipleComponentsProduceDistinctBuckets", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{
+				"platform": "aws",
+				"cni":      map[string]any{"driver": "cilium"},
+				"dns":      map[string]any{"public_domain": "example.com"},
+			}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "platform-aws"},
+				When:     "platform == 'aws'",
+				TerraformComponents: []blueprintv1alpha1.ConditionalTerraformComponent{
+					{
+						TerraformComponent: blueprintv1alpha1.TerraformComponent{Path: "cluster/aws-cilium"},
+						When:               "cni.driver == 'cilium'",
+						Requires:           []blueprintv1alpha1.RequirementBlock{{Paths: []string{"aws.cilium_role_arn"}}},
+					},
+					{
+						TerraformComponent: blueprintv1alpha1.TerraformComponent{Path: "dns/aws-zone"},
+						When:               "dns.public_domain != ''",
+						Requires:           []blueprintv1alpha1.RequirementBlock{{Paths: []string{"aws.public_zone_id"}}},
+					},
+				},
+			},
+		}
+		_, _, err := processor.ProcessFacets(target, facets)
+		if err == nil {
+			t.Fatal("Expected aggregated error")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "Because platform == 'aws' && cni.driver == 'cilium':") {
+			t.Errorf("Expected cilium bucket, got: %s", msg)
+		}
+		if !strings.Contains(msg, "Because platform == 'aws' && dns.public_domain != '':") {
+			t.Errorf("Expected dns bucket, got: %s", msg)
+		}
+		if !strings.Contains(msg, "aws.cilium_role_arn") || !strings.Contains(msg, "aws.public_zone_id") {
+			t.Errorf("Expected both paths listed, got: %s", msg)
+		}
+	})
+
+	t.Run("FacetAndComponentRequiresAggregateTogether", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"platform": "aws", "cni": map[string]any{"driver": "cilium"}}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "platform-aws"},
+				When:     "platform == 'aws'",
+				Requires: []blueprintv1alpha1.RequirementBlock{
+					{Paths: []string{"aws.region"}},
+				},
+				TerraformComponents: []blueprintv1alpha1.ConditionalTerraformComponent{
+					{
+						TerraformComponent: blueprintv1alpha1.TerraformComponent{Path: "cluster/aws-cilium"},
+						When:               "cni.driver == 'cilium'",
+						Requires:           []blueprintv1alpha1.RequirementBlock{{Paths: []string{"aws.cilium_role_arn"}}},
+					},
+				},
+			},
+		}
+		_, _, err := processor.ProcessFacets(target, facets)
+		if err == nil {
+			t.Fatal("Expected aggregated error")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "Because platform == 'aws':") {
+			t.Errorf("Expected facet-level bucket, got: %s", msg)
+		}
+		if !strings.Contains(msg, "Because platform == 'aws' && cni.driver == 'cilium':") {
+			t.Errorf("Expected component-level bucket, got: %s", msg)
+		}
+		if !strings.Contains(msg, "aws.region") || !strings.Contains(msg, "aws.cilium_role_arn") {
+			t.Errorf("Expected both paths listed, got: %s", msg)
+		}
+	})
+
+	t.Run("CrossFacetConfigBlockSatisfiesComponentRequire", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"platform": "aws", "cni": map[string]any{"driver": "cilium"}}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		producerOrdinal := 100
+		consumerOrdinal := 200
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "aws-defaults"},
+				Ordinal:  &producerOrdinal,
+				When:     "platform == 'aws'",
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "aws", Body: map[string]any{"value": map[string]any{"cilium_role_arn": "arn:aws:iam::123:role/cilium"}}},
+				},
+			},
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "platform-aws"},
+				Ordinal:  &consumerOrdinal,
+				When:     "platform == 'aws'",
+				TerraformComponents: []blueprintv1alpha1.ConditionalTerraformComponent{
+					{
+						TerraformComponent: blueprintv1alpha1.TerraformComponent{Path: "cluster/aws-cilium"},
+						When:               "cni.driver == 'cilium'",
+						Requires:           []blueprintv1alpha1.RequirementBlock{{Paths: []string{"aws.cilium_role_arn"}}},
+					},
+				},
+			},
+		}
+		if _, _, err := processor.ProcessFacets(target, facets); err != nil {
+			t.Fatalf("Expected convergence to satisfy the requirement, got %v", err)
+		}
+	})
+
+	t.Run("ComponentRequiresWhenSkipsBlockButComponentStillIncluded", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"platform": "aws", "cni": map[string]any{"driver": "cilium"}}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "platform-aws"},
+				When:     "platform == 'aws'",
+				TerraformComponents: []blueprintv1alpha1.ConditionalTerraformComponent{
+					{
+						TerraformComponent: blueprintv1alpha1.TerraformComponent{Path: "cluster/aws-cilium"},
+						When:               "cni.driver == 'cilium'",
+						Requires: []blueprintv1alpha1.RequirementBlock{
+							{When: "aws.advanced == true", Paths: []string{"aws.advanced_role_arn"}},
+						},
+					},
+				},
+			},
+		}
+		if _, _, err := processor.ProcessFacets(target, facets); err != nil {
+			t.Fatalf("Expected no error when the block's own When is false, got %v", err)
+		}
+	})
+
+	t.Run("ComponentWhenErrorIsSurfaced", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"platform": "aws"}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "platform-aws"},
+				When:     "platform == 'aws'",
+				TerraformComponents: []blueprintv1alpha1.ConditionalTerraformComponent{
+					{
+						TerraformComponent: blueprintv1alpha1.TerraformComponent{Path: "broken"},
+						When:               "this is not a valid expression!!!",
+						Requires:           []blueprintv1alpha1.RequirementBlock{{Paths: []string{"x"}}},
+					},
+				},
+			},
+		}
+		_, _, err := processor.ProcessFacets(target, facets)
+		if err == nil {
+			t.Fatal("Expected error from invalid component When")
+		}
+		if !strings.Contains(err.Error(), "terraform component when") {
+			t.Errorf("Expected error to mention terraform component when, got: %v", err)
+		}
+	})
+}

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -5280,3 +5280,353 @@ func TestEvaluateCondition_EvaluatesAgainstScope(t *testing.T) {
 		}
 	})
 }
+
+// =============================================================================
+// Test Public Methods
+// =============================================================================
+
+func TestProcessor_ProcessFacets_Requires(t *testing.T) {
+	t.Run("SatisfiedByContextValues", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{
+				"cluster": map[string]any{"name": "mycluster"},
+				"dns":     map[string]any{"domain": "example.com"},
+			}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "consumer"},
+				Requires: []blueprintv1alpha1.RequirementBlock{
+					{Paths: []string{"cluster.name", "dns.domain"}},
+				},
+			},
+		}
+		if _, _, err := processor.ProcessFacets(target, facets); err != nil {
+			t.Fatalf("Expected no error when requirements are satisfied, got %v", err)
+		}
+	})
+
+	t.Run("ConditionalBlockSkippedWhenFalse", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"provider": "docker"}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "aws-only"},
+				Requires: []blueprintv1alpha1.RequirementBlock{
+					{When: "provider == 'aws'", Paths: []string{"aws.region"}},
+				},
+			},
+		}
+		if _, _, err := processor.ProcessFacets(target, facets); err != nil {
+			t.Fatalf("Expected no error; aws block should be skipped, got %v", err)
+		}
+	})
+
+	t.Run("UnsatisfiedRequirementProducesAggregatedError", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"provider": "aws"}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "provider-aws"},
+				When:     "provider == 'aws'",
+				Requires: []blueprintv1alpha1.RequirementBlock{
+					{Paths: []string{"aws.region", "aws.account_id"}},
+				},
+			},
+		}
+		_, _, err := processor.ProcessFacets(target, facets)
+		if err == nil {
+			t.Fatal("Expected error for unsatisfied requirements, got nil")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "Required configuration is missing") {
+			t.Errorf("Expected aggregated header, got: %s", msg)
+		}
+		if !strings.Contains(msg, "aws.region") || !strings.Contains(msg, "aws.account_id") {
+			t.Errorf("Expected both paths listed, got: %s", msg)
+		}
+		if !strings.Contains(msg, "Because provider == 'aws':") {
+			t.Errorf("Expected condition heading, got: %s", msg)
+		}
+		if strings.Contains(msg, "facet") {
+			t.Errorf("Expected error to not mention 'facet', got: %s", msg)
+		}
+	})
+
+	t.Run("EmptyValueIsTreatedAsMissing", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{
+				"dns":  map[string]any{"domain": ""},
+				"tags": []any{},
+			}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "consumer"},
+				Requires: []blueprintv1alpha1.RequirementBlock{
+					{Paths: []string{"dns.domain", "tags"}},
+				},
+			},
+		}
+		_, _, err := processor.ProcessFacets(target, facets)
+		if err == nil {
+			t.Fatal("Expected error for empty values, got nil")
+		}
+		if !strings.Contains(err.Error(), "dns.domain") || !strings.Contains(err.Error(), "tags") {
+			t.Errorf("Expected both empty paths reported, got: %s", err.Error())
+		}
+	})
+
+	t.Run("FalseAndZeroAreTreatedAsPresent", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{
+				"feature":  map[string]any{"enabled": false},
+				"replicas": 0,
+			}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "consumer"},
+				Requires: []blueprintv1alpha1.RequirementBlock{
+					{Paths: []string{"feature.enabled", "replicas"}},
+				},
+			},
+		}
+		if _, _, err := processor.ProcessFacets(target, facets); err != nil {
+			t.Fatalf("Expected false/0 to satisfy requirement, got error: %v", err)
+		}
+	})
+
+	t.Run("CrossFacetConfigBlockSatisfiesAfterDeferral", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"provider": "incus", "cluster": map[string]any{"name": "demo"}}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "consumer"},
+				Ordinal:  intPtr(200),
+				Requires: []blueprintv1alpha1.RequirementBlock{
+					{Paths: []string{"talos.cluster_name"}},
+				},
+			},
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "config-talos"},
+				Ordinal:  intPtr(100),
+				When:     "provider == 'incus'",
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "talos", Body: map[string]any{"value": map[string]any{"cluster_name": "${cluster.name}"}}},
+				},
+			},
+		}
+		if _, _, err := processor.ProcessFacets(target, facets); err != nil {
+			t.Fatalf("Expected requirement to be satisfied via config block in later round, got: %v", err)
+		}
+	})
+
+	t.Run("MessageRendersUnderConditionHeading", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"observability": map[string]any{"enabled": true}}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "obs"},
+				Requires: []blueprintv1alpha1.RequirementBlock{
+					{
+						When:    "observability.enabled",
+						Paths:   []string{"observability.endpoint", "observability.token"},
+						Message: "See docs/observability for setup.",
+					},
+				},
+			},
+		}
+		_, _, err := processor.ProcessFacets(target, facets)
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "Because observability.enabled:") {
+			t.Errorf("Expected condition heading, got: %s", msg)
+		}
+		if !strings.Contains(msg, "See docs/observability for setup.") {
+			t.Errorf("Expected message text in error, got: %s", msg)
+		}
+		if !strings.Contains(msg, "observability.endpoint") || !strings.Contains(msg, "observability.token") {
+			t.Errorf("Expected both paths in error, got: %s", msg)
+		}
+	})
+
+	t.Run("AggregatesAcrossMultipleFacets", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"provider": "aws"}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "facet-a"},
+				Requires: []blueprintv1alpha1.RequirementBlock{
+					{Paths: []string{"cluster.name"}},
+				},
+			},
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "facet-b"},
+				When:     "provider == 'aws'",
+				Requires: []blueprintv1alpha1.RequirementBlock{
+					{Paths: []string{"aws.region"}},
+				},
+			},
+		}
+		_, _, err := processor.ProcessFacets(target, facets)
+		if err == nil {
+			t.Fatal("Expected aggregated error, got nil")
+		}
+		msg := err.Error()
+		if !strings.Contains(msg, "Required:") {
+			t.Errorf("Expected unconditional 'Required:' heading, got: %s", msg)
+		}
+		if !strings.Contains(msg, "Because provider == 'aws':") {
+			t.Errorf("Expected conditional heading, got: %s", msg)
+		}
+		if !strings.Contains(msg, "cluster.name") || !strings.Contains(msg, "aws.region") {
+			t.Errorf("Expected both paths, got: %s", msg)
+		}
+		if !strings.Contains(msg, "2 missing values") {
+			t.Errorf("Expected '2 missing values' summary, got: %s", msg)
+		}
+	})
+
+	t.Run("SelfReferenceNeverSatisfied", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"provider": "incus", "cluster": map[string]any{"name": "demo"}}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "self-referencing"},
+				When:     "provider == 'incus'",
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "self", Body: map[string]any{"value": map[string]any{"k": "${cluster.name}"}}},
+				},
+				Requires: []blueprintv1alpha1.RequirementBlock{
+					{Paths: []string{"self.k"}},
+				},
+			},
+		}
+		_, _, err := processor.ProcessFacets(target, facets)
+		if err == nil {
+			t.Fatal("Expected error for self-referenced requirement, got nil")
+		}
+		if !strings.Contains(err.Error(), "self.k") {
+			t.Errorf("Expected self.k path in error, got: %s", err.Error())
+		}
+	})
+}
+
+// =============================================================================
+// Test Helpers
+// =============================================================================
+
+func TestFormatRequirementsError(t *testing.T) {
+	t.Run("UnconditionalBucketRendersFirst", func(t *testing.T) {
+		pending := map[string]facetRequirementMisses{
+			"a": {FacetName: "a", Misses: []requirementBlockMiss{
+				{Condition: "", Paths: []string{"cluster.name"}},
+			}},
+			"b": {FacetName: "b", Misses: []requirementBlockMiss{
+				{Condition: "provider == 'aws'", Paths: []string{"aws.region"}},
+			}},
+		}
+		msg := formatRequirementsError(pending).Error()
+		idxRequired := strings.Index(msg, "Required:")
+		idxBecause := strings.Index(msg, "Because provider == 'aws':")
+		if idxRequired < 0 || idxBecause < 0 {
+			t.Fatalf("Missing headings in: %s", msg)
+		}
+		if idxRequired > idxBecause {
+			t.Error("Expected 'Required:' to appear before conditional heading")
+		}
+	})
+
+	t.Run("MergesSameConditionAcrossFacets", func(t *testing.T) {
+		pending := map[string]facetRequirementMisses{
+			"a": {FacetName: "a", Misses: []requirementBlockMiss{
+				{Condition: "provider == 'aws'", Paths: []string{"aws.region"}},
+			}},
+			"b": {FacetName: "b", Misses: []requirementBlockMiss{
+				{Condition: "provider == 'aws'", Paths: []string{"aws.account_id"}},
+			}},
+		}
+		msg := formatRequirementsError(pending).Error()
+		if c := strings.Count(msg, "Because provider == 'aws':"); c != 1 {
+			t.Errorf("Expected one merged heading, got %d. Msg: %s", c, msg)
+		}
+		if !strings.Contains(msg, "aws.region") || !strings.Contains(msg, "aws.account_id") {
+			t.Error("Expected both paths under merged heading")
+		}
+	})
+
+	t.Run("MessageIndentedAboveDeeperPaths", func(t *testing.T) {
+		pending := map[string]facetRequirementMisses{
+			"obs": {FacetName: "obs", Misses: []requirementBlockMiss{
+				{Condition: "observability.enabled", Message: "See docs/obs.", Paths: []string{"observability.token"}},
+			}},
+		}
+		msg := formatRequirementsError(pending).Error()
+		if !strings.Contains(msg, "    See docs/obs.\n") {
+			t.Errorf("Expected message indented at 4 spaces, got: %s", msg)
+		}
+		if !strings.Contains(msg, "      - observability.token") {
+			t.Errorf("Expected path indented at 6 spaces under message, got: %s", msg)
+		}
+	})
+
+	t.Run("FooterUsesSingularForOneMissing", func(t *testing.T) {
+		pending := map[string]facetRequirementMisses{
+			"a": {FacetName: "a", Misses: []requirementBlockMiss{
+				{Paths: []string{"cluster.name"}},
+			}},
+		}
+		msg := formatRequirementsError(pending).Error()
+		if !strings.Contains(msg, "1 missing value.") {
+			t.Errorf("Expected singular footer, got: %s", msg)
+		}
+	})
+
+	t.Run("ErrorDoesNotMentionFacet", func(t *testing.T) {
+		pending := map[string]facetRequirementMisses{
+			"facet-name-here": {FacetName: "facet-name-here", Misses: []requirementBlockMiss{
+				{Paths: []string{"cluster.name"}},
+			}},
+		}
+		msg := formatRequirementsError(pending).Error()
+		if strings.Contains(msg, "facet") {
+			t.Errorf("Expected error not to mention 'facet', got: %s", msg)
+		}
+	})
+}

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -5555,10 +5555,10 @@ func TestProcessor_ProcessFacets_Requires(t *testing.T) {
 func TestFormatRequirementsError(t *testing.T) {
 	t.Run("UnconditionalBucketRendersFirst", func(t *testing.T) {
 		pending := map[string]facetRequirementMisses{
-			"a": {FacetName: "a", Misses: []requirementBlockMiss{
+			"a": {Misses: []requirementBlockMiss{
 				{Condition: "", Paths: []string{"cluster.name"}},
 			}},
-			"b": {FacetName: "b", Misses: []requirementBlockMiss{
+			"b": {Misses: []requirementBlockMiss{
 				{Condition: "platform == 'aws'", Paths: []string{"aws.region"}},
 			}},
 		}
@@ -5575,10 +5575,10 @@ func TestFormatRequirementsError(t *testing.T) {
 
 	t.Run("MergesSameConditionAcrossFacets", func(t *testing.T) {
 		pending := map[string]facetRequirementMisses{
-			"a": {FacetName: "a", Misses: []requirementBlockMiss{
+			"a": {Misses: []requirementBlockMiss{
 				{Condition: "platform == 'aws'", Paths: []string{"aws.region"}},
 			}},
-			"b": {FacetName: "b", Misses: []requirementBlockMiss{
+			"b": {Misses: []requirementBlockMiss{
 				{Condition: "platform == 'aws'", Paths: []string{"aws.account_id"}},
 			}},
 		}
@@ -5593,7 +5593,7 @@ func TestFormatRequirementsError(t *testing.T) {
 
 	t.Run("MessageIndentedAboveDeeperPaths", func(t *testing.T) {
 		pending := map[string]facetRequirementMisses{
-			"obs": {FacetName: "obs", Misses: []requirementBlockMiss{
+			"obs": {Misses: []requirementBlockMiss{
 				{Condition: "observability.enabled", Message: "See docs/obs.", Paths: []string{"observability.token"}},
 			}},
 		}
@@ -5608,7 +5608,7 @@ func TestFormatRequirementsError(t *testing.T) {
 
 	t.Run("FooterUsesSingularForOneMissing", func(t *testing.T) {
 		pending := map[string]facetRequirementMisses{
-			"a": {FacetName: "a", Misses: []requirementBlockMiss{
+			"a": {Misses: []requirementBlockMiss{
 				{Paths: []string{"cluster.name"}},
 			}},
 		}
@@ -5620,7 +5620,7 @@ func TestFormatRequirementsError(t *testing.T) {
 
 	t.Run("ErrorDoesNotMentionFacet", func(t *testing.T) {
 		pending := map[string]facetRequirementMisses{
-			"facet-name-here": {FacetName: "facet-name-here", Misses: []requirementBlockMiss{
+			"facet-name-here": {Misses: []requirementBlockMiss{
 				{Paths: []string{"cluster.name"}},
 			}},
 		}

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -1,12 +1,14 @@
 package project
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/composer"
+	"github.com/windsorcli/cli/pkg/composer/blueprint"
 	"github.com/windsorcli/cli/pkg/provisioner"
 	"github.com/windsorcli/cli/pkg/runtime"
 	"github.com/windsorcli/cli/pkg/runtime/config"
@@ -188,6 +190,10 @@ func (p *Project) Initialize(overwrite bool, blueprintURL ...string) error {
 	}
 
 	if err := p.Composer.BlueprintHandler.LoadBlueprint(blueprintURL...); err != nil {
+		var reqErr *blueprint.RequirementsError
+		if errors.As(err, &reqErr) {
+			return err
+		}
 		return fmt.Errorf("failed to load blueprint data: %w", err)
 	}
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> This PR adds new required-input validation to the facet processing pipeline; a misconfigured facet will now produce a hard error where it previously passed silently, which is the right behavior but warrants careful review of the convergence semantics.
>
> **Overview**
>
> The change introduces a `requires` section to the `Facet` type. When a facet is active its requirement blocks are evaluated against the merged scope before the facet is included in the composition; unsatisfied blocks cause the facet to be deferred and retried across up to ten convergence rounds. After the final round, any still-unsatisfied paths across all active facets are aggregated into a single user-facing error grouped by effective condition, never by facet name.
>
> The implementation is well-tested: unit tests cover the happy path, conditional skipping, empty-vs-false/zero semantics, cross-facet config satisfaction via deferral, self-referential deadlock, and multi-facet aggregation. Integration tests validate both the success and failure paths end-to-end against real fixture contexts.
>
> Reviewed by Claude for commit `31529c5`.

<!-- /claude-code-review:summary -->
