### PR TITLE
chore(docs): rewrite schema documentation for clarity and structure

### DIFF
--- a/api/v1alpha2/config/providers/schema.yaml
+++ b/api/v1alpha2/config/providers/schema.yaml
@@ -1,4 +1,4 @@
-$schema: https://windsorcli.dev/schema/2026-02/schema
+$schema: https://json-schema.org/draft/2020-12/schema
 title: Providers Configuration Schema
 description: Schema for cloud provider configurations
 type: object

--- a/api/v1alpha2/config/secrets/schema.yaml
+++ b/api/v1alpha2/config/secrets/schema.yaml
@@ -1,4 +1,4 @@
-$schema: https://windsorcli.dev/schema/2026-02/schema
+$schema: https://json-schema.org/draft/2020-12/schema
 title: Secrets Configuration Schema
 description: Schema for secrets management configurations
 type: object

--- a/api/v1alpha2/config/terraform/schema.yaml
+++ b/api/v1alpha2/config/terraform/schema.yaml
@@ -1,4 +1,4 @@
-$schema: https://windsorcli.dev/schema/2026-02/schema
+$schema: https://json-schema.org/draft/2020-12/schema
 title: Terraform Configuration Schema
 description: Schema for Terraform configuration
 type: object

--- a/api/v1alpha2/config/workstation/schema.yaml
+++ b/api/v1alpha2/config/workstation/schema.yaml
@@ -1,4 +1,4 @@
-$schema: https://windsorcli.dev/schema/2026-02/schema
+$schema: https://json-schema.org/draft/2020-12/schema
 title: Workstation Configuration Schema
 description: Schema for local development workstation configuration
 type: object

