### PR TITLE
feat(bootstrap): enable confirmation prompt for local mode

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -173,7 +173,7 @@ var bootstrapCmd = &cobra.Command{
 
 		var confirmFn provisioner.BootstrapConfirmFn
 		finishPlan := func(error) {}
-		if proj.Runtime.Global && !bootstrapYes {
+		if !bootstrapYes {
 			confirmFn, finishPlan = makeBootstrapConfirmFn(cmd.InOrStdin(), os.Stderr)
 		}
 
@@ -216,8 +216,10 @@ var bootstrapCmd = &cobra.Command{
 //
 // Anything other than "y" or "yes" (case-insensitive) at the prompt returns
 // false — including empty input and EOF, so non-interactive callers must pass
-// --yes. Reserved for global mode by the caller; in local project mode the
-// operator has the directory-level cue and can run `windsor plan` separately.
+// --yes. Fires in both global and local project modes; the directory-level
+// cue alone isn't enough to tell an operator which components and
+// kustomizations are about to move, especially when bootstrap re-applies on
+// top of partial state.
 func makeBootstrapConfirmFn(in io.Reader, out io.Writer) (provisioner.BootstrapConfirmFn, func(error)) {
 	resolved := false
 	confirmFn := func(summary *provisioner.BootstrapSummary) bool {

--- a/cmd/bootstrap_test.go
+++ b/cmd/bootstrap_test.go
@@ -925,4 +925,34 @@ func TestBootstrapCmd(t *testing.T) {
 			t.Error("Up must not be called after a declined summary-confirm in local mode")
 		}
 	})
+
+	t.Run("LocalModeSummaryConfirmExitsCleanlyOnEmptyStdin", func(t *testing.T) {
+		// Given a local-project runtime and empty stdin (non-interactive without
+		// --yes), the prompt receives EOF and treats it as "no" — exit is clean
+		// rather than producing a non-zero failure. Mirrors the global-mode case
+		// so the prompt-read loop is locked in for both modes.
+		mocks := setupBootstrapTest(t)
+		mocks.Runtime.Global = false
+		var upCalled bool
+		mocks.TerraformStack.UpFunc = func(_ *blueprintv1alpha1.Blueprint, _ ...func(id string) error) error {
+			upCalled = true
+			return nil
+		}
+		proj := newBootstrapTestProject(mocks)
+
+		cmd := createTestBootstrapCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{})
+		cmd.SetContext(ctx)
+		cmd.SetIn(strings.NewReader(""))
+
+		err := cmd.Execute()
+
+		if err != nil {
+			t.Fatalf("Expected clean exit on EOF stdin, got error: %v", err)
+		}
+		if upCalled {
+			t.Error("Up must not be called when EOF declines summary-confirm in local mode")
+		}
+	})
 }

--- a/cmd/bootstrap_test.go
+++ b/cmd/bootstrap_test.go
@@ -182,7 +182,7 @@ func TestBootstrapCmd(t *testing.T) {
 
 		cmd := createTestBootstrapCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
-		cmd.SetArgs([]string{})
+		cmd.SetArgs([]string{"--yes"})
 		cmd.SetContext(ctx)
 
 		// When executing bootstrap
@@ -217,7 +217,7 @@ func TestBootstrapCmd(t *testing.T) {
 
 		cmd := createTestBootstrapCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
-		cmd.SetArgs([]string{})
+		cmd.SetArgs([]string{"--yes"})
 		cmd.SetContext(ctx)
 
 		// When executing bootstrap
@@ -252,7 +252,7 @@ func TestBootstrapCmd(t *testing.T) {
 
 		cmd := createTestBootstrapCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
-		cmd.SetArgs([]string{})
+		cmd.SetArgs([]string{"--yes"})
 		cmd.SetContext(ctx)
 
 		// When executing bootstrap
@@ -305,7 +305,7 @@ func TestBootstrapCmd(t *testing.T) {
 
 		cmd := createTestBootstrapCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
-		cmd.SetArgs([]string{})
+		cmd.SetArgs([]string{"--yes"})
 		cmd.SetContext(ctx)
 
 		if err := cmd.Execute(); err != nil {
@@ -347,7 +347,7 @@ func TestBootstrapCmd(t *testing.T) {
 
 		cmd := createTestBootstrapCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
-		cmd.SetArgs([]string{})
+		cmd.SetArgs([]string{"--yes"})
 		cmd.SetContext(ctx)
 
 		if err := cmd.Execute(); err != nil {
@@ -394,7 +394,7 @@ func TestBootstrapCmd(t *testing.T) {
 
 		cmd := createTestBootstrapCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
-		cmd.SetArgs([]string{})
+		cmd.SetArgs([]string{"--yes"})
 		cmd.SetContext(ctx)
 
 		err := cmd.Execute()
@@ -422,7 +422,7 @@ func TestBootstrapCmd(t *testing.T) {
 
 		cmd := createTestBootstrapCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
-		cmd.SetArgs([]string{"staging"})
+		cmd.SetArgs([]string{"staging", "--yes"})
 		cmd.SetContext(ctx)
 
 		// When executing bootstrap with a positional context arg
@@ -449,7 +449,7 @@ func TestBootstrapCmd(t *testing.T) {
 
 		cmd := createTestBootstrapCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
-		cmd.SetArgs([]string{"--blueprint", "oci://example.com/test:v1"})
+		cmd.SetArgs([]string{"--blueprint", "oci://example.com/test:v1", "--yes"})
 		cmd.SetContext(ctx)
 
 		// When executing bootstrap with --blueprint
@@ -488,7 +488,7 @@ func TestBootstrapCmd(t *testing.T) {
 
 		cmd := createTestBootstrapCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
-		cmd.SetArgs([]string{"--set", "dns.enabled=false"})
+		cmd.SetArgs([]string{"--set", "dns.enabled=false", "--yes"})
 		cmd.SetContext(ctx)
 
 		// When executing bootstrap with --set
@@ -626,7 +626,9 @@ func TestBootstrapCmd(t *testing.T) {
 	})
 
 	t.Run("PromptsAndProceedsOnYes", func(t *testing.T) {
-		// Given a context whose values.yaml already exists (simulating prior configuration)
+		// Given a context whose values.yaml already exists (simulating prior configuration),
+		// the operator faces two prompts in sequence: the existing-context guard and the
+		// bootstrap summary. Sending "y" to each lets bootstrap proceed end-to-end.
 		mocks := setupBootstrapTest(t)
 		configRoot := mocks.TmpDir + "/contexts/test-context"
 		if err := os.MkdirAll(configRoot, 0755); err != nil {
@@ -641,9 +643,9 @@ func TestBootstrapCmd(t *testing.T) {
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
 		cmd.SetArgs([]string{})
 		cmd.SetContext(ctx)
-		cmd.SetIn(strings.NewReader("y\n"))
+		cmd.SetIn(strings.NewReader("y\ny\n"))
 
-		// When executing bootstrap with "y" on stdin
+		// When executing bootstrap with "y" answers for both prompts
 		if err := cmd.Execute(); err != nil {
 			t.Fatalf("Expected success when user confirms with y, got %v", err)
 		}
@@ -863,10 +865,12 @@ func TestBootstrapCmd(t *testing.T) {
 		}
 	})
 
-	t.Run("LocalModeSkipsSummaryConfirm", func(t *testing.T) {
-		// Given a local-project runtime (Global=false), the global-only
-		// summary-confirm prompt does not fire and bootstrap proceeds without
-		// stdin.
+	t.Run("LocalModeShowsSummaryConfirmAndProceedsOnYes", func(t *testing.T) {
+		// Given a local-project runtime (Global=false), the summary-confirm
+		// prompt fires before apply — the directory-level cue isn't enough
+		// to tell an operator which components are about to move when
+		// bootstrap re-applies on top of partial state. Answering "y" lets
+		// bootstrap continue and Up is invoked.
 		mocks := setupBootstrapTest(t)
 		mocks.Runtime.Global = false
 		var upCalled bool
@@ -880,16 +884,45 @@ func TestBootstrapCmd(t *testing.T) {
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
 		cmd.SetArgs([]string{})
 		cmd.SetContext(ctx)
-		// No stdin — local-mode bootstrap with no values.yaml has no prompts at all.
+		cmd.SetIn(strings.NewReader("y\n"))
 
 		// When executing bootstrap
 		if err := cmd.Execute(); err != nil {
-			t.Fatalf("Expected success in local mode, got %v", err)
+			t.Fatalf("Expected success on yes-confirm, got %v", err)
 		}
 
-		// Then Up runs without any prompt
+		// Then Up runs after the prompt is accepted
 		if !upCalled {
-			t.Error("Up must run in local-project mode")
+			t.Error("Up must run in local-project mode after summary-confirm")
+		}
+	})
+
+	t.Run("LocalModeSummaryConfirmExitsCleanlyOnNo", func(t *testing.T) {
+		// Given a local-project runtime, declining the summary-confirm prompt
+		// exits cleanly with no error and apply does not run — same shape as
+		// the global-mode declined case.
+		mocks := setupBootstrapTest(t)
+		mocks.Runtime.Global = false
+		var upCalled bool
+		mocks.TerraformStack.UpFunc = func(_ *blueprintv1alpha1.Blueprint, _ ...func(id string) error) error {
+			upCalled = true
+			return nil
+		}
+		proj := newBootstrapTestProject(mocks)
+
+		cmd := createTestBootstrapCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{})
+		cmd.SetContext(ctx)
+		cmd.SetIn(strings.NewReader("n\n"))
+
+		err := cmd.Execute()
+
+		if err != nil {
+			t.Fatalf("Expected clean exit on declined plan-confirm, got error: %v", err)
+		}
+		if upCalled {
+			t.Error("Up must not be called after a declined summary-confirm in local mode")
 		}
 	})
 }

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -50,7 +50,9 @@ type SetupOptions struct {
 }
 
 // suppressProcessStdout redirects os.Stdout to a pipe drained to io.Discard for the
-// duration of the test so that commands using fmt.Print do not pollute the terminal. Restores on t.Cleanup.
+// duration of the test so that commands using fmt.Print do not pollute the terminal.
+// The reader goroutine drains continuously — Windows pipe buffers are ~4KB, so deferring
+// the drain to t.Cleanup deadlocks any test that writes more than that. Restores on t.Cleanup.
 func suppressProcessStdout(t *testing.T) {
 	t.Helper()
 	r, w, err := os.Pipe()
@@ -59,15 +61,21 @@ func suppressProcessStdout(t *testing.T) {
 	}
 	orig := os.Stdout
 	os.Stdout = w
-	t.Cleanup(func() {
-		w.Close()
+	done := make(chan struct{})
+	go func() {
 		io.Copy(io.Discard, r)
+		close(done)
+	}()
+	t.Cleanup(func() {
 		os.Stdout = orig
+		w.Close()
+		<-done
 	})
 }
 
 // suppressProcessStderr redirects os.Stderr to a pipe drained to io.Discard for the
-// duration of the test so that command error and progress messages do not pollute the terminal. Restores on t.Cleanup.
+// duration of the test so that command error and progress messages do not pollute the
+// terminal. See suppressProcessStdout for why the drain runs in a goroutine. Restores on t.Cleanup.
 func suppressProcessStderr(t *testing.T) {
 	t.Helper()
 	r, w, err := os.Pipe()
@@ -76,10 +84,15 @@ func suppressProcessStderr(t *testing.T) {
 	}
 	orig := os.Stderr
 	os.Stderr = w
-	t.Cleanup(func() {
-		w.Close()
+	done := make(chan struct{})
+	go func() {
 		io.Copy(io.Discard, r)
+		close(done)
+	}()
+	t.Cleanup(func() {
 		os.Stderr = orig
+		w.Close()
+		<-done
 	})
 }
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> This PR changes bootstrap's interactive behavior for all local-mode callers; any automation invoking `windsor bootstrap` in local project mode without `--yes` will now block on stdin or exit cleanly with "Apply skipped."
>
> **Overview**
>
> The core change is a single line in `bootstrap.go`: the `proj.Runtime.Global` guard is removed so that the summary-confirm prompt fires regardless of mode. Eight existing local-mode tests gain `--yes` to continue passing; `LocalModeSkipsSummaryConfirm` is renamed and rewritten as `LocalModeShowsSummaryConfirmAndProceedsOnYes`, and two new tests cover the "n" and EOF decline paths with proper `upCalled` assertions confirming apply is skipped.
>
> The latest push also corrects a Windows pipe-buffer deadlock in the test helpers: `suppressProcessStdout` and `suppressProcessStderr` now drain the read end in a background goroutine rather than deferring the drain to `t.Cleanup`, eliminating the risk of a blocked write stalling the test before cleanup runs.
>
> Reviewed by Claude for commit `ee950b65`.

<!-- /claude-code-review:summary -->
