### PR TITLE
fix(terraform): update destroy plan arguments to prevent auto-approve flag

### DIFF
--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -1325,8 +1325,8 @@ func (s *TerraformStack) planOneTerraformDestroySummary(component *blueprintv1al
 	}
 
 	terraformCommand := s.runtime.ToolsManager.GetTerraformCommand()
-	planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan", "-destroy", "-json", "-no-color"}
-	planArgs = append(planArgs, terraformArgs.DestroyArgs...)
+	planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan", "-json", "-no-color"}
+	planArgs = append(planArgs, terraformArgs.PlanDestroyArgs...)
 	planEnv := selectTerraformCommandEnv(terraformVars, true)
 	planOutput, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, planEnv, planArgs...)
 	if err != nil {

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -3851,14 +3851,22 @@ func TestStack_PlanDestroySummary(t *testing.T) {
 		results := stack.PlanDestroySummary(createTestBlueprint())
 
 		// Then the plan command included -destroy and used destroy-mode env
-		var sawDestroyFlag bool
+		var sawDestroyFlag, sawAutoApprove bool
 		for _, a := range capturedArgs {
 			if a == "-destroy" {
 				sawDestroyFlag = true
 			}
+			if a == "-auto-approve" {
+				sawAutoApprove = true
+			}
 		}
 		if !sawDestroyFlag {
 			t.Errorf("expected -destroy flag in plan args, got %v", capturedArgs)
+		}
+		// terraform plan rejects -auto-approve (apply/destroy flag); leaking it in
+		// from DestroyArgs caused every destroy plan to fail with exit status 1.
+		if sawAutoApprove {
+			t.Errorf("plan -destroy must not include -auto-approve, got args %v", capturedArgs)
 		}
 		if capturedEnv["TF_VAR_operation"] != "destroy" {
 			t.Errorf("expected TF_VAR_operation=destroy, got %q", capturedEnv["TF_VAR_operation"])


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This is an isolated correctness fix in a single plan-only code path with no impact on apply or destroy operations.
>
> **Overview**
>
> `planOneTerraformDestroySummary` was appending `DestroyArgs` to its `terraform plan` invocation. In non-interactive mode, `DestroyArgs` includes `-auto-approve`, which `terraform plan` rejects outright, causing every destroy preview to fail with exit status 1. The fix replaces `DestroyArgs` with the purpose-built `PlanDestroyArgs`, which carries `-destroy` and var-file args but no `-auto-approve`.
>
> The updated test adds an assertion that `-auto-approve` is absent from the plan invocation alongside the existing check that `-destroy` is present, closing the regression gap cleanly. One minor follow-up worth a separate commit: the function header comment on `planOneTerraformDestroySummary` still reads "TF_VAR_operation=destroy + DestroyArgs" and should be updated to "PlanDestroyArgs" to keep the documentation accurate.
>
> Reviewed by Claude for commit `1facb94b`.

<!-- /claude-code-review:summary -->
