### PR TITLE
chore: add migration hint for legacy windsorcli schema URI in validation

### DIFF
--- a/pkg/runtime/config/schema_validator.go
+++ b/pkg/runtime/config/schema_validator.go
@@ -154,13 +154,13 @@ func (sv *SchemaValidator) ensureCompiled() (*jsonschema.Schema, error) {
 }
 
 // validateSchemaStructure verifies the loaded fragment carries the canonical draft 2020-12
-// $schema URI. The legacy windsorcli dialect URI returns a migration hint pointing at
+// $schema URI. The retired windsorcli dialect URI returns a migration hint pointing at
 // the canonical replacement so operators upgrading from v0.8 get an actionable error
 // instead of a stock "unsupported schema version".
 func (sv *SchemaValidator) validateSchemaStructure(schema map[string]any) error {
 	const (
 		canonicalSchemaURI = "https://json-schema.org/draft/2020-12/schema"
-		legacyWindsorURI   = "https://windsorcli.dev/schema/2026-02/schema"
+		legacyWindsorURI   = "https://windsorcli.dev/draft/2026-02/schema"
 	)
 
 	schemaVersion, ok := schema["$schema"]

--- a/pkg/runtime/config/schema_validator.go
+++ b/pkg/runtime/config/schema_validator.go
@@ -154,15 +154,25 @@ func (sv *SchemaValidator) ensureCompiled() (*jsonschema.Schema, error) {
 }
 
 // validateSchemaStructure verifies the loaded fragment carries the canonical draft 2020-12
-// $schema URI.
+// $schema URI. The legacy windsorcli dialect URI returns a migration hint pointing at
+// the canonical replacement so operators upgrading from v0.8 get an actionable error
+// instead of a stock "unsupported schema version".
 func (sv *SchemaValidator) validateSchemaStructure(schema map[string]any) error {
+	const (
+		canonicalSchemaURI = "https://json-schema.org/draft/2020-12/schema"
+		legacyWindsorURI   = "https://windsorcli.dev/schema/2026-02/schema"
+	)
+
 	schemaVersion, ok := schema["$schema"]
 	if !ok {
 		return fmt.Errorf("missing required '$schema' field")
 	}
 
 	if schemaStr, ok := schemaVersion.(string); ok {
-		if schemaStr != "https://json-schema.org/draft/2020-12/schema" {
+		if schemaStr == legacyWindsorURI {
+			return fmt.Errorf("the '%s' dialect was removed in v0.9.0; replace '$schema' with '%s'", legacyWindsorURI, canonicalSchemaURI)
+		}
+		if schemaStr != canonicalSchemaURI {
 			return fmt.Errorf("unsupported schema version: %s", schemaStr)
 		}
 	}

--- a/pkg/runtime/config/schema_validator_test.go
+++ b/pkg/runtime/config/schema_validator_test.go
@@ -106,6 +106,36 @@ type: object
 		}
 	})
 
+	t.Run("ErrorLegacyWindsorURIPointsAtMigration", func(t *testing.T) {
+		// Given a schema validator
+		mockShell := shell.NewMockShell()
+		validator := NewSchemaValidator(mockShell)
+
+		// And a schema file using the retired windsorcli dialect URI
+		schemaContent := `
+$schema: https://windsorcli.dev/schema/2026-02/schema
+title: Test Schema
+type: object
+`
+
+		validator.Shims.ReadFile = func(path string) ([]byte, error) {
+			return []byte(schemaContent), nil
+		}
+
+		// When loading the schema
+		err := validator.LoadSchema("/test/schema.yaml")
+
+		// Then the error names the removed URI and points at the canonical replacement
+		if err == nil {
+			t.Fatal("Expected error for legacy windsorcli schema URI")
+		}
+
+		expected := "invalid schema structure: the 'https://windsorcli.dev/schema/2026-02/schema' dialect was removed in v0.9.0; replace '$schema' with 'https://json-schema.org/draft/2020-12/schema'"
+		if err.Error() != expected {
+			t.Errorf("Expected migration-hint error, got: %v", err)
+		}
+	})
+
 	t.Run("ErrorMissingSchemaField", func(t *testing.T) {
 		// Given a schema validator
 		mockShell := shell.NewMockShell()

--- a/pkg/runtime/config/schema_validator_test.go
+++ b/pkg/runtime/config/schema_validator_test.go
@@ -113,7 +113,7 @@ type: object
 
 		// And a schema file using the retired windsorcli dialect URI
 		schemaContent := `
-$schema: https://windsorcli.dev/schema/2026-02/schema
+$schema: https://windsorcli.dev/draft/2026-02/schema
 title: Test Schema
 type: object
 `
@@ -130,7 +130,7 @@ type: object
 			t.Fatal("Expected error for legacy windsorcli schema URI")
 		}
 
-		expected := "invalid schema structure: the 'https://windsorcli.dev/schema/2026-02/schema' dialect was removed in v0.9.0; replace '$schema' with 'https://json-schema.org/draft/2020-12/schema'"
+		expected := "invalid schema structure: the 'https://windsorcli.dev/draft/2026-02/schema' dialect was removed in v0.9.0; replace '$schema' with 'https://json-schema.org/draft/2020-12/schema'"
 		if err.Error() != expected {
 			t.Errorf("Expected migration-hint error, got: %v", err)
 		}


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This is an isolated, single-function change that affects only the error message quality for one URI variant — schemas carrying either URI are still correctly rejected.
>
> **Overview**
>
> The PR adds a specific migration-hint error for schemas that still carry the retired `https://windsorcli.dev/schema/2026-02/schema` URI, replacing the generic "unsupported schema version" message with one that names the canonical replacement. The preceding punchlist commit (`9fe373aa`) silently removed two Windsor-specific URIs from the accepted list — `https://windsorcli.dev/schema/2026-02/schema` and the `draft` sibling (`https://windsorcli.dev/draft/2026-02/schema`) — but this PR only adds a hint for the first. Operators whose schema files carry the `draft` variant still receive the unhelpful generic error.
>
> Reviewed by Claude for commit `390d38c5`.

<!-- /claude-code-review:summary -->
