### PR TITLE
chore(docs): Blueprint schema docs

### DIFF
--- a/docs/reference/blueprint.md
+++ b/docs/reference/blueprint.md
@@ -1,317 +1,162 @@
 ---
 title: "Blueprint"
-description: "Windsor blueprints reference collections of Kustomize and Terraform resources"
+description: "Top-level blueprint definition."
 ---
 # Blueprint
-The blueprint stores references and configuration specific to a context. It's configured in a `blueprint.yaml` file located in your context's configuration folder, such as `contexts/local/blueprint.yaml`.
 
-When you run `windsor init local`, a default local blueprint file is created. The sections in this file are outlined below.
+Top-level blueprint definition. Lives at contexts/<context>/blueprint.yaml and
+declares the Terraform components and Flux kustomizations that windsor will
+apply for that context, plus the sources those components come from and the
+variable substitutions shared across them.
 
-```yaml
-kind: Blueprint
-apiVersion: blueprints.windsorcli.dev/v1alpha1
-metadata: # ...
-repository: #...
-sources: #...
-terraform: #...
-kustomize: #...
-```
+## Fields
 
-| Field       | Type                   | Description                                                                 |
-|-------------|------------------------|-----------------------------------------------------------------------------|
-| `kind`      | `string`               | Specifies the blueprint type, adhering to Kubernetes conventions.           |
-| `apiVersion`| `string`               | Indicates the API schema version of the blueprint.                          |
-| `metadata`  | `Metadata`             | Contains core information about the blueprint, such as identity and authors.|
-| `repository`| `Repository`           | Provides details about the source repository of the blueprint.              |
-| `sources`   | `[]Source`             | Lists external resources referenced by the blueprint.                       |
-| `terraform` | `[]TerraformComponent` | Includes Terraform modules within the blueprint.                            |
-| `kustomize` | `[]Kustomization`      | Contains Kustomization configurations in the blueprint.                     |
-| `configMaps`| `map[string]map[string]string` | Standalone ConfigMaps to be created, not tied to specific kustomizations. These ConfigMaps are referenced by all kustomizations in PostBuild substitution. |
+| Field | Type | Description |
+|------|------|-------------|
+| `kind` | `string` | Resource kind, following Kubernetes conventions. Must be 'Blueprint'. **(required)** |
+| `apiVersion` | `string` | API schema version. Must be 'blueprints.windsorcli.dev/v1alpha1'. **(required)** |
+| `metadata` | `object` | Identity for the blueprint. **(required)** |
+| `backend` | `string` | Names the terraform component that terminates the backend tier. When set, 'windsor bootstrap' applies the backend component (and every component declared before it) against local state first, then migrates state to the configured remote backend before applying the rest of the graph. |
+| `configMaps` | `object` | Standalone ConfigMaps to create. Each top-level key is a ConfigMap name; its map-of-string value is the .data payload. These are referenced by every kustomization in PostBuild substitution. |
+| `kustomize` | `array<object>` | Flux kustomizations included in the blueprint. Each entry maps to a Kustomization resource the provisioner applies to the cluster, in topologically sorted dependsOn order. |
+| `repository` | `object` | Source repository this blueprint was bootstrapped from. |
+| `sources` | `array<object>` | External resources referenced by the blueprint. Each source is an OCI blueprint artifact or a Git repository that contributes Terraform modules and/or kustomize bases consumable by the components below. |
+| `substitutions` | `object` | Blueprint-level substitutions injected into 'values-common' and made available to every kustomization via PostBuild substitution. Values may use expression syntax (e.g. '${dns.domain}') resolved against facet config blocks. |
+| `terraform` | `array<object>` | Terraform components included in the blueprint, in declaration order. Components are reordered topologically by dependsOn at apply time. |
 
-For information about Facets, see the [Facets Reference](facets.md). For schema validation, see the [Schema Reference](schema.md). For blueprint metadata, see the [Metadata Reference](metadata.md).
+## metadata
 
-### Metadata
-Core information about the blueprint, including its identity and authors.
+| Field | Type | Description |
+|------|------|-------------|
+| `name` | `string` | Blueprint's unique identifier within the project. **(required)** |
+| `description` | `string` | One-line overview of what this blueprint provisions. |
 
-```yaml
-metadata:
-  name: local
-  description: Builds a local cloud environment
-  authors:
-    - "@rmvangun"
-    - "@tvangundy"
-```
+## kustomize[]
 
-| Field         | Type     | Description                                      |
-|---------------|----------|--------------------------------------------------|
-| `name`        | `string` | The blueprint's unique identifier.               |
-| `description` | `string` | A brief overview of the blueprint.               |
-| `authors`     | `[]string` | Creators or maintainers of the blueprint.      |
+| Field | Type | Description |
+|------|------|-------------|
+| `name` | `string` | Identifier for the kustomization; referenced by dependsOn. **(required)** |
+| `path` | `string` | Path within the source containing the kustomize base. **(required)** |
+| `components` | `array<string>` | Kustomize components to compose into this kustomization. |
+| `dependsOn` | `array<string>` | Names of kustomizations that must reconcile before this one. |
+| `destroy` | `string` | Whether to delete this kustomization during 'windsor down' / 'windsor destroy'. Boolean or expression. Defaults to true. |
+| `destroyOnly` | `boolean` | When true, the kustomization only runs during destroy. Useful for teardown-only resources (e.g. cleanup jobs). |
+| `enabled` | `string` | Whether to include this kustomization in the final blueprint. Boolean or expression. Defaults to true. |
+| `force` | `boolean` | Force-apply resources Flux would otherwise refuse to update. |
+| `interval` | `string` | Reconciliation interval, expressed as a Go duration string (e.g. '5m', '1h'). Defaults to a mode-appropriate value chosen by the provisioner (short poll for pull mode, long fallback for push). |
+| `namespace` | `string` | Namespace where the Flux Kustomization object itself lives. Defaults to the gitops namespace. DependsOn references always resolve in the gitops namespace; cross-namespace dependencies are not supported. |
+| `patches` | `array<object>` | Strategic-merge or Flux-style patches applied to the kustomization. Each entry is either a 'path:' to a patch file relative to the kustomization, or a 'patch:' inline YAML body with an optional 'target:' selector (kind / name / namespace). |
+| `prune` | `boolean` | Garbage-collect resources removed from the source. Defaults to true. |
+| `retryInterval` | `string` | Duration to wait before retrying a failed reconciliation (e.g. '2m'). |
+| `source` | `string` | Name of the source (from the sources list) that provides this kustomization. Defaults to the blueprint's primary source when unset. |
+| `substitutions` | `object` | PostBuild variable substitutions for this kustomization. Collected into a 'values-<name>' ConfigMap that Flux substitutes from. |
+| `targetNamespace` | `string` | Populates spec.targetNamespace, instructing Flux to override the namespace of every resource reconciled by this kustomization. |
+| `timeout` | `string` | Maximum duration for a single reconciliation attempt (e.g. '10m'). |
+| `wait` | `boolean` | Wait for resources to settle before declaring reconciliation complete. |
 
