### PR TITLE
fix(runtime/config): enhance cross-field schema validation and update related tests

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -149,6 +149,10 @@ var initCmd = &cobra.Command{
 			return err
 		}
 
+		if err := proj.Runtime.ConfigHandler.ValidateContextValues(); err != nil {
+			return fmt.Errorf("invalid configuration: %w", err)
+		}
+
 		blueprintURL, err := resolveBlueprintURL(initBlueprint, initPlatform, contextName, rt.TemplateRoot, true)
 		if err != nil {
 			return err

--- a/pkg/runtime/config/accessors.go
+++ b/pkg/runtime/config/accessors.go
@@ -231,9 +231,10 @@ func (c *configHandler) GetStringMap(key string, defaultValue ...map[string]stri
 
 // Set assigns a configuration value at the specified hierarchical path in the configHandler's internal data map.
 // The input value is automatically converted to the appropriate type according to the schema, if available.
-// If a schema is present, Set validates only the dynamic fields of the configuration map after the new value is set.
-// Returns an error if the path is invalid, schema validation fails, or if value assignment encounters an issue.
-// Changes made by this method are in-memory and must be persisted separately via SaveConfig.
+// Set does not validate against the schema; callers that compose configuration via multiple Set calls leave
+// the map in transient states that only satisfy cross-field rules once composition completes. Run
+// ValidateContextValues after composition to surface schema violations. Returns an error if the path is
+// invalid or if value assignment encounters an issue. Changes are in-memory; persist via SaveConfig.
 func (c *configHandler) Set(path string, value any) error {
 	if path == "" {
 		return fmt.Errorf("path cannot be empty")
@@ -245,15 +246,6 @@ func (c *configHandler) Set(path string, value any) error {
 	convertedValue := c.convertStringValue(value)
 	pathKeys := parsePath(path)
 	setValueInMap(c.data, pathKeys, convertedValue)
-
-	if c.schemaValidator != nil && c.schemaValidator.Schema != nil {
-		_, dynamicFields := c.separateStaticAndDynamicFields(c.data)
-		if result, err := c.schemaValidator.Validate(dynamicFields); err != nil {
-			return fmt.Errorf("error validating context value: %w", err)
-		} else if !result.Valid {
-			return fmt.Errorf("context value validation failed: %v", result.Errors)
-		}
-	}
 	return nil
 }
 

--- a/pkg/runtime/config/accessors_test.go
+++ b/pkg/runtime/config/accessors_test.go
@@ -202,9 +202,8 @@ properties:
 		}
 	})
 
-	t.Run("SetValidatesPathsAndSchema", func(t *testing.T) {
+	t.Run("SetValidatesPaths", func(t *testing.T) {
 		mocks := setupConfigMocks(t)
-		tmpDir, _ := mocks.Shell.GetProjectRoot()
 		handler := NewConfigHandler(mocks.Shell)
 
 		if err := handler.Set("valid.path", "value"); err != nil {
@@ -216,6 +215,12 @@ properties:
 		if err := handler.Set("invalid..path", "value"); err == nil {
 			t.Fatal("Expected error for invalid path")
 		}
+	})
+
+	t.Run("SetDoesNotValidateAgainstSchema", func(t *testing.T) {
+		mocks := setupConfigMocks(t)
+		tmpDir, _ := mocks.Shell.GetProjectRoot()
+		handler := NewConfigHandler(mocks.Shell)
 
 		schemaDir := filepath.Join(tmpDir, "contexts", "_template")
 		if err := os.MkdirAll(schemaDir, 0755); err != nil {
@@ -235,8 +240,12 @@ additionalProperties: false
 			t.Fatalf("Expected no error loading schema, got %v", err)
 		}
 
-		if err := handler.Set("disallowed_key", "value"); err == nil {
-			t.Fatal("Expected schema validation error for disallowed key")
+		// Schema violations surface from ValidateContextValues, not from Set.
+		if err := handler.Set("disallowed_key", "value"); err != nil {
+			t.Fatalf("Set should not validate against schema, got %v", err)
+		}
+		if err := handler.ValidateContextValues(); err == nil {
+			t.Fatal("Expected validation error from ValidateContextValues for disallowed key")
 		}
 	})
 }

--- a/pkg/runtime/config/handler.go
+++ b/pkg/runtime/config/handler.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"maps"
 	"path/filepath"
-	"reflect"
 	"strings"
 
 	"github.com/windsorcli/cli/api/v1alpha1"
@@ -548,15 +547,16 @@ func (c *configHandler) LoadSchemaFromBytes(schemaContent []byte) error {
 	return nil
 }
 
-// ValidateContextValues runs schema validation on the current context's dynamic fields.
-// Use before impactful operations (e.g. windsor up) so invalid or typo'd values.yaml fails fast.
-// Returns nil if no schema is loaded or if validation passes; returns an error if validation fails.
+// ValidateContextValues runs schema validation on the full context configuration map. Cross-field
+// rules spanning static (v1alpha1.Context) and dynamic fields are evaluated against the unified map,
+// matching the file-load validation path. Use before impactful operations (e.g. windsor up) and after
+// compositional Set sequences. Returns nil if no schema is loaded or if validation passes; returns an
+// error if validation fails.
 func (c *configHandler) ValidateContextValues() error {
 	if c.schemaValidator == nil || c.schemaValidator.Schema == nil {
 		return nil
 	}
-	_, dynamicFields := c.separateStaticAndDynamicFields(c.data)
-	if result, err := c.schemaValidator.Validate(dynamicFields); err != nil {
+	if result, err := c.schemaValidator.Validate(c.data); err != nil {
 		return fmt.Errorf("error validating context values: %w", err)
 	} else if !result.Valid {
 		return fmt.Errorf("context value validation failed: %v", result.Errors)
@@ -632,43 +632,6 @@ func (c *configHandler) mapToContext(data map[string]any) *v1alpha1.Context {
 	}
 
 	return &context
-}
-
-// separateStaticAndDynamicFields splits the data map into static fields (matching v1alpha1.Context schema)
-// and dynamic fields (everything else). This is used when saving to separate windsor.yaml from values.yaml.
-func (c *configHandler) separateStaticAndDynamicFields(data map[string]any) (static map[string]any, dynamic map[string]any) {
-	static = make(map[string]any)
-	dynamic = make(map[string]any)
-
-	for key, value := range data {
-		if c.isKeyInStaticSchema(key) {
-			static[key] = value
-		} else {
-			dynamic[key] = value
-		}
-	}
-
-	return static, dynamic
-}
-
-// isKeyInStaticSchema determines whether the provided key exists as a top-level field
-// in the static windsor.yaml schema, represented by v1alpha1.Context. It checks both
-// direct keys and those nested with dot notation (e.g., "environment.TEST_VAR" -> "environment").
-// Returns true if the top-level key matches a YAML field tag in v1alpha1.Context, false otherwise.
-func (c *configHandler) isKeyInStaticSchema(key string) bool {
-	topLevelKey := key
-	if dotIndex := strings.Index(key, "."); dotIndex != -1 {
-		topLevelKey = key[:dotIndex]
-	}
-	contextType := reflect.TypeOf(v1alpha1.Context{})
-	for i := 0; i < contextType.NumField(); i++ {
-		field := contextType.Field(i)
-		yamlTag := strings.Split(field.Tag.Get("yaml"), ",")[0]
-		if yamlTag == topLevelKey {
-			return true
-		}
-	}
-	return false
 }
 
 // deepMerge recursively merges two maps with overlay values taking precedence.

--- a/pkg/runtime/config/handler_test.go
+++ b/pkg/runtime/config/handler_test.go
@@ -1425,7 +1425,7 @@ func TestConfigHandler_ValidateContextValues(t *testing.T) {
 		}
 	})
 
-	t.Run("ReturnsErrorWhenDynamicFieldsFailValidation", func(t *testing.T) {
+	t.Run("ReturnsErrorWhenContextValuesFailValidation", func(t *testing.T) {
 		handler, tmpDir := setupPrivateTestHandler(t)
 		schemaPath := filepath.Join(tmpDir, "schema.yaml")
 		schemaContent := `$schema: https://json-schema.org/draft/2020-12/schema
@@ -1443,34 +1443,105 @@ additionalProperties: false
 
 		err := handler.ValidateContextValues()
 		if err == nil {
-			t.Fatal("Expected validation error for disallowed dynamic key")
+			t.Fatal("Expected validation error for disallowed key")
 		}
 		if !strings.Contains(err.Error(), "context value validation failed") {
 			t.Errorf("Expected validation failure error, got %v", err)
 		}
 	})
 
-	t.Run("ValidatesOnlyDynamicFields", func(t *testing.T) {
+	t.Run("ValidatesStaticFieldsAgainstSchema", func(t *testing.T) {
 		handler, tmpDir := setupPrivateTestHandler(t)
 		schemaPath := filepath.Join(tmpDir, "schema.yaml")
 		schemaContent := `$schema: https://json-schema.org/draft/2020-12/schema
 type: object
 properties:
-  dynamic_key:
+  provider:
     type: string
-additionalProperties: false
+    enum: [docker, incus]
 `
 		os.WriteFile(schemaPath, []byte(schemaContent), 0644)
 		if err := handler.LoadSchema(schemaPath); err != nil {
 			t.Fatalf("Expected no error loading schema, got %v", err)
 		}
-		handler.data = map[string]any{
-			"provider":    "docker",
-			"dynamic_key": "value",
+		handler.data = map[string]any{"provider": "not-allowed"}
+
+		err := handler.ValidateContextValues()
+		if err == nil {
+			t.Fatal("Expected validation error for static field violating schema")
+		}
+		if !strings.Contains(err.Error(), "context value validation failed") {
+			t.Errorf("Expected validation failure error, got %v", err)
+		}
+	})
+
+	t.Run("FiresCrossFieldRuleSpanningStaticAndDynamic", func(t *testing.T) {
+		handler, tmpDir := setupPrivateTestHandler(t)
+		schemaPath := filepath.Join(tmpDir, "schema.yaml")
+		// gateway (dynamic) requires dns (static) when access is private — exercises a rule that
+		// the prior dynamicFields-only validation path filtered out and silently passed.
+		schemaContent := `$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+properties:
+  gateway:
+    type: object
+    properties:
+      access:
+        type: string
+  dns:
+    type: object
+    properties:
+      private_domain:
+        type: string
+allOf:
+  - if:
+      properties:
+        gateway:
+          type: object
+          properties:
+            access:
+              const: private
+          required: [access]
+      required: [gateway]
+    then:
+      required: [dns]
+      properties:
+        dns:
+          type: object
+          required: [private_domain]
+          properties:
+            private_domain:
+              type: string
+              minLength: 1
+`
+		os.WriteFile(schemaPath, []byte(schemaContent), 0644)
+		if err := handler.LoadSchema(schemaPath); err != nil {
+			t.Fatalf("Expected no error loading schema, got %v", err)
 		}
 
+		// Violation: gateway.access=private without dns.private_domain.
+		handler.data = map[string]any{
+			"gateway": map[string]any{"access": "private"},
+		}
+		if err := handler.ValidateContextValues(); err == nil {
+			t.Fatal("Expected cross-field rule to fire when gateway.access=private and dns.private_domain is missing")
+		}
+
+		// Satisfied: both fields present.
+		handler.data = map[string]any{
+			"gateway": map[string]any{"access": "private"},
+			"dns":     map[string]any{"private_domain": "internal.example"},
+		}
 		if err := handler.ValidateContextValues(); err != nil {
-			t.Fatalf("Expected static fields to be excluded from validation, got %v", err)
+			t.Fatalf("Expected cross-field rule to pass when both fields are set, got %v", err)
+		}
+
+		// Non-triggering: if-condition not met.
+		handler.data = map[string]any{
+			"gateway": map[string]any{"access": "public"},
+		}
+		if err := handler.ValidateContextValues(); err != nil {
+			t.Fatalf("Expected validation to pass when if-condition is not met, got %v", err)
 		}
 	})
 }

--- a/pkg/test/runner.go
+++ b/pkg/test/runner.go
@@ -210,6 +210,11 @@ func (r *TestRunner) createGenerator(terraformOutputs map[string]map[string]any)
 			}
 		}
 
+		// Validate after the loop, not per-Set: Go-map iteration order is random.
+		if err := rt.ConfigHandler.ValidateContextValues(); err != nil {
+			return nil, err
+		}
+
 		if err := rt.InitializeComponents(); err != nil {
 			return nil, fmt.Errorf("failed to initialize components: %w", err)
 		}

--- a/pkg/test/runner_test.go
+++ b/pkg/test/runner_test.go
@@ -2180,6 +2180,70 @@ func TestTestRunner_createGenerator(t *testing.T) {
 			t.Error("Expected blueprint to be generated")
 		}
 	})
+
+	t.Run("CrossFieldRuleSpanningStaticAndDynamicFires", func(t *testing.T) {
+		mocks := setupTestRunnerMocks(t)
+		templateDir := filepath.Join(mocks.TmpDir, "contexts", "_template")
+		// gateway (dynamic) requires dns.private_domain (static) when access is private.
+		schemaContent := `$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+properties:
+  gateway:
+    type: object
+    properties:
+      access:
+        type: string
+  dns:
+    type: object
+    properties:
+      private_domain:
+        type: string
+allOf:
+  - if:
+      properties:
+        gateway:
+          type: object
+          properties:
+            access:
+              const: private
+          required: [access]
+      required: [gateway]
+    then:
+      required: [dns]
+      properties:
+        dns:
+          type: object
+          required: [private_domain]
+          properties:
+            private_domain:
+              type: string
+              minLength: 1
+`
+		createTestFile(t, templateDir, "schema.yaml", schemaContent)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		// Satisfied: gateway dynamic and dns static both set; Set loop's random order must not
+		// cause spurious failures, and the final ValidateContextValues call must pass.
+		satisfied := map[string]any{
+			"gateway": map[string]any{"access": "private"},
+			"dns":     map[string]any{"private_domain": "internal.example"},
+		}
+		for i := 0; i < 10; i++ {
+			generator := runner.createGenerator(nil)
+			if _, err := generator(satisfied); err != nil {
+				t.Fatalf("iteration %d: expected satisfied cross-field rule to pass, got %v", i, err)
+			}
+		}
+
+		// Violation: dns omitted. ValidateContextValues after the Set loop must surface this.
+		violation := map[string]any{
+			"gateway": map[string]any{"access": "private"},
+		}
+		generator := runner.createGenerator(nil)
+		if _, err := generator(violation); err == nil {
+			t.Fatal("expected cross-field rule violation to be surfaced from runner")
+		}
+	})
 }
 
 // =============================================================================


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> The change extends `ValidateContextValues` to cover the full merged config map (including static v1alpha1.Context fields), which was previously unavailable to schema rules, affecting any callers of that function and the new `cmd/init.go` call site.
>
> **Overview**
>
> This PR fixes a silent correctness gap: cross-field JSON Schema rules that reference both static (windsor.yaml) and dynamic (values.yaml) fields were never evaluated because `ValidateContextValues` only passed the dynamic subset to the validator. The fix removes per-`Set` validation (which misfired during Go-map iteration due to random key order) and defers to a single `ValidateContextValues` call after all fields are composed, adding that call in `cmd/init.go` and `pkg/test/runner.go`.
>
> The main risk is schema compatibility. Schemas using `additionalProperties: false` that enumerate only values.yaml keys will now fail when the runtime has set system-level static fields such as `provider`, `platform`, or `dns` — fields the old dynamic-only validator never saw. The `values_source.go` load-time validator still covers only the dynamic subset, so the two validation paths remain semantically inconsistent. Schema authors will need to either enumerate all static context fields or remove top-level `additionalProperties: false` to avoid false-positive errors from the new `init` validation path.
>
> Reviewed by Claude for commit `3505958`.

<!-- /claude-code-review:summary -->
