### PR TITLE
feat(composer/blueprint): preserve user-authored backend in minimal blueprint creation

### DIFF
--- a/pkg/composer/blueprint/writer.go
+++ b/pkg/composer/blueprint/writer.go
@@ -104,14 +104,14 @@ func (w *BaseBlueprintWriter) Write(blueprint *blueprintv1alpha1.Blueprint, over
 // Private Methods
 // =============================================================================
 
-// createMinimalBlueprint creates the referential blueprint form: metadata, repository, and
-// createMinimalBlueprint creates a minimal blueprint with only sources, metadata, and API version.
-// This is used for first-time initialization when components come from referenced blueprints
-// rather than being explicitly listed in the user blueprint. The initBlueprintURLs parameter
-// contains blueprint URLs that should be added as sources with install: true, using their metadata
-// names from the loaded blueprints. When contexts/_template exists, a "template" source (install: true,
-// no URL) is included so the blueprint declares local template; no GitRepository/OCIRepository is
-// created for it—components from template reference repository: or another source by name.
+// createMinimalBlueprint creates the referential blueprint form: metadata, repository, sources,
+// and any user-authored top-level overrides (currently Backend). Components come from referenced
+// blueprints rather than being explicitly listed in the user blueprint. The initBlueprintURLs
+// parameter contains blueprint URLs that should be added as sources with install: true, using
+// their metadata names from the loaded blueprints. When contexts/_template exists, a "template"
+// source (install: true, no URL) is included so the blueprint declares local template; no
+// GitRepository/OCIRepository is created for it—components from template reference repository:
+// or another source by name.
 func (w *BaseBlueprintWriter) createMinimalBlueprint(blueprint *blueprintv1alpha1.Blueprint, initBlueprintURLs ...string) *blueprintv1alpha1.Blueprint {
 	metadata := blueprint.Metadata
 	if w.runtime != nil && w.runtime.ContextName != "" {
@@ -127,6 +127,9 @@ func (w *BaseBlueprintWriter) createMinimalBlueprint(blueprint *blueprintv1alpha
 	}
 	if blueprint.Repository.Url != "" {
 		minimal.Repository = blueprint.Repository
+	}
+	if blueprint.Backend != "" {
+		minimal.Backend = blueprint.Backend
 	}
 
 	trueVal := true

--- a/pkg/composer/blueprint/writer_test.go
+++ b/pkg/composer/blueprint/writer_test.go
@@ -155,6 +155,75 @@ func TestWriter_Write(t *testing.T) {
 		}
 	})
 
+	t.Run("PreservesUserBackendInReferentialForm", func(t *testing.T) {
+		// Given a blueprint carrying a user-authored top-level backend field.
+		// `windsor init --reset` rewrites blueprint.yaml from the loaded blueprint,
+		// so a regression here would silently drop the user's backend selection.
+		mocks := setupWriterMocks(t)
+		writer := NewBlueprintWriter(mocks.Runtime)
+
+		var writtenData []byte
+		writer.shims.Stat = func(path string) (os.FileInfo, error) {
+			return nil, os.ErrNotExist
+		}
+		writer.shims.MkdirAll = func(path string, perm os.FileMode) error {
+			return nil
+		}
+		writer.shims.WriteFile = func(path string, data []byte, perm os.FileMode) error {
+			writtenData = data
+			return nil
+		}
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Kind:       "Blueprint",
+			ApiVersion: "v1alpha1",
+			Metadata:   blueprintv1alpha1.Metadata{Name: "test"},
+			Backend:    "my-component",
+		}
+
+		// When writing with overwrite=true
+		if err := writer.Write(blueprint, true); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then blueprint.yaml should contain the backend field
+		if !strings.Contains(string(writtenData), "backend: my-component") {
+			t.Errorf("Expected blueprint.yaml to preserve backend, got:\n%s", writtenData)
+		}
+	})
+
+	t.Run("OmitsBackendKeyWhenEmpty", func(t *testing.T) {
+		// Given a blueprint with no backend set, the omitempty tag should keep
+		// the key out of blueprint.yaml entirely.
+		mocks := setupWriterMocks(t)
+		writer := NewBlueprintWriter(mocks.Runtime)
+
+		var writtenData []byte
+		writer.shims.Stat = func(path string) (os.FileInfo, error) {
+			return nil, os.ErrNotExist
+		}
+		writer.shims.MkdirAll = func(path string, perm os.FileMode) error {
+			return nil
+		}
+		writer.shims.WriteFile = func(path string, data []byte, perm os.FileMode) error {
+			writtenData = data
+			return nil
+		}
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Kind:       "Blueprint",
+			ApiVersion: "v1alpha1",
+			Metadata:   blueprintv1alpha1.Metadata{Name: "test"},
+		}
+
+		if err := writer.Write(blueprint, true); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if strings.Contains(string(writtenData), "backend:") {
+			t.Errorf("Expected no backend key when empty, got:\n%s", writtenData)
+		}
+	})
+
 	t.Run("WritesMinimalBlueprintWithInitURLsWhenFileDoesNotExist", func(t *testing.T) {
 		// Given a writer, no existing file, and initBlueprintURLs
 		mocks := setupWriterMocks(t)


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Isolated change to a single private method, guarded by two new tests; no shared infrastructure is affected.
>
> **Overview**
>
> The PR adds three lines to `createMinimalBlueprint` so the `Backend` field is preserved when the writer emits the referential form of `blueprint.yaml`. Without the fix, `windsor init --reset` silently drops any user-specified backend. The pattern mirrors the existing `Repository.Url` guard immediately above it.
>
> The `Write` function header comment still says "metadata, repository, and sources only," which is now slightly stale — the `createMinimalBlueprint` comment was updated to name `Backend` as a preserved field, but `Write`'s was not. Both new tests use real YAML marshalling (the shim is not overridden), so their string assertions are end-to-end rather than shallow.
>
> Reviewed by Claude for commit `de5260df`.

<!-- /claude-code-review:summary -->
