### PR TITLE
fix(ci): skip chocolatey packaging on snapshot versions to ensure valid SemVer

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -187,7 +187,11 @@ jobs:
         uses: goreleaser/goreleaser-action@1a80836c5c9d9e5755a25cb59ec6f45a3b5f41a8 # v7.2.1
         with:
           version: "~> v2"
-          args: release --snapshot --clean --skip=sign
+          # chocolatey packaging rejects the snapshot version string
+          # (nightly-SNAPSHOT-<sha> isn't valid SemVer); skip it on nightlies.
+          # Real releases run on a tag with a SemVer version, so chocolatey
+          # still ships via the separate `release` job below.
+          args: release --snapshot --clean --skip=sign,chocolatey
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_SHA: ${{ github.sha }}


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This is a CI-only change to a single workflow step with no effect on release packaging or end-user artifacts.
>
> **Overview**
>
> The PR adds `chocolatey` to the `--skip` flag in GoReleaser's snapshot job, preventing it from attempting to package for Chocolatey when the version string is `nightly-SNAPSHOT-<sha>` — a format Chocolatey rejects as non-SemVer. The fix is a one-word addition to an existing argument; the separate `release` job that runs on real SemVer tags is untouched, so Chocolatey packages for production releases continue to ship normally.
>
> Reviewed by Claude for commit `6ed6f99`.

<!-- /claude-code-review:summary -->
