### PR TITLE
feat(init): reject non-git directories and ensure project anchor creation

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -52,7 +51,10 @@ var initCmd = &cobra.Command{
 		// Without this, an `init` run in an empty directory would fall back to
 		// global mode (via GetProjectRoot) and silently operate against $HOME.
 		if len(rtOpts) == 0 {
-			if err := ensureProjectAnchor(); err != nil {
+			if err := shell.EnsureGitRepository(); err != nil {
+				return err
+			}
+			if err := shell.EnsureProjectAnchor(); err != nil {
 				return fmt.Errorf("failed to initialize project: %w", err)
 			}
 		}
@@ -173,35 +175,6 @@ var initCmd = &cobra.Command{
 
 		return nil
 	},
-}
-
-// ensureProjectAnchor writes a minimal windsor.yaml in the current working
-// directory when no project file is found anywhere in the walk-up path. This
-// anchors `windsor init` to the cwd so subsequent runtime resolution does not
-// fall back to global mode and silently operate against $HOME/.config/windsor.
-// If a project file already exists at or above the cwd, this is a no-op.
-func ensureProjectAnchor() error {
-	cwd, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("failed to get working directory: %w", err)
-	}
-	dir := cwd
-	for i := 0; i <= shell.MaxFolderSearchDepth; i++ {
-		if _, err := os.Stat(filepath.Join(dir, "windsor.yaml")); err == nil {
-			return nil
-		}
-		if _, err := os.Stat(filepath.Join(dir, "windsor.yml")); err == nil {
-			return nil
-		}
-		parent := filepath.Dir(dir)
-		if parent == dir {
-			break
-		}
-		dir = parent
-	}
-	// windsor.yaml is user-readable project config, 0644 matches the project
-	// convention used by typed_source.EnsureRoot.
-	return os.WriteFile(filepath.Join(cwd, "windsor.yaml"), []byte("version: v1alpha1\n"), 0644) // #nosec G306
 }
 
 func init() {

--- a/cmd/init_test.go
+++ b/cmd/init_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -1159,94 +1158,3 @@ func TestInitCmd(t *testing.T) {
 	})
 }
 
-func TestEnsureProjectAnchor(t *testing.T) {
-	setup := func(t *testing.T) string {
-		t.Helper()
-		origDir, err := os.Getwd()
-		if err != nil {
-			t.Fatalf("Failed to get working directory: %v", err)
-		}
-		tmpDir := t.TempDir()
-		if err := os.Chdir(tmpDir); err != nil {
-			t.Fatalf("Failed to chdir: %v", err)
-		}
-		t.Cleanup(func() {
-			_ = os.Chdir(origDir)
-		})
-		// Isolate HOME so a real global windsor.yaml doesn't shortcut detection.
-		t.Setenv("HOME", tmpDir)
-		// Resolve any symlinks (macOS /var -> /private/var) so our string compare matches.
-		resolved, err := filepath.EvalSymlinks(tmpDir)
-		if err != nil {
-			return tmpDir
-		}
-		return resolved
-	}
-
-	t.Run("WritesMinimalWindsorYamlWhenNoProjectExists", func(t *testing.T) {
-		// Given an empty directory
-		tmpDir := setup(t)
-
-		// When ensureProjectAnchor is called
-		if err := ensureProjectAnchor(); err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-
-		// Then a minimal windsor.yaml should be created in cwd
-		data, err := os.ReadFile(filepath.Join(tmpDir, "windsor.yaml"))
-		if err != nil {
-			t.Fatalf("Expected windsor.yaml to exist, got %v", err)
-		}
-		if !strings.Contains(string(data), "version: v1alpha1") {
-			t.Errorf("Expected minimal v1alpha1 root config, got: %s", string(data))
-		}
-	})
-
-	t.Run("NoOpWhenProjectAlreadyExistsInCwd", func(t *testing.T) {
-		// Given a directory that already has windsor.yaml
-		tmpDir := setup(t)
-		existing := []byte("version: v1alpha1\ncustom: preserved\n")
-		if err := os.WriteFile(filepath.Join(tmpDir, "windsor.yaml"), existing, 0644); err != nil {
-			t.Fatalf("Failed to seed windsor.yaml: %v", err)
-		}
-
-		// When ensureProjectAnchor is called
-		if err := ensureProjectAnchor(); err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-
-		// Then the existing file should not be overwritten
-		data, err := os.ReadFile(filepath.Join(tmpDir, "windsor.yaml"))
-		if err != nil {
-			t.Fatalf("Expected windsor.yaml to exist, got %v", err)
-		}
-		if string(data) != string(existing) {
-			t.Errorf("Expected existing windsor.yaml preserved, got: %s", string(data))
-		}
-	})
-
-	t.Run("NoOpWhenProjectExistsInParentDirectory", func(t *testing.T) {
-		// Given a parent directory containing windsor.yaml and a cwd below it
-		tmpDir := setup(t)
-		subDir := filepath.Join(tmpDir, "sub")
-		if err := os.MkdirAll(subDir, 0755); err != nil {
-			t.Fatalf("Failed to create subdir: %v", err)
-		}
-		if err := os.WriteFile(filepath.Join(tmpDir, "windsor.yaml"), []byte("version: v1alpha1\n"), 0644); err != nil {
-			t.Fatalf("Failed to seed windsor.yaml: %v", err)
-		}
-		if err := os.Chdir(subDir); err != nil {
-			t.Fatalf("Failed to chdir to subdir: %v", err)
-		}
-
-		// When ensureProjectAnchor is called
-		if err := ensureProjectAnchor(); err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-
-		// Then no windsor.yaml should be created in the subdir
-		if _, err := os.Stat(filepath.Join(subDir, "windsor.yaml")); err == nil {
-			t.Error("Expected no windsor.yaml in subdir (parent already has one)")
-		}
-	})
-}

