### PR TITLE
fix(network): sharpen Linux DNS detection and Windows NRPT compare

### DIFF
--- a/cmd/helpers_test.go
+++ b/cmd/helpers_test.go
@@ -211,6 +211,9 @@ func NewMockShellWithCapture(capture *ShellCapture) *shell.MockShell {
 	}
 	m.ExecSilentFunc = func(command string, args ...string) (string, error) {
 		capture.SilentCalls = append(capture.SilentCalls, ShellCall{Command: command, Args: args})
+		if command == "systemctl" && len(args) == 2 && args[0] == "is-active" && args[1] == "systemd-resolved" {
+			return "active", nil
+		}
 		return "", nil
 	}
 	m.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {

--- a/pkg/workstation/network/linux_network.go
+++ b/pkg/workstation/network/linux_network.go
@@ -17,6 +17,15 @@ import (
 // ensuring proper network connectivity between the host and guest VM environments.
 
 // =============================================================================
+// Constants
+// =============================================================================
+
+// systemdResolvedRequiredHint surfaces when either the resolved service is not
+// active or /etc/resolv.conf does not point at its stub. Names the supported
+// distros + the manual-config escape hatch for distros without systemd-resolved.
+const systemdResolvedRequiredHint = "DNS configuration on this distro requires systemd-resolved, which is not running. Windsor's supported Linux DNS setup uses a systemd-resolved drop-in at /etc/systemd/resolved.conf.d/. To enable: 'sudo systemctl enable --now systemd-resolved' (Ubuntu/Debian/Fedora/openSUSE), then re-run 'windsor configure network'. If your distro doesn't ship systemd-resolved (Alpine, Void, Devuan, NixOS, Slackware), you'll need to wire DNS manually — add 'nameserver <address>' for *.<domain> via your distro's resolver (resolvconf, dnsmasq, unbound). See docs/guides/troubleshooting.md#dns-on-non-systemd-linux."
+
+// =============================================================================
 // Public Methods
 // =============================================================================
 
@@ -70,9 +79,10 @@ func (n *BaseNetworkManager) ConfigureHostRoute() error {
 	return nil
 }
 
-// ConfigureDNS configures systemd-resolved so only the configured dns.domain uses our resolver;
-// global DNS is unchanged. Resolver IP is read from config (dns.resolver_ip, or derived: 127.0.0.1 in
-// localhost mode, else dns.address).
+// ConfigureDNS installs a systemd-resolved drop-in scoping dns.domain to our resolver; global DNS is
+// unchanged. Probes `systemctl is-active systemd-resolved` first so distros that don't ship resolved
+// fail with an actionable hint, and warns non-fatally when NetworkManager's `dns=default` mode would
+// rewrite /etc/resolv.conf and shadow the drop-in.
 func (n *BaseNetworkManager) ConfigureDNS() error {
 	domain := n.configHandler.GetString("dns.domain")
 	if domain == "" {
@@ -87,9 +97,13 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 		return fmt.Errorf("DNS address is not configured")
 	}
 
+	if status, err := n.shell.ExecSilent("systemctl", "is-active", "systemd-resolved"); err != nil || strings.TrimSpace(status) != "active" {
+		return fmt.Errorf("%s", systemdResolvedRequiredHint)
+	}
+
 	resolvConf, err := n.shims.ReadLink("/etc/resolv.conf")
 	if err != nil || !isSystemdResolvedStubLink(resolvConf) {
-		return fmt.Errorf("systemd-resolved is not in use. Please configure DNS manually or use a compatible system")
+		return fmt.Errorf("%s", systemdResolvedRequiredHint)
 	}
 
 	dropInDir := "/etc/systemd/resolved.conf.d"
@@ -117,6 +131,10 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 
 	if _, err := n.shell.ExecSudo("", "systemctl", "restart", "systemd-resolved"); err != nil {
 		return fmt.Errorf("failed to restart systemd-resolved: %w", err)
+	}
+
+	if msg := n.networkManagerShadowsResolverWarning(domain); msg != "" {
+		fmt.Fprintln(os.Stderr, msg)
 	}
 
 	return nil
@@ -201,6 +219,61 @@ func (n *BaseNetworkManager) needsPrivilegeForResolver(desiredIP string) bool {
 	}
 	expectedContent := fmt.Sprintf("[Resolve]\nDomains=~%s\nDNS=%s\n", domain, desiredIP)
 	return string(existingContent) != expectedContent
+}
+
+// networkManagerShadowsResolverWarning returns a non-fatal hint when NM is active and configured to
+// rewrite /etc/resolv.conf directly (dns=default, or dns= unset). Walks NetworkManager.conf then
+// conf.d/*.conf in lexical order — last [main] dns= wins. Returns "" otherwise.
+func (n *BaseNetworkManager) networkManagerShadowsResolverWarning(domain string) string {
+	status, err := n.shell.ExecSilent("systemctl", "is-active", "NetworkManager")
+	if err != nil || strings.TrimSpace(status) != "active" {
+		return ""
+	}
+
+	paths := []string{"/etc/NetworkManager/NetworkManager.conf"}
+	if matches, _ := n.shims.Glob("/etc/NetworkManager/conf.d/*.conf"); len(matches) > 0 {
+		paths = append(paths, matches...)
+	}
+	dnsSetting := ""
+	for _, p := range paths {
+		if v, ok := readNetworkManagerMainDNS(n.shims.ReadFile, p); ok {
+			dnsSetting = v
+		}
+	}
+
+	if dnsSetting != "" && dnsSetting != "default" {
+		return ""
+	}
+	return fmt.Sprintf("\n\033[33m⚠\033[0m NetworkManager is configured with 'dns=default' (or unset). NM will rewrite /etc/resolv.conf directly, which can shadow the systemd-resolved drop-in this command just wrote. If '*.%s' fails to resolve after this, add 'dns=systemd-resolved' to /etc/NetworkManager/conf.d/dns.conf and run 'sudo systemctl reload NetworkManager'.", domain)
+}
+
+// readNetworkManagerMainDNS parses an NM-style INI file and returns the dns=
+// value from the [main] section if present. Honors comments (# and ;) and is
+// section-aware so a stray `dns=` in `[connection]` or similar doesn't leak.
+func readNetworkManagerMainDNS(readFile func(string) ([]byte, error), path string) (value string, found bool) {
+	data, err := readFile(path)
+	if err != nil {
+		return "", false
+	}
+	inMain := false
+	for _, raw := range strings.Split(string(data), "\n") {
+		line := strings.TrimSpace(raw)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, ";") {
+			continue
+		}
+		if strings.HasPrefix(line, "[") && strings.HasSuffix(line, "]") {
+			inMain = line == "[main]"
+			continue
+		}
+		if !inMain {
+			continue
+		}
+		parts := strings.SplitN(line, "=", 2)
+		if len(parts) == 2 && strings.TrimSpace(parts[0]) == "dns" {
+			return strings.TrimSpace(parts[1]), true
+		}
+	}
+	return "", false
 }
 
 // needsPrivilegeForHostRoute reports whether sudo is required to add the host route for the guest.

--- a/pkg/workstation/network/linux_network.go
+++ b/pkg/workstation/network/linux_network.go
@@ -20,10 +20,16 @@ import (
 // Constants
 // =============================================================================
 
-// systemdResolvedRequiredHint surfaces when either the resolved service is not
-// active or /etc/resolv.conf does not point at its stub. Names the supported
-// distros + the manual-config escape hatch for distros without systemd-resolved.
-const systemdResolvedRequiredHint = "DNS configuration on this distro requires systemd-resolved, which is not running. Windsor's supported Linux DNS setup uses a systemd-resolved drop-in at /etc/systemd/resolved.conf.d/. To enable: 'sudo systemctl enable --now systemd-resolved' (Ubuntu/Debian/Fedora/openSUSE), then re-run 'windsor configure network'. If your distro doesn't ship systemd-resolved (Alpine, Void, Devuan, NixOS, Slackware), you'll need to wire DNS manually — add 'nameserver <address>' for *.<domain> via your distro's resolver (resolvconf, dnsmasq, unbound). See docs/guides/troubleshooting.md#dns-on-non-systemd-linux."
+// systemdResolvedNotRunningHint surfaces when `systemctl is-active systemd-resolved` reports
+// inactive. Names the supported distros + the manual-config escape hatch for distros that
+// don't ship systemd-resolved at all (Alpine, Void, NixOS, etc.).
+const systemdResolvedNotRunningHint = "DNS configuration on this distro requires systemd-resolved, which is not running. Windsor's supported Linux DNS setup uses a systemd-resolved drop-in at /etc/systemd/resolved.conf.d/. To enable: 'sudo systemctl enable --now systemd-resolved' (Ubuntu/Debian/Fedora/openSUSE), then re-run 'windsor configure network'. If your distro doesn't ship systemd-resolved (Alpine, Void, Devuan, NixOS, Slackware), you'll need to wire DNS manually — add 'nameserver <address>' for *.<domain> via your distro's resolver (resolvconf, dnsmasq, unbound). See docs/guides/troubleshooting.md#dns-on-non-systemd-linux."
+
+// systemdResolvedSymlinkHint surfaces when the resolved service is active but /etc/resolv.conf
+// does not symlink to its stub. The drop-in we'd write would be ignored in that state because
+// resolv.conf bypasses resolved entirely. Common causes: NetworkManager with `dns=default`,
+// manual edits, or distro defaults that haven't switched over.
+const systemdResolvedSymlinkHint = "systemd-resolved is active but /etc/resolv.conf is not pointing at its stub resolver, so any drop-in we write would be ignored. Restore the symlink with 'sudo ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf', then re-run 'windsor configure network'. If NetworkManager keeps rewriting /etc/resolv.conf, set 'dns=systemd-resolved' in /etc/NetworkManager/conf.d/dns.conf and reload NetworkManager. See docs/guides/troubleshooting.md#dns-on-non-systemd-linux."
 
 // =============================================================================
 // Public Methods
@@ -98,12 +104,12 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 	}
 
 	if status, err := n.shell.ExecSilent("systemctl", "is-active", "systemd-resolved"); err != nil || strings.TrimSpace(status) != "active" {
-		return fmt.Errorf("%s", systemdResolvedRequiredHint)
+		return fmt.Errorf("%s", systemdResolvedNotRunningHint)
 	}
 
 	resolvConf, err := n.shims.ReadLink("/etc/resolv.conf")
 	if err != nil || !isSystemdResolvedStubLink(resolvConf) {
-		return fmt.Errorf("%s", systemdResolvedRequiredHint)
+		return fmt.Errorf("%s", systemdResolvedSymlinkHint)
 	}
 
 	dropInDir := "/etc/systemd/resolved.conf.d"

--- a/pkg/workstation/network/linux_network.go
+++ b/pkg/workstation/network/linux_network.go
@@ -250,7 +250,7 @@ func (n *BaseNetworkManager) networkManagerShadowsResolverWarning(domain string)
 	if dnsSetting != "" && dnsSetting != "default" {
 		return ""
 	}
-	return fmt.Sprintf("\n\033[33m⚠\033[0m NetworkManager is configured with 'dns=default' (or unset). NM will rewrite /etc/resolv.conf directly, which can shadow the systemd-resolved drop-in this command just wrote. If '*.%s' fails to resolve after this, add 'dns=systemd-resolved' to /etc/NetworkManager/conf.d/dns.conf and run 'sudo systemctl reload NetworkManager'.", domain)
+	return fmt.Sprintf("\n⚠ NetworkManager is configured with 'dns=default' (or unset). NM will rewrite /etc/resolv.conf directly, which can shadow the systemd-resolved drop-in this command just wrote. If '*.%s' fails to resolve after this, add 'dns=systemd-resolved' to /etc/NetworkManager/conf.d/dns.conf and run 'sudo systemctl reload NetworkManager'.", domain)
 }
 
 // readNetworkManagerMainDNS parses an NM-style INI file and returns the dns=

