### PR TITLE
chore(docs): add testing schema documentation and examples

### DIFF
--- a/docs/reference/blueprint.md
+++ b/docs/reference/blueprint.md
@@ -123,32 +123,32 @@ metadata:
   description: Local workstation blueprint
   name: local
 sources:
-- name: core
-  url: oci://ghcr.io/windsorcli/core:v0.3.0
-- name: modules
-  ref:
-    branch: main
-  url: github.com/org/terraform-modules
+  - name: core
+    url: oci://ghcr.io/windsorcli/core:v0.3.0
+  - name: modules
+    ref:
+      branch: main
+    url: github.com/org/terraform-modules
 terraform:
-- inputs:
-    cluster_name: local
-  name: cluster
-  path: cluster/talos
-  source: core
-- dependsOn:
-  - cluster
-  name: dns
-  path: dns/coredns
-  source: core
+  - inputs:
+      cluster_name: local
+    name: cluster
+    path: cluster/talos
+    source: core
+  - dependsOn:
+      - cluster
+    name: dns
+    path: dns/coredns
+    source: core
 kustomize:
-- name: flux-system
-  path: flux-system
-  source: core
-- dependsOn:
-  - flux-system
-  name: dns
-  path: dns
-  source: core
+  - name: flux-system
+    path: flux-system
+    source: core
+  - dependsOn:
+      - flux-system
+    name: dns
+    path: dns
+    source: core
 substitutions:
   external_domain: example.test
 ```

--- a/docs/reference/metadata.md
+++ b/docs/reference/metadata.md
@@ -30,8 +30,8 @@ version: 1.0.0
 description: A sample blueprint
 author: John Doe
 tags:
-- infrastructure
-- kubernetes
+  - infrastructure
+  - kubernetes
 homepage: https://example.com/my-blueprint
 license: MIT
 cliVersion: ">=0.7.1"

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -1,0 +1,120 @@
+---
+title: "Testing"
+description: "Schema for windsor test files (*.test.yaml) consumed by 'windsor test'."
+---
+# Testing
+
+Schema for windsor test files (*.test.yaml) consumed by 'windsor test'. Test
+files live under contexts/_template/tests/ and define cases that apply input
+values to configuration, compose the blueprint in isolation, and assert that
+specific terraform components and kustomizations are present (or absent).
+
+## Fields
+
+| Field | Type | Description |
+|------|------|-------------|
+| `cases` | `array<object>` | Test cases to execute. **(required)** |
+
+## cases[]
+
+| Field | Type | Description |
+|------|------|-------------|
+| `name` | `string` | Unique identifier for the test case. **(required)** |
+| `exclude` | `object` | Components and kustomizations that must NOT be present in the composed blueprint. Same partial-match semantics as 'expect'. |
+| `expect` | `object` | Components and kustomizations that must be present in the composed blueprint. Partial matching: only fields you specify are checked. |
+| `expectError` | `boolean` | When true, the test passes only if blueprint composition fails. Use for testing invalid configurations that the framework should reject. Defaults to false. |
+| `terraformOutputs` | `object` | Mock outputs for terraform_output() expressions. Keys are component IDs; values are maps of output key to value. Example: terraformOutputs.network.vpc_id = "vpc-123". |
+| `values` | `object` | Configuration values to apply before composing the blueprint. These override any existing configuration for the test. Dotted keys are allowed (e.g. 'cluster.driver: talos'). |
+
+### cases[].exclude
+
+| Field | Type | Description |
+|------|------|-------------|
+| `kustomize` | `array<object>` | Kustomizations to assert on. |
+| `terraform` | `array<object>` | Terraform components to assert on. |
+
+#### cases[].exclude.kustomize[]
+
+| Field | Type | Description |
+|------|------|-------------|
+| `components` | `array<string>` | Expected kustomize components. Match is 'contains'. |
+| `dependsOn` | `array<string>` | Expected dependency names. Match is 'contains'. |
+| `name` | `string` | Kustomization name. Used as the match key. |
+| `path` | `string` | Expected path. Asserted only when set. |
+| `source` | `string` | Expected source name. Asserted only when set. |
+| `substitutions` | `object` | Expected PostBuild substitutions. Strict equality per key — every specified key must be present with the exact expected value. |
+
+#### cases[].exclude.terraform[]
+
+| Field | Type | Description |
+|------|------|-------------|
+| `dependsOn` | `array<string>` | Expected dependency IDs. Match is 'contains' — the actual list may have extras. |
+| `inputs` | `object` | Expected input values. Strict equality per key — every specified key must be present with the exact expected value. |
+| `name` | `string` | Component name (or path-derived ID when name is omitted). Used as the match key. |
+| `path` | `string` | Module path. Used as the match key when 'name' is omitted. |
+| `source` | `string` | Expected source name. Asserted only when set. |
+
+### cases[].expect
+
+| Field | Type | Description |
+|------|------|-------------|
+| `kustomize` | `array<object>` | Kustomizations to assert on. |
+| `terraform` | `array<object>` | Terraform components to assert on. |
+
+#### cases[].expect.kustomize[]
+
+| Field | Type | Description |
+|------|------|-------------|
+| `components` | `array<string>` | Expected kustomize components. Match is 'contains'. |
+| `dependsOn` | `array<string>` | Expected dependency names. Match is 'contains'. |
+| `name` | `string` | Kustomization name. Used as the match key. |
+| `path` | `string` | Expected path. Asserted only when set. |
+| `source` | `string` | Expected source name. Asserted only when set. |
+| `substitutions` | `object` | Expected PostBuild substitutions. Strict equality per key — every specified key must be present with the exact expected value. |
+
+#### cases[].expect.terraform[]
+
+| Field | Type | Description |
+|------|------|-------------|
+| `dependsOn` | `array<string>` | Expected dependency IDs. Match is 'contains' — the actual list may have extras. |
+| `inputs` | `object` | Expected input values. Strict equality per key — every specified key must be present with the exact expected value. |
+| `name` | `string` | Component name (or path-derived ID when name is omitted). Used as the match key. |
+| `path` | `string` | Module path. Used as the match key when 'name' is omitted. |
+| `source` | `string` | Expected source name. Asserted only when set. |
+
+## Examples
+
+```yaml
+cases:
+- exclude:
+    terraform:
+    - name: vnet
+  expect:
+    terraform:
+    - dependsOn:
+      - network
+      name: vpc
+      source: core
+  name: aws-platform-includes-vpc
+  values:
+    platform: aws
+- expectError: true
+  name: missing-required-fails
+  values: {}
+- expect:
+    kustomize:
+    - name: dns
+      substitutions:
+        external_dns_zone_id: Z123456
+  name: dns-substitution-uses-terraform-output
+  terraformOutputs:
+    network:
+      external_dns_zone_id: Z123456
+```
+
+## See also
+
+- [`windsor test`](commands/test.md)
+- [Blueprint reference](blueprint.md), [Facets reference](facets.md)
+- [Blueprint testing](https://www.windsorcli.dev/docs/blueprints/testing)
+- Source schema: [pkg/runtime/config/schemas/artifacts/testing.yaml](https://github.com/windsorcli/cli/blob/main/pkg/runtime/config/schemas/artifacts/testing.yaml)

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -86,30 +86,30 @@ specific terraform components and kustomizations are present (or absent).
 
 ```yaml
 cases:
