### PR TITLE
feat(blueprint): implement topological sorting for config block evaluation order

### DIFF
--- a/pkg/composer/blueprint/config_block_order.go
+++ b/pkg/composer/blueprint/config_block_order.go
@@ -1,0 +1,132 @@
+// The config_block_order file orders config blocks for evaluation by their inter-block
+// reference dependencies. The order built up by mergeFacetScopeIntoGlobal reflects facet
+// processing order, which does not necessarily match evaluation order: a block that
+// references another block must be evaluated after the block it references, regardless
+// of which facet wrote which first. Topological sort of the block dependency graph
+// produces an order where every block evaluates after the blocks it depends on.
+package blueprint
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+// collectBlockRefs walks value (string, map, or slice) and returns the set of block names
+// referenced via ${...} expressions. blockNames is the set of valid block names; references
+// whose first dotted segment does not match a known block (e.g. context values like
+// cluster.driver) are ignored. self-references (a block referencing itself) are also
+// dropped — same-block iteration handles those.
+func collectBlockRefs(value any, blockNames map[string]bool, selfName string) []string {
+	seen := make(map[string]bool)
+	var walk func(v any)
+	walk = func(v any) {
+		switch x := v.(type) {
+		case string:
+			for _, ref := range extractExprASTRefs(x) {
+				head := ref
+				if dot := strings.Index(ref, "."); dot >= 0 {
+					head = ref[:dot]
+				}
+				if head == selfName {
+					continue
+				}
+				if !blockNames[head] {
+					continue
+				}
+				seen[head] = true
+			}
+		case map[string]any:
+			for _, sub := range x {
+				walk(sub)
+			}
+		case []any:
+			for _, sub := range x {
+				walk(sub)
+			}
+		}
+	}
+	walk(value)
+	result := make([]string, 0, len(seen))
+	for r := range seen {
+		result = append(result, r)
+	}
+	sort.Strings(result)
+	return result
+}
+
+// topoSortConfigBlocks returns block names sorted so that every block appears after the
+// blocks it references. globalScope is the merged config scope (block name -> body). The
+// fallback order is consulted only as a stability hint when two blocks have no relative
+// dependency: alphabetical tiebreak by block name. Returns an error naming the cycle when
+// the dependency graph is not acyclic.
+func topoSortConfigBlocks(globalScope map[string]any) ([]string, error) {
+	if len(globalScope) == 0 {
+		return nil, nil
+	}
+	blockNames := make(map[string]bool, len(globalScope))
+	blocks := make([]string, 0, len(globalScope))
+	for name := range globalScope {
+		blockNames[name] = true
+		blocks = append(blocks, name)
+	}
+	sort.Strings(blocks)
+
+	// edges[prereq] = list of dependents; inDeg[name] = number of unmet prereqs.
+	edges := make(map[string][]string, len(blocks))
+	inDeg := make(map[string]int, len(blocks))
+	for _, b := range blocks {
+		inDeg[b] = 0
+	}
+	for _, name := range blocks {
+		for _, prereq := range collectBlockRefs(globalScope[name], blockNames, name) {
+			edges[prereq] = append(edges[prereq], name)
+			inDeg[name]++
+		}
+	}
+
+	// Kahn's algorithm. A sorted ready queue keeps the output deterministic when two
+	// blocks are independent (alphabetical tiebreak).
+	ready := make([]string, 0, len(blocks))
+	for _, b := range blocks {
+		if inDeg[b] == 0 {
+			ready = append(ready, b)
+		}
+	}
+	sort.Strings(ready)
+
+	result := make([]string, 0, len(blocks))
+	for len(ready) > 0 {
+		n := ready[0]
+		ready = ready[1:]
+		result = append(result, n)
+		dependents := edges[n]
+		sort.Strings(dependents)
+		for _, d := range dependents {
+			inDeg[d]--
+			if inDeg[d] == 0 {
+				// Insert into ready in sorted position.
+				pos := sort.SearchStrings(ready, d)
+				ready = append(ready, "")
+				copy(ready[pos+1:], ready[pos:])
+				ready[pos] = d
+			}
+		}
+	}
+
+	if len(result) != len(blocks) {
+		remaining := make([]string, 0, len(blocks)-len(result))
+		for _, b := range blocks {
+			if inDeg[b] > 0 {
+				remaining = append(remaining, b)
+			}
+		}
+		return nil, fmt.Errorf("circular reference among config blocks: %s", strings.Join(remaining, ", "))
+	}
+
+	return result, nil
+}

