### PR TITLE
fix(test): Catch unregistered Terraform outputs in facets

### DIFF
--- a/integration/fixtures/derived-config/contexts/_template/facets/config-base.yaml
+++ b/integration/fixtures/derived-config/contexts/_template/facets/config-base.yaml
@@ -21,6 +21,8 @@ config:
     common_config_patches: "${string(block_a.common_patch)}"
 
 terraform:
+- name: workstation
+  path: workstation/test
 - name: cluster
   path: cluster/test
   inputs:

--- a/integration/fixtures/derived-config/contexts/_template/facets/config-base.yaml
+++ b/integration/fixtures/derived-config/contexts/_template/facets/config-base.yaml
@@ -21,6 +21,7 @@ config:
     common_config_patches: "${string(block_a.common_patch)}"
 
 terraform:
+# Registered so option-merge.yaml's terraform_output('workstation', 'registries') call resolves against a real component.
 - name: workstation
   path: workstation/test
 - name: cluster

--- a/integration/fixtures/test-tf-output-unregistered/contexts/_template/blueprint.yaml
+++ b/integration/fixtures/test-tf-output-unregistered/contexts/_template/blueprint.yaml
@@ -1,0 +1,5 @@
+kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: test-tf-output-unregistered
+  description: Exercises the windsor test gap where terraform_output() against an unregistered component used to resolve silently

--- a/integration/fixtures/test-tf-output-unregistered/contexts/_template/facets/platform.yaml
+++ b/integration/fixtures/test-tf-output-unregistered/contexts/_template/facets/platform.yaml
@@ -1,0 +1,14 @@
+kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: platform
+  description: cluster eagerly references dns-zone outputs; dns-zone is gated by dns.public_domain
+
+terraform:
+  - name: dns-zone
+    path: dns/zone
+    when: (dns.public_domain ?? '') != ''
+  - name: cluster
+    path: cluster
+    inputs:
+      cert_manager_hosted_zone_ids: "${(terraform_output('dns-zone', 'zone_id') ?? '') != '' ? [terraform_output('dns-zone', 'zone_id')] : []}"

--- a/integration/fixtures/test-tf-output-unregistered/contexts/_template/tests/platform.test.yaml
+++ b/integration/fixtures/test-tf-output-unregistered/contexts/_template/tests/platform.test.yaml
@@ -1,0 +1,27 @@
+# Cases for the windsor test harness exercising the gap between windsor test and windsor
+# bootstrap: an eager terraform_output() referencing an unregistered component must surface
+# the same "component not found" failure that the live runtime raises at env-var build time.
+
+cases:
+
+  # dns.public_domain set: dns-zone is registered and the cluster input resolves cleanly.
+  - name: dns_zone_registered_resolves
+    values:
+      terraform:
+        enabled: true
+      dns:
+        public_domain: example.com
+    terraformOutputs:
+      dns-zone:
+        zone_id: Z123ABC
+
+  # dns.public_domain unset: dns-zone is filtered out, but cluster eagerly calls
+  # terraform_output('dns-zone', ...). windsor test must fail to match windsor bootstrap.
+  - name: dns_zone_unregistered_fails
+    values:
+      terraform:
+        enabled: true
+    terraformOutputs:
+      cluster:
+        endpoint: https://cluster.local
+    expectError: true

--- a/integration/fixtures/test-tf-output-unregistered/windsor.yaml
+++ b/integration/fixtures/test-tf-output-unregistered/windsor.yaml
@@ -1,0 +1,4 @@
+version: v1alpha1
+contexts:
+  default: {}
+  test: {}

--- a/integration/test_test.go
+++ b/integration/test_test.go
@@ -41,3 +41,25 @@ func TestWindsorTest_FacetRequiresFixture(t *testing.T) {
 		t.Errorf("expected PASS or ✓ in output: %s", out)
 	}
 }
+
+// TestWindsorTest_TerraformOutputUnregisteredFixture exercises the gap the bug report
+// identified: a facet whose terraform component eagerly calls terraform_output() against
+// a sibling that is gated out by `when:` must fail windsor test, mirroring the
+// "component not found" error windsor bootstrap raises at env-var build time.
+//
+// The fixture defines two cases: one where the gated component is registered (resolves)
+// and one where it is not (must fail). The whole `windsor test` run passes only when
+// both cases behave as declared — the failing case is declared with expectError: true.
+func TestWindsorTest_TerraformOutputUnregisteredFixture(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "test-tf-output-unregistered")
+	env = append(env, "WINDSOR_CONTEXT=test")
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"test"}, env)
+	if err != nil {
+		t.Fatalf("windsor test: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
+	}
+	out := string(stdout) + string(stderr)
+	if !strings.Contains(out, "PASS") && !strings.Contains(out, "✓") {
+		t.Errorf("expected PASS or ✓ in output: %s", out)
+	}
+}

