### PR TITLE
feat(network): enhance host route configuration for macOS and Linux with persistence support

### DIFF
--- a/pkg/workstation/network/darwin_network.go
+++ b/pkg/workstation/network/darwin_network.go
@@ -5,6 +5,7 @@ package network
 
 import (
 	"fmt"
+	"net"
 	"os"
 	"strings"
 
@@ -21,8 +22,11 @@ import (
 // =============================================================================
 
 // ConfigureHostRoute ensures that a network route from the host to the VM guest is established.
-// Guest address is read from config (workstation.address). It checks if a route for the network
-// CIDR already exists with that gateway; if not, adds the route with elevated permissions.
+// Guest address is read from config (workstation.address). Installs the route in the live routing
+// table via `route add` when missing, then registers it as an additional route via
+// `networksetup -setadditionalroutes` so it survives reboots. The persistence step is best-effort:
+// if no primary network service can be detected, the live route is left in place and a warning is
+// printed.
 func (n *BaseNetworkManager) ConfigureHostRoute() error {
 	networkCIDR := n.configHandler.GetString("network.cidr_block")
 	if networkCIDR == "" {
@@ -33,29 +37,30 @@ func (n *BaseNetworkManager) ConfigureHostRoute() error {
 		return fmt.Errorf("guest address is required")
 	}
 
-	networkPrefix := strings.Split(networkCIDR, "/")[0]
-	output, err := n.shell.ExecSilent("route", "-n", "get", networkPrefix)
+	routeInKernel, err := n.macOSRouteInKernel(networkCIDR, guestIP)
 	if err != nil {
-		return fmt.Errorf("failed to check if route exists: %w", err)
+		return err
 	}
 
-	routeExists := false
-
-	found := map[string]string{}
-	for _, line := range strings.Split(output, "\n") {
-		line = strings.TrimSpace(line)
-		if parts := strings.SplitN(line, ":", 2); len(parts) == 2 {
-			key := strings.ToLower(strings.TrimSpace(parts[0]))
-			val := strings.TrimSpace(parts[1])
-			found[key] = val
+	service, getRoutesOutput, err := n.macOSPrimaryServiceAndRoutes()
+	if err != nil {
+		// Persistence unavailable — fall back to ephemeral-only with warning.
+		if !routeInKernel {
+			tui.Pause()
+			if os.Geteuid() != 0 && !n.sudoCached() {
+				fmt.Fprintf(os.Stderr, "\033[33m⚠\033[0m Network configuration may require elevated privileges\n")
+			}
+			if out, addErr := n.shell.ExecSudo("Adding host route", "route", "-nv", "add", "-net", networkCIDR, guestIP); addErr != nil {
+				return fmt.Errorf("failed to add route: %w, output: %s", addErr, out)
+			}
 		}
+		fmt.Fprintf(os.Stderr, "⚠ host route to %s installed but will not survive reboot on this system: %v\n", guestIP, err)
+		return nil
 	}
 
-	if strings.TrimSpace(found["destination"]) == networkPrefix && strings.TrimSpace(found["gateway"]) == guestIP {
-		routeExists = true
-	}
+	routePersistent := macOSRouteAlreadyPersistent(getRoutesOutput, networkCIDR, guestIP)
 
-	if routeExists {
+	if routeInKernel && routePersistent {
 		return nil
 	}
 
@@ -63,17 +68,22 @@ func (n *BaseNetworkManager) ConfigureHostRoute() error {
 	if os.Geteuid() != 0 && !n.sudoCached() {
 		fmt.Fprintf(os.Stderr, "\033[33m⚠\033[0m Network configuration may require elevated privileges\n")
 	}
-	output, err = n.shell.ExecSudo(
-		"Adding host route",
-		"route",
-		"-nv",
-		"add",
-		"-net",
-		networkCIDR,
-		guestIP,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to add route: %w, output: %s", err, output)
+
+	if !routeInKernel {
+		if out, err := n.shell.ExecSudo("Adding host route", "route", "-nv", "add", "-net", networkCIDR, guestIP); err != nil {
+			return fmt.Errorf("failed to add route: %w, output: %s", err, out)
+		}
+	}
+
+	if !routePersistent {
+		args, err := macOSSetAdditionalRoutesArgs(service, getRoutesOutput, networkCIDR, guestIP)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "⚠ host route to %s installed but persistence step skipped: %v\n", guestIP, err)
+			return nil
+		}
+		if _, err := n.shell.ExecSudo("Persisting host route", "networksetup", args...); err != nil {
+			fmt.Fprintf(os.Stderr, "⚠ host route to %s installed but persistence step failed: %v\n", guestIP, err)
+		}
 	}
 	return nil
 }
@@ -123,8 +133,8 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 }
 
 // RevertHostRoute removes the host-to-guest route previously added by ConfigureHostRoute on macOS.
-// Idempotent: no-op when the network CIDR is unset, and tolerates "not in table" if the route was
-// never installed or has already been removed.
+// Idempotent: no-op when the network CIDR is unset, tolerates "not in table" for the live route
+// delete, and removes the matching networksetup additional-route entry when present.
 func (n *BaseNetworkManager) RevertHostRoute() error {
 	networkCIDR := n.configHandler.GetString("network.cidr_block")
 	if networkCIDR == "" {
@@ -132,10 +142,18 @@ func (n *BaseNetworkManager) RevertHostRoute() error {
 	}
 	output, err := n.shell.ExecSudo("", "route", "-nv", "delete", "-net", networkCIDR)
 	if err != nil {
-		if strings.Contains(output, "not in table") {
-			return nil
+		if !strings.Contains(output, "not in table") {
+			return fmt.Errorf("Error deleting host route: %w, output: %s", err, output)
 		}
-		return fmt.Errorf("Error deleting host route: %w, output: %s", err, output)
+	}
+	if service, getRoutesOutput, err := n.macOSPrimaryServiceAndRoutes(); err == nil {
+		guestIP := n.configHandler.GetString("workstation.address")
+		args, removed := macOSRemoveAdditionalRouteArgs(service, getRoutesOutput, networkCIDR, guestIP)
+		if removed {
+			if _, err := n.shell.ExecSudo("", "networksetup", args...); err != nil {
+				return fmt.Errorf("Error removing persistent host route: %w", err)
+			}
+		}
 	}
 	return nil
 }
@@ -193,6 +211,148 @@ func (n *BaseNetworkManager) sudoCached() bool {
 	return err == nil
 }
 
+// macOSRouteInKernel reports whether the live routing table already has the configured CIDR
+// routed via guestIP. Backed by `route -n get <networkPrefix>` parsed for destination + gateway.
+func (n *BaseNetworkManager) macOSRouteInKernel(networkCIDR, guestIP string) (bool, error) {
+	networkPrefix := strings.Split(networkCIDR, "/")[0]
+	output, err := n.shell.ExecSilent("route", "-n", "get", networkPrefix)
+	if err != nil {
+		return false, fmt.Errorf("failed to check if route exists: %w", err)
+	}
+	found := map[string]string{}
+	for _, line := range strings.Split(output, "\n") {
+		line = strings.TrimSpace(line)
+		if parts := strings.SplitN(line, ":", 2); len(parts) == 2 {
+			key := strings.ToLower(strings.TrimSpace(parts[0]))
+			val := strings.TrimSpace(parts[1])
+			found[key] = val
+		}
+	}
+	return strings.TrimSpace(found["destination"]) == networkPrefix && strings.TrimSpace(found["gateway"]) == guestIP, nil
+}
+
+// macOSPrimaryServiceAndRoutes returns the primary network service name (the first non-disabled
+// service from `networksetup -listallnetworkservices`) and the current additional-routes block
+// for that service (`networksetup -getadditionalroutes <service>`). The output blob is passed to
+// downstream helpers so they can either parse existing triples or emit the right replacement set.
+func (n *BaseNetworkManager) macOSPrimaryServiceAndRoutes() (service string, routesOutput string, err error) {
+	listOutput, err := n.shell.ExecSilent("networksetup", "-listallnetworkservices")
+	if err != nil {
+		return "", "", fmt.Errorf("failed to list network services: %w", err)
+	}
+	service = pickPrimaryNetworkService(listOutput)
+	if service == "" {
+		return "", "", fmt.Errorf("no enabled network service found")
+	}
+	routesOutput, err = n.shell.ExecSilent("networksetup", "-getadditionalroutes", service)
+	if err != nil {
+		return "", "", fmt.Errorf("failed to read additional routes for %q: %w", service, err)
+	}
+	return service, routesOutput, nil
+}
+
+// pickPrimaryNetworkService returns the first enabled service name from the output of
+// `networksetup -listallnetworkservices`. Disabled services are prefixed with `*` in the listing
+// and skipped. The preamble line ("An asterisk (*) denotes ...") is recognised and skipped too.
+func pickPrimaryNetworkService(listOutput string) string {
+	for _, line := range strings.Split(listOutput, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "An asterisk") || strings.HasPrefix(line, "*") {
+			continue
+		}
+		return line
+	}
+	return ""
+}
+
+// parseAdditionalRoutes parses the body of `networksetup -getadditionalroutes <service>` into a
+// slice of {dest, mask, router} triples. "There aren't any" / blank output yields an empty slice.
+func parseAdditionalRoutes(getRoutesOutput string) [][3]string {
+	var triples [][3]string
+	for _, line := range strings.Split(getRoutesOutput, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 3 && net.ParseIP(fields[0]) != nil && net.ParseIP(fields[2]) != nil {
+			triples = append(triples, [3]string{fields[0], fields[1], fields[2]})
+		}
+	}
+	return triples
+}
+
+// macOSRouteAlreadyPersistent reports whether the desired (cidr, gateway) is already among the
+// service's persistent additional routes.
+func macOSRouteAlreadyPersistent(getRoutesOutput, networkCIDR, guestIP string) bool {
+	dest, mask, err := cidrToDestMask(networkCIDR)
+	if err != nil {
+		return false
+	}
+	for _, t := range parseAdditionalRoutes(getRoutesOutput) {
+		if t[0] == dest && t[1] == mask && t[2] == guestIP {
+			return true
+		}
+	}
+	return false
+}
+
+// macOSSetAdditionalRoutesArgs builds the argv for `networksetup -setadditionalroutes` that
+// appends the new (cidr, gateway) entry to the service's existing triples. Caller invokes
+// `n.shell.ExecSudo("", "networksetup", args...)`.
+func macOSSetAdditionalRoutesArgs(service, getRoutesOutput, networkCIDR, guestIP string) ([]string, error) {
+	dest, mask, err := cidrToDestMask(networkCIDR)
+	if err != nil {
+		return nil, err
+	}
+	triples := parseAdditionalRoutes(getRoutesOutput)
+	triples = append(triples, [3]string{dest, mask, guestIP})
+	args := []string{"-setadditionalroutes", service}
+	for _, t := range triples {
+		args = append(args, t[0], t[1], t[2])
+	}
+	return args, nil
+}
+
+// macOSRemoveAdditionalRouteArgs builds the argv for `networksetup -setadditionalroutes` that
+// drops any matching entry for the supplied (cidr, gateway). When guestIP is unset (revert called
+// with no workstation.address), drops any entry whose dest+mask matches regardless of gateway —
+// catches stale rows where the gateway changed between configure and revert. Returns removed=false
+// when there is nothing to remove, so the caller can skip the sudo call entirely.
+func macOSRemoveAdditionalRouteArgs(service, getRoutesOutput, networkCIDR, guestIP string) (args []string, removed bool) {
+	dest, mask, err := cidrToDestMask(networkCIDR)
+	if err != nil {
+		return nil, false
+	}
+	original := parseAdditionalRoutes(getRoutesOutput)
+	kept := original[:0:0]
+	for _, t := range original {
+		if t[0] == dest && t[1] == mask && (guestIP == "" || t[2] == guestIP) {
+			removed = true
+			continue
+		}
+		kept = append(kept, t)
+	}
+	if !removed {
+		return nil, false
+	}
+	args = []string{"-setadditionalroutes", service}
+	for _, t := range kept {
+		args = append(args, t[0], t[1], t[2])
+	}
+	return args, true
+}
+
+// cidrToDestMask converts a CIDR string ("192.168.5.0/24") to the dest + dotted-decimal mask
+// pair networksetup expects ("192.168.5.0", "255.255.255.0"). IPv4 only.
+func cidrToDestMask(networkCIDR string) (dest, mask string, err error) {
+	_, ipnet, err := net.ParseCIDR(networkCIDR)
+	if err != nil {
+		return "", "", fmt.Errorf("invalid CIDR %q: %w", networkCIDR, err)
+	}
+	if len(ipnet.Mask) != 4 {
+		return "", "", fmt.Errorf("only IPv4 CIDRs are supported, got %q", networkCIDR)
+	}
+	mask = fmt.Sprintf("%d.%d.%d.%d", ipnet.Mask[0], ipnet.Mask[1], ipnet.Mask[2], ipnet.Mask[3])
+	return ipnet.IP.String(), mask, nil
+}
+
 // resolverAlreadyConfigured reports whether the resolver file content already has a nameserver line for desiredIP.
 // Used to skip writing and sudo when the effective config matches. Parses lines and checks the first nameserver line.
 func resolverAlreadyConfigured(content, desiredIP string) bool {
@@ -233,19 +393,9 @@ func (n *BaseNetworkManager) needsPrivilegeForHostRoute(guestAddress string) boo
 	if networkCIDR == "" || guestAddress == "" {
 		return false
 	}
-	networkPrefix := strings.Split(networkCIDR, "/")[0]
-	output, err := n.shell.ExecSilent("route", "-n", "get", networkPrefix)
+	inKernel, err := n.macOSRouteInKernel(networkCIDR, guestAddress)
 	if err != nil {
 		return false
 	}
-	found := map[string]string{}
-	for _, line := range strings.Split(output, "\n") {
-		line = strings.TrimSpace(line)
-		if parts := strings.SplitN(line, ":", 2); len(parts) == 2 {
-			key := strings.ToLower(strings.TrimSpace(parts[0]))
-			val := strings.TrimSpace(parts[1])
-			found[key] = val
-		}
-	}
-	return strings.TrimSpace(found["destination"]) != networkPrefix || strings.TrimSpace(found["gateway"]) != guestAddress
+	return !inKernel
 }

--- a/pkg/workstation/network/darwin_network_test.go
+++ b/pkg/workstation/network/darwin_network_test.go
@@ -160,6 +160,112 @@ func TestDarwinNetworkManager_ConfigureHostRoute(t *testing.T) {
 			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
 		}
 	})
+
+	t.Run("PersistsRouteViaNetworksetupWhenServiceAvailable", func(t *testing.T) {
+		// Given a primary network service is available and no persistent route exists yet
+		manager, mocks := setup(t)
+		mocks.ConfigHandler.Set("network.cidr_block", "192.168.5.0/24")
+		mocks.ConfigHandler.Set("workstation.address", "192.168.5.1")
+		mocks.Shell.ExecSilentFunc = func(command string, args ...string) (string, error) {
+			if command == "networksetup" && len(args) > 0 && args[0] == "-listallnetworkservices" {
+				return "An asterisk (*) denotes that a network service is disabled.\nWi-Fi\n*USB 10/100\n", nil
+			}
+			if command == "networksetup" && len(args) > 0 && args[0] == "-getadditionalroutes" {
+				return "There aren't any.\n", nil
+			}
+			return "", nil
+		}
+		var setAdditionalArgs []string
+		mocks.Shell.ExecSudoFunc = func(_, command string, args ...string) (string, error) {
+			if command == "networksetup" && len(args) > 0 && args[0] == "-setadditionalroutes" {
+				setAdditionalArgs = append([]string{}, args...)
+			}
+			return "", nil
+		}
+
+		if err := manager.ConfigureHostRoute(); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Then setadditionalroutes was invoked with our triple after the service name
+		if len(setAdditionalArgs) < 5 {
+			t.Fatalf("expected setadditionalroutes to be invoked, got args=%v", setAdditionalArgs)
+		}
+		for i, want := range []string{"-setadditionalroutes", "Wi-Fi", "192.168.5.0", "255.255.255.0", "192.168.5.1"} {
+			if setAdditionalArgs[i] != want {
+				t.Errorf("arg[%d] = %q, want %q (full args=%v)", i, setAdditionalArgs[i], want, setAdditionalArgs)
+			}
+		}
+	})
+
+	t.Run("EphemeralFallbackWhenNoServiceDetected", func(t *testing.T) {
+		// Given no enabled network service is available
+		manager, mocks := setup(t)
+		mocks.ConfigHandler.Set("network.cidr_block", "192.168.5.0/24")
+		mocks.ConfigHandler.Set("workstation.address", "192.168.5.1")
+		mocks.Shell.ExecSilentFunc = func(command string, args ...string) (string, error) {
+			if command == "networksetup" {
+				return "An asterisk (*) denotes that a network service is disabled.\n", nil
+			}
+			return "", nil
+		}
+		var routeAdded bool
+		var setAdditionalCalled bool
+		mocks.Shell.ExecSudoFunc = func(_, command string, args ...string) (string, error) {
+			if command == "route" && len(args) > 1 && args[1] == "add" {
+				routeAdded = true
+			}
+			if command == "networksetup" && len(args) > 0 && args[0] == "-setadditionalroutes" {
+				setAdditionalCalled = true
+			}
+			return "", nil
+		}
+
+		if err := manager.ConfigureHostRoute(); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Then the live route was added but no persistence call fired
+		if !routeAdded {
+			t.Error("expected ephemeral route to be added")
+		}
+		if setAdditionalCalled {
+			t.Error("expected no networksetup -setadditionalroutes call when no service is available")
+		}
+	})
+
+	t.Run("SkipsPersistenceWhenAlreadyPersistent", func(t *testing.T) {
+		// Given the route is already in the kernel and already persistent
+		manager, mocks := setup(t)
+		mocks.ConfigHandler.Set("network.cidr_block", "192.168.5.0/24")
+		mocks.ConfigHandler.Set("workstation.address", "192.168.5.1")
+		mocks.Shell.ExecSilentFunc = func(command string, args ...string) (string, error) {
+			if command == "route" && len(args) >= 2 && args[0] == "-n" && args[1] == "get" {
+				return "   route to: 192.168.5.0\ndestination: 192.168.5.0\n    gateway: 192.168.5.1\n", nil
+			}
+			if command == "networksetup" && len(args) > 0 && args[0] == "-listallnetworkservices" {
+				return "Wi-Fi\n", nil
+			}
+			if command == "networksetup" && len(args) > 0 && args[0] == "-getadditionalroutes" {
+				return "192.168.5.0 255.255.255.0 192.168.5.1\n", nil
+			}
+			return "", nil
+		}
+		var anySudoCall bool
+		mocks.Shell.ExecSudoFunc = func(_, _ string, _ ...string) (string, error) {
+			anySudoCall = true
+			return "", nil
+		}
+
+		if err := manager.ConfigureHostRoute(); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Then no sudo invocation occurred (route + persistence both already in place)
+		if anySudoCall {
+			t.Error("expected zero sudo calls when route is both live and persistent")
+		}
+	})
 }
 
 func TestDarwinNetworkManager_ConfigureDNS(t *testing.T) {

--- a/pkg/workstation/network/linux_network.go
+++ b/pkg/workstation/network/linux_network.go
@@ -35,8 +35,12 @@ const systemdResolvedSymlinkHint = "systemd-resolved is active but /etc/resolv.c
 // Public Methods
 // =============================================================================
 
-// ConfigureHostRoute sets up the local development network for Linux.
-// Guest address is read from config (workstation.address).
+// ConfigureHostRoute sets up the local development network for Linux. Guest address is read from
+// config (workstation.address). Installs the route in the live routing table via `ip route add`
+// when missing, then writes a systemd-networkd drop-in at /etc/systemd/network/windsor-<context>.network
+// (or registers a persistent route via `nmcli` when NetworkManager owns the connection) so the
+// route survives reboot. When neither persistence mechanism is available the live route is left in
+// place and an actionable warning is printed.
 func (n *BaseNetworkManager) ConfigureHostRoute() error {
 	networkCIDR := n.configHandler.GetString("network.cidr_block")
 	if networkCIDR == "" {
@@ -47,39 +51,23 @@ func (n *BaseNetworkManager) ConfigureHostRoute() error {
 		return fmt.Errorf("guest address is required")
 	}
 
-	output, err := n.shell.ExecSilent("ip", "route", "show", networkCIDR)
+	routeInKernel, err := n.linuxRouteInKernel(networkCIDR, guestIP)
 	if err != nil {
-		return fmt.Errorf("failed to check if route exists: %w", err)
+		return err
 	}
 
-	routeExists := false
-	lines := strings.Split(output, "\n")
-	for _, line := range lines {
-		if strings.Contains(line, guestIP) {
-			routeExists = true
-			break
+	if !routeInKernel {
+		if os.Geteuid() != 0 {
+			tui.Pause()
+			fmt.Fprintf(os.Stderr, "\n\033[33m⚠\033[0m Network configuration may require elevated privileges\n")
+		}
+		if out, err := n.shell.ExecSudo("Adding host route", "ip", "route", "add", networkCIDR, "via", guestIP); err != nil {
+			return fmt.Errorf("failed to add route: %w, output: %s", err, out)
 		}
 	}
 
-	if routeExists {
-		return nil
-	}
-
-	if os.Geteuid() != 0 {
-		tui.Pause()
-		fmt.Fprintf(os.Stderr, "\n\033[33m⚠\033[0m Network configuration may require elevated privileges\n")
-	}
-	output, err = n.shell.ExecSudo(
-		"Adding host route",
-		"ip",
-		"route",
-		"add",
-		networkCIDR,
-		"via",
-		guestIP,
-	)
-	if err != nil {
-		return fmt.Errorf("failed to add route: %w, output: %s", err, output)
+	if err := n.persistLinuxHostRoute(networkCIDR, guestIP); err != nil {
+		fmt.Fprintf(os.Stderr, "⚠ host route to %s installed but will not survive reboot on this system (%v). After every reboot you'll need to re-run 'windsor configure network'. For persistent routes, see docs/guides/troubleshooting.md#persistent-routes-without-systemd-networkd.\n", guestIP, err)
 	}
 
 	return nil
@@ -151,19 +139,20 @@ func (n *BaseNetworkManager) ConfigureDNS() error {
 // =============================================================================
 
 // RevertHostRoute removes the host-to-guest route previously added by ConfigureHostRoute on Linux.
-// Idempotent: no-op when the network CIDR is unset, and tolerates "No such process" (the exit
-// signal from ip route del when the destination isn't in the table).
+// Idempotent: no-op when the network CIDR is unset, tolerates "No such process" for the live
+// delete, removes any matching systemd-networkd drop-in, and drops the NetworkManager persistent
+// route when one was installed via nmcli.
 func (n *BaseNetworkManager) RevertHostRoute() error {
 	networkCIDR := n.configHandler.GetString("network.cidr_block")
 	if networkCIDR == "" {
 		return nil
 	}
 	output, err := n.shell.ExecSudo("", "ip", "route", "del", networkCIDR)
-	if err != nil {
-		if strings.Contains(output, "No such process") {
-			return nil
-		}
+	if err != nil && !strings.Contains(output, "No such process") {
 		return fmt.Errorf("failed to delete host route: %w, output: %s", err, output)
+	}
+	if err := n.unpersistLinuxHostRoute(networkCIDR); err != nil {
+		return fmt.Errorf("failed to remove persistent host route: %w", err)
 	}
 	return nil
 }
@@ -282,6 +271,127 @@ func readNetworkManagerMainDNS(readFile func(string) ([]byte, error), path strin
 	return "", false
 }
 
+// linuxRouteInKernel reports whether the live routing table already has the configured CIDR
+// routed via guestIP. Backed by `ip route show <cidr>` parsed for the gateway.
+func (n *BaseNetworkManager) linuxRouteInKernel(networkCIDR, guestIP string) (bool, error) {
+	output, err := n.shell.ExecSilent("ip", "route", "show", networkCIDR)
+	if err != nil {
+		return false, fmt.Errorf("failed to check if route exists: %w", err)
+	}
+	for _, line := range strings.Split(output, "\n") {
+		if strings.Contains(line, guestIP) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+// persistLinuxHostRoute installs a reboot-surviving host route via the host's network manager.
+// Tries systemd-networkd first (writes /etc/systemd/network/windsor-<context>.network and asks
+// networkctl to reload). Falls back to NetworkManager when nmcli is active (appends an ipv4.routes
+// entry on the first active connection). Returns an error when neither backend is available — the
+// caller surfaces that as a non-fatal "won't survive reboot" warning to the operator.
+func (n *BaseNetworkManager) persistLinuxHostRoute(networkCIDR, guestIP string) error {
+	if status, err := n.shell.ExecSilent("systemctl", "is-active", "systemd-networkd"); err == nil && strings.TrimSpace(status) == "active" {
+		return n.writeNetworkdHostRouteDropIn(networkCIDR, guestIP)
+	}
+	if status, err := n.shell.ExecSilent("systemctl", "is-active", "NetworkManager"); err == nil && strings.TrimSpace(status) == "active" {
+		return n.addNetworkManagerPersistentRoute(networkCIDR, guestIP)
+	}
+	return fmt.Errorf("no systemd-networkd or NetworkManager detected")
+}
+
+// writeNetworkdHostRouteDropIn writes a per-context drop-in to /etc/systemd/network/ that
+// declares the route, then asks `networkctl reload` to pick it up. The Match=* clause keeps the
+// drop-in interface-agnostic since the route is "via <guestIP>" — systemd-networkd resolves the
+// outgoing interface from the gateway at apply time.
+func (n *BaseNetworkManager) writeNetworkdHostRouteDropIn(networkCIDR, guestIP string) error {
+	contextName := n.configHandler.GetContext()
+	if contextName == "" {
+		contextName = "default"
+	}
+	path := fmt.Sprintf("/etc/systemd/network/windsor-%s.network", contextName)
+	content := fmt.Sprintf("[Match]\nName=*\n\n[Route]\nDestination=%s\nGateway=%s\n", networkCIDR, guestIP)
+	existing, readErr := n.shims.ReadFile(path)
+	if readErr == nil && string(existing) == content {
+		return nil
+	}
+	if err := n.writeFileWithSudo(path, []byte(content)); err != nil {
+		return fmt.Errorf("failed to write systemd-networkd drop-in: %w", err)
+	}
+	if _, err := n.shell.ExecSudo("", "networkctl", "reload"); err != nil {
+		return fmt.Errorf("failed to reload systemd-networkd: %w", err)
+	}
+	return nil
+}
+
+// addNetworkManagerPersistentRoute appends a persistent ipv4.routes entry on the first active
+// NetworkManager connection. Skips when an identical "<dest> <gateway>" entry already exists.
+func (n *BaseNetworkManager) addNetworkManagerPersistentRoute(networkCIDR, guestIP string) error {
+	conn, err := n.firstActiveNetworkManagerConnection()
+	if err != nil {
+		return err
+	}
+	current, err := n.shell.ExecSilent("nmcli", "-t", "-f", "ipv4.routes", "connection", "show", conn)
+	if err == nil {
+		needle := networkCIDR + " " + guestIP
+		if strings.Contains(current, needle) {
+			return nil
+		}
+	}
+	if _, err := n.shell.ExecSudo("", "nmcli", "connection", "modify", conn, "+ipv4.routes", networkCIDR+" "+guestIP); err != nil {
+		return fmt.Errorf("nmcli connection modify failed: %w", err)
+	}
+	return nil
+}
+
+// firstActiveNetworkManagerConnection returns the name of the first active NM connection
+// (terse output: NAME on the first column). Used to pick the connection profile that owns the
+// route we're persisting.
+func (n *BaseNetworkManager) firstActiveNetworkManagerConnection() (string, error) {
+	output, err := n.shell.ExecSilent("nmcli", "-t", "-f", "NAME", "connection", "show", "--active")
+	if err != nil {
+		return "", fmt.Errorf("nmcli connection show failed: %w", err)
+	}
+	for _, line := range strings.Split(output, "\n") {
+		if name := strings.TrimSpace(line); name != "" {
+			return name, nil
+		}
+	}
+	return "", fmt.Errorf("no active NetworkManager connection")
+}
+
+// unpersistLinuxHostRoute removes whichever persistent route configuration ConfigureHostRoute
+// installed: the systemd-networkd drop-in if it exists (followed by a best-effort
+// `networkctl reload` whose failure does not break revert), and the matching nmcli ipv4.routes
+// entry if NetworkManager is active (mismatched entries return non-zero from nmcli but revert is
+// idempotent — that exit is intentionally swallowed). Both branches are no-ops when their backend
+// isn't in use.
+func (n *BaseNetworkManager) unpersistLinuxHostRoute(networkCIDR string) error {
+	contextName := n.configHandler.GetContext()
+	if contextName == "" {
+		contextName = "default"
+	}
+	path := fmt.Sprintf("/etc/systemd/network/windsor-%s.network", contextName)
+	if _, err := n.shims.Stat(path); err == nil {
+		if _, err := n.shell.ExecSudo("", "rm", "-f", path); err != nil {
+			return fmt.Errorf("failed to remove systemd-networkd drop-in: %w", err)
+		}
+		_, _ = n.shell.ExecSudo("", "networkctl", "reload")
+	}
+	if status, err := n.shell.ExecSilent("systemctl", "is-active", "NetworkManager"); err == nil && strings.TrimSpace(status) == "active" {
+		if conn, err := n.firstActiveNetworkManagerConnection(); err == nil {
+			guestIP := n.configHandler.GetString("workstation.address")
+			value := networkCIDR
+			if guestIP != "" {
+				value = networkCIDR + " " + guestIP
+			}
+			_, _ = n.shell.ExecSudo("", "nmcli", "connection", "modify", conn, "-ipv4.routes", value)
+		}
+	}
+	return nil
+}
+
 // needsPrivilegeForHostRoute reports whether sudo is required to add the host route for the guest.
 // It returns true when the route for network.cidr_block via guestAddress does not yet exist;
 // it returns false when the route exists, when CIDR or guest is unset, or when the route check fails.
@@ -290,14 +400,9 @@ func (n *BaseNetworkManager) needsPrivilegeForHostRoute(guestAddress string) boo
 	if networkCIDR == "" || guestAddress == "" {
 		return false
 	}
-	output, err := n.shell.ExecSilent("ip", "route", "show", networkCIDR)
+	inKernel, err := n.linuxRouteInKernel(networkCIDR, guestAddress)
 	if err != nil {
 		return false
 	}
-	for _, line := range strings.Split(output, "\n") {
-		if strings.Contains(line, guestAddress) {
-			return false
-		}
-	}
-	return true
+	return !inKernel
 }

--- a/pkg/workstation/network/linux_network.go
+++ b/pkg/workstation/network/linux_network.go
@@ -326,18 +326,19 @@ func (n *BaseNetworkManager) writeNetworkdHostRouteDropIn(networkCIDR, guestIP s
 }
 
 // addNetworkManagerPersistentRoute appends a persistent ipv4.routes entry on the first active
-// NetworkManager connection. Skips when an identical "<dest> <gateway>" entry already exists.
+// NetworkManager connection. The duplicate guard probes for both the CIDR and the gateway as
+// independent substrings in `nmcli -t -f ipv4.routes` — format-agnostic across NM versions
+// (modern NM emits `{ ip = …, nh = …, mt = N }`; older ones emit `<cidr> <gateway>`). False
+// positives are limited to the unlikely case of a different route already containing both
+// strings, where the worst outcome is skipping an already-correct add.
 func (n *BaseNetworkManager) addNetworkManagerPersistentRoute(networkCIDR, guestIP string) error {
 	conn, err := n.firstActiveNetworkManagerConnection()
 	if err != nil {
 		return err
 	}
 	current, err := n.shell.ExecSilent("nmcli", "-t", "-f", "ipv4.routes", "connection", "show", conn)
-	if err == nil {
-		needle := networkCIDR + " " + guestIP
-		if strings.Contains(current, needle) {
-			return nil
-		}
+	if err == nil && strings.Contains(current, networkCIDR) && strings.Contains(current, guestIP) {
+		return nil
 	}
 	if _, err := n.shell.ExecSudo("", "nmcli", "connection", "modify", conn, "+ipv4.routes", networkCIDR+" "+guestIP); err != nil {
 		return fmt.Errorf("nmcli connection modify failed: %w", err)
@@ -364,9 +365,11 @@ func (n *BaseNetworkManager) firstActiveNetworkManagerConnection() (string, erro
 // unpersistLinuxHostRoute removes whichever persistent route configuration ConfigureHostRoute
 // installed: the systemd-networkd drop-in if it exists (followed by a best-effort
 // `networkctl reload` whose failure does not break revert), and the matching nmcli ipv4.routes
-// entry if NetworkManager is active (mismatched entries return non-zero from nmcli but revert is
-// idempotent — that exit is intentionally swallowed). Both branches are no-ops when their backend
-// isn't in use.
+// entry if NetworkManager is active. The NM removal uses the CIDR alone — NM 1.36+ (Ubuntu 22.04+,
+// Debian 12+, Fedora 40+) matches routes by destination prefix on `-ipv4.routes`, so this catches
+// stale entries whose gateway no longer matches the current workstation.address. Both branches are
+// no-ops when their backend isn't in use; nmcli non-zero exits on no-match are intentionally
+// swallowed since revert is idempotent.
 func (n *BaseNetworkManager) unpersistLinuxHostRoute(networkCIDR string) error {
 	contextName := n.configHandler.GetContext()
 	if contextName == "" {
@@ -381,12 +384,7 @@ func (n *BaseNetworkManager) unpersistLinuxHostRoute(networkCIDR string) error {
 	}
 	if status, err := n.shell.ExecSilent("systemctl", "is-active", "NetworkManager"); err == nil && strings.TrimSpace(status) == "active" {
 		if conn, err := n.firstActiveNetworkManagerConnection(); err == nil {
-			guestIP := n.configHandler.GetString("workstation.address")
-			value := networkCIDR
-			if guestIP != "" {
-				value = networkCIDR + " " + guestIP
-			}
-			_, _ = n.shell.ExecSudo("", "nmcli", "connection", "modify", conn, "-ipv4.routes", value)
+			_, _ = n.shell.ExecSudo("", "nmcli", "connection", "modify", conn, "-ipv4.routes", networkCIDR)
 		}
 	}
 	return nil

--- a/pkg/workstation/network/linux_network_test.go
+++ b/pkg/workstation/network/linux_network_test.go
@@ -165,6 +165,133 @@ func TestLinuxNetworkManager_ConfigureHostRoute(t *testing.T) {
 			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
 		}
 	})
+
+	t.Run("PersistsRouteViaNetworkdWhenAvailable", func(t *testing.T) {
+		// Given systemd-networkd is active and our drop-in is not yet present
+		manager, mocks := setup(t)
+		if err := mocks.ConfigHandler.SetContext("local"); err != nil {
+			t.Fatalf("set context: %v", err)
+		}
+		mocks.ConfigHandler.Set("network.cidr_block", "192.168.5.0/24")
+		mocks.ConfigHandler.Set("workstation.address", "192.168.5.1")
+		mocks.Shell.ExecSilentFunc = func(command string, args ...string) (string, error) {
+			if command == "systemctl" && len(args) == 2 && args[0] == "is-active" && args[1] == "systemd-networkd" {
+				return "active", nil
+			}
+			return "", nil
+		}
+		var capturedPath string
+		var capturedContent []byte
+		mocks.Shims.WriteFile = func(path string, data []byte, _ os.FileMode) error {
+			capturedPath = path
+			capturedContent = append([]byte{}, data...)
+			return nil
+		}
+		mocks.Shims.ReadFile = func(_ string) ([]byte, error) { return nil, os.ErrNotExist }
+		var networkctlReloaded bool
+		mocks.Shell.ExecSudoFunc = func(_, command string, args ...string) (string, error) {
+			if command == "networkctl" && len(args) > 0 && args[0] == "reload" {
+				networkctlReloaded = true
+			}
+			return "", nil
+		}
+
+		if err := manager.ConfigureHostRoute(); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Then the staged drop-in file targets the per-context path and contains the route
+		if !strings.HasSuffix(capturedPath, "windsor-local.network") && !strings.Contains(capturedPath, "windsor-local") {
+			t.Errorf("expected staged drop-in basename to include windsor-local.network, got %q", capturedPath)
+		}
+		body := string(capturedContent)
+		for _, want := range []string{"[Route]", "Destination=192.168.5.0/24", "Gateway=192.168.5.1"} {
+			if !strings.Contains(body, want) {
+				t.Errorf("expected drop-in to contain %q, got: %s", want, body)
+			}
+		}
+		if !networkctlReloaded {
+			t.Error("expected networkctl reload to fire after drop-in write")
+		}
+	})
+
+	t.Run("PersistsRouteViaNetworkManagerWhenNetworkdInactive", func(t *testing.T) {
+		// Given systemd-networkd is inactive but NetworkManager is active
+		manager, mocks := setup(t)
+		mocks.ConfigHandler.Set("network.cidr_block", "192.168.5.0/24")
+		mocks.ConfigHandler.Set("workstation.address", "192.168.5.1")
+		mocks.Shell.ExecSilentFunc = func(command string, args ...string) (string, error) {
+			if command == "systemctl" && len(args) == 2 && args[0] == "is-active" {
+				if args[1] == "systemd-networkd" {
+					return "inactive", fmt.Errorf("exit status 3")
+				}
+				if args[1] == "NetworkManager" {
+					return "active", nil
+				}
+			}
+			if command == "nmcli" && len(args) >= 5 && args[0] == "-t" && args[3] == "connection" && args[4] == "show" {
+				return "Wired connection 1\n", nil
+			}
+			return "", nil
+		}
+		var modifyArgs []string
+		mocks.Shell.ExecSudoFunc = func(_, command string, args ...string) (string, error) {
+			if command == "nmcli" && len(args) > 0 && args[0] == "connection" {
+				modifyArgs = append([]string{}, args...)
+			}
+			return "", nil
+		}
+
+		if err := manager.ConfigureHostRoute(); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Then nmcli was used to append the route to the first active connection
+		if len(modifyArgs) < 5 {
+			t.Fatalf("expected nmcli connection modify call, got args=%v", modifyArgs)
+		}
+		for i, want := range []string{"connection", "modify", "Wired connection 1", "+ipv4.routes", "192.168.5.0/24 192.168.5.1"} {
+			if modifyArgs[i] != want {
+				t.Errorf("arg[%d] = %q, want %q (full args=%v)", i, modifyArgs[i], want, modifyArgs)
+			}
+		}
+	})
+
+	t.Run("WarnsWhenNoPersistenceBackendAvailable", func(t *testing.T) {
+		// Given neither systemd-networkd nor NetworkManager is active
+		manager, mocks := setup(t)
+		mocks.ConfigHandler.Set("network.cidr_block", "192.168.5.0/24")
+		mocks.ConfigHandler.Set("workstation.address", "192.168.5.1")
+		mocks.Shell.ExecSilentFunc = func(command string, args ...string) (string, error) {
+			if command == "systemctl" && len(args) == 2 && args[0] == "is-active" {
+				return "inactive", fmt.Errorf("exit status 3")
+			}
+			return "", nil
+		}
+		var ipRouteAdded bool
+		var persistenceCallSeen bool
+		mocks.Shell.ExecSudoFunc = func(_, command string, args ...string) (string, error) {
+			if command == "ip" && len(args) > 1 && args[1] == "add" {
+				ipRouteAdded = true
+			}
+			if command == "nmcli" || command == "networkctl" {
+				persistenceCallSeen = true
+			}
+			return "", nil
+		}
+
+		if err := manager.ConfigureHostRoute(); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Then the live route was added but no persistence call fired
+		if !ipRouteAdded {
+			t.Error("expected ephemeral route to still be added when no persistence backend is available")
+		}
+		if persistenceCallSeen {
+			t.Error("expected no nmcli/networkctl call when both backends are inactive")
+		}
+	})
 }
 
 func TestLinuxNetworkManager_ConfigureDNS(t *testing.T) {

--- a/pkg/workstation/network/linux_network_test.go
+++ b/pkg/workstation/network/linux_network_test.go
@@ -180,16 +180,20 @@ func TestLinuxNetworkManager_ConfigureHostRoute(t *testing.T) {
 			}
 			return "", nil
 		}
-		var capturedPath string
 		var capturedContent []byte
-		mocks.Shims.WriteFile = func(path string, data []byte, _ os.FileMode) error {
-			capturedPath = path
+		mocks.Shims.WriteFile = func(_ string, data []byte, _ os.FileMode) error {
 			capturedContent = append([]byte{}, data...)
 			return nil
 		}
 		mocks.Shims.ReadFile = func(_ string) ([]byte, error) { return nil, os.ErrNotExist }
+		// writeFileWithSudo stages into a temp dir then `sudo mv <temp> <dest>`. Capture the
+		// final destination from the mv args (not from WriteFile, which sees the temp path).
+		var destPath string
 		var networkctlReloaded bool
 		mocks.Shell.ExecSudoFunc = func(_, command string, args ...string) (string, error) {
+			if command == "mv" && len(args) == 2 {
+				destPath = args[1]
+			}
 			if command == "networkctl" && len(args) > 0 && args[0] == "reload" {
 				networkctlReloaded = true
 			}
@@ -200,9 +204,9 @@ func TestLinuxNetworkManager_ConfigureHostRoute(t *testing.T) {
 			t.Fatalf("expected no error, got %v", err)
 		}
 
-		// Then the staged drop-in file targets the per-context path and contains the route
-		if !strings.HasSuffix(capturedPath, "windsor-local.network") && !strings.Contains(capturedPath, "windsor-local") {
-			t.Errorf("expected staged drop-in basename to include windsor-local.network, got %q", capturedPath)
+		// Then the drop-in lands at the per-context path and contains the route
+		if destPath != "/etc/systemd/network/windsor-local.network" {
+			t.Errorf("expected drop-in destination /etc/systemd/network/windsor-local.network, got %q", destPath)
 		}
 		body := string(capturedContent)
 		for _, want := range []string{"[Route]", "Destination=192.168.5.0/24", "Gateway=192.168.5.1"} {


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> This PR modifies `ConfigureHostRoute` and `RevertHostRoute` on both macOS and Linux, touching sudo-elevated shell execution and system network configuration files that affect all users of the machine.
>
> **Overview**
>
> The change adds boot-persistence to the host-to-guest route that Windsor installs. On macOS it registers the route via `networksetup -setadditionalroutes` on the first enabled service; on Linux it writes a systemd-networkd drop-in or appends an `nmcli` ipv4.routes entry, falling back to a non-fatal warning when neither backend is active. Revert is extended to remove the persistent entries in both cases.
>
> Two medium-severity issues sit in the Linux NetworkManager path: the duplicate-route guard uses substring matching against nmcli's terse output (format not guaranteed stable across versions), and revert silently leaves a stale NM route when `workstation.address` changes between configure and revert. The macOS side has a lower-severity issue where the service selection picks the first-in-list rather than the currently active interface.
>
> Reviewed by Claude for commit `d0565b14`.

<!-- /claude-code-review:summary -->