--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -723,7 +723,7 @@ func (h *BaseBlueprintHandler) processAndCompose() error {
 		wg.Add(1)
 		go func(l BlueprintLoader, name string) {
 			defer wg.Done()
-			scope, _, err := h.processLoader(l)
+			scope, err := h.processLoader(l)
 			if err != nil {
 				mu.Lock()
 				var reqErr *RequirementsError
@@ -846,19 +846,19 @@ func (h *BaseBlueprintHandler) processAndCompose() error {
 // Facets with 'when' conditions are evaluated, and only matching facets contribute their
 // terraform components and kustomizations. The loader's source name is passed to the processor
 // to set the Source field on facet-derived components. Facets are processed directly against
-// the loader's blueprint, modifying it in place. Returns the evaluated config scope and block
-// order for this loader so the handler can merge scopes from all loaders.
-func (h *BaseBlueprintHandler) processLoader(loader BlueprintLoader) (map[string]any, []string, error) {
+// the loader's blueprint, modifying it in place. Returns the evaluated config scope for this
+// loader so the handler can merge scopes from all loaders.
+func (h *BaseBlueprintHandler) processLoader(loader BlueprintLoader) (map[string]any, error) {
 	facets := loader.GetFacets()
 	if len(facets) == 0 {
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	sourceName := loader.GetSourceName()
 	bp := loader.GetBlueprint()
-	scope, order, err := h.processor.ProcessFacets(bp, facets, sourceName)
+	scope, err := h.processor.ProcessFacets(bp, facets, sourceName)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 	if concrete, ok := h.processor.(*BaseBlueprintProcessor); ok {
 		h.deferredPathsMu.Lock()
@@ -867,7 +867,7 @@ func (h *BaseBlueprintHandler) processLoader(loader BlueprintLoader) (map[string
 		}
 		h.deferredPathsMu.Unlock()
 	}
-	return scope, order, nil
+	return scope, nil
 }
 
 // getConfigValues retrieves the current context's configuration values from the ConfigHandler.

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -224,7 +224,7 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 				return nil, nil, fmt.Errorf("facet %s: %w", facet.Metadata.Name, errMerge)
 			}
 		}
-		if err := p.evaluateGlobalScopeConfig(globalScope, configBlockOrder, contextScope); err != nil {
+		if err := p.evaluateGlobalScopeConfig(globalScope, contextScope); err != nil {
 			return nil, nil, err
 		}
 		mergeBase := contextScope
@@ -550,8 +550,10 @@ func (p *BaseBlueprintProcessor) mergeConfigBlocks(scope map[string]any, existin
 // with globalScope (facet config blocks) so expressions can reference both (e.g.
 // cluster.controlplanes.schedulable from values and talos.controlplanes from config blocks).
 // Same-block references are supported by re-evaluating each block until stable. Mutates
-// globalScope in place. Block names are iterated in configBlockOrder.
-func (p *BaseBlueprintProcessor) evaluateGlobalScopeConfig(globalScope map[string]any, configBlockOrder []string, contextScope map[string]any) error {
+// globalScope in place. Block evaluation order is determined by topoSortConfigBlocks —
+// each block evaluates after every block it references, regardless of which facet wrote
+// which first; alphabetical tiebreak for independent blocks.
+func (p *BaseBlueprintProcessor) evaluateGlobalScopeConfig(globalScope map[string]any, contextScope map[string]any) error {
 	if globalScope == nil {
 		return nil
 	}
@@ -560,13 +562,13 @@ func (p *BaseBlueprintProcessor) evaluateGlobalScopeConfig(globalScope map[strin
 			contextScope = vals
 		}
 	}
-	names := configBlockOrder
-	if len(names) == 0 {
-		names = make([]string, 0, len(globalScope))
-		for name := range globalScope {
-			names = append(names, name)
-		}
-		sort.Strings(names)
+	// Order blocks by their inter-block reference dependencies, not by the order facets
+	// happened to write them. A block that references another must evaluate after the
+	// block it references, regardless of authoring order. topoSortConfigBlocks returns
+	// blocks in dependency order with alphabetical tiebreak.
+	names, err := topoSortConfigBlocks(globalScope)
+	if err != nil {
+		return err
 	}
 	const maxSameBlockPasses = 5
 	const maxCrossBlockRounds = 5

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -37,10 +37,10 @@ var strategyPrecedence = map[string]int{
 // BlueprintProcessor evaluates when: conditions on facets, terraform components, and kustomizations.
 // It determines inclusion/exclusion based on boolean condition results.
 // The processor is stateless and shared across all loaders.
-// ProcessFacets returns the evaluated config scope and block order for the loader so callers can merge
+// ProcessFacets returns the evaluated config scope for the loader so callers can merge
 // scopes from multiple loaders (e.g. for user overlay and final terraform input evaluation).
 type BlueprintProcessor interface {
-	ProcessFacets(target *blueprintv1alpha1.Blueprint, facets []blueprintv1alpha1.Facet, sourceName ...string) (scope map[string]any, order []string, err error)
+	ProcessFacets(target *blueprintv1alpha1.Blueprint, facets []blueprintv1alpha1.Facet, sourceName ...string) (scope map[string]any, err error)
 }
 
 // =============================================================================
@@ -146,16 +146,16 @@ func (p *BaseBlueprintProcessor) GetDeferredPaths() map[string]bool {
 // If sourceName is set, it updates Source on components lacking it. The target blueprint is modified in place.
 // Returns: evaluated config scope and block order for the loader. Runtime ConfigHandler context values are
 // merged over facet-derived scope so 'when' or component expressions use the actual config.
-func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Blueprint, facets []blueprintv1alpha1.Facet, sourceName ...string) (map[string]any, []string, error) {
+func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Blueprint, facets []blueprintv1alpha1.Facet, sourceName ...string) (map[string]any, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.deferredPaths = make(map[string]bool)
 	if target == nil {
-		return nil, nil, fmt.Errorf("target blueprint cannot be nil")
+		return nil, fmt.Errorf("target blueprint cannot be nil")
 	}
 
 	if len(facets) == 0 {
-		return nil, nil, nil
+		return nil, nil
 	}
 
 	var contextScope map[string]any
@@ -183,7 +183,6 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 	scope := contextScope
 	var globalScope map[string]any
 	var cfgEntries map[string]*blueprintv1alpha1.ConfigBlock
-	var configBlockOrder []string
 	includedFacets := make([]blueprintv1alpha1.Facet, 0, len(sortedFacets))
 	prevIncludedSet := make(map[string]bool)
 	pendingRequirements := make(map[string]facetRequirementMisses)
@@ -192,7 +191,6 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 		includedFacets = includedFacets[:0]
 		globalScope = nil
 		cfgEntries = nil
-		configBlockOrder = nil
 		pendingRequirements = make(map[string]facetRequirementMisses)
 		passScope := scope
 		if passScope == nil && contextScope != nil {
@@ -204,14 +202,14 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 		for _, facet := range sortedFacets {
 			shouldInclude, err := p.shouldIncludeFacet(facet, passScope)
 			if err != nil {
-				return nil, nil, err
+				return nil, err
 			}
 			if !shouldInclude {
 				continue
 			}
 			misses, err := p.evaluateRequirements(facet, passScope)
 			if err != nil {
-				return nil, nil, err
+				return nil, err
 			}
 			if len(misses) > 0 {
 				pendingRequirements[facet.Metadata.Name] = facetRequirementMisses{Misses: misses}
@@ -219,13 +217,13 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 			}
 			includedFacets = append(includedFacets, facet)
 			var errMerge error
-			globalScope, cfgEntries, configBlockOrder, errMerge = p.mergeFacetScopeIntoGlobal(facet, globalScope, cfgEntries, configBlockOrder, passScope)
+			globalScope, cfgEntries, errMerge = p.mergeFacetScopeIntoGlobal(facet, globalScope, cfgEntries, passScope)
 			if errMerge != nil {
-				return nil, nil, fmt.Errorf("facet %s: %w", facet.Metadata.Name, errMerge)
+				return nil, fmt.Errorf("facet %s: %w", facet.Metadata.Name, errMerge)
 			}
 		}
 		if err := p.evaluateGlobalScopeConfig(globalScope, contextScope); err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		mergeBase := contextScope
 		if mergeBase == nil {
@@ -253,15 +251,15 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 	}
 
 	if len(pendingRequirements) > 0 {
-		return nil, nil, formatRequirementsError(pendingRequirements)
+		return nil, formatRequirementsError(pendingRequirements)
 	}
 
 	for _, facet := range includedFacets {
 		if err := p.collectTerraformComponents(facet, sourceName, terraformByID, scope); err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		if err := p.collectKustomizations(facet, sourceName, kustomizationByName, scope); err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 		if facet.Backend != "" {
 			target.Backend = facet.Backend
@@ -270,7 +268,7 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 		if len(facet.Substitutions) > 0 {
 			evaluated, deferredKeys, err := p.evaluateSubstitutions(facet.Substitutions, facet.Path, scope)
 			if err != nil {
-				return nil, nil, fmt.Errorf("error evaluating substitutions for facet '%s': %w", facet.Metadata.Name, err)
+				return nil, fmt.Errorf("error evaluating substitutions for facet '%s': %w", facet.Metadata.Name, err)
 			}
 			if target.Substitutions == nil {
 				target.Substitutions = make(map[string]string)
@@ -300,9 +298,9 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 	}
 
 	if err := p.applyCollectedComponents(target, terraformByID, kustomizationByName, scope); err != nil {
-		return nil, nil, err
+		return nil, err
 	}
-	return globalScope, configBlockOrder, nil
+	return globalScope, nil
 }
 
 // =============================================================================
@@ -359,12 +357,13 @@ func (p *BaseBlueprintProcessor) scopeForConfigBlock(contextScope, globalScope m
 
 // mergeFacetScopeIntoGlobal merges the facet's config block structure into the global scope
 // (accumulated from prior facets) without evaluating config body expressions. Returns the
-// updated global scope, per-block meta (ordinal and strategy), and config block name order.
-// Config body expressions are evaluated later in evaluateGlobalScopeConfig.
+// updated global scope and per-block meta (ordinal and strategy). Config body expressions
+// are evaluated later in evaluateGlobalScopeConfig, which determines its own evaluation
+// order via topoSortConfigBlocks based on inter-block references.
 // For a given name, only blocks whose when condition is true contribute; if multiple blocks
 // with the same name have when true, their bodies are deep-merged in list order (later overlay).
 // Merge precedence: higher ordinal wins; when ordinals match, strategy precedence remove > replace > merge.
-func (p *BaseBlueprintProcessor) mergeFacetScopeIntoGlobal(facet blueprintv1alpha1.Facet, globalScope map[string]any, existing map[string]*blueprintv1alpha1.ConfigBlock, order []string, contextScope map[string]any) (map[string]any, map[string]*blueprintv1alpha1.ConfigBlock, []string, error) {
+func (p *BaseBlueprintProcessor) mergeFacetScopeIntoGlobal(facet blueprintv1alpha1.Facet, globalScope map[string]any, existing map[string]*blueprintv1alpha1.ConfigBlock, contextScope map[string]any) (map[string]any, map[string]*blueprintv1alpha1.ConfigBlock, error) {
 	facetOrdinal := resolvedFacetOrdinal(facet)
 	incoming := make(map[string]*blueprintv1alpha1.ConfigBlock)
 	byName := make(map[string][]any)
@@ -377,7 +376,7 @@ func (p *BaseBlueprintProcessor) mergeFacetScopeIntoGlobal(facet blueprintv1alph
 		if block.When != "" {
 			shouldInclude, err := p.shouldIncludeComponent(block.When, facet.Path, contextScope)
 			if err != nil {
-				return nil, nil, order, fmt.Errorf("config block %q when: %w", block.Name, err)
+				return nil, nil, fmt.Errorf("config block %q when: %w", block.Name, err)
 			}
 			if !shouldInclude {
 				continue
@@ -458,22 +457,15 @@ func (p *BaseBlueprintProcessor) mergeFacetScopeIntoGlobal(facet blueprintv1alph
 		}
 		cb := incoming[name]
 		cb.Body = map[string]any{"value": body}
-		for i := 0; i < len(order); i++ {
-			if order[i] == name {
-				order = append(order[:i], order[i+1:]...)
-				break
-			}
-		}
-		order = append(order, name)
 	}
 	if len(incoming) == 0 {
-		return globalScope, existing, order, nil
+		return globalScope, existing, nil
 	}
 	mergedScope, mergedEntries, err := p.mergeConfigBlocks(globalScope, existing, incoming)
 	if err != nil {
-		return nil, nil, order, err
+		return nil, nil, err
 	}
-	return mergedScope, mergedEntries, order, nil
+	return mergedScope, mergedEntries, nil
 }
 
 // mergeConfigBlocks merges incoming config blocks into the global scope using ordinal and strategy.

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -182,7 +182,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 		target := &blueprintv1alpha1.Blueprint{}
 
 		// When processing empty facets
-		_, _, err := processor.ProcessFacets(target, nil)
+		_, err := processor.ProcessFacets(target, nil)
 
 		// Then should return empty blueprint
 		if err != nil {
@@ -212,7 +212,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 
 		// When processing facets
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then facet components should be included
 		if err != nil {
@@ -246,7 +246,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 
 		// When processing facets
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then facet should be included
 		if err != nil {
@@ -276,7 +276,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 		}
 
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
@@ -306,7 +306,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 
 		// When processing facets
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then facet should be excluded
 		if err != nil {
@@ -336,7 +336,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 		}
 
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
@@ -367,7 +367,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 
 		// When processing facets
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then components should be in sorted facet order (ordinal then name; both ordinal 0 so name tiebreak: a before z)
 		if err != nil {
@@ -408,7 +408,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 		}
 
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
@@ -444,7 +444,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 		}
 
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
@@ -490,7 +490,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 		}
 
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
@@ -536,7 +536,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 
 		// When processing facets (inputs are not evaluated in processor; handler evaluates with merged scope)
 		target := &blueprintv1alpha1.Blueprint{}
-		scope, _, err := processor.ProcessFacets(target, facets)
+		scope, err := processor.ProcessFacets(target, facets)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
@@ -565,7 +565,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 
 		// When processing facets
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then kustomization should be included
 		if err != nil {
@@ -601,7 +601,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 
 		// When processing facets
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then only unconditional component should be included
 		if err != nil {
@@ -637,7 +637,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 
 		// When processing facets
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then only unconditional kustomization should be included
 		if err != nil {
@@ -668,7 +668,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 
 		// When processing facets
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then should return error
 		if err == nil {
@@ -695,7 +695,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 
 		// When processing facets
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then should return error
 		if err == nil {
@@ -722,7 +722,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 
 		// When processing facets
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then should return error
 		if err == nil {
@@ -750,7 +750,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 
 		// When processing facets
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then facet should be included (string "true" is truthy)
 		if err != nil {
@@ -791,7 +791,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 
 		// When processing facets
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then substitutions should be evaluated
 		if err != nil {
@@ -836,7 +836,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 		}
 
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
@@ -884,7 +884,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 		}
 
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
@@ -926,7 +926,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 
 		// When processing facets
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then non-string inputs should be preserved
 		if err != nil {
@@ -961,7 +961,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 
 		// When processing facets
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then should return error for malformed expression
 		if err == nil {
@@ -989,7 +989,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 
 		// When processing facets
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then should return error for malformed expression
 		if err == nil {
@@ -1013,7 +1013,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 
 		// When processing with sourceName
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets, "test-source")
+		_, err := processor.ProcessFacets(target, facets, "test-source")
 
 		// Then source should be assigned
 		if err != nil {
@@ -1040,7 +1040,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 
 		// When processing with sourceName
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets, "new-source")
+		_, err := processor.ProcessFacets(target, facets, "new-source")
 
 		// Then existing source should be preserved
 		if err != nil {
@@ -1070,7 +1070,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 
 		// When processing facets
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then should return error
 		if err == nil {
@@ -1100,7 +1100,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 
 		// When processing facets
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then should return error
 		if err == nil {
@@ -1129,7 +1129,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 			},
 		}
 		target := &blueprintv1alpha1.Blueprint{}
-		scope, _, err := processor.ProcessFacets(target, facets)
+		scope, err := processor.ProcessFacets(target, facets)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -1150,7 +1150,7 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 			},
 		}
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 		if err == nil {
 			t.Error("Expected error for invalid config block strategy")
 		}
@@ -1206,7 +1206,7 @@ func TestProcessor_ProcessFacets_Config(t *testing.T) {
 				},
 			},
 		}
-		scope, _, err := processor.ProcessFacets(target, facets)
+		scope, err := processor.ProcessFacets(target, facets)
 		if err != nil {
 			t.Fatalf("ProcessFacets failed: %v", err)
 		}
@@ -1260,7 +1260,7 @@ func TestProcessor_ProcessFacets_Config(t *testing.T) {
 				},
 			},
 		}
-		scope, _, err := processor.ProcessFacets(target, facets)
+		scope, err := processor.ProcessFacets(target, facets)
 		if err != nil {
 			t.Fatalf("ProcessFacets failed: %v", err)
 		}
@@ -1312,7 +1312,7 @@ func TestProcessor_ProcessFacets_Config(t *testing.T) {
 				},
 			},
 		}
-		scope, _, err := processor.ProcessFacets(target, facets)
+		scope, err := processor.ProcessFacets(target, facets)
 		if err != nil {
 			t.Fatalf("ProcessFacets failed: %v", err)
 		}
@@ -1363,7 +1363,7 @@ func TestProcessor_ProcessFacets_Config(t *testing.T) {
 				},
 			},
 		}
-		scope, _, err := processor.ProcessFacets(target, facets)
+		scope, err := processor.ProcessFacets(target, facets)
 		if err != nil {
 			t.Fatalf("ProcessFacets failed: %v", err)
 		}
@@ -1405,7 +1405,7 @@ func TestProcessor_ProcessFacets_Config(t *testing.T) {
 				},
 			},
 		}
-		scope, _, err := processor.ProcessFacets(target, facets)
+		scope, err := processor.ProcessFacets(target, facets)
 		if err != nil {
 			t.Fatalf("ProcessFacets failed: %v", err)
 		}
@@ -1447,7 +1447,7 @@ func TestProcessor_ProcessFacets_Config(t *testing.T) {
 				},
 			},
 		}
-		scope, _, err := processor.ProcessFacets(target, facets)
+		scope, err := processor.ProcessFacets(target, facets)
 		if err != nil {
 			t.Fatalf("ProcessFacets failed: %v", err)
 		}
@@ -1486,7 +1486,7 @@ func TestProcessor_ProcessFacets_Config(t *testing.T) {
 				},
 			},
 		}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 		if err != nil {
 			t.Fatalf("ProcessFacets failed: %v", err)
 		}
@@ -1522,7 +1522,7 @@ func TestProcessor_ProcessFacets_Config(t *testing.T) {
 				},
 			},
 		}
-		scope, _, err := processor.ProcessFacets(target, facets)
+		scope, err := processor.ProcessFacets(target, facets)
 		if err != nil {
 			t.Fatalf("ProcessFacets failed: %v", err)
 		}
@@ -1560,7 +1560,7 @@ func TestProcessor_ProcessFacets_Config(t *testing.T) {
 				},
 			},
 		}
-		scope, _, err := processor.ProcessFacets(target, facets)
+		scope, err := processor.ProcessFacets(target, facets)
 		if err != nil {
 			t.Fatalf("ProcessFacets failed: %v", err)
 		}
@@ -1601,7 +1601,7 @@ func TestProcessor_ProcessFacets_Config(t *testing.T) {
 				},
 			},
 		}
-		scope, _, err := processor.ProcessFacets(target, facets)
+		scope, err := processor.ProcessFacets(target, facets)
 		if err != nil {
 			t.Fatalf("ProcessFacets failed: %v", err)
 		}
@@ -1668,7 +1668,7 @@ func TestProcessor_ProcessFacets_ConfigBlockEvaluationOrder(t *testing.T) {
 				},
 			},
 		}
-		scope, _, err := processor.ProcessFacets(target, facets)
+		scope, err := processor.ProcessFacets(target, facets)
 		if err != nil {
 			t.Fatalf("ProcessFacets failed: %v", err)
 		}
@@ -1718,7 +1718,7 @@ func TestProcessor_ProcessFacets_ConfigBlockEvaluationOrder(t *testing.T) {
 				},
 			},
 		}
-		scope, _, err := processor.ProcessFacets(target, facets)
+		scope, err := processor.ProcessFacets(target, facets)
 		if err != nil {
 			t.Fatalf("ProcessFacets failed: %v", err)
 		}
@@ -1750,7 +1750,7 @@ func TestProcessor_ProcessFacets_ConfigBlockEvaluationOrder(t *testing.T) {
 				},
 			},
 		}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 		if err == nil {
 			t.Fatal("Expected error for circular references between alpha and beta")
 		}
