### PR TITLE
feat(destroy): implement prevent_destroy preflight gate and override option

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -62,6 +62,8 @@ With a component name, destroys every layer (Terraform and/or Kustomize) that co
 			}
 			tuiplan.DestroySummary(os.Stdout, summary.Terraform, summary.Kustomize, os.Getenv("NO_COLOR") != "")
 
+			warnPreventDestroy(cmd.ErrOrStderr(), summary.Terraform)
+
 			contextName := proj.Runtime.ContextName
 			desc := fmt.Sprintf("This will permanently destroy all infrastructure in context %q.", contextName)
 			if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, contextName); err != nil {
@@ -115,6 +117,8 @@ With a component name, destroys every layer (Terraform and/or Kustomize) that co
 			return fmt.Errorf("error generating destroy plan: %w", err)
 		}
 		tuiplan.DestroySummary(os.Stdout, tfResults, k8sResults, os.Getenv("NO_COLOR") != "")
+
+		warnPreventDestroy(cmd.ErrOrStderr(), tfResults)
 
 		desc := fmt.Sprintf("This will permanently destroy component %q across all layers.", componentID)
 		if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, componentID); err != nil {
@@ -173,6 +177,8 @@ var destroyTerraformCmd = &cobra.Command{
 			}
 			tuiplan.DestroySummary(os.Stdout, summary.Terraform, nil, os.Getenv("NO_COLOR") != "")
 
+			warnPreventDestroy(cmd.ErrOrStderr(), summary.Terraform)
+
 			contextName := proj.Runtime.ContextName
 			desc := fmt.Sprintf("This will permanently destroy all Terraform components in context %q.", contextName)
 			if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, contextName); err != nil {
@@ -201,6 +207,8 @@ var destroyTerraformCmd = &cobra.Command{
 			return fmt.Errorf("error generating destroy plan: %w", err)
 		}
 		tuiplan.DestroySummary(os.Stdout, []terraforminfra.TerraformComponentPlan{tfResult}, nil, os.Getenv("NO_COLOR") != "")
+
+		warnPreventDestroy(cmd.ErrOrStderr(), []terraforminfra.TerraformComponentPlan{tfResult})
 
 		desc := fmt.Sprintf("This will permanently destroy Terraform component %q.", componentID)
 		if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, componentID); err != nil {
@@ -324,6 +332,30 @@ func reportSkippedDestroyComponents(w io.Writer, skipped []string) {
 	}
 	fmt.Fprintln(w, "   if previously bootstrapped, cloud resources may now be orphaned —")
 	fmt.Fprintln(w, "   verify in your cloud console; remediate with `terraform import` if needed.")
+}
+
+// warnPreventDestroy emits a stderr warning naming any resource addresses
+// that terraform's plan -destroy flagged with `lifecycle { prevent_destroy =
+// true }`. The wrapper deliberately does not refuse — operators who run
+// `windsor destroy` typically want convergence on zero, and a partial
+// destroy that halts mid-graph leaves more mess than a destroy that surfaces
+// the protected addresses up front. Module authors who want hard protection
+// should gate their resources on TF_VAR_operation / TF_VAR_ephemeral and
+// design the destroy contract in HCL; see docs/spikes/terraform-lifecycle-hardening.md §6.2.
+// No-op when protected is empty.
+func warnPreventDestroy(w io.Writer, plans []terraforminfra.TerraformComponentPlan) {
+	var protected []string
+	for _, p := range plans {
+		protected = append(protected, p.Protected...)
+	}
+	if len(protected) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "warning: terraform will refuse to destroy %d resource(s) protected by lifecycle { prevent_destroy = true }:\n", len(protected))
+	for _, addr := range protected {
+		fmt.Fprintf(w, "  %s\n", addr)
+	}
+	fmt.Fprintln(w, "   the destroy may halt partway; remove the lifecycle block in HCL to enable tear-down.")
 }
 
 // resolveDestroyConfirmation gates a destructive operation. If --confirm was supplied it must

--- a/cmd/destroy_test.go
+++ b/cmd/destroy_test.go
@@ -206,6 +206,52 @@ func TestConfirmDestroy(t *testing.T) {
 	})
 }
 
