### PR TITLE
fix(runtime): update workstation runtime defaults for dev platforms

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -446,8 +446,12 @@ func (rt *Runtime) ApplyConfigDefaults(flagOverrides ...map[string]any) error {
 				overridePlatform = p
 			}
 		}
-		platformExplicit := overridePlatform != "" || existingPlatform != ""
-		if isDevMode && workstationRuntime == "" && !platformExplicit {
+		effectivePlatform := overridePlatform
+		if effectivePlatform == "" {
+			effectivePlatform = existingPlatform
+		}
+		needsWorkstationRuntime := effectivePlatform == "" || effectivePlatform == "docker" || effectivePlatform == "incus"
+		if isDevMode && workstationRuntime == "" && needsWorkstationRuntime {
 			switch runtime.GOOS {
 			case "darwin", "windows":
 				workstationRuntime = "docker-desktop"

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1632,7 +1632,7 @@ func TestRuntime_ApplyConfigDefaults(t *testing.T) {
 		}
 	})
 
-	t.Run("SkipsWorkstationRuntimeDefaultWhenPlatformIsNonWorkstation", func(t *testing.T) {
+	t.Run("SkipsWorkstationRuntimeDefaultWhenPlatformIsNonWorkstationViaFlagOverride", func(t *testing.T) {
 		for _, platform := range []string{"aws", "azure", "gcp", "metal", "none", "hyperv"} {
 			t.Run(platform, func(t *testing.T) {
 				mocks := setupRuntimeMocks(t)
@@ -1667,7 +1667,44 @@ func TestRuntime_ApplyConfigDefaults(t *testing.T) {
 		}
 	})
 
-	t.Run("DefaultsWorkstationRuntimeWhenPlatformIsWorkstation", func(t *testing.T) {
+	t.Run("SkipsWorkstationRuntimeDefaultWhenPlatformIsNonWorkstationViaSavedConfig", func(t *testing.T) {
+		for _, platform := range []string{"aws", "azure", "gcp", "metal", "none", "hyperv"} {
+			t.Run(platform, func(t *testing.T) {
+				mocks := setupRuntimeMocks(t)
+				rt := mocks.Runtime
+				rt.ContextName = "local"
+
+				mockConfigHandler := mocks.ConfigHandler.(*config.MockConfigHandler)
+				mockConfigHandler.IsLoadedFunc = func() bool { return false }
+				mockConfigHandler.IsDevModeFunc = func(_ string) bool { return true }
+				mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+					if key == "platform" {
+						return platform
+					}
+					if len(defaultValue) > 0 {
+						return defaultValue[0]
+					}
+					return ""
+				}
+				mockConfigHandler.SetDefaultFunc = func(_ v1alpha1.Context) error { return nil }
+
+				setCalls := make(map[string]any)
+				mockConfigHandler.SetFunc = func(key string, value any) error {
+					setCalls[key] = value
+					return nil
+				}
+
+				if err := rt.ApplyConfigDefaults(); err != nil {
+					t.Fatalf("Expected no error, got: %v", err)
+				}
+				if _, ok := setCalls["workstation.runtime"]; ok {
+					t.Errorf("Expected workstation.runtime NOT to be set for platform=%q, got setCalls=%v", platform, setCalls)
+				}
+			})
+		}
+	})
+
+	t.Run("DefaultsWorkstationRuntimeWhenPlatformIsWorkstationViaFlagOverride", func(t *testing.T) {
 		for _, platform := range []string{"docker", "incus"} {
 			t.Run(platform, func(t *testing.T) {
 				mocks := setupRuntimeMocks(t)
@@ -1692,6 +1729,43 @@ func TestRuntime_ApplyConfigDefaults(t *testing.T) {
 				}
 
 				if err := rt.ApplyConfigDefaults(map[string]any{"platform": platform}); err != nil {
+					t.Fatalf("Expected no error, got: %v", err)
+				}
+				if _, ok := setCalls["workstation.runtime"]; !ok {
+					t.Errorf("Expected workstation.runtime to be set for platform=%q, got setCalls=%v", platform, setCalls)
+				}
+			})
+		}
+	})
+
+	t.Run("DefaultsWorkstationRuntimeWhenPlatformIsWorkstationViaSavedConfig", func(t *testing.T) {
+		for _, platform := range []string{"docker", "incus"} {
+			t.Run(platform, func(t *testing.T) {
+				mocks := setupRuntimeMocks(t)
+				rt := mocks.Runtime
+				rt.ContextName = "local"
+
+				mockConfigHandler := mocks.ConfigHandler.(*config.MockConfigHandler)
+				mockConfigHandler.IsLoadedFunc = func() bool { return false }
+				mockConfigHandler.IsDevModeFunc = func(_ string) bool { return true }
+				mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+					if key == "platform" {
+						return platform
+					}
+					if len(defaultValue) > 0 {
+						return defaultValue[0]
+					}
+					return ""
+				}
+				mockConfigHandler.SetDefaultFunc = func(_ v1alpha1.Context) error { return nil }
+
+				setCalls := make(map[string]any)
+				mockConfigHandler.SetFunc = func(key string, value any) error {
+					setCalls[key] = value
+					return nil
+				}
+
+				if err := rt.ApplyConfigDefaults(); err != nil {
 					t.Fatalf("Expected no error, got: %v", err)
 				}
 				if _, ok := setCalls["workstation.runtime"]; !ok {

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1632,8 +1632,8 @@ func TestRuntime_ApplyConfigDefaults(t *testing.T) {
 		}
 	})
 
-	t.Run("SkipsWorkstationRuntimeDefaultWhenPlatformIsExplicit", func(t *testing.T) {
-		for _, platform := range []string{"aws", "azure", "gcp", "metal", "none", "docker", "incus", "hyperv"} {
+	t.Run("SkipsWorkstationRuntimeDefaultWhenPlatformIsNonWorkstation", func(t *testing.T) {
+		for _, platform := range []string{"aws", "azure", "gcp", "metal", "none", "hyperv"} {
 			t.Run(platform, func(t *testing.T) {
 				mocks := setupRuntimeMocks(t)
 				rt := mocks.Runtime
@@ -1662,6 +1662,40 @@ func TestRuntime_ApplyConfigDefaults(t *testing.T) {
 				}
 				if _, ok := setCalls["workstation.runtime"]; ok {
 					t.Errorf("Expected workstation.runtime NOT to be set for platform=%q, got setCalls=%v", platform, setCalls)
+				}
+			})
+		}
+	})
+
+	t.Run("DefaultsWorkstationRuntimeWhenPlatformIsWorkstation", func(t *testing.T) {
+		for _, platform := range []string{"docker", "incus"} {
+			t.Run(platform, func(t *testing.T) {
+				mocks := setupRuntimeMocks(t)
+				rt := mocks.Runtime
+				rt.ContextName = "local"
+
+				mockConfigHandler := mocks.ConfigHandler.(*config.MockConfigHandler)
+				mockConfigHandler.IsLoadedFunc = func() bool { return false }
+				mockConfigHandler.IsDevModeFunc = func(_ string) bool { return true }
+				mockConfigHandler.GetStringFunc = func(_ string, defaultValue ...string) string {
+					if len(defaultValue) > 0 {
+						return defaultValue[0]
+					}
+					return ""
+				}
+				mockConfigHandler.SetDefaultFunc = func(_ v1alpha1.Context) error { return nil }
+
+				setCalls := make(map[string]any)
+				mockConfigHandler.SetFunc = func(key string, value any) error {
+					setCalls[key] = value
+					return nil
+				}
+
+				if err := rt.ApplyConfigDefaults(map[string]any{"platform": platform}); err != nil {
+					t.Fatalf("Expected no error, got: %v", err)
+				}
+				if _, ok := setCalls["workstation.runtime"]; !ok {
+					t.Errorf("Expected workstation.runtime to be set for platform=%q, got setCalls=%v", platform, setCalls)
 				}
 			})
 		}


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low-Medium Risk**
>
> This targets `ApplyConfigDefaults` in dev mode; the blast radius is narrow and affects only users running dev mode with `docker` or `incus` as their platform who have no `workstationRuntime` already set.
>
> **Overview**
>
> The PR recognizes that `docker` and `incus` are workstation-local platforms that still benefit from a `workstationRuntime` default (e.g., `docker-desktop` on macOS/Windows) in dev mode. The previous logic skipped the default for any explicitly set platform; the fix narrows that skip to non-workstation platforms. The implementation introduces `effectivePlatform` to resolve the active platform via the same `overridePlatform` > `existingPlatform` precedence as before, then gates the default on a short explicit allowlist. Tests correctly remove `docker` and `incus` from the prior non-workstation skip list and add a new case verifying the default is applied.
>
> The one gap worth noting: the added test only exercises the `overridePlatform` branch; the `existingPlatform` branch — the path a user with `platform: docker` already in their saved config would hit — is not directly tested.
>
> Reviewed by Claude for commit `6bd9fde8`.

<!-- /claude-code-review:summary -->
