### PR TITLE
fix(flux): handle missing kubeconfig in destroy plan to ensure idempotency

### DIFF
--- a/pkg/provisioner/flux/stack.go
+++ b/pkg/provisioner/flux/stack.go
@@ -292,9 +292,14 @@ func (s *FluxStack) PlanComponentSummary(blueprint *blueprintv1alpha1.Blueprint,
 // kustomizations only (DestroyOnly hooks are applied during destroy and are
 // not user-facing here), and any pinned with destroy=false are filtered out.
 // A kustomization that is absent from the cluster yields IsNew=true so the
-// renderer shows "(not deployed)". An error from the cluster propagates as
-// the function-level error, since destroy itself cannot proceed without
-// cluster connectivity — falling back would produce a misleading plan.
+// renderer shows "(not deployed)". A missing kubeconfig is treated the same
+// way: kustomizations are cluster-scoped resources, so "no cluster reachable"
+// implies "nothing deployed" by definition. This keeps `windsor destroy`
+// idempotent — after the cluster's terraform component tears down the
+// kubeconfig, a subsequent destroy can still plan and run terraform-only
+// teardown rather than failing to query a cluster that no longer exists.
+// Other cluster errors still propagate, since they can indicate transient
+// connectivity problems where falling back would produce a misleading plan.
 func (s *FluxStack) PlanDestroySummary(blueprint *blueprintv1alpha1.Blueprint) ([]KustomizePlan, error) {
 	if blueprint == nil {
 		return nil, nil
@@ -378,6 +383,14 @@ func (s *FluxStack) planOneKustomizeDestroySummary(k blueprintv1alpha1.Kustomiza
 
 	entries, err := s.kubernetesManager.GetKustomizationInventory(k.Name, namespace)
 	if err != nil {
+		// A missing kubeconfig means the cluster the kustomization would live on does
+		// not exist — typically right after `windsor destroy` tore down the cluster's
+		// terraform component. Treat as "not deployed" so subsequent destroy cycles
+		// can still produce a plan.
+		if errors.Is(err, os.ErrNotExist) {
+			result.IsNew = true
+			return result, nil
+		}
 		return result, fmt.Errorf("error querying kustomization %q inventory: %w", k.Name, err)
 	}
 	if entries == nil {

--- a/pkg/provisioner/flux/stack_test.go
+++ b/pkg/provisioner/flux/stack_test.go
@@ -885,6 +885,36 @@ func TestFluxStack_PlanDestroySummary(t *testing.T) {
 		}
 	})
 
+	t.Run("TreatsMissingKubeconfigAsNotDeployed", func(t *testing.T) {
+		// After `windsor destroy` tears down the cluster's terraform component,
+		// the kubeconfig is gone. Subsequent destroy cycles must still produce a
+		// plan rather than fail to query a cluster that no longer exists. The
+		// kustomizations are by definition not deployed (they live on the cluster
+		// that was just destroyed), so each result should be IsNew=true.
+		m := setupFluxMocks(t)
+		m.kubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
+			return nil, fmt.Errorf("stat /home/user/.kube/config: %w", os.ErrNotExist)
+		}
+		s := newTestFluxStack(m)
+
+		results, err := s.PlanDestroySummary(testBlueprint())
+
+		if err != nil {
+			t.Fatalf("expected nil error when kubeconfig is missing, got %v", err)
+		}
+		if len(results) == 0 {
+			t.Fatal("expected results for blueprint kustomizations, got none")
+		}
+		for _, r := range results {
+			if !r.IsNew {
+				t.Errorf("expected IsNew=true for kustomization %q when kubeconfig is missing, got false", r.Name)
+			}
+			if len(r.Resources) != 0 {
+				t.Errorf("expected no resources for kustomization %q, got %#v", r.Name, r.Resources)
+			}
+		}
+	})
+
 	t.Run("FiltersDestroyOnlyAndDestroyFalse", func(t *testing.T) {
 		// destroyOnly hooks and pinned destroy=false kustomizations are filtered
 		// to match DeleteBlueprint's eligibility gate.


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> The change is isolated to the destroy-plan kustomization query path in a single private helper and is fully reversible.
>
> **Overview**
>
> This PR makes `windsor destroy` idempotent across back-to-back destroy cycles. When the cluster's Terraform component is torn down first, its kubeconfig file disappears; the previous code propagated the resulting file-not-found error from `client-go` as a hard failure, preventing further destroy runs from planning. The fix intercepts `os.ErrNotExist` at the point where `planOneKustomizeDestroySummary` queries the live kustomization inventory and marks each kustomization as `IsNew=true` ("not deployed"), allowing terraform-only teardown to proceed.
>
> The sentinel matching is reliable: `client-go` v0.36 returns an unwrapped `*os.PathError` (ENOENT) directly from `os.Stat` when the explicit kubeconfig path is absent, and that error propagates without re-wrapping through the full `ensureClient` → `GetResource` → `GetKustomizationInventory` chain. Other cluster errors — transient connectivity failures, auth failures — remain hard errors, matching the stated intent.
>
> Reviewed by Claude for commit `1407481`.
<!-- /claude-code-review:summary -->
