### PR TITLE
chore(terraform): implement unified refresh policy to skip refresh for empty state and handle errors gracefully

### DIFF
--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -1105,7 +1105,7 @@ func (s *TerraformStack) refreshIfStateNonEmpty(component *blueprintv1alpha1.Ter
 		return nil
 	}
 	if err := s.refreshComponentState(component, terraformVars, terraformArgs); err != nil {
-		fmt.Fprintf(s.warningWriter, "warning: terraform refresh failed for %s; continuing with plan/apply (terraform will refresh again during plan): %v\n", component.Path, err)
+		fmt.Fprintf(s.warningWriter, "warning: terraform refresh failed for %s; continuing with plan against the last-known state (plan runs with -refresh=false; any persistent state divergence will surface as a plan error): %v\n", component.Path, err)
 	}
 	return nil
 }

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -269,13 +269,12 @@ func (s *TerraformStack) Up(blueprint *blueprintv1alpha1.Blueprint, onApply ...f
 				return err
 			}
 
-			terraformCommand := s.runtime.ToolsManager.GetTerraformCommand()
-			refreshArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "refresh"}
-			refreshArgs = append(refreshArgs, terraformArgs.RefreshArgs...)
-			refreshEnv := selectTerraformCommandEnv(terraformVars, true)
-			_, _ = s.runtime.Shell.ExecSilentWithEnv(terraformCommand, refreshEnv, refreshArgs...)
+			if err := s.refreshIfStateNonEmpty(&component, terraformVars, terraformArgs); err != nil {
+				return err
+			}
 
-			planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan"}
+			terraformCommand := s.runtime.ToolsManager.GetTerraformCommand()
+			planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan", "-refresh=false"}
 			planArgs = append(planArgs, terraformArgs.PlanArgs...)
 			planEnv := selectTerraformCommandEnv(terraformVars, true)
 			if _, err = s.runtime.Shell.ExecSilentWithEnv(terraformCommand, planEnv, planArgs...); err != nil {
@@ -754,8 +753,12 @@ func (s *TerraformStack) Apply(blueprint *blueprintv1alpha1.Blueprint, component
 			return err
 		}
 
+		if err := s.refreshIfStateNonEmpty(component, terraformVars, terraformArgs); err != nil {
+			return err
+		}
+
 		terraformCommand := s.runtime.ToolsManager.GetTerraformCommand()
-		planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan"}
+		planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan", "-refresh=false"}
 		planArgs = append(planArgs, terraformArgs.PlanArgs...)
 		planEnv := selectTerraformCommandEnv(terraformVars, true)
 		if _, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, planEnv, planArgs...); err != nil {
@@ -1081,6 +1084,29 @@ func (s *TerraformStack) planComponents(blueprint *blueprintv1alpha1.Blueprint, 
 		}
 	}
 
+	return nil
+}
+
+// refreshIfStateNonEmpty runs refresh only when the component's state contains resources,
+// matching the §4.4 unified refresh policy: if state is empty there is nothing to reconcile,
+// so refresh is skipped (and the subsequent plan will surface any deeper config issue with
+// a clearer error than refresh would). When state is non-empty and refresh fails, the error
+// is logged to s.warningWriter and swallowed — the caller's plan/apply will run anyway, and
+// any persistent problem will resurface there with a more actionable message. The state-check
+// itself failing is propagated; callers can't safely proceed without knowing whether state is
+// empty. Used by Up and Apply; Destroy retains its own refresh handling because its fallback
+// (-refresh=true on destroy) is destroy-specific.
+func (s *TerraformStack) refreshIfStateNonEmpty(component *blueprintv1alpha1.TerraformComponent, terraformVars map[string]string, terraformArgs *envvars.TerraformArgs) error {
+	hasResources, err := s.hasStateResources(component, terraformVars)
+	if err != nil {
+		return err
+	}
+	if !hasResources {
+		return nil
+	}
+	if err := s.refreshComponentState(component, terraformVars, terraformArgs); err != nil {
+		fmt.Fprintf(s.warningWriter, "warning: terraform refresh failed for %s; continuing with plan/apply (terraform will refresh again during plan): %v\n", component.Path, err)
+	}
 	return nil
 }
 

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -2606,6 +2606,30 @@ func TestStack_Apply(t *testing.T) {
 			t.Errorf("Expected stderr warning to mention refresh failure, got: %s", warnings.String())
 		}
 	})
