### PR TITLE
feat(provisioner): Show destroy plan

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -4,10 +4,16 @@ import (
 	"bufio"
 	"fmt"
 	"io"
+	"os"
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/windsorcli/cli/pkg/provisioner"
+	fluxinfra "github.com/windsorcli/cli/pkg/provisioner/flux"
+	terraforminfra "github.com/windsorcli/cli/pkg/provisioner/terraform"
 	"github.com/windsorcli/cli/pkg/runtime/tools"
+	"github.com/windsorcli/cli/pkg/tui"
+	tuiplan "github.com/windsorcli/cli/pkg/tui/plan"
 )
 
 // =============================================================================
@@ -39,12 +45,25 @@ With a component name, destroys every layer (Terraform and/or Kustomize) that co
 		blueprint := proj.Composer.BlueprintHandler.Generate()
 
 		if len(args) == 0 {
+			// Auth must precede the plan: terraform plan -destroy and the live
+			// inventory query both need credentials, and a credential failure
+			// should surface before the operator is asked to confirm.
+			if err := requireCloudAuth(cmd, proj); err != nil {
+				return err
+			}
+			var summary *provisioner.DestroyPlanSummary
+			if err := tui.WithProgress("Generating destroy plan...", func() error {
+				var planErr error
+				summary, planErr = proj.Provisioner.PlanDestroyAll(blueprint)
+				return planErr
+			}); err != nil {
+				return fmt.Errorf("error generating destroy plan: %w", err)
+			}
+			tuiplan.DestroySummary(os.Stdout, summary.Terraform, summary.Kustomize, os.Getenv("NO_COLOR") != "")
+
 			contextName := proj.Runtime.ContextName
 			desc := fmt.Sprintf("This will permanently destroy all infrastructure in context %q.", contextName)
 			if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, contextName); err != nil {
-				return err
-			}
-			if err := requireCloudAuth(cmd, proj); err != nil {
 				return err
 			}
 			skipped, err := proj.Provisioner.Teardown(blueprint, false)
@@ -63,18 +82,42 @@ With a component name, destroys every layer (Terraform and/or Kustomize) that co
 			return fmt.Errorf("component %q not found in blueprint", componentID)
 		}
 
-		desc := fmt.Sprintf("This will permanently destroy component %q across all layers.", componentID)
-		if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, componentID); err != nil {
-			return err
-		}
-
-		// Gate auth before either teardown so a credential failure can't strand a both-layer
-		// component half-destroyed (kustomize gone, terraform state intact).
+		// Gate auth before plan (for any terraform leg) so credential failures
+		// surface before the prompt rather than between plan and confirm.
 		if inTerraform {
 			if err := requireCloudAuth(cmd, proj); err != nil {
 				return err
 			}
 		}
+
+		var tfResults []terraforminfra.TerraformComponentPlan
+		var k8sResults []fluxinfra.KustomizePlan
+		if err := tui.WithProgress("Generating destroy plan...", func() error {
+			if inTerraform {
+				result, err := proj.Provisioner.PlanDestroyTerraformComponentSummary(blueprint, componentID)
+				if err != nil {
+					return err
+				}
+				tfResults = []terraforminfra.TerraformComponentPlan{result}
+			}
+			if inKustomize {
+				result, err := proj.Provisioner.PlanDestroyKustomizeComponentSummary(blueprint, componentID)
+				if err != nil {
+					return err
+				}
+				k8sResults = []fluxinfra.KustomizePlan{result}
+			}
+			return nil
+		}); err != nil {
+			return fmt.Errorf("error generating destroy plan: %w", err)
+		}
+		tuiplan.DestroySummary(os.Stdout, tfResults, k8sResults, os.Getenv("NO_COLOR") != "")
+
+		desc := fmt.Sprintf("This will permanently destroy component %q across all layers.", componentID)
+		if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, componentID); err != nil {
+			return err
+		}
+
 		if inKustomize {
 			if err := proj.Provisioner.DestroyKustomize(blueprint, componentID); err != nil {
 				return fmt.Errorf("error destroying kustomization %s: %w", componentID, err)
@@ -113,12 +156,22 @@ var destroyTerraformCmd = &cobra.Command{
 		blueprint := proj.Composer.BlueprintHandler.Generate()
 
 		if len(args) == 0 {
+			if err := requireCloudAuth(cmd, proj); err != nil {
+				return err
+			}
+			var summary *provisioner.DestroyPlanSummary
+			if err := tui.WithProgress("Generating destroy plan...", func() error {
+				var planErr error
+				summary, planErr = proj.Provisioner.PlanDestroyTerraformSummary(blueprint)
+				return planErr
+			}); err != nil {
+				return fmt.Errorf("error generating destroy plan: %w", err)
+			}
+			tuiplan.DestroySummary(os.Stdout, summary.Terraform, nil, os.Getenv("NO_COLOR") != "")
+
 			contextName := proj.Runtime.ContextName
 			desc := fmt.Sprintf("This will permanently destroy all Terraform components in context %q.", contextName)
 			if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, contextName); err != nil {
-				return err
-			}
-			if err := requireCloudAuth(cmd, proj); err != nil {
 				return err
 			}
 			skipped, err := proj.Provisioner.Teardown(blueprint, true)
@@ -130,11 +183,21 @@ var destroyTerraformCmd = &cobra.Command{
 		}
 
 		componentID := args[0]
-		desc := fmt.Sprintf("This will permanently destroy Terraform component %q.", componentID)
-		if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, componentID); err != nil {
+		if err := requireCloudAuth(cmd, proj); err != nil {
 			return err
 		}
-		if err := requireCloudAuth(cmd, proj); err != nil {
+		var tfResult terraforminfra.TerraformComponentPlan
+		if err := tui.WithProgress("Generating destroy plan...", func() error {
+			var planErr error
+			tfResult, planErr = proj.Provisioner.PlanDestroyTerraformComponentSummary(blueprint, componentID)
+			return planErr
+		}); err != nil {
+			return fmt.Errorf("error generating destroy plan: %w", err)
+		}
+		tuiplan.DestroySummary(os.Stdout, []terraforminfra.TerraformComponentPlan{tfResult}, nil, os.Getenv("NO_COLOR") != "")
+
+		desc := fmt.Sprintf("This will permanently destroy Terraform component %q.", componentID)
+		if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, componentID); err != nil {
 			return err
 		}
 		skipped, err := proj.Provisioner.TeardownComponent(blueprint, componentID)
@@ -166,6 +229,16 @@ var destroyKustomizeCmd = &cobra.Command{
 		blueprint := proj.Composer.BlueprintHandler.Generate()
 
 		if len(args) == 0 {
+			var summary *provisioner.DestroyPlanSummary
+			if err := tui.WithProgress("Generating destroy plan...", func() error {
+				var planErr error
+				summary, planErr = proj.Provisioner.PlanDestroyKustomizeSummary(blueprint)
+				return planErr
+			}); err != nil {
+				return fmt.Errorf("error generating destroy plan: %w", err)
+			}
+			tuiplan.DestroySummary(os.Stdout, nil, summary.Kustomize, os.Getenv("NO_COLOR") != "")
+
 			contextName := proj.Runtime.ContextName
 			desc := fmt.Sprintf("This will permanently destroy all Flux kustomizations in context %q.", contextName)
 			if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, contextName); err != nil {
@@ -178,6 +251,16 @@ var destroyKustomizeCmd = &cobra.Command{
 		}
 
 		componentID := args[0]
+		var k8sResult fluxinfra.KustomizePlan
+		if err := tui.WithProgress("Generating destroy plan...", func() error {
+			var planErr error
+			k8sResult, planErr = proj.Provisioner.PlanDestroyKustomizeComponentSummary(blueprint, componentID)
+			return planErr
+		}); err != nil {
+			return fmt.Errorf("error generating destroy plan: %w", err)
+		}
+		tuiplan.DestroySummary(os.Stdout, nil, []fluxinfra.KustomizePlan{k8sResult}, os.Getenv("NO_COLOR") != "")
+
 		desc := fmt.Sprintf("This will permanently destroy Flux kustomization %q.", componentID)
 		if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, componentID); err != nil {
 			return err

--- a/cmd/destroy_test.go
+++ b/cmd/destroy_test.go
@@ -497,6 +497,80 @@ func TestDestroyCmd(t *testing.T) {
 			t.Error("CheckAuth must not be invoked for a kustomize-only component destroy")
 		}
 	})
+
+	t.Run("InvokesDestroyPlanBeforePrompt", func(t *testing.T) {
+		// The destroy preview must run before the confirmation prompt so the
+		// operator can see what will be torn down. Verify by ordering: the
+		// PlanDestroySummary call must happen, and it must happen before
+		// destroy-actual (DestroyAll) fires.
+		mocks := setupDestroyTest(t)
+		var planCalled, destroyCalled bool
+		var planBeforeDestroy bool
+		mocks.TerraformStack.PlanDestroySummaryFunc = func(bp *blueprintv1alpha1.Blueprint) []terraforminfra.TerraformComponentPlan {
+			planCalled = true
+			if !destroyCalled {
+				planBeforeDestroy = true
+			}
+			return nil
+		}
+		mocks.TerraformStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, excludeIDs ...string) ([]string, error) {
+			destroyCalled = true
+			return nil, nil
+		}
+		proj := newDestroyProject(mocks)
+
+		cmd := createTestDestroyCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--confirm=test-context"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if !planCalled {
+			t.Error("expected PlanDestroySummary to be invoked before prompt")
+		}
+		if !planBeforeDestroy {
+			t.Error("expected PlanDestroySummary to fire BEFORE DestroyAll")
+		}
+	})
+
+	t.Run("DestroyPlanErrorAbortsBeforePrompt", func(t *testing.T) {
+		// A plan error means we don't have a truthful preview to show, and
+		// destroy itself can't proceed without the cluster (the most likely
+		// cause of a plan error). The flow must abort before either the prompt
+		// or the actual destroy fires.
+		mocks := setupDestroyTest(t)
+		var destroyCalled bool
+		// Force the flux destroy plan to error by stubbing the kubernetes
+		// manager — that path runs after the terraform stack init, making
+		// PlanDestroyAll fail. (Terraform side returns nil plan.)
+		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
+			return nil, fmt.Errorf("connection refused")
+		}
+		mocks.TerraformStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, excludeIDs ...string) ([]string, error) {
+			destroyCalled = true
+			return nil, nil
+		}
+		proj := newDestroyProject(mocks)
+
+		cmd := createTestDestroyCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--confirm=test-context"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		if err == nil {
+			t.Fatal("expected plan error to abort destroy, got nil")
+		}
+		if !strings.Contains(err.Error(), "destroy plan") {
+			t.Errorf("expected error to mention destroy plan, got: %v", err)
+		}
+		if destroyCalled {
+			t.Error("DestroyAll must not run after a plan error")
+		}
+	})
 }
 
 func TestDestroyTerraformCmd(t *testing.T) {

--- a/integration/destroy_test.go
+++ b/integration/destroy_test.go
@@ -215,3 +215,30 @@ terraform:
 		t.Errorf("destroy must skip structural validation; saw validator prose in output:\n%s", combined)
 	}
 }
+
+// TestDestroy_ShowsDestroyPlanBeforePromptOrConfirm verifies the operator-
+// facing payoff of this PR: a "Windsor Destroy Plan" preview appears in the
+// destroy output before the prompt fires (or, with --confirm supplied, before
+// the actual destroy). The plan fixture has no kustomizations, so we exercise
+// only the terraform side which works without a live cluster.
+func TestDestroy_ShowsDestroyPlanBeforePromptOrConfirm(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
+	if err != nil {
+		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
+	}
+	env = append(env, "WINDSOR_CONTEXT=local")
+	_, stderr, err = helpers.RunCLI(dir, []string{"apply", "terraform", "null"}, env)
+	if err != nil {
+		t.Fatalf("apply terraform null: %v\nstderr: %s", err, stderr)
+	}
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"destroy", "--confirm=local", "terraform"}, env)
+	if err != nil {
+		t.Fatalf("destroy terraform: %v\nstderr: %s", err, stderr)
+	}
+	combined := string(stdout) + string(stderr)
+	if !strings.Contains(combined, "Windsor Destroy Plan") {
+		t.Errorf("expected 'Windsor Destroy Plan' header in output, got:\n%s", combined)
+	}
+}

