### PR TITLE
chore(cmd): refine command descriptions for clarity and consistency

### DIFF
--- a/cmd/context.go
+++ b/cmd/context.go
@@ -27,8 +27,8 @@ var removedContextCmd = &cobra.Command{
 
 var getContextAliasCmd = &cobra.Command{
 	Use:          "get-context",
-	Short:        "Alias for 'get context'",
-	Long:         "Alias for 'get context'",
+	Short:        "Get the current context",
+	Long:         "Get the current context (alias for 'get context').",
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return getContextCmd.RunE(cmd, args)
@@ -37,8 +37,8 @@ var getContextAliasCmd = &cobra.Command{
 
 var setContextAliasCmd = &cobra.Command{
 	Use:          "set-context [context]",
-	Short:        "Alias for 'set context'",
-	Long:         "Alias for 'set context'",
+	Short:        "Set the current context",
+	Long:         "Set the current context (alias for 'set context').",
 	SilenceUsage: true,
 	Args:         cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -10,7 +10,7 @@ import (
 var hookCmd = &cobra.Command{
 	Use:          "hook",
 	Short:        "Print the shell hook for a target shell",
-	Long:         "Prints out shell hook information for each platform (zsh,bash,fish,tcsh,powershell).",
+	Long:         "Print the shell hook for the specified platform (zsh, bash, fish, tcsh, powershell).",
 	SilenceUsage: true,
 	Args:         cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -9,7 +9,7 @@ import (
 
 var hookCmd = &cobra.Command{
 	Use:          "hook",
-	Short:        "Prints out shell hook information per platform (zsh,bash,fish,tcsh,powershell).",
+	Short:        "Print the shell hook for a target shell",
 	Long:         "Prints out shell hook information for each platform (zsh,bash,fish,tcsh,powershell).",
 	SilenceUsage: true,
 	Args:         cobra.ExactArgs(1),

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,8 +45,8 @@ func Execute() error {
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:               "windsor",
-	Short:             "A command line interface to assist your cloud native development workflow",
-	Long:              "A command line interface to assist your cloud native development workflow",
+	Short:             "CLI for cloud-native development workflows",
+	Long:              "CLI for cloud-native development workflows.",
 	PersistentPreRunE: commandPreflight,
 }
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This change touches only Cobra help strings across three files; no logic, behavior, or test surface is affected.
>
> **Overview**
>
> The PR tightens command descriptions for `rootCmd`, `hookCmd`, and the `get-context`/`set-context` alias commands. Short descriptions are rewritten in imperative voice, redundant framing ("A command line interface to assist your…") is trimmed, and the alias commands' Long descriptions now note the alias relationship explicitly. The one substantive finding — `hookCmd`'s Long still reads "each platform" after the Short was updated to "a target shell" — is flagged as an inline comment.
>
> Reviewed by Claude for commit `db6abb6`.

<!-- /claude-code-review:summary -->