+
+	t.Run("PropagatesStateCheckErrorBeforeRunningPlan", func(t *testing.T) {
+		// Given a stack whose hasStateResources fails (terraform show -json errors)
+		stack, mocks := setup(t)
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" && len(args) >= 3 && args[1] == "show" && args[2] == "-json" {
+				return "", fmt.Errorf("simulated show -json failure")
+			}
+			return "", nil
+		}
+		blueprint := createTestBlueprint()
+
+		// When Apply runs
+		err := stack.Apply(blueprint, "local/path")
+
+		// Then the state-check error propagates — Apply must not silently fall through
+		// to plan against an unknown state
+		if err == nil {
+			t.Fatal("Expected state-check error to propagate, got nil")
+		}
+		if !strings.Contains(err.Error(), "error reading terraform state JSON") {
+			t.Errorf("Expected error to mention terraform state JSON, got %v", err)
+		}
+	})
 }
 
 func TestStack_Destroy(t *testing.T) {

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -6,6 +6,7 @@ package terraform
 // verifying error handling, mock interactions, and infrastructure state management.
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -229,6 +230,17 @@ func setupWindsorStackMocks(t *testing.T, opts ...*SetupOptions) *TerraformTestM
 	terraformEnv := envvars.NewTerraformEnvPrinter(mocks.Shell, mocks.ConfigHandler, mockToolsManager, mockTerraformProvider)
 	mocks.Runtime.EnvPrinters.TerraformEnv = terraformEnv
 
+	// Default `terraform show -json` to a valid empty-state response so Up/Apply's
+	// pre-plan hasStateResources check can parse the output and short-circuit refresh
+	// for tests that don't override (the §4.4 unified refresh policy added this call).
+	// Tests asserting the refresh-fires path override this to return non-empty state.
+	mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+		if command == "terraform" && len(args) >= 3 && args[1] == "show" && args[2] == "-json" {
+			return `{"values":{"root_module":{"resources":[]}}}`, nil
+		}
+		return "", nil
+	}
+
 	return mocks
 }
 
@@ -368,6 +380,9 @@ func TestStack_Up(t *testing.T) {
 		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
 			if command == "terraform" && len(args) > 0 && strings.HasPrefix(args[0], "-chdir=") && len(args) > 1 && args[1] == "plan" {
 				return "", fmt.Errorf("mock error running terraform plan")
+			}
+			if command == "terraform" && len(args) >= 3 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[]}}}`, nil
 			}
 			return "", nil
 		}
@@ -525,6 +540,9 @@ func TestStack_Up(t *testing.T) {
 			if len(args) > 1 && args[1] == "plan" {
 				capturedEnv = env
 			}
+			if command == "terraform" && len(args) >= 3 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[]}}}`, nil
+			}
 			return "", nil
 		}
 
@@ -539,6 +557,139 @@ func TestStack_Up(t *testing.T) {
 		}
 	})
 
