### PR TITLE
chore: remove deprecated flags and context command group

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -1,8 +1,29 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
 )
+
+// removedContextCmd intercepts `windsor context …` and returns a migration hint
+// instead of cobra's default "unknown command". The legacy hidden group was
+// removed in v0.9.0; this stub exists only to give pre-v0.9.0 scripts an
+// actionable error message and can be deleted in v0.10.0.
+var removedContextCmd = &cobra.Command{
+	Use:                "context",
+	Short:              "Removed: use 'windsor get context' / 'windsor set context'",
+	SilenceUsage:       true,
+	DisableFlagParsing: true,
+	Args:               cobra.ArbitraryArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		replacement := "windsor get context"
+		if len(args) > 0 && args[0] == "set" {
+			replacement = "windsor set context"
+		}
+		return fmt.Errorf("'windsor context' was removed in v0.9.0; use '%s' instead. See the v0.9.0 release notes for migration", replacement)
+	},
+}
 
 var getContextAliasCmd = &cobra.Command{
 	Use:          "get-context",
@@ -26,6 +47,7 @@ var setContextAliasCmd = &cobra.Command{
 }
 
 func init() {
+	rootCmd.AddCommand(removedContextCmd)
 	rootCmd.AddCommand(getContextAliasCmd)
 	rootCmd.AddCommand(setContextAliasCmd)
 }

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -4,38 +4,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// contextCmd represents the context command group (legacy, kept for backward compatibility)
-var contextCmd = &cobra.Command{
-	Use:    "context",
-	Short:  "Manage contexts (legacy)",
-	Long:   "Manage contexts for the application. This command is kept for backward compatibility. Use 'windsor get contexts' and 'windsor set context' instead.",
-	Hidden: true,
-}
-
-// contextGetCmd routes to the new get context command
-var contextGetCmd = &cobra.Command{
-	Use:          "get",
-	Short:        "Get the current context",
-	Long:         "Retrieve and display the current context from the configuration",
-	SilenceUsage: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return getContextCmd.RunE(cmd, args)
-	},
-}
-
-// contextSetCmd routes to the new set context command
-var contextSetCmd = &cobra.Command{
-	Use:          "set [context]",
-	Short:        "Set the current context",
-	Long:         "Set the current context in the configuration and save it",
-	Args:         cobra.ExactArgs(1),
-	SilenceUsage: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return setContextCmd.RunE(cmd, args)
-	},
-}
-
-// getContextAliasCmd is an alias for the get command
 var getContextAliasCmd = &cobra.Command{
 	Use:          "get-context",
 	Short:        "Alias for 'get context'",
@@ -46,12 +14,11 @@ var getContextAliasCmd = &cobra.Command{
 	},
 }
 
-// setContextAliasCmd is an alias for the set command
 var setContextAliasCmd = &cobra.Command{
 	Use:          "set-context [context]",
 	Short:        "Alias for 'set context'",
-	SilenceUsage: true,
 	Long:         "Alias for 'set context'",
+	SilenceUsage: true,
 	Args:         cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return setContextCmd.RunE(cmd, args)
@@ -59,10 +26,6 @@ var setContextAliasCmd = &cobra.Command{
 }
 
 func init() {
-	contextCmd.AddCommand(contextGetCmd)
-	contextCmd.AddCommand(contextSetCmd)
-	rootCmd.AddCommand(contextCmd)
-
 	rootCmd.AddCommand(getContextAliasCmd)
 	rootCmd.AddCommand(setContextAliasCmd)
 }

--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -220,17 +220,31 @@ func TestContextCmd(t *testing.T) {
 		}
 	})
 
