### PR TITLE
chore(docs): add supply chain verification section with SLSA attestation and CycloneDX SBOM details

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -281,6 +281,37 @@ This document describes how to install the Windsor CLI on your development works
 
     </details>
 
+## Supply Chain Verification
+
+Every Windsor release ships with two artifacts beyond the binary and GPG signature: a CycloneDX SBOM per archive, and a SLSA v1.0 build-provenance attestation covering every release artifact. These let supply-chain reviewers verify both *what* is in the release (the SBOM) and *how* it was built (the attestation, signed via GitHub's OIDC-backed Sigstore root). The per-platform GPG checks above cover binary tamper detection; the steps in this section cover provenance and dependency review.
+
+### SLSA Build Provenance
+
+Each release archive, checksums file, and SBOM is covered by a SLSA v1.0 build-provenance attestation signed via Sigstore and published to GitHub's attestation API. Verify any downloaded artifact with [`gh attestation verify`](https://cli.github.com/manual/gh_attestation_verify) (`gh` ≥ 2.49.0):
+
+```bash
+gh attestation verify windsor_{{ config.extra.release_version }}_darwin_arm64.tar.gz --repo windsorcli/cli
+```
+
+The command fetches the attestation from `github.com/windsorcli/cli/attestations`, confirms the artifact's hash matches the signed claim, and verifies the signer was the Windsor CLI release workflow running on a GitHub-hosted runner. A successful run prints `✓ Verification succeeded!` and confirms the artifact was produced by the published release pipeline rather than a side-channel build.
+
+### CycloneDX SBOM
+
+Each release archive is accompanied by a sibling `.sbom.cdx.json` file with the full dependency tree in CycloneDX 1.5 format. Download it from the release page alongside the archive:
+
+```bash
+curl -L -o windsor_{{ config.extra.release_version }}_darwin_arm64.tar.gz.sbom.cdx.json \
+  https://github.com/windsorcli/cli/releases/download/v{{ config.extra.release_version }}/windsor_{{ config.extra.release_version }}_darwin_arm64.tar.gz.sbom.cdx.json
+```
+
+Common consumers:
+
+- **[`grype`](https://github.com/anchore/grype)** — scan the SBOM for known CVEs: `grype sbom:windsor_{{ config.extra.release_version }}_darwin_arm64.tar.gz.sbom.cdx.json`
+- **[`cyclonedx-cli`](https://github.com/CycloneDX/cyclonedx-cli)** — convert to SPDX, diff against a previous release, or check against a policy file
+- **Manual inspection** — `jq '.components[] | {name, version}' windsor_*.sbom.cdx.json` lists every dependency with its pinned version
+
+The SBOM file is covered by the same SLSA attestation as the archive, so a single `gh attestation verify` run confirms provenance for both.
+
 ## Version Check
 
 To verify the installation and check the version of the Windsor CLI, execute the following command:

--- a/docs/install.md
+++ b/docs/install.md
@@ -283,7 +283,9 @@ This document describes how to install the Windsor CLI on your development works
 
 ## Supply Chain Verification
 
-Every Windsor release ships with two artifacts beyond the binary and GPG signature: a CycloneDX SBOM per archive, and a SLSA v1.0 build-provenance attestation covering every release artifact. These let supply-chain reviewers verify both *what* is in the release (the SBOM) and *how* it was built (the attestation, signed via GitHub's OIDC-backed Sigstore root). The per-platform GPG checks above cover binary tamper detection; the steps in this section cover provenance and dependency review.
+Every Windsor release ships with two artifacts beyond the binary and GPG signature: a CycloneDX SBOM per archive, and a SLSA v1.0 build-provenance attestation covering every GitHub release asset (archives, checksums file, and SBOMs). These let supply-chain reviewers verify both *what* is in the release (the SBOM) and *how* it was built (the attestation, signed via GitHub's OIDC-backed Sigstore root). The per-platform GPG checks above cover binary tamper detection; the steps in this section cover provenance and dependency review.
+
+> **Note for Chocolatey users:** The `.nupkg` published to chocolatey.org wraps the Windows zip from this same release but is not itself covered by the SLSA attestation. To verify provenance of the binary you got via `choco install`, download the matching `windsor_<version>_windows_amd64.zip` from the GitHub release and run `gh attestation verify` on it — the binary inside is byte-identical to the one Chocolatey installed.
 
 ### SLSA Build Provenance
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This is a documentation-only change to a single markdown file, isolated from any runtime code or build configuration. The risk is low: a factual inaccuracy in the docs could mislead users about attestation coverage, but no execution path is affected.
>
> **Overview**
>
> The PR adds a new "Supply Chain Verification" section to `docs/install.md` documenting how to verify SLSA v1.0 build-provenance attestations and how to download and consume the CycloneDX SBOM that accompanies each release archive. The technical claims — artifact patterns covered by attestation, SBOM naming convention, CycloneDX format, and the `gh attestation verify` invocation — are consistent with the CI workflow in `ci.yaml` and the goreleaser config.
>
> One sentence in the introduction describes the attestation as "covering every release artifact," which is broader than what the CI step actually attests. Chocolatey packages distributed to chocolatey.org fall outside the attested set; all other GitHub release assets (archives, checksums, SBOMs) are correctly covered.
>
> Reviewed by Claude for commit `06c78f4`.

<!-- /claude-code-review:summary -->
