### PR TITLE
fix(provisioner): Enhance bootstrap probe logic to handle incomplete backend config

### DIFF
--- a/pkg/provisioner/bootstrap.go
+++ b/pkg/provisioner/bootstrap.go
@@ -98,7 +98,7 @@ func (i *Provisioner) Bootstrap(blueprint *blueprintv1alpha1.Blueprint, confirm 
 			fmt.Fprintln(os.Stderr, "proceeding with local-then-migrate dance — abort with Ctrl-C if your backend already exists and this is a transient probe failure.")
 			pauseForProbeWarning(os.Stderr, probeErrorPause)
 		} else if hasRemote {
-			fmt.Fprintf(os.Stderr, "Probe found existing state for pivot %q in configured backend — skipping bootstrap dance, applying as a normal up.\n", pivotID)
+			fmt.Fprintf(os.Stderr, "Probe found existing state for pivot %q in configured backend — applying without pivot.\n", pivotID)
 			if err := i.Up(blueprint, onApply...); err != nil {
 				return false, err
 			}

--- a/pkg/provisioner/bootstrap.go
+++ b/pkg/provisioner/bootstrap.go
@@ -88,16 +88,22 @@ func (i *Provisioner) Bootstrap(blueprint *blueprintv1alpha1.Blueprint, confirm 
 		return false, err
 	}
 
-	hasRemote, probeErr := i.HasRemoteState(blueprint, pivotID)
-	if probeErr != nil {
-		fmt.Fprintf(os.Stderr, "warning: probe of configured backend for pivot %q failed: %v — proceeding with local-then-migrate dance (correct on first-time bootstrap; abort with Ctrl-C if your backend already exists and this is a transient probe failure)\n", pivotID, probeErr)
-		pauseForProbeWarning(os.Stderr, probeErrorPause)
-	} else if hasRemote {
-		fmt.Fprintf(os.Stderr, "Probe found existing state for pivot %q in configured backend — skipping bootstrap dance, applying as a normal up.\n", pivotID)
-		if err := i.Up(blueprint, onApply...); err != nil {
-			return false, err
+	if i.runtime != nil && i.runtime.TerraformProvider != nil && !i.runtime.TerraformProvider.BackendConfigComplete() {
+		fmt.Fprintf(os.Stderr, "Probe: no backend config present for pivot %q yet — running first-time bootstrap dance.\n", pivotID)
+	} else {
+		hasRemote, probeErr := i.HasRemoteState(blueprint, pivotID)
+		if probeErr != nil {
+			fmt.Fprintf(os.Stderr, "warning: probe of configured backend for pivot %q failed:\n", pivotID)
+			fmt.Fprintf(os.Stderr, "%v\n\n", probeErr)
+			fmt.Fprintln(os.Stderr, "proceeding with local-then-migrate dance — abort with Ctrl-C if your backend already exists and this is a transient probe failure.")
+			pauseForProbeWarning(os.Stderr, probeErrorPause)
+		} else if hasRemote {
+			fmt.Fprintf(os.Stderr, "Probe found existing state for pivot %q in configured backend — skipping bootstrap dance, applying as a normal up.\n", pivotID)
+			if err := i.Up(blueprint, onApply...); err != nil {
+				return false, err
+			}
+			return true, nil
 		}
-		return true, nil
 	}
 
 	pivotOnly := blueprintWithOnly(blueprint, pivotID)

--- a/pkg/provisioner/bootstrap_test.go
+++ b/pkg/provisioner/bootstrap_test.go
@@ -1218,8 +1218,8 @@ func TestProvisioner_Bootstrap(t *testing.T) {
 		stderrBytes, _ := io.ReadAll(r)
 		stderrOutput := string(stderrBytes)
 
-		if !strings.Contains(stderrOutput, "skipping bootstrap dance") {
-			t.Errorf("Expected stderr to mention skipping the dance, got: %q", stderrOutput)
+		if !strings.Contains(stderrOutput, "applying without pivot") {
+			t.Errorf("Expected stderr to mention applying without pivot, got: %q", stderrOutput)
 		}
 		if !strings.Contains(stderrOutput, `"backend"`) {
 			t.Errorf("Expected stderr to name the pivot, got: %q", stderrOutput)

--- a/pkg/provisioner/bootstrap_test.go
+++ b/pkg/provisioner/bootstrap_test.go
@@ -11,6 +11,7 @@ import (
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	terraforminfra "github.com/windsorcli/cli/pkg/provisioner/terraform"
 	"github.com/windsorcli/cli/pkg/runtime/config"
+	terraformruntime "github.com/windsorcli/cli/pkg/runtime/terraform"
 )
 
 // =============================================================================
@@ -979,6 +980,84 @@ func TestProvisioner_Bootstrap(t *testing.T) {
 		}
 		if len(upBlueprints) != 1 || len(upBlueprints[0].TerraformComponents) != 2 {
 			t.Errorf("Expected single Up call against full blueprint, got %#v", upBlueprints)
+		}
+	})
+
+	t.Run("ProbeShortCircuitsWhenBackendConfigNotPresent", func(t *testing.T) {
+		// First-time bootstrap: no backend.tfvars file yet, no nested
+		// terraform.backend.azurerm config in values.yaml. terraform init
+		// against the configured remote would fail with "container_name:
+		// EOF" — terraform asking interactively for required fields. That
+		// failure isn't useful diagnostic noise; it's just the default state
+		// before the backend module's own apply produces the missing config.
+		// Bootstrap detects this via TerraformProvider.BackendConfigComplete
+		// and skips the probe entirely, emitting a single calm "running
+		// first-time bootstrap dance" line in place of the warning + wrapped
+		// terraform error + countdown.
+		mocks := setupProvisionerMocks(t)
+		mocks.Runtime.TerraformProvider.(*terraformruntime.MockTerraformProvider).BackendConfigCompleteFunc = func() bool { return false }
+		bp := &blueprintv1alpha1.Blueprint{
+			Metadata: blueprintv1alpha1.Metadata{Name: "test"},
+			TerraformComponents: []blueprintv1alpha1.TerraformComponent{
+				{Path: "backend"},
+			},
+		}
+		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockCH.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "terraform.backend.type" {
+				return "azurerm"
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
+		mockStack := terraforminfra.NewMockStack()
+		probeFired := false
+		mockStack.HasRemoteStateFunc = func(_ *blueprintv1alpha1.Blueprint, _ string) (bool, error) {
+			probeFired = true
+			return false, nil
+		}
+		mockStack.UpFunc = func(_ *blueprintv1alpha1.Blueprint, _ ...func(id string) error) error {
+			return nil
+		}
+		mockStack.MigrateStateFunc = func(_ *blueprintv1alpha1.Blueprint) ([]string, error) {
+			return nil, nil
+		}
+
+		r, w, pipeErr := os.Pipe()
+		if pipeErr != nil {
+			t.Fatalf("Pipe failed: %v", pipeErr)
+		}
+		origStderr := os.Stderr
+		os.Stderr = w
+		defer func() { os.Stderr = origStderr }()
+
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+
+		_, err := provisioner.Bootstrap(bp, nil)
+
+		w.Close()
+		stderrBytes, _ := io.ReadAll(r)
+		stderrOutput := string(stderrBytes)
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if probeFired {
+			t.Error("HasRemoteState must not be called when backend config is incomplete — short-circuit avoids the wasteful terraform init")
+		}
+		if !strings.Contains(stderrOutput, "no backend config present") {
+			t.Errorf("Expected calm short-circuit message, got: %q", stderrOutput)
+		}
+		if !strings.Contains(stderrOutput, `"backend"`) {
+			t.Errorf("Expected stderr to name the pivot, got: %q", stderrOutput)
+		}
+		if strings.Contains(stderrOutput, "warning:") {
+			t.Errorf("Short-circuit must NOT use the warning marker — that's reserved for real probe failures with config present, got: %q", stderrOutput)
+		}
+		if strings.Contains(stderrOutput, "Ctrl-C") {
+			t.Errorf("Short-circuit must NOT include the Ctrl-C countdown — there's no probe failure to ask the operator about, got: %q", stderrOutput)
 		}
 	})
 

--- a/pkg/runtime/terraform/mock_provider.go
+++ b/pkg/runtime/terraform/mock_provider.go
@@ -18,6 +18,7 @@ type MockTerraformProvider struct {
 	CacheOutputsFunc            func(componentID string) error
 	GetTFDataDirFunc            func(componentID string) (string, error)
 	GetStatePathFunc            func(componentID string) (string, error)
+	BackendConfigCompleteFunc   func() bool
 	GetEnvVarsFunc              func(componentID string, interactive bool) (map[string]string, *TerraformArgs, error)
 	FormatArgsForEnvFunc        func(args []string) string
 	ClearCacheFunc              func()
@@ -115,6 +116,16 @@ func (m *MockTerraformProvider) GetStatePath(componentID string) (string, error)
 		return m.GetStatePathFunc(componentID)
 	}
 	return "", nil
+}
+
+// BackendConfigComplete implements TerraformProvider. Default is true so most
+// tests exercise the probe path; tests for the no-config short-circuit set
+// BackendConfigCompleteFunc explicitly to return false.
+func (m *MockTerraformProvider) BackendConfigComplete() bool {
+	if m.BackendConfigCompleteFunc != nil {
+		return m.BackendConfigCompleteFunc()
+	}
+	return true
 }
 
 // GetEnvVars implements TerraformProvider.

--- a/pkg/runtime/terraform/provider.go
+++ b/pkg/runtime/terraform/provider.go
@@ -81,6 +81,7 @@ type TerraformProvider interface {
 	CacheOutputs(componentID string) error
 	GetTFDataDir(componentID string) (string, error)
 	GetStatePath(componentID string) (string, error)
+	BackendConfigComplete() bool
 	GetEnvVars(componentID string, interactive bool) (map[string]string, *TerraformArgs, error)
 	FormatArgsForEnv(args []string) string
 	ClearCache()
@@ -634,6 +635,50 @@ func (p *terraformProvider) GetStatePath(componentID string) (string, error) {
 	}
 	statePath := filepath.Join(path, actualComponentID, "terraform.tfstate")
 	return statePath, nil
+}
+
+// BackendConfigComplete reports whether the configured remote backend has
+// enough config — a backend.tfvars file or a populated nested config block —
+// for `terraform init` to even attempt connecting. Local/empty backends are
+// always complete. Lets Bootstrap's probe distinguish "we don't know where
+// the remote is yet" (first-time bootstrap, the dance is the right path
+// without a confusing terraform-error dump) from "we know where it is but
+// can't reach it" (real warning, operator may want to abort).
+func (p *terraformProvider) BackendConfigComplete() bool {
+	backendType := p.configHandler.GetString("terraform.backend.type", "local")
+	if backendType == "" || backendType == "local" {
+		return true
+	}
+
+	if configRoot, err := p.configHandler.GetConfigRoot(); err == nil {
+		for _, candidate := range []string{
+			filepath.Join(configRoot, "backend.tfvars"),
+			filepath.Join(configRoot, "terraform", "backend.tfvars"),
+		} {
+			if _, err := p.Shims.Stat(candidate); err == nil {
+				return true
+			}
+		}
+	}
+
+	cfg := p.configHandler.GetConfig().Terraform
+	if cfg == nil || cfg.Backend == nil {
+		return false
+	}
+	switch backendType {
+	case "azurerm":
+		return cfg.Backend.AzureRM != nil &&
+			cfg.Backend.AzureRM.StorageAccountName != nil &&
+			cfg.Backend.AzureRM.ContainerName != nil
+	case "s3":
+		return cfg.Backend.S3 != nil && cfg.Backend.S3.Bucket != nil
+	case "kubernetes":
+		// Kubernetes uses the ambient kubeconfig by default; an empty nested
+		// config block is normal. Treat as complete — if init fails, that's
+		// a real probe failure (cluster unreachable / auth) worth surfacing.
+		return true
+	}
+	return false
 }
 
 // =============================================================================

--- a/pkg/runtime/terraform/provider.go
+++ b/pkg/runtime/terraform/provider.go
@@ -641,9 +641,14 @@ func (p *terraformProvider) GetStatePath(componentID string) (string, error) {
 // enough config — a backend.tfvars file or a populated nested config block —
 // for `terraform init` to even attempt connecting. Local/empty backends are
 // always complete. Lets Bootstrap's probe distinguish "we don't know where
-// the remote is yet" (first-time bootstrap, the dance is the right path
-// without a confusing terraform-error dump) from "we know where it is but
-// can't reach it" (real warning, operator may want to abort).
+// the remote is yet" (first-time bootstrap) from "we know where it is but
+// can't reach it" (real warning).
+//
+// Default for unrecognized backend types is true: the predicate's job is to
+// catch the well-understood first-time-bootstrap case for the backends
+// Windsor knows about. For anything else (gcs, http, consul, remote, cos),
+// we don't know what's required — let the probe run and surface real init
+// failures via the warning path rather than silently disable detection.
 func (p *terraformProvider) BackendConfigComplete() bool {
 	backendType := p.configHandler.GetString("terraform.backend.type", "local")
 	if backendType == "" || backendType == "local" {
@@ -661,24 +666,24 @@ func (p *terraformProvider) BackendConfigComplete() bool {
 		}
 	}
 
-	cfg := p.configHandler.GetConfig().Terraform
-	if cfg == nil || cfg.Backend == nil {
-		return false
+	// Kubernetes uses the ambient kubeconfig; a nested config block is
+	// optional. Reachable from here even when cfg.Backend is nil.
+	if backendType == "kubernetes" {
+		return true
 	}
+
+	cfg := p.configHandler.GetConfig().Terraform
 	switch backendType {
 	case "azurerm":
-		return cfg.Backend.AzureRM != nil &&
+		return cfg != nil && cfg.Backend != nil && cfg.Backend.AzureRM != nil &&
 			cfg.Backend.AzureRM.StorageAccountName != nil &&
 			cfg.Backend.AzureRM.ContainerName != nil
 	case "s3":
-		return cfg.Backend.S3 != nil && cfg.Backend.S3.Bucket != nil
-	case "kubernetes":
-		// Kubernetes uses the ambient kubeconfig by default; an empty nested
-		// config block is normal. Treat as complete — if init fails, that's
-		// a real probe failure (cluster unreachable / auth) worth surfacing.
-		return true
+		return cfg != nil && cfg.Backend != nil && cfg.Backend.S3 != nil &&
+			cfg.Backend.S3.Bucket != nil
 	}
-	return false
+
+	return true
 }
 
 // =============================================================================

--- a/pkg/runtime/terraform/provider_public_test.go
+++ b/pkg/runtime/terraform/provider_public_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+	terraformcfg "github.com/windsorcli/cli/api/v1alpha1/terraform"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	"github.com/windsorcli/cli/pkg/runtime/evaluator"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
@@ -2370,6 +2371,129 @@ terraform:
 		}
 		if !strings.Contains(err.Error(), "windsor scratch path") {
 			t.Errorf("Expected error about windsor scratch path, got: %v", err)
+		}
+	})
+}
+
+func TestTerraformProvider_BackendConfigComplete(t *testing.T) {
+	stringPtr := func(s string) *string { return &s }
+
+	t.Run("LocalBackendIsAlwaysComplete", func(t *testing.T) {
+		mocks := setupMocks(t, &SetupOptions{BackendType: "local"})
+		if !mocks.Provider.BackendConfigComplete() {
+			t.Error("Expected local backend to be complete")
+		}
+	})
+
+	t.Run("EmptyBackendIsAlwaysComplete", func(t *testing.T) {
+		mocks := setupMocks(t, &SetupOptions{BackendType: ""})
+		if !mocks.Provider.BackendConfigComplete() {
+			t.Error("Expected empty backend type to be complete")
+		}
+	})
+
+	t.Run("BackendTfvarsAtConfigRootMakesItComplete", func(t *testing.T) {
+		mocks := setupMocks(t, &SetupOptions{BackendType: "azurerm"})
+		mocks.Provider.Shims.Stat = func(path string) (os.FileInfo, error) {
+			if path == filepath.Join("/test/config", "backend.tfvars") {
+				return nil, nil
+			}
+			return nil, os.ErrNotExist
+		}
+		if !mocks.Provider.BackendConfigComplete() {
+			t.Error("Expected presence of backend.tfvars to mark backend as complete")
+		}
+	})
+
+	t.Run("KubernetesIsCompleteEvenWithoutNestedBlock", func(t *testing.T) {
+		// Regression: cfg.Backend nil guard previously returned false before
+		// the kubernetes case was reached. Kubernetes uses ambient kubeconfig
+		// so a missing nested block is the normal case.
+		mocks := setupMocks(t, &SetupOptions{BackendType: "kubernetes"})
+		mocks.ConfigHandler.GetConfigFunc = func() *blueprintv1alpha1.Context {
+			return &blueprintv1alpha1.Context{} // Terraform == nil
+		}
+		if !mocks.Provider.BackendConfigComplete() {
+			t.Error("Expected kubernetes backend to be complete without a nested config block")
+		}
+	})
+
+	t.Run("UnrecognizedBackendDefaultsToComplete", func(t *testing.T) {
+		// Regression: the trailing default previously returned false, which
+		// permanently disabled the probe for any backend Windsor doesn't
+		// special-case (gcs, http, consul, remote, cos, ...). Default-allow
+		// lets the probe run; real init failures surface via the warning path.
+		mocks := setupMocks(t, &SetupOptions{BackendType: "gcs"})
+		mocks.ConfigHandler.GetConfigFunc = func() *blueprintv1alpha1.Context {
+			return &blueprintv1alpha1.Context{}
+		}
+		if !mocks.Provider.BackendConfigComplete() {
+			t.Error("Expected unrecognized backend type 'gcs' to default to complete")
+		}
+	})
+
+	t.Run("AzureRMRequiresStorageAccountAndContainer", func(t *testing.T) {
+		mocks := setupMocks(t, &SetupOptions{BackendType: "azurerm"})
+
+		// Missing both
+		mocks.ConfigHandler.GetConfigFunc = func() *blueprintv1alpha1.Context {
+			return &blueprintv1alpha1.Context{
+				Terraform: &terraformcfg.TerraformConfig{Backend: &terraformcfg.BackendConfig{}},
+			}
+		}
+		if mocks.Provider.BackendConfigComplete() {
+			t.Error("Expected azurerm with no nested config to be incomplete")
+		}
+
+		// Only storage_account_name
+		mocks.ConfigHandler.GetConfigFunc = func() *blueprintv1alpha1.Context {
+			return &blueprintv1alpha1.Context{
+				Terraform: &terraformcfg.TerraformConfig{Backend: &terraformcfg.BackendConfig{
+					AzureRM: &terraformcfg.AzureRMBackend{StorageAccountName: stringPtr("sa")},
+				}},
+			}
+		}
+		if mocks.Provider.BackendConfigComplete() {
+			t.Error("Expected azurerm with only storage_account_name to be incomplete")
+		}
+
+		// Both fields present
+		mocks.ConfigHandler.GetConfigFunc = func() *blueprintv1alpha1.Context {
+			return &blueprintv1alpha1.Context{
+				Terraform: &terraformcfg.TerraformConfig{Backend: &terraformcfg.BackendConfig{
+					AzureRM: &terraformcfg.AzureRMBackend{
+						StorageAccountName: stringPtr("sa"),
+						ContainerName:      stringPtr("c"),
+					},
+				}},
+			}
+		}
+		if !mocks.Provider.BackendConfigComplete() {
+			t.Error("Expected azurerm with storage_account_name and container_name to be complete")
+		}
+	})
+
+	t.Run("S3RequiresBucket", func(t *testing.T) {
+		mocks := setupMocks(t, &SetupOptions{BackendType: "s3"})
+
+		mocks.ConfigHandler.GetConfigFunc = func() *blueprintv1alpha1.Context {
+			return &blueprintv1alpha1.Context{
+				Terraform: &terraformcfg.TerraformConfig{Backend: &terraformcfg.BackendConfig{}},
+			}
+		}
+		if mocks.Provider.BackendConfigComplete() {
+			t.Error("Expected s3 with no nested config to be incomplete")
+		}
+
+		mocks.ConfigHandler.GetConfigFunc = func() *blueprintv1alpha1.Context {
+			return &blueprintv1alpha1.Context{
+				Terraform: &terraformcfg.TerraformConfig{Backend: &terraformcfg.BackendConfig{
+					S3: &terraformcfg.S3Backend{Bucket: stringPtr("b")},
+				}},
+			}
+		}
+		if !mocks.Provider.BackendConfigComplete() {
+			t.Error("Expected s3 with bucket to be complete")
 		}
 	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> This PR modifies the bootstrap probe path — a decision point controlling whether the first-time bootstrap dance runs or is skipped — so a subtle logic error here can either destroy existing remote state or leave a first-time bootstrap silently stuck.
>
> **Overview**
>
> The change adds a pre-probe guard in `Bootstrap` that calls a new `BackendConfigComplete()` method on the `TerraformProvider` interface. When the method returns false, the probe is skipped and an informational message is emitted instead of the confusing terraform EOF or interactive-prompt error that fires during a genuine first-time bootstrap. The message emitted on the happy-path probe hit was also tightened from "skipping bootstrap dance, applying as a normal up" to the clearer "applying without pivot".
>
> This commit corrects the two issues flagged in the prior review. The default return for unrecognized backend types is now `true`, meaning the probe runs for gcs, http, consul, and similar backends Windsor does not special-case, surfacing real init failures rather than silently disabling detection. The `kubernetes` case has been moved before the `cfg.Backend` nil check so it is always reachable; a missing nested config block is the normal case for kubernetes since it uses the ambient kubeconfig. Both fixes are covered by new regression tests.
>
> Reviewed by Claude for commit `0f78ac7`.

<!-- /claude-code-review:summary -->