+func TestWarnPreventDestroy(t *testing.T) {
+	t.Run("EmitsNothingWhenNoProtectedResources", func(t *testing.T) {
+		// Given plans with no protected addresses
+		plans := []terraforminfra.TerraformComponentPlan{
+			{ComponentID: "vpc", Destroy: 3},
+			{ComponentID: "cluster", Destroy: 5},
+		}
+		var buf strings.Builder
+
+		// When the warning runs
+		warnPreventDestroy(&buf, plans)
+
+		// Then stderr is silent — common path, no noise
+		if buf.Len() != 0 {
+			t.Errorf("expected no output, got %q", buf.String())
+		}
+	})
+
+	t.Run("ListsEveryProtectedAddressAcrossComponentsWithRemediation", func(t *testing.T) {
+		// Given multiple components, two of which report protected resources
+		plans := []terraforminfra.TerraformComponentPlan{
+			{ComponentID: "vpc", Destroy: 3},
+			{ComponentID: "data", Protected: []string{"aws_db_instance.production"}},
+			{ComponentID: "audit", Protected: []string{"aws_s3_bucket.logs", "aws_kms_key.audit"}},
+		}
+		var buf strings.Builder
+
+		// When the warning runs
+		warnPreventDestroy(&buf, plans)
+
+		// Then it names every address, the total count, and the remediation
+		out := buf.String()
+		if !strings.Contains(out, "3 resource(s)") {
+			t.Errorf("expected count '3 resource(s)' in output, got %q", out)
+		}
+		for _, addr := range []string{"aws_db_instance.production", "aws_s3_bucket.logs", "aws_kms_key.audit"} {
+			if !strings.Contains(out, addr) {
+				t.Errorf("expected address %q in output, got %q", addr, out)
+			}
+		}
+		if !strings.Contains(out, "remove the lifecycle block") {
+			t.Errorf("expected remediation in output, got %q", out)
+		}
+	})
+}
+
 // =============================================================================
 // Test Cases
 // =============================================================================

--- a/integration/destroy_test.go
+++ b/integration/destroy_test.go
@@ -242,3 +242,43 @@ func TestDestroy_ShowsDestroyPlanBeforePromptOrConfirm(t *testing.T) {
 		t.Errorf("expected 'Windsor Destroy Plan' header in output, got:\n%s", combined)
 	}
 }
+
+// TestDestroyTerraform_WarnsWhenPreventDestroySet covers the destroy-time
+// observability hook added for the terraform-lifecycle-hardening D1 finding.
+// A component with `lifecycle { prevent_destroy = true }` is applied, then
+// destroy is invoked: the wrapper surfaces a stderr warning naming the
+// protected addresses (so the operator knows what's coming), and terraform
+// itself enforces the lifecycle block. The wrapper deliberately does not
+// refuse — convergence-on-zero with visibility beats a wrapper-level gate
+// that just trades our error for terraform's.
+func TestDestroyTerraform_WarnsWhenPreventDestroySet(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "prevent-destroy")
+	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
+	if err != nil {
+		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
+	}
+	env = append(env, "WINDSOR_CONTEXT=local")
+	_, stderr, err = helpers.RunCLI(dir, []string{"apply", "terraform", "protected"}, env)
+	if err != nil {
+		t.Fatalf("apply terraform protected: %v\nstderr: %s", err, stderr)
+	}
+
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"destroy", "--confirm=protected", "terraform", "protected"}, env)
+	// terraform itself refuses the destroy, so the command exits non-zero.
+	if err == nil {
+		t.Fatalf("expected destroy to fail at the terraform layer, but it succeeded.\nstdout: %s\nstderr: %s", stdout, stderr)
+	}
+	combined := string(stdout) + string(stderr)
+	// The wrapper's warning surfaced ahead of terraform's enforcement so the
+	// operator sees the protected address before the underlying tool errors.
+	if !strings.Contains(combined, "terraform will refuse to destroy") {
+		t.Errorf("expected wrapper warning in output, got:\n%s", combined)
+	}
+	if !strings.Contains(combined, "null_resource.guarded") {
+		t.Errorf("expected protected resource address in output, got:\n%s", combined)
+	}
+	if !strings.Contains(combined, "remove the lifecycle block") {
+		t.Errorf("expected remediation hint in output, got:\n%s", combined)
+	}
+}

--- a/integration/fixtures/prevent-destroy/contexts/_template/blueprint.yaml
+++ b/integration/fixtures/prevent-destroy/contexts/_template/blueprint.yaml
@@ -1,0 +1,7 @@
+kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: prevent-destroy
+  description: Fixture for the prevent_destroy preflight gate
+terraform:
+  - path: "protected"