@@ -1809,7 +1809,7 @@ func TestProcessor_ProcessFacets_ConfigDeferredValues(t *testing.T) {
 			},
 		}
 
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 		if err != nil {
 			t.Fatalf("ProcessFacets failed: %v", err)
 		}
@@ -1840,7 +1840,7 @@ func TestProcessor_ProcessFacets_Substitutions(t *testing.T) {
 		}
 
 		// When processing facets
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then target.Substitutions should contain the facet values
 		if err != nil {
@@ -1887,7 +1887,7 @@ func TestProcessor_ProcessFacets_Substitutions(t *testing.T) {
 		}
 
 		// When processing facets
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then substitution expressions should be evaluated against config scope
 		if err != nil {
@@ -1922,7 +1922,7 @@ func TestProcessor_ProcessFacets_Substitutions(t *testing.T) {
 		}
 
 		// When processing facets
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then the higher-ordinal facet's value should win
 		if err != nil {
@@ -1950,7 +1950,7 @@ func TestProcessor_ProcessFacets_Substitutions(t *testing.T) {
 		}
 
 		// When processing facets
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then substitutions from excluded facet should not appear
 		if err != nil {
@@ -1979,7 +1979,7 @@ func TestProcessor_ProcessFacets_Substitutions(t *testing.T) {
 		}
 
 		// When processing facets
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 		tc.Finalize(target, nil, "")
 
 		// Then the trace collector should have a contribution for each substitution key
@@ -2011,7 +2011,7 @@ func TestProcessor_ProcessFacets_Backend(t *testing.T) {
 		}
 
 		// When processing facets
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then target.Backend should hold the facet value
 		if err != nil {
@@ -2043,7 +2043,7 @@ func TestProcessor_ProcessFacets_Backend(t *testing.T) {
 		}
 
 		// When processing facets
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then the higher-ordinal facet's value wins
 		if err != nil {
@@ -2064,7 +2064,7 @@ func TestProcessor_ProcessFacets_Backend(t *testing.T) {
 		}
 
 		// When processing facets
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then target.Backend is preserved
 		if err != nil {
@@ -2092,7 +2092,7 @@ func TestProcessor_ProcessFacets_Backend(t *testing.T) {
 		}
 
 		// When processing facets
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then target.Backend stays empty
 		if err != nil {
@@ -3561,7 +3561,7 @@ func TestProcessor_ExpressionEvaluation(t *testing.T) {
 		}
 
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
@@ -3607,7 +3607,7 @@ func TestProcessor_ExpressionEvaluation(t *testing.T) {
 		}
 
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
@@ -3653,7 +3653,7 @@ func TestProcessor_ExpressionEvaluation(t *testing.T) {
 		}
 
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
@@ -3699,7 +3699,7 @@ func TestProcessor_ExpressionEvaluation(t *testing.T) {
 		}
 
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
@@ -3745,7 +3745,7 @@ func TestProcessor_ExpressionEvaluation(t *testing.T) {
 		}
 
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
@@ -3790,7 +3790,7 @@ func TestProcessor_ExpressionEvaluation(t *testing.T) {
 		}
 
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
@@ -3830,7 +3830,7 @@ func TestProcessor_ExpressionEvaluation(t *testing.T) {
 		}
 
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
@@ -3869,7 +3869,7 @@ func TestProcessor_ExpressionEvaluation(t *testing.T) {
 		}
 
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
@@ -3909,7 +3909,7 @@ func TestProcessor_ExpressionEvaluation(t *testing.T) {
 		}
 
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		if err == nil {
 			t.Error("Expected error for deferred expression in dependsOn")
@@ -3946,7 +3946,7 @@ func TestProcessor_ExpressionEvaluation(t *testing.T) {
 		}
 
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		if err == nil {
 			t.Error("Expected error for deferred expression in components")
@@ -3981,7 +3981,7 @@ func TestProcessor_ExpressionEvaluation(t *testing.T) {
 		}
 
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
@@ -4022,7 +4022,7 @@ func TestProcessor_ExpressionEvaluation(t *testing.T) {
 		}
 
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
@@ -4057,7 +4057,7 @@ func TestProcessor_ExpressionEvaluation(t *testing.T) {
 		}
 
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
@@ -4096,7 +4096,7 @@ func TestProcessor_ComponentConditionInheritance(t *testing.T) {
 
 		// When processing facets
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then component should be included (inherited facet condition is true)
 		if err != nil {
@@ -4130,7 +4130,7 @@ func TestProcessor_ComponentConditionInheritance(t *testing.T) {
 
 		// When processing facets
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then component should be excluded (inherited facet condition is false)
 		if err != nil {
@@ -4164,7 +4164,7 @@ func TestProcessor_ComponentConditionInheritance(t *testing.T) {
 
 		// When processing facets
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then kustomization should be included (inherited facet condition is true)
 		if err != nil {
@@ -4202,7 +4202,7 @@ func TestProcessor_ComponentConditionInheritance(t *testing.T) {
 
 		// When processing facets
 		target := &blueprintv1alpha1.Blueprint{}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 
 		// Then component should be excluded (its own condition is false, even though facet condition is true)
 		if err != nil {
@@ -5448,7 +5448,7 @@ func TestProcessor_ProcessFacets_Requires(t *testing.T) {
 				},
 			},
 		}
-		if _, _, err := processor.ProcessFacets(target, facets); err != nil {
+		if _, err := processor.ProcessFacets(target, facets); err != nil {
 			t.Fatalf("Expected no error when requirements are satisfied, got %v", err)
 		}
 	})
@@ -5468,7 +5468,7 @@ func TestProcessor_ProcessFacets_Requires(t *testing.T) {
 				},
 			},
 		}
-		if _, _, err := processor.ProcessFacets(target, facets); err != nil {
+		if _, err := processor.ProcessFacets(target, facets); err != nil {
 			t.Fatalf("Expected no error; aws block should be skipped, got %v", err)
 		}
 	})
@@ -5489,7 +5489,7 @@ func TestProcessor_ProcessFacets_Requires(t *testing.T) {
 				},
 			},
 		}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 		if err == nil {
 			t.Fatal("Expected error for unsatisfied requirements, got nil")
 		}
@@ -5526,7 +5526,7 @@ func TestProcessor_ProcessFacets_Requires(t *testing.T) {
 				},
 			},
 		}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 		if err == nil {
 			t.Fatal("Expected error for empty values, got nil")
 		}
@@ -5553,7 +5553,7 @@ func TestProcessor_ProcessFacets_Requires(t *testing.T) {
 				},
 			},
 		}
-		if _, _, err := processor.ProcessFacets(target, facets); err != nil {
+		if _, err := processor.ProcessFacets(target, facets); err != nil {
 			t.Fatalf("Expected false/0 to satisfy requirement, got error: %v", err)
 		}
 	})
@@ -5582,7 +5582,7 @@ func TestProcessor_ProcessFacets_Requires(t *testing.T) {
 				},
 			},
 		}
-		if _, _, err := processor.ProcessFacets(target, facets); err != nil {
+		if _, err := processor.ProcessFacets(target, facets); err != nil {
 			t.Fatalf("Expected requirement to be satisfied via config block in later round, got: %v", err)
 		}
 	})
@@ -5606,7 +5606,7 @@ func TestProcessor_ProcessFacets_Requires(t *testing.T) {
 				},
 			},
 		}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 		if err == nil {
 			t.Fatal("Expected error, got nil")
 		}
