### PR TITLE
chore(docs): add docs-check job to CI for command reference regeneration

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -194,6 +194,9 @@ jobs:
             echo "::error::Run 'task docs:gen:commands' locally and commit the result."
             echo "Changes:"
             echo "$changes"
+            # Intent-to-add the new pages so 'git diff' shows their full content
+            # as additions, not just '?? new-file.md' lines in the status output.
+            git add -N docs/reference/commands/
             git --no-pager diff docs/reference/commands/
             exit 1
           fi

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -160,6 +160,44 @@ jobs:
           GOTOOLCHAIN: 'auto'
           GOFLAGS: '-buildvcs=false'
 
+  docs-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0 renovate: depName=actions/setup-go
+        with:
+          go-version-file: go.mod
+
+      - name: Cache Go Modules
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/go-build
+            ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Regenerate command reference
+        run: go run ./internal/gendocs commands
+
+      - name: Fail if regen produced a diff
+        run: |
+          # Use git status (not git diff) so untracked files (new cobra commands)
+          # are detected alongside modifications and deletions.
+          changes=$(git status --porcelain docs/reference/commands/)
+          if [ -n "$changes" ]; then
+            echo "::error::docs/reference/commands/ is out of sync with cmd/*.go."
+            echo "::error::Run 'task docs:gen:commands' locally and commit the result."
+            echo "Changes:"
+            echo "$changes"
+            git --no-pager diff docs/reference/commands/
+            exit 1
+          fi
+
   build-nightly:
     runs-on: windows-latest
     needs: [build-and-test, sast-scan]

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 *.so
 *.dylib
 
+# Local dev binary produced by `go build ./internal/gendocs`.
+# The dev workflow is `go run ./internal/gendocs ...`; this guards against accidental commits.
+/gendocs
+
 # Test binary, built with `go test -c`
 *.test
 

--- a/Taskfile.yaml
+++ b/Taskfile.yaml
@@ -126,6 +126,11 @@ tasks:
       - go install github.com/securego/gosec/v2/cmd/gosec@latest
       - gosec ./...
 
+  docs:gen:commands:
+    desc: Regenerate docs/reference/commands/ from the cobra command tree. CI fails on any diff.
+    cmds:
+      - go run ./internal/gendocs commands
+
   run:
     desc: Run the Windsor CLI
     cmds:

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -12,9 +12,26 @@ import (
 var applyWaitFlag bool // Wait for kustomization resources to be ready after applying
 
 var applyCmd = &cobra.Command{
-	Use:          "apply",
-	Short:        "Apply infrastructure changes",
-	Long:         "Apply infrastructure changes for Windsor environment components by running Terraform and installing the blueprint.",
+	Use:   "apply",
+	Short: "Apply terraform and install the blueprint.",
+	Long: `Run Terraform components, then install the Flux blueprint. Use the 'terraform' or 'kustomize' subcommand to scope to a single layer.
+
+For workstation contexts, prefer 'windsor up' — it does the same work plus VM management.
+
+Pass --wait to block until kustomizations report ready.`,
+	Example: `# Apply everything and block until ready
+windsor apply --wait
+
+# Apply only the cluster terraform component
+windsor apply terraform cluster
+
+# Apply just the dns kustomization
+windsor apply kustomize dns`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)\n" +
+			"[`plan`](plan.md), [`destroy`](destroy.md), [`up`](up.md), [`bootstrap`](bootstrap.md)",
+		"docs.source": "cmd/apply.go",
+	},
 	Args:         cobra.NoArgs,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -67,10 +84,20 @@ var applyCmd = &cobra.Command{
 }
 
 var applyTerraformCmd = &cobra.Command{
-	Use:          "terraform <project>",
-	Aliases:      []string{"tf"},
-	Short:        "Apply Terraform changes for a specific project",
-	Long:         "Apply Terraform changes for a specific project layer.",
+	Use:     "terraform <component>",
+	Aliases: []string{"tf"},
+	Short:   "Apply Terraform changes for a single component.",
+	Long:    `Run terraform apply for a single component. The <component> argument is required and must match a terraform component declared in the blueprint.`,
+	Example: `# Apply the cluster component
+windsor apply terraform cluster
+
+# Same, using the 'tf' alias
+windsor apply tf cluster`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)\n" +
+			"[`apply`](apply.md), [`plan terraform`](plan-terraform.md), [`destroy terraform`](destroy-terraform.md)",
+		"docs.source": "cmd/apply.go",
+	},
 	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -99,9 +126,24 @@ var applyTerraformCmd = &cobra.Command{
 }
 
 var applyKustomizeCmd = &cobra.Command{
-	Use:          "kustomize [name]",
-	Short:        "Apply Flux kustomization(s) to the cluster",
-	Long:         "Apply a single Flux kustomization to the cluster by name, or all kustomizations when no argument is given.",
+	Use:   "kustomize [name]",
+	Short: "Apply Flux kustomization(s) to the cluster.",
+	Long: `Apply a single Flux kustomization to the cluster by name, or all kustomizations when no argument is given.
+
+When a name is supplied with --wait, the wait scope is narrowed to only that kustomization.`,
+	Example: `# Apply all kustomizations
+windsor apply kustomize
+
+# Apply just the dns kustomization
+windsor apply kustomize dns
+
+# Apply and wait for one kustomization to be ready
+windsor apply kustomize dns --wait`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)\n" +
+			"[`apply`](apply.md), [`plan kustomize`](plan-kustomize.md), [`destroy kustomize`](destroy-kustomize.md)",
+		"docs.source": "cmd/apply.go",
+	},
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -152,8 +194,8 @@ var applyKustomizeCmd = &cobra.Command{
 }
 
 func init() {
-	applyCmd.Flags().BoolVar(&applyWaitFlag, "wait", false, "Wait for kustomization resources to be ready")
-	applyKustomizeCmd.Flags().BoolVar(&applyWaitFlag, "wait", false, "Wait for kustomization resources to be ready")
+	applyCmd.Flags().BoolVar(&applyWaitFlag, "wait", false, "Wait for kustomization resources to be ready.")
+	applyKustomizeCmd.Flags().BoolVar(&applyWaitFlag, "wait", false, "Wait for kustomization resources to be ready.")
 	applyCmd.AddCommand(applyTerraformCmd)
 	applyCmd.AddCommand(applyKustomizeCmd)
 	rootCmd.AddCommand(applyCmd)

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -43,9 +43,30 @@ var (
 // first-run / subsequent-run branching. Without an in-blueprint backend tier, bootstrap
 // forwards to a single Up pass against the configured backend.
 var bootstrapCmd = &cobra.Command{
-	Use:          "bootstrap [context]",
-	Short:        "Bootstrap a fresh environment end-to-end",
-	Long:         "First-run setup for a context: applies Terraform, installs the Flux blueprint, and migrates state to the configured remote backend. Use `windsor apply` for everything after.",
+	Use:   "bootstrap [context]",
+	Short: "Bootstrap a fresh environment end-to-end.",
+	Long: `First-run setup for a context: applies Terraform, installs the Flux blueprint, migrates state to the configured remote backend, and waits for kustomizations.
+
+When the blueprint declares a backend Terraform component, bootstrap runs a two-phase apply to resolve the chicken-and-egg case where the remote backend (S3 bucket, DynamoDB table, etc.) lives in infrastructure Terraform must create first:
+
+    1. Override terraform.backend.type to 'local' in memory and apply only the backend component.
+    2. Restore the configured backend type and migrate the backend component's state.
+    3. Subsequent components init directly against the remote backend.
+
+When no backend component exists, bootstrap falls through to a single apply against whatever backend is configured.
+
+Re-running on an existing context prompts for confirmation. Pass --yes (or -y) to skip the prompt in CI.`,
+	Example: `# Bootstrap a new staging context on AWS
+windsor bootstrap staging --platform=aws --blueprint=ghcr.io/myorg/blueprint:v1.0.0
+
+# Re-bootstrap an existing context, scripted (skip the prompt)
+windsor bootstrap prod --yes`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)\n" +
+			"[Terraform components](https://www.windsorcli.dev/docs/components/terraform)\n" +
+			"[`init`](init.md), [`apply`](apply.md), [`destroy`](destroy.md)",
+		"docs.source": "cmd/bootstrap.go",
+	},
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -350,9 +371,9 @@ func confirmBootstrapIfContextExists(in io.Reader, configRoot, contextName strin
 }
 
 func init() {
-	bootstrapCmd.Flags().StringVar(&bootstrapPlatform, "platform", "", "Target platform [none|metal|docker|aws|azure|gcp|hyperv]")
-	bootstrapCmd.Flags().StringVar(&bootstrapBlueprint, "blueprint", "", "Blueprint OCI reference (oci://ghcr.io/org/repo:tag, ghcr.io/org/repo:tag, or org/repo:tag — host defaults to ghcr.io; tag is required)")
-	bootstrapCmd.Flags().StringSliceVar(&bootstrapSetFlags, "set", []string{}, "Override config values, e.g. --set cluster.endpoint=https://localhost:6443")
-	bootstrapCmd.Flags().BoolVarP(&bootstrapYes, "yes", "y", false, "Skip all confirmation prompts")
+	bootstrapCmd.Flags().StringVar(&bootstrapPlatform, "platform", "", "Target platform: none, metal, docker, aws, azure, gcp, hyperv.")
+	bootstrapCmd.Flags().StringVar(&bootstrapBlueprint, "blueprint", "", "Blueprint OCI reference. Accepts oci://host/org/repo:tag, host/org/repo:tag, or org/repo:tag (host defaults to ghcr.io). Tag is required.")
+	bootstrapCmd.Flags().StringSliceVar(&bootstrapSetFlags, "set", []string{}, "Override config values, e.g. --set dns.enabled=false. May be repeated.")
+	bootstrapCmd.Flags().BoolVarP(&bootstrapYes, "yes", "y", false, "Skip all confirmation prompts.")
 	rootCmd.AddCommand(bootstrapCmd)
 }

--- a/cmd/build_id.go
+++ b/cmd/build_id.go
@@ -11,18 +11,24 @@ var buildIdNewFlag bool
 
 var buildIdCmd = &cobra.Command{
 	Use:   "build-id",
-	Short: "Manage build IDs for artifact tagging",
-	Long: `Manage build IDs for artifact tagging in local development environments.
+	Short: "Print or generate a build ID.",
+	Long: `Print the current build ID, or generate a new one with --new. Build IDs are stored in .windsor/.build-id and are available to your tools as:
 
-The build-id command provides functionality to retrieve and generate new build IDs
-that are used for tagging Docker images and other artifacts during development.
-Build IDs are stored persistently in the .windsor/.build-id file and are available
-as the BUILD_ID environment variable and postBuild variable in Kustomizations.
+  - the BUILD_ID environment variable
+  - a postBuild substitution in Flux kustomizations
 
-Examples:
-  windsor build-id                    # Output current build ID
-  windsor build-id --new              # Generate and output new build ID
-  BUILD_ID=$(windsor build-id --new) && docker build -t myapp:$BUILD_ID .`,
+The ID starts with the current date (YYMMDD) and includes a same-day counter so artifacts tagged on the same day stay sortable.`,
+	Example: `# Read the current build ID
+windsor build-id
+
+# Generate a new build ID and tag an image with it
+BUILD_ID=$(windsor build-id --new)
+docker build -t myapp:$BUILD_ID .`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Workstation overview](https://www.windsorcli.dev/docs/workstation/overview)\n" +
+			"[`env`](env.md)",
+		"docs.source": "cmd/build_id.go",
+	},
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var rtOpts []*runtime.Runtime
@@ -51,6 +57,6 @@ Examples:
 }
 
 func init() {
-	buildIdCmd.Flags().BoolVar(&buildIdNewFlag, "new", false, "Generate a new build ID")
+	buildIdCmd.Flags().BoolVar(&buildIdNewFlag, "new", false, "Generate and print a new build ID.")
 	rootCmd.AddCommand(buildIdCmd)
 }

--- a/cmd/bundle.go
+++ b/cmd/bundle.go
@@ -11,24 +11,29 @@ import (
 // bundleCmd represents the bundle command
 var bundleCmd = &cobra.Command{
 	Use:   "bundle",
-	Short: "Bundle blueprints into a .tar.gz archive",
-	Long: `Bundle your Windsor blueprints into a compressed archive for distribution.
+	Short: "Bundle the blueprint into a .tar.gz archive.",
+	Long: `Bundle the current blueprint into a .tar.gz archive for sharing or offline deployment.
 
-This command packages your blueprints into a .tar.gz file that can be shared,
-stored, or deployed to target environments.
+Uses metadata.yaml ('name', 'version') to derive the output filename when --tag is not given. If neither is set, --tag is required.
 
-Examples:
-  # Bundle with automatic naming
-  windsor bundle -t myapp:v1.0.0
+When --output is a directory, the filename is derived from the tag.`,
+	Example: `# Bundle using metadata.yaml for name/version, into the current directory
+windsor bundle
 
-  # Bundle to specific file
-  windsor bundle -t myapp:v1.0.0 -o myapp-v1.0.0.tar.gz
+# Explicit tag, auto-generated filename
+windsor bundle -t myapp:v1.0.0
 
-  # Bundle to directory (filename auto-generated)
-  windsor bundle -t myapp:v1.0.0 -o ./dist/
+# Explicit tag, explicit output path
+windsor bundle -t myapp:v1.0.0 -o ./dist/myapp-v1.0.0.tar.gz
 
-  # Bundle using metadata.yaml for name/version
-  windsor bundle`,
+# Tag set, output is a directory (filename auto-generated)
+windsor bundle -t myapp:v1.0.0 -o ./dist/`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Sharing blueprints](https://www.windsorcli.dev/docs/blueprints/sharing)\n" +
+			"[Metadata reference](../metadata.md)\n" +
+			"[`push`](push.md)",
+		"docs.source": "cmd/bundle.go",
+	},
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var rtOpts []*runtime.Runtime
@@ -61,6 +66,6 @@ Examples:
 
 func init() {
 	rootCmd.AddCommand(bundleCmd)
-	bundleCmd.Flags().StringP("output", "o", ".", "Output path for bundle archive (file or directory)")
-	bundleCmd.Flags().StringP("tag", "t", "", "Tag in 'name:version' format (required if no metadata.yaml or missing name/version)")
+	bundleCmd.Flags().StringP("output", "o", ".", "Output path for the archive. May be a file or a directory.")
+	bundleCmd.Flags().StringP("tag", "t", "", "Tag in 'name:version' form. Required when metadata.yaml lacks name or version.")
 }

--- a/cmd/check.go
+++ b/cmd/check.go
@@ -22,9 +22,18 @@ var (
 )
 
 var checkCmd = &cobra.Command{
-	Use:          "check",
-	Short:        "Check the tool versions",
-	Long:         "Check the tool versions required by the project",
+	Use:   "check",
+	Short: "Verify required tools are installed.",
+	Long: `Runs the standard preflight in two passes: tool version checks for local CLIs (terraform, kubectl, talosctl, etc.), then a credential check for the platform configured on the current context (e.g. 'aws sts get-caller-identity' for platform aws).
+
+Fails fast if a required tool is missing or at the wrong version, or if credentials don't resolve.`,
+	Example: `# Verify the toolchain and cloud credentials
+windsor check`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Getting started](https://www.windsorcli.dev/docs/cli/getting-started)\n" +
+			"[`upgrade`](upgrade.md), [`up`](up.md)",
+		"docs.source": "cmd/check.go",
+	},
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var rtOpts []*runtime.Runtime
@@ -64,9 +73,24 @@ var checkCmd = &cobra.Command{
 }
 
 var checkNodeHealthCmd = &cobra.Command{
-	Use:          "node-health",
-	Short:        "Check the health of cluster nodes",
-	Long:         "Check the health status of specified cluster nodes",
+	Use:   "node-health",
+	Short: "Check the health of cluster nodes.",
+	Long: `Probe one or more cluster nodes for readiness. Useful after 'windsor upgrade' or for routine monitoring.
+
+At least one of --nodes or --k8s-endpoint must be set.`,
+	Example: `# Health-check one node, polling through a reboot
+windsor check node-health --nodes=10.0.0.5 --wait-for-reboot
+
+# Verify all nodes report Ready via the configured Kubernetes endpoint
+windsor check node-health --k8s-endpoint --ready
+
+# Check a specific Talos version on a set of nodes
+windsor check node-health --nodes=10.0.0.5,10.0.0.6 --version=v1.13.3`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Getting started](https://www.windsorcli.dev/docs/cli/getting-started)\n" +
+			"[`upgrade`](upgrade.md), [`up`](up.md)",
+		"docs.source": "cmd/check.go",
+	},
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
@@ -133,12 +157,12 @@ func init() {
 	checkCmd.AddCommand(checkNodeHealthCmd)
 
 	// Add flags for node health check
-	checkNodeHealthCmd.Flags().DurationVar(&nodeHealthTimeout, "timeout", 0, "Maximum time to wait for nodes to be ready (default 5m)")
-	checkNodeHealthCmd.Flags().StringSliceVar(&nodeHealthNodes, "nodes", []string{}, "Nodes to check (optional)")
-	checkNodeHealthCmd.Flags().StringVar(&nodeHealthVersion, "version", "", "Expected version to check against (optional)")
-	checkNodeHealthCmd.Flags().StringVar(&k8sEndpoint, "k8s-endpoint", "", "Perform Kubernetes API health check (use --k8s-endpoint or --k8s-endpoint=https://endpoint:6443)")
+	checkNodeHealthCmd.Flags().DurationVar(&nodeHealthTimeout, "timeout", 0, "Maximum time to wait for nodes to be ready. Default 5m.")
+	checkNodeHealthCmd.Flags().StringSliceVar(&nodeHealthNodes, "nodes", []string{}, "Node addresses to check.")
+	checkNodeHealthCmd.Flags().StringVar(&nodeHealthVersion, "version", "", "Expected Talos version. Reports a mismatch if set.")
+	checkNodeHealthCmd.Flags().StringVar(&k8sEndpoint, "k8s-endpoint", "", "Probe the Kubernetes API at this URL, or pass without value to use the configured endpoint.")
 	checkNodeHealthCmd.Flags().Lookup("k8s-endpoint").NoOptDefVal = "true"
-	checkNodeHealthCmd.Flags().BoolVar(&checkNodeReady, "ready", false, "Check Kubernetes node readiness status")
-	checkNodeHealthCmd.Flags().StringSliceVar(&nodeHealthSkipServices, "skip-services", []string{}, "Service names to ignore during health checks (e.g., dashboard)")
-	checkNodeHealthCmd.Flags().BoolVar(&nodeHealthWaitForReboot, "wait-for-reboot", false, "Poll until the Talos API goes offline (reboot started), then wait for it to come back up")
+	checkNodeHealthCmd.Flags().BoolVar(&checkNodeReady, "ready", false, "Check Kubernetes node readiness in addition to Talos.")
+	checkNodeHealthCmd.Flags().StringSliceVar(&nodeHealthSkipServices, "skip-services", []string{}, "Service names to ignore (e.g., dashboard).")
+	checkNodeHealthCmd.Flags().BoolVar(&nodeHealthWaitForReboot, "wait-for-reboot", false, "Poll until the Talos API goes offline (reboot started), then wait for it to come back.")
 }

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -24,14 +24,39 @@ var configureNetworkPreflight = workstation.PreflightConfigureNetwork
 
 var configureCmd = &cobra.Command{
 	Use:   "configure",
-	Short: "Configure Windsor resources",
-	Long:  "Configure Windsor resources such as workstation host/guest networking and DNS.",
+	Short: "Configure workstation resources.",
+	Long:  `Configure workstation host/guest resources. Currently supports networking and DNS via the 'network' subcommand.`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Workstation overview](https://www.windsorcli.dev/docs/workstation/overview)\n" +
+			"[`up`](up.md)",
+		"docs.source": "cmd/configure.go",
+	},
 }
 
 var configureNetworkCmd = &cobra.Command{
-	Use:          "network",
-	Short:        "Configure workstation host/guest networking and DNS",
-	Long:         "Run after 'windsor up' has provisioned the workstation. Installs the host route + in-VM forwarding required for cluster reachability on VM-backed runtimes, and writes the per-domain DNS resolver entry so '*.<dns.domain>' resolves to the cluster's DNS service. Prompts for sudo on macOS/Linux; must be run from an Administrator PowerShell on Windows. Use --dns-address to override the DNS service address; --dry-run to describe what would change without invoking sudo; --revert to remove the host configuration this command previously installed.",
+	Use:   "network",
+	Short: "Configure workstation host/guest networking and DNS.",
+	Long: `Run after 'windsor up' has provisioned the workstation. Installs the host route and in-VM forwarding required for cluster reachability on VM-backed runtimes, and writes the per-domain DNS resolver entry so '*.<dns.domain>' resolves to the cluster's DNS service.
+
+Prompts for sudo on macOS/Linux; must be run from an Administrator PowerShell on Windows. Use --dry-run to preview without modifying host state, or --revert to remove the host configuration this command previously installed.
+
+If the current context has no workstation enabled, the command is a no-op and prints 'workstation disabled'.`,
+	Example: `# Wire network using the DNS address from Terraform workstation output
+windsor configure network
+
+# Preview the changes without invoking sudo
+windsor configure network --dry-run
+
+# Wire network and explicitly set the DNS service address
+windsor configure network --dns-address=10.5.0.2
+
+# Remove the host configuration installed by this command
+windsor configure network --revert`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Workstation overview](https://www.windsorcli.dev/docs/workstation/overview)\n" +
+			"[`up`](up.md)",
+		"docs.source": "cmd/configure.go",
+	},
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var opts []*project.Project

