### PR TITLE
feat(cmd/version): labels nightly builds

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -25,6 +25,7 @@ builds:
       - "-s -w"
       - "-X 'github.com/{{ .Env.GITHUB_REPOSITORY }}/pkg/constants.Version={{ .Version }}'"
       - "-X 'github.com/{{ .Env.GITHUB_REPOSITORY }}/pkg/constants.CommitSHA={{ .Env.GITHUB_SHA }}'"
+      - "-X 'github.com/{{ .Env.GITHUB_REPOSITORY }}/pkg/constants.BuildDate={{ .Date }}'"
       - "-X 'github.com/{{ .Env.GITHUB_REPOSITORY }}/pkg/secrets.version={{ .Version }}'"
       - "-X 'github.com/{{ .Env.GITHUB_REPOSITORY }}/pkg/constants.PinnedBlueprintURL={{ .Env.PINNED_BLUEPRINT_URL }}'"
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -20,7 +20,13 @@ var versionCmd = &cobra.Command{
 	SilenceUsage: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		platform := fmt.Sprintf("%s/%s", Goos, runtime.GOARCH)
-		cmd.Printf("Version: %s\nCommit SHA: %s\nPlatform: %s\n", annotatedVersion(constants.Version), constants.CommitSHA, platform)
+		cmd.Printf("Version: %s\nCommit SHA: %s\nBuild Date: %s\nGo: %s\nPlatform: %s\n",
+			annotatedVersion(constants.Version),
+			constants.CommitSHA,
+			constants.BuildDate,
+			runtime.Version(),
+			platform,
+		)
 	},
 }
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"runtime"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/windsorcli/cli/pkg/constants"
@@ -19,8 +20,20 @@ var versionCmd = &cobra.Command{
 	SilenceUsage: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		platform := fmt.Sprintf("%s/%s", Goos, runtime.GOARCH)
-		cmd.Printf("Version: %s\nCommit SHA: %s\nPlatform: %s\n", constants.Version, constants.CommitSHA, platform)
+		cmd.Printf("Version: %s\nCommit SHA: %s\nPlatform: %s\n", annotatedVersion(constants.Version), constants.CommitSHA, platform)
 	},
+}
+
+// annotatedVersion appends a "(nightly build)" marker to goreleaser-snapshot
+// versions so operators reading `windsor version` can tell at a glance that the
+// binary is an unreleased main-branch build rather than a tagged release.
+// Goreleaser emits version strings like "0.0.0-SNAPSHOT-abc1234" in --snapshot
+// mode; tagged releases use clean semver and are returned unchanged.
+func annotatedVersion(v string) string {
+	if strings.Contains(strings.ToLower(v), "snapshot") {
+		return v + " (nightly build)"
+	}
+	return v
 }
 
 func init() {

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -80,3 +80,25 @@ func TestVersionCmd(t *testing.T) {
 		}
 	})
 }
+
+func TestAnnotatedVersion(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"taggedRelease", "0.9.0", "0.9.0"},
+		{"taggedReleaseCandidate", "0.9.0-rc.1", "0.9.0-rc.1"},
+		{"goreleaserSnapshot", "0.0.0-SNAPSHOT-abc1234", "0.0.0-SNAPSHOT-abc1234 (nightly build)"},
+		{"lowercaseSnapshot", "1.2.3-snapshot-deadbee", "1.2.3-snapshot-deadbee (nightly build)"},
+		{"devBuildUnannotated", "dev", "dev"},
+		{"emptyVersion", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := annotatedVersion(tc.in); got != tc.want {
+				t.Errorf("annotatedVersion(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -79,6 +80,26 @@ func TestVersionCmd(t *testing.T) {
 			t.Error("Expected empty stderr")
 		}
 	})
+}
+
+// TestVersionCmd_OutputStructure pins the field labels operators see on
+// `windsor version`. The §3.2 contract is: Version, Commit SHA, Build Date,
+// Go, Platform — five lines, in that order. Regressing the structure breaks
+// scripts that grep for these labels and supply-chain reviewers comparing
+// nightly vs tagged builds at a glance.
+func TestVersionCmd_OutputStructure(t *testing.T) {
+	rootCmd.SetArgs([]string{"version"})
+	stdout, _ := captureOutput(t)
+	rootCmd.SetOut(stdout)
+	rootCmd.SetErr(stdout)
+	if err := Execute(); err != nil {
+		t.Fatalf("version command: %v", err)
+	}
+	for _, label := range []string{"Version:", "Commit SHA:", "Build Date:", "Go:", "Platform:"} {
+		if !strings.Contains(stdout.String(), label) {
+			t.Errorf("expected output to contain %q, got:\n%s", label, stdout.String())
+		}
+	}
 }
 
 func TestAnnotatedVersion(t *testing.T) {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -8,6 +8,10 @@ var Version = "dev"
 // CommitSHA is the git commit SHA, set at build time via ldflags
 var CommitSHA = "none"
 
+// BuildDate is the RFC 3339 build timestamp, set at build time via ldflags
+// (goreleaser's `{{ .Date }}` template). Unset in `go build` / `go install`.
+var BuildDate = "unknown"
+
 // The Constants package provides centralized default values and configuration constants
 // It provides shared constants for default settings, timeouts, versions, and resource configurations
 // The Constants package serves as a single source of truth for default values across the application


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> The change modifies the output format of an established CLI command in a backward-incompatible way, which is the primary risk for any automation that parses `windsor version` programmatically.
>
> **Overview**
>
> This PR extends `windsor version` output from three fields to five by adding Build Date (injected at link time via a goreleaser ldflags template) and Go runtime version. It also annotates goreleaser snapshot version strings with a `(nightly build)` suffix so operators can distinguish nightly binaries from tagged releases at a glance.
>
> The behavioral changes are intentional and unit-tested. The risk lies in scripts that parse `windsor version` line-by-line or extract the Version field for bare-semver comparison — both will break silently on snapshot builds after this change.
>
> Reviewed by Claude for commit `b054bed5`.

<!-- /claude-code-review:summary -->