--- a/pkg/workstation/network/linux_network_test.go
+++ b/pkg/workstation/network/linux_network_test.go
@@ -6,6 +6,7 @@ package network
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -664,6 +665,7 @@ func TestLinuxNetworkManager_NetworkManagerShadowsResolverWarning(t *testing.T) 
 					matches = append(matches, path)
 				}
 			}
+			sort.Strings(matches)
 			return matches, nil
 		}
 	}

--- a/pkg/workstation/network/linux_network_test.go
+++ b/pkg/workstation/network/linux_network_test.go
@@ -289,21 +289,24 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 		// When configuring DNS
 		err := manager.ConfigureDNS()
 
-		// Then the operator-facing hint surfaces — names the supported distros
-		// and points at the manual-config escape hatch for unsupported ones
+		// Then the symlink-specific hint surfaces — names the actual condition
+		// and points at the symlink recovery, not 'systemctl enable --now'
 		if err == nil {
 			t.Fatalf("expected error, got nil")
 		}
 		for _, want := range []string{
-			"systemd-resolved",
-			"sudo systemctl enable --now systemd-resolved",
-			"Ubuntu/Debian/Fedora/openSUSE",
-			"Alpine, Void, Devuan, NixOS, Slackware",
+			"systemd-resolved is active but /etc/resolv.conf is not pointing at its stub",
+			"sudo ln -sf /run/systemd/resolve/stub-resolv.conf /etc/resolv.conf",
+			"NetworkManager",
 			"troubleshooting.md#dns-on-non-systemd-linux",
 		} {
 			if !strings.Contains(err.Error(), want) {
 				t.Errorf("expected hint to include %q, got: %s", want, err.Error())
 			}
+		}
+		// And the not-running hint's signature phrase MUST NOT appear here
+		if strings.Contains(err.Error(), "which is not running") {
+			t.Errorf("expected symlink hint, got not-running hint: %s", err.Error())
 		}
 	})
 