@@ -5647,7 +5647,7 @@ func TestProcessor_ProcessFacets_Requires(t *testing.T) {
 				},
 			},
 		}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 		if err == nil {
 			t.Fatal("Expected aggregated error, got nil")
 		}
@@ -5679,7 +5679,7 @@ func TestProcessor_ProcessFacets_Requires(t *testing.T) {
 				},
 			},
 		}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 		if err == nil {
 			t.Fatal("Expected error for self-referenced requirement, got nil")
 		}
@@ -5832,7 +5832,7 @@ func TestProcessor_ProcessFacets_ComponentRequires(t *testing.T) {
 				},
 			},
 		}
-		if _, _, err := processor.ProcessFacets(target, facets); err != nil {
+		if _, err := processor.ProcessFacets(target, facets); err != nil {
 			t.Fatalf("Expected no error when component requires are satisfied, got %v", err)
 		}
 	})
@@ -5859,7 +5859,7 @@ func TestProcessor_ProcessFacets_ComponentRequires(t *testing.T) {
 				},
 			},
 		}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 		if err == nil {
 			t.Fatal("Expected error for unsatisfied component requirement")
 		}
@@ -5894,7 +5894,7 @@ func TestProcessor_ProcessFacets_ComponentRequires(t *testing.T) {
 				},
 			},
 		}