-	t.Run("RemovedContextGroupRejected", func(t *testing.T) {
+	t.Run("RemovedContextGroupPrintsMigrationHintForGet", func(t *testing.T) {
 		_, _ = setup(t)
 		rootCmd.SetArgs([]string{"context", "get"})
 
 		err := Execute()
 
 		if err == nil {
-			t.Fatal("Expected error for removed 'context' command group, got nil")
+			t.Fatal("Expected migration error for removed 'context get', got nil")
 		}
-		if !strings.Contains(err.Error(), "unknown command \"context\"") {
-			t.Errorf("Expected 'unknown command \"context\"' error, got: %v", err)
+		if !strings.Contains(err.Error(), "use 'windsor get context'") {
+			t.Errorf("Expected migration hint to suggest 'windsor get context', got: %v", err)
+		}
+	})
+
+	t.Run("RemovedContextGroupPrintsMigrationHintForSet", func(t *testing.T) {
+		_, _ = setup(t)
+		rootCmd.SetArgs([]string{"context", "set", "staging"})
+
+		err := Execute()
+
+		if err == nil {
+			t.Fatal("Expected migration error for removed 'context set', got nil")
+		}
+		if !strings.Contains(err.Error(), "use 'windsor set context'") {
+			t.Errorf("Expected migration hint to suggest 'windsor set context', got: %v", err)
 		}
 	})
 }

--- a/cmd/context_test.go
+++ b/cmd/context_test.go
@@ -18,7 +18,6 @@ func TestContextCmd(t *testing.T) {
 	setup := func(t *testing.T) (*bytes.Buffer, *bytes.Buffer) {
 		t.Helper()
 
-		// Clear environment variables that could affect tests
 		origContext := os.Getenv("WINDSOR_CONTEXT")
 		os.Unsetenv("WINDSOR_CONTEXT")
 		t.Cleanup(func() {
@@ -27,7 +26,6 @@ func TestContextCmd(t *testing.T) {
 			}
 		})
 
-		// Change to a temporary directory without a config file
 		origDir, err := os.Getwd()
 		if err != nil {
 			t.Fatalf("Failed to get working directory: %v", err)
@@ -44,7 +42,6 @@ func TestContextCmd(t *testing.T) {
 			t.Fatalf("Failed to change to temp directory: %v", err)
 		}
 
-		// Cleanup to change back to original directory
 		t.Cleanup(func() {
 			if err := os.Chdir(origDir); err != nil {
 				t.Logf("Warning: Failed to change back to original directory: %v", err)
@@ -62,21 +59,16 @@ func TestContextCmd(t *testing.T) {
 	}
 
 	t.Run("GetContext", func(t *testing.T) {
-		// Given proper output capture in a directory without config
 		stdout, _ := setup(t)
-		// Don't set up mocks - we want to test real behavior
 		rootCmd.SetContext(context.Background())
-		rootCmd.SetArgs([]string{"context", "get"})
+		rootCmd.SetArgs([]string{"get", "context"})
 
-		// When executing the command
 		err := Execute()
 
-		// Then no error should occur
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
 
-		// And should output default context (real behavior)
 		output := stdout.String()
 		expectedOutput := "local\n"
 		if output != expectedOutput {
@@ -85,21 +77,17 @@ func TestContextCmd(t *testing.T) {
 	})
 
 	t.Run("SetContextNoArgs", func(t *testing.T) {
-		// Given proper output capture in a directory without config
 		_, _ = setup(t)
 		setupMocks(t)
 
-		rootCmd.SetArgs([]string{"context", "set"})
+		rootCmd.SetArgs([]string{"set", "context"})
 
-		// When executing the command
 		err := Execute()
 
-		// Then an error should occur
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}
 
-		// And error should contain usage message
 		expectedError := "accepts 1 arg(s), received 0"
 		if err.Error() != expectedError {
 			t.Errorf("Expected error %q, got %q", expectedError, err.Error())
@@ -107,7 +95,6 @@ func TestContextCmd(t *testing.T) {
 	})
 
 	t.Run("SetContext", func(t *testing.T) {
-		// Given proper output capture in a directory without config
 		_, _ = setup(t)
 		mocks := setupMocks(t)
 		tmpDir := mocks.TmpDir
@@ -129,12 +116,10 @@ func TestContextCmd(t *testing.T) {
 		ctx := context.WithValue(context.Background(), runtimeOverridesKey, mocks.Runtime)
 		rootCmd.SetContext(ctx)
 
-		rootCmd.SetArgs([]string{"context", "set", "new-context"})
+		rootCmd.SetArgs([]string{"set", "context", "new-context"})
 
-		// When executing the command
 		err := Execute()
 
-		// Then no error should occur
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -156,7 +141,7 @@ func TestContextCmd(t *testing.T) {
 
 		ctx := context.WithValue(context.Background(), runtimeOverridesKey, mocks.Runtime)
 		rootCmd.SetContext(ctx)
-		rootCmd.SetArgs([]string{"context", "set", "missing-context"})
+		rootCmd.SetArgs([]string{"set", "context", "missing-context"})
 
 		err := Execute()
 		if err == nil {
@@ -170,21 +155,16 @@ func TestContextCmd(t *testing.T) {
 	})
 
 	t.Run("GetContextAlias", func(t *testing.T) {
-		// Given proper output capture in a directory without config
 		stdout, _ := setup(t)
-		// Don't set up mocks - we want to test real behavior
 
 		rootCmd.SetArgs([]string{"get-context"})
 
-		// When executing the command
 		err := Execute()
 
-		// Then no error should occur
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
 
-		// And should output the current context (may be "local" or previously set context)
 		output := stdout.String()
 		if output == "" {
 			t.Error("Expected some output, got empty string")
@@ -192,21 +172,17 @@ func TestContextCmd(t *testing.T) {
 	})
 
 	t.Run("SetContextAliasNoArgs", func(t *testing.T) {
-		// Given proper output capture in a directory without config
 		_, _ = setup(t)
 		setupMocks(t)
 
 		rootCmd.SetArgs([]string{"set-context"})
 
-		// When executing the command
 		err := Execute()
 
-		// Then an error should occur
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}
 
-		// And error should contain usage message
 		expectedError := "accepts 1 arg(s), received 0"
 		if err.Error() != expectedError {
 			t.Errorf("Expected error %q, got %q", expectedError, err.Error())
@@ -214,7 +190,6 @@ func TestContextCmd(t *testing.T) {
 	})
 
 	t.Run("SetContextAlias", func(t *testing.T) {
-		// Given proper output capture in a directory without config
 		_, _ = setup(t)
 		mocks := setupMocks(t)
 		tmpDir := mocks.TmpDir
@@ -238,12 +213,24 @@ func TestContextCmd(t *testing.T) {
 
 		rootCmd.SetArgs([]string{"set-context", "new-context"})
 
-		// When executing the command
 		err := Execute()
 
-		// Then no error should occur
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("RemovedContextGroupRejected", func(t *testing.T) {
+		_, _ = setup(t)
+		rootCmd.SetArgs([]string{"context", "get"})
+
+		err := Execute()
+
+		if err == nil {
+			t.Fatal("Expected error for removed 'context' command group, got nil")
+		}
+		if !strings.Contains(err.Error(), "unknown command \"context\"") {
+			t.Errorf("Expected 'unknown command \"context\"' error, got: %v", err)
 		}
 	})
 }
@@ -277,7 +264,6 @@ func TestContextCmd_ErrorScenarios(t *testing.T) {
 			Shell:       mockShell,
 			ProjectRoot: "",
 		}
-		// NewRuntime will panic with invalid shell, so we test that
 		defer func() {
 			if r := recover(); r == nil {
 				t.Error("Expected NewRuntime to panic with invalid shell")
@@ -301,7 +287,7 @@ func TestContextCmd_ErrorScenarios(t *testing.T) {
 		ctx := context.WithValue(context.Background(), runtimeOverridesKey, mocks.Runtime)
 		rootCmd.SetContext(ctx)
 
-		rootCmd.SetArgs([]string{"context", "get"})
+		rootCmd.SetArgs([]string{"get", "context"})
 
 		err := Execute()
 
@@ -326,7 +312,6 @@ func TestContextCmd_ErrorScenarios(t *testing.T) {
 			Shell:       mockShell,
 			ProjectRoot: "",
 		}
-		// NewRuntime will panic with invalid shell, so we test that
 		defer func() {
 			if r := recover(); r == nil {
 				t.Error("Expected NewRuntime to panic with invalid shell")
@@ -337,10 +322,8 @@ func TestContextCmd_ErrorScenarios(t *testing.T) {
 		ctx := context.WithValue(context.Background(), runtimeOverridesKey, rtOverride)
 		rootCmd.SetContext(ctx)
 
-		rootCmd.SetArgs([]string{"context", "set", "test-context"})
+		rootCmd.SetArgs([]string{"set", "context", "test-context"})
 
-		// Note: NewRuntime will panic, so Execute won't be reached
-		// This test needs to be updated to test for panics instead
 		_ = Execute()
 	})
 
@@ -373,7 +356,7 @@ func TestContextCmd_ErrorScenarios(t *testing.T) {
 		ctx := context.WithValue(context.Background(), runtimeOverridesKey, mocks.Runtime)
 		rootCmd.SetContext(ctx)
 
-		rootCmd.SetArgs([]string{"context", "set", "test-context"})
+		rootCmd.SetArgs([]string{"set", "context", "test-context"})
 
 		err := Execute()
 
@@ -412,7 +395,7 @@ func TestContextCmd_ErrorScenarios(t *testing.T) {
 		ctx := context.WithValue(context.Background(), runtimeOverridesKey, mocks.Runtime)
 		rootCmd.SetContext(ctx)
 
-		rootCmd.SetArgs([]string{"context", "set", "test-context"})
+		rootCmd.SetArgs([]string{"set", "context", "test-context"})
 
 		err := Execute()
 
@@ -461,7 +444,7 @@ func TestContextCmd_ErrorScenarios(t *testing.T) {
 		ctx := context.WithValue(context.Background(), runtimeOverridesKey, mocks.Runtime)
 		rootCmd.SetContext(ctx)
 
-		rootCmd.SetArgs([]string{"context", "set", "test-context"})
+		rootCmd.SetArgs([]string{"set", "context", "test-context"})
 
 		err := Execute()
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -30,7 +30,6 @@ var (
 	initArch           string
 	initDocker         bool
 	initGitLivereload  bool
-	initProvider       string
 	initPlatform       string
 	initBlueprint      string
 	initEndpoint       string
@@ -82,13 +81,6 @@ var initCmd = &cobra.Command{
 			currentContext := rt.ConfigHandler.GetContext()
 			if currentContext != "" {
 				contextName = currentContext
-			}
-		}
-
-		if initProvider != "" {
-			fmt.Fprintf(os.Stderr, "\033[33mWarning: The --provider flag is deprecated and will be removed in a future version. Please use --platform instead.\033[0m\n")
-			if initPlatform == "" {
-				initPlatform = initProvider
 			}
 		}
 
@@ -225,7 +217,6 @@ func init() {
 	initCmd.Flags().BoolVar(&initDocker, "docker", false, "Enable Docker")
 	initCmd.Flags().BoolVar(&initGitLivereload, "git-livereload", false, "Enable Git Livereload")
 	initCmd.Flags().StringVar(&initPlatform, "platform", "", "Specify the platform to use [none|metal|docker|aws|azure|gcp|hyperv]")
-	initCmd.Flags().StringVar(&initProvider, "provider", "", "Deprecated: use --platform instead")
 	initCmd.Flags().StringVar(&initBlueprint, "blueprint", "", "Specify the blueprint to use")
 	initCmd.Flags().StringVar(&initEndpoint, "endpoint", "", "Specify the kubernetes API endpoint")
 	initCmd.Flags().StringSliceVar(&initSetFlags, "set", []string{}, "Override configuration values. Example: --set cluster.endpoint=https://localhost:6443")

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/pflag"
 	"github.com/windsorcli/cli/pkg/composer"
 	"github.com/windsorcli/cli/pkg/composer/blueprint"
-	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/runtime"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	"github.com/windsorcli/cli/pkg/runtime/tools"
@@ -48,7 +47,6 @@ func setupInitTest(t *testing.T, opts ...*SetupOptions) *InitMocks {
 	initArch = ""
 	initDocker = false
 	initGitLivereload = false
-	initProvider = ""
 	initPlatform = ""
 	initBlueprint = ""
 	initEndpoint = ""
@@ -598,309 +596,6 @@ func TestInitCmd(t *testing.T) {
 		}
 	})
 
-	t.Run("LocalContextUsesDefaultBlueprint", func(t *testing.T) {
-		// Given a local context with no explicit provider or blueprint
-		initProvider = ""
-		initBlueprint = ""
-		contextName := "local"
-
-		// When processing the init logic (local assumes default OCI blueprint when none provided)
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, "reset", false)
-		ctx = context.WithValue(ctx, "trust", true)
-
-		if initProvider != "" && initBlueprint == "" {
-			initBlueprint = constants.GetEffectiveBlueprintURL()
-		} else if contextName == "local" && initBlueprint == "" {
-			initBlueprint = constants.GetEffectiveBlueprintURL()
-		}
-		if initBlueprint != "" {
-			ctx = context.WithValue(ctx, "blueprint", initBlueprint)
-		}
-
-		// Then blueprint should be set to default OCI (local always assumes default blueprint when none provided)
-		if blueprintCtx := ctx.Value("blueprint"); blueprintCtx == nil {
-			t.Errorf("Expected default blueprint to be set for local context without --blueprint or provider")
-		} else if blueprint, ok := blueprintCtx.(string); !ok {
-			t.Errorf("Expected blueprint context value to be a string")
-		} else if blueprint != constants.GetEffectiveBlueprintURL() {
-			t.Errorf("Expected blueprint to be default OCI URL, got %s", blueprint)
-		}
-	})
-
-	t.Run("LocalContextWithExplicitProvider", func(t *testing.T) {
-		initProvider = "aws"
-		initBlueprint = ""
-
-		// When processing the init logic
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, "reset", false)
-		ctx = context.WithValue(ctx, "trust", true)
-
-		// If provider is set and blueprint is not set, set blueprint
-		if initProvider != "" && initBlueprint == "" {
-			initBlueprint = constants.DefaultOCIBlueprintURL
-		}
-		if initBlueprint != "" {
-			ctx = context.WithValue(ctx, "blueprint", initBlueprint)
-		}
-
-		// Then the explicit provider should be used and OCI blueprint should be set
-		if initProvider != "aws" {
-			t.Errorf("Expected provider to be 'aws', got %s", initProvider)
-		}
-
-		if blueprintCtx := ctx.Value("blueprint"); blueprintCtx == nil {
-			t.Errorf("Expected blueprint to be set in context when explicit provider is specified")
-		} else if blueprint, ok := blueprintCtx.(string); !ok {
-			t.Errorf("Expected blueprint context value to be a string")
-		} else if blueprint != constants.DefaultOCIBlueprintURL {
-			t.Errorf("Expected blueprint to be %s, got %s", constants.DefaultOCIBlueprintURL, blueprint)
-		}
-	})
-
-	t.Run("LocalContextWithExplicitBlueprint", func(t *testing.T) {
-		initProvider = ""
-		initBlueprint = "oci://custom/blueprint:v1.0.0"
-
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, "reset", false)
-		ctx = context.WithValue(ctx, "trust", true)
-
-		if initProvider != "" && initBlueprint == "" {
-			initBlueprint = constants.DefaultOCIBlueprintURL
-		}
-		if initBlueprint != "" {
-			ctx = context.WithValue(ctx, "blueprint", initBlueprint)
-		}
-
-		// Then the explicit blueprint should be used
-		if blueprintCtx := ctx.Value("blueprint"); blueprintCtx == nil {
-			t.Errorf("Expected blueprint to be set in context")
-		} else if blueprint, ok := blueprintCtx.(string); !ok {
-			t.Errorf("Expected blueprint context value to be a string")
-		} else if blueprint != "oci://custom/blueprint:v1.0.0" {
-			t.Errorf("Expected blueprint to be oci://custom/blueprint:v1.0.0, got %s", blueprint)
-		}
-	})
-
-	t.Run("NonLocalContext", func(t *testing.T) {
-		// Given a non-local context with no explicit provider or blueprint
-		args := []string{"aws"}
-		initProvider = ""
-		initBlueprint = ""
-
-		// When processing the init logic
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, "reset", false)
-		ctx = context.WithValue(ctx, "trust", true)
-
-		// If context is "local" and neither provider nor blueprint is set, set both
-		if len(args) > 0 && strings.HasPrefix(args[0], "local") && initProvider == "" && initBlueprint == "" {
-			initProvider = "generic"
-			initBlueprint = constants.DefaultOCIBlueprintURL
-		}
-
-		// If provider is set and blueprint is not set, set blueprint (covers all providers, including local)
-		if initProvider != "" && initBlueprint == "" {
-			initBlueprint = constants.DefaultOCIBlueprintURL
-		}
-
-		// If blueprint is set, use it (overrides all)
-		if initBlueprint != "" {
-			ctx = context.WithValue(ctx, "blueprint", initBlueprint)
-		}
-
-		// Then provider should not be auto-set and blueprint should not be set
-		if initProvider != "" {
-			t.Errorf("Expected provider to not be auto-set for non-local context, got %s", initProvider)
-		}
-
-		if blueprintCtx := ctx.Value("blueprint"); blueprintCtx != nil {
-			t.Errorf("Expected blueprint to not be set when no provider is specified, got %v", blueprintCtx)
-		}
-	})
-
-	t.Run("ProviderAutoBlueprint", func(t *testing.T) {
-		// Given a provider is specified
-		initProvider = "aws"
-		initBlueprint = ""
-
-		// When processing the init logic
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, "reset", false)
-		ctx = context.WithValue(ctx, "trust", true)
-
-		// If provider is set and blueprint is not set, set blueprint (covers all providers, including local)
-		if initProvider != "" && initBlueprint == "" {
-			initBlueprint = constants.DefaultOCIBlueprintURL
-		}
-
-		if initBlueprint != "" {
-			ctx = context.WithValue(ctx, "blueprint", initBlueprint)
-		}
-
-		// Then the blueprint should be set correctly
-		if blueprintCtx := ctx.Value("blueprint"); blueprintCtx == nil {
-			t.Errorf("Expected blueprint to be set in context when provider is specified")
-		} else if blueprint, ok := blueprintCtx.(string); !ok {
-			t.Errorf("Expected blueprint context value to be a string")
-		} else if blueprint != constants.DefaultOCIBlueprintURL {
-			t.Errorf("Expected blueprint to be %s, got %s", constants.DefaultOCIBlueprintURL, blueprint)
-		}
-	})
-
-	t.Run("ExplicitBlueprintOverrides", func(t *testing.T) {
-		// Given an explicit blueprint is specified
-		initProvider = "aws"
-		initBlueprint = "oci://custom/blueprint:v1.0.0"
-
-		// When processing the init logic
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, "reset", false)
-		ctx = context.WithValue(ctx, "trust", true)
-
-		// If provider is set and blueprint is not set, set blueprint (covers all providers, including local)
-		if initProvider != "" && initBlueprint == "" {
-			initBlueprint = constants.DefaultOCIBlueprintURL
-		}
-
-		if initBlueprint != "" {
-			ctx = context.WithValue(ctx, "blueprint", initBlueprint)
-		}
-
-		// Then the explicit blueprint should be used instead of the default
-		if blueprintCtx := ctx.Value("blueprint"); blueprintCtx == nil {
-			t.Errorf("Expected blueprint to be set in context")
-		} else if blueprint, ok := blueprintCtx.(string); !ok {
-			t.Errorf("Expected blueprint context value to be a string")
-		} else if blueprint != "oci://custom/blueprint:v1.0.0" {
-			t.Errorf("Expected blueprint to be oci://custom/blueprint:v1.0.0, got %s", blueprint)
-		}
-	})
-
-	t.Run("PlatformAutoBlueprint", func(t *testing.T) {
-		// Given a platform is specified
-		initPlatform = "aws"
-		initProvider = ""
-		initBlueprint = ""
-
-		// When processing the init logic
-		ctx := context.Background()
-		ctx = context.WithValue(ctx, "reset", false)
-		ctx = context.WithValue(ctx, "trust", true)
-
-		// When --platform is set (primary) and no blueprint, set default blueprint
-		if initPlatform != "" && initBlueprint == "" {
-			initBlueprint = constants.DefaultOCIBlueprintURL
-		}
-
-		if initBlueprint != "" {
-			ctx = context.WithValue(ctx, "blueprint", initBlueprint)
-		}
-
-		// Then the blueprint should be set correctly
-		if blueprintCtx := ctx.Value("blueprint"); blueprintCtx == nil {
-			t.Errorf("Expected blueprint to be set in context when platform is specified")
-		} else if blueprint, ok := blueprintCtx.(string); !ok {
-			t.Errorf("Expected blueprint context value to be a string")
-		} else if blueprint != constants.DefaultOCIBlueprintURL {
-			t.Errorf("Expected blueprint to be %s, got %s", constants.DefaultOCIBlueprintURL, blueprint)
-		}
-	})
-
-	t.Run("LocalContextVariations", func(t *testing.T) {
-		testCases := []struct {
-			name              string
-			args              []string
-			provider          string
-			blueprint         string
-			expectedProvider  string
-			expectedBlueprint string
-		}{
-			{
-				name:              "local context with no flags",
-				args:              []string{"local"},
-				provider:          "",
-				blueprint:         "",
-				expectedProvider:  "local",
-				expectedBlueprint: "",
-			},
-			{
-				name:              "local-dev context with no flags",
-				args:              []string{"local-dev"},
-				provider:          "",
-				blueprint:         "",
-				expectedProvider:  "local",
-				expectedBlueprint: "",
-			},
-			{
-				name:              "local context with explicit provider",
-				args:              []string{"local"},
-				provider:          "aws",
-				blueprint:         "",
-				expectedProvider:  "aws",
-				expectedBlueprint: constants.DefaultOCIBlueprintURL,
-			},
-			{
-				name:              "local context with explicit blueprint",
-				args:              []string{"local"},
-				provider:          "",
-				blueprint:         "oci://custom/blueprint:v1.0.0",
-				expectedProvider:  "",
-				expectedBlueprint: "oci://custom/blueprint:v1.0.0",
-			},
-			{
-				name:              "local context with both explicit provider and blueprint",
-				args:              []string{"local"},
-				provider:          "azure",
-				blueprint:         "oci://custom/blueprint:v1.0.0",
-				expectedProvider:  "azure",
-				expectedBlueprint: "oci://custom/blueprint:v1.0.0",
-			},
-		}
-
-		for _, tc := range testCases {
-			t.Run(tc.name, func(t *testing.T) {
-				// Given the test case parameters
-				initProvider = tc.provider
-				initBlueprint = tc.blueprint
-
-				ctx := context.Background()
-				ctx = context.WithValue(ctx, "reset", false)
-				ctx = context.WithValue(ctx, "trust", true)
-
-				if initProvider != "" && initBlueprint == "" {
-					initBlueprint = constants.DefaultOCIBlueprintURL
-				}
-				if initBlueprint != "" {
-					ctx = context.WithValue(ctx, "blueprint", initBlueprint)
-				}
-
-				if len(tc.args) > 0 && strings.HasPrefix(tc.args[0], "local") && initProvider == "" && tc.expectedProvider != "" {
-					initProvider = tc.expectedProvider
-				}
-
-				// Then verify the results
-				if tc.expectedProvider != "" {
-					if initProvider != tc.expectedProvider {
-						t.Errorf("Expected provider to be %s, got %s", tc.expectedProvider, initProvider)
-					}
-				}
-
-				if tc.expectedBlueprint != "" {
-					if blueprintCtx := ctx.Value("blueprint"); blueprintCtx == nil {
-						t.Errorf("Expected blueprint to be set in context")
-					} else if blueprint, ok := blueprintCtx.(string); !ok {
-						t.Errorf("Expected blueprint context value to be a string")
-					} else if blueprint != tc.expectedBlueprint {
-						t.Errorf("Expected blueprint to be %s, got %s", tc.expectedBlueprint, blueprint)
-					}
-				}
-			})
-		}
-	})
-
 	t.Run("RunEAutoProviderBlueprintLogic", func(t *testing.T) {
 		// Given a temporary directory with mocked dependencies
 		mocks := setupInitTest(t)
@@ -910,24 +605,6 @@ func TestInitCmd(t *testing.T) {
 		ctx := context.WithValue(context.Background(), runtimeOverridesKey, mocks.Runtime)
 		ctx = context.WithValue(ctx, composerOverridesKey, mocks.Composer)
 		cmd.SetArgs([]string{"local"})
-		cmd.SetContext(ctx)
-		err := cmd.Execute()
-
-		// Then no error should occur and the logic should be executed
-		if err != nil {
-			t.Errorf("Expected success, got error: %v", err)
-		}
-	})
-
-	t.Run("RunEExplicitProviderAutoBlueprint", func(t *testing.T) {
-		// Given a temporary directory with mocked dependencies
-		mocks := setupInitTest(t)
-
-		// When executing the init command with explicit provider
-		cmd := createTestInitCmd()
-		ctx := context.WithValue(context.Background(), runtimeOverridesKey, mocks.Runtime)
-		ctx = context.WithValue(ctx, composerOverridesKey, mocks.Composer)
-		cmd.SetArgs([]string{"--provider", "aws"})
 		cmd.SetContext(ctx)
 		err := cmd.Execute()
 
@@ -973,7 +650,7 @@ func TestInitCmd(t *testing.T) {
 			"--reset",
 			"--docker",
 			"--git-livereload",
-			"--provider", "aws",
+			"--platform", "aws",
 		})
 		cmd.SetContext(ctx)
 		err := cmd.Execute()
@@ -997,7 +674,7 @@ func TestInitCmd(t *testing.T) {
 		}
 	})
 
-	t.Run("RunEDeprecatedProviderFlag", func(t *testing.T) {
+	t.Run("RunERemovedProviderFlagRejected", func(t *testing.T) {
 		mocks := setupInitTest(t)
 		cmd := createTestInitCmd()
 		ctx := context.WithValue(context.Background(), runtimeOverridesKey, mocks.Runtime)
@@ -1005,23 +682,11 @@ func TestInitCmd(t *testing.T) {
 		cmd.SetArgs([]string{"--provider", "aws"})
 		cmd.SetContext(ctx)
 		err := cmd.Execute()
-		if err != nil {
-			t.Errorf("Expected success with deprecated --provider, got error: %v", err)
+		if err == nil {
+			t.Fatal("Expected error for removed --provider flag, got nil")
 		}
-	})
-
-	t.Run("RunEPlatformAndProviderConflict", func(t *testing.T) {
-		mocks := setupInitTest(t)
-		cmd := createTestInitCmd()
-		ctx := context.WithValue(context.Background(), runtimeOverridesKey, mocks.Runtime)
-		ctx = context.WithValue(ctx, composerOverridesKey, mocks.Composer)
-		cmd.SetArgs([]string{"--platform", "aws", "--provider", "azure"})
-		cmd.SetContext(ctx)
-		err := cmd.Execute()
-
-		// Then no error should occur - platform overrides provider
-		if err != nil {
-			t.Errorf("Expected success, got error: %v", err)
+		if !strings.Contains(err.Error(), "unknown flag: --provider") {
+			t.Errorf("Expected 'unknown flag: --provider' error, got: %v", err)
 		}
 	})
 
@@ -1115,19 +780,19 @@ func TestInitCmd(t *testing.T) {
 		}
 	})
 
-	t.Run("RunEExplicitProviderOverridesContextName", func(t *testing.T) {
+	t.Run("RunEExplicitPlatformOverridesContextName", func(t *testing.T) {
 		// Given a temporary directory with mocked dependencies
 		mocks := setupInitTest(t)
 
-		// When executing the init command with explicit provider that differs from context name
+		// When executing the init command with explicit platform that differs from context name
 		cmd := createTestInitCmd()
 		ctx := context.WithValue(context.Background(), runtimeOverridesKey, mocks.Runtime)
 		ctx = context.WithValue(ctx, composerOverridesKey, mocks.Composer)
-		cmd.SetArgs([]string{"aws", "--provider", "azure"}) // Context name vs explicit provider
+		cmd.SetArgs([]string{"aws", "--platform", "azure"})
 		cmd.SetContext(ctx)
 		err := cmd.Execute()
 
-		// Then no error should occur and explicit provider should be used
+		// Then no error should occur and explicit platform should be used
 		if err != nil {
 			t.Errorf("Expected success, got error: %v", err)
 		}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -15,8 +15,7 @@ import (
 )
 
 var (
-	waitFlag    bool // Declare the wait flag
-	installFlag bool // Deprecated: no-op, kept for backwards compatibility
+	waitFlag    bool
 	upVmDriver  string
 	upPlatform  string
 	upBlueprint string
@@ -182,8 +181,6 @@ func buildUpFlagOverrides() (map[string]any, error) {
 
 func init() {
 	upCmd.Flags().BoolVar(&waitFlag, "wait", false, "Wait for kustomization resources to be ready")
-	upCmd.Flags().BoolVar(&installFlag, "install", false, "")
-	_ = upCmd.Flags().MarkDeprecated("install", "the --install flag is no longer needed and will be removed in a future release")
 	upCmd.Flags().StringVar(&upVmDriver, "vm-driver", "", "VM driver (colima, colima-incus, docker-desktop, docker)")
 	upCmd.Flags().StringVar(&upPlatform, "platform", "", "Specify the platform to use [none|metal|docker|aws|azure|gcp|hyperv]")
 	upCmd.Flags().StringVar(&upBlueprint, "blueprint", "", "Specify the blueprint to use")

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -252,24 +252,6 @@ func TestUpCmd(t *testing.T) {
 		}
 	})
 
-	t.Run("DeprecatedInstallFlagIsNoOp", func(t *testing.T) {
-		// Given a project with a workstation configured
-		mocks := setupUpTest(t)
-		proj := newUpTestProject(mocks, true)
-
-		// When executing the up command with the deprecated --install flag
-		cmd := createTestUpCmd()
-		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
-		cmd.SetContext(ctx)
-		cmd.SetArgs([]string{"--install"})
-		err := cmd.Execute()
-
-		// Then no error should occur (flag is a no-op)
-		if err != nil {
-			t.Errorf("Expected success with deprecated --install flag, got error: %v", err)
-		}
-	})
-
 	t.Run("ProvisionerUpError", func(t *testing.T) {
 		// Given a terraform stack that fails during Up
 		mocks := setupUpTest(t)

--- a/docs/guides/contexts.md
+++ b/docs/guides/contexts.md
@@ -20,7 +20,7 @@ You create a Windsor project by running `windsor init`. When doing so, it automa
 To create another context, say one representing production, you run:
 
 ```bash
-windsor init production --provider aws
+windsor init production --platform aws
 ```
 
 This will create a folder, `contexts/production` with a basic `blueprint.yaml` file and default `windsor.yaml` file.
@@ -30,13 +30,13 @@ This will create a folder, `contexts/production` with a basic `blueprint.yaml` f
 You can switch contexts by running:
 
 ```bash
-windsor context set <context-name>
+windsor set context <context-name>
 ```
 
 You can see the current context by running:
 
 ```bash
-windsor context get
+windsor get context
 ```
 
 Additionally, the `WINDSOR_CONTEXT` environment variable is available to you.

--- a/docs/guides/terraform.md
+++ b/docs/guides/terraform.md
@@ -105,7 +105,7 @@ In your project, the `terraform/` directory houses your standard Terraform files
 - **Terraform Directory**: `terraform/database/postgres`
 - **Local Context Variables**: `contexts/local/terraform/database/postgres.tfvars`
 
-When you set a context using `windsor context set`, the Windsor CLI automatically includes the appropriate `.tfvars` files in your Terraform commands. This means running `terraform plan` in the `terraform/database/postgres` directory is equivalent to:
+When you set a context using `windsor set context`, the Windsor CLI automatically includes the appropriate `.tfvars` files in your Terraform commands. This means running `terraform plan` in the `terraform/database/postgres` directory is equivalent to:
 
 ```bash
 terraform plan --var-file path/to/contexts/local/terraform/database/postgres.tfvars

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -60,7 +60,7 @@ windsor check
 Verify that the default 'local' context was selected:
 
 ```sh
-windsor context get
+windsor get context
 ```
 
 ### Start the environment

--- a/docs/reference/contexts.md
+++ b/docs/reference/contexts.md
@@ -120,13 +120,13 @@ This creates:
 Switch contexts by running:
 
 ```bash
-windsor context set <context-name>
+windsor set context <context-name>
 ```
 
 View the current context:
 
 ```bash
-windsor context get
+windsor get context
 ```
 
 The current context is also available via the `WINDSOR_CONTEXT` environment variable.

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -72,21 +72,31 @@ func TestInit_RejectsRemovedProviderFlag(t *testing.T) {
 	}
 }
 
-// TestContext_RejectsRemovedHiddenContextGroup verifies that the hidden
-// `windsor context get|set` legacy command group, deprecated in favor of
-// `windsor get context` / `windsor set context`, is no longer registered.
-func TestContext_RejectsRemovedHiddenContextGroup(t *testing.T) {
+// TestContext_RemovedGroupReturnsMigrationHint verifies that invocations of the
+// removed `windsor context …` group return a migration-friendly error pointing
+// at the replacement command, rather than cobra's default "unknown command".
+// The friendly stub is scheduled for deletion in v0.10.0.
+func TestContext_RemovedGroupReturnsMigrationHint(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "default")
 	if _, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env); err != nil {
 		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
 	}
+
 	_, stderr, err := helpers.RunCLI(dir, []string{"context", "get"}, env)
 	if err == nil {
-		t.Fatal("expected failure for removed 'context' command group, got success")
+		t.Fatal("expected migration error for 'context get', got success")
 	}
-	if !strings.Contains(string(stderr), "unknown command") {
-		t.Errorf("expected stderr to mention 'unknown command', got: %s", stderr)
+	if !strings.Contains(string(stderr), "use 'windsor get context'") {
+		t.Errorf("expected migration hint suggesting 'windsor get context', got: %s", stderr)
+	}
+
+	_, stderr, err = helpers.RunCLI(dir, []string{"context", "set", "staging"}, env)
+	if err == nil {
+		t.Fatal("expected migration error for 'context set', got success")
+	}
+	if !strings.Contains(string(stderr), "use 'windsor set context'") {
+		t.Errorf("expected migration hint suggesting 'windsor set context', got: %s", stderr)
 	}
 }
 

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -79,9 +79,6 @@ func TestInit_RejectsRemovedProviderFlag(t *testing.T) {
 func TestContext_RemovedGroupReturnsMigrationHint(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "default")
-	if _, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env); err != nil {
-		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
-	}
 
 	_, stderr, err := helpers.RunCLI(dir, []string{"context", "get"}, env)
 	if err == nil {

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -58,6 +58,38 @@ func getPathValue(data map[string]any, path ...string) (any, bool) {
 	return current, true
 }
 
+// TestInit_RejectsRemovedProviderFlag verifies that --provider, the long
+// deprecated alias for --platform, no longer parses. Removed in v0.9.0.
+func TestInit_RejectsRemovedProviderFlag(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "default")
+	_, stderr, err := helpers.RunCLI(dir, []string{"init", "prod", "--provider", "aws"}, env)
+	if err == nil {
+		t.Fatal("expected failure for removed --provider flag, got success")
+	}
+	if !strings.Contains(string(stderr), "unknown flag: --provider") {
+		t.Errorf("expected stderr to mention 'unknown flag: --provider', got: %s", stderr)
+	}
+}
+
+// TestContext_RejectsRemovedHiddenContextGroup verifies that the hidden
+// `windsor context get|set` legacy command group, deprecated in favor of
+// `windsor get context` / `windsor set context`, is no longer registered.
+func TestContext_RejectsRemovedHiddenContextGroup(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "default")
+	if _, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env); err != nil {
+		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
+	}
+	_, stderr, err := helpers.RunCLI(dir, []string{"context", "get"}, env)
+	if err == nil {
+		t.Fatal("expected failure for removed 'context' command group, got success")
+	}
+	if !strings.Contains(string(stderr), "unknown command") {
+		t.Errorf("expected stderr to mention 'unknown command', got: %s", stderr)
+	}
+}
+
 func TestInit_PersistsSetValues(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "default")

--- a/integration/up_test.go
+++ b/integration/up_test.go
@@ -49,6 +49,21 @@ func TestUp_FailsWhenNotInTrustedDirectory(t *testing.T) {
 	}
 }
 
+// TestUp_RejectsRemovedInstallFlag verifies that the long-deprecated --install
+// flag no longer parses. Removed in v0.9.0; the flag was a no-op shim retained
+// only to warn users mid-deprecation.
+func TestUp_RejectsRemovedInstallFlag(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "up")
+	_, stderr, err := helpers.RunCLI(dir, []string{"up", "--install"}, env)
+	if err == nil {
+		t.Fatal("expected failure for removed --install flag, got success")
+	}
+	if !strings.Contains(string(stderr), "unknown flag: --install") {
+		t.Errorf("expected stderr to mention 'unknown flag: --install', got: %s", stderr)
+	}
+}
+
 // TestUp_AcceptsWaitFlag verifies that --wait is a recognised flag and does not
 // cause an "unknown flag" error in the no-op path.
 func TestUp_AcceptsWaitFlag(t *testing.T) {


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> This PR removes three previously deprecated CLI surfaces that were still silently accepted; any existing scripts or pipelines using them will now receive hard errors instead of deprecation warnings.
>
> **Overview**
>
> The change promotes three long-announced deprecations to hard removals: the hidden `windsor context get|set` command group (replaced by `windsor get context` / `windsor set context`), the `--provider` flag on `windsor init` (replaced by `--platform`), and the no-op `--install` flag on `windsor up`. All three surfaces were shimmed with warnings in prior releases; this PR drops the shims entirely.
>
> Rejection behavior is verified at both the unit level (new `RemovedContextGroupRejected`, `RunERemovedProviderFlagRejected` sub-tests) and through three new integration tests that assert the specific `unknown command` / `unknown flag` error text cobra now returns.
>
> Reviewed by Claude for commit `dedf028d`.

<!-- /claude-code-review:summary -->
