### PR TITLE
fix(runtime): skip workstation runtime default when platform is explicitly set

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -442,7 +442,7 @@ func (rt *Runtime) ApplyConfigDefaults(flagOverrides ...map[string]any) error {
 		}
 		overridePlatform := ""
 		if len(flagOverrides) > 0 && flagOverrides[0] != nil {
-			if p, ok := flagOverrides[0]["platform"].(string); ok {
+			if p, ok := flagOverrides[0]["platform"].(string); ok && p != "" {
 				overridePlatform = p
 			}
 		}
@@ -472,12 +472,6 @@ func (rt *Runtime) ApplyConfigDefaults(flagOverrides ...map[string]any) error {
 		}
 
 		if existingPlatform == "" && isDevMode {
-			overridePlatform := ""
-			if len(flagOverrides) > 0 && flagOverrides[0] != nil {
-				if p, ok := flagOverrides[0]["platform"].(string); ok && p != "" {
-					overridePlatform = p
-				}
-			}
 			if overridePlatform != "" {
 				if err := rt.ConfigHandler.Set("platform", overridePlatform); err != nil {
 					return fmt.Errorf("failed to set platform from overrides: %w", err)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -440,7 +440,14 @@ func (rt *Runtime) ApplyConfigDefaults(flagOverrides ...map[string]any) error {
 				workstationRuntime = driver
 			}
 		}
-		if isDevMode && workstationRuntime == "" {
+		overridePlatform := ""
+		if len(flagOverrides) > 0 && flagOverrides[0] != nil {
+			if p, ok := flagOverrides[0]["platform"].(string); ok {
+				overridePlatform = p
+			}
+		}
+		platformExplicit := overridePlatform != "" || existingPlatform != ""
+		if isDevMode && workstationRuntime == "" && !platformExplicit {
 			switch runtime.GOOS {
 			case "darwin", "windows":
 				workstationRuntime = "docker-desktop"

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1631,6 +1631,71 @@ func TestRuntime_ApplyConfigDefaults(t *testing.T) {
 			t.Errorf("Expected platform to be set to 'incus', got: %s", platformSet)
 		}
 	})
+
+	t.Run("SkipsWorkstationRuntimeDefaultWhenPlatformIsExplicit", func(t *testing.T) {
+		for _, platform := range []string{"aws", "azure", "gcp", "metal", "none", "docker", "incus", "hyperv"} {
+			t.Run(platform, func(t *testing.T) {
+				mocks := setupRuntimeMocks(t)
+				rt := mocks.Runtime
+				rt.ContextName = "local"
+
+				mockConfigHandler := mocks.ConfigHandler.(*config.MockConfigHandler)
+				mockConfigHandler.IsLoadedFunc = func() bool { return false }
+				mockConfigHandler.IsDevModeFunc = func(_ string) bool { return true }
+				mockConfigHandler.GetStringFunc = func(_ string, defaultValue ...string) string {
+					if len(defaultValue) > 0 {
+						return defaultValue[0]
+					}
+					return ""
+				}
+				mockConfigHandler.SetDefaultFunc = func(_ v1alpha1.Context) error { return nil }
+
+				setCalls := make(map[string]any)
+				mockConfigHandler.SetFunc = func(key string, value any) error {
+					setCalls[key] = value
+					return nil
+				}
+
+				err := rt.ApplyConfigDefaults(map[string]any{"platform": platform})
+				if err != nil {
+					t.Fatalf("Expected no error, got: %v", err)
+				}
+				if _, ok := setCalls["workstation.runtime"]; ok {
+					t.Errorf("Expected workstation.runtime NOT to be set for platform=%q, got setCalls=%v", platform, setCalls)
+				}
+			})
+		}
+	})
+
+	t.Run("DefaultsWorkstationRuntimeWhenNoPlatformInDevMode", func(t *testing.T) {
+		mocks := setupRuntimeMocks(t)
+		rt := mocks.Runtime
+		rt.ContextName = "local"
+
+		mockConfigHandler := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockConfigHandler.IsLoadedFunc = func() bool { return false }
+		mockConfigHandler.IsDevModeFunc = func(_ string) bool { return true }
+		mockConfigHandler.GetStringFunc = func(_ string, defaultValue ...string) string {
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
+		mockConfigHandler.SetDefaultFunc = func(_ v1alpha1.Context) error { return nil }
+
+		setCalls := make(map[string]any)
+		mockConfigHandler.SetFunc = func(key string, value any) error {
+			setCalls[key] = value
+			return nil
+		}
+
+		if err := rt.ApplyConfigDefaults(); err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if _, ok := setCalls["workstation.runtime"]; !ok {
+			t.Errorf("Expected workstation.runtime to be set when no platform is chosen, got setCalls=%v", setCalls)
+		}
+	})
 }
 
 func TestRuntime_SaveConfig(t *testing.T) {


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This is a targeted two-file change that guards a single conditional in `ApplyConfigDefaults`; the logic is well-contained and the new tests cover the primary paths.
>
> **Overview**
>
> The PR fixes a regression where dev-mode would auto-assign a `workstation.runtime` default (docker-desktop on macOS/Windows, docker elsewhere) even when an explicit target platform was already provided via CLI flag or existing config. The guard is implemented by extracting the incoming platform override and combining it with the pre-loaded `existingPlatform` into a `platformExplicit` boolean before the runtime-default branch.
>
> The new `overridePlatform` variable introduced here is shadowed by a pre-existing inner re-declaration at line 475, which re-reads the same flag with a slightly different guard (`ok && p != ""` vs. `ok`). This is a latent maintainability issue flagged inline but does not affect correctness today.
>
> Reviewed by Claude for commit `d408b8f5`.

<!-- /claude-code-review:summary -->