--- a/pkg/workstation/network/linux_network_test.go
+++ b/pkg/workstation/network/linux_network_test.go
@@ -279,25 +279,55 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 		}
 	})
 
-	t.Run("SystemdResolvedNotInUse", func(t *testing.T) {
-		// Given a network manager with systemd-resolved not in use
+	t.Run("ResolvConfNotPointingAtStubReturnsActionableHint", func(t *testing.T) {
+		// Given systemd-resolved is active but /etc/resolv.conf is not its stub
 		manager, mocks := setup(t)
-
-		// And mocking systemd-resolved being in use
 		mocks.Shims.ReadLink = func(_ string) (string, error) {
 			return "/etc/resolv.conf", nil
 		}
 
-		// And configuring DNS
+		// When configuring DNS
 		err := manager.ConfigureDNS()
 
-		// Then an error should occur
+		// Then the operator-facing hint surfaces — names the supported distros
+		// and points at the manual-config escape hatch for unsupported ones
 		if err == nil {
 			t.Fatalf("expected error, got nil")
 		}
-		expectedError := "systemd-resolved is not in use. Please configure DNS manually or use a compatible system"
-		if !strings.Contains(err.Error(), expectedError) {
-			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
+		for _, want := range []string{
+			"systemd-resolved",
+			"sudo systemctl enable --now systemd-resolved",
+			"Ubuntu/Debian/Fedora/openSUSE",
+			"Alpine, Void, Devuan, NixOS, Slackware",
+			"troubleshooting.md#dns-on-non-systemd-linux",
+		} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("expected hint to include %q, got: %s", want, err.Error())
+			}
+		}
+	})
+
+	t.Run("SystemctlInactiveReturnsActionableHint", func(t *testing.T) {
+		// Given systemd-resolved is not active (distros without it shipped:
+		// Alpine, Void, etc., or systems where the operator disabled it)
+		manager, mocks := setup(t)
+		mocks.Shell.ExecSilentFunc = func(command string, args ...string) (string, error) {
+			if command == "systemctl" && len(args) == 2 && args[0] == "is-active" && args[1] == "systemd-resolved" {
+				return "inactive", fmt.Errorf("exit status 3")
+			}
+			return "", nil
+		}
+
+		// When configuring DNS
+		err := manager.ConfigureDNS()
+
+		// Then the same operator-facing hint surfaces — the symlink check is
+		// not reached, but the hint copy works for both failure modes
+		if err == nil {
+			t.Fatalf("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "systemd-resolved, which is not running") {
+			t.Errorf("expected hint mentioning systemd-resolved not running, got: %s", err.Error())
 		}
 	})
 
@@ -590,6 +620,130 @@ func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {
 		// Then the deferred cleanup removed the same temp directory the helper created
 		if removedPath != "/tmp/windsor-net-mock" {
 			t.Fatalf("expected temp dir cleanup of %q, got %q", "/tmp/windsor-net-mock", removedPath)
+		}
+	})
+}
+
+func TestLinuxNetworkManager_NetworkManagerShadowsResolverWarning(t *testing.T) {
+	setup := func(t *testing.T) (*BaseNetworkManager, *NetworkTestMocks) {
+		t.Helper()
+		mocks := setupNetworkMocks(t)
+		manager := NewBaseNetworkManager(mocks.Runtime)
+		manager.shims = mocks.Shims
+		return manager, mocks
+	}
+
+	// nmActiveAndConfig wires the systemctl probe to report NetworkManager
+	// active, and stubs ReadFile + Glob to return the supplied main config and
+	// optional conf.d overrides keyed by path.
+	nmActiveAndConfig := func(mocks *NetworkTestMocks, files map[string]string) {
+		mocks.Shell.ExecSilentFunc = func(command string, args ...string) (string, error) {
+			if command == "systemctl" && len(args) == 2 && args[0] == "is-active" {
+				if args[1] == "systemd-resolved" || args[1] == "NetworkManager" {
+					return "active", nil
+				}
+			}
+			return "", nil
+		}
+		mocks.Shims.ReadFile = func(path string) ([]byte, error) {
+			if body, ok := files[path]; ok {
+				return []byte(body), nil
+			}
+			return nil, os.ErrNotExist
+		}
+		mocks.Shims.Glob = func(pattern string) ([]string, error) {
+			if pattern != "/etc/NetworkManager/conf.d/*.conf" {
+				return nil, nil
+			}
+			var matches []string
+			for path := range files {
+				if strings.HasPrefix(path, "/etc/NetworkManager/conf.d/") {
+					matches = append(matches, path)
+				}
+			}
+			return matches, nil
+		}
+	}
+
+	t.Run("NoWarningWhenNetworkManagerInactive", func(t *testing.T) {
+		manager, mocks := setup(t)
+		mocks.Shell.ExecSilentFunc = func(command string, args ...string) (string, error) {
+			if command == "systemctl" && len(args) == 2 && args[0] == "is-active" && args[1] == "NetworkManager" {
+				return "inactive", fmt.Errorf("exit status 3")
+			}
+			if command == "systemctl" && len(args) == 2 && args[0] == "is-active" && args[1] == "systemd-resolved" {
+				return "active", nil
+			}
+			return "", nil
+		}
+
+		if msg := manager.networkManagerShadowsResolverWarning("example.com"); msg != "" {
+			t.Errorf("expected no warning when NM inactive, got: %s", msg)
+		}
+	})
+
+	t.Run("WarnsWhenDnsExplicitlyDefault", func(t *testing.T) {
+		manager, mocks := setup(t)
+		nmActiveAndConfig(mocks, map[string]string{
+			"/etc/NetworkManager/NetworkManager.conf": "[main]\ndns=default\n",
+		})
+
+		msg := manager.networkManagerShadowsResolverWarning("local.test")
+		if msg == "" {
+			t.Fatal("expected warning for dns=default, got empty string")
+		}
+		for _, want := range []string{"dns=default", "local.test", "dns=systemd-resolved"} {
+			if !strings.Contains(msg, want) {
+				t.Errorf("expected warning to include %q, got: %s", want, msg)
+			}
+		}
+	})
+
+	t.Run("WarnsWhenDnsKeyMissingFromMainSection", func(t *testing.T) {
+		manager, mocks := setup(t)
+		nmActiveAndConfig(mocks, map[string]string{
+			"/etc/NetworkManager/NetworkManager.conf": "[main]\nplugins=keyfile\n",
+		})
+
+		if msg := manager.networkManagerShadowsResolverWarning("example.com"); msg == "" {
+			t.Error("expected warning when dns= is unset (NM treats unset as default)")
+		}
+	})
+
+	t.Run("NoWarningWhenDnsExplicitlyDefersToSystemdResolved", func(t *testing.T) {
+		manager, mocks := setup(t)
+		nmActiveAndConfig(mocks, map[string]string{
+			"/etc/NetworkManager/NetworkManager.conf": "[main]\ndns=systemd-resolved\n",
+		})
+
+		if msg := manager.networkManagerShadowsResolverWarning("example.com"); msg != "" {
+			t.Errorf("expected no warning when dns=systemd-resolved, got: %s", msg)
+		}
+	})
+
+	t.Run("ConfDOverridesMainConfig", func(t *testing.T) {
+		// Given main says dns=default but conf.d overrides to systemd-resolved
+		manager, mocks := setup(t)
+		nmActiveAndConfig(mocks, map[string]string{
+			"/etc/NetworkManager/NetworkManager.conf":     "[main]\ndns=default\n",
+			"/etc/NetworkManager/conf.d/dns-override.conf": "[main]\ndns=systemd-resolved\n",
+		})
+
+		if msg := manager.networkManagerShadowsResolverWarning("example.com"); msg != "" {
+			t.Errorf("expected no warning when conf.d overrides to systemd-resolved, got: %s", msg)
+		}
+	})
+
+	t.Run("DnsSettingInWrongSectionIsIgnored", func(t *testing.T) {
+		// Given dns= appears outside [main]
+		manager, mocks := setup(t)
+		nmActiveAndConfig(mocks, map[string]string{
+			"/etc/NetworkManager/NetworkManager.conf": "[connection]\ndns=systemd-resolved\n",
+		})
+
+		// Then no main setting is found and the warning still fires (unset == default)
+		if msg := manager.networkManagerShadowsResolverWarning("example.com"); msg == "" {
+			t.Error("expected warning when dns= is outside [main] (it doesn't count)")
 		}
 	})
 }