--- a/pkg/provisioner/flux/mock_stack.go
+++ b/pkg/provisioner/flux/mock_stack.go
@@ -19,8 +19,10 @@ type MockStack struct {
 	PlanAllFunc              func(blueprint *blueprintv1alpha1.Blueprint) error
 	PlanJSONFunc             func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
 	PlanAllJSONFunc          func(blueprint *blueprintv1alpha1.Blueprint) error
-	PlanSummaryFunc          func(blueprint *blueprintv1alpha1.Blueprint) ([]KustomizePlan, []string)
-	PlanComponentSummaryFunc func(blueprint *blueprintv1alpha1.Blueprint, name string) KustomizePlan
+	PlanSummaryFunc                 func(blueprint *blueprintv1alpha1.Blueprint) ([]KustomizePlan, []string)
+	PlanComponentSummaryFunc        func(blueprint *blueprintv1alpha1.Blueprint, name string) KustomizePlan
+	PlanDestroySummaryFunc          func(blueprint *blueprintv1alpha1.Blueprint) ([]KustomizePlan, error)
+	PlanDestroyComponentSummaryFunc func(blueprint *blueprintv1alpha1.Blueprint, name string) KustomizePlan
 }
 
 // =============================================================================
@@ -80,6 +82,22 @@ func (m *MockStack) PlanSummary(blueprint *blueprintv1alpha1.Blueprint) ([]Kusto
 func (m *MockStack) PlanComponentSummary(blueprint *blueprintv1alpha1.Blueprint, name string) KustomizePlan {
 	if m.PlanComponentSummaryFunc != nil {
 		return m.PlanComponentSummaryFunc(blueprint, name)
+	}
+	return KustomizePlan{Name: name}
+}
+
+// PlanDestroySummary is a mock implementation of the PlanDestroySummary method.
+func (m *MockStack) PlanDestroySummary(blueprint *blueprintv1alpha1.Blueprint) ([]KustomizePlan, error) {
+	if m.PlanDestroySummaryFunc != nil {
+		return m.PlanDestroySummaryFunc(blueprint)
+	}
+	return nil, nil
+}
+
+// PlanDestroyComponentSummary is a mock implementation of the PlanDestroyComponentSummary method.
+func (m *MockStack) PlanDestroyComponentSummary(blueprint *blueprintv1alpha1.Blueprint, name string) KustomizePlan {
+	if m.PlanDestroyComponentSummaryFunc != nil {
+		return m.PlanDestroyComponentSummaryFunc(blueprint, name)
 	}
 	return KustomizePlan{Name: name}
 }

--- a/pkg/provisioner/flux/stack.go
+++ b/pkg/provisioner/flux/stack.go
@@ -44,6 +44,8 @@ type Stack interface {
 	PlanAllJSON(blueprint *blueprintv1alpha1.Blueprint) error
 	PlanSummary(blueprint *blueprintv1alpha1.Blueprint) ([]KustomizePlan, []string)
 	PlanComponentSummary(blueprint *blueprintv1alpha1.Blueprint, name string) KustomizePlan
+	PlanDestroySummary(blueprint *blueprintv1alpha1.Blueprint) ([]KustomizePlan, error)
+	PlanDestroyComponentSummary(blueprint *blueprintv1alpha1.Blueprint, name string) KustomizePlan
 }
 
 // KustomizePlan holds the plan result for a single Flux kustomization.
@@ -276,6 +278,130 @@ func (s *FluxStack) PlanComponentSummary(blueprint *blueprintv1alpha1.Blueprint,
 	namespace := s.gitopsNamespace()
 
 	return s.planOneKustomizeSummary(blueprint, k, namespace, fluxMissing, kustomizeMissing)
+}
+
+// PlanDestroySummary returns the per-kustomization preview of what
+// `windsor destroy` will tear down at the flux layer. Unlike PlanSummary,
+// this is sourced from the cluster's live state — specifically the
+// .status.inventory.entries on each Kustomization, which is exactly what flux
+// uses to drive prune behavior — rather than from `kustomize build` of the
+// blueprint. Showing blueprint-derived resources for a destroy preview would
+// lie when the cluster has drifted, so we read truth from the cluster.
+//
+// The kustomization set mirrors DeleteBlueprint's eligibility gate: regular
+// kustomizations only (DestroyOnly hooks are applied during destroy and are
+// not user-facing here), and any pinned with destroy=false are filtered out.
+// A kustomization that is absent from the cluster yields IsNew=true so the
+// renderer shows "(not deployed)". An error from the cluster propagates as
+// the function-level error, since destroy itself cannot proceed without
+// cluster connectivity — falling back would produce a misleading plan.
+func (s *FluxStack) PlanDestroySummary(blueprint *blueprintv1alpha1.Blueprint) ([]KustomizePlan, error) {
+	if blueprint == nil {
+		return nil, nil
+	}
+
+	namespace := s.gitopsNamespace()
+
+	var results []KustomizePlan
+	for _, k := range blueprint.Kustomizations {
+		if !kustomizationDestroyEligible(k) {
+			continue
+		}
+		result, err := s.planOneKustomizeDestroySummary(k, namespace)
+		if err != nil {
+			return nil, err
+		}
+		results = append(results, result)
+	}
+	return results, nil
+}
+
+// PlanDestroyComponentSummary returns the destroy preview for a single named
+// kustomization. A pinned destroy=false or DestroyOnly kustomization returns
+// Err — DeleteBlueprint would skip it, so producing a plan would mislead.
+func (s *FluxStack) PlanDestroyComponentSummary(blueprint *blueprintv1alpha1.Blueprint, name string) KustomizePlan {
+	result := KustomizePlan{Name: name}
+
+	if blueprint == nil {
+		result.Err = fmt.Errorf("blueprint not provided")
+		return result
+	}
+
+	k, ok := findKustomization(blueprint, name)
+	if !ok {
+		result.Err = fmt.Errorf("kustomization %q not found in blueprint", name)
+		return result
+	}
+	if k.DestroyOnly != nil && *k.DestroyOnly {
+		result.Err = fmt.Errorf("kustomization %q is destroyOnly; not eligible for direct destroy", name)
+		return result
+	}
+	if d := k.Destroy.ToBool(); d != nil && !*d {
+		result.Err = fmt.Errorf("kustomization %q is pinned with destroy=false", name)
+		return result
+	}
+
+	resolved, err := s.planOneKustomizeDestroySummary(k, s.gitopsNamespace())
+	if err != nil {
+		resolved.Err = err
+	}
+	return resolved
+}
+
+// kustomizationDestroyEligible mirrors the gate inside DeleteBlueprint so the
+// destroy-plan set matches the destroy-execute set. DestroyOnly kustomizations
+// are skipped (they're hooks applied during destroy, not user-visible
+// resources to preview), and any pinned destroy=false are skipped.
+func kustomizationDestroyEligible(k blueprintv1alpha1.Kustomization) bool {
+	if k.DestroyOnly != nil && *k.DestroyOnly {
+		return false
+	}
+	if d := k.Destroy.ToBool(); d != nil && !*d {
+		return false
+	}
+	return true
+}
+
+// planOneKustomizeDestroySummary computes the destroy preview for one
+// kustomization. Pulls flux's live inventory and tags every entry as Delete.
+// IsNew marks the not-deployed case so the renderer shows "(not deployed)" —
+// reusing the apply-side IsNew field rather than introducing a new flag.
+func (s *FluxStack) planOneKustomizeDestroySummary(k blueprintv1alpha1.Kustomization, namespace string) (KustomizePlan, error) {
+	result := KustomizePlan{Name: k.Name}
+
+	entries, err := s.kubernetesManager.GetKustomizationInventory(k.Name, namespace)
+	if err != nil {
+		return result, fmt.Errorf("error querying kustomization %q inventory: %w", k.Name, err)
+	}
+	if entries == nil {
+		// Kustomization not present in the cluster: nothing to destroy.
+		result.IsNew = true
+		return result, nil
+	}
+
+	resources := make([]ResourceChange, 0, len(entries))
+	for _, e := range entries {
+		resources = append(resources, ResourceChange{
+			Address: inventoryAddress(e),
+			Action:  ActionDelete,
+		})
+	}
+	result.Resources = resources
+	result.Removed = len(resources)
+	return result, nil
+}
+
+// inventoryAddress renders a Kubernetes inventory entry in flux's banner
+// convention: "<Kind>/<namespace>/<name>" for namespaced resources,
+// "<Kind>/<name>" for cluster-scoped ones. Group is intentionally omitted from
+// the visible address — Kind is what operators recognise; group disambiguates
+// CRDs but at the cost of every line getting a noisy "apps." or "networking.
+// k8s.io." prefix. Same trade-off as the apply-side parser.
+func inventoryAddress(e kubernetes.InventoryEntry) string {
+	if e.Namespace == "" {
+		return fmt.Sprintf("%s/%s", e.Kind, e.Name)
+	}
+	return fmt.Sprintf("%s/%s/%s", e.Kind, e.Namespace, e.Name)
 }
 
 // PlanAllJSON runs kustomize build for every non-destroyOnly kustomization in the blueprint,

--- a/pkg/provisioner/flux/stack.go
+++ b/pkg/provisioner/flux/stack.go
@@ -396,7 +396,12 @@ func (s *FluxStack) planOneKustomizeDestroySummary(k blueprintv1alpha1.Kustomiza
 // "<Kind>/<name>" for cluster-scoped ones. Group is intentionally omitted from
 // the visible address — Kind is what operators recognise; group disambiguates
 // CRDs but at the cost of every line getting a noisy "apps." or "networking.
-// k8s.io." prefix. Same trade-off as the apply-side parser.
+// k8s.io." prefix. Same trade-off as the apply-side parser. Residual risk:
+// when a cluster carries two CRDs with the same Kind across different groups
+// (e.g., a vendor's Deployment alongside apps/Deployment), the rendered
+// addresses collide and the operator must consult the cluster directly to
+// distinguish them. Rare in practice, but worth knowing about when reviewing
+// a plan against a heavily-customised cluster.
 func inventoryAddress(e kubernetes.InventoryEntry) string {
 	if e.Namespace == "" {
 		return fmt.Sprintf("%s/%s", e.Kind, e.Name)

--- a/pkg/provisioner/flux/stack.go
+++ b/pkg/provisioner/flux/stack.go
@@ -351,10 +351,17 @@ func (s *FluxStack) PlanDestroyComponentSummary(blueprint *blueprintv1alpha1.Blu
 // kustomizationDestroyEligible mirrors the gate inside DeleteBlueprint so the
 // destroy-plan set matches the destroy-execute set. DestroyOnly kustomizations
 // are skipped (they're hooks applied during destroy, not user-visible
-// resources to preview), and any pinned destroy=false are skipped.
+// resources to preview), and any pinned destroy=false are skipped. The
+// explicit nil check on Destroy mirrors componentDestroyEnabled on the
+// terraform side: ToBool happens to handle a nil receiver today, but the
+// guard reads more clearly at the call site and survives future refactors of
+// ToBool without breakage.
 func kustomizationDestroyEligible(k blueprintv1alpha1.Kustomization) bool {
 	if k.DestroyOnly != nil && *k.DestroyOnly {
 		return false
+	}
+	if k.Destroy == nil {
+		return true
 	}
 	if d := k.Destroy.ToBool(); d != nil && !*d {
 		return false

--- a/pkg/provisioner/flux/stack_test.go
+++ b/pkg/provisioner/flux/stack_test.go
@@ -773,6 +773,215 @@ func TestFluxStack_PlanSummary(t *testing.T) {
 	})
 }
 
+func TestFluxStack_PlanDestroySummary(t *testing.T) {
+	t.Run("ReturnsNilForNilBlueprint", func(t *testing.T) {
+		m := setupFluxMocks(t)
+		s := newTestFluxStack(m)
+		got, err := s.PlanDestroySummary(nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != nil {
+			t.Errorf("expected nil, got %#v", got)
+		}
+	})
+
+	t.Run("BuildsResourceListFromClusterInventory", func(t *testing.T) {
+		// Given a kubernetes manager that returns inventory entries for the
+		// kustomization
+		m := setupFluxMocks(t)
+		m.kubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
+			if name == "my-app" {
+				return []kubernetes.InventoryEntry{
+					{Namespace: "monitoring", Name: "grafana", Group: "apps", Kind: "Deployment"},
+					{Namespace: "monitoring", Name: "grafana-config", Group: "", Kind: "ConfigMap"},
+					{Namespace: "", Name: "admin", Group: "rbac.authorization.k8s.io", Kind: "ClusterRole"},
+				}, nil
+			}
+			return nil, nil
+		}
+		s := newTestFluxStack(m)
+
+		// When PlanDestroySummary runs against the test blueprint
+		results, err := s.PlanDestroySummary(testBlueprint())
+
+		// Then the eligible kustomizations are returned and resources are
+		// addressed in flux's banner format with action Delete
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// testBlueprint has my-app, infra-base, cleanup-only(destroyOnly).
+		// destroyOnly is filtered, so two results.
+		if len(results) != 2 {
+			t.Fatalf("expected 2 results, got %d: %#v", len(results), results)
+		}
+		var myApp KustomizePlan
+		for _, r := range results {
+			if r.Name == "my-app" {
+				myApp = r
+			}
+		}
+		if myApp.Name == "" {
+			t.Fatalf("expected my-app result, got %#v", results)
+		}
+		want := []ResourceChange{
+			{Address: "Deployment/monitoring/grafana", Action: ActionDelete},
+			{Address: "ConfigMap/monitoring/grafana-config", Action: ActionDelete},
+			{Address: "ClusterRole/admin", Action: ActionDelete},
+		}
+		if len(myApp.Resources) != len(want) {
+			t.Fatalf("expected %d resources, got %d: %#v", len(want), len(myApp.Resources), myApp.Resources)
+		}
+		for i, r := range myApp.Resources {
+			if r != want[i] {
+				t.Errorf("[%d] expected %#v, got %#v", i, want[i], r)
+			}
+		}
+		if myApp.Removed != len(want) {
+			t.Errorf("expected Removed=%d, got %d", len(want), myApp.Removed)
+		}
+	})
+
+	t.Run("MarksKustomizationNewWhenAbsentFromCluster", func(t *testing.T) {
+		// Given a kubernetes manager that returns nil entries (kustomization not
+		// present in the cluster)
+		m := setupFluxMocks(t)
+		m.kubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
+			return nil, nil
+		}
+		s := newTestFluxStack(m)
+
+		results, err := s.PlanDestroySummary(testBlueprint())
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		for _, r := range results {
+			if !r.IsNew {
+				t.Errorf("expected IsNew=true for absent kustomization %q, got false", r.Name)
+			}
+			if len(r.Resources) != 0 {
+				t.Errorf("expected no resources for absent kustomization %q, got %#v", r.Name, r.Resources)
+			}
+		}
+	})
+
+	t.Run("PropagatesClusterErrorToCaller", func(t *testing.T) {
+		// Cluster unreachable: destroy can't proceed without it, so we error
+		// rather than return a misleading partial plan.
+		m := setupFluxMocks(t)
+		m.kubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
+			return nil, fmt.Errorf("connection refused")
+		}
+		s := newTestFluxStack(m)
+
+		_, err := s.PlanDestroySummary(testBlueprint())
+
+		if err == nil {
+			t.Fatal("expected error from cluster failure, got nil")
+		}
+		if !strings.Contains(err.Error(), "connection refused") {
+			t.Errorf("expected cluster error to propagate, got %v", err)
+		}
+	})
+
+	t.Run("FiltersDestroyOnlyAndDestroyFalse", func(t *testing.T) {
+		// destroyOnly hooks and pinned destroy=false kustomizations are filtered
+		// to match DeleteBlueprint's eligibility gate.
+		m := setupFluxMocks(t)
+		var visited []string
+		m.kubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
+			visited = append(visited, name)
+			return []kubernetes.InventoryEntry{}, nil
+		}
+		falseVal := false
+		trueVal := true
+		bp := &blueprintv1alpha1.Blueprint{
+			Metadata: blueprintv1alpha1.Metadata{Name: "t"},
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "regular"},
+				{Name: "pinned-off", Destroy: &blueprintv1alpha1.BoolExpression{Value: &falseVal}},
+				{Name: "hook-only", DestroyOnly: &trueVal},
+			},
+		}
+		s := newTestFluxStack(m)
+
+		_, err := s.PlanDestroySummary(bp)
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(visited) != 1 || visited[0] != "regular" {
+			t.Errorf("expected only 'regular' kustomization to be queried, got %v", visited)
+		}
+	})
+}
+
+func TestFluxStack_PlanDestroyComponentSummary(t *testing.T) {
+	t.Run("ReturnsErrorForNilBlueprint", func(t *testing.T) {
+		m := setupFluxMocks(t)
+		s := newTestFluxStack(m)
+		got := s.PlanDestroyComponentSummary(nil, "x")
+		if got.Err == nil {
+			t.Error("expected error for nil blueprint, got nil")
+		}
+	})
+
+	t.Run("ReturnsErrorForMissingKustomization", func(t *testing.T) {
+		m := setupFluxMocks(t)
+		s := newTestFluxStack(m)
+		got := s.PlanDestroyComponentSummary(testBlueprint(), "nonexistent")
+		if got.Err == nil || !strings.Contains(got.Err.Error(), "not found") {
+			t.Errorf("expected not-found error, got %v", got.Err)
+		}
+	})
+
+	t.Run("RejectsDestroyOnly", func(t *testing.T) {
+		// destroyOnly kustomizations are skipped by DeleteBlueprint, so
+		// previewing one would mislead.
+		m := setupFluxMocks(t)
+		s := newTestFluxStack(m)
+		got := s.PlanDestroyComponentSummary(testBlueprint(), "cleanup-only")
+		if got.Err == nil || !strings.Contains(got.Err.Error(), "destroyOnly") {
+			t.Errorf("expected destroyOnly error, got %v", got.Err)
+		}
+	})
+
+	t.Run("RejectsDestroyFalsePinned", func(t *testing.T) {
+		falseVal := false
+		bp := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "pinned", Destroy: &blueprintv1alpha1.BoolExpression{Value: &falseVal}},
+			},
+		}
+		m := setupFluxMocks(t)
+		s := newTestFluxStack(m)
+		got := s.PlanDestroyComponentSummary(bp, "pinned")
+		if got.Err == nil || !strings.Contains(got.Err.Error(), "destroy=false") {
+			t.Errorf("expected destroy=false error, got %v", got.Err)
+		}
+	})
+
+	t.Run("ReturnsResourcesForNamedKustomization", func(t *testing.T) {
+		m := setupFluxMocks(t)
+		m.kubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
+			return []kubernetes.InventoryEntry{
+				{Namespace: "monitoring", Name: "grafana", Group: "apps", Kind: "Deployment"},
+			}, nil
+		}
+		s := newTestFluxStack(m)
+
+		got := s.PlanDestroyComponentSummary(testBlueprint(), "my-app")
+
+		if got.Err != nil {
+			t.Fatalf("unexpected error: %v", got.Err)
+		}
+		if len(got.Resources) != 1 || got.Resources[0].Action != ActionDelete {
+			t.Errorf("expected one Delete resource, got %#v", got.Resources)
+		}
+	})
+}
+
 func TestCountDiffLines(t *testing.T) {
 	t.Run("CountsAddedAndRemovedLines", func(t *testing.T) {
 		// Given a unified diff with additions and removals

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -47,10 +47,24 @@ type KubernetesManager interface {
 	CheckGitRepositoryStatus() error
 	GetKustomizationStatus(names []string) (map[string]bool, error)
 	KustomizationExists(name, namespace string) (bool, error)
+	GetKustomizationInventory(name, namespace string) ([]InventoryEntry, error)
 	WaitForKubernetesHealthy(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error
 	GetNodeReadyStatus(ctx context.Context, nodeNames []string) (map[string]bool, error)
 	ApplyBlueprint(blueprint *blueprintv1alpha1.Blueprint, namespace string) error
 	DeleteBlueprint(blueprint *blueprintv1alpha1.Blueprint, namespace string) error
+}
+
+// InventoryEntry identifies one resource Flux is tracking for a Kustomization,
+// decoded from a single .status.inventory.entries[] record. The encoded form
+// flux writes is "<namespace>_<name>_<group>_<kind>"; namespace is empty for
+// cluster-scoped resources, group is empty for core API objects ("v1"). These
+// entries are exactly what flux deletes when a Kustomization is removed, so
+// they are the truthful source for "what will go away on destroy."
+type InventoryEntry struct {
+	Group     string
+	Kind      string
+	Namespace string
+	Name      string
 }
 
 // =============================================================================
@@ -553,6 +567,70 @@ func (k *BaseKubernetesManager) KustomizationExists(name, namespace string) (boo
 		return false, err
 	}
 	return true, nil
+}
+
+// GetKustomizationInventory returns the list of resources Flux is currently
+// tracking for the named Kustomization, decoded from its
+// .status.inventory.entries field. This is what flux uses to drive prune
+// behavior, so it is the authoritative source for "what will be deleted when
+// this Kustomization is removed." Returns (nil, nil) when the Kustomization
+// itself is absent (a destroy-plan caller should treat that as "not deployed"
+// rather than an error). Returns an empty slice when the Kustomization exists
+// but has no inventory yet (e.g., suspended, or never reconciled). Other API
+// errors and malformed inventory entries propagate.
+func (k *BaseKubernetesManager) GetKustomizationInventory(name, namespace string) ([]InventoryEntry, error) {
+	gvr := schema.GroupVersionResource{
+		Group:    "kustomize.toolkit.fluxcd.io",
+		Version:  "v1",
+		Resource: "kustomizations",
+	}
+	obj, err := k.client.GetResource(gvr, namespace, name)
+	if err != nil {
+		if isNotFoundError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	rawEntries, found, err := unstructured.NestedSlice(obj.Object, "status", "inventory", "entries")
+	if err != nil {
+		return nil, fmt.Errorf("error reading inventory for kustomization %q in namespace %q: %w", name, namespace, err)
+	}
+	if !found {
+		return []InventoryEntry{}, nil
+	}
+	entries := make([]InventoryEntry, 0, len(rawEntries))
+	for _, raw := range rawEntries {
+		entryMap, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+		id, _ := entryMap["id"].(string)
+		entry, ok := decodeInventoryID(id)
+		if !ok {
+			continue
+		}
+		entries = append(entries, entry)
+	}
+	return entries, nil
+}
+
+// decodeInventoryID parses a flux inventory ID of the form
+// "<namespace>_<name>_<group>_<kind>" into an InventoryEntry. Namespace is
+// empty for cluster-scoped resources; group is empty for core API objects.
+// Returns (zero, false) when the ID does not have exactly four underscore-
+// separated fields — flux always emits four, so anything else is a malformed
+// entry we should drop rather than misrender.
+func decodeInventoryID(id string) (InventoryEntry, bool) {
+	parts := strings.SplitN(id, "_", 4)
+	if len(parts) != 4 {
+		return InventoryEntry{}, false
+	}
+	return InventoryEntry{
+		Namespace: parts[0],
+		Name:      parts[1],
+		Group:     parts[2],
+		Kind:      parts[3],
+	}, true
 }
 
 // WaitForKubernetesHealthy waits for the Kubernetes API to become healthy within the context deadline.

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -576,8 +576,13 @@ func (k *BaseKubernetesManager) KustomizationExists(name, namespace string) (boo
 // this Kustomization is removed." Returns (nil, nil) when the Kustomization
 // itself is absent (a destroy-plan caller should treat that as "not deployed"
 // rather than an error). Returns an empty slice when the Kustomization exists
-// but has no inventory yet (e.g., suspended, or never reconciled). Other API
-// errors and malformed inventory entries propagate.
+// but has no inventory yet (e.g., suspended, or never reconciled). API errors
+// reading the Kustomization or its inventory propagate. Individual entries
+// that fail to decode (malformed IDs, unexpected field shapes) are silently
+// dropped — flux always emits well-formed IDs, so this branch is rare in
+// practice, and resilience matters more than completeness here: failing the
+// whole destroy preview because of one corrupt entry would be worse than
+// rendering a slightly truncated list.
 func (k *BaseKubernetesManager) GetKustomizationInventory(name, namespace string) ([]InventoryEntry, error) {
 	gvr := schema.GroupVersionResource{
 		Group:    "kustomize.toolkit.fluxcd.io",

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -4906,3 +4906,122 @@ func TestBaseKubernetesManager_KustomizationExists(t *testing.T) {
 		}
 	})
 }
+
+// =============================================================================
+// Test GetKustomizationInventory
+// =============================================================================
+
+func TestBaseKubernetesManager_GetKustomizationInventory(t *testing.T) {
+	t.Run("DecodesEntriesFromInventoryStatus", func(t *testing.T) {
+		// Given a kustomization whose status carries inventory entries with the
+		// flux ID encoding "<ns>_<name>_<group>_<kind>"
+		m := setupKubernetesMocks(t)
+		m.KubernetesClient.(*client.MockKubernetesClient).GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			obj := &unstructured.Unstructured{}
+			obj.Object = map[string]any{
+				"status": map[string]any{
+					"inventory": map[string]any{
+						"entries": []any{
+							map[string]any{"id": "monitoring_grafana_apps_Deployment", "v": "v1"},
+							map[string]any{"id": "monitoring_grafana-config__ConfigMap", "v": "v1"},
+							map[string]any{"id": "_admin_rbac.authorization.k8s.io_ClusterRole", "v": "v1"},
+						},
+					},
+				},
+			}
+			return obj, nil
+		}
+		manager := NewKubernetesManager(m.KubernetesClient, m.ConfigHandler)
+
+		// When GetKustomizationInventory runs
+		entries, err := manager.GetKustomizationInventory("monitoring", "flux-system")
+
+		// Then each entry is decoded with namespace/name/group/kind set; cluster-
+		// scoped resources have empty namespace; core API objects have empty group
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		want := []InventoryEntry{
+			{Namespace: "monitoring", Name: "grafana", Group: "apps", Kind: "Deployment"},
+			{Namespace: "monitoring", Name: "grafana-config", Group: "", Kind: "ConfigMap"},
+			{Namespace: "", Name: "admin", Group: "rbac.authorization.k8s.io", Kind: "ClusterRole"},
+		}
+		if len(entries) != len(want) {
+			t.Fatalf("expected %d entries, got %d: %#v", len(want), len(entries), entries)
+		}
+		for i, e := range entries {
+			if e != want[i] {
+				t.Errorf("[%d] expected %#v, got %#v", i, want[i], e)
+			}
+		}
+	})
+
+	t.Run("ReturnsNilWhenKustomizationAbsent", func(t *testing.T) {
+		// Absent kustomization is not an error in the destroy-plan context — it
+		// just means "not deployed yet, nothing to destroy."
+		m := setupKubernetesMocks(t)
+		m.KubernetesClient.(*client.MockKubernetesClient).GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			return nil, fmt.Errorf("%q not found", name)
+		}
+		manager := NewKubernetesManager(m.KubernetesClient, m.ConfigHandler)
+
+		entries, err := manager.GetKustomizationInventory("not-yet", "flux-system")
+
+		if err != nil {
+			t.Fatalf("expected no error for not-found, got %v", err)
+		}
+		if entries != nil {
+			t.Errorf("expected nil entries for not-found, got %#v", entries)
+		}
+	})
+
+	t.Run("ReturnsEmptySliceWhenInventoryAbsent", func(t *testing.T) {
+		// Kustomization exists but has not reconciled (suspended, or never
+		// applied) — inventory is missing, but this is distinct from
+		// kustomization-not-found and we surface it as an empty slice.
+		m := setupKubernetesMocks(t)
+		m.KubernetesClient.(*client.MockKubernetesClient).GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			return &unstructured.Unstructured{Object: map[string]any{"status": map[string]any{}}}, nil
+		}
+		manager := NewKubernetesManager(m.KubernetesClient, m.ConfigHandler)
+
+		entries, err := manager.GetKustomizationInventory("suspended", "flux-system")
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if entries == nil || len(entries) != 0 {
+			t.Errorf("expected empty (non-nil) slice, got %#v", entries)
+		}
+	})
+
+	t.Run("DropsMalformedEntries", func(t *testing.T) {
+		// IDs without exactly four underscore-separated fields are flux malformed
+		// — skip rather than misrender.
+		m := setupKubernetesMocks(t)
+		m.KubernetesClient.(*client.MockKubernetesClient).GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			obj := &unstructured.Unstructured{}
+			obj.Object = map[string]any{
+				"status": map[string]any{
+					"inventory": map[string]any{
+						"entries": []any{
+							map[string]any{"id": "garbage", "v": "v1"},
+							map[string]any{"id": "ns_name__Kind", "v": "v1"},
+						},
+					},
+				},
+			}
+			return obj, nil
+		}
+		manager := NewKubernetesManager(m.KubernetesClient, m.ConfigHandler)
+
+		entries, err := manager.GetKustomizationInventory("x", "flux-system")
+
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(entries) != 1 || entries[0].Kind != "Kind" {
+			t.Errorf("expected only the well-formed entry, got %#v", entries)
+		}
+	})
+}

