### PR TITLE
bug(artifact): add anonymous fallback for OCI artifact downloads on auth errors

### DIFF
--- a/.claude/skills/go-style/SKILL.md
+++ b/.claude/skills/go-style/SKILL.md
@@ -103,6 +103,61 @@ The replacement for all three is the same: delete the comment. If the rationale 
 
 Function headers should describe behavior, not narrate motivation. A header that runs past ~6 lines is usually doing the same job as an in-body novel — moved up to a "legal" location. Trim to: *what it does*, *what it returns*, and *the one constraint a caller must know about*. Drop incident history, design alternatives considered, and "Note on X" tangents — those belong in the commit message.
 
+## Error classification
+
+**Detect error categories with `errors.As` / `errors.Is` against typed errors. Do not use `strings.Contains(err.Error(), ...)` to classify errors.**
+
+Error text is part of the surface, not the contract. It varies between library versions, between providers (ghcr, ECR, ACR, GAR all phrase the "denied" case differently), and gets reshaped every time an upstream layer wraps with `fmt.Errorf("...: %w", err)`. Substring matching on those strings produces three failure modes that have already bitten this codebase:
+
+1. **False negatives.** A new library version or a different provider returns a string your pattern list does not match, and an auth failure silently looks like a generic error to the caller.
+2. **False positives.** Generic patterns like `"POST https://"` or `"blobs/uploads"` flag *any* push error as an auth error, even when the real cause is a network reset, a malformed manifest, or a 5xx from the registry.
+3. **Pattern-list drift.** Each new failure mode adds another string to the list. The list grows. It is never audited. Some entries become dead code, others contradict each other.
+
+The replacement is structural. Almost every Go library that produces categorized errors exposes them as typed errors — use those:
+
+```go
+// ❌ Sketchy substring matching
+if strings.Contains(err.Error(), "UNAUTHORIZED") ||
+    strings.Contains(err.Error(), "DENIED") ||
+    strings.Contains(err.Error(), "POST https://") { // false positive: matches any push error
+    // ...
+}
+
+// ✅ Typed check via errors.As — works through wrapping, version-stable
+var tErr *transport.Error
+if errors.As(err, &tErr) {
+    if tErr.StatusCode == http.StatusUnauthorized || tErr.StatusCode == http.StatusForbidden {
+        // ...
+    }
+    for _, d := range tErr.Errors {
+        if d.Code == transport.UnauthorizedErrorCode || d.Code == transport.DeniedErrorCode {
+            // ...
+        }
+    }
+}
+```
+
+The same rule applies to sentinel errors (`errors.Is(err, io.EOF)`, `errors.Is(err, context.DeadlineExceeded)`), to typed wrappers (`*os.PathError`, `*net.OpError`), and to custom errors defined in this codebase.
+
+### If a library does not expose a typed error
+
+Define your own typed error at the boundary where the library result enters Windsor code, and wrap the raw error with `%w`. From that point on, every downstream check is `errors.As` / `errors.Is` against the typed wrapper — never substring matching on the original library text. Example:
+
+```go
+// At the package boundary that calls the external tool:
+type ExitError struct { Code int; Err error }
+func (e *ExitError) Error() string { return e.Err.Error() }
+func (e *ExitError) Unwrap() error { return e.Err }
+
+if exitErr, ok := raw.(*exec.ExitError); ok {
+    return &ExitError{Code: exitErr.ExitCode(), Err: exitErr}
+}
+```
+
+Downstream callers then do `errors.As(err, &*ExitError)` — no substring matching anywhere in the chain.
+
+The rule has no fallback clause. If you find yourself reaching for `strings.Contains(err.Error(), ...)`, the fix is to add a typed wrapper at the boundary, not to add a substring pattern.
+
 ## Section header naming rule
 
 Section headers must use the **generic category names** listed above — never the name of a specific method, type, or feature. For example:
@@ -120,3 +175,4 @@ All tests for public methods belong under a single `// Test Public Methods` head
 - No inline comments inside function bodies.
 - Naming is consistent with existing package terminology.
 - No dump files introduced.
+- No `strings.Contains(err.Error(), ...)` (or equivalent) for error classification. Use `errors.As` / `errors.Is` against typed errors; if a library lacks one, define a typed wrapper at the boundary.

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -43,7 +43,14 @@ Examples:
 
 		rt := runtime.NewRuntime(rtOpts...)
 