-		if _, _, err := processor.ProcessFacets(target, facets); err != nil {
+		if _, err := processor.ProcessFacets(target, facets); err != nil {
 			t.Fatalf("Expected no error when component is excluded by When, got %v", err)
 		}
 	})
@@ -5921,7 +5921,7 @@ func TestProcessor_ProcessFacets_ComponentRequires(t *testing.T) {
 				},
 			},
 		}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 		if err == nil {
 			t.Fatal("Expected error for unsatisfied kustomization requirement")
 		}
@@ -5956,7 +5956,7 @@ func TestProcessor_ProcessFacets_ComponentRequires(t *testing.T) {
 				},
 			},
 		}
-		if _, _, err := processor.ProcessFacets(target, facets); err != nil {
+		if _, err := processor.ProcessFacets(target, facets); err != nil {
 			t.Fatalf("Expected no error when kustomization is excluded by When, got %v", err)
 		}
 	})
@@ -5984,7 +5984,7 @@ func TestProcessor_ProcessFacets_ComponentRequires(t *testing.T) {
 				},
 			},
 		}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 		if err == nil {
 			t.Fatal("Expected error for unsatisfied config-block requirement")
 		}
@@ -6020,7 +6020,7 @@ func TestProcessor_ProcessFacets_ComponentRequires(t *testing.T) {
 				},
 			},
 		}