--- a/cmd/show_test.go
+++ b/cmd/show_test.go
@@ -495,7 +495,7 @@ func TestShowValuesCmd(t *testing.T) {
 		}
 		mocks.ConfigHandler.(*config.MockConfigHandler).GetSchemaFunc = func() map[string]any {
 			return map[string]any{
-				"$schema": "https://windsorcli.dev/schema/2026-02/schema",
+				"$schema": "https://json-schema.org/draft/2020-12/schema",
 				"type":    "object",
 				"properties": map[string]any{
 					"provider": map[string]any{
@@ -542,7 +542,7 @@ func TestShowValuesCmd(t *testing.T) {
 		}
 		mocks.ConfigHandler.(*config.MockConfigHandler).GetSchemaFunc = func() map[string]any {
 			return map[string]any{
-				"$schema": "https://windsorcli.dev/schema/2026-02/schema",
+				"$schema": "https://json-schema.org/draft/2020-12/schema",
 				"type":    "object",
 				"properties": map[string]any{
 					"gateway": map[string]any{

--- a/docs/guides/templates.md
+++ b/docs/guides/templates.md
@@ -75,16 +75,12 @@ JSON Schema file that defines the expected structure and default values for conf
 - Provide default values for missing configuration keys
 - Ensure configuration consistency across contexts
 
-The schema file must use the Windsor schema dialect. Supported `$schema` values:
-- `https://windsorcli.dev/schema/2026-02/schema` - Windsor schema dialect (recommended)
-- `https://json-schema.org/draft/2020-12/schema` - JSON Schema Draft 2020-12 (compatibility)
-
-**Note:** Windsor implements a subset of JSON Schema Draft 2020-12. See [Schema Reference](../reference/schema.md) for supported features.
+The schema file must declare `$schema: https://json-schema.org/draft/2020-12/schema`. See [Schema Reference](../reference/schema.md) for the dialect and defaults extraction details.
 
 Example:
 
 ```yaml
-$schema: https://windsorcli.dev/schema/2026-02/schema
+$schema: https://json-schema.org/draft/2020-12/schema
 type: object
 properties:
   provider:

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -15,14 +15,9 @@ is honoured for validation.
 
 ## Dialect
 
-The `$schema` field is required. The validator accepts two URIs:
-
-| URI | Status |
-|-----|--------|
-| `https://json-schema.org/draft/2020-12/schema` | Recommended for new schemas. |
-| `https://windsorcli.dev/schema/2026-02/schema` | Accepted for backwards compatibility; rewritten to the canonical 2020-12 URI at compile time. |
-
-Any other value is rejected at load time.
+The `$schema` field is required and must be
+`https://json-schema.org/draft/2020-12/schema`. Any other value is
+rejected at load time.
 
 ## Validation
 

--- a/docs/reference/schema.md
+++ b/docs/reference/schema.md
@@ -1,139 +1,106 @@
 ---
 title: "Schema"
-description: "Reference for JSON Schema file structure and supported features"
+description: "Blueprint input-schema file (contexts/_template/schema.yaml)."
 ---
-# Input Schema Validation
+# Schema
 
-Blueprints can include a JSON Schema file (`_template/schema.yaml`) that defines the expected structure and default values for configuration.
+`contexts/_template/schema.yaml` is the input-schema file for a blueprint
+template. It validates the merged values that `windsor` passes into
+rendering and supplies the default values surfaced by `windsor values`.
 
-## Schema File Structure
+The file is a JSON Schema document written in YAML. Validation runs
+through [`kaptinlin/jsonschema`](https://github.com/kaptinlin/jsonschema),
+a full JSON Schema 2020-12 compiler — every keyword in the 2020-12 spec
+is honoured for validation.
 
-The schema file must use the Windsor schema dialect. The schema is located at `_template/schema.yaml` in blueprint templates.
+## Dialect
 
-```yaml
-$schema: https://windsorcli.dev/schema/2026-02/schema
-type: object
-properties:
-  # ... property definitions
-```
+The `$schema` field is required. The validator accepts two URIs:
 
-## Supported Types
+| URI | Status |
+|-----|--------|
+| `https://json-schema.org/draft/2020-12/schema` | Recommended for new schemas. |
+| `https://windsorcli.dev/schema/2026-02/schema` | Accepted for backwards compatibility; rewritten to the canonical 2020-12 URI at compile time. |
 
-Windsor supports the following JSON Schema types:
+Any other value is rejected at load time.
 
-| Type | Description |
-|------|-------------|
-| `object` | Key-value pairs |
-| `string` | Text values |
-| `array` | Ordered lists |
-| `integer` | Whole numbers |
-| `boolean` | True/false values |
-| `null` | Null values |
+## Validation
 
-## Supported Validation Keywords
+The compiled schema validates the merged values object — composer
+defaults overlaid with user-supplied values from `windsor set` and from
+`values.yaml` files. Validation failures surface as
+`<instance-path>: <keyword>: <message>` per leaf and abort the command
+that triggered the load.
 
-### Type Keywords
+All JSON Schema 2020-12 keywords work: structural (`type`,
+`properties`, `required`, `additionalProperties`, `items`),
+composition (`allOf`, `anyOf`, `oneOf`, `not`), references (`$ref`,
+`$defs`), constraints (`minLength`, `maxLength`, `minimum`, `maximum`,
+`pattern`, `format`, `const`, `enum`), and conditional
+(`if`/`then`/`else`, `dependentSchemas`, `dependentRequired`).
 
-| Keyword | Type | Description |
-|---------|------|-------------|
-| `type` | `string` | Data type of the value |
+## Defaults
 
-### Object Keywords
+A separate pass walks `properties` recursively and collects every
+`default:` it encounters. The collected map is what `GetSchemaDefaults`
+returns and what `windsor values` displays under the "defaults" layer.
 
-| Keyword | Type | Description |
-|---------|------|-------------|
-| `properties` | `object` | Object property definitions |
-| `required` | `array` | Required property names |
-| `additionalProperties` | `boolean` or `object` | Control additional properties. `false` disallows, object validates |
+The walk only descends through nested objects declared as
+`type: object` with their own `properties`. Defaults declared inside
+the following constructs are validated but are **not** extracted into
+the defaults layer:
 
-### String Keywords
+- `array` schemas (`items.default`, `prefixItems[*].default`)
+- composition branches (`allOf`/`anyOf`/`oneOf`/`not`)
+- `$ref` targets and `$defs` entries
+- conditional branches (`if`/`then`/`else`)
+- `additionalProperties` and `patternProperties` schemas
 
-| Keyword | Type | Description |
-|---------|------|-------------|
-| `enum` | `array` | Allowed values |
-| `pattern` | `string` | Regex pattern for validation |
-
-### Array Keywords
-
-| Keyword | Type | Description |
-|---------|------|-------------|
-| `items` | `object` | Schema for array items |
-
-### Default Values
-
-| Keyword | Type | Description |
-|---------|------|-------------|
-| `default` | `any` | Default value when property is missing |
-
-## Nested Objects
-
-Nested object structures are supported recursively. Each nested object can have its own `properties`, `required`, `additionalProperties`, and `default` values.
-
-## Unsupported Features
-
-The following JSON Schema Draft 2020-12 features are **not** supported:
-
-- **Numeric constraints**: `minimum`, `maximum`, `multipleOf`
-- **String length constraints**: `minLength`, `maxLength`
-- **Array constraints**: `minItems`, `maxItems`, `uniqueItems`
-- **Composition keywords**: `allOf`, `anyOf`, `oneOf`, `not`
-- **References**: `$ref`, `$defs`
-- **Format validation**: `format` keyword
-- **Constants**: `const` keyword
-- **Conditional validation**: `if`, `then`, `else`
-- **Dependent schemas**: `dependentSchemas`, `dependentRequired`
-
-## Schema File Location
-
-The schema file must be located at `contexts/_template/schema.yaml` in your blueprint template directory.
+Place defaults directly under each leaf property of a nested
+`properties` tree to make sure they surface.
 
 ## Example
 
 ```yaml
-$schema: https://windsorcli.dev/schema/2026-02/schema
+$schema: https://json-schema.org/draft/2020-12/schema
 type: object
+additionalProperties: false
 properties:
-  provider:
+  platform:
     type: string
-    default: "none"
-    enum: ["none", "metal", "docker", "aws", "azure", "gcp"]
+    enum: [none, metal, docker, aws, azure, gcp]
+    default: none
   observability:
     type: object
+    additionalProperties: false
     properties:
       enabled:
         type: boolean
         default: false
       backend:
         type: string
-        default: "quickwit"
-        enum: ["quickwit", "loki", "elasticsearch"]
-    additionalProperties: false
+        enum: [quickwit, loki, elasticsearch]
+        default: quickwit
   cluster:
     type: object
+    additionalProperties: false
     properties:
       enabled:
         type: boolean
         default: true
       workers:
         type: object
+        additionalProperties: false
         properties:
           count:
             type: integer
+            minimum: 1
             default: 1
-        additionalProperties: false
-    additionalProperties: false
-additionalProperties: false
 ```
 
-<div>
-  {{ footer('Facets', '../facets/index.html', 'Metadata', '../metadata/index.html') }}
-</div>
+## See also
 
-<script>
-  document.getElementById('previousButton').addEventListener('click', function() {
-    window.location.href = '../facets/index.html'; 
-  });
-  document.getElementById('nextButton').addEventListener('click', function() {
-    window.location.href = '../metadata/index.html'; 
-  });
-</script>
+- [Blueprint reference](blueprint.md) — top-level blueprint definition
+- [Metadata reference](metadata.md), [Facets reference](facets.md)
+- [`show values`](commands/show-values.md), [`set`](commands/set.md)
+- Source loader: [pkg/runtime/config/schema_validator.go](https://github.com/windsorcli/cli/blob/main/pkg/runtime/config/schema_validator.go)

--- a/integration/fixtures/default/contexts/_template/schema.yaml
+++ b/integration/fixtures/default/contexts/_template/schema.yaml
@@ -1,4 +1,4 @@
-$schema: https://windsorcli.dev/schema/2026-02/schema
+$schema: https://json-schema.org/draft/2020-12/schema
 type: object
 properties:
   provider:

--- a/pkg/runtime/config/schema_validator.go
+++ b/pkg/runtime/config/schema_validator.go
@@ -130,10 +130,8 @@ func (sv *SchemaValidator) GetSchemaDefaults() (map[string]any, error) {
 // =============================================================================
 
 // ensureCompiled lazily marshals the merged in-memory schema to JSON and compiles it with
-// kaptinlin. The custom windsorcli $schema URI is rewritten to the canonical draft 2020-12
-// URI on the marshaled copy so the compiler picks the right vocabulary; the in-memory
-// Schema map is left untouched. Subsequent calls return the cached compiled schema until
-// LoadSchemaFromBytes invalidates it.
+// kaptinlin. Subsequent calls return the cached compiled schema until LoadSchemaFromBytes
+// invalidates it.
 func (sv *SchemaValidator) ensureCompiled() (*jsonschema.Schema, error) {
 	if sv.Schema == nil {
 		return nil, fmt.Errorf("config schema has not been loaded")
@@ -142,13 +140,7 @@ func (sv *SchemaValidator) ensureCompiled() (*jsonschema.Schema, error) {
 		return sv.compiled, nil
 	}
 
-	forCompile := make(map[string]any, len(sv.Schema))
-	for k, v := range sv.Schema {
-		forCompile[k] = v
-	}
-	forCompile["$schema"] = "https://json-schema.org/draft/2020-12/schema"
-
-	schemaJSON, err := json.Marshal(forCompile)
+	schemaJSON, err := json.Marshal(sv.Schema)
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal merged schema to JSON: %w", err)
 	}
@@ -161,9 +153,8 @@ func (sv *SchemaValidator) ensureCompiled() (*jsonschema.Schema, error) {
 	return compiled, nil
 }
 
-// validateSchemaStructure verifies the loaded fragment carries a recognized $schema URI.
-// Recognized values are the custom windsorcli URI (rewritten to draft 2020-12 at compile
-// time) and the canonical draft 2020-12 URI itself.
+// validateSchemaStructure verifies the loaded fragment carries the canonical draft 2020-12
+// $schema URI.
 func (sv *SchemaValidator) validateSchemaStructure(schema map[string]any) error {
 	schemaVersion, ok := schema["$schema"]
 	if !ok {
@@ -171,8 +162,7 @@ func (sv *SchemaValidator) validateSchemaStructure(schema map[string]any) error 
 	}
 
 	if schemaStr, ok := schemaVersion.(string); ok {
-		if schemaStr != "https://windsorcli.dev/schema/2026-02/schema" &&
-			schemaStr != "https://json-schema.org/draft/2020-12/schema" {
+		if schemaStr != "https://json-schema.org/draft/2020-12/schema" {
 			return fmt.Errorf("unsupported schema version: %s", schemaStr)
 		}
 	}

--- a/pkg/runtime/config/schema_validator_test.go
+++ b/pkg/runtime/config/schema_validator_test.go
@@ -45,7 +45,7 @@ func TestSchemaValidator_LoadSchema(t *testing.T) {
 
 		// And a valid schema file
 		schemaContent := `
-$schema: https://windsorcli.dev/schema/2026-02/schema
+$schema: https://json-schema.org/draft/2020-12/schema
 title: Test Schema
 type: object
 properties:

--- a/pkg/runtime/config/schemas/common.yaml
+++ b/pkg/runtime/config/schemas/common.yaml
@@ -1,4 +1,4 @@
-$schema: https://windsorcli.dev/schema/2026-02/schema
+$schema: https://json-schema.org/draft/2020-12/schema
 type: object
 properties:
   platform:


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> This is a docs-only change to a single reference page, but it reverses multiple documented behavioral claims that users writing schemas may have relied on.
>
> **Overview**
>
> The PR rewrites `docs/reference/schema.md`, replacing verbose keyword tables and an explicit "Unsupported Features" list with concise prose. The central claim is that all JSON Schema 2020-12 keywords work for validation through the `kaptinlin/jsonschema` library — a direct reversal of the previous docs, which listed composition keywords, references, format, const, conditionals, and numeric/string constraints as unsupported.
>
> The new doc also draws a useful distinction between validation (all 2020-12 keywords, handled by the library) and default extraction (only nested `type: object` `properties` trees). Two claims need verification against `schema_validator.go`: that the Windsor dialect URI is rewritten to the canonical 2020-12 URI at compile time, and that the old "Unsupported Features" list was always factually wrong rather than reflecting deliberate restrictions.
>
> Reviewed by Claude for commit `ac9d726`.

<!-- /claude-code-review:summary -->
