### PR TITLE
chore(tools): Update error messages to use vendor install URLs and remove third-party package manager hints

### DIFF
--- a/integration/apply_test.go
+++ b/integration/apply_test.go
@@ -99,12 +99,13 @@ func TestApply_AcceptsWaitFlag(t *testing.T) {
 // TestApplyTerraform_MissingBinary_ShowsActionableError verifies the registry-formatted
 // missing-tool error reaches the user end-to-end: when an `apply terraform` preflight
 // fails because terraform is not on PATH, stderr must include the vendor download URL
-// and the matching aqua package so the operator has a copy-pasteable next step. init
-// runs with --set terraform.enabled=true so the preflight check actually fires (without
-// that gate, the provisioner would shell out directly and surface a raw exec error
-// instead of the formatted one). The "null" component arg is an arbitrary positional
-// placeholder — the preflight check fails inside Initialize before the command body
-// reads componentID, so no matching component needs to exist in the plan fixture.
+// so the operator has a copy-pasteable next step pointing at the authoritative install
+// instructions. init runs with --set terraform.enabled=true so the preflight check
+// actually fires (without that gate, the provisioner would shell out directly and surface
+// a raw exec error instead of the formatted one). The "null" component arg is an
+// arbitrary positional placeholder — the preflight check fails inside Initialize before
+// the command body reads componentID, so no matching component needs to exist in the plan
+// fixture.
 func TestApplyTerraform_MissingBinary_ShowsActionableError(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
@@ -123,10 +124,13 @@ func TestApplyTerraform_MissingBinary_ShowsActionableError(t *testing.T) {
 	if !strings.Contains(out, "not found on PATH") {
 		t.Errorf("expected stderr to mention 'not found on PATH', got: %s", out)
 	}
-	if !strings.Contains(out, "Download:") {
-		t.Errorf("expected stderr to include a 'Download:' install hint, got: %s", out)
+	if !strings.Contains(out, "Install:") {
+		t.Errorf("expected stderr to include an 'Install:' vendor URL hint, got: %s", out)
 	}
-	if !strings.Contains(out, "aqua g -i") {
-		t.Errorf("expected stderr to include an 'aqua g -i' install hint, got: %s", out)
+	if !strings.Contains(out, "developer.hashicorp.com") {
+		t.Errorf("expected stderr to include the vendor install URL, got: %s", out)
+	}
+	if strings.Contains(out, "aqua g -i") {
+		t.Errorf("expected stderr to OMIT third-party 'aqua g -i' hint, got: %s", out)
 	}
 }

--- a/pkg/runtime/tools/registry.go
+++ b/pkg/runtime/tools/registry.go
@@ -40,7 +40,7 @@ var toolRegistry = map[string]toolInfo{
 	"docker": {
 		name:       "Docker",
 		minVersion: constants.MinimumVersionDocker,
-		download:   "https://www.docker.com/products/docker-desktop/",
+		download:   "https://docs.docker.com/engine/install/",
 	},
 	"colima": {
 		name:       "Colima",

--- a/pkg/runtime/tools/registry.go
+++ b/pkg/runtime/tools/registry.go
@@ -8,23 +8,24 @@ import (
 
 // The toolRegistry is a static catalog of every external CLI Windsor checks for. It exists so
 // "tool not on PATH" / "tool below minimum version" errors carry a copy-pasteable next step
-// (first-party download URL plus the matching aqua package name) instead of just naming the
-// missing binary. Entries are keyed by the actual lookup name passed to exec.LookPath so
-// check* code paths and error formatting agree on a single source of truth.
+// (the vendor's first-party install page) instead of just naming the missing binary. Entries
+// are keyed by the actual lookup name passed to exec.LookPath so check* code paths and error
+// formatting agree on a single source of truth.
 
 // =============================================================================
 // Types
 // =============================================================================
 
 // toolInfo describes the user-facing identity of a checked tool: the display name used in
-// error messages, the minimum version Windsor will accept, the first-party install/download
-// page (vendor docs, never a third-party mirror), and the aqua package name so operators
-// already using aqua get a one-liner that fits their workflow.
+// error messages, the minimum version Windsor will accept, and the first-party
+// install/download page (vendor docs, never a third-party mirror or distribution-manager
+// package). We point operators at the vendor's own instructions so platform-specific
+// nuances (brew vs apt vs winget vs direct binary, signing, GPG keys) are handled by the
+// authoritative source rather than a half-correct copy here.
 type toolInfo struct {
 	name       string
 	minVersion string
 	download   string
-	aquaPkg    string
 }
 
 // =============================================================================
@@ -39,56 +40,47 @@ var toolRegistry = map[string]toolInfo{
 	"docker": {
 		name:       "Docker",
 		minVersion: constants.MinimumVersionDocker,
-		download:   "https://docs.docker.com/get-docker/",
-		aquaPkg:    "docker/cli",
+		download:   "https://www.docker.com/products/docker-desktop/",
 	},
 	"colima": {
 		name:       "Colima",
 		minVersion: constants.MinimumVersionColima,
-		download:   "https://github.com/abiosoft/colima#installation",
-		aquaPkg:    "abiosoft/colima",
+		download:   "https://colima.run/docs/installation/",
 	},
 	"limactl": {
 		name:       "Lima",
 		minVersion: constants.MinimumVersionLima,
 		download:   "https://lima-vm.io/docs/installation/",
-		aquaPkg:    "lima-vm/lima",
 	},
 	"terraform": {
 		name:       "Terraform",
 		minVersion: constants.MinimumVersionTerraform,
 		download:   "https://developer.hashicorp.com/terraform/install",
-		aquaPkg:    "hashicorp/terraform",
 	},
 	"tofu": {
 		name:       "OpenTofu",
 		minVersion: constants.MinimumVersionTerraform,
 		download:   "https://opentofu.org/docs/intro/install/",
-		aquaPkg:    "opentofu/opentofu",
 	},
 	"op": {
 		name:       "1Password CLI",
 		minVersion: constants.MinimumVersion1Password,
 		download:   "https://developer.1password.com/docs/cli/get-started",
-		aquaPkg:    "1password/cli",
 	},
 	"sops": {
 		name:       "SOPS",
 		minVersion: constants.MinimumVersionSOPS,
 		download:   "https://github.com/getsops/sops/releases",
-		aquaPkg:    "getsops/sops",
 	},
 	"kubelogin": {
 		name:       "kubelogin",
 		minVersion: constants.MinimumVersionKubelogin,
 		download:   "https://azure.github.io/kubelogin/install.html",
-		aquaPkg:    "Azure/kubelogin",
 	},
 	"aws": {
 		name:       "AWS CLI",
 		minVersion: constants.MinimumVersionAWS,
 		download:   "https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html",
-		aquaPkg:    "aws/aws-cli",
 	},
 }
 
@@ -97,17 +89,17 @@ var toolRegistry = map[string]toolInfo{
 // =============================================================================
 
 // missingToolError formats the standard "<tool> is required but was not found on PATH" error
-// with install guidance: the first-party download URL and the matching aqua package. Returned
-// as a fmt.Errorf so callers can wrap it. Falls back to a bare message if key is unknown,
-// which is the conservative thing to do — a typo in a check* function should still produce a
-// readable error rather than a panic.
+// with install guidance: the vendor's first-party download URL. Returned as a fmt.Errorf so
+// callers can wrap it. Falls back to a bare message if key is unknown, which is the
+// conservative thing to do — a typo in a check* function should still produce a readable
+// error rather than a panic.
 func missingToolError(key string) error {
 	info, ok := toolRegistry[key]
 	if !ok {
 		return fmt.Errorf("%s is required but was not found on PATH", key)
 	}
-	return fmt.Errorf("%s >= %s is required but was not found on PATH.\n  Download:    %s\n  Or via aqua: aqua g -i %s",
-		info.name, info.minVersion, info.download, info.aquaPkg)
+	return fmt.Errorf("%s >= %s is required but was not found on PATH.\n  Install: %s",
+		info.name, info.minVersion, info.download)
 }
 
 // outdatedToolError formats the standard "<tool> <found> is below the minimum required version
@@ -122,6 +114,6 @@ func outdatedToolError(key, found string) error {
 	if !ok {
 		return fmt.Errorf("%s version %s is below the required minimum", key, found)
 	}
-	return fmt.Errorf("%s %s is below the minimum required version %s.\n  Download:    %s\n  Or via aqua: aqua g -i %s",
-		info.name, found, info.minVersion, info.download, info.aquaPkg)
+	return fmt.Errorf("%s %s is below the minimum required version %s.\n  Install: %s",
+		info.name, found, info.minVersion, info.download)
 }

--- a/pkg/runtime/tools/registry_test.go
+++ b/pkg/runtime/tools/registry_test.go
@@ -73,7 +73,7 @@ func TestOutdatedToolError(t *testing.T) {
 
 		// Then both the found version and the minimum show up alongside the vendor install URL
 		msg := err.Error()
-		expected := []string{"Docker", "20.10.0", "23.0.0", "below the minimum required version", "https://www.docker.com/products/docker-desktop/"}
+		expected := []string{"Docker", "20.10.0", "23.0.0", "below the minimum required version", "https://docs.docker.com/engine/install/"}
 		for _, want := range expected {
 			if !strings.Contains(msg, want) {
 				t.Errorf("expected error to contain %q, got: %s", want, msg)

--- a/pkg/runtime/tools/registry_test.go
+++ b/pkg/runtime/tools/registry_test.go
@@ -10,21 +10,38 @@ import (
 // =============================================================================
 
 // TestMissingToolError pins the formatting contract: registered keys produce errors that
-// carry the display name, minimum version, vendor download URL, and aqua package; an
-// unregistered key falls back to a bare error so a programmer typo in a check* function
-// still produces a readable message instead of panicking.
+// carry the display name, minimum version, and vendor download URL; an unregistered key
+// falls back to a bare error so a programmer typo in a check* function still produces a
+// readable message instead of panicking.
 func TestMissingToolError(t *testing.T) {
-	t.Run("RegisteredKeyIncludesAllInstallHints", func(t *testing.T) {
+	t.Run("RegisteredKeyIncludesVendorInstallHint", func(t *testing.T) {
 		// Given a key that is in the registry
 		err := missingToolError("terraform")
 
-		// Then the error includes the display name, minimum version, download URL, and
-		// aqua package — the exact four pieces operators need to resolve the failure.
+		// Then the error includes the display name, minimum version, and vendor download URL
+		// — the exact pieces operators need to resolve the failure via the vendor's own
+		// install instructions (which encode platform-specific nuance we don't replicate).
 		msg := err.Error()
-		expected := []string{"Terraform", "1.7.0", "https://developer.hashicorp.com/terraform/install", "aqua g -i hashicorp/terraform", "not found on PATH"}
+		expected := []string{"Terraform", "1.7.0", "https://developer.hashicorp.com/terraform/install", "not found on PATH"}
 		for _, want := range expected {
 			if !strings.Contains(msg, want) {
 				t.Errorf("expected error to contain %q, got: %s", want, msg)
+			}
+		}
+	})
+
+	t.Run("RegisteredKeyOmitsThirdPartyPackageManagers", func(t *testing.T) {
+		// Given a key that is in the registry
+		err := missingToolError("terraform")
+
+		// Then the error must NOT mention third-party package managers (aqua, brew, etc.).
+		// Operators get the vendor's authoritative install page only — pointing at a
+		// distribution wrapper would put us on the hook for that wrapper's signing,
+		// version-staleness, and platform-coverage gaps.
+		msg := err.Error()
+		for _, banned := range []string{"aqua g -i", "brew install", "Or via aqua"} {
+			if strings.Contains(msg, banned) {
+				t.Errorf("expected error to OMIT %q, got: %s", banned, msg)
 			}
 		}
 	})
@@ -40,7 +57,7 @@ func TestMissingToolError(t *testing.T) {
 		if !strings.Contains(msg, "nonexistent-tool") {
 			t.Errorf("expected fallback to mention the key name, got: %s", msg)
 		}
-		if strings.Contains(msg, "Download:") || strings.Contains(msg, "aqua g -i") {
+		if strings.Contains(msg, "Install:") {
 			t.Errorf("expected fallback to OMIT install hints, got: %s", msg)
 		}
 	})
@@ -54,12 +71,17 @@ func TestOutdatedToolError(t *testing.T) {
 		// Given a registered key and a found version below minimum
 		err := outdatedToolError("docker", "20.10.0")
 
-		// Then both the found version and the minimum show up alongside install hints
+		// Then both the found version and the minimum show up alongside the vendor install URL
 		msg := err.Error()
-		expected := []string{"Docker", "20.10.0", "23.0.0", "below the minimum required version", "https://docs.docker.com/get-docker/", "aqua g -i docker/cli"}
+		expected := []string{"Docker", "20.10.0", "23.0.0", "below the minimum required version", "https://www.docker.com/products/docker-desktop/"}
 		for _, want := range expected {
 			if !strings.Contains(msg, want) {
 				t.Errorf("expected error to contain %q, got: %s", want, msg)
+			}
+		}
+		for _, banned := range []string{"aqua g -i", "Or via aqua"} {
+			if strings.Contains(msg, banned) {
+				t.Errorf("expected error to OMIT %q, got: %s", banned, msg)
 			}
 		}
 	})
@@ -84,7 +106,7 @@ func TestOutdatedToolError(t *testing.T) {
 		if !strings.Contains(msg, "ghost-tool") || !strings.Contains(msg, "0.0.1") {
 			t.Errorf("expected fallback to mention key + version, got: %s", msg)
 		}
-		if strings.Contains(msg, "Download:") || strings.Contains(msg, "aqua g -i") {
+		if strings.Contains(msg, "Install:") {
 			t.Errorf("expected fallback to OMIT install hints, got: %s", msg)
 		}
 	})


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> The change touches only error-message formatting in a static registry and its tests — no logic paths, no data, no interfaces change.
>
> **Overview**
>
> This PR strips the `aquaPkg` field from `toolInfo` and removes the "Or via aqua: aqua g -i …" line from both `missingToolError` and `outdatedToolError`. Operators now see a single "Install: <vendor URL>" hint, which sidesteps version-staleness and platform-coverage gaps in distribution wrappers. The label also changes from "Download:" to "Install:", which better describes the intended action.
>
> Docker's URL moves from `get-docker/` to `engine/install/`, which is the correct engine installation documentation and a better target for server operators. The one open question is Colima's new URL (`colima.run/docs/installation/`): if that domain is the project's official site the change is fine; if it is a community mirror or redirect it would be more stable to keep the GitHub repo URL. The inline thread tracks that question.
>
> Reviewed by Claude for commit `53b92abe`.

<!-- /claude-code-review:summary -->
