### PR TITLE
fix(terraform): remove -force-copy from default init flags to preserve safety prompt during apply operations

### DIFF
--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -29,9 +29,14 @@ import (
 // =============================================================================
 
 // defaultInitFlags are passed to `terraform init` for normal apply/inspect operations.
-// MigrateState uses -migrate-state + -force-copy inline instead, since moving state must
-// not reinstall providers.
-var defaultInitFlags = []string{"-upgrade", "-force-copy"}
+// -force-copy is intentionally absent: it suppresses terraform's "yes, copy the state"
+// safety prompt, which is only desired when the operator has explicitly asked for state
+// migration. Apply/Up/Plan/Destroy paths inherit no migration intent, so leaving the
+// prompt available means an unintended migration (e.g. a backend pointer mismatch)
+// surfaces as a clear refusal rather than silently auto-copying state. MigrateState and
+// MigrateComponentState pass `-migrate-state -force-copy` explicitly when migration is
+// the requested operation; see migrateOneComponent.
+var defaultInitFlags = []string{"-upgrade"}
 
 // =============================================================================
 // Types

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -690,6 +690,42 @@ func TestStack_Up(t *testing.T) {
 			t.Errorf("Expected error to mention terraform state JSON, got %v", err)
 		}
 	})
+
+	t.Run("DoesNotPassForceCopyFlag", func(t *testing.T) {
+		// Up's init must not include -force-copy: the flag suppresses terraform's
+		// "yes, copy the state" safety prompt and belongs only on the explicit
+		// state-migration path (MigrateState / MigrateComponentState). Leaving the
+		// prompt available on apply-side init means an unintended migration (e.g. a
+		// backend pointer mismatch) surfaces as a clear refusal rather than silently
+		// auto-copying state.
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+
+		var forceCopySeen bool
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == "init" {
+				for _, a := range args {
+					if a == "-force-copy" {
+						forceCopySeen = true
+					}
+				}
+			}
+			if command == "terraform" && len(args) >= 3 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[]}}}`, nil
+			}
+			return "", nil
+		}
+
+		// When Up runs
+		if err := stack.Up(blueprint); err != nil {
+			t.Fatalf("Expected Up to succeed, got %v", err)
+		}
+
+		// Then no init invocation carried -force-copy
+		if forceCopySeen {
+			t.Error("Expected Up's init not to include -force-copy; the flag belongs only on the explicit state-migration path")
+		}
+	})
 }
 
 func TestStack_MigrateState(t *testing.T) {

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -692,12 +692,6 @@ func TestStack_Up(t *testing.T) {
 	})
 
 	t.Run("DoesNotPassForceCopyFlag", func(t *testing.T) {
-		// Up's init must not include -force-copy: the flag suppresses terraform's
-		// "yes, copy the state" safety prompt and belongs only on the explicit
-		// state-migration path (MigrateState / MigrateComponentState). Leaving the
-		// prompt available on apply-side init means an unintended migration (e.g. a
-		// backend pointer mismatch) surfaces as a clear refusal rather than silently
-		// auto-copying state.
 		stack, mocks := setup(t)
 		blueprint := createTestBlueprint()
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> The change is isolated to a single package-level variable and its test; no shared infrastructure, CLI surface, or migration code path is affected.
>
> **Overview**
>
> This PR removes `-force-copy` from `defaultInitFlags`, the flag slice shared by every non-migration `terraform init` call (`Up`, `Plan`, `Destroy`, `Inspect`). The flag was silently auto-copying state on backend mismatches; without it, terraform will fail in non-interactive contexts rather than auto-migrate — a safe-fail posture. The explicit migration path in `migrateOneComponent` retains `-migrate-state -force-copy` directly.
>
> A follow-up commit cleans up in-body comments from the new `TestStack_Up` sub-test. The test intercepts `ExecSilentWithEnvFunc` and asserts that no `init` invocation carries `-force-copy`; because all non-migration callers share the same variable, coverage through `Up` is sufficient to assert the invariant across the board.
>
> Reviewed by Claude for commit `922de6b`.

<!-- /claude-code-review:summary -->