-- exclude:
-    terraform:
-    - name: vnet
-  expect:
-    terraform:
-    - dependsOn:
-      - network
-      name: vpc
-      source: core
-  name: aws-platform-includes-vpc
-  values:
-    platform: aws
-- expectError: true
-  name: missing-required-fails
-  values: {}
-- expect:
-    kustomize:
-    - name: dns
-      substitutions:
+  - exclude:
+      terraform:
+        - name: vnet
+    expect:
+      terraform:
+        - dependsOn:
+            - network
+          name: vpc
+          source: core
+    name: aws-platform-includes-vpc
+    values:
+      platform: aws
+  - expectError: true
+    name: missing-required-fails
+    values: {}
+  - expect:
+      kustomize:
+        - name: dns
+          substitutions:
+            external_dns_zone_id: Z123456
+    name: dns-substitution-uses-terraform-output
+    terraformOutputs:
+      network:
         external_dns_zone_id: Z123456
-  name: dns-substitution-uses-terraform-output
-  terraformOutputs:
-    network:
-      external_dns_zone_id: Z123456
 ```
 
 ## See also

--- a/internal/gendocs/schema.go
+++ b/internal/gendocs/schema.go
@@ -331,6 +331,11 @@ func schemaFieldRow(name string, propSchema map[string]any, required bool, root 
 // fenced yaml code block. Each example is a yaml.MapSlice so author-defined
 // field order survives the round-trip and the rendered YAML matches the
 // source-of-truth format operators write.
+//
+// MarshalWithOptions(IndentSequence(true)) makes sequence items indent two
+// spaces beneath their parent key — without it, '- item' lands at the same
+// column as sibling mapping keys, which strict YAML 1.2 parsers may reject
+// (or read as a sibling key rather than a list value).
 func writeSchemaExamples(w io.Writer, examples []yaml.MapSlice) {
 	if len(examples) == 0 {
 		return
@@ -338,7 +343,7 @@ func writeSchemaExamples(w io.Writer, examples []yaml.MapSlice) {
 	fmt.Fprintln(w, "## Examples")
 	fmt.Fprintln(w)
 	for _, ex := range examples {
-		body, err := yaml.Marshal(ex)
+		body, err := yaml.MarshalWithOptions(ex, yaml.IndentSequence(true))
 		if err != nil {
 			continue
 		}

--- a/pkg/runtime/config/schemas/artifacts/testing.seealso.md
+++ b/pkg/runtime/config/schemas/artifacts/testing.seealso.md
@@ -1,0 +1,3 @@
+- [`windsor test`](commands/test.md)
+- [Blueprint reference](blueprint.md), [Facets reference](facets.md)
+- [Blueprint testing](https://www.windsorcli.dev/docs/blueprints/testing)

--- a/pkg/runtime/config/schemas/artifacts/testing.yaml
+++ b/pkg/runtime/config/schemas/artifacts/testing.yaml
@@ -1,0 +1,163 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+title: Testing
+description: |
+  Schema for windsor test files (*.test.yaml) consumed by 'windsor test'. Test
+  files live under contexts/_template/tests/ and define cases that apply input
+  values to configuration, compose the blueprint in isolation, and assert that
+  specific terraform components and kustomizations are present (or absent).
+type: object
+required:
+  - cases
+additionalProperties: false
+properties:
+  cases:
+    type: array
+    description: Test cases to execute.
+    items:
+      type: object
+      required:
+        - name
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          description: Unique identifier for the test case.
+        values:
+          type: object
+          additionalProperties: true
+          description: |
+            Configuration values to apply before composing the blueprint.
+            These override any existing configuration for the test. Dotted
+            keys are allowed (e.g. 'cluster.driver: talos').
+        terraformOutputs:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties: true
+          description: |
+            Mock outputs for terraform_output() expressions. Keys are
+            component IDs; values are maps of output key to value. Example:
+            terraformOutputs.network.vpc_id = "vpc-123".
+        expect:
+          $ref: '#/$defs/expectation'
+          description: |
+            Components and kustomizations that must be present in the composed
+            blueprint. Partial matching: only fields you specify are checked.
+        exclude:
+          $ref: '#/$defs/expectation'
+          description: |
+            Components and kustomizations that must NOT be present in the
+            composed blueprint. Same partial-match semantics as 'expect'.
+        expectError:
+          type: boolean
+          description: |
+            When true, the test passes only if blueprint composition fails.
+            Use for testing invalid configurations that the framework should
+            reject. Defaults to false.
+$defs:
+  expectation:
+    type: object
+    description: |
+      A subset of the Blueprint shape, used for assertions. Additional
+      Blueprint fields are accepted but not checked — only the fields below
+      participate in matching.
+    additionalProperties: true
+    properties:
+      terraform:
+        type: array
+        description: Terraform components to assert on.
+        items:
+          $ref: '#/$defs/terraformMatch'
+      kustomize:
+        type: array
+        description: Kustomizations to assert on.
+        items:
+          $ref: '#/$defs/kustomizeMatch'
+  terraformMatch:
+    type: object
+    description: |
+      Terraform component matcher. The component is selected by 'name' (if
+      set) or by 'path'; only the fields below are compared, with array
+      fields ('dependsOn') matched by contains rather than equality.
+    additionalProperties: true
+    properties:
+      name:
+        type: string
+        description: Component name (or path-derived ID when name is omitted). Used as the match key.
+      path:
+        type: string
+        description: Module path. Used as the match key when 'name' is omitted.
+      source:
+        type: string
+        description: Expected source name. Asserted only when set.
+      dependsOn:
+        type: array
+        items:
+          type: string
+        description: Expected dependency IDs. Match is 'contains' — the actual list may have extras.
+      inputs:
+        type: object
+        additionalProperties: true
+        description: |
+          Expected input values. Strict equality per key — every specified
+          key must be present with the exact expected value.
+  kustomizeMatch:
+    type: object
+    description: |
+      Kustomization matcher. Selected by 'name'; only the fields below are
+      compared, with array fields ('dependsOn', 'components') matched by
+      contains rather than equality.
+    additionalProperties: true
+    properties:
+      name:
+        type: string
+        description: Kustomization name. Used as the match key.
+      path:
+        type: string
+        description: Expected path. Asserted only when set.
+      source:
+        type: string
+        description: Expected source name. Asserted only when set.
+      dependsOn:
+        type: array
+        items:
+          type: string
+        description: Expected dependency names. Match is 'contains'.
+      components:
+        type: array
+        items:
+          type: string
+        description: Expected kustomize components. Match is 'contains'.
+      substitutions:
+        type: object
+        additionalProperties:
+          type: string
+        description: |
+          Expected PostBuild substitutions. Strict equality per key — every
+          specified key must be present with the exact expected value.
+examples:
+  - cases:
+      - name: aws-platform-includes-vpc
+        values:
+          platform: aws
+        expect:
+          terraform:
+            - name: vpc
+              source: core
+              dependsOn:
+                - network
+        exclude:
+          terraform:
+            - name: vnet
+      - name: missing-required-fails
+        values: {}
+        expectError: true
+      - name: dns-substitution-uses-terraform-output
+        terraformOutputs:
+          network:
+            external_dns_zone_id: Z123456
+        expect:
+          kustomize:
+            - name: dns
+              substitutions:
+                external_dns_zone_id: Z123456

--- a/pkg/runtime/config/schemas/artifacts/testing.yaml
+++ b/pkg/runtime/config/schemas/artifacts/testing.yaml
@@ -79,7 +79,7 @@ $defs:
       Terraform component matcher. The component is selected by 'name' (if
       set) or by 'path'; only the fields below are compared, with array
       fields ('dependsOn') matched by contains rather than equality.
-    additionalProperties: true
+    additionalProperties: false
     properties:
       name:
         type: string
@@ -107,7 +107,7 @@ $defs:
       Kustomization matcher. Selected by 'name'; only the fields below are
       compared, with array fields ('dependsOn', 'components') matched by
       contains rather than equality.
-    additionalProperties: true
+    additionalProperties: false
     properties:
       name:
         type: string


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This PR adds only documentation and a JSON Schema artifact; it touches no Go code and has no behavioral impact on the CLI.
>
> **Overview**
>
> The change introduces `docs/reference/testing.md`, a reference page for the `*.test.yaml` schema consumed by `windsor test`, alongside the backing schema file `testing.yaml` and its `seealso` companion. The schema defines test cases with `expect`/`exclude` assertion blocks, mock `terraformOutputs`, and an `expectError` flag for negative testing.
>
> Two issues are worth addressing: the `dependsOn` sequence in the docs example is indented at the same column as its sibling keys, which parses as `null` rather than a list; and the `terraformMatch`/`kustomizeMatch` defs use `additionalProperties: true`, meaning field-name typos in user test files pass schema validation silently.
>
> Reviewed by Claude for commit `405f171a`.

<!-- /claude-code-review:summary -->
