### PR TITLE
feat(schema): enhance schema handling with conditional defaults and system schema merging

### DIFF
--- a/pkg/runtime/config/handler.go
+++ b/pkg/runtime/config/handler.go
@@ -107,6 +107,8 @@ func NewConfigHandler(shell shell.Shell) ConfigHandler {
 	handler.values = newValuesSource(handler.shims, handler.schemaValidator, handler.policy)
 	handler.typed = newTypedSource(handler.shims, handler.schemaValidator)
 
+	handler.applySystemSchemaPlugins()
+
 	return handler
 }
 
@@ -195,7 +197,7 @@ func (c *configHandler) LoadConfigForContext(contextName string) error {
 
 	hasLoadedFiles := false
 
-	if c.schemaValidator != nil && c.schemaValidator.Schema == nil {
+	if c.schemaValidator != nil {
 		schemaPath := filepath.Join(projectRoot, "contexts", "_template", "schema.yaml")
 		if _, err := c.shims.Stat(schemaPath); err == nil {
 			if err := c.LoadSchema(schemaPath); err != nil {
@@ -689,13 +691,14 @@ func (c *configHandler) deepMerge(base, overlay map[string]any) map[string]any {
 	return result
 }
 
-// applySystemSchemaPlugins applies system-level schema plugins to the loaded schema.
-// These plugins load schema definitions from embedded YAML files in schemas/ directory
-// and merge them into the loaded schema. System schemas define features like substitutions
-// that are always available regardless of the blueprint schema definition.
+// applySystemSchemaPlugins applies system-level schema defaults to the loaded schema.
+// These plugins load schema definitions from embedded YAML files in schemas/ directory and
+// merge them as defaults: anything an authoritative source (blueprint, API schemas) already
+// defines wins on conflict. This keeps the embedded schemas as a pre-bootstrap safety net
+// without overriding blueprints that define the same fields (e.g., a richer platform enum).
 // This method is extensible - add new schema.yaml files to schemas/ to include additional system schemas.
 func (c *configHandler) applySystemSchemaPlugins() {
-	if c.schemaValidator == nil || c.schemaValidator.Schema == nil {
+	if c.schemaValidator == nil {
 		return
 	}
 
@@ -715,7 +718,7 @@ func (c *configHandler) applySystemSchemaPlugins() {
 			continue
 		}
 
-		if err := c.schemaValidator.LoadSchemaFromBytes(schemaContent); err != nil {
+		if err := c.schemaValidator.MergeSystemDefaults(schemaContent); err != nil {
 			continue
 		}
 	}

--- a/pkg/runtime/config/handler_test.go
+++ b/pkg/runtime/config/handler_test.go
@@ -1412,6 +1412,33 @@ properties:
 			t.Errorf("Expected no error, got %v", err)
 		}
 	})
+
+	t.Run("BlueprintSchemaWinsOverEmbeddedDefaults", func(t *testing.T) {
+		// Given a handler and a blueprint schema that defines a richer platform enum than
+		// the embedded schemas/common.yaml fallback (which omits hyperv)
+		handler, _ := setupPrivateTestHandler(t)
+
+		blueprintSchema := []byte(`$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+properties:
+  platform:
+    type: string
+    enum: [docker, incus, hyperv, metal]
+    default: docker
+additionalProperties: true
+`)
+
+		// When loading the blueprint schema (which triggers applySystemSchemaPlugins)
+		if err := handler.LoadSchemaFromBytes(blueprintSchema); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then values that match the blueprint enum but not the embedded fallback should validate
+		handler.data = map[string]any{"platform": "hyperv"}
+		if err := handler.ValidateContextValues(); err != nil {
+			t.Errorf("Expected blueprint enum to win and accept 'hyperv', got: %v", err)
+		}
+	})
 }
 
 func TestConfigHandler_ValidateContextValues(t *testing.T) {

--- a/pkg/runtime/config/resolve.go
+++ b/pkg/runtime/config/resolve.go
@@ -37,7 +37,7 @@ func (c *configHandler) GetContextValues() (map[string]any, error) {
 	}
 
 	result = c.deepMerge(result, c.data)
-	c.applyPlatformDerivedDefaults(result)
+	c.applySchemaConditionalDefaults(result)
 	c.applyWorkstationDefaults(result)
 	c.ensureClusterStructure(result)
 	c.applyClusterTopologyDefaults(result)
@@ -50,37 +50,51 @@ func (c *configHandler) GetContextValues() (map[string]any, error) {
 // Private Methods
 // =============================================================================
 
-// applyPlatformDerivedDefaults injects derived platform defaults into effective values without mutating stored config.
-func (c *configHandler) applyPlatformDerivedDefaults(values map[string]any) {
-	platform := ""
-	if p, ok := getValueByPathFromMap(values, parsePath("platform")).(string); ok {
-		platform = p
+// applySchemaConditionalDefaults reads platform-derived defaults (and any other conditional
+// defaults the schema declares via top-level allOf+if/then) and fills them into effective
+// values where missing. The platform→cluster.driver table lives in the embedded common.yaml
+// schema and may be extended or overridden by a blueprint's own allOf branches.
+// Provider falls back as the match key when platform is unset, preserving legacy v1alpha1
+// behavior without polluting the values map.
+func (c *configHandler) applySchemaConditionalDefaults(values map[string]any) {
+	if c.schemaValidator == nil {
+		return
 	}
-	if platform == "" {
-		if p, ok := getValueByPathFromMap(values, parsePath("provider")).(string); ok {
-			platform = p
+
+	matchValues := values
+	if _, hasPlatform := values["platform"]; !hasPlatform {
+		if provider, ok := values["provider"].(string); ok && provider != "" {
+			matchValues = make(map[string]any, len(values)+1)
+			for k, v := range values {
+				matchValues[k] = v
+			}
+			matchValues["platform"] = provider
 		}
 	}
 
-	switch platform {
-	case "docker", "incus", "metal", "omni":
-		c.setDerivedValueIfMissing(values, "cluster.driver", "talos")
-	case "aws":
-		c.setDerivedValueIfMissing(values, "cluster.driver", "eks")
-	case "azure":
-		c.setDerivedValueIfMissing(values, "cluster.driver", "aks")
-	case "gcp":
-		c.setDerivedValueIfMissing(values, "cluster.driver", "gke")
-	}
-}
-
-// setDerivedValueIfMissing writes a derived value only when the path is not already present.
-func (c *configHandler) setDerivedValueIfMissing(values map[string]any, path string, value any) {
-	pathKeys := parsePath(path)
-	if hasValueAtPath(values, pathKeys) {
+	defaults, err := c.schemaValidator.ConditionalDefaults(matchValues)
+	if err != nil || len(defaults) == 0 {
 		return
 	}
-	setValueInMap(values, pathKeys, value)
+	c.fillMissingFromDefaults(values, defaults)
+}
+
+// fillMissingFromDefaults recursively merges defaults into values where the corresponding
+// path is absent. Existing values always win; this is the resolver-side counterpart to the
+// schema's default-extraction semantics.
+func (c *configHandler) fillMissingFromDefaults(values, defaults map[string]any) {
+	for key, defValue := range defaults {
+		existing, exists := values[key]
+		if !exists {
+			values[key] = defValue
+			continue
+		}
+		existingMap, existingOK := existing.(map[string]any)
+		defMap, defOK := defValue.(map[string]any)
+		if existingOK && defOK {
+			c.fillMissingFromDefaults(existingMap, defMap)
+		}
+	}
 }
 
 // applyWorkstationDefaults materializes workstation defaults required by runtime consumers.

--- a/pkg/runtime/config/resolve_test.go
+++ b/pkg/runtime/config/resolve_test.go
@@ -262,6 +262,142 @@ func TestConfigHandler_GetContextValues_Resolve(t *testing.T) {
 		}
 	})
 
+	t.Run("DerivesTalosDriverFromHypervPlatform", func(t *testing.T) {
+		handler, _ := setupPrivateTestHandler(t)
+		if err := handler.Set("platform", "hyperv"); err != nil {
+			t.Fatalf("Expected no error setting platform, got %v", err)
+		}
+
+		values, err := handler.GetContextValues()
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		clusterValues, ok := values["cluster"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected cluster map, got %T", values["cluster"])
+		}
+		if clusterValues["driver"] != "talos" {
+			t.Errorf("Expected cluster.driver=talos for hyperv, got %v", clusterValues["driver"])
+		}
+	})
+
+	t.Run("DerivesDriverFromProviderWhenPlatformUnset", func(t *testing.T) {
+		handler, _ := setupPrivateTestHandler(t)
+		if err := handler.Set("provider", "gcp"); err != nil {
+			t.Fatalf("Expected no error setting provider, got %v", err)
+		}
+
+		values, err := handler.GetContextValues()
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		clusterValues, ok := values["cluster"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected cluster map, got %T", values["cluster"])
+		}
+		if clusterValues["driver"] != "gke" {
+			t.Errorf("Expected cluster.driver=gke from provider fallback, got %v", clusterValues["driver"])
+		}
+		if values["platform"] != nil {
+			t.Errorf("Expected platform to remain unset (provider fallback should not pollute values), got %v", values["platform"])
+		}
+	})
+
+	t.Run("BlueprintAllOfDoesNotClobberEmbeddedDriverDerivation", func(t *testing.T) {
+		// Given a blueprint schema that declares its own allOf for unrelated cross-field
+		// validation (mirroring the real windsorcli/core schema, which requires `email`
+		// when `dns.public_domain` is set). The embedded platform→driver branches must
+		// survive the blueprint load so that platform: hyperv still derives talos.
+		handler, _ := setupPrivateTestHandler(t)
+		blueprintSchema := []byte(`$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+properties:
+  platform:
+    type: string
+  email:
+    type: string
+  dns:
+    type: object
+    properties:
+      public_domain:
+        type: string
+allOf:
+  - if:
+      properties:
+        dns:
+          properties:
+            public_domain:
+              minLength: 1
+    then:
+      required: [email]
+additionalProperties: true
+`)
+		if err := handler.LoadSchemaFromBytes(blueprintSchema); err != nil {
+			t.Fatalf("Failed to load blueprint schema: %v", err)
+		}
+		if err := handler.Set("platform", "hyperv"); err != nil {
+			t.Fatalf("Expected no error setting platform, got %v", err)
+		}
+
+		values, err := handler.GetContextValues()
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		clusterValues, ok := values["cluster"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected cluster map, got %T", values["cluster"])
+		}
+		if clusterValues["driver"] != "talos" {
+			t.Errorf("Expected platform=hyperv to derive cluster.driver=talos even with blueprint allOf, got %v", clusterValues["driver"])
+		}
+	})
+
+	t.Run("BlueprintAllOfBranchesOverrideEmbeddedDriver", func(t *testing.T) {
+		// Given a handler whose blueprint schema redefines the platform=docker branch
+		handler, _ := setupPrivateTestHandler(t)
+		blueprintSchema := []byte(`$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+properties:
+  platform:
+    type: string
+allOf:
+  - if:
+      properties:
+        platform:
+          const: docker
+    then:
+      properties:
+        cluster:
+          type: object
+          properties:
+            driver:
+              default: my-custom-driver
+additionalProperties: true
+`)
+		if err := handler.LoadSchemaFromBytes(blueprintSchema); err != nil {
+			t.Fatalf("Failed to load blueprint schema: %v", err)
+		}
+		if err := handler.Set("platform", "docker"); err != nil {
+			t.Fatalf("Expected no error setting platform, got %v", err)
+		}
+
+		values, err := handler.GetContextValues()
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		clusterValues, ok := values["cluster"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected cluster map, got %T", values["cluster"])
+		}
+		if clusterValues["driver"] != "my-custom-driver" {
+			t.Errorf("Expected blueprint conditional to win for docker, got %v", clusterValues["driver"])
+		}
+	})
+
 	t.Run("DoesNotOverrideExplicitDerivedTargets", func(t *testing.T) {
 		handler, _ := setupPrivateTestHandler(t)
 		if err := handler.Set("platform", "aws"); err != nil {

--- a/pkg/runtime/config/schema_validator.go
+++ b/pkg/runtime/config/schema_validator.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"maps"
+	"reflect"
 
 	"github.com/goccy/go-yaml"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
@@ -86,6 +87,30 @@ func (sv *SchemaValidator) LoadSchemaFromBytes(schemaContent []byte) error {
 	return nil
 }
 
+// MergeSystemDefaults merges system-level schema defaults into the existing schema.
+// Unlike LoadSchemaFromBytes, the existing schema wins on conflicts; the system schema only
+// fills in fields the existing schema does not define. Use this for embedded fallback schemas
+// that should not override an authoritative source like a blueprint schema. If no schema is
+// loaded, the system schema becomes the schema.
+func (sv *SchemaValidator) MergeSystemDefaults(schemaContent []byte) error {
+	var newSchema map[string]any
+	if err := yaml.Unmarshal(schemaContent, &newSchema); err != nil {
+		return fmt.Errorf("failed to parse schema YAML: %w", err)
+	}
+
+	if err := sv.validateSchemaStructure(newSchema); err != nil {
+		return fmt.Errorf("invalid schema structure: %w", err)
+	}
+
+	if sv.Schema == nil {
+		sv.Schema = newSchema
+		return nil
+	}
+
+	sv.Schema = sv.mergeSchema(newSchema, sv.Schema)
+	return nil
+}
+
 // Validate validates user values against the loaded schema
 // Returns validation result with errors and defaults
 func (sv *SchemaValidator) Validate(values map[string]any) (*SchemaValidationResult, error) {
@@ -121,6 +146,109 @@ func (sv *SchemaValidator) GetSchemaDefaults() (map[string]any, error) {
 	}
 
 	return sv.extractDefaults(sv.Schema)
+}
+
+// ConditionalDefaults evaluates the schema's top-level allOf branches and returns the
+// combined defaults from any branch whose `if` schema matches the provided values. Each
+// branch must take the shape `{if: {...}, then: {...}}`; only top-level property matchers
+// of the form `if.properties.<key>.const` and `if.properties.<key>.enum` are evaluated.
+// This is the mechanism by which the embedded schema expresses platform-derived defaults
+// (e.g. platform: aws → cluster.driver: eks) without baking the table into Go code.
+// Returns an empty map when no schema is loaded or no branches match.
+func (sv *SchemaValidator) ConditionalDefaults(values map[string]any) (map[string]any, error) {
+	out := make(map[string]any)
+	if sv.Schema == nil {
+		return out, nil
+	}
+	branches, ok := sv.Schema["allOf"].([]any)
+	if !ok {
+		return out, nil
+	}
+	for _, branch := range branches {
+		branchMap, ok := branch.(map[string]any)
+		if !ok {
+			continue
+		}
+		ifSchema, hasIf := branchMap["if"].(map[string]any)
+		thenSchema, hasThen := branchMap["then"].(map[string]any)
+		if !hasIf || !hasThen {
+			continue
+		}
+		if !sv.matchesIfSchema(ifSchema, values) {
+			continue
+		}
+		thenDefaults, err := sv.extractDefaults(thenSchema)
+		if err != nil {
+			return nil, fmt.Errorf("failed to extract conditional defaults: %w", err)
+		}
+		out = sv.deepMergeMaps(out, thenDefaults)
+	}
+	return out, nil
+}
+
+// matchesIfSchema returns true when values satisfy the supported subset of an `if` schema.
+// Only `properties.<key>.const` and `properties.<key>.enum` matchers on top-level keys are
+// honored; any other shape (nested matchers, type assertions, allOf/oneOf in if) is treated
+// as non-matching to keep the evaluator predictable for the platform-mapping use case.
+func (sv *SchemaValidator) matchesIfSchema(ifSchema map[string]any, values map[string]any) bool {
+	props, ok := ifSchema["properties"].(map[string]any)
+	if !ok {
+		return false
+	}
+	for key, raw := range props {
+		matcher, ok := raw.(map[string]any)
+		if !ok {
+			return false
+		}
+		actual, hasValue := values[key]
+		if !hasValue {
+			return false
+		}
+		if constVal, hasConst := matcher["const"]; hasConst {
+			if actual != constVal {
+				return false
+			}
+			continue
+		}
+		if enumRaw, hasEnum := matcher["enum"]; hasEnum {
+			enumList, ok := enumRaw.([]any)
+			if !ok {
+				return false
+			}
+			matched := false
+			for _, candidate := range enumList {
+				if actual == candidate {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				return false
+			}
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+// deepMergeMaps merges overlay into base recursively. Map-valued keys merge; scalars in
+// overlay replace base values. Used to combine defaults from multiple matching allOf branches.
+func (sv *SchemaValidator) deepMergeMaps(base, overlay map[string]any) map[string]any {
+	out := make(map[string]any, len(base))
+	for k, v := range base {
+		out[k] = v
+	}
+	for k, v := range overlay {
+		if existing, ok := out[k].(map[string]any); ok {
+			if incoming, ok := v.(map[string]any); ok {
+				out[k] = sv.deepMergeMaps(existing, incoming)
+				continue
+			}
+		}
+		out[k] = v
+	}
+	return out
 }
 
 // =============================================================================
@@ -428,12 +556,43 @@ func (sv *SchemaValidator) mergeSchema(base, overlay map[string]any) map[string]
 			merged[k] = sv.mergeRequired(base["required"], v)
 		case "items":
 			merged[k] = sv.mergeItemsSchema(base["items"], v)
+		case "allOf":
+			merged[k] = sv.mergeAllOf(base["allOf"], v)
 		default:
 			merged[k] = v
 		}
 	}
 
 	return merged
+}
+
+// mergeAllOf concatenates two `allOf` arrays so independent conditional branches from a base
+// schema (e.g. embedded platform→driver mappings) and an overlay schema (e.g. blueprint
+// cross-field validations) both remain in effect after merge. Branches that are structurally
+// identical are deduplicated, which keeps the result stable when applySystemSchemaPlugins
+// re-runs the embedded schema as defaults after a blueprint load.
+func (sv *SchemaValidator) mergeAllOf(base, overlay any) []any {
+	var combined []any
+	if baseSlice, ok := base.([]any); ok {
+		combined = append(combined, baseSlice...)
+	}
+	overlaySlice, ok := overlay.([]any)
+	if !ok {
+		return combined
+	}
+	for _, branch := range overlaySlice {
+		dup := false
+		for _, existing := range combined {
+			if reflect.DeepEqual(existing, branch) {
+				dup = true
+				break
+			}
+		}
+		if !dup {
+			combined = append(combined, branch)
+		}
+	}
+	return combined
 }
 
 // mergeProperties merges two property maps, with overlay properties overriding base properties.

--- a/pkg/runtime/config/schema_validator_test.go
+++ b/pkg/runtime/config/schema_validator_test.go
@@ -364,6 +364,263 @@ additionalProperties: false
 	})
 }
 
+func TestSchemaValidator_MergeSystemDefaults(t *testing.T) {
+	t.Run("ExistingSchemaWinsOnConflict", func(t *testing.T) {
+		// Given a schema validator with an authoritative schema already loaded (e.g. blueprint)
+		validator := NewSchemaValidator(shell.NewMockShell())
+
+		blueprintSchema := `$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+properties:
+  platform:
+    type: string
+    enum: [docker, incus, hyperv, metal]
+    default: docker
+additionalProperties: true
+`
+		if err := validator.LoadSchemaFromBytes([]byte(blueprintSchema)); err != nil {
+			t.Fatalf("Failed to load blueprint schema: %v", err)
+		}
+
+		// And a system defaults schema that defines a narrower platform enum
+		systemDefaults := `$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+properties:
+  platform:
+    type: string
+    enum: [docker, incus, metal]
+    default: docker
+additionalProperties: true
+`
+
+		// When merging the system defaults
+		if err := validator.MergeSystemDefaults([]byte(systemDefaults)); err != nil {
+			t.Fatalf("Failed to merge system defaults: %v", err)
+		}
+
+		// Then the blueprint's enum (which includes hyperv) wins
+		result, err := validator.Validate(map[string]any{"platform": "hyperv"})
+		if err != nil {
+			t.Fatalf("Validation failed: %v", err)
+		}
+		if !result.Valid {
+			t.Errorf("Expected blueprint enum to win and accept 'hyperv', got errors: %v", result.Errors)
+		}
+	})
+
+	t.Run("FillsInMissingFields", func(t *testing.T) {
+		// Given a schema validator with a blueprint that omits workstation
+		validator := NewSchemaValidator(shell.NewMockShell())
+
+		blueprintSchema := `$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+properties:
+  platform:
+    type: string
+    enum: [docker]
+additionalProperties: true
+`
+		if err := validator.LoadSchemaFromBytes([]byte(blueprintSchema)); err != nil {
+			t.Fatalf("Failed to load blueprint schema: %v", err)
+		}
+
+		// And a system defaults schema that adds a workstation property
+		systemDefaults := `$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+properties:
+  workstation:
+    type: object
+    properties:
+      runtime:
+        type: string
+        enum: [colima, docker]
+        default: colima
+additionalProperties: true
+`
+
+		// When merging the system defaults
+		if err := validator.MergeSystemDefaults([]byte(systemDefaults)); err != nil {
+			t.Fatalf("Failed to merge system defaults: %v", err)
+		}
+
+		// Then workstation is added from the system defaults and its default flows through
+		defaults, err := validator.GetSchemaDefaults()
+		if err != nil {
+			t.Fatalf("Failed to get defaults: %v", err)
+		}
+		workstation, ok := defaults["workstation"].(map[string]any)
+		if !ok {
+			t.Fatal("Expected workstation defaults to be filled in from system schema")
+		}
+		if workstation["runtime"] != "colima" {
+			t.Errorf("Expected workstation.runtime default 'colima', got %v", workstation["runtime"])
+		}
+	})
+
+	t.Run("LoadsAsBaseWhenNoSchemaPresent", func(t *testing.T) {
+		// Given a schema validator with no schema loaded
+		validator := NewSchemaValidator(shell.NewMockShell())
+
+		systemDefaults := `$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+properties:
+  platform:
+    type: string
+    enum: [docker, incus]
+    default: docker
+additionalProperties: true
+`
+
+		// When merging system defaults
+		if err := validator.MergeSystemDefaults([]byte(systemDefaults)); err != nil {
+			t.Fatalf("Failed to merge system defaults: %v", err)
+		}
+
+		// Then the system schema becomes the active schema
+		defaults, err := validator.GetSchemaDefaults()
+		if err != nil {
+			t.Fatalf("Failed to get defaults: %v", err)
+		}
+		if defaults["platform"] != "docker" {
+			t.Errorf("Expected system schema to be loaded as base, got platform default %v", defaults["platform"])
+		}
+	})
+
+	t.Run("ReturnsErrorOnInvalidYAML", func(t *testing.T) {
+		validator := NewSchemaValidator(shell.NewMockShell())
+
+		err := validator.MergeSystemDefaults([]byte("invalid yaml [[["))
+		if err == nil {
+			t.Error("Expected error for invalid YAML, got nil")
+		}
+	})
+}
+
+func TestSchemaValidator_ConditionalDefaults(t *testing.T) {
+	conditionalSchema := `$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+properties:
+  platform:
+    type: string
+  cluster:
+    type: object
+    properties:
+      driver:
+        type: string
+allOf:
+  - if:
+      properties:
+        platform:
+          enum: [docker, incus, metal]
+    then:
+      properties:
+        cluster:
+          type: object
+          properties:
+            driver:
+              default: talos
+  - if:
+      properties:
+        platform:
+          const: aws
+    then:
+      properties:
+        cluster:
+          type: object
+          properties:
+            driver:
+              default: eks
+additionalProperties: true
+`
+
+	t.Run("ReturnsDefaultsForMatchingConst", func(t *testing.T) {
+		validator := NewSchemaValidator(shell.NewMockShell())
+		if err := validator.LoadSchemaFromBytes([]byte(conditionalSchema)); err != nil {
+			t.Fatalf("Failed to load schema: %v", err)
+		}
+
+		got, err := validator.ConditionalDefaults(map[string]any{"platform": "aws"})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		cluster, ok := got["cluster"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected cluster map in defaults, got %T", got["cluster"])
+		}
+		if cluster["driver"] != "eks" {
+			t.Errorf("Expected driver=eks for platform=aws, got %v", cluster["driver"])
+		}
+	})
+
+	t.Run("ReturnsDefaultsForMatchingEnumMember", func(t *testing.T) {
+		validator := NewSchemaValidator(shell.NewMockShell())
+		if err := validator.LoadSchemaFromBytes([]byte(conditionalSchema)); err != nil {
+			t.Fatalf("Failed to load schema: %v", err)
+		}
+
+		got, err := validator.ConditionalDefaults(map[string]any{"platform": "incus"})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		cluster, ok := got["cluster"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected cluster map in defaults, got %T", got["cluster"])
+		}
+		if cluster["driver"] != "talos" {
+			t.Errorf("Expected driver=talos for platform=incus, got %v", cluster["driver"])
+		}
+	})
+
+	t.Run("ReturnsEmptyForNonMatchingPlatform", func(t *testing.T) {
+		validator := NewSchemaValidator(shell.NewMockShell())
+		if err := validator.LoadSchemaFromBytes([]byte(conditionalSchema)); err != nil {
+			t.Fatalf("Failed to load schema: %v", err)
+		}
+
+		got, err := validator.ConditionalDefaults(map[string]any{"platform": "azure"})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("Expected no defaults for unmatched platform, got %v", got)
+		}
+	})
+
+	t.Run("ReturnsEmptyWhenSchemaHasNoAllOf", func(t *testing.T) {
+		validator := NewSchemaValidator(shell.NewMockShell())
+		plainSchema := `$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+properties:
+  platform:
+    type: string
+additionalProperties: true
+`
+		if err := validator.LoadSchemaFromBytes([]byte(plainSchema)); err != nil {
+			t.Fatalf("Failed to load schema: %v", err)
+		}
+
+		got, err := validator.ConditionalDefaults(map[string]any{"platform": "aws"})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("Expected empty defaults when no allOf present, got %v", got)
+		}
+	})
+
+	t.Run("ReturnsEmptyWhenSchemaNotLoaded", func(t *testing.T) {
+		validator := NewSchemaValidator(shell.NewMockShell())
+
+		got, err := validator.ConditionalDefaults(map[string]any{"platform": "aws"})
+		if err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("Expected empty defaults when no schema loaded, got %v", got)
+		}
+	})
+}
+
 func TestSchemaValidator_ExtractDefaults(t *testing.T) {
 	t.Run("SuccessSimpleDefaults", func(t *testing.T) {
 		// Given a schema validator with loaded schema
@@ -2797,6 +3054,112 @@ func TestSchemaValidator_mergeSchema(t *testing.T) {
 		// Then non-merged keywords should be overridden
 		if merged["additionalProperties"] != false {
 			t.Error("Expected additionalProperties to be overridden to false")
+		}
+	})
+
+	t.Run("ConcatenatesAllOfBranchesAcrossSchemas", func(t *testing.T) {
+		// Given a base schema with conditional defaults (e.g. embedded platform→driver)
+		// and an overlay schema with unrelated cross-field conditionals (e.g. blueprint
+		// requiring email when public_domain is set), both sets of branches must remain.
+		validator := NewSchemaValidator(shell.NewMockShell())
+
+		base := map[string]any{
+			"$schema": "https://json-schema.org/draft/2020-12/schema",
+			"type":    "object",
+			"allOf": []any{
+				map[string]any{
+					"if": map[string]any{
+						"properties": map[string]any{
+							"platform": map[string]any{"const": "aws"},
+						},
+					},
+					"then": map[string]any{
+						"properties": map[string]any{
+							"cluster": map[string]any{
+								"properties": map[string]any{
+									"driver": map[string]any{"default": "eks"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		overlay := map[string]any{
+			"$schema": "https://json-schema.org/draft/2020-12/schema",
+			"type":    "object",
+			"allOf": []any{
+				map[string]any{
+					"if": map[string]any{
+						"properties": map[string]any{
+							"dns": map[string]any{
+								"properties": map[string]any{
+									"public_domain": map[string]any{"minLength": 1},
+								},
+							},
+						},
+					},
+					"then": map[string]any{
+						"required": []any{"email"},
+					},
+				},
+			},
+		}
+
+		merged := validator.mergeSchema(base, overlay)
+
+		mergedAllOf, ok := merged["allOf"].([]any)
+		if !ok {
+			t.Fatalf("Expected merged allOf to be a slice, got %T", merged["allOf"])
+		}
+		if len(mergedAllOf) != 2 {
+			t.Fatalf("Expected 2 allOf branches after merge, got %d", len(mergedAllOf))
+		}
+	})
+
+	t.Run("DeduplicatesIdenticalAllOfBranches", func(t *testing.T) {
+		// Given the same conditional branch present in both base and overlay (which happens
+		// when applySystemSchemaPlugins re-runs the embedded schema after a blueprint load),
+		// the merge must dedupe by structural equality so the branch isn't applied twice.
+		validator := NewSchemaValidator(shell.NewMockShell())
+
+		branch := map[string]any{
+			"if": map[string]any{
+				"properties": map[string]any{
+					"platform": map[string]any{"const": "aws"},
+				},
+			},
+			"then": map[string]any{
+				"properties": map[string]any{
+					"cluster": map[string]any{
+						"properties": map[string]any{
+							"driver": map[string]any{"default": "eks"},
+						},
+					},
+				},
+			},
+		}
+
+		base := map[string]any{
+			"$schema": "https://json-schema.org/draft/2020-12/schema",
+			"type":    "object",
+			"allOf":   []any{branch},
+		}
+		overlay := map[string]any{
+			"$schema": "https://json-schema.org/draft/2020-12/schema",
+			"type":    "object",
+			"allOf":   []any{branch},
+		}
+
+		merged := validator.mergeSchema(base, overlay)
+
+		mergedAllOf, ok := merged["allOf"].([]any)
+		if !ok {
+			t.Fatalf("Expected merged allOf to be a slice, got %T", merged["allOf"])
+		}
+		if len(mergedAllOf) != 1 {
+			t.Errorf("Expected dedup to leave 1 branch, got %d", len(mergedAllOf))
 		}
 	})
 }

--- a/pkg/runtime/config/schemas/common.yaml
+++ b/pkg/runtime/config/schemas/common.yaml
@@ -7,10 +7,18 @@ properties:
       - none
       - docker
       - incus
+      - hyperv
       - metal
+      - omni
       - aws
       - azure
       - gcp
+
+  cluster:
+    type: object
+    properties:
+      driver:
+        type: string
 
   workstation:
     type: object
@@ -62,3 +70,51 @@ properties:
             description: Forward DNS servers
         additionalProperties: false
     additionalProperties: false
+
+allOf:
+  # Platform → cluster.driver derivation. The CLI applies these as fallbacks: an
+  # explicit cluster.driver from a blueprint default or user config always wins.
+  - if:
+      properties:
+        platform:
+          enum: [docker, incus, hyperv, metal, omni]
+    then:
+      properties:
+        cluster:
+          type: object
+          properties:
+            driver:
+              default: talos
+  - if:
+      properties:
+        platform:
+          const: aws
+    then:
+      properties:
+        cluster:
+          type: object
+          properties:
+            driver:
+              default: eks
+  - if:
+      properties:
+        platform:
+          const: azure
+    then:
+      properties:
+        cluster:
+          type: object
+          properties:
+            driver:
+              default: aks
+  - if:
+      properties:
+        platform:
+          const: gcp
+    then:
+      properties:
+        cluster:
+          type: object
+          properties:
+            driver:
+              default: gke

--- a/pkg/workstation/virt/colima_virt_test.go
+++ b/pkg/workstation/virt/colima_virt_test.go
@@ -312,7 +312,7 @@ func TestColimaVirt_WriteConfig(t *testing.T) {
 		colimaVirt := NewColimaVirt(mocks.Runtime)
 		colimaVirt.setShims(mocks.Shims)
 
-		if err := mocks.ConfigHandler.Set("workstation.runtime", "other"); err != nil {
+		if err := mocks.ConfigHandler.Set("workstation.runtime", "docker"); err != nil {
 			t.Fatalf("Failed to set workstation.runtime: %v", err)
 		}
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> This PR touches `GetContextValues`, a call-path shared across the CLI, replacing a hard-coded platform-to-driver switch with schema-driven `allOf`/`if`/`then` evaluation and adding a constructor-time system schema bootstrap.
>
> **Overview**
>
> The change moves the platform → `cluster.driver` derivation table from Go code into the embedded `common.yaml` schema as `allOf` branches, evaluated at resolve time by the new `ConditionalDefaults` method. Blueprint schemas loaded later merge their own `allOf` branches on top; `MergeSystemDefaults` uses the existing schema as the winner on conflicts, so blueprints override embedded defaults without replicating unrelated branches. `mergeAllOf` deduplicates identical branches so embedded defaults survive repeated `LoadConfigForContext` calls without multiplying.
>
> The open correctness concern flagged inline remains: `matchesIfSchema` compares `const` values via Go's `!=` on `interface{}`, which panics when a blueprint provides a non-scalar const. All current schemas use string scalars so no test triggers this today. This push fixes a test that was using an invalid `workstation.runtime` value after the enum was formalized in `common.yaml`.
>
> Reviewed by Claude for commit `d2951a27`.

<!-- /claude-code-review:summary -->