--- a/pkg/provisioner/kubernetes/mock_kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/mock_kubernetes_manager.go
@@ -31,6 +31,7 @@ type MockKubernetesManager struct {
 	ApplyOCIRepositoryFunc              func(repo *sourcev1.OCIRepository) error
 	CheckGitRepositoryStatusFunc        func() error
 	KustomizationExistsFunc             func(name, namespace string) (bool, error)
+	GetKustomizationInventoryFunc       func(name, namespace string) ([]InventoryEntry, error)
 	WaitForKubernetesHealthyFunc        func(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error
 	GetNodeReadyStatusFunc              func(ctx context.Context, nodeNames []string) (map[string]bool, error)
 	ApplyBlueprintFunc                  func(blueprint *blueprintv1alpha1.Blueprint, namespace string) error
@@ -146,6 +147,14 @@ func (m *MockKubernetesManager) KustomizationExists(name, namespace string) (boo
 		return m.KustomizationExistsFunc(name, namespace)
 	}
 	return false, nil
+}
+
+// GetKustomizationInventory implements KubernetesManager interface
+func (m *MockKubernetesManager) GetKustomizationInventory(name, namespace string) ([]InventoryEntry, error) {
+	if m.GetKustomizationInventoryFunc != nil {
+		return m.GetKustomizationInventoryFunc(name, namespace)
+	}
+	return nil, nil
 }
 
 // WaitForKubernetesHealthy waits for the Kubernetes API endpoint to be healthy with polling and timeout

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -69,6 +69,19 @@ type PlanSummary struct {
 	Hints     []string
 }
 
+// DestroyPlanSummary holds aggregated destroy-plan results across all
+// infrastructure layers. The shape mirrors PlanSummary but without the Hints
+// field: destroy is gated on a working cluster (the kustomize layer queries
+// flux's live inventory), so a tooling-missing fallback is not part of the
+// destroy contract — fail fast instead. The TerraformComponentPlan and
+// KustomizePlan entries here come from the destroy-side producers; renderers
+// must use a destroy-aware formatter to translate IsNew correctly (apply-side
+// "(new)" becomes destroy-side "(no state)" / "(not deployed)").
+type DestroyPlanSummary struct {
+	Terraform []terraforminfra.TerraformComponentPlan
+	Kustomize []fluxinfra.KustomizePlan
+}
+
 // NodeHealthCheckOptions contains options for node health checking.
 type NodeHealthCheckOptions struct {
 	Nodes               []string
@@ -589,6 +602,36 @@ func (i *Provisioner) PlanKustomizeComponentSummary(blueprint *blueprintv1alpha1
 	return i.FluxStack.PlanComponentSummary(blueprint, name), nil
 }
 
+// PlanDestroyTerraformComponentSummary previews the destroy plan for a single
+// Terraform component. Returns an error if blueprint is nil, stack init fails,
+// or the component is pinned destroy=false (which Teardown would skip).
+func (i *Provisioner) PlanDestroyTerraformComponentSummary(blueprint *blueprintv1alpha1.Blueprint, componentID string) (terraforminfra.TerraformComponentPlan, error) {
+	if blueprint == nil {
+		return terraforminfra.TerraformComponentPlan{}, fmt.Errorf("blueprint not provided")
+	}
+	if err := i.ensureTerraformStack(); err != nil {
+		return terraforminfra.TerraformComponentPlan{}, err
+	}
+	if i.TerraformStack == nil {
+		return terraforminfra.TerraformComponentPlan{}, fmt.Errorf("terraform is disabled")
+	}
+	return i.TerraformStack.PlanDestroyComponentSummary(blueprint, componentID), nil
+}
+
+// PlanDestroyKustomizeComponentSummary previews the destroy plan for a single
+// Flux kustomization by querying its live inventory. Returns an error if
+// blueprint is nil, stack init fails, or the kustomization is destroyOnly /
+// pinned destroy=false (which DeleteBlueprint would skip).
+func (i *Provisioner) PlanDestroyKustomizeComponentSummary(blueprint *blueprintv1alpha1.Blueprint, name string) (fluxinfra.KustomizePlan, error) {
+	if blueprint == nil {
+		return fluxinfra.KustomizePlan{}, fmt.Errorf("blueprint not provided")
+	}
+	if err := i.ensureFluxStack(); err != nil {
+		return fluxinfra.KustomizePlan{}, err
+	}
+	return i.FluxStack.PlanDestroyComponentSummary(blueprint, name), nil
+}
+
 // PlanTerraformSummary runs a best-effort summary plan across every Terraform
 // component in the blueprint without touching the Flux/Kustomize layer.
 // Returns an error only when blueprint is nil or stack initialisation fails.
@@ -651,6 +694,78 @@ func (i *Provisioner) PlanAll(blueprint *blueprintv1alpha1.Blueprint) (*PlanSumm
 		Terraform: tfSummary.Terraform,
 		Kustomize: k8sSummary.Kustomize,
 		Hints:     k8sSummary.Hints,
+	}, nil
+}
+
+// PlanDestroyTerraformSummary previews the destroy plan for every Terraform
+// component the blueprint would actually tear down (filtering destroy=false
+// pins). Mirrors PlanTerraformSummary but uses `terraform plan -destroy -json`
+// per component. Returns an error only when blueprint is nil or stack init
+// fails.
+func (i *Provisioner) PlanDestroyTerraformSummary(blueprint *blueprintv1alpha1.Blueprint) (*DestroyPlanSummary, error) {
+	if blueprint == nil {
+		return nil, fmt.Errorf("blueprint not provided")
+	}
+
+	summary := &DestroyPlanSummary{}
+
+	if err := i.ensureTerraformStack(); err != nil {
+		return nil, err
+	}
+	if i.TerraformStack != nil {
+		summary.Terraform = i.TerraformStack.PlanDestroySummary(blueprint)
+	}
+
+	return summary, nil
+}
+
+// PlanDestroyKustomizeSummary previews the destroy plan for every eligible
+// Flux kustomization by querying live cluster inventory. Returns an error if
+// the cluster is unreachable — destroy itself cannot proceed without it, so a
+// blueprint-derived fallback would mislead. DestroyOnly hooks and destroy=
+// false pinned kustomizations are filtered to match DeleteBlueprint.
+func (i *Provisioner) PlanDestroyKustomizeSummary(blueprint *blueprintv1alpha1.Blueprint) (*DestroyPlanSummary, error) {
+	if blueprint == nil {
+		return nil, fmt.Errorf("blueprint not provided")
+	}
+
+	summary := &DestroyPlanSummary{}
+
+	if err := i.ensureFluxStack(); err != nil {
+		return nil, err
+	}
+	results, err := i.FluxStack.PlanDestroySummary(blueprint)
+	if err != nil {
+		return nil, err
+	}
+	summary.Kustomize = results
+
+	return summary, nil
+}
+
+// PlanDestroyAll previews the destroy plan across both Terraform and Flux
+// layers. Initialises each stack as needed and aggregates the results into
+// a single DestroyPlanSummary for rendering. A cluster failure on the flux
+// side aborts the whole plan — destroy needs the cluster, so a partial plan
+// would be misleading.
+func (i *Provisioner) PlanDestroyAll(blueprint *blueprintv1alpha1.Blueprint) (*DestroyPlanSummary, error) {
+	if blueprint == nil {
+		return nil, fmt.Errorf("blueprint not provided")
+	}
+
+	tfSummary, err := i.PlanDestroyTerraformSummary(blueprint)
+	if err != nil {
+		return nil, err
+	}
+
+	k8sSummary, err := i.PlanDestroyKustomizeSummary(blueprint)
+	if err != nil {
+		return nil, err
+	}
+
+	return &DestroyPlanSummary{
+		Terraform: tfSummary.Terraform,
+		Kustomize: k8sSummary.Kustomize,
 	}, nil
 }
 

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -3072,6 +3072,254 @@ func TestProvisioner_PlanAll(t *testing.T) {
 	})
 }
 
