### PR TITLE
feat(platform): add hyperv support to platform options

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -334,7 +334,7 @@ func confirmBootstrapIfContextExists(in io.Reader, configRoot, contextName strin
 }
 
 func init() {
-	bootstrapCmd.Flags().StringVar(&bootstrapPlatform, "platform", "", "Target platform [none|metal|docker|aws|azure|gcp]")
+	bootstrapCmd.Flags().StringVar(&bootstrapPlatform, "platform", "", "Target platform [none|metal|docker|aws|azure|gcp|hyperv]")
 	bootstrapCmd.Flags().StringVar(&bootstrapBlueprint, "blueprint", "", "Blueprint OCI reference (oci://ghcr.io/org/repo:tag, ghcr.io/org/repo:tag, or org/repo:tag — host defaults to ghcr.io; tag is required)")
 	bootstrapCmd.Flags().StringSliceVar(&bootstrapSetFlags, "set", []string{}, "Override config values, e.g. --set dns.enabled=false")
 	bootstrapCmd.Flags().BoolVarP(&bootstrapYes, "yes", "y", false, "Skip all confirmation prompts")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -220,7 +220,7 @@ func init() {
 	initCmd.Flags().StringVar(&initArch, "vm-arch", "", "Specify the architecture for Colima")
 	initCmd.Flags().BoolVar(&initDocker, "docker", false, "Enable Docker")
 	initCmd.Flags().BoolVar(&initGitLivereload, "git-livereload", false, "Enable Git Livereload")
-	initCmd.Flags().StringVar(&initPlatform, "platform", "", "Specify the platform to use [none|metal|docker|aws|azure|gcp]")
+	initCmd.Flags().StringVar(&initPlatform, "platform", "", "Specify the platform to use [none|metal|docker|aws|azure|gcp|hyperv]")
 	initCmd.Flags().StringVar(&initProvider, "provider", "", "Deprecated: use --platform instead")
 	initCmd.Flags().StringVar(&initBlueprint, "blueprint", "", "Specify the blueprint to use")
 	initCmd.Flags().StringVar(&initEndpoint, "endpoint", "", "Specify the kubernetes API endpoint")

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -147,7 +147,7 @@ func init() {
 	upCmd.Flags().BoolVar(&installFlag, "install", false, "")
 	_ = upCmd.Flags().MarkDeprecated("install", "the --install flag is no longer needed and will be removed in a future release")
 	upCmd.Flags().StringVar(&upVmDriver, "vm-driver", "", "VM driver (colima, colima-incus, docker-desktop, docker)")
-	upCmd.Flags().StringVar(&upPlatform, "platform", "", "Specify the platform to use [none|metal|docker|aws|azure|gcp]")
+	upCmd.Flags().StringVar(&upPlatform, "platform", "", "Specify the platform to use [none|metal|docker|aws|azure|gcp|hyperv]")
 	upCmd.Flags().StringVar(&upBlueprint, "blueprint", "", "Specify the blueprint to use")
 	upCmd.Flags().StringSliceVar(&upSetFlags, "set", []string{}, "Override configuration values. Example: --set dns.enabled=false")
 	rootCmd.AddCommand(upCmd)

--- a/pkg/runtime/config/resolve.go
+++ b/pkg/runtime/config/resolve.go
@@ -63,7 +63,7 @@ func (c *configHandler) applyPlatformDerivedDefaults(values map[string]any) {
 	}
 
 	switch platform {
-	case "docker", "incus", "metal", "omni":
+	case "docker", "incus", "metal", "omni", "hyperv":
 		c.setDerivedValueIfMissing(values, "cluster.driver", "talos")
 	case "aws":
 		c.setDerivedValueIfMissing(values, "cluster.driver", "eks")

--- a/pkg/runtime/config/resolve_test.go
+++ b/pkg/runtime/config/resolve_test.go
@@ -245,6 +245,26 @@ func TestConfigHandler_GetContextValues_Resolve(t *testing.T) {
 		}
 	})
 
+	t.Run("DerivesTalosDriverFromHypervPlatform", func(t *testing.T) {
+		handler, _ := setupPrivateTestHandler(t)
+		if err := handler.Set("platform", "hyperv"); err != nil {
+			t.Fatalf("Expected no error setting platform, got %v", err)
+		}
+
+		values, err := handler.GetContextValues()
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		clusterValues, ok := values["cluster"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected cluster map, got %T", values["cluster"])
+		}
+		if clusterValues["driver"] != "talos" {
+			t.Errorf("Expected cluster.driver=talos, got %v", clusterValues["driver"])
+		}
+	})
+
 	t.Run("DerivesCloudDriverFromPlatform", func(t *testing.T) {
 		handler, _ := setupPrivateTestHandler(t)
 		if err := handler.Set("platform", "azure"); err != nil {

--- a/pkg/runtime/config/schemas/common.yaml
+++ b/pkg/runtime/config/schemas/common.yaml
@@ -11,6 +11,7 @@ properties:
       - aws
       - azure
       - gcp
+      - hyperv
 
   workstation:
     type: object


### PR DESCRIPTION
…init, and up commands

<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> This PR adds `hyperv` as a recognized platform value across the CLI, schema, and config resolution, but one behavioral gap in terraform backend defaulting remains, requiring users to supply `terraform.backend.type` manually.
>
> **Overview**
>
> The change extends the `--platform` flag to accept `hyperv` in `bootstrap`, `init`, and `up`, adds it to the JSON Schema enum in `common.yaml`, and wires up `cluster.driver=talos` derivation in `applyPlatformDerivedDefaults` — addressing the gap from the previous review. A unit test covers the new derivation path.
>
> The outstanding gap is in `cmd/workstation_defaults.go`: the switch that injects `terraform.backend.type=kubernetes` for `metal`, `docker`, and `incus` does not include `hyperv`. Users who run `windsor init --platform hyperv` or `windsor up --platform hyperv` will not receive a default state backend and must supply `--set terraform.backend.type=kubernetes` manually, unlike every other local platform.
>
> Reviewed by Claude for commit `5ee0eab`.

<!-- /claude-code-review:summary -->
