### PR TITLE
fix(network): enhance Windows NRPT handling with PowerShell scripts and GPO warning

### DIFF
--- a/pkg/workstation/network/windows_network.go
+++ b/pkg/workstation/network/windows_network.go
@@ -17,6 +17,55 @@ import (
 // ensuring proper network connectivity between the host and guest VM environments.
 
 // =============================================================================
+// Constants
+// =============================================================================
+
+// NRPT PowerShell scripts read their parameters from $env:WINDSOR_NRPT_* set by the Go side via
+// ExecSilentWithEnv / ExecProgressWithEnv, eliminating fmt.Sprintf interpolation into PowerShell
+// source strings. TF-output-derived values (domain, dns IP) are validated upstream, so this is
+// defense-in-depth, but it also makes the scripts easier to read in isolation.
+
+// nrptCheckScript returns the comma-joined NameServers for the first NRPT rule matching the
+// configured namespace, or empty when no rule exists. Go parses the first entry for compare.
+const nrptCheckScript = `
+$r = Get-DnsClientNrptRule | Where-Object { $_.Namespace -eq $env:WINDSOR_NRPT_NAMESPACE } | Select-Object -First 1
+if (-not $r) { '' } else { ($r.NameServers -join ',') }
+`
+
+// nrptAddOrUpdateScript installs or updates the per-domain NRPT rule with administrator privileges.
+// Display name reads $env:WINDSOR_NRPT_DOMAIN; NameServer reads $env:WINDSOR_NRPT_DNS.
+const nrptAddOrUpdateScript = `
+$namespace = $env:WINDSOR_NRPT_NAMESPACE
+$dns = $env:WINDSOR_NRPT_DNS
+$existingRule = Get-DnsClientNrptRule | Where-Object { $_.Namespace -eq $namespace }
+if ($existingRule) {
+  Set-DnsClientNrptRule -Namespace $namespace -NameServers $dns
+} else {
+  Add-DnsClientNrptRule -Namespace $namespace -NameServers $dns -DisplayName ("Local DNS for " + $env:WINDSOR_NRPT_DOMAIN)
+}
+if ($?) {
+  Clear-DnsClientCache
+}
+`
+
+// nrptRevertScript removes the per-domain NRPT rule. -ErrorAction SilentlyContinue keeps revert
+// idempotent: a missing rule is not an error.
+const nrptRevertScript = `
+Remove-DnsClientNrptRule -Namespace $env:WINDSOR_NRPT_NAMESPACE -Force -ErrorAction SilentlyContinue
+`
+
+// nrptEffectiveFirstNameServerScript returns the first effective NameServer for the configured
+// namespace (post-GPO merge), or empty when no effective rule exists. Used by R23 to detect when a
+// Group Policy is shadowing our local NRPT rule.
+const nrptEffectiveFirstNameServerScript = `
+$rule = Get-DnsClientNrptPolicy -Effective -ErrorAction SilentlyContinue | Where-Object { $_.Namespace -eq $env:WINDSOR_NRPT_NAMESPACE } | Select-Object -First 1
+if ($rule) {
+  $servers = $rule.NameServers -join ','
+  ($servers.Split(',') | Select-Object -First 1).Trim()
+}
+`
+
+// =============================================================================
 // Public Methods
 // =============================================================================
 
@@ -75,7 +124,9 @@ func (n *BaseNetworkManager) ConfigureHostRoute() error {
 // ConfigureDNS installs a per-domain NRPT rule for dns.domain. The existence check returns the rule's
 // NameServers comma-joined; Go parses the first entry and compares against the desired IP, matching
 // needsPrivilegeForResolver so rules carrying extra operator-added entries are not rewritten on every
-// run. Privileged add/update fires only on first-IP mismatch.
+// run. Privileged add/update fires only on first-IP mismatch. After a successful add/update (or when
+// the rule was already correct), probes Get-DnsClientNrptPolicy -Effective and warns non-fatally if
+// a GPO is overriding our rule. PowerShell args pass via $env:WINDSOR_NRPT_* (no string interpolation).
 func (n *BaseNetworkManager) ConfigureDNS() error {
 	domain := n.configHandler.GetString("dns.domain")
 	if domain == "" {
@@ -95,16 +146,17 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 	}
 
 	namespace := "." + domain
+	nrptEnv := map[string]string{
+		"WINDSOR_NRPT_NAMESPACE": namespace,
+		"WINDSOR_NRPT_DNS":       dns,
+		"WINDSOR_NRPT_DOMAIN":    domain,
+	}
 
-	checkScript := fmt.Sprintf(`
-$r = Get-DnsClientNrptRule | Where-Object { $_.Namespace -eq '%s' } | Select-Object -First 1
-if (-not $r) { '' } else { ($r.NameServers -join ',') }
-`, namespace)
-
-	output, err := n.shell.ExecSilent(
+	output, err := n.shell.ExecSilentWithEnv(
 		"powershell",
+		nrptEnv,
 		"-Command",
-		checkScript,
+		nrptCheckScript,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to check existing DNS rules for %s: %w", domain, err)
@@ -119,28 +171,20 @@ if (-not $r) { '' } else { ($r.NameServers -join ',') }
 		n.dnsChanged = true
 		fmt.Fprintf(os.Stderr, "\n\033[33m⚠\033[0m DNS configuration requires elevated privileges\n")
 
-		addOrUpdateScript := fmt.Sprintf(`
-$namespace = '%s'
-$existingRule = Get-DnsClientNrptRule | Where-Object { $_.Namespace -eq $namespace }
-if ($existingRule) {
-  Set-DnsClientNrptRule -Namespace $namespace -NameServers "%s"
-} else {
-  Add-DnsClientNrptRule -Namespace $namespace -NameServers "%s" -DisplayName "Local DNS for %s"
-}
-if ($?) {
-  Clear-DnsClientCache
-}
-`, namespace, dns, dns, domain)
-
-		_, err = n.shell.ExecProgress(
+		_, err = n.shell.ExecProgressWithEnv(
 			fmt.Sprintf("Configuring DNS for '*.%s'", domain),
 			"powershell",
+			nrptEnv,
 			"-Command",
-			addOrUpdateScript,
+			nrptAddOrUpdateScript,
 		)
 		if err != nil {
 			return fmt.Errorf("failed to add or update DNS rule for %s: %w", domain, err)
 		}
+	}
+
+	if msg := n.gpoOverridesNrptRuleWarning(nrptEnv, dns); msg != "" {
+		fmt.Fprintln(os.Stderr, msg)
 	}
 
 	return nil
@@ -180,9 +224,8 @@ func (n *BaseNetworkManager) RevertDNS() error {
 	if err := validateDomain(domain); err != nil {
 		return err
 	}
-	namespace := "." + domain
-	script := fmt.Sprintf("Remove-DnsClientNrptRule -Namespace '%s' -Force -ErrorAction SilentlyContinue", namespace)
-	if _, err := n.shell.ExecSilent("powershell", "-Command", script); err != nil {
+	env := map[string]string{"WINDSOR_NRPT_NAMESPACE": "." + domain}
+	if _, err := n.shell.ExecSilentWithEnv("powershell", env, "-Command", nrptRevertScript); err != nil {
 		return fmt.Errorf("failed to remove DNS rule: %w", err)
 	}
 	return nil
@@ -206,12 +249,8 @@ func (n *BaseNetworkManager) needsPrivilegeForResolver(desiredIP string) bool {
 	if err := validateDomain(domain); err != nil {
 		return false
 	}
-	namespace := "." + domain
-	script := fmt.Sprintf(`
-$r = Get-DnsClientNrptRule | Where-Object { $_.Namespace -eq '%s' } | Select-Object -First 1
-if (-not $r) { '' } else { ($r.NameServers -join ',') }
-`, namespace)
-	output, err := n.shell.ExecSilent("powershell", "-Command", script)
+	env := map[string]string{"WINDSOR_NRPT_NAMESPACE": "." + domain}
+	output, err := n.shell.ExecSilentWithEnv("powershell", env, "-Command", nrptCheckScript)
 	if err != nil {
 		return false
 	}
@@ -223,6 +262,23 @@ if (-not $r) { '' } else { ($r.NameServers -join ',') }
 		currentIP = strings.TrimSpace(currentIP[:idx])
 	}
 	return currentIP != desiredIP
+}
+
+// gpoOverridesNrptRuleWarning queries the effective NRPT policy (post-GPO merge) and returns a
+// non-fatal hint when the first effective name server for our namespace differs from desiredIP.
+// Returns "" when there is no effective rule, when the call fails, or when the effective server
+// matches — all benign on stand-alone machines and on GPO-friendly enterprise images. The "%[1]s"
+// in the warning is the GPO-served IP so operators can spot which policy is winning.
+func (n *BaseNetworkManager) gpoOverridesNrptRuleWarning(env map[string]string, desiredIP string) string {
+	output, err := n.shell.ExecSilentWithEnv("powershell", env, "-Command", nrptEffectiveFirstNameServerScript)
+	if err != nil {
+		return ""
+	}
+	effectiveIP := strings.TrimSpace(output)
+	if effectiveIP == "" || effectiveIP == desiredIP {
+		return ""
+	}
+	return fmt.Sprintf("\n⚠ NRPT rule for *.%s was added locally, but the effective rule resolves to a different name server (%s). This usually means a Group Policy is overriding the local rule. Contact your IT administrator to permit per-machine NRPT for *.%s, or use the IP-based access pattern documented in docs/guides/troubleshooting.md#windows-nrpt-gpo-conflict.", env["WINDSOR_NRPT_DOMAIN"], effectiveIP, env["WINDSOR_NRPT_DOMAIN"])
 }
 
 // needsPrivilegeForHostRoute reports whether a host route for the configured network CIDR and guest IP

--- a/pkg/workstation/network/windows_network_test.go
+++ b/pkg/workstation/network/windows_network_test.go
@@ -4,10 +4,38 @@
 package network
 
 import (
+	"bytes"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 	"testing"
 )
+
+// captureStderr swaps os.Stderr for a pipe, runs fn, and returns whatever the function wrote.
+// Used to assert on operator-facing warnings emitted via fmt.Fprintln(os.Stderr, ...).
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	orig := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stderr = w
+	defer func() { os.Stderr = orig }()
+
+	done := make(chan struct{})
+	var buf bytes.Buffer
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		close(done)
+	}()
+
+	fn()
+	_ = w.Close()
+	<-done
+	return buf.String()
+}
 
 // =============================================================================
 // Test Public Methods
@@ -250,34 +278,22 @@ func TestWindowsNetworkManager_ConfigureDNS(t *testing.T) {
 			t.Fatalf("expected no error, got %v", err)
 		}
 
-		// And capturing namespace and nameservers
+		// And capturing namespace and nameservers from the env map (R24: scripts are now
+		// fixed constants that read $env:WINDSOR_NRPT_*; the values flow via the env arg)
 		var capturedNamespace string
 		var capturedNameServers string
-		mocks.Shell.ExecSilentFunc = func(command string, args ...string) (string, error) {
-			if command == "powershell" && len(args) > 1 && args[0] == "-Command" {
-				script := args[1]
-				if strings.Contains(script, "Get-DnsClientNrptRule") {
-					// Extract namespace from the check script's Where-Object filter.
-					if match := strings.Split(script, "Namespace -eq '"); len(match) > 1 {
-						parts := strings.SplitN(match[1], "'", 2)
-						if len(parts) > 0 {
-							capturedNamespace = parts[0]
-						}
-					}
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command == "powershell" && env != nil {
+				if ns, ok := env["WINDSOR_NRPT_NAMESPACE"]; ok {
+					capturedNamespace = ns
 				}
 			}
 			return "", nil
 		}
-		// The addOrUpdate script (used to actually install the rule) is dispatched
-		// via ExecProgress; its -NameServers parameter is the literal we want.
-		mocks.Shell.ExecProgressFunc = func(message, command string, args ...string) (string, error) {
-			if command == "powershell" && len(args) > 1 && args[0] == "-Command" {
-				script := args[1]
-				if match := strings.Split(script, "-NameServers \""); len(match) > 1 {
-					parts := strings.SplitN(match[1], "\"", 2)
-					if len(parts) > 0 {
-						capturedNameServers = parts[0]
-					}
+		mocks.Shell.ExecProgressWithEnvFunc = func(message, command string, env map[string]string, args ...string) (string, error) {
+			if command == "powershell" && env != nil {
+				if dns, ok := env["WINDSOR_NRPT_DNS"]; ok {
+					capturedNameServers = dns
 				}
 			}
 			return "", nil
@@ -534,6 +550,169 @@ func TestWindowsNetworkManager_ConfigureDNS(t *testing.T) {
 			if strings.Contains(checkScript, broken) {
 				t.Fatalf("check script still uses the broken array-vs-scalar comparison %q, got: %q", broken, checkScript)
 			}
+		}
+	})
+
+	t.Run("NrptValuesFlowThroughEnvVarsNotScriptInterpolation", func(t *testing.T) {
+		// R24 regression guard: namespace, DNS, and domain values must reach PowerShell via
+		// $env:WINDSOR_NRPT_* (defense-in-depth against script-interpolation injection if
+		// validateDomain / validateIPAddress ever regress). The PS script itself must NOT
+		// contain the literal namespace / IP strings.
+		manager, mocks := setup(t)
+		mocks.ConfigHandler.Set("dns.domain", "example.com")
+		mocks.ConfigHandler.Set("workstation.dns.address", "1.2.3.4")
+
+		var checkEnv map[string]string
+		var checkScript string
+		var addOrUpdateEnv map[string]string
+		var addOrUpdateScript string
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command == "powershell" && len(args) > 1 && strings.Contains(args[1], "Get-DnsClientNrptRule") {
+				checkEnv = env
+				checkScript = args[1]
+			}
+			return "", nil
+		}
+		mocks.Shell.ExecProgressWithEnvFunc = func(message, command string, env map[string]string, args ...string) (string, error) {
+			if command == "powershell" && len(args) > 1 && strings.Contains(args[1], "Add-DnsClientNrptRule") {
+				addOrUpdateEnv = env
+				addOrUpdateScript = args[1]
+			}
+			return "", nil
+		}
+
+		if err := manager.ConfigureDNS(); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Check script: env carries namespace, script must reference $env:WINDSOR_NRPT_NAMESPACE
+		if got := checkEnv["WINDSOR_NRPT_NAMESPACE"]; got != ".example.com" {
+			t.Errorf("expected check env WINDSOR_NRPT_NAMESPACE=.example.com, got %q", got)
+		}
+		if !strings.Contains(checkScript, "$env:WINDSOR_NRPT_NAMESPACE") {
+			t.Errorf("expected check script to reference $env:WINDSOR_NRPT_NAMESPACE, got: %q", checkScript)
+		}
+		if strings.Contains(checkScript, ".example.com") {
+			t.Errorf("check script must not interpolate the namespace literal, got: %q", checkScript)
+		}
+
+		// AddOrUpdate script: env carries dns + domain, script must reference both env vars
+		if got := addOrUpdateEnv["WINDSOR_NRPT_DNS"]; got != "1.2.3.4" {
+			t.Errorf("expected addOrUpdate env WINDSOR_NRPT_DNS=1.2.3.4, got %q", got)
+		}
+		if got := addOrUpdateEnv["WINDSOR_NRPT_DOMAIN"]; got != "example.com" {
+			t.Errorf("expected addOrUpdate env WINDSOR_NRPT_DOMAIN=example.com, got %q", got)
+		}
+		for _, want := range []string{"$env:WINDSOR_NRPT_NAMESPACE", "$env:WINDSOR_NRPT_DNS", "$env:WINDSOR_NRPT_DOMAIN"} {
+			if !strings.Contains(addOrUpdateScript, want) {
+				t.Errorf("expected addOrUpdate script to reference %s, got: %q", want, addOrUpdateScript)
+			}
+		}
+		for _, banned := range []string{"1.2.3.4", "'.example.com'", "\"example.com\""} {
+			if strings.Contains(addOrUpdateScript, banned) {
+				t.Errorf("addOrUpdate script must not interpolate %q, got: %q", banned, addOrUpdateScript)
+			}
+		}
+	})
+
+	t.Run("GpoOverrideWarningFiresWhenEffectiveNameServerDiffers", func(t *testing.T) {
+		// R23: when a Group Policy NRPT rule resolves *.<domain> to a different name server
+		// than the one we just installed, surface a non-fatal warning naming the GPO-served IP.
+		manager, mocks := setup(t)
+		mocks.ConfigHandler.Set("dns.domain", "corp.test")
+		mocks.ConfigHandler.Set("workstation.dns.address", "1.2.3.4")
+
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command != "powershell" || len(args) < 2 {
+				return "", nil
+			}
+			switch {
+			case strings.Contains(args[1], "Get-DnsClientNrptRule"):
+				// Local rule already matches → no addOrUpdate fires
+				return "1.2.3.4", nil
+			case strings.Contains(args[1], "Get-DnsClientNrptPolicy -Effective"):
+				// GPO is serving a different IP
+				return "10.0.0.1", nil
+			}
+			return "", nil
+		}
+
+		stderr := captureStderr(t, func() {
+			if err := manager.ConfigureDNS(); err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+
+		for _, want := range []string{
+			"NRPT rule for *.corp.test",
+			"10.0.0.1",
+			"Group Policy",
+			"troubleshooting.md#windows-nrpt-gpo-conflict",
+		} {
+			if !strings.Contains(stderr, want) {
+				t.Errorf("expected stderr warning to include %q, got: %s", want, stderr)
+			}
+		}
+	})
+
+	t.Run("NoGpoWarningWhenEffectiveMatchesOurIP", func(t *testing.T) {
+		// When the effective NRPT name server matches what we set, there's no GPO override.
+		manager, mocks := setup(t)
+		mocks.ConfigHandler.Set("dns.domain", "corp.test")
+		mocks.ConfigHandler.Set("workstation.dns.address", "1.2.3.4")
+
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command != "powershell" || len(args) < 2 {
+				return "", nil
+			}
+			switch {
+			case strings.Contains(args[1], "Get-DnsClientNrptRule"):
+				return "1.2.3.4", nil
+			case strings.Contains(args[1], "Get-DnsClientNrptPolicy -Effective"):
+				return "1.2.3.4", nil
+			}
+			return "", nil
+		}
+
+		stderr := captureStderr(t, func() {
+			if err := manager.ConfigureDNS(); err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+
+		if strings.Contains(stderr, "Group Policy") {
+			t.Errorf("expected no GPO warning when effective NRPT matches; got: %s", stderr)
+		}
+	})
+
+	t.Run("NoGpoWarningWhenEffectiveQueryFails", func(t *testing.T) {
+		// Some Windows editions / WSL2 hosts don't expose Get-DnsClientNrptPolicy; the probe
+		// must fail open (no warning) rather than scaring the operator with a noise message.
+		manager, mocks := setup(t)
+		mocks.ConfigHandler.Set("dns.domain", "corp.test")
+		mocks.ConfigHandler.Set("workstation.dns.address", "1.2.3.4")
+
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command != "powershell" || len(args) < 2 {
+				return "", nil
+			}
+			switch {
+			case strings.Contains(args[1], "Get-DnsClientNrptRule"):
+				return "1.2.3.4", nil
+			case strings.Contains(args[1], "Get-DnsClientNrptPolicy -Effective"):
+				return "", fmt.Errorf("Get-DnsClientNrptPolicy not recognized")
+			}
+			return "", nil
+		}
+
+		stderr := captureStderr(t, func() {
+			if err := manager.ConfigureDNS(); err != nil {
+				t.Fatalf("expected no error, got %v", err)
+			}
+		})
+
+		if strings.Contains(stderr, "Group Policy") || strings.Contains(stderr, "NRPT rule") {
+			t.Errorf("expected GPO probe failure to be silent; got stderr: %s", stderr)
 		}
 	})
 }

--- a/pkg/workstation/network/windows_network_test.go
+++ b/pkg/workstation/network/windows_network_test.go
@@ -741,14 +741,16 @@ func TestWindowsNetworkManager_RevertDNS(t *testing.T) {
 		}
 	})
 
-	t.Run("RemoveScriptInterpolatesNamespaceWithLeadingDot", func(t *testing.T) {
+	t.Run("RemoveScriptUsesEnvVarNamespace", func(t *testing.T) {
 		// Given a configured domain
 		manager, mocks := setup(t)
 		mocks.ConfigHandler.Set("dns.domain", "local.test")
 		var capturedScript string
-		mocks.Shell.ExecSilentFunc = func(command string, args ...string) (string, error) {
+		var capturedEnv map[string]string
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
 			if command == "powershell" && len(args) > 1 && args[0] == "-Command" {
 				capturedScript = args[1]
+				capturedEnv = env
 			}
 			return "", nil
 		}
@@ -758,13 +760,19 @@ func TestWindowsNetworkManager_RevertDNS(t *testing.T) {
 			t.Fatalf("expected nil error, got %v", err)
 		}
 
-		// Then the PowerShell script invokes Remove-DnsClientNrptRule with .<domain> namespace
-		// and silent error handling
+		// Then the env carries the namespace with leading dot, the script references it via
+		// $env:WINDSOR_NRPT_NAMESPACE (no interpolated literal), and idempotency is preserved
+		if got := capturedEnv["WINDSOR_NRPT_NAMESPACE"]; got != ".local.test" {
+			t.Errorf("expected WINDSOR_NRPT_NAMESPACE=.local.test, got %q", got)
+		}
 		if !strings.Contains(capturedScript, "Remove-DnsClientNrptRule") {
 			t.Errorf("expected Remove-DnsClientNrptRule in script, got: %q", capturedScript)
 		}
-		if !strings.Contains(capturedScript, "'.local.test'") {
-			t.Errorf("expected '.local.test' namespace interpolated, got: %q", capturedScript)
+		if !strings.Contains(capturedScript, "$env:WINDSOR_NRPT_NAMESPACE") {
+			t.Errorf("expected script to reference $env:WINDSOR_NRPT_NAMESPACE, got: %q", capturedScript)
+		}
+		if strings.Contains(capturedScript, ".local.test") {
+			t.Errorf("script must not interpolate the namespace literal, got: %q", capturedScript)
 		}
 		if !strings.Contains(capturedScript, "ErrorAction SilentlyContinue") {
 			t.Errorf("expected SilentlyContinue for idempotency, got: %q", capturedScript)

--- a/pkg/workstation/network/windows_network_test.go
+++ b/pkg/workstation/network/windows_network_test.go
@@ -4,38 +4,10 @@
 package network
 
 import (
-	"bytes"
 	"fmt"
-	"io"
-	"os"
 	"strings"
 	"testing"
 )
-
-// captureStderr swaps os.Stderr for a pipe, runs fn, and returns whatever the function wrote.
-// Used to assert on operator-facing warnings emitted via fmt.Fprintln(os.Stderr, ...).
-func captureStderr(t *testing.T, fn func()) string {
-	t.Helper()
-	orig := os.Stderr
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("pipe: %v", err)
-	}
-	os.Stderr = w
-	defer func() { os.Stderr = orig }()
-
-	done := make(chan struct{})
-	var buf bytes.Buffer
-	go func() {
-		_, _ = io.Copy(&buf, r)
-		close(done)
-	}()
-
-	fn()
-	_ = w.Close()
-	<-done
-	return buf.String()
-}
 
 // =============================================================================
 // Test Public Methods
@@ -617,40 +589,29 @@ func TestWindowsNetworkManager_ConfigureDNS(t *testing.T) {
 
 	t.Run("GpoOverrideWarningFiresWhenEffectiveNameServerDiffers", func(t *testing.T) {
 		// R23: when a Group Policy NRPT rule resolves *.<domain> to a different name server
-		// than the one we just installed, surface a non-fatal warning naming the GPO-served IP.
+		// than the one we just installed, the helper returns a non-fatal warning naming the
+		// GPO-served IP. Asserts on the helper's return value (no os.Stderr swap, parallel-safe).
 		manager, mocks := setup(t)
-		mocks.ConfigHandler.Set("dns.domain", "corp.test")
-		mocks.ConfigHandler.Set("workstation.dns.address", "1.2.3.4")
-
 		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
-			if command != "powershell" || len(args) < 2 {
-				return "", nil
-			}
-			switch {
-			case strings.Contains(args[1], "Get-DnsClientNrptRule"):
-				// Local rule already matches → no addOrUpdate fires
-				return "1.2.3.4", nil
-			case strings.Contains(args[1], "Get-DnsClientNrptPolicy -Effective"):
-				// GPO is serving a different IP
+			if command == "powershell" && len(args) >= 2 && strings.Contains(args[1], "Get-DnsClientNrptPolicy -Effective") {
 				return "10.0.0.1", nil
 			}
 			return "", nil
 		}
 
-		stderr := captureStderr(t, func() {
-			if err := manager.ConfigureDNS(); err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
-		})
-
+		env := map[string]string{"WINDSOR_NRPT_NAMESPACE": ".corp.test", "WINDSOR_NRPT_DOMAIN": "corp.test"}
+		msg := manager.gpoOverridesNrptRuleWarning(env, "1.2.3.4")
+		if msg == "" {
+			t.Fatal("expected GPO override warning, got empty string")
+		}
 		for _, want := range []string{
 			"NRPT rule for *.corp.test",
 			"10.0.0.1",
 			"Group Policy",
 			"troubleshooting.md#windows-nrpt-gpo-conflict",
 		} {
-			if !strings.Contains(stderr, want) {
-				t.Errorf("expected stderr warning to include %q, got: %s", want, stderr)
+			if !strings.Contains(msg, want) {
+				t.Errorf("expected warning to include %q, got: %s", want, msg)
 			}
 		}
 	})
@@ -658,61 +619,33 @@ func TestWindowsNetworkManager_ConfigureDNS(t *testing.T) {
 	t.Run("NoGpoWarningWhenEffectiveMatchesOurIP", func(t *testing.T) {
 		// When the effective NRPT name server matches what we set, there's no GPO override.
 		manager, mocks := setup(t)
-		mocks.ConfigHandler.Set("dns.domain", "corp.test")
-		mocks.ConfigHandler.Set("workstation.dns.address", "1.2.3.4")
-
 		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
-			if command != "powershell" || len(args) < 2 {
-				return "", nil
-			}
-			switch {
-			case strings.Contains(args[1], "Get-DnsClientNrptRule"):
-				return "1.2.3.4", nil
-			case strings.Contains(args[1], "Get-DnsClientNrptPolicy -Effective"):
+			if command == "powershell" && len(args) >= 2 && strings.Contains(args[1], "Get-DnsClientNrptPolicy -Effective") {
 				return "1.2.3.4", nil
 			}
 			return "", nil
 		}
 
-		stderr := captureStderr(t, func() {
-			if err := manager.ConfigureDNS(); err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
-		})
-
-		if strings.Contains(stderr, "Group Policy") {
-			t.Errorf("expected no GPO warning when effective NRPT matches; got: %s", stderr)
+		env := map[string]string{"WINDSOR_NRPT_NAMESPACE": ".corp.test", "WINDSOR_NRPT_DOMAIN": "corp.test"}
+		if msg := manager.gpoOverridesNrptRuleWarning(env, "1.2.3.4"); msg != "" {
+			t.Errorf("expected no warning when effective NRPT matches; got: %s", msg)
 		}
 	})
 
 	t.Run("NoGpoWarningWhenEffectiveQueryFails", func(t *testing.T) {
 		// Some Windows editions / WSL2 hosts don't expose Get-DnsClientNrptPolicy; the probe
-		// must fail open (no warning) rather than scaring the operator with a noise message.
+		// must fail open (return "") rather than scaring the operator with a noise message.
 		manager, mocks := setup(t)
-		mocks.ConfigHandler.Set("dns.domain", "corp.test")
-		mocks.ConfigHandler.Set("workstation.dns.address", "1.2.3.4")
-
 		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
-			if command != "powershell" || len(args) < 2 {
-				return "", nil
-			}
-			switch {
-			case strings.Contains(args[1], "Get-DnsClientNrptRule"):
-				return "1.2.3.4", nil
-			case strings.Contains(args[1], "Get-DnsClientNrptPolicy -Effective"):
+			if command == "powershell" && len(args) >= 2 && strings.Contains(args[1], "Get-DnsClientNrptPolicy -Effective") {
 				return "", fmt.Errorf("Get-DnsClientNrptPolicy not recognized")
 			}
 			return "", nil
 		}
 
-		stderr := captureStderr(t, func() {
-			if err := manager.ConfigureDNS(); err != nil {
-				t.Fatalf("expected no error, got %v", err)
-			}
-		})
-
-		if strings.Contains(stderr, "Group Policy") || strings.Contains(stderr, "NRPT rule") {
-			t.Errorf("expected GPO probe failure to be silent; got stderr: %s", stderr)
+		env := map[string]string{"WINDSOR_NRPT_NAMESPACE": ".corp.test", "WINDSOR_NRPT_DOMAIN": "corp.test"}
+		if msg := manager.gpoOverridesNrptRuleWarning(env, "1.2.3.4"); msg != "" {
+			t.Errorf("expected GPO probe failure to be silent; got: %s", msg)
 		}
 	})
 }


### PR DESCRIPTION
> [!NOTE]
>
> **Medium Risk**
>
> This PR changes Windows DNS configuration behavior and introduces a new runtime PowerShell subprocess call on every `windsor up`. The change is isolated to Windows, but DNS misconfiguration can silently break guest VM connectivity for all users on that platform.
>
> **Overview**
>
> The PR replaces `fmt.Sprintf` interpolation of domain and IP values into PowerShell script strings with constant scripts that read those values from `WINDSOR_NRPT_*` environment variables. This is a genuine security hardening: even though `validateDomain` and `validateIPAddress` guard the inputs, env-var passing removes any residual PS-injection surface entirely. A new `gpoOverridesNrptRuleWarning` helper queries `Get-DnsClientNrptPolicy -Effective` after each `ConfigureDNS` call and emits a non-fatal stderr warning when a Group Policy is overriding the local rule.
>
> The GPO probe fires on every `ConfigureDNS` call — not only on first install — so operators with a persistent GPO conflict will see the warning on every `windsor up`. That is likely intentional, but worth confirming to avoid operator fatigue on enterprise machines where the conflict cannot be resolved locally.
>