--- a/cmd/context.go
+++ b/cmd/context.go
@@ -13,6 +13,7 @@ import (
 var removedContextCmd = &cobra.Command{
 	Use:                "context",
 	Short:              "Removed: use 'windsor get context' / 'windsor set context'",
+	Hidden:             true,
 	SilenceUsage:       true,
 	DisableFlagParsing: true,
 	Args:               cobra.ArbitraryArgs,
@@ -29,6 +30,7 @@ var getContextAliasCmd = &cobra.Command{
 	Use:          "get-context",
 	Short:        "Get the current context",
 	Long:         "Get the current context (alias for 'get context').",
+	Hidden:       true,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return getContextCmd.RunE(cmd, args)
@@ -39,6 +41,7 @@ var setContextAliasCmd = &cobra.Command{
 	Use:          "set-context [context]",
 	Short:        "Set the current context",
 	Long:         "Set the current context (alias for 'set context').",
+	Hidden:       true,
 	SilenceUsage: true,
 	Args:         cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -25,11 +25,26 @@ var destroyConfirm string
 
 var destroyCmd = &cobra.Command{
 	Use:   "destroy [component]",
-	Short: "Destroy infrastructure components",
-	Long: `Destroy infrastructure components for Windsor environment.
+	Short: "Destroy live infrastructure.",
+	Long: `Destroy live infrastructure. With no argument, removes every Flux kustomization, then every Terraform component. With a component name, destroys that component across both layers (Terraform and/or Kustomize).
 
-With no argument, destroys all Flux kustomizations then all Terraform components.
-With a component name, destroys every layer (Terraform and/or Kustomize) that contains that component.`,
+Every form requires confirmation. Either type the context or component name at the prompt, or pass --confirm=<expected> to satisfy the gate non-interactively (CI-safe). The --confirm value must match the prompt token exactly; mismatches abort the operation.
+
+If terraform reports resources protected by 'lifecycle { prevent_destroy = true }', destroy warns up front so the operator knows the destroy may halt partway through. Resources whose state is empty are skipped with a warning naming any potentially orphaned cloud resources.`,
+	Example: `# Destroy everything in the current context (interactive)
+windsor destroy
+# → prompts: Type "local" to confirm:
+
+# Same, scripted
+windsor destroy --confirm=local
+
+# Destroy just the dns component (across both layers)
+windsor destroy dns --confirm=dns`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)\n" +
+			"[`apply`](apply.md), [`down`](down.md), [`plan`](plan.md)",
+		"docs.source": "cmd/destroy.go",
+	},
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -146,10 +161,20 @@ With a component name, destroys every layer (Terraform and/or Kustomize) that co
 }
 
 var destroyTerraformCmd = &cobra.Command{
-	Use:          "terraform [project]",
-	Aliases:      []string{"tf"},
-	Short:        "Destroy Terraform component(s)",
-	Long:         "Destroy a specific Terraform component, or all components when no argument is given.",
+	Use:     "terraform [component]",
+	Aliases: []string{"tf"},
+	Short:   "Destroy Terraform component(s).",
+	Long: `Destroy a specific Terraform component, or all components when no argument is given. Inherits --confirm from the parent 'destroy' command.`,
+	Example: `# Destroy a single terraform component
+windsor destroy terraform cluster --confirm=cluster
+
+# Destroy every terraform component in the current context
+windsor destroy terraform --confirm=local`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)\n" +
+			"[`destroy`](destroy.md), [`apply terraform`](apply-terraform.md), [`plan terraform`](plan-terraform.md)",
+		"docs.source": "cmd/destroy.go",
+	},
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -228,10 +253,20 @@ var destroyTerraformCmd = &cobra.Command{
 }
 
 var destroyKustomizeCmd = &cobra.Command{
-	Use:          "kustomize [name]",
-	Aliases:      []string{"k8s"},
-	Short:        "Destroy Flux kustomization(s)",
-	Long:         "Delete a specific Flux kustomization from the cluster, or all kustomizations when no argument is given.",
+	Use:     "kustomize [name]",
+	Aliases: []string{"k8s"},
+	Short:   "Destroy Flux kustomization(s).",
+	Long: `Delete a specific Flux kustomization from the cluster, or all kustomizations when no argument is given. Inherits --confirm from the parent 'destroy' command.`,
+	Example: `# Delete a single kustomization
+windsor destroy kustomize dns --confirm=dns
+
+# Delete every kustomization in the current context
+windsor destroy kustomize --confirm=local`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)\n" +
+			"[`destroy`](destroy.md), [`apply kustomize`](apply-kustomize.md), [`plan kustomize`](plan-kustomize.md)",
+		"docs.source": "cmd/destroy.go",
+	},
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -375,7 +410,7 @@ func resolveDestroyConfirmation(r io.Reader, w io.Writer, description, expected 
 // context name (for layer-wide destroy) or component name (for targeted destroy); this is the
 // CI-safe equivalent of the interactive prompt. There is no flag that skips confirmation entirely.
 func init() {
-	destroyCmd.PersistentFlags().StringVar(&destroyConfirm, "confirm", "", "Context or component name to confirm destruction (bypasses interactive prompt)")
+	destroyCmd.PersistentFlags().StringVar(&destroyConfirm, "confirm", "", "Context or component name to confirm destruction. Must match the prompt token exactly; mismatches abort.")
 	destroyCmd.AddCommand(destroyTerraformCmd)
 	destroyCmd.AddCommand(destroyKustomizeCmd)
 	rootCmd.AddCommand(destroyCmd)

--- a/cmd/down.go
+++ b/cmd/down.go
@@ -10,9 +10,22 @@ import (
 )
 
 var downCmd = &cobra.Command{
-	Use:          "down",
-	Short:        "Stop the local workstation environment",
-	Long:         "Stop the local workstation environment by tearing down the VM, stopping container runtimes, and cleaning up context artifacts.",
+	Use:   "down",
+	Short: "Stop the local workstation environment.",
+	Long: `Tear down the workstation VM, stop container runtimes, and clear local context artifacts (.kube, .talos, generated terraform stubs, etc.). Live infrastructure is NOT destroyed by down — run 'windsor destroy' first if you need to remove cloud resources. Workstation contexts only.
+
+If any host-side network or DNS configuration was previously installed by 'windsor configure network', down prints a follow-up command at the end so the operator can clean up leftover host state.`,
+	Example: `# Standard teardown
+windsor down
+
+# Full teardown including cloud infrastructure
+windsor destroy --confirm=local
+windsor down`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)\n" +
+			"[`up`](up.md), [`destroy`](destroy.md), [`configure network`](configure-network.md)",
+		"docs.source": "cmd/down.go",
+	},
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// `windsor down` stops the local workstation (container runtime + colima VM if

--- a/cmd/env.go
+++ b/cmd/env.go
@@ -10,9 +10,27 @@ import (
 )
 
 var envCmd = &cobra.Command{
-	Use:          "env",
-	Short:        "Output commands to set environment variables",
-	Long:         "Output commands to set environment variables for the application.",
+	Use:   "env",
+	Short: "Print shell commands to export project env vars.",
+	Long: `Print shell commands that export the project's environment variables.
+Source the output, or rely on 'windsor hook' to do this automatically when you
+cd into a project.
+
+The variables include AWS, Kubernetes, Docker, Talos, and Terraform credentials
+and config paths derived from the current context.`,
+	Example: `# Source env vars manually
+eval "$(windsor env)"
+
+# Same, with secrets decrypted (1Password / SOPS)
+eval "$(windsor env --decrypt)"
+
+# Show what would be exported
+windsor env`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Environment reference](../environment.md), [Environment Injection](https://www.windsorcli.dev/docs/cli/environment-injection)\n" +
+			"[`hook`](hook.md), [`exec`](exec.md)",
+		"docs.source": "cmd/env.go",
+	},
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		hook, _ := cmd.Flags().GetBool("hook")
@@ -119,7 +137,7 @@ var envCmd = &cobra.Command{
 }
 
 func init() {
-	envCmd.Flags().Bool("decrypt", false, "Decrypt secrets before setting environment variables")
-	envCmd.Flags().Bool("hook", false, "Flag that indicates the command is being executed by the hook")
+	envCmd.Flags().Bool("decrypt", false, "Decrypt secrets before exporting env vars.")
+	envCmd.Flags().Bool("hook", false, "Non-fatal mode: suppress warnings and exit 0 on errors so a misconfigured project never breaks the prompt. The shell hook installed by 'windsor hook' invokes 'windsor env --decrypt --hook' automatically.")
 	rootCmd.AddCommand(envCmd)
 }

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -10,9 +10,26 @@ import (
 
 // execCmd represents the exec command
 var execCmd = &cobra.Command{
-	Use:          "exec [command] [args...]",
-	Short:        "Execute a command with environment variables",
-	Long:         "Execute a command with environment variables loaded from configuration and secrets",
+	Use:   "exec [--] <command> [args...]",
+	Short: "Run a command with project env vars injected.",
+	Long: `Run a command with the project's environment variables and decrypted secrets injected. Useful for one-off commands that need the full Windsor environment without sourcing it into your shell.
+
+exec is implicitly --decrypt: 1Password and SOPS secrets are dereferenced before the child process starts.
+
+If the command you're running takes flags of its own — long (--foo) or short (-x) — pass '--' first so they aren't parsed as 'windsor' flags. Without it, Cobra intercepts the flag and aborts with 'unknown flag'. The '--' is unnecessary only when the inner command takes no flags or only positional arguments.`,
+	Example: `# Inner command has its own flags — separate with --
+windsor exec -- terraform plan --var-file=staging.tfvars
+windsor exec -- kubectl logs my-pod --tail=50
+windsor exec -- helm install my-app ./chart --namespace=apps
+
+# A wrapper script that takes no flags itself
+windsor exec ./scripts/deploy.sh`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Environment reference](../environment.md), [Environment Injection](https://www.windsorcli.dev/docs/cli/environment-injection)\n" +
+			"[Secrets Management](https://www.windsorcli.dev/docs/cli/secrets-management)\n" +
+			"[`env`](env.md), [`hook`](hook.md)",
+		"docs.source": "cmd/exec.go",
+	},
 	Args:         cobra.MinimumNArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/explain.go
+++ b/cmd/explain.go
@@ -16,17 +16,20 @@ var explainCmd = &cobra.Command{
 	Long: `Print the value at the given dotted path and the contributions that produced it. Use explain to debug blueprint composition: when a value isn't what you expected, it tells you which facet, source, or expression set it (and which others were overridden).
 
 Path patterns:
-  terraform.<component>.inputs.<field>             A terraform input value.
-  terraform.<component>.inputs.<field>.components  List of contributions for a list field.
-  kustomize.<name>.substitutions.<key>             A Flux substitution.
-  kustomize.<name>.patches                         Patches applied to a kustomization.
-  configMaps.<name>.<key>                          A blueprint-level ConfigMap entry.
+
+    terraform.<component>.inputs.<field>             A terraform input value.
+    terraform.<component>.inputs.<field>.components  List of contributions for a list field.
+    kustomize.<name>.substitutions.<key>             A Flux substitution.
+    kustomize.<name>.components                      List of components in a kustomization.
+    configMaps.<name>.<key>                          A blueprint-level ConfigMap entry.
+    substitutions.<key>                              A blueprint-level substitution.
 
 Status markers in the output:
-  (deferred)  value depends on a terraform output not yet available
-  (empty)     resolved to an empty string
-  (not set)   the referenced facet config was never provided
-  (cycle)     the expression chain forms a cycle`,
+
+    (deferred)  value depends on a terraform output not yet available
+    (empty)     resolved to an empty string
+    (not set)   the referenced facet config was never provided
+    (cycle)     the expression chain forms a cycle`,
 	Example: `# Where does the cluster endpoint come from?
 windsor explain terraform.cluster.inputs.cluster_endpoint
 

--- a/cmd/explain.go
+++ b/cmd/explain.go
@@ -12,10 +12,37 @@ import (
 
 var explainCmd = &cobra.Command{
 	Use:   "explain <path>",
-	Short: "Explain where a blueprint value comes from",
-	Long:  "Explain a value in the composed blueprint by path (e.g. terraform.cluster.inputs.common_config_patches, kustomize.dns.substitutions.external_domain, configMaps.values-common.DOMAIN). Prints the value and its contributions.",
-	Args:  cobra.ExactArgs(1),
-	RunE:  runExplain,
+	Short: "Trace a blueprint value back to its sources.",
+	Long: `Print the value at the given dotted path and the contributions that produced it. Use explain to debug blueprint composition: when a value isn't what you expected, it tells you which facet, source, or expression set it (and which others were overridden).
+
+Path patterns:
+  terraform.<component>.inputs.<field>             A terraform input value.
+  terraform.<component>.inputs.<field>.components  List of contributions for a list field.
+  kustomize.<name>.substitutions.<key>             A Flux substitution.
+  kustomize.<name>.patches                         Patches applied to a kustomization.
+  configMaps.<name>.<key>                          A blueprint-level ConfigMap entry.
+
+Status markers in the output:
+  (deferred)  value depends on a terraform output not yet available
+  (empty)     resolved to an empty string
+  (not set)   the referenced facet config was never provided
+  (cycle)     the expression chain forms a cycle`,
+	Example: `# Where does the cluster endpoint come from?
+windsor explain terraform.cluster.inputs.cluster_endpoint
+
+# Trace a Flux substitution
+windsor explain kustomize.dns.substitutions.external_domain
+
+# Inspect a list field's contributions
+windsor explain terraform.cluster.inputs.common_config_patches.components`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Explain guide](https://www.windsorcli.dev/docs/cli/explain)\n" +
+			"[`show`](show.md), [`plan`](plan.md)\n" +
+			"[Facets reference](../facets.md), [Blueprint reference](../blueprint.md)",
+		"docs.source": "cmd/explain.go",
+	},
+	Args: cobra.ExactArgs(1),
+	RunE: runExplain,
 }
 
 func init() {

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -16,15 +16,31 @@ import (
 // getCmd represents the get command group
 var getCmd = &cobra.Command{
 	Use:   "get",
-	Short: "Display one or many resources",
-	Long:  "Display one or many resources",
+	Short: "Display Windsor resources.",
+	Long:  `Display Windsor resources. Currently supports listing contexts and printing the current context.`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Contexts guide](https://www.windsorcli.dev/docs/cli/contexts), [Contexts reference](../contexts.md)\n" +
+			"[`set`](set.md)",
+		"docs.source": "cmd/get.go",
+	},
 }
 
 // getContextsCmd lists all available contexts
 var getContextsCmd = &cobra.Command{
-	Use:          "contexts",
-	Short:        "List all available contexts",
-	Long:         "List all available contexts in the project. The current context is marked with an asterisk (*).",
+	Use:   "contexts",
+	Short: "List all available contexts.",
+	Long: `List contexts in the project. Output is a tab-aligned table with columns NAME, PROVIDER, BACKEND, CURRENT. The current context is marked with '*'. The PROVIDER column shows the configured platform (column header retained for backwards compatibility); BACKEND shows the configured terraform.backend.type or '<none>' when unset.`,
+	Example: `windsor get contexts
+
+# Sample output:
+#   NAME    PROVIDER  BACKEND  CURRENT
+#   local   docker    <none>   *
+#   prod    aws       s3`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Contexts guide](https://www.windsorcli.dev/docs/cli/contexts), [Contexts reference](../contexts.md)\n" +
+			"[`set`](set.md)",
+		"docs.source": "cmd/get.go",
+	},
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var rtOpts []*runtime.Runtime
@@ -115,9 +131,16 @@ var getContextsCmd = &cobra.Command{
 
 // getContextCmd gets the current context
 var getContextCmd = &cobra.Command{
-	Use:          "context",
-	Short:        "Get the current context",
-	Long:         "Retrieve and display the current context from the configuration",
+	Use:   "context",
+	Short: "Print the current context.",
+	Long:  `Print the name of the current context to stdout.`,
+	Example: `windsor get context
+# → local`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Contexts guide](https://www.windsorcli.dev/docs/cli/contexts), [Contexts reference](../contexts.md)\n" +
+			"[`set context`](set-context.md)",
+		"docs.source": "cmd/get.go",
+	},
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var rtOpts []*runtime.Runtime

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -29,7 +29,7 @@ var getCmd = &cobra.Command{
 var getContextsCmd = &cobra.Command{
 	Use:   "contexts",
 	Short: "List all available contexts.",
-	Long: `List contexts in the project. Output is a tab-aligned table with columns NAME, PROVIDER, BACKEND, CURRENT. The current context is marked with '*'. The PROVIDER column shows the configured platform (column header retained for backwards compatibility); BACKEND shows the configured terraform.backend.type or '<none>' when unset.`,
+	Long:  `List contexts in the project. Output is a tab-aligned table with columns NAME, PROVIDER, BACKEND, CURRENT. The current context is marked with '*'. The PROVIDER column shows the configured platform (column header retained for backwards compatibility); BACKEND shows the configured terraform.backend.type or '<none>' when unset.`,
 	Example: `windsor get contexts
 
 # Sample output:

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -8,9 +8,27 @@ import (
 )
 
 var hookCmd = &cobra.Command{
-	Use:          "hook",
-	Short:        "Print the shell hook for a target shell",
-	Long:         "Print the shell hook for the specified platform (zsh, bash, fish, tcsh, powershell).",
+	Use:   "hook <shell>",
+	Short: "Print shell init code for the given shell.",
+	Long: `Print init code that wires 'windsor env' into your shell. The hook re-runs 'windsor env --hook' whenever your prompt fires, exporting Windsor's per-context environment variables automatically when you cd into a project.
+
+Supported shells: zsh, bash, fish, tcsh, powershell.
+
+Add the output to your shell's rc file (or evaluate it directly during shell startup) so the hook installs on every new session.`,
+	Example: `# zsh / bash
+eval "$(windsor hook zsh)"
+eval "$(windsor hook bash)"
+
+# fish
+windsor hook fish | source
+
+# powershell
+windsor hook powershell | Out-String | Invoke-Expression`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Getting started](https://www.windsorcli.dev/docs/cli/getting-started)\n" +
+			"[`env`](env.md), [`exec`](exec.md)",
+		"docs.source": "cmd/hook.go",
+	},
 	SilenceUsage: true,
 	Args:         cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -36,9 +36,26 @@ var (
 )
 
 var initCmd = &cobra.Command{
-	Use:          "init [context]",
-	Short:        "Initialize the application environment",
-	Long:         "Initialize the application environment with the specified context configuration",
+	Use:   "init [context]",
+	Short: "Scaffold or re-initialize a Windsor context.",
+	Long: `Scaffold a Windsor project. Writes windsor.yaml at the project root if missing, creates contexts/<context>/, and adds the current directory to the trusted-folders list. Re-running on an existing context updates configuration; pass --reset to overwrite generated files and clean .terraform.
+
+If no context is given, the current context is used; if none is set, 'local' is used.
+
+The directory must be a git repository — init refuses to run in an empty or non-git directory to prevent silently scaffolding against $HOME.`,
+	Example: `# Scaffold a local context with the docker VM driver
+windsor init local --vm-driver=docker
+
+# Re-initialize and overwrite generated files
+windsor init local --reset
+
+# Initialize an AWS staging context
+windsor init staging --platform=aws --aws-profile=staging`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle), [Contexts reference](../contexts.md)\n" +
+			"[`up`](up.md), [`apply`](apply.md), [`bootstrap`](bootstrap.md)",
+		"docs.source": "cmd/init.go",
+	},
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -178,21 +195,21 @@ var initCmd = &cobra.Command{
 }
 
 func init() {
-	initCmd.Flags().BoolVar(&initReset, "reset", false, "Reset/overwrite existing files and clean .terraform directory")
-	initCmd.Flags().StringVar(&initBackend, "backend", "", "Specify the backend to use")
-	initCmd.Flags().StringVar(&initAwsProfile, "aws-profile", "", "Specify the AWS profile to use")
-	initCmd.Flags().StringVar(&initAwsEndpointURL, "aws-endpoint-url", "", "Specify the AWS endpoint URL to use")
-	initCmd.Flags().StringVar(&initVmDriver, "vm-driver", "", "VM driver (colima, colima-incus, docker-desktop, docker).")
-	initCmd.Flags().IntVar(&initCpu, "vm-cpu", 0, "Specify the number of CPUs for Colima")
-	initCmd.Flags().IntVar(&initDisk, "vm-disk", 0, "Specify the disk size for Colima")
-	initCmd.Flags().IntVar(&initMemory, "vm-memory", 0, "Specify the memory size for Colima")
-	initCmd.Flags().StringVar(&initArch, "vm-arch", "", "Specify the architecture for Colima")
-	initCmd.Flags().BoolVar(&initDocker, "docker", false, "Enable Docker")
-	initCmd.Flags().BoolVar(&initGitLivereload, "git-livereload", false, "Enable Git Livereload")
-	initCmd.Flags().StringVar(&initPlatform, "platform", "", "Specify the platform to use [none|metal|docker|aws|azure|gcp|hyperv]")
-	initCmd.Flags().StringVar(&initBlueprint, "blueprint", "", "Specify the blueprint to use")
-	initCmd.Flags().StringVar(&initEndpoint, "endpoint", "", "Specify the kubernetes API endpoint")
-	initCmd.Flags().StringSliceVar(&initSetFlags, "set", []string{}, "Override configuration values. Example: --set cluster.endpoint=https://localhost:6443")
+	initCmd.Flags().BoolVar(&initReset, "reset", false, "Overwrite existing files and clean .terraform.")
+	initCmd.Flags().StringVar(&initBackend, "backend", "", "Terraform backend type.")
+	initCmd.Flags().StringVar(&initAwsProfile, "aws-profile", "", "AWS profile name.")
+	initCmd.Flags().StringVar(&initAwsEndpointURL, "aws-endpoint-url", "", "AWS endpoint URL.")
+	initCmd.Flags().StringVar(&initVmDriver, "vm-driver", "", "VM driver: colima, colima-incus, docker-desktop, docker.")
+	initCmd.Flags().IntVar(&initCpu, "vm-cpu", 0, "CPU count for the workstation VM.")
+	initCmd.Flags().IntVar(&initDisk, "vm-disk", 0, "Disk size for the workstation VM (GB).")
+	initCmd.Flags().IntVar(&initMemory, "vm-memory", 0, "Memory for the workstation VM (GB).")
+	initCmd.Flags().StringVar(&initArch, "vm-arch", "", "CPU architecture for the workstation VM.")
+	initCmd.Flags().BoolVar(&initDocker, "docker", false, "Enable Docker.")
+	initCmd.Flags().BoolVar(&initGitLivereload, "git-livereload", false, "Enable git livereload.")
+	initCmd.Flags().StringVar(&initPlatform, "platform", "", "Target platform: none, metal, docker, aws, azure, gcp, hyperv.")
+	initCmd.Flags().StringVar(&initBlueprint, "blueprint", "", "Blueprint OCI reference or local path.")
+	initCmd.Flags().StringVar(&initEndpoint, "endpoint", "", "Kubernetes API endpoint.")
+	initCmd.Flags().StringSliceVar(&initSetFlags, "set", []string{}, "Override config values, e.g. --set dns.enabled=false. May be repeated.")
 
 	rootCmd.AddCommand(initCmd)
 }

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -10,8 +10,20 @@ import (
 var installWaitFlag bool
 
 var installCmd = &cobra.Command{
-	Use:          "install",
-	Short:        "Install the blueprint's cluster-level services",
+	Use:   "install",
+	Short: "Install the blueprint's Flux kustomizations.",
+	Long: `Apply only the Flux kustomizations to the cluster, skipping Terraform. Use this when Terraform has already been applied separately (e.g. by another tool or pipeline) and you only want to hand the cluster off to Flux.
+
+For most workflows, prefer 'windsor apply', which runs Terraform and Flux in the right order.
+
+Pass --wait to block until kustomizations report ready.`,
+	Example: `# Install kustomizations and wait for them to settle
+windsor install --wait`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Kustomize guide](https://www.windsorcli.dev/docs/guides/kustomize)\n" +
+			"[`apply`](apply.md), [`apply kustomize`](apply-kustomize.md)",
+		"docs.source": "cmd/install.go",
+	},
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// `install` applies the blueprint to the cluster (Flux + kustomizations); it does not
@@ -40,6 +52,6 @@ var installCmd = &cobra.Command{
 }
 
 func init() {
-	installCmd.Flags().BoolVar(&installWaitFlag, "wait", false, "Wait for kustomizations to be ready")
+	installCmd.Flags().BoolVar(&installWaitFlag, "wait", false, "Wait for kustomization resources to be ready.")
 	rootCmd.AddCommand(installCmd)
 }

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -20,9 +20,31 @@ var planSummary bool
 var planJSON bool
 
 var planCmd = &cobra.Command{
-	Use:          "plan [component]",
-	Short:        "Plan infrastructure changes",
-	Long:         "Plan infrastructure changes for Windsor environment components.\n\nWith no argument, shows a summary plan across all Terraform components and Flux\nkustomizations. With a component name, runs a full streaming plan for every\nlayer (Terraform and/or Kustomize) that contains that component.",
+	Use:   "plan [component]",
+	Short: "Preview terraform and Flux changes.",
+	Long: `Preview pending changes across Terraform components and Flux kustomizations without applying them.
+
+With no argument, prints a compact summary across all components. Components that have never been applied show as '(new)' so you can distinguish first-time creates from updates.
+
+With a component name, runs a full streaming plan for every layer (Terraform and/or Kustomize) that contains that component. Use a subcommand to restrict to a single layer.
+
+The --summary, --json, and --no-color flags are persistent and apply to all subcommands.`,
+	Example: `# Compact summary across both layers
+windsor plan
+
+# Full streaming plan for one component (both layers)
+windsor plan cluster
+
+# JSON-formatted summary, suitable for CI parsing
+windsor plan --summary --json
+
+# Just terraform, just one component
+windsor plan terraform cluster`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)\n" +
+			"[`apply`](apply.md), [`show`](show.md), [`explain`](explain.md)",
+		"docs.source": "cmd/plan.go",
+	},
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -124,10 +146,23 @@ var planCmd = &cobra.Command{
 }
 
 var planTerraformCmd = &cobra.Command{
-	Use:          "terraform [project]",
-	Aliases:      []string{"tf"},
-	Short:        "Plan Terraform changes",
-	Long:         "Stream terraform init and plan for a specific component, or all components when no argument is given. Use --summary for a compact table or --json for machine-readable counts.",
+	Use:     "terraform [component]",
+	Aliases: []string{"tf"},
+	Short:   "Plan Terraform changes.",
+	Long: `Stream 'terraform init' and 'terraform plan' for a specific component, or all components when no argument is given. Inherits --summary, --json, and --no-color from the parent 'plan' command.`,
+	Example: `# Stream the plan for one component
+windsor plan terraform cluster
+
+# Compact summary across all components
+windsor plan terraform --summary
+
+# Machine-readable JSON of all component plans
+windsor plan terraform --json`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)\n" +
+			"[`plan`](plan.md), [`apply terraform`](apply-terraform.md), [`destroy terraform`](destroy-terraform.md)",
+		"docs.source": "cmd/plan.go",
+	},
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -192,10 +227,20 @@ var planTerraformCmd = &cobra.Command{
 }
 
 var planKustomizeCmd = &cobra.Command{
-	Use:          "kustomize [component]",
-	Aliases:      []string{"k8s"},
-	Short:        "Plan Flux kustomization changes",
-	Long:         "Stream flux diff for a specific kustomization, or all kustomizations when no argument is given. Use --summary for a compact table or --json for machine-readable counts.",
+	Use:     "kustomize [component]",
+	Aliases: []string{"k8s"},
+	Short:   "Plan Flux kustomization changes.",
+	Long: `Stream 'flux diff' for a specific kustomization, or all kustomizations when no argument is given. Inherits --summary, --json, and --no-color from the parent 'plan' command.`,
+	Example: `# Stream the diff for one kustomization
+windsor plan kustomize dns
+
+# Compact summary across all kustomizations
+windsor plan kustomize --summary`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)\n" +
+			"[`plan`](plan.md), [`apply kustomize`](apply-kustomize.md), [`destroy kustomize`](destroy-kustomize.md)",
+		"docs.source": "cmd/plan.go",
+	},
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -251,9 +296,9 @@ var planKustomizeCmd = &cobra.Command{
 
 // init registers plan subcommands and persistent flags on the plan command group.
 func init() {
-	planCmd.PersistentFlags().BoolVar(&planNoColor, "no-color", false, "Disable color output")
-	planCmd.PersistentFlags().BoolVar(&planSummary, "summary", false, "Show a compact summary table instead of streaming output")
-	planCmd.PersistentFlags().BoolVar(&planJSON, "json", false, "Output as JSON; on subcommands streams full plan JSON, on root 'plan' outputs summary as JSON")
+	planCmd.PersistentFlags().BoolVar(&planNoColor, "no-color", false, "Disable color output.")
+	planCmd.PersistentFlags().BoolVar(&planSummary, "summary", false, "Show a compact summary table instead of streaming output.")
+	planCmd.PersistentFlags().BoolVar(&planJSON, "json", false, "Output as JSON. Streams full plan JSON on subcommands; emits the summary as JSON on root 'plan'.")
 	planCmd.AddCommand(planTerraformCmd)
 	planCmd.AddCommand(planKustomizeCmd)
 	rootCmd.AddCommand(planCmd)

--- a/cmd/push.go
+++ b/cmd/push.go
@@ -12,23 +12,27 @@ import (
 
 // pushCmd represents the push command
 var pushCmd = &cobra.Command{
-	Use:   "push [registry/repo:tag]",
-	Short: "Push blueprints to an OCI registry",
-	Long: `Push your Windsor blueprints to an OCI registry for sharing and deployment.
+	Use:   "push <registry/repo[:tag]>",
+	Short: "Push the blueprint to an OCI registry.",
+	Long: `Bundle the current blueprint and push it to an OCI-compatible registry (Docker Hub, GHCR, ECR, etc.). The pushed artifact is consumable by FluxCD's OCIRepository.
 
-This command packages your blueprint and pushes it to any OCI-compatible registry
-like Docker Hub, GitHub Container Registry, or AWS ECR. The artifacts are compatible
-with FluxCD's OCIRepository.
+The registry argument is required. When the tag is omitted, metadata.yaml ('name', 'version') is used to derive it.
 
-Examples:
-  # Push to Docker Hub
-  windsor push docker.io/myuser/myblueprint:v1.0.0
+Authentication uses your existing Docker credential helper. If push fails with an auth error, the CLI suggests 'docker login <registry>'.`,
+	Example: `# Docker Hub
+windsor push docker.io/myorg/myblueprint:v1.0.0
 
-  # Push to GitHub Container Registry  
-  windsor push ghcr.io/myorg/myblueprint:v1.0.0
+# GitHub Container Registry
+windsor push ghcr.io/myorg/myblueprint:v1.0.0
 
-  # Push using metadata.yaml for name/version
-  windsor push registry.example.com/blueprints`,
+# Tag derived from metadata.yaml
+windsor push registry.example.com/myorg/myblueprint`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Sharing blueprints](https://www.windsorcli.dev/docs/blueprints/sharing)\n" +
+			"[Metadata reference](../metadata.md)\n" +
+			"[`bundle`](bundle.md)",
+		"docs.source": "cmd/push.go",
+	},
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 0 {

--- a/cmd/root_test.go
+++ b/cmd/root_test.go
@@ -424,6 +424,27 @@ func TestRootCmd(t *testing.T) {
 			t.Errorf("Expected no error, got %v", err)
 		}
 	})
+
+	t.Run("RootCmdAccessor", func(t *testing.T) {
+		// Given the cmd package init() blocks have run
+
+		// When RootCmd is called
+		got := RootCmd()
+
+		// Then it returns the assembled root command with subcommands registered.
+		// Asserting via the version subcommand because it is one of the simplest,
+		// most stable commands; the precise list of subcommands is verified
+		// indirectly by the gendocs generator's own tests.
+		if got == nil {
+			t.Fatal("RootCmd returned nil")
+		}
+		if got.Use != "windsor" {
+			t.Errorf("expected Use=windsor, got %q", got.Use)
+		}
+		if _, _, err := got.Find([]string{"version"}); err != nil {
+			t.Errorf("expected to find 'version' subcommand: %v", err)
+		}
+	})
 }
 
 func TestRootCmd_PersistentPreRunE(t *testing.T) {

--- a/cmd/set.go
+++ b/cmd/set.go
@@ -12,15 +12,28 @@ import (
 // setCmd represents the set command group
 var setCmd = &cobra.Command{
 	Use:   "set",
-	Short: "Set a resource",
-	Long:  "Set a resource",
+	Short: "Set a Windsor resource.",
+	Long:  `Set a Windsor resource. Currently supports 'context'.`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Contexts guide](https://www.windsorcli.dev/docs/cli/contexts), [Contexts reference](../contexts.md)\n" +
+			"[`init`](init.md), [`get`](get.md)",
+		"docs.source": "cmd/set.go",
+	},
 }
 
 // setContextCmd sets the current context
 var setContextCmd = &cobra.Command{
-	Use:          "context [context-name]",
-	Short:        "Set the current context",
-	Long:         "Set the current context in the configuration and save it",
+	Use:   "context [context-name]",
+	Short: "Switch the current context.",
+	Long:  `Switch the current context and persist the choice to the project config. The context directory must already exist (created by 'windsor init').`,
+	Example: `windsor set context staging
+windsor get context
+# → staging`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Contexts guide](https://www.windsorcli.dev/docs/cli/contexts), [Contexts reference](../contexts.md)\n" +
+			"[`init`](init.md), [`get context`](get-context.md)",
+		"docs.source": "cmd/set.go",
+	},
 	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -23,14 +23,36 @@ var showValuesJSON bool
 
 var showCmd = &cobra.Command{
 	Use:   "show",
-	Short: "Display rendered resources",
-	Long:  "Display fully rendered resources to stdout, including all computed fields from blueprint composition.",
+	Short: "Display rendered resources.",
+	Long: `Print rendered Windsor resources to stdout. Reads the project state and runs blueprint composition without applying anything.
+
+Unresolved deferred values render as '<deferred>' by default in 'blueprint' and 'kustomization' output; pass --raw to keep the original expression text instead.`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)\n" +
+			"[`explain`](explain.md), [`plan`](plan.md)\n" +
+			"[Blueprint reference](../blueprint.md), [Configuration reference](../configuration.md)",
+		"docs.source": "cmd/show.go",
+	},
 }
 
 var showBlueprintCmd = &cobra.Command{
-	Use:          "blueprint",
-	Short:        "Display the fully rendered blueprint",
-	Long:         "Display the fully rendered blueprint to stdout, including all fields from underlying sources and computed values. Defaults to YAML, use --json for JSON. Unresolved deferred values are shown as <deferred> by default; use --raw to show expression text.",
+	Use:   "blueprint",
+	Short: "Display the fully rendered blueprint.",
+	Long:  `Print the fully composed blueprint to stdout, including all fields from underlying sources and computed values. Defaults to YAML; use --json for JSON. Unresolved deferred values render as '<deferred>' by default; use --raw to keep the original expression text instead.`,
+	Example: `# Print the composed blueprint as YAML
+windsor show blueprint
+
+# Same, but keep deferred expressions visible
+windsor show blueprint --raw
+
+# JSON output for tooling
+windsor show blueprint --json`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)\n" +
+			"[`explain`](explain.md), [`plan`](plan.md)\n" +
+			"[Blueprint reference](../blueprint.md)",
+		"docs.source": "cmd/show.go",
+	},
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		_, blueprint, deferredPaths, validationErr := getBlueprint(cmd)
@@ -55,9 +77,20 @@ var showBlueprintCmd = &cobra.Command{
 }
 
 var showKustomizationCmd = &cobra.Command{
-	Use:          "kustomization <component-name>",
-	Short:        "Display the Flux Kustomization resource for a component",
-	Long:         "Display the Flux Kustomization resource for the specified component to stdout. Defaults to YAML, use --json for JSON. Unresolved deferred values are shown as <deferred> by default; use --raw to show expression text.",
+	Use:   "kustomization <component-name>",
+	Short: "Display the Flux Kustomization resource for a component.",
+	Long:  `Print the Flux Kustomization resource for the named component, including blueprint-level ConfigMaps in postBuild.substituteFrom. The output matches what 'windsor apply' would write to the cluster. Defaults to YAML; use --json for JSON. Unresolved deferred values render as '<deferred>' by default; use --raw to keep the original expression text instead.`,
+	Example: `# Inspect the Flux Kustomization for one component
+windsor show kustomization dns
+
+# JSON for tooling
+windsor show kustomization dns --json`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)\n" +
+			"[`apply`](apply.md), [`plan`](plan.md)\n" +
+			"[Blueprint reference](../blueprint.md)",
+		"docs.source": "cmd/show.go",
+	},
 	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -94,9 +127,20 @@ var showKustomizationCmd = &cobra.Command{
 }
 
 var showValuesCmd = &cobra.Command{
-	Use:          "values",
-	Short:        "Display the effective context values",
-	Long:         "Display the effective context values to stdout, combining schema defaults with values.yaml overrides. YAML output includes schema descriptions as comments. Use --json for plain JSON.",
+	Use:   "values",
+	Short: "Display the effective context values.",
+	Long:  `Print the effective context values, merging schema defaults with values.yaml overrides. YAML output includes schema descriptions as comments. Use --json for plain JSON.`,
+	Example: `# Effective values for the current context, with schema descriptions
+windsor show values
+
+# Plain JSON for tooling
+windsor show values --json`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)\n" +
+			"[`explain`](explain.md)\n" +
+			"[Configuration reference](../configuration.md)",
+		"docs.source": "cmd/show.go",
+	},
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		values, schema, err := getValues(cmd)
@@ -114,11 +158,11 @@ var showValuesCmd = &cobra.Command{
 }
 
 func init() {
-	showBlueprintCmd.Flags().BoolVar(&showBlueprintJSON, "json", false, "Output as JSON instead of YAML")
-	showBlueprintCmd.Flags().BoolVar(&showBlueprintRaw, "raw", false, "Output unresolved deferred values as expression text instead of <deferred>")
-	showKustomizationCmd.Flags().BoolVar(&showKustomizationJSON, "json", false, "Output as JSON instead of YAML")
-	showKustomizationCmd.Flags().BoolVar(&showKustomizationRaw, "raw", false, "Output unresolved deferred values as expression text instead of <deferred>")
-	showValuesCmd.Flags().BoolVar(&showValuesJSON, "json", false, "Output as JSON instead of YAML")
+	showBlueprintCmd.Flags().BoolVar(&showBlueprintJSON, "json", false, "Output as JSON instead of YAML.")
+	showBlueprintCmd.Flags().BoolVar(&showBlueprintRaw, "raw", false, "Keep deferred expressions as text instead of <deferred>.")
+	showKustomizationCmd.Flags().BoolVar(&showKustomizationJSON, "json", false, "Output as JSON instead of YAML.")
+	showKustomizationCmd.Flags().BoolVar(&showKustomizationRaw, "raw", false, "Keep deferred expressions as text instead of <deferred>.")
+	showValuesCmd.Flags().BoolVar(&showValuesJSON, "json", false, "Output as JSON instead of YAML.")
 	showCmd.AddCommand(showBlueprintCmd)
 	showCmd.AddCommand(showKustomizationCmd)
 	showCmd.AddCommand(showValuesCmd)

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -10,9 +10,23 @@ import (
 )
 
 var testCmd = &cobra.Command{
-	Use:          "test [test-name]",
-	Short:        "Run blueprint composition tests",
-	Long:         "Run static tests that validate blueprint composition against expected outputs. Tests are defined in contexts/_template/tests/ directory.",
+	Use:   "test [test-name]",
+	Short: "Run blueprint composition tests.",
+	Long: `Run static tests that compare blueprint composition against expected outputs. Tests live in contexts/_template/tests/ as '*.test.yaml' files.
+
+A test runs the blueprint composer in isolation (no terraform, no cluster, no live secrets) and asserts the resulting blueprint, kustomization, or values match a fixture. Use 'windsor test' to validate that schema or facet changes don't accidentally regress composition.
+
+When a test name is provided, only that test runs; otherwise every test under contexts/_template/tests/ runs.`,
+	Example: `# Run all tests
+windsor test
+
+# Run a single named test
+windsor test cluster-defaults`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Blueprint testing](https://www.windsorcli.dev/docs/blueprints/testing)\n" +
+			"[Testing reference](../testing.md)",
+		"docs.source": "cmd/test.go",
+	},
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var opts []*project.Project

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -23,9 +23,27 @@ var (
 )
 
 var upCmd = &cobra.Command{
-	Use:          "up",
-	Short:        "Bring up the local workstation environment",
-	Long:         "Bring up the local workstation environment by starting the VM, applying Terraform, and installing the blueprint.",
+	Use:   "up",
+	Short: "Bring up the local workstation environment.",
+	Long: `Start the workstation VM, run Terraform components, then install the Flux blueprint. Workstation contexts only — for non-workstation contexts, use 'windsor apply'. If the current context has no workstation, up exits with a hint and does no work.
+
+Returns once the install request has been issued. Pass --wait to block until kustomizations report ready.
+
+If any host-side network or DNS configuration was deferred (because it requires sudo / elevation), up prints a follow-up command at the end so the operator knows what to run next.`,
+	Example: `# Bring up the workstation and wait for everything to be ready
+windsor up --wait
+
+# Override an inline config value at startup
+windsor up --set cluster.workers.count=3
+
+# Initialize and bring up with a specific blueprint
+windsor up --blueprint=ghcr.io/myorg/blueprint:v1.0.0`,
+	Annotations: map[string]string{
+		"docs.seealso": "[Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)\n" +
+			"[Workstation overview](https://www.windsorcli.dev/docs/workstation/overview)\n" +
+			"[`down`](down.md), [`apply`](apply.md), [`destroy`](destroy.md)",
+		"docs.source": "cmd/up.go",
+	},
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var opts []*project.Project
@@ -180,10 +198,10 @@ func buildUpFlagOverrides() (map[string]any, error) {
 }
 
 func init() {
-	upCmd.Flags().BoolVar(&waitFlag, "wait", false, "Wait for kustomization resources to be ready")
-	upCmd.Flags().StringVar(&upVmDriver, "vm-driver", "", "VM driver (colima, colima-incus, docker-desktop, docker)")
-	upCmd.Flags().StringVar(&upPlatform, "platform", "", "Specify the platform to use [none|metal|docker|aws|azure|gcp|hyperv]")
-	upCmd.Flags().StringVar(&upBlueprint, "blueprint", "", "Specify the blueprint to use")
-	upCmd.Flags().StringSliceVar(&upSetFlags, "set", []string{}, "Override configuration values. Example: --set cluster.endpoint=https://localhost:6443")
+	upCmd.Flags().BoolVar(&waitFlag, "wait", false, "Wait for kustomization resources to be ready.")
+	upCmd.Flags().StringVar(&upVmDriver, "vm-driver", "", "VM driver: colima, colima-incus, docker-desktop, docker.")
+	upCmd.Flags().StringVar(&upPlatform, "platform", "", "Target platform: none, metal, docker, aws, azure, gcp, hyperv.")
+	upCmd.Flags().StringVar(&upBlueprint, "blueprint", "", "Blueprint OCI reference or local path.")
+	upCmd.Flags().StringSliceVar(&upSetFlags, "set", []string{}, "Override config values, e.g. --set dns.enabled=false. May be repeated.")
 	rootCmd.AddCommand(upCmd)
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -22,16 +22,31 @@ var (
 )
 
 var upgradeCmd = &cobra.Command{
-	Use:          "upgrade",
-	Short:        "Upgrade cluster resources",
-	Long:         "Upgrade cluster nodes and other resources",
+	Use:   "upgrade",
+	Short: "Upgrade cluster components.",
+	Long:  `Upgrade cluster components. Currently supports Talos node upgrades via the 'cluster' (parallel) and 'node' (one-at-a-time, with health verification) subcommands.`,
+	Annotations: map[string]string{
+		"docs.seealso": "[`check node-health`](check-node-health.md)",
+		"docs.source":  "cmd/upgrade.go",
+	},
 	SilenceUsage: true,
 }
 
 var upgradeClusterCmd = &cobra.Command{
-	Use:          "cluster",
-	Short:        "Upgrade cluster nodes",
-	Long:         "Upgrade specified cluster nodes to a new version",
+	Use:   "cluster",
+	Short: "Upgrade cluster nodes in parallel.",
+	Long: `Initiate a Talos upgrade on the named nodes in parallel. Returns once the upgrade requests are accepted; nodes reboot asynchronously.
+
+Use 'windsor check node-health --wait-for-reboot' afterward to verify each node comes back healthy.`,
+	Example: `# Upgrade all controlplane nodes in parallel
+windsor upgrade cluster \
+  --nodes=10.0.0.5,10.0.0.6,10.0.0.7 \
+  --image=ghcr.io/siderolabs/installer:v1.13.0`,
+	Annotations: map[string]string{
+		"docs.seealso": "[`upgrade node`](upgrade-node.md)\n" +
+			"[`check node-health`](check-node-health.md)",
+		"docs.source": "cmd/upgrade.go",
+	},
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var rtOpts []*runtime.Runtime
@@ -67,9 +82,19 @@ var upgradeClusterCmd = &cobra.Command{
 }
 
 var upgradeNodeCmd = &cobra.Command{
-	Use:          "node",
-	Short:        "Upgrade a single cluster node and wait for it to rejoin",
-	Long:         "Send an upgrade request to a single Talos node, wait for it to reboot, then verify it is healthy",
+	Use:   "node",
+	Short: "Upgrade a single cluster node and wait for it to rejoin.",
+	Long:  `Send an upgrade request to a single Talos node, wait for it to reboot, then verify it is healthy. Suitable for rolling upgrades one node at a time.`,
+	Example: `# Roll one node, blocking until it is healthy
+windsor upgrade node --node=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.0
+
+# Same with a longer timeout for slow rebooters
+windsor upgrade node --node=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.0 --timeout=20m`,
+	Annotations: map[string]string{
+		"docs.seealso": "[`upgrade cluster`](upgrade-cluster.md)\n" +
+			"[`check node-health`](check-node-health.md)",
+		"docs.source": "cmd/upgrade.go",
+	},
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if !cmd.Flags().Changed("timeout") {
@@ -122,14 +147,14 @@ func init() {
 	upgradeCmd.AddCommand(upgradeClusterCmd)
 	upgradeCmd.AddCommand(upgradeNodeCmd)
 
-	upgradeClusterCmd.Flags().StringSliceVar(&upgradeNodes, "nodes", []string{}, "Nodes to upgrade (required)")
-	upgradeClusterCmd.Flags().StringVar(&upgradeImage, "image", "", "Image to upgrade to (required for Talos)")
+	upgradeClusterCmd.Flags().StringSliceVar(&upgradeNodes, "nodes", []string{}, "Node addresses to upgrade. Required.")
+	upgradeClusterCmd.Flags().StringVar(&upgradeImage, "image", "", "Talos image to upgrade to. Required.")
 	_ = upgradeClusterCmd.MarkFlagRequired("nodes")
 	_ = upgradeClusterCmd.MarkFlagRequired("image")
 
-	upgradeNodeCmd.Flags().StringVar(&upgradeNodeAddr, "node", "", "Node IP address to upgrade (required)")
-	upgradeNodeCmd.Flags().StringVar(&upgradeNodeImage, "image", "", "Talos image to upgrade to (required)")
-	upgradeNodeCmd.Flags().DurationVar(&upgradeNodeTimeout, "timeout", 0, "Overall timeout (default 10m)")
+	upgradeNodeCmd.Flags().StringVar(&upgradeNodeAddr, "node", "", "Node IP address to upgrade. Required.")
+	upgradeNodeCmd.Flags().StringVar(&upgradeNodeImage, "image", "", "Talos image to upgrade to. Required.")
+	upgradeNodeCmd.Flags().DurationVar(&upgradeNodeTimeout, "timeout", 0, "Overall timeout. Default 10m.")
 	_ = upgradeNodeCmd.MarkFlagRequired("node")
 	_ = upgradeNodeCmd.MarkFlagRequired("image")
 }

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -14,9 +14,20 @@ var Goos = runtime.GOOS
 
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
-	Use:          "version",
-	Short:        "Display the current version",
-	Long:         "Display the current version of the application",
+	Use:   "version",
+	Short: "Print the CLI version, commit, build date, Go toolchain, and platform.",
+	Long: `Print five lines: the semver Version, the build's Commit SHA, the Build Date, the Go toolchain that built the binary, and the target Platform (GOOS/GOARCH).
+
+Snapshot builds emitted by goreleaser have ' (nightly build)' appended to the Version line so operators can tell at a glance that the binary is an unreleased main-branch build rather than a tagged release. Tagged releases use clean semver and are returned unchanged.`,
+	Example: `$ windsor version
+Version: 0.9.0
+Commit SHA: 4e0d9104
+Build Date: 2026-05-27T18:30:00Z
+Go: go1.26.3
+Platform: darwin/arm64`,
+	Annotations: map[string]string{
+		"docs.source": "cmd/version.go",
+	},
 	SilenceUsage: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		platform := fmt.Sprintf("%s/%s", Goos, runtime.GOARCH)

--- a/docs/reference/commands/apply-kustomize.md
+++ b/docs/reference/commands/apply-kustomize.md
@@ -1,0 +1,38 @@
+---
+title: "windsor apply kustomize"
+description: "Apply Flux kustomization(s) to the cluster."
+---
+# windsor apply kustomize
+
+```sh
+windsor apply kustomize [name] [flags]
+```
+
+Apply a single Flux kustomization to the cluster by name, or all kustomizations when no argument is given.
+
+When a name is supplied with --wait, the wait scope is narrowed to only that kustomization.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--wait` | `false` | Wait for kustomization resources to be ready. |
+
+## Examples
+
+```sh
+# Apply all kustomizations
+windsor apply kustomize
+
+# Apply just the dns kustomization
+windsor apply kustomize dns
+
+# Apply and wait for one kustomization to be ready
+windsor apply kustomize dns --wait
+```
+
+## See also
+
+- [Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)
+- [`apply`](apply.md), [`plan kustomize`](plan-kustomize.md), [`destroy kustomize`](destroy-kustomize.md)
+- Source: [cmd/apply.go](https://github.com/windsorcli/cli/blob/main/cmd/apply.go)

--- a/docs/reference/commands/apply-terraform.md
+++ b/docs/reference/commands/apply-terraform.md
@@ -1,0 +1,27 @@
+---
+title: "windsor apply terraform"
+description: "Apply Terraform changes for a single component."
+---
+# windsor apply terraform
+
+```sh
+windsor apply terraform <component>
+```
+
+Run terraform apply for a single component. The <component> argument is required and must match a terraform component declared in the blueprint.
+
+## Examples
+
+```sh
+# Apply the cluster component
+windsor apply terraform cluster
+
+# Same, using the 'tf' alias
+windsor apply tf cluster
+```
+
+## See also
+
+- [Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)
+- [`apply`](apply.md), [`plan terraform`](plan-terraform.md), [`destroy terraform`](destroy-terraform.md)
+- Source: [cmd/apply.go](https://github.com/windsorcli/cli/blob/main/cmd/apply.go)

--- a/docs/reference/commands/apply.md
+++ b/docs/reference/commands/apply.md
@@ -1,0 +1,45 @@
+---
+title: "windsor apply"
+description: "Apply terraform and install the blueprint."
+---
+# windsor apply
+
+```sh
+windsor apply [flags]
+```
+
+Run Terraform components, then install the Flux blueprint. Use the 'terraform' or 'kustomize' subcommand to scope to a single layer.
+
+For workstation contexts, prefer 'windsor up' — it does the same work plus VM management.
+
+Pass --wait to block until kustomizations report ready.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--wait` | `false` | Wait for kustomization resources to be ready. |
+
+## Subcommands
+
+- [`windsor apply kustomize`](apply-kustomize.md) — Apply Flux kustomization(s) to the cluster.
+- [`windsor apply terraform`](apply-terraform.md) — Apply Terraform changes for a single component.
+
+## Examples
+
+```sh
+# Apply everything and block until ready
+windsor apply --wait
+
+# Apply only the cluster terraform component
+windsor apply terraform cluster
+
+# Apply just the dns kustomization
+windsor apply kustomize dns
+```
+
+## See also
+
+- [Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)
+- [`plan`](plan.md), [`destroy`](destroy.md), [`up`](up.md), [`bootstrap`](bootstrap.md)
+- Source: [cmd/apply.go](https://github.com/windsorcli/cli/blob/main/cmd/apply.go)

--- a/docs/reference/commands/bootstrap.md
+++ b/docs/reference/commands/bootstrap.md
@@ -1,0 +1,47 @@
+---
+title: "windsor bootstrap"
+description: "Bootstrap a fresh environment end-to-end."
+---
+# windsor bootstrap
+
+```sh
+windsor bootstrap [context] [flags]
+```
+
+First-run setup for a context: applies Terraform, installs the Flux blueprint, migrates state to the configured remote backend, and waits for kustomizations.
+
+When the blueprint declares a backend Terraform component, bootstrap runs a two-phase apply to resolve the chicken-and-egg case where the remote backend (S3 bucket, DynamoDB table, etc.) lives in infrastructure Terraform must create first:
+
+    1. Override terraform.backend.type to 'local' in memory and apply only the backend component.
+    2. Restore the configured backend type and migrate the backend component's state.
+    3. Subsequent components init directly against the remote backend.
+
+When no backend component exists, bootstrap falls through to a single apply against whatever backend is configured.
+
+Re-running on an existing context prompts for confirmation. Pass --yes (or -y) to skip the prompt in CI.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--blueprint` | `""` | Blueprint OCI reference. Accepts oci://host/org/repo:tag, host/org/repo:tag, or org/repo:tag (host defaults to ghcr.io). Tag is required. |
+| `--platform` | `""` | Target platform: none, metal, docker, aws, azure, gcp, hyperv. |
+| `--set` | `[]` | Override config values, e.g. --set dns.enabled=false. May be repeated. |
+| `-y`, `--yes` | `false` | Skip all confirmation prompts. |
+
+## Examples
+
+```sh
+# Bootstrap a new staging context on AWS
+windsor bootstrap staging --platform=aws --blueprint=ghcr.io/myorg/blueprint:v1.0.0
+
+# Re-bootstrap an existing context, scripted (skip the prompt)
+windsor bootstrap prod --yes
+```
+
+## See also
+
+- [Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)
+- [Terraform components](https://www.windsorcli.dev/docs/components/terraform)
+- [`init`](init.md), [`apply`](apply.md), [`destroy`](destroy.md)
+- Source: [cmd/bootstrap.go](https://github.com/windsorcli/cli/blob/main/cmd/bootstrap.go)

--- a/docs/reference/commands/build-id.md
+++ b/docs/reference/commands/build-id.md
@@ -1,0 +1,39 @@
+---
+title: "windsor build-id"
+description: "Print or generate a build ID."
+---
+# windsor build-id
+
+```sh
+windsor build-id [flags]
+```
+
+Print the current build ID, or generate a new one with --new. Build IDs are stored in .windsor/.build-id and are available to your tools as:
+
+  - the BUILD_ID environment variable
+  - a postBuild substitution in Flux kustomizations
+
+The ID starts with the current date (YYMMDD) and includes a same-day counter so artifacts tagged on the same day stay sortable.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--new` | `false` | Generate and print a new build ID. |
+
+## Examples
+
+```sh
+# Read the current build ID
+windsor build-id
+
+# Generate a new build ID and tag an image with it
+BUILD_ID=$(windsor build-id --new)
+docker build -t myapp:$BUILD_ID .
+```
+
+## See also
+
+- [Workstation overview](https://www.windsorcli.dev/docs/workstation/overview)
+- [`env`](env.md)
+- Source: [cmd/build_id.go](https://github.com/windsorcli/cli/blob/main/cmd/build_id.go)

--- a/docs/reference/commands/bundle.md
+++ b/docs/reference/commands/bundle.md
@@ -1,0 +1,45 @@
+---
+title: "windsor bundle"
+description: "Bundle the blueprint into a .tar.gz archive."
+---
+# windsor bundle
+
+```sh
+windsor bundle [flags]
+```
+
+Bundle the current blueprint into a .tar.gz archive for sharing or offline deployment.
+
+Uses metadata.yaml ('name', 'version') to derive the output filename when --tag is not given. If neither is set, --tag is required.
+
+When --output is a directory, the filename is derived from the tag.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-o`, `--output` | `.` | Output path for the archive. May be a file or a directory. |
+| `-t`, `--tag` | `""` | Tag in 'name:version' form. Required when metadata.yaml lacks name or version. |
+
+## Examples
+
+```sh
+# Bundle using metadata.yaml for name/version, into the current directory
+windsor bundle
+
+# Explicit tag, auto-generated filename
+windsor bundle -t myapp:v1.0.0
+
+# Explicit tag, explicit output path
+windsor bundle -t myapp:v1.0.0 -o ./dist/myapp-v1.0.0.tar.gz
+
+# Tag set, output is a directory (filename auto-generated)
+windsor bundle -t myapp:v1.0.0 -o ./dist/
+```
+
+## See also
+
+- [Sharing blueprints](https://www.windsorcli.dev/docs/blueprints/sharing)
+- [Metadata reference](../metadata.md)
+- [`push`](push.md)
+- Source: [cmd/bundle.go](https://github.com/windsorcli/cli/blob/main/cmd/bundle.go)

--- a/docs/reference/commands/check-node-health.md
+++ b/docs/reference/commands/check-node-health.md
@@ -1,0 +1,44 @@
+---
+title: "windsor check node-health"
+description: "Check the health of cluster nodes."
+---
+# windsor check node-health
+
+```sh
+windsor check node-health [flags]
+```
+
+Probe one or more cluster nodes for readiness. Useful after 'windsor upgrade' or for routine monitoring.
+
+At least one of --nodes or --k8s-endpoint must be set.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--k8s-endpoint` | `""` | Probe the Kubernetes API at this URL, or pass without value to use the configured endpoint. |
+| `--nodes` | `[]` | Node addresses to check. |
+| `--ready` | `false` | Check Kubernetes node readiness in addition to Talos. |
+| `--skip-services` | `[]` | Service names to ignore (e.g., dashboard). |
+| `--timeout` | `0s` | Maximum time to wait for nodes to be ready. Default 5m. |
+| `--version` | `""` | Expected Talos version. Reports a mismatch if set. |
+| `--wait-for-reboot` | `false` | Poll until the Talos API goes offline (reboot started), then wait for it to come back. |
+
+## Examples
+
+```sh
+# Health-check one node, polling through a reboot
+windsor check node-health --nodes=10.0.0.5 --wait-for-reboot
+
+# Verify all nodes report Ready via the configured Kubernetes endpoint
+windsor check node-health --k8s-endpoint --ready
+
+# Check a specific Talos version on a set of nodes
+windsor check node-health --nodes=10.0.0.5,10.0.0.6 --version=v1.13.3
+```
+
+## See also
+
+- [Getting started](https://www.windsorcli.dev/docs/cli/getting-started)
+- [`upgrade`](upgrade.md), [`up`](up.md)
+- Source: [cmd/check.go](https://github.com/windsorcli/cli/blob/main/cmd/check.go)

--- a/docs/reference/commands/check.md
+++ b/docs/reference/commands/check.md
@@ -1,0 +1,30 @@
+---
+title: "windsor check"
+description: "Verify required tools are installed."
+---
+# windsor check
+
+```sh
+windsor check
+```
+
+Runs the standard preflight in two passes: tool version checks for local CLIs (terraform, kubectl, talosctl, etc.), then a credential check for the platform configured on the current context (e.g. 'aws sts get-caller-identity' for platform aws).
+
+Fails fast if a required tool is missing or at the wrong version, or if credentials don't resolve.
+
+## Subcommands
+
+- [`windsor check node-health`](check-node-health.md) — Check the health of cluster nodes.
+
+## Examples
+
+```sh
+# Verify the toolchain and cloud credentials
+windsor check
+```
+
+## See also
+
+- [Getting started](https://www.windsorcli.dev/docs/cli/getting-started)
+- [`upgrade`](upgrade.md), [`up`](up.md)
+- Source: [cmd/check.go](https://github.com/windsorcli/cli/blob/main/cmd/check.go)

--- a/docs/reference/commands/configure-network.md
+++ b/docs/reference/commands/configure-network.md
@@ -1,0 +1,45 @@
+---
+title: "windsor configure network"
+description: "Configure workstation host/guest networking and DNS."
+---
+# windsor configure network
+
+```sh
+windsor configure network [flags]
+```
+
+Run after 'windsor up' has provisioned the workstation. Installs the host route and in-VM forwarding required for cluster reachability on VM-backed runtimes, and writes the per-domain DNS resolver entry so '*.<dns.domain>' resolves to the cluster's DNS service.
+
+Prompts for sudo on macOS/Linux; must be run from an Administrator PowerShell on Windows. Use --dry-run to preview without modifying host state, or --revert to remove the host configuration this command previously installed.
+
+If the current context has no workstation enabled, the command is a no-op and prints 'workstation disabled'.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--dns-address` | `""` | DNS service address (e.g. from Terraform workstation output) |
+| `--dry-run` | `false` | Describe what 'configure network' would do without invoking sudo or modifying host state |
+| `--revert` | `false` | Remove the host route, in-VM forwarding, and DNS resolver entry previously installed by 'configure network' |
+
+## Examples
+
+```sh
+# Wire network using the DNS address from Terraform workstation output
+windsor configure network
+
+# Preview the changes without invoking sudo
+windsor configure network --dry-run
+
+# Wire network and explicitly set the DNS service address
+windsor configure network --dns-address=10.5.0.2
+
+# Remove the host configuration installed by this command
+windsor configure network --revert
+```
+
+## See also
+
+- [Workstation overview](https://www.windsorcli.dev/docs/workstation/overview)
+- [`up`](up.md)
+- Source: [cmd/configure.go](https://github.com/windsorcli/cli/blob/main/cmd/configure.go)

--- a/docs/reference/commands/configure.md
+++ b/docs/reference/commands/configure.md
@@ -1,0 +1,21 @@
+---
+title: "windsor configure"
+description: "Configure workstation resources."
+---
+# windsor configure
+
+```sh
+windsor configure
+```
+
+Configure workstation host/guest resources. Currently supports networking and DNS via the 'network' subcommand.
+
+## Subcommands
+
+- [`windsor configure network`](configure-network.md) — Configure workstation host/guest networking and DNS.
+
+## See also
+
+- [Workstation overview](https://www.windsorcli.dev/docs/workstation/overview)
+- [`up`](up.md)
+- Source: [cmd/configure.go](https://github.com/windsorcli/cli/blob/main/cmd/configure.go)

--- a/docs/reference/commands/destroy-kustomize.md
+++ b/docs/reference/commands/destroy-kustomize.md
@@ -1,0 +1,27 @@
+---
+title: "windsor destroy kustomize"
+description: "Destroy Flux kustomization(s)."
+---
+# windsor destroy kustomize
+
+```sh
+windsor destroy kustomize [name]
+```
+
+Delete a specific Flux kustomization from the cluster, or all kustomizations when no argument is given. Inherits --confirm from the parent 'destroy' command.
+
+## Examples
+
+```sh
+# Delete a single kustomization
+windsor destroy kustomize dns --confirm=dns
+
+# Delete every kustomization in the current context
+windsor destroy kustomize --confirm=local
+```
+
+## See also
+
+- [Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)
+- [`destroy`](destroy.md), [`apply kustomize`](apply-kustomize.md), [`plan kustomize`](plan-kustomize.md)
+- Source: [cmd/destroy.go](https://github.com/windsorcli/cli/blob/main/cmd/destroy.go)

--- a/docs/reference/commands/destroy-terraform.md
+++ b/docs/reference/commands/destroy-terraform.md
@@ -1,0 +1,27 @@
+---
+title: "windsor destroy terraform"
+description: "Destroy Terraform component(s)."
+---
+# windsor destroy terraform
+
+```sh
+windsor destroy terraform [component]
+```
+
+Destroy a specific Terraform component, or all components when no argument is given. Inherits --confirm from the parent 'destroy' command.
+
+## Examples
+
+```sh
+# Destroy a single terraform component
+windsor destroy terraform cluster --confirm=cluster
+
+# Destroy every terraform component in the current context
+windsor destroy terraform --confirm=local
+```
+
+## See also
+
+- [Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)
+- [`destroy`](destroy.md), [`apply terraform`](apply-terraform.md), [`plan terraform`](plan-terraform.md)
+- Source: [cmd/destroy.go](https://github.com/windsorcli/cli/blob/main/cmd/destroy.go)

--- a/docs/reference/commands/destroy.md
+++ b/docs/reference/commands/destroy.md
@@ -1,0 +1,46 @@
+---
+title: "windsor destroy"
+description: "Destroy live infrastructure."
+---
+# windsor destroy
+
+```sh
+windsor destroy [component]
+```
+
+Destroy live infrastructure. With no argument, removes every Flux kustomization, then every Terraform component. With a component name, destroys that component across both layers (Terraform and/or Kustomize).
+
+Every form requires confirmation. Either type the context or component name at the prompt, or pass --confirm=<expected> to satisfy the gate non-interactively (CI-safe). The --confirm value must match the prompt token exactly; mismatches abort the operation.
+
+If terraform reports resources protected by 'lifecycle { prevent_destroy = true }', destroy warns up front so the operator knows the destroy may halt partway through. Resources whose state is empty are skipped with a warning naming any potentially orphaned cloud resources.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--confirm` | `""` | Context or component name to confirm destruction. Must match the prompt token exactly; mismatches abort. |
+
+## Subcommands
+
+- [`windsor destroy kustomize`](destroy-kustomize.md) — Destroy Flux kustomization(s).
+- [`windsor destroy terraform`](destroy-terraform.md) — Destroy Terraform component(s).
+
+## Examples
+
+```sh
+# Destroy everything in the current context (interactive)
+windsor destroy
+# → prompts: Type "local" to confirm:
+
+# Same, scripted
+windsor destroy --confirm=local
+
+# Destroy just the dns component (across both layers)
+windsor destroy dns --confirm=dns
+```
+
+## See also
+
+- [Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)
+- [`apply`](apply.md), [`down`](down.md), [`plan`](plan.md)
+- Source: [cmd/destroy.go](https://github.com/windsorcli/cli/blob/main/cmd/destroy.go)

--- a/docs/reference/commands/down.md
+++ b/docs/reference/commands/down.md
@@ -1,0 +1,30 @@
+---
+title: "windsor down"
+description: "Stop the local workstation environment."
+---
+# windsor down
+
+```sh
+windsor down
+```
+
+Tear down the workstation VM, stop container runtimes, and clear local context artifacts (.kube, .talos, generated terraform stubs, etc.). Live infrastructure is NOT destroyed by down — run 'windsor destroy' first if you need to remove cloud resources. Workstation contexts only.
+
+If any host-side network or DNS configuration was previously installed by 'windsor configure network', down prints a follow-up command at the end so the operator can clean up leftover host state.
+
+## Examples
+
+```sh
+# Standard teardown
+windsor down
+
+# Full teardown including cloud infrastructure
+windsor destroy --confirm=local
+windsor down
+```
+
+## See also
+
+- [Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)
+- [`up`](up.md), [`destroy`](destroy.md), [`configure network`](configure-network.md)
+- Source: [cmd/down.go](https://github.com/windsorcli/cli/blob/main/cmd/down.go)

--- a/docs/reference/commands/env.md
+++ b/docs/reference/commands/env.md
@@ -1,0 +1,42 @@
+---
+title: "windsor env"
+description: "Print shell commands to export project env vars."
+---
+# windsor env
+
+```sh
+windsor env [flags]
+```
+
+Print shell commands that export the project's environment variables.
+Source the output, or rely on 'windsor hook' to do this automatically when you
+cd into a project.
+
+The variables include AWS, Kubernetes, Docker, Talos, and Terraform credentials
+and config paths derived from the current context.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--decrypt` | `false` | Decrypt secrets before exporting env vars. |
+| `--hook` | `false` | Non-fatal mode: suppress warnings and exit 0 on errors so a misconfigured project never breaks the prompt. The shell hook installed by 'windsor hook' invokes 'windsor env --decrypt --hook' automatically. |
+
+## Examples
+
+```sh
+# Source env vars manually
+eval "$(windsor env)"
+
+# Same, with secrets decrypted (1Password / SOPS)
+eval "$(windsor env --decrypt)"
+
+# Show what would be exported
+windsor env
+```
+
+## See also
+
+- [Environment reference](../environment.md), [Environment Injection](https://www.windsorcli.dev/docs/cli/environment-injection)
+- [`hook`](hook.md), [`exec`](exec.md)
+- Source: [cmd/env.go](https://github.com/windsorcli/cli/blob/main/cmd/env.go)

--- a/docs/reference/commands/exec.md
+++ b/docs/reference/commands/exec.md
@@ -1,0 +1,34 @@
+---
+title: "windsor exec"
+description: "Run a command with project env vars injected."
+---
+# windsor exec
+
+```sh
+windsor exec [--] <command> [args...]
+```
+
+Run a command with the project's environment variables and decrypted secrets injected. Useful for one-off commands that need the full Windsor environment without sourcing it into your shell.
+
+exec is implicitly --decrypt: 1Password and SOPS secrets are dereferenced before the child process starts.
+
+If the command you're running takes flags of its own — long (--foo) or short (-x) — pass '--' first so they aren't parsed as 'windsor' flags. Without it, Cobra intercepts the flag and aborts with 'unknown flag'. The '--' is unnecessary only when the inner command takes no flags or only positional arguments.
+
+## Examples
+
+```sh
+# Inner command has its own flags — separate with --
+windsor exec -- terraform plan --var-file=staging.tfvars
+windsor exec -- kubectl logs my-pod --tail=50
+windsor exec -- helm install my-app ./chart --namespace=apps
+
+# A wrapper script that takes no flags itself
+windsor exec ./scripts/deploy.sh
+```
+
+## See also
+
+- [Environment reference](../environment.md), [Environment Injection](https://www.windsorcli.dev/docs/cli/environment-injection)
+- [Secrets Management](https://www.windsorcli.dev/docs/cli/secrets-management)
+- [`env`](env.md), [`hook`](hook.md)
+- Source: [cmd/exec.go](https://github.com/windsorcli/cli/blob/main/cmd/exec.go)

--- a/docs/reference/commands/explain.md
+++ b/docs/reference/commands/explain.md
@@ -1,0 +1,47 @@
+---
+title: "windsor explain"
+description: "Trace a blueprint value back to its sources."
+---
+# windsor explain
+
+```sh
+windsor explain <path>
+```
+
+Print the value at the given dotted path and the contributions that produced it. Use explain to debug blueprint composition: when a value isn't what you expected, it tells you which facet, source, or expression set it (and which others were overridden).
+
+Path patterns:
+
+    terraform.<component>.inputs.<field>             A terraform input value.
+    terraform.<component>.inputs.<field>.components  List of contributions for a list field.
+    kustomize.<name>.substitutions.<key>             A Flux substitution.
+    kustomize.<name>.components                      List of components in a kustomization.
+    configMaps.<name>.<key>                          A blueprint-level ConfigMap entry.
+    substitutions.<key>                              A blueprint-level substitution.
+
+Status markers in the output:
+
+    (deferred)  value depends on a terraform output not yet available
+    (empty)     resolved to an empty string
+    (not set)   the referenced facet config was never provided
+    (cycle)     the expression chain forms a cycle
+
+## Examples
+
+```sh
+# Where does the cluster endpoint come from?
+windsor explain terraform.cluster.inputs.cluster_endpoint
+
+# Trace a Flux substitution
+windsor explain kustomize.dns.substitutions.external_domain
+
+# Inspect a list field's contributions
+windsor explain terraform.cluster.inputs.common_config_patches.components
+```
+
+## See also
+
+- [Explain guide](https://www.windsorcli.dev/docs/cli/explain)
+- [`show`](show.md), [`plan`](plan.md)
+- [Facets reference](../facets.md), [Blueprint reference](../blueprint.md)
+- Source: [cmd/explain.go](https://github.com/windsorcli/cli/blob/main/cmd/explain.go)

--- a/docs/reference/commands/get-context.md
+++ b/docs/reference/commands/get-context.md
@@ -1,0 +1,24 @@
+---
+title: "windsor get context"
+description: "Print the current context."
+---
+# windsor get context
+
+```sh
+windsor get context
+```
+
+Print the name of the current context to stdout.
+
+## Examples
+
+```sh
+windsor get context
+# → local
+```
+
+## See also
+
+- [Contexts guide](https://www.windsorcli.dev/docs/cli/contexts), [Contexts reference](../contexts.md)
+- [`set context`](set-context.md)
+- Source: [cmd/get.go](https://github.com/windsorcli/cli/blob/main/cmd/get.go)

--- a/docs/reference/commands/get-contexts.md
+++ b/docs/reference/commands/get-contexts.md
@@ -1,0 +1,28 @@
+---
+title: "windsor get contexts"
+description: "List all available contexts."
+---
+# windsor get contexts
+
+```sh
+windsor get contexts
+```
+
+List contexts in the project. Output is a tab-aligned table with columns NAME, PROVIDER, BACKEND, CURRENT. The current context is marked with '*'. The PROVIDER column shows the configured platform (column header retained for backwards compatibility); BACKEND shows the configured terraform.backend.type or '<none>' when unset.
+
+## Examples
+
+```sh
+windsor get contexts
+
+# Sample output:
+#   NAME    PROVIDER  BACKEND  CURRENT
+#   local   docker    <none>   *
+#   prod    aws       s3
+```
+
+## See also
+
+- [Contexts guide](https://www.windsorcli.dev/docs/cli/contexts), [Contexts reference](../contexts.md)
+- [`set`](set.md)
+- Source: [cmd/get.go](https://github.com/windsorcli/cli/blob/main/cmd/get.go)

--- a/docs/reference/commands/get.md
+++ b/docs/reference/commands/get.md
@@ -1,0 +1,22 @@
+---
+title: "windsor get"
+description: "Display Windsor resources."
+---
+# windsor get
+
+```sh
+windsor get
+```
+
+Display Windsor resources. Currently supports listing contexts and printing the current context.
+
+## Subcommands
+
+- [`windsor get context`](get-context.md) — Print the current context.
+- [`windsor get contexts`](get-contexts.md) — List all available contexts.
+
+## See also
+
+- [Contexts guide](https://www.windsorcli.dev/docs/cli/contexts), [Contexts reference](../contexts.md)
+- [`set`](set.md)
+- Source: [cmd/get.go](https://github.com/windsorcli/cli/blob/main/cmd/get.go)

--- a/docs/reference/commands/hook.md
+++ b/docs/reference/commands/hook.md
@@ -1,0 +1,35 @@
+---
+title: "windsor hook"
+description: "Print shell init code for the given shell."
+---
+# windsor hook
+
+```sh
+windsor hook <shell>
+```
+
+Print init code that wires 'windsor env' into your shell. The hook re-runs 'windsor env --hook' whenever your prompt fires, exporting Windsor's per-context environment variables automatically when you cd into a project.
+
+Supported shells: zsh, bash, fish, tcsh, powershell.
+
+Add the output to your shell's rc file (or evaluate it directly during shell startup) so the hook installs on every new session.
+
+## Examples
+
+```sh
+# zsh / bash
+eval "$(windsor hook zsh)"
+eval "$(windsor hook bash)"
+
+# fish
+windsor hook fish | source
+
+# powershell
+windsor hook powershell | Out-String | Invoke-Expression
+```
+
+## See also
+
+- [Getting started](https://www.windsorcli.dev/docs/cli/getting-started)
+- [`env`](env.md), [`exec`](exec.md)
+- Source: [cmd/hook.go](https://github.com/windsorcli/cli/blob/main/cmd/hook.go)

--- a/docs/reference/commands/init.md
+++ b/docs/reference/commands/init.md
@@ -1,0 +1,54 @@
+---
+title: "windsor init"
+description: "Scaffold or re-initialize a Windsor context."
+---
+# windsor init
+
+```sh
+windsor init [context] [flags]
+```
+
+Scaffold a Windsor project. Writes windsor.yaml at the project root if missing, creates contexts/<context>/, and adds the current directory to the trusted-folders list. Re-running on an existing context updates configuration; pass --reset to overwrite generated files and clean .terraform.
+
+If no context is given, the current context is used; if none is set, 'local' is used.
+
+The directory must be a git repository — init refuses to run in an empty or non-git directory to prevent silently scaffolding against $HOME.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--aws-endpoint-url` | `""` | AWS endpoint URL. |
+| `--aws-profile` | `""` | AWS profile name. |
+| `--backend` | `""` | Terraform backend type. |
+| `--blueprint` | `""` | Blueprint OCI reference or local path. |
+| `--docker` | `false` | Enable Docker. |
+| `--endpoint` | `""` | Kubernetes API endpoint. |
+| `--git-livereload` | `false` | Enable git livereload. |
+| `--platform` | `""` | Target platform: none, metal, docker, aws, azure, gcp, hyperv. |
+| `--reset` | `false` | Overwrite existing files and clean .terraform. |
+| `--set` | `[]` | Override config values, e.g. --set dns.enabled=false. May be repeated. |
+| `--vm-arch` | `""` | CPU architecture for the workstation VM. |
+| `--vm-cpu` | `0` | CPU count for the workstation VM. |
+| `--vm-disk` | `0` | Disk size for the workstation VM (GB). |
+| `--vm-driver` | `""` | VM driver: colima, colima-incus, docker-desktop, docker. |
+| `--vm-memory` | `0` | Memory for the workstation VM (GB). |
+
+## Examples
+
+```sh
+# Scaffold a local context with the docker VM driver
+windsor init local --vm-driver=docker
+
+# Re-initialize and overwrite generated files
+windsor init local --reset
+
+# Initialize an AWS staging context
+windsor init staging --platform=aws --aws-profile=staging
+```
+
+## See also
+
+- [Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle), [Contexts reference](../contexts.md)
+- [`up`](up.md), [`apply`](apply.md), [`bootstrap`](bootstrap.md)
+- Source: [cmd/init.go](https://github.com/windsorcli/cli/blob/main/cmd/init.go)

--- a/docs/reference/commands/install.md
+++ b/docs/reference/commands/install.md
@@ -1,0 +1,34 @@
+---
+title: "windsor install"
+description: "Install the blueprint's Flux kustomizations."
+---
+# windsor install
+
+```sh
+windsor install [flags]
+```
+
+Apply only the Flux kustomizations to the cluster, skipping Terraform. Use this when Terraform has already been applied separately (e.g. by another tool or pipeline) and you only want to hand the cluster off to Flux.
+
+For most workflows, prefer 'windsor apply', which runs Terraform and Flux in the right order.
+
+Pass --wait to block until kustomizations report ready.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--wait` | `false` | Wait for kustomization resources to be ready. |
+
+## Examples
+
+```sh
+# Install kustomizations and wait for them to settle
+windsor install --wait
+```
+
+## See also
+
+- [Kustomize guide](https://www.windsorcli.dev/docs/guides/kustomize)
+- [`apply`](apply.md), [`apply kustomize`](apply-kustomize.md)
+- Source: [cmd/install.go](https://github.com/windsorcli/cli/blob/main/cmd/install.go)

--- a/docs/reference/commands/plan-kustomize.md
+++ b/docs/reference/commands/plan-kustomize.md
@@ -1,0 +1,27 @@
+---
+title: "windsor plan kustomize"
+description: "Plan Flux kustomization changes."
+---
+# windsor plan kustomize
+
+```sh
+windsor plan kustomize [component]
+```
+
+Stream 'flux diff' for a specific kustomization, or all kustomizations when no argument is given. Inherits --summary, --json, and --no-color from the parent 'plan' command.
+
+## Examples
+
+```sh
+# Stream the diff for one kustomization
+windsor plan kustomize dns
+
+# Compact summary across all kustomizations
+windsor plan kustomize --summary
+```
+
+## See also
+
+- [Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)
+- [`plan`](plan.md), [`apply kustomize`](apply-kustomize.md), [`destroy kustomize`](destroy-kustomize.md)
+- Source: [cmd/plan.go](https://github.com/windsorcli/cli/blob/main/cmd/plan.go)

--- a/docs/reference/commands/plan-terraform.md
+++ b/docs/reference/commands/plan-terraform.md
@@ -1,0 +1,30 @@
+---
+title: "windsor plan terraform"
+description: "Plan Terraform changes."
+---
+# windsor plan terraform
+
+```sh
+windsor plan terraform [component]
+```
+
+Stream 'terraform init' and 'terraform plan' for a specific component, or all components when no argument is given. Inherits --summary, --json, and --no-color from the parent 'plan' command.
+
+## Examples
+
+```sh
+# Stream the plan for one component
+windsor plan terraform cluster
+
+# Compact summary across all components
+windsor plan terraform --summary
+
+# Machine-readable JSON of all component plans
+windsor plan terraform --json
+```
+
+## See also
+
+- [Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)
+- [`plan`](plan.md), [`apply terraform`](apply-terraform.md), [`destroy terraform`](destroy-terraform.md)
+- Source: [cmd/plan.go](https://github.com/windsorcli/cli/blob/main/cmd/plan.go)

--- a/docs/reference/commands/plan.md
+++ b/docs/reference/commands/plan.md
@@ -1,0 +1,52 @@
+---
+title: "windsor plan"
+description: "Preview terraform and Flux changes."
+---
+# windsor plan
+
+```sh
+windsor plan [component]
+```
+
+Preview pending changes across Terraform components and Flux kustomizations without applying them.
+
+With no argument, prints a compact summary across all components. Components that have never been applied show as '(new)' so you can distinguish first-time creates from updates.
+
+With a component name, runs a full streaming plan for every layer (Terraform and/or Kustomize) that contains that component. Use a subcommand to restrict to a single layer.
+
+The --summary, --json, and --no-color flags are persistent and apply to all subcommands.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--json` | `false` | Output as JSON. Streams full plan JSON on subcommands; emits the summary as JSON on root 'plan'. |
+| `--no-color` | `false` | Disable color output. |
+| `--summary` | `false` | Show a compact summary table instead of streaming output. |
+
+## Subcommands
+
+- [`windsor plan kustomize`](plan-kustomize.md) — Plan Flux kustomization changes.
+- [`windsor plan terraform`](plan-terraform.md) — Plan Terraform changes.
+
+## Examples
+
+```sh
+# Compact summary across both layers
+windsor plan
+
+# Full streaming plan for one component (both layers)
+windsor plan cluster
+
+# JSON-formatted summary, suitable for CI parsing
+windsor plan --summary --json
+
+# Just terraform, just one component
+windsor plan terraform cluster
+```
+
+## See also
+
+- [Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)
+- [`apply`](apply.md), [`show`](show.md), [`explain`](explain.md)
+- Source: [cmd/plan.go](https://github.com/windsorcli/cli/blob/main/cmd/plan.go)

--- a/docs/reference/commands/push.md
+++ b/docs/reference/commands/push.md
@@ -1,0 +1,35 @@
+---
+title: "windsor push"
+description: "Push the blueprint to an OCI registry."
+---
+# windsor push
+
+```sh
+windsor push <registry/repo[:tag]>
+```
+
+Bundle the current blueprint and push it to an OCI-compatible registry (Docker Hub, GHCR, ECR, etc.). The pushed artifact is consumable by FluxCD's OCIRepository.
+
+The registry argument is required. When the tag is omitted, metadata.yaml ('name', 'version') is used to derive it.
+
+Authentication uses your existing Docker credential helper. If push fails with an auth error, the CLI suggests 'docker login <registry>'.
+
+## Examples
+
+```sh
+# Docker Hub
+windsor push docker.io/myorg/myblueprint:v1.0.0
+
+# GitHub Container Registry
+windsor push ghcr.io/myorg/myblueprint:v1.0.0
+
+# Tag derived from metadata.yaml
+windsor push registry.example.com/myorg/myblueprint
+```
+
+## See also
+
+- [Sharing blueprints](https://www.windsorcli.dev/docs/blueprints/sharing)
+- [Metadata reference](../metadata.md)
+- [`bundle`](bundle.md)
+- Source: [cmd/push.go](https://github.com/windsorcli/cli/blob/main/cmd/push.go)

--- a/docs/reference/commands/set-context.md
+++ b/docs/reference/commands/set-context.md
@@ -1,0 +1,25 @@
+---
+title: "windsor set context"
+description: "Switch the current context."
+---
+# windsor set context
+
+```sh
+windsor set context [context-name]
+```
+
+Switch the current context and persist the choice to the project config. The context directory must already exist (created by 'windsor init').
+
+## Examples
+
+```sh
+windsor set context staging
+windsor get context
+# → staging
+```
+
+## See also
+
+- [Contexts guide](https://www.windsorcli.dev/docs/cli/contexts), [Contexts reference](../contexts.md)
+- [`init`](init.md), [`get context`](get-context.md)
+- Source: [cmd/set.go](https://github.com/windsorcli/cli/blob/main/cmd/set.go)

--- a/docs/reference/commands/set.md
+++ b/docs/reference/commands/set.md
@@ -1,0 +1,21 @@
+---
+title: "windsor set"
+description: "Set a Windsor resource."
+---
+# windsor set
+
+```sh
+windsor set
+```
+
+Set a Windsor resource. Currently supports 'context'.
+
+## Subcommands
+
+- [`windsor set context`](set-context.md) — Switch the current context.
+
+## See also
+
+- [Contexts guide](https://www.windsorcli.dev/docs/cli/contexts), [Contexts reference](../contexts.md)
+- [`init`](init.md), [`get`](get.md)
+- Source: [cmd/set.go](https://github.com/windsorcli/cli/blob/main/cmd/set.go)

--- a/docs/reference/commands/show-blueprint.md
+++ b/docs/reference/commands/show-blueprint.md
@@ -1,0 +1,38 @@
+---
+title: "windsor show blueprint"
+description: "Display the fully rendered blueprint."
+---
+# windsor show blueprint
+
+```sh
+windsor show blueprint [flags]
+```
+
+Print the fully composed blueprint to stdout, including all fields from underlying sources and computed values. Defaults to YAML; use --json for JSON. Unresolved deferred values render as '<deferred>' by default; use --raw to keep the original expression text instead.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--json` | `false` | Output as JSON instead of YAML. |
+| `--raw` | `false` | Keep deferred expressions as text instead of <deferred>. |
+
+## Examples
+
+```sh
+# Print the composed blueprint as YAML
+windsor show blueprint
+
+# Same, but keep deferred expressions visible
+windsor show blueprint --raw
+
+# JSON output for tooling
+windsor show blueprint --json
+```
+
+## See also
+
+- [Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)
+- [`explain`](explain.md), [`plan`](plan.md)
+- [Blueprint reference](../blueprint.md)
+- Source: [cmd/show.go](https://github.com/windsorcli/cli/blob/main/cmd/show.go)

--- a/docs/reference/commands/show-kustomization.md
+++ b/docs/reference/commands/show-kustomization.md
@@ -1,0 +1,35 @@
+---
+title: "windsor show kustomization"
+description: "Display the Flux Kustomization resource for a component."
+---
+# windsor show kustomization
+
+```sh
+windsor show kustomization <component-name> [flags]
+```
+
+Print the Flux Kustomization resource for the named component, including blueprint-level ConfigMaps in postBuild.substituteFrom. The output matches what 'windsor apply' would write to the cluster. Defaults to YAML; use --json for JSON. Unresolved deferred values render as '<deferred>' by default; use --raw to keep the original expression text instead.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--json` | `false` | Output as JSON instead of YAML. |
+| `--raw` | `false` | Keep deferred expressions as text instead of <deferred>. |
+
+## Examples
+
+```sh
+# Inspect the Flux Kustomization for one component
+windsor show kustomization dns
+
+# JSON for tooling
+windsor show kustomization dns --json
+```
+
+## See also
+
+- [Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)
+- [`apply`](apply.md), [`plan`](plan.md)
+- [Blueprint reference](../blueprint.md)
+- Source: [cmd/show.go](https://github.com/windsorcli/cli/blob/main/cmd/show.go)

--- a/docs/reference/commands/show-values.md
+++ b/docs/reference/commands/show-values.md
@@ -1,0 +1,34 @@
+---
+title: "windsor show values"
+description: "Display the effective context values."
+---
+# windsor show values
+
+```sh
+windsor show values [flags]
+```
+
+Print the effective context values, merging schema defaults with values.yaml overrides. YAML output includes schema descriptions as comments. Use --json for plain JSON.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--json` | `false` | Output as JSON instead of YAML. |
+
+## Examples
+
+```sh
+# Effective values for the current context, with schema descriptions
+windsor show values
+
+# Plain JSON for tooling
+windsor show values --json
+```
+
+## See also
+
+- [Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)
+- [`explain`](explain.md)
+- [Configuration reference](../configuration.md)
+- Source: [cmd/show.go](https://github.com/windsorcli/cli/blob/main/cmd/show.go)

--- a/docs/reference/commands/show.md
+++ b/docs/reference/commands/show.md
@@ -1,0 +1,26 @@
+---
+title: "windsor show"
+description: "Display rendered resources."
+---
+# windsor show
+
+```sh
+windsor show
+```
+
+Print rendered Windsor resources to stdout. Reads the project state and runs blueprint composition without applying anything.
+
+Unresolved deferred values render as '<deferred>' by default in 'blueprint' and 'kustomization' output; pass --raw to keep the original expression text instead.
+
+## Subcommands
+
+- [`windsor show blueprint`](show-blueprint.md) — Display the fully rendered blueprint.
+- [`windsor show kustomization`](show-kustomization.md) — Display the Flux Kustomization resource for a component.
+- [`windsor show values`](show-values.md) — Display the effective context values.
+
+## See also
+
+- [Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)
+- [`explain`](explain.md), [`plan`](plan.md)
+- [Blueprint reference](../blueprint.md), [Configuration reference](../configuration.md)
+- Source: [cmd/show.go](https://github.com/windsorcli/cli/blob/main/cmd/show.go)

--- a/docs/reference/commands/test.md
+++ b/docs/reference/commands/test.md
@@ -1,0 +1,31 @@
+---
+title: "windsor test"
+description: "Run blueprint composition tests."
+---
+# windsor test
+
+```sh
+windsor test [test-name]
+```
+
+Run static tests that compare blueprint composition against expected outputs. Tests live in contexts/_template/tests/ as '*.test.yaml' files.
+
+A test runs the blueprint composer in isolation (no terraform, no cluster, no live secrets) and asserts the resulting blueprint, kustomization, or values match a fixture. Use 'windsor test' to validate that schema or facet changes don't accidentally regress composition.
+
+When a test name is provided, only that test runs; otherwise every test under contexts/_template/tests/ runs.
+
+## Examples
+
+```sh
+# Run all tests
+windsor test
+
+# Run a single named test
+windsor test cluster-defaults
+```
+
+## See also
+
+- [Blueprint testing](https://www.windsorcli.dev/docs/blueprints/testing)
+- [Testing reference](../testing.md)
+- Source: [cmd/test.go](https://github.com/windsorcli/cli/blob/main/cmd/test.go)

--- a/docs/reference/commands/up.md
+++ b/docs/reference/commands/up.md
@@ -1,0 +1,45 @@
+---
+title: "windsor up"
+description: "Bring up the local workstation environment."
+---
+# windsor up
+
+```sh
+windsor up [flags]
+```
+
+Start the workstation VM, run Terraform components, then install the Flux blueprint. Workstation contexts only — for non-workstation contexts, use 'windsor apply'. If the current context has no workstation, up exits with a hint and does no work.
+
+Returns once the install request has been issued. Pass --wait to block until kustomizations report ready.
+
+If any host-side network or DNS configuration was deferred (because it requires sudo / elevation), up prints a follow-up command at the end so the operator knows what to run next.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--blueprint` | `""` | Blueprint OCI reference or local path. |
+| `--platform` | `""` | Target platform: none, metal, docker, aws, azure, gcp, hyperv. |
+| `--set` | `[]` | Override config values, e.g. --set dns.enabled=false. May be repeated. |
+| `--vm-driver` | `""` | VM driver: colima, colima-incus, docker-desktop, docker. |
+| `--wait` | `false` | Wait for kustomization resources to be ready. |
+
+## Examples
+
+```sh
+# Bring up the workstation and wait for everything to be ready
+windsor up --wait
+
+# Override an inline config value at startup
+windsor up --set cluster.workers.count=3
+
+# Initialize and bring up with a specific blueprint
+windsor up --blueprint=ghcr.io/myorg/blueprint:v1.0.0
+```
+
+## See also
+
+- [Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)
+- [Workstation overview](https://www.windsorcli.dev/docs/workstation/overview)
+- [`down`](down.md), [`apply`](apply.md), [`destroy`](destroy.md)
+- Source: [cmd/up.go](https://github.com/windsorcli/cli/blob/main/cmd/up.go)

--- a/docs/reference/commands/upgrade-cluster.md
+++ b/docs/reference/commands/upgrade-cluster.md
@@ -1,0 +1,35 @@
+---
+title: "windsor upgrade cluster"
+description: "Upgrade cluster nodes in parallel."
+---
+# windsor upgrade cluster
+
+```sh
+windsor upgrade cluster [flags]
+```
+
+Initiate a Talos upgrade on the named nodes in parallel. Returns once the upgrade requests are accepted; nodes reboot asynchronously.
+
+Use 'windsor check node-health --wait-for-reboot' afterward to verify each node comes back healthy.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--image` | `""` | Talos image to upgrade to. Required. |
+| `--nodes` | `[]` | Node addresses to upgrade. Required. |
+
+## Examples
+
+```sh
+# Upgrade all controlplane nodes in parallel
+windsor upgrade cluster \
+  --nodes=10.0.0.5,10.0.0.6,10.0.0.7 \
+  --image=ghcr.io/siderolabs/installer:v1.13.0
+```
+
+## See also
+
+- [`upgrade node`](upgrade-node.md)
+- [`check node-health`](check-node-health.md)
+- Source: [cmd/upgrade.go](https://github.com/windsorcli/cli/blob/main/cmd/upgrade.go)

--- a/docs/reference/commands/upgrade-node.md
+++ b/docs/reference/commands/upgrade-node.md
@@ -1,0 +1,35 @@
+---
+title: "windsor upgrade node"
+description: "Upgrade a single cluster node and wait for it to rejoin."
+---
+# windsor upgrade node
+
+```sh
+windsor upgrade node [flags]
+```
+
+Send an upgrade request to a single Talos node, wait for it to reboot, then verify it is healthy. Suitable for rolling upgrades one node at a time.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--image` | `""` | Talos image to upgrade to. Required. |
+| `--node` | `""` | Node IP address to upgrade. Required. |
+| `--timeout` | `0s` | Overall timeout. Default 10m. |
+
+## Examples
+
+```sh
+# Roll one node, blocking until it is healthy
+windsor upgrade node --node=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.0
+
+# Same with a longer timeout for slow rebooters
+windsor upgrade node --node=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.0 --timeout=20m
+```
+
+## See also
+
+- [`upgrade cluster`](upgrade-cluster.md)
+- [`check node-health`](check-node-health.md)
+- Source: [cmd/upgrade.go](https://github.com/windsorcli/cli/blob/main/cmd/upgrade.go)

--- a/docs/reference/commands/upgrade.md
+++ b/docs/reference/commands/upgrade.md
@@ -1,0 +1,21 @@
+---
+title: "windsor upgrade"
+description: "Upgrade cluster components."
+---
+# windsor upgrade
+
+```sh
+windsor upgrade
+```
+
+Upgrade cluster components. Currently supports Talos node upgrades via the 'cluster' (parallel) and 'node' (one-at-a-time, with health verification) subcommands.
+
+## Subcommands
+
+- [`windsor upgrade cluster`](upgrade-cluster.md) — Upgrade cluster nodes in parallel.
+- [`windsor upgrade node`](upgrade-node.md) — Upgrade a single cluster node and wait for it to rejoin.
+
+## See also
+
+- [`check node-health`](check-node-health.md)
+- Source: [cmd/upgrade.go](https://github.com/windsorcli/cli/blob/main/cmd/upgrade.go)

--- a/docs/reference/commands/version.md
+++ b/docs/reference/commands/version.md
@@ -1,0 +1,28 @@
+---
+title: "windsor version"
+description: "Print the CLI version, commit, build date, Go toolchain, and platform."
+---
+# windsor version
+
+```sh
+windsor version
+```
+
+Print five lines: the semver Version, the build's Commit SHA, the Build Date, the Go toolchain that built the binary, and the target Platform (GOOS/GOARCH).
+
+Snapshot builds emitted by goreleaser have ' (nightly build)' appended to the Version line so operators can tell at a glance that the binary is an unreleased main-branch build rather than a tagged release. Tagged releases use clean semver and are returned unchanged.
+
+## Examples
+
+```sh
+$ windsor version
+Version: 0.9.0
+Commit SHA: 4e0d9104
+Build Date: 2026-05-27T18:30:00Z
+Go: go1.26.3
+Platform: darwin/arm64
+```
+
+## See also
+
+- Source: [cmd/version.go](https://github.com/windsorcli/cli/blob/main/cmd/version.go)

--- a/internal/gendocs/commands.go
+++ b/internal/gendocs/commands.go
@@ -1,9 +1,8 @@
-// commands.go emits docs/reference/commands/*.md from the cobra command tree
-// exposed by cmd.RootCmd(). Each cobra command becomes one markdown file
-// named <full-command-with-underscores>.md, matching cobra's standard
-// GenMarkdownTreeCustom layout. A filePrepender injects Astro-compatible YAML
-// frontmatter (title, description) so the windsorcli.github.io content
-// collection ingests the output without further processing.
+// commands.go is the cobra entry point for the `gendocs commands` subcommand.
+// It walks cmd.RootCmd() and emits one markdown file per command via the
+// renderer in render.go. The destination directory is wiped before each run so
+// renamed or removed commands do not leave stale pages behind — a future CI
+// gate that regenerates and asserts `git diff --exit-code` relies on this.
 
 package main
 
@@ -11,10 +10,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/spf13/cobra/doc"
 	cliCmd "github.com/windsorcli/cli/cmd"
 )
 
@@ -31,10 +28,6 @@ func commandsCmd() *cobra.Command {
 	return cmd
 }
 
-// generateCommands wipes outDir, then walks cmd.RootCmd() and emits one
-// markdown file per command. The destination is recreated empty each run so
-// renamed or removed commands do not leave stale pages behind — a future CI
-// gate that regenerates and asserts `git diff --exit-code` relies on this.
 func generateCommands(outDir string) error {
 	if err := os.RemoveAll(outDir); err != nil {
 		return fmt.Errorf("clear output dir: %w", err)
@@ -43,60 +36,39 @@ func generateCommands(outDir string) error {
 		return fmt.Errorf("create output dir: %w", err)
 	}
 
-	root := cliCmd.RootCmd()
-	root.DisableAutoGenTag = true
-
-	// frontmatter closes over root so the emitter and the per-file frontmatter
-	// always operate on the same pre-configured command tree. cobra's
-	// GenMarkdownTreeCustom passes the destination filename (basename only); we
-	// derive the command's full invocation by replacing underscores with spaces
-	// and stripping the .md suffix.
-	frontmatter := func(filename string) string {
-		base := strings.TrimSuffix(filepath.Base(filename), ".md")
-		invocation := strings.ReplaceAll(base, "_", " ")
-		short := lookupShort(root, base)
-
-		var b strings.Builder
-		fmt.Fprintln(&b, "---")
-		fmt.Fprintf(&b, "title: %q\n", invocation)
-		if short != "" {
-			fmt.Fprintf(&b, "description: %q\n", short)
-		}
-		fmt.Fprintln(&b, "---")
-		fmt.Fprintln(&b)
-		return b.String()
-	}
-
-	return doc.GenMarkdownTreeCustom(root, outDir, frontmatter, linkHandler)
+	return emitTree(cliCmd.RootCmd(), outDir)
 }
 
-// linkHandler rewrites the inter-command links cobra emits at the bottom of
-// each page. cobra's default produces `[windsor apply](windsor_apply.md)`;
-// we keep that filename (matches what GenMarkdownTreeCustom writes) but
-// could rewrite to the published site URL here if needed later.
-func linkHandler(name string) string {
-	return name
+// emitTree walks the command tree, writing one file per visible command. The
+// root cobra command (`windsor` itself) is skipped — the site renders its own
+// index from the file listing rather than relying on a generated index page.
+func emitTree(cmd *cobra.Command, outDir string) error {
+	if !cmd.Hidden && cmd.HasParent() {
+		if err := writeCommandFile(cmd, outDir); err != nil {
+			return err
+		}
+	}
+	for _, sub := range cmd.Commands() {
+		if sub.Hidden || sub.Name() == "help" {
+			continue
+		}
+		if err := emitTree(sub, outDir); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
-// lookupShort walks the command tree to find the cobra.Command whose full
-// underscore-joined name matches base, returning its Short text. Used by
-// frontmatter so the description field stays in sync with cobra's Short
-// without a second source of truth.
-func lookupShort(root *cobra.Command, base string) string {
-	if base == root.Name() {
-		return root.Short
+func writeCommandFile(cmd *cobra.Command, outDir string) error {
+	path := filepath.Join(outDir, commandFilename(cmd))
+	// #nosec G304 - outDir is operator-supplied via --out; filename derives from package-controlled cobra command names
+	f, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create %s: %w", path, err)
 	}
-	parts := strings.Split(base, "_")
-	if len(parts) == 0 || parts[0] != root.Name() {
-		return ""
+	defer f.Close()
+	if err := renderCommand(f, cmd); err != nil {
+		return fmt.Errorf("render %s: %w", path, err)
 	}
-	c := root
-	for _, p := range parts[1:] {
-		next, _, err := c.Find([]string{p})
-		if err != nil || next == c {
-			return ""
-		}
-		c = next
-	}
-	return c.Short
+	return nil
 }

--- a/internal/gendocs/commands_test.go
+++ b/internal/gendocs/commands_test.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"errors"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -10,9 +13,109 @@ import (
 	"github.com/spf13/pflag"
 )
 
+// brokenWriter fails every Write with the wrapped error. Used to exercise
+// the errWriter short-circuit path.
+type brokenWriter struct{ err error }
+
+func (b brokenWriter) Write(p []byte) (int, error) { return 0, b.err }
+
 // =============================================================================
 // Test Public Methods
 // =============================================================================
+
+func TestErrWriter(t *testing.T) {
+	t.Run("PassesWritesThroughWhenHealthy", func(t *testing.T) {
+		// Given an errWriter wrapping a healthy writer
+		var buf strings.Builder
+		ew := &errWriter{w: &buf}
+
+		// When several writes go through
+		n, err := fmt.Fprint(ew, "hello, ")
+		if err != nil || n != len("hello, ") {
+			t.Fatalf("first write: n=%d err=%v", n, err)
+		}
+		_, _ = fmt.Fprint(ew, "world")
+
+		// Then output reaches the underlying writer and no error is captured
+		if got := buf.String(); got != "hello, world" {
+			t.Errorf("buf = %q, want %q", got, "hello, world")
+		}
+		if ew.err != nil {
+			t.Errorf("expected ew.err to be nil, got %v", ew.err)
+		}
+	})
+
+	t.Run("CapturesFirstError", func(t *testing.T) {
+		// Given an errWriter wrapping a broken writer that always fails
+		sentinel := errors.New("disk full")
+		ew := &errWriter{w: brokenWriter{err: sentinel}}
+
+		// When the first write fails
+		_, err := fmt.Fprint(ew, "hello")
+		if !errors.Is(err, sentinel) {
+			t.Fatalf("expected first write to surface sentinel, got %v", err)
+		}
+
+		// Then the captured error matches the sentinel
+		if !errors.Is(ew.err, sentinel) {
+			t.Errorf("ew.err = %v, want %v", ew.err, sentinel)
+		}
+	})
+
+	t.Run("ShortCircuitsAfterFirstErrorWithoutLooping", func(t *testing.T) {
+		// Given an errWriter that has already captured an error
+		ew := &errWriter{w: brokenWriter{err: errors.New("boom")}}
+		_, _ = fmt.Fprint(ew, "first")
+
+		// When subsequent writes happen
+		// (fmt.Fprintf would loop on partial writes; this confirms the n=len(p)
+		// short-circuit return prevents that)
+		n, err := fmt.Fprintf(ew, "second %s third", "value")
+
+		// Then the second write reports success so the caller doesn't retry
+		if err != nil {
+			t.Errorf("expected nil error from short-circuited write, got %v", err)
+		}
+		if n == 0 {
+			t.Errorf("expected non-zero byte count from short-circuited write, got 0")
+		}
+
+		// And the captured error is still the first one
+		if ew.err == nil || ew.err.Error() != "boom" {
+			t.Errorf("expected ew.err to remain the first error, got %v", ew.err)
+		}
+	})
+}
+
+func TestRenderCommandSurfacesWriteErrors(t *testing.T) {
+	t.Run("ReturnsErrorWhenWriterFails", func(t *testing.T) {
+		// Given a writer that always fails and any cobra command
+		sentinel := errors.New("write failed")
+		cmd := &cobra.Command{Use: "windsor", Short: "test"}
+
+		// When renderCommand runs against the broken writer
+		err := renderCommand(brokenWriter{err: sentinel}, cmd)
+
+		// Then the underlying write error surfaces — would silently truncate
+		// the .md file otherwise
+		if !errors.Is(err, sentinel) {
+			t.Errorf("renderCommand error = %v, want %v", err, sentinel)
+		}
+	})
+
+	t.Run("ReturnsNilWhenWriterSucceeds", func(t *testing.T) {
+		// Given a healthy writer
+		cmd := &cobra.Command{Use: "windsor", Short: "test"}
+
+		// When renderCommand runs
+		err := renderCommand(io.Discard, cmd)
+
+		// Then no error is returned
+		if err != nil {
+			t.Errorf("renderCommand error = %v, want nil", err)
+		}
+	})
+}
 
 func TestCommandFilename(t *testing.T) {
 	t.Run("RootCommand", func(t *testing.T) {

--- a/internal/gendocs/commands_test.go
+++ b/internal/gendocs/commands_test.go
@@ -1,0 +1,230 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// =============================================================================
+// Test Public Methods
+// =============================================================================
+
+func TestCommandFilename(t *testing.T) {
+	t.Run("RootCommand", func(t *testing.T) {
+		// Given a root cobra command
+		root := &cobra.Command{Use: "windsor"}
+
+		// When commandFilename is called
+		got := commandFilename(root)
+
+		// Then the filename is just the root name with a .md suffix
+		want := "windsor.md"
+		if got != want {
+			t.Errorf("commandFilename(root) = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("TopLevelSubcommand", func(t *testing.T) {
+		// Given a top-level subcommand
+		root := &cobra.Command{Use: "windsor"}
+		child := &cobra.Command{Use: "env"}
+		root.AddCommand(child)
+
+		// When commandFilename is called
+		got := commandFilename(child)
+
+		// Then the root prefix is dropped
+		want := "env.md"
+		if got != want {
+			t.Errorf("commandFilename(env) = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("NestedSubcommand", func(t *testing.T) {
+		// Given a nested subcommand windsor apply terraform
+		root := &cobra.Command{Use: "windsor"}
+		apply := &cobra.Command{Use: "apply"}
+		terraform := &cobra.Command{Use: "terraform <component>"}
+		apply.AddCommand(terraform)
+		root.AddCommand(apply)
+
+		// When commandFilename is called
+		got := commandFilename(terraform)
+
+		// Then ancestors after the root are joined with dashes
+		want := "apply-terraform.md"
+		if got != want {
+			t.Errorf("commandFilename(apply terraform) = %q, want %q", got, want)
+		}
+	})
+}
+
+func TestFlagRows(t *testing.T) {
+	t.Run("RendersOwnFlagWithDefault", func(t *testing.T) {
+		// Given a flagset with one flag and a default
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		fs.Bool("wait", false, "Wait for things.")
+
+		// When flagRows is called
+		rows := flagRows(fs)
+
+		// Then a single row is rendered with the default value in code-fenced form
+		if len(rows) != 1 {
+			t.Fatalf("expected 1 row, got %d: %v", len(rows), rows)
+		}
+		if !strings.Contains(rows[0], "`--wait`") || !strings.Contains(rows[0], "`false`") {
+			t.Errorf("row missing flag name or default: %q", rows[0])
+		}
+	})
+
+	t.Run("RendersShorthand", func(t *testing.T) {
+		// Given a flag with a shorthand
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		fs.StringP("output", "o", ".", "Output path.")
+
+		// When flagRows is called
+		rows := flagRows(fs)
+
+		// Then the row contains both the shorthand and the long form
+		if len(rows) != 1 {
+			t.Fatalf("expected 1 row, got %d: %v", len(rows), rows)
+		}
+		if !strings.Contains(rows[0], "`-o`") || !strings.Contains(rows[0], "`--output`") {
+			t.Errorf("row missing shorthand or long form: %q", rows[0])
+		}
+	})
+
+	t.Run("ExcludesHelpAndHidden", func(t *testing.T) {
+		// Given a flagset with a visible flag, a hidden flag, and --help
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		fs.Bool("visible", false, "Visible flag.")
+		fs.Bool("hidden", false, "Hidden flag.")
+		_ = fs.MarkHidden("hidden")
+		fs.BoolP("help", "h", false, "Help.")
+
+		// When flagRows is called
+		rows := flagRows(fs)
+
+		// Then only the visible flag is rendered
+		if len(rows) != 1 {
+			t.Fatalf("expected 1 row, got %d: %v", len(rows), rows)
+		}
+		if !strings.Contains(rows[0], "`--visible`") {
+			t.Errorf("expected visible flag in row, got %q", rows[0])
+		}
+	})
+
+	t.Run("EscapesPipesInDescription", func(t *testing.T) {
+		// Given a flag whose description contains a pipe (enum-style)
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		fs.String("platform", "", "Platform: aws|azure|gcp.")
+
+		// When flagRows is called
+		rows := flagRows(fs)
+
+		// Then pipes are escaped so the markdown table layout survives
+		if len(rows) != 1 {
+			t.Fatalf("expected 1 row, got %d: %v", len(rows), rows)
+		}
+		if strings.Contains(rows[0], "aws|azure") {
+			t.Errorf("expected pipes to be escaped, got %q", rows[0])
+		}
+		if !strings.Contains(rows[0], `aws\|azure`) {
+			t.Errorf("expected escaped pipes in row, got %q", rows[0])
+		}
+	})
+
+	t.Run("EmptyDefaultRendersAsQuotedEmpty", func(t *testing.T) {
+		// Given a string flag with no default
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		fs.String("name", "", "Name.")
+
+		// When flagRows is called
+		rows := flagRows(fs)
+
+		// Then the empty default renders as "" (not as a blank cell)
+		if len(rows) != 1 {
+			t.Fatalf("expected 1 row, got %d: %v", len(rows), rows)
+		}
+		if !strings.Contains(rows[0], `""`) {
+			t.Errorf("expected empty default to render as \"\", got %q", rows[0])
+		}
+	})
+}
+
+func TestVisibleSubcommands(t *testing.T) {
+	t.Run("ExcludesHiddenAndHelp", func(t *testing.T) {
+		// Given a tree with a visible child, a hidden child, and a help subcommand
+		root := &cobra.Command{Use: "root"}
+		root.AddCommand(&cobra.Command{Use: "visible"})
+		root.AddCommand(&cobra.Command{Use: "secret", Hidden: true})
+		root.AddCommand(&cobra.Command{Use: "help"})
+
+		// When visibleSubcommands is called
+		got := visibleSubcommands(root)
+
+		// Then only the visible child is returned
+		if len(got) != 1 || got[0].Name() != "visible" {
+			names := make([]string, 0, len(got))
+			for _, c := range got {
+				names = append(names, c.Name())
+			}
+			t.Errorf("visibleSubcommands = %v, want [visible]", names)
+		}
+	})
+}
+
+func TestGenerateCommands(t *testing.T) {
+	t.Run("WritesFilesForVisibleCommands", func(t *testing.T) {
+		// Given a temporary output directory
+		out := t.TempDir()
+
+		// When generateCommands is called against the real windsor command tree
+		if err := generateCommands(out); err != nil {
+			t.Fatalf("generateCommands: %v", err)
+		}
+
+		// Then a stable, low-churn command (version) has a file emitted with valid
+		// frontmatter and the expected h1. Using version because its surface is
+		// minimal — any other command would also work but version is least likely
+		// to change shape over time.
+		raw, err := os.ReadFile(filepath.Join(out, "version.md"))
+		if err != nil {
+			t.Fatalf("read version.md: %v", err)
+		}
+		body := string(raw)
+		if !strings.HasPrefix(body, "---\n") {
+			t.Errorf("version.md missing frontmatter prefix, got: %q", body[:min(40, len(body))])
+		}
+		if !strings.Contains(body, `title: "windsor version"`) {
+			t.Error("version.md missing expected title in frontmatter")
+		}
+		if !strings.Contains(body, "# windsor version\n") {
+			t.Error("version.md missing expected h1 heading")
+		}
+	})
+
+	t.Run("WipesStaleFilesBeforeRegenerating", func(t *testing.T) {
+		// Given an output directory with a stale file from a previous run
+		out := t.TempDir()
+		stalePath := filepath.Join(out, "stale-deleted-command.md")
+		if err := os.WriteFile(stalePath, []byte("stale\n"), 0o600); err != nil {
+			t.Fatalf("seed stale file: %v", err)
+		}
+
+		// When generateCommands runs
+		if err := generateCommands(out); err != nil {
+			t.Fatalf("generateCommands: %v", err)
+		}
+
+		// Then the stale file is gone — required so the CI gate's diff is meaningful
+		if _, err := os.Stat(stalePath); !os.IsNotExist(err) {
+			t.Errorf("expected stale file to be removed; got err=%v", err)
+		}
+	})
+}

--- a/internal/gendocs/render.go
+++ b/internal/gendocs/render.go
@@ -23,16 +23,42 @@ import (
 
 const sourceURLPrefix = "https://github.com/windsorcli/cli/blob/main/"
 
+// errWriter wraps an io.Writer and captures the first write error encountered,
+// turning subsequent writes into no-ops that report success. This lets the
+// per-section helpers continue using the bare fmt.Fprintf style instead of
+// branching on errors after every call; renderCommand surfaces the captured
+// error at the end so a full disk or broken pipe during doc generation
+// produces a non-nil error rather than a silently truncated .md file.
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (e *errWriter) Write(p []byte) (int, error) {
+	if e.err != nil {
+		// Report success after the first error so fmt.Fprintf doesn't loop
+		// retrying the rest of the format string. renderCommand checks e.err
+		// at the end of the section sequence.
+		return len(p), nil
+	}
+	n, err := e.w.Write(p)
+	if err != nil {
+		e.err = err
+	}
+	return n, err
+}
+
 func renderCommand(w io.Writer, cmd *cobra.Command) error {
-	writeFrontmatter(w, cmd)
-	fmt.Fprintf(w, "# %s\n\n", cmd.CommandPath())
-	writeSynopsis(w, cmd)
-	writeLong(w, cmd)
-	writeFlagsTable(w, cmd)
-	writeSubcommands(w, cmd)
-	writeExamples(w, cmd)
-	writeSeeAlso(w, cmd)
-	return nil
+	ew := &errWriter{w: w}
+	writeFrontmatter(ew, cmd)
+	fmt.Fprintf(ew, "# %s\n\n", cmd.CommandPath())
+	writeSynopsis(ew, cmd)
+	writeLong(ew, cmd)
+	writeFlagsTable(ew, cmd)
+	writeSubcommands(ew, cmd)
+	writeExamples(ew, cmd)
+	writeSeeAlso(ew, cmd)
+	return ew.err
 }
 
 func writeFrontmatter(w io.Writer, cmd *cobra.Command) {

--- a/internal/gendocs/render.go
+++ b/internal/gendocs/render.go
@@ -1,0 +1,182 @@
+// render.go produces the markdown for one cobra command. The output shape
+// matches the windsorcli.github.io house style for CLI reference: frontmatter
+// for the Astro content collection, h1 for the command name, a synopsis fence,
+// the cmd.Long body as prose, a flag table (own flags only — inherited globals
+// are excluded as noise), an optional examples block, an optional subcommands
+// list, and a "See also" section sourced from cmd.Annotations.
+//
+// Annotations consumed:
+//
+//	docs.seealso  newline-separated markdown bullets (each line becomes one "- " entry)
+//	docs.source   path to the source file (rendered as "Source: [path](github-link)")
+
+package main
+
+import (
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+const sourceURLPrefix = "https://github.com/windsorcli/cli/blob/main/"
+
+func renderCommand(w io.Writer, cmd *cobra.Command) error {
+	writeFrontmatter(w, cmd)
+	fmt.Fprintf(w, "# %s\n\n", cmd.CommandPath())
+	writeSynopsis(w, cmd)
+	writeLong(w, cmd)
+	writeFlagsTable(w, cmd)
+	writeSubcommands(w, cmd)
+	writeExamples(w, cmd)
+	writeSeeAlso(w, cmd)
+	return nil
+}
+
+func writeFrontmatter(w io.Writer, cmd *cobra.Command) {
+	fmt.Fprintln(w, "---")
+	fmt.Fprintf(w, "title: %q\n", cmd.CommandPath())
+	if cmd.Short != "" {
+		fmt.Fprintf(w, "description: %q\n", cmd.Short)
+	}
+	fmt.Fprintln(w, "---")
+}
+
+func writeSynopsis(w io.Writer, cmd *cobra.Command) {
+	fmt.Fprintln(w, "```sh")
+	fmt.Fprintln(w, cmd.UseLine())
+	fmt.Fprintln(w, "```")
+	fmt.Fprintln(w)
+}
+
+func writeLong(w io.Writer, cmd *cobra.Command) {
+	body := strings.TrimSpace(cmd.Long)
+	if body == "" {
+		return
+	}
+	fmt.Fprintln(w, body)
+	fmt.Fprintln(w)
+}
+
+// writeFlagsTable renders only the command's own flags (cmd.Flags()), excluding
+// inherited persistent flags from parents. This matches the hand-written
+// reference convention — globals like --verbose / --no-cache are documented
+// once at the root rather than duplicated on every page. Cobra's auto-added
+// --help is also skipped as boilerplate.
+func writeFlagsTable(w io.Writer, cmd *cobra.Command) {
+	rows := flagRows(cmd.Flags())
+	if len(rows) == 0 {
+		return
+	}
+	fmt.Fprintln(w, "## Flags")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "| Flag | Default | Description |")
+	fmt.Fprintln(w, "|------|---------|-------------|")
+	for _, r := range rows {
+		fmt.Fprintln(w, r)
+	}
+	fmt.Fprintln(w)
+}
+
+func flagRows(set *pflag.FlagSet) []string {
+	var rows []string
+	set.VisitAll(func(f *pflag.Flag) {
+		if f.Hidden || f.Name == "help" {
+			return
+		}
+		name := "`--" + f.Name + "`"
+		if f.Shorthand != "" {
+			name = "`-" + f.Shorthand + "`, " + name
+		}
+		def := f.DefValue
+		if def == "" {
+			def = `""`
+		}
+		rows = append(rows, fmt.Sprintf("| %s | `%s` | %s |", name, def, escapePipes(f.Usage)))
+	})
+	return rows
+}
+
+func writeSubcommands(w io.Writer, cmd *cobra.Command) {
+	subs := visibleSubcommands(cmd)
+	if len(subs) == 0 {
+		return
+	}
+	fmt.Fprintln(w, "## Subcommands")
+	fmt.Fprintln(w)
+	for _, c := range subs {
+		fmt.Fprintf(w, "- [`%s`](%s) — %s\n", c.CommandPath(), commandFilename(c), c.Short)
+	}
+	fmt.Fprintln(w)
+}
+
+func writeExamples(w io.Writer, cmd *cobra.Command) {
+	ex := strings.TrimSpace(cmd.Example)
+	if ex == "" {
+		return
+	}
+	fmt.Fprintln(w, "## Examples")
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "```sh")
+	fmt.Fprintln(w, ex)
+	fmt.Fprintln(w, "```")
+	fmt.Fprintln(w)
+}
+
+func writeSeeAlso(w io.Writer, cmd *cobra.Command) {
+	seealso := strings.TrimSpace(cmd.Annotations["docs.seealso"])
+	source := strings.TrimSpace(cmd.Annotations["docs.source"])
+	if seealso == "" && source == "" {
+		return
+	}
+	fmt.Fprintln(w, "## See also")
+	fmt.Fprintln(w)
+	if seealso != "" {
+		for _, line := range strings.Split(seealso, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			fmt.Fprintf(w, "- %s\n", line)
+		}
+	}
+	if source != "" {
+		fmt.Fprintf(w, "- Source: [%s](%s%s)\n", source, sourceURLPrefix, source)
+	}
+}
+
+// visibleSubcommands returns subcommands that should appear in documentation —
+// cobra's auto-added "help" command and any Hidden commands are excluded.
+func visibleSubcommands(cmd *cobra.Command) []*cobra.Command {
+	var out []*cobra.Command
+	for _, c := range cmd.Commands() {
+		if c.Hidden || c.Name() == "help" {
+			continue
+		}
+		out = append(out, c)
+	}
+	return out
+}
+
+// commandFilename returns the on-disk filename for a command's reference page.
+// Root command ("windsor") becomes windsor.md; subcommands drop the root and
+// join the remaining ancestors with dashes (e.g. "apply terraform" → "apply-terraform.md").
+func commandFilename(cmd *cobra.Command) string {
+	parts := strings.Fields(cmd.CommandPath())
+	if len(parts) == 0 {
+		return ""
+	}
+	if len(parts) == 1 {
+		return parts[0] + ".md"
+	}
+	return strings.Join(parts[1:], "-") + ".md"
+}
+
+// escapePipes escapes the pipe character so it doesn't break the markdown
+// table layout when it appears in flag descriptions (e.g. enum lists like
+// [foo|bar|baz]).
+func escapePipes(s string) string {
+	return strings.ReplaceAll(s, "|", `\|`)
+}

--- a/internal/gendocs/render.go
+++ b/internal/gendocs/render.go
@@ -60,13 +60,18 @@ func writeLong(w io.Writer, cmd *cobra.Command) {
 	fmt.Fprintln(w)
 }
 
-// writeFlagsTable renders only the command's own flags (cmd.Flags()), excluding
-// inherited persistent flags from parents. This matches the hand-written
-// reference convention — globals like --verbose / --no-cache are documented
-// once at the root rather than duplicated on every page. Cobra's auto-added
-// --help is also skipped as boilerplate.
+// writeFlagsTable renders only the command's own flags via cmd.LocalFlags() —
+// the local non-persistent flagset plus any persistent flags declared on this
+// command. Inherited persistent flags from ancestors are excluded so globals
+// like --verbose / --no-cache aren't duplicated on every page; a parent
+// command's persistent flags are documented on the parent page and noted as
+// inherited in the subcommand's Long. Cobra's auto-added --help is also
+// skipped as boilerplate.
+//
+// We use LocalFlags() rather than Flags() because Flags() relies on cobra's
+// Execute() to merge persistent flags, which never runs during doc generation.
 func writeFlagsTable(w io.Writer, cmd *cobra.Command) {
-	rows := flagRows(cmd.Flags())
+	rows := flagRows(cmd.LocalFlags())
 	if len(rows) == 0 {
 		return
 	}


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This PR touches only documentation tooling and help text — no runtime logic, flag parsing, or command routing is modified, so the blast radius is limited to the generated reference pages and CI output.
>
> **Overview**
>
> The PR enriches every cobra command definition with `Long`, `Example`, and `Annotations` fields, then replaces the `cobra/doc.GenMarkdownTreeCustom`-based emitter with a hand-written renderer (`render.go`) that produces site-compatible markdown for windsorcli.github.io. A new `docs-check` CI job enforces that the generated pages stay in sync with the command tree by re-running the generator and failing on any diff.
>
> The only two findings are low-severity: `renderCommand` always returns `nil` and silently drops write errors from its helpers, and the `git diff` in the CI failure path omits newly untracked files (new commands). Neither affects correctness of the CLI or the sync gate.
>
> Reviewed by Claude for commit `cb3ba7ed`.

<!-- /claude-code-review:summary -->