-### Repository
-Details the source repository of the blueprint.
+### kustomize[].patches[]
 
-```yaml
-repository:
-  url: https://github.com/sample-org/blueprint
-  ref:
-    branch: main
-  secretName: git-creds
-```
+| Field | Type | Description |
+|------|------|-------------|
+| `patch` | `string` | Inline patch body as YAML (Flux format). |
+| `path` | `string` | Path to a patch file relative to the kustomization (blueprint format). |
+| `target` | `object` | Selector for the patch (Flux format). Used with 'patch:'. |
 
-| Field        | Type        | Description                                           |
-|--------------|-------------|-------------------------------------------------------|
-| `url`        | `string`    | The repository location.                              |
-| `ref`        | `Reference` | Details the branch, tag, or commit to use.            |
-| `secretName` | `string`    | The name of the k8s secret containing git credentials.|
+## repository
 
-### Source
-A dependency from which Terraform and Kustomize components may be sourced. Sources can be OCI blueprint artifacts or Git repositories containing Terraform modules.
+| Field | Type | Description |
+|------|------|-------------|
+| `ref` | `object` | A specific version or state of a repository or source (one of branch / tag / semver / commit). |
+| `secretName` | `string` | Name of a Flux secret holding credentials for the repository. |
+| `url` | `string` | Repository URL. |
 
-```yaml
-sources:
-  - name: core
-    url: oci://ghcr.io/windsorcli/core:v0.3.0
-    deploy: true  # Merge this source's components (default: true)
-  - name: reference
-    url: oci://ghcr.io/windsorcli/reference:v0.3.0
-    deploy: false  # Index-only: don't merge, but allow component reference
-  - name: modules
-    url: github.com/org/terraform-modules
-    ref:
-      branch: main
-    # deploy flag only applies to OCI sources
-```
+### repository.ref
 
