### PR TITLE
feat: enhance Terraform destroy functionality with continue-on-error option

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -416,7 +416,7 @@ func resolveDestroyConfirmation(r io.Reader, w io.Writer, description, expected 
 // the existing per-error abort already surfaces failures, so no extra output
 // is needed; this only fires when the operator opted into best-effort mode.
 // Returns nil when destroyContinue is false or when no failures were recorded.
-func finishContinueDestroy(w io.Writer, result terraforminfra.DestroyResult) error {
+func finishContinueDestroy(w io.Writer, result provisioner.DestroyResult) error {
 	if !destroyContinue {
 		return nil
 	}

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -33,7 +33,9 @@ var destroyCmd = &cobra.Command{
 
 Every form requires confirmation. Either type the context or component name at the prompt, or pass --confirm=<expected> to satisfy the gate non-interactively (CI-safe). The --confirm value must match the prompt token exactly; mismatches abort the operation.
 
-If terraform reports resources protected by 'lifecycle { prevent_destroy = true }', destroy warns up front so the operator knows the destroy may halt partway through. Resources whose state is empty are skipped with a warning naming any potentially orphaned cloud resources.`,
+If terraform reports resources protected by 'lifecycle { prevent_destroy = true }', destroy warns up front so the operator knows the destroy may halt partway through. Resources whose state is empty are skipped with a warning naming any potentially orphaned cloud resources.
+
+The default behavior is to abort on the first per-component destroy failure. Pass --continue to keep going past individual failures, collect them, and print a one-line summary at the end (windsor destroy: N destroyed, N no-op (empty state), N failed (...), backend tier deferred). When --continue leaves any non-tier component un-destroyed, the backend tier is NOT attempted — this prevents destroying the state store while other components still depend on it. Rerun 'windsor destroy --continue' after resolving the underlying failures; the second pass picks up where the first left off and converges on a clean slate.`,
 	Example: `# Destroy everything in the current context (interactive)
 windsor destroy
 # → prompts: Type "local" to confirm:
@@ -42,7 +44,10 @@ windsor destroy
 windsor destroy --confirm=local
 
 # Destroy just the dns component (across both layers)
-windsor destroy dns --confirm=dns`,
+windsor destroy dns --confirm=dns
+
+# Continue past per-component failures and converge by rerunning
+windsor destroy --confirm=local --continue`,
 	Annotations: map[string]string{
 		"docs.seealso": "[`apply`](apply.md), [`down`](down.md), [`plan`](plan.md)",
 		"docs.source": "cmd/destroy.go",

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -35,7 +35,7 @@ Every form requires confirmation. Either type the context or component name at t
 
 If terraform reports resources protected by 'lifecycle { prevent_destroy = true }', destroy warns up front so the operator knows the destroy may halt partway through. Resources whose state is empty are skipped with a warning naming any potentially orphaned cloud resources.
 
-The default behavior is to abort on the first per-component destroy failure. Pass --continue to keep going past individual failures, collect them, and print a one-line summary at the end (windsor destroy: N destroyed, N no-op (empty state), N failed (...), backend tier deferred). When --continue leaves any non-tier component un-destroyed, the backend tier is NOT attempted — this prevents destroying the state store while other components still depend on it. Rerun 'windsor destroy --continue' after resolving the underlying failures; the second pass picks up where the first left off and converges on a clean slate.`,
+The default behavior is to abort on the first per-component destroy failure. Pass --continue to keep going past individual failures, collect them, and print a one-line summary at the end (windsor destroy: N destroyed, N no-op (empty state), N failed (...), backend tier deferred). --continue is layer-wide only and is refused when combined with a component argument — on a single component there is nothing to continue past. When --continue leaves any non-tier component un-destroyed, the backend tier is NOT attempted — this prevents destroying the state store while other components still depend on it. Rerun 'windsor destroy --continue' after resolving the underlying failures; the second pass picks up where the first left off and converges on a clean slate.`,
 	Example: `# Destroy everything in the current context (interactive)
 windsor destroy
 # → prompts: Type "local" to confirm:
@@ -55,6 +55,9 @@ windsor destroy --confirm=local --continue`,
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireContinueScope(args); err != nil {
+			return err
+		}
 		// `destroy` (no args, or with a component name that may live in either layer) can
 		// dispatch to terraform or kustomize destroy paths depending on blueprint contents.
 		// Layer choice is data-driven so requirements can't be statically narrowed; request
@@ -184,6 +187,9 @@ windsor destroy terraform --confirm=local`,
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireContinueScope(args); err != nil {
+			return err
+		}
 		// `destroy terraform` only invokes terraform; kustomize/k8s/docker tools are not used.
 		// Skip-validation tolerates a deployed-but-misordered blueprint so teardown can run
 		// against a setup the validator would otherwise reject.
@@ -275,6 +281,9 @@ windsor destroy kustomize --confirm=local`,
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := requireContinueScope(args); err != nil {
+			return err
+		}
 		// `destroy kustomize` only talks to the cluster API; terraform/docker tools are not used.
 		// Skip-validation tolerates a deployed-but-misordered blueprint.
 		proj, err := prepareProjectSkipValidation(cmd, tools.Requirements{Secrets: true, Kubelogin: true})
@@ -411,6 +420,19 @@ func resolveDestroyConfirmation(r io.Reader, w io.Writer, description, expected 
 	return confirmDestroy(r, w, description, expected)
 }
 
+// requireContinueScope refuses --continue when a component argument is also
+// present. The flag's contract (best-effort across multiple components plus a
+// summary line) only makes sense for a layer-wide destroy; on a single
+// component there is nothing to continue past. Without this guard the flag
+// is silently ignored, which gives the operator the default abort-on-error
+// behaviour while believing they opted into best-effort.
+func requireContinueScope(args []string) error {
+	if destroyContinue && len(args) > 0 {
+		return fmt.Errorf("--continue applies to layer-wide destroy only; omit the component argument or drop --continue")
+	}
+	return nil
+}
+
 // finishContinueDestroy emits the one-line --continue summary on stderr and
 // returns a non-zero exit error when any component failed. Without --continue
 // the existing per-error abort already surfaces failures, so no extra output
@@ -450,7 +472,7 @@ func finishContinueDestroy(w io.Writer, result provisioner.DestroyResult) error 
 // tier is deferred when any non-tier component is left un-destroyed (rerun to converge).
 func init() {
 	destroyCmd.PersistentFlags().StringVar(&destroyConfirm, "confirm", "", "Context or component name to confirm destruction. Must match the prompt token exactly; mismatches abort.")
-	destroyCmd.PersistentFlags().BoolVar(&destroyContinue, "continue", false, "Continue past per-component destroy failures and report a summary at the end. Backend tier is deferred when any non-tier component fails.")
+	destroyCmd.PersistentFlags().BoolVar(&destroyContinue, "continue", false, "Continue past per-component destroy failures and report a summary at the end. Layer-wide destroy only — refuses when combined with a component argument. Backend tier is deferred when any non-tier component fails.")
 	destroyCmd.AddCommand(destroyTerraformCmd)
 	destroyCmd.AddCommand(destroyKustomizeCmd)
 	rootCmd.AddCommand(destroyCmd)

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -21,7 +21,10 @@ import (
 // Destroy Commands
 // =============================================================================
 
-var destroyConfirm string
+var (
+	destroyConfirm  string
+	destroyContinue bool
+)
 
 var destroyCmd = &cobra.Command{
 	Use:   "destroy [component]",
@@ -84,12 +87,12 @@ windsor destroy dns --confirm=dns`,
 				return err
 			}
 			return stacklock.With(cmd.Context(), proj.Runtime, "destroy", func() error {
-				skipped, err := proj.Provisioner.Teardown(blueprint, false)
-				reportSkippedDestroyComponents(cmd.ErrOrStderr(), skipped)
+				result, err := proj.Provisioner.Teardown(blueprint, false, destroyContinue)
+				reportSkippedDestroyComponents(cmd.ErrOrStderr(), result.Skipped)
 				if err != nil {
 					return fmt.Errorf("error destroying all components: %w", err)
 				}
-				return nil
+				return finishContinueDestroy(cmd.ErrOrStderr(), result)
 			})
 		}
 
@@ -208,12 +211,12 @@ windsor destroy terraform --confirm=local`,
 				return err
 			}
 			return stacklock.With(cmd.Context(), proj.Runtime, "destroy", func() error {
-				skipped, err := proj.Provisioner.Teardown(blueprint, true)
-				reportSkippedDestroyComponents(cmd.ErrOrStderr(), skipped)
+				result, err := proj.Provisioner.Teardown(blueprint, true, destroyContinue)
+				reportSkippedDestroyComponents(cmd.ErrOrStderr(), result.Skipped)
 				if err != nil {
 					return fmt.Errorf("error destroying all terraform: %w", err)
 				}
-				return nil
+				return finishContinueDestroy(cmd.ErrOrStderr(), result)
 			})
 		}
 
@@ -403,11 +406,46 @@ func resolveDestroyConfirmation(r io.Reader, w io.Writer, description, expected 
 	return confirmDestroy(r, w, description, expected)
 }
 
-// init registers destroy subcommands and the --confirm flag. --confirm must exactly match the
+// finishContinueDestroy emits the one-line --continue summary on stderr and
+// returns a non-zero exit error when any component failed. Without --continue
+// the existing per-error abort already surfaces failures, so no extra output
+// is needed; this only fires when the operator opted into best-effort mode.
+// Returns nil when destroyContinue is false or when no failures were recorded.
+func finishContinueDestroy(w io.Writer, result terraforminfra.DestroyResult) error {
+	if !destroyContinue {
+		return nil
+	}
+	parts := []string{
+		fmt.Sprintf("%d destroyed", len(result.Destroyed)),
+		fmt.Sprintf("%d no-op (empty state)", len(result.Skipped)),
+	}
+	if len(result.Failed) > 0 {
+		failedIDs := make([]string, 0, len(result.Failed))
+		for _, f := range result.Failed {
+			failedIDs = append(failedIDs, f.ID)
+		}
+		parts = append(parts, fmt.Sprintf("%d failed (%s)", len(result.Failed), strings.Join(failedIDs, ", ")))
+	} else {
+		parts = append(parts, "0 failed")
+	}
+	if result.TierDeferred {
+		parts = append(parts, "backend tier deferred")
+	}
+	fmt.Fprintf(w, "windsor destroy: %s\n", strings.Join(parts, ", "))
+	if len(result.Failed) > 0 {
+		return fmt.Errorf("destroy completed with %d failure(s); rerun `windsor destroy --continue` after resolving them", len(result.Failed))
+	}
+	return nil
+}
+
+// init registers destroy subcommands and persistent flags. --confirm must exactly match the
 // context name (for layer-wide destroy) or component name (for targeted destroy); this is the
-// CI-safe equivalent of the interactive prompt. There is no flag that skips confirmation entirely.
+// CI-safe equivalent of the interactive prompt. --continue switches the bulk destroy passes
+// to best-effort: per-component failures are collected rather than aborting, and the backend
+// tier is deferred when any non-tier component is left un-destroyed (rerun to converge).
 func init() {
 	destroyCmd.PersistentFlags().StringVar(&destroyConfirm, "confirm", "", "Context or component name to confirm destruction. Must match the prompt token exactly; mismatches abort.")
+	destroyCmd.PersistentFlags().BoolVar(&destroyContinue, "continue", false, "Continue past per-component destroy failures and report a summary at the end. Backend tier is deferred when any non-tier component fails.")
 	destroyCmd.AddCommand(destroyTerraformCmd)
 	destroyCmd.AddCommand(destroyKustomizeCmd)
 	rootCmd.AddCommand(destroyCmd)

--- a/cmd/destroy_test.go
+++ b/cmd/destroy_test.go
@@ -650,8 +650,10 @@ func TestDestroyCmd(t *testing.T) {
 		if !strings.Contains(out, "windsor destroy:") {
 			t.Errorf("Expected summary line on stderr, got: %q", out)
 		}
-		if !strings.Contains(out, "1 destroyed") {
-			t.Errorf("Expected summary to report 1 destroyed, got: %q", out)
+		// Fixture blueprint has 1 kustomization ("my-app") + 1 terraform component
+		// stub returns ("cluster"); the summary counts both layers.
+		if !strings.Contains(out, "2 destroyed") {
+			t.Errorf("Expected summary to report 2 destroyed (1 kustomize + 1 terraform), got: %q", out)
 		}
 		if !strings.Contains(out, "0 failed") {
 			t.Errorf("Expected summary to report 0 failed, got: %q", out)

--- a/cmd/destroy_test.go
+++ b/cmd/destroy_test.go
@@ -717,11 +717,34 @@ func TestDestroyCmd(t *testing.T) {
 			t.Errorf("Summary must not print without --continue, got: %q", stderr.String())
 		}
 	})
+
+	t.Run("ContinueRejectedWithComponentArgument", func(t *testing.T) {
+		// Given --continue is combined with a component argument, the cmd must
+		// refuse instead of silently ignoring the flag — TeardownComponent does
+		// not honor continueOnError and there is nothing to continue past on a
+		// single component anyway.
+		mocks := setupDestroyTest(t)
+		proj := newDestroyProject(mocks)
+
+		cmd := createTestDestroyCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--confirm=my-app", "--continue", "my-app"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		if err == nil {
+			t.Fatal("Expected --continue with component arg to be rejected")
+		}
+		if !strings.Contains(err.Error(), "--continue applies to layer-wide destroy only") {
+			t.Errorf("Expected scope-mismatch error, got: %v", err)
+		}
+	})
 }
 
 func TestDestroyTerraformCmd(t *testing.T) {
 	createTestDestroyTerraformCmd := func() *cobra.Command {
 		destroyConfirm = ""
+		destroyContinue = false
 		cmd := &cobra.Command{
 			Use:  "terraform",
 			RunE: destroyTerraformCmd.RunE,
@@ -882,11 +905,33 @@ func TestDestroyTerraformCmd(t *testing.T) {
 			t.Errorf("Expected destroy error, got: %v", err)
 		}
 	})
+
+	t.Run("ContinueRejectedWithComponentArgument", func(t *testing.T) {
+		// Inherits --continue from the parent destroy command but the terraform
+		// single-component path also calls TeardownComponent which ignores the
+		// flag — refuse rather than silently accept.
+		mocks := setupDestroyTest(t)
+		proj := newDestroyProject(mocks)
+
+		cmd := createTestDestroyTerraformCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--confirm=cluster", "--continue", "cluster"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		if err == nil {
+			t.Fatal("Expected --continue with component arg to be rejected")
+		}
+		if !strings.Contains(err.Error(), "--continue applies to layer-wide destroy only") {
+			t.Errorf("Expected scope-mismatch error, got: %v", err)
+		}
+	})
 }
 
 func TestDestroyKustomizeCmd(t *testing.T) {
 	createTestDestroyKustomizeCmd := func() *cobra.Command {
 		destroyConfirm = ""
+		destroyContinue = false
 		cmd := &cobra.Command{
 			Use:  "kustomize",
 			RunE: destroyKustomizeCmd.RunE,
@@ -1045,6 +1090,27 @@ func TestDestroyKustomizeCmd(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "error destroying kustomization") {
 			t.Errorf("Expected destroy error, got: %v", err)
+		}
+	})
+
+	t.Run("ContinueRejectedWithComponentArgument", func(t *testing.T) {
+		// `destroy kustomize` inherits --continue from the parent; the
+		// single-name path does not honor it either, so refuse rather than
+		// silently accept.
+		mocks := setupDestroyTest(t)
+		proj := newDestroyProject(mocks)
+
+		cmd := createTestDestroyKustomizeCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--confirm=my-app", "--continue", "my-app"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		if err == nil {
+			t.Fatal("Expected --continue with component arg to be rejected")
+		}
+		if !strings.Contains(err.Error(), "--continue applies to layer-wide destroy only") {
+			t.Errorf("Expected scope-mismatch error, got: %v", err)
 		}
 	})
 }

--- a/cmd/destroy_test.go
+++ b/cmd/destroy_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -104,7 +105,7 @@ func setupDestroyTest(t *testing.T, opts ...*SetupOptions) *DestroyMocks {
 	mockBlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint { return testBlueprint }
 
 	mockTerraformStack := terraforminfra.NewMockStack()
-	mockTerraformStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, excludeIDs ...string) ([]string, error) { return nil, nil }
+	mockTerraformStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) { return terraforminfra.DestroyResult{}, nil }
 	mockTerraformStack.DestroyFunc = func(bp *blueprintv1alpha1.Blueprint, componentID string) (bool, error) { return false, nil }
 
 	mockKubernetesManager := kubernetes.NewMockKubernetesManager()
@@ -259,6 +260,7 @@ func TestWarnPreventDestroy(t *testing.T) {
 func TestDestroyCmd(t *testing.T) {
 	createTestDestroyCmd := func() *cobra.Command {
 		destroyConfirm = ""
+		destroyContinue = false
 		cmd := &cobra.Command{
 			Use:  "destroy",
 			RunE: destroyCmd.RunE,
@@ -468,9 +470,9 @@ func TestDestroyCmd(t *testing.T) {
 		mocks := setupDestroyTest(t)
 		mocks.ToolsManager.CheckAuthFunc = func() error { return fmt.Errorf("aws credentials did not resolve") }
 		destroyAllCalled := false
-		mocks.TerraformStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ ...string) ([]string, error) {
+		mocks.TerraformStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyResult, error) {
 			destroyAllCalled = true
-			return nil, nil
+			return terraforminfra.DestroyResult{}, nil
 		}
 		proj := newDestroyProject(mocks)
 
@@ -559,9 +561,9 @@ func TestDestroyCmd(t *testing.T) {
 			}
 			return nil
 		}
-		mocks.TerraformStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, excludeIDs ...string) ([]string, error) {
+		mocks.TerraformStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) {
 			destroyCalled = true
-			return nil, nil
+			return terraforminfra.DestroyResult{}, nil
 		}
 		proj := newDestroyProject(mocks)
 
@@ -595,9 +597,9 @@ func TestDestroyCmd(t *testing.T) {
 		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
 			return nil, fmt.Errorf("connection refused")
 		}
-		mocks.TerraformStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, excludeIDs ...string) ([]string, error) {
+		mocks.TerraformStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) {
 			destroyCalled = true
-			return nil, nil
+			return terraforminfra.DestroyResult{}, nil
 		}
 		proj := newDestroyProject(mocks)
 
@@ -615,6 +617,102 @@ func TestDestroyCmd(t *testing.T) {
 		}
 		if destroyCalled {
 			t.Error("DestroyAll must not run after a plan error")
+		}
+	})
+
+	t.Run("ContinueFlagPropagatesAndPrintsSummaryOnSuccess", func(t *testing.T) {
+		// Given --continue is passed and the stack reports a clean destroy,
+		// the cmd layer must forward continueOnError=true to Teardown and
+		// render the one-line summary on stderr.
+		mocks := setupDestroyTest(t)
+		var seenContinue bool
+		mocks.TerraformStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, continueOnError bool, _ ...string) (terraforminfra.DestroyResult, error) {
+			seenContinue = continueOnError
+			return terraforminfra.DestroyResult{Destroyed: []string{"cluster"}}, nil
+		}
+		proj := newDestroyProject(mocks)
+
+		var stderr bytes.Buffer
+		cmd := createTestDestroyCmd()
+		cmd.SetErr(&stderr)
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--confirm=test-context", "--continue"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		if err != nil {
+			t.Fatalf("Expected --continue with clean result to succeed, got %v", err)
+		}
+		if !seenContinue {
+			t.Error("Expected --continue to propagate continueOnError=true to Teardown")
+		}
+		out := stderr.String()
+		if !strings.Contains(out, "windsor destroy:") {
+			t.Errorf("Expected summary line on stderr, got: %q", out)
+		}
+		if !strings.Contains(out, "1 destroyed") {
+			t.Errorf("Expected summary to report 1 destroyed, got: %q", out)
+		}
+		if !strings.Contains(out, "0 failed") {
+			t.Errorf("Expected summary to report 0 failed, got: %q", out)
+		}
+	})
+
+	t.Run("ContinueFlagReturnsErrorAndNamesFailures", func(t *testing.T) {
+		// Given --continue is passed and the stack reports per-component failures,
+		// the cmd layer must return a non-zero exit error after printing the summary
+		// (so re-running converges; CI sees the failure).
+		mocks := setupDestroyTest(t)
+		mocks.TerraformStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyResult, error) {
+			return terraforminfra.DestroyResult{
+				Destroyed: []string{"vpc"},
+				Failed:    []terraforminfra.ComponentFailure{{ID: "iam", Err: fmt.Errorf("permission denied")}},
+			}, nil
+		}
+		proj := newDestroyProject(mocks)
+
+		var stderr bytes.Buffer
+		cmd := createTestDestroyCmd()
+		cmd.SetErr(&stderr)
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--confirm=test-context", "--continue"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		if err == nil {
+			t.Fatal("Expected non-zero exit when --continue surfaces failures")
+		}
+		if !strings.Contains(err.Error(), "destroy completed with 1 failure") {
+			t.Errorf("Expected error to report failure count, got: %v", err)
+		}
+		out := stderr.String()
+		if !strings.Contains(out, "1 failed (iam)") {
+			t.Errorf("Expected summary to name failed component, got: %q", out)
+		}
+	})
+
+	t.Run("NoSummaryWithoutContinueFlag", func(t *testing.T) {
+		// Given the operator did not pass --continue, the summary line must not
+		// appear (current behavior is unchanged; opt-in only).
+		mocks := setupDestroyTest(t)
+		mocks.TerraformStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyResult, error) {
+			return terraforminfra.DestroyResult{Destroyed: []string{"cluster"}}, nil
+		}
+		proj := newDestroyProject(mocks)
+
+		var stderr bytes.Buffer
+		cmd := createTestDestroyCmd()
+		cmd.SetErr(&stderr)
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--confirm=test-context"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if strings.Contains(stderr.String(), "windsor destroy:") {
+			t.Errorf("Summary must not print without --continue, got: %q", stderr.String())
 		}
 	})
 }

--- a/cmd/destroy_test.go
+++ b/cmd/destroy_test.go
@@ -105,7 +105,7 @@ func setupDestroyTest(t *testing.T, opts ...*SetupOptions) *DestroyMocks {
 	mockBlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint { return testBlueprint }
 
 	mockTerraformStack := terraforminfra.NewMockStack()
-	mockTerraformStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) { return terraforminfra.DestroyResult{}, nil }
+	mockTerraformStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) { return terraforminfra.DestroyOutcome{}, nil }
 	mockTerraformStack.DestroyFunc = func(bp *blueprintv1alpha1.Blueprint, componentID string) (bool, error) { return false, nil }
 
 	mockKubernetesManager := kubernetes.NewMockKubernetesManager()
@@ -470,9 +470,9 @@ func TestDestroyCmd(t *testing.T) {
 		mocks := setupDestroyTest(t)
 		mocks.ToolsManager.CheckAuthFunc = func() error { return fmt.Errorf("aws credentials did not resolve") }
 		destroyAllCalled := false
-		mocks.TerraformStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyResult, error) {
+		mocks.TerraformStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyOutcome, error) {
 			destroyAllCalled = true
-			return terraforminfra.DestroyResult{}, nil
+			return terraforminfra.DestroyOutcome{}, nil
 		}
 		proj := newDestroyProject(mocks)
 
@@ -561,9 +561,9 @@ func TestDestroyCmd(t *testing.T) {
 			}
 			return nil
 		}
-		mocks.TerraformStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) {
+		mocks.TerraformStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) {
 			destroyCalled = true
-			return terraforminfra.DestroyResult{}, nil
+			return terraforminfra.DestroyOutcome{}, nil
 		}
 		proj := newDestroyProject(mocks)
 
@@ -597,9 +597,9 @@ func TestDestroyCmd(t *testing.T) {
 		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
 			return nil, fmt.Errorf("connection refused")
 		}
-		mocks.TerraformStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) {
+		mocks.TerraformStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) {
 			destroyCalled = true
-			return terraforminfra.DestroyResult{}, nil
+			return terraforminfra.DestroyOutcome{}, nil
 		}
 		proj := newDestroyProject(mocks)
 
@@ -626,9 +626,9 @@ func TestDestroyCmd(t *testing.T) {
 		// render the one-line summary on stderr.
 		mocks := setupDestroyTest(t)
 		var seenContinue bool
-		mocks.TerraformStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, continueOnError bool, _ ...string) (terraforminfra.DestroyResult, error) {
+		mocks.TerraformStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, continueOnError bool, _ ...string) (terraforminfra.DestroyOutcome, error) {
 			seenContinue = continueOnError
-			return terraforminfra.DestroyResult{Destroyed: []string{"cluster"}}, nil
+			return terraforminfra.DestroyOutcome{Destroyed: []string{"cluster"}}, nil
 		}
 		proj := newDestroyProject(mocks)
 
@@ -663,8 +663,8 @@ func TestDestroyCmd(t *testing.T) {
 		// the cmd layer must return a non-zero exit error after printing the summary
 		// (so re-running converges; CI sees the failure).
 		mocks := setupDestroyTest(t)
-		mocks.TerraformStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyResult, error) {
-			return terraforminfra.DestroyResult{
+		mocks.TerraformStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyOutcome, error) {
+			return terraforminfra.DestroyOutcome{
 				Destroyed: []string{"vpc"},
 				Failed:    []terraforminfra.ComponentFailure{{ID: "iam", Err: fmt.Errorf("permission denied")}},
 			}, nil
@@ -695,8 +695,8 @@ func TestDestroyCmd(t *testing.T) {
 		// Given the operator did not pass --continue, the summary line must not
 		// appear (current behavior is unchanged; opt-in only).
 		mocks := setupDestroyTest(t)
-		mocks.TerraformStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyResult, error) {
-			return terraforminfra.DestroyResult{Destroyed: []string{"cluster"}}, nil
+		mocks.TerraformStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyOutcome, error) {
+			return terraforminfra.DestroyOutcome{Destroyed: []string{"cluster"}}, nil
 		}
 		proj := newDestroyProject(mocks)
 

--- a/docs/reference/commands/destroy.md
+++ b/docs/reference/commands/destroy.md
@@ -14,14 +14,14 @@ Every form requires confirmation. Either type the context or component name at t
 
 If terraform reports resources protected by 'lifecycle { prevent_destroy = true }', destroy warns up front so the operator knows the destroy may halt partway through. Resources whose state is empty are skipped with a warning naming any potentially orphaned cloud resources.
 
-The default behavior is to abort on the first per-component destroy failure. Pass --continue to keep going past individual failures, collect them, and print a one-line summary at the end (windsor destroy: N destroyed, N no-op (empty state), N failed (...), backend tier deferred). When --continue leaves any non-tier component un-destroyed, the backend tier is NOT attempted — this prevents destroying the state store while other components still depend on it. Rerun 'windsor destroy --continue' after resolving the underlying failures; the second pass picks up where the first left off and converges on a clean slate.
+The default behavior is to abort on the first per-component destroy failure. Pass --continue to keep going past individual failures, collect them, and print a one-line summary at the end (windsor destroy: N destroyed, N no-op (empty state), N failed (...), backend tier deferred). --continue is layer-wide only and is refused when combined with a component argument — on a single component there is nothing to continue past. When --continue leaves any non-tier component un-destroyed, the backend tier is NOT attempted — this prevents destroying the state store while other components still depend on it. Rerun 'windsor destroy --continue' after resolving the underlying failures; the second pass picks up where the first left off and converges on a clean slate.
 
 ## Flags
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--confirm` | `""` | Context or component name to confirm destruction. Must match the prompt token exactly; mismatches abort. |
-| `--continue` | `false` | Continue past per-component destroy failures and report a summary at the end. Backend tier is deferred when any non-tier component fails. |
+| `--continue` | `false` | Continue past per-component destroy failures and report a summary at the end. Layer-wide destroy only — refuses when combined with a component argument. Backend tier is deferred when any non-tier component fails. |
 
 ## Subcommands
 

--- a/docs/reference/commands/destroy.md
+++ b/docs/reference/commands/destroy.md
@@ -14,11 +14,14 @@ Every form requires confirmation. Either type the context or component name at t
 
 If terraform reports resources protected by 'lifecycle { prevent_destroy = true }', destroy warns up front so the operator knows the destroy may halt partway through. Resources whose state is empty are skipped with a warning naming any potentially orphaned cloud resources.
 
+The default behavior is to abort on the first per-component destroy failure. Pass `--continue` to keep going past individual failures, collect them, and print a one-line summary at the end (`windsor destroy: N destroyed, N no-op (empty state), N failed (...), backend tier deferred`). When `--continue` leaves any non-tier component un-destroyed, the backend tier is **not** attempted — this prevents destroying the state store while other components still depend on it. Rerun `windsor destroy --continue` after resolving the underlying failures; the second pass picks up where the first left off and converges on a clean slate.
+
 ## Flags
 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--confirm` | `""` | Context or component name to confirm destruction. Must match the prompt token exactly; mismatches abort. |
+| `--continue` | `false` | Continue past per-component destroy failures and report a summary at the end. Backend tier is deferred when any non-tier component fails. |
 
 ## Subcommands
 
@@ -37,6 +40,9 @@ windsor destroy --confirm=local
 
 # Destroy just the dns component (across both layers)
 windsor destroy dns --confirm=dns
+
+# Continue past per-component failures and converge by rerunning
+windsor destroy --confirm=local --continue
 ```
 
 ## See also

--- a/docs/reference/commands/destroy.md
+++ b/docs/reference/commands/destroy.md
@@ -14,7 +14,7 @@ Every form requires confirmation. Either type the context or component name at t
 
 If terraform reports resources protected by 'lifecycle { prevent_destroy = true }', destroy warns up front so the operator knows the destroy may halt partway through. Resources whose state is empty are skipped with a warning naming any potentially orphaned cloud resources.
 
-The default behavior is to abort on the first per-component destroy failure. Pass `--continue` to keep going past individual failures, collect them, and print a one-line summary at the end (`windsor destroy: N destroyed, N no-op (empty state), N failed (...), backend tier deferred`). When `--continue` leaves any non-tier component un-destroyed, the backend tier is **not** attempted — this prevents destroying the state store while other components still depend on it. Rerun `windsor destroy --continue` after resolving the underlying failures; the second pass picks up where the first left off and converges on a clean slate.
+The default behavior is to abort on the first per-component destroy failure. Pass --continue to keep going past individual failures, collect them, and print a one-line summary at the end (windsor destroy: N destroyed, N no-op (empty state), N failed (...), backend tier deferred). When --continue leaves any non-tier component un-destroyed, the backend tier is NOT attempted — this prevents destroying the state store while other components still depend on it. Rerun 'windsor destroy --continue' after resolving the underlying failures; the second pass picks up where the first left off and converges on a clean slate.
 
 ## Flags
 

--- a/integration/destroy_test.go
+++ b/integration/destroy_test.go
@@ -54,6 +54,49 @@ func TestDestroyTerraform_SucceedsAllWithMinimalLocalConfig(t *testing.T) {
 	}
 }
 
+func TestDestroyTerraform_ContinueFlagSucceedsAndPrintsSummary(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
+	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
+	if err != nil {
+		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
+	}
+	env = append(env, "WINDSOR_CONTEXT=local")
+	_, stderr, err = helpers.RunCLI(dir, []string{"apply", "terraform", "null"}, env)
+	if err != nil {
+		t.Fatalf("apply terraform null: %v\nstderr: %s", err, stderr)
+	}
+	_, stderr, err = helpers.RunCLI(dir, []string{"destroy", "--confirm=local", "--continue", "terraform"}, env)
+	if err != nil {
+		t.Fatalf("destroy --continue terraform: %v\nstderr: %s", err, stderr)
+	}
+	if !strings.Contains(string(stderr), "windsor destroy:") {
+		t.Errorf("expected --continue summary line on stderr, got: %s", stderr)
+	}
+	if !strings.Contains(string(stderr), "0 failed") {
+		t.Errorf("expected summary to report 0 failed on a clean run, got: %s", stderr)
+	}
+}
+
+func TestDestroy_ContinueFlagAcceptedWithoutConfirmMatch(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
+	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
+	if err != nil {
+		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
+	}
+	env = append(env, "WINDSOR_CONTEXT=local")
+	_, stderr, err = helpers.RunCLI(dir, []string{"destroy", "--continue", "--confirm=wrong", "terraform"}, env)
+	if err == nil {
+		t.Fatal("expected failure but command succeeded")
+	}
+	if !strings.Contains(string(stderr), "confirmation failed") {
+		t.Errorf("expected stderr to mention 'confirmation failed', got: %s", stderr)
+	}
+}
+
 func TestDestroyTerraform_FailsWhenNotInTrustedDirectory(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")

--- a/integration/destroy_test.go
+++ b/integration/destroy_test.go
@@ -79,6 +79,24 @@ func TestDestroyTerraform_ContinueFlagSucceedsAndPrintsSummary(t *testing.T) {
 	}
 }
 
+func TestDestroy_ContinueFlagRefusedWithComponentArgument(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
+	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
+	if err != nil {
+		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
+	}
+	env = append(env, "WINDSOR_CONTEXT=local")
+	_, stderr, err = helpers.RunCLI(dir, []string{"destroy", "--confirm=null", "--continue", "terraform", "null"}, env)
+	if err == nil {
+		t.Fatal("expected --continue with component arg to be rejected")
+	}
+	if !strings.Contains(string(stderr), "layer-wide destroy only") {
+		t.Errorf("expected stderr to mention the scope restriction, got: %s", stderr)
+	}
+}
+
 func TestDestroy_ContinueFlagAcceptedWithoutConfirmMatch(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")

--- a/pkg/provisioner/destroy.go
+++ b/pkg/provisioner/destroy.go
@@ -8,6 +8,17 @@ import (
 )
 
 // =============================================================================
+// Constants
+// =============================================================================
+
+// KustomizeFailureID is the sentinel ID used when the kustomize Uninstall step
+// fails under continue-on-error mode. The kustomize layer surfaces a single
+// aggregate failure rather than per-Kustomization entries, so the tier-gate
+// logic in Teardown can distinguish kustomize failures (which do not block
+// the terraform backend tier) from terraform-component failures (which do).
+const KustomizeFailureID = "kustomize"
+
+// =============================================================================
 // Types
 // =============================================================================
 
@@ -72,7 +83,7 @@ func (i *Provisioner) Teardown(blueprint *blueprintv1alpha1.Blueprint, terraform
 		return result, stage1Err
 	}
 
-	if len(result.Failed) > 0 {
+	if hasTerraformFailure(result.Failed) {
 		result.TierDeferred = true
 		return result, nil
 	}
@@ -108,6 +119,22 @@ func (i *Provisioner) TeardownComponent(blueprint *blueprintv1alpha1.Blueprint, 
 // =============================================================================
 // Private Helpers
 // =============================================================================
+
+// hasTerraformFailure reports whether the failure list contains any entry
+// that belongs to a terraform component (i.e., not the kustomize-aggregate
+// sentinel). Used by Teardown's tier gate: kustomize failures do not block
+// the backend terraform tier because kustomize resources do not depend on
+// terraform state. Without this filter, a kustomize Uninstall error would
+// permanently defer the tier on every rerun, because the cluster is the
+// thing kustomize most often fails against.
+func hasTerraformFailure(failed []ComponentFailure) bool {
+	for _, f := range failed {
+		if f.ID != KustomizeFailureID {
+			return true
+		}
+	}
+	return false
+}
 
 // mergeSkipped returns the union of two skipped-component lists in input order
 // without duplicates. MigrateState and DestroyAll both report dir-missing

--- a/pkg/provisioner/destroy.go
+++ b/pkg/provisioner/destroy.go
@@ -8,6 +8,28 @@ import (
 )
 
 // =============================================================================
+// Types
+// =============================================================================
+
+// ComponentFailure is a per-component error captured during continue-on-error
+// destroy. Aliased from the terraform package so callers can use a single
+// type identity across the layer boundary without duplication.
+type ComponentFailure = terraforminfra.ComponentFailure
+
+// DestroyResult is the cmd-facing aggregate of a destroy pass. Destroyed,
+// Skipped, and Failed roll up every component the provisioner attempted —
+// kustomize plus terraform — and TierDeferred records the provisioner-layer
+// decision to leave the backend tier alone when a non-tier component still
+// needs work. Fields for additional destroy layers (e.g. Helm) belong on
+// this type, not on the terraform-package outcome.
+type DestroyResult struct {
+	Destroyed    []string
+	Skipped      []string
+	Failed       []ComponentFailure
+	TierDeferred bool
+}
+
+// =============================================================================
 // Public Methods
 // =============================================================================
 
@@ -21,8 +43,8 @@ import (
 // when Stage 1 produced zero failures, to avoid destroying the state store
 // while other components still depend on it. The tier-deferred flag on the
 // result signals when Stage 2 was skipped for this reason.
-func (i *Provisioner) Teardown(blueprint *blueprintv1alpha1.Blueprint, terraformOnly bool, continueOnError bool) (terraforminfra.DestroyResult, error) {
-	var result terraforminfra.DestroyResult
+func (i *Provisioner) Teardown(blueprint *blueprintv1alpha1.Blueprint, terraformOnly bool, continueOnError bool) (DestroyResult, error) {
+	var result DestroyResult
 	backendType := i.configHandler.GetString("terraform.backend.type", "local")
 	if backendType == "kubernetes" && blueprint.Backend == "" {
 		return result, fmt.Errorf("blueprint configures terraform.backend.type=kubernetes but does not declare Blueprint.Backend; set `backend: <cluster-component-id>` at the blueprint top level to name the terraform component that provisions the cluster")

--- a/pkg/provisioner/destroy.go
+++ b/pkg/provisioner/destroy.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+	terraforminfra "github.com/windsorcli/cli/pkg/provisioner/terraform"
 )
 
 // =============================================================================
@@ -14,19 +15,24 @@ import (
 // (or DestroyAllTerraform when terraformOnly). With a tier declared via
 // Blueprint.Backend, Stage 1 destroys non-tier components against the
 // configured backend, then Stage 2 pins local, pulls every tier member's state
-// to local, and destroys the tier in reverse declaration order. Returns the
-// IDs of components skipped because their state was empty.
-func (i *Provisioner) Teardown(blueprint *blueprintv1alpha1.Blueprint, terraformOnly bool) ([]string, error) {
+// to local, and destroys the tier in reverse declaration order. When
+// continueOnError is true, per-component destroy errors in Stage 1 are
+// collected rather than aborting the loop; the backend tier is only attempted
+// when Stage 1 produced zero failures, to avoid destroying the state store
+// while other components still depend on it. The tier-deferred flag on the
+// result signals when Stage 2 was skipped for this reason.
+func (i *Provisioner) Teardown(blueprint *blueprintv1alpha1.Blueprint, terraformOnly bool, continueOnError bool) (terraforminfra.DestroyResult, error) {
+	var result terraforminfra.DestroyResult
 	backendType := i.configHandler.GetString("terraform.backend.type", "local")
 	if backendType == "kubernetes" && blueprint.Backend == "" {
-		return nil, fmt.Errorf("blueprint configures terraform.backend.type=kubernetes but does not declare Blueprint.Backend; set `backend: <cluster-component-id>` at the blueprint top level to name the terraform component that provisions the cluster")
+		return result, fmt.Errorf("blueprint configures terraform.backend.type=kubernetes but does not declare Blueprint.Backend; set `backend: <cluster-component-id>` at the blueprint top level to name the terraform component that provisions the cluster")
 	}
 	tier := blueprint.BackendTier()
 	if backendType == "" || backendType == "local" || len(tier) == 0 {
 		if terraformOnly {
-			return i.DestroyAllTerraform(blueprint)
+			return i.DestroyAllTerraform(blueprint, continueOnError)
 		}
-		return i.DestroyAll(blueprint)
+		return i.DestroyAll(blueprint, continueOnError)
 	}
 
 	tierIDs := make([]string, 0, len(tier))
@@ -34,15 +40,19 @@ func (i *Provisioner) Teardown(blueprint *blueprintv1alpha1.Blueprint, terraform
 		tierIDs = append(tierIDs, c.GetID())
 	}
 
-	var skipped []string
 	var stage1Err error
 	if terraformOnly {
-		skipped, stage1Err = i.DestroyAllTerraform(blueprint, tierIDs...)
+		result, stage1Err = i.DestroyAllTerraform(blueprint, continueOnError, tierIDs...)
 	} else {
-		skipped, stage1Err = i.DestroyAll(blueprint, tierIDs...)
+		result, stage1Err = i.DestroyAll(blueprint, continueOnError, tierIDs...)
 	}
 	if stage1Err != nil {
-		return skipped, stage1Err
+		return result, stage1Err
+	}
+
+	if len(result.Failed) > 0 {
+		result.TierDeferred = true
+		return result, nil
 	}
 
 	tierBP := blueprintWithComponents(blueprint, tier)
@@ -51,11 +61,13 @@ func (i *Provisioner) Teardown(blueprint *blueprintv1alpha1.Blueprint, terraform
 		if err != nil {
 			return err
 		}
-		destroySkipped, destroyErr := i.DestroyAllTerraform(tierBP)
-		skipped = mergeSkipped(skipped, mergeSkipped(migrationSkipped, destroySkipped))
+		tierResult, destroyErr := i.DestroyAllTerraform(tierBP, continueOnError)
+		result.Destroyed = append(result.Destroyed, tierResult.Destroyed...)
+		result.Skipped = mergeSkipped(result.Skipped, mergeSkipped(migrationSkipped, tierResult.Skipped))
+		result.Failed = append(result.Failed, tierResult.Failed...)
 		return destroyErr
 	})
-	return skipped, err
+	return result, err
 }
 
 // TeardownComponent destroys a single terraform component. Targeting any

--- a/pkg/provisioner/destroy_test.go
+++ b/pkg/provisioner/destroy_test.go
@@ -40,9 +40,9 @@ func TestProvisioner_Teardown(t *testing.T) {
 		}
 		destroyAllCalled := false
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyResult, error) {
+		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyOutcome, error) {
 			destroyAllCalled = true
-			return terraforminfra.DestroyResult{}, nil
+			return terraforminfra.DestroyOutcome{}, nil
 		}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
 
@@ -82,9 +82,9 @@ func TestProvisioner_Teardown(t *testing.T) {
 		}
 		mockStack := terraforminfra.NewMockStack()
 		destroyAllCalls := 0
-		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyResult, error) {
+		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyOutcome, error) {
 			destroyAllCalls++
-			return terraforminfra.DestroyResult{}, nil
+			return terraforminfra.DestroyOutcome{}, nil
 		}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
 
@@ -128,9 +128,9 @@ func TestProvisioner_Teardown(t *testing.T) {
 		}
 		mockStack := terraforminfra.NewMockStack()
 		var seenExclude []string
-		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) {
+		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) {
 			seenExclude = excludeIDs
-			return terraforminfra.DestroyResult{}, nil
+			return terraforminfra.DestroyOutcome{}, nil
 		}
 		migrateCalled := false
 		mockStack.MigrateStateFunc = func(_ *blueprintv1alpha1.Blueprint) ([]string, error) {
@@ -187,11 +187,11 @@ func TestProvisioner_Teardown(t *testing.T) {
 		var destroyAllBlueprints []*blueprintv1alpha1.Blueprint
 		var destroyAllExcludes [][]string
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(b *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) {
+		mockStack.DestroyAllFunc = func(b *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) {
 			ops = append(ops, fmt.Sprintf("destroyAll:exclude=%v", excludeIDs))
 			destroyAllBlueprints = append(destroyAllBlueprints, b)
 			destroyAllExcludes = append(destroyAllExcludes, excludeIDs)
-			return terraforminfra.DestroyResult{}, nil
+			return terraforminfra.DestroyOutcome{}, nil
 		}
 		mockStack.MigrateStateFunc = func(_ *blueprintv1alpha1.Blueprint) ([]string, error) {
 			ops = append(ops, "migrate")
@@ -259,10 +259,10 @@ func TestProvisioner_Teardown(t *testing.T) {
 		var destroyAllBlueprints []*blueprintv1alpha1.Blueprint
 		var destroyAllExcludes [][]string
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(b *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) {
+		mockStack.DestroyAllFunc = func(b *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) {
 			destroyAllBlueprints = append(destroyAllBlueprints, b)
 			destroyAllExcludes = append(destroyAllExcludes, excludeIDs)
-			return terraforminfra.DestroyResult{}, nil
+			return terraforminfra.DestroyOutcome{}, nil
 		}
 		var migrateBlueprints []*blueprintv1alpha1.Blueprint
 		mockStack.MigrateStateFunc = func(b *blueprintv1alpha1.Blueprint) ([]string, error) {
@@ -326,8 +326,8 @@ func TestProvisioner_Teardown(t *testing.T) {
 			return nil
 		}
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyResult, error) {
-			return terraforminfra.DestroyResult{}, fmt.Errorf("non-tier destroy failed")
+		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyOutcome, error) {
+			return terraforminfra.DestroyOutcome{}, fmt.Errorf("non-tier destroy failed")
 		}
 		migrateCalled := false
 		mockStack.MigrateStateFunc = func(_ *blueprintv1alpha1.Blueprint) ([]string, error) {
@@ -385,10 +385,10 @@ func TestProvisioner_Teardown(t *testing.T) {
 		}
 		mockStack := terraforminfra.NewMockStack()
 		destroyAllCalls := 0
-		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyResult, error) {
+		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyOutcome, error) {
 			destroyAllCalls++
 			ops = append(ops, "destroyAll")
-			return terraforminfra.DestroyResult{}, nil
+			return terraforminfra.DestroyOutcome{}, nil
 		}
 		mockStack.MigrateStateFunc = func(_ *blueprintv1alpha1.Blueprint) ([]string, error) {
 			ops = append(ops, "migrate-fail")
@@ -449,7 +449,7 @@ func TestProvisioner_Teardown(t *testing.T) {
 			return nil
 		}
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyResult, error) { return terraforminfra.DestroyResult{}, nil }
+		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyOutcome, error) { return terraforminfra.DestroyOutcome{}, nil }
 		mockStack.MigrateStateFunc = func(_ *blueprintv1alpha1.Blueprint) ([]string, error) { return nil, nil }
 
 		r, w, pipeErr := os.Pipe()
@@ -505,12 +505,12 @@ func TestProvisioner_Teardown(t *testing.T) {
 		mockCH.SetFunc = func(_ string, _ any) error { return nil }
 		mockStack := terraforminfra.NewMockStack()
 		destroyAllCalls := 0
-		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyResult, error) {
+		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyOutcome, error) {
 			destroyAllCalls++
 			if destroyAllCalls == 1 {
-				return terraforminfra.DestroyResult{Skipped: []string{"gitops"}}, nil
+				return terraforminfra.DestroyOutcome{Skipped: []string{"gitops"}}, nil
 			}
-			return terraforminfra.DestroyResult{Skipped: []string{"backend"}}, nil
+			return terraforminfra.DestroyOutcome{Skipped: []string{"backend"}}, nil
 		}
 		mockStack.MigrateStateFunc = func(_ *blueprintv1alpha1.Blueprint) ([]string, error) {
 			return []string{"backend"}, nil
@@ -561,8 +561,8 @@ func TestProvisioner_Teardown(t *testing.T) {
 		}
 		mockStack := terraforminfra.NewMockStack()
 		migrateCalled := false
-		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyResult, error) {
-			return terraforminfra.DestroyResult{
+		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyOutcome, error) {
+			return terraforminfra.DestroyOutcome{
 				Failed: []terraforminfra.ComponentFailure{{ID: "cluster", Err: fmt.Errorf("cluster destroy failed")}},
 			}, nil
 		}
@@ -619,9 +619,9 @@ func TestProvisioner_Teardown(t *testing.T) {
 		mockStack := terraforminfra.NewMockStack()
 		migrateCalled := false
 		destroyAllCalls := 0
-		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyResult, error) {
+		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyOutcome, error) {
 			destroyAllCalls++
-			return terraforminfra.DestroyResult{Destroyed: []string{fmt.Sprintf("pass%d", destroyAllCalls)}}, nil
+			return terraforminfra.DestroyOutcome{Destroyed: []string{fmt.Sprintf("pass%d", destroyAllCalls)}}, nil
 		}
 		mockStack.MigrateStateFunc = func(_ *blueprintv1alpha1.Blueprint) ([]string, error) {
 			migrateCalled = true
@@ -662,11 +662,11 @@ func TestProvisioner_Teardown(t *testing.T) {
 			return ""
 		}
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, continueOnError bool, _ ...string) (terraforminfra.DestroyResult, error) {
+		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, continueOnError bool, _ ...string) (terraforminfra.DestroyOutcome, error) {
 			if !continueOnError {
 				t.Error("Expected continueOnError=true to be propagated to stack")
 			}
-			return terraforminfra.DestroyResult{
+			return terraforminfra.DestroyOutcome{
 				Destroyed: []string{"vpc"},
 				Failed:    []terraforminfra.ComponentFailure{{ID: "iam", Err: fmt.Errorf("permission denied")}},
 			}, nil

--- a/pkg/provisioner/destroy_test.go
+++ b/pkg/provisioner/destroy_test.go
@@ -687,6 +687,80 @@ func TestProvisioner_Teardown(t *testing.T) {
 			t.Errorf("Expected Destroyed=[vpc], got %v", result.Destroyed)
 		}
 	})
+
+	t.Run("ContinueAttemptsTierWhenOnlyKustomizeFailed", func(t *testing.T) {
+		// Given a tier blueprint where kustomize Uninstall fails but every
+		// non-tier terraform component destroys cleanly. Kustomize does not
+		// depend on terraform state, so the backend tier MUST still be
+		// attempted — otherwise the tier is permanently deferred on every
+		// rerun (kustomize is most likely to fail against a cluster that's
+		// already partially gone).
+		mocks := setupProvisionerMocks(t)
+		bp := &blueprintv1alpha1.Blueprint{
+			Backend:  "backend",
+			Metadata: blueprintv1alpha1.Metadata{Name: "test"},
+			TerraformComponents: []blueprintv1alpha1.TerraformComponent{
+				{Path: "backend"},
+				{Path: "cluster"},
+			},
+		}
+		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockCH.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "terraform.backend.type" {
+				return "s3"
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
+		mockCH.SetFunc = func(_ string, _ any) error { return nil }
+		mocks.KubernetesManager.DeleteBlueprintFunc = func(_ *blueprintv1alpha1.Blueprint, _ string) error {
+			return fmt.Errorf("cluster API unreachable")
+		}
+		mockStack := terraforminfra.NewMockStack()
+		migrateCalled := false
+		destroyAllCalls := 0
+		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyOutcome, error) {
+			destroyAllCalls++
+			return terraforminfra.DestroyOutcome{Destroyed: []string{fmt.Sprintf("pass%d", destroyAllCalls)}}, nil
+		}
+		mockStack.MigrateStateFunc = func(_ *blueprintv1alpha1.Blueprint) ([]string, error) {
+			migrateCalled = true
+			return nil, nil
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{
+			TerraformStack:    mockStack,
+			KubernetesManager: mocks.KubernetesManager,
+		})
+
+		// When Teardown runs the full destroy (terraformOnly=false) with continueOnError=true
+		result, err := provisioner.Teardown(bp, false, true)
+
+		// Then the kustomize failure is recorded, but the tier is NOT deferred —
+		// terraform component failures are the only thing that should defer the tier.
+		if err != nil {
+			t.Fatalf("Expected continueOnError to absorb kustomize failure, got %v", err)
+		}
+		if result.TierDeferred {
+			t.Error("Expected TierDeferred=false when only kustomize failed (kustomize does not depend on terraform state)")
+		}
+		if !migrateCalled {
+			t.Error("Expected MigrateState to run when terraform stage 1 was clean")
+		}
+		if destroyAllCalls != 2 {
+			t.Errorf("Expected Stage 1 + Stage 2 DestroyAll calls (2), got %d", destroyAllCalls)
+		}
+		var foundKustomize bool
+		for _, f := range result.Failed {
+			if f.ID == KustomizeFailureID {
+				foundKustomize = true
+			}
+		}
+		if !foundKustomize {
+			t.Errorf("Expected kustomize failure to remain in result.Failed, got %v", result.Failed)
+		}
+	})
 }
 
 func TestProvisioner_TeardownComponent(t *testing.T) {

--- a/pkg/provisioner/destroy_test.go
+++ b/pkg/provisioner/destroy_test.go
@@ -40,13 +40,13 @@ func TestProvisioner_Teardown(t *testing.T) {
 		}
 		destroyAllCalled := false
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ ...string) ([]string, error) {
+		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyResult, error) {
 			destroyAllCalled = true
-			return nil, nil
+			return terraforminfra.DestroyResult{}, nil
 		}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
 
-		_, err := provisioner.Teardown(bp, true)
+		_, err := provisioner.Teardown(bp, true, false)
 		if err == nil {
 			t.Fatal("Expected error for kubernetes backend without Blueprint.Backend, got nil")
 		}
@@ -82,13 +82,13 @@ func TestProvisioner_Teardown(t *testing.T) {
 		}
 		mockStack := terraforminfra.NewMockStack()
 		destroyAllCalls := 0
-		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ ...string) ([]string, error) {
+		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyResult, error) {
 			destroyAllCalls++
-			return nil, nil
+			return terraforminfra.DestroyResult{}, nil
 		}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
 
-		if _, err := provisioner.Teardown(createTestBlueprint(), true); err != nil {
+		if _, err := provisioner.Teardown(createTestBlueprint(), true, false); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 		if destroyAllCalls != 1 {
@@ -128,9 +128,9 @@ func TestProvisioner_Teardown(t *testing.T) {
 		}
 		mockStack := terraforminfra.NewMockStack()
 		var seenExclude []string
-		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, excludeIDs ...string) ([]string, error) {
+		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) {
 			seenExclude = excludeIDs
-			return nil, nil
+			return terraforminfra.DestroyResult{}, nil
 		}
 		migrateCalled := false
 		mockStack.MigrateStateFunc = func(_ *blueprintv1alpha1.Blueprint) ([]string, error) {
@@ -139,7 +139,7 @@ func TestProvisioner_Teardown(t *testing.T) {
 		}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
 
-		if _, err := provisioner.Teardown(bp, true); err != nil {
+		if _, err := provisioner.Teardown(bp, true, false); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 		if setCalled {
@@ -187,11 +187,11 @@ func TestProvisioner_Teardown(t *testing.T) {
 		var destroyAllBlueprints []*blueprintv1alpha1.Blueprint
 		var destroyAllExcludes [][]string
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(b *blueprintv1alpha1.Blueprint, excludeIDs ...string) ([]string, error) {
+		mockStack.DestroyAllFunc = func(b *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) {
 			ops = append(ops, fmt.Sprintf("destroyAll:exclude=%v", excludeIDs))
 			destroyAllBlueprints = append(destroyAllBlueprints, b)
 			destroyAllExcludes = append(destroyAllExcludes, excludeIDs)
-			return nil, nil
+			return terraforminfra.DestroyResult{}, nil
 		}
 		mockStack.MigrateStateFunc = func(_ *blueprintv1alpha1.Blueprint) ([]string, error) {
 			ops = append(ops, "migrate")
@@ -199,7 +199,7 @@ func TestProvisioner_Teardown(t *testing.T) {
 		}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
 
-		if _, err := provisioner.Teardown(bp, true); err != nil {
+		if _, err := provisioner.Teardown(bp, true, false); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
@@ -259,10 +259,10 @@ func TestProvisioner_Teardown(t *testing.T) {
 		var destroyAllBlueprints []*blueprintv1alpha1.Blueprint
 		var destroyAllExcludes [][]string
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(b *blueprintv1alpha1.Blueprint, excludeIDs ...string) ([]string, error) {
+		mockStack.DestroyAllFunc = func(b *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) {
 			destroyAllBlueprints = append(destroyAllBlueprints, b)
 			destroyAllExcludes = append(destroyAllExcludes, excludeIDs)
-			return nil, nil
+			return terraforminfra.DestroyResult{}, nil
 		}
 		var migrateBlueprints []*blueprintv1alpha1.Blueprint
 		mockStack.MigrateStateFunc = func(b *blueprintv1alpha1.Blueprint) ([]string, error) {
@@ -271,7 +271,7 @@ func TestProvisioner_Teardown(t *testing.T) {
 		}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
 
-		if _, err := provisioner.Teardown(bp, true); err != nil {
+		if _, err := provisioner.Teardown(bp, true, false); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
@@ -326,8 +326,8 @@ func TestProvisioner_Teardown(t *testing.T) {
 			return nil
 		}
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ ...string) ([]string, error) {
-			return nil, fmt.Errorf("non-tier destroy failed")
+		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyResult, error) {
+			return terraforminfra.DestroyResult{}, fmt.Errorf("non-tier destroy failed")
 		}
 		migrateCalled := false
 		mockStack.MigrateStateFunc = func(_ *blueprintv1alpha1.Blueprint) ([]string, error) {
@@ -336,7 +336,7 @@ func TestProvisioner_Teardown(t *testing.T) {
 		}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
 
-		_, err := provisioner.Teardown(bp, true)
+		_, err := provisioner.Teardown(bp, true, false)
 		if err == nil {
 			t.Fatal("Expected error from Stage 1 failure, got nil")
 		}
@@ -385,10 +385,10 @@ func TestProvisioner_Teardown(t *testing.T) {
 		}
 		mockStack := terraforminfra.NewMockStack()
 		destroyAllCalls := 0
-		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ ...string) ([]string, error) {
+		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyResult, error) {
 			destroyAllCalls++
 			ops = append(ops, "destroyAll")
-			return nil, nil
+			return terraforminfra.DestroyResult{}, nil
 		}
 		mockStack.MigrateStateFunc = func(_ *blueprintv1alpha1.Blueprint) ([]string, error) {
 			ops = append(ops, "migrate-fail")
@@ -396,7 +396,7 @@ func TestProvisioner_Teardown(t *testing.T) {
 		}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
 
-		_, err := provisioner.Teardown(bp, true)
+		_, err := provisioner.Teardown(bp, true, false)
 		if err == nil {
 			t.Fatal("Expected error from Stage 2 migration failure, got nil")
 		}
@@ -449,7 +449,7 @@ func TestProvisioner_Teardown(t *testing.T) {
 			return nil
 		}
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ ...string) ([]string, error) { return nil, nil }
+		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyResult, error) { return terraforminfra.DestroyResult{}, nil }
 		mockStack.MigrateStateFunc = func(_ *blueprintv1alpha1.Blueprint) ([]string, error) { return nil, nil }
 
 		r, w, pipeErr := os.Pipe()
@@ -461,7 +461,7 @@ func TestProvisioner_Teardown(t *testing.T) {
 		defer func() { os.Stderr = origStderr }()
 
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
-		_, err := provisioner.Teardown(bp, true)
+		_, err := provisioner.Teardown(bp, true, false)
 
 		w.Close()
 		stderrBytes, _ := io.ReadAll(r)
@@ -505,30 +505,186 @@ func TestProvisioner_Teardown(t *testing.T) {
 		mockCH.SetFunc = func(_ string, _ any) error { return nil }
 		mockStack := terraforminfra.NewMockStack()
 		destroyAllCalls := 0
-		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ ...string) ([]string, error) {
+		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyResult, error) {
 			destroyAllCalls++
 			if destroyAllCalls == 1 {
-				return []string{"gitops"}, nil
+				return terraforminfra.DestroyResult{Skipped: []string{"gitops"}}, nil
 			}
-			return []string{"backend"}, nil
+			return terraforminfra.DestroyResult{Skipped: []string{"backend"}}, nil
 		}
 		mockStack.MigrateStateFunc = func(_ *blueprintv1alpha1.Blueprint) ([]string, error) {
 			return []string{"backend"}, nil
 		}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
 
-		skipped, err := provisioner.Teardown(bp, true)
+		result, err := provisioner.Teardown(bp, true, false)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 		expected := []string{"gitops", "backend"}
-		if len(skipped) != len(expected) {
-			t.Fatalf("Expected %v, got %v", expected, skipped)
+		if len(result.Skipped) != len(expected) {
+			t.Fatalf("Expected %v, got %v", expected, result.Skipped)
 		}
 		for i, want := range expected {
-			if skipped[i] != want {
-				t.Errorf("skipped[%d]: got %q, want %q", i, skipped[i], want)
+			if result.Skipped[i] != want {
+				t.Errorf("skipped[%d]: got %q, want %q", i, result.Skipped[i], want)
 			}
+		}
+	})
+
+	t.Run("ContinueDefersTierWhenNonTierHasFailures", func(t *testing.T) {
+		// Given a blueprint with a backend tier and a non-tier component whose
+		// Stage 1 destroy reported a failure under continueOnError mode
+		mocks := setupProvisionerMocks(t)
+		bp := &blueprintv1alpha1.Blueprint{
+			Backend:  "backend",
+			Metadata: blueprintv1alpha1.Metadata{Name: "test"},
+			TerraformComponents: []blueprintv1alpha1.TerraformComponent{
+				{Path: "backend"},
+				{Path: "cluster"},
+			},
+		}
+		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockCH.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "terraform.backend.type" {
+				return "s3"
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
+		setCalled := false
+		mockCH.SetFunc = func(_ string, _ any) error {
+			setCalled = true
+			return nil
+		}
+		mockStack := terraforminfra.NewMockStack()
+		migrateCalled := false
+		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyResult, error) {
+			return terraforminfra.DestroyResult{
+				Failed: []terraforminfra.ComponentFailure{{ID: "cluster", Err: fmt.Errorf("cluster destroy failed")}},
+			}, nil
+		}
+		mockStack.MigrateStateFunc = func(_ *blueprintv1alpha1.Blueprint) ([]string, error) {
+			migrateCalled = true
+			return nil, nil
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+
+		// When Teardown runs with continueOnError=true
+		result, err := provisioner.Teardown(bp, true, true)
+
+		// Then no error is returned (failure is collected), the tier is deferred,
+		// and Stage 2 backend migration never engages
+		if err != nil {
+			t.Fatalf("Expected continueOnError to absorb per-component failure, got %v", err)
+		}
+		if !result.TierDeferred {
+			t.Error("Expected TierDeferred=true when non-tier destroy left a failure")
+		}
+		if len(result.Failed) != 1 || result.Failed[0].ID != "cluster" {
+			t.Errorf("Expected failures to include cluster, got %v", result.Failed)
+		}
+		if migrateCalled {
+			t.Error("MigrateState must not run when non-tier failures left the tier deferred")
+		}
+		if setCalled {
+			t.Error("Backend override must not engage when tier is deferred")
+		}
+	})
+
+	t.Run("ContinueAttemptsTierWhenStage1Clean", func(t *testing.T) {
+		// Given a Stage 1 destroy that completes with zero failures
+		mocks := setupProvisionerMocks(t)
+		bp := &blueprintv1alpha1.Blueprint{
+			Backend:  "backend",
+			Metadata: blueprintv1alpha1.Metadata{Name: "test"},
+			TerraformComponents: []blueprintv1alpha1.TerraformComponent{
+				{Path: "backend"},
+				{Path: "cluster"},
+			},
+		}
+		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockCH.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "terraform.backend.type" {
+				return "s3"
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
+		mockCH.SetFunc = func(_ string, _ any) error { return nil }
+		mockStack := terraforminfra.NewMockStack()
+		migrateCalled := false
+		destroyAllCalls := 0
+		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyResult, error) {
+			destroyAllCalls++
+			return terraforminfra.DestroyResult{Destroyed: []string{fmt.Sprintf("pass%d", destroyAllCalls)}}, nil
+		}
+		mockStack.MigrateStateFunc = func(_ *blueprintv1alpha1.Blueprint) ([]string, error) {
+			migrateCalled = true
+			return nil, nil
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+
+		// When Teardown runs with continueOnError=true
+		result, err := provisioner.Teardown(bp, true, true)
+
+		// Then the backend tier is attempted (Stage 2 runs) and TierDeferred stays false
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if result.TierDeferred {
+			t.Error("Expected TierDeferred=false when Stage 1 was clean")
+		}
+		if !migrateCalled {
+			t.Error("Expected MigrateState to run when Stage 1 produced no failures")
+		}
+		if destroyAllCalls != 2 {
+			t.Errorf("Expected Stage 1 + Stage 2 DestroyAll calls (2), got %d", destroyAllCalls)
+		}
+	})
+
+	t.Run("ContinueCollectsLocalBackendFailures", func(t *testing.T) {
+		// Given a local backend (no tier) and a stack that reports per-component
+		// failures via DestroyResult.Failed in continueOnError mode
+		mocks := setupProvisionerMocks(t)
+		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockCH.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "terraform.backend.type" {
+				return "local"
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
+		mockStack := terraforminfra.NewMockStack()
+		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, continueOnError bool, _ ...string) (terraforminfra.DestroyResult, error) {
+			if !continueOnError {
+				t.Error("Expected continueOnError=true to be propagated to stack")
+			}
+			return terraforminfra.DestroyResult{
+				Destroyed: []string{"vpc"},
+				Failed:    []terraforminfra.ComponentFailure{{ID: "iam", Err: fmt.Errorf("permission denied")}},
+			}, nil
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+
+		// When Teardown runs with continueOnError=true
+		result, err := provisioner.Teardown(createTestBlueprint(), true, true)
+
+		// Then per-component failures surface in result.Failed without aborting
+		if err != nil {
+			t.Fatalf("Expected continueOnError to absorb per-component failure, got %v", err)
+		}
+		if len(result.Failed) != 1 || result.Failed[0].ID != "iam" {
+			t.Errorf("Expected failure list to contain iam, got %v", result.Failed)
+		}
+		if len(result.Destroyed) != 1 || result.Destroyed[0] != "vpc" {
+			t.Errorf("Expected Destroyed=[vpc], got %v", result.Destroyed)
 		}
 	})
 }

--- a/pkg/provisioner/flux/stack.go
+++ b/pkg/provisioner/flux/stack.go
@@ -309,7 +309,7 @@ func (s *FluxStack) PlanDestroySummary(blueprint *blueprintv1alpha1.Blueprint) (
 
 	var results []KustomizePlan
 	for _, k := range blueprint.Kustomizations {
-		if !kustomizationDestroyEligible(k) {
+		if !KustomizationDestroyEligible(k) {
 			continue
 		}
 		result, err := s.planOneKustomizeDestroySummary(k, namespace)
@@ -351,27 +351,6 @@ func (s *FluxStack) PlanDestroyComponentSummary(blueprint *blueprintv1alpha1.Blu
 		resolved.Err = err
 	}
 	return resolved
-}
-
-// kustomizationDestroyEligible mirrors the gate inside DeleteBlueprint so the
-// destroy-plan set matches the destroy-execute set. DestroyOnly kustomizations
-// are skipped (they're hooks applied during destroy, not user-visible
-// resources to preview), and any pinned destroy=false are skipped. The
-// explicit nil check on Destroy mirrors componentDestroyEnabled on the
-// terraform side: ToBool happens to handle a nil receiver today, but the
-// guard reads more clearly at the call site and survives future refactors of
-// ToBool without breakage.
-func kustomizationDestroyEligible(k blueprintv1alpha1.Kustomization) bool {
-	if k.DestroyOnly != nil && *k.DestroyOnly {
-		return false
-	}
-	if k.Destroy == nil {
-		return true
-	}
-	if d := k.Destroy.ToBool(); d != nil && !*d {
-		return false
-	}
-	return true
 }
 
 // planOneKustomizeDestroySummary computes the destroy preview for one
@@ -962,4 +941,29 @@ func findKustomization(blueprint *blueprintv1alpha1.Blueprint, name string) (blu
 		}
 	}
 	return blueprintv1alpha1.Kustomization{}, false
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+// KustomizationDestroyEligible mirrors the gate inside DeleteBlueprint so the
+// destroy-plan set matches the destroy-execute set. DestroyOnly kustomizations
+// are skipped (they're hooks applied during destroy, not user-visible
+// resources to preview), and any pinned destroy=false are skipped. The
+// explicit nil check on Destroy mirrors componentDestroyEnabled on the
+// terraform side: ToBool happens to handle a nil receiver today, but the
+// guard reads more clearly at the call site and survives future refactors of
+// ToBool without breakage.
+func KustomizationDestroyEligible(k blueprintv1alpha1.Kustomization) bool {
+	if k.DestroyOnly != nil && *k.DestroyOnly {
+		return false
+	}
+	if k.Destroy == nil {
+		return true
+	}
+	if d := k.Destroy.ToBool(); d != nil && !*d {
+		return false
+	}
+	return true
 }

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -494,6 +494,12 @@ func (i *Provisioner) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continu
 				return result, err
 			}
 			result.Failed = append(result.Failed, ComponentFailure{ID: "kustomize", Err: err})
+		} else {
+			for _, k := range blueprint.Kustomizations {
+				if fluxinfra.KustomizationDestroyEligible(k) {
+					result.Destroyed = append(result.Destroyed, k.Name)
+				}
+			}
 		}
 	}
 

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -375,21 +375,22 @@ func (i *Provisioner) Down(blueprint *blueprintv1alpha1.Blueprint) error {
 // applied, fully torn down already, or upstream destroy collapsed their cloud objects out from
 // under them); cmd-layer callers surface them in the user-facing summary so an operator can see
 // "these were no-ops" alongside "these were destroyed".
-func (i *Provisioner) DestroyAllTerraform(blueprint *blueprintv1alpha1.Blueprint, excludeIDs ...string) ([]string, error) {
+func (i *Provisioner) DestroyAllTerraform(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) {
+	var result terraforminfra.DestroyResult
 	if blueprint == nil {
-		return nil, fmt.Errorf("blueprint not provided")
+		return result, fmt.Errorf("blueprint not provided")
 	}
 	if err := i.ensureTerraformStack(); err != nil {
-		return nil, err
+		return result, err
 	}
 	if i.TerraformStack == nil {
-		return nil, fmt.Errorf("terraform is disabled")
+		return result, fmt.Errorf("terraform is disabled")
 	}
-	skipped, err := i.TerraformStack.DestroyAll(blueprint, excludeIDs...)
+	result, err := i.TerraformStack.DestroyAll(blueprint, continueOnError, excludeIDs...)
 	if err != nil {
-		return skipped, fmt.Errorf("failed to run terraform destroy: %w", err)
+		return result, fmt.Errorf("failed to run terraform destroy: %w", err)
 	}
-	return skipped, nil
+	return result, nil
 }
 
 // Apply runs terraform init, plan, and apply for a single component identified by componentID.
@@ -478,30 +479,35 @@ func (i *Provisioner) DestroyKustomize(blueprint *blueprintv1alpha1.Blueprint, c
 // was empty (never applied, already torn down) alongside any error from either step —
 // paired with the error so callers see what was no-op'd even when a later step fails.
 // Returns an error if either step fails.
-func (i *Provisioner) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, excludeIDs ...string) ([]string, error) {
+func (i *Provisioner) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) {
+	var result terraforminfra.DestroyResult
 	if blueprint == nil {
-		return nil, fmt.Errorf("blueprint not provided")
+		return result, fmt.Errorf("blueprint not provided")
 	}
 
 	if i.KubernetesManager != nil && i.kubeconfigPresent() {
 		if err := i.Uninstall(blueprint); err != nil {
-			return nil, err
+			if !continueOnError {
+				return result, err
+			}
+			result.Failed = append(result.Failed, terraforminfra.ComponentFailure{ID: "kustomize", Err: err})
 		}
 	}
 
 	if err := i.ensureTerraformStack(); err != nil {
-		return nil, err
+		return result, err
 	}
-	var skipped []string
 	if i.TerraformStack != nil {
-		s, err := i.TerraformStack.DestroyAll(blueprint, excludeIDs...)
-		skipped = s
+		tfResult, err := i.TerraformStack.DestroyAll(blueprint, continueOnError, excludeIDs...)
+		result.Destroyed = append(result.Destroyed, tfResult.Destroyed...)
+		result.Skipped = append(result.Skipped, tfResult.Skipped...)
+		result.Failed = append(result.Failed, tfResult.Failed...)
 		if err != nil {
-			return skipped, fmt.Errorf("failed to run terraform destroy: %w", err)
+			return result, fmt.Errorf("failed to run terraform destroy: %w", err)
 		}
 	}
 
-	return skipped, nil
+	return result, nil
 }
 
 // Plan runs terraform init and plan for a single component identified by componentID.

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -375,8 +375,8 @@ func (i *Provisioner) Down(blueprint *blueprintv1alpha1.Blueprint) error {
 // applied, fully torn down already, or upstream destroy collapsed their cloud objects out from
 // under them); cmd-layer callers surface them in the user-facing summary so an operator can see
 // "these were no-ops" alongside "these were destroyed".
-func (i *Provisioner) DestroyAllTerraform(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) {
-	var result terraforminfra.DestroyResult
+func (i *Provisioner) DestroyAllTerraform(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyResult, error) {
+	var result DestroyResult
 	if blueprint == nil {
 		return result, fmt.Errorf("blueprint not provided")
 	}
@@ -386,7 +386,10 @@ func (i *Provisioner) DestroyAllTerraform(blueprint *blueprintv1alpha1.Blueprint
 	if i.TerraformStack == nil {
 		return result, fmt.Errorf("terraform is disabled")
 	}
-	result, err := i.TerraformStack.DestroyAll(blueprint, continueOnError, excludeIDs...)
+	outcome, err := i.TerraformStack.DestroyAll(blueprint, continueOnError, excludeIDs...)
+	result.Destroyed = outcome.Destroyed
+	result.Skipped = outcome.Skipped
+	result.Failed = outcome.Failed
 	if err != nil {
 		return result, fmt.Errorf("failed to run terraform destroy: %w", err)
 	}
@@ -479,8 +482,8 @@ func (i *Provisioner) DestroyKustomize(blueprint *blueprintv1alpha1.Blueprint, c
 // was empty (never applied, already torn down) alongside any error from either step —
 // paired with the error so callers see what was no-op'd even when a later step fails.
 // Returns an error if either step fails.
-func (i *Provisioner) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) {
-	var result terraforminfra.DestroyResult
+func (i *Provisioner) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyResult, error) {
+	var result DestroyResult
 	if blueprint == nil {
 		return result, fmt.Errorf("blueprint not provided")
 	}
@@ -490,7 +493,7 @@ func (i *Provisioner) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continu
 			if !continueOnError {
 				return result, err
 			}
-			result.Failed = append(result.Failed, terraforminfra.ComponentFailure{ID: "kustomize", Err: err})
+			result.Failed = append(result.Failed, ComponentFailure{ID: "kustomize", Err: err})
 		}
 	}
 
@@ -498,10 +501,10 @@ func (i *Provisioner) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continu
 		return result, err
 	}
 	if i.TerraformStack != nil {
-		tfResult, err := i.TerraformStack.DestroyAll(blueprint, continueOnError, excludeIDs...)
-		result.Destroyed = append(result.Destroyed, tfResult.Destroyed...)
-		result.Skipped = append(result.Skipped, tfResult.Skipped...)
-		result.Failed = append(result.Failed, tfResult.Failed...)
+		outcome, err := i.TerraformStack.DestroyAll(blueprint, continueOnError, excludeIDs...)
+		result.Destroyed = append(result.Destroyed, outcome.Destroyed...)
+		result.Skipped = append(result.Skipped, outcome.Skipped...)
+		result.Failed = append(result.Failed, outcome.Failed...)
 		if err != nil {
 			return result, fmt.Errorf("failed to run terraform destroy: %w", err)
 		}

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -493,7 +493,7 @@ func (i *Provisioner) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continu
 			if !continueOnError {
 				return result, err
 			}
-			result.Failed = append(result.Failed, ComponentFailure{ID: "kustomize", Err: err})
+			result.Failed = append(result.Failed, ComponentFailure{ID: KustomizeFailureID, Err: err})
 		} else {
 			for _, k := range blueprint.Kustomizations {
 				if fluxinfra.KustomizationDestroyEligible(k) {

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -135,7 +135,7 @@ func setupProvisionerMocks(t *testing.T, opts ...func(*ProvisionerTestMocks)) *P
 
 	terraformStack := terraforminfra.NewMockStack()
 	terraformStack.UpFunc = func(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(id string) (bool, error)) (bool, error) { return false, nil }
-	terraformStack.DestroyAllFunc = func(blueprint *blueprintv1alpha1.Blueprint, excludeIDs ...string) ([]string, error) { return nil, nil }
+	terraformStack.DestroyAllFunc = func(blueprint *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) { return terraforminfra.DestroyResult{}, nil }
 
 	fluxStack := fluxinfra.NewMockStack()
 
@@ -726,11 +726,11 @@ func TestProvisioner_DestroyAllTerraform(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, excludeIDs ...string) ([]string, error) { return nil, nil }
+		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) { return terraforminfra.DestroyResult{}, nil }
 		opts := &Provisioner{TerraformStack: mockStack}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
-		_, err := provisioner.DestroyAllTerraform(createTestBlueprint())
+		_, err := provisioner.DestroyAllTerraform(createTestBlueprint(), false)
 
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)
@@ -741,7 +741,7 @@ func TestProvisioner_DestroyAllTerraform(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler)
 
-		_, err := provisioner.DestroyAllTerraform(nil)
+		_, err := provisioner.DestroyAllTerraform(nil, false)
 
 		if err == nil {
 			t.Error("Expected error for nil blueprint")
@@ -765,7 +765,7 @@ func TestProvisioner_DestroyAllTerraform(t *testing.T) {
 		}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler)
 
-		_, err := provisioner.DestroyAllTerraform(createTestBlueprint())
+		_, err := provisioner.DestroyAllTerraform(createTestBlueprint(), false)
 
 		if err == nil {
 			t.Error("Expected error when terraform is disabled")
@@ -778,13 +778,13 @@ func TestProvisioner_DestroyAllTerraform(t *testing.T) {
 	t.Run("ErrorDestroyAllFails", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, excludeIDs ...string) ([]string, error) {
-			return nil, fmt.Errorf("terraform destroy all failed")
+		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) {
+			return terraforminfra.DestroyResult{}, fmt.Errorf("terraform destroy all failed")
 		}
 		opts := &Provisioner{TerraformStack: mockStack}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
-		_, err := provisioner.DestroyAllTerraform(createTestBlueprint())
+		_, err := provisioner.DestroyAllTerraform(createTestBlueprint(), false)
 
 		if err == nil {
 			t.Error("Expected error for terraform destroy all failure")
@@ -1733,11 +1733,11 @@ func TestProvisioner_DestroyAll(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
 		mocks.KubernetesManager.DeleteBlueprintFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) error { return nil }
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, excludeIDs ...string) ([]string, error) { return nil, nil }
+		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) { return terraforminfra.DestroyResult{}, nil }
 		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
-		_, err := provisioner.DestroyAll(createTestBlueprint())
+		_, err := provisioner.DestroyAll(createTestBlueprint(), false)
 
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)
@@ -1747,12 +1747,12 @@ func TestProvisioner_DestroyAll(t *testing.T) {
 	t.Run("SuccessNoKubernetesManager", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, excludeIDs ...string) ([]string, error) { return nil, nil }
+		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) { return terraforminfra.DestroyResult{}, nil }
 		opts := &Provisioner{TerraformStack: mockStack}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 		provisioner.KubernetesManager = nil
 
-		_, err := provisioner.DestroyAll(createTestBlueprint())
+		_, err := provisioner.DestroyAll(createTestBlueprint(), false)
 
 		if err != nil {
 			t.Errorf("Expected no error when kubernetes manager is nil, got: %v", err)
@@ -1763,7 +1763,7 @@ func TestProvisioner_DestroyAll(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler)
 
-		_, err := provisioner.DestroyAll(nil)
+		_, err := provisioner.DestroyAll(nil, false)
 
 		if err == nil {
 			t.Error("Expected error for nil blueprint")
@@ -1781,7 +1781,7 @@ func TestProvisioner_DestroyAll(t *testing.T) {
 		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
-		_, err := provisioner.DestroyAll(createTestBlueprint())
+		_, err := provisioner.DestroyAll(createTestBlueprint(), false)
 
 		if err == nil {
 			t.Error("Expected error when uninstall fails")
@@ -1795,13 +1795,13 @@ func TestProvisioner_DestroyAll(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
 		mocks.KubernetesManager.DeleteBlueprintFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) error { return nil }
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, excludeIDs ...string) ([]string, error) {
-			return nil, fmt.Errorf("terraform down failed")
+		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) {
+			return terraforminfra.DestroyResult{}, fmt.Errorf("terraform down failed")
 		}
 		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
-		_, err := provisioner.DestroyAll(createTestBlueprint())
+		_, err := provisioner.DestroyAll(createTestBlueprint(), false)
 
 		if err == nil {
 			t.Error("Expected error when terraform down fails")
@@ -1827,14 +1827,14 @@ func TestProvisioner_DestroyAll(t *testing.T) {
 			return nil
 		}
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, excludeIDs ...string) ([]string, error) {
+		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) {
 			terraformDestroyCalled = true
-			return nil, nil
+			return terraforminfra.DestroyResult{}, nil
 		}
 		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
-		_, err := provisioner.DestroyAll(createTestBlueprint())
+		_, err := provisioner.DestroyAll(createTestBlueprint(), false)
 		if err != nil {
 			t.Fatalf("expected no error when kubeconfig missing, got: %v", err)
 		}
@@ -1857,11 +1857,11 @@ func TestProvisioner_DestroyAll(t *testing.T) {
 			return nil
 		}
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, excludeIDs ...string) ([]string, error) { return nil, nil }
+		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) { return terraforminfra.DestroyResult{}, nil }
 		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
-		if _, err := provisioner.DestroyAll(createTestBlueprint()); err != nil {
+		if _, err := provisioner.DestroyAll(createTestBlueprint(), false); err != nil {
 			t.Fatalf("expected no error, got: %v", err)
 		}
 		if !uninstallCalled {

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -135,7 +135,7 @@ func setupProvisionerMocks(t *testing.T, opts ...func(*ProvisionerTestMocks)) *P
 
 	terraformStack := terraforminfra.NewMockStack()
 	terraformStack.UpFunc = func(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(id string) (bool, error)) (bool, error) { return false, nil }
-	terraformStack.DestroyAllFunc = func(blueprint *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) { return terraforminfra.DestroyResult{}, nil }
+	terraformStack.DestroyAllFunc = func(blueprint *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) { return terraforminfra.DestroyOutcome{}, nil }
 
 	fluxStack := fluxinfra.NewMockStack()
 
@@ -726,7 +726,7 @@ func TestProvisioner_DestroyAllTerraform(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) { return terraforminfra.DestroyResult{}, nil }
+		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) { return terraforminfra.DestroyOutcome{}, nil }
 		opts := &Provisioner{TerraformStack: mockStack}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
@@ -778,8 +778,8 @@ func TestProvisioner_DestroyAllTerraform(t *testing.T) {
 	t.Run("ErrorDestroyAllFails", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) {
-			return terraforminfra.DestroyResult{}, fmt.Errorf("terraform destroy all failed")
+		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) {
+			return terraforminfra.DestroyOutcome{}, fmt.Errorf("terraform destroy all failed")
 		}
 		opts := &Provisioner{TerraformStack: mockStack}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
@@ -1733,7 +1733,7 @@ func TestProvisioner_DestroyAll(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
 		mocks.KubernetesManager.DeleteBlueprintFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) error { return nil }
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) { return terraforminfra.DestroyResult{}, nil }
+		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) { return terraforminfra.DestroyOutcome{}, nil }
 		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
@@ -1747,7 +1747,7 @@ func TestProvisioner_DestroyAll(t *testing.T) {
 	t.Run("SuccessNoKubernetesManager", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) { return terraforminfra.DestroyResult{}, nil }
+		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) { return terraforminfra.DestroyOutcome{}, nil }
 		opts := &Provisioner{TerraformStack: mockStack}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 		provisioner.KubernetesManager = nil
@@ -1795,8 +1795,8 @@ func TestProvisioner_DestroyAll(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
 		mocks.KubernetesManager.DeleteBlueprintFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) error { return nil }
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) {
-			return terraforminfra.DestroyResult{}, fmt.Errorf("terraform down failed")
+		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) {
+			return terraforminfra.DestroyOutcome{}, fmt.Errorf("terraform down failed")
 		}
 		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
@@ -1827,9 +1827,9 @@ func TestProvisioner_DestroyAll(t *testing.T) {
 			return nil
 		}
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) {
+		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) {
 			terraformDestroyCalled = true
-			return terraforminfra.DestroyResult{}, nil
+			return terraforminfra.DestroyOutcome{}, nil
 		}
 		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
@@ -1857,7 +1857,7 @@ func TestProvisioner_DestroyAll(t *testing.T) {
 			return nil
 		}
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyResult, error) { return terraforminfra.DestroyResult{}, nil }
+		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) { return terraforminfra.DestroyOutcome{}, nil }
 		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -1868,6 +1868,84 @@ func TestProvisioner_DestroyAll(t *testing.T) {
 			t.Error("expected DeleteBlueprint to run when kubeconfig is present")
 		}
 	})
+
+	t.Run("CountsEligibleKustomizationsInDestroyedOnSuccess", func(t *testing.T) {
+		// Given a blueprint with multiple eligible kustomizations and a successful Uninstall
+		mocks := setupProvisionerMocks(t)
+		bp := &blueprintv1alpha1.Blueprint{
+			Metadata: blueprintv1alpha1.Metadata{Name: "test"},
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "dns"},
+				{Name: "ingress"},
+				{Name: "cert-manager"},
+			},
+		}
+		mocks.KubernetesManager.DeleteBlueprintFunc = func(_ *blueprintv1alpha1.Blueprint, _ string) error { return nil }
+		mockStack := terraforminfra.NewMockStack()
+		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyOutcome, error) {
+			return terraforminfra.DestroyOutcome{}, nil
+		}
+		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
+
+		// When DestroyAll runs and Uninstall succeeds
+		result, err := provisioner.DestroyAll(bp, false)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then each eligible kustomization name appears in result.Destroyed so the
+		// summary count reflects the work that actually happened (not zero, as it did
+		// before — undercounting on mixed kustomize+terraform contexts).
+		want := map[string]bool{"dns": false, "ingress": false, "cert-manager": false}
+		for _, name := range result.Destroyed {
+			if _, ok := want[name]; ok {
+				want[name] = true
+			}
+		}
+		for name, seen := range want {
+			if !seen {
+				t.Errorf("Expected kustomization %q in result.Destroyed, got %v", name, result.Destroyed)
+			}
+		}
+	})
+
+	t.Run("SkipsIneligibleKustomizationsFromDestroyedCount", func(t *testing.T) {
+		// Given a blueprint with three kustomizations: one eligible, one pinned
+		// Destroy=false, and one DestroyOnly=true — DeleteBlueprint would only
+		// process the eligible one, so the count must match.
+		mocks := setupProvisionerMocks(t)
+		destroyFalse := false
+		destroyOnly := true
+		bp := &blueprintv1alpha1.Blueprint{
+			Metadata: blueprintv1alpha1.Metadata{Name: "test"},
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "dns"},
+				{Name: "keep-me", Destroy: &blueprintv1alpha1.BoolExpression{Value: &destroyFalse, IsExpr: false}},
+				{Name: "hook-only", DestroyOnly: &destroyOnly},
+			},
+		}
+		mocks.KubernetesManager.DeleteBlueprintFunc = func(_ *blueprintv1alpha1.Blueprint, _ string) error { return nil }
+		mockStack := terraforminfra.NewMockStack()
+		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyOutcome, error) {
+			return terraforminfra.DestroyOutcome{}, nil
+		}
+		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
+
+		// When DestroyAll runs
+		result, err := provisioner.DestroyAll(bp, false)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then only the eligible kustomization name appears in result.Destroyed;
+		// the pinned-skip and destroy-only entries are excluded to mirror what
+		// DeleteBlueprint actually processes.
+		if len(result.Destroyed) != 1 || result.Destroyed[0] != "dns" {
+			t.Errorf("Expected result.Destroyed=[dns], got %v", result.Destroyed)
+		}
+	})
 }
 
 func TestProvisioner_Close(t *testing.T) {

--- a/pkg/provisioner/terraform/mock_stack.go
+++ b/pkg/provisioner/terraform/mock_stack.go
@@ -23,7 +23,7 @@ type MockStack struct {
 	InitComponentFunc              func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
 	RemoveLocalStateFunc           func(componentID string) error
 	PostApplyFunc             func(fns ...func(id string) error)
-	DestroyAllFunc            func(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyResult, error)
+	DestroyAllFunc            func(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyOutcome, error)
 	PlanFunc                  func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
 	PlanAllFunc               func(blueprint *blueprintv1alpha1.Blueprint) error
 	PlanJSONFunc              func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
@@ -113,11 +113,11 @@ func (m *MockStack) PostApply(fns ...func(id string) error) {
 }
 
 // DestroyAll is a mock implementation of the DestroyAll method.
-func (m *MockStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyResult, error) {
+func (m *MockStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyOutcome, error) {
 	if m.DestroyAllFunc != nil {
 		return m.DestroyAllFunc(blueprint, continueOnError, excludeIDs...)
 	}
-	return DestroyResult{}, nil
+	return DestroyOutcome{}, nil
 }
 
 // Plan is a mock implementation of the Plan method.

--- a/pkg/provisioner/terraform/mock_stack.go
+++ b/pkg/provisioner/terraform/mock_stack.go
@@ -23,7 +23,7 @@ type MockStack struct {
 	InitComponentFunc              func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
 	RemoveLocalStateFunc           func(componentID string) error
 	PostApplyFunc             func(fns ...func(id string) error)
-	DestroyAllFunc            func(blueprint *blueprintv1alpha1.Blueprint, excludeIDs ...string) ([]string, error)
+	DestroyAllFunc            func(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyResult, error)
 	PlanFunc                  func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
 	PlanAllFunc               func(blueprint *blueprintv1alpha1.Blueprint) error
 	PlanJSONFunc              func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
@@ -113,11 +113,11 @@ func (m *MockStack) PostApply(fns ...func(id string) error) {
 }
 
 // DestroyAll is a mock implementation of the DestroyAll method.
-func (m *MockStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, excludeIDs ...string) ([]string, error) {
+func (m *MockStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyResult, error) {
 	if m.DestroyAllFunc != nil {
-		return m.DestroyAllFunc(blueprint, excludeIDs...)
+		return m.DestroyAllFunc(blueprint, continueOnError, excludeIDs...)
 	}
-	return nil, nil
+	return DestroyResult{}, nil
 }
 
 // Plan is a mock implementation of the Plan method.

--- a/pkg/provisioner/terraform/mock_stack_test.go
+++ b/pkg/provisioner/terraform/mock_stack_test.go
@@ -57,13 +57,13 @@ func TestMockStack_DestroyAll(t *testing.T) {
 	t.Run("WithFuncSet", func(t *testing.T) {
 		// Given a new MockStack with a custom DestroyAllFunc that returns an error
 		mock := NewMockStack()
-		mock.DestroyAllFunc = func(blueprint *blueprintv1alpha1.Blueprint, excludeIDs ...string) ([]string, error) {
-			return nil, mockDownErr
+		mock.DestroyAllFunc = func(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyResult, error) {
+			return DestroyResult{}, mockDownErr
 		}
 
 		// When Down is called
 		blueprint := &blueprintv1alpha1.Blueprint{}
-		_, err := mock.DestroyAll(blueprint)
+		_, err := mock.DestroyAll(blueprint, false)
 
 		// Then the custom error should be returned
 		if err != mockDownErr {
@@ -77,7 +77,7 @@ func TestMockStack_DestroyAll(t *testing.T) {
 
 		// When Down is called
 		blueprint := &blueprintv1alpha1.Blueprint{}
-		_, err := mock.DestroyAll(blueprint)
+		_, err := mock.DestroyAll(blueprint, false)
 
 		// Then no error should be returned
 		if err != nil {

--- a/pkg/provisioner/terraform/mock_stack_test.go
+++ b/pkg/provisioner/terraform/mock_stack_test.go
@@ -57,8 +57,8 @@ func TestMockStack_DestroyAll(t *testing.T) {
 	t.Run("WithFuncSet", func(t *testing.T) {
 		// Given a new MockStack with a custom DestroyAllFunc that returns an error
 		mock := NewMockStack()
-		mock.DestroyAllFunc = func(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyResult, error) {
-			return DestroyResult{}, mockDownErr
+		mock.DestroyAllFunc = func(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyOutcome, error) {
+			return DestroyOutcome{}, mockDownErr
 		}
 
 		// When Down is called

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -157,6 +157,27 @@ type tfState struct {
 	} `json:"values"`
 }
 
+// ComponentFailure is a per-component error captured during continue-on-error
+// destroy. ID is the terraform component's blueprint identifier; Err is the
+// terraform destroy error that the operator can use to diagnose.
+type ComponentFailure struct {
+	ID  string
+	Err error
+}
+
+// DestroyResult tallies the outcome of a destroy pass. Destroyed lists
+// component IDs whose terraform destroy ran to completion. Skipped lists
+// component IDs whose state was empty (no-op). Failed lists per-component
+// failures from continue-on-error mode. TierDeferred is true when the backend
+// tier was not attempted because the non-tier pass left at least one
+// destroy unresolved.
+type DestroyResult struct {
+	Destroyed    []string
+	Skipped      []string
+	Failed       []ComponentFailure
+	TierDeferred bool
+}
+
 // =============================================================================
 // Interfaces
 // =============================================================================
@@ -178,7 +199,7 @@ type Stack interface {
 	InitComponent(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
 	RemoveLocalState(componentID string) error
 	PostApply(fns ...func(id string) error)
-	DestroyAll(blueprint *blueprintv1alpha1.Blueprint, excludeIDs ...string) ([]string, error)
+	DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyResult, error)
 	Plan(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
 	PlanAll(blueprint *blueprintv1alpha1.Blueprint) error
 	PlanJSON(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
@@ -538,15 +559,18 @@ func (s *TerraformStack) MigrateComponentState(blueprint *blueprintv1alpha1.Blue
 // the rest when state is empty at either check. Components with Destroy=false are skipped.
 // excludeIDs are skipped entirely (used by symmetric-destroy flow at the cmd layer to peel
 // off the backend component from the bulk pass — it gets destroyed last, after its state
-// is migrated to local). Returns IDs skipped due to empty state, paired with any error.
-func (s *TerraformStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, excludeIDs ...string) ([]string, error) {
+// is migrated to local). When continueOnError is true, per-component destroy errors are
+// collected in DestroyResult.Failed and the loop proceeds to the next component; when
+// false, the first error aborts and is returned alongside a partial DestroyResult.
+func (s *TerraformStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyResult, error) {
+	var result DestroyResult
 	if blueprint == nil {
-		return nil, fmt.Errorf("blueprint not provided")
+		return result, fmt.Errorf("blueprint not provided")
 	}
 
 	currentDir, err := s.shims.Getwd()
 	if err != nil {
-		return nil, fmt.Errorf("error getting current directory: %v", err)
+		return result, fmt.Errorf("error getting current directory: %v", err)
 	}
 
 	defer func() {
@@ -555,7 +579,7 @@ func (s *TerraformStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, excl
 
 	projectRoot := s.runtime.ProjectRoot
 	if projectRoot == "" {
-		return nil, fmt.Errorf("error getting project root: project root is empty")
+		return result, fmt.Errorf("error getting project root: project root is empty")
 	}
 	components := s.resolveTerraformComponents(blueprint, projectRoot)
 
@@ -571,7 +595,6 @@ func (s *TerraformStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, excl
 		}
 	}()
 
-	var skipped []string
 	for i := len(components) - 1; i >= 0; i-- {
 		component := components[i]
 
@@ -587,7 +610,7 @@ func (s *TerraformStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, excl
 		}
 
 		if _, err := s.shims.Stat(component.FullPath); os.IsNotExist(err) {
-			skipped = append(skipped, component.GetID())
+			result.Skipped = append(result.Skipped, component.GetID())
 			continue
 		}
 
@@ -597,7 +620,7 @@ func (s *TerraformStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, excl
 			backendOverridePaths = append(backendOverridePaths, backendOverridePath)
 		}
 		if err != nil {
-			return skipped, err
+			return result, err
 		}
 
 		componentSkipped := false
@@ -670,15 +693,22 @@ func (s *TerraformStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, excl
 			}
 			return nil
 		}); err != nil {
-			return skipped, err
+			if continueOnError {
+				result.Failed = append(result.Failed, ComponentFailure{ID: component.GetID(), Err: err})
+				s.clearBackendPointer(terraformVars)
+				continue
+			}
+			return result, err
 		}
 		if componentSkipped {
-			skipped = append(skipped, component.GetID())
+			result.Skipped = append(result.Skipped, component.GetID())
+		} else {
+			result.Destroyed = append(result.Destroyed, component.GetID())
 		}
 		s.clearBackendPointer(terraformVars)
 	}
 
-	return skipped, nil
+	return result, nil
 }
 
 // Plan runs terraform init and plan for a single component identified by componentID.

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -165,17 +165,16 @@ type ComponentFailure struct {
 	Err error
 }
 
-// DestroyResult tallies the outcome of a destroy pass. Destroyed lists
-// component IDs whose terraform destroy ran to completion. Skipped lists
-// component IDs whose state was empty (no-op). Failed lists per-component
-// failures from continue-on-error mode. TierDeferred is true when the backend
-// tier was not attempted because the non-tier pass left at least one
-// destroy unresolved.
-type DestroyResult struct {
-	Destroyed    []string
-	Skipped      []string
-	Failed       []ComponentFailure
-	TierDeferred bool
+// DestroyOutcome tallies what a single terraform destroy pass produced.
+// Destroyed lists component IDs whose terraform destroy ran to completion;
+// Skipped lists component IDs whose state was empty (no-op); Failed lists
+// per-component failures collected when continue-on-error is true. Aggregate
+// cross-layer concerns (backend-tier deferral, kustomize counts) live on the
+// provisioner-layer result type, not here.
+type DestroyOutcome struct {
+	Destroyed []string
+	Skipped   []string
+	Failed    []ComponentFailure
 }
 
 // =============================================================================
@@ -199,7 +198,7 @@ type Stack interface {
 	InitComponent(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
 	RemoveLocalState(componentID string) error
 	PostApply(fns ...func(id string) error)
-	DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyResult, error)
+	DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyOutcome, error)
 	Plan(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
 	PlanAll(blueprint *blueprintv1alpha1.Blueprint) error
 	PlanJSON(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
@@ -560,10 +559,10 @@ func (s *TerraformStack) MigrateComponentState(blueprint *blueprintv1alpha1.Blue
 // excludeIDs are skipped entirely (used by symmetric-destroy flow at the cmd layer to peel
 // off the backend component from the bulk pass — it gets destroyed last, after its state
 // is migrated to local). When continueOnError is true, per-component destroy errors are
-// collected in DestroyResult.Failed and the loop proceeds to the next component; when
-// false, the first error aborts and is returned alongside a partial DestroyResult.
-func (s *TerraformStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyResult, error) {
-	var result DestroyResult
+// collected in DestroyOutcome.Failed and the loop proceeds to the next component; when
+// false, the first error aborts and is returned alongside a partial DestroyOutcome.
+func (s *TerraformStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyOutcome, error) {
+	var result DestroyOutcome
 	if blueprint == nil {
 		return result, fmt.Errorf("blueprint not provided")
 	}

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -619,6 +619,10 @@ func (s *TerraformStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, cont
 			backendOverridePaths = append(backendOverridePaths, backendOverridePath)
 		}
 		if err != nil {
+			if continueOnError {
+				result.Failed = append(result.Failed, ComponentFailure{ID: component.GetID(), Err: err})
+				continue
+			}
 			return result, err
 		}
 

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -1786,6 +1786,61 @@ func TestStack_DestroyAll(t *testing.T) {
 		}
 	})
 
+	t.Run("ContinueOnErrorAbsorbsSetupEnvironmentFailure", func(t *testing.T) {
+		// Given a stack whose TerraformProvider.GetEnvVars fails for one
+		// component (e.g. malformed provider alias, missing env var) and
+		// succeeds for another. Before the fix, setupTerraformEnvironment
+		// returned mid-loop with the error and the entire continueOnError
+		// loop aborted, silently skipping all subsequent components.
+		stack, mocks := setup(t)
+		mocks.Runtime.TerraformProvider.ClearCache()
+
+		projectRoot := os.Getenv("WINDSOR_PROJECT_ROOT")
+		contextName := mocks.Runtime.ContextName
+		blueprint := createTestBlueprint()
+		blueprint.TerraformComponents = []blueprintv1alpha1.TerraformComponent{
+			{Source: "source1", Path: "first"},
+			{Source: "source1", Path: "broken"},
+		}
+		for _, p := range []string{"first", "broken"} {
+			dir := filepath.Join(projectRoot, ".windsor", "contexts", contextName, "terraform", p)
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				t.Fatalf("Failed to create directory %s: %v", dir, err)
+			}
+		}
+
+		// Inject a TerraformProvider whose GetEnvVars fails for "broken" only.
+		mocks.Runtime.TerraformProvider = &terraformRuntime.MockTerraformProvider{
+			GetEnvVarsFunc: func(componentID string, interactive bool) (map[string]string, *terraformRuntime.TerraformArgs, error) {
+				if strings.Contains(componentID, "broken") {
+					return nil, nil, fmt.Errorf("mock setup failure for %s", componentID)
+				}
+				return map[string]string{}, &terraformRuntime.TerraformArgs{}, nil
+			},
+		}
+
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" && len(args) >= 3 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[{"address":"aws_s3_bucket.example"}]}}}`, nil
+			}
+			return "", nil
+		}
+
+		// When DestroyAll runs with continueOnError=true
+		result, err := stack.DestroyAll(blueprint, true)
+
+		// Then the setup failure is collected and the follow-up component still destroys
+		if err != nil {
+			t.Fatalf("Expected continueOnError to absorb setup failure, got %v", err)
+		}
+		if len(result.Failed) != 1 || result.Failed[0].ID != "broken" {
+			t.Errorf("Expected exactly one failure for \"broken\", got %v", result.Failed)
+		}
+		if len(result.Destroyed) != 1 || result.Destroyed[0] != "first" {
+			t.Errorf("Expected \"first\" to destroy successfully after \"broken\" failed setup, got %v", result.Destroyed)
+		}
+	})
+
 }
 
 func TestNewShims(t *testing.T) {

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -1076,7 +1076,7 @@ func TestStack_DestroyAll(t *testing.T) {
 		stack, _ := setup(t)
 		blueprint := createTestBlueprint()
 
-		if _, err := stack.DestroyAll(blueprint); err != nil {
+		if _, err := stack.DestroyAll(blueprint, false); err != nil {
 			t.Errorf("Expected Down to return nil, got %v", err)
 		}
 	})
@@ -1088,7 +1088,7 @@ func TestStack_DestroyAll(t *testing.T) {
 		}
 
 		blueprint := createTestBlueprint()
-		_, err := stack.DestroyAll(blueprint)
+		_, err := stack.DestroyAll(blueprint, false)
 		expectedError := "error getting current directory"
 		if !strings.Contains(err.Error(), expectedError) {
 			t.Fatalf("Expected error to contain %q, got %q", expectedError, err.Error())
@@ -1104,15 +1104,15 @@ func TestStack_DestroyAll(t *testing.T) {
 
 		// When DestroyAll runs against a blueprint with two components
 		blueprint := createTestBlueprint()
-		skipped, err := stack.DestroyAll(blueprint)
+		skipped, err := stack.DestroyAll(blueprint, false)
 
 		// Then no error is returned and both components appear in the skipped list,
 		// matching MigrateState's contract for missing-on-disk components.
 		if err != nil {
 			t.Fatalf("Expected no error when directory doesn't exist, got %v", err)
 		}
-		if len(skipped) != len(blueprint.TerraformComponents) {
-			t.Fatalf("Expected %d skipped components, got %d: %v", len(blueprint.TerraformComponents), len(skipped), skipped)
+		if len(skipped.Skipped) != len(blueprint.TerraformComponents) {
+			t.Fatalf("Expected %d skipped components, got %d: %v", len(blueprint.TerraformComponents), len(skipped.Skipped), skipped.Skipped)
 		}
 	})
 
@@ -1150,7 +1150,7 @@ func TestStack_DestroyAll(t *testing.T) {
 			return "", nil
 		}
 
-		if _, err := stack.DestroyAll(blueprint, "backend"); err != nil {
+		if _, err := stack.DestroyAll(blueprint, false, "backend"); err != nil {
 			t.Errorf("Expected DestroyAll to return nil, got %v", err)
 		}
 
@@ -1209,7 +1209,7 @@ func TestStack_DestroyAll(t *testing.T) {
 			return "", nil
 		}
 
-		if _, err := stack.DestroyAll(blueprint); err != nil {
+		if _, err := stack.DestroyAll(blueprint, false); err != nil {
 			t.Errorf("Expected Down to return nil, got %v", err)
 		}
 
@@ -1273,7 +1273,7 @@ func TestStack_DestroyAll(t *testing.T) {
 			return "", nil
 		}
 
-		if _, err := stack.DestroyAll(blueprint); err != nil {
+		if _, err := stack.DestroyAll(blueprint, false); err != nil {
 			t.Errorf("Expected Down to return nil, got %v", err)
 		}
 
@@ -1322,7 +1322,7 @@ func TestStack_DestroyAll(t *testing.T) {
 		}
 
 		blueprint := createTestBlueprint()
-		_, err := stack.DestroyAll(blueprint)
+		_, err := stack.DestroyAll(blueprint, false)
 		expectedError := "error running terraform destroy for"
 		if err == nil {
 			t.Fatalf("Expected destroy error, got nil")
@@ -1338,7 +1338,7 @@ func TestStack_DestroyAll(t *testing.T) {
 
 	t.Run("NilBlueprint", func(t *testing.T) {
 		stack, _ := setup(t)
-		_, err := stack.DestroyAll(nil)
+		_, err := stack.DestroyAll(nil, false)
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}
@@ -1351,7 +1351,7 @@ func TestStack_DestroyAll(t *testing.T) {
 		stack, mocks := setup(t)
 		mocks.Runtime.ProjectRoot = ""
 		blueprint := createTestBlueprint()
-		_, err := stack.DestroyAll(blueprint)
+		_, err := stack.DestroyAll(blueprint, false)
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}
@@ -1377,7 +1377,7 @@ func TestStack_DestroyAll(t *testing.T) {
 		blueprint := createTestBlueprint()
 
 		// When running Down
-		_, err := stack.DestroyAll(blueprint)
+		_, err := stack.DestroyAll(blueprint, false)
 
 		// Then it should succeed (cleanup errors are ignored)
 		if err != nil {
@@ -1410,7 +1410,7 @@ func TestStack_DestroyAll(t *testing.T) {
 			},
 		}
 
-		if _, err := stack.DestroyAll(blueprint); err != nil {
+		if _, err := stack.DestroyAll(blueprint, false); err != nil {
 			t.Errorf("Expected Down to succeed with named component, got %v", err)
 		}
 	})
@@ -1447,7 +1447,7 @@ func TestStack_DestroyAll(t *testing.T) {
 			},
 		}
 
-		if _, err := stack.DestroyAll(blueprint); err != nil {
+		if _, err := stack.DestroyAll(blueprint, false); err != nil {
 			t.Errorf("Expected Down to succeed with named component with source, got %v", err)
 		}
 	})
@@ -1474,7 +1474,7 @@ func TestStack_DestroyAll(t *testing.T) {
 			return "", nil
 		}
 
-		_, _ = stack.DestroyAll(blueprint)
+		_, _ = stack.DestroyAll(blueprint, false)
 
 		// Then TF_VAR_operation is "destroy"
 		if capturedEnv == nil {
@@ -1540,7 +1540,7 @@ func TestStack_DestroyAll(t *testing.T) {
 		}
 
 		// When destroying all components
-		if _, err := stack.DestroyAll(blueprint); err != nil {
+		if _, err := stack.DestroyAll(blueprint, false); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
@@ -1630,14 +1630,14 @@ func TestStack_DestroyAll(t *testing.T) {
 			return "", nil
 		}
 
-		skipped, err := stack.DestroyAll(blueprint)
+		skipped, err := stack.DestroyAll(blueprint, false)
 		warningOutput := captured.String()
 
 		if err != nil {
 			t.Fatalf("Expected DestroyAll to tolerate refresh failure on one component, got %v", err)
 		}
-		if len(skipped) != 0 {
-			t.Errorf("Expected no skipped components (state was non-empty), got %v", skipped)
+		if len(skipped.Skipped) != 0 {
+			t.Errorf("Expected no skipped components (state was non-empty), got %v", skipped.Skipped)
 		}
 
 		// local/path (refresh failed) must have used -refresh=true on destroy.
@@ -1683,6 +1683,106 @@ func TestStack_DestroyAll(t *testing.T) {
 		}
 		if strings.Contains(warningOutput, "warning: terraform refresh failed for remote/path") {
 			t.Errorf("No warning expected for remote/path (refresh succeeded), got: %q", warningOutput)
+		}
+	})
+
+	t.Run("ContinueOnErrorCollectsPerComponentFailures", func(t *testing.T) {
+		// Given a blueprint with two components where the first-processed component's
+		// terraform destroy returns an error, continueOnError=true must record the
+		// failure and move on rather than aborting the loop.
+		stack, mocks := setup(t)
+		mocks.Runtime.TerraformProvider.ClearCache()
+
+		projectRoot := os.Getenv("WINDSOR_PROJECT_ROOT")
+		contextName := mocks.Runtime.ContextName
+		blueprint := createTestBlueprint()
+		blueprint.TerraformComponents = []blueprintv1alpha1.TerraformComponent{
+			{Source: "source1", Path: "first"},
+			{Source: "source1", Path: "second"},
+		}
+		for _, p := range []string{"first", "second"} {
+			dir := filepath.Join(projectRoot, ".windsor", "contexts", contextName, "terraform", p)
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				t.Fatalf("Failed to create directory %s: %v", dir, err)
+			}
+		}
+
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" && len(args) >= 3 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[{"address":"aws_s3_bucket.example"}]}}}`, nil
+			}
+			if command == "terraform" && len(args) > 1 && args[1] == "destroy" {
+				if strings.Contains(filepath.ToSlash(args[0]), "/second") {
+					return "boom", fmt.Errorf("mock destroy failure for second")
+				}
+				return "", nil
+			}
+			return "", nil
+		}
+
+		// When DestroyAll runs with continueOnError=true
+		result, err := stack.DestroyAll(blueprint, true)
+
+		// Then the failure is collected and the follow-up component still destroys
+		if err != nil {
+			t.Fatalf("Expected continueOnError to absorb per-component failure, got %v", err)
+		}
+		if len(result.Failed) != 1 || result.Failed[0].ID != "second" {
+			t.Errorf("Expected exactly one failure for \"second\", got %v", result.Failed)
+		}
+		if len(result.Destroyed) != 1 || result.Destroyed[0] != "first" {
+			t.Errorf("Expected \"first\" to destroy successfully after \"second\" failed, got %v", result.Destroyed)
+		}
+	})
+
+	t.Run("NoContinueAbortsOnFirstFailure", func(t *testing.T) {
+		// Given the same two-component blueprint where the first-processed (reverse
+		// order: "second") destroy fails, continueOnError=false must abort and the
+		// follow-up component must not be attempted.
+		stack, mocks := setup(t)
+		mocks.Runtime.TerraformProvider.ClearCache()
+
+		projectRoot := os.Getenv("WINDSOR_PROJECT_ROOT")
+		contextName := mocks.Runtime.ContextName
+		blueprint := createTestBlueprint()
+		blueprint.TerraformComponents = []blueprintv1alpha1.TerraformComponent{
+			{Source: "source1", Path: "first"},
+			{Source: "source1", Path: "second"},
+		}
+		for _, p := range []string{"first", "second"} {
+			dir := filepath.Join(projectRoot, ".windsor", "contexts", contextName, "terraform", p)
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				t.Fatalf("Failed to create directory %s: %v", dir, err)
+			}
+		}
+
+		var destroyAttempts []string
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" && len(args) >= 3 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[{"address":"aws_s3_bucket.example"}]}}}`, nil
+			}
+			if command == "terraform" && len(args) > 1 && args[1] == "destroy" {
+				normalized := filepath.ToSlash(args[0])
+				switch {
+				case strings.Contains(normalized, "/second"):
+					destroyAttempts = append(destroyAttempts, "second")
+					return "boom", fmt.Errorf("mock destroy failure for second")
+				case strings.Contains(normalized, "/first"):
+					destroyAttempts = append(destroyAttempts, "first")
+				}
+			}
+			return "", nil
+		}
+
+		// When DestroyAll runs with continueOnError=false
+		_, err := stack.DestroyAll(blueprint, false)
+
+		// Then the first failure aborts and the follow-up component is not attempted
+		if err == nil {
+			t.Fatal("Expected destroy to abort on first error")
+		}
+		if len(destroyAttempts) != 1 || destroyAttempts[0] != "second" {
+			t.Errorf("Expected only \"second\" to have been attempted before abort, got %v", destroyAttempts)
 		}
 	})
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **High Risk**
>
> This PR modifies the infrastructure teardown path — a destructive, largely irreversible operation — and introduces new best-effort semantics whose correctness depends on careful interaction between the kustomize and terraform layers.
>
> **Overview**
>
> The PR adds a `--continue` flag to `windsor destroy` that switches bulk teardown from abort-on-first-failure to collect-and-report mode. Per-component terraform failures are gathered into a `DestroyResult` struct, the backend tier is deferred when Stage 1 has failures, and a one-line summary is printed at the end. The `--continue` flag is refused when combined with a named-component argument to prevent silent no-ops. Existing behavior without the flag is unchanged.
>
> Two issues remain before merge. First, `DestroyResult.Failed` is populated by both the kustomize layer (as `ComponentFailure{ID:"kustomize"}`) and the terraform layer, but the tier-deferral guard `if len(result.Failed) > 0` does not distinguish between them. A kustomize `Uninstall` failure with otherwise clean terraform will set `TierDeferred=true`, permanently blocking backend tier cleanup on re-runs. Second, `setupTerraformEnvironment` failures abort the `DestroyAll` loop immediately regardless of `continueOnError`, creating an asymmetry with the destroy-step error handling that users would not expect from a best-effort mode.
>
> Reviewed by Claude for commit `8260834f`.

<!-- /claude-code-review:summary -->
