### PR TITLE
chore(ci): add nightly build workflow and update release naming conventions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,6 +160,53 @@ jobs:
           GOTOOLCHAIN: 'auto'
           GOFLAGS: '-buildvcs=false'
 
+  build-nightly:
+    runs-on: ubuntu-latest
+    needs: [build-and-test, sast-scan]
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    concurrency:
+      group: build-nightly
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 renovate: depName=actions/setup-go
+        with:
+          go-version-file: go.mod
+
+      - name: Pin blueprint to core :latest
+        run: echo "PINNED_BLUEPRINT_URL=oci://ghcr.io/windsorcli/core:latest" >> $GITHUB_ENV
+        shell: bash
+
+      - name: Build artifacts (GoReleaser snapshot)
+        uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
+        with:
+          version: "~> v2"
+          args: release --snapshot --clean --skip=sign
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_SHA: ${{ github.sha }}
+
+      - name: Replace nightly release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SHA: ${{ github.sha }}
+        run: |
+          gh release delete nightly --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" || true
+          gh release create nightly \
+            --repo "$GITHUB_REPOSITORY" \
+            --prerelease \
+            --target "$SHA" \
+            --title "Nightly (latest main)" \
+            --notes "Rolling build from \`main\` @ ${SHA:0:7}. Unstable — for users living on the edge." \
+            dist/windsor_nightly_*.tar.gz dist/windsor_nightly_*.zip dist/checksums.txt
+        shell: bash
+
   release:
     runs-on: windows-latest
     needs: [build-and-test, sast-scan]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -197,6 +197,15 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SHA: ${{ github.sha }}
         run: |
+          shopt -s nullglob
+          artifacts=(dist/windsor_nightly_*.tar.gz dist/windsor_nightly_*.zip)
+          shopt -u nullglob
+
+          if [[ ${#artifacts[@]} -eq 0 ]]; then
+            echo "No nightly artifacts found in dist/" >&2
+            exit 1
+          fi
+
           gh release delete nightly --yes --cleanup-tag --repo "$GITHUB_REPOSITORY" || true
           gh release create nightly \
             --repo "$GITHUB_REPOSITORY" \
@@ -204,7 +213,7 @@ jobs:
             --target "$SHA" \
             --title "Nightly (latest main)" \
             --notes "Rolling build from \`main\` @ ${SHA:0:7}. Unstable — for users living on the edge." \
-            dist/windsor_nightly_*.tar.gz dist/windsor_nightly_*.zip dist/checksums.txt
+            "${artifacts[@]}" dist/checksums.txt
         shell: bash
 
   release:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,11 +31,19 @@ builds:
 # Archive configuration
 archives:
   - id: windsor
+    name_template: >-
+      {{- .ProjectName }}_
+      {{- if .IsSnapshot }}nightly{{ else }}{{ .Version }}{{ end }}_
+      {{- .Os }}_{{ .Arch -}}
     formats:
       - tar.gz
     format_overrides:
       - goos: windows
         format: zip
+
+checksum:
+  name_template: >-
+    {{- if .IsSnapshot }}checksums.txt{{ else }}{{ .ProjectName }}_{{ .Version }}_checksums.txt{{ end -}}
 
 changelog:
   sort: asc


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This is a purely additive CI change; no application code is modified, and the new nightly job is gated behind `github.ref == 'refs/heads/main'` so it cannot interfere with PR builds or the existing release workflow.
>
> **Overview**
>
> The PR introduces a `build-nightly` CI job that fires on every push to `main` after `build-and-test` and `sast-scan` pass, replacing a rolling `nightly` GitHub pre-release with fresh GoReleaser snapshot artifacts. It pairs this with `.goreleaser.yaml` changes that inject `nightly` into archive and checksum file names for snapshot builds, so the nightly upload glob resolves cleanly to `dist/windsor_nightly_*` and `dist/checksums.txt`.
>
> The follow-up push adds `shopt -s nullglob` around the artifact collection and an explicit empty-array guard, cleanly resolving the earlier glob-safety concern. The `dist/checksums.txt` path remains a static literal — GoReleaser guarantees it for snapshot builds — and the `aqua.yaml` bump is a routine dependency update.
>
> Reviewed by Claude for commit `49d1317`.

<!-- /claude-code-review:summary -->