+func TestProvisioner_PlanDestroyTerraformSummary(t *testing.T) {
+	t.Run("ReturnsErrorForNilBlueprint", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		p := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{
+			TerraformStack:    mocks.TerraformStack,
+			FluxStack:         mocks.FluxStack,
+			KubernetesManager: mocks.KubernetesManager,
+			KubernetesClient:  mocks.KubernetesClient,
+		})
+
+		summary, err := p.PlanDestroyTerraformSummary(nil)
+		if err == nil {
+			t.Fatal("expected error for nil blueprint, got nil")
+		}
+		if summary != nil {
+			t.Errorf("expected nil summary, got %v", summary)
+		}
+	})
+
+	t.Run("InvokesTerraformDestroyOnly", func(t *testing.T) {
+		// PlanDestroyTerraformSummary must not touch the flux side — its
+		// counterpart on the apply path is the same gate. Verify by failing the
+		// test if FluxStack.PlanDestroySummary is called.
+		mocks := setupProvisionerMocks(t)
+		mocks.TerraformStack.(*terraforminfra.MockStack).PlanDestroySummaryFunc = func(bp *blueprintv1alpha1.Blueprint) []terraforminfra.TerraformComponentPlan {
+			return []terraforminfra.TerraformComponentPlan{{ComponentID: "cluster", Destroy: 5}}
+		}
+		mocks.FluxStack.PlanDestroySummaryFunc = func(bp *blueprintv1alpha1.Blueprint) ([]fluxinfra.KustomizePlan, error) {
+			t.Fatal("FluxStack.PlanDestroySummary should not be called by PlanDestroyTerraformSummary")
+			return nil, nil
+		}
+		p := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{
+			TerraformStack:    mocks.TerraformStack,
+			FluxStack:         mocks.FluxStack,
+			KubernetesManager: mocks.KubernetesManager,
+			KubernetesClient:  mocks.KubernetesClient,
+		})
+
+		summary, err := p.PlanDestroyTerraformSummary(createTestBlueprint())
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(summary.Terraform) != 1 || summary.Terraform[0].ComponentID != "cluster" {
+			t.Errorf("expected terraform destroy result for cluster, got %v", summary.Terraform)
+		}
+		if summary.Kustomize != nil {
+			t.Errorf("expected nil kustomize slice, got %v", summary.Kustomize)
+		}
+	})
+}
+
+func TestProvisioner_PlanDestroyKustomizeSummary(t *testing.T) {
+	t.Run("ReturnsErrorForNilBlueprint", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		p := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{
+			TerraformStack:    mocks.TerraformStack,
+			FluxStack:         mocks.FluxStack,
+			KubernetesManager: mocks.KubernetesManager,
+			KubernetesClient:  mocks.KubernetesClient,
+		})
+
+		summary, err := p.PlanDestroyKustomizeSummary(nil)
+		if err == nil {
+			t.Fatal("expected error for nil blueprint, got nil")
+		}
+		if summary != nil {
+			t.Errorf("expected nil summary, got %v", summary)
+		}
+	})
+
+	t.Run("ReturnsKustomizeResultsOnly", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		mocks.TerraformStack.(*terraforminfra.MockStack).PlanDestroySummaryFunc = func(bp *blueprintv1alpha1.Blueprint) []terraforminfra.TerraformComponentPlan {
+			t.Fatal("TerraformStack.PlanDestroySummary should not be called by PlanDestroyKustomizeSummary")
+			return nil
+		}
+		mocks.FluxStack.PlanDestroySummaryFunc = func(bp *blueprintv1alpha1.Blueprint) ([]fluxinfra.KustomizePlan, error) {
+			return []fluxinfra.KustomizePlan{{Name: "monitoring", Removed: 12}}, nil
+		}
+		p := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{
+			TerraformStack:    mocks.TerraformStack,
+			FluxStack:         mocks.FluxStack,
+			KubernetesManager: mocks.KubernetesManager,
+			KubernetesClient:  mocks.KubernetesClient,
+		})
+
+		summary, err := p.PlanDestroyKustomizeSummary(createTestBlueprint())
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(summary.Kustomize) != 1 || summary.Kustomize[0].Name != "monitoring" {
+			t.Errorf("expected kustomize destroy result for monitoring, got %v", summary.Kustomize)
+		}
+	})
+
+	t.Run("PropagatesClusterErrorFromFluxStack", func(t *testing.T) {
+		// The flux destroy plan errors on cluster failure (truthful — fall-back
+		// would lie). The aggregator must propagate so the cmd layer can fail
+		// before prompting for destroy.
+		mocks := setupProvisionerMocks(t)
+		mocks.FluxStack.PlanDestroySummaryFunc = func(bp *blueprintv1alpha1.Blueprint) ([]fluxinfra.KustomizePlan, error) {
+			return nil, fmt.Errorf("connection refused")
+		}
+		p := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{
+			TerraformStack:    mocks.TerraformStack,
+			FluxStack:         mocks.FluxStack,
+			KubernetesManager: mocks.KubernetesManager,
+			KubernetesClient:  mocks.KubernetesClient,
+		})
+
+		summary, err := p.PlanDestroyKustomizeSummary(createTestBlueprint())
+		if err == nil || !strings.Contains(err.Error(), "connection refused") {
+			t.Errorf("expected cluster error to propagate, got err=%v summary=%v", err, summary)
+		}
+	})
+}
+
+func TestProvisioner_PlanDestroyAll(t *testing.T) {
+	t.Run("ReturnsErrorForNilBlueprint", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		p := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{
+			TerraformStack:    mocks.TerraformStack,
+			FluxStack:         mocks.FluxStack,
+			KubernetesManager: mocks.KubernetesManager,
+			KubernetesClient:  mocks.KubernetesClient,
+		})
+
+		summary, err := p.PlanDestroyAll(nil)
+		if err == nil {
+			t.Fatal("expected error for nil blueprint, got nil")
+		}
+		if summary != nil {
+			t.Errorf("expected nil summary, got %v", summary)
+		}
+	})
+
+	t.Run("AggregatesBothLayers", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		mocks.TerraformStack.(*terraforminfra.MockStack).PlanDestroySummaryFunc = func(bp *blueprintv1alpha1.Blueprint) []terraforminfra.TerraformComponentPlan {
+			return []terraforminfra.TerraformComponentPlan{{ComponentID: "cluster", Destroy: 7}}
+		}
+		mocks.FluxStack.PlanDestroySummaryFunc = func(bp *blueprintv1alpha1.Blueprint) ([]fluxinfra.KustomizePlan, error) {
+			return []fluxinfra.KustomizePlan{{Name: "monitoring", Removed: 12}}, nil
+		}
+		p := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{
+			TerraformStack:    mocks.TerraformStack,
+			FluxStack:         mocks.FluxStack,
+			KubernetesManager: mocks.KubernetesManager,
+			KubernetesClient:  mocks.KubernetesClient,
+		})
+
+		summary, err := p.PlanDestroyAll(createTestBlueprint())
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(summary.Terraform) != 1 || summary.Terraform[0].ComponentID != "cluster" {
+			t.Errorf("expected terraform destroy result for cluster, got %v", summary.Terraform)
+		}
+		if len(summary.Kustomize) != 1 || summary.Kustomize[0].Name != "monitoring" {
+			t.Errorf("expected kustomize destroy result for monitoring, got %v", summary.Kustomize)
+		}
+	})
+
+	t.Run("AbortsOnClusterFailure", func(t *testing.T) {
+		// Flux returns error -> PlanDestroyAll must abort and return that error
+		// so the cmd layer doesn't prompt for destroy.
+		mocks := setupProvisionerMocks(t)
+		mocks.FluxStack.PlanDestroySummaryFunc = func(bp *blueprintv1alpha1.Blueprint) ([]fluxinfra.KustomizePlan, error) {
+			return nil, fmt.Errorf("connection refused")
+		}
+		p := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{
+			TerraformStack:    mocks.TerraformStack,
+			FluxStack:         mocks.FluxStack,
+			KubernetesManager: mocks.KubernetesManager,
+			KubernetesClient:  mocks.KubernetesClient,
+		})
+
+		summary, err := p.PlanDestroyAll(createTestBlueprint())
+		if err == nil || !strings.Contains(err.Error(), "connection refused") {
+			t.Errorf("expected cluster error to propagate, got err=%v summary=%v", err, summary)
+		}
+	})
+}
+
+func TestProvisioner_PlanDestroyTerraformComponentSummary(t *testing.T) {
+	t.Run("ReturnsErrorForNilBlueprint", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		p := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{
+			TerraformStack: mocks.TerraformStack,
+		})
+
+		_, err := p.PlanDestroyTerraformComponentSummary(nil, "x")
+		if err == nil {
+			t.Fatal("expected error for nil blueprint, got nil")
+		}
+	})
+
+	t.Run("DelegatesToTerraformStack", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		mocks.TerraformStack.(*terraforminfra.MockStack).PlanDestroyComponentSummaryFunc = func(bp *blueprintv1alpha1.Blueprint, id string) terraforminfra.TerraformComponentPlan {
+			return terraforminfra.TerraformComponentPlan{ComponentID: id, Destroy: 4}
+		}
+		p := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{
+			TerraformStack: mocks.TerraformStack,
+		})
+
+		got, err := p.PlanDestroyTerraformComponentSummary(createTestBlueprint(), "cluster")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.ComponentID != "cluster" || got.Destroy != 4 {
+			t.Errorf("expected delegated result, got %#v", got)
+		}
+	})
+}
+
+func TestProvisioner_PlanDestroyKustomizeComponentSummary(t *testing.T) {
+	t.Run("ReturnsErrorForNilBlueprint", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		p := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{
+			FluxStack: mocks.FluxStack,
+		})
+
+		_, err := p.PlanDestroyKustomizeComponentSummary(nil, "x")
+		if err == nil {
+			t.Fatal("expected error for nil blueprint, got nil")
+		}
+	})
+
+	t.Run("DelegatesToFluxStack", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		mocks.FluxStack.PlanDestroyComponentSummaryFunc = func(bp *blueprintv1alpha1.Blueprint, name string) fluxinfra.KustomizePlan {
+			return fluxinfra.KustomizePlan{Name: name, Removed: 8}
+		}
+		p := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{
+			FluxStack: mocks.FluxStack,
+		})
+
+		got, err := p.PlanDestroyKustomizeComponentSummary(createTestBlueprint(), "monitoring")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got.Name != "monitoring" || got.Removed != 8 {
+			t.Errorf("expected delegated result, got %#v", got)
+		}
+	})
+}
+
 func TestVersionFromImage(t *testing.T) {
 	cases := []struct {
 		image    string

--- a/pkg/provisioner/terraform/mock_stack.go
+++ b/pkg/provisioner/terraform/mock_stack.go
@@ -30,8 +30,10 @@ type MockStack struct {
 	PlanAllJSONFunc           func(blueprint *blueprintv1alpha1.Blueprint) error
 	ApplyFunc                 func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
 	DestroyFunc               func(blueprint *blueprintv1alpha1.Blueprint, componentID string) (bool, error)
-	PlanSummaryFunc           func(blueprint *blueprintv1alpha1.Blueprint) []TerraformComponentPlan
-	PlanComponentSummaryFunc  func(blueprint *blueprintv1alpha1.Blueprint, componentID string) TerraformComponentPlan
+	PlanSummaryFunc                 func(blueprint *blueprintv1alpha1.Blueprint) []TerraformComponentPlan
+	PlanComponentSummaryFunc        func(blueprint *blueprintv1alpha1.Blueprint, componentID string) TerraformComponentPlan
+	PlanDestroySummaryFunc          func(blueprint *blueprintv1alpha1.Blueprint) []TerraformComponentPlan
+	PlanDestroyComponentSummaryFunc func(blueprint *blueprintv1alpha1.Blueprint, componentID string) TerraformComponentPlan
 }
 
 // =============================================================================
@@ -178,6 +180,22 @@ func (m *MockStack) PlanSummary(blueprint *blueprintv1alpha1.Blueprint) []Terraf
 func (m *MockStack) PlanComponentSummary(blueprint *blueprintv1alpha1.Blueprint, componentID string) TerraformComponentPlan {
 	if m.PlanComponentSummaryFunc != nil {
 		return m.PlanComponentSummaryFunc(blueprint, componentID)
+	}
+	return TerraformComponentPlan{ComponentID: componentID}
+}
+
+// PlanDestroySummary is a mock implementation of the PlanDestroySummary method.
+func (m *MockStack) PlanDestroySummary(blueprint *blueprintv1alpha1.Blueprint) []TerraformComponentPlan {
+	if m.PlanDestroySummaryFunc != nil {
+		return m.PlanDestroySummaryFunc(blueprint)
+	}
+	return nil
+}
+
+// PlanDestroyComponentSummary is a mock implementation of the PlanDestroyComponentSummary method.
+func (m *MockStack) PlanDestroyComponentSummary(blueprint *blueprintv1alpha1.Blueprint, componentID string) TerraformComponentPlan {
+	if m.PlanDestroyComponentSummaryFunc != nil {
+		return m.PlanDestroyComponentSummaryFunc(blueprint, componentID)
 	}
 	return TerraformComponentPlan{ComponentID: componentID}
 }

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -155,6 +155,8 @@ type Stack interface {
 	Destroy(blueprint *blueprintv1alpha1.Blueprint, componentID string) (bool, error)
 	PlanSummary(blueprint *blueprintv1alpha1.Blueprint) []TerraformComponentPlan
 	PlanComponentSummary(blueprint *blueprintv1alpha1.Blueprint, componentID string) TerraformComponentPlan
+	PlanDestroySummary(blueprint *blueprintv1alpha1.Blueprint) []TerraformComponentPlan
+	PlanDestroyComponentSummary(blueprint *blueprintv1alpha1.Blueprint, componentID string) TerraformComponentPlan
 }
 
 // =============================================================================
@@ -868,6 +870,75 @@ func (s *TerraformStack) PlanSummary(blueprint *blueprintv1alpha1.Blueprint) []T
 	return results
 }
 
+// PlanDestroySummary runs terraform init and `plan -destroy` for every component
+// in the blueprint that is not pinned with Destroy=false, capturing the destroy
+// counts and the per-resource list rather than printing them. Components with
+// Destroy=false are filtered out so the rendered plan matches what Teardown
+// would actually destroy — including them would lie. As with PlanSummary,
+// errors are recorded per-component and the summary continues so callers
+// receive partial results for independent layers. Returns nil if blueprint is
+// nil or projectRoot is unset.
+func (s *TerraformStack) PlanDestroySummary(blueprint *blueprintv1alpha1.Blueprint) []TerraformComponentPlan {
+	if blueprint == nil {
+		return nil
+	}
+
+	projectRoot := s.runtime.ProjectRoot
+	if projectRoot == "" {
+		return nil
+	}
+
+	components := s.resolveTerraformComponents(blueprint, projectRoot)
+	results := make([]TerraformComponentPlan, 0, len(components))
+	for i := range components {
+		if !componentDestroyEnabled(&components[i]) {
+			continue
+		}
+		results = append(results, s.planOneTerraformDestroySummary(&components[i]))
+	}
+	return results
+}
+
+// PlanDestroyComponentSummary runs terraform init and `plan -destroy` for a
+// single component and returns its structured plan result. If the component is
+// not found, a result with a non-nil Err is returned rather than an error, to
+// match PlanComponentSummary. A component pinned with Destroy=false also
+// returns Err — Teardown would skip it, so producing a destroy plan for it
+// would mislead the operator.
+func (s *TerraformStack) PlanDestroyComponentSummary(blueprint *blueprintv1alpha1.Blueprint, componentID string) TerraformComponentPlan {
+	result := TerraformComponentPlan{ComponentID: componentID}
+
+	if blueprint == nil {
+		result.Err = fmt.Errorf("blueprint not provided")
+		return result
+	}
+
+	projectRoot := s.runtime.ProjectRoot
+	if projectRoot == "" {
+		result.Err = fmt.Errorf("error getting project root: project root is empty")
+		return result
+	}
+
+	components := s.resolveTerraformComponents(blueprint, projectRoot)
+	var component *blueprintv1alpha1.TerraformComponent
+	for i := range components {
+		if components[i].GetID() == componentID {
+			component = &components[i]
+			break
+		}
+	}
+	if component == nil {
+		result.Err = fmt.Errorf("terraform component %q not found in blueprint", componentID)
+		return result
+	}
+	if !componentDestroyEnabled(component) {
+		result.Err = fmt.Errorf("terraform component %q is pinned with destroy=false", componentID)
+		return result
+	}
+
+	return s.planOneTerraformDestroySummary(component)
+}
+
 // PlanComponentSummary runs terraform init and plan for a single component and returns its
 // structured plan result. It resolves only the requested component from the blueprint,
 // so no other components are initialised or planned. If the component is not found, a
@@ -1200,6 +1271,72 @@ func (s *TerraformStack) planOneTerraformSummary(component *blueprintv1alpha1.Te
 
 	result.Add, result.Change, result.Destroy, result.NoChanges, result.Resources = parseTerraformPlanJSON(planOutput)
 	return result
+}
+
+// planOneTerraformDestroySummary computes the destroy plan for one component.
+// Mirrors planOneTerraformSummary but invokes `plan -destroy -json` and uses
+// terraform destroy-mode env (TF_VAR_operation=destroy + DestroyArgs) so the
+// rendered plan reflects what Teardown will actually do, including any
+// destroy-time-only provider config the component opts into.
+//
+// IsNew is repurposed for the destroy context: a component with no state has
+// nothing to destroy, so we set IsNew=true and skip plan. Callers render this
+// as "(no state)" rather than "(new)" — same condition, different language —
+// to avoid running plan against an empty state which would emit a misleading
+// "all destroys" event stream or fail when reading dependent layers.
+func (s *TerraformStack) planOneTerraformDestroySummary(component *blueprintv1alpha1.TerraformComponent) TerraformComponentPlan {
+	result := TerraformComponentPlan{ComponentID: component.GetID(), Path: component.Path}
+
+	terraformVars, terraformArgs, cleanup, err := s.prepareComponentEnv(component)
+	if err != nil {
+		result.Err = err
+		return result
+	}
+	defer cleanup()
+	terraformVars["TF_VAR_operation"] = "destroy"
+
+	if err := s.runTerraformInit(component, terraformVars, terraformArgs, defaultInitFlags...); err != nil {
+		result.Err = err
+		return result
+	}
+
+	hasState, err := s.hasStateResources(component, terraformVars)
+	if err != nil {
+		result.Err = err
+		return result
+	}
+	if !hasState {
+		result.IsNew = true
+		return result
+	}
+
+	terraformCommand := s.runtime.ToolsManager.GetTerraformCommand()
+	planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan", "-destroy", "-json", "-no-color"}
+	planArgs = append(planArgs, terraformArgs.DestroyArgs...)
+	planEnv := selectTerraformCommandEnv(terraformVars, true)
+	planOutput, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, planEnv, planArgs...)
+	if err != nil {
+		result.Err = fmt.Errorf("error running terraform plan -destroy for %s: %w", component.Path, err)
+		return result
+	}
+
+	result.Add, result.Change, result.Destroy, result.NoChanges, result.Resources = parseTerraformPlanJSON(planOutput)
+	return result
+}
+
+// componentDestroyEnabled reports whether a component should be included in a
+// destroy plan. A component is included unless its Destroy field is set and
+// resolves to false; absent or true means "destroy normally." This mirrors the
+// gate inside DestroyAll so the planned set matches the executed set.
+func componentDestroyEnabled(component *blueprintv1alpha1.TerraformComponent) bool {
+	if component.Destroy == nil {
+		return true
+	}
+	d := component.Destroy.ToBool()
+	if d == nil {
+		return true
+	}
+	return *d
 }
 
 // prepareComponentEnv saves the current directory, validates the component's directory exists,

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -81,6 +81,17 @@ type initCacheKey struct {
 // upstream state), so Add/Change/Destroy are zero and NoChanges is false. JSON
 // consumers detecting "pending work" must check IsNew alongside the counts —
 // `IsNew || Add+Change+Destroy > 0` rather than counts alone.
+//
+// IsNew has two operator-facing meanings depending on which producer populated
+// the struct, and the struct itself does not carry a mode flag — callers route
+// this disambiguation. Apply-side producers (PlanSummary,
+// PlanComponentSummary) set IsNew when the component has never been applied,
+// rendered as "(new)". Destroy-side producers (PlanDestroySummary,
+// PlanDestroyComponentSummary) set IsNew when there is no state to destroy,
+// rendered as "(no state)". Renderers must therefore route apply and destroy
+// results through distinct formatters — calling the apply-side formatter on a
+// destroy-side result would emit "(new)" for a component that has nothing to
+// tear down, which is misleading.
 type TerraformComponentPlan struct {
 	ComponentID string
 	Path        string
@@ -1280,10 +1291,13 @@ func (s *TerraformStack) planOneTerraformSummary(component *blueprintv1alpha1.Te
 // destroy-time-only provider config the component opts into.
 //
 // IsNew is repurposed for the destroy context: a component with no state has
-// nothing to destroy, so we set IsNew=true and skip plan. Callers render this
-// as "(no state)" rather than "(new)" — same condition, different language —
-// to avoid running plan against an empty state which would emit a misleading
-// "all destroys" event stream or fail when reading dependent layers.
+// nothing to destroy, so we set IsNew=true and skip plan. Callers MUST route
+// this output through a destroy-aware formatter that renders IsNew as
+// "(no state)" rather than "(new)". The TerraformComponentPlan struct does
+// not carry a mode flag, so passing a destroy-side result through the
+// apply-side formatter would emit "(new)" for a component that has nothing to
+// tear down — see the IsNew contract on TerraformComponentPlan for the full
+// disambiguation rule.
 func (s *TerraformStack) planOneTerraformDestroySummary(component *blueprintv1alpha1.TerraformComponent) TerraformComponentPlan {
 	result := TerraformComponentPlan{ComponentID: component.GetID(), Path: component.Path}
 

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -3808,6 +3808,218 @@ func TestStack_PlanSummary(t *testing.T) {
 	})
 }
 
+func TestStack_PlanDestroySummary(t *testing.T) {
+	setup := func(t *testing.T) (*TerraformStack, *TerraformTestMocks) {
+		t.Helper()
+		mocks := setupWindsorStackMocks(t)
+		stack := NewStack(mocks.Runtime).(*TerraformStack)
+		stack.shims = mocks.Shims
+		return stack, mocks
+	}
+
+	t.Run("ReturnsNilForNilBlueprint", func(t *testing.T) {
+		stack, _ := setup(t)
+		if got := stack.PlanDestroySummary(nil); got != nil {
+			t.Errorf("expected nil, got %v", got)
+		}
+	})
+
+	t.Run("InvokesPlanInDestroyModeAndCapturesResources", func(t *testing.T) {
+		// Given a shell that records the plan args and returns a destroy event
+		// stream (every planned_change action="delete")
+		stack, mocks := setup(t)
+		var capturedArgs []string
+		var capturedEnv map[string]string
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 2 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[{"address":"aws_s3_bucket.example"}]}}}`, nil
+			}
+			if len(args) > 1 && args[1] == "plan" {
+				capturedArgs = append([]string{}, args...)
+				capturedEnv = env
+				return strings.Join([]string{
+					`{"type":"planned_change","change":{"resource":{"addr":"aws_s3_bucket.logs"},"action":"delete"}}`,
+					`{"type":"planned_change","change":{"resource":{"addr":"aws_iam_role.eks"},"action":"delete"}}`,
+					`{"type":"change_summary","changes":{"add":0,"change":0,"remove":2}}`,
+					``,
+				}, "\n"), nil
+			}
+			return "", nil
+		}
+
+		// When PlanDestroySummary runs
+		results := stack.PlanDestroySummary(createTestBlueprint())
+
+		// Then the plan command included -destroy and used destroy-mode env
+		var sawDestroyFlag bool
+		for _, a := range capturedArgs {
+			if a == "-destroy" {
+				sawDestroyFlag = true
+			}
+		}
+		if !sawDestroyFlag {
+			t.Errorf("expected -destroy flag in plan args, got %v", capturedArgs)
+		}
+		if capturedEnv["TF_VAR_operation"] != "destroy" {
+			t.Errorf("expected TF_VAR_operation=destroy, got %q", capturedEnv["TF_VAR_operation"])
+		}
+		// And resources came back tagged Delete
+		if len(results) == 0 {
+			t.Fatal("expected at least one result")
+		}
+		r := results[0]
+		if r.Destroy != 2 {
+			t.Errorf("expected destroy=2, got %d", r.Destroy)
+		}
+		if len(r.Resources) != 2 {
+			t.Fatalf("expected 2 resources, got %#v", r.Resources)
+		}
+		for _, rc := range r.Resources {
+			if rc.Action != ActionDelete {
+				t.Errorf("expected ActionDelete, got %v for %q", rc.Action, rc.Address)
+			}
+		}
+	})
+
+	t.Run("MarksComponentNewWhenStateIsEmpty", func(t *testing.T) {
+		// Given empty state (renderer will show "(no state)")
+		stack, mocks := setup(t)
+		var planCalled bool
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 2 && args[1] == "show" && args[2] == "-json" {
+				return "{}", nil
+			}
+			if len(args) > 1 && args[1] == "plan" {
+				planCalled = true
+			}
+			return "", nil
+		}
+
+		results := stack.PlanDestroySummary(createTestBlueprint())
+
+		if len(results) == 0 {
+			t.Fatal("expected results")
+		}
+		for _, r := range results {
+			if !r.IsNew {
+				t.Errorf("expected IsNew=true (no state to destroy) for %q, got false", r.ComponentID)
+			}
+		}
+		if planCalled {
+			t.Error("plan must not be invoked when state is empty")
+		}
+	})
+
+	t.Run("FiltersComponentsPinnedWithDestroyFalse", func(t *testing.T) {
+		// Given a blueprint with one component pinned destroy=false
+		stack, mocks := setup(t)
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 2 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[{"address":"x.y"}]}}}`, nil
+			}
+			if len(args) > 1 && args[1] == "plan" {
+				return `{"type":"change_summary","changes":{"add":0,"change":0,"remove":1}}` + "\n", nil
+			}
+			return "", nil
+		}
+		falseVal := false
+		falseBool := &blueprintv1alpha1.BoolExpression{Value: &falseVal}
+		bp := &blueprintv1alpha1.Blueprint{
+			Metadata: blueprintv1alpha1.Metadata{Name: "t"},
+			TerraformComponents: []blueprintv1alpha1.TerraformComponent{
+				{Path: "a", Destroy: falseBool},
+				{Path: "b"},
+			},
+		}
+
+		results := stack.PlanDestroySummary(bp)
+
+		// Then only the unpinned component shows up
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result (b only), got %d: %#v", len(results), results)
+		}
+		if results[0].Path != "b" {
+			t.Errorf("expected path=b, got %q", results[0].Path)
+		}
+	})
+}
+
+func TestStack_PlanDestroyComponentSummary(t *testing.T) {
+	setup := func(t *testing.T) (*TerraformStack, *TerraformTestMocks) {
+		t.Helper()
+		mocks := setupWindsorStackMocks(t)
+		stack := NewStack(mocks.Runtime).(*TerraformStack)
+		stack.shims = mocks.Shims
+		return stack, mocks
+	}
+
+	t.Run("ReturnsErrorForNilBlueprint", func(t *testing.T) {
+		stack, _ := setup(t)
+		if got := stack.PlanDestroyComponentSummary(nil, "x"); got.Err == nil {
+			t.Error("expected error for nil blueprint, got nil")
+		}
+	})
+
+	t.Run("ReturnsErrorForMissingComponent", func(t *testing.T) {
+		stack, _ := setup(t)
+		got := stack.PlanDestroyComponentSummary(createTestBlueprint(), "nonexistent")
+		if got.Err == nil || !strings.Contains(got.Err.Error(), "not found") {
+			t.Errorf("expected not-found error, got %v", got.Err)
+		}
+	})
+
+	t.Run("ReturnsErrorForDestroyFalseComponent", func(t *testing.T) {
+		// A pinned-destroy=false component returns an error rather than running
+		// plan — Teardown would skip it, so producing a destroy plan would lie.
+		stack, _ := setup(t)
+		falseVal := false
+		falseBool := &blueprintv1alpha1.BoolExpression{Value: &falseVal}
+		bp := &blueprintv1alpha1.Blueprint{
+			TerraformComponents: []blueprintv1alpha1.TerraformComponent{
+				{Name: "pinned", Path: "a", Destroy: falseBool},
+			},
+		}
+		got := stack.PlanDestroyComponentSummary(bp, "pinned")
+		if got.Err == nil || !strings.Contains(got.Err.Error(), "destroy=false") {
+			t.Errorf("expected destroy=false error, got %v", got.Err)
+		}
+	})
+
+	t.Run("RunsForNamedComponent", func(t *testing.T) {
+		stack, mocks := setup(t)
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 2 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[{"address":"x.y"}]}}}`, nil
+			}
+			if len(args) > 1 && args[1] == "plan" {
+				return strings.Join([]string{
+					`{"type":"planned_change","change":{"resource":{"addr":"aws_s3.bucket"},"action":"delete"}}`,
+					`{"type":"change_summary","changes":{"add":0,"change":0,"remove":1}}`,
+					``,
+				}, "\n"), nil
+			}
+			return "", nil
+		}
+		bp := &blueprintv1alpha1.Blueprint{
+			TerraformComponents: []blueprintv1alpha1.TerraformComponent{
+				{Name: "mycomp", Path: "local/path"},
+			},
+		}
+
+		got := stack.PlanDestroyComponentSummary(bp, "mycomp")
+
+		if got.Err != nil {
+			t.Fatalf("unexpected error: %v", got.Err)
+		}
+		if got.Destroy != 1 {
+			t.Errorf("expected destroy=1, got %d", got.Destroy)
+		}
+		if len(got.Resources) != 1 || got.Resources[0].Action != ActionDelete {
+			t.Errorf("expected one Delete resource, got %#v", got.Resources)
+		}
+	})
+}
+
 func TestParseTerraformPlanJSON(t *testing.T) {
 	t.Run("ParsesCountsAndResourcesFromEventStream", func(t *testing.T) {
 		// Given a terraform plan -json event stream with summary + planned changes

--- a/pkg/tui/plan/plan.go
+++ b/pkg/tui/plan/plan.go
@@ -506,3 +506,203 @@ func truncateFirstLine(s string) string {
 	}
 	return s
 }
+
+// =============================================================================
+// Destroy renderer
+// =============================================================================
+
+// DestroySummary writes a destroy-plan preview to w. The shape mirrors Summary
+// but with destroy-aware semantics: the header reads "Windsor Destroy Plan",
+// counts collapse to "-N" since every resource is a delete, and IsNew renders
+// as "(no state)" / "(not deployed)" instead of "(new)" — honoring the IsNew
+// dual-meaning contract documented on TerraformComponentPlan. The footer is
+// removed (no streaming-plan equivalent for destroy) and there is no hints
+// block (destroy is gated on a working cluster, so a tooling-missing fallback
+// is not part of the destroy contract). Callers prepend the "this will
+// permanently destroy..." confirmation language; this function only renders
+// the plan body.
+func DestroySummary(w io.Writer, tfPlans []terraforminfra.TerraformComponentPlan, k8sPlans []fluxinfra.KustomizePlan, noColor bool) {
+	nameWidth := 20
+	for _, p := range tfPlans {
+		if n := len(terraformDisplayName(p)); n > nameWidth {
+			nameWidth = n
+		}
+	}
+	for _, p := range k8sPlans {
+		if len(p.Name) > nameWidth {
+			nameWidth = len(p.Name)
+		}
+	}
+	nameWidth += 2
+
+	sep := strings.Repeat("═", nameWidth+26)
+	fmt.Fprintf(w, "\nWindsor Destroy Plan\n%s\n", sep)
+
+	if len(tfPlans) > 0 {
+		fmt.Fprintln(w, "\nTerraform")
+		for _, p := range tfPlans {
+			fmt.Fprintf(w, "  %-*s  %s\n", nameWidth, terraformDisplayName(p), formatTerraformDestroyPlan(p, noColor))
+			if p.Err != nil {
+				lines := strings.Split(strings.TrimSpace(p.Err.Error()), "\n")
+				for _, line := range lines[1:] {
+					fmt.Fprintf(w, "  %s  %s\n", strings.Repeat(" ", nameWidth), line)
+				}
+			}
+			writeResourceList(w, terraformResourceChanges(p.Resources), noColor)
+		}
+	}
+
+	if len(k8sPlans) > 0 {
+		fmt.Fprintln(w, "\nKustomize")
+		for _, p := range k8sPlans {
+			fmt.Fprintf(w, "  %-*s  %s\n", nameWidth, p.Name, formatKustomizeDestroyPlan(p, noColor))
+			if p.Err != nil {
+				lines := strings.Split(strings.TrimSpace(p.Err.Error()), "\n")
+				for _, line := range lines[1:] {
+					fmt.Fprintf(w, "  %s  %s\n", strings.Repeat(" ", nameWidth), line)
+				}
+			}
+			writeResourceList(w, kustomizeResourceChanges(p.Resources), noColor)
+		}
+	}
+
+	if len(tfPlans) == 0 && len(k8sPlans) == 0 {
+		fmt.Fprintln(w, "\n  (no components in blueprint)")
+	}
+
+	fmt.Fprintln(w)
+}
+
+// DestroySummaryJSON encodes destroy-plan results as JSON to w. The schema
+// mirrors SummaryJSON but is_new is documented as carrying its destroy-side
+// meaning ("no state to destroy") so machine consumers can interpret correctly.
+// Action strings on resources are still create/update/delete/replace, but the
+// only value destroy plans actually emit is "delete".
+func DestroySummaryJSON(w io.Writer, tfPlans []terraforminfra.TerraformComponentPlan, k8sPlans []fluxinfra.KustomizePlan) error {
+	type resourceRow struct {
+		Address string `json:"address"`
+		Action  string `json:"action"`
+	}
+	type tfRow struct {
+		Component string        `json:"component"`
+		Path      string        `json:"path,omitempty"`
+		Destroy   int           `json:"destroy"`
+		NoChanges bool          `json:"no_changes"`
+		IsNew     bool          `json:"is_new"`
+		Resources []resourceRow `json:"resources,omitempty"`
+		Error     string        `json:"error,omitempty"`
+	}
+	type k8sRow struct {
+		Name      string        `json:"name"`
+		Removed   int           `json:"removed"`
+		IsNew     bool          `json:"is_new"`
+		Degraded  bool          `json:"degraded"`
+		Resources []resourceRow `json:"resources,omitempty"`
+		Error     string        `json:"error,omitempty"`
+	}
+	type output struct {
+		Terraform []tfRow  `json:"terraform,omitempty"`
+		Kustomize []k8sRow `json:"kustomize,omitempty"`
+	}
+
+	out := output{}
+	for _, p := range tfPlans {
+		row := tfRow{
+			Component: p.ComponentID,
+			Path:      p.Path,
+			Destroy:   p.Destroy,
+			NoChanges: p.NoChanges,
+			IsNew:     p.IsNew,
+		}
+		for _, r := range p.Resources {
+			row.Resources = append(row.Resources, resourceRow{Address: r.Address, Action: terraformActionString(r.Action)})
+		}
+		if p.Err != nil {
+			row.Error = p.Err.Error()
+		}
+		out.Terraform = append(out.Terraform, row)
+	}
+	for _, p := range k8sPlans {
+		row := k8sRow{Name: p.Name, Removed: p.Removed, IsNew: p.IsNew, Degraded: p.Degraded}
+		for _, r := range p.Resources {
+			row.Resources = append(row.Resources, resourceRow{Address: r.Address, Action: kustomizeActionString(r.Action)})
+		}
+		if p.Err != nil {
+			row.Error = p.Err.Error()
+		}
+		out.Kustomize = append(out.Kustomize, row)
+	}
+
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(out)
+}
+
+// formatTerraformDestroyPlan returns the right-hand-side status string for one
+// Terraform component on the destroy path. IsNew here means "no state to
+// destroy" — distinct from the apply-side meaning of "never applied" — so it
+// renders as "(no state)" rather than "(new)". When Resources is populated,
+// the count is rendered as "-N" (every entry is a delete in destroy mode).
+// When Resources is empty but Destroy>0 (older code path without resource
+// enumeration), fall back to the raw count for honesty.
+func formatTerraformDestroyPlan(p terraforminfra.TerraformComponentPlan, noColor bool) string {
+	if p.Err != nil {
+		msg := truncateFirstLine(p.Err.Error())
+		if noColor {
+			return fmt.Sprintf("(error: %s)", msg)
+		}
+		return fmt.Sprintf("\033[31m(error: %s)\033[0m", msg)
+	}
+	if p.IsNew {
+		if noColor {
+			return "(no state)"
+		}
+		return "\033[36m(no state)\033[0m"
+	}
+	if len(p.Resources) > 0 {
+		return formatDestroyCount(len(terraformResourceChanges(p.Resources)), noColor)
+	}
+	if p.NoChanges || p.Destroy == 0 {
+		return "(nothing to destroy)"
+	}
+	return formatDestroyCount(p.Destroy, noColor)
+}
+
+// formatKustomizeDestroyPlan returns the right-hand-side status string for one
+// Flux kustomization on the destroy path. IsNew means "kustomization is not
+// present in the cluster" — the cluster-query equivalent of terraform's
+// "(no state)" — and renders as "(not deployed)". Resources populated implies
+// a "-N" count; absent resources with non-zero Removed falls back to the
+// inventory count.
+func formatKustomizeDestroyPlan(p fluxinfra.KustomizePlan, noColor bool) string {
+	if p.Err != nil {
+		msg := truncateFirstLine(p.Err.Error())
+		if noColor {
+			return fmt.Sprintf("(error: %s)", msg)
+		}
+		return fmt.Sprintf("\033[31m(error: %s)\033[0m", msg)
+	}
+	if p.IsNew {
+		if noColor {
+			return "(not deployed)"
+		}
+		return "\033[36m(not deployed)\033[0m"
+	}
+	if len(p.Resources) > 0 {
+		return formatDestroyCount(len(kustomizeResourceChanges(p.Resources)), noColor)
+	}
+	if p.Removed == 0 {
+		return "(nothing to destroy)"
+	}
+	return formatDestroyCount(p.Removed, noColor)
+}
+
+// formatDestroyCount renders the per-component "-N" count in red, matching the
+// resource-list symbol vocabulary. Distinct from formatRawCounts (apply path)
+// because destroy plans only ever have one bucket.
+func formatDestroyCount(n int, noColor bool) string {
+	if noColor {
+		return fmt.Sprintf("-%d", n)
+	}
+	return fmt.Sprintf("\033[31m-%d\033[0m", n)
+}

--- a/pkg/tui/plan/plan_test.go
+++ b/pkg/tui/plan/plan_test.go
@@ -355,3 +355,224 @@ func TestRenderPlanSummary(t *testing.T) {
 		}
 	})
 }
+
+func TestFormatTerraformDestroyPlan(t *testing.T) {
+	t.Run("RendersNoStateWhenIsNew", func(t *testing.T) {
+		// IsNew on the destroy path means "no state to destroy" — must render
+		// "(no state)" rather than the apply-side "(new)" per the IsNew dual-
+		// meaning contract on TerraformComponentPlan.
+		got := formatTerraformDestroyPlan(terraforminfra.TerraformComponentPlan{
+			ComponentID: "vpc",
+			IsNew:       true,
+		}, true)
+		if got != "(no state)" {
+			t.Errorf("expected (no state), got %q", got)
+		}
+	})
+
+	t.Run("ErrorTakesPrecedenceOverIsNew", func(t *testing.T) {
+		got := formatTerraformDestroyPlan(terraforminfra.TerraformComponentPlan{
+			ComponentID: "vpc",
+			IsNew:       true,
+			Err:         fmt.Errorf("boom"),
+		}, true)
+		if !strings.Contains(got, "boom") {
+			t.Errorf("expected error message to win, got %q", got)
+		}
+	})
+
+	t.Run("RendersDestroyCountFromResources", func(t *testing.T) {
+		// When Resources is populated, the count is the resource list length —
+		// the header row matches what the operator sees expanded below it.
+		got := formatTerraformDestroyPlan(terraforminfra.TerraformComponentPlan{
+			ComponentID: "cluster",
+			Destroy:     5,
+			Resources: []terraforminfra.ResourceChange{
+				{Address: "aws_eks.main", Action: terraforminfra.ActionDelete},
+				{Address: "aws_iam_role.eks", Action: terraforminfra.ActionDelete},
+			},
+		}, true)
+		if got != "-2" {
+			t.Errorf("expected -2 (resource-derived), got %q", got)
+		}
+	})
+
+	t.Run("FallsBackToDestroyFieldWhenResourcesEmpty", func(t *testing.T) {
+		// Without Resources we fall back to the raw Destroy field for honesty.
+		got := formatTerraformDestroyPlan(terraforminfra.TerraformComponentPlan{
+			ComponentID: "vpc",
+			Destroy:     7,
+		}, true)
+		if got != "-7" {
+			t.Errorf("expected -7, got %q", got)
+		}
+	})
+
+	t.Run("RendersNothingToDestroyWhenZero", func(t *testing.T) {
+		// Edge case: state exists but plan -destroy reports zero deletions.
+		// Should not silently pretend there's work; explicit message instead.
+		got := formatTerraformDestroyPlan(terraforminfra.TerraformComponentPlan{
+			ComponentID: "vpc",
+		}, true)
+		if got != "(nothing to destroy)" {
+			t.Errorf("expected (nothing to destroy), got %q", got)
+		}
+	})
+}
+
+func TestFormatKustomizeDestroyPlan(t *testing.T) {
+	t.Run("RendersNotDeployedWhenIsNew", func(t *testing.T) {
+		// IsNew on the kustomize destroy path means "kustomization absent from
+		// cluster" — render as "(not deployed)" to match operator vocabulary.
+		got := formatKustomizeDestroyPlan(fluxinfra.KustomizePlan{
+			Name:  "monitoring",
+			IsNew: true,
+		}, true)
+		if got != "(not deployed)" {
+			t.Errorf("expected (not deployed), got %q", got)
+		}
+	})
+
+	t.Run("RendersDestroyCountFromResources", func(t *testing.T) {
+		got := formatKustomizeDestroyPlan(fluxinfra.KustomizePlan{
+			Name:    "monitoring",
+			Removed: 99,
+			Resources: []fluxinfra.ResourceChange{
+				{Address: "Deployment/monitoring/grafana", Action: fluxinfra.ActionDelete},
+				{Address: "ConfigMap/monitoring/grafana-config", Action: fluxinfra.ActionDelete},
+				{Address: "Service/monitoring/grafana", Action: fluxinfra.ActionDelete},
+			},
+		}, true)
+		if got != "-3" {
+			t.Errorf("expected -3 (resource-derived), got %q", got)
+		}
+	})
+
+	t.Run("RendersNothingToDestroyForEmptyKustomization", func(t *testing.T) {
+		// Kustomization exists but has empty inventory (e.g., suspended) — say
+		// so explicitly.
+		got := formatKustomizeDestroyPlan(fluxinfra.KustomizePlan{
+			Name: "monitoring",
+		}, true)
+		if got != "(nothing to destroy)" {
+			t.Errorf("expected (nothing to destroy), got %q", got)
+		}
+	})
+}
+
+func TestDestroySummary(t *testing.T) {
+	t.Run("HeaderReadsDestroyPlanNotPlanSummary", func(t *testing.T) {
+		// The header text disambiguates apply-vs-destroy at a glance for the
+		// operator. Distinct from Summary's "Windsor Plan Summary".
+		var buf strings.Builder
+		DestroySummary(&buf, nil, nil, true)
+		out := buf.String()
+		if !strings.Contains(out, "Windsor Destroy Plan") {
+			t.Errorf("expected Windsor Destroy Plan header, got:\n%s", out)
+		}
+		if strings.Contains(out, "Windsor Plan Summary") {
+			t.Errorf("did not expect apply-side header, got:\n%s", out)
+		}
+	})
+
+	t.Run("RendersIsNewAsNoStateForTerraform", func(t *testing.T) {
+		// End-to-end check that a destroy-side TerraformComponentPlan with
+		// IsNew=true does not regress to the apply-side "(new)" string.
+		var buf strings.Builder
+		DestroySummary(&buf,
+			[]terraforminfra.TerraformComponentPlan{{ComponentID: "vpc", IsNew: true}},
+			nil, true)
+		out := buf.String()
+		if !strings.Contains(out, "(no state)") {
+			t.Errorf("expected (no state) for IsNew terraform component, got:\n%s", out)
+		}
+		if strings.Contains(out, "(new)") {
+			t.Errorf("destroy renderer must not emit (new) — IsNew dual-meaning regression, got:\n%s", out)
+		}
+	})
+
+	t.Run("RendersIsNewAsNotDeployedForKustomize", func(t *testing.T) {
+		var buf strings.Builder
+		DestroySummary(&buf, nil,
+			[]fluxinfra.KustomizePlan{{Name: "monitoring", IsNew: true}},
+			true)
+		out := buf.String()
+		if !strings.Contains(out, "(not deployed)") {
+			t.Errorf("expected (not deployed) for IsNew kustomization, got:\n%s", out)
+		}
+		if strings.Contains(out, "(new)") {
+			t.Errorf("destroy renderer must not emit (new), got:\n%s", out)
+		}
+	})
+
+	t.Run("EnumeratesDeleteResourcesUnderEachComponent", func(t *testing.T) {
+		// Operators see the same "- <address>" list shape they get on the apply
+		// side, just with delete-only entries.
+		var buf strings.Builder
+		DestroySummary(&buf,
+			[]terraforminfra.TerraformComponentPlan{{
+				ComponentID: "cluster", Path: "cluster/aws-eks", Destroy: 2,
+				Resources: []terraforminfra.ResourceChange{
+					{Address: "aws_eks_cluster.main", Action: terraforminfra.ActionDelete},
+					{Address: "aws_iam_role.eks", Action: terraforminfra.ActionDelete},
+				},
+			}},
+			[]fluxinfra.KustomizePlan{{
+				Name: "monitoring", Removed: 1,
+				Resources: []fluxinfra.ResourceChange{
+					{Address: "Deployment/monitoring/grafana", Action: fluxinfra.ActionDelete},
+				},
+			}},
+			true)
+		out := buf.String()
+		for _, want := range []string{
+			"- aws_eks_cluster.main",
+			"- aws_iam_role.eks",
+			"- Deployment/monitoring/grafana",
+		} {
+			if !strings.Contains(out, want) {
+				t.Errorf("expected output to contain %q, got:\n%s", want, out)
+			}
+		}
+	})
+}
+
+func TestDestroySummaryJSON(t *testing.T) {
+	t.Run("EmitsResourcesWithDeleteAction", func(t *testing.T) {
+		var buf strings.Builder
+		err := DestroySummaryJSON(&buf,
+			[]terraforminfra.TerraformComponentPlan{{
+				ComponentID: "cluster",
+				Destroy:     2,
+				Resources: []terraforminfra.ResourceChange{
+					{Address: "aws_eks_cluster.main", Action: terraforminfra.ActionDelete},
+				},
+			}},
+			[]fluxinfra.KustomizePlan{{
+				Name:    "monitoring",
+				Removed: 1,
+				Resources: []fluxinfra.ResourceChange{
+					{Address: "Deployment/monitoring/grafana", Action: fluxinfra.ActionDelete},
+				},
+			}},
+		)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		out := buf.String()
+		for _, want := range []string{
+			`"address": "aws_eks_cluster.main"`,
+			`"action": "delete"`,
+			`"address": "Deployment/monitoring/grafana"`,
+		} {
+			if !strings.Contains(out, want) {
+				t.Errorf("expected JSON to contain %q, got:\n%s", want, out)
+			}
+		}
+		// Schema should not carry the apply-side add/change/no_changes counts
+		// for kustomize since they don't apply to destroy.
+		if strings.Contains(out, `"add":`) || strings.Contains(out, `"change":`) {
+			t.Errorf("destroy JSON should not carry apply-side counts, got:\n%s", out)
+		}
+	})
+}


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> This PR touches shared provisioner interfaces across the Terraform and Flux stacks and wires a new plan-preview pipeline into every `windsor destroy` command path, so regressions would silently skip the preview or misrender resource counts.
>
> **Overview**
>
> The PR adds `PlanDestroySummary` and `PlanDestroyComponentSummary` to both the Terraform and Flux `Stack` interfaces and wires them into all destroy command paths — full destroy, terraform-only, kustomize-only, and single-component variants — so the operator sees a resource list before the confirmation prompt. The Terraform side runs `terraform plan -destroy -json` with destroy-mode environment variables and filters `destroy=false` pinned components. The Flux side queries live cluster inventory from `.status.inventory.entries` rather than building from blueprint manifests, since cluster state is the authoritative source of what Flux will actually prune.
>
> The two findings from earlier passes are now closed. `kustomizationDestroyEligible` received the explicit nil guard on `k.Destroy` that mirrors the terraform side, and `GetKustomizationInventory`'s header comment now accurately documents that malformed inventory entries are silently dropped rather than propagated. One low-severity note remains open: `inventoryAddress` omits the API group from the rendered address, which can produce ambiguous output on clusters with overlapping CRD Kinds across groups.
>
> Reviewed by Claude for commit `b97df7eb`.

<!-- /claude-code-review:summary -->
