### PR TITLE
fix(runtime/env): Facilitate smoother Azure auth activation

### DIFF
--- a/api/v1alpha1/azure/azure_config.go
+++ b/api/v1alpha1/azure/azure_config.go
@@ -1,10 +1,8 @@
 package azure
 
-// AzureConfig represents the Azure configuration
+// AzureConfig represents the Azure configuration. Azure integration activates whenever this
+// block is present in a context (or when platform is "azure"); no separate enabled flag.
 type AzureConfig struct {
-	// Enabled indicates whether Azure integration is enabled.
-	Enabled *bool `yaml:"enabled,omitempty"`
-
 	// SubscriptionID is the Azure subscription identifier
 	SubscriptionID *string `yaml:"subscription_id,omitempty"`
 
@@ -13,15 +11,17 @@ type AzureConfig struct {
 
 	// Environment specifies the Azure cloud environment (e.g. "public", "usgovernment")
 	Environment *string `yaml:"environment,omitempty"`
+
+	// KubeloginMode overrides the kubelogin login mode for AAD-enabled AKS kubeconfigs.
+	// Empty (default) auto-detects from the active credential chain. Set to "msi" on
+	// managed-identity runners; other values match kubelogin's own modes.
+	KubeloginMode *string `yaml:"kubelogin_mode,omitempty"`
 }
 
 // Merge performs a deep merge of the current AzureConfig with another AzureConfig.
 func (base *AzureConfig) Merge(overlay *AzureConfig) {
 	if overlay == nil {
 		return
-	}
-	if overlay.Enabled != nil {
-		base.Enabled = overlay.Enabled
 	}
 	if overlay.SubscriptionID != nil {
 		base.SubscriptionID = overlay.SubscriptionID
@@ -32,6 +32,9 @@ func (base *AzureConfig) Merge(overlay *AzureConfig) {
 	if overlay.Environment != nil {
 		base.Environment = overlay.Environment
 	}
+	if overlay.KubeloginMode != nil {
+		base.KubeloginMode = overlay.KubeloginMode
+	}
 }
 
 // Copy creates a deep copy of the AzureConfig object
@@ -40,9 +43,9 @@ func (c *AzureConfig) Copy() *AzureConfig {
 		return nil
 	}
 	return &AzureConfig{
-		Enabled:        c.Enabled,
 		SubscriptionID: c.SubscriptionID,
 		TenantID:       c.TenantID,
 		Environment:    c.Environment,
+		KubeloginMode:  c.KubeloginMode,
 	}
 }

--- a/api/v1alpha1/azure/azure_config_test.go
+++ b/api/v1alpha1/azure/azure_config_test.go
@@ -15,53 +15,50 @@ func TestAzureConfig(t *testing.T) {
 			{
 				name: "AllFields",
 				base: &AzureConfig{
-					Enabled:        boolPtr(false),
 					SubscriptionID: stringPtr("old-sub"),
 					TenantID:       stringPtr("old-tenant"),
 					Environment:    stringPtr("old-env"),
+					KubeloginMode:  stringPtr("azurecli"),
 				},
 				overlay: &AzureConfig{
-					Enabled:        boolPtr(true),
 					SubscriptionID: stringPtr("new-sub"),
 					TenantID:       stringPtr("new-tenant"),
 					Environment:    stringPtr("new-env"),
+					KubeloginMode:  stringPtr("workloadidentity"),
 				},
 				expected: &AzureConfig{
-					Enabled:        boolPtr(true),
 					SubscriptionID: stringPtr("new-sub"),
 					TenantID:       stringPtr("new-tenant"),
 					Environment:    stringPtr("new-env"),
+					KubeloginMode:  stringPtr("workloadidentity"),
 				},
 			},
 			{
 				name: "PartialOverlay",
 				base: &AzureConfig{
-					Enabled:        boolPtr(false),
 					SubscriptionID: stringPtr("old-sub"),
 					TenantID:       stringPtr("old-tenant"),
 					Environment:    stringPtr("old-env"),
 				},
 				overlay: &AzureConfig{
-					Enabled: boolPtr(true),
+					KubeloginMode: stringPtr("msi"),
 				},
 				expected: &AzureConfig{
-					Enabled:        boolPtr(true),
 					SubscriptionID: stringPtr("old-sub"),
 					TenantID:       stringPtr("old-tenant"),
 					Environment:    stringPtr("old-env"),
+					KubeloginMode:  stringPtr("msi"),
 				},
 			},
 			{
 				name: "NilOverlay",
 				base: &AzureConfig{
-					Enabled:        boolPtr(false),
 					SubscriptionID: stringPtr("old-sub"),
 					TenantID:       stringPtr("old-tenant"),
 					Environment:    stringPtr("old-env"),
 				},
 				overlay: nil,
 				expected: &AzureConfig{
-					Enabled:        boolPtr(false),
 					SubscriptionID: stringPtr("old-sub"),
 					TenantID:       stringPtr("old-tenant"),
 					Environment:    stringPtr("old-env"),
@@ -73,37 +70,10 @@ func TestAzureConfig(t *testing.T) {
 			t.Run(tt.name, func(t *testing.T) {
 				tt.base.Merge(tt.overlay)
 
-				if tt.base.Enabled == nil || tt.expected.Enabled == nil {
-					if tt.base.Enabled != tt.expected.Enabled {
-						t.Errorf("Expected Enabled to be %v, got %v", tt.expected.Enabled, tt.base.Enabled)
-					}
-				} else if *tt.base.Enabled != *tt.expected.Enabled {
-					t.Errorf("Expected Enabled to be %v, got %v", *tt.expected.Enabled, *tt.base.Enabled)
-				}
-
-				if tt.base.SubscriptionID == nil || tt.expected.SubscriptionID == nil {
-					if tt.base.SubscriptionID != tt.expected.SubscriptionID {
-						t.Errorf("Expected SubscriptionID to be %v, got %v", tt.expected.SubscriptionID, tt.base.SubscriptionID)
-					}
-				} else if *tt.base.SubscriptionID != *tt.expected.SubscriptionID {
-					t.Errorf("Expected SubscriptionID to be %v, got %v", *tt.expected.SubscriptionID, *tt.base.SubscriptionID)
-				}
-
-				if tt.base.TenantID == nil || tt.expected.TenantID == nil {
-					if tt.base.TenantID != tt.expected.TenantID {
-						t.Errorf("Expected TenantID to be %v, got %v", tt.expected.TenantID, tt.base.TenantID)
-					}
-				} else if *tt.base.TenantID != *tt.expected.TenantID {
-					t.Errorf("Expected TenantID to be %v, got %v", *tt.expected.TenantID, *tt.base.TenantID)
-				}
-
-				if tt.base.Environment == nil || tt.expected.Environment == nil {
-					if tt.base.Environment != tt.expected.Environment {
-						t.Errorf("Expected Environment to be %v, got %v", tt.expected.Environment, tt.base.Environment)
-					}
-				} else if *tt.base.Environment != *tt.expected.Environment {
-					t.Errorf("Expected Environment to be %v, got %v", *tt.expected.Environment, *tt.base.Environment)
-				}
+				assertStringPtrEq(t, "SubscriptionID", tt.base.SubscriptionID, tt.expected.SubscriptionID)
+				assertStringPtrEq(t, "TenantID", tt.base.TenantID, tt.expected.TenantID)
+				assertStringPtrEq(t, "Environment", tt.base.Environment, tt.expected.Environment)
+				assertStringPtrEq(t, "KubeloginMode", tt.base.KubeloginMode, tt.expected.KubeloginMode)
 			})
 		}
 	})
@@ -116,16 +86,16 @@ func TestAzureConfig(t *testing.T) {
 			{
 				name: "AllFields",
 				original: &AzureConfig{
-					Enabled:        boolPtr(true),
 					SubscriptionID: stringPtr("sub"),
 					TenantID:       stringPtr("tenant"),
 					Environment:    stringPtr("env"),
+					KubeloginMode:  stringPtr("azurecli"),
 				},
 			},
 			{
 				name: "SomeFields",
 				original: &AzureConfig{
-					Enabled: boolPtr(true),
+					KubeloginMode: stringPtr("workloadidentity"),
 				},
 			},
 			{
@@ -153,44 +123,33 @@ func TestAzureConfig(t *testing.T) {
 					t.Error("Expected copy to be a new instance")
 				}
 
-				if tt.original.Enabled == nil {
-					if copy.Enabled != nil {
-						t.Error("Expected Enabled to be nil")
-					}
-				} else if copy.Enabled == nil || *copy.Enabled != *tt.original.Enabled {
-					t.Errorf("Expected Enabled to be %v, got %v", tt.original.Enabled, copy.Enabled)
-				}
-
-				if tt.original.SubscriptionID == nil {
-					if copy.SubscriptionID != nil {
-						t.Error("Expected SubscriptionID to be nil")
-					}
-				} else if copy.SubscriptionID == nil || *copy.SubscriptionID != *tt.original.SubscriptionID {
-					t.Errorf("Expected SubscriptionID to be %v, got %v", tt.original.SubscriptionID, copy.SubscriptionID)
-				}
-
-				if tt.original.TenantID == nil {
-					if copy.TenantID != nil {
-						t.Error("Expected TenantID to be nil")
-					}
-				} else if copy.TenantID == nil || *copy.TenantID != *tt.original.TenantID {
-					t.Errorf("Expected TenantID to be %v, got %v", tt.original.TenantID, copy.TenantID)
-				}
-
-				if tt.original.Environment == nil {
-					if copy.Environment != nil {
-						t.Error("Expected Environment to be nil")
-					}
-				} else if copy.Environment == nil || *copy.Environment != *tt.original.Environment {
-					t.Errorf("Expected Environment to be %v, got %v", tt.original.Environment, copy.Environment)
-				}
+				assertStringPtrEq(t, "SubscriptionID", copy.SubscriptionID, tt.original.SubscriptionID)
+				assertStringPtrEq(t, "TenantID", copy.TenantID, tt.original.TenantID)
+				assertStringPtrEq(t, "Environment", copy.Environment, tt.original.Environment)
+				assertStringPtrEq(t, "KubeloginMode", copy.KubeloginMode, tt.original.KubeloginMode)
 			})
 		}
 	})
 }
 
