### PR TITLE
chore(docs): add command documentation generator for Windsor CLI

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,6 +42,15 @@ func Execute() error {
 	return rootCmd.ExecuteContext(ctx)
 }
 
+// RootCmd exposes the assembled cobra command tree for tooling that needs to
+// introspect commands without executing them — currently the reference-doc
+// generator under internal/gendocs. Importing the cmd package triggers the
+// init() blocks that register every subcommand, so this accessor reflects the
+// full tree by the time any caller invokes it.
+func RootCmd() *cobra.Command {
+	return rootCmd
+}
+
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
 	Use:               "windsor",

--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/containernetworking/cni v1.3.0 // indirect
 	github.com/coreos/go-semver v0.3.1 // indirect
 	github.com/cosi-project/runtime v1.14.1 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.7 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/docker/cli v29.4.3+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.9.4 // indirect
@@ -102,6 +103,7 @@ require (
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/planetscale/vtprotobuf v0.6.1-0.20250313105119-ba97887b0a25 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sasha-s/go-deadlock v0.3.6 // indirect
 	github.com/siderolabs/crypto v0.6.5 // indirect
 	github.com/siderolabs/gen v0.8.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -41,6 +41,8 @@ github.com/coreos/go-semver v0.3.1/go.mod h1:irMmmIw/7yzSRPWryHsK7EYSg09caPQL03V
 github.com/cosi-project/runtime v1.14.1 h1:1mxuH0zGXdJIy6762kaQsd+7C9MmzzuvIVIfWd867Os=
 github.com/cosi-project/runtime v1.14.1/go.mod h1:SfzpfNx7YwK8byi1X6ytikDXVMmbC7UpiCWdzntRf8M=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/cpuguy83/go-md2man/v2 v2.0.7 h1:zbFlGlXEAKlwXpmvle3d8Oe3YnkKIK4xSRTd3sHPnBo=
+github.com/cpuguy83/go-md2man/v2 v2.0.7/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc h1:U9qPSI2PIWSS1VwoXQT9A3Wy9MM3WgvqSxFWenqJduM=
@@ -228,6 +230,8 @@ github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRI
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
+github.com/russross/blackfriday v1.6.0 h1:KqfZb0pUVN2lYqZUYRddxF4OR8ZMURnJIG5Y3VRLtww=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/go-glob v1.0.0 h1:iQh3xXAumdQ+4Ufa5b25cRpC5TYKlno6hsv6Cb3pkBk=
 github.com/ryanuber/go-glob v1.0.0/go.mod h1:807d1WSdnB0XRJzKNil9Om6lcp/3a0v4qIHxIXzX/Yc=

--- a/internal/gendocs/commands.go
+++ b/internal/gendocs/commands.go
@@ -33,8 +33,8 @@ func commandsCmd() *cobra.Command {
 
 // generateCommands wipes outDir, then walks cmd.RootCmd() and emits one
 // markdown file per command. The destination is recreated empty each run so
-// renamed or removed commands do not leave stale pages behind — the CI gate
-// that runs `task docs:gen:commands && git diff --exit-code` relies on this.
+// renamed or removed commands do not leave stale pages behind — a future CI
+// gate that regenerates and asserts `git diff --exit-code` relies on this.
 func generateCommands(outDir string) error {
 	if err := os.RemoveAll(outDir); err != nil {
 		return fmt.Errorf("clear output dir: %w", err)
@@ -100,4 +100,3 @@ func lookupShort(root *cobra.Command, base string) string {
 	}
 	return c.Short
 }
-

--- a/internal/gendocs/commands.go
+++ b/internal/gendocs/commands.go
@@ -46,28 +46,28 @@ func generateCommands(outDir string) error {
 	root := cliCmd.RootCmd()
 	root.DisableAutoGenTag = true
 
-	return doc.GenMarkdownTreeCustom(root, outDir, frontmatter, linkHandler)
-}
+	// frontmatter closes over root so the emitter and the per-file frontmatter
+	// always operate on the same pre-configured command tree. cobra's
+	// GenMarkdownTreeCustom passes the destination filename (basename only); we
+	// derive the command's full invocation by replacing underscores with spaces
+	// and stripping the .md suffix.
+	frontmatter := func(filename string) string {
+		base := strings.TrimSuffix(filepath.Base(filename), ".md")
+		invocation := strings.ReplaceAll(base, "_", " ")
+		short := lookupShort(root, base)
 
-// frontmatter returns the YAML frontmatter prepended to each generated
-// markdown file. cobra's GenMarkdownTreeCustom passes the destination
-// filename (basename only); we derive the command's full invocation by
-// replacing underscores with spaces and stripping the .md suffix.
-func frontmatter(filename string) string {
-	base := strings.TrimSuffix(filepath.Base(filename), ".md")
-	invocation := strings.ReplaceAll(base, "_", " ")
-	root := cliCmd.RootCmd()
-	short := lookupShort(root, base)
-
-	var b strings.Builder
-	fmt.Fprintln(&b, "---")
-	fmt.Fprintf(&b, "title: %q\n", invocation)
-	if short != "" {
-		fmt.Fprintf(&b, "description: %q\n", short)
+		var b strings.Builder
+		fmt.Fprintln(&b, "---")
+		fmt.Fprintf(&b, "title: %q\n", invocation)
+		if short != "" {
+			fmt.Fprintf(&b, "description: %q\n", short)
+		}
+		fmt.Fprintln(&b, "---")
+		fmt.Fprintln(&b)
+		return b.String()
 	}
-	fmt.Fprintln(&b, "---")
-	fmt.Fprintln(&b)
-	return b.String()
+
+	return doc.GenMarkdownTreeCustom(root, outDir, frontmatter, linkHandler)
 }
 
 // linkHandler rewrites the inter-command links cobra emits at the bottom of

--- a/internal/gendocs/commands.go
+++ b/internal/gendocs/commands.go
@@ -1,0 +1,103 @@
+// commands.go emits docs/reference/commands/*.md from the cobra command tree
+// exposed by cmd.RootCmd(). Each cobra command becomes one markdown file
+// named <full-command-with-underscores>.md, matching cobra's standard
+// GenMarkdownTreeCustom layout. A filePrepender injects Astro-compatible YAML
+// frontmatter (title, description) so the windsorcli.github.io content
+// collection ingests the output without further processing.
+
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+	cliCmd "github.com/windsorcli/cli/cmd"
+)
+
+func commandsCmd() *cobra.Command {
+	var outDir string
+	cmd := &cobra.Command{
+		Use:   "commands",
+		Short: "Generate markdown reference for windsor commands",
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return generateCommands(outDir)
+		},
+	}
+	cmd.Flags().StringVar(&outDir, "out", "docs/reference/commands", "output directory")
+	return cmd
+}
+
+// generateCommands wipes outDir, then walks cmd.RootCmd() and emits one
+// markdown file per command. The destination is recreated empty each run so
+// renamed or removed commands do not leave stale pages behind — the CI gate
+// that runs `task docs:gen:commands && git diff --exit-code` relies on this.
+func generateCommands(outDir string) error {
+	if err := os.RemoveAll(outDir); err != nil {
+		return fmt.Errorf("clear output dir: %w", err)
+	}
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return fmt.Errorf("create output dir: %w", err)
+	}
+
+	root := cliCmd.RootCmd()
+	root.DisableAutoGenTag = true
+
+	return doc.GenMarkdownTreeCustom(root, outDir, frontmatter, linkHandler)
+}
+
+// frontmatter returns the YAML frontmatter prepended to each generated
+// markdown file. cobra's GenMarkdownTreeCustom passes the destination
+// filename (basename only); we derive the command's full invocation by
+// replacing underscores with spaces and stripping the .md suffix.
+func frontmatter(filename string) string {
+	base := strings.TrimSuffix(filepath.Base(filename), ".md")
+	invocation := strings.ReplaceAll(base, "_", " ")
+	root := cliCmd.RootCmd()
+	short := lookupShort(root, base)
+
+	var b strings.Builder
+	fmt.Fprintln(&b, "---")
+	fmt.Fprintf(&b, "title: %q\n", invocation)
+	if short != "" {
+		fmt.Fprintf(&b, "description: %q\n", short)
+	}
+	fmt.Fprintln(&b, "---")
+	fmt.Fprintln(&b)
+	return b.String()
+}
+
+// linkHandler rewrites the inter-command links cobra emits at the bottom of
+// each page. cobra's default produces `[windsor apply](windsor_apply.md)`;
+// we keep that filename (matches what GenMarkdownTreeCustom writes) but
+// could rewrite to the published site URL here if needed later.
+func linkHandler(name string) string {
+	return name
+}
+
+// lookupShort walks the command tree to find the cobra.Command whose full
+// underscore-joined name matches base, returning its Short text. Used by
+// frontmatter so the description field stays in sync with cobra's Short
+// without a second source of truth.
+func lookupShort(root *cobra.Command, base string) string {
+	if base == root.Name() {
+		return root.Short
+	}
+	parts := strings.Split(base, "_")
+	if len(parts) == 0 || parts[0] != root.Name() {
+		return ""
+	}
+	c := root
+	for _, p := range parts[1:] {
+		next, _, err := c.Find([]string{p})
+		if err != nil || next == c {
+			return ""
+		}
+		c = next
+	}
+	return c.Short
+}
+

--- a/internal/gendocs/commands.go
+++ b/internal/gendocs/commands.go
@@ -39,7 +39,7 @@ func generateCommands(outDir string) error {
 	if err := os.RemoveAll(outDir); err != nil {
 		return fmt.Errorf("clear output dir: %w", err)
 	}
-	if err := os.MkdirAll(outDir, 0o755); err != nil {
+	if err := os.MkdirAll(outDir, 0o750); err != nil {
 		return fmt.Errorf("create output dir: %w", err)
 	}
 

--- a/internal/gendocs/main.go
+++ b/internal/gendocs/main.go
@@ -1,0 +1,32 @@
+// gendocs generates the published reference documentation for the windsor CLI
+// by introspecting source-of-truth artifacts (cobra command tree, schemas,
+// env-var registry) and emitting markdown under docs/reference/.
+//
+// Subcommands map 1:1 to reference-page categories:
+//
+//	commands  cobra → docs/reference/commands/
+//
+// Future subcommands (schema, env, contexts) follow the same pattern: one file
+// per generator, one entry under main(), one Taskfile target.
+
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	root := &cobra.Command{
+		Use:   "gendocs",
+		Short: "Generate Windsor CLI reference documentation",
+	}
+	root.AddCommand(commandsCmd())
+
+	if err := root.Execute(); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This PR adds a standalone documentation generator with no effect on the CLI binary — the only production-code change is an exported `RootCmd()` accessor in `cmd/root.go`.
>
> **Overview**
>
> The PR introduces `internal/gendocs`, a `go run`-able tool that walks the cobra command tree and emits one Markdown file per command under `docs/reference/commands/`. Each file gets Astro-compatible YAML frontmatter derived from cobra's `Short` field. The directory is wiped on every run so removed commands do not leave stale pages, and two new indirect dependencies (`go-md2man/v2`, `blackfriday/v2`) are pulled in transitively by `cobra/doc`.
>
> The design has one latent coupling: `frontmatter` is a package-level function that fetches `RootCmd()` independently on each file rather than capturing the pre-configured pointer from `generateCommands`. A comment also references a CI gate (`task docs:gen:commands`) that is not yet defined in the Taskfile.
>
> Reviewed by Claude for commit `137d4959`.

<!-- /claude-code-review:summary -->