--- a/pkg/test/runner.go
+++ b/pkg/test/runner.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
+	"sync"
 
 	"github.com/goccy/go-yaml"
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
@@ -210,7 +212,6 @@ func (r *TestRunner) createGenerator(terraformOutputs map[string]map[string]any)
 			}
 		}
 
-		// Validate after the loop, not per-Set: Go-map iteration order is random.
 		if err := rt.ConfigHandler.ValidateContextValues(); err != nil {
 			return nil, err
 		}
@@ -218,6 +219,11 @@ func (r *TestRunner) createGenerator(terraformOutputs map[string]map[string]any)
 		if err := rt.InitializeComponents(); err != nil {
 			return nil, fmt.Errorf("failed to initialize components: %w", err)
 		}
+
+		testBlueprintHandler := blueprint.NewBlueprintHandler(rt, r.artifactBuilder)
+
+		referencedComponents := make(map[string]struct{})
+		var referencedMu sync.Mutex
 
 		if len(terraformOutputs) > 0 {
 			mockProvider := &terraform.MockTerraformProvider{
@@ -231,10 +237,13 @@ func (r *TestRunner) createGenerator(terraformOutputs map[string]map[string]any)
 			if rt.ConfigHandler.GetBool("terraform.enabled", false) {
 				rt.TerraformProvider = mockProvider
 			}
-			registerTerraformOutputHelperForMock(mockProvider, rt.Evaluator)
+			recordReference := func(componentID string) {
+				referencedMu.Lock()
+				referencedComponents[componentID] = struct{}{}
+				referencedMu.Unlock()
+			}
+			registerTerraformOutputHelperForMock(mockProvider, rt.Evaluator, recordReference)
 		}
-
-		testBlueprintHandler := blueprint.NewBlueprintHandler(rt, r.artifactBuilder)
 
 		defaultURL := r.DefaultBlueprintURL
 		if defaultURL == "" {
@@ -263,8 +272,52 @@ func (r *TestRunner) createGenerator(terraformOutputs map[string]map[string]any)
 			return nil, fmt.Errorf("failed to generate blueprint")
 		}
 
+		if err := validateTerraformOutputReferences(bp, referencedComponents, &referencedMu); err != nil {
+			return nil, err
+		}
+
 		return bp, nil
 	}
+}
+
+// validateTerraformOutputReferences fails composition when a terraform_output() expression named a
+// component that the composed blueprint does not contain. This mirrors the live runtime error raised
+// at env-var build time ("component not found: <name>") so the failure surfaces in windsor test rather
+// than leaking into windsor bootstrap. Missing names are sorted and joined into a single error so the
+// operator sees every offending reference in one pass rather than fixing one and re-running.
+func validateTerraformOutputReferences(bp *blueprintv1alpha1.Blueprint, referenced map[string]struct{}, mu *sync.Mutex) error {
+	if bp == nil || len(referenced) == 0 {
+		return nil
+	}
+
+	registered := make(map[string]struct{}, len(bp.TerraformComponents)*2)
+	for _, c := range bp.TerraformComponents {
+		if c.Path != "" {
+			registered[c.Path] = struct{}{}
+		}
+		if c.Name != "" {
+			registered[c.Name] = struct{}{}
+		}
+	}
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	var missing []string
+	for ref := range referenced {
+		if _, ok := registered[ref]; !ok {
+			missing = append(missing, ref)
+		}
+	}
+	if len(missing) == 0 {
+		return nil
+	}
+
+	sort.Strings(missing)
+	if len(missing) == 1 {
+		return fmt.Errorf("component not found: %s", missing[0])
+	}
+	return fmt.Errorf("component not found: %s", strings.Join(missing, ", "))
 }
 
 // normalizeTestValue converts YAML-unmarshaled values (e.g. map[interface{}]interface{}) to