--- a/integration/fixtures/prevent-destroy/terraform/protected/main.tf
+++ b/integration/fixtures/prevent-destroy/terraform/protected/main.tf
@@ -1,0 +1,5 @@
+resource "null_resource" "guarded" {
+  lifecycle {
+    prevent_destroy = true
+  }
+}

--- a/integration/fixtures/prevent-destroy/windsor.yaml
+++ b/integration/fixtures/prevent-destroy/windsor.yaml
@@ -1,0 +1,3 @@
+version: v1alpha1
+contexts:
+  local: {}

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -106,7 +106,17 @@ type TerraformComponentPlan struct {
 	NoChanges   bool
 	IsNew       bool
 	Resources   []ResourceChange
-	Err         error
+	// Protected lists resource addresses that terraform reports cannot be
+	// destroyed because their config sets `lifecycle { prevent_destroy = true }`.
+	// Populated only on destroy-plan paths; nil on apply-plan paths.
+	// Informational — cmd/destroy.go surfaces these as a stderr warning so the
+	// operator knows terraform will halt the destroy partway. The wrapper does
+	// not refuse: half-completed destroys orphan more state than letting the
+	// operator see the addresses and decide. Module authors who want a hard
+	// gate should consume TF_VAR_operation / TF_VAR_ephemeral and design the
+	// destroy contract in HCL.
+	Protected []string
+	Err       error
 }
 
 // Action enumerates the kinds of changes a plan can produce for a single resource.
@@ -1360,12 +1370,22 @@ func (s *TerraformStack) planOneTerraformDestroySummary(component *blueprintv1al
 	planArgs = append(planArgs, terraformArgs.PlanDestroyArgs...)
 	planEnv := selectTerraformCommandEnv(terraformVars, true)
 	planOutput, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, planEnv, planArgs...)
+	// terraform exits non-zero when any resource has prevent_destroy = true,
+	// but still emits the diagnostic events naming them. Look for those addresses
+	// regardless of exec error so the preflight can surface them; otherwise the
+	// gate has nothing to act on and the operator just sees a raw plan failure.
+	protected := extractPreventDestroyAddresses(planOutput)
 	if err != nil {
+		if len(protected) > 0 {
+			result.Protected = protected
+			return result
+		}
 		result.Err = fmt.Errorf("error running terraform plan -destroy for %s: %w", component.Path, err)
 		return result
 	}
 
 	result.Add, result.Change, result.Destroy, result.NoChanges, result.Resources = parseTerraformPlanJSON(planOutput)
+	result.Protected = protected
 	return result
 }
 
@@ -1645,6 +1665,78 @@ func parseTerraformPlanJSON(output string) (add, change, destroy int, noChanges 
 		noChanges = true
 	}
 	return
+}
+
+// extractPreventDestroyAddresses scans the line-delimited JSON event stream
+// emitted by `terraform plan -destroy -json` for diagnostic events that
+// terraform produces when a resource has `lifecycle { prevent_destroy = true }`.
+// The diagnostic summary is the canonical signal — terraform emits
+// "Instance cannot be destroyed" verbatim for this case. The address comes from
+// `diagnostic.address` when present (newer terraform/tofu), with a fallback to
+// parsing the `detail` string which always starts with "Resource <addr> has
+// lifecycle.prevent_destroy set". Returns the addresses in the order they
+// appear; duplicates are preserved so callers see each occurrence. Lines that
+// aren't JSON or don't parse are silently skipped, since terraform interleaves
+// non-event output.
+func extractPreventDestroyAddresses(output string) []string {
+	type diagnostic struct {
+		Severity string `json:"severity"`
+		Summary  string `json:"summary"`
+		Address  string `json:"address"`
+		Detail   string `json:"detail"`
+	}
+	type event struct {
+		Type       string      `json:"type"`
+		Diagnostic *diagnostic `json:"diagnostic,omitempty"`
+	}
+
+	var addresses []string
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || !strings.HasPrefix(line, "{") {
+			continue
+		}
+		var ev event
+		if err := json.Unmarshal([]byte(line), &ev); err != nil {
+			continue
+		}
+		if ev.Type != "diagnostic" || ev.Diagnostic == nil {
+			continue
+		}
+		if ev.Diagnostic.Severity != "error" {
+			continue
+		}
+		if ev.Diagnostic.Summary != "Instance cannot be destroyed" {
+			continue
+		}
+		addr := ev.Diagnostic.Address
+		if addr == "" {
+			addr = preventDestroyAddressFromDetail(ev.Diagnostic.Detail)
+		}
+		if addr == "" {
+			continue
+		}
+		addresses = append(addresses, stripModuleMain(addr))
+	}
+	return addresses
+}
+
+// preventDestroyAddressFromDetail extracts the resource address from a
+// "Instance cannot be destroyed" diagnostic detail. Terraform's detail string
+// always opens with "Resource <addr> has lifecycle.prevent_destroy set"; we
+// pull the substring between those markers. Returns "" when the pattern
+// doesn't match, so the caller can skip the malformed event.
+func preventDestroyAddressFromDetail(detail string) string {
+	const prefix = "Resource "
+	const suffix = " has lifecycle.prevent_destroy set"
+	if !strings.HasPrefix(detail, prefix) {
+		return ""
+	}
+	end := strings.Index(detail, suffix)
+	if end < len(prefix) {
+		return ""
+	}
+	return detail[len(prefix):end]
 }
 
 // mapTerraformAction maps a `terraform plan -json` change.action string to the

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -1372,11 +1372,17 @@ func (s *TerraformStack) planOneTerraformDestroySummary(component *blueprintv1al
 	planOutput, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, planEnv, planArgs...)
 	// terraform exits non-zero when any resource has prevent_destroy = true,
 	// but still emits the diagnostic events naming them. Look for those addresses
