### PR TITLE
chore(docs): update facets documentation and add JSON schema for facets

### DIFF
--- a/api/v1alpha1/facet_types.go
+++ b/api/v1alpha1/facet_types.go
@@ -77,8 +77,9 @@ type Facet struct {
 	// When nil, the loader derives ordinal from the facet file basename (e.g. config-* 100, provider-base/platform-base 199, provider-/platform- 200, options- 300, addon-/addons- 400).
 	Ordinal *int `yaml:"ordinal,omitempty"`
 
-	// When is a CEL expression that determines if this facet should be applied.
-	// The expression is evaluated against user configuration values.
+	// When is an expression that determines if this facet should be applied.
+	// The expression is evaluated against user configuration values via the
+	// expr-lang/expr library (NOT Google's CEL).
 	// Examples: "provider == 'aws'", "observability.enabled == true && observability.backend == 'quickwit'"
 	When string `yaml:"when,omitempty"`
 
@@ -110,8 +111,9 @@ type Facet struct {
 type ConditionalTerraformComponent struct {
 	TerraformComponent `yaml:",inline"`
 
-	// When is a CEL expression that determines if this terraform component should be applied.
-	// If empty, the component is always applied when the parent facet matches.
+	// When is an expression (expr-lang/expr) that determines if this terraform
+	// component should be applied. If empty, the component is always applied
+	// when the parent facet matches.
 	When string `yaml:"when,omitempty"`
 
 	// Strategy determines how this component is merged into the blueprint.

--- a/docs/reference/facets.md
+++ b/docs/reference/facets.md
@@ -25,7 +25,7 @@ and are composed in ordinal order (lower-priority first).
 | `requires` | `array<object>` | Input-requirement blocks for the facet as a whole. When the facet is active and a block's optional 'when' holds, every path in that block must resolve to a present, non-empty value in the merged scope. Unsatisfied paths across every active facet are aggregated into a single user-facing error. |
 | `substitutions` | `object` | Top-level key/value pairs evaluated with facet scope and injected into 'values-common', making them available to every kustomization via PostBuild substitution. Values may use expression syntax (e.g. '${dns.domain}') resolved against active facet config blocks. |
 | `terraform` | `array<object>` | Terraform components contributed by this facet. Each entry extends the blueprint's TerraformComponent shape with conditional fields (when, strategy, ordinal, requires). |
-| `when` | `string` | CEL expression that gates the facet. Evaluated against merged configuration values; the facet is applied only when the expression yields true. Examples: "platform == 'aws'", "observability.enabled == true && observability.backend == 'quickwit'". Empty 'when' means the facet always applies. |
+| `when` | `string` | Expression that gates the facet. Evaluated against merged configuration values; the facet is applied only when the expression yields true. Examples: "platform == 'aws'", "observability.enabled == true && observability.backend == 'quickwit'". Empty 'when' means the facet always applies. |
 
 ## metadata
 
@@ -43,7 +43,7 @@ and are composed in ordinal order (lower-priority first).
 | `ordinal` | `integer` | Per-block override of the facet's ordinal for merge precedence. Higher wins on conflict. When unset, the parent facet's ordinal is used. |
 | `requires` | `array<object>` | Requirement blocks scoped to this config block. Evaluated only when the parent facet is active AND this block's 'when' holds; missing paths surface under the effective AND condition. |
 | `strategy` | `string` | How this block merges with same-named blocks from other facets. 'merge' (default) deep-merges; 'replace' overwrites; 'remove' deletes the block from scope. One of: `merge`, `replace`, `remove`. |
-| `when` | `string` | Optional CEL expression that gates this block. Empty means the block is always evaluated when the parent facet is active. |
+| `when` | `string` | Optional expression that gates this block. Empty means the block is always evaluated when the parent facet is active. |
 
 ### config[].requires[]
 
@@ -51,7 +51,7 @@ and are composed in ordinal order (lower-priority first).
 |------|------|-------------|
 | `paths` | `array<string>` | Dotted scope keys whose values must be present and non-empty. Required; the parser rejects an empty list. **(required)** |
 | `message` | `string` | Optional author-supplied context surfaced under this block's heading in the aggregated error. |
-| `when` | `string` | Optional CEL expression gating this requirement. Empty means the paths are required whenever the parent (facet, config block, or component) is active. |
+| `when` | `string` | Optional expression gating this requirement. Empty means the paths are required whenever the parent (facet, config block, or component) is active. |
 
 ## kustomize[]
 
@@ -60,7 +60,7 @@ and are composed in ordinal order (lower-priority first).
 | `ordinal` | `integer` | Per-kustomization override of the facet's ordinal for merge precedence. |
 | `requires` | `array<object>` | Requirement blocks scoped to this kustomization. Evaluated only when the parent facet is active and this kustomization's 'when' holds. |
 | `strategy` | `string` | How this kustomization is merged into the blueprint. 'merge' (default) deep-merges with existing kustomizations matching the same Name; 'replace' overwrites; 'remove' deletes the matching existing kustomization's non-index fields. Remove operations are always applied last. One of: `merge`, `replace`, `remove`. |
-| `when` | `string` | CEL expression that gates this kustomization. Empty means the kustomization is always applied when the parent facet matches. |
+| `when` | `string` | Expression that gates this kustomization. Empty means the kustomization is always applied when the parent facet matches. |
 
 ### kustomize[].requires[]
 
@@ -68,7 +68,7 @@ and are composed in ordinal order (lower-priority first).
 |------|------|-------------|
 | `paths` | `array<string>` | Dotted scope keys whose values must be present and non-empty. Required; the parser rejects an empty list. **(required)** |
 | `message` | `string` | Optional author-supplied context surfaced under this block's heading in the aggregated error. |
-| `when` | `string` | Optional CEL expression gating this requirement. Empty means the paths are required whenever the parent (facet, config block, or component) is active. |
+| `when` | `string` | Optional expression gating this requirement. Empty means the paths are required whenever the parent (facet, config block, or component) is active. |
 
 ## requires[]
 
@@ -76,7 +76,7 @@ and are composed in ordinal order (lower-priority first).
 |------|------|-------------|
 | `paths` | `array<string>` | Dotted scope keys whose values must be present and non-empty. Required; the parser rejects an empty list. **(required)** |
 | `message` | `string` | Optional author-supplied context surfaced under this block's heading in the aggregated error. |
-| `when` | `string` | Optional CEL expression gating this requirement. Empty means the paths are required whenever the parent (facet, config block, or component) is active. |
+| `when` | `string` | Optional expression gating this requirement. Empty means the paths are required whenever the parent (facet, config block, or component) is active. |
 
 ## terraform[]
 
@@ -85,7 +85,7 @@ and are composed in ordinal order (lower-priority first).
 | `ordinal` | `integer` | Per-component override of the facet's ordinal for merge precedence. |
 | `requires` | `array<object>` | Requirement blocks scoped to this component. Evaluated only when the parent facet is active and this component's 'when' holds. |
 | `strategy` | `string` | How this component is merged into the blueprint. 'merge' (default) deep-merges with existing components matching the same Path and Source; 'replace' overwrites; 'remove' deletes the matching existing component's non-index fields. Remove operations are always applied last. One of: `merge`, `replace`, `remove`. |
-| `when` | `string` | CEL expression that gates this component. Empty means the component is always applied when the parent facet matches. |
+| `when` | `string` | Expression that gates this component. Empty means the component is always applied when the parent facet matches. |
 
 ### terraform[].requires[]
 
@@ -93,7 +93,7 @@ and are composed in ordinal order (lower-priority first).
 |------|------|-------------|
 | `paths` | `array<string>` | Dotted scope keys whose values must be present and non-empty. Required; the parser rejects an empty list. **(required)** |
 | `message` | `string` | Optional author-supplied context surfaced under this block's heading in the aggregated error. |
-| `when` | `string` | Optional CEL expression gating this requirement. Empty means the paths are required whenever the parent (facet, config block, or component) is active. |
+| `when` | `string` | Optional expression gating this requirement. Empty means the paths are required whenever the parent (facet, config block, or component) is active. |
 
 ## Examples
 

--- a/docs/reference/facets.md
+++ b/docs/reference/facets.md
@@ -1,346 +1,146 @@
 ---
 title: "Facets"
-description: "Reference for conditional blueprint fragments"
+description: "Conditional blueprint fragments that compose into a base blueprint."
 ---
 # Facets
 
-Facets are conditional blueprint fragments that enable modular composition of blueprints based on user configuration values. They allow you to conditionally include Terraform components and Kustomizations in your blueprint based on expressions evaluated against your `windsor.yaml` and `values.yaml` configurations.
+Conditional blueprint fragments that compose into a base blueprint. A facet
+declares terraform components, kustomizations, configuration blocks, and
+substitutions that are merged into the blueprint only when the facet's
+'when' expression evaluates to true against the operator's configuration.
+Facets live under contexts/_template/facets/ as one .yaml file per facet
+and are composed in ordinal order (lower-priority first).
 
-## Facet Definition
+## Fields
 
-A Facet is defined in a YAML file, typically located in `_template/facets/` directory of a blueprint:
+| Field | Type | Description |
+|------|------|-------------|
+| `kind` | `string` | Resource kind, following Kubernetes conventions. Must be 'Facet'. **(required)** |
+| `apiVersion` | `string` | API schema version. Must be 'blueprints.windsorcli.dev/v1alpha1'. **(required)** |
+| `metadata` | `object` | Identity for the facet. **(required)** |
+| `backend` | `string` | Contributes to Blueprint.backend (the terraform component that terminates the backend tier). The composer merges this across active facets by ordinal precedence; the highest-ordinal non-empty value wins. |
+| `config` | `array<object>` | Named configuration blocks exposed at scope root. Terraform inputs and kustomize substitutions reference '<name>' (scalar/list values) or '<name>.<key>' (map values), e.g. 'talos.controlplanes'. |
+| `kustomize` | `array<object>` | Kustomizations contributed by this facet. Each entry extends the blueprint's Kustomization shape with conditional fields (when, strategy, ordinal, requires). |
+| `ordinal` | `integer` | Merge precedence relative to other facets. Higher ordinal wins on conflict (processed later). When unset, the loader derives an ordinal from the file basename: 'config-*' = 100; 'provider-*' or 'platform-*' with '-base' in the name = 199; other 'provider-*' / 'platform-*' = 200; 'option-*' / 'options-*' = 300; 'addon-*' / 'addons-*' = 400; no match = 0. |
+| `requires` | `array<object>` | Input-requirement blocks for the facet as a whole. When the facet is active and a block's optional 'when' holds, every path in that block must resolve to a present, non-empty value in the merged scope. Unsatisfied paths across every active facet are aggregated into a single user-facing error. |
+| `substitutions` | `object` | Top-level key/value pairs evaluated with facet scope and injected into 'values-common', making them available to every kustomization via PostBuild substitution. Values may use expression syntax (e.g. '${dns.domain}') resolved against active facet config blocks. |
+| `terraform` | `array<object>` | Terraform components contributed by this facet. Each entry extends the blueprint's TerraformComponent shape with conditional fields (when, strategy, ordinal, requires). |
+| `when` | `string` | CEL expression that gates the facet. Evaluated against merged configuration values; the facet is applied only when the expression yields true. Examples: "platform == 'aws'", "observability.enabled == true && observability.backend == 'quickwit'". Empty 'when' means the facet always applies. |
+
+## metadata
+
+| Field | Type | Description |
+|------|------|-------------|
+| `name` | `string` | Facet's unique identifier within the template. **(required)** |
+| `description` | `string` | One-line overview of what the facet contributes. |
+
+## config[]
+
+| Field | Type | Description |
+|------|------|-------------|
+| `name` | `string` | Block identifier; exposed at scope root. **(required)** |
+| `value` | `any` | The block's content. May be a scalar, list, or map. References from terraform.inputs and kustomize.substitutions use the block name for scalar/list, or '<name>.<key>' when value is a map. **(required)** |
+| `ordinal` | `integer` | Per-block override of the facet's ordinal for merge precedence. Higher wins on conflict. When unset, the parent facet's ordinal is used. |
+| `requires` | `array<object>` | Requirement blocks scoped to this config block. Evaluated only when the parent facet is active AND this block's 'when' holds; missing paths surface under the effective AND condition. |
+| `strategy` | `string` | How this block merges with same-named blocks from other facets. 'merge' (default) deep-merges; 'replace' overwrites; 'remove' deletes the block from scope. One of: `merge`, `replace`, `remove`. |
+| `when` | `string` | Optional CEL expression that gates this block. Empty means the block is always evaluated when the parent facet is active. |
+
+### config[].requires[]
+
+| Field | Type | Description |
+|------|------|-------------|
+| `paths` | `array<string>` | Dotted scope keys whose values must be present and non-empty. Required; the parser rejects an empty list. **(required)** |
+| `message` | `string` | Optional author-supplied context surfaced under this block's heading in the aggregated error. |
+| `when` | `string` | Optional CEL expression gating this requirement. Empty means the paths are required whenever the parent (facet, config block, or component) is active. |
+
+## kustomize[]
+
+| Field | Type | Description |
+|------|------|-------------|
+| `ordinal` | `integer` | Per-kustomization override of the facet's ordinal for merge precedence. |
+| `requires` | `array<object>` | Requirement blocks scoped to this kustomization. Evaluated only when the parent facet is active and this kustomization's 'when' holds. |
+| `strategy` | `string` | How this kustomization is merged into the blueprint. 'merge' (default) deep-merges with existing kustomizations matching the same Name; 'replace' overwrites; 'remove' deletes the matching existing kustomization's non-index fields. Remove operations are always applied last. One of: `merge`, `replace`, `remove`. |
+| `when` | `string` | CEL expression that gates this kustomization. Empty means the kustomization is always applied when the parent facet matches. |
+
+### kustomize[].requires[]
+
+| Field | Type | Description |
+|------|------|-------------|
+| `paths` | `array<string>` | Dotted scope keys whose values must be present and non-empty. Required; the parser rejects an empty list. **(required)** |
+| `message` | `string` | Optional author-supplied context surfaced under this block's heading in the aggregated error. |
+| `when` | `string` | Optional CEL expression gating this requirement. Empty means the paths are required whenever the parent (facet, config block, or component) is active. |
+
+## requires[]
+
+| Field | Type | Description |
+|------|------|-------------|
+| `paths` | `array<string>` | Dotted scope keys whose values must be present and non-empty. Required; the parser rejects an empty list. **(required)** |
+| `message` | `string` | Optional author-supplied context surfaced under this block's heading in the aggregated error. |
+| `when` | `string` | Optional CEL expression gating this requirement. Empty means the paths are required whenever the parent (facet, config block, or component) is active. |
+
+## terraform[]
+
+| Field | Type | Description |
+|------|------|-------------|
+| `ordinal` | `integer` | Per-component override of the facet's ordinal for merge precedence. |
+| `requires` | `array<object>` | Requirement blocks scoped to this component. Evaluated only when the parent facet is active and this component's 'when' holds. |
+| `strategy` | `string` | How this component is merged into the blueprint. 'merge' (default) deep-merges with existing components matching the same Path and Source; 'replace' overwrites; 'remove' deletes the matching existing component's non-index fields. Remove operations are always applied last. One of: `merge`, `replace`, `remove`. |
+| `when` | `string` | CEL expression that gates this component. Empty means the component is always applied when the parent facet matches. |
+
+### terraform[].requires[]
+
+| Field | Type | Description |
+|------|------|-------------|
+| `paths` | `array<string>` | Dotted scope keys whose values must be present and non-empty. Required; the parser rejects an empty list. **(required)** |
+| `message` | `string` | Optional author-supplied context surfaced under this block's heading in the aggregated error. |
+| `when` | `string` | Optional CEL expression gating this requirement. Empty means the paths are required whenever the parent (facet, config block, or component) is active. |
+
+## Examples
 
 ```yaml
 kind: Facet
 apiVersion: blueprints.windsorcli.dev/v1alpha1
 metadata:
-  name: aws-facet
-  description: AWS-specific infrastructure components
-when: provider == 'aws'
-terraform:
-  - path: network/vpc
-    source: core
-    inputs:
-      cidr: ${network.cidr_block ?? "10.0.0.0/16"}
-      enable_nat: ${network.enable_nat ?? true}
-    strategy: merge
-kustomize:
-  - name: ingress
-    path: ingress/base
-    source: core
-    components:
-      - nginx
-      - nginx/nodeport
-    substitutions:
-      domain: ${dns.domain}
-    strategy: merge
-```
-
-| Field       | Type                              | Description                                                                 |
-|-------------|-----------------------------------|-----------------------------------------------------------------------------|
-| `kind`      | `string`                          | Must be `Facet`.                                                          |
-| `apiVersion`| `string`                          | Must be `blueprints.windsorcli.dev/v1alpha1`.                               |
-| `metadata`  | `Metadata`                        | Facet metadata including name and description.                            |
-| `ordinal`   | `integer` (optional)              | Order in which this facet is applied relative to others. Higher ordinal = higher precedence when merging. When omitted, derived from the facet file basename (see [Default ordinal from filename](#default-ordinal-from-filename)). |
-| `when`      | `string`                          | Expression that determines if the facet should be applied. Evaluated against configuration values. If empty or evaluates to `true`, the facet is applied. |
-| `config`    | `[]ConfigBlock`                   | Named configuration blocks evaluated in blueprint context; referenced as `<name>.<key>` (e.g. `talos.controlplanes`) from terraform inputs and kustomize substitutions, same style as context (`cluster.*`, `network.*`). |
-| `requires`  | `[]RequirementBlock`              | Input requirement blocks. When the facet is active and a block's optional `when` holds, every path must resolve to a present, non-empty value. Unsatisfied paths are aggregated into a single user-facing error. See [Requires](#requires). |
-| `terraform` | `[]ConditionalTerraformComponent` | Terraform components to include when the facet matches.                  |
-| `kustomize` | `[]ConditionalKustomization`       | Kustomizations to include when the facet matches.                         |
-
-Facets inherit Repository and Sources from the base blueprint they are merged into.
-
-### Default ordinal from filename
-
-When a facet does not set `ordinal` in YAML, it is derived from the facet file **basename** (e.g. `config-cluster.yaml`, `provider-base.yaml`). This determines processing order: facets are sorted by ordinal ascending, then by `metadata.name` for tiebreak. Higher ordinal means higher precedence when merging (processed later, wins on conflict).
-
-| Condition | Ordinal |
-|-----------|--------|
-| `config-*` | 100 |
-| `provider-*` or `platform-*` with `-base` in name (e.g. `provider-base.yaml`, `platform-base.yaml`) | 199 |
-| `provider-*` or `platform-*` (others) | 200 |
-| `option-*` or `options-*` | 300 |
-| `addon-*` or `addons-*` | 400 |
-| (no match) | 0 |
-
-Terraform and kustomize components can set an optional `ordinal` to override the facet ordinal for that component's merge precedence.
-
-## Config
-
-Facets can define **config** blocks to build generic configuration (e.g. Talos node lists, patch vars) in-facet instead of external YAML files. Config is **merged globally** across all active facets in processing order (by facet ordinal, then by facet name). Merging is **deep**: same config block name merges block bodies recursively (later keys overwrite). At evaluation time, facet config is merged into the **same scope** as context (schema / values from `windsor.yaml` and `values.yaml`): one canonical root. So `talos.controlplanes` and `cluster.controlplanes` are siblings; expressions see both. When a key exists in both context and facet config, **facet config wins**—so blueprint authors can intentionally override or transform input values (e.g. a config block that derives or rewrites `cluster` for downstream use). Use distinct block names (e.g. `talos`, `gitops`) to add derived values; use the same name as a context key only when you want to override or transform that value for the blueprint.
-
-`config` is a list of named blocks. Each block has:
-
-- **name** – Exposed at scope root; expressions use `name.key` (e.g. `talos.controlplanes`).
-- **when** (optional) – Expression; if present and false, the block is skipped.
-- **body** – Remaining keys (e.g. `controlplanes`, `workers`, `patchVars`); values may contain `${}` expressions.
-- **requires** (optional) – Input requirements evaluated only when this block's `when` holds; see [RequirementBlock](#requirementblock).
-
-Config blocks are evaluated in blueprint context only (no facet config in scope). References from terraform or kustomize use `<name>.<key>`.
-
-```yaml
+  description: AWS platform components
+  name: platform-aws
+when: platform == 'aws'
 config:
-  - name: talos
-    when: provider == 'incus' || provider == 'docker'
-    controlplanes: ${cluster.controlplanes}
-    workers: ${cluster.workers}
-    patchVars:
-      certSANs: ${cluster.apiServer.certSANs}
-      poolPath: ${cluster.storage.poolPath}
-
+  - name: aws
+    value:
+      region: us-east-1
 terraform:
-  - name: cluster
-    path: cluster
-    inputs:
-      controlplanes: ${talos.controlplanes}
-      workers: ${talos.workers}
-      common_config_patches: ${yamlString("../configs/talos/common-patch.yaml", talos.patchVars)}
-```
-
-Evaluation order: facets are processed by ordinal (ascending), then by name. First, each facet's config block **structure** (name, when, body keys) is merged into a global scope (same block name merges block bodies recursively); config body expressions are **not** evaluated yet. After all facets are merged, config body expressions are evaluated once in blueprint context (very late). Then terraform and kustomize components are collected; their inputs and substitutions can reference the evaluated `<name>.<key>` (e.g. `talos.controlplanes`).
-
-## RequirementBlock
-
-A `requires` field may appear on `Facet`, `ConfigBlock`, `ConditionalTerraformComponent`, and `ConditionalKustomization`. Each entry is a `RequirementBlock`:
-
-| Field     | Type       | Required | Description                                                                                       |
-|-----------|------------|----------|---------------------------------------------------------------------------------------------------|
-| `when`    | `string`   | no       | Expression gating the block. Empty means always required while the parent facet/component is active. |
-| `paths`   | `[]string` | yes      | Dotted scope keys (e.g. `aws.region`, `cluster.workers.count`) that must resolve to a present, non-empty value. |
-| `message` | `string`   | no       | Optional author context surfaced under the condition heading in the aggregated error.              |
-
-Presence semantics: `nil`, `""`, empty slice, and empty map count as **missing**; `false` and `0` count as **present**. The check verifies that the user has declared a value, not that the value is truthy.
-
-For composition rules, deferral semantics, and worked examples, see the conceptual guide: [Blueprint facets — Requires](https://docs.windsorcli.dev/blueprints/facets#requires).
-
-## Conditional Logic
-
-Facets use the [Go expr library](https://github.com/expr-lang/expr) for expression evaluation. Expressions are evaluated against your configuration values from `windsor.yaml` and `values.yaml`.
-
-### Expression Syntax
-
-Expressions support:
-
-- **Equality/inequality**: `==`, `!=`
-- **Logical operators**: `&&`, `||`
-- **Parentheses for grouping**: `(expression)`
-- **Nested object access**: `provider`, `cluster.driver`, `workstation.runtime`, `cluster.workers.count`
-- **String literals**: Use single quotes: `'aws'`, `'talos'`, `'local'`
-- **Boolean values**: `true`, `false`
-- **Numeric values**: `1`, `2.5`
-- **Null coalescing**: `value ?? default`
-- **Functions**: `values()`, `jsonnet()`, `file()`
-
-### Expression Examples
-
-```yaml
-# Simple equality check
-when: provider == 'aws'
-
-# Multiple conditions
-when: provider == 'aws' && cluster.driver == 'eks'
-
-# Nested property access
-when: cluster.driver == 'talos'
-
-# Complex logical expressions
-when: cluster.driver == 'eks' || cluster.driver == 'aks'
-
-# Null coalescing
-when: observability.enabled ?? false
-```
-
-## ConditionalTerraformComponent
-
-Extends `TerraformComponent` with conditional logic and merge strategy support.
-
-| Field      | Type                | Description                                                                 |
-|------------|---------------------|-----------------------------------------------------------------------------|
-| `path`     | `string`            | Path of the Terraform module. Required.                                     |
-| `source`   | `string`            | Source of the Terraform module. Optional.                                   |
-| `inputs`   | `map[string]any`    | Configuration values for the module. Supports `${}` expressions.            |
-| `dependsOn`| `[]string`          | Dependencies of this terraform component.                                    |
-| `destroy`  | `*bool`             | Determines if the component should be destroyed during down operations.     |
-| `parallelism`| `int`             | Limits the number of concurrent operations as Terraform walks the graph.     |
-| `when`     | `string`            | Expression that determines if this component should be applied. If empty, the component is always applied when the parent facet matches. |
-| `ordinal`  | `integer` (optional)| Overrides the facet ordinal for this component's merge precedence. When omitted, the facet's ordinal is used. Higher ordinal wins when merging. |
-| `strategy` | `string`            | Merge strategy: `merge` (default), `replace`, or `remove`. Only available in facets.  |
-| `requires` | `[]RequirementBlock`| Input requirements evaluated only when this component's `when` holds; missing paths are bucketed under the AND of facet, component, and block `when`. See [RequirementBlock](#requirementblock). |
-
-### Merge Strategies
-
-**Merge (default)**:
-- Matches on `Path` and `Source`
-- Deep merges `inputs` maps (overlay values override base values)
-- Appends unique dependencies to `dependsOn`
-- Updates `destroy` and `parallelism` if provided
-- If no matching component exists, the component is appended
-
-**Replace**:
-- Matches on `Path` and `Source`
-- Completely replaces the matching component with the new one
-- All existing inputs, dependencies, and settings are discarded
-- If no matching component exists, the component is appended
-
-### Input Evaluation
-
-Input values support:
-
-- **Expressions**: Use `${}` syntax (e.g., `${cluster.workers.count}`, `${cluster.workers.count + 2}`)
-- **String literals**: Plain strings are treated as literals
-- **Other types**: Numbers, booleans, etc. are passed through as-is
-
-Expressions support:
-- Direct property access: `${provider}`
-- Nested access: `${cluster.workers.count}`
-- Arithmetic: `${cluster.workers.count * 2}`
-- Null coalescing: `${cluster.endpoint ?? "https://localhost:6443"}`
-- Functions: `${values(cluster.controlplanes.nodes)}`
-- File loading: `${jsonnet("config.jsonnet")}`, `${file("key.pem")}`
-
-## ConditionalKustomization
-
-Extends `Kustomization` with conditional logic and merge strategy support.
-
-| Field          | Type                | Description                                                                 |
-|----------------|---------------------|-----------------------------------------------------------------------------|
-| `name`         | `string`            | Name of the kustomization. Required.                                        |
-| `path`         | `string`            | Path of the kustomization. Required.                                        |
-| `source`       | `string`            | Source of the kustomization. Optional.                                      |
-| `dependsOn`    | `[]string`          | Dependencies of this kustomization.                                          |
-| `components`   | `[]string`          | Components to include in the kustomization.                                  |
-| `patches`      | `[]BlueprintPatch`  | Patches to apply to the kustomization.                                      |
-| `substitutions`| `map[string]string` | Values for post-build variable replacement. Supports `${}` expressions.      |
-| `when`         | `string`            | Expression that determines if this kustomization should be applied. If empty, the kustomization is always applied when the parent facet matches. |
-| `ordinal`      | `integer` (optional) | Overrides the facet ordinal for this kustomization's merge precedence. When omitted, the facet's ordinal is used. Higher ordinal wins when merging. |
-| `strategy`     | `string`            | Merge strategy: `merge` (default), `replace`, or `remove`. Only available in facets.  |
-| `requires`     | `[]RequirementBlock`| Input requirements evaluated only when this kustomization's `when` holds; missing paths are bucketed under the AND of facet, kustomization, and block `when`. See [RequirementBlock](#requirementblock). |
-
-### Merge Strategies
-
-**Merge (default)**:
-- Matches on `Name`
-- Appends unique components to the `components` array
-- Appends unique dependencies to `dependsOn`
-- Updates `path`, `source`, and `destroy` if provided
-- Appends patches to the existing patches array
-- If no matching kustomization exists, the kustomization is appended
-
-**Replace**:
-- Matches on `Name`
-- Completely replaces the matching kustomization with the new one
-- All existing components, dependencies, patches, and settings are discarded
-- If no matching kustomization exists, the kustomization is appended
-
-### Substitutions
-
-Substitutions are:
-- Converted to strings (as required by Flux post-build substitution)
-- Stored in ConfigMaps
-- Available in Kubernetes manifests via Flux's postBuild substitution
-- Support `${}` expression interpolation
-
-### Kustomization Patches
-
-Patches support expression interpolation in the `patch` field content using `${}` syntax.
-
-**Blueprint Format** (path-based):
-```yaml
-kustomize:
-  - name: my-app
-    path: apps/my-app
-    patches:
-      - path: patches/custom-patch.yaml
-```
-
-**Flux Format** (inline with target selector):
-```yaml
-kustomize:
-  - name: my-app
-    path: apps/my-app
-    patches:
-      - patch: |-
-          - op: replace
-            path: /spec/replicas
-            value: ${replicas ?? 3}
-        target:
-          kind: Deployment
-          name: my-app
-          namespace: default
-```
-
-Patch content in the `patch` field supports expression interpolation:
-- Direct property access: `${dns.domain}`
-- Nested access: `${cluster.workers.count}`
-- Null coalescing: `${replicas ?? 3}`
-- String interpolation: `"${context}-config"`
-
-When using the `merge` strategy (default), patches are appended to existing patches. When using the `replace` strategy, all existing patches are discarded and replaced with the new patches.
-
-## File Loading Functions
-
-Facets support two file loading functions for dynamic configuration:
-
-### jsonnet()
-
-Loads and evaluates a Jsonnet file:
-
-```yaml
-terraform:
-  - path: cluster/talos
+  - inputs:
+      cidr: ${aws.cidr ?? '10.0.0.0/16'}
+    name: vpc
+    path: aws/vpc
     source: core
-    inputs:
-      config: ${jsonnet("talos-config.jsonnet")}
-      worker_patches: ${jsonnet("talos-config.jsonnet").worker_config_patches}
+kustomize:
+  - name: aws-load-balancer-controller
+    path: addons/aws-lb-controller
+    source: core
 ```
-
-- Takes a relative path to a `.jsonnet` file
-- Evaluates the Jsonnet file with access to configuration values
-- Returns the evaluated result (can be any JSON-compatible type)
-- Paths are relative to the facet file location
-
-### file()
-
-Loads a file as a string:
 
 ```yaml
+kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  description: Adds observability stack when enabled
+  name: addon-observability
+when: observability.enabled == true
+requires:
+  - message: Observability is enabled; choose a backend (quickwit, victoriametrics).
+    paths:
+      - observability.backend
 kustomize:
-  - name: ingress
-    path: ingress/base
-    substitutions:
-      tls_cert: ${file("certs/tls.crt")}
-      tls_key: ${file("certs/tls.key")}
+  - name: observability
+    path: addons/observability
+    source: core
+    when: observability.backend == 'quickwit'
 ```
 
-- Takes a relative path to any file
-- Returns the file contents as a string
-- Paths are relative to the facet file location
+## See also
 
-### Path Resolution
-
-Both functions resolve paths relative to the facet file location:
-- Facet at `_template/facets/aws.yaml` can reference `config.jsonnet` in the same directory
-- Use `../configs/config.jsonnet` for files in parent directories
-- Paths work with both local filesystem and in-memory template data (from archives)
-
-## Facet Loading
-
-Facets are automatically loaded from:
-- `_template/facets/*.yaml` - Individual facet files
-- `_template/facets/**/*.yaml` - Nested facet directories
-
-Facets are processed in alphabetical order by name, then merged into the base blueprint.
-
-<div>
-  {{ footer('Contexts', '../contexts/index.html', 'Schema', '../schema/index.html') }}
-</div>
-
-<script>
-  document.getElementById('previousButton').addEventListener('click', function() {
-    window.location.href = '../contexts/index.html'; 
-  });
-  document.getElementById('nextButton').addEventListener('click', function() {
-    window.location.href = '../schema/index.html'; 
-  });
-</script>
-
+- [Blueprint reference](blueprint.md) — for the inherited TerraformComponent and Kustomization fields
+- [`apply`](commands/apply.md), [`up`](commands/up.md), [`explain`](commands/explain.md)
+- [Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)
+- Source schema: [pkg/runtime/config/schemas/artifacts/facets.yaml](https://github.com/windsorcli/cli/blob/main/pkg/runtime/config/schemas/artifacts/facets.yaml)

--- a/internal/gendocs/schema.go
+++ b/internal/gendocs/schema.go
@@ -301,6 +301,14 @@ type nestedSection struct {
 // reads 'array<object>' rather than 'array<>' when items use a local ref.
 func schemaFieldRow(name string, propSchema map[string]any, required bool, root map[string]any) string {
 	typeName := typeOf(propSchema)
+	if typeName == "" {
+		// JSON Schema permits omitting 'type' to mean "any value" (scalar,
+		// list, map, etc. — used for fields like ConfigBlock.value where
+		// the body is intentionally polymorphic). Rendering this as 'any'
+		// keeps the type column readable rather than emitting an empty
+		// backtick cell.
+		typeName = "any"
+	}
 	if typeName == "array" {
 		if items, ok := propSchema["items"].(map[string]any); ok {
 			items = resolveRef(items, root)

--- a/internal/gendocs/schema_test.go
+++ b/internal/gendocs/schema_test.go
@@ -223,6 +223,20 @@ func TestSchemaFieldRow(t *testing.T) {
 		}
 	})
 
+	t.Run("RendersAnyForUntypedField", func(t *testing.T) {
+		// Given a property with no 'type' constraint (JSON Schema accepts
+		// any value — used for polymorphic fields like ConfigBlock.value)
+		propSchema := map[string]any{"description": "Polymorphic body."}
+
+		// When schemaFieldRow is called
+		got := schemaFieldRow("value", propSchema, false, nil)
+
+		// Then the type column renders 'any' rather than an empty backtick
+		if !strings.Contains(got, "`any`") {
+			t.Errorf("expected untyped field to render as 'any', got %q", got)
+		}
+	})
+
 	t.Run("RendersUnionTypeWithSlashSeparator", func(t *testing.T) {
 		// Given a property with the JSON Schema 2020-12 array-of-types form
 		// (used for fields that accept e.g. a literal boolean or an expression string)

--- a/pkg/runtime/config/schemas/artifacts/facets.seealso.md
+++ b/pkg/runtime/config/schemas/artifacts/facets.seealso.md
@@ -1,0 +1,3 @@
+- [Blueprint reference](blueprint.md) — for the inherited TerraformComponent and Kustomization fields
+- [`apply`](commands/apply.md), [`up`](commands/up.md), [`explain`](commands/explain.md)
+- [Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)

--- a/pkg/runtime/config/schemas/artifacts/facets.yaml
+++ b/pkg/runtime/config/schemas/artifacts/facets.yaml
@@ -49,7 +49,7 @@ properties:
   when:
     type: string
     description: |
-      CEL expression that gates the facet. Evaluated against merged
+      Expression that gates the facet. Evaluated against merged
       configuration values; the facet is applied only when the expression
       yields true. Examples: "platform == 'aws'",
       "observability.enabled == true && observability.backend == 'quickwit'".
@@ -122,7 +122,7 @@ $defs:
       when:
         type: string
         description: |
-          Optional CEL expression that gates this block. Empty means the
+          Optional expression that gates this block. Empty means the
           block is always evaluated when the parent facet is active.
       value:
         description: |
@@ -165,7 +165,7 @@ $defs:
       when:
         type: string
         description: |
-          Optional CEL expression gating this requirement. Empty means the
+          Optional expression gating this requirement. Empty means the
           paths are required whenever the parent (facet, config block, or
           component) is active.
       paths:
@@ -193,7 +193,7 @@ $defs:
       when:
         type: string
         description: |
-          CEL expression that gates this component. Empty means the
+          Expression that gates this component. Empty means the
           component is always applied when the parent facet matches.
       strategy:
         type: string
@@ -231,7 +231,7 @@ $defs:
       when:
         type: string
         description: |
-          CEL expression that gates this kustomization. Empty means the
+          Expression that gates this kustomization. Empty means the
           kustomization is always applied when the parent facet matches.
       strategy:
         type: string

--- a/pkg/runtime/config/schemas/artifacts/facets.yaml
+++ b/pkg/runtime/config/schemas/artifacts/facets.yaml
@@ -1,0 +1,294 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+title: Facets
+description: |
+  Conditional blueprint fragments that compose into a base blueprint. A facet
+  declares terraform components, kustomizations, configuration blocks, and
+  substitutions that are merged into the blueprint only when the facet's
+  'when' expression evaluates to true against the operator's configuration.
+  Facets live under contexts/_template/facets/ as one .yaml file per facet
+  and are composed in ordinal order (lower-priority first).
+type: object
+required:
+  - kind
+  - apiVersion
+  - metadata
+additionalProperties: false
+properties:
+  kind:
+    type: string
+    description: Resource kind, following Kubernetes conventions. Must be 'Facet'.
+    enum:
+      - Facet
+  apiVersion:
+    type: string
+    description: API schema version. Must be 'blueprints.windsorcli.dev/v1alpha1'.
+    enum:
+      - blueprints.windsorcli.dev/v1alpha1
+  metadata:
+    description: Identity for the facet.
+    type: object
+    required:
+      - name
+    additionalProperties: false
+    properties:
+      name:
+        type: string
+        description: Facet's unique identifier within the template.
+      description:
+        type: string
+        description: One-line overview of what the facet contributes.
+  ordinal:
+    type: integer
+    description: |
+      Merge precedence relative to other facets. Higher ordinal wins on
+      conflict (processed later). When unset, the loader derives an ordinal
+      from the file basename: 'config-*' = 100; 'provider-*' or
+      'platform-*' with '-base' in the name = 199; other 'provider-*' /
+      'platform-*' = 200; 'option-*' / 'options-*' = 300; 'addon-*' /
+      'addons-*' = 400; no match = 0.
+  when:
+    type: string
+    description: |
+      CEL expression that gates the facet. Evaluated against merged
+      configuration values; the facet is applied only when the expression
+      yields true. Examples: "platform == 'aws'",
+      "observability.enabled == true && observability.backend == 'quickwit'".
+      Empty 'when' means the facet always applies.
+  backend:
+    type: string
+    description: |
+      Contributes to Blueprint.backend (the terraform component that
+      terminates the backend tier). The composer merges this across active
+      facets by ordinal precedence; the highest-ordinal non-empty value wins.
+  config:
+    type: array
+    description: |
+      Named configuration blocks exposed at scope root. Terraform inputs and
+      kustomize substitutions reference '<name>' (scalar/list values) or
+      '<name>.<key>' (map values), e.g. 'talos.controlplanes'.
+    items:
+      $ref: '#/$defs/configBlock'
+  requires:
+    type: array
+    description: |
+      Input-requirement blocks for the facet as a whole. When the facet is
+      active and a block's optional 'when' holds, every path in that block
+      must resolve to a present, non-empty value in the merged scope.
+      Unsatisfied paths across every active facet are aggregated into a
+      single user-facing error.
+    items:
+      $ref: '#/$defs/requirementBlock'
+  terraform:
+    type: array
+    description: |
+      Terraform components contributed by this facet. Each entry extends the
+      blueprint's TerraformComponent shape with conditional fields (when,
+      strategy, ordinal, requires).
+    items:
+      $ref: '#/$defs/conditionalTerraformComponent'
+  kustomize:
+    type: array
+    description: |
+      Kustomizations contributed by this facet. Each entry extends the
+      blueprint's Kustomization shape with conditional fields (when,
+      strategy, ordinal, requires).
+    items:
+      $ref: '#/$defs/conditionalKustomization'
+  substitutions:
+    type: object
+    additionalProperties:
+      type: string
+    description: |
+      Top-level key/value pairs evaluated with facet scope and injected into
+      'values-common', making them available to every kustomization via
+      PostBuild substitution. Values may use expression syntax (e.g.
+      '${dns.domain}') resolved against active facet config blocks.
+$defs:
+  configBlock:
+    type: object
+    required:
+      - name
+      - value
+    additionalProperties: false
+    description: |
+      A named configuration block. The body lives under 'value' and is
+      exposed at scope root under 'name' (scalar/list) or 'name.<key>'
+      (map). Only the fields below are permitted — extra keys raise a
+      parse-time error.
+    properties:
+      name:
+        type: string
+        description: Block identifier; exposed at scope root.
+      when:
+        type: string
+        description: |
+          Optional CEL expression that gates this block. Empty means the
+          block is always evaluated when the parent facet is active.
+      value:
+        description: |
+          The block's content. May be a scalar, list, or map. References
+          from terraform.inputs and kustomize.substitutions use the block
+          name for scalar/list, or '<name>.<key>' when value is a map.
+      strategy:
+        type: string
+        enum:
+          - merge
+          - replace
+          - remove
+        description: |
+          How this block merges with same-named blocks from other facets.
+          'merge' (default) deep-merges; 'replace' overwrites; 'remove'
+          deletes the block from scope.
+      ordinal:
+        type: integer
+        description: |
+          Per-block override of the facet's ordinal for merge precedence.
+          Higher wins on conflict. When unset, the parent facet's ordinal is
+          used.
+      requires:
+        type: array
+        description: |
+          Requirement blocks scoped to this config block. Evaluated only
+          when the parent facet is active AND this block's 'when' holds;
+          missing paths surface under the effective AND condition.
+        items:
+          $ref: '#/$defs/requirementBlock'
+  requirementBlock:
+    type: object
+    required:
+      - paths
+    additionalProperties: false
+    description: |
+      Declares scope paths that must resolve to present, non-empty values
+      for the parent facet's activation to be well-formed.
+    properties:
+      when:
+        type: string
+        description: |
+          Optional CEL expression gating this requirement. Empty means the
+          paths are required whenever the parent (facet, config block, or
+          component) is active.
+      paths:
+        type: array
+        minItems: 1
+        items:
+          type: string
+        description: |
+          Dotted scope keys whose values must be present and non-empty.
+          Required; the parser rejects an empty list.
+      message:
+        type: string
+        description: |
+          Optional author-supplied context surfaced under this block's
+          heading in the aggregated error.
+  conditionalTerraformComponent:
+    type: object
+    additionalProperties: true
+    description: |
+      Inherits every field from the blueprint's TerraformComponent shape
+      (name, source, path, dependsOn, inputs, destroy, parallelism,
+      enabled) and adds the conditional fields below. See the [Blueprint
+      reference](blueprint.md) for the inherited fields.
+    properties:
+      when:
+        type: string
+        description: |
+          CEL expression that gates this component. Empty means the
+          component is always applied when the parent facet matches.
+      strategy:
+        type: string
+        enum:
+          - merge
+          - replace
+          - remove
+        description: |
+          How this component is merged into the blueprint. 'merge' (default)
+          deep-merges with existing components matching the same Path and
+          Source; 'replace' overwrites; 'remove' deletes the matching
+          existing component's non-index fields. Remove operations are
+          always applied last.
+      ordinal:
+        type: integer
+        description: Per-component override of the facet's ordinal for merge precedence.
+      requires:
+        type: array
+        description: |
+          Requirement blocks scoped to this component. Evaluated only when
+          the parent facet is active and this component's 'when' holds.
+        items:
+          $ref: '#/$defs/requirementBlock'
+  conditionalKustomization:
+    type: object
+    additionalProperties: true
+    description: |
+      Inherits every field from the blueprint's Kustomization shape (name,
+      path, source, namespace, targetNamespace, dependsOn, interval,
+      retryInterval, timeout, patches, wait, force, prune, components,
+      destroy, destroyOnly, enabled, substitutions) and adds the conditional
+      fields below. See the [Blueprint reference](blueprint.md) for the
+      inherited fields.
+    properties:
+      when:
+        type: string
+        description: |
+          CEL expression that gates this kustomization. Empty means the
+          kustomization is always applied when the parent facet matches.
+      strategy:
+        type: string
+        enum:
+          - merge
+          - replace
+          - remove
+        description: |
+          How this kustomization is merged into the blueprint. 'merge'
+          (default) deep-merges with existing kustomizations matching the
+          same Name; 'replace' overwrites; 'remove' deletes the matching
+          existing kustomization's non-index fields. Remove operations are
+          always applied last.
+      ordinal:
+        type: integer
+        description: Per-kustomization override of the facet's ordinal for merge precedence.
+      requires:
+        type: array
+        description: |
+          Requirement blocks scoped to this kustomization. Evaluated only
+          when the parent facet is active and this kustomization's 'when'
+          holds.
+        items:
+          $ref: '#/$defs/requirementBlock'
+examples:
+  - kind: Facet
+    apiVersion: blueprints.windsorcli.dev/v1alpha1
+    metadata:
+      name: platform-aws
+      description: AWS platform components
+    when: "platform == 'aws'"
+    config:
+      - name: aws
+        value:
+          region: us-east-1
+    terraform:
+      - name: vpc
+        source: core
+        path: aws/vpc
+        inputs:
+          cidr: "${aws.cidr ?? '10.0.0.0/16'}"
+    kustomize:
+      - name: aws-load-balancer-controller
+        path: addons/aws-lb-controller
+        source: core
+  - kind: Facet
+    apiVersion: blueprints.windsorcli.dev/v1alpha1
+    metadata:
+      name: addon-observability
+      description: Adds observability stack when enabled
+    when: "observability.enabled == true"
+    requires:
+      - paths:
+          - observability.backend
+        message: Observability is enabled; choose a backend (quickwit, victoriametrics).
+    kustomize:
+      - name: observability
+        path: addons/observability
+        source: core
+        when: "observability.backend == 'quickwit'"


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Documentation-only change with no runtime code modified; the blast radius is limited to user-facing reference material.
>
> **Overview**
>
> This PR adds `pkg/runtime/config/schemas/artifacts/facets.yaml`, a formal JSON Schema for the Facet resource type, and rewrites `docs/reference/facets.md` to be schema-derived. The new doc replaces the previous verbose-prose format with compact field tables. The small fix in `internal/gendocs/schema.go` correctly handles polymorphic schema fields (no `type` constraint) by rendering them as `any` rather than emitting an empty backtick cell; the new test covers this case well.
>
> The `configBlock` schema uses `additionalProperties: false` and requires an explicit `value` field, which matches the current `ConfigBlock.UnmarshalYAML` implementation exactly. The one factual error carried into both `facets.yaml` and the generated doc is the "CEL expression" label applied to all `when` fields — the project uses `github.com/expr-lang/expr`, not Google's Common Expression Language, so users consulting CEL documentation would find inapplicable syntax.
>
> Reviewed by Claude for commit `c18fbaf8`.

<!-- /claude-code-review:summary -->
