### PR TITLE
fix(blueprint): Update GenerateResolved to return error for unresolved substitutions

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -20,7 +20,7 @@ var applyCmd = &cobra.Command{
 		// `windsor apply` runs whatever is in the blueprint — terraform components and Flux
 		// kustomizations both — so the tool surface is not statically narrowable. Request
 		// AllRequirements() and let the per-tool config gates inside CheckRequirements decide
-		// what actually runs (e.g. azure.enabled controls kubelogin).
+		// what actually runs (e.g. platform=="azure" or an azure: block triggers kubelogin).
 		proj, err := prepareProject(cmd, tools.AllRequirements())
 		if err != nil {
 			return err
@@ -41,7 +41,11 @@ var applyCmd = &cobra.Command{
 
 		// Re-generate with deferred substitutions resolved now that terraform
 		// outputs are available from the Up step above.
-		blueprint = proj.Composer.BlueprintHandler.GenerateResolved()
+		var resolveErr error
+		blueprint, resolveErr = proj.Composer.BlueprintHandler.GenerateResolved()
+		if resolveErr != nil {
+			return fmt.Errorf("error resolving blueprint substitutions: %w", resolveErr)
+		}
 
 		if err := proj.Provisioner.Install(cmd.Context(), blueprint); err != nil {
 			return fmt.Errorf("error applying kustomize: %w", err)

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -187,7 +187,10 @@ var bootstrapCmd = &cobra.Command{
 			return nil
 		}
 
-		blueprint := proj.Composer.BlueprintHandler.GenerateResolved()
+		blueprint, err := proj.Composer.BlueprintHandler.GenerateResolved()
+		if err != nil {
+			return fmt.Errorf("error resolving blueprint substitutions: %w", err)
+		}
 
 		if err := proj.Provisioner.Install(cmd.Context(), blueprint); err != nil {
 			return fmt.Errorf("error installing blueprint: %w", err)

--- a/cmd/bootstrap_test.go
+++ b/cmd/bootstrap_test.go
@@ -91,7 +91,7 @@ func setupBootstrapTest(t *testing.T, opts ...*SetupOptions) *BootstrapMocks {
 		Metadata: blueprintv1alpha1.Metadata{Name: "test"},
 	}
 	mockBlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint { return testBlueprint }
-	mockBlueprintHandler.GenerateResolvedFunc = func() *blueprintv1alpha1.Blueprint { return testBlueprint }
+	mockBlueprintHandler.GenerateResolvedFunc = func() (*blueprintv1alpha1.Blueprint, error) { return testBlueprint, nil }
 
 	mockTerraformStack := terraforminfra.NewMockStack()
 	mockTerraformStack.UpFunc = func(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(id string) error) error { return nil }
@@ -273,7 +273,7 @@ func TestBootstrapCmd(t *testing.T) {
 			},
 		}
 		mocks.BlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint { return backendBlueprint }
-		mocks.BlueprintHandler.GenerateResolvedFunc = func() *blueprintv1alpha1.Blueprint { return backendBlueprint }
+		mocks.BlueprintHandler.GenerateResolvedFunc = func() (*blueprintv1alpha1.Blueprint, error) { return backendBlueprint, nil }
 
 		var timeline []string
 		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -21,7 +21,10 @@ var installCmd = &cobra.Command{
 			return err
 		}
 
-		blueprint := proj.Composer.BlueprintHandler.GenerateResolved()
+		blueprint, err := proj.Composer.BlueprintHandler.GenerateResolved()
+		if err != nil {
+			return fmt.Errorf("error resolving blueprint substitutions: %w", err)
+		}
 		if err := proj.Provisioner.Install(cmd.Context(), blueprint); err != nil {
 			return fmt.Errorf("error installing blueprint: %w", err)
 		}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -93,8 +93,15 @@ var upCmd = &cobra.Command{
 		}
 
 		// Re-generate with deferred substitutions resolved now that terraform
-		// outputs are available from the Up step above.
-		blueprint := proj.Composer.BlueprintHandler.GenerateResolved()
+		// outputs are available from the Up step above. A failure here surfaces
+		// an unresolved expression by name (e.g. "kustomize.dns.substitutions.
+		// external_dns_tenant_id: terraform output 'tenant_id' for component
+		// cluster not found"), preventing the raw `${...}` source text from
+		// reaching Flux ConfigMaps and downstream Helm renders.
+		blueprint, err := proj.Composer.BlueprintHandler.GenerateResolved()
+		if err != nil {
+			return fmt.Errorf("error resolving blueprint substitutions: %w", err)
+		}
 
 		if err := proj.Provisioner.Install(cmd.Context(), blueprint); err != nil {
 			return fmt.Errorf("error installing blueprint: %w", err)

--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -22,7 +22,7 @@ type BlueprintHandler interface {
 	GetTerraformComponents() []blueprintv1alpha1.TerraformComponent
 	GetLocalTemplateData() (map[string][]byte, error)
 	Generate() *blueprintv1alpha1.Blueprint
-	GenerateResolved() *blueprintv1alpha1.Blueprint
+	GenerateResolved() (*blueprintv1alpha1.Blueprint, error)
 	Explain(path string) (*ExplainTrace, error)
 	GetDeferredPaths() map[string]bool
 }
@@ -229,16 +229,29 @@ func (h *BaseBlueprintHandler) Generate() *blueprintv1alpha1.Blueprint {
 // is never mutated, so subsequent Generate() or GenerateResolved() calls start from the original
 // deferred expressions. Callers that only display the blueprint (e.g. windsor show) should use
 // Generate() instead to preserve deferred placeholders.
-func (h *BaseBlueprintHandler) GenerateResolved() *blueprintv1alpha1.Blueprint {
+//
+// Returns an error when a deferred substitution cannot be resolved (e.g. terraform_output()
+// references a missing key, or terraform itself errors during the lookup). The previous behavior
+// was to swallow these errors and leave the raw `${...}` source in the substitution map — which
+// then leaked into Flux ConfigMaps and downstream Helm renders, where the literal expression
+// text was treated as a config value (e.g. external-dns reading "${terraform_output('cluster',
+// 'tenant_id') ?? ''}" as the tenant ID and crashlooping with "invalid tenantID"). The contract
+// is now: an unresolved expression must never reach a ConfigMap. Operators see the failure at
+// blueprint-resolution time with the offending key + path called out by name, instead of via a
+// downstream pod crashloop minutes later.
+func (h *BaseBlueprintHandler) GenerateResolved() (*blueprintv1alpha1.Blueprint, error) {
 	bp := h.Generate()
 	if bp == nil {
-		return nil
+		return nil, nil
 	}
 	resolved := bp.DeepCopy()
 	h.composedBlueprint = resolved
-	h.resolveDeferredSubstitutions()
+	err := h.resolveDeferredSubstitutions()
 	h.composedBlueprint = bp
-	return resolved
+	if err != nil {
+		return nil, err
+	}
+	return resolved, nil
 }
 
 // GetDeferredPaths returns composed paths whose values were deferred during expression evaluation.
@@ -264,14 +277,21 @@ func (h *BaseBlueprintHandler) GetDeferredPaths() map[string]bool {
 // (after terraform apply). Only substitutions marked as deferred during composition are
 // re-evaluated; already-resolved substitutions are left untouched. Covers global substitutions,
 // blueprint-level ConfigMaps, and per-kustomization substitutions.
-func (h *BaseBlueprintHandler) resolveDeferredSubstitutions() {
+//
+// Returns the first evaluation error encountered (with the substitution path named, e.g.
+// "kustomize.dns.substitutions.external_dns_tenant_id") so the operator sees exactly which
+// expression failed. Leaving an unresolved expression in place — the previous behavior — let
+// raw `${terraform_output(...)}` source text leak into Flux ConfigMaps; downstream Helm
+// renders then treated the literal expression as a config value. Failing here surfaces the
+// problem at blueprint-resolution time, before anything is written to the cluster.
+func (h *BaseBlueprintHandler) resolveDeferredSubstitutions() error {
 	if h.runtime == nil || h.runtime.Evaluator == nil || h.composedBlueprint == nil {
-		return
+		return nil
 	}
 
 	deferred := h.GetDeferredPaths()
 	if len(deferred) == 0 {
-		return
+		return nil
 	}
 
 	bp := h.composedBlueprint
@@ -280,9 +300,11 @@ func (h *BaseBlueprintHandler) resolveDeferredSubstitutions() {
 		if !deferred["substitutions."+key] {
 			continue
 		}
-		if str := h.resolveDeferred(value); str != nil {
-			bp.Substitutions[key] = *str
+		str, err := h.resolveDeferred(value)
+		if err != nil {
+			return fmt.Errorf("substitutions.%s: %w", key, err)
 		}
+		bp.Substitutions[key] = str
 	}
 
 	for name, configMap := range bp.ConfigMaps {
@@ -290,9 +312,11 @@ func (h *BaseBlueprintHandler) resolveDeferredSubstitutions() {
 			if !deferred["configmaps."+name+"."+key] {
 				continue
 			}
-			if str := h.resolveDeferred(value); str != nil {
-				bp.ConfigMaps[name][key] = *str
+			str, err := h.resolveDeferred(value)
+			if err != nil {
+				return fmt.Errorf("configmaps.%s.%s: %w", name, key, err)
 			}
+			bp.ConfigMaps[name][key] = str
 		}
 	}
 
@@ -302,30 +326,38 @@ func (h *BaseBlueprintHandler) resolveDeferredSubstitutions() {
 			if !deferred["kustomize."+k.Name+".substitutions."+key] {
 				continue
 			}
-			if str := h.resolveDeferred(value); str != nil {
-				k.Substitutions[key] = *str
+			str, err := h.resolveDeferred(value)
+			if err != nil {
+				return fmt.Errorf("kustomize.%s.substitutions.%s: %w", k.Name, key, err)
 			}
+			k.Substitutions[key] = str
 		}
 	}
+
+	return nil
 }
 
 // resolveDeferred evaluates a single expression with evaluateDeferred=true using the composed
-// scope. Returns a pointer to the resolved string, or nil if evaluation fails (leaving the
-// original value unchanged for the next Generate() call to retry).
-func (h *BaseBlueprintHandler) resolveDeferred(expr string) *string {
+// scope. Returns the resolved string on success, or an error when the expression cannot be
+// evaluated (e.g. terraform_output() references a missing module output, or terraform itself
+// errors). The previous behavior — swallowing the error and returning a sentinel that callers
+// interpreted as "leave the original raw expression in place" — is the bug that lets unresolved
+// `${terraform_output(...)}` text leak into ConfigMaps. Operators with a legitimately-optional
+// reference should write `?? <fallback>` in the expression itself; nil from the evaluator
+// (with no coalesce) renders as the empty string here, which is the operator's explicit choice
+// rather than a silent failure.
+func (h *BaseBlueprintHandler) resolveDeferred(expr string) (string, error) {
 	resolved, err := h.runtime.Evaluator.Evaluate(expr, "", h.composedScope, true)
 	if err != nil {
-		return nil
+		return "", err
 	}
-	var s string
 	if resolved == nil {
-		s = ""
-	} else if str, ok := resolved.(string); ok {
-		s = str
-	} else {
-		s = fmt.Sprintf("%v", resolved)
+		return "", nil
 	}
-	return &s
+	if str, ok := resolved.(string); ok {
+		return str, nil
+	}
+	return fmt.Sprintf("%v", resolved), nil
 }
 
 // deriveConfigMapDeferredPaths propagates deferred status to ConfigMap entries that inherited

--- a/pkg/composer/blueprint/handler_test.go
+++ b/pkg/composer/blueprint/handler_test.go
@@ -1205,7 +1205,10 @@ func TestHandler_GenerateResolved(t *testing.T) {
 		}
 
 		// When calling GenerateResolved
-		resolved := handler.GenerateResolved()
+		resolved, err := handler.GenerateResolved()
+		if err != nil {
+			t.Fatalf("Expected no error for resolvable substitution, got %v", err)
+		}
 
 		// Then the returned blueprint is a separate object
 		if resolved == handler.composedBlueprint {
@@ -1224,11 +1227,63 @@ func TestHandler_GenerateResolved(t *testing.T) {
 		handler := NewBlueprintHandler(mocks.Runtime, mocks.ArtifactBuilder)
 
 		// When calling GenerateResolved
-		result := handler.GenerateResolved()
+		result, err := handler.GenerateResolved()
+		if err != nil {
+			t.Fatalf("Expected no error when no blueprint, got %v", err)
+		}
 
 		// Then should return nil
 		if result != nil {
 			t.Error("Expected nil when no blueprint")
+		}
+	})
+
+	t.Run("PropagatesEvaluatorErrorWithSubstitutionPath", func(t *testing.T) {
+		// Given a handler with a deferred substitution whose underlying expression errors
+		// during the deferred-resolution pass — e.g. a terraform_output() that references a
+		// missing module key, or a terraform shell failure. Previously the handler would
+		// swallow the error and leave the raw `${...}` source string in the substitution
+		// map, which then leaked into Flux ConfigMaps and downstream Helm renders. Now the
+		// error must surface here, named by its substitution path, so the operator sees the
+		// failure at blueprint-resolution time instead of via a downstream pod crashloop.
+		mocks := setupHandlerMocks(t)
+		mocks.Runtime.Evaluator = &evaluator.MockExpressionEvaluator{
+			EvaluateFunc: func(expr string, _ string, _ map[string]any, _ bool) (any, error) {
+				return nil, fmt.Errorf("terraform output 'tenant_id' for component cluster not found")
+			},
+		}
+		handler := NewBlueprintHandler(mocks.Runtime, mocks.ArtifactBuilder)
+		handler.composedBlueprint = &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{
+					Name: "dns",
+					Substitutions: map[string]string{
+						"external_dns_tenant_id": "${terraform_output('cluster', 'tenant_id') ?? ''}",
+					},
+				},
+			},
+		}
+		handler.deferredPaths = map[string]bool{
+			"kustomize.dns.substitutions.external_dns_tenant_id": true,
+		}
+
+		// When calling GenerateResolved
+		resolved, err := handler.GenerateResolved()
+
+		// Then the error surfaces with the substitution path called out by name —
+		// "kustomize.dns.substitutions.external_dns_tenant_id" — so the operator can grep
+		// directly from the failure to the offending facet entry.
+		if err == nil {
+			t.Fatal("Expected GenerateResolved to surface the evaluator error, got nil")
+		}
+		if !strings.Contains(err.Error(), "kustomize.dns.substitutions.external_dns_tenant_id") {
+			t.Errorf("Expected error to name the substitution path, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "tenant_id") {
+			t.Errorf("Expected error to preserve the underlying evaluator message, got: %v", err)
+		}
+		if resolved != nil {
+			t.Error("Expected nil blueprint on resolve failure (no partial results to consume)")
 		}
 	})
 }

--- a/pkg/composer/blueprint/mock_blueprint_handler.go
+++ b/pkg/composer/blueprint/mock_blueprint_handler.go
@@ -12,7 +12,7 @@ type MockBlueprintHandler struct {
 	GetTerraformComponentsFunc func() []blueprintv1alpha1.TerraformComponent
 	GetLocalTemplateDataFunc   func() (map[string][]byte, error)
 	GenerateFunc               func() *blueprintv1alpha1.Blueprint
-	GenerateResolvedFunc       func() *blueprintv1alpha1.Blueprint
+	GenerateResolvedFunc       func() (*blueprintv1alpha1.Blueprint, error)
 	ExplainFunc                func(string) (*ExplainTrace, error)
 	GetDeferredPathsFunc       func() map[string]bool
 	skipValidation             bool
@@ -88,11 +88,11 @@ func (m *MockBlueprintHandler) Generate() *blueprintv1alpha1.Blueprint {
 }
 
 // GenerateResolved calls the mock GenerateResolvedFunc if set, otherwise falls back to Generate.
-func (m *MockBlueprintHandler) GenerateResolved() *blueprintv1alpha1.Blueprint {
+func (m *MockBlueprintHandler) GenerateResolved() (*blueprintv1alpha1.Blueprint, error) {
 	if m.GenerateResolvedFunc != nil {
 		return m.GenerateResolvedFunc()
 	}
-	return m.Generate()
+	return m.Generate(), nil
 }
 
 // Explain calls the mock ExplainFunc if set, otherwise returns nil.


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> This is a behavioral interface change: errors that were previously swallowed silently now propagate to callers, which can break workflows that relied (perhaps inadvertently) on the silent-fallback behavior.
>
> **Overview**
>
> The PR changes `GenerateResolved()` to return `(*Blueprint, error)` so that evaluator failures during deferred substitution resolution — most commonly a missing terraform output — are surfaced to the operator at resolution time rather than silently leaving a raw `${terraform_output(...)}` expression in a ConfigMap, where it would reach Flux and cause downstream pod crashloops. All four command callers (`apply`, `bootstrap`, `install`, `up`) are updated consistently, the mock is updated, and a new test case covers the error propagation path with path-qualified error messages.
>
> The error on the first unresolvable substitution; operators with multiple broken expressions will see one failure per run. Operators who want an expression to be optional should write `?? ""` as a fallback in the expression itself.
>
> Reviewed by Claude for commit `666d1a2d`.

<!-- /claude-code-review:summary -->