--- a/pkg/workstation/network/network_test.go
+++ b/pkg/workstation/network/network_test.go
@@ -36,6 +36,7 @@ func setupDefaultShims() *Shims {
 		MkdirAll:  func(path string, perm os.FileMode) error { return nil },
 		MkdirTemp: func(dir, pattern string) (string, error) { return "/tmp/windsor-test", nil },
 		RemoveAll: func(path string) error { return nil },
+		Glob:      func(pattern string) ([]string, error) { return nil, nil },
 	}
 }
 
@@ -94,6 +95,11 @@ contexts:
 		return "", nil
 	}
 	mockShell.ExecSilentFunc = func(command string, args ...string) (string, error) {
+		// Default systemd-resolved as active so existing tests pass the
+		// ConfigureDNS preflight without each one re-mocking the probe.
+		if command == "systemctl" && len(args) == 2 && args[0] == "is-active" && args[1] == "systemd-resolved" {
+			return "active", nil
+		}
 		return "", nil
 	}
 	mockShell.ExecSilentWithTimeoutFunc = func(command string, args []string, timeout time.Duration) (string, error) {

--- a/pkg/workstation/network/shims.go
+++ b/pkg/workstation/network/shims.go
@@ -3,6 +3,7 @@ package network
 import (
 	"net"
 	"os"
+	"path/filepath"
 	"runtime"
 )
 
@@ -25,6 +26,7 @@ type Shims struct {
 	MkdirAll  func(string, os.FileMode) error
 	MkdirTemp func(dir, pattern string) (string, error)
 	RemoveAll func(string) error
+	Glob      func(pattern string) ([]string, error)
 }
 
 // NetworkInterfaceProvider abstracts the system's network interface operations
@@ -60,6 +62,7 @@ func NewShims() *Shims {
 		MkdirAll:  os.MkdirAll,
 		MkdirTemp: os.MkdirTemp,
 		RemoveAll: os.RemoveAll,
+		Glob:      filepath.Glob,
 	}
 }
 