-		if _, _, err := processor.ProcessFacets(target, facets); err != nil {
+		if _, err := processor.ProcessFacets(target, facets); err != nil {
 			t.Fatalf("Expected no error when config block is excluded by When, got %v", err)
 		}
 	})
@@ -6054,7 +6054,7 @@ func TestProcessor_ProcessFacets_ComponentRequires(t *testing.T) {
 				},
 			},
 		}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 		if err == nil {
 			t.Fatal("Expected aggregated error")
 		}
@@ -6090,7 +6090,7 @@ func TestProcessor_ProcessFacets_ComponentRequires(t *testing.T) {
 				},
 			},
 		}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 		if err == nil {
 			t.Fatal("Expected aggregated error")
 		}
@@ -6134,7 +6134,7 @@ func TestProcessor_ProcessFacets_ComponentRequires(t *testing.T) {
 				},
 			},
 		}
-		if _, _, err := processor.ProcessFacets(target, facets); err != nil {
+		if _, err := processor.ProcessFacets(target, facets); err != nil {
 			t.Fatalf("Expected convergence to satisfy the requirement, got %v", err)
 		}
 	})
@@ -6161,7 +6161,7 @@ func TestProcessor_ProcessFacets_ComponentRequires(t *testing.T) {
 				},
 			},
 		}
