### PR TITLE
feat(workstation/network): add domain validation and improve file handling in ConfigureDNS

### DIFF
--- a/pkg/workstation/network/darwin_network.go
+++ b/pkg/workstation/network/darwin_network.go
@@ -179,6 +179,9 @@ func (n *BaseNetworkManager) needsPrivilegeForResolver(desiredIP string) bool {
 	if tld == "" {
 		return false
 	}
+	if err := validateDomain(tld); err != nil {
+		return false
+	}
 	resolverFile := fmt.Sprintf("/etc/resolver/%s", tld)
 	existingContent, err := n.shims.ReadFile(resolverFile)
 	if err != nil {

--- a/pkg/workstation/network/darwin_network.go
+++ b/pkg/workstation/network/darwin_network.go
@@ -85,6 +85,9 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 	if tld == "" {
 		return fmt.Errorf("DNS domain is not configured")
 	}
+	if err := validateDomain(tld); err != nil {
+		return err
+	}
 
 	dnsIP := n.effectiveResolverIP()
 	if dnsIP == "" {
@@ -107,36 +110,13 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 	}
 
 	if _, err := n.shims.Stat(resolverDir); os.IsNotExist(err) {
-		if _, err := n.shell.ExecSudo(
-			"Creating resolver directory",
-			"mkdir",
-			"-p",
-			resolverDir,
-		); err != nil {
+		if _, err := n.shell.ExecSudo("", "mkdir", "-p", resolverDir); err != nil {
 			return fmt.Errorf("Error creating resolver directory: %w", err)
 		}
 	}
 
-	tempResolverFile := fmt.Sprintf("/tmp/%s", tld)
-	if err := n.shims.WriteFile(tempResolverFile, []byte(content), 0644); err != nil {
-		return fmt.Errorf("Error writing to temporary resolver file: %w", err)
-	}
-
-	if _, err := n.shell.ExecSudo(
-		"",
-		"mv",
-		tempResolverFile,
-		resolverFile,
-	); err != nil {
-		return fmt.Errorf("Error moving resolver file: %w", err)
-	}
-	if _, err := n.shell.ExecSudo(
-		"",
-		"chmod",
-		"0644",
-		resolverFile,
-	); err != nil {
-		return fmt.Errorf("Error setting resolver file mode: %w", err)
+	if err := n.writeFileWithSudo(resolverFile, []byte(content)); err != nil {
+		return fmt.Errorf("Error installing resolver file: %w", err)
 	}
 
 	return nil

--- a/pkg/workstation/network/darwin_network_test.go
+++ b/pkg/workstation/network/darwin_network_test.go
@@ -330,7 +330,7 @@ func TestDarwinNetworkManager_ConfigureDNS(t *testing.T) {
 		if err == nil {
 			t.Fatalf("expected error, got nil")
 		}
-		expectedError := "Error writing to temporary resolver file: mock error writing to temporary resolver file"
+		expectedError := "Error installing resolver file: failed to stage file: mock error writing to temporary resolver file"
 		if err.Error() != expectedError {
 			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
 		}
@@ -361,7 +361,7 @@ func TestDarwinNetworkManager_ConfigureDNS(t *testing.T) {
 		if err == nil {
 			t.Fatalf("expected error, got nil")
 		}
-		expectedError := "Error moving resolver file: mock error moving resolver file"
+		expectedError := "Error installing resolver file: failed to install file: mock error moving resolver file"
 		if err.Error() != expectedError {
 			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
 		}
@@ -379,6 +379,24 @@ func TestDarwinNetworkManager_ConfigureDNS(t *testing.T) {
 		// Then no error should occur
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("DomainWithPathSeparatorRejected", func(t *testing.T) {
+		// Given a malformed DNS domain that would let configuration escape the resolver directory
+		manager, mocks := setup(t)
+		mocks.ConfigHandler.Set("dns.domain", "evil/../etc/passwd")
+
+		// When configuring DNS
+		err := manager.ConfigureDNS()
+
+		// Then validation rejects it before any filesystem or shell operation runs
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		expectedError := `invalid DNS domain "evil/../etc/passwd": contains path separator`
+		if err.Error() != expectedError {
+			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
 		}
 	})
 }

--- a/pkg/workstation/network/darwin_network_test.go
+++ b/pkg/workstation/network/darwin_network_test.go
@@ -399,6 +399,36 @@ func TestDarwinNetworkManager_ConfigureDNS(t *testing.T) {
 			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
 		}
 	})
+
+	t.Run("DotOnlyDomainRejectedBeforeMv", func(t *testing.T) {
+		// Given a dot-only DNS domain. /etc/resolver/.. resolves to /etc/, so without this guard
+		// a subsequent sudo mv would deposit the staged drop-in at /etc/drop-in.
+		manager, mocks := setup(t)
+		mocks.ConfigHandler.Set("dns.domain", "..")
+		mocks.ConfigHandler.Set("workstation.dns.address", "1.2.3.4")
+
+		// And tracking whether a sudo mv (or any sudo) ever runs
+		var sudoCommands []string
+		mocks.Shell.ExecSudoFunc = func(_, command string, _ ...string) (string, error) {
+			sudoCommands = append(sudoCommands, command)
+			return "", nil
+		}
+
+		// When configuring DNS
+		err := manager.ConfigureDNS()
+
+		// Then validation rejects with the empty-label error before any sudo step runs
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		expectedError := `invalid DNS domain "..": contains empty label`
+		if err.Error() != expectedError {
+			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
+		}
+		if len(sudoCommands) != 0 {
+			t.Fatalf("expected zero sudo invocations before validation rejection, got %v", sudoCommands)
+		}
+	})
 }
 
 func TestDarwinNetworkManager_FlushDNS(t *testing.T) {

--- a/pkg/workstation/network/darwin_network_test.go
+++ b/pkg/workstation/network/darwin_network_test.go
@@ -382,7 +382,7 @@ func TestDarwinNetworkManager_ConfigureDNS(t *testing.T) {
 		}
 	})
 
-	t.Run("DomainWithPathSeparatorRejected", func(t *testing.T) {
+	t.Run("DomainOutsideAllowlistRejected", func(t *testing.T) {
 		// Given a malformed DNS domain that would let configuration escape the resolver directory
 		manager, mocks := setup(t)
 		mocks.ConfigHandler.Set("dns.domain", "evil/../etc/passwd")
@@ -394,7 +394,7 @@ func TestDarwinNetworkManager_ConfigureDNS(t *testing.T) {
 		if err == nil {
 			t.Fatalf("expected error, got nil")
 		}
-		expectedError := `invalid DNS domain "evil/../etc/passwd": contains path separator`
+		expectedError := `invalid DNS domain "evil/../etc/passwd": must contain only letters, digits, hyphen, and dot`
 		if err.Error() != expectedError {
 			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
 		}

--- a/pkg/workstation/network/linux_network.go
+++ b/pkg/workstation/network/linux_network.go
@@ -147,6 +147,9 @@ func (n *BaseNetworkManager) needsPrivilegeForResolver(desiredIP string) bool {
 	if domain == "" {
 		return false
 	}
+	if err := validateDomain(domain); err != nil {
+		return false
+	}
 	resolvConf, err := n.shims.ReadLink("/etc/resolv.conf")
 	if err != nil || !isSystemdResolvedStubLink(resolvConf) {
 		return false

--- a/pkg/workstation/network/linux_network.go
+++ b/pkg/workstation/network/linux_network.go
@@ -78,6 +78,9 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 	if domain == "" {
 		return fmt.Errorf("DNS domain is not configured")
 	}
+	if err := validateDomain(domain); err != nil {
+		return err
+	}
 
 	dnsIP := n.effectiveResolverIP()
 	if dnsIP == "" {
@@ -85,7 +88,7 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 	}
 
 	resolvConf, err := n.shims.ReadLink("/etc/resolv.conf")
-	if err != nil || resolvConf != "../run/systemd/resolve/stub-resolv.conf" {
+	if err != nil || !isSystemdResolvedStubLink(resolvConf) {
 		return fmt.Errorf("systemd-resolved is not in use. Please configure DNS manually or use a compatible system")
 	}
 
@@ -104,33 +107,15 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 		fmt.Fprintf(os.Stderr, "\n\033[33m⚠\033[0m DNS configuration may require elevated privileges\n")
 	}
 
-	_, err = n.shell.ExecSudo(
-		"Creating DNS configuration directory",
-		"mkdir",
-		"-p",
-		dropInDir,
-	)
-	if err != nil {
+	if _, err := n.shell.ExecSudo("", "mkdir", "-p", dropInDir); err != nil {
 		return fmt.Errorf("failed to create drop-in directory: %w", err)
 	}
 
-	_, err = n.shell.ExecSudo(
-		"Writing DNS configuration to "+dropInFile,
-		"bash",
-		"-c",
-		fmt.Sprintf("echo '%s' | sudo tee %s", expectedContent, dropInFile),
-	)
-	if err != nil {
+	if err := n.writeFileWithSudo(dropInFile, []byte(expectedContent)); err != nil {
 		return fmt.Errorf("failed to write DNS configuration: %w", err)
 	}
 
-	_, err = n.shell.ExecSudo(
-		"Restarting systemd-resolved",
-		"systemctl",
-		"restart",
-		"systemd-resolved",
-	)
-	if err != nil {
+	if _, err := n.shell.ExecSudo("", "systemctl", "restart", "systemd-resolved"); err != nil {
 		return fmt.Errorf("failed to restart systemd-resolved: %w", err)
 	}
 
@@ -146,6 +131,14 @@ func (n *BaseNetworkManager) FlushDNS() error {
 	return nil
 }
 
+// isSystemdResolvedStubLink reports whether the /etc/resolv.conf symlink target points at
+// systemd-resolved's stub resolver. Accepts both the relative form (most distros) and the
+// absolute form (Fedora, some Ubuntu cloud images).
+func isSystemdResolvedStubLink(target string) bool {
+	return target == "../run/systemd/resolve/stub-resolv.conf" ||
+		target == "/run/systemd/resolve/stub-resolv.conf"
+}
+
 // needsPrivilegeForResolver reports whether sudo is required to apply the desired DNS resolver IP
 // for the configured domain. It returns true when systemd-resolved is in use and the current
 // drop-in for dns.domain is missing, unreadable, or has different Domains= or DNS= values.
@@ -155,7 +148,7 @@ func (n *BaseNetworkManager) needsPrivilegeForResolver(desiredIP string) bool {
 		return false
 	}
 	resolvConf, err := n.shims.ReadLink("/etc/resolv.conf")
-	if err != nil || resolvConf != "../run/systemd/resolve/stub-resolv.conf" {
+	if err != nil || !isSystemdResolvedStubLink(resolvConf) {
 		return false
 	}
 	dropInFile := fmt.Sprintf("/etc/systemd/resolved.conf.d/dns-override-%s.conf", domain)

--- a/pkg/workstation/network/linux_network_test.go
+++ b/pkg/workstation/network/linux_network_test.go
@@ -208,30 +208,17 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 			return "../run/systemd/resolve/stub-resolv.conf", nil
 		}
 
-		// And capturing the content
+		// And capturing the content via the temp-file write shim
 		var capturedContent []byte
+		mocks.Shims.WriteFile = func(_ string, data []byte, _ os.FileMode) error {
+			capturedContent = data
+			return nil
+		}
 		mocks.Shims.ReadFile = func(_ string) ([]byte, error) {
 			if capturedContent != nil {
 				return capturedContent, nil
 			}
 			return nil, os.ErrNotExist
-		}
-
-		// And capturing the drop-in file content
-		mocks.Shell.ExecSudoFunc = func(description, command string, args ...string) (string, error) {
-			if command == "bash" && args[0] == "-c" {
-				cmdStr := args[1]
-				if strings.Contains(cmdStr, "echo '") && strings.Contains(cmdStr, "' | sudo tee") {
-					start := strings.Index(cmdStr, "echo '") + 6
-					end := strings.Index(cmdStr, "' | sudo tee")
-					if start < end {
-						content := cmdStr[start:end]
-						capturedContent = []byte(content)
-					}
-				}
-				return "", nil
-			}
-			return "", nil
 		}
 
 		// And configuring DNS
@@ -390,9 +377,9 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 			return nil, os.ErrNotExist
 		}
 
-		// And mocking DNS config writing error
+		// And mocking DNS config writing error on the mv into place
 		mocks.Shell.ExecSudoFunc = func(description, command string, args ...string) (string, error) {
-			if command == "bash" && args[0] == "-c" {
+			if command == "mv" {
 				return "", fmt.Errorf("mock error writing config")
 			}
 			return "", nil
@@ -405,7 +392,7 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 		if err == nil {
 			t.Fatalf("expected error, got nil")
 		}
-		expectedError := "failed to write DNS configuration: mock error writing config"
+		expectedError := "failed to write DNS configuration: failed to install file: mock error writing config"
 		if !strings.Contains(err.Error(), expectedError) {
 			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
 		}
@@ -445,6 +432,164 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 		expectedError := "failed to restart systemd-resolved: mock error restarting service"
 		if !strings.Contains(err.Error(), expectedError) {
 			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("AbsoluteSymlinkAccepted", func(t *testing.T) {
+		// Given systemd-resolved exposes the absolute stub-resolv.conf symlink form (Fedora, some Ubuntu cloud images)
+		manager, mocks := setup(t)
+		mocks.ConfigHandler.Set("dns.domain", "example.com")
+		mocks.ConfigHandler.Set("workstation.dns.address", "1.2.3.4")
+		mocks.Shims.ReadLink = func(_ string) (string, error) {
+			return "/run/systemd/resolve/stub-resolv.conf", nil
+		}
+		mocks.Shims.ReadFile = func(_ string) ([]byte, error) {
+			return nil, os.ErrNotExist
+		}
+
+		// When configuring DNS
+		err := manager.ConfigureDNS()
+
+		// Then no error should occur — the absolute symlink form is treated as systemd-resolved in use
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("ErrorStagingTempFile", func(t *testing.T) {
+		// Given the temp-file write for the DNS drop-in fails
+		manager, mocks := setup(t)
+		mocks.ConfigHandler.Set("dns.domain", "example.com")
+		mocks.ConfigHandler.Set("workstation.dns.address", "1.2.3.4")
+		mocks.Shims.ReadLink = func(_ string) (string, error) {
+			return "../run/systemd/resolve/stub-resolv.conf", nil
+		}
+		mocks.Shims.ReadFile = func(_ string) ([]byte, error) {
+			return nil, os.ErrNotExist
+		}
+		mocks.Shims.WriteFile = func(_ string, _ []byte, _ os.FileMode) error {
+			return fmt.Errorf("mock error staging temp file")
+		}
+
+		// When configuring DNS
+		err := manager.ConfigureDNS()
+
+		// Then the staging error surfaces and no sudo write is attempted
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		expectedError := "failed to write DNS configuration: failed to stage file: mock error staging temp file"
+		if !strings.Contains(err.Error(), expectedError) {
+			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("ErrorCreatingTempDir", func(t *testing.T) {
+		// Given the private temp dir cannot be created
+		manager, mocks := setup(t)
+		mocks.ConfigHandler.Set("dns.domain", "example.com")
+		mocks.ConfigHandler.Set("workstation.dns.address", "1.2.3.4")
+		mocks.Shims.ReadLink = func(_ string) (string, error) {
+			return "../run/systemd/resolve/stub-resolv.conf", nil
+		}
+		mocks.Shims.ReadFile = func(_ string) ([]byte, error) {
+			return nil, os.ErrNotExist
+		}
+		mocks.Shims.MkdirTemp = func(_, _ string) (string, error) {
+			return "", fmt.Errorf("mock mkdirtemp failure")
+		}
+
+		// When configuring DNS
+		err := manager.ConfigureDNS()
+
+		// Then the helper's temp-dir error surfaces with context
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		expectedError := "failed to write DNS configuration: failed to create temp directory: mock mkdirtemp failure"
+		if !strings.Contains(err.Error(), expectedError) {
+			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("ErrorSettingFileMode", func(t *testing.T) {
+		// Given the post-mv chmod on the drop-in fails
+		manager, mocks := setup(t)
+		mocks.ConfigHandler.Set("dns.domain", "example.com")
+		mocks.ConfigHandler.Set("workstation.dns.address", "1.2.3.4")
+		mocks.Shims.ReadLink = func(_ string) (string, error) {
+			return "../run/systemd/resolve/stub-resolv.conf", nil
+		}
+		mocks.Shims.ReadFile = func(_ string) ([]byte, error) {
+			return nil, os.ErrNotExist
+		}
+		mocks.Shell.ExecSudoFunc = func(_, command string, args ...string) (string, error) {
+			if command == "chmod" {
+				return "", fmt.Errorf("mock error setting mode")
+			}
+			return "", nil
+		}
+
+		// When configuring DNS
+		err := manager.ConfigureDNS()
+
+		// Then the chmod error surfaces
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		expectedError := "failed to write DNS configuration: failed to set file mode: mock error setting mode"
+		if !strings.Contains(err.Error(), expectedError) {
+			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("DomainWithPathSeparatorRejected", func(t *testing.T) {
+		// Given a malformed DNS domain that would let configuration escape the drop-in directory
+		manager, mocks := setup(t)
+		mocks.ConfigHandler.Set("dns.domain", "evil/../etc/passwd")
+
+		// When configuring DNS
+		err := manager.ConfigureDNS()
+
+		// Then validation rejects it before any filesystem or shell operation runs
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		expectedError := `invalid DNS domain "evil/../etc/passwd": contains path separator`
+		if err.Error() != expectedError {
+			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("TempDirCleanedUpOnSuccess", func(t *testing.T) {
+		// Given a successful DNS configuration run
+		manager, mocks := setup(t)
+		mocks.ConfigHandler.Set("dns.domain", "example.com")
+		mocks.ConfigHandler.Set("workstation.dns.address", "1.2.3.4")
+		mocks.Shims.ReadLink = func(_ string) (string, error) {
+			return "../run/systemd/resolve/stub-resolv.conf", nil
+		}
+		mocks.Shims.ReadFile = func(_ string) ([]byte, error) {
+			return nil, os.ErrNotExist
+		}
+
+		var removedPath string
+		mocks.Shims.MkdirTemp = func(_, _ string) (string, error) {
+			return "/tmp/windsor-net-mock", nil
+		}
+		mocks.Shims.RemoveAll = func(path string) error {
+			removedPath = path
+			return nil
+		}
+
+		// When configuring DNS
+		if err := manager.ConfigureDNS(); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Then the deferred cleanup removed the same temp directory the helper created
+		if removedPath != "/tmp/windsor-net-mock" {
+			t.Fatalf("expected temp dir cleanup of %q, got %q", "/tmp/windsor-net-mock", removedPath)
 		}
 	})
 }

--- a/pkg/workstation/network/linux_network_test.go
+++ b/pkg/workstation/network/linux_network_test.go
@@ -543,7 +543,7 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 		}
 	})
 
-	t.Run("DomainWithPathSeparatorRejected", func(t *testing.T) {
+	t.Run("DomainOutsideAllowlistRejected", func(t *testing.T) {
 		// Given a malformed DNS domain that would let configuration escape the drop-in directory
 		manager, mocks := setup(t)
 		mocks.ConfigHandler.Set("dns.domain", "evil/../etc/passwd")
@@ -555,7 +555,7 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 		if err == nil {
 			t.Fatalf("expected error, got nil")
 		}
-		expectedError := `invalid DNS domain "evil/../etc/passwd": contains path separator`
+		expectedError := `invalid DNS domain "evil/../etc/passwd": must contain only letters, digits, hyphen, and dot`
 		if err.Error() != expectedError {
 			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
 		}

--- a/pkg/workstation/network/network.go
+++ b/pkg/workstation/network/network.go
@@ -1,7 +1,10 @@
 package network
 
 import (
+	"fmt"
 	"net"
+	"path/filepath"
+	"strings"
 
 	"github.com/windsorcli/cli/pkg/runtime"
 	"github.com/windsorcli/cli/pkg/runtime/config"
@@ -93,6 +96,43 @@ func (n *BaseNetworkManager) NeedsPrivilege() bool {
 // isLocalhostMode checks if the system is in localhost mode.
 func (n *BaseNetworkManager) isLocalhostMode() bool {
 	return n.configHandler.GetString("workstation.runtime") == "docker-desktop"
+}
+
+// validateDomain rejects DNS domains containing path separators that would let configuration values
+// escape the intended filesystem layout when interpolated into temp or drop-in file paths.
+// Caller is responsible for the "empty domain" check.
+func validateDomain(domain string) error {
+	if strings.ContainsAny(domain, `/\`) {
+		return fmt.Errorf("invalid DNS domain %q: contains path separator", domain)
+	}
+	return nil
+}
+
+// writeFileWithSudo stages content in a freshly-created private temp directory (mode 0700) and
+// then sudo-moves it to destPath and sudo-chmods it to 0644. Using MkdirTemp ensures the source
+// path is unpredictable and that an unprivileged local user cannot pre-create a symlink at the
+// source before the sudo mv runs. The temp directory is removed on every exit path.
+func (n *BaseNetworkManager) writeFileWithSudo(destPath string, content []byte) error {
+	tempDir, err := n.shims.MkdirTemp("", "windsor-net-")
+	if err != nil {
+		return fmt.Errorf("failed to create temp directory: %w", err)
+	}
+	defer n.shims.RemoveAll(tempDir)
+
+	tempPath := filepath.Join(tempDir, "drop-in")
+	if err := n.shims.WriteFile(tempPath, content, 0644); err != nil {
+		return fmt.Errorf("failed to stage file: %w", err)
+	}
+
+	if _, err := n.shell.ExecSudo("", "mv", tempPath, destPath); err != nil {
+		return fmt.Errorf("failed to install file: %w", err)
+	}
+
+	if _, err := n.shell.ExecSudo("", "chmod", "0644", destPath); err != nil {
+		return fmt.Errorf("failed to set file mode: %w", err)
+	}
+
+	return nil
 }
 
 // effectiveResolverIP returns the resolver IP for DNS config: dns.address when set (by config, migration for

--- a/pkg/workstation/network/network.go
+++ b/pkg/workstation/network/network.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net"
 	"path/filepath"
-	"strings"
 
 	"github.com/windsorcli/cli/pkg/runtime"
 	"github.com/windsorcli/cli/pkg/runtime/config"
@@ -98,12 +97,17 @@ func (n *BaseNetworkManager) isLocalhostMode() bool {
 	return n.configHandler.GetString("workstation.runtime") == "docker-desktop"
 }
 
-// validateDomain rejects DNS domains containing path separators that would let configuration values
-// escape the intended filesystem layout when interpolated into temp or drop-in file paths.
+// validateDomain restricts DNS domains to the RFC 1123 label character set (letters, digits,
+// hyphen, dot). The allowlist excludes shell metacharacters, quotes, and path separators that
+// would let configuration values escape downstream interpolation contexts — filesystem paths
+// on Linux/macOS, PowerShell single-quoted strings on Windows, command lines on every platform.
 // Caller is responsible for the "empty domain" check.
 func validateDomain(domain string) error {
-	if strings.ContainsAny(domain, `/\`) {
-		return fmt.Errorf("invalid DNS domain %q: contains path separator", domain)
+	for _, r := range domain {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '.' {
+			continue
+		}
+		return fmt.Errorf("invalid DNS domain %q: must contain only letters, digits, hyphen, and dot", domain)
 	}
 	return nil
 }

--- a/pkg/workstation/network/network.go
+++ b/pkg/workstation/network/network.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"net"
 	"path/filepath"
+	"slices"
+	"strings"
 
 	"github.com/windsorcli/cli/pkg/runtime"
 	"github.com/windsorcli/cli/pkg/runtime/config"
@@ -98,9 +100,10 @@ func (n *BaseNetworkManager) isLocalhostMode() bool {
 }
 
 // validateDomain restricts DNS domains to the RFC 1123 label character set (letters, digits,
-// hyphen, dot). The allowlist excludes shell metacharacters, quotes, and path separators that
-// would let configuration values escape downstream interpolation contexts — filesystem paths
-// on Linux/macOS, PowerShell single-quoted strings on Windows, command lines on every platform.
+// hyphen, dot) and rejects empty labels. The character allowlist excludes shell metacharacters,
+// quotes, and path separators; the empty-label check rejects dot-only ("..", ".") and dot-edge
+// ("foo.", ".foo", "foo..bar") values that would escape into parent directories when interpolated
+// into a filesystem path under sudo (e.g. /etc/resolver/.. resolves to /etc/ on darwin).
 // Caller is responsible for the "empty domain" check.
 func validateDomain(domain string) error {
 	for _, r := range domain {
@@ -108,6 +111,9 @@ func validateDomain(domain string) error {
 			continue
 		}
 		return fmt.Errorf("invalid DNS domain %q: must contain only letters, digits, hyphen, and dot", domain)
+	}
+	if slices.Contains(strings.Split(domain, "."), "") {
+		return fmt.Errorf("invalid DNS domain %q: contains empty label", domain)
 	}
 	return nil
 }

--- a/pkg/workstation/network/network_test.go
+++ b/pkg/workstation/network/network_test.go
@@ -240,9 +240,9 @@ func TestNetworkManager_ConfigureGuest(t *testing.T) {
 // =============================================================================
 
 func TestValidateDomain(t *testing.T) {
-	t.Run("AcceptsTypicalDomains", func(t *testing.T) {
-		// Given domains that span the realistic config surface
-		cases := []string{"example.com", "local.test", "dev.example.io", "a", "x-y_z.com"}
+	t.Run("AcceptsRFC1123LabelCharsetDomains", func(t *testing.T) {
+		// Given domains using only RFC 1123 label characters (letters, digits, hyphen, dot)
+		cases := []string{"example.com", "local.test", "dev.example.io", "a", "x-y-z.com", "12345.test", "a-b.c-d.e"}
 
 		// When validating each
 		for _, d := range cases {
@@ -253,20 +253,36 @@ func TestValidateDomain(t *testing.T) {
 		}
 	})
 
-	t.Run("RejectsPathSeparators", func(t *testing.T) {
-		// Given domains containing path separators that would let configuration escape filesystem layout
-		cases := []string{"evil/../etc/passwd", "a\\b", "/leading-slash", "x/y"}
+	t.Run("RejectsCharactersOutsideAllowlist", func(t *testing.T) {
+		// Given domains containing characters that would let configuration escape downstream
+		// interpolation contexts — filesystem paths, PowerShell single-quoted strings, shell command lines
+		cases := []string{
+			"evil/../etc/passwd",       // path separator
+			"a\\b",                     // backslash
+			"/leading-slash",           // leading slash
+			"x/y",                      // embedded slash
+			"a'; calc; '",              // single quote → PowerShell injection
+			`a"b`,                      // double quote
+			"a b",                      // whitespace
+			"a;b",                      // shell statement separator
+			"a$b",                      // shell variable
+			"a`b`",                     // shell command substitution
+			"a&b",                      // shell background / chain
+			"a|b",                      // shell pipe
+			"with_underscore.test",     // underscore not in RFC 1123 label set
+			"unicödé.com",              // non-ASCII
+		}
 
 		// When validating each
 		for _, d := range cases {
-			// Then validation rejects with the path-separator error
+			// Then validation rejects with the allowlist error
 			err := validateDomain(d)
 			if err == nil {
 				t.Errorf("expected %q to be rejected, got nil", d)
 				continue
 			}
-			if !strings.Contains(err.Error(), "contains path separator") {
-				t.Errorf("expected path-separator error for %q, got %v", d, err)
+			if !strings.Contains(err.Error(), "must contain only letters, digits, hyphen, and dot") {
+				t.Errorf("expected allowlist error for %q, got %v", d, err)
 			}
 		}
 	})

--- a/pkg/workstation/network/network_test.go
+++ b/pkg/workstation/network/network_test.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -311,15 +312,17 @@ func TestNetworkManager_writeFileWithSudo(t *testing.T) {
 			t.Fatalf("expected no error, got %v", err)
 		}
 
-		// Then the helper stages inside the private temp dir, mvs to the destination, and chmods 0644
-		if stagedPath != stagedDir+"/drop-in" {
-			t.Errorf("expected staged path under %q, got %q", stagedDir, stagedPath)
+		// Then the helper stages inside the private temp dir, mvs to the destination, and chmods 0644.
+		// filepath.Join uses the host separator (backslash on Windows) — assert with the same primitive.
+		expectedStagedPath := filepath.Join(stagedDir, "drop-in")
+		if stagedPath != expectedStagedPath {
+			t.Errorf("expected staged path %q, got %q", expectedStagedPath, stagedPath)
 		}
 		if string(stagedContent) != "payload" {
 			t.Errorf("expected staged content %q, got %q", "payload", string(stagedContent))
 		}
-		if mvSrc != stagedDir+"/drop-in" || mvDest != "/etc/some-dest" {
-			t.Errorf("expected mv %q -> %q, got %q -> %q", stagedDir+"/drop-in", "/etc/some-dest", mvSrc, mvDest)
+		if mvSrc != expectedStagedPath || mvDest != "/etc/some-dest" {
+			t.Errorf("expected mv %q -> %q, got %q -> %q", expectedStagedPath, "/etc/some-dest", mvSrc, mvDest)
 		}
 		if chmodMode != "0644" || chmodTarget != "/etc/some-dest" {
 			t.Errorf("expected chmod 0644 %q, got chmod %q %q", "/etc/some-dest", chmodMode, chmodTarget)

--- a/pkg/workstation/network/network_test.go
+++ b/pkg/workstation/network/network_test.go
@@ -33,6 +33,8 @@ func setupDefaultShims() *Shims {
 		ReadFile:  func(path string) ([]byte, error) { return nil, nil },
 		ReadLink:  func(path string) (string, error) { return "", nil },
 		MkdirAll:  func(path string, perm os.FileMode) error { return nil },
+		MkdirTemp: func(dir, pattern string) (string, error) { return "/tmp/windsor-test", nil },
+		RemoveAll: func(path string) error { return nil },
 	}
 }
 
@@ -228,6 +230,129 @@ func TestNetworkManager_ConfigureGuest(t *testing.T) {
 		// Then no error should be returned
 		if err != nil {
 			t.Fatalf("expected no error, got %v", err)
+		}
+	})
+}
+
+// =============================================================================
+// Test Private Methods
+// =============================================================================
+
+func TestValidateDomain(t *testing.T) {
+	t.Run("AcceptsTypicalDomains", func(t *testing.T) {
+		// Given domains that span the realistic config surface
+		cases := []string{"example.com", "local.test", "dev.example.io", "a", "x-y_z.com"}
+
+		// When validating each
+		for _, d := range cases {
+			// Then validation passes
+			if err := validateDomain(d); err != nil {
+				t.Errorf("expected %q to be accepted, got %v", d, err)
+			}
+		}
+	})
+
+	t.Run("RejectsPathSeparators", func(t *testing.T) {
+		// Given domains containing path separators that would let configuration escape filesystem layout
+		cases := []string{"evil/../etc/passwd", "a\\b", "/leading-slash", "x/y"}
+
+		// When validating each
+		for _, d := range cases {
+			// Then validation rejects with the path-separator error
+			err := validateDomain(d)
+			if err == nil {
+				t.Errorf("expected %q to be rejected, got nil", d)
+				continue
+			}
+			if !strings.Contains(err.Error(), "contains path separator") {
+				t.Errorf("expected path-separator error for %q, got %v", d, err)
+			}
+		}
+	})
+}
+
+func TestNetworkManager_writeFileWithSudo(t *testing.T) {
+	setup := func(t *testing.T) (*BaseNetworkManager, *NetworkTestMocks) {
+		t.Helper()
+		mocks := setupNetworkMocks(t)
+		manager := NewBaseNetworkManager(mocks.Runtime)
+		manager.shims = mocks.Shims
+		return manager, mocks
+	}
+
+	t.Run("StagesAndInstallsContent", func(t *testing.T) {
+		// Given a happy-path environment
+		manager, mocks := setup(t)
+
+		var stagedDir, stagedPath string
+		var stagedContent []byte
+		mocks.Shims.MkdirTemp = func(_, _ string) (string, error) {
+			stagedDir = "/tmp/windsor-net-mock"
+			return stagedDir, nil
+		}
+		mocks.Shims.WriteFile = func(path string, data []byte, _ os.FileMode) error {
+			stagedPath = path
+			stagedContent = data
+			return nil
+		}
+		var mvSrc, mvDest, chmodMode, chmodTarget string
+		mocks.Shell.ExecSudoFunc = func(_, command string, args ...string) (string, error) {
+			switch command {
+			case "mv":
+				mvSrc, mvDest = args[0], args[1]
+			case "chmod":
+				chmodMode, chmodTarget = args[0], args[1]
+			}
+			return "", nil
+		}
+
+		// When writing a file
+		if err := manager.writeFileWithSudo("/etc/some-dest", []byte("payload")); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Then the helper stages inside the private temp dir, mvs to the destination, and chmods 0644
+		if stagedPath != stagedDir+"/drop-in" {
+			t.Errorf("expected staged path under %q, got %q", stagedDir, stagedPath)
+		}
+		if string(stagedContent) != "payload" {
+			t.Errorf("expected staged content %q, got %q", "payload", string(stagedContent))
+		}
+		if mvSrc != stagedDir+"/drop-in" || mvDest != "/etc/some-dest" {
+			t.Errorf("expected mv %q -> %q, got %q -> %q", stagedDir+"/drop-in", "/etc/some-dest", mvSrc, mvDest)
+		}
+		if chmodMode != "0644" || chmodTarget != "/etc/some-dest" {
+			t.Errorf("expected chmod 0644 %q, got chmod %q %q", "/etc/some-dest", chmodMode, chmodTarget)
+		}
+	})
+
+	t.Run("RemovesTempDirOnFailureAfterStaging", func(t *testing.T) {
+		// Given mv into place fails after a successful temp-file stage
+		manager, mocks := setup(t)
+		mocks.Shims.MkdirTemp = func(_, _ string) (string, error) {
+			return "/tmp/windsor-net-fail", nil
+		}
+		var removedPath string
+		mocks.Shims.RemoveAll = func(path string) error {
+			removedPath = path
+			return nil
+		}
+		mocks.Shell.ExecSudoFunc = func(_, command string, _ ...string) (string, error) {
+			if command == "mv" {
+				return "", fmt.Errorf("mv boom")
+			}
+			return "", nil
+		}
+
+		// When writing a file
+		err := manager.writeFileWithSudo("/etc/some-dest", []byte("payload"))
+
+		// Then the helper surfaces the install error and the deferred cleanup runs
+		if err == nil || !strings.Contains(err.Error(), "failed to install file: mv boom") {
+			t.Fatalf("expected install error, got %v", err)
+		}
+		if removedPath != "/tmp/windsor-net-fail" {
+			t.Errorf("expected cleanup of %q, got %q", "/tmp/windsor-net-fail", removedPath)
 		}
 	})
 }

--- a/pkg/workstation/network/network_test.go
+++ b/pkg/workstation/network/network_test.go
@@ -253,6 +253,35 @@ func TestValidateDomain(t *testing.T) {
 		}
 	})
 
+	t.Run("RejectsEmptyLabels", func(t *testing.T) {
+		// Given domains whose character set is allowlisted but whose dot structure produces empty
+		// labels — dot-only strings collapse to a parent-directory traversal when interpolated
+		// into a filesystem path (e.g. /etc/resolver/.. resolves to /etc/ on darwin).
+		cases := []string{
+			".",        // single dot
+			"..",       // double dot — the darwin traversal exploit
+			"...",      // triple dot
+			".foo",     // leading dot
+			"foo.",     // trailing dot
+			"foo..bar", // consecutive dots
+			"..bar",    // leading double dot
+			"bar..",    // trailing double dot
+		}
+
+		// When validating each
+		for _, d := range cases {
+			// Then validation rejects with the empty-label error
+			err := validateDomain(d)
+			if err == nil {
+				t.Errorf("expected %q to be rejected, got nil", d)
+				continue
+			}
+			if !strings.Contains(err.Error(), "contains empty label") {
+				t.Errorf("expected empty-label error for %q, got %v", d, err)
+			}
+		}
+	})
+
 	t.Run("RejectsCharactersOutsideAllowlist", func(t *testing.T) {
 		// Given domains containing characters that would let configuration escape downstream
 		// interpolation contexts — filesystem paths, PowerShell single-quoted strings, shell command lines

--- a/pkg/workstation/network/shims.go
+++ b/pkg/workstation/network/shims.go
@@ -23,6 +23,8 @@ type Shims struct {
 	ReadFile  func(string) ([]byte, error)
 	ReadLink  func(string) (string, error)
 	MkdirAll  func(string, os.FileMode) error
+	MkdirTemp func(dir, pattern string) (string, error)
+	RemoveAll func(string) error
 }
 
 // NetworkInterfaceProvider abstracts the system's network interface operations
@@ -56,6 +58,8 @@ func NewShims() *Shims {
 		ReadFile:  os.ReadFile,
 		ReadLink:  os.Readlink,
 		MkdirAll:  os.MkdirAll,
+		MkdirTemp: os.MkdirTemp,
+		RemoveAll: os.RemoveAll,
 	}
 }
 

--- a/pkg/workstation/network/windows_network.go
+++ b/pkg/workstation/network/windows_network.go
@@ -73,6 +73,9 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 	if domain == "" {
 		return fmt.Errorf("DNS domain is not configured")
 	}
+	if err := validateDomain(domain); err != nil {
+		return err
+	}
 
 	dnsIP := n.effectiveResolverIP()
 	if dnsIP == "" {
@@ -153,6 +156,9 @@ func (n *BaseNetworkManager) FlushDNS() error {
 func (n *BaseNetworkManager) needsPrivilegeForResolver(desiredIP string) bool {
 	domain := n.configHandler.GetString("dns.domain")
 	if domain == "" {
+		return false
+	}
+	if err := validateDomain(domain); err != nil {
 		return false
 	}
 	namespace := "." + domain

--- a/pkg/workstation/network/windows_network.go
+++ b/pkg/workstation/network/windows_network.go
@@ -86,7 +86,7 @@ $namespace = '%s'
 $allRules = Get-DnsClientNrptRule
 $existingRule = $allRules | Where-Object { $_.Namespace -eq $namespace }
 if ($existingRule) {
-  if ($existingRule.NameServers -ne "%s") {
+  if (($existingRule.NameServers -join ',') -ne "%s") {
     $false
   } else {
     $true

--- a/pkg/workstation/network/windows_network_test.go
+++ b/pkg/workstation/network/windows_network_test.go
@@ -430,6 +430,43 @@ func TestWindowsNetworkManager_ConfigureDNS(t *testing.T) {
 		}
 	})
 
+	t.Run("DomainWithSingleQuoteRejectedBeforePowerShellRuns", func(t *testing.T) {
+		// Given a DNS domain containing a single quote, which would close the PowerShell
+		// single-quoted string literal `$namespace = '.<domain>'` and inject arbitrary commands.
+		manager, mocks := setup(t)
+		mocks.ConfigHandler.Set("dns.domain", `evil'; calc; '`)
+		mocks.ConfigHandler.Set("workstation.dns.address", "1.2.3.4")
+
+		// And tracking whether any PowerShell ever runs
+		var psInvoked bool
+		mocks.Shell.ExecSilentFunc = func(command string, _ ...string) (string, error) {
+			if command == "powershell" {
+				psInvoked = true
+			}
+			return "", nil
+		}
+		mocks.Shell.ExecProgressFunc = func(_, command string, _ ...string) (string, error) {
+			if command == "powershell" {
+				psInvoked = true
+			}
+			return "", nil
+		}
+
+		// When configuring DNS
+		err := manager.ConfigureDNS()
+
+		// Then validation rejects before any PowerShell process is spawned
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "must contain only letters, digits, hyphen, and dot") {
+			t.Fatalf("expected allowlist rejection error, got %q", err.Error())
+		}
+		if psInvoked {
+			t.Fatal("PowerShell was invoked despite invalid domain — validation must run before any script execution")
+		}
+	})
+
 	t.Run("CheckScriptJoinsNameServersBeforeCompare", func(t *testing.T) {
 		// Given the rule check must handle NRPT rules whose NameServers is a multi-element array
 		// (a plain $existingRule.NameServers -ne "<ip>" compares array-to-scalar and always reports mismatch).

--- a/pkg/workstation/network/windows_network_test.go
+++ b/pkg/workstation/network/windows_network_test.go
@@ -266,8 +266,10 @@ func TestWindowsNetworkManager_ConfigureDNS(t *testing.T) {
 						}
 					}
 
-					// Extract nameservers from the script
-					nameserversMatch := strings.Split(script, "NameServers -ne \"")
+					// Extract nameservers from the script — the check joins NameServers before comparing
+					// to handle multi-server NRPT rules, so the right-hand side of -ne is the only place
+					// the literal lives.
+					nameserversMatch := strings.Split(script, "-join ',') -ne \"")
 					if len(nameserversMatch) > 1 {
 						parts := strings.Split(nameserversMatch[1], "\"")
 						if len(parts) > 1 {
@@ -425,6 +427,35 @@ func TestWindowsNetworkManager_ConfigureDNS(t *testing.T) {
 		expectedError := "DNS address is not configured"
 		if !strings.Contains(err.Error(), expectedError) {
 			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
+		}
+	})
+
+	t.Run("CheckScriptJoinsNameServersBeforeCompare", func(t *testing.T) {
+		// Given the rule check must handle NRPT rules whose NameServers is a multi-element array
+		// (a plain $existingRule.NameServers -ne "<ip>" compares array-to-scalar and always reports mismatch).
+		manager, mocks := setup(t)
+		mocks.ConfigHandler.Set("dns.domain", "example.com")
+		mocks.ConfigHandler.Set("workstation.dns.address", "1.2.3.4")
+
+		var checkScript string
+		mocks.Shell.ExecSilentFunc = func(command string, args ...string) (string, error) {
+			if command == "powershell" && len(args) > 1 && args[0] == "-Command" && strings.Contains(args[1], "Get-DnsClientNrptRule") {
+				checkScript = args[1]
+			}
+			return "", nil
+		}
+
+		// When configuring DNS
+		if err := manager.ConfigureDNS(); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Then the check script joins NameServers into a comma-separated string before comparing
+		if !strings.Contains(checkScript, "($existingRule.NameServers -join ',') -ne") {
+			t.Fatalf("expected check script to join NameServers before comparing, got: %q", checkScript)
+		}
+		if strings.Contains(checkScript, "$existingRule.NameServers -ne") {
+			t.Fatalf("check script still uses the broken array-vs-scalar comparison, got: %q", checkScript)
 		}
 	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> The PR hardens DNS configuration writes on Darwin, Linux, and Windows; both open concerns from the prior review are resolved in this push.
>
> **Overview**
>
> The PR improves `ConfigureDNS` in two areas. It introduces `writeFileWithSudo`, which stages content in a randomly-named private temp directory (mode 0700) before sudo-moving it to the final destination, eliminating the predictable `/tmp/<tld>` symlink-race surface and the `bash -c echo | sudo tee` shell-composition risk from the old Linux path. It also adds `validateDomain`, which enforces a strict RFC 1123 character allowlist across Darwin, Linux, and Windows — including the PowerShell path flagged in the prior review.
>
> The dot-only traversal gap (`..` producing `/etc/resolver/..` → `/etc/`) is closed by a post-loop empty-label check that rejects dot-leading, dot-trailing, and consecutive-dot domains. The Windows NameServers array-vs-scalar comparison bug is fixed by joining the array before the `-ne` test. The Linux `isSystemdResolvedStubLink` helper now accepts both the relative symlink form (most distros) and the absolute form (Fedora, some Ubuntu cloud images). Test coverage across all three platforms is thorough.
>
> Reviewed by Claude for commit `2c60ac49`.

<!-- /claude-code-review:summary -->