+	t.Run("PassesRefreshFalseToPlanSinceRefreshFiresExplicitlyFirst", func(t *testing.T) {
+		// Given a stack and a blueprint
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+
+		// When Up is called, capture the plan args
+		var capturedPlanArgs []string
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" && len(args) > 1 && args[1] == "plan" {
+				capturedPlanArgs = args
+			}
+			if command == "terraform" && len(args) >= 3 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[]}}}`, nil
+			}
+			return "", nil
+		}
+
+		_ = stack.Up(blueprint)
+
+		// Then plan was called with -refresh=false (refresh ran explicitly before)
+		var sawRefreshFalse bool
+		for _, a := range capturedPlanArgs {
+			if a == "-refresh=false" {
+				sawRefreshFalse = true
+				break
+			}
+		}
+		if !sawRefreshFalse {
+			t.Errorf("Expected plan args to include -refresh=false, got %v", capturedPlanArgs)
+		}
+	})
+
+	t.Run("SkipsRefreshWhenStateIsEmpty", func(t *testing.T) {
+		// Given a stack whose state-show returns empty state
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+
+		var sawRefreshExec bool
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" && len(args) > 1 && args[1] == "refresh" {
+				sawRefreshExec = true
+			}
+			if command == "terraform" && len(args) >= 3 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[]}}}`, nil
+			}
+			return "", nil
+		}
+
+		// When Up runs
+		_ = stack.Up(blueprint)
+
+		// Then refresh was never invoked — empty state means nothing to reconcile
+		if sawRefreshExec {
+			t.Error("Expected refresh to be skipped when state is empty, but it was invoked")
+		}
+	})
+
+	t.Run("RefreshFiresWhenStateIsNonEmpty", func(t *testing.T) {
+		// Given a stack whose state-show returns a populated state
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+
+		var sawRefreshExec bool
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" && len(args) > 1 && args[1] == "refresh" {
+				sawRefreshExec = true
+			}
+			if command == "terraform" && len(args) >= 3 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[{"address":"aws_s3_bucket.example"}]}}}`, nil
+			}
+			return "", nil
+		}
+
+		// When Up runs
+		_ = stack.Up(blueprint)
+
+		// Then refresh was invoked because state is non-empty
+		if !sawRefreshExec {
+			t.Error("Expected refresh to be invoked when state is non-empty, but it was not")
+		}
+	})
+
+	t.Run("WarnsAndContinuesWhenRefreshFailsOnNonEmptyState", func(t *testing.T) {
+		// Given a stack with non-empty state and a refresh that fails
+		stack, mocks := setup(t)
+		warnings := &bytes.Buffer{}
+		stack.warningWriter = warnings
+
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" && len(args) > 1 && args[1] == "refresh" {
+				return "", fmt.Errorf("simulated refresh failure")
+			}
+			if command == "terraform" && len(args) >= 3 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[{"address":"aws_s3_bucket.example"}]}}}`, nil
+			}
+			return "", nil
+		}
+		blueprint := createTestBlueprint()
+
+		// When Up runs
+		err := stack.Up(blueprint)
+
+		// Then no error surfaces (warn-but-continue policy) and the warning names the failure
+		if err != nil {
+			t.Fatalf("Expected refresh failure on non-empty state to be tolerated, got %v", err)
+		}
+		if !strings.Contains(warnings.String(), "terraform refresh failed") {
+			t.Errorf("Expected stderr warning to mention refresh failure, got: %s", warnings.String())
+		}
+	})
+
+	t.Run("PropagatesStateCheckErrorBeforeRunningPlan", func(t *testing.T) {
+		// Given a stack whose hasStateResources fails (terraform show -json errors)
+		stack, mocks := setup(t)
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" && len(args) >= 3 && args[1] == "show" && args[2] == "-json" {
+				return "", fmt.Errorf("simulated show -json failure")
+			}
+			return "", nil
+		}
+		blueprint := createTestBlueprint()
+
+		// When Up runs
+		err := stack.Up(blueprint)
+
+		// Then the state-check error propagates
+		if err == nil {
+			t.Fatal("Expected state-check error to propagate, got nil")
+		}
+		if !strings.Contains(err.Error(), "error reading terraform state JSON") {
+			t.Errorf("Expected error to mention terraform state JSON, got %v", err)
+		}
+	})
 }
 
 func TestStack_MigrateState(t *testing.T) {
@@ -2256,6 +2407,9 @@ func TestStack_Apply(t *testing.T) {
 			if command == "terraform" && len(args) > 1 && args[1] == "plan" {
 				return "", fmt.Errorf("mock error running terraform plan")
 			}
+			if command == "terraform" && len(args) >= 3 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[]}}}`, nil
+			}
 			return "", nil
 		}
 		blueprint := createTestBlueprint()
@@ -2350,6 +2504,9 @@ func TestStack_Apply(t *testing.T) {
 			if len(args) > 1 && args[1] == "plan" {
 				capturedEnv = env
 			}
+			if command == "terraform" && len(args) >= 3 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[]}}}`, nil
+			}
 			return "", nil
 		}
 
