### PR TITLE
chore(runtime): improve error messages for uninitialized components and context decoding

### DIFF
--- a/pkg/runtime/config/handler.go
+++ b/pkg/runtime/config/handler.go
@@ -322,7 +322,7 @@ func (c *configHandler) SetDefault(context v1alpha1.Context) error {
 
 	var contextMap map[string]any
 	if err := c.shims.YamlUnmarshal(contextData, &contextMap); err != nil {
-		return fmt.Errorf("error unmarshalling context to map: %w", err)
+		return fmt.Errorf("error decoding context: %w", err)
 	}
 
 	c.data = c.deepMerge(c.data, contextMap)
@@ -522,7 +522,7 @@ func (c *configHandler) GetSchema() map[string]any {
 // Returns error if schema file doesn't exist or is invalid.
 func (c *configHandler) LoadSchema(schemaPath string) error {
 	if c.schemaValidator == nil {
-		return fmt.Errorf("schema validator not initialized")
+		return fmt.Errorf("runtime not fully initialized: schema validator missing")
 	}
 	if err := c.schemaValidator.LoadSchema(schemaPath); err != nil {
 		return err
@@ -538,7 +538,7 @@ func (c *configHandler) LoadSchema(schemaPath string) error {
 // Returns error if schema content is invalid.
 func (c *configHandler) LoadSchemaFromBytes(schemaContent []byte) error {
 	if c.schemaValidator == nil {
-		return fmt.Errorf("schema validator not initialized")
+		return fmt.Errorf("runtime not fully initialized: schema validator missing")
 	}
 	if err := c.schemaValidator.LoadSchemaFromBytes(schemaContent); err != nil {
 		return err

--- a/pkg/runtime/config/handler_test.go
+++ b/pkg/runtime/config/handler_test.go
@@ -1332,8 +1332,8 @@ properties:
 		if err == nil {
 			t.Error("Expected error when schema validator is nil")
 		}
-		if !strings.Contains(err.Error(), "schema validator not initialized") {
-			t.Errorf("Expected error about schema validator not initialized, got: %v", err)
+		if !strings.Contains(err.Error(), "schema validator missing") {
+			t.Errorf("Expected error about schema validator missing, got: %v", err)
 		}
 	})
 }
@@ -1375,8 +1375,8 @@ properties:
 		if err == nil {
 			t.Error("Expected error when schema validator is nil")
 		}
-		if !strings.Contains(err.Error(), "schema validator not initialized") {
-			t.Errorf("Expected error about schema validator not initialized, got: %v", err)
+		if !strings.Contains(err.Error(), "schema validator missing") {
+			t.Errorf("Expected error about schema validator missing, got: %v", err)
 		}
 	})
 

--- a/pkg/runtime/config/schema_validator.go
+++ b/pkg/runtime/config/schema_validator.go
@@ -120,7 +120,7 @@ func (sv *SchemaValidator) Validate(values map[string]any) (*SchemaValidationRes
 // touching kaptinlin's compiled form — see extractDefaults for why.
 func (sv *SchemaValidator) GetSchemaDefaults() (map[string]any, error) {
 	if sv.Schema == nil {
-		return nil, fmt.Errorf("no schema loaded - call LoadSchema first")
+		return nil, fmt.Errorf("config schema has not been loaded")
 	}
 	return extractDefaults(sv.Schema), nil
 }
@@ -136,7 +136,7 @@ func (sv *SchemaValidator) GetSchemaDefaults() (map[string]any, error) {
 // LoadSchemaFromBytes invalidates it.
 func (sv *SchemaValidator) ensureCompiled() (*jsonschema.Schema, error) {
 	if sv.Schema == nil {
-		return nil, fmt.Errorf("no schema loaded - call LoadSchema first")
+		return nil, fmt.Errorf("config schema has not been loaded")
 	}
 	if sv.compiled != nil {
 		return sv.compiled, nil

--- a/pkg/runtime/config/schema_validator_test.go
+++ b/pkg/runtime/config/schema_validator_test.go
@@ -653,7 +653,7 @@ func TestSchemaValidator_Validate(t *testing.T) {
 			t.Fatal("Expected error when no schema loaded")
 		}
 
-		expectedError := "no schema loaded - call LoadSchema first"
+		expectedError := "config schema has not been loaded"
 		if err.Error() != expectedError {
 			t.Errorf("Expected error '%s', got: %v", expectedError, err)
 		}
@@ -674,7 +674,7 @@ func TestSchemaValidator_GetSchemaDefaults(t *testing.T) {
 			t.Fatal("Expected error when no schema loaded")
 		}
 
-		expectedError := "no schema loaded - call LoadSchema first"
+		expectedError := "config schema has not been loaded"
 		if err.Error() != expectedError {
 			t.Errorf("Expected error '%s', got: %v", expectedError, err)
 		}

--- a/pkg/runtime/config/typed_source.go
+++ b/pkg/runtime/config/typed_source.go
@@ -86,7 +86,7 @@ func (s *typedSource) LoadRoot(
 
 		var contextMap map[string]any
 		if err := s.shims.YamlUnmarshal(contextData, &contextMap); err != nil {
-			return nil, true, fmt.Errorf("error unmarshalling context config to map: %w", err)
+			return nil, true, fmt.Errorf("error decoding context config: %w", err)
 		}
 
 		return contextMap, true, nil

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -591,7 +591,7 @@ func (rt *Runtime) ResolveConfig(flagOverrides map[string]any) error {
 // .windsor/contexts/<context>/workstation.yaml and excluded from values.yaml.
 func (rt *Runtime) SaveConfig(overwrite ...bool) error {
 	if rt.ConfigHandler == nil {
-		return fmt.Errorf("config handler not initialized")
+		return fmt.Errorf("runtime not fully initialized: config handler missing")
 	}
 	if v := rt.ConfigHandler.GetString("provider"); v != "" {
 		if rt.ConfigHandler.GetString("platform") == "" {

--- a/pkg/runtime/tools/tools_manager.go
+++ b/pkg/runtime/tools/tools_manager.go
@@ -345,7 +345,7 @@ func (t *BaseToolsManager) checkOnePassword() error {
 
 	out, err := t.shell.ExecSilentWithTimeout("op", []string{"--version"}, 5*time.Second)
 	if err != nil {
-		return fmt.Errorf("1Password CLI --version failed: %v", err)
+		return fmt.Errorf("1Password CLI --version failed: %w", err)
 	}
 
 	version := extractVersion(out)


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This PR makes isolated, in-place string substitutions to error messages with no logic changes, except one deliberate error-wrapping fix; all changes are confined to the runtime and config packages.
>
> **Overview**
>
> The PR replaces vague or jargon-heavy error messages with clearer, more consistent alternatives across the config handler, schema validator, typed source, tools manager, and top-level runtime. Nil-component guards now follow a uniform `"runtime not fully initialized: X missing"` pattern, and the YAML-specific term "unmarshalling" is replaced with "decoding" in two places.
>
> The one non-cosmetic change is the `%v` → `%w` fix in `tools_manager.go`, which correctly wraps the underlying shell error for the first time, enabling error chain inspection. All tests are updated in lockstep to match the new messages.
>
> Reviewed by Claude for commit `ae6d7570`.

<!-- /claude-code-review:summary -->