-	// regardless of exec error so the preflight can surface them; otherwise the
-	// gate has nothing to act on and the operator just sees a raw plan failure.
+	// regardless of exec error so the warning can surface them; otherwise the
+	// operator just sees a raw plan failure.
 	protected := extractPreventDestroyAddresses(planOutput)
 	if err != nil {
 		if len(protected) > 0 {
+			// Parse whatever planned_change / change_summary events terraform
+			// emitted before the diagnostic — without this, plan counts stay
+			// zero and the renderer shows "(no changes)" while the warning
+			// says N resources can't be destroyed, two directly contradictory
+			// signals to the operator.
+			result.Add, result.Change, result.Destroy, result.NoChanges, result.Resources = parseTerraformPlanJSON(planOutput)
 			result.Protected = protected
 			return result
 		}

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -4430,3 +4430,114 @@ func TestParseTerraformPlanJSON(t *testing.T) {
 	})
 }
 
+func TestExtractPreventDestroyAddresses(t *testing.T) {
+	t.Run("ReturnsNilForEmptyOrNonDiagnosticOutput", func(t *testing.T) {
+		// Given an event stream with only planned_change and change_summary events
+		output := strings.Join([]string{
+			`{"type":"planned_change","change":{"resource":{"addr":"module.main.aws_s3_bucket.x"},"action":"delete"}}`,
+			`{"type":"change_summary","changes":{"add":0,"change":0,"remove":1}}`,
+			``,
+		}, "\n")
+
+		// When extracting prevent_destroy addresses
+		got := extractPreventDestroyAddresses(output)
+
+		// Then none are reported
+		if got != nil {
+			t.Errorf("expected nil, got %#v", got)
+		}
+
+		// And empty output produces nil too
+		if extractPreventDestroyAddresses("") != nil {
+			t.Error("expected nil for empty output")
+		}
+	})
+
+	t.Run("ExtractsAddressesAndStripsModuleMainPrefix", func(t *testing.T) {
+		// Given a stream with two prevent_destroy diagnostics and other noise
+		output := strings.Join([]string{
+			`Initialising backend...`,
+			`{"type":"diagnostic","diagnostic":{"severity":"error","summary":"Instance cannot be destroyed","address":"module.main.aws_db_instance.production"}}`,
+			`{"type":"planned_change","change":{"resource":{"addr":"module.main.aws_s3_bucket.audit"},"action":"delete"}}`,
+			`{"type":"diagnostic","diagnostic":{"severity":"error","summary":"Instance cannot be destroyed","address":"module.main.aws_s3_bucket.audit"}}`,
+			`{"type":"change_summary","changes":{"add":0,"change":0,"remove":1}}`,
+			`trailing junk`,
+			``,
+		}, "\n")
+
+		// When extracting
+		got := extractPreventDestroyAddresses(output)
+
+		// Then both addresses are reported in order, module.main. prefix stripped
+		want := []string{"aws_db_instance.production", "aws_s3_bucket.audit"}
+		if len(got) != len(want) {
+			t.Fatalf("expected %d addresses, got %d: %#v", len(want), len(got), got)
+		}
+		for i, addr := range got {
+			if addr != want[i] {
+				t.Errorf("addr[%d]: expected %q, got %q", i, want[i], addr)
+			}
+		}
+	})
+
+	t.Run("IgnoresNonPreventDestroyDiagnostics", func(t *testing.T) {
+		// Given diagnostics that aren't the prevent_destroy signal — wrong severity,
+		// wrong summary, or wrong type entirely
+		output := strings.Join([]string{
+			`{"type":"diagnostic","diagnostic":{"severity":"warning","summary":"Instance cannot be destroyed","address":"module.main.aws_db_instance.warn_only"}}`,
+			`{"type":"diagnostic","diagnostic":{"severity":"error","summary":"Provider produced inconsistent result","address":"module.main.aws_iam_role.x"}}`,
+			`{"type":"some_other_event","diagnostic":{"severity":"error","summary":"Instance cannot be destroyed","address":"module.main.aws_s3_bucket.y"}}`,
+			``,
+		}, "\n")
+
+		// When extracting
+		got := extractPreventDestroyAddresses(output)
+
+		// Then none qualify
+		if got != nil {
+			t.Errorf("expected nil, got %#v", got)
+		}
+	})
+
+	t.Run("FallsBackToDetailWhenAddressFieldIsMissing", func(t *testing.T) {
+		// Given the diagnostic shape that real terraform emits — no `address` field
+		// but `detail` opens with "Resource <addr> has lifecycle.prevent_destroy set"
+		output := strings.Join([]string{
+			`{"type":"diagnostic","diagnostic":{"severity":"error","summary":"Instance cannot be destroyed","detail":"Resource module.main.null_resource.guarded has lifecycle.prevent_destroy set, but the plan calls for this resource to be destroyed."}}`,
+			`{"type":"diagnostic","diagnostic":{"severity":"error","summary":"Instance cannot be destroyed","detail":"Resource aws_db_instance.primary has lifecycle.prevent_destroy set."}}`,
+			``,
+		}, "\n")
+
+		// When extracting
+		got := extractPreventDestroyAddresses(output)
+
+		// Then both addresses are parsed out of the detail
+		want := []string{"null_resource.guarded", "aws_db_instance.primary"}
+		if len(got) != len(want) {
+			t.Fatalf("expected %d addresses, got %d: %#v", len(want), len(got), got)
+		}
+		for i, addr := range got {
+			if addr != want[i] {
+				t.Errorf("addr[%d]: expected %q, got %q", i, want[i], addr)
+			}
+		}
+	})
+
+	t.Run("SkipsDiagnosticsWithNoExtractableAddress", func(t *testing.T) {
+		// Given a malformed diagnostic — no address, no parseable detail
+		output := strings.Join([]string{
+			`{"type":"diagnostic","diagnostic":{"severity":"error","summary":"Instance cannot be destroyed","detail":"some unrelated message"}}`,
+			`{"type":"diagnostic","diagnostic":{"severity":"error","summary":"Instance cannot be destroyed"}}`,
+			``,
+		}, "\n")
+
+		// When extracting
+		got := extractPreventDestroyAddresses(output)
+
+		// Then nothing is reported — silent skip beats reporting empty strings
+		if got != nil {
+			t.Errorf("expected nil for unparseable diagnostics, got %#v", got)
+		}
+	})
+}
+


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> This PR modifies all four destroy entry points to surface `prevent_destroy`-protected addresses before the confirmation prompt; errors on the destroy path are high-stakes and the fix to plan-count rendering required care.
>
> **Overview**
>
> The change scans the `terraform plan -destroy -json` event stream for "Instance cannot be destroyed" diagnostics and collects resource addresses into a new `Protected []string` field on `TerraformComponentPlan`. All destroy commands call `warnPreventDestroy` before the confirmation prompt, naming each protected address so the operator is not surprised when terraform halts the graph midway. The wrapper intentionally does not block — terraform enforces the constraint itself, and a wrapper-level gate would just trade the CLI's error for terraform's error while hiding the specific addresses.
>
> This push fixes a rendering bug from the previous commit: when terraform exits non-zero due to `prevent_destroy`, `parseTerraformPlanJSON` is now called before the early return so plan counts (add/change/destroy) are populated. Without this, the TUI showed "(no changes)" while the warning reported N resources cannot be touched — directly contradictory signals. Test coverage includes the parser, the warning formatter, and an integration test that verifies the warning appears before terraform refuses the destroy.
>
> Reviewed by Claude for commit `6296412`.

<!-- /claude-code-review:summary -->