@@ -2361,6 +2518,92 @@ func TestStack_Apply(t *testing.T) {
 		}
 		if capturedEnv["TF_VAR_operation"] != "apply" {
 			t.Errorf("Expected TF_VAR_operation to be %q, got %q", "apply", capturedEnv["TF_VAR_operation"])
+		}
+	})
+
+	t.Run("PassesRefreshFalseToPlanSinceRefreshFiresExplicitlyFirst", func(t *testing.T) {
+		// Given a stack and a single component
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+
+		// When Apply is called, capture the plan args
+		var capturedPlanArgs []string
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" && len(args) > 1 && args[1] == "plan" {
+				capturedPlanArgs = args
+			}
+			if command == "terraform" && len(args) >= 3 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[]}}}`, nil
+			}
+			return "", nil
+		}
+
+		_ = stack.Apply(blueprint, "local/path")
+
+		// Then plan was called with -refresh=false (refresh ran explicitly before)
+		var sawRefreshFalse bool
+		for _, a := range capturedPlanArgs {
+			if a == "-refresh=false" {
+				sawRefreshFalse = true
+				break
+			}
+		}
+		if !sawRefreshFalse {
+			t.Errorf("Expected plan args to include -refresh=false, got %v", capturedPlanArgs)
+		}
+	})
+
+	t.Run("RefreshFiresWhenStateIsNonEmpty", func(t *testing.T) {
+		// Given a stack whose state-show returns a populated state
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+
+		var sawRefreshExec bool
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" && len(args) > 1 && args[1] == "refresh" {
+				sawRefreshExec = true
+			}
+			if command == "terraform" && len(args) >= 3 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[{"address":"aws_s3_bucket.example"}]}}}`, nil
+			}
+			return "", nil
+		}
+
+		// When Apply runs
+		_ = stack.Apply(blueprint, "local/path")
+
+		// Then refresh was invoked because state is non-empty
+		if !sawRefreshExec {
+			t.Error("Expected refresh to be invoked when state is non-empty, but it was not")
+		}
+	})
+
+	t.Run("WarnsAndContinuesWhenRefreshFailsOnNonEmptyState", func(t *testing.T) {
+		// Given a stack with non-empty state and a refresh that fails
+		stack, mocks := setup(t)
+		warnings := &bytes.Buffer{}
+		stack.warningWriter = warnings
+
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" && len(args) > 1 && args[1] == "refresh" {
+				return "", fmt.Errorf("simulated refresh failure")
+			}
+			if command == "terraform" && len(args) >= 3 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[{"address":"aws_s3_bucket.example"}]}}}`, nil
+			}
+			return "", nil
+		}
+		blueprint := createTestBlueprint()
+
+		// When Apply runs
+		err := stack.Apply(blueprint, "local/path")
+
+		// Then no error surfaces (warn-but-continue) and the warning names the failure
+		if err != nil {
+			t.Fatalf("Expected refresh failure on non-empty state to be tolerated, got %v", err)
+		}
+		if !strings.Contains(warnings.String(), "terraform refresh failed") {
+			t.Errorf("Expected stderr warning to mention refresh failure, got: %s", warnings.String())
 		}
 	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> The change touches the refresh/plan sequence for every `Up` and `Apply` call, and introduces a new hard-failure path where `terraform show -json` errors now stop those operations rather than being silently discarded.
>
> **Overview**
>
> This PR centralizes the refresh policy for `Up` and `Apply`: a new `refreshIfStateNonEmpty` helper skips refresh when state is empty, tolerates refresh failures on non-empty state with a warning, and passes `-refresh=false` to plan since refresh now happens explicitly beforehand. The logic mirrors the existing `Destroy` policy, and the test suite adds symmetric coverage across both operations.
>
> Both concerns from the prior review have been addressed: the warning message now accurately states that plan runs with `-refresh=false`, and a symmetric `PropagatesStateCheckErrorBeforeRunningPlan` test has been added to the `Apply` suite. No new findings in the follow-up commits.
>
> Reviewed by Claude for commit `b7cf5622`.

<!-- /claude-code-review:summary -->