--- a/integration/apply_test.go
+++ b/integration/apply_test.go
@@ -17,6 +17,7 @@ import (
 func TestApplyTerraform_SucceedsWithMinimalLocalConfig(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
 	if err != nil {
 		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
@@ -52,6 +53,7 @@ func TestApplyTerraform_FailsWithNoArgument(t *testing.T) {
 func TestApplyTerraform_FailsForNonexistentComponent(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
 	if err != nil {
 		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
@@ -69,6 +71,7 @@ func TestApplyTerraform_FailsForNonexistentComponent(t *testing.T) {
 func TestApplyKustomize_AcceptsWaitFlag(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
 	if err != nil {
 		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
@@ -84,6 +87,7 @@ func TestApplyKustomize_AcceptsWaitFlag(t *testing.T) {
 func TestApply_AcceptsWaitFlag(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
 	if err != nil {
 		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
@@ -109,6 +113,7 @@ func TestApply_AcceptsWaitFlag(t *testing.T) {
 func TestApplyTerraform_MissingBinary_ShowsActionableError(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
 
 	if _, stderr, err := helpers.RunCLI(dir, []string{"init", "local", "--set", "terraform.enabled=true"}, env); err != nil {
 		t.Fatalf("init local --set terraform.enabled=true: %v\nstderr: %s", err, stderr)

--- a/integration/bootstrap_test.go
+++ b/integration/bootstrap_test.go
@@ -125,6 +125,7 @@ func TestBootstrap_GlobalModeExitsCleanlyWhenPlanDeclined(t *testing.T) {
 func TestBootstrap_DanceIsScopedToTier(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "backend-first")
+	helpers.MarkAsGitRepo(t, dir)
 	if _, stderr, err := helpers.RunCLI(dir, []string{"init", "local", "--set", "terraform.backend.type=s3"}, env); err != nil {
 		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
 	}

--- a/integration/destroy_test.go
+++ b/integration/destroy_test.go
@@ -19,6 +19,7 @@ import (
 func TestDestroyTerraform_SucceedsWithMinimalLocalConfig(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
 	if err != nil {
 		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
@@ -37,6 +38,7 @@ func TestDestroyTerraform_SucceedsWithMinimalLocalConfig(t *testing.T) {
 func TestDestroyTerraform_SucceedsAllWithMinimalLocalConfig(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
 	if err != nil {
 		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
@@ -67,6 +69,7 @@ func TestDestroyTerraform_FailsWhenNotInTrustedDirectory(t *testing.T) {
 func TestDestroy_FailsWhenConfirmFlagDoesNotMatch(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
 	if err != nil {
 		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
@@ -84,6 +87,7 @@ func TestDestroy_FailsWhenConfirmFlagDoesNotMatch(t *testing.T) {
 func TestDestroyTerraform_FailsForNonexistentComponent(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
 	if err != nil {
 		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
@@ -109,6 +113,7 @@ func TestDestroyTerraform_FailsForNonexistentComponent(t *testing.T) {
 func TestDestroyTerraform_SkipsComponentWithEmptyState(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
 	if err != nil {
 		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
@@ -144,6 +149,7 @@ func TestDestroyTerraform_SkipsComponentWithEmptyState(t *testing.T) {
 func TestDestroyTerraform_LocalBackendSkipsMigrationDance(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "backend-first")
+	helpers.MarkAsGitRepo(t, dir)
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
 	if err != nil {
 		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
@@ -181,6 +187,7 @@ func TestDestroyTerraform_LocalBackendSkipsMigrationDance(t *testing.T) {
 func TestDestroy_TolerantOfReorderedBackend(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "backend-first")
+	helpers.MarkAsGitRepo(t, dir)
 	if _, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env); err != nil {
 		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
 	}
@@ -219,6 +226,7 @@ terraform:
 func TestDestroy_ShowsDestroyPlanBeforePromptOrConfirm(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
 	if err != nil {
 		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
@@ -249,6 +257,7 @@ func TestDestroy_ShowsDestroyPlanBeforePromptOrConfirm(t *testing.T) {
 func TestDestroyTerraform_WarnsWhenPreventDestroySet(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "prevent-destroy")
+	helpers.MarkAsGitRepo(t, dir)
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
 	if err != nil {
 		t.Fatalf("init local: %v\nstderr: %s", err, stderr)

--- a/integration/helpers/helpers.go
+++ b/integration/helpers/helpers.go
@@ -135,8 +135,8 @@ func envForHome(homeDir string) []string {
 
 // CopyFixtureOnly copies the named fixture into a temp dir and returns workDir and env
 // (HOME/USERPROFILE set to a temp dir). Does not run windsor init, so the dir is not trusted.
-// Creates an empty .git/ in workDir so that `windsor init`'s git-repository
-// precondition is satisfied; fixtures already model real project directories.
+// Does NOT create .git/; tests that subsequently run `windsor init` must call
+// MarkAsGitRepo to satisfy init's git-repository precondition.
 func CopyFixtureOnly(t *testing.T, name string) (workDir string, env []string) {
 	t.Helper()
 	src := FixturePath(name)
@@ -147,11 +147,20 @@ func CopyFixtureOnly(t *testing.T, name string) (workDir string, env []string) {
 	if err := CopyFixture(src, workDir); err != nil {
 		t.Fatalf("copy fixture: %v", err)
 	}
+	env = envForHome(t.TempDir())
+	return workDir, env
+}
+
+// MarkAsGitRepo creates an empty .git/ in workDir so that `windsor init`'s
+// git-repository precondition is satisfied. Use after CopyFixtureOnly when the
+// test will subsequently invoke `windsor init` (or any command that requires
+// a project-scoped runtime). Pairs with CopyFixtureOnly's deliberately clean
+// baseline; callers that don't run init should not call this helper.
+func MarkAsGitRepo(t *testing.T, workDir string) {
+	t.Helper()
 	if err := os.MkdirAll(filepath.Join(workDir, ".git"), 0755); err != nil {
 		t.Fatalf("mkdir .git: %v", err)
 	}
-	env = envForHome(t.TempDir())
-	return workDir, env
 }
 
 // MinimalPATHEnv returns env with any PATH entry replaced by a minimal PATH (/usr/bin:/bin).
@@ -172,10 +181,12 @@ func MinimalPATHEnv(env []string) []string {
 
 // PrepareFixture copies the named fixture into a temp dir, runs windsor init with a temp
 // HOME so the dir is trusted, and returns workDir and env. Include env in RunCLI so the
-// trusted check passes.
+// trusted check passes. Marks the workdir as a git repo before init because init
+// requires it.
 func PrepareFixture(t *testing.T, name string) (workDir string, env []string) {
 	t.Helper()
 	workDir, env = CopyFixtureOnly(t, name)
+	MarkAsGitRepo(t, workDir)
 	stdout, stderr, err := RunCLI(workDir, []string{"init"}, env)
 	if err != nil {
 		t.Fatalf("windsor init: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)

--- a/integration/helpers/helpers.go
+++ b/integration/helpers/helpers.go
@@ -135,6 +135,8 @@ func envForHome(homeDir string) []string {
 
 // CopyFixtureOnly copies the named fixture into a temp dir and returns workDir and env
 // (HOME/USERPROFILE set to a temp dir). Does not run windsor init, so the dir is not trusted.
+// Creates an empty .git/ in workDir so that `windsor init`'s git-repository
+// precondition is satisfied; fixtures already model real project directories.
 func CopyFixtureOnly(t *testing.T, name string) (workDir string, env []string) {
 	t.Helper()
 	src := FixturePath(name)
@@ -144,6 +146,9 @@ func CopyFixtureOnly(t *testing.T, name string) (workDir string, env []string) {
 	workDir = t.TempDir()
 	if err := CopyFixture(src, workDir); err != nil {
 		t.Fatalf("copy fixture: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(workDir, ".git"), 0755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
 	}
 	env = envForHome(t.TempDir())
 	return workDir, env

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -100,6 +100,7 @@ func TestContext_RemovedGroupReturnsMigrationHint(t *testing.T) {
 func TestInit_PersistsSetValues(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "default")
+	helpers.MarkAsGitRepo(t, dir)
 
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local", "--set", "dns.enabled=false", "--set", "cluster.endpoint=https://127.0.0.1:6443"}, env)
 	if err != nil {
@@ -119,6 +120,7 @@ func TestInit_PersistsSetValues(t *testing.T) {
 func TestInit_DevPlatformGoesToWorkstationState(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "default")
+	helpers.MarkAsGitRepo(t, dir)
 
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local-dev", "--platform", "docker"}, env)
 	if err != nil {
@@ -146,6 +148,7 @@ func TestInit_DevPlatformGoesToWorkstationState(t *testing.T) {
 func TestInit_NonDevPlatformStaysInValues(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "default")
+	helpers.MarkAsGitRepo(t, dir)
 
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "prod", "--platform", "aws"}, env)
 	if err != nil {
@@ -173,6 +176,7 @@ func TestInit_NonDevPlatformStaysInValues(t *testing.T) {
 func TestInit_RepeatedInitIsIdempotentForExplicitValues(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "default")
+	helpers.MarkAsGitRepo(t, dir)
 
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local", "--set", "custom.value=one"}, env)
 	if err != nil {
@@ -194,6 +198,7 @@ func TestInit_RepeatedInitIsIdempotentForExplicitValues(t *testing.T) {
 func TestInit_PreservesUserValuesAcrossInit(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "default")
+	helpers.MarkAsGitRepo(t, dir)
 	contextDir := filepath.Join(dir, "contexts", "prod")
 	if err := os.MkdirAll(contextDir, 0755); err != nil {
 		t.Fatalf("expected no error creating context dir, got %v", err)
@@ -217,6 +222,7 @@ func TestInit_PreservesUserValuesAcrossInit(t *testing.T) {
 func TestInit_SetContextThenInitUsesSelectedContext(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "default")
+	helpers.MarkAsGitRepo(t, dir)
 
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "prod", "--platform", "aws"}, env)
 	if err != nil {
@@ -244,6 +250,7 @@ func TestInit_SetContextThenInitUsesSelectedContext(t *testing.T) {
 func TestInit_DevContextOwnershipStableAcrossReinit(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "default")
+	helpers.MarkAsGitRepo(t, dir)
 
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local-dev", "--platform", "docker", "--set", "dns.enabled=false"}, env)
 	if err != nil {
@@ -277,9 +284,7 @@ func TestInit_DevContextOwnershipStableAcrossReinit(t *testing.T) {
 func TestInit_CreatesProjectAnchorInEmptyDirectory(t *testing.T) {
 	t.Parallel()
 	workDir := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(workDir, ".git"), 0755); err != nil {
-		t.Fatalf("mkdir .git: %v", err)
-	}
+	helpers.MarkAsGitRepo(t, workDir)
 	homeDir := t.TempDir()
 	env := []string{
 		"HOME=" + homeDir,
@@ -335,6 +340,7 @@ func TestInit_RejectsNonGitDirectory(t *testing.T) {
 func TestInit_NoAnchorWhenProjectExistsInParent(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "default")
+	helpers.MarkAsGitRepo(t, dir)
 	subDir := filepath.Join(dir, "nested", "deeper")
 	if err := os.MkdirAll(subDir, 0755); err != nil {
 		t.Fatalf("mkdir subdir: %v", err)
@@ -353,6 +359,7 @@ func TestInit_NoAnchorWhenProjectExistsInParent(t *testing.T) {
 func TestInit_InvalidValuesDoNotBlockShowCommand(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "default")
+	helpers.MarkAsGitRepo(t, dir)
 
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "default"}, env)
 	if err != nil {
@@ -383,6 +390,7 @@ func TestInit_InvalidValuesDoNotBlockShowCommand(t *testing.T) {
 func TestInit_DoesNotRequireDocker_EvenWhenDockerEnabled(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "default")
+	helpers.MarkAsGitRepo(t, dir)
 
 	stripped := helpers.MinimalPATHEnv(env)
 
@@ -398,6 +406,7 @@ func TestInit_DoesNotRequireDocker_EvenWhenDockerEnabled(t *testing.T) {
 func TestInit_AcceptsBlueprintWithDeclaredBackendTier(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "backend-first")
+	helpers.MarkAsGitRepo(t, dir)
 	stdout, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
 	if err != nil {
 		t.Fatalf("expected init to succeed for backend-tier fixture, got %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
@@ -411,6 +420,7 @@ func TestInit_AcceptsBlueprintWithDeclaredBackendTier(t *testing.T) {
 func TestInit_RejectsBlueprintWithUnresolvedBackendField(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "backend-unresolved")
+	helpers.MarkAsGitRepo(t, dir)
 	stdout, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
 	if err == nil {
 		t.Fatalf("expected init to fail for unresolved backend, got success\nstdout: %s\nstderr: %s", stdout, stderr)
@@ -434,6 +444,7 @@ func TestInit_RejectsBlueprintWithUnresolvedBackendField(t *testing.T) {
 func TestInit_PlatformAwsDefaultsBackendTypeToS3(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
 	stdout, stderr, err := helpers.RunCLI(dir, []string{"init", "aws-test", "--platform", "aws", "--set", "dns.enabled=false"}, env)
 	if err != nil {
 		t.Logf("init exited: %v (tolerated)\nstdout: %s\nstderr: %s", err, stdout, stderr)
@@ -456,6 +467,7 @@ func TestInit_PlatformAwsDefaultsBackendTypeToS3(t *testing.T) {
 func TestInit_PlatformAzureDefaultsBackendTypeToAzurerm(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
 	stdout, stderr, err := helpers.RunCLI(dir, []string{"init", "azure-test", "--platform", "azure", "--set", "dns.enabled=false"}, env)
 	if err != nil {
 		t.Logf("init exited: %v (tolerated)\nstdout: %s\nstderr: %s", err, stdout, stderr)
@@ -480,6 +492,7 @@ func TestInit_PlatformAzureDefaultsBackendTypeToAzurerm(t *testing.T) {
 func TestInit_PlatformMetalDefaultsBackendTypeToKubernetes(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
 	stdout, stderr, err := helpers.RunCLI(dir, []string{"init", "metal-test", "--platform", "metal", "--set", "dns.enabled=false"}, env)
 	if err != nil {
 		t.Logf("init exited: %v (tolerated)\nstdout: %s\nstderr: %s", err, stdout, stderr)
@@ -505,6 +518,7 @@ func TestInit_PlatformMetalDefaultsBackendTypeToKubernetes(t *testing.T) {
 func TestInit_UnmappedPlatformDoesNotDefaultBackendType(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
 	stdout, stderr, err := helpers.RunCLI(dir, []string{"init", "gcp-test", "--platform", "gcp", "--set", "dns.enabled=false"}, env)
 	if err != nil {
 		t.Logf("init exited: %v (tolerated)\nstdout: %s\nstderr: %s", err, stdout, stderr)

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -277,6 +277,9 @@ func TestInit_DevContextOwnershipStableAcrossReinit(t *testing.T) {
 func TestInit_CreatesProjectAnchorInEmptyDirectory(t *testing.T) {
 	t.Parallel()
 	workDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workDir, ".git"), 0755); err != nil {
+		t.Fatalf("mkdir .git: %v", err)
+	}
 	homeDir := t.TempDir()
 	env := []string{
 		"HOME=" + homeDir,
@@ -297,6 +300,32 @@ func TestInit_CreatesProjectAnchorInEmptyDirectory(t *testing.T) {
 	globalProject := filepath.Join(homeDir, ".config", "windsor", "windsor.yaml")
 	if _, err := os.Stat(globalProject); err == nil {
 		t.Errorf("init should anchor to cwd, but also created windsor.yaml in global home: %s", globalProject)
+	}
+}
+
+// TestInit_RejectsNonGitDirectory verifies that running `windsor init` outside
+// a git repository fails fast with an actionable hint rather than producing a
+// confusing downstream error. The README documents `git init` as a prerequisite;
+// this test pins the operator-facing message.
+func TestInit_RejectsNonGitDirectory(t *testing.T) {
+	t.Parallel()
+	workDir := t.TempDir()
+	homeDir := t.TempDir()
+	env := []string{
+		"HOME=" + homeDir,
+		"USERPROFILE=" + homeDir,
+		"PATH=" + os.Getenv("PATH"),
+	}
+
+	_, stderr, err := helpers.RunCLI(workDir, []string{"init"}, env)
+	if err == nil {
+		t.Fatal("expected init to fail in a non-git directory, got success")
+	}
+	if !strings.Contains(string(stderr), "must run inside a git repository") {
+		t.Errorf("expected stderr to mention 'must run inside a git repository', got: %s", stderr)
+	}
+	if !strings.Contains(string(stderr), "git init") {
+		t.Errorf("expected stderr to suggest 'git init', got: %s", stderr)
 	}
 }
 

--- a/integration/plan_test.go
+++ b/integration/plan_test.go
@@ -64,6 +64,7 @@ func TestPlanTerraform_FailsForNonexistentComponent(t *testing.T) {
 func TestPlanTerraform_SucceedsWithMinimalLocalConfig(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
 	if err != nil {
 		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
@@ -109,6 +110,7 @@ func TestPlanKustomize_SucceedsWithEmptyKustomizations(t *testing.T) {
 	t.Parallel()
 	skipIfFluxNotInstalled(t)
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
 	if err != nil {
 		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
@@ -135,6 +137,7 @@ func TestPlan_FailsWhenNotInTrustedDirectory(t *testing.T) {
 func TestPlan_SucceedsWithEmptyBlueprint(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
 	if err != nil {
 		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
@@ -152,6 +155,7 @@ func TestPlan_SucceedsWithEmptyBlueprint(t *testing.T) {
 func TestPlanTerraform_SummaryFlagShowsSummaryTable(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
 	if err != nil {
 		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
@@ -169,6 +173,7 @@ func TestPlanTerraform_SummaryFlagShowsSummaryTable(t *testing.T) {
 func TestPlanTerraform_JSONFlagOutputsJSON(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
 	if err != nil {
 		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
@@ -186,6 +191,7 @@ func TestPlanTerraform_JSONFlagOutputsJSON(t *testing.T) {
 func TestPlanTerraform_SummaryFlagWithComponent(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
 	if err != nil {
 		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
@@ -203,6 +209,7 @@ func TestPlanTerraform_SummaryFlagWithComponent(t *testing.T) {
 func TestPlanKustomize_SummaryFlagShowsSummaryTable(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
 	if err != nil {
 		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
@@ -239,6 +246,7 @@ func TestPlanKustomize_FailsWhenKustomizationNotInBlueprint(t *testing.T) {
 func TestPlan_FooterHintAppearsForNewComponents(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
 	if err != nil {
 		t.Fatalf("init local: %v\nstderr: %s", err, stderr)

--- a/integration/up_test.go
+++ b/integration/up_test.go
@@ -21,6 +21,7 @@ import (
 func TestUp_NoOpWhenWorkstationDisabled(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "up")
+	helpers.MarkAsGitRepo(t, dir)
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "staging"}, env)
 	if err != nil {
 		t.Fatalf("init staging: %v\nstderr: %s", err, stderr)
@@ -69,6 +70,7 @@ func TestUp_RejectsRemovedInstallFlag(t *testing.T) {
 func TestUp_AcceptsWaitFlag(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "up")
+	helpers.MarkAsGitRepo(t, dir)
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "staging"}, env)
 	if err != nil {
 		t.Fatalf("init staging: %v\nstderr: %s", err, stderr)
@@ -86,6 +88,7 @@ func TestUp_AcceptsWaitFlag(t *testing.T) {
 func TestUp_AcceptsSetFlag(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "up")
+	helpers.MarkAsGitRepo(t, dir)
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "staging"}, env)
 	if err != nil {
 		t.Fatalf("init staging: %v\nstderr: %s", err, stderr)
@@ -115,6 +118,7 @@ func TestUp_AcceptsSetFlag(t *testing.T) {
 func TestUp_FailsOnMalformedSetFlag(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "up")
+	helpers.MarkAsGitRepo(t, dir)
 	_, stderr, err := helpers.RunCLI(dir, []string{"init", "staging"}, env)
 	if err != nil {
 		t.Fatalf("init staging: %v\nstderr: %s", err, stderr)

--- a/pkg/runtime/shell/anchor.go
+++ b/pkg/runtime/shell/anchor.go
@@ -1,0 +1,74 @@
+package shell
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// The anchor.go file provides pure filesystem-walk helpers used by `windsor
+// init` to verify project identity before any runtime is constructed:
+//   - EnsureGitRepository asserts the cwd is inside a git repository, since
+//     Windsor relies on git for trusted-directory ownership and blueprint refs.
+//   - EnsureProjectAnchor writes a minimal windsor.yaml in the cwd when no
+//     project file exists anywhere up the walk, preventing init from falling
+//     back to the global $HOME config and silently operating against it.
+// Both functions are stateless and exported so cmd/ stays a thin cobra layer.
+
+// =============================================================================
+// Public Functions
+// =============================================================================
+
+// EnsureGitRepository returns an actionable error when no .git entry exists at
+// or above the current working directory. Windsor relies on git for project-
+// state ownership (trusted directories, blueprint refs, terraform state
+// placement); running init in a bare directory produces opaque errors
+// downstream, so the missing-repo case is surfaced here with a one-line
+// operator hint. The walk caps at MaxFolderSearchDepth to match GetProjectRoot.
+func EnsureGitRepository() error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get working directory: %w", err)
+	}
+	dir := cwd
+	for i := 0; i <= MaxFolderSearchDepth; i++ {
+		if _, err := os.Stat(filepath.Join(dir, ".git")); err == nil {
+			return nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	return fmt.Errorf("windsor init must run inside a git repository. Run 'git init' first")
+}
+
+// EnsureProjectAnchor writes a minimal windsor.yaml in the current working
+// directory when no project file is found anywhere in the walk-up path. This
+// anchors `windsor init` to the cwd so subsequent runtime resolution does not
+// fall back to global mode and silently operate against $HOME/.config/windsor.
+// If a project file already exists at or above the cwd, this is a no-op.
+func EnsureProjectAnchor() error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get working directory: %w", err)
+	}
+	dir := cwd
+	for i := 0; i <= MaxFolderSearchDepth; i++ {
+		if _, err := os.Stat(filepath.Join(dir, "windsor.yaml")); err == nil {
+			return nil
+		}
+		if _, err := os.Stat(filepath.Join(dir, "windsor.yml")); err == nil {
+			return nil
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	// windsor.yaml is user-readable project config, 0644 matches the project
+	// convention used by typed_source.EnsureRoot.
+	return os.WriteFile(filepath.Join(cwd, "windsor.yaml"), []byte("version: v1alpha1\n"), 0644) // #nosec G306
+}

--- a/pkg/runtime/shell/anchor_test.go
+++ b/pkg/runtime/shell/anchor_test.go
@@ -1,0 +1,183 @@
+package shell
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEnsureProjectAnchor(t *testing.T) {
+	setup := func(t *testing.T) string {
+		t.Helper()
+		origDir, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("Failed to get working directory: %v", err)
+		}
+		tmpDir := t.TempDir()
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatalf("Failed to chdir: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = os.Chdir(origDir)
+		})
+		// Isolate HOME so a real global windsor.yaml doesn't shortcut detection.
+		t.Setenv("HOME", tmpDir)
+		// Resolve any symlinks (macOS /var -> /private/var) so our string compare matches.
+		resolved, err := filepath.EvalSymlinks(tmpDir)
+		if err != nil {
+			return tmpDir
+		}
+		return resolved
+	}
+
+	t.Run("WritesMinimalWindsorYamlWhenNoProjectExists", func(t *testing.T) {
+		// Given an empty directory
+		tmpDir := setup(t)
+
+		// When EnsureProjectAnchor is called
+		if err := EnsureProjectAnchor(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then a minimal windsor.yaml should be created in cwd
+		data, err := os.ReadFile(filepath.Join(tmpDir, "windsor.yaml"))
+		if err != nil {
+			t.Fatalf("Expected windsor.yaml to exist, got %v", err)
+		}
+		if !strings.Contains(string(data), "version: v1alpha1") {
+			t.Errorf("Expected minimal v1alpha1 root config, got: %s", string(data))
+		}
+	})
+
+	t.Run("NoOpWhenProjectAlreadyExistsInCwd", func(t *testing.T) {
+		// Given a directory that already has windsor.yaml
+		tmpDir := setup(t)
+		existing := []byte("version: v1alpha1\ncustom: preserved\n")
+		if err := os.WriteFile(filepath.Join(tmpDir, "windsor.yaml"), existing, 0644); err != nil {
+			t.Fatalf("Failed to seed windsor.yaml: %v", err)
+		}
+
+		// When EnsureProjectAnchor is called
+		if err := EnsureProjectAnchor(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the existing file should not be overwritten
+		data, err := os.ReadFile(filepath.Join(tmpDir, "windsor.yaml"))
+		if err != nil {
+			t.Fatalf("Expected windsor.yaml to exist, got %v", err)
+		}
+		if string(data) != string(existing) {
+			t.Errorf("Expected existing windsor.yaml preserved, got: %s", string(data))
+		}
+	})
+
+	t.Run("NoOpWhenProjectExistsInParentDirectory", func(t *testing.T) {
+		// Given a parent directory containing windsor.yaml and a cwd below it
+		tmpDir := setup(t)
+		subDir := filepath.Join(tmpDir, "sub")
+		if err := os.MkdirAll(subDir, 0755); err != nil {
+			t.Fatalf("Failed to create subdir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(tmpDir, "windsor.yaml"), []byte("version: v1alpha1\n"), 0644); err != nil {
+			t.Fatalf("Failed to seed windsor.yaml: %v", err)
+		}
+		if err := os.Chdir(subDir); err != nil {
+			t.Fatalf("Failed to chdir to subdir: %v", err)
+		}
+
+		// When EnsureProjectAnchor is called
+		if err := EnsureProjectAnchor(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then no windsor.yaml should be created in the subdir
+		if _, err := os.Stat(filepath.Join(subDir, "windsor.yaml")); err == nil {
+			t.Error("Expected no windsor.yaml in subdir (parent already has one)")
+		}
+	})
+}
+
+func TestEnsureGitRepository(t *testing.T) {
+	setup := func(t *testing.T) string {
+		t.Helper()
+		origDir, err := os.Getwd()
+		if err != nil {
+			t.Fatalf("Failed to get working directory: %v", err)
+		}
+		tmpDir := t.TempDir()
+		if err := os.Chdir(tmpDir); err != nil {
+			t.Fatalf("Failed to chdir: %v", err)
+		}
+		t.Cleanup(func() {
+			_ = os.Chdir(origDir)
+		})
+		// Isolate HOME so a real ~/.git doesn't shortcut detection.
+		t.Setenv("HOME", tmpDir)
+		resolved, err := filepath.EvalSymlinks(tmpDir)
+		if err != nil {
+			return tmpDir
+		}
+		return resolved
+	}
+
+	t.Run("ReturnsNilWhenGitDirInCwd", func(t *testing.T) {
+		// Given a directory with .git/
+		tmpDir := setup(t)
+		if err := os.MkdirAll(filepath.Join(tmpDir, ".git"), 0755); err != nil {
+			t.Fatalf("Failed to create .git: %v", err)
+		}
+
+		if err := EnsureGitRepository(); err != nil {
+			t.Errorf("Expected no error with .git present, got %v", err)
+		}
+	})
+
+	t.Run("ReturnsNilWhenGitFileInCwd", func(t *testing.T) {
+		// Given a directory with .git as a file (worktree / submodule layout)
+		tmpDir := setup(t)
+		if err := os.WriteFile(filepath.Join(tmpDir, ".git"), []byte("gitdir: ../parent/.git/worktrees/x\n"), 0644); err != nil {
+			t.Fatalf("Failed to create .git file: %v", err)
+		}
+
+		if err := EnsureGitRepository(); err != nil {
+			t.Errorf("Expected no error with .git file present, got %v", err)
+		}
+	})
+
+	t.Run("ReturnsNilWhenGitDirInParent", func(t *testing.T) {
+		// Given a parent directory with .git/ and a cwd below it
+		tmpDir := setup(t)
+		if err := os.MkdirAll(filepath.Join(tmpDir, ".git"), 0755); err != nil {
+			t.Fatalf("Failed to create .git: %v", err)
+		}
+		subDir := filepath.Join(tmpDir, "sub")
+		if err := os.MkdirAll(subDir, 0755); err != nil {
+			t.Fatalf("Failed to create subdir: %v", err)
+		}
+		if err := os.Chdir(subDir); err != nil {
+			t.Fatalf("Failed to chdir to subdir: %v", err)
+		}
+
+		if err := EnsureGitRepository(); err != nil {
+			t.Errorf("Expected no error walking up to parent .git, got %v", err)
+		}
+	})
+
+	t.Run("ReturnsActionableErrorWhenNoGit", func(t *testing.T) {
+		// Given a directory with no .git anywhere up the walk
+		_ = setup(t)
+
+		err := EnsureGitRepository()
+		if err == nil {
+			t.Fatal("Expected error when no .git present, got nil")
+		}
+		if !strings.Contains(err.Error(), "must run inside a git repository") {
+			t.Errorf("Expected hint about git repository, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "git init") {
+			t.Errorf("Expected suggestion to run 'git init', got: %v", err)
+		}
+	})
+}

--- a/pkg/runtime/shell/shell.go
+++ b/pkg/runtime/shell/shell.go
@@ -26,10 +26,9 @@ import (
 // Constants
 // =============================================================================
 
-// MaxFolderSearchDepth is the maximum depth to search for the project root.
-// Exported so callers performing their own walk-up (e.g. ensureProjectAnchor in
-// cmd/init.go) can match the traversal bounds GetProjectRoot uses, preventing
-// divergence where one finds an ancestor windsor.yaml that the other misses.
+// MaxFolderSearchDepth is the maximum depth to search for the project root,
+// shared by GetProjectRoot and the EnsureGitRepository / EnsureProjectAnchor
+// helpers so all walk-up traversals stop at the same boundary.
 const MaxFolderSearchDepth = 10
 
 // SessionTokenPrefix is the prefix used for session token files


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> A shared integration test helper now injects a fake `.git/` directory into every fixture it creates, which could silently corrupt the "no git" baseline for non-init tests.
>
> **Overview**
>
> This PR extracts `ensureProjectAnchor` from `cmd/init.go` into the `shell` package as the exported `EnsureProjectAnchor`, and pairs it with a new `EnsureGitRepository` guard that fails fast when `windsor init` is run outside any git repository. The change also migrates the associated unit tests to `pkg/runtime/shell/anchor_test.go`, adds a matching integration test that pins the user-facing error message, and updates the `MaxFolderSearchDepth` comment to name both new helpers.
>
> The guard itself is sound — it walks up via `os.Stat(".git")` within `MaxFolderSearchDepth`, handles both `.git/` directories and `.git` files (worktrees/submodules), and surfaces an actionable hint. The structural concern is in `integration/helpers/helpers.go`: `CopyFixtureOnly` now unconditionally creates an empty `.git/` in every fixture workdir rather than delegating that setup to the tests that require it.
>
> Reviewed by Claude for commit `02c61c73`.

<!-- /claude-code-review:summary -->