-| Field        | Type       | Description                                      |
-|--------------|------------|--------------------------------------------------|
-| `name`       | `string`   | Identifies the source.                           |
-| `url`        | `string`   | The source location. Supports Git URLs and OCI URLs (oci://registry/repo:tag). |
-| `pathPrefix` | `string`   | Prefix to the source path. Defaults to `terraform` if not specified. |
-| `ref`        | `Reference`| Details the branch, tag, or commit to use. Not needed for OCI URLs with embedded tags. |
-| `secretName` | `string`   | The secret for source access.                    |
-| `deploy`     | `bool` or `string` | For OCI sources only: whether to merge this source's components into the final blueprint. Can be a boolean (`true`/`false`) or an expression (e.g., `${some.condition ?? true}`). Defaults to `true` if not specified. |
+| Field | Type | Description |
+|------|------|-------------|
+| `branch` | `string` | Branch to follow. |
+| `commit` | `string` | Specific commit SHA. |
+| `name` | `string` | Named reference. |
+| `semver` | `string` | Semver constraint (e.g. '>=1.0.0'). |
+| `tag` | `string` | Specific tag. |
 
-**Source Types:**
+## sources[]
 
-- **OCI Sources** (`oci://` URLs): Blueprint artifacts that can have their components merged. When `deploy: true` (or not specified), the source's components are merged directly into the final blueprint. When `deploy: false`, the source is "index-only" - its components aren't merged, but other components can reference it via `source: <name>`.
-- **Git Sources** (Git URLs): Terraform module repositories. These are not loaded as blueprints and their components cannot be merged. They remain in the Sources array for component reference only. The `deploy` flag does not apply to Git sources.
+| Field | Type | Description |
+|------|------|-------------|
+| `name` | `string` | Identifier for the source; referenced by 'source:' on terraform / kustomize components. **(required)** |
+| `install` | `string` | For OCI sources, whether to merge this source's components into the final blueprint. Accepts a boolean (true/false) or an expression (e.g. '${some.condition ?? true}') evaluated against facet config. Defaults to true. Has no effect on Git sources. |
+| `pathPrefix` | `string` | Path prefix applied to the source. Defaults to 'terraform' when unset. |
+| `ref` | `object` | A specific version or state of a repository or source (one of branch / tag / semver / commit). |
+| `secretName` | `string` | Name of a Flux secret holding credentials for the source. |
+| `url` | `string` | Source location. Accepts Git URLs and OCI URLs (oci://registry/repo:tag). |
 
-**Notes:**
-- For OCI sources, the URL should include the tag/version directly (e.g., `oci://registry.example.com/repo:v1.0.0`). The `ref` field is optional for OCI sources when the tag is specified in the URL.
-- The `deploy` flag only applies to OCI sources. It defaults to `true` if not specified, meaning OCI sources have their components merged by default.
-- Sources with `deploy: false` are still available for component reference - components can use `source: <name>` to reference them, and the source URL will be resolved appropriately.
+### sources[].ref
 
-### Reference
-A reference to a specific git state or version
+| Field | Type | Description |
+|------|------|-------------|
+| `branch` | `string` | Branch to follow. |
+| `commit` | `string` | Specific commit SHA. |
+| `name` | `string` | Named reference. |
+| `semver` | `string` | Semver constraint (e.g. '>=1.0.0'). |
+| `tag` | `string` | Specific tag. |
 
-```yaml
-reference:
-  branch: main
-  tag: v1.0.0
-  semver: ~1.0.0
-  name: refs/heads/main
-  commit: 1a2b3c4d5e6f7g8h9i0j
-```
+## terraform[]
 
-| Field   | Type   | Description                                      |
-|---------|--------|--------------------------------------------------|
-| `branch`| `string` | Branch to use.                                 |
-| `tag`   | `string` | Tag to use.                                    |
-| `semver`| `string` | Semantic version constraint to use (e.g., `~1.0.0`, `>=1.0.0`). |
-| `name`  | `string` | Name of the reference.                         |
-| `commit`| `string` | Commit hash to use.                            |
+| Field | Type | Description |
+|------|------|-------------|
+| `path` | `string` | Path of the module within the source. **(required)** |
+| `dependsOn` | `array<string>` | IDs of components that must apply before this one. |
+| `destroy` | `string` | Whether to destroy this component during 'windsor down' / 'windsor destroy'. Boolean (true/false) or expression (e.g. '${cluster.destroy ?? true}'). Defaults to true. |
+| `enabled` | `string` | Whether to include this component in the final blueprint. Boolean (true/false) or expression. Defaults to true. |
+| `inputs` | `object` | Module input values. Plain values pass through as literals; values using '${expr}' syntax are evaluated against facet config at apply time. Used to generate tfvars and not written to the final context blueprint.yaml. |
+| `name` | `string` | Optional name. When set, becomes the unique identifier for the component (used by dependsOn and context variables) instead of path. |
+| `parallelism` | `string` | Caps concurrent operations during 'terraform apply' / 'terraform destroy' for this component (the -parallelism flag). Integer or expression (e.g. '${cluster.parallelism ?? 10}'). |
+| `source` | `string` | Name of the source (from the sources list) that provides this module. |
 
-### TerraformComponent
-A local or remote reference to a Terraform module or "component" of the blueprint.
-
-```yaml
-terraform:
-  # A Terraform module defined in the "core" repository source
-  - source: core
-    path: cluster/talos
-  
-  # A Terraform module defined within the current blueprint source
-  - path: apps/my-infra
-    parallelism: 5
-  
-  # A Terraform module from a local archive source
-  - source: archive-source
-    path: cluster/talos
-```
-
-| Field      | Type                             | Description                                      |
-|------------|----------------------------------|--------------------------------------------------|
-| `source`   | `string`                         | Source of the Terraform module. Must be included in the list of sources. Supports Git repositories, OCI artifacts, and file:// archive URLs. |
-| `path`     | `string`                         | Path of the Terraform module relative to the `terraform/` folder (for Git/OCI sources) or within the archive (for file:// sources).                    |
-| `inputs`   | `map[string]any`                  | Configuration values for the module. These values can be expressions using `${}` syntax (e.g., `${cluster.name}`) or literals. Values with `${}` are evaluated as expressions, plain values are passed through as literals. These are used for generating tfvars files and are not written to the final context blueprint.yaml. |
-| `dependsOn`| `[]string`                       | Dependencies of this terraform component.        |
-| `destroy`  | `*bool`                          | Determines if the component should be destroyed during down operations. Defaults to true if not specified. |
-| `parallelism`| `int`                         | Limits the number of concurrent operations as Terraform walks the graph. Corresponds to the `-parallelism` flag. |
-
-### Kustomization
-For more information on Flux Kustomizations, which are sets of resources and configurations applied to a Kubernetes cluster, visit [Flux Kustomizations Documentation](https://fluxcd.io/flux/components/kustomize/kustomizations/). Most parameters are not necessary to define.
-
-```yaml
-kustomize:
-  # A reference to a csi driver from the "core" source that implements longhorn
-  - name: system-csi
-    source: core
-    path: csi 
-    components:
-      - longhorn
-
-  # A reference to a local folder containing kubernetes manifests outlining "my-app"
-  - name: my-app
-    dependsOn:
-      - system-csi
-    path: apps/my-app
-```
-
-
-| Field         | Type                | Description                                      |
-|---------------|---------------------|--------------------------------------------------|
-| `name`        | `string`            | Name of the kustomization.                       |
-| `path`        | `string`            | Path of the kustomization.                       |
-| `source`      | `string`            | Source of the kustomization.                     |
-| `dependsOn`   | `[]string`          | Dependencies of this kustomization.              |
-| `interval`    | `*metav1.Duration`  | Interval for applying the kustomization.         |
-| `retryInterval`| `*metav1.Duration` | Retry interval for a failed kustomization.       |
-| `timeout`     | `*metav1.Duration`  | Timeout for the kustomization to complete.       |
-| `patches`     | `[]BlueprintPatch` | Patches to apply to the kustomization. Supports both blueprint format (path) and Flux format (patch + target). |
-| `wait`        | `*bool`             | Wait for the kustomization to be fully applied.  |
-| `force`       | `*bool`             | Force apply the kustomization.                   |
-| `prune`       | `*bool`             | Enable garbage collection of resources that are no longer present in the source. |
-| `components`  | `[]string`          | Components to include in the kustomization.      |
-| `cleanup`     | `[]string`          | Components to include in a cleanup kustomization that runs before this kustomization is deleted. The cleanup kustomization uses the path `<kustomization-path>/cleanup` with these as components. |
-| `destroy`     | `*bool`             | Determines if the kustomization should be destroyed during down operations. Defaults to true if not specified. |
-| `destroyOnly` | `*bool`             | Indicates that this kustomization should only run during destroy operations. When true, the kustomization is skipped during apply/up operations and only executed during destroy. Destroy-only kustomizations run before regular kustomizations during destroy, in normal dependency order. |
-| `substitutions` | `map[string]string` | Values for post-build variable replacement, collected and stored in ConfigMaps for use by Flux postBuild substitution. All values are converted to strings. These are used for generating ConfigMaps and are not written to the final context blueprint.yaml. |
-
-#### Patches
-
-Patches are provided via Facets, not directly in blueprint definitions. See the [Facets Reference](facets.md#kustomization-patches) for details on how to define patches in facets.
-
-## Cluster Variables
-When running `windsor install`, Kubernetes resources are applied. These resources include a configmap that introduces [post-build variables](https://fluxcd.io/flux/components/kustomize/kustomizations/#post-build-variable-substitution) into the Kubernetes manifests. These variables are outlined as follows:
-
-| Key                     | Description                                                        |
-|-------------------------|--------------------------------------------------------------------|
-| `BUILD_ID`              | Build identifier for artifact tagging, generated by `windsor build-id`. Format: YYMMDD.RANDOM.# |
-| `CONTEXT`               | Specifies the context name, e.g., local.                           |
-| `DOMAIN`                | The domain used for subdomain registration, e.g., test.            |
-| `LOADBALANCER_IP_END`   | The final IP in the range for load balancer assignments.           |
-| `LOADBALANCER_IP_RANGE` | Complete range of load balancer IPs, e.g., 10.5.1.1-10.5.1.10.     |
-| `LOADBALANCER_IP_START` | The initial IP in the range for load balancer assignments.         |
-| `LOCAL_VOLUME_PATH`     | Directory path for local volume storage, e.g., /var/mnt/local.    |
-| `REGISTRY_URL`          | Base URL for the container image registry, e.g., registry.test.    |
-
-## Example: Local Blueprint
-When you run `windsor init local`, a default local blueprint is generated:
+## Examples
 
 ```yaml
 kind: Blueprint
 apiVersion: blueprints.windsorcli.dev/v1alpha1
 metadata:
+  description: Local workstation blueprint
   name: local
-  description: This blueprint configures core for running on docker desktop
-repository:
-  url: http://git.test/git/core
-  ref:
-    branch: main
-  secretName: flux-system
 sources:
 - name: core
-  url: github.com/windsorcli/core
+  url: oci://ghcr.io/windsorcli/core:v0.3.0
+- name: modules
   ref:
     branch: main
-- name: oci-source
-  url: oci://ghcr.io/windsorcli/core:v0.3.0
+  url: github.com/org/terraform-modules
 terraform:
-- path: cluster/talos
-- path: gitops/flux
+- inputs:
+    cluster_name: local
+  name: cluster
+  path: cluster/talos
+  source: core
+- dependsOn:
+  - cluster
+  name: dns
+  path: dns/coredns
+  source: core
 kustomize:
-- name: policy-base
-  path: policy/base
-  components:
-  - kyverno
-- name: policy-resources
-  path: policy/resources
-  dependsOn:
-  - policy-base
-- name: csi
-  path: csi
-  dependsOn:
-  - policy-resources
-  components:
-  - openebs
-  - openebs/dynamic-localpv
-- name: ingress
-  path: ingress/base
-  dependsOn:
-  - pki-resources
-  force: true
-  components:
-  - nginx
-  - nginx/nodeport
-  - nginx/coredns
-  - nginx/flux-webhook
-  - nginx/web
-- name: pki-base
-  path: pki/base
-  dependsOn:
-  - policy-resources
-  force: true
-  components:
-  - cert-manager
-  - trust-manager
-- name: pki-resources
-  path: pki/resources
-  dependsOn:
-  - pki-base
-  force: true
-  components:
-  - private-issuer/ca
-  - public-issuer/selfsigned
-- name: dns
+- name: flux-system
+  path: flux-system
+  source: core
+- dependsOn:
+  - flux-system
+  name: dns
   path: dns
-  dependsOn:
-  - ingress
-  - pki-base
-  force: true
-  components:
-  - coredns
-  - coredns/etcd
-  - external-dns
-  - external-dns/localhost
-  - external-dns/coredns
-  - external-dns/ingress
-- name: gitops
-  path: gitops/flux
-  dependsOn:
-  - ingress
-  force: true
-  components:
-  - webhook
-- name: demo
-  path: demo
-  dependsOn:
-  - ingress
-  force: true
-  components:
-  - bookinfo
-  - bookinfo/ingress
+  source: core
+substitutions:
+  external_domain: example.test
 ```
 
-<div>
-  {{ footer('Securing Secrets', '../../security/secrets/index.html', 'Configuration', '../configuration/index.html') }}
-</div>
+## See also
 
-<script>
-  document.getElementById('previousButton').addEventListener('click', function() {
-    window.location.href = '../../security/secrets/index.html'; 
-  });
-  document.getElementById('nextButton').addEventListener('click', function() {
-    window.location.href = '../configuration/index.html'; 
-  });
-</script>
+- [Facets reference](facets.md), [Metadata reference](metadata.md), [Schema reference](schema.md)
+- [`apply`](commands/apply.md), [`up`](commands/up.md), [`bootstrap`](commands/bootstrap.md), [`destroy`](commands/destroy.md)
+- [`show blueprint`](commands/show-blueprint.md), [`explain`](commands/explain.md)
+- [Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle), [Sharing blueprints](https://www.windsorcli.dev/docs/blueprints/sharing)
+- Source schema: [pkg/runtime/config/schemas/artifacts/blueprint.yaml](https://github.com/windsorcli/cli/blob/main/pkg/runtime/config/schemas/artifacts/blueprint.yaml)

--- a/docs/reference/blueprint.md
+++ b/docs/reference/blueprint.md
@@ -39,9 +39,9 @@ variable substitutions shared across them.
 | `path` | `string` | Path within the source containing the kustomize base. **(required)** |
 | `components` | `array<string>` | Kustomize components to compose into this kustomization. |
 | `dependsOn` | `array<string>` | Names of kustomizations that must reconcile before this one. |
-| `destroy` | `string` | Whether to delete this kustomization during 'windsor down' / 'windsor destroy'. Boolean or expression. Defaults to true. |
+| `destroy` | `boolean / string` | Whether to delete this kustomization during 'windsor down' / 'windsor destroy'. Boolean or expression. Defaults to true. |
 | `destroyOnly` | `boolean` | When true, the kustomization only runs during destroy. Useful for teardown-only resources (e.g. cleanup jobs). |
-| `enabled` | `string` | Whether to include this kustomization in the final blueprint. Boolean or expression. Defaults to true. |
+| `enabled` | `boolean / string` | Whether to include this kustomization in the final blueprint. Boolean or expression. Defaults to true. |
 | `force` | `boolean` | Force-apply resources Flux would otherwise refuse to update. |
 | `interval` | `string` | Reconciliation interval, expressed as a Go duration string (e.g. '5m', '1h'). Defaults to a mode-appropriate value chosen by the provisioner (short poll for pull mode, long fallback for push). |
 | `namespace` | `string` | Namespace where the Flux Kustomization object itself lives. Defaults to the gitops namespace. DependsOn references always resolve in the gitops namespace; cross-namespace dependencies are not supported. |
@@ -85,7 +85,7 @@ variable substitutions shared across them.
 | Field | Type | Description |
 |------|------|-------------|
 | `name` | `string` | Identifier for the source; referenced by 'source:' on terraform / kustomize components. **(required)** |
-| `install` | `string` | For OCI sources, whether to merge this source's components into the final blueprint. Accepts a boolean (true/false) or an expression (e.g. '${some.condition ?? true}') evaluated against facet config. Defaults to true. Has no effect on Git sources. |
+| `install` | `boolean / string` | For OCI sources, whether to merge this source's components into the final blueprint. Accepts a boolean (true/false) or an expression (e.g. '${some.condition ?? true}') evaluated against facet config. Defaults to true. Has no effect on Git sources. |
 | `pathPrefix` | `string` | Path prefix applied to the source. Defaults to 'terraform' when unset. |
 | `ref` | `object` | A specific version or state of a repository or source (one of branch / tag / semver / commit). |
 | `secretName` | `string` | Name of a Flux secret holding credentials for the source. |
@@ -107,11 +107,11 @@ variable substitutions shared across them.
 |------|------|-------------|
 | `path` | `string` | Path of the module within the source. **(required)** |
 | `dependsOn` | `array<string>` | IDs of components that must apply before this one. |
-| `destroy` | `string` | Whether to destroy this component during 'windsor down' / 'windsor destroy'. Boolean (true/false) or expression (e.g. '${cluster.destroy ?? true}'). Defaults to true. |
-| `enabled` | `string` | Whether to include this component in the final blueprint. Boolean (true/false) or expression. Defaults to true. |
+| `destroy` | `boolean / string` | Whether to destroy this component during 'windsor down' / 'windsor destroy'. Boolean (true/false) or expression (e.g. '${cluster.destroy ?? true}'). Defaults to true. |
+| `enabled` | `boolean / string` | Whether to include this component in the final blueprint. Boolean (true/false) or expression. Defaults to true. |
 | `inputs` | `object` | Module input values. Plain values pass through as literals; values using '${expr}' syntax are evaluated against facet config at apply time. Used to generate tfvars and not written to the final context blueprint.yaml. |
 | `name` | `string` | Optional name. When set, becomes the unique identifier for the component (used by dependsOn and context variables) instead of path. |
-| `parallelism` | `string` | Caps concurrent operations during 'terraform apply' / 'terraform destroy' for this component (the -parallelism flag). Integer or expression (e.g. '${cluster.parallelism ?? 10}'). |
+| `parallelism` | `integer / string` | Caps concurrent operations during 'terraform apply' / 'terraform destroy' for this component (the -parallelism flag). Integer or expression (e.g. '${cluster.parallelism ?? 10}'). |
 | `source` | `string` | Name of the source (from the sources list) that provides this module. |
 
 ## Examples

--- a/internal/gendocs/schema.go
+++ b/internal/gendocs/schema.go
@@ -153,7 +153,10 @@ func renderSchema(w io.Writer, schema map[string]any, examples []yaml.MapSlice, 
 		fmt.Fprintln(ew)
 	}
 
-	writeSchemaFields(ew, schema, "")
+	// The root schema is passed through every recursion so writeSchemaFields
+	// can resolve local '$ref: #/$defs/<name>' lookups without re-reading the
+	// source file.
+	writeSchemaFields(ew, schema, "", schema)
 	writeSchemaExamples(ew, examples)
 	writeSchemaSeeAlso(ew, seealso, sourcePath)
 	return ew.err
@@ -169,10 +172,14 @@ func writeSchemaFrontmatter(w io.Writer, title, description string) {
 }
 
 // writeSchemaFields renders the top-level field table for an object schema,
-// then recurses into nested object properties as h2/h3 subsections. headingPath
-// tracks the breadcrumb so nested headings read like "## Workstation" rather
-// than just "## (object)".
-func writeSchemaFields(w io.Writer, schema map[string]any, headingPath string) {
+// then recurses into nested object properties and array<object> items as
+// subsections. headingPath tracks the breadcrumb so nested headings read like
+// "## repository" rather than just "## (object)"; array<object> subsections
+// get a trailing "[]" so it's clear the fields describe each item rather than
+// the array itself. root is the document root, passed through so local
+// '$ref: #/$defs/<name>' references resolve at any depth.
+func writeSchemaFields(w io.Writer, schema map[string]any, headingPath string, root map[string]any) {
+	schema = resolveRef(schema, root)
 	if typeOf(schema) != "object" {
 		return
 	}
@@ -206,20 +213,79 @@ func writeSchemaFields(w io.Writer, schema map[string]any, headingPath string) {
 		if propSchema == nil {
 			continue
 		}
-		fmt.Fprintln(w, schemaFieldRow(name, propSchema, required[name]))
-		if typeOf(propSchema) == "object" && hasProperties(propSchema) {
-			label := name
-			if headingPath != "" {
-				label = headingPath + "." + name
-			}
-			nested = append(nested, nestedSection{label: label, schema: propSchema})
+		propSchema = resolveRef(propSchema, root)
+		fmt.Fprintln(w, schemaFieldRow(name, propSchema, required[name], root))
+		if sub, label := nestedSchemaFor(propSchema, name, headingPath, root); sub != nil {
+			nested = append(nested, nestedSection{label: label, schema: sub})
 		}
 	}
 	fmt.Fprintln(w)
 
 	for _, n := range nested {
-		writeSchemaFields(w, n.schema, n.label)
+		writeSchemaFields(w, n.schema, n.label, root)
 	}
+}
+
+// nestedSchemaFor returns the schema to recurse into (and its heading label)
+// when a property warrants a subsection. Object schemas with properties
+// recurse directly; array<object> schemas recurse into items with a "[]"
+// suffix on the label so the reader can tell the field table describes each
+// item rather than the array itself. Returns nil when no subsection should be
+// emitted (primitive, array of primitives, empty object).
+func nestedSchemaFor(propSchema map[string]any, name, headingPath string, root map[string]any) (map[string]any, string) {
+	base := name
+	if headingPath != "" {
+		base = headingPath + "." + name
+	}
+	if typeOf(propSchema) == "object" && hasProperties(propSchema) {
+		return propSchema, base
+	}
+	if typeOf(propSchema) == "array" {
+		items, _ := propSchema["items"].(map[string]any)
+		if items == nil {
+			return nil, ""
+		}
+		items = resolveRef(items, root)
+		if typeOf(items) == "object" && hasProperties(items) {
+			return items, base + "[]"
+		}
+	}
+	return nil, ""
+}
+
+// resolveRef looks up '$ref: #/$defs/<name>' against root and returns the
+// referenced schema merged with any sibling fields on the original (description,
+// etc. — JSON Schema 2020-12 allows siblings to $ref). Returns the input
+// schema unchanged when no local $ref is present or the lookup fails. Only
+// handles the local '#/$defs/<name>' form; external/remote refs aren't
+// supported because our schemas don't use them.
+func resolveRef(schema, root map[string]any) map[string]any {
+	if schema == nil {
+		return nil
+	}
+	ref, _ := schema["$ref"].(string)
+	if ref == "" || !strings.HasPrefix(ref, "#/$defs/") {
+		return schema
+	}
+	defs, _ := root["$defs"].(map[string]any)
+	if defs == nil {
+		return schema
+	}
+	target, _ := defs[strings.TrimPrefix(ref, "#/$defs/")].(map[string]any)
+	if target == nil {
+		return schema
+	}
+	merged := make(map[string]any, len(target)+len(schema))
+	for k, v := range target {
+		merged[k] = v
+	}
+	for k, v := range schema {
+		if k == "$ref" {
+			continue
+		}
+		merged[k] = v
+	}
+	return merged
 }
 
 type nestedSection struct {
@@ -230,18 +296,26 @@ type nestedSection struct {
 // schemaFieldRow renders one row of the field table. The Type column uses
 // 'array<string>' for typed arrays, the bare type name otherwise. Required
 // fields get a bold "**(required)**" suffix in Description; defaults get
-// "Default: `<value>`"; enums get "One of: `a`, `b`, `c`".
-func schemaFieldRow(name string, propSchema map[string]any, required bool) string {
+// "Default: `<value>`"; enums get "One of: `a`, `b`, `c`". root is the
+// document root, used to resolve '$ref' on array items so the Type column
+// reads 'array<object>' rather than 'array<>' when items use a local ref.
+func schemaFieldRow(name string, propSchema map[string]any, required bool, root map[string]any) string {
 	typeName := typeOf(propSchema)
 	if typeName == "array" {
 		if items, ok := propSchema["items"].(map[string]any); ok {
+			items = resolveRef(items, root)
 			if itemType := typeOf(items); itemType != "" {
 				typeName = "array<" + itemType + ">"
 			}
 		}
 	}
 	desc := collapseWhitespace(stringField(propSchema, "description"))
-	if enum, ok := propSchema["enum"].([]any); ok && len(enum) > 0 {
+	if enum, ok := propSchema["enum"].([]any); ok && len(enum) > 1 {
+		// Single-value enums are effectively constants — the field's description
+		// already names the required value (e.g. "Must be 'Blueprint'"), so the
+		// extra "One of: `Blueprint`." reads as redundant noise. Two-or-more
+		// values still get the listing since the description usually can't
+		// enumerate them all inline.
 		desc = appendSentence(desc, "One of: "+formatEnum(enum)+".")
 	}
 	if def, ok := propSchema["default"]; ok {

--- a/internal/gendocs/schema.go
+++ b/internal/gendocs/schema.go
@@ -396,9 +396,26 @@ func collapseWhitespace(s string) string {
 // helpers
 // =============================================================================
 
+// typeOf returns the JSON Schema 'type' as a display string. Supports both the
+// single-type form ('type: string') and the JSON Schema 2020-12 array-of-types
+// form ('type: [boolean, string]'), which authors use when a field legitimately
+// accepts more than one shape (e.g. a literal or an expression). The array
+// form is joined with ' / ' rather than the conventional pipe so the result
+// doesn't break markdown table rendering downstream.
 func typeOf(schema map[string]any) string {
-	t, _ := schema["type"].(string)
-	return t
+	switch t := schema["type"].(type) {
+	case string:
+		return t
+	case []any:
+		parts := make([]string, 0, len(t))
+		for _, x := range t {
+			if s, ok := x.(string); ok {
+				parts = append(parts, s)
+			}
+		}
+		return strings.Join(parts, " / ")
+	}
+	return ""
 }
 
 func hasProperties(schema map[string]any) bool {

--- a/internal/gendocs/schema_test.go
+++ b/internal/gendocs/schema_test.go
@@ -223,6 +223,27 @@ func TestSchemaFieldRow(t *testing.T) {
 		}
 	})
 
+	t.Run("RendersUnionTypeWithSlashSeparator", func(t *testing.T) {
+		// Given a property with the JSON Schema 2020-12 array-of-types form
+		// (used for fields that accept e.g. a literal boolean or an expression string)
+		propSchema := map[string]any{
+			"type":        []any{"boolean", "string"},
+			"description": "Boolean or expression.",
+		}
+
+		// When schemaFieldRow is called
+		got := schemaFieldRow("destroy", propSchema, false, nil)
+
+		// Then the type column renders the union joined by ' / ' (not '|',
+		// which would break the markdown table layout)
+		if !strings.Contains(got, "`boolean / string`") {
+			t.Errorf("expected union type rendered with slash separator, got %q", got)
+		}
+		if strings.Contains(got, "|") && !strings.HasPrefix(got, "| `destroy`") {
+			t.Errorf("expected no stray pipes inside cells, got %q", got)
+		}
+	})
+
 	t.Run("EscapesPipesInDescription", func(t *testing.T) {
 		// Given a description containing a pipe character (enum-style)
 		propSchema := map[string]any{"type": "string", "description": "Format: a|b|c."}

--- a/internal/gendocs/schema_test.go
+++ b/internal/gendocs/schema_test.go
@@ -150,7 +150,7 @@ func TestSchemaFieldRow(t *testing.T) {
 		propSchema := map[string]any{"type": "string", "description": "Blueprint name."}
 
 		// When schemaFieldRow is called for a non-required field
-		got := schemaFieldRow("name", propSchema, false)
+		got := schemaFieldRow("name", propSchema, false, nil)
 
 		// Then the row contains the name, type, and description
 		want := "| `name` | `string` | Blueprint name. |"
@@ -164,7 +164,7 @@ func TestSchemaFieldRow(t *testing.T) {
 		propSchema := map[string]any{"type": "string", "description": "Blueprint name."}
 
 		// When schemaFieldRow is called with required=true
-		got := schemaFieldRow("name", propSchema, true)
+		got := schemaFieldRow("name", propSchema, true, nil)
 
 		// Then the description ends with the bold (required) marker
 		if !strings.Contains(got, "**(required)**") {
@@ -181,7 +181,7 @@ func TestSchemaFieldRow(t *testing.T) {
 		}
 
 		// When schemaFieldRow is called
-		got := schemaFieldRow("platform", propSchema, false)
+		got := schemaFieldRow("platform", propSchema, false, nil)
 
 		// Then the description includes the enum values in backticks
 		if !strings.Contains(got, "One of: `aws`, `azure`, `gcp`.") {
@@ -198,7 +198,7 @@ func TestSchemaFieldRow(t *testing.T) {
 		}
 
 		// When schemaFieldRow is called
-		got := schemaFieldRow("dns", propSchema, false)
+		got := schemaFieldRow("dns", propSchema, false, nil)
 
 		// Then the description includes the default in backticks
 		if !strings.Contains(got, "Default: `true`.") {
@@ -215,7 +215,7 @@ func TestSchemaFieldRow(t *testing.T) {
 		}
 
 		// When schemaFieldRow is called
-		got := schemaFieldRow("tags", propSchema, false)
+		got := schemaFieldRow("tags", propSchema, false, nil)
 
 		// Then the type column shows the element type
 		if !strings.Contains(got, "`array<string>`") {
@@ -228,7 +228,7 @@ func TestSchemaFieldRow(t *testing.T) {
 		propSchema := map[string]any{"type": "string", "description": "Format: a|b|c."}
 
 		// When schemaFieldRow is called
-		got := schemaFieldRow("fmt", propSchema, false)
+		got := schemaFieldRow("fmt", propSchema, false, nil)
 
 		// Then pipes are escaped so the markdown table layout survives
 		if strings.Contains(got, "a|b|c") {
@@ -357,6 +357,91 @@ func TestRenderSchemaHeadingDepthLadder(t *testing.T) {
 			if !strings.Contains(out, want) {
 				t.Errorf("expected heading %q in output", want)
 			}
+		}
+	})
+}
+
+func TestRenderSchemaResolvesRefAndExpandsArrayItems(t *testing.T) {
+	t.Run("ArrayItemsExpandedAsSubsection", func(t *testing.T) {
+		// Given a schema with an array-of-objects property — the most common
+		// shape for blueprint sources, terraform components, etc.
+		schema := map[string]any{
+			"title": "Blueprint",
+			"type":  "object",
+			"properties": map[string]any{
+				"sources": map[string]any{
+					"type":        "array",
+					"description": "Sources.",
+					"items": map[string]any{
+						"type":     "object",
+						"required": []any{"name"},
+						"properties": map[string]any{
+							"name": map[string]any{"type": "string", "description": "Source name."},
+							"url":  map[string]any{"type": "string", "description": "Source URL."},
+						},
+					},
+				},
+			},
+		}
+
+		// When renderSchema runs
+		var buf bytes.Buffer
+		if err := renderSchema(&buf, schema, nil, "", ""); err != nil {
+			t.Fatalf("renderSchema: %v", err)
+		}
+		out := buf.String()
+
+		// Then the array property gets a "[]"-suffixed subsection listing each item's fields
+		if !strings.Contains(out, "## sources[]\n") {
+			t.Error("expected '## sources[]' subsection heading for array<object> items")
+		}
+		if !strings.Contains(out, "| `name` | `string` | Source name. **(required)** |") {
+			t.Error("expected items.name field row in sources[] subsection")
+		}
+		if !strings.Contains(out, "| `url` | `string` | Source URL. |") {
+			t.Error("expected items.url field row in sources[] subsection")
+		}
+	})
+
+	t.Run("LocalRefResolvedFromDefs", func(t *testing.T) {
+		// Given a schema where a property uses '$ref: #/$defs/<name>' to point
+		// at a shared definition (DRY for reused types like Reference)
+		schema := map[string]any{
+			"title": "Repo",
+			"type":  "object",
+			"properties": map[string]any{
+				"ref": map[string]any{"$ref": "#/$defs/reference"},
+			},
+			"$defs": map[string]any{
+				"reference": map[string]any{
+					"type":        "object",
+					"description": "A repo reference.",
+					"properties": map[string]any{
+						"branch": map[string]any{"type": "string", "description": "Branch."},
+						"tag":    map[string]any{"type": "string", "description": "Tag."},
+					},
+				},
+			},
+		}
+
+		// When renderSchema runs
+		var buf bytes.Buffer
+		if err := renderSchema(&buf, schema, nil, "", ""); err != nil {
+			t.Fatalf("renderSchema: %v", err)
+		}
+		out := buf.String()
+
+		// Then the top table reports the property as 'object' (resolved type),
+		// not the empty string that an unresolved $ref would produce
+		if !strings.Contains(out, "| `ref` | `object` |") {
+			t.Error("expected 'ref' row to show resolved 'object' type")
+		}
+		// And the referenced schema's fields render as a subsection
+		if !strings.Contains(out, "## ref\n") {
+			t.Error("expected '## ref' subsection from resolved $ref")
+		}
+		if !strings.Contains(out, "| `branch` | `string` | Branch. |") {
+			t.Error("expected resolved $ref branch field")
 		}
 	})
 }

--- a/pkg/runtime/config/schemas/artifacts/blueprint.seealso.md
+++ b/pkg/runtime/config/schemas/artifacts/blueprint.seealso.md
@@ -1,0 +1,4 @@
+- [Facets reference](facets.md), [Metadata reference](metadata.md), [Schema reference](schema.md)
+- [`apply`](commands/apply.md), [`up`](commands/up.md), [`bootstrap`](commands/bootstrap.md), [`destroy`](commands/destroy.md)
+- [`show blueprint`](commands/show-blueprint.md), [`explain`](commands/explain.md)
+- [Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle), [Sharing blueprints](https://www.windsorcli.dev/docs/blueprints/sharing)

--- a/pkg/runtime/config/schemas/artifacts/blueprint.yaml
+++ b/pkg/runtime/config/schemas/artifacts/blueprint.yaml
@@ -1,0 +1,326 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+title: Blueprint
+description: |
+  Top-level blueprint definition. Lives at contexts/<context>/blueprint.yaml and
+  declares the Terraform components and Flux kustomizations that windsor will
+  apply for that context, plus the sources those components come from and the
+  variable substitutions shared across them.
+type: object
+required:
+  - kind
+  - apiVersion
+  - metadata
+additionalProperties: false
+properties:
+  kind:
+    type: string
+    description: |
+      Resource kind, following Kubernetes conventions. Must be 'Blueprint'.
+    enum:
+      - Blueprint
+  apiVersion:
+    type: string
+    description: |
+      API schema version. Must be 'blueprints.windsorcli.dev/v1alpha1'.
+    enum:
+      - blueprints.windsorcli.dev/v1alpha1
+  metadata:
+    description: Identity for the blueprint.
+    type: object
+    required:
+      - name
+    additionalProperties: false
+    properties:
+      name:
+        type: string
+        description: Blueprint's unique identifier within the project.
+      description:
+        type: string
+        description: One-line overview of what this blueprint provisions.
+  backend:
+    type: string
+    description: |
+      Names the terraform component that terminates the backend tier. When set,
+      'windsor bootstrap' applies the backend component (and every component
+      declared before it) against local state first, then migrates state to the
+      configured remote backend before applying the rest of the graph.
+  repository:
+    description: Source repository this blueprint was bootstrapped from.
+    type: object
+    additionalProperties: false
+    properties:
+      url:
+        type: string
+        description: Repository URL.
+      ref:
+        $ref: '#/$defs/reference'
+      secretName:
+        type: string
+        description: Name of a Flux secret holding credentials for the repository.
+  sources:
+    type: array
+    description: |
+      External resources referenced by the blueprint. Each source is an OCI
+      blueprint artifact or a Git repository that contributes Terraform modules
+      and/or kustomize bases consumable by the components below.
+    items:
+      type: object
+      required:
+        - name
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          description: Identifier for the source; referenced by 'source:' on terraform / kustomize components.
+        url:
+          type: string
+          description: Source location. Accepts Git URLs and OCI URLs (oci://registry/repo:tag).
+        pathPrefix:
+          type: string
+          description: Path prefix applied to the source. Defaults to 'terraform' when unset.
+        ref:
+          $ref: '#/$defs/reference'
+        secretName:
+          type: string
+          description: Name of a Flux secret holding credentials for the source.
+        install:
+          type: string
+          description: |
+            For OCI sources, whether to merge this source's components into the
+            final blueprint. Accepts a boolean (true/false) or an expression
+            (e.g. '${some.condition ?? true}') evaluated against facet config.
+            Defaults to true. Has no effect on Git sources.
+  terraform:
+    type: array
+    description: |
+      Terraform components included in the blueprint, in declaration order.
+      Components are reordered topologically by dependsOn at apply time.
+    items:
+      type: object
+      required:
+        - path
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          description: |
+            Optional name. When set, becomes the unique identifier for the
+            component (used by dependsOn and context variables) instead of path.
+        source:
+          type: string
+          description: Name of the source (from the sources list) that provides this module.
+        path:
+          type: string
+          description: Path of the module within the source.
+        dependsOn:
+          type: array
+          items:
+            type: string
+          description: IDs of components that must apply before this one.
+        inputs:
+          type: object
+          additionalProperties: true
+          description: |
+            Module input values. Plain values pass through as literals; values
+            using '${expr}' syntax are evaluated against facet config at apply
+            time. Used to generate tfvars and not written to the final context
+            blueprint.yaml.
+        destroy:
+          type: string
+          description: |
+            Whether to destroy this component during 'windsor down' / 'windsor
+            destroy'. Boolean (true/false) or expression
+            (e.g. '${cluster.destroy ?? true}'). Defaults to true.
+        parallelism:
+          type: string
+          description: |
+            Caps concurrent operations during 'terraform apply' / 'terraform
+            destroy' for this component (the -parallelism flag). Integer or
+            expression (e.g. '${cluster.parallelism ?? 10}').
+        enabled:
+          type: string
+          description: |
+            Whether to include this component in the final blueprint. Boolean
+            (true/false) or expression. Defaults to true.
+  kustomize:
+    type: array
+    description: |
+      Flux kustomizations included in the blueprint. Each entry maps to a
+      Kustomization resource the provisioner applies to the cluster, in
+      topologically sorted dependsOn order.
+    items:
+      type: object
+      required:
+        - name
+        - path
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          description: Identifier for the kustomization; referenced by dependsOn.
+        path:
+          type: string
+          description: Path within the source containing the kustomize base.
+        source:
+          type: string
+          description: Name of the source (from the sources list) that provides this kustomization. Defaults to the blueprint's primary source when unset.
+        namespace:
+          type: string
+          description: |
+            Namespace where the Flux Kustomization object itself lives. Defaults
+            to the gitops namespace. DependsOn references always resolve in the
+            gitops namespace; cross-namespace dependencies are not supported.
+        targetNamespace:
+          type: string
+          description: |
+            Populates spec.targetNamespace, instructing Flux to override the
+            namespace of every resource reconciled by this kustomization.
+        dependsOn:
+          type: array
+          items:
+            type: string
+          description: Names of kustomizations that must reconcile before this one.
+        interval:
+          type: string
+          description: |
+            Reconciliation interval, expressed as a Go duration string
+            (e.g. '5m', '1h'). Defaults to a mode-appropriate value chosen by
+            the provisioner (short poll for pull mode, long fallback for push).
+        retryInterval:
+          type: string
+          description: Duration to wait before retrying a failed reconciliation (e.g. '2m').
+        timeout:
+          type: string
+          description: Maximum duration for a single reconciliation attempt (e.g. '10m').
+        patches:
+          type: array
+          description: |
+            Strategic-merge or Flux-style patches applied to the kustomization.
+            Each entry is either a 'path:' to a patch file relative to the
+            kustomization, or a 'patch:' inline YAML body with an optional
+            'target:' selector (kind / name / namespace).
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              path:
+                type: string
+                description: Path to a patch file relative to the kustomization (blueprint format).
+              patch:
+                type: string
+                description: Inline patch body as YAML (Flux format).
+              target:
+                type: object
+                description: Selector for the patch (Flux format). Used with 'patch:'.
+                additionalProperties: true
+        wait:
+          type: boolean
+          description: Wait for resources to settle before declaring reconciliation complete.
+        force:
+          type: boolean
+          description: Force-apply resources Flux would otherwise refuse to update.
+        prune:
+          type: boolean
+          description: Garbage-collect resources removed from the source. Defaults to true.
+        components:
+          type: array
+          items:
+            type: string
+          description: Kustomize components to compose into this kustomization.
+        destroy:
+          type: string
+          description: |
+            Whether to delete this kustomization during 'windsor down' /
+            'windsor destroy'. Boolean or expression. Defaults to true.
+        destroyOnly:
+          type: boolean
+          description: |
+            When true, the kustomization only runs during destroy. Useful for
+            teardown-only resources (e.g. cleanup jobs).
+        enabled:
+          type: string
+          description: |
+            Whether to include this kustomization in the final blueprint.
+            Boolean or expression. Defaults to true.
+        substitutions:
+          type: object
+          additionalProperties:
+            type: string
+          description: |
+            PostBuild variable substitutions for this kustomization. Collected
+            into a 'values-<name>' ConfigMap that Flux substitutes from.
+  substitutions:
+    type: object
+    additionalProperties:
+      type: string
+    description: |
+      Blueprint-level substitutions injected into 'values-common' and made
+      available to every kustomization via PostBuild substitution. Values may
+      use expression syntax (e.g. '${dns.domain}') resolved against facet
+      config blocks.
+  configMaps:
+    type: object
+    additionalProperties:
+      type: object
+      additionalProperties:
+        type: string
+    description: |
+      Standalone ConfigMaps to create. Each top-level key is a ConfigMap name;
+      its map-of-string value is the .data payload. These are referenced by
+      every kustomization in PostBuild substitution.
+$defs:
+  reference:
+    type: object
+    description: A specific version or state of a repository or source (one of branch / tag / semver / commit).
+    additionalProperties: false
+    properties:
+      branch:
+        type: string
+        description: Branch to follow.
+      tag:
+        type: string
+        description: Specific tag.
+      semver:
+        type: string
+        description: Semver constraint (e.g. '>=1.0.0').
+      name:
+        type: string
+        description: Named reference.
+      commit:
+        type: string
+        description: Specific commit SHA.
+examples:
+  - kind: Blueprint
+    apiVersion: blueprints.windsorcli.dev/v1alpha1
+    metadata:
+      name: local
+      description: Local workstation blueprint
+    sources:
+      - name: core
+        url: oci://ghcr.io/windsorcli/core:v0.3.0
+      - name: modules
+        url: github.com/org/terraform-modules
+        ref:
+          branch: main
+    terraform:
+      - name: cluster
+        source: core
+        path: cluster/talos
+        inputs:
+          cluster_name: local
+      - name: dns
+        source: core
+        path: dns/coredns
+        dependsOn:
+          - cluster
+    kustomize:
+      - name: flux-system
+        path: flux-system
+        source: core
+      - name: dns
+        path: dns
+        source: core
+        dependsOn:
+          - flux-system
+    substitutions:
+      external_domain: example.test

--- a/pkg/runtime/config/schemas/artifacts/blueprint.yaml
+++ b/pkg/runtime/config/schemas/artifacts/blueprint.yaml
@@ -84,7 +84,7 @@ properties:
           type: string
           description: Name of a Flux secret holding credentials for the source.
         install:
-          type: string
+          type: [boolean, string]
           description: |
             For OCI sources, whether to merge this source's components into the
             final blueprint. Accepts a boolean (true/false) or an expression
@@ -126,19 +126,19 @@ properties:
             time. Used to generate tfvars and not written to the final context
             blueprint.yaml.
         destroy:
-          type: string
+          type: [boolean, string]
           description: |
             Whether to destroy this component during 'windsor down' / 'windsor
             destroy'. Boolean (true/false) or expression
             (e.g. '${cluster.destroy ?? true}'). Defaults to true.
         parallelism:
-          type: string
+          type: [integer, string]
           description: |
             Caps concurrent operations during 'terraform apply' / 'terraform
             destroy' for this component (the -parallelism flag). Integer or
             expression (e.g. '${cluster.parallelism ?? 10}').
         enabled:
-          type: string
+          type: [boolean, string]
           description: |
             Whether to include this component in the final blueprint. Boolean
             (true/false) or expression. Defaults to true.
@@ -228,7 +228,7 @@ properties:
             type: string
           description: Kustomize components to compose into this kustomization.
         destroy:
-          type: string
+          type: [boolean, string]
           description: |
             Whether to delete this kustomization during 'windsor down' /
             'windsor destroy'. Boolean or expression. Defaults to true.
@@ -238,7 +238,7 @@ properties:
             When true, the kustomization only runs during destroy. Useful for
             teardown-only resources (e.g. cleanup jobs).
         enabled:
-          type: string
+          type: [boolean, string]
           description: |
             Whether to include this kustomization in the final blueprint.
             Boolean or expression. Defaults to true.


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This PR touches only documentation tooling and reference docs; no runtime paths are affected.
>
> **Overview**
>
> The PR adds a machine-readable JSON Schema for the blueprint format (`blueprint.yaml`) and upgrades the schema documentation generator to resolve `#/$defs/` local references and emit array-of-object sub-sections with a `[]` suffix. The generated content replaces the hand-written `docs/reference/blueprint.md`, substantially trimming that file. The `resolveRef` helper gracefully falls back on unresolvable refs rather than panicking, and two new test cases cover both the `$ref` and array-expansion paths.
>
> Two schema design points are worth confirming: `destroy` and `enabled` are typed as `string` but users would naturally write `destroy: true` (YAML boolean), which `additionalProperties: false` would then reject; and `install` replaces the previously documented `deploy` field on source items — a potential rename that should be called out explicitly if existing blueprints need updating. The old docs also listed `metadata.authors` and `kustomize[].cleanup` which are absent from the new schema; worth verifying those fields are intentionally removed.
>
> Reviewed by Claude for commit `56469be8`.

<!-- /claude-code-review:summary -->
