### PR TITLE
feat: add holder-info sidecar for stack lock management

### DIFF
--- a/pkg/provisioner/stacklock/stacklock.go
+++ b/pkg/provisioner/stacklock/stacklock.go
@@ -11,6 +11,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -46,6 +47,14 @@ const lockDirPerm = 0o755
 // stackLockFilename is the basename written under WindsorScratchPath.
 const stackLockFilename = ".stacklock"
 
+// stackLockInfoSuffix is appended to the lock-file path to produce the
+// sidecar holder-info file. Kept as a sidecar (rather than written into the
+// flock'd file body) to avoid interacting with byte-range locking on Windows.
+const stackLockInfoSuffix = ".info"
+
+// lockInfoPerm is the mode used when writing the holder-info sidecar.
+const lockInfoPerm = 0o644
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -60,8 +69,9 @@ const (
 	Shared
 )
 
-// LockInfo records who holds a stack lock and why. Serialised into the lock-file body
-// for inspection by future --inspect (§7.6) tooling; not load-bearing for correctness.
+// LockInfo records who holds a stack lock and why. Persisted into a sidecar
+// file next to the lock so a blocked contender can name the holder in its
+// busy error and operators can identify the holding process.
 type LockInfo struct {
 	ID        string    `json:"id"`
 	Operation string    `json:"operation"`
@@ -71,6 +81,7 @@ type LockInfo struct {
 	ProjectID string    `json:"project_id"`
 	Context   string    `json:"context"`
 	Created   time.Time `json:"created"`
+	PID       int       `json:"pid"`
 }
 
 // Release frees a previously-acquired lock. Implementations must be idempotent:
@@ -90,8 +101,8 @@ func (e *LockBusyError) Error() string {
 	if e.Holder == nil {
 		return fmt.Sprintf("stack lock at %s is held by another windsor process", e.Path)
 	}
-	return fmt.Sprintf("stack lock at %s is held by %s (operation=%s, started=%s)",
-		e.Path, e.Holder.Who, e.Holder.Operation, e.Holder.Created.Format(time.RFC3339))
+	return fmt.Sprintf("stack lock at %s is held by %s (PID=%d, operation=%s, started=%s)",
+		e.Path, e.Holder.Who, e.Holder.PID, e.Holder.Operation, e.Holder.Created.Format(time.RFC3339))
 }
 
 // =============================================================================
@@ -143,9 +154,10 @@ func With(ctx context.Context, rt *runtime.Runtime, operation string, fn func() 
 	return fn()
 }
 
-// NewInfo constructs the LockInfo persisted into the lock-file body for a given
-// runtime and operation label. The result is diagnostic only — Acquire writes it
-// into the body so the next contender's busy error can name the holder.
+// NewInfo constructs the LockInfo persisted into the holder-info sidecar for a
+// given runtime and operation label. The result is diagnostic only — Acquire
+// writes it next to the lock so the next contender's busy error can name the
+// holder and the holding PID.
 func NewInfo(rt *runtime.Runtime, operation string) LockInfo {
 	return LockInfo{
 		ID:        newLockID(),
@@ -156,6 +168,7 @@ func NewInfo(rt *runtime.Runtime, operation string) LockInfo {
 		ProjectID: hashProjectRoot(rt.ProjectRoot),
 		Context:   rt.ContextName,
 		Created:   time.Now().UTC(),
+		PID:       os.Getpid(),
 	}
 }
 
@@ -178,10 +191,11 @@ type localFlockLock struct {
 
 // Acquire takes the lock, retrying every acquireRetryInterval until it is held,
 // the timeout elapses, or ctx is cancelled. Cancellation returns ctx.Err();
-// timeout returns *LockBusyError with Holder=nil — the local-flock backend does
-// not persist holder identity (the body-write would race with the flock on
-// Windows). Future backends with their own metadata stores can populate Holder.
-// info is accepted for interface stability but is ignored by this implementation.
+// timeout returns *LockBusyError, populating Holder from the sidecar info file
+// when one is present. After flock succeeds, info is persisted to a sidecar
+// (<path>.info) via atomic temp+rename so a future contender's busy error can
+// name the holder and PID. The sidecar is removed by Release; it is diagnostic
+// only and a missing or partial file is not load-bearing for correctness.
 func (s *localFlockLock) Acquire(ctx context.Context, info LockInfo, timeout time.Duration) (Release, error) {
 	if timeout <= 0 {
 		timeout = DefaultTimeout
@@ -190,6 +204,7 @@ func (s *localFlockLock) Acquire(ctx context.Context, info LockInfo, timeout tim
 		return nil, fmt.Errorf("create lock directory: %w", err)
 	}
 	flk := flock.New(s.path)
+	infoPath := s.path + stackLockInfoSuffix
 	deadline := time.Now().Add(timeout)
 	for {
 		locked, err := flk.TryLock()
@@ -200,7 +215,7 @@ func (s *localFlockLock) Acquire(ctx context.Context, info LockInfo, timeout tim
 			break
 		}
 		if time.Now().After(deadline) {
-			return nil, &LockBusyError{Path: s.path}
+			return nil, &LockBusyError{Path: s.path, Holder: readHolderInfo(infoPath)}
 		}
 		select {
 		case <-ctx.Done():
@@ -208,7 +223,11 @@ func (s *localFlockLock) Acquire(ctx context.Context, info LockInfo, timeout tim
 		case <-time.After(acquireRetryInterval):
 		}
 	}
-	return makeRelease(flk), nil
+	if info.PID == 0 {
+		info.PID = os.Getpid()
+	}
+	writeHolderInfo(infoPath, info)
+	return makeRelease(flk, infoPath), nil
 }
 
 // Inspect is reserved for the operator-facing `windsor stack lock --inspect`
@@ -223,17 +242,21 @@ func (s *localFlockLock) ForceRelease(ctx context.Context, lockID string, reason
 	return errOperationNotSupported
 }
 
-// makeRelease returns the closure handed back from Acquire. flk and the once
-// guard are scoped to this Release, not to the localFlockLock receiver, so
-// reusing the same lock instance for a second Acquire produces an independent
-// Release that does not interfere with this one. The first call returns the
+// makeRelease returns the closure handed back from Acquire. flk, infoPath,
+// and the once guard are scoped to this Release, not to the localFlockLock
+// receiver, so reusing the same lock instance for a second Acquire produces
+// an independent Release that does not interfere with this one. The first
+// call removes the holder-info sidecar (best-effort) and returns the
 // underlying Unlock result; subsequent calls return nil so callers may safely
 // defer release alongside an explicit earlier release without double-unlocking.
-func makeRelease(flk *flock.Flock) Release {
+func makeRelease(flk *flock.Flock, infoPath string) Release {
 	var once sync.Once
 	return func() error {
 		var err error
 		once.Do(func() {
+			if infoPath != "" {
+				_ = os.Remove(infoPath)
+			}
 			err = flk.Unlock()
 		})
 		return err
@@ -243,6 +266,40 @@ func makeRelease(flk *flock.Flock) Release {
 // =============================================================================
 // Helpers
 // =============================================================================
+
+// writeHolderInfo persists the holder LockInfo to the sidecar path via an
+// atomic temp+rename so a concurrent reader never observes a partial file.
+// Failures are swallowed because the sidecar is diagnostic only — losing it
+// degrades busy-error detail but does not affect lock correctness.
+func writeHolderInfo(path string, info LockInfo) {
+	data, err := json.Marshal(info)
+	if err != nil {
+		return
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, lockInfoPerm); err != nil {
+		return
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+	}
+}
+
+// readHolderInfo returns the LockInfo recorded by the current holder, or nil
+// when the sidecar is absent or unparseable. Used by Acquire to populate
+// LockBusyError.Holder on contention; callers must not depend on a non-nil
+// result for correctness.
+func readHolderInfo(path string) *LockInfo {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var info LockInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return nil
+	}
+	return &info
+}
 
 // newLockID generates a 128-bit random ID rendered as 32 hex characters.
 // Used only to identify lock holders in audit messages; collision risk is negligible.

--- a/pkg/provisioner/stacklock/stacklock.go
+++ b/pkg/provisioner/stacklock/stacklock.go
@@ -278,6 +278,7 @@ func writeHolderInfo(path string, info LockInfo) {
 	}
 	tmp := path + ".tmp"
 	if err := os.WriteFile(tmp, data, lockInfoPerm); err != nil {
+		_ = os.Remove(tmp)
 		return
 	}
 	if err := os.Rename(tmp, path); err != nil {

--- a/pkg/provisioner/stacklock/stacklock.go
+++ b/pkg/provisioner/stacklock/stacklock.go
@@ -290,6 +290,7 @@ func writeHolderInfo(path string, info LockInfo) {
 // LockBusyError.Holder on contention; callers must not depend on a non-nil
 // result for correctness.
 func readHolderInfo(path string) *LockInfo {
+	// #nosec G304 - path is the lock's sidecar location configured by the runtime, not user-supplied at call time
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil

--- a/pkg/provisioner/stacklock/stacklock_test.go
+++ b/pkg/provisioner/stacklock/stacklock_test.go
@@ -2,6 +2,7 @@ package stacklock
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -9,6 +10,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/gofrs/flock"
 
 	"github.com/windsorcli/cli/pkg/runtime"
 )
@@ -144,11 +147,15 @@ func TestLocalFlockLock_Acquire(t *testing.T) {
 		}
 	})
 
-	t.Run("returns a busy error with nil Holder for the local-flock backend", func(t *testing.T) {
-		// Given a held lock
+	t.Run("populates Holder from the sidecar info file on contention", func(t *testing.T) {
+		// Given a held lock whose holder wrote a populated LockInfo to the sidecar
 		path := filepath.Join(t.TempDir(), ".stacklock")
 		first := NewLocalFlockLock(path)
-		release1, err := first.Acquire(context.Background(), newTestLockInfo(), time.Second)
+		holderInfo := newTestLockInfo()
+		holderInfo.Who = "ci@runner-9"
+		holderInfo.Operation = "bootstrap"
+		holderInfo.PID = 4242
+		release1, err := first.Acquire(context.Background(), holderInfo, time.Second)
 		if err != nil {
 			t.Fatalf("first acquire: %v", err)
 		}
@@ -158,17 +165,109 @@ func TestLocalFlockLock_Acquire(t *testing.T) {
 		second := NewLocalFlockLock(path)
 		_, err = second.Acquire(context.Background(), newTestLockInfo(), 100*time.Millisecond)
 
-		// Then a *LockBusyError surfaces with Path set and Holder nil
-		// (this backend does not persist holder identity into the lock file)
+		// Then a *LockBusyError surfaces with Path set and Holder populated from the sidecar
+		var busy *LockBusyError
+		if !errors.As(err, &busy) {
+			t.Fatalf("expected *LockBusyError, got %T: %v", err, err)
+		}
+		if busy.Path != path {
+			t.Fatalf("expected Path %q, got %q", path, busy.Path)
+		}
+		if busy.Holder == nil {
+			t.Fatal("expected non-nil Holder populated from sidecar")
+		}
+		if busy.Holder.Who != "ci@runner-9" || busy.Holder.Operation != "bootstrap" || busy.Holder.PID != 4242 {
+			t.Fatalf("expected holder ci@runner-9/bootstrap/PID=4242, got %+v", busy.Holder)
+		}
+	})
+
+	t.Run("returns a busy error with nil Holder when no sidecar is present", func(t *testing.T) {
+		// Given a lock file held by an external flock with no sidecar written
+		// (simulates a non-windsor flock holder or a holder that died mid-write)
+		path := filepath.Join(t.TempDir(), ".stacklock")
+		external := flock.New(path)
+		locked, err := external.TryLock()
+		if err != nil || !locked {
+			t.Fatalf("external flock: locked=%v err=%v", locked, err)
+		}
+		t.Cleanup(func() { _ = external.Unlock() })
+
+		// When a windsor instance times out
+		sl := NewLocalFlockLock(path)
+		_, err = sl.Acquire(context.Background(), newTestLockInfo(), 100*time.Millisecond)
+
+		// Then a *LockBusyError surfaces with Holder nil — no diagnostic data available
 		var busy *LockBusyError
 		if !errors.As(err, &busy) {
 			t.Fatalf("expected *LockBusyError, got %T: %v", err, err)
 		}
 		if busy.Holder != nil {
-			t.Fatalf("expected nil Holder for local-flock backend, got %+v", busy.Holder)
+			t.Fatalf("expected nil Holder without sidecar, got %+v", busy.Holder)
 		}
-		if busy.Path != path {
-			t.Fatalf("expected Path %q, got %q", path, busy.Path)
+	})
+
+	t.Run("writes the holder-info sidecar on acquire and removes it on release", func(t *testing.T) {
+		// Given an acquired lock
+		path := filepath.Join(t.TempDir(), ".stacklock")
+		sidecar := path + ".info"
+		sl := NewLocalFlockLock(path)
+		info := newTestLockInfo()
+		info.PID = 9999
+		release, err := sl.Acquire(context.Background(), info, time.Second)
+		if err != nil {
+			t.Fatalf("acquire: %v", err)
+		}
+
+		// Then the sidecar exists and decodes to the holder's LockInfo
+		data, err := os.ReadFile(sidecar)
+		if err != nil {
+			t.Fatalf("read sidecar: %v", err)
+		}
+		var got LockInfo
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("decode sidecar: %v", err)
+		}
+		if got.Who != info.Who || got.PID != 9999 {
+			t.Fatalf("sidecar contents: got %+v want Who=%s PID=9999", got, info.Who)
+		}
+
+		// When the lock is released
+		if err := release(); err != nil {
+			t.Fatalf("release: %v", err)
+		}
+
+		// Then the sidecar is removed
+		if _, err := os.Stat(sidecar); !os.IsNotExist(err) {
+			t.Fatalf("expected sidecar removed, stat err=%v", err)
+		}
+	})
+
+	t.Run("populates PID with os.Getpid when caller passes 0", func(t *testing.T) {
+		// Given a lock acquired with info.PID unset (the With code path doesn't
+		// always go through NewInfo, so Acquire defends against a zero PID)
+		path := filepath.Join(t.TempDir(), ".stacklock")
+		sl := NewLocalFlockLock(path)
+		info := newTestLockInfo()
+		info.PID = 0
+		release, err := sl.Acquire(context.Background(), info, time.Second)
+		if err != nil {
+			t.Fatalf("acquire: %v", err)
+		}
+		t.Cleanup(func() { _ = release() })
+
+		// When the sidecar is read back
+		data, err := os.ReadFile(path + ".info")
+		if err != nil {
+			t.Fatalf("read sidecar: %v", err)
+		}
+		var got LockInfo
+		if err := json.Unmarshal(data, &got); err != nil {
+			t.Fatalf("decode sidecar: %v", err)
+		}
+
+		// Then PID reflects the running process
+		if got.PID != os.Getpid() {
+			t.Fatalf("expected PID=%d, got %d", os.Getpid(), got.PID)
 		}
 	})
 
@@ -297,18 +396,19 @@ func TestLockBusyError_Error(t *testing.T) {
 		}
 	})
 
-	t.Run("includes who and operation when the holder is known", func(t *testing.T) {
+	t.Run("includes who, PID, and operation when the holder is known", func(t *testing.T) {
 		// Given a busy error with a populated holder
 		info := newTestLockInfo()
 		info.Who = "ci@runner-7"
 		info.Operation = "apply"
+		info.PID = 12345
 		e := &LockBusyError{Path: "/tmp/x.stacklock", Holder: &info}
 
 		// When formatting
 		msg := e.Error()
 
-		// Then both fields appear
-		for _, want := range []string{"ci@runner-7", "apply"} {
+		// Then who, PID, and operation all appear so operators can identify the blocker
+		for _, want := range []string{"ci@runner-7", "PID=12345", "apply"} {
 			if !strings.Contains(msg, want) {
 				t.Fatalf("expected %q in message, got %q", want, msg)
 			}
@@ -427,16 +527,19 @@ func TestWith(t *testing.T) {
 			return nil
 		})
 
-		// Then a LockBusyError surfaces (Holder is nil for the local-flock backend)
+		// Then a LockBusyError surfaces with Holder populated from the peer's sidecar
 		var busy *LockBusyError
 		if !errors.As(err, &busy) {
 			t.Fatalf("expected *LockBusyError, got %T: %v", err, err)
+		}
+		if busy.Holder == nil || busy.Holder.Who != "peer@host" || busy.Holder.Operation != "destroy" {
+			t.Fatalf("expected holder peer@host/destroy, got %+v", busy.Holder)
 		}
 	})
 }
 
 func TestNewInfo(t *testing.T) {
-	t.Run("populates operation, mode, context and a non-empty ID", func(t *testing.T) {
+	t.Run("populates operation, mode, context, PID, and a non-empty ID", func(t *testing.T) {
 		// Given a runtime with a context and project root
 		rt := &runtime.Runtime{ContextName: "ctx-A", ProjectRoot: "/some/root"}
 
@@ -461,6 +564,9 @@ func TestNewInfo(t *testing.T) {
 		}
 		if info.ProjectID == "" {
 			t.Fatal("expected non-empty ProjectID")
+		}
+		if info.PID != os.Getpid() {
+			t.Fatalf("expected PID=%d, got %d", os.Getpid(), info.PID)
 		}
 	})
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This is an additive diagnostic layer on the existing stack-lock primitive; it does not change how the flock is acquired or released, and all new I/O failures are silently swallowed by design.
>
> **Overview**
>
> The PR adds a `.stacklock.info` sidecar file written via atomic `temp+rename` after a successful flock acquire, removed before the flock is released. This lets a blocked contender read the sidecar on timeout and surface the holder's identity — including PID — in the `LockBusyError` message. A new `PID int` field is added to `LockInfo` and wired into both `NewInfo` and `Acquire`.
>
> One behavioral note worth tracking: if a Windsor process is killed before `Release` runs, the OS drops the flock but the sidecar is not cleaned up. The next contender that times out will surface the dead process's PID as the apparent holder. This is bounded — the orphan is overwritten the next time the path is acquired — but could confuse operators during a post-crash retry. Since the sidecar is explicitly documented as diagnostic-only, this is an acceptable trade-off rather than a correctness gap.
>
> Reviewed by Claude for commit `d7040d38`.

<!-- /claude-code-review:summary -->