-func boolPtr(b bool) *bool {
-	return &b
+func assertStringPtrEq(t *testing.T, name string, got, want *string) {
+	t.Helper()
+	if got == nil || want == nil {
+		if got != want {
+			t.Errorf("%s: got %v, want %v", name, deref(got), deref(want))
+		}
+		return
+	}
+	if *got != *want {
+		t.Errorf("%s: got %q, want %q", name, *got, *want)
+	}
+}
+
+func deref(s *string) any {
+	if s == nil {
+		return nil
+	}
+	return *s
 }
 
 func stringPtr(s string) *string {

--- a/api/v1alpha1/config_types_test.go
+++ b/api/v1alpha1/config_types_test.go
@@ -22,7 +22,6 @@ func TestConfig_Merge(t *testing.T) {
 				AWSEndpointURL: ptrString("https://base.aws.endpoint"),
 			},
 			Azure: &azure.AzureConfig{
-				Enabled:        ptrBool(true),
 				SubscriptionID: ptrString("base-sub"),
 				TenantID:       ptrString("base-tenant"),
 				Environment:    ptrString("base-cloud"),
@@ -68,7 +67,6 @@ func TestConfig_Merge(t *testing.T) {
 				AWSEndpointURL: ptrString("https://overlay.aws.endpoint"),
 			},
 			Azure: &azure.AzureConfig{
-				Enabled:        ptrBool(false),
 				SubscriptionID: ptrString("overlay-sub"),
 				TenantID:       ptrString("overlay-tenant"),
 				Environment:    ptrString("overlay-cloud"),
@@ -113,9 +111,6 @@ func TestConfig_Merge(t *testing.T) {
 
 		if base.AWS.AWSEndpointURL == nil || *base.AWS.AWSEndpointURL != "https://overlay.aws.endpoint" {
 			t.Errorf("AWS AWSEndpointURL mismatch: expected 'https://overlay.aws.endpoint', got '%s'", *base.AWS.AWSEndpointURL)
-		}
-		if base.Azure.Enabled == nil || *base.Azure.Enabled != false {
-			t.Errorf("Azure Enabled mismatch: expected false, got %v", *base.Azure.Enabled)
 		}
 		if base.Azure.SubscriptionID == nil || *base.Azure.SubscriptionID != "overlay-sub" {
 			t.Errorf("Azure SubscriptionID mismatch: expected 'overlay-sub', got '%s'", *base.Azure.SubscriptionID)
@@ -164,7 +159,6 @@ func TestConfig_Merge(t *testing.T) {
 				AWSEndpointURL: ptrString("https://base.aws.endpoint"),
 			},
 			Azure: &azure.AzureConfig{
-				Enabled:        ptrBool(true),
 				SubscriptionID: ptrString("base-sub"),
 				TenantID:       ptrString("base-tenant"),
 				Environment:    ptrString("base-cloud"),
@@ -210,9 +204,6 @@ func TestConfig_Merge(t *testing.T) {
 
 		if base.AWS.AWSEndpointURL == nil || *base.AWS.AWSEndpointURL != "https://base.aws.endpoint" {
 			t.Errorf("AWS AWSEndpointURL mismatch: expected 'https://base.aws.endpoint', got '%s'", *base.AWS.AWSEndpointURL)
-		}
-		if base.Azure.Enabled == nil || *base.Azure.Enabled != true {
-			t.Errorf("Azure Enabled mismatch: expected true, got %v", *base.Azure.Enabled)
 		}
 		if base.Azure.SubscriptionID == nil || *base.Azure.SubscriptionID != "base-sub" {
 			t.Errorf("Azure SubscriptionID mismatch: expected 'base-sub', got '%s'", *base.Azure.SubscriptionID)
@@ -263,7 +254,6 @@ func TestConfig_Merge(t *testing.T) {
 				AWSEndpointURL: ptrString("https://overlay.aws.endpoint"),
 			},
 			Azure: &azure.AzureConfig{
-				Enabled:        ptrBool(false),
 				SubscriptionID: ptrString("overlay-sub"),
 				TenantID:       ptrString("overlay-tenant"),
 				Environment:    ptrString("overlay-cloud"),
@@ -308,9 +298,6 @@ func TestConfig_Merge(t *testing.T) {
 
 		if base.AWS.AWSEndpointURL == nil || *base.AWS.AWSEndpointURL != "https://overlay.aws.endpoint" {
 			t.Errorf("AWS AWSEndpointURL mismatch: expected 'https://overlay.aws.endpoint', got '%s'", *base.AWS.AWSEndpointURL)
-		}
-		if base.Azure.Enabled == nil || *base.Azure.Enabled != false {
-			t.Errorf("Azure Enabled mismatch: expected false, got %v", *base.Azure.Enabled)
 		}
 		if base.Azure.SubscriptionID == nil || *base.Azure.SubscriptionID != "overlay-sub" {
 			t.Errorf("Azure SubscriptionID mismatch: expected 'overlay-sub', got '%s'", *base.Azure.SubscriptionID)
@@ -380,7 +367,6 @@ func TestConfig_Copy(t *testing.T) {
 				AWSEndpointURL: ptrString("https://original.aws.endpoint"),
 			},
 			Azure: &azure.AzureConfig{
-				Enabled:        ptrBool(true),
 				SubscriptionID: ptrString("original-sub"),
 				TenantID:       ptrString("original-tenant"),
 				Environment:    ptrString("original-cloud"),
@@ -426,9 +412,6 @@ func TestConfig_Copy(t *testing.T) {
 		}
 		if original.AWS.AWSEndpointURL == nil || copy.AWS.AWSEndpointURL == nil || *original.AWS.AWSEndpointURL != *copy.AWS.AWSEndpointURL {
 			t.Errorf("AWS AWSEndpointURL mismatch: expected %v, got %v", *original.AWS.AWSEndpointURL, *copy.AWS.AWSEndpointURL)
-		}
-		if original.Azure.Enabled == nil || copy.Azure.Enabled == nil || *original.Azure.Enabled != *copy.Azure.Enabled {
-			t.Errorf("Azure Enabled mismatch: expected %v, got %v", *original.Azure.Enabled, *copy.Azure.Enabled)
 		}
 		if original.Azure.SubscriptionID == nil || copy.Azure.SubscriptionID == nil || *original.Azure.SubscriptionID != *copy.Azure.SubscriptionID {
 			t.Errorf("Azure SubscriptionID mismatch: expected %v, got %v", *original.Azure.SubscriptionID, *copy.Azure.SubscriptionID)

--- a/api/v1alpha2/config/providers/azure/azure.go
+++ b/api/v1alpha2/config/providers/azure/azure.go
@@ -1,10 +1,8 @@
 package azure
 
-// AzureConfig represents the Azure configuration
+// AzureConfig represents the Azure configuration. Azure integration activates whenever this
+// block is present in a context (or when platform is "azure"); no separate enabled flag.
 type AzureConfig struct {
-	// Enabled indicates whether Azure integration is enabled.
-	Enabled *bool `yaml:"enabled,omitempty"`
-
 	// SubscriptionID is the Azure subscription identifier
 	SubscriptionID *string `yaml:"subscription_id,omitempty"`
 
@@ -19,9 +17,6 @@ type AzureConfig struct {
 func (base *AzureConfig) Merge(overlay *AzureConfig) {
 	if overlay == nil {
 		return
-	}
-	if overlay.Enabled != nil {
-		base.Enabled = overlay.Enabled
 	}
 	if overlay.SubscriptionID != nil {
 		base.SubscriptionID = overlay.SubscriptionID
@@ -41,10 +36,6 @@ func (c *AzureConfig) DeepCopy() *AzureConfig {
 	}
 	copied := &AzureConfig{}
 
-	if c.Enabled != nil {
-		enabledCopy := *c.Enabled
-		copied.Enabled = &enabledCopy
-	}
 	if c.SubscriptionID != nil {
 		subscriptionCopy := *c.SubscriptionID
 		copied.SubscriptionID = &subscriptionCopy

--- a/api/v1alpha2/config/providers/azure/azure.go
+++ b/api/v1alpha2/config/providers/azure/azure.go
@@ -11,6 +11,11 @@ type AzureConfig struct {
 
 	// Environment specifies the Azure cloud environment (e.g. "public", "usgovernment")
 	Environment *string `yaml:"environment,omitempty"`
+
+	// KubeloginMode overrides the kubelogin login mode for AAD-enabled AKS kubeconfigs.
+	// Empty (default) auto-detects from the active credential chain. Set to "msi" on
+	// managed-identity runners; other values match kubelogin's own modes.
+	KubeloginMode *string `yaml:"kubelogin_mode,omitempty"`
 }
 
 // Merge performs a deep merge of the current AzureConfig with another AzureConfig.
@@ -26,6 +31,9 @@ func (base *AzureConfig) Merge(overlay *AzureConfig) {
 	}
 	if overlay.Environment != nil {
 		base.Environment = overlay.Environment
+	}
+	if overlay.KubeloginMode != nil {
+		base.KubeloginMode = overlay.KubeloginMode
 	}
 }
 
@@ -47,6 +55,10 @@ func (c *AzureConfig) DeepCopy() *AzureConfig {
 	if c.Environment != nil {
 		environmentCopy := *c.Environment
 		copied.Environment = &environmentCopy
+	}
+	if c.KubeloginMode != nil {
+		kubeloginModeCopy := *c.KubeloginMode
+		copied.KubeloginMode = &kubeloginModeCopy
 	}
 
 	return copied

--- a/api/v1alpha2/config/providers/azure/azure_test.go
+++ b/api/v1alpha2/config/providers/azure/azure_test.go
@@ -11,11 +11,13 @@ func TestAzureConfig_Merge(t *testing.T) {
 			SubscriptionID: stringPtr("old-sub"),
 			TenantID:       stringPtr("old-tenant"),
 			Environment:    stringPtr("old-env"),
+			KubeloginMode:  stringPtr("old-mode"),
 		}
 		overlay := &AzureConfig{
 			SubscriptionID: stringPtr("new-sub"),
 			TenantID:       stringPtr("new-tenant"),
 			Environment:    stringPtr("new-env"),
+			KubeloginMode:  stringPtr("msi"),
 		}
 
 		base.Merge(overlay)
@@ -29,6 +31,9 @@ func TestAzureConfig_Merge(t *testing.T) {
 		if base.Environment == nil || *base.Environment != "new-env" {
 			t.Errorf("Expected Environment to be 'new-env', got %v", base.Environment)
 		}
+		if base.KubeloginMode == nil || *base.KubeloginMode != "msi" {
+			t.Errorf("Expected KubeloginMode to be 'msi', got %v", base.KubeloginMode)
+		}
 	})
 
 	t.Run("MergePartialOverlay", func(t *testing.T) {
@@ -36,6 +41,7 @@ func TestAzureConfig_Merge(t *testing.T) {
 			SubscriptionID: stringPtr("old-sub"),
 			TenantID:       stringPtr("old-tenant"),
 			Environment:    stringPtr("old-env"),
+			KubeloginMode:  stringPtr("old-mode"),
 		}
 		overlay := &AzureConfig{
 			TenantID: stringPtr("new-tenant"),
@@ -52,6 +58,9 @@ func TestAzureConfig_Merge(t *testing.T) {
 		if base.Environment == nil || *base.Environment != "old-env" {
 			t.Errorf("Expected Environment to remain 'old-env', got %v", base.Environment)
 		}
+		if base.KubeloginMode == nil || *base.KubeloginMode != "old-mode" {
+			t.Errorf("Expected KubeloginMode to remain 'old-mode', got %v", base.KubeloginMode)
+		}
 	})
 
 	t.Run("MergeWithNilOverlay", func(t *testing.T) {
@@ -59,6 +68,7 @@ func TestAzureConfig_Merge(t *testing.T) {
 			SubscriptionID: stringPtr("old-sub"),
 			TenantID:       stringPtr("old-tenant"),
 			Environment:    stringPtr("old-env"),
+			KubeloginMode:  stringPtr("old-mode"),
 		}
 		original := base.DeepCopy()
 
@@ -73,6 +83,9 @@ func TestAzureConfig_Merge(t *testing.T) {
 		if base.Environment == nil || *base.Environment != *original.Environment {
 			t.Errorf("Expected Environment to remain unchanged")
 		}
+		if base.KubeloginMode == nil || *base.KubeloginMode != *original.KubeloginMode {
+			t.Errorf("Expected KubeloginMode to remain unchanged")
+		}
 	})
 }
 
@@ -83,6 +96,7 @@ func TestAzureConfig_Copy(t *testing.T) {
 			SubscriptionID: stringPtr("sub"),
 			TenantID:       stringPtr("tenant"),
 			Environment:    stringPtr("env"),
+			KubeloginMode:  stringPtr("msi"),
 		}
 
 		copy := original.DeepCopy()
@@ -101,6 +115,12 @@ func TestAzureConfig_Copy(t *testing.T) {
 		}
 		if copy.Environment == nil || *copy.Environment != *original.Environment {
 			t.Errorf("Expected Environment to be copied correctly")
+		}
+		if copy.KubeloginMode == nil || *copy.KubeloginMode != *original.KubeloginMode {
+			t.Errorf("Expected KubeloginMode to be copied correctly")
+		}
+		if copy.KubeloginMode == original.KubeloginMode {
+			t.Error("Expected KubeloginMode pointer to be a new allocation")
 		}
 	})
 
@@ -122,6 +142,9 @@ func TestAzureConfig_Copy(t *testing.T) {
 		}
 		if copy.Environment != nil {
 			t.Error("Expected Environment to be nil")
+		}
+		if copy.KubeloginMode != nil {
+			t.Error("Expected KubeloginMode to be nil")
 		}
 	})
 

--- a/api/v1alpha2/config/providers/azure/azure_test.go
+++ b/api/v1alpha2/config/providers/azure/azure_test.go
@@ -8,13 +8,11 @@ import (
 func TestAzureConfig_Merge(t *testing.T) {
 	t.Run("MergeAllFields", func(t *testing.T) {
 		base := &AzureConfig{
-			Enabled:        boolPtr(false),
 			SubscriptionID: stringPtr("old-sub"),
 			TenantID:       stringPtr("old-tenant"),
 			Environment:    stringPtr("old-env"),
 		}
 		overlay := &AzureConfig{
-			Enabled:        boolPtr(true),
 			SubscriptionID: stringPtr("new-sub"),
 			TenantID:       stringPtr("new-tenant"),
 			Environment:    stringPtr("new-env"),
@@ -22,50 +20,42 @@ func TestAzureConfig_Merge(t *testing.T) {
 
 		base.Merge(overlay)
 
-		if base.Enabled == nil || *base.Enabled != true {
-			t.Errorf("Expected Enabled to be true, got %v", base.Enabled)
-		}
 		if base.SubscriptionID == nil || *base.SubscriptionID != "new-sub" {
-			t.Errorf("Expected SubscriptionID to be 'new-sub', got %s", *base.SubscriptionID)
+			t.Errorf("Expected SubscriptionID to be 'new-sub', got %v", base.SubscriptionID)
 		}
 		if base.TenantID == nil || *base.TenantID != "new-tenant" {
-			t.Errorf("Expected TenantID to be 'new-tenant', got %s", *base.TenantID)
+			t.Errorf("Expected TenantID to be 'new-tenant', got %v", base.TenantID)
 		}
 		if base.Environment == nil || *base.Environment != "new-env" {
-			t.Errorf("Expected Environment to be 'new-env', got %s", *base.Environment)
+			t.Errorf("Expected Environment to be 'new-env', got %v", base.Environment)
 		}
 	})
 
 	t.Run("MergePartialOverlay", func(t *testing.T) {
 		base := &AzureConfig{
-			Enabled:        boolPtr(false),
 			SubscriptionID: stringPtr("old-sub"),
 			TenantID:       stringPtr("old-tenant"),
 			Environment:    stringPtr("old-env"),
 		}
 		overlay := &AzureConfig{
-			Enabled: boolPtr(true),
+			TenantID: stringPtr("new-tenant"),
 		}
 
 		base.Merge(overlay)
 
-		if base.Enabled == nil || *base.Enabled != true {
-			t.Errorf("Expected Enabled to be true, got %v", base.Enabled)
+		if base.TenantID == nil || *base.TenantID != "new-tenant" {
+			t.Errorf("Expected TenantID to be 'new-tenant', got %v", base.TenantID)
 		}
 		if base.SubscriptionID == nil || *base.SubscriptionID != "old-sub" {
-			t.Errorf("Expected SubscriptionID to remain 'old-sub', got %s", *base.SubscriptionID)
-		}
-		if base.TenantID == nil || *base.TenantID != "old-tenant" {
-			t.Errorf("Expected TenantID to remain 'old-tenant', got %s", *base.TenantID)
+			t.Errorf("Expected SubscriptionID to remain 'old-sub', got %v", base.SubscriptionID)
 		}
 		if base.Environment == nil || *base.Environment != "old-env" {
-			t.Errorf("Expected Environment to remain 'old-env', got %s", *base.Environment)
+			t.Errorf("Expected Environment to remain 'old-env', got %v", base.Environment)
 		}
 	})
 
 	t.Run("MergeWithNilOverlay", func(t *testing.T) {
 		base := &AzureConfig{
-			Enabled:        boolPtr(false),
 			SubscriptionID: stringPtr("old-sub"),
 			TenantID:       stringPtr("old-tenant"),
 			Environment:    stringPtr("old-env"),
@@ -74,9 +64,6 @@ func TestAzureConfig_Merge(t *testing.T) {
 
 		base.Merge(nil)
 
-		if base.Enabled == nil || *base.Enabled != *original.Enabled {
-			t.Errorf("Expected Enabled to remain unchanged")
-		}
 		if base.SubscriptionID == nil || *base.SubscriptionID != *original.SubscriptionID {
 			t.Errorf("Expected SubscriptionID to remain unchanged")
 		}
@@ -89,11 +76,10 @@ func TestAzureConfig_Merge(t *testing.T) {
 	})
 }
 
-// TestAzureConfig_Copy tests the Copy method of AzureConfig
+// TestAzureConfig_Copy tests the DeepCopy method of AzureConfig
 func TestAzureConfig_Copy(t *testing.T) {
 	t.Run("CopyAllFields", func(t *testing.T) {
 		original := &AzureConfig{
-			Enabled:        boolPtr(true),
 			SubscriptionID: stringPtr("sub"),
 			TenantID:       stringPtr("tenant"),
 			Environment:    stringPtr("env"),
@@ -106,9 +92,6 @@ func TestAzureConfig_Copy(t *testing.T) {
 		}
 		if copy == original {
 			t.Error("Expected copy to be a new instance")
-		}
-		if copy.Enabled == nil || *copy.Enabled != *original.Enabled {
-			t.Errorf("Expected Enabled to be copied correctly")
 		}
 		if copy.SubscriptionID == nil || *copy.SubscriptionID != *original.SubscriptionID {
 			t.Errorf("Expected SubscriptionID to be copied correctly")
@@ -123,7 +106,7 @@ func TestAzureConfig_Copy(t *testing.T) {
 
 	t.Run("CopySomeFields", func(t *testing.T) {
 		original := &AzureConfig{
-			Enabled: boolPtr(true),
+			TenantID: stringPtr("tenant"),
 		}
 
 		copy := original.DeepCopy()
@@ -131,14 +114,11 @@ func TestAzureConfig_Copy(t *testing.T) {
 		if copy == nil {
 			t.Fatal("Expected non-nil copy")
 		}
-		if copy.Enabled == nil || *copy.Enabled != *original.Enabled {
-			t.Errorf("Expected Enabled to be copied correctly")
+		if copy.TenantID == nil || *copy.TenantID != *original.TenantID {
+			t.Errorf("Expected TenantID to be copied correctly")
 		}
 		if copy.SubscriptionID != nil {
 			t.Error("Expected SubscriptionID to be nil")
-		}
-		if copy.TenantID != nil {
-			t.Error("Expected TenantID to be nil")
 		}
 		if copy.Environment != nil {
 			t.Error("Expected Environment to be nil")
@@ -153,10 +133,6 @@ func TestAzureConfig_Copy(t *testing.T) {
 			t.Error("Expected nil copy for nil original")
 		}
 	})
-}
-
-func boolPtr(b bool) *bool {
-	return &b
 }
 
 func stringPtr(s string) *string {

--- a/api/v1alpha2/config/providers/providers_test.go
+++ b/api/v1alpha2/config/providers/providers_test.go
@@ -7,12 +7,15 @@ import (
 	"github.com/windsorcli/cli/api/v1alpha2/config/providers/azure"
 )
 
-// awsProfileA and awsProfileB stand in for the two distinct states the merge/copy tests
-// previously expressed via aws.Enabled = true/false. The Enabled field has been removed; any
-// non-nil AWS field works as the "did the merge run" signal.
+// awsProfileA/B and azureTenantA/B stand in for the two distinct states the merge/copy tests
+// previously expressed via aws.Enabled / azure.Enabled = true/false. The Enabled fields have
+// been removed in both providers; any non-nil leaf field works as the "did the merge run"
+// signal — these tests use AWSProfile and TenantID since they're the most operator-visible.
 const (
-	awsProfileA = "profile-a"
-	awsProfileB = "profile-b"
+	awsProfileA  = "profile-a"
+	awsProfileB  = "profile-b"
+	azureTenantA = "tenant-a"
+	azureTenantB = "tenant-b"
 )
 
 // TestProvidersConfig_Merge tests the Merge method of ProvidersConfig
@@ -23,7 +26,7 @@ func TestProvidersConfig_Merge(t *testing.T) {
 				AWSProfile: stringPtr(awsProfileA),
 			},
 			Azure: &azure.AzureConfig{
-				Enabled: boolPtr(false),
+				TenantID: stringPtr(azureTenantA),
 			},
 		}
 		original := base.DeepCopy()
@@ -33,7 +36,7 @@ func TestProvidersConfig_Merge(t *testing.T) {
 		if base.AWS == nil || *base.AWS.AWSProfile != *original.AWS.AWSProfile {
 			t.Errorf("Expected AWS config to remain unchanged")
 		}
-		if base.Azure == nil || *base.Azure.Enabled != *original.Azure.Enabled {
+		if base.Azure == nil || *base.Azure.TenantID != *original.Azure.TenantID {
 			t.Errorf("Expected Azure config to remain unchanged")
 		}
 	})
@@ -44,7 +47,7 @@ func TestProvidersConfig_Merge(t *testing.T) {
 				AWSProfile: stringPtr(awsProfileA),
 			},
 			Azure: &azure.AzureConfig{
-				Enabled: boolPtr(false),
+				TenantID: stringPtr(azureTenantA),
 			},
 		}
 		overlay := &ProvidersConfig{}
@@ -54,8 +57,8 @@ func TestProvidersConfig_Merge(t *testing.T) {
 		if base.AWS == nil || *base.AWS.AWSProfile != awsProfileA {
 			t.Errorf("Expected AWS config to remain at profile %q", awsProfileA)
 		}
-		if base.Azure == nil || *base.Azure.Enabled {
-			t.Errorf("Expected Azure config to remain disabled")
+		if base.Azure == nil || *base.Azure.TenantID != azureTenantA {
+			t.Errorf("Expected Azure config to remain at tenant %q", azureTenantA)
 		}
 	})
 
@@ -65,7 +68,7 @@ func TestProvidersConfig_Merge(t *testing.T) {
 				AWSProfile: stringPtr(awsProfileA),
 			},
 			Azure: &azure.AzureConfig{
-				Enabled: boolPtr(false),
+				TenantID: stringPtr(azureTenantA),
 			},
 		}
 		overlay := &ProvidersConfig{
@@ -73,7 +76,7 @@ func TestProvidersConfig_Merge(t *testing.T) {
 				AWSProfile: stringPtr(awsProfileB),
 			},
 			Azure: &azure.AzureConfig{
-				Enabled: boolPtr(true),
+				TenantID: stringPtr(azureTenantB),
 			},
 		}
 
@@ -82,8 +85,8 @@ func TestProvidersConfig_Merge(t *testing.T) {
 		if base.AWS == nil || *base.AWS.AWSProfile != awsProfileB {
 			t.Errorf("Expected AWS profile to be %q after merge, got %q", awsProfileB, *base.AWS.AWSProfile)
 		}
-		if base.Azure == nil || !*base.Azure.Enabled {
-			t.Errorf("Expected Azure config to be enabled after merge")
+		if base.Azure == nil || *base.Azure.TenantID != azureTenantB {
+			t.Errorf("Expected Azure tenant to be %q after merge, got %q", azureTenantB, *base.Azure.TenantID)
 		}
 	})
 
@@ -93,7 +96,7 @@ func TestProvidersConfig_Merge(t *testing.T) {
 				AWSProfile: stringPtr(awsProfileA),
 			},
 			Azure: &azure.AzureConfig{
-				Enabled: boolPtr(false),
+				TenantID: stringPtr(azureTenantA),
 			},
 		}
 		overlay := &ProvidersConfig{
@@ -107,8 +110,8 @@ func TestProvidersConfig_Merge(t *testing.T) {
 		if base.AWS == nil || *base.AWS.AWSProfile != awsProfileB {
 			t.Errorf("Expected AWS profile to be %q after merge", awsProfileB)
 		}
-		if base.Azure == nil || *base.Azure.Enabled {
-			t.Errorf("Expected Azure config to remain disabled")
+		if base.Azure == nil || *base.Azure.TenantID != azureTenantA {
+			t.Errorf("Expected Azure tenant to remain %q", azureTenantA)
 		}
 	})
 
@@ -118,12 +121,12 @@ func TestProvidersConfig_Merge(t *testing.T) {
 				AWSProfile: stringPtr(awsProfileA),
 			},
 			Azure: &azure.AzureConfig{
-				Enabled: boolPtr(false),
+				TenantID: stringPtr(azureTenantA),
 			},
 		}
 		overlay := &ProvidersConfig{
 			Azure: &azure.AzureConfig{
-				Enabled: boolPtr(true),
+				TenantID: stringPtr(azureTenantB),
 			},
 		}
 
@@ -132,8 +135,8 @@ func TestProvidersConfig_Merge(t *testing.T) {
 		if base.AWS == nil || *base.AWS.AWSProfile != awsProfileA {
 			t.Errorf("Expected AWS profile to remain %q", awsProfileA)
 		}
-		if base.Azure == nil || !*base.Azure.Enabled {
-			t.Errorf("Expected Azure config to be enabled after merge")
+		if base.Azure == nil || *base.Azure.TenantID != azureTenantB {
+			t.Errorf("Expected Azure tenant to be %q after merge", azureTenantB)
 		}
 	})
 
@@ -144,7 +147,7 @@ func TestProvidersConfig_Merge(t *testing.T) {
 				AWSProfile: stringPtr(awsProfileA),
 			},
 			Azure: &azure.AzureConfig{
-				Enabled: boolPtr(false),
+				TenantID: stringPtr(azureTenantA),
 			},
 		}
 
@@ -153,15 +156,15 @@ func TestProvidersConfig_Merge(t *testing.T) {
 		if base.AWS == nil || *base.AWS.AWSProfile != awsProfileA {
 			t.Errorf("Expected AWS config to be initialized with profile %q", awsProfileA)
 		}
-		if base.Azure == nil || *base.Azure.Enabled {
-			t.Errorf("Expected Azure config to be initialized and disabled")
+		if base.Azure == nil || *base.Azure.TenantID != azureTenantA {
+			t.Errorf("Expected Azure config to be initialized with tenant %q", azureTenantA)
 		}
 	})
 
 	t.Run("MergeWithNilBaseAWS", func(t *testing.T) {
 		base := &ProvidersConfig{
 			Azure: &azure.AzureConfig{
-				Enabled: boolPtr(false),
+				TenantID: stringPtr(azureTenantA),
 			},
 		}
 		overlay := &ProvidersConfig{
@@ -175,8 +178,8 @@ func TestProvidersConfig_Merge(t *testing.T) {
 		if base.AWS == nil || *base.AWS.AWSProfile != awsProfileA {
 			t.Errorf("Expected AWS config to be initialized with profile %q", awsProfileA)
 		}
-		if base.Azure == nil || *base.Azure.Enabled {
-			t.Errorf("Expected Azure config to remain disabled")
+		if base.Azure == nil || *base.Azure.TenantID != azureTenantA {
+			t.Errorf("Expected Azure tenant to remain %q", azureTenantA)
 		}
 	})
 
@@ -188,7 +191,7 @@ func TestProvidersConfig_Merge(t *testing.T) {
 		}
 		overlay := &ProvidersConfig{
 			Azure: &azure.AzureConfig{
-				Enabled: boolPtr(false),
+				TenantID: stringPtr(azureTenantA),
 			},
 		}
 
@@ -197,8 +200,8 @@ func TestProvidersConfig_Merge(t *testing.T) {
 		if base.AWS == nil || *base.AWS.AWSProfile != awsProfileA {
 			t.Errorf("Expected AWS profile to remain %q", awsProfileA)
 		}
-		if base.Azure == nil || *base.Azure.Enabled {
-			t.Errorf("Expected Azure config to be initialized and disabled")
+		if base.Azure == nil || *base.Azure.TenantID != azureTenantA {
+			t.Errorf("Expected Azure config to be initialized with tenant %q", azureTenantA)
 		}
 	})
 }
@@ -235,7 +238,7 @@ func TestProvidersConfig_Copy(t *testing.T) {
 				AWSProfile: stringPtr(awsProfileA),
 			},
 			Azure: &azure.AzureConfig{
-				Enabled: boolPtr(false),
+				TenantID: stringPtr(azureTenantA),
 			},
 		}
 
@@ -250,7 +253,7 @@ func TestProvidersConfig_Copy(t *testing.T) {
 		if copied.AWS == nil || *copied.AWS.AWSProfile != *config.AWS.AWSProfile {
 			t.Errorf("Expected AWS config to be copied correctly")
 		}
-		if copied.Azure == nil || *copied.Azure.Enabled != *config.Azure.Enabled {
+		if copied.Azure == nil || *copied.Azure.TenantID != *config.Azure.TenantID {
 			t.Errorf("Expected Azure config to be copied correctly")
 		}
 	})
@@ -281,7 +284,7 @@ func TestProvidersConfig_Copy(t *testing.T) {
 				AWSProfile: stringPtr(awsProfileA),
 			},
 			Azure: &azure.AzureConfig{
-				Enabled: boolPtr(false),
+				TenantID: stringPtr(azureTenantA),
 			},
 		}
 
@@ -289,12 +292,12 @@ func TestProvidersConfig_Copy(t *testing.T) {
 
 		// Modify original to verify independence
 		*config.AWS.AWSProfile = awsProfileB
-		*config.Azure.Enabled = true
+		*config.Azure.TenantID = azureTenantB
 
 		if *copied.AWS.AWSProfile != awsProfileA {
 			t.Error("Expected copied AWS config to remain independent")
 		}
-		if *copied.Azure.Enabled != false {
+		if *copied.Azure.TenantID != azureTenantA {
 			t.Error("Expected copied Azure config to remain independent")
 		}
 	})
@@ -318,10 +321,6 @@ func TestProvidersConfig_Copy(t *testing.T) {
 			t.Error("Expected Azure to be nil in copy")
 		}
 	})
-}
-
-func boolPtr(b bool) *bool {
-	return &b
 }
 
 func stringPtr(s string) *string {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -180,6 +180,8 @@ const MinimumVersionSOPS = "3.10.0"
 
 const MinimumVersionAWS = "2.0.0"
 
+const MinimumVersionAzure = "2.50.0"
+
 // DefaultAKSOIDCServerID is the standard Azure AKS OIDC server ID (application ID of the
 // Microsoft-managed enterprise application "Azure Kubernetes Service AAD Server").
 // This is the same for all AKS clusters with AKS-managed Azure AD enabled.

--- a/pkg/runtime/env/azure_env.go
+++ b/pkg/runtime/env/azure_env.go
@@ -7,8 +7,10 @@ package env
 
 import (
 	"fmt"
+	"os"
 	"path/filepath"
 
+	"github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
 )
@@ -45,28 +47,27 @@ func NewAzureEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler) *
 // =============================================================================
 
 // GetEnvVars retrieves the environment variables for the Azure environment.
-// In global mode (no windsor.yaml in the project tree) AZURE_CONFIG_DIR is not
-// emitted so the az CLI defers to the operator's ambient ~/.azure config; the
-// project-level identifiers (ARM_SUBSCRIPTION_ID, ARM_TENANT_ID, ARM_ENVIRONMENT)
-// are still emitted because they describe which Azure account/tenant the
-// context targets, not whose credentials are used.
+// In project mode AZURE_CONFIG_DIR always points at the context's .azure dir,
+// matching how the AWS env printer scopes AWS_CONFIG_FILE — keeps `az login`
+// from contaminating the operator's global ~/.azure. In global mode it is not
+// emitted; ARM_SUBSCRIPTION_ID / ARM_TENANT_ID / ARM_ENVIRONMENT are emitted in
+// both modes because they describe which account/tenant the context targets.
 func (e *AzureEnvPrinter) GetEnvVars() (map[string]string, error) {
 	envVars := make(map[string]string)
 	global := e.shell.IsGlobal()
 
-	// Get the current context configuration
+	if !global {
+		configRoot, err := e.configHandler.GetConfigRoot()
+		if err != nil {
+			return nil, fmt.Errorf("error retrieving configuration root directory: %w", err)
+		}
+		azureConfigDir := filepath.Join(configRoot, ".azure")
+		envVars["AZURE_CONFIG_DIR"] = filepath.ToSlash(azureConfigDir)
+		envVars["AZURE_CORE_LOGIN_EXPERIENCE_V2"] = "false"
+	}
+
 	config := e.configHandler.GetConfig()
 	if config != nil && config.Azure != nil {
-		if !global {
-			configRoot, err := e.configHandler.GetConfigRoot()
-			if err != nil {
-				return nil, fmt.Errorf("error retrieving configuration root directory: %w", err)
-			}
-			azureConfigDir := filepath.Join(configRoot, ".azure")
-			envVars["AZURE_CONFIG_DIR"] = filepath.ToSlash(azureConfigDir)
-			envVars["AZURE_CORE_LOGIN_EXPERIENCE_V2"] = "false"
-		}
-
 		if config.Azure.SubscriptionID != nil {
 			envVars["ARM_SUBSCRIPTION_ID"] = *config.Azure.SubscriptionID
 		}
@@ -78,5 +79,27 @@ func (e *AzureEnvPrinter) GetEnvVars() (map[string]string, error) {
 		}
 	}
 
+	envVars["TF_VAR_kubelogin_mode"] = e.resolveKubeloginMode(config)
+
 	return envVars, nil
+}
+
+// resolveKubeloginMode returns the kubelogin login mode for the AKS
+// kubeconfig, in precedence order: azure.kubelogin_mode (operator override,
+// the only path that handles managed-identity since MI has no env signal) →
+// AZURE_FEDERATED_TOKEN_FILE → workloadidentity → AZURE_CLIENT_SECRET /
+// AZURE_CLIENT_CERTIFICATE_PATH → spn → otherwise → azurecli.
+func (e *AzureEnvPrinter) resolveKubeloginMode(config *v1alpha1.Context) string {
+	if config != nil && config.Azure != nil && config.Azure.KubeloginMode != nil {
+		if v := *config.Azure.KubeloginMode; v != "" {
+			return v
+		}
+	}
+	if os.Getenv("AZURE_FEDERATED_TOKEN_FILE") != "" {
+		return "workloadidentity"
+	}
+	if os.Getenv("AZURE_CLIENT_SECRET") != "" || os.Getenv("AZURE_CLIENT_CERTIFICATE_PATH") != "" {
+		return "spn"
+	}
+	return "azurecli"
 }

--- a/pkg/runtime/env/azure_env.go
+++ b/pkg/runtime/env/azure_env.go
@@ -50,8 +50,10 @@ func NewAzureEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler) *
 // In project mode AZURE_CONFIG_DIR always points at the context's .azure dir,
 // matching how the AWS env printer scopes AWS_CONFIG_FILE — keeps `az login`
 // from contaminating the operator's global ~/.azure. In global mode it is not
-// emitted; ARM_SUBSCRIPTION_ID / ARM_TENANT_ID / ARM_ENVIRONMENT are emitted in
-// both modes because they describe which account/tenant the context targets.
+// emitted; ARM_SUBSCRIPTION_ID / ARM_TENANT_ID / ARM_ENVIRONMENT and
+// TF_VAR_kubelogin_mode are emitted in both modes — the ARM_* vars describe
+// the target account/tenant and TF_VAR_kubelogin_mode feeds terraform, which
+// runs from global shells too.
 func (e *AzureEnvPrinter) GetEnvVars() (map[string]string, error) {
 	envVars := make(map[string]string)
 	global := e.shell.IsGlobal()

--- a/pkg/runtime/env/azure_env_test.go
+++ b/pkg/runtime/env/azure_env_test.go
@@ -147,10 +147,10 @@ func TestAzureEnv_GetEnvVars(t *testing.T) {
 		}
 
 		// Then AZURE_CONFIG_DIR and AZURE_CORE_LOGIN_EXPERIENCE_V2 are NOT emitted —
-		// the az CLI defers to the operator's ambient ~/.azure config. The project-
-		// level identifiers (subscription, tenant, environment) still flow through
-		// because they describe which Azure account the context targets, not whose
-		// credentials are used.
+		// the az CLI defers to the operator's ambient ~/.azure config. ARM_* and
+		// TF_VAR_kubelogin_mode still flow through: ARM_* describes which Azure
+		// account the context targets, and TF_VAR_kubelogin_mode feeds terraform
+		// (which runs from global shells too).
 		if _, ok := envVars["AZURE_CONFIG_DIR"]; ok {
 			t.Errorf("AZURE_CONFIG_DIR should not be set in global mode, got %q", envVars["AZURE_CONFIG_DIR"])
 		}
@@ -162,6 +162,9 @@ func TestAzureEnv_GetEnvVars(t *testing.T) {
 		}
 		if got := envVars["ARM_TENANT_ID"]; got != "test-tenant" {
 			t.Errorf("ARM_TENANT_ID = %q, want %q", got, "test-tenant")
+		}
+		if _, ok := envVars["TF_VAR_kubelogin_mode"]; !ok {
+			t.Error("TF_VAR_kubelogin_mode should be set in global mode (terraform runs from global shells)")
 		}
 	})
 

--- a/pkg/runtime/env/azure_env_test.go
+++ b/pkg/runtime/env/azure_env_test.go
@@ -165,8 +165,8 @@ func TestAzureEnv_GetEnvVars(t *testing.T) {
 		}
 	})
 
-	t.Run("MissingConfiguration", func(t *testing.T) {
-		// Given a printer with no Azure configuration
+	t.Run("MissingAzureConfigBlockStillScopesConfigDirInProjectMode", func(t *testing.T) {
+		// Given a project-mode context with platform: azure and no azure: block
 		baseMocks := setupEnvMocks(t)
 		mocks := setupAzureEnvMocks(t, &EnvTestMocks{
 			ConfigHandler: config.NewConfigHandler(baseMocks.Shell),
@@ -186,12 +186,230 @@ contexts:
 		// When GetEnvVars is called
 		envVars, err := printer.GetEnvVars()
 
-		// Then no error should be returned and environment variables should be empty
+		// Then AZURE_CONFIG_DIR is scoped to the context anyway, and no ARM_* vars
+		// are emitted since the azure: block isn't there to source them.
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
-		if len(envVars) != 0 {
-			t.Errorf("Expected empty environment variables, got %v", envVars)
+		configRoot, _ := mocks.ConfigHandler.GetConfigRoot()
+		want := filepath.ToSlash(filepath.Join(configRoot, ".azure"))
+		if got := envVars["AZURE_CONFIG_DIR"]; got != want {
+			t.Errorf("AZURE_CONFIG_DIR = %q, want %q (must scope to context even without azure: block)", got, want)
+		}
+		if got := envVars["AZURE_CORE_LOGIN_EXPERIENCE_V2"]; got != "false" {
+			t.Errorf("AZURE_CORE_LOGIN_EXPERIENCE_V2 = %q, want %q", got, "false")
+		}
+		for _, k := range []string{"ARM_SUBSCRIPTION_ID", "ARM_TENANT_ID", "ARM_ENVIRONMENT"} {
+			if _, ok := envVars[k]; ok {
+				t.Errorf("%s should not be set when the azure: block is absent, got %q", k, envVars[k])
+			}
+		}
+	})
+}
+
+// TestAzureEnv_KubeloginMode pins the auto-detect chain so the same blueprint
+// resolves to the right kubelogin mode across laptop, OIDC runner, SPN runner,
+// and AKS pod without per-context input.
+func TestAzureEnv_KubeloginMode(t *testing.T) {
+	clearAmbient := func(t *testing.T) {
+		t.Helper()
+		t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "")
+		t.Setenv("AZURE_CLIENT_SECRET", "")
+		t.Setenv("AZURE_CLIENT_CERTIFICATE_PATH", "")
+	}
+
+	setupPrinter := func(t *testing.T, configStr string) (*AzureEnvPrinter, config.ConfigHandler) {
+		t.Helper()
+		baseMocks := setupEnvMocks(t)
+		mocks := setupAzureEnvMocks(t, &EnvTestMocks{
+			ConfigHandler: config.NewConfigHandler(baseMocks.Shell),
+		})
+		// SetContext before LoadConfigString — the loader slices on the current context name.
+		mocks.ConfigHandler.SetContext("test-context")
+		if err := mocks.ConfigHandler.LoadConfigString(configStr); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+		printer := NewAzureEnvPrinter(mocks.Shell, mocks.ConfigHandler)
+		printer.shims = mocks.Shims
+		return printer, mocks.ConfigHandler
+	}
+
+	t.Run("DefaultsToAzureCliWhenNoSignals", func(t *testing.T) {
+		// Given an azure context with no SPN/WI/MI env signal — the laptop developer case
+		clearAmbient(t)
+		printer, _ := setupPrinter(t, `
+version: v1alpha1
+contexts:
+  test-context:
+    azure:
+      tenant_id: 11111111-2222-3333-4444-555555555555
+`)
+
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars: %v", err)
+		}
+
+		// Then TF_VAR_kubelogin_mode = azurecli (kubelogin reuses the active `az` session)
+		if got := envVars["TF_VAR_kubelogin_mode"]; got != "azurecli" {
+			t.Errorf("TF_VAR_kubelogin_mode = %q, want %q (default for laptop dev)", got, "azurecli")
+		}
+	})
+
+	t.Run("DetectsWorkloadIdentityFromFederatedTokenFile", func(t *testing.T) {
+		// Given a runner with AKS Workload Identity / OIDC env injected
+		t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/var/run/secrets/azure/tokens/azure-identity-token")
+		t.Setenv("AZURE_CLIENT_SECRET", "")
+		t.Setenv("AZURE_CLIENT_CERTIFICATE_PATH", "")
+		printer, _ := setupPrinter(t, `
+version: v1alpha1
+contexts:
+  test-context:
+    azure:
+      tenant_id: 11111111-2222-3333-4444-555555555555
+`)
+
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars: %v", err)
+		}
+
+		// Then TF_VAR_kubelogin_mode = workloadidentity (matches azurerm provider's own choice)
+		if got := envVars["TF_VAR_kubelogin_mode"]; got != "workloadidentity" {
+			t.Errorf("TF_VAR_kubelogin_mode = %q, want %q under AZURE_FEDERATED_TOKEN_FILE", got, "workloadidentity")
+		}
+	})
+
+	t.Run("DetectsSpnFromClientSecret", func(t *testing.T) {
+		// Given a CI runner with SPN secret env
+		t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "")
+		t.Setenv("AZURE_CLIENT_SECRET", "spn-secret-value")
+		t.Setenv("AZURE_CLIENT_CERTIFICATE_PATH", "")
+		printer, _ := setupPrinter(t, `
+version: v1alpha1
+contexts:
+  test-context:
+    azure:
+      tenant_id: 11111111-2222-3333-4444-555555555555
+`)
+
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars: %v", err)
+		}
+
+		if got := envVars["TF_VAR_kubelogin_mode"]; got != "spn" {
+			t.Errorf("TF_VAR_kubelogin_mode = %q, want %q under AZURE_CLIENT_SECRET", got, "spn")
+		}
+	})
+
+	t.Run("DetectsSpnFromCertificatePath", func(t *testing.T) {
+		// Given a runner with SPN cert auth — same kubelogin mode as secret-based SPN
+		t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "")
+		t.Setenv("AZURE_CLIENT_SECRET", "")
+		t.Setenv("AZURE_CLIENT_CERTIFICATE_PATH", "/secrets/spn.pem")
+		printer, _ := setupPrinter(t, `
+version: v1alpha1
+contexts:
+  test-context:
+    azure:
+      tenant_id: 11111111-2222-3333-4444-555555555555
+`)
+
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars: %v", err)
+		}
+
+		if got := envVars["TF_VAR_kubelogin_mode"]; got != "spn" {
+			t.Errorf("TF_VAR_kubelogin_mode = %q, want %q under AZURE_CLIENT_CERTIFICATE_PATH", got, "spn")
+		}
+	})
+
+	t.Run("OperatorOverrideWinsOverAutoDetect", func(t *testing.T) {
+		// Given azure.kubelogin_mode=msi in values.yaml on a laptop with no env signals
+		// — the only path that handles managed-identity, which has no env to detect.
+		clearAmbient(t)
+		printer, _ := setupPrinter(t, `
+version: v1alpha1
+contexts:
+  test-context:
+    azure:
+      tenant_id: 11111111-2222-3333-4444-555555555555
+      kubelogin_mode: msi
+`)
+
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars: %v", err)
+		}
+
+		// Then the override wins (auto-detect would have returned azurecli)
+		if got := envVars["TF_VAR_kubelogin_mode"]; got != "msi" {
+			t.Errorf("TF_VAR_kubelogin_mode = %q, want %q (operator override)", got, "msi")
+		}
+	})
+
+	t.Run("OperatorOverrideWinsEvenWithSpnEnvSet", func(t *testing.T) {
+		// Given SPN env set (auto-detect would pick spn) and operator-pinned override
+		t.Setenv("AZURE_CLIENT_SECRET", "spn-secret-value")
+		printer, _ := setupPrinter(t, `
+version: v1alpha1
+contexts:
+  test-context:
+    azure:
+      tenant_id: 11111111-2222-3333-4444-555555555555
+      kubelogin_mode: workloadidentity
+`)
+
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars: %v", err)
+		}
+
+		if got := envVars["TF_VAR_kubelogin_mode"]; got != "workloadidentity" {
+			t.Errorf("TF_VAR_kubelogin_mode = %q, want %q (operator override beats env auto-detect)", got, "workloadidentity")
+		}
+	})
+
+	t.Run("EmptyOverrideFallsThroughToAutoDetect", func(t *testing.T) {
+		// Given azure.kubelogin_mode is set but empty — fall through to auto-detect
+		clearAmbient(t)
+		printer, _ := setupPrinter(t, `
+version: v1alpha1
+contexts:
+  test-context:
+    azure:
+      tenant_id: 11111111-2222-3333-4444-555555555555
+      kubelogin_mode: ""
+`)
+
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars: %v", err)
+		}
+
+		if got := envVars["TF_VAR_kubelogin_mode"]; got != "azurecli" {
+			t.Errorf("TF_VAR_kubelogin_mode = %q, want %q (empty override → auto-detect)", got, "azurecli")
+		}
+	})
+
+	t.Run("ExportedWhenAzureBlockIsAbsent", func(t *testing.T) {
+		// Given platform: azure with no azure: block — TF_VAR_kubelogin_mode must still export
+		clearAmbient(t)
+		printer, _ := setupPrinter(t, `
+version: v1alpha1
+contexts:
+  test-context: {}
+`)
+
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars: %v", err)
+		}
+
+		if got := envVars["TF_VAR_kubelogin_mode"]; got != "azurecli" {
+			t.Errorf("TF_VAR_kubelogin_mode = %q, want %q (must be set even with no azure: block)", got, "azurecli")
 		}
 	})
 }

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -711,7 +711,6 @@ func (rt *Runtime) initializeEnvPrinters() {
 	if clusterDriver == "" {
 		clusterDriver = rt.ConfigHandler.GetString("cluster.driver", "")
 	}
-	azureEnabled := rt.ConfigHandler.GetBool("azure.enabled", false)
 	gcpEnabled := rt.ConfigHandler.GetBool("gcp.enabled", false)
 	clusterEnabled := clusterDriver != ""
 	needsDocker := rt.needsDockerEnv()
@@ -727,7 +726,7 @@ func (rt *Runtime) initializeEnvPrinters() {
 	if rt.EnvPrinters.AwsEnv == nil && (hasAWSConfig || platform == "aws") {
 		rt.EnvPrinters.AwsEnv = env.NewAwsEnvPrinter(rt.Shell, rt.ConfigHandler)
 	}
-	if rt.EnvPrinters.AzureEnv == nil && azureEnabled && hasAzureConfig {
+	if rt.EnvPrinters.AzureEnv == nil && (hasAzureConfig || platform == "azure") {
 		rt.EnvPrinters.AzureEnv = env.NewAzureEnvPrinter(rt.Shell, rt.ConfigHandler)
 	}
 	if rt.EnvPrinters.GcpEnv == nil && gcpEnabled && hasGCPConfig {

--- a/pkg/runtime/tools/registry.go
+++ b/pkg/runtime/tools/registry.go
@@ -82,6 +82,11 @@ var toolRegistry = map[string]toolInfo{
 		minVersion: constants.MinimumVersionAWS,
 		download:   "https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html",
 	},
+	"az": {
+		name:       "Azure CLI",
+		minVersion: constants.MinimumVersionAzure,
+		download:   "https://learn.microsoft.com/en-us/cli/azure/install-azure-cli",
+	},
 }
 
 // =============================================================================

--- a/pkg/runtime/tools/registry_test.go
+++ b/pkg/runtime/tools/registry_test.go
@@ -120,7 +120,7 @@ func TestToolRegistry_KeysMatchCheckFunctions(t *testing.T) {
 	// Each entry is a binary name passed to execLookPath inside a check* function.
 	// "tofu" is included alongside "terraform" because GetTerraformCommand can return
 	// either depending on the configured driver; both must format errors identically.
-	expectedKeys := []string{"docker", "colima", "limactl", "terraform", "tofu", "op", "sops", "kubelogin", "aws"}
+	expectedKeys := []string{"docker", "colima", "limactl", "terraform", "tofu", "op", "sops", "kubelogin", "aws", "az"}
 	for _, key := range expectedKeys {
 		if _, ok := toolRegistry[key]; !ok {
 			t.Errorf("toolRegistry is missing %q — a check* function looks up this binary, so a missing entry would degrade its error to the bare fallback (no Download / aqua hints)", key)

--- a/pkg/runtime/tools/tools_manager.go
+++ b/pkg/runtime/tools/tools_manager.go
@@ -686,11 +686,33 @@ func (t *BaseToolsManager) checkAzureAuth() error {
 	if err != nil {
 		return fmt.Errorf("cannot resolve context-scoped Azure env for credential check: %w", err)
 	}
-	args := []string{"rest", "--method", "get", "--uri", "https://management.azure.com/tenants?api-version=2020-01-01", "--output", "none"}
+	cfg := t.configHandler.GetConfig()
+	azureEnv := ""
+	if cfg != nil && cfg.Azure != nil && cfg.Azure.Environment != nil {
+		azureEnv = *cfg.Azure.Environment
+	}
+	uri := fmt.Sprintf("https://%s/tenants?api-version=2020-01-01", armTenantEndpoint(azureEnv))
+	args := []string{"rest", "--method", "get", "--uri", uri, "--output", "none"}
 	if _, err := t.shell.ExecSilentWithEnvAndTimeout("az", env, args, 30*time.Second); err != nil {
 		return fmt.Errorf("%s", t.azureAuthHint())
 	}
 	return nil
+}
+
+// armTenantEndpoint maps an azure.environment value to its ARM host. Sovereign clouds
+// (usgovernment, china, german) have separate endpoints; az CLI does not rewrite explicit
+// --uri values, so the host must be selected up-front. Unknown/empty values default to public.
+func armTenantEndpoint(env string) string {
+	switch env {
+	case "usgovernment":
+		return "management.usgovcloudapi.net"
+	case "china":
+		return "management.chinacloudapi.cn"
+	case "german":
+		return "management.microsoftazure.de"
+	default:
+		return "management.azure.com"
+	}
 }
 
 // azureContextEnv returns env vars scoping the az CLI to the context's .azure/ dir.

--- a/pkg/runtime/tools/tools_manager.go
+++ b/pkg/runtime/tools/tools_manager.go
@@ -172,7 +172,7 @@ func (t *BaseToolsManager) CheckRequirements(reqs Requirements) error {
 		}
 	}
 
-	if reqs.Kubelogin && t.configHandler.GetBool("azure.enabled") {
+	if reqs.Kubelogin && t.azureEnabled() {
 		if err := t.checkKubelogin(); err != nil {
 			return err
 		}
@@ -442,6 +442,11 @@ func (t *BaseToolsManager) CheckAuth() error {
 			return err
 		}
 	}
+	if t.azureEnabled() {
+		if err := t.checkAzureAuth(); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -649,6 +654,142 @@ func awsEnvPrefix(configRoot string) string {
 		filepath.ToSlash(filepath.Join(awsConfigDir, "config")),
 		filepath.ToSlash(filepath.Join(awsConfigDir, "credentials")),
 	)
+}
+
+// azureEnabled reports whether the current context exercises Azure.
+func (t *BaseToolsManager) azureEnabled() bool {
+	platform := t.configHandler.GetString("platform")
+	if platform == "" {
+		platform = t.configHandler.GetString("provider")
+	}
+	if platform == "azure" {
+		return true
+	}
+	cfg := t.configHandler.GetConfig()
+	return cfg != nil && cfg.Azure != nil
+}
+
+// checkAzureAuth verifies the az CLI is present and its cached credentials can reach ARM.
+// Probes `az rest .../tenants` (a real ARM call) rather than `az account get-access-token`
+// (a cache-only read that passes on revoked/expired refresh tokens). When ambient SDK
+// credentials are set and az is absent, skips — terraform's own SDK will handle auth.
+func (t *BaseToolsManager) checkAzureAuth() error {
+	if hasAmbientAzureCredentials() {
+		if _, err := execLookPath("az"); err != nil {
+			return nil
+		}
+	}
+	if err := t.checkAzureBinary(); err != nil {
+		return err
+	}
+	env, err := t.azureContextEnv()
+	if err != nil {
+		return fmt.Errorf("cannot resolve context-scoped Azure env for credential check: %w", err)
+	}
+	args := []string{"rest", "--method", "get", "--uri", "https://management.azure.com/tenants?api-version=2020-01-01", "--output", "none"}
+	if _, err := t.shell.ExecSilentWithEnvAndTimeout("az", env, args, 30*time.Second); err != nil {
+		return fmt.Errorf("%s", t.azureAuthHint())
+	}
+	return nil
+}
+
+// azureContextEnv returns env vars scoping the az CLI to the context's .azure/ dir.
+// Returns nil when ambient SDK credentials are present (don't mask the native chain) or
+// in global mode (defer to ~/.azure/).
+func (t *BaseToolsManager) azureContextEnv() (map[string]string, error) {
+	if hasAmbientAzureCredentials() {
+		return nil, nil
+	}
+	if t.shell.IsGlobal() {
+		return nil, nil
+	}
+	configRoot, err := t.configHandler.GetConfigRoot()
+	if err != nil {
+		return nil, err
+	}
+	azureConfigDir := filepath.Join(configRoot, ".azure")
+	return map[string]string{
+		"AZURE_CONFIG_DIR":               filepath.ToSlash(azureConfigDir),
+		"AZURE_CORE_LOGIN_EXPERIENCE_V2": "false",
+	}, nil
+}
+
+// hasAmbientAzureCredentials reports whether the parent env already carries Azure
+// credentials (Workload Identity / SPN secret / SPN cert). MI has no env signal and
+// is intentionally not detected here — those runners fall through to the az CLI check.
+func hasAmbientAzureCredentials() bool {
+	if os.Getenv("AZURE_FEDERATED_TOKEN_FILE") != "" {
+		return true
+	}
+	if os.Getenv("AZURE_CLIENT_SECRET") != "" {
+		return true
+	}
+	if os.Getenv("AZURE_CLIENT_CERTIFICATE_PATH") != "" {
+		return true
+	}
+	return false
+}
+
+// checkAzureBinary verifies the Azure CLI is available in PATH and meets the minimum version.
+func (t *BaseToolsManager) checkAzureBinary() error {
+	if _, err := execLookPath("az"); err != nil {
+		return missingToolError("az")
+	}
+
+	out, err := t.shell.ExecSilentWithTimeout("az", []string{"--version"}, 10*time.Second)
+	if err != nil {
+		return fmt.Errorf("az --version failed: %v", err)
+	}
+	version := extractVersion(out)
+	if version == "" {
+		return fmt.Errorf("failed to extract az CLI version")
+	}
+	if compareVersion(version, constants.MinimumVersionAzure) < 0 {
+		return outdatedToolError("az", version)
+	}
+
+	return nil
+}
+
+// azureAuthHint returns the recovery command for an Azure auth failure: `az login`
+// (pinned to azure.tenant_id when set), prefixed with AZURE_CONFIG_DIR in project mode
+// when the current env doesn't already point at the context dir.
+func (t *BaseToolsManager) azureAuthHint() string {
+	tenantID := ""
+	cfg := t.configHandler.GetConfig()
+	if cfg != nil && cfg.Azure != nil && cfg.Azure.TenantID != nil {
+		tenantID = *cfg.Azure.TenantID
+	}
+
+	tenantArg := ""
+	if tenantID != "" {
+		tenantArg = fmt.Sprintf(" --tenant %s", tenantID)
+	}
+
+	if t.shell.IsGlobal() {
+		return fmt.Sprintf("Azure CLI session has likely expired or is not initialized. Run:\n  az login%s", tenantArg)
+	}
+
+	configRoot, err := t.configHandler.GetConfigRoot()
+	if err != nil || configRoot == "" {
+		return fmt.Sprintf("Azure CLI session has likely expired or is not initialized. Run:\n  az login%s", tenantArg)
+	}
+	azureConfigDir := filepath.Join(configRoot, ".azure")
+	prefix := ""
+	if !azureEnvPointsAtContext(azureConfigDir) {
+		prefix = fmt.Sprintf("AZURE_CONFIG_DIR=%q ", filepath.ToSlash(azureConfigDir))
+	}
+	return fmt.Sprintf("Azure CLI session for context %q has likely expired or is not initialized. Run:\n  %saz login%s",
+		t.configHandler.GetContext(), prefix, tenantArg)
+}
+
+// azureEnvPointsAtContext reports whether AZURE_CONFIG_DIR already resolves to configDir.
+func azureEnvPointsAtContext(configDir string) bool {
+	cd := os.Getenv("AZURE_CONFIG_DIR")
+	if cd == "" {
+		return false
+	}
+	return filepath.ToSlash(cd) == filepath.ToSlash(configDir)
 }
 
 // detectAWSProfileState classifies the named profile in the AWS config INI at path. Missing

--- a/pkg/runtime/tools/tools_manager_test.go
+++ b/pkg/runtime/tools/tools_manager_test.go
@@ -2998,6 +2998,71 @@ contexts:
 			t.Errorf("AZURE_CONFIG_DIR should not be set in global mode, got %q", capturedEnv["AZURE_CONFIG_DIR"])
 		}
 	})
+
+	t.Run("AzureSovereignCloudRoutesProbeToSovereignEndpoint", func(t *testing.T) {
+		// Given azure.environment names a sovereign cloud, the probe URI must target
+		// that cloud's ARM host — az CLI does not rewrite explicit --uri values, so a
+		// hardcoded management.azure.com would hit the wrong endpoint and surface as a
+		// false auth failure for usgovernment / china tenants.
+		cases := []struct {
+			env  string
+			host string
+		}{
+			{"usgovernment", "management.usgovcloudapi.net"},
+			{"china", "management.chinacloudapi.cn"},
+			{"german", "management.microsoftazure.de"},
+		}
+		for _, tc := range cases {
+			t.Run(tc.env, func(t *testing.T) {
+				mocks, toolsManager := setup(t, fmt.Sprintf(`
+contexts:
+  test:
+    platform: azure
+    azure:
+      tenant_id: 11111111-2222-3333-4444-555555555555
+      environment: %s
+`, tc.env))
+				azBinaryMock(t)
+				var restArgs []string
+				mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+					return fmt.Sprintf("azure-cli                         %s\n", constants.MinimumVersionAzure), nil
+				}
+				mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+					if command == "az" && len(args) >= 1 && args[0] == "rest" {
+						restArgs = args
+						return ``, nil
+					}
+					return "", fmt.Errorf("command not mocked: %v", args)
+				}
+				if err := toolsManager.CheckAuth(); err != nil {
+					t.Fatalf("Expected CheckAuth to succeed for env %q, got %v", tc.env, err)
+				}
+				wantURI := fmt.Sprintf("https://%s/tenants", tc.host)
+				if !strings.Contains(strings.Join(restArgs, " "), wantURI) {
+					t.Errorf("Expected probe URI to contain %q for env %q, got args: %v", wantURI, tc.env, restArgs)
+				}
+			})
+		}
+	})
+}
+
+func Test_armTenantEndpoint(t *testing.T) {
+	cases := []struct {
+		env  string
+		want string
+	}{
+		{"", "management.azure.com"},
+		{"public", "management.azure.com"},
+		{"usgovernment", "management.usgovcloudapi.net"},
+		{"china", "management.chinacloudapi.cn"},
+		{"german", "management.microsoftazure.de"},
+		{"unknown-cloud", "management.azure.com"},
+	}
+	for _, tc := range cases {
+		if got := armTenantEndpoint(tc.env); got != tc.want {
+			t.Errorf("armTenantEndpoint(%q) = %q, want %q", tc.env, got, tc.want)
+		}
+	}
 }
 
 func Test_azureAuthHint(t *testing.T) {

--- a/pkg/runtime/tools/tools_manager_test.go
+++ b/pkg/runtime/tools/tools_manager_test.go
@@ -672,8 +672,11 @@ contexts:
 		mocks.ConfigHandler.Set("docker.enabled", false)
 		mocks.ConfigHandler.Set("terraform.enabled", false)
 		mocks.ConfigHandler.Set("secrets.sops.enabled", false)
-		mocks.ConfigHandler.Set("azure.enabled", false)
 		mocks.ConfigHandler.Set("workstation.runtime", "none")
+		// Azure is gated on platform=="azure" or an azure: block being present, not on
+		// a separate `azure.enabled` flag (we removed that to match AWS). Setting
+		// azure.enabled=false here would actually OPT IN to the kubelogin check by
+		// causing the config handler to materialize the azure block as a side effect.
 		originalExecLookPath := execLookPath
 		execLookPath = func(name string) (string, error) {
 			return "", exec.ErrNotFound
@@ -2519,6 +2522,668 @@ sso_account_id = 123456789012
 		}
 		if !strings.Contains(hint, "aws configure --profile") {
 			t.Errorf("Expected access-key setup hint in configRoot-failure fallback, got: %q", hint)
+		}
+	})
+}
+
+// =============================================================================
+// Azure auth tests
+// =============================================================================
+
+func TestToolsManager_checkAzureBinary(t *testing.T) {
+	setup := func(t *testing.T) (*Mocks, *BaseToolsManager) {
+		t.Helper()
+		mocks := setupMocks(t)
+		toolsManager := NewToolsManager(mocks.ConfigHandler, mocks.Shell)
+		return mocks, toolsManager
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		// Given az is available and meets the minimum version
+		mocks, toolsManager := setup(t)
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			if name == "az" {
+				return "/usr/bin/az", nil
+			}
+			return originalExecLookPath(name)
+		}
+		t.Cleanup(func() { execLookPath = originalExecLookPath })
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			if command == "az" && len(args) == 1 && args[0] == "--version" {
+				return fmt.Sprintf("azure-cli                         %s\n", constants.MinimumVersionAzure), nil
+			}
+			return "", fmt.Errorf("command not mocked: %s %v", command, args)
+		}
+		// When checking the az binary
+		err := toolsManager.checkAzureBinary()
+		// Then no error — checkAzureBinary must NOT invoke `az rest`; that lives in
+		// CheckAuth, which fires only from bootstrap/up/apply preflights and
+		// `windsor check`.
+		if err != nil {
+			t.Errorf("Expected checkAzureBinary to succeed, got %v", err)
+		}
+	})
+
+	t.Run("AzNotAvailable", func(t *testing.T) {
+		// Given az is not in PATH
+		_, toolsManager := setup(t)
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			if name == "az" {
+				return "", exec.ErrNotFound
+			}
+			return originalExecLookPath(name)
+		}
+		t.Cleanup(func() { execLookPath = originalExecLookPath })
+		// When checking az
+		err := toolsManager.checkAzureBinary()
+		// Then error mentions not on PATH and points to the vendor install URL
+		if err == nil {
+			t.Fatal("Expected error when az is not in PATH")
+		}
+		if !strings.Contains(err.Error(), "Azure CLI") || !strings.Contains(err.Error(), "not found on PATH") {
+			t.Errorf("Expected 'Azure CLI ... not found on PATH' in error, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "https://learn.microsoft.com/en-us/cli/azure/install-azure-cli") {
+			t.Errorf("Expected vendor install URL in error, got: %v", err)
+		}
+	})
+
+	t.Run("VersionTooLow", func(t *testing.T) {
+		// Given az reports a version below the minimum
+		mocks, toolsManager := setup(t)
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			if name == "az" {
+				return "/usr/bin/az", nil
+			}
+			return originalExecLookPath(name)
+		}
+		t.Cleanup(func() { execLookPath = originalExecLookPath })
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			if command == "az" && len(args) == 1 && args[0] == "--version" {
+				return "azure-cli                         1.2.3\n", nil
+			}
+			return "", fmt.Errorf("command not mocked")
+		}
+		// When checking az
+		err := toolsManager.checkAzureBinary()
+		// Then the version-too-low error surfaces
+		if err == nil {
+			t.Fatal("Expected error when az version is too low")
+		}
+		if !strings.Contains(err.Error(), "below the minimum required version") {
+			t.Errorf("Expected version-too-low error, got: %v", err)
+		}
+	})
+}
+
+func TestToolsManager_CheckAuthAzure(t *testing.T) {
+	setup := func(t *testing.T, configStr string) (*Mocks, *BaseToolsManager) {
+		t.Helper()
+		// Clear every env var the ambient-credentials guards consult so CheckAuth behaves
+		// identically across dev laptops, AKS Workload Identity pods, and CI runners.
+		t.Setenv("AWS_WEB_IDENTITY_TOKEN_FILE", "")
+		t.Setenv("AWS_CONTAINER_CREDENTIALS_RELATIVE_URI", "")
+		t.Setenv("AWS_CONTAINER_CREDENTIALS_FULL_URI", "")
+		t.Setenv("AWS_ACCESS_KEY_ID", "")
+		t.Setenv("AWS_SECRET_ACCESS_KEY", "")
+		t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "")
+		t.Setenv("AZURE_CLIENT_SECRET", "")
+		t.Setenv("AZURE_CLIENT_CERTIFICATE_PATH", "")
+		t.Setenv("AZURE_CONFIG_DIR", "")
+		mocks := setupMocks(t, &SetupOptions{ConfigStr: configStr})
+		toolsManager := NewToolsManager(mocks.ConfigHandler, mocks.Shell)
+		return mocks, toolsManager
+	}
+
+	azBinaryMock := func(t *testing.T) {
+		t.Helper()
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			if name == "az" {
+				return "/usr/bin/az", nil
+			}
+			return "", exec.ErrNotFound
+		}
+		t.Cleanup(func() { execLookPath = originalExecLookPath })
+	}
+
+	t.Run("AzurePlatformWithAzCliMissing", func(t *testing.T) {
+		// Given platform: azure and the az CLI is not in PATH
+		_, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: azure
+`)
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			return "", exec.ErrNotFound
+		}
+		t.Cleanup(func() { execLookPath = originalExecLookPath })
+
+		// When CheckAuth runs
+		err := toolsManager.CheckAuth()
+		// Then the missing-binary error surfaces with the vendor install URL — the binary
+		// check is part of CheckAuth so bootstrap/up preflights catch a missing CLI before
+		// they try to resolve credentials.
+		if err == nil {
+			t.Fatal("Expected error when az CLI is missing")
+		}
+		if !strings.Contains(err.Error(), "Azure CLI") || !strings.Contains(err.Error(), "not found on PATH") {
+			t.Errorf("Expected 'Azure CLI ... not found on PATH' error, got: %v", err)
+		}
+	})
+
+	t.Run("AzurePlatformWithValidCredentials", func(t *testing.T) {
+		// Given platform: azure, the az CLI is installed, and `az rest` against ARM's
+		// /tenants endpoint returns successfully (the API call AAD validates server-side,
+		// not a cache lookup, so a stale access token gets rejected here even when
+		// `account get-access-token` would silently return it from msal_token_cache.bin).
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: azure
+    azure:
+      tenant_id: 11111111-2222-3333-4444-555555555555
+`)
+		azBinaryMock(t)
+		var restArgs []string
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			if command == "az" && len(args) == 1 && args[0] == "--version" {
+				return fmt.Sprintf("azure-cli                         %s\n", constants.MinimumVersionAzure), nil
+			}
+			return "", fmt.Errorf("command not mocked: %s %v", command, args)
+		}
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			if command == "az" && len(args) >= 1 && args[0] == "rest" {
+				restArgs = args
+				return ``, nil
+			}
+			return "", fmt.Errorf("command not mocked: %v", args)
+		}
+		// When CheckAuth runs
+		err := toolsManager.CheckAuth()
+		// Then the probe is `az rest` against management.azure.com/tenants — a real ARM
+		// API call that exercises the credential server-side. NOT `az account get-access-
+		// token`, which is a cache lookup and silently returns stale tokens.
+		if err != nil {
+			t.Errorf("Expected CheckAuth to succeed when az rest resolves, got %v", err)
+		}
+		joined := strings.Join(restArgs, " ")
+		if !strings.Contains(joined, "https://management.azure.com/tenants") {
+			t.Errorf("Expected ARM /tenants endpoint, got args: %v", restArgs)
+		}
+		if strings.Contains(joined, "get-access-token") {
+			t.Errorf("Probe must not be get-access-token (cache lookup, silently passes on stale tokens), got args: %v", restArgs)
+		}
+	})
+
+	t.Run("AzurePlatformWithoutTenantIDStillRunsTheProbe", func(t *testing.T) {
+		// Given platform: azure with NO azure.tenant_id configured
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: azure
+`)
+		azBinaryMock(t)
+		var restArgs []string
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			return fmt.Sprintf("azure-cli                         %s\n", constants.MinimumVersionAzure), nil
+		}
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			if command == "az" && len(args) >= 1 && args[0] == "rest" {
+				restArgs = args
+				return ``, nil
+			}
+			return "", fmt.Errorf("command not mocked")
+		}
+		// When CheckAuth runs
+		err := toolsManager.CheckAuth()
+		// Then the same `az rest` probe runs — it doesn't need --tenant because /tenants
+		// returns whichever tenants the active credential is authorized for, and the
+		// server-side validation catches a dead session regardless of tenant pinning.
+		if err != nil {
+			t.Errorf("Expected CheckAuth to succeed, got %v", err)
+		}
+		joined := strings.Join(restArgs, " ")
+		if !strings.Contains(joined, "https://management.azure.com/tenants") {
+			t.Errorf("Expected ARM /tenants endpoint, got args: %v", restArgs)
+		}
+		if strings.Contains(joined, "--tenant") {
+			t.Errorf("az rest does not take --tenant for /tenants — pinning would be ignored, got args: %v", restArgs)
+		}
+	})
+
+	t.Run("AzurePlatformIgnoresArmTenantIDEnv", func(t *testing.T) {
+		// Given ARM_TENANT_ID is exported in the parent environment (windsor exports it
+		// from azure.tenant_id, so reading it back would be circular)
+		t.Setenv("ARM_TENANT_ID", "envvar00-1111-2222-3333-444444444444")
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: azure
+`)
+		azBinaryMock(t)
+		var restArgs []string
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			return fmt.Sprintf("azure-cli                         %s\n", constants.MinimumVersionAzure), nil
+		}
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			if command == "az" && len(args) >= 1 && args[0] == "rest" {
+				restArgs = args
+				return ``, nil
+			}
+			return "", fmt.Errorf("command not mocked")
+		}
+		// When CheckAuth runs
+		err := toolsManager.CheckAuth()
+		// Then ARM_TENANT_ID does not leak into the probe args — the probe doesn't read
+		// it (windsor exports it from azure.tenant_id, so reading it back would echo the
+		// field we already check) and the /tenants endpoint doesn't take --tenant anyway.
+		if err != nil {
+			t.Errorf("Expected CheckAuth to succeed, got %v", err)
+		}
+		joined := strings.Join(restArgs, " ")
+		if strings.Contains(joined, "envvar00-1111-2222-3333-444444444444") {
+			t.Errorf("ARM_TENANT_ID must not influence the probe, got args: %v", restArgs)
+		}
+	})
+
+	t.Run("AzurePlatformExpiredTokenSurfacesActionableHint", func(t *testing.T) {
+		// Given platform: azure with tenant_id configured, the az CLI is installed, but
+		// `az rest` against ARM fails because the refresh token expired (the AADSTS700082
+		// case in the bug report)
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: azure
+    azure:
+      tenant_id: 11111111-2222-3333-4444-555555555555
+`)
+		azBinaryMock(t)
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			if command == "az" && len(args) == 1 && args[0] == "--version" {
+				return fmt.Sprintf("azure-cli                         %s\n", constants.MinimumVersionAzure), nil
+			}
+			return "", fmt.Errorf("command not mocked")
+		}
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			return "", fmt.Errorf("AADSTS700082: refresh token expired")
+		}
+		// When CheckAuth runs
+		err := toolsManager.CheckAuth()
+		// Then the surfaced error names ONLY the actionable next step — the `az login`
+		// command — without the doubled "command execution failed" + raw az stderr stack.
+		// The hint is the only thing the operator needs to read to recover.
+		if err == nil {
+			t.Fatal("Expected CheckAuth to fail when get-access-token errors")
+		}
+		if !strings.Contains(err.Error(), "az login") {
+			t.Errorf("Expected `az login` remediation in error, got: %v", err)
+		}
+		if strings.Contains(err.Error(), "command execution failed") {
+			t.Errorf("Expected raw shell-exec error text to be suppressed, got: %v", err)
+		}
+		if strings.Contains(err.Error(), "AADSTS700082") {
+			t.Errorf("Expected vendor stderr to be suppressed in favor of the windsor hint, got: %v", err)
+		}
+	})
+
+	t.Run("AzurePlatformInjectsContextScopedConfigDir", func(t *testing.T) {
+		// Given platform: azure with tenant_id and the az CLI is installed
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: azure
+    azure:
+      tenant_id: 11111111-2222-3333-4444-555555555555
+`)
+		azBinaryMock(t)
+		var capturedEnv map[string]string
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			return fmt.Sprintf("azure-cli                         %s\n", constants.MinimumVersionAzure), nil
+		}
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			if command == "az" && len(args) >= 1 && args[0] == "rest" {
+				capturedEnv = env
+			}
+			return ``, nil
+		}
+		// When CheckAuth runs
+		if err := toolsManager.CheckAuth(); err != nil {
+			t.Fatalf("Expected CheckAuth to succeed, got %v", err)
+		}
+		// Then `az account get-access-token` received the context-scoped AZURE_CONFIG_DIR so
+		// it resolves against the context's .azure/ rather than whatever happens to be active
+		// in the parent shell — without this, CheckAuth could green-light bootstrap using
+		// stale global credentials that terraform apply would later fail on.
+		configRoot, err := mocks.ConfigHandler.GetConfigRoot()
+		if err != nil {
+			t.Fatalf("GetConfigRoot failed: %v", err)
+		}
+		want := filepath.ToSlash(filepath.Join(configRoot, ".azure"))
+		if capturedEnv["AZURE_CONFIG_DIR"] != want {
+			t.Errorf("AZURE_CONFIG_DIR = %q, want %q", capturedEnv["AZURE_CONFIG_DIR"], want)
+		}
+	})
+
+	t.Run("AzurePlatformWithTenantIDPinsLoginToTenant", func(t *testing.T) {
+		// Given platform: azure with an explicit tenant_id and an expired token
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: azure
+    azure:
+      tenant_id: 3d8e9161-441c-44e9-b50a-1d9a78c67ab0
+`)
+		azBinaryMock(t)
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			return fmt.Sprintf("azure-cli                         %s\n", constants.MinimumVersionAzure), nil
+		}
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			return "", fmt.Errorf("AADSTS700082: refresh token expired")
+		}
+		// When CheckAuth runs
+		err := toolsManager.CheckAuth()
+		// Then the suggested `az login` is pinned to the configured tenant — operators with
+		// multiple tenants land in the right one without guessing, mirroring how AWS pins the
+		// suggestion to a specific profile when aws.profile is set.
+		if err == nil {
+			t.Fatal("Expected CheckAuth to fail")
+		}
+		if !strings.Contains(err.Error(), "az login --tenant 3d8e9161-441c-44e9-b50a-1d9a78c67ab0") {
+			t.Errorf("Expected tenant-pinned az login command, got: %v", err)
+		}
+	})
+
+	t.Run("AzureConfigBlockTriggersAuthCheck", func(t *testing.T) {
+		// Given the context has an azure block (no platform set) with tenant_id configured,
+		// and `az rest` against ARM fails
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    azure:
+      subscription_id: 00000000-0000-0000-0000-000000000000
+      tenant_id: 11111111-2222-3333-4444-555555555555
+`)
+		azBinaryMock(t)
+		restCalled := false
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			return fmt.Sprintf("azure-cli                         %s\n", constants.MinimumVersionAzure), nil
+		}
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			if command == "az" && len(args) >= 1 && args[0] == "rest" {
+				restCalled = true
+				return "", fmt.Errorf("Please run 'az login'")
+			}
+			return "", fmt.Errorf("command not mocked")
+		}
+		// When CheckAuth runs
+		err := toolsManager.CheckAuth()
+		// Then `az rest` was invoked and the error surfaced — an azure block alone is
+		// enough to gate on credentials, matching the env-printer activation rule.
+		if !restCalled {
+			t.Error("Expected az rest to be invoked when azure block is present")
+		}
+		if err == nil {
+			t.Error("Expected CheckAuth to surface the credential failure")
+		}
+	})
+
+	t.Run("AzurePlatformWorkloadIdentitySkipsCliCheckWhenAzAbsent", func(t *testing.T) {
+		// Given AKS Workload Identity has injected AZURE_FEDERATED_TOKEN_FILE and the az CLI
+		// is absent — typical of a minimal pod image where the cluster's federation handles
+		// auth and the CLI was never installed
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: azure
+`)
+		t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/var/run/secrets/azure/tokens/azure-identity-token")
+		t.Setenv("AZURE_CLIENT_ID", "00000000-0000-0000-0000-000000000000")
+		t.Setenv("AZURE_TENANT_ID", "00000000-0000-0000-0000-000000000000")
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			return "", exec.ErrNotFound
+		}
+		t.Cleanup(func() { execLookPath = originalExecLookPath })
+		azCalled := false
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			azCalled = true
+			return "", nil
+		}
+		// When CheckAuth runs
+		err := toolsManager.CheckAuth()
+		// Then CheckAuth is a no-op — terraform's azurerm provider will exercise the native
+		// Workload Identity chain at apply time. Requiring az here would be a false negative,
+		// since az isn't part of the runtime credential path for terraform under WI at all.
+		if err != nil {
+			t.Errorf("Expected CheckAuth to be a no-op under Workload Identity without az CLI, got %v", err)
+		}
+		if azCalled {
+			t.Error("az must not be invoked when az is absent under ambient creds")
+		}
+	})
+
+	t.Run("AzurePlatformGlobalModeOmitsConfigDirInjection", func(t *testing.T) {
+		// Given platform: azure with tenant_id and the shell reports global mode (operator
+		// invoking windsor outside a project tree)
+		mocks, toolsManager := setup(t, `
+contexts:
+  test:
+    platform: azure
+    azure:
+      tenant_id: 11111111-2222-3333-4444-555555555555
+`)
+		mocks.Shell.IsGlobalFunc = func() bool { return true }
+		azBinaryMock(t)
+		var capturedEnv map[string]string
+		mocks.Shell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {
+			return fmt.Sprintf("azure-cli                         %s\n", constants.MinimumVersionAzure), nil
+		}
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			capturedEnv = env
+			return `{"id":"00000000-0000-0000-0000-000000000000"}`, nil
+		}
+		// When CheckAuth runs
+		if err := toolsManager.CheckAuth(); err != nil {
+			t.Fatalf("Expected CheckAuth to succeed, got %v", err)
+		}
+		// Then AZURE_CONFIG_DIR is NOT injected — the SDK resolves from the operator's
+		// ambient ~/.azure/, matching the AWS global-mode behavior of deferring config-dir
+		// scoping to the operator.
+		if _, ok := capturedEnv["AZURE_CONFIG_DIR"]; ok {
+			t.Errorf("AZURE_CONFIG_DIR should not be set in global mode, got %q", capturedEnv["AZURE_CONFIG_DIR"])
+		}
+	})
+}
+
+func Test_azureAuthHint(t *testing.T) {
+	t.Run("ProjectModeWithoutTenantPrefixesContextScopedConfigDir", func(t *testing.T) {
+		// Given a toolsManager in project mode with no tenant_id configured, and the parent
+		// shell does NOT have AZURE_CONFIG_DIR pointing at the context (plain shell — windsor
+		// env hasn't been sourced)
+		t.Setenv("AZURE_CONFIG_DIR", "")
+		mocks := setupMocks(t, &SetupOptions{ConfigStr: `
+contexts:
+  test:
+    platform: azure
+`})
+		toolsManager := NewToolsManager(mocks.ConfigHandler, mocks.Shell)
+		// When azureAuthHint runs
+		hint := toolsManager.azureAuthHint()
+		// Then the suggested `az login` is prefixed with AZURE_CONFIG_DIR pointing at the
+		// context's .azure/ so credentials land in the right place — operators in a plain
+		// shell get a copy-pasteable command that doesn't contaminate ~/.azure with this
+		// context's tokens.
+		if !strings.Contains(hint, "AZURE_CONFIG_DIR=") {
+			t.Errorf("Expected AZURE_CONFIG_DIR prefix when shell env doesn't point at context, got: %q", hint)
+		}
+		if !strings.Contains(hint, "az login") {
+			t.Errorf("Expected `az login` in hint, got: %q", hint)
+		}
+		if strings.Contains(hint, "--tenant") {
+			t.Errorf("Expected no --tenant flag when tenant_id is unset, got: %q", hint)
+		}
+	})
+
+	t.Run("ProjectModeWithSourcedShellOmitsEnvPrefix", func(t *testing.T) {
+		// Given a toolsManager in project mode where the shell already exports
+		// AZURE_CONFIG_DIR pointing at the context (windsor env has been sourced)
+		mocks := setupMocks(t, &SetupOptions{ConfigStr: `
+contexts:
+  test:
+    platform: azure
+`})
+		configRoot, err := mocks.ConfigHandler.GetConfigRoot()
+		if err != nil {
+			t.Fatalf("GetConfigRoot failed: %v", err)
+		}
+		t.Setenv("AZURE_CONFIG_DIR", filepath.ToSlash(filepath.Join(configRoot, ".azure")))
+		toolsManager := NewToolsManager(mocks.ConfigHandler, mocks.Shell)
+		// When azureAuthHint runs
+		hint := toolsManager.azureAuthHint()
+		// Then the hint emits a bare `az login` with no env prefix — the operator's shell
+		// will resolve AZURE_CONFIG_DIR from its own env, so prefixing would just be noise
+		// in the common case.
+		if strings.Contains(hint, "AZURE_CONFIG_DIR=") {
+			t.Errorf("Hint should omit AZURE_CONFIG_DIR= prefix when shell env already points at context, got: %q", hint)
+		}
+	})
+
+	t.Run("GlobalModeOmitsEnvPrefix", func(t *testing.T) {
+		// Given a toolsManager in global mode
+		mocks := setupMocks(t)
+		mocks.Shell.IsGlobalFunc = func() bool { return true }
+		toolsManager := NewToolsManager(mocks.ConfigHandler, mocks.Shell)
+		// When azureAuthHint runs
+		hint := toolsManager.azureAuthHint()
+		// Then no AZURE_CONFIG_DIR prefix is emitted — in global mode windsor defers to the
+		// operator's ambient ~/.azure/, so prefixing would point them at a context dir we
+		// have no business writing to.
+		if strings.Contains(hint, "AZURE_CONFIG_DIR=") {
+			t.Errorf("Expected no AZURE_CONFIG_DIR prefix in global mode, got: %q", hint)
+		}
+		if !strings.Contains(hint, "az login") {
+			t.Errorf("Expected `az login` in hint, got: %q", hint)
+		}
+	})
+
+	t.Run("TenantIDIsAppendedToLoginCommand", func(t *testing.T) {
+		// Given a context configured with an explicit Azure tenant_id
+		mocks := setupMocks(t, &SetupOptions{ConfigStr: `
+contexts:
+  test:
+    platform: azure
+    azure:
+      tenant_id: 11111111-2222-3333-4444-555555555555
+`})
+		mocks.Shell.IsGlobalFunc = func() bool { return true }
+		toolsManager := NewToolsManager(mocks.ConfigHandler, mocks.Shell)
+		// When azureAuthHint runs
+		hint := toolsManager.azureAuthHint()
+		// Then the suggested `az login` is pinned to the configured tenant — operators with
+		// multiple tenants get a one-shot command that lands in the right tenant without
+		// having to think about it.
+		if !strings.Contains(hint, "az login --tenant 11111111-2222-3333-4444-555555555555") {
+			t.Errorf("Expected tenant-pinned az login command, got: %q", hint)
+		}
+	})
+}
+
+func Test_azureContextEnv(t *testing.T) {
+	clearAmbientAzure := func(t *testing.T) {
+		t.Helper()
+		t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "")
+		t.Setenv("AZURE_CLIENT_SECRET", "")
+		t.Setenv("AZURE_CLIENT_CERTIFICATE_PATH", "")
+	}
+
+	t.Run("ProjectModeReturnsContextScopedConfigDir", func(t *testing.T) {
+		// Given a tools manager in project mode with no ambient azure creds
+		clearAmbientAzure(t)
+		mocks := setupMocks(t)
+		toolsManager := NewToolsManager(mocks.ConfigHandler, mocks.Shell)
+
+		// When azureContextEnv is invoked
+		env, err := toolsManager.azureContextEnv()
+
+		// Then AZURE_CONFIG_DIR points at the context's .azure/ and the v2 login experience
+		// is disabled (which mirrors azure_env.go and matches what `az login` from a windsor
+		// shell expects).
+		if err != nil {
+			t.Fatalf("azureContextEnv returned error: %v", err)
+		}
+		configRoot, err := mocks.ConfigHandler.GetConfigRoot()
+		if err != nil {
+			t.Fatalf("GetConfigRoot failed: %v", err)
+		}
+		want := filepath.ToSlash(filepath.Join(configRoot, ".azure"))
+		if env["AZURE_CONFIG_DIR"] != want {
+			t.Errorf("AZURE_CONFIG_DIR = %q, want %q", env["AZURE_CONFIG_DIR"], want)
+		}
+		if env["AZURE_CORE_LOGIN_EXPERIENCE_V2"] != "false" {
+			t.Errorf("AZURE_CORE_LOGIN_EXPERIENCE_V2 = %q, want %q", env["AZURE_CORE_LOGIN_EXPERIENCE_V2"], "false")
+		}
+	})
+
+	t.Run("GlobalModeReturnsNil", func(t *testing.T) {
+		// Given a tools manager in global mode
+		clearAmbientAzure(t)
+		mocks := setupMocks(t)
+		mocks.Shell.IsGlobalFunc = func() bool { return true }
+		toolsManager := NewToolsManager(mocks.ConfigHandler, mocks.Shell)
+
+		// When azureContextEnv is invoked
+		env, err := toolsManager.azureContextEnv()
+
+		// Then (nil, nil) is returned — the SDK should resolve from the operator's ambient
+		// ~/.azure/ rather than a context-scoped dir.
+		if err != nil {
+			t.Fatalf("azureContextEnv returned error: %v", err)
+		}
+		if env != nil {
+			t.Errorf("expected nil env in global mode, got %v", env)
+		}
+	})
+
+	t.Run("AmbientWorkloadIdentityReturnsNil", func(t *testing.T) {
+		// Given a Workload Identity environment (AZURE_FEDERATED_TOKEN_FILE set)
+		t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "/var/run/secrets/azure/tokens/azure-identity-token")
+		mocks := setupMocks(t)
+		toolsManager := NewToolsManager(mocks.ConfigHandler, mocks.Shell)
+
+		// When azureContextEnv is invoked
+		env, err := toolsManager.azureContextEnv()
+
+		// Then (nil, nil) — overriding AZURE_CONFIG_DIR would point az at a directory whose
+		// federated-token state isn't compatible with the SDK's WI flow, masking the native
+		// credential chain.
+		if err != nil {
+			t.Fatalf("azureContextEnv returned error: %v", err)
+		}
+		if env != nil {
+			t.Errorf("expected nil env under Workload Identity, got %v", env)
+		}
+	})
+
+	t.Run("AmbientClientSecretReturnsNil", func(t *testing.T) {
+		// Given an SPN environment (AZURE_CLIENT_SECRET set)
+		t.Setenv("AZURE_CLIENT_SECRET", "secret")
+		mocks := setupMocks(t)
+		toolsManager := NewToolsManager(mocks.ConfigHandler, mocks.Shell)
+
+		// When azureContextEnv is invoked
+		env, err := toolsManager.azureContextEnv()
+
+		// Then (nil, nil) — same reasoning as Workload Identity.
+		if err != nil {
+			t.Fatalf("azureContextEnv returned error: %v", err)
+		}
+		if env != nil {
+			t.Errorf("expected nil env under SPN client_secret, got %v", env)
 		}
 	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> Shared infrastructure change: all Azure contexts are affected by the activation-gate and `CheckAuth` path changes; no data-loss risk, but a behavioral edge case in WI setups with `az` installed remains open.
>
> **Overview**
>
> This PR replaces `azure.enabled` with presence-based activation (matching the AWS pattern), adds `KubeloginMode` to both v1alpha1 and v1alpha2 schemas, and introduces a live `az rest` credential probe in `CheckAuth` to catch expired tokens before bootstrap. The sovereign-cloud concern from the previous review is resolved: `armTenantEndpoint` now routes the probe to the correct ARM host for usgovernment, china, and german clouds.
>
> One behavioral edge case remains: when ambient SDK credentials (Workload Identity, SPN secret, or SPN cert) are present and `az` is installed but not configured, `checkAzureAuth` still runs the `az rest` probe and will fail. The skip logic only fires when `az` is absent. WI pods that ship `az` as a base-image artifact but rely on the federated token chain for terraform will hit a false auth failure. The test suite covers the az-absent skip path but not the az-present-unconfigured case.
>
> Reviewed by Claude for commit `00d1759`.

<!-- /claude-code-review:summary -->