--- a/pkg/workstation/network/windows_network.go
+++ b/pkg/workstation/network/windows_network.go
@@ -72,10 +72,10 @@ func (n *BaseNetworkManager) ConfigureHostRoute() error {
 	return nil
 }
 
-// ConfigureDNS sets up a per-domain DNS rule using Windows NRPT. Resolver IP is read from config
-// (dns.resolver_ip, or derived: 127.0.0.1 in localhost mode, else dns.address). The domain is normalized
-// to a leading-dot namespace for NRPT. If no matching rule exists or the rule's name servers differ,
-// an add or update is performed with administrator privileges.
+// ConfigureDNS installs a per-domain NRPT rule for dns.domain. The existence check returns the rule's
+// NameServers comma-joined; Go parses the first entry and compares against the desired IP, matching
+// needsPrivilegeForResolver so rules carrying extra operator-added entries are not rewritten on every
+// run. Privileged add/update fires only on first-IP mismatch.
 func (n *BaseNetworkManager) ConfigureDNS() error {
 	domain := n.configHandler.GetString("dns.domain")
 	if domain == "" {
@@ -97,19 +97,9 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 	namespace := "." + domain
 
 	checkScript := fmt.Sprintf(`
-$namespace = '%s'
-$allRules = Get-DnsClientNrptRule
-$existingRule = $allRules | Where-Object { $_.Namespace -eq $namespace }
-if ($existingRule) {
-  if (($existingRule.NameServers -join ',') -ne "%s") {
-    $false
-  } else {
-    $true
-  }
-} else {
-  $false
-}
-`, namespace, dns)
+$r = Get-DnsClientNrptRule | Where-Object { $_.Namespace -eq '%s' } | Select-Object -First 1
+if (-not $r) { '' } else { ($r.NameServers -join ',') }
+`, namespace)
 
 	output, err := n.shell.ExecSilent(
 		"powershell",
@@ -120,7 +110,12 @@ if ($existingRule) {
 		return fmt.Errorf("failed to check existing DNS rules for %s: %w", domain, err)
 	}
 
-	if strings.TrimSpace(output) == "False" || output == "" {
+	currentIP := strings.TrimSpace(output)
+	if idx := strings.Index(currentIP, ","); idx > 0 {
+		currentIP = strings.TrimSpace(currentIP[:idx])
+	}
+
+	if currentIP != dns {
 		n.dnsChanged = true
 		fmt.Fprintf(os.Stderr, "\n\033[33m⚠\033[0m DNS configuration requires elevated privileges\n")
 

--- a/pkg/workstation/network/windows_network_test.go
+++ b/pkg/workstation/network/windows_network_test.go
@@ -257,26 +257,27 @@ func TestWindowsNetworkManager_ConfigureDNS(t *testing.T) {
 			if command == "powershell" && len(args) > 1 && args[0] == "-Command" {
 				script := args[1]
 				if strings.Contains(script, "Get-DnsClientNrptRule") {
-					// Extract namespace from the script
-					namespaceMatch := strings.Split(script, "$namespace = '")
-					if len(namespaceMatch) > 1 {
-						namespaceParts := strings.Split(namespaceMatch[1], "'")
-						if len(namespaceParts) > 0 {
-							capturedNamespace = namespaceParts[0]
+					// Extract namespace from the check script's Where-Object filter.
+					if match := strings.Split(script, "Namespace -eq '"); len(match) > 1 {
+						parts := strings.SplitN(match[1], "'", 2)
+						if len(parts) > 0 {
+							capturedNamespace = parts[0]
 						}
 					}
-
-					// Extract nameservers from the script — the check joins NameServers before comparing
-					// to handle multi-server NRPT rules, so the right-hand side of -ne is the only place
-					// the literal lives.
-					nameserversMatch := strings.Split(script, "-join ',') -ne \"")
-					if len(nameserversMatch) > 1 {
-						parts := strings.Split(nameserversMatch[1], "\"")
-						if len(parts) > 1 {
-							capturedNameServers = strings.Trim(parts[0], "\"")
-						}
+				}
+			}
+			return "", nil
+		}
+		// The addOrUpdate script (used to actually install the rule) is dispatched
+		// via ExecProgress; its -NameServers parameter is the literal we want.
+		mocks.Shell.ExecProgressFunc = func(message, command string, args ...string) (string, error) {
+			if command == "powershell" && len(args) > 1 && args[0] == "-Command" {
+				script := args[1]
+				if match := strings.Split(script, "-NameServers \""); len(match) > 1 {
+					parts := strings.SplitN(match[1], "\"", 2)
+					if len(parts) > 0 {
+						capturedNameServers = parts[0]
 					}
-					return "", nil
 				}
 			}
 			return "", nil
@@ -299,6 +300,40 @@ func TestWindowsNetworkManager_ConfigureDNS(t *testing.T) {
 		expectedNameServers := "127.0.0.1"
 		if capturedNameServers != expectedNameServers {
 			t.Errorf("expected nameservers to be %q, got %q", expectedNameServers, capturedNameServers)
+		}
+	})
+
+	t.Run("ExistingRuleWithOurIPFirstIsLeftAlone", func(t *testing.T) {
+		// Given an NRPT rule whose first NameServer is our desired IP, followed by
+		// operator-added entries (NameServers comma-joins as "1.2.3.4,5.6.7.8")
+		manager, mocks := setup(t)
+		mocks.ConfigHandler.Set("dns.domain", "example.com")
+		mocks.ConfigHandler.Set("workstation.dns.address", "1.2.3.4")
+
+		var addOrUpdateCalled bool
+		mocks.Shell.ExecSilentFunc = func(command string, args ...string) (string, error) {
+			if command == "powershell" && len(args) > 1 && strings.Contains(args[1], "Get-DnsClientNrptRule") {
+				return "1.2.3.4,5.6.7.8", nil
+			}
+			return "", nil
+		}
+		mocks.Shell.ExecProgressFunc = func(message, command string, args ...string) (string, error) {
+			if command == "powershell" && len(args) > 1 && (strings.Contains(args[1], "Set-DnsClientNrptRule") || strings.Contains(args[1], "Add-DnsClientNrptRule")) {
+				addOrUpdateCalled = true
+			}
+			return "", nil
+		}
+
+		// When configuring DNS
+		if err := manager.ConfigureDNS(); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Then no rewrite is issued — the first NameServer already matches our IP.
+		// The pre-fix comparison ($_.NameServers -join ',' -ne "1.2.3.4") would have
+		// returned $false here and triggered a redundant elevation.
+		if addOrUpdateCalled {
+			t.Errorf("expected no NRPT rewrite when first NameServer already matches; got privileged update")
 		}
 	})
 

--- a/pkg/workstation/network/windows_network_test.go
+++ b/pkg/workstation/network/windows_network_test.go
@@ -502,9 +502,12 @@ func TestWindowsNetworkManager_ConfigureDNS(t *testing.T) {
 		}
 	})
 
-	t.Run("CheckScriptJoinsNameServersBeforeCompare", func(t *testing.T) {
-		// Given the rule check must handle NRPT rules whose NameServers is a multi-element array
-		// (a plain $existingRule.NameServers -ne "<ip>" compares array-to-scalar and always reports mismatch).
+	t.Run("CheckScriptHandlesNameServersAsArray", func(t *testing.T) {
+		// Regression guard for the original array-vs-scalar NRPT bug: a plain
+		// $r.NameServers -ne "<ip>" compares array-to-scalar and always reports mismatch.
+		// The current check joins NameServers and returns the comma-string for Go-side
+		// first-IP comparison (see needsPrivilegeForResolver), so the array case is handled
+		// regardless of where the compare lives.
 		manager, mocks := setup(t)
 		mocks.ConfigHandler.Set("dns.domain", "example.com")
 		mocks.ConfigHandler.Set("workstation.dns.address", "1.2.3.4")
@@ -522,12 +525,15 @@ func TestWindowsNetworkManager_ConfigureDNS(t *testing.T) {
 			t.Fatalf("expected no error, got %v", err)
 		}
 
-		// Then the check script joins NameServers into a comma-separated string before comparing
-		if !strings.Contains(checkScript, "($existingRule.NameServers -join ',') -ne") {
-			t.Fatalf("expected check script to join NameServers before comparing, got: %q", checkScript)
+		// Then the check script must join NameServers (handles the multi-element array)
+		if !strings.Contains(checkScript, "NameServers -join ','") {
+			t.Fatalf("expected check script to join NameServers (handles array), got: %q", checkScript)
 		}
-		if strings.Contains(checkScript, "$existingRule.NameServers -ne") {
-			t.Fatalf("check script still uses the broken array-vs-scalar comparison, got: %q", checkScript)
+		// And must not regress to the broken array-vs-scalar PowerShell comparison
+		for _, broken := range []string{"$existingRule.NameServers -ne", "$r.NameServers -ne"} {
+			if strings.Contains(checkScript, broken) {
+				t.Fatalf("check script still uses the broken array-vs-scalar comparison %q, got: %q", broken, checkScript)
+			}
 		}
 	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> This PR touches shared Linux and Windows DNS configuration logic that runs with elevated privileges and writes system-level files; the risk is concentrated in a misleading error message that could send operators in the wrong direction.
>
> **Overview**
>
> The change adds a preflight `systemctl is-active systemd-resolved` probe to the Linux `ConfigureDNS` path so operators on systemd-free distros receive an actionable error with recovery steps instead of a generic failure. A new `networkManagerShadowsResolverWarning` function warns (non-fatally) when NetworkManager's `dns=default` mode would shadow the drop-in just written. On Windows, the NRPT existence check is rewritten to emit the comma-joined `NameServers` value rather than a boolean, so only the first IP is compared and operator-added extra nameservers no longer trigger a redundant privileged rewrite.
>
> One structural concern spans both error paths on Linux: the single `systemdResolvedRequiredHint` constant is returned both when the service is not running and when the `/etc/resolv.conf` symlink is not pointing at the stub resolver. In the second case systemd-resolved is confirmed active, so the phrase "which is not running" in the hint is factually wrong and points operators at the wrong recovery action.
>
> Reviewed by Claude for commit `da1c484`.

<!-- /claude-code-review:summary -->