-		comp := composer.NewComposer(rt)
+		var compOpts []*composer.Composer
+		if overridesVal := cmd.Context().Value(composerOverridesKey); overridesVal != nil {
+			if c, ok := overridesVal.(*composer.Composer); ok {
+				compOpts = []*composer.Composer{c}
+			}
+		}
+
+		comp := composer.NewComposer(rt, compOpts...)
 
 		registryURL, err := comp.Push(args[0])
 		if err != nil {

--- a/cmd/push_test.go
+++ b/cmd/push_test.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/spf13/cobra"
+	"github.com/windsorcli/cli/pkg/composer"
 	"github.com/windsorcli/cli/pkg/composer/artifact"
 	"github.com/windsorcli/cli/pkg/composer/blueprint"
 	"github.com/windsorcli/cli/pkg/runtime/config"
@@ -21,6 +24,8 @@ import (
 // =============================================================================
 
 type PushMocks struct {
+	Composer        *composer.Composer
+	ArtifactBuilder *artifact.MockArtifact
 }
 
 // setupPushTest sets up the test environment for push command tests.
@@ -62,16 +67,19 @@ func setupPushTest(t *testing.T) (*PushMocks, *Mocks) {
 		return map[string][]byte{}, nil
 	}
 
-	// Mock artifact builder
+	// Mock artifact builder — default returns a wrapped *transport.Error so the auth-classification
+	// path in push.go (and its docker-login hint) is exercised end-to-end with a realistic shape
 	mockArtifactBuilder := artifact.NewMockArtifact()
 	mockArtifactBuilder.BundleFunc = func() error {
 		return nil
 	}
 	mockArtifactBuilder.PushFunc = func(registryBase string, repoName string, tag string) error {
-		return fmt.Errorf("authentication failed: unauthorized")
+		return fmt.Errorf("failed to push artifact: %w", &transport.Error{StatusCode: http.StatusUnauthorized})
 	}
 
-	return &PushMocks{}, baseMocks
+	mockComposer := &composer.Composer{ArtifactBuilder: mockArtifactBuilder}
+
+	return &PushMocks{Composer: mockComposer, ArtifactBuilder: mockArtifactBuilder}, baseMocks
 }
 
 // createTestPushCmd creates a new cobra.Command for testing the push command.
@@ -96,63 +104,93 @@ func TestPushCmdWithRuntime(t *testing.T) {
 	suppressProcessStdout(t)
 	suppressProcessStderr(t)
 
-	t.Run("SuccessWithRuntime", func(t *testing.T) {
-		// Given proper setup with runtime override
-		_, mocks := setupPushTest(t)
+	t.Run("ClassifiesAuthFailureAndReturnsHint", func(t *testing.T) {
+		// Given a mock composer whose ArtifactBuilder returns a wrapped *transport.Error{401}
+		pushMocks, mocks := setupPushTest(t)
 		cmd := createTestPushCmd()
 		ctx := context.WithValue(context.Background(), runtimeOverridesKey, mocks.Runtime)
+		ctx = context.WithValue(ctx, composerOverridesKey, pushMocks.Composer)
 		cmd.SetContext(ctx)
 		cmd.SetArgs([]string{"registry.example.com/repo:v1.0.0"})
 
 		// When executing the push command
 		err := cmd.Execute()
 
-		// Then it should fail with authentication error (expected in tests)
+		// Then push.go should classify it via IsAuthenticationError and return the auth-failed hint
 		if err == nil {
-			t.Error("Expected authentication error, got nil")
+			t.Fatal("Expected authentication error, got nil")
 		}
 		if !strings.Contains(err.Error(), "Authentication failed") {
-			t.Errorf("Expected authentication error, got %v", err)
+			t.Errorf("Expected 'Authentication failed' (auth-classified), got %v", err)
 		}
 	})
 
-	t.Run("SuccessWithoutTag", func(t *testing.T) {
-		// Given proper setup with runtime override
-		_, mocks := setupPushTest(t)
+	t.Run("ClassifiesAuthFailureWithoutTag", func(t *testing.T) {
+		// Given the same auth scenario but with a registry URL missing an explicit tag
+		pushMocks, mocks := setupPushTest(t)
 		cmd := createTestPushCmd()
 		ctx := context.WithValue(context.Background(), runtimeOverridesKey, mocks.Runtime)
+		ctx = context.WithValue(ctx, composerOverridesKey, pushMocks.Composer)
 		cmd.SetContext(ctx)
 		cmd.SetArgs([]string{"registry.example.com/repo"})
 
 		// When executing the push command
 		err := cmd.Execute()
 
-		// Then it should fail with authentication error (expected in tests)
+		// Then the auth-classification path should still fire — argument parsing happens before push
 		if err == nil {
-			t.Error("Expected authentication error, got nil")
+			t.Fatal("Expected authentication error, got nil")
 		}
 		if !strings.Contains(err.Error(), "Authentication failed") {
-			t.Errorf("Expected authentication error, got %v", err)
+			t.Errorf("Expected 'Authentication failed' (auth-classified), got %v", err)
 		}
 	})
 
-	t.Run("SuccessWithOciUrl", func(t *testing.T) {
-		// Given proper setup with runtime override
-		_, mocks := setupPushTest(t)
+	t.Run("ClassifiesAuthFailureWithOciUrl", func(t *testing.T) {
+		// Given the same auth scenario with an oci:// prefixed URL
+		pushMocks, mocks := setupPushTest(t)
 		cmd := createTestPushCmd()
 		ctx := context.WithValue(context.Background(), runtimeOverridesKey, mocks.Runtime)
+		ctx = context.WithValue(ctx, composerOverridesKey, pushMocks.Composer)
 		cmd.SetContext(ctx)
 		cmd.SetArgs([]string{"oci://ghcr.io/windsorcli/core:v0.0.0"})
 
 		// When executing the push command
 		err := cmd.Execute()
 
-		// Then it should fail with authentication error (expected in tests)
+		// Then auth classification should fire regardless of URL prefix
 		if err == nil {
-			t.Error("Expected authentication error, got nil")
+			t.Fatal("Expected authentication error, got nil")
 		}
 		if !strings.Contains(err.Error(), "Authentication failed") {
-			t.Errorf("Expected authentication error, got %v", err)
+			t.Errorf("Expected 'Authentication failed' (auth-classified), got %v", err)
+		}
+	})
+
+	t.Run("PassesThroughNonAuthErrors", func(t *testing.T) {
+		// Given a mock composer whose ArtifactBuilder returns a non-auth error
+		pushMocks, mocks := setupPushTest(t)
+		pushMocks.ArtifactBuilder.PushFunc = func(registryBase, repoName, tag string) error {
+			return fmt.Errorf("network timeout: dial tcp: i/o timeout")
+		}
+		cmd := createTestPushCmd()
+		ctx := context.WithValue(context.Background(), runtimeOverridesKey, mocks.Runtime)
+		ctx = context.WithValue(ctx, composerOverridesKey, pushMocks.Composer)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"registry.example.com/repo:v1.0.0"})
+
+		// When executing the push command
+		err := cmd.Execute()
+
+		// Then push.go should NOT classify it as auth — surfaces the underlying error verbatim
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if strings.Contains(err.Error(), "Authentication failed") {
+			t.Errorf("Non-auth error misclassified as auth: %v", err)
+		}
+		if !strings.Contains(err.Error(), "network timeout") {
+			t.Errorf("Expected underlying error to surface, got %v", err)
 		}
 	})
 

--- a/pkg/composer/artifact/artifact.go
+++ b/pkg/composer/artifact/artifact.go
@@ -1348,9 +1348,13 @@ func (a *ArtifactBuilder) extractArtifactToCache(artifactData []byte, extraction
 // Downloads the first layer of the OCI image which contains the artifact data.
 // Returns the uncompressed layer data as bytes for further processing.
 // Authenticates via the Docker keychain so private registries work; if the registry rejects
-// those credentials (401/403), retries anonymously so public artifacts still pull when the
-// local Docker config holds stale or scope-limited tokens. If the anonymous retry also fails,
-// the original keychain error is returned so the underlying auth failure remains visible.
+// those credentials (per IsAuthenticationError), retries anonymously so public artifacts still
+// pull when the local Docker config holds stale or scope-limited tokens. In verbose mode, on
+// a successful anonymous retry, emits a stderr note naming the registry so an operator who
+// opts into the detail can see that their configured credentials were bypassed; silent in
+// normal mode because the case is common for any user who has ever run `docker login`.
+// If the anonymous retry also fails, the original keychain error is returned so the
+// underlying auth failure remains visible.
 func (a *ArtifactBuilder) downloadOCIArtifact(registry, repository, tag string) ([]byte, error) {
 	ref := fmt.Sprintf("%s/%s:%s", registry, repository, tag)
 
@@ -1362,6 +1366,9 @@ func (a *ArtifactBuilder) downloadOCIArtifact(registry, repository, tag string) 
 	img, err := a.shims.RemoteImage(parsedRef, remote.WithAuthFromKeychain(authn.DefaultKeychain))
 	if err != nil && IsAuthenticationError(err) {
 		if anonImg, anonErr := a.shims.RemoteImage(parsedRef, remote.WithAuth(authn.Anonymous)); anonErr == nil {
+			if a.shell.IsVerbose() {
+				fmt.Fprintf(os.Stderr, "keychain credentials rejected by %s; pulled anonymously\n", registry)
+			}
 			img, err = anonImg, nil
 		}
 	}

--- a/pkg/composer/artifact/artifact.go
+++ b/pkg/composer/artifact/artifact.go
@@ -581,41 +581,27 @@ func ParseRegistryURL(registryURL string) (registryBase, repoName, tag string, e
 	return registryBase, repoName, tag, nil
 }
 
-// IsAuthenticationError checks if the error is related to authentication failure.
-// It examines common authentication error patterns in error messages to determine
-// if the failure is due to authentication issues rather than other problems.
+// IsAuthenticationError reports whether err originates from a registry authentication or
+// authorization failure, detected via the *transport.Error type from go-containerregistry
+// (HTTP 401/403 or UNAUTHORIZED/DENIED diagnostic codes). Walks the wrap chain via errors.As,
+// so wrapping with fmt.Errorf("...: %w", err) is transparent. Used by the push command to
+// decide whether to hint the user to run `docker login`.
 func IsAuthenticationError(err error) bool {
 	if err == nil {
 		return false
 	}
-
-	errStr := err.Error()
-
-	authErrorPatterns := []string{
-		"UNAUTHORIZED",
-		"unauthorized",
-		"DENIED",
-		"authentication required",
-		"authentication failed",
-		"not authorized",
-		"access denied",
-		"login required",
-		"credentials required",
-		"401",
-		"403",
-		"unauthenticated",
-		"User cannot be authenticated",
-		"failed to push artifact",
-		"POST https://",
-		"blobs/uploads",
+	var tErr *transport.Error
+	if !errors.As(err, &tErr) {
+		return false
 	}
-
-	for _, pattern := range authErrorPatterns {
-		if strings.Contains(errStr, pattern) {
+	if tErr.StatusCode == http.StatusUnauthorized || tErr.StatusCode == http.StatusForbidden {
+		return true
+	}
+	for _, d := range tErr.Errors {
+		if d.Code == transport.UnauthorizedErrorCode || d.Code == transport.DeniedErrorCode {
 			return true
 		}
 	}
-
 	return false
 }
 

--- a/pkg/composer/artifact/artifact.go
+++ b/pkg/composer/artifact/artifact.go
@@ -1360,12 +1360,9 @@ func (a *ArtifactBuilder) downloadOCIArtifact(registry, repository, tag string) 
 	}
 
 	img, err := a.shims.RemoteImage(parsedRef, remote.WithAuthFromKeychain(authn.DefaultKeychain))
-	if err != nil {
-		var tErr *transport.Error
-		if errors.As(err, &tErr) && (tErr.StatusCode == http.StatusUnauthorized || tErr.StatusCode == http.StatusForbidden) {
-			if anonImg, anonErr := a.shims.RemoteImage(parsedRef, remote.WithAuth(authn.Anonymous)); anonErr == nil {
-				img, err = anonImg, nil
-			}
+	if err != nil && IsAuthenticationError(err) {
+		if anonImg, anonErr := a.shims.RemoteImage(parsedRef, remote.WithAuth(authn.Anonymous)); anonErr == nil {
+			img, err = anonImg, nil
 		}
 	}
 	if err != nil {

--- a/pkg/composer/artifact/artifact.go
+++ b/pkg/composer/artifact/artifact.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -17,6 +18,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/static"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 	"github.com/windsorcli/cli/pkg/constants"
@@ -592,6 +594,7 @@ func IsAuthenticationError(err error) bool {
 	authErrorPatterns := []string{
 		"UNAUTHORIZED",
 		"unauthorized",
+		"DENIED",
 		"authentication required",
 		"authentication failed",
 		"not authorized",
@@ -1358,6 +1361,10 @@ func (a *ArtifactBuilder) extractArtifactToCache(artifactData []byte, extraction
 // Constructs an OCI reference from registry, repository, and tag components.
 // Downloads the first layer of the OCI image which contains the artifact data.
 // Returns the uncompressed layer data as bytes for further processing.
+// Authenticates via the Docker keychain so private registries work; if the registry rejects
+// those credentials (401/403), retries anonymously so public artifacts still pull when the
+// local Docker config holds stale or scope-limited tokens. If the anonymous retry also fails,
+// the original keychain error is returned so the underlying auth failure remains visible.
 func (a *ArtifactBuilder) downloadOCIArtifact(registry, repository, tag string) ([]byte, error) {
 	ref := fmt.Sprintf("%s/%s:%s", registry, repository, tag)
 
@@ -1367,6 +1374,14 @@ func (a *ArtifactBuilder) downloadOCIArtifact(registry, repository, tag string) 
 	}
 
 	img, err := a.shims.RemoteImage(parsedRef, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		var tErr *transport.Error
+		if errors.As(err, &tErr) && (tErr.StatusCode == http.StatusUnauthorized || tErr.StatusCode == http.StatusForbidden) {
+			if anonImg, anonErr := a.shims.RemoteImage(parsedRef, remote.WithAuth(authn.Anonymous)); anonErr == nil {
+				img, err = anonImg, nil
+			}
+		}
+	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to get image: %w", err)
 	}

--- a/pkg/composer/artifact/artifact_helpers_test.go
+++ b/pkg/composer/artifact/artifact_helpers_test.go
@@ -2,8 +2,11 @@ package artifact
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 	"testing"
+
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 )
 
 func TestParseOCIReference(t *testing.T) {
@@ -266,146 +269,73 @@ func TestParseRegistryURL(t *testing.T) {
 	})
 }
 func TestIsAuthenticationError(t *testing.T) {
-	t.Run("ReturnsTrueForUNAUTHORIZED", func(t *testing.T) {
-		// Given an error with UNAUTHORIZED
-		err := fmt.Errorf("UNAUTHORIZED: access denied")
+	t.Run("ReturnsTrueForWrappedTransportError401", func(t *testing.T) {
+		// Given a *transport.Error with HTTP 401 wrapped by fmt.Errorf %w (the shape the push
+		// path actually produces: composer.Push wraps artifact.Push wraps shim's transport.Error)
+		err := fmt.Errorf("failed to push artifact: %w", &transport.Error{StatusCode: http.StatusUnauthorized})
 
 		// When checking if it's an authentication error
 		result := IsAuthenticationError(err)
 
-		// Then it should return true
+		// Then errors.As should reach through the wrap chain and classify as auth
 		if !result {
-			t.Error("Expected true for UNAUTHORIZED error")
+			t.Error("Expected true for wrapped transport.Error with status 401")
 		}
 	})
 
-	t.Run("ReturnsTrueForUnauthorized", func(t *testing.T) {
-		// Given an error with unauthorized
-		err := fmt.Errorf("unauthorized access")
+	t.Run("ReturnsTrueForWrappedTransportError403", func(t *testing.T) {
+		// Given a *transport.Error with HTTP 403 wrapped through the push call chain
+		err := fmt.Errorf("failed to push artifact: %w", &transport.Error{StatusCode: http.StatusForbidden})
 
 		// When checking if it's an authentication error
 		result := IsAuthenticationError(err)
 
-		// Then it should return true
+		// Then it should be classified as auth
 		if !result {
-			t.Error("Expected true for unauthorized error")
+			t.Error("Expected true for wrapped transport.Error with status 403")
 		}
 	})
 
-	t.Run("ReturnsTrueForRegistryDENIED", func(t *testing.T) {
-		// Given the literal error string ghcr.io returns when the token endpoint refuses credentials
-		err := fmt.Errorf("GET https://ghcr.io/token?scope=repository:org/repo:pull&service=ghcr.io: DENIED: requested access to the resource is denied")
+	t.Run("ReturnsTrueForTransportErrorWithUnauthorizedDiagnostic", func(t *testing.T) {
+		// Given a *transport.Error whose HTTP status is not 401/403 but whose diagnostic
+		// payload carries an UNAUTHORIZED code (some registries return 200 OK on the token
+		// endpoint with the auth refusal embedded in the body diagnostics)
+		err := &transport.Error{StatusCode: http.StatusOK, Errors: []transport.Diagnostic{{Code: transport.UnauthorizedErrorCode}}}
 
 		// When checking if it's an authentication error
 		result := IsAuthenticationError(err)
 
-		// Then it should be classified as an auth error so push.go can hint the user to log in
+		// Then the diagnostic code should be honored
 		if !result {
-			t.Error("Expected true for registry DENIED error")
+			t.Error("Expected true for transport.Error with UNAUTHORIZED diagnostic code")
 		}
 	})
 
-	t.Run("ReturnsTrueForAuthenticationRequired", func(t *testing.T) {
-		// Given an error with authentication required
-		err := fmt.Errorf("authentication required to access this resource")
+	t.Run("ReturnsTrueForTransportErrorWithDeniedDiagnostic", func(t *testing.T) {
+		// Given a *transport.Error carrying a DENIED diagnostic code (ghcr.io's token-endpoint
+		// shape — the exact case that triggered this fix)
+		err := &transport.Error{StatusCode: http.StatusOK, Errors: []transport.Diagnostic{{Code: transport.DeniedErrorCode}}}
 
 		// When checking if it's an authentication error
 		result := IsAuthenticationError(err)
 
-		// Then it should return true
+		// Then the diagnostic code should be honored
 		if !result {
-			t.Error("Expected true for authentication required error")
+			t.Error("Expected true for transport.Error with DENIED diagnostic code")
 		}
 	})
 
-	t.Run("ReturnsTrueForAuthenticationFailed", func(t *testing.T) {
-		// Given an error with authentication failed
-		err := fmt.Errorf("authentication failed")
+	t.Run("ReturnsFalseForTransportErrorWithNonAuthStatus", func(t *testing.T) {
+		// Given a *transport.Error with a status code unrelated to auth (404 from a missing manifest)
+		err := &transport.Error{StatusCode: http.StatusNotFound}
 
 		// When checking if it's an authentication error
 		result := IsAuthenticationError(err)
 
-		// Then it should return true
-		if !result {
-			t.Error("Expected true for authentication failed error")
-		}
-	})
-
-	t.Run("ReturnsTrueForHTTP401", func(t *testing.T) {
-		// Given an error with HTTP 401
-		err := fmt.Errorf("HTTP 401: unauthorized")
-
-		// When checking if it's an authentication error
-		result := IsAuthenticationError(err)
-
-		// Then it should return true
-		if !result {
-			t.Error("Expected true for HTTP 401 error")
-		}
-	})
-
-	t.Run("ReturnsTrueForHTTP403", func(t *testing.T) {
-		// Given an error with HTTP 403
-		err := fmt.Errorf("HTTP 403: forbidden")
-
-		// When checking if it's an authentication error
-		result := IsAuthenticationError(err)
-
-		// Then it should return true
-		if !result {
-			t.Error("Expected true for HTTP 403 error")
-		}
-	})
-
-	t.Run("ReturnsTrueForBlobsUploads", func(t *testing.T) {
-		// Given an error with blobs/uploads
-		err := fmt.Errorf("POST https://registry.com/v2/repo/blobs/uploads: unauthorized")
-
-		// When checking if it's an authentication error
-		result := IsAuthenticationError(err)
-
-		// Then it should return true
-		if !result {
-			t.Error("Expected true for blobs/uploads error")
-		}
-	})
-
-	t.Run("ReturnsTrueForPOSTHTTPS", func(t *testing.T) {
-		// Given an error with POST https://
-		err := fmt.Errorf("POST https://registry.com/v2/repo/manifests/latest: unauthorized")
-
-		// When checking if it's an authentication error
-		result := IsAuthenticationError(err)
-
-		// Then it should return true
-		if !result {
-			t.Error("Expected true for POST https:// error")
-		}
-	})
-
-	t.Run("ReturnsTrueForFailedToPushArtifact", func(t *testing.T) {
-		// Given an error with failed to push artifact
-		err := fmt.Errorf("failed to push artifact: unauthorized")
-
-		// When checking if it's an authentication error
-		result := IsAuthenticationError(err)
-
-		// Then it should return true
-		if !result {
-			t.Error("Expected true for failed to push artifact error")
-		}
-	})
-
-	t.Run("ReturnsTrueForUserCannotBeAuthenticated", func(t *testing.T) {
-		// Given an error with User cannot be authenticated
-		err := fmt.Errorf("User cannot be authenticated")
-
-		// When checking if it's an authentication error
-		result := IsAuthenticationError(err)
-
-		// Then it should return true
-		if !result {
-			t.Error("Expected true for User cannot be authenticated error")
+		// Then it should NOT be classified as auth — the prior substring impl would falsely
+		// match "404" against any error containing that digit
+		if result {
+			t.Error("Expected false for transport.Error 404 — not an auth failure")
 		}
 	})
 
@@ -422,42 +352,17 @@ func TestIsAuthenticationError(t *testing.T) {
 		}
 	})
 
-	t.Run("ReturnsFalseForGenericError", func(t *testing.T) {
-		// Given a generic error
-		err := fmt.Errorf("network timeout")
+	t.Run("ReturnsFalseForNonTransportError", func(t *testing.T) {
+		// Given an error that is not a *transport.Error and contains no embedded one — for example
+		// a network timeout or a pre-flight error before any registry round-trip
+		err := fmt.Errorf("network timeout: dial tcp: i/o timeout")
 
 		// When checking if it's an authentication error
 		result := IsAuthenticationError(err)
 
-		// Then it should return false
+		// Then it should return false — only typed registry auth errors qualify
 		if result {
-			t.Error("Expected false for generic error")
-		}
-	})
-
-	t.Run("ReturnsFalseForParseError", func(t *testing.T) {
-		// Given a parse error
-		err := fmt.Errorf("failed to parse JSON")
-
-		// When checking if it's an authentication error
-		result := IsAuthenticationError(err)
-
-		// Then it should return false
-		if result {
-			t.Error("Expected false for parse error")
-		}
-	})
-
-	t.Run("ReturnsFalseForNotFoundError", func(t *testing.T) {
-		// Given a not found error
-		err := fmt.Errorf("resource not found")
-
-		// When checking if it's an authentication error
-		result := IsAuthenticationError(err)
-
-		// Then it should return false
-		if result {
-			t.Error("Expected false for not found error")
+			t.Error("Expected false for non-transport error")
 		}
 	})
 }

--- a/pkg/composer/artifact/artifact_helpers_test.go
+++ b/pkg/composer/artifact/artifact_helpers_test.go
@@ -292,6 +292,19 @@ func TestIsAuthenticationError(t *testing.T) {
 		}
 	})
 
+	t.Run("ReturnsTrueForRegistryDENIED", func(t *testing.T) {
+		// Given the literal error string ghcr.io returns when the token endpoint refuses credentials
+		err := fmt.Errorf("GET https://ghcr.io/token?scope=repository:org/repo:pull&service=ghcr.io: DENIED: requested access to the resource is denied")
+
+		// When checking if it's an authentication error
+		result := IsAuthenticationError(err)
+
+		// Then it should be classified as an auth error so push.go can hint the user to log in
+		if !result {
+			t.Error("Expected true for registry DENIED error")
+		}
+	})
+
 	t.Run("ReturnsTrueForAuthenticationRequired", func(t *testing.T) {
 		// Given an error with authentication required
 		err := fmt.Errorf("authentication required to access this resource")

--- a/pkg/composer/artifact/artifact_private_test.go
+++ b/pkg/composer/artifact/artifact_private_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -15,6 +16,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
+	"github.com/google/go-containerregistry/pkg/v1/remote/transport"
 	"github.com/google/go-containerregistry/pkg/v1/static"
 	"github.com/google/go-containerregistry/pkg/v1/types"
 )
@@ -1290,6 +1292,98 @@ func TestArtifactBuilder_downloadOCIArtifact(t *testing.T) {
 		// Then exactly one option (the keychain auth option) should be forwarded so private registries authenticate
 		if len(capturedOptions) != 1 {
 			t.Fatalf("expected 1 remote option to be forwarded for keychain auth, got %d", len(capturedOptions))
+		}
+	})
+
+	t.Run("RetriesAnonymouslyWhenKeychainRejectedByRegistry", func(t *testing.T) {
+		// Given a registry that rejects keychain credentials but accepts anonymous access
+		builder, mocks := setup(t)
+
+		mocks.Shims.ParseReference = func(ref string, opts ...name.Option) (name.Reference, error) {
+			return nil, nil
+		}
+
+		callCount := 0
+		mocks.Shims.RemoteImage = func(ref name.Reference, options ...remote.Option) (v1.Image, error) {
+			callCount++
+			if callCount == 1 {
+				return nil, &transport.Error{StatusCode: http.StatusForbidden, Errors: []transport.Diagnostic{{Code: transport.DeniedErrorCode}}}
+			}
+			return nil, nil
+		}
+		mocks.Shims.ImageLayers = func(img v1.Image) ([]v1.Layer, error) {
+			return nil, fmt.Errorf("stop after retry succeeded")
+		}
+
+		// When downloadOCIArtifact is called
+		_, err := builder.downloadOCIArtifact("ghcr.io", "windsorcli/core", "v0.7.0-rc.1")
+
+		// Then RemoteImage should be called twice (keychain then anonymous)
+		if callCount != 2 {
+			t.Fatalf("expected 2 RemoteImage calls (keychain + anonymous retry), got %d", callCount)
+		}
+		// And execution should proceed past the get-image step, reaching ImageLayers
+		if err == nil || !strings.Contains(err.Error(), "failed to get image layers") {
+			t.Fatalf("expected retry to succeed and execution to reach ImageLayers, got %v", err)
+		}
+	})
+
+	t.Run("PreservesOriginalErrorWhenAnonymousRetryAlsoFails", func(t *testing.T) {
+		// Given a registry that rejects both keychain and anonymous access with distinguishable errors
+		builder, mocks := setup(t)
+
+		mocks.Shims.ParseReference = func(ref string, opts ...name.Option) (name.Reference, error) {
+			return nil, nil
+		}
+
+		callCount := 0
+		mocks.Shims.RemoteImage = func(ref name.Reference, options ...remote.Option) (v1.Image, error) {
+			callCount++
+			if callCount == 1 {
+				return nil, &transport.Error{StatusCode: http.StatusUnauthorized, Errors: []transport.Diagnostic{{Code: transport.DeniedErrorCode, Message: "keychain-denied-marker"}}}
+			}
+			return nil, &transport.Error{StatusCode: http.StatusNotFound, Errors: []transport.Diagnostic{{Code: transport.ManifestUnknownErrorCode, Message: "anon-not-found-marker"}}}
+		}
+
+		// When downloadOCIArtifact is called
+		_, err := builder.downloadOCIArtifact("ghcr.io", "private/repo", "v1.0.0")
+
+		// Then the keychain error should be surfaced (it carries the real auth failure reason),
+		// not the anonymous-retry error
+		if err == nil {
+			t.Fatal("expected error when both attempts fail")
+		}
+		if !strings.Contains(err.Error(), "keychain-denied-marker") {
+			t.Errorf("expected original keychain error to be preserved, got %v", err)
+		}
+		if strings.Contains(err.Error(), "anon-not-found-marker") {
+			t.Errorf("expected anonymous-retry error to be suppressed, got %v", err)
+		}
+	})
+
+	t.Run("DoesNotRetryOnNonAuthError", func(t *testing.T) {
+		// Given a non-authentication failure on the first RemoteImage call
+		builder, mocks := setup(t)
+
+		mocks.Shims.ParseReference = func(ref string, opts ...name.Option) (name.Reference, error) {
+			return nil, nil
+		}
+
+		callCount := 0
+		mocks.Shims.RemoteImage = func(ref name.Reference, options ...remote.Option) (v1.Image, error) {
+			callCount++
+			return nil, fmt.Errorf("connection refused")
+		}
+
+		// When downloadOCIArtifact is called
+		_, err := builder.downloadOCIArtifact("registry.example.com", "modules", "v1.0.0")
+
+		// Then no anonymous retry should happen
+		if callCount != 1 {
+			t.Fatalf("expected exactly 1 RemoteImage call for non-auth error, got %d", callCount)
+		}
+		if err == nil || !strings.Contains(err.Error(), "connection refused") {
+			t.Errorf("expected original error to be returned, got %v", err)
 		}
 	})
 }

--- a/pkg/composer/artifact/artifact_private_test.go
+++ b/pkg/composer/artifact/artifact_private_test.go
@@ -1328,6 +1328,40 @@ func TestArtifactBuilder_downloadOCIArtifact(t *testing.T) {
 		}
 	})
 
+	t.Run("RetriesAnonymouslyOnDeniedDiagnosticWithNonAuthStatus", func(t *testing.T) {
+		// Given a *transport.Error whose HTTP status is not 401/403 but whose Diagnostic.Code is
+		// DENIED — the ghcr.io token-endpoint shape that IsAuthenticationError catches and
+		// that the old inline status-only gate would have missed
+		builder, mocks := setup(t)
+
+		mocks.Shims.ParseReference = func(ref string, opts ...name.Option) (name.Reference, error) {
+			return nil, nil
+		}
+
+		callCount := 0
+		mocks.Shims.RemoteImage = func(ref name.Reference, options ...remote.Option) (v1.Image, error) {
+			callCount++
+			if callCount == 1 {
+				return nil, &transport.Error{StatusCode: http.StatusOK, Errors: []transport.Diagnostic{{Code: transport.DeniedErrorCode}}}
+			}
+			return nil, nil
+		}
+		mocks.Shims.ImageLayers = func(img v1.Image) ([]v1.Layer, error) {
+			return nil, fmt.Errorf("stop after retry succeeded")
+		}
+
+		// When downloadOCIArtifact is called
+		_, err := builder.downloadOCIArtifact("ghcr.io", "windsorcli/core", "v0.7.0-rc.1")
+
+		// Then the anonymous retry should fire on the diagnostic-only auth refusal
+		if callCount != 2 {
+			t.Fatalf("expected 2 RemoteImage calls (keychain + anonymous retry on DENIED diagnostic), got %d", callCount)
+		}
+		if err == nil || !strings.Contains(err.Error(), "failed to get image layers") {
+			t.Fatalf("expected retry to succeed and execution to reach ImageLayers, got %v", err)
+		}
+	})
+
 	t.Run("PreservesOriginalErrorWhenAnonymousRetryAlsoFails", func(t *testing.T) {
 		// Given a registry that rejects both keychain and anonymous access with distinguishable errors
 		builder, mocks := setup(t)


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> The anonymous fallback in `downloadOCIArtifact` affects all OCI pulls; the one open medium finding is that credential bypass is silent in non-verbose mode.
>
> **Overview**
>
> This PR replaces the substring-pattern list in `IsAuthenticationError` with typed `errors.As` checks against `*transport.Error`, covering both HTTP status codes (401/403) and diagnostic codes (UNAUTHORIZED/DENIED). When keychain credentials are rejected by the registry, `downloadOCIArtifact` retries anonymously so public artifacts still pull when local tokens are stale. Push tests are rewritten to produce real `*transport.Error` shapes, and the `errors.As`/`errors.Is` convention is documented in SKILL.md.
>
> The retry gate now correctly delegates to `IsAuthenticationError` (closing the previous medium thread on that point). In verbose mode a message names the bypassed registry; in non-verbose mode the fallback is silent, which remains the one open medium concern — an operator whose credentials are stale will see a successful pull with no indication that configured auth was skipped. One Low thread (in-body comment in `cmd/push_test.go`) also remains open.
>
> Reviewed by Claude for commit `1d31f531`.

<!-- /claude-code-review:summary -->