-		if _, _, err := processor.ProcessFacets(target, facets); err != nil {
+		if _, err := processor.ProcessFacets(target, facets); err != nil {
 			t.Fatalf("Expected no error when the block's own When is false, got %v", err)
 		}
 	})
@@ -6186,7 +6186,7 @@ func TestProcessor_ProcessFacets_ComponentRequires(t *testing.T) {
 				},
 			},
 		}
-		_, _, err := processor.ProcessFacets(target, facets)
+		_, err := processor.ProcessFacets(target, facets)
 		if err == nil {
 			t.Fatal("Expected error from invalid component When")
 		}

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -1619,6 +1619,150 @@ func TestProcessor_ProcessFacets_Config(t *testing.T) {
 	})
 }
 
+func TestProcessor_ProcessFacets_ConfigBlockEvaluationOrder(t *testing.T) {
+	// These tests pin the dependency-driven evaluation order for config blocks. The
+	// processor must evaluate a block AFTER every block it references via ${...}, no
+	// matter which facet wrote each block or in what source order the blocks appear.
+
+	t.Run("ConsumerWrittenBeforeProducerStillEvaluatesAfter", func(t *testing.T) {
+		// Mirrors the production core blueprint failure: a low-ordinal facet writes a
+		// consumer block (talos_common.k8s_service_host) that calls a function on
+		// network_effective.cidr_block. A higher-ordinal facet writes network_effective,
+		// whose cidr_block references network_cidr_effective from a third facet. With
+		// authoring-order evaluation the consumer would evaluate first and call cidrhost
+		// on an unevaluated template string. With dependency-order evaluation each
+		// block evaluates only after its prerequisites.
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		ord100, ord200, ord300 := 100, 200, 300
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "consumer-first"},
+				Ordinal:  &ord100,
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "talos_common", Body: map[string]any{"value": map[string]any{
+						"k8s_service_host": "${cidrhost(network_effective.cidr_block, 10)}",
+					}}},
+				},
+			},
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "network-mid"},
+				Ordinal:  &ord200,
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "network_effective", Body: map[string]any{"value": map[string]any{
+						"cidr_block": "${network_cidr_effective.value}",
+					}}},
+				},
+			},
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "network-root"},
+				Ordinal:  &ord300,
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "network_cidr_effective", Body: map[string]any{"value": map[string]any{
+						"value": "10.5.0.0/16",
+					}}},
+				},
+			},
+		}
+		scope, _, err := processor.ProcessFacets(target, facets)
+		if err != nil {
+			t.Fatalf("ProcessFacets failed: %v", err)
+		}
+		talos, ok := scope["talos_common"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected talos_common map, got %T", scope["talos_common"])
+		}
+		if talos["k8s_service_host"] != "10.5.0.10" {
+			t.Errorf("Expected talos_common.k8s_service_host='10.5.0.10' (cidrhost of evaluated network), got %v", talos["k8s_service_host"])
+		}
+	})
+
+	t.Run("ExtendedBlockKeepsDependencyOrderingNotSourceOrder", func(t *testing.T) {
+		// Mirrors the platform-base / platform-hyperv scenario: one facet writes the
+		// producer block (network with a self-defaulting cidr_block), a higher-ordinal
+		// facet writes both an extension of network (gateway) and a consumer block
+		// (hyperv_effective) whose value calls cidrhost on the producer. The
+		// dependency-driven order must put network ahead of hyperv_effective even though
+		// authoring order in the high-ordinal facet lists hyperv_effective first.
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		low, high := 100, 200
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "platform-base"},
+				Ordinal:  &low,
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "network", Body: map[string]any{"value": map[string]any{
+						"cidr_block": "${network.cidr_block ?? '10.5.0.0/16'}",
+					}}},
+				},
+			},
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "platform-hyperv"},
+				Ordinal:  &high,
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "hyperv_effective", Body: map[string]any{"value": map[string]any{
+						"nat_host_address": "${cidrhost(network.cidr_block ?? '10.5.0.0/16', 1)}",
+					}}},
+					{Name: "network", Body: map[string]any{"value": map[string]any{
+						"gateway": "10.5.0.1",
+					}}},
+				},
+			},
+		}
+		scope, _, err := processor.ProcessFacets(target, facets)
+		if err != nil {
+			t.Fatalf("ProcessFacets failed: %v", err)
+		}
+		hyperv, ok := scope["hyperv_effective"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected hyperv_effective map, got %T", scope["hyperv_effective"])
+		}
+		if hyperv["nat_host_address"] != "10.5.0.1" {
+			t.Errorf("Expected hyperv_effective.nat_host_address='10.5.0.1', got %v", hyperv["nat_host_address"])
+		}
+	})
+
+	t.Run("CircularReferenceProducesError", func(t *testing.T) {
+		// Two blocks reference each other through different keys; no valid evaluation
+		// order exists. The topo sort must surface this as an explicit error rather
+		// than silently looping until the cross-block retry budget is exhausted.
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "cycle"},
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "alpha", Body: map[string]any{"value": map[string]any{"x": "${beta.y}"}}},
+					{Name: "beta", Body: map[string]any{"value": map[string]any{"y": "${alpha.x}"}}},
+				},
+			},
+		}
+		_, _, err := processor.ProcessFacets(target, facets)
+		if err == nil {
+			t.Fatal("Expected error for circular references between alpha and beta")
+		}
+		if !strings.Contains(err.Error(), "circular reference") {
+			t.Errorf("Expected error to mention 'circular reference', got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "alpha") || !strings.Contains(err.Error(), "beta") {
+			t.Errorf("Expected error to name both blocks in cycle, got: %v", err)
+		}
+	})
+}
+
 func TestProcessor_ProcessFacets_ConfigDeferredValues(t *testing.T) {
 	t.Run("DeferredConfigBlockValuePreservesExpressionInSubstitution", func(t *testing.T) {
 		// Given a config block with a deferred helper and a substitution that

--- a/pkg/composer/blueprint/trace_test.go
+++ b/pkg/composer/blueprint/trace_test.go
@@ -47,8 +47,8 @@ func setupExplainHandler(t *testing.T, bp *blueprintv1alpha1.Blueprint, scope ma
 
 type explainTestProcessor struct{}
 
-func (explainTestProcessor) ProcessFacets(target *blueprintv1alpha1.Blueprint, facets []blueprintv1alpha1.Facet, sourceName ...string) (map[string]any, []string, error) {
-	return nil, nil, nil
+func (explainTestProcessor) ProcessFacets(target *blueprintv1alpha1.Blueprint, facets []blueprintv1alpha1.Facet, sourceName ...string) (map[string]any, error) {
+	return nil, nil
 }
 
 // =============================================================================


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> The change alters config block evaluation order for all blueprint processors, which affects any multi-facet deployment where authoring order differed from dependency order.
>
> **Overview**
>
> This PR replaces authoring-order evaluation of config blocks with a topological sort over their inter-block `${...}` references. A new `config_block_order.go` implements Kahn's algorithm with alphabetical tiebreaking; `evaluateGlobalScopeConfig` now derives its own evaluation order via `topoSortConfigBlocks` rather than consuming the `configBlockOrder` slice threaded through `mergeFacetScopeIntoGlobal`. Three targeted tests cover the production failure case (consumer written before producer), an extended-block ordering scenario, and explicit cycle detection.
>
> One inconsistency is left behind: `ProcessFacets` still accumulates and returns `configBlockOrder` (authoring order) as its second return value, while all current callers discard it with `_`. The interface doc and return signature no longer reflect reality, and a future caller who tries to use that value will get the wrong order silently. The accumulation and return should be removed or replaced with the toposort result in a follow-on.
>
> Reviewed by Claude for commit `c10045a7`.

<!-- /claude-code-review:summary -->
