### PR TITLE
fix(provisioner): gate workstation startup behind operator confirmation in Bootstrap

### DIFF
--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -241,12 +241,12 @@ func (p *Project) Bootstrap(confirm provisioner.BootstrapConfirmFn) (*blueprintv
 		return nil, false, false, fmt.Errorf("blueprint not loaded")
 	}
 
-	backendType := p.configHandler.GetString("terraform.backend.type", "local")
-	if err := provisioner.ValidateBootstrap(blueprint, backendType); err != nil {
+	if err := provisioner.ValidateBootstrap(blueprint); err != nil {
 		return blueprint, false, false, err
 	}
 
 	if confirm != nil {
+		backendType := p.configHandler.GetString("terraform.backend.type", "local")
 		summary := provisioner.BuildBootstrapSummary(blueprint, p.contextName, backendType)
 		if !confirm(summary) {
 			return blueprint, false, false, nil

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -241,10 +241,6 @@ func (p *Project) Bootstrap(confirm provisioner.BootstrapConfirmFn) (*blueprintv
 		return nil, false, false, fmt.Errorf("blueprint not loaded")
 	}
 
-	if err := provisioner.ValidateBootstrap(blueprint); err != nil {
-		return blueprint, false, false, err
-	}
-
 	if confirm != nil {
 		backendType := p.configHandler.GetString("terraform.backend.type", "local")
 		summary := provisioner.BuildBootstrapSummary(blueprint, p.contextName, backendType)

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -226,16 +226,34 @@ func (p *Project) Up() (*blueprintv1alpha1.Blueprint, bool, error) {
 	return p.runApply(p.Provisioner.Up)
 }
 
-// Bootstrap is Up's first-run sibling: workstation prep runs first (so the backend component's
-// apply has a live cluster on docker/colima/incus), then the provisioner pins backend.type=local
-// for one Up pass and migrates state to the configured remote backend at the end. When confirm
-// is non-nil, the provisioner runs a combined Terraform + Kustomize plan summary inside the
-// same backend override and hands it to confirm; returning false aborts cleanly with applied=false.
+// Bootstrap is Up's first-run sibling. Operator confirmation runs first against a cheap
+// blueprint summary; only after acceptance does workstation prep run (so declining never
+// triggers privileged work like DNS resolver writes or sudo prompts). Then the provisioner
+// pins backend.type=local for one Up pass and migrates state to the configured remote
+// backend at the end.
 //
-// Returns (blueprint, applied, halted, err). applied=false when confirm declined. halted=true
-// means one of the inner Up calls signaled a clean halt-after-component.
+// Returns (blueprint, applied, halted, err). applied=false when confirm declined; in that
+// case no workstation startup or terraform work has happened. halted=true means one of the
+// inner Up calls signaled a clean halt-after-component.
 func (p *Project) Bootstrap(confirm provisioner.BootstrapConfirmFn) (*blueprintv1alpha1.Blueprint, bool, bool, error) {
-	blueprint, onApply, err := p.prepareForApply()
+	blueprint := p.Composer.BlueprintHandler.Generate()
+	if blueprint == nil {
+		return nil, false, false, fmt.Errorf("blueprint not loaded")
+	}
+
+	backendType := p.configHandler.GetString("terraform.backend.type", "local")
+	if err := provisioner.ValidateBootstrap(blueprint, backendType); err != nil {
+		return blueprint, false, false, err
+	}
+
+	if confirm != nil {
+		summary := provisioner.BuildBootstrapSummary(blueprint, p.contextName, backendType)
+		if !confirm(summary) {
+			return blueprint, false, false, nil
+		}
+	}
+
+	onApply, err := p.prepareWorkstationForApply(blueprint)
 	if err != nil {
 		return nil, false, false, err
 	}
@@ -243,11 +261,11 @@ func (p *Project) Bootstrap(confirm provisioner.BootstrapConfirmFn) (*blueprintv
 	if onApply != nil {
 		hooks = []func(string) (bool, error){onApply}
 	}
-	applied, halted, err := p.Provisioner.Bootstrap(blueprint, confirm, hooks...)
+	halted, err := p.Provisioner.Bootstrap(blueprint, hooks...)
 	if err != nil {
 		return nil, false, false, fmt.Errorf("error starting infrastructure: %w", err)
 	}
-	return blueprint, applied, halted, nil
+	return blueprint, true, halted, nil
 }
 
 // PerformCleanup removes context-specific artifacts: config state and
@@ -308,21 +326,34 @@ func (p *Project) runApply(fn func(*blueprintv1alpha1.Blueprint, ...func(string)
 	return blueprint, halted, nil
 }
 
-// prepareForApply runs workstation lifecycle hooks before any terraform applies.
-// Shared by Up and Bootstrap.
+// prepareForApply generates the blueprint and runs workstation lifecycle hooks before any
+// terraform applies. Used by Up; Bootstrap drives the two halves separately so confirmation
+// gates workstation prep.
 func (p *Project) prepareForApply() (*blueprintv1alpha1.Blueprint, func(string) (bool, error), error) {
-	p.EnsureWorkstation()
 	blueprint := p.Composer.BlueprintHandler.Generate()
+	onApply, err := p.prepareWorkstationForApply(blueprint)
+	if err != nil {
+		return nil, nil, err
+	}
+	return blueprint, onApply, nil
+}
+
+// prepareWorkstationForApply runs the privileged half of pre-apply setup: workstation Up
+// (DNS resolver writes, host routes, container runtime). Split out so Bootstrap can gate
+// it on operator confirmation — declining the plan must not trigger sudo prompts or
+// /etc/resolver writes.
+func (p *Project) prepareWorkstationForApply(blueprint *blueprintv1alpha1.Blueprint) (func(string) (bool, error), error) {
+	p.EnsureWorkstation()
 	if p.Workstation == nil {
-		return blueprint, nil, nil
+		return nil, nil
 	}
 	p.Workstation.PrepareForUp(blueprint)
 	if err := p.Workstation.Up(); err != nil {
-		return nil, nil, fmt.Errorf("error starting workstation: %w", err)
+		return nil, fmt.Errorf("error starting workstation: %w", err)
 	}
 	onApply := p.Workstation.MakeApplyHook()
 	if postApply := p.Workstation.MakePostApplyHook(); postApply != nil {
 		p.Provisioner.OnTerraformPostApply(postApply)
 	}
-	return blueprint, onApply, nil
+	return onApply, nil
 }

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -1593,6 +1593,153 @@ func TestProject_Bootstrap(t *testing.T) {
 		}
 	})
 
+	t.Run("ConfirmFiresBeforeWorkstationStart", func(t *testing.T) {
+		// Declining the plan must not trigger any privileged work — historically
+		// Workstation.Up ran before confirm, so declining still wrote /etc/resolver
+		// entries and prompted for sudo. Confirm must gate workstation startup.
+		mocks := setupProjectMocks(t)
+		mockConfig := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockConfig.IsDevModeFunc = func(_ string) bool { return true }
+		mockConfig.GetBoolFunc = func(key string, _ ...bool) bool {
+			return key == "terraform.enabled"
+		}
+
+		var timeline []string
+		mockBH := mocks.Composer.BlueprintHandler.(*blueprint.MockBlueprintHandler)
+		mockBH.GenerateFunc = func() *v1alpha1.Blueprint {
+			timeline = append(timeline, "generate")
+			return &v1alpha1.Blueprint{}
+		}
+
+		mockStack := terraforminfra.NewMockStack()
+		mockStack.UpFunc = func(_ *v1alpha1.Blueprint, _ ...func(id string) (bool, error)) (bool, error) {
+			timeline = append(timeline, "provisioner_up")
+			return false, nil
+		}
+		prov := provisioner.NewProvisioner(mocks.Runtime, mocks.Composer.BlueprintHandler, &provisioner.Provisioner{TerraformStack: mockStack})
+
+		proj := NewProject("test-context", &Project{
+			Runtime:     mocks.Runtime,
+			Composer:    mocks.Composer,
+			Provisioner: prov,
+		})
+		if err := proj.Configure(nil); err != nil {
+			t.Fatalf("Configure: %v", err)
+		}
+		mockVM := virt.NewMockVirt()
+		mockVM.UpFunc = func(_ ...bool) error {
+			timeline = append(timeline, "workstation_up")
+			return nil
+		}
+		if proj.Workstation != nil {
+			proj.Workstation.VirtualMachine = mockVM
+			proj.Workstation.ContainerRuntime = nil
+			proj.Workstation.NetworkManager = nil
+		}
+
+		var confirmAt int
+		confirm := func(_ *provisioner.BootstrapSummary) bool {
+			confirmAt = len(timeline)
+			timeline = append(timeline, "confirm")
+			return false
+		}
+
+		_, applied, _, err := proj.Bootstrap(confirm)
+		if err != nil {
+			t.Fatalf("Expected no error on decline, got: %v", err)
+		}
+		if applied {
+			t.Error("Expected applied=false when confirm declines")
+		}
+
+		for _, step := range timeline {
+			if step == "workstation_up" {
+				t.Errorf("Workstation.Up must not run on decline, timeline: %v", timeline)
+			}
+			if step == "provisioner_up" {
+				t.Errorf("Provisioner Up must not run on decline, timeline: %v", timeline)
+			}
+		}
+		if confirmAt == 0 {
+			t.Fatalf("Expected confirm to fire, timeline: %v", timeline)
+		}
+	})
+
+	t.Run("ConfirmDeclineReturnsBlueprintAndAppliedFalse", func(t *testing.T) {
+		// Acceptance returns applied=true; decline returns applied=false. The blueprint
+		// is returned in both cases so callers can render summaries off it.
+		mocks := setupProjectMocks(t)
+		expectedBP := &v1alpha1.Blueprint{
+			TerraformComponents: []v1alpha1.TerraformComponent{{Path: "marker"}},
+		}
+		mockBH := mocks.Composer.BlueprintHandler.(*blueprint.MockBlueprintHandler)
+		mockBH.GenerateFunc = func() *v1alpha1.Blueprint { return expectedBP }
+		prov := provisioner.NewProvisioner(mocks.Runtime, mocks.Composer.BlueprintHandler)
+
+		proj := NewProject("test-context", &Project{
+			Runtime:     mocks.Runtime,
+			Composer:    mocks.Composer,
+			Provisioner: prov,
+		})
+
+		bp, applied, _, err := proj.Bootstrap(func(_ *provisioner.BootstrapSummary) bool { return false })
+		if err != nil {
+			t.Fatalf("Expected no error on decline, got: %v", err)
+		}
+		if applied {
+			t.Error("Expected applied=false on decline")
+		}
+		if bp != expectedBP {
+			t.Errorf("Expected blueprint to round-trip, got %#v", bp)
+		}
+	})
+
+	t.Run("KubernetesBackendValidationFiresBeforeConfirm", func(t *testing.T) {
+		// Configuration errors (e.g. terraform.backend.type=kubernetes without
+		// Blueprint.Backend) must fail fast — the operator should not see a plan,
+		// confirm, and then receive a hard error after deciding.
+		mocks := setupProjectMocks(t)
+		mockConfig := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockConfig.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "terraform.backend.type" {
+				return "kubernetes"
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
+		mockBH := mocks.Composer.BlueprintHandler.(*blueprint.MockBlueprintHandler)
+		mockBH.GenerateFunc = func() *v1alpha1.Blueprint {
+			// Backend field omitted — must trigger validation error.
+			return &v1alpha1.Blueprint{
+				TerraformComponents: []v1alpha1.TerraformComponent{{Path: "cluster"}},
+			}
+		}
+		prov := provisioner.NewProvisioner(mocks.Runtime, mocks.Composer.BlueprintHandler)
+
+		proj := NewProject("test-context", &Project{
+			Runtime:     mocks.Runtime,
+			Composer:    mocks.Composer,
+			Provisioner: prov,
+		})
+
+		confirmCalled := false
+		_, _, _, err := proj.Bootstrap(func(_ *provisioner.BootstrapSummary) bool {
+			confirmCalled = true
+			return true
+		})
+		if err == nil {
+			t.Fatal("Expected validation error, got nil")
+		}
+		if !strings.Contains(err.Error(), "Blueprint.Backend") {
+			t.Errorf("Expected error to name Blueprint.Backend, got: %v", err)
+		}
+		if confirmCalled {
+			t.Error("Confirm callback must not run when validation fails fast")
+		}
+	})
+
 	t.Run("WrapsProvisionerErrorAsStartingInfrastructure", func(t *testing.T) {
 		mocks := setupProjectMocks(t)
 		mockConfig := mocks.ConfigHandler.(*config.MockConfigHandler)

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -1694,52 +1694,6 @@ func TestProject_Bootstrap(t *testing.T) {
 		}
 	})
 
-	t.Run("KubernetesBackendValidationFiresBeforeConfirm", func(t *testing.T) {
-		// Configuration errors (e.g. terraform.backend.type=kubernetes without
-		// Blueprint.Backend) must fail fast — the operator should not see a plan,
-		// confirm, and then receive a hard error after deciding.
-		mocks := setupProjectMocks(t)
-		mockConfig := mocks.ConfigHandler.(*config.MockConfigHandler)
-		mockConfig.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "terraform.backend.type" {
-				return "kubernetes"
-			}
-			if len(defaultValue) > 0 {
-				return defaultValue[0]
-			}
-			return ""
-		}
-		mockBH := mocks.Composer.BlueprintHandler.(*blueprint.MockBlueprintHandler)
-		mockBH.GenerateFunc = func() *v1alpha1.Blueprint {
-			// Backend field omitted — must trigger validation error.
-			return &v1alpha1.Blueprint{
-				TerraformComponents: []v1alpha1.TerraformComponent{{Path: "cluster"}},
-			}
-		}
-		prov := provisioner.NewProvisioner(mocks.Runtime, mocks.Composer.BlueprintHandler)
-
-		proj := NewProject("test-context", &Project{
-			Runtime:     mocks.Runtime,
-			Composer:    mocks.Composer,
-			Provisioner: prov,
-		})
-
-		confirmCalled := false
-		_, _, _, err := proj.Bootstrap(func(_ *provisioner.BootstrapSummary) bool {
-			confirmCalled = true
-			return true
-		})
-		if err == nil {
-			t.Fatal("Expected validation error, got nil")
-		}
-		if !strings.Contains(err.Error(), "Blueprint.Backend") {
-			t.Errorf("Expected error to name Blueprint.Backend, got: %v", err)
-		}
-		if confirmCalled {
-			t.Error("Confirm callback must not run when validation fails fast")
-		}
-	})
-
 	t.Run("WrapsProvisionerErrorAsStartingInfrastructure", func(t *testing.T) {
 		mocks := setupProjectMocks(t)
 		mockConfig := mocks.ConfigHandler.(*config.MockConfigHandler)

--- a/pkg/provisioner/bootstrap.go
+++ b/pkg/provisioner/bootstrap.go
@@ -39,34 +39,21 @@ type BootstrapConfirmFn func(*BootstrapSummary) bool
 // configured backend; Stage 3 applies non-tier components. The algorithm is idempotent —
 // every bootstrap runs the same flow regardless of whether the backend already exists.
 //
-// Returns (applied, halted, err). applied=true means bootstrap proceeded past confirm;
-// halted=true means one of the inner Up calls signaled a clean halt-after-component
-// (e.g. cluster reachability needs operator action). On halt the caller surfaces the
-// deferred-work summary; bootstrap is partially complete and the operator re-runs after
-// addressing it.
-func (i *Provisioner) Bootstrap(blueprint *blueprintv1alpha1.Blueprint, confirm BootstrapConfirmFn, onApply ...func(id string) (bool, error)) (bool, bool, error) {
-	if blueprint == nil {
-		return false, false, fmt.Errorf("blueprint not provided")
-	}
-
+// Returns (halted, err). halted=true means one of the inner Up calls signaled a clean
+// halt-after-component (e.g. cluster reachability needs operator action). On halt the
+// caller surfaces the deferred-work summary; bootstrap is partially complete and the
+// operator re-runs after addressing it. Operator confirmation is the project layer's
+// responsibility — callers gate Bootstrap on the operator's decision so declining the
+// plan never reaches privileged work (workstation startup, DNS, etc.).
+func (i *Provisioner) Bootstrap(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(id string) (bool, error)) (bool, error) {
 	backendType := i.configHandler.GetString("terraform.backend.type", "local")
-	if backendType == "kubernetes" && blueprint.Backend == "" {
-		return false, false, fmt.Errorf("blueprint configures terraform.backend.type=kubernetes but does not declare Blueprint.Backend; set `backend: <cluster-component-id>` at the blueprint top level to name the terraform component that provisions the cluster")
-	}
-
-	if confirm != nil {
-		if !confirm(i.bootstrapSummary(blueprint)) {
-			return false, false, nil
-		}
+	if err := ValidateBootstrap(blueprint, backendType); err != nil {
+		return false, err
 	}
 
 	tier := blueprint.BackendTier()
 	if backendType == "" || backendType == "local" || len(tier) == 0 {
-		halted, err := i.Up(blueprint, onApply...)
-		if err != nil {
-			return false, false, err
-		}
-		return true, halted, nil
+		return i.Up(blueprint, onApply...)
 	}
 
 	tierBP := blueprintWithComponents(blueprint, tier)
@@ -84,19 +71,19 @@ func (i *Provisioner) Bootstrap(blueprint *blueprintv1alpha1.Blueprint, confirm 
 		tierHalted = halted
 		return nil
 	}); err != nil {
-		return false, false, err
+		return false, err
 	}
 	if tierHalted {
 		// Halt during tier apply — don't migrate state or run non-tier components yet.
-		return true, true, nil
+		return true, nil
 	}
 
 	skipped, err := i.MigrateState(tierBP)
 	if err != nil {
-		return false, false, err
+		return false, err
 	}
 	if len(skipped) > 0 {
-		return false, false, fmt.Errorf("bootstrap migration skipped tier components after a successful local apply: %v — their directories should have been materialised by Up", skipped)
+		return false, fmt.Errorf("bootstrap migration skipped tier components after a successful local apply: %v — their directories should have been materialised by Up", skipped)
 	}
 
 	for _, c := range tier {
@@ -106,26 +93,35 @@ func (i *Provisioner) Bootstrap(blueprint *blueprintv1alpha1.Blueprint, confirm 
 	}
 
 	if len(nonTierBP.TerraformComponents) == 0 {
-		return true, false, nil
+		return false, nil
 	}
-	halted, err := i.Up(nonTierBP, onApply...)
-	if err != nil {
-		return false, false, err
-	}
-	return true, halted, nil
+	return i.Up(nonTierBP, onApply...)
 }
 
-// =============================================================================
-// Private Helpers
-// =============================================================================
-
-// bootstrapSummary builds the operator-visible intent description from the blueprint and config.
-func (i *Provisioner) bootstrapSummary(blueprint *blueprintv1alpha1.Blueprint) *BootstrapSummary {
-	summary := &BootstrapSummary{
-		BackendType: i.configHandler.GetString("terraform.backend.type", "local"),
+// ValidateBootstrap performs cheap, side-effect-free checks on the inputs to a bootstrap.
+// Callers run this before any privileged work or operator prompt so a structurally invalid
+// configuration (nil blueprint, terraform.backend.type=kubernetes without Blueprint.Backend)
+// fails fast rather than after the operator has confirmed a plan that cannot succeed.
+func ValidateBootstrap(blueprint *blueprintv1alpha1.Blueprint, backendType string) error {
+	if blueprint == nil {
+		return fmt.Errorf("blueprint not provided")
 	}
-	if i.runtime != nil {
-		summary.ContextName = i.runtime.ContextName
+	if backendType == "kubernetes" && blueprint.Backend == "" {
+		return fmt.Errorf("blueprint configures terraform.backend.type=kubernetes but does not declare Blueprint.Backend; set `backend: <cluster-component-id>` at the blueprint top level to name the terraform component that provisions the cluster")
+	}
+	return nil
+}
+
+// BuildBootstrapSummary constructs the operator-visible intent description for a bootstrap,
+// independent of any Provisioner instance so the project layer can render the plan before
+// committing to privileged work.
+func BuildBootstrapSummary(blueprint *blueprintv1alpha1.Blueprint, contextName, backendType string) *BootstrapSummary {
+	summary := &BootstrapSummary{
+		ContextName: contextName,
+		BackendType: backendType,
+	}
+	if summary.BackendType == "" {
+		summary.BackendType = "local"
 	}
 	for _, c := range blueprint.TerraformComponents {
 		if c.Enabled != nil && !c.Enabled.IsEnabled() {
@@ -141,6 +137,10 @@ func (i *Provisioner) bootstrapSummary(blueprint *blueprintv1alpha1.Blueprint) *
 	}
 	return summary
 }
+
+// =============================================================================
+// Private Helpers
+// =============================================================================
 
 // blueprintWithComponents returns a shallow copy of bp containing only the given
 // terraform components, in their order in the slice. Non-terraform fields are shared.

--- a/pkg/provisioner/bootstrap.go
+++ b/pkg/provisioner/bootstrap.go
@@ -46,11 +46,11 @@ type BootstrapConfirmFn func(*BootstrapSummary) bool
 // responsibility — callers gate Bootstrap on the operator's decision so declining the
 // plan never reaches privileged work (workstation startup, DNS, etc.).
 func (i *Provisioner) Bootstrap(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(id string) (bool, error)) (bool, error) {
-	backendType := i.configHandler.GetString("terraform.backend.type", "local")
-	if err := ValidateBootstrap(blueprint, backendType); err != nil {
+	if err := ValidateBootstrap(blueprint); err != nil {
 		return false, err
 	}
 
+	backendType := i.configHandler.GetString("terraform.backend.type", "local")
 	tier := blueprint.BackendTier()
 	if backendType == "" || backendType == "local" || len(tier) == 0 {
 		return i.Up(blueprint, onApply...)
@@ -98,16 +98,12 @@ func (i *Provisioner) Bootstrap(blueprint *blueprintv1alpha1.Blueprint, onApply 
 	return i.Up(nonTierBP, onApply...)
 }
 
-// ValidateBootstrap performs cheap, side-effect-free checks on the inputs to a bootstrap.
-// Callers run this before any privileged work or operator prompt so a structurally invalid
-// configuration (nil blueprint, terraform.backend.type=kubernetes without Blueprint.Backend)
-// fails fast rather than after the operator has confirmed a plan that cannot succeed.
-func ValidateBootstrap(blueprint *blueprintv1alpha1.Blueprint, backendType string) error {
+// ValidateBootstrap performs cheap, side-effect-free checks on the blueprint before any
+// privileged work or operator prompt so a structurally invalid input fails fast rather
+// than after the operator has confirmed a plan that cannot succeed.
+func ValidateBootstrap(blueprint *blueprintv1alpha1.Blueprint) error {
 	if blueprint == nil {
 		return fmt.Errorf("blueprint not provided")
-	}
-	if backendType == "kubernetes" && blueprint.Backend == "" {
-		return fmt.Errorf("blueprint configures terraform.backend.type=kubernetes but does not declare Blueprint.Backend; set `backend: <cluster-component-id>` at the blueprint top level to name the terraform component that provisions the cluster")
 	}
 	return nil
 }

--- a/pkg/provisioner/bootstrap.go
+++ b/pkg/provisioner/bootstrap.go
@@ -46,8 +46,8 @@ type BootstrapConfirmFn func(*BootstrapSummary) bool
 // responsibility — callers gate Bootstrap on the operator's decision so declining the
 // plan never reaches privileged work (workstation startup, DNS, etc.).
 func (i *Provisioner) Bootstrap(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(id string) (bool, error)) (bool, error) {
-	if err := ValidateBootstrap(blueprint); err != nil {
-		return false, err
+	if blueprint == nil {
+		return false, fmt.Errorf("blueprint not provided")
 	}
 
 	backendType := i.configHandler.GetString("terraform.backend.type", "local")
@@ -96,16 +96,6 @@ func (i *Provisioner) Bootstrap(blueprint *blueprintv1alpha1.Blueprint, onApply 
 		return false, nil
 	}
 	return i.Up(nonTierBP, onApply...)
-}
-
-// ValidateBootstrap performs cheap, side-effect-free checks on the blueprint before any
-// privileged work or operator prompt so a structurally invalid input fails fast rather
-// than after the operator has confirmed a plan that cannot succeed.
-func ValidateBootstrap(blueprint *blueprintv1alpha1.Blueprint) error {
-	if blueprint == nil {
-		return fmt.Errorf("blueprint not provided")
-	}
-	return nil
 }
 
 // BuildBootstrapSummary constructs the operator-visible intent description for a bootstrap,

--- a/pkg/provisioner/bootstrap_test.go
+++ b/pkg/provisioner/bootstrap_test.go
@@ -620,26 +620,6 @@ func TestProvisioner_Bootstrap(t *testing.T) {
 	})
 }
 
-func TestValidateBootstrap(t *testing.T) {
-	t.Run("NilBlueprintReturnsError", func(t *testing.T) {
-		if err := ValidateBootstrap(nil); err == nil {
-			t.Fatal("Expected error for nil blueprint")
-		}
-	})
-
-	t.Run("NonNilBlueprintPasses", func(t *testing.T) {
-		// terraform.backend.type and Blueprint.Backend are orthogonal: backend.type
-		// names the state store, Blueprint.Backend (optional) names the component
-		// that provisions it for the dance. ValidateBootstrap intentionally does
-		// not couple them — backend.type=kubernetes with Blueprint.Backend unset is
-		// the "external cluster already exists" case and must pass.
-		bp := &blueprintv1alpha1.Blueprint{}
-		if err := ValidateBootstrap(bp); err != nil {
-			t.Errorf("Expected no error for empty blueprint, got: %v", err)
-		}
-	})
-}
-
 func TestBuildBootstrapSummary(t *testing.T) {
 	t.Run("PopulatesContextAndBackend", func(t *testing.T) {
 		bp := &blueprintv1alpha1.Blueprint{}

--- a/pkg/provisioner/bootstrap_test.go
+++ b/pkg/provisioner/bootstrap_test.go
@@ -26,15 +26,13 @@ func TestProvisioner_Bootstrap(t *testing.T) {
 		}
 	})
 
-	t.Run("KubernetesWithoutBackendFieldErrorsBeforeAnyMutation", func(t *testing.T) {
-		// A kubernetes-configured backend with no Blueprint.Backend would silently
-		// fall through to plain Up against a cluster that does not yet exist. Refuse
-		// before any state-mutating work runs. The project layer is responsible for
-		// the equivalent fail-fast before its operator-facing confirm prompt fires.
+	t.Run("KubernetesBackendWithoutBlueprintBackendCollapsesToUp", func(t *testing.T) {
+		// terraform.backend.type=kubernetes with no Blueprint.Backend is the
+		// "external cluster already provisioned" case. Bootstrap forwards to Up
+		// without the local-pin/migrate dance — len(tier) == 0 short-circuits.
 		mocks := setupProvisionerMocks(t)
 		bp := &blueprintv1alpha1.Blueprint{
 			TerraformComponents: []blueprintv1alpha1.TerraformComponent{
-				{Path: "cluster/talos"},
 				{Path: "workloads/argocd"},
 			},
 		}
@@ -48,34 +46,26 @@ func TestProvisioner_Bootstrap(t *testing.T) {
 			}
 			return ""
 		}
-		setCalled := false
-		mockCH.SetFunc = func(_ string, _ any) error {
-			setCalled = true
+		var ops []string
+		mockCH.SetFunc = func(key string, value any) error {
+			if key == "terraform.backend.type" {
+				ops = append(ops, fmt.Sprintf("set:%v", value))
+			}
 			return nil
 		}
-		upCalled := false
 		mockStack := terraforminfra.NewMockStack()
 		mockStack.UpFunc = func(_ *blueprintv1alpha1.Blueprint, _ ...func(id string) (bool, error)) (bool, error) {
-			upCalled = true
+			ops = append(ops, "up")
 			return false, nil
 		}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
 
-		_, err := provisioner.Bootstrap(bp)
-		if err == nil {
-			t.Fatal("Expected error for kubernetes backend without Blueprint.Backend, got nil")
+		if _, err := provisioner.Bootstrap(bp); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
 		}
-		if !strings.Contains(err.Error(), "Blueprint.Backend") {
-			t.Errorf("Expected error to name the missing field, got: %v", err)
-		}
-		if !strings.Contains(err.Error(), "kubernetes") {
-			t.Errorf("Expected error to name the backend type, got: %v", err)
-		}
-		if setCalled {
-			t.Error("No backend override may engage when refusing")
-		}
-		if upCalled {
-			t.Error("No apply may run when refusing")
+		// Must be a plain Up — no backend pinning, no migrate dance.
+		if len(ops) != 1 || ops[0] != "up" {
+			t.Errorf("Expected ops=[up], got %v", ops)
 		}
 	})
 
@@ -632,37 +622,20 @@ func TestProvisioner_Bootstrap(t *testing.T) {
 
 func TestValidateBootstrap(t *testing.T) {
 	t.Run("NilBlueprintReturnsError", func(t *testing.T) {
-		if err := ValidateBootstrap(nil, "local"); err == nil {
+		if err := ValidateBootstrap(nil); err == nil {
 			t.Fatal("Expected error for nil blueprint")
 		}
 	})
 
-	t.Run("KubernetesBackendWithoutBlueprintBackendFieldErrors", func(t *testing.T) {
-		bp := &blueprintv1alpha1.Blueprint{
-			TerraformComponents: []blueprintv1alpha1.TerraformComponent{{Path: "cluster"}},
-		}
-		err := ValidateBootstrap(bp, "kubernetes")
-		if err == nil {
-			t.Fatal("Expected error when terraform.backend.type=kubernetes and Blueprint.Backend is unset")
-		}
-		if !strings.Contains(err.Error(), "Blueprint.Backend") || !strings.Contains(err.Error(), "kubernetes") {
-			t.Errorf("Expected error to name both kubernetes and Blueprint.Backend, got: %v", err)
-		}
-	})
-
-	t.Run("KubernetesBackendWithBlueprintBackendFieldPasses", func(t *testing.T) {
-		bp := &blueprintv1alpha1.Blueprint{Backend: "cluster"}
-		if err := ValidateBootstrap(bp, "kubernetes"); err != nil {
-			t.Errorf("Expected no error with Blueprint.Backend set, got: %v", err)
-		}
-	})
-
-	t.Run("NonKubernetesBackendPasses", func(t *testing.T) {
+	t.Run("NonNilBlueprintPasses", func(t *testing.T) {
+		// terraform.backend.type and Blueprint.Backend are orthogonal: backend.type
+		// names the state store, Blueprint.Backend (optional) names the component
+		// that provisions it for the dance. ValidateBootstrap intentionally does
+		// not couple them — backend.type=kubernetes with Blueprint.Backend unset is
+		// the "external cluster already exists" case and must pass.
 		bp := &blueprintv1alpha1.Blueprint{}
-		for _, backend := range []string{"", "local", "s3", "azurerm", "gcs"} {
-			if err := ValidateBootstrap(bp, backend); err != nil {
-				t.Errorf("backend %q: expected no error, got: %v", backend, err)
-			}
+		if err := ValidateBootstrap(bp); err != nil {
+			t.Errorf("Expected no error for empty blueprint, got: %v", err)
 		}
 	})
 }

--- a/pkg/provisioner/bootstrap_test.go
+++ b/pkg/provisioner/bootstrap_test.go
@@ -21,16 +21,16 @@ func TestProvisioner_Bootstrap(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler)
 
-		if _, _, err := provisioner.Bootstrap(nil, nil); err == nil {
+		if _, err := provisioner.Bootstrap(nil); err == nil {
 			t.Fatal("Expected error for nil blueprint, got nil")
 		}
 	})
 
-	t.Run("KubernetesWithoutBackendFieldErrorsBeforeConfirmAndAnyMutation", func(t *testing.T) {
+	t.Run("KubernetesWithoutBackendFieldErrorsBeforeAnyMutation", func(t *testing.T) {
 		// A kubernetes-configured backend with no Blueprint.Backend would silently
 		// fall through to plain Up against a cluster that does not yet exist. Refuse
-		// before the confirmation prompt fires — an operator should not see a full
-		// bootstrap summary, confirm intent, and then receive the hard error.
+		// before any state-mutating work runs. The project layer is responsible for
+		// the equivalent fail-fast before its operator-facing confirm prompt fires.
 		mocks := setupProvisionerMocks(t)
 		bp := &blueprintv1alpha1.Blueprint{
 			TerraformComponents: []blueprintv1alpha1.TerraformComponent{
@@ -61,13 +61,7 @@ func TestProvisioner_Bootstrap(t *testing.T) {
 		}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
 
-		confirmCalled := false
-		confirm := func(_ *BootstrapSummary) bool {
-			confirmCalled = true
-			return true
-		}
-
-		_, _, err := provisioner.Bootstrap(bp, confirm)
+		_, err := provisioner.Bootstrap(bp)
 		if err == nil {
 			t.Fatal("Expected error for kubernetes backend without Blueprint.Backend, got nil")
 		}
@@ -76,9 +70,6 @@ func TestProvisioner_Bootstrap(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "kubernetes") {
 			t.Errorf("Expected error to name the backend type, got: %v", err)
-		}
-		if confirmCalled {
-			t.Error("Confirm callback must not run when refusing — fail-fast before the prompt")
 		}
 		if setCalled {
 			t.Error("No backend override may engage when refusing")
@@ -125,12 +116,9 @@ func TestProvisioner_Bootstrap(t *testing.T) {
 		}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
 
-		applied, _, err := provisioner.Bootstrap(bp, nil)
+		_, err := provisioner.Bootstrap(bp)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
-		}
-		if !applied {
-			t.Fatal("Expected applied=true")
 		}
 		expected := []string{"up"}
 		if len(ops) != len(expected) || ops[0] != expected[0] {
@@ -174,12 +162,9 @@ func TestProvisioner_Bootstrap(t *testing.T) {
 		}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
 
-		applied, _, err := provisioner.Bootstrap(bp, nil)
+		_, err := provisioner.Bootstrap(bp)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
-		}
-		if !applied {
-			t.Fatal("Expected applied=true")
 		}
 		expected := []string{"up"}
 		if len(ops) != len(expected) || ops[0] != expected[0] {
@@ -235,12 +220,9 @@ func TestProvisioner_Bootstrap(t *testing.T) {
 		}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
 
-		applied, _, err := provisioner.Bootstrap(bp, nil)
+		_, err := provisioner.Bootstrap(bp)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
-		}
-		if !applied {
-			t.Fatal("Expected applied=true with no confirm callback")
 		}
 
 		expected := []string{"set:local", "migrate", "up", "set:azurerm", "migrate", "up"}
@@ -323,12 +305,9 @@ func TestProvisioner_Bootstrap(t *testing.T) {
 		}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
 
-		applied, _, err := provisioner.Bootstrap(bp, nil)
+		_, err := provisioner.Bootstrap(bp)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
-		}
-		if !applied {
-			t.Fatal("Expected applied=true")
 		}
 
 		expected := []string{"set:local", "migrate", "up", "set:s3", "migrate", "up"}
@@ -402,12 +381,9 @@ func TestProvisioner_Bootstrap(t *testing.T) {
 		}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
 
-		applied, _, err := provisioner.Bootstrap(bp, nil)
+		_, err := provisioner.Bootstrap(bp)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
-		}
-		if !applied {
-			t.Fatal("Expected applied=true")
 		}
 
 		expected := []string{"set:local", "migrate", "up", "set:s3", "migrate"}
@@ -461,7 +437,7 @@ func TestProvisioner_Bootstrap(t *testing.T) {
 		}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
 
-		_, _, err := provisioner.Bootstrap(bp, nil)
+		_, err := provisioner.Bootstrap(bp)
 		if err == nil {
 			t.Fatal("Expected error, got nil")
 		}
@@ -516,7 +492,7 @@ func TestProvisioner_Bootstrap(t *testing.T) {
 		}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
 
-		_, _, err := provisioner.Bootstrap(bp, nil)
+		_, err := provisioner.Bootstrap(bp)
 		if err == nil {
 			t.Fatal("Expected error from Stage 2 migrate failure, got nil")
 		}
@@ -561,118 +537,12 @@ func TestProvisioner_Bootstrap(t *testing.T) {
 		}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
 
-		_, _, err := provisioner.Bootstrap(bp, nil)
+		_, err := provisioner.Bootstrap(bp)
 		if err == nil {
 			t.Fatal("Expected error for skipped-after-apply, got nil")
 		}
 		if !strings.Contains(err.Error(), "skipped") || !strings.Contains(err.Error(), "backend") {
 			t.Errorf("Expected error to name skipped component, got: %v", err)
-		}
-	})
-
-	t.Run("ConfirmReceivesSummaryBeforeAnyMutation", func(t *testing.T) {
-		// confirm runs with the summary before any state-touching op fires.
-		mocks := setupProvisionerMocks(t)
-		bp := &blueprintv1alpha1.Blueprint{
-			Backend: "backend",
-			TerraformComponents: []blueprintv1alpha1.TerraformComponent{
-				{Path: "backend"},
-			},
-			Kustomizations: []blueprintv1alpha1.Kustomization{
-				{Name: "argocd"},
-			},
-		}
-
-		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
-		mockCH.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "terraform.backend.type" {
-				return "s3"
-			}
-			if len(defaultValue) > 0 {
-				return defaultValue[0]
-			}
-			return ""
-		}
-
-		mockStack := terraforminfra.NewMockStack()
-		mockStack.UpFunc = func(_ *blueprintv1alpha1.Blueprint, _ ...func(id string) (bool, error)) (bool, error) { return false, nil }
-		mockStack.MigrateStateFunc = func(_ *blueprintv1alpha1.Blueprint) ([]string, error) { return nil, nil }
-		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
-
-		var received *BootstrapSummary
-		confirm := func(s *BootstrapSummary) bool {
-			received = s
-			return true
-		}
-
-		applied, _, err := provisioner.Bootstrap(bp, confirm)
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if !applied {
-			t.Fatal("Expected applied=true")
-		}
-		if received == nil {
-			t.Fatal("Expected confirm callback to receive summary")
-		}
-		if received.BackendType != "s3" {
-			t.Errorf("Expected BackendType=s3 in summary, got %q", received.BackendType)
-		}
-		if len(received.Terraform) != 1 || received.Terraform[0].ComponentID != "backend" {
-			t.Errorf("Expected summary to list [backend], got %#v", received.Terraform)
-		}
-		if len(received.Kustomize) != 1 || received.Kustomize[0] != "argocd" {
-			t.Errorf("Expected summary to list [argocd] kustomize, got %#v", received.Kustomize)
-		}
-	})
-
-	t.Run("ConfirmDeclineSkipsAllWork", func(t *testing.T) {
-		mocks := setupProvisionerMocks(t)
-		bp := &blueprintv1alpha1.Blueprint{
-			Backend: "backend",
-			TerraformComponents: []blueprintv1alpha1.TerraformComponent{
-				{Path: "backend"},
-			},
-		}
-
-		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
-		mockCH.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "terraform.backend.type" {
-				return "s3"
-			}
-			if len(defaultValue) > 0 {
-				return defaultValue[0]
-			}
-			return ""
-		}
-
-		var setCalled, upCalled, migrateCalled bool
-		mockCH.SetFunc = func(key string, _ any) error {
-			if key == "terraform.backend.type" {
-				setCalled = true
-			}
-			return nil
-		}
-		mockStack := terraforminfra.NewMockStack()
-		mockStack.UpFunc = func(_ *blueprintv1alpha1.Blueprint, _ ...func(id string) (bool, error)) (bool, error) {
-			upCalled = true
-			return false, nil
-		}
-		mockStack.MigrateStateFunc = func(_ *blueprintv1alpha1.Blueprint) ([]string, error) {
-			migrateCalled = true
-			return nil, nil
-		}
-		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
-
-		applied, _, err := provisioner.Bootstrap(bp, func(_ *BootstrapSummary) bool { return false })
-		if err != nil {
-			t.Fatalf("Expected no error on decline, got %v", err)
-		}
-		if applied {
-			t.Error("Expected applied=false when confirm declines")
-		}
-		if setCalled || upCalled || migrateCalled {
-			t.Errorf("Expected no state-touching ops on decline, got set=%v up=%v migrate=%v", setCalled, upCalled, migrateCalled)
 		}
 	})
 
@@ -731,7 +601,7 @@ func TestProvisioner_Bootstrap(t *testing.T) {
 		defer func() { os.Stderr = origStderr }()
 
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
-		applied, _, err := provisioner.Bootstrap(bp, nil)
+		_, err := provisioner.Bootstrap(bp)
 
 		w.Close()
 		stderrBytes, _ := io.ReadAll(r)
@@ -739,9 +609,6 @@ func TestProvisioner_Bootstrap(t *testing.T) {
 
 		if err != nil {
 			t.Fatalf("Expected no error (cleanup failure is warning-only), got %v", err)
-		}
-		if !applied {
-			t.Fatal("Expected applied=true")
 		}
 		if !strings.Contains(stderrOutput, "permission denied") {
 			t.Errorf("Expected stderr warning to include underlying cause, got: %q", stderrOutput)
@@ -759,6 +626,105 @@ func TestProvisioner_Bootstrap(t *testing.T) {
 		}
 		if !sawSecondUp {
 			t.Errorf("Expected Stage 3 Up after cleanup warning, got %v", ops)
+		}
+	})
+}
+
+func TestValidateBootstrap(t *testing.T) {
+	t.Run("NilBlueprintReturnsError", func(t *testing.T) {
+		if err := ValidateBootstrap(nil, "local"); err == nil {
+			t.Fatal("Expected error for nil blueprint")
+		}
+	})
+
+	t.Run("KubernetesBackendWithoutBlueprintBackendFieldErrors", func(t *testing.T) {
+		bp := &blueprintv1alpha1.Blueprint{
+			TerraformComponents: []blueprintv1alpha1.TerraformComponent{{Path: "cluster"}},
+		}
+		err := ValidateBootstrap(bp, "kubernetes")
+		if err == nil {
+			t.Fatal("Expected error when terraform.backend.type=kubernetes and Blueprint.Backend is unset")
+		}
+		if !strings.Contains(err.Error(), "Blueprint.Backend") || !strings.Contains(err.Error(), "kubernetes") {
+			t.Errorf("Expected error to name both kubernetes and Blueprint.Backend, got: %v", err)
+		}
+	})
+
+	t.Run("KubernetesBackendWithBlueprintBackendFieldPasses", func(t *testing.T) {
+		bp := &blueprintv1alpha1.Blueprint{Backend: "cluster"}
+		if err := ValidateBootstrap(bp, "kubernetes"); err != nil {
+			t.Errorf("Expected no error with Blueprint.Backend set, got: %v", err)
+		}
+	})
+
+	t.Run("NonKubernetesBackendPasses", func(t *testing.T) {
+		bp := &blueprintv1alpha1.Blueprint{}
+		for _, backend := range []string{"", "local", "s3", "azurerm", "gcs"} {
+			if err := ValidateBootstrap(bp, backend); err != nil {
+				t.Errorf("backend %q: expected no error, got: %v", backend, err)
+			}
+		}
+	})
+}
+
+func TestBuildBootstrapSummary(t *testing.T) {
+	t.Run("PopulatesContextAndBackend", func(t *testing.T) {
+		bp := &blueprintv1alpha1.Blueprint{}
+		s := BuildBootstrapSummary(bp, "staging", "s3")
+		if s.ContextName != "staging" {
+			t.Errorf("Expected ContextName=staging, got %q", s.ContextName)
+		}
+		if s.BackendType != "s3" {
+			t.Errorf("Expected BackendType=s3, got %q", s.BackendType)
+		}
+	})
+
+	t.Run("EmptyBackendDefaultsToLocal", func(t *testing.T) {
+		bp := &blueprintv1alpha1.Blueprint{}
+		s := BuildBootstrapSummary(bp, "local", "")
+		if s.BackendType != "local" {
+			t.Errorf("Expected BackendType=local when input empty, got %q", s.BackendType)
+		}
+	})
+
+	t.Run("ListsEnabledTerraformComponentsAndKustomizations", func(t *testing.T) {
+		bp := &blueprintv1alpha1.Blueprint{
+			TerraformComponents: []blueprintv1alpha1.TerraformComponent{
+				{Path: "backend"},
+				{Path: "cluster"},
+			},
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "argocd"},
+				{Name: "monitoring"},
+			},
+		}
+		s := BuildBootstrapSummary(bp, "local", "s3")
+		if len(s.Terraform) != 2 || s.Terraform[0].ComponentID != "backend" || s.Terraform[1].ComponentID != "cluster" {
+			t.Errorf("Expected terraform [backend, cluster], got %#v", s.Terraform)
+		}
+		if len(s.Kustomize) != 2 || s.Kustomize[0] != "argocd" || s.Kustomize[1] != "monitoring" {
+			t.Errorf("Expected kustomize [argocd, monitoring], got %#v", s.Kustomize)
+		}
+	})
+
+	t.Run("OmitsDisabledTerraformComponents", func(t *testing.T) {
+		falseValue := false
+		disabled := &blueprintv1alpha1.BoolExpression{Value: &falseValue}
+		bp := &blueprintv1alpha1.Blueprint{
+			TerraformComponents: []blueprintv1alpha1.TerraformComponent{
+				{Path: "backend"},
+				{Path: "skipped", Enabled: disabled},
+				{Path: "cluster"},
+			},
+		}
+		s := BuildBootstrapSummary(bp, "local", "local")
+		if len(s.Terraform) != 2 {
+			t.Fatalf("Expected 2 enabled components, got %d (%#v)", len(s.Terraform), s.Terraform)
+		}
+		for _, e := range s.Terraform {
+			if e.ComponentID == "skipped" {
+				t.Errorf("Disabled component leaked into summary: %#v", s.Terraform)
+			}
 		}
 	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> The change restructures how operator confirmation gates workstation setup in Bootstrap, affecting an initialisation flow that writes to /etc/resolver and invokes sudo; the risk sits in the silent behavioural change to kubernetes-backend handling.
>
> **Overview**
>
> This PR fixes a bug where `Workstation.Up` — which writes DNS resolver entries and can prompt for sudo — ran before the operator could decline the bootstrap plan. Confirmation is now checked first against a lightweight blueprint summary, and workstation startup only proceeds after acceptance. The provisioner's `Bootstrap` signature is simplified: the `applied` return value and `confirm` callback both move to the project layer.
>
> The change also removes an explicit fast-fail guard for `backend.type=kubernetes` with no `Blueprint.Backend` set, treating that combination as the "external cluster already provisioned" path rather than a configuration error. This is a semantic behaviour change worth validating against real operator workflows before merging.
>
> Reviewed by Claude for commit `7ee02ca`.

<!-- /claude-code-review:summary -->