@@ -787,10 +840,18 @@ func (r *TestRunner) validateInvalidDependencies(bp *blueprintv1alpha1.Blueprint
 // for use in test scenarios. This allows tests to provide mock Terraform output values without requiring actual
 // Terraform state or infrastructure. The helper validates that exactly two string arguments (component ID and output key)
 // are provided. Unlike production, it always evaluates immediately (ignores the deferred flag) since mock outputs
-// are always available during test execution. If the key exists in the component's outputs, it returns the value
-// (which can be any type: string, array, object, etc.). If the key does not exist, it returns nil (not an error),
-// enabling the ?? fallback operator to work correctly in expressions.
-func registerTerraformOutputHelperForMock(mockProvider *terraform.MockTerraformProvider, eval evaluator.ExpressionEvaluator) {
+// are always available during test execution.
+//
+// The recordReference callback (when non-nil) is invoked with each component ID the expression references. The runner
+// uses this to collect a deferred validation set: after composition completes, any referenced component absent from the
+// composed blueprint surfaces as "component not found: <name>", matching the live runtime error raised at env-var
+// building time. Validation must run after Generate() because facet processing and the composer evaluate inputs before
+// any single facet's components reach the composedBlueprint; an inline check inside the helper would false-positive on
+// same-facet sibling references. The callback is optional so helper-level unit tests need not wire it.
+//
+// If the key exists in the supplied mock outputs, the value is returned; if not, nil is returned (not an error) so the
+// ?? fallback operator continues to work for deferred wiring patterns (key absent on a registered component).
+func registerTerraformOutputHelperForMock(mockProvider *terraform.MockTerraformProvider, eval evaluator.ExpressionEvaluator, recordReference func(componentID string)) {
 	eval.Register("terraform_output", func(params []any, deferred bool) (any, error) {
 		if len(params) != 2 {
 			return nil, fmt.Errorf("terraform_output() requires exactly 2 arguments (component, key), got %d", len(params))
@@ -802,6 +863,10 @@ func registerTerraformOutputHelperForMock(mockProvider *terraform.MockTerraformP
 		key, ok := params[1].(string)
 		if !ok {
 			return nil, fmt.Errorf("terraform_output() key must be a string, got %T", params[1])
+		}
+
+		if recordReference != nil {
+			recordReference(component)
 		}
 
 		outputs, err := mockProvider.GetTerraformOutputs(component)

--- a/pkg/test/runner_test.go
+++ b/pkg/test/runner_test.go
@@ -2181,6 +2181,88 @@ func TestTestRunner_createGenerator(t *testing.T) {
 		}
 	})
 
+	t.Run("ErrorsWhenFacetTerraformInputReferencesUnregisteredComponent", func(t *testing.T) {
+		// Given a facet whose terraform component eagerly references terraform_output()
+		// for a sibling component that is gated by a `when:` condition the test disables.
+		// This mirrors the failure mode the bug report describes: windsor bootstrap errors
+		// at env-var time with "component not found: dns-zone" but windsor test silently
+		// resolved the expression to empty, hiding the failure until live runs.
+		mocks := setupTestRunnerMocks(t)
+		templateDir := filepath.Join(mocks.TmpDir, "contexts", "_template")
+		facetsDir := filepath.Join(templateDir, "facets")
+		createTestFile(t, facetsDir, "platform.yaml", `kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: platform
+terraform:
+  - name: dns-zone
+    path: dns/zone
+    when: dns.public_domain != null
+  - name: cluster
+    path: cluster
+    inputs:
+      cert_manager_hosted_zone_ids: "${(terraform_output('dns-zone', 'zone_id') ?? '') != '' ? [terraform_output('dns-zone', 'zone_id')] : []}"
+`)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		terraformOutputs := map[string]map[string]any{
+			"cluster": {"endpoint": "https://cluster.local"},
+		}
+		generator := runner.createGenerator(terraformOutputs)
+
+		// When the generator composes a config where dns.public_domain is unset so dns-zone is filtered out
+		_, err := generator(map[string]any{
+			"terraform.enabled": true,
+		})
+
+		// Then composition fails with the same "component not found" message the live
+		// runtime raises, so the test loop catches the regression locally
+		if err == nil {
+			t.Fatal("Expected error when terraform input references unregistered component, got nil")
+		}
+		if !strings.Contains(err.Error(), "component not found: dns-zone") {
+			t.Errorf("Expected error to contain 'component not found: dns-zone', got: %v", err)
+		}
+	})
+
+	t.Run("ResolvesWhenFacetTerraformInputReferencesRegisteredComponent", func(t *testing.T) {
+		// Given the same facet but a config that enables the dns-zone component
+		mocks := setupTestRunnerMocks(t)
+		templateDir := filepath.Join(mocks.TmpDir, "contexts", "_template")
+		facetsDir := filepath.Join(templateDir, "facets")
+		createTestFile(t, facetsDir, "platform.yaml", `kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: platform
+terraform:
+  - name: dns-zone
+    path: dns/zone
+    when: dns.public_domain != null
+  - name: cluster
+    path: cluster
+    inputs:
+      cert_manager_hosted_zone_ids: "${(terraform_output('dns-zone', 'zone_id') ?? '') != '' ? [terraform_output('dns-zone', 'zone_id')] : []}"
+`)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		// And terraformOutputs supplies dns-zone.zone_id
+		terraformOutputs := map[string]map[string]any{
+			"dns-zone": {"zone_id": "Z123ABC"},
+		}
+		generator := runner.createGenerator(terraformOutputs)
+
+		// When the generator composes with dns.public_domain set so dns-zone is registered
+		_, err := generator(map[string]any{
+			"terraform.enabled": true,
+			"dns":               map[string]any{"public_domain": "example.com"},
+		})
+
+		// Then composition succeeds: dns-zone is in the composition and its output resolves
+		if err != nil {
+			t.Fatalf("Expected no error when component is registered, got: %v", err)
+		}
+	})
+
 	t.Run("CrossFieldRuleSpanningStaticAndDynamicFires", func(t *testing.T) {
 		mocks := setupTestRunnerMocks(t)
 		templateDir := filepath.Join(mocks.TmpDir, "contexts", "_template")
@@ -2315,7 +2397,7 @@ func TestRegisterTerraformOutputHelperForMock(t *testing.T) {
 			},
 		}
 		eval := setupEvaluatorForHelperTest(t)
-		registerTerraformOutputHelperForMock(mockProvider, eval)
+		registerTerraformOutputHelperForMock(mockProvider, eval, nil)
 
 		result, err := eval.Evaluate(`${terraform_output("compute", "controlplanes")}`, "", nil, true)
 
@@ -2346,7 +2428,7 @@ func TestRegisterTerraformOutputHelperForMock(t *testing.T) {
 			},
 		}
 		eval := setupEvaluatorForHelperTest(t)
-		registerTerraformOutputHelperForMock(mockProvider, eval)
+		registerTerraformOutputHelperForMock(mockProvider, eval, nil)
 
 		result, err := eval.Evaluate(`${terraform_output("network", "nonexistent") ?? "default"}`, "", nil, true)
 
@@ -2359,13 +2441,16 @@ func TestRegisterTerraformOutputHelperForMock(t *testing.T) {
 	})
 
 	t.Run("ReturnsNilWhenComponentDoesNotExist", func(t *testing.T) {
+		// The helper itself never errors on an unknown component — it resolves to nil so the ??
+		// fallback can apply. The runner performs the registration check after Generate() returns
+		// using the references collected by the recordReference callback.
 		mockProvider := &terraform.MockTerraformProvider{
 			GetTerraformOutputsFunc: func(componentID string) (map[string]any, error) {
 				return make(map[string]any), nil
 			},
 		}
 		eval := setupEvaluatorForHelperTest(t)
-		registerTerraformOutputHelperForMock(mockProvider, eval)
+		registerTerraformOutputHelperForMock(mockProvider, eval, nil)
 
 		result, err := eval.Evaluate(`${terraform_output("nonexistent", "key") ?? "fallback"}`, "", nil, true)
 
@@ -2377,6 +2462,37 @@ func TestRegisterTerraformOutputHelperForMock(t *testing.T) {
 		}
 	})
 
+	t.Run("InvokesRecordReferenceForEveryComponentReference", func(t *testing.T) {
+		// Given a helper wired with a recordReference callback
+		mockProvider := &terraform.MockTerraformProvider{
+			GetTerraformOutputsFunc: func(componentID string) (map[string]any, error) {
+				if componentID == "network" {
+					return map[string]any{"vpc_id": "vpc-123"}, nil
+				}
+				return make(map[string]any), nil
+			},
+		}
+		eval := setupEvaluatorForHelperTest(t)
+		var recorded []string
+		registerTerraformOutputHelperForMock(mockProvider, eval, func(componentID string) {
+			recorded = append(recorded, componentID)
+		})
+
+		// When expressions reference multiple components, including one that has no supplied outputs
+		if _, err := eval.Evaluate(`${terraform_output("network", "vpc_id")}`, "", nil, true); err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		if _, err := eval.Evaluate(`${terraform_output("dns-zone", "zone_id") ?? ""}`, "", nil, true); err != nil {
+			t.Fatalf("Unexpected error: %v", err)
+		}
+
+		// Then every referenced component ID is recorded so the runner can validate registration
+		// against the composed blueprint after Generate() returns
+		if len(recorded) != 2 || recorded[0] != "network" || recorded[1] != "dns-zone" {
+			t.Errorf("Expected recorded references [network dns-zone], got %v", recorded)
+		}
+	})
+
 	t.Run("EvaluatesImmediatelyEvenWhenDeferredIsFalse", func(t *testing.T) {
 		mockProvider := &terraform.MockTerraformProvider{
 			GetTerraformOutputsFunc: func(componentID string) (map[string]any, error) {
@@ -2384,7 +2500,7 @@ func TestRegisterTerraformOutputHelperForMock(t *testing.T) {
 			},
 		}
 		eval := setupEvaluatorForHelperTest(t)
-		registerTerraformOutputHelperForMock(mockProvider, eval)
+		registerTerraformOutputHelperForMock(mockProvider, eval, nil)
 
 		result, err := eval.Evaluate(`prefix-${terraform_output("component", "key")}-suffix`, "", nil, false)
 
@@ -2411,7 +2527,7 @@ func TestRegisterTerraformOutputHelperForMock(t *testing.T) {
 			},
 		}
 		eval := setupEvaluatorForHelperTest(t)
-		registerTerraformOutputHelperForMock(mockProvider, eval)
+		registerTerraformOutputHelperForMock(mockProvider, eval, nil)
 
 		result, err := eval.Evaluate(`${terraform_output("compute", "controlplanes")}`, "", nil, true)
 
@@ -2436,7 +2552,7 @@ func TestRegisterTerraformOutputHelperForMock(t *testing.T) {
 			},
 		}
 		eval := setupEvaluatorForHelperTest(t)
-		registerTerraformOutputHelperForMock(mockProvider, eval)
+		registerTerraformOutputHelperForMock(mockProvider, eval, nil)
 
 		result, err := eval.Evaluate(`${terraform_output("network", "vpc_id")}`, "", nil, true)
 
@@ -2455,7 +2571,7 @@ func TestRegisterTerraformOutputHelperForMock(t *testing.T) {
 			},
 		}
 		eval := setupEvaluatorForHelperTest(t)
-		registerTerraformOutputHelperForMock(mockProvider, eval)
+		registerTerraformOutputHelperForMock(mockProvider, eval, nil)
 
 		_, err := eval.Evaluate(`${terraform_output("component")}`, "", nil, true)
 
@@ -2474,7 +2590,7 @@ func TestRegisterTerraformOutputHelperForMock(t *testing.T) {
 			},
 		}
 		eval := setupEvaluatorForHelperTest(t)
-		registerTerraformOutputHelperForMock(mockProvider, eval)
+		registerTerraformOutputHelperForMock(mockProvider, eval, nil)
 
 		_, err := eval.Evaluate(`${terraform_output(123, "key")}`, "", nil, true)
 
@@ -2493,7 +2609,7 @@ func TestRegisterTerraformOutputHelperForMock(t *testing.T) {
 			},
 		}
 		eval := setupEvaluatorForHelperTest(t)
-		registerTerraformOutputHelperForMock(mockProvider, eval)
+		registerTerraformOutputHelperForMock(mockProvider, eval, nil)
 
 		_, err := eval.Evaluate(`${terraform_output("component", 456)}`, "", nil, true)
 

--- a/pkg/test/runner_test.go
+++ b/pkg/test/runner_test.go
@@ -2197,7 +2197,7 @@ metadata:
 terraform:
   - name: dns-zone
     path: dns/zone
-    when: dns.public_domain != null
+    when: (dns.public_domain ?? '') != ''
   - name: cluster
     path: cluster
     inputs:
@@ -2237,7 +2237,7 @@ metadata:
 terraform:
   - name: dns-zone
     path: dns/zone
-    when: dns.public_domain != null
+    when: (dns.public_domain ?? '') != ''
   - name: cluster
     path: cluster
     inputs:


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> All changes are confined to the test runner, test fixtures, and integration tests; no production behavior is modified.
>
> **Overview**
>
> This PR fixes a gap between `windsor test` and `windsor bootstrap`: when a facet's Terraform input calls `terraform_output()` against a component gated out by a `when:` condition, the test runner previously resolved the expression silently to nil rather than surfacing the "component not found" error that the live runtime raises at env-var build time. The fix wires a `recordReference` callback into the mock helper and, after blueprint composition completes, validates that every referenced component ID appears in the composed blueprint.
>
> As a side effect, the new validation also exposed a latent bug in the existing `derived-config` fixture, where `option-merge.yaml` called `terraform_output('workstation', ...)` against a component that was never declared as a Terraform entry — that fixture is corrected here as well.
>
> Reviewed by Claude for commit `a7d6c409`.

<!-- /claude-code-review:summary -->
