### PR TITLE
feat(composer): implement local .gitignore writing for Windsor-owned directories

### DIFF
--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -534,3 +534,56 @@ func TestInit_UnmappedPlatformDoesNotDefaultBackendType(t *testing.T) {
 		t.Errorf("expected no platform-default backend type for --platform gcp, got values.yaml:\n%s", body)
 	}
 }
+
+// TestInit_WritesLocalGitignoresAndLeavesProjectRootAlone verifies that
+// `windsor init` drops self-contained .gitignore files into the Windsor-owned
+// folders it creates (.windsor/, contexts/<ctx>/) and never modifies the
+// project-root .gitignore.
+func TestInit_WritesLocalGitignoresAndLeavesProjectRootAlone(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "default")
+	helpers.MarkAsGitRepo(t, dir)
+
+	rootGitignore := filepath.Join(dir, ".gitignore")
+	userRootContent := "node_modules/\n*.log\n"
+	if err := os.WriteFile(rootGitignore, []byte(userRootContent), 0644); err != nil {
+		t.Fatalf("expected no error seeding project-root .gitignore, got %v", err)
+	}
+
+	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local", "--set", "dns.enabled=false"}, env)
+	if err != nil {
+		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
+	}
+
+	windsorIgnore := filepath.Join(dir, ".windsor", ".gitignore")
+	content, readErr := os.ReadFile(windsorIgnore)
+	if readErr != nil {
+		t.Fatalf("expected .windsor/.gitignore at %s, got %v", windsorIgnore, readErr)
+	}
+	if string(content) != "*\n" {
+		t.Errorf("expected .windsor/.gitignore to contain self-ignore marker, got: %q", string(content))
+	}
+
+	contextIgnore := filepath.Join(dir, "contexts", "local", ".gitignore")
+	content, readErr = os.ReadFile(contextIgnore)
+	if readErr != nil {
+		t.Fatalf("expected contexts/local/.gitignore at %s, got %v", contextIgnore, readErr)
+	}
+	expected := ".kube/\n.talos/\n.omni/\n.aws/\n.azure/\n.gcp/\n"
+	if string(content) != expected {
+		t.Errorf("expected contexts/local/.gitignore to contain credential dirs, got: %q", string(content))
+	}
+
+	templateIgnore := filepath.Join(dir, "contexts", "_template", ".gitignore")
+	if _, err := os.Stat(templateIgnore); !os.IsNotExist(err) {
+		t.Errorf("expected contexts/_template/.gitignore to not exist, got stat err: %v", err)
+	}
+
+	rootAfter, readErr := os.ReadFile(rootGitignore)
+	if readErr != nil {
+		t.Fatalf("expected project-root .gitignore to still exist, got %v", readErr)
+	}
+	if string(rootAfter) != userRootContent {
+		t.Errorf("project-root .gitignore was modified; before=%q after=%q", userRootContent, string(rootAfter))
+	}
+}

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/windsorcli/cli/pkg/composer/artifact"
 	"github.com/windsorcli/cli/pkg/composer/blueprint"
@@ -162,8 +161,8 @@ func (r *Composer) Generate(overwrite ...bool) error {
 		return fmt.Errorf("failed to process terraform modules: %w", err)
 	}
 
-	if err := r.generateGitignore(); err != nil {
-		return fmt.Errorf("failed to generate .gitignore: %w", err)
+	if err := r.writeLocalGitignores(); err != nil {
+		return fmt.Errorf("failed to write local gitignores: %w", err)
 	}
 
 	if r.configHandler.GetBool("terraform.enabled", true) {
@@ -179,93 +178,67 @@ func (r *Composer) Generate(overwrite ...bool) error {
 // Private Methods
 // =============================================================================
 
-// generateGitignore creates or updates the .gitignore file with Windsor-specific entries.
-// It ensures Windsor-specific paths are excluded from version control while preserving user-defined entries.
-func (r *Composer) generateGitignore() error {
-	gitIgnoreLines := []string{
-		"# managed by windsor cli",
-		".windsor/",
-		".volumes/",
-		"terraform/**/backend_override.tf",
-		"contexts/**/.kube/",
-		"contexts/**/.talos/",
-		"contexts/**/.omni/",
-		"contexts/**/.aws/",
-		"contexts/**/.azure/",
-		"contexts/**/.gcp/",
+// windsorMarkerContent is written to .gitignore inside Windsor-owned folders
+// (.windsor/, .volumes/). The pattern ignores every file in the folder including
+// the .gitignore itself, which keeps the folder invisible to `git status` so
+// users never have to commit Windsor-managed scaffolding.
+const windsorMarkerContent = "*\n"
+
+// contextIgnoreContent is written to contexts/<ctx>/.gitignore to keep
+// per-context credential and state directories out of version control.
+const contextIgnoreContent = ".kube/\n.talos/\n.omni/\n.aws/\n.azure/\n.gcp/\n"
+
+// writeLocalGitignores writes self-contained .gitignore files into Windsor-owned
+// folders so re-running Windsor never touches the project-root .gitignore.
+// Each file is written once: if a target .gitignore already exists, it is left
+// alone. .volumes/ and contexts/ are skipped silently when the directory itself
+// is absent; .windsor/ is created if missing.
+func (r *Composer) writeLocalGitignores() error {
+	windsorDir := filepath.Join(r.projectRoot, ".windsor")
+	if err := os.MkdirAll(windsorDir, 0750); err != nil {
+		return fmt.Errorf("failed to ensure .windsor directory: %w", err)
+	}
+	if err := writeIfMissing(filepath.Join(windsorDir, ".gitignore"), windsorMarkerContent); err != nil {
+		return fmt.Errorf("failed to write .windsor/.gitignore: %w", err)
 	}
 
-	gitignorePath := filepath.Join(r.projectRoot, ".gitignore")
-
-	// #nosec G304 - gitignorePath is constructed from trusted project root
-	content, err := os.ReadFile(gitignorePath)
-	if err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("failed to read .gitignore: %w", err)
-	}
-
-	if os.IsNotExist(err) {
-		content = []byte{}
-	}
-
-	existingLines := make(map[string]struct{})
-	commentedNormalized := make(map[string]struct{})
-	var unmanagedLines []string
-	lines := strings.Split(string(content), "\n")
-	for i, line := range lines {
-		existingLines[line] = struct{}{}
-
-		trimmed := strings.TrimLeft(line, " \t")
-		if strings.HasPrefix(trimmed, "#") {
-			norm := normalizeGitignoreComment(trimmed)
-			if norm != "" {
-				commentedNormalized[norm] = struct{}{}
-			}
+	volumesDir := filepath.Join(r.projectRoot, ".volumes")
+	if _, err := os.Stat(volumesDir); err == nil {
+		if err := writeIfMissing(filepath.Join(volumesDir, ".gitignore"), windsorMarkerContent); err != nil {
+			return fmt.Errorf("failed to write .volumes/.gitignore: %w", err)
 		}
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("failed to stat .volumes: %w", err)
+	}
 
-		if i == len(lines)-1 && line == "" {
+	contextsDir := filepath.Join(r.projectRoot, "contexts")
+	entries, err := os.ReadDir(contextsDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to read contexts directory: %w", err)
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() || entry.Name() == "_template" {
 			continue
 		}
-		unmanagedLines = append(unmanagedLines, line)
-	}
-
-	for _, line := range gitIgnoreLines {
-		if line == "# managed by windsor cli" {
-			if _, exists := existingLines[line]; !exists {
-				unmanagedLines = append(unmanagedLines, "")
-				unmanagedLines = append(unmanagedLines, line)
-			}
-			continue
-		}
-
-		if _, exists := existingLines[line]; !exists {
-			if _, commentedExists := commentedNormalized[line]; !commentedExists {
-				unmanagedLines = append(unmanagedLines, line)
-			}
+		target := filepath.Join(contextsDir, entry.Name(), ".gitignore")
+		if err := writeIfMissing(target, contextIgnoreContent); err != nil {
+			return fmt.Errorf("failed to write contexts/%s/.gitignore: %w", entry.Name(), err)
 		}
 	}
-
-	finalContent := strings.Join(unmanagedLines, "\n")
-
-	if !strings.HasSuffix(finalContent, "\n") {
-		finalContent += "\n"
-	}
-
-	// #nosec G306,G703 - .gitignore files use standard 0644 permissions; gitignorePath is constructed from trusted project root
-	if err := os.WriteFile(gitignorePath, []byte(finalContent), 0644); err != nil {
-		return fmt.Errorf("failed to write to .gitignore: %w", err)
-	}
-
 	return nil
 }
 
-// normalizeGitignoreComment normalizes a commented .gitignore line to its uncommented form.
-// It removes all leading #, whitespace, and trailing whitespace.
-func normalizeGitignoreComment(line string) string {
-	trimmed := strings.TrimLeft(line, " \t")
-	if !strings.HasPrefix(trimmed, "#") {
-		return ""
+// writeIfMissing writes content to path with 0644 perms only when the file
+// does not yet exist. Existing files are left untouched.
+func writeIfMissing(path, content string) error {
+	if _, err := os.Stat(path); err == nil {
+		return nil
+	} else if !os.IsNotExist(err) {
+		return err
 	}
-	noHash := strings.TrimLeft(trimmed, "#")
-	noHash = strings.TrimLeft(noHash, " \t")
-	return strings.TrimSpace(noHash)
+	// #nosec G306 - .gitignore files use standard 0644 permissions
+	return os.WriteFile(path, []byte(content), 0644)
 }

--- a/pkg/composer/composer_test.go
+++ b/pkg/composer/composer_test.go
@@ -809,8 +809,8 @@ func TestComposer_Generate(t *testing.T) {
 		}
 	})
 
-	t.Run("ErrorFromGenerateGitignore", func(t *testing.T) {
-		// Given mocks with generateGitignore failing (simulated via file system error)
+	t.Run("ErrorFromWriteLocalGitignores", func(t *testing.T) {
+		// Given mocks with writeLocalGitignores failing (simulated via file system error)
 		mocks := setupComposerMocks(t)
 		mocks.BlueprintHandler.LoadBlueprintFunc = func(...string) error {
 			return nil
@@ -832,8 +832,8 @@ func TestComposer_Generate(t *testing.T) {
 			t.Fatal("Expected error, got nil")
 		}
 
-		if !strings.Contains(err.Error(), "failed to generate .gitignore") {
-			t.Errorf("Expected error about generating .gitignore, got: %v", err)
+		if !strings.Contains(err.Error(), "failed to write local gitignores") {
+			t.Errorf("Expected error about writing local gitignores, got: %v", err)
 		}
 	})
 
@@ -884,397 +884,207 @@ func TestComposer_Generate(t *testing.T) {
 // Test Private Methods
 // =============================================================================
 
-func TestComposer_generateGitignore(t *testing.T) {
-	t.Run("CreatesNewFile", func(t *testing.T) {
-		// Given a composer with temporary project root
+func TestComposer_writeLocalGitignores(t *testing.T) {
+	t.Run("WritesWindsorMarkerWhenMissing", func(t *testing.T) {
+		// Given a composer with no pre-existing .windsor/.gitignore
 		mocks := setupComposerMocks(t)
 		composer := createComposerWithMocks(mocks)
 
-		// When generating gitignore
-		err := composer.generateGitignore()
+		// When writing local gitignores
+		err := composer.writeLocalGitignores()
 
 		// Then no error should occur
 		if err != nil {
 			t.Fatalf("Expected no error, got: %v", err)
 		}
 
-		// And .gitignore file should be created
-		gitignorePath := filepath.Join(mocks.Runtime.ProjectRoot, ".gitignore")
-		content, readErr := os.ReadFile(gitignorePath)
+		// And .windsor/.gitignore should exist with self-ignore content
+		path := filepath.Join(mocks.Runtime.ProjectRoot, ".windsor", ".gitignore")
+		content, readErr := os.ReadFile(path)
 		if readErr != nil {
-			t.Fatalf("Expected .gitignore to be created, got error: %v", readErr)
+			t.Fatalf("Expected .windsor/.gitignore to be created, got error: %v", readErr)
 		}
-
-		// And file should contain Windsor entries
-		contentStr := string(content)
-		if !strings.Contains(contentStr, "# managed by windsor cli") {
-			t.Error("Expected .gitignore to contain Windsor header")
-		}
-
-		if !strings.Contains(contentStr, ".windsor/") {
-			t.Error("Expected .gitignore to contain .windsor/ entry")
+		if string(content) != "*\n" {
+			t.Errorf("Expected self-ignore marker content, got: %q", string(content))
 		}
 	})
 
-	t.Run("UpdatesExistingFile", func(t *testing.T) {
-		// Given a composer with existing .gitignore
+	t.Run("LeavesExistingWindsorGitignoreUntouched", func(t *testing.T) {
+		// Given a composer with a pre-existing .windsor/.gitignore the user edited
 		mocks := setupComposerMocks(t)
-		existingContent := "existing-entry\n"
-		gitignorePath := filepath.Join(mocks.Runtime.ProjectRoot, ".gitignore")
-		if err := os.WriteFile(gitignorePath, []byte(existingContent), 0644); err != nil {
-			t.Fatalf("Failed to create existing .gitignore: %v", err)
+		windsorDir := filepath.Join(mocks.Runtime.ProjectRoot, ".windsor")
+		if err := os.MkdirAll(windsorDir, 0750); err != nil {
+			t.Fatalf("Failed to create .windsor: %v", err)
+		}
+		path := filepath.Join(windsorDir, ".gitignore")
+		existing := "# user wrote this\n*.log\n"
+		if err := os.WriteFile(path, []byte(existing), 0644); err != nil {
+			t.Fatalf("Failed to seed .windsor/.gitignore: %v", err)
 		}
 		composer := createComposerWithMocks(mocks)
 
-		// When generating gitignore
-		err := composer.generateGitignore()
+		// When writing local gitignores
+		err := composer.writeLocalGitignores()
 
 		// Then no error should occur
 		if err != nil {
 			t.Fatalf("Expected no error, got: %v", err)
 		}
 
-		// And file should contain both existing and new entries
-		content, readErr := os.ReadFile(gitignorePath)
+		// And the user's file should be unchanged
+		content, readErr := os.ReadFile(path)
 		if readErr != nil {
-			t.Fatalf("Failed to read .gitignore: %v", readErr)
+			t.Fatalf("Failed to read .windsor/.gitignore: %v", readErr)
 		}
-
-		contentStr := string(content)
-		if !strings.Contains(contentStr, "existing-entry") {
-			t.Error("Expected .gitignore to preserve existing entry")
-		}
-
-		if !strings.Contains(contentStr, ".windsor/") {
-			t.Error("Expected .gitignore to contain new Windsor entry")
+		if string(content) != existing {
+			t.Errorf("Expected user content preserved, got: %q", string(content))
 		}
 	})
 
-	t.Run("PreservesUserEntries", func(t *testing.T) {
-		// Given a composer with existing .gitignore with user entries
+	t.Run("SkipsVolumesWhenAbsent", func(t *testing.T) {
+		// Given a composer with no .volumes/ directory
 		mocks := setupComposerMocks(t)
-		existingContent := "user-entry-1\nuser-entry-2\n"
-		gitignorePath := filepath.Join(mocks.Runtime.ProjectRoot, ".gitignore")
-		if err := os.WriteFile(gitignorePath, []byte(existingContent), 0644); err != nil {
-			t.Fatalf("Failed to create existing .gitignore: %v", err)
-		}
 		composer := createComposerWithMocks(mocks)
 
-		// When generating gitignore
-		err := composer.generateGitignore()
+		// When writing local gitignores
+		err := composer.writeLocalGitignores()
 
 		// Then no error should occur
 		if err != nil {
 			t.Fatalf("Expected no error, got: %v", err)
 		}
 
-		// And file should contain all user entries
-		content, readErr := os.ReadFile(gitignorePath)
-		if readErr != nil {
-			t.Fatalf("Failed to read .gitignore: %v", readErr)
-		}
-
-		contentStr := string(content)
-		if !strings.Contains(contentStr, "user-entry-1") {
-			t.Error("Expected .gitignore to preserve user-entry-1")
-		}
-
-		if !strings.Contains(contentStr, "user-entry-2") {
-			t.Error("Expected .gitignore to preserve user-entry-2")
+		// And .volumes/.gitignore should not be created
+		path := filepath.Join(mocks.Runtime.ProjectRoot, ".volumes", ".gitignore")
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("Expected .volumes/.gitignore to not exist, got stat err: %v", err)
 		}
 	})
 
-	t.Run("HandlesCommentedEntries", func(t *testing.T) {
-		// Given a composer with existing .gitignore with commented Windsor entry
+	t.Run("WritesVolumesMarkerWhenPresent", func(t *testing.T) {
+		// Given a composer with .volumes/ pre-existing
 		mocks := setupComposerMocks(t)
-		existingContent := "# .windsor/\nuser-entry\n"
-		gitignorePath := filepath.Join(mocks.Runtime.ProjectRoot, ".gitignore")
-		if err := os.WriteFile(gitignorePath, []byte(existingContent), 0644); err != nil {
-			t.Fatalf("Failed to create existing .gitignore: %v", err)
+		volumesDir := filepath.Join(mocks.Runtime.ProjectRoot, ".volumes")
+		if err := os.MkdirAll(volumesDir, 0750); err != nil {
+			t.Fatalf("Failed to create .volumes: %v", err)
 		}
 		composer := createComposerWithMocks(mocks)
 
-		// When generating gitignore
-		err := composer.generateGitignore()
+		// When writing local gitignores
+		err := composer.writeLocalGitignores()
 
 		// Then no error should occur
 		if err != nil {
 			t.Fatalf("Expected no error, got: %v", err)
 		}
 
-		// And file should not duplicate the entry (commented entry stays commented)
-		content, readErr := os.ReadFile(gitignorePath)
+		// And .volumes/.gitignore should exist with self-ignore content
+		path := filepath.Join(volumesDir, ".gitignore")
+		content, readErr := os.ReadFile(path)
 		if readErr != nil {
-			t.Fatalf("Failed to read .gitignore: %v", readErr)
+			t.Fatalf("Expected .volumes/.gitignore to be created, got error: %v", readErr)
 		}
+		if string(content) != "*\n" {
+			t.Errorf("Expected self-ignore marker content, got: %q", string(content))
+		}
+	})
 
-		contentStr := string(content)
-		if !strings.Contains(contentStr, "# .windsor/") {
-			t.Error("Expected commented entry # .windsor/ to remain in file")
-		}
-		lines := strings.Split(contentStr, "\n")
-		uncommentedCount := 0
-		for _, line := range lines {
-			if strings.TrimSpace(line) == ".windsor/" {
-				uncommentedCount++
+	t.Run("WritesContextGitignoresForEachContext", func(t *testing.T) {
+		// Given a composer with two contexts and a _template
+		mocks := setupComposerMocks(t)
+		root := mocks.Runtime.ProjectRoot
+		for _, name := range []string{"local", "prod", "_template"} {
+			if err := os.MkdirAll(filepath.Join(root, "contexts", name), 0750); err != nil {
+				t.Fatalf("Failed to create context dir %s: %v", name, err)
 			}
 		}
-		if uncommentedCount > 0 {
-			t.Errorf("Expected .windsor/ to not be added when commented, got %d uncommented occurrences", uncommentedCount)
-		}
-	})
-
-	t.Run("AddsMissingEntries", func(t *testing.T) {
-		// Given a composer with existing .gitignore missing some Windsor entries
-		mocks := setupComposerMocks(t)
-		existingContent := "# managed by windsor cli\n.windsor/\n"
-		gitignorePath := filepath.Join(mocks.Runtime.ProjectRoot, ".gitignore")
-		if err := os.WriteFile(gitignorePath, []byte(existingContent), 0644); err != nil {
-			t.Fatalf("Failed to create existing .gitignore: %v", err)
-		}
 		composer := createComposerWithMocks(mocks)
 
-		// When generating gitignore
-		err := composer.generateGitignore()
+		// When writing local gitignores
+		err := composer.writeLocalGitignores()
 
 		// Then no error should occur
 		if err != nil {
 			t.Fatalf("Expected no error, got: %v", err)
 		}
 
-		// And file should contain all Windsor entries
-		content, readErr := os.ReadFile(gitignorePath)
-		if readErr != nil {
-			t.Fatalf("Failed to read .gitignore: %v", readErr)
-		}
-
-		contentStr := string(content)
-		requiredEntries := []string{".windsor/", ".volumes/", "terraform/**/backend_override.tf"}
-		for _, entry := range requiredEntries {
-			if !strings.Contains(contentStr, entry) {
-				t.Errorf("Expected .gitignore to contain %s", entry)
+		// And each non-template context should have a .gitignore with cred dirs
+		expected := ".kube/\n.talos/\n.omni/\n.aws/\n.azure/\n.gcp/\n"
+		for _, name := range []string{"local", "prod"} {
+			path := filepath.Join(root, "contexts", name, ".gitignore")
+			content, readErr := os.ReadFile(path)
+			if readErr != nil {
+				t.Fatalf("Expected contexts/%s/.gitignore, got error: %v", name, readErr)
+			}
+			if string(content) != expected {
+				t.Errorf("contexts/%s/.gitignore content mismatch: got %q", name, string(content))
 			}
 		}
+
+		// And _template should have no .gitignore created
+		templatePath := filepath.Join(root, "contexts", "_template", ".gitignore")
+		if _, err := os.Stat(templatePath); !os.IsNotExist(err) {
+			t.Errorf("Expected contexts/_template/.gitignore to not exist, got stat err: %v", err)
+		}
 	})
 
-	t.Run("HandlesTrailingNewline", func(t *testing.T) {
-		// Given a composer with existing .gitignore without trailing newline
+	t.Run("SkipsContextsWhenDirectoryAbsent", func(t *testing.T) {
+		// Given a composer with no contexts/ directory
 		mocks := setupComposerMocks(t)
-		existingContent := "user-entry"
-		gitignorePath := filepath.Join(mocks.Runtime.ProjectRoot, ".gitignore")
-		if err := os.WriteFile(gitignorePath, []byte(existingContent), 0644); err != nil {
-			t.Fatalf("Failed to create existing .gitignore: %v", err)
+		composer := createComposerWithMocks(mocks)
+
+		// When writing local gitignores
+		err := composer.writeLocalGitignores()
+
+		// Then no error should occur
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+	})
+
+	t.Run("DoesNotTouchProjectRootGitignore", func(t *testing.T) {
+		// Given a composer with a project-root .gitignore containing user content
+		mocks := setupComposerMocks(t)
+		rootGitignore := filepath.Join(mocks.Runtime.ProjectRoot, ".gitignore")
+		userContent := "node_modules/\n*.log\n"
+		if err := os.WriteFile(rootGitignore, []byte(userContent), 0644); err != nil {
+			t.Fatalf("Failed to seed project root .gitignore: %v", err)
 		}
 		composer := createComposerWithMocks(mocks)
 
-		// When generating gitignore
-		err := composer.generateGitignore()
+		// When writing local gitignores
+		err := composer.writeLocalGitignores()
 
 		// Then no error should occur
 		if err != nil {
 			t.Fatalf("Expected no error, got: %v", err)
 		}
 
-		// And file should end with newline
-		content, readErr := os.ReadFile(gitignorePath)
+		// And the project-root .gitignore should be byte-identical to what the user wrote
+		content, readErr := os.ReadFile(rootGitignore)
 		if readErr != nil {
-			t.Fatalf("Failed to read .gitignore: %v", readErr)
+			t.Fatalf("Failed to read project-root .gitignore: %v", readErr)
 		}
-
-		if len(content) > 0 && content[len(content)-1] != '\n' {
-			t.Error("Expected .gitignore to end with newline")
+		if string(content) != userContent {
+			t.Errorf("Project-root .gitignore was modified; got: %q", string(content))
 		}
 	})
 
-	t.Run("ErrorFromWriteFile", func(t *testing.T) {
-		// Given a composer with existing .gitignore that can be read
+	t.Run("ErrorWhenWindsorParentUncreatable", func(t *testing.T) {
+		// Given a composer whose project root cannot be created (parent unwritable)
 		mocks := setupComposerMocks(t)
-		existingContent := "existing-entry\n"
-		gitignorePath := filepath.Join(mocks.Runtime.ProjectRoot, ".gitignore")
-		if err := os.WriteFile(gitignorePath, []byte(existingContent), 0644); err != nil {
-			t.Fatalf("Failed to create existing .gitignore: %v", err)
-		}
+		mocks.Runtime.ProjectRoot = "/nonexistent/path/that/cannot/be/written"
 		composer := createComposerWithMocks(mocks)
 
-		// Make the .gitignore file itself read-only to simulate write failure
-		if err := os.Chmod(gitignorePath, 0444); err != nil {
-			t.Fatalf("Failed to make .gitignore read-only: %v", err)
-		}
-		defer func() {
-			os.Chmod(gitignorePath, 0644)
-		}()
+		// When writing local gitignores
+		err := composer.writeLocalGitignores()
 
-		// When generating gitignore
-		err := composer.generateGitignore()
-
-		// Then error should be returned (write will fail due to read-only file)
+		// Then an error should be returned
 		if err == nil {
 			t.Fatal("Expected error, got nil")
 		}
-
-		if !strings.Contains(err.Error(), "failed to write to .gitignore") && !strings.Contains(err.Error(), "permission denied") {
-			t.Errorf("Expected error about writing .gitignore or permission denied, got: %v", err)
-		}
-	})
-
-	t.Run("HandlesEmptyExistingFile", func(t *testing.T) {
-		// Given a composer with empty existing .gitignore
-		mocks := setupComposerMocks(t)
-		gitignorePath := filepath.Join(mocks.Runtime.ProjectRoot, ".gitignore")
-		if err := os.WriteFile(gitignorePath, []byte(""), 0644); err != nil {
-			t.Fatalf("Failed to create empty .gitignore: %v", err)
-		}
-		composer := createComposerWithMocks(mocks)
-
-		// When generating gitignore
-		err := composer.generateGitignore()
-
-		// Then no error should occur
-		if err != nil {
-			t.Fatalf("Expected no error, got: %v", err)
-		}
-
-		// And file should contain Windsor entries
-		content, readErr := os.ReadFile(gitignorePath)
-		if readErr != nil {
-			t.Fatalf("Failed to read .gitignore: %v", readErr)
-		}
-
-		contentStr := string(content)
-		if !strings.Contains(contentStr, "# managed by windsor cli") {
-			t.Error("Expected .gitignore to contain Windsor header")
-		}
-	})
-
-	t.Run("HandlesFileWithOnlyComments", func(t *testing.T) {
-		// Given a composer with existing .gitignore with only comments
-		mocks := setupComposerMocks(t)
-		existingContent := "# comment 1\n# comment 2\n"
-		gitignorePath := filepath.Join(mocks.Runtime.ProjectRoot, ".gitignore")
-		if err := os.WriteFile(gitignorePath, []byte(existingContent), 0644); err != nil {
-			t.Fatalf("Failed to create existing .gitignore: %v", err)
-		}
-		composer := createComposerWithMocks(mocks)
-
-		// When generating gitignore
-		err := composer.generateGitignore()
-
-		// Then no error should occur
-		if err != nil {
-			t.Fatalf("Expected no error, got: %v", err)
-		}
-
-		// And file should contain both comments and Windsor entries
-		content, readErr := os.ReadFile(gitignorePath)
-		if readErr != nil {
-			t.Fatalf("Failed to read .gitignore: %v", readErr)
-		}
-
-		contentStr := string(content)
-		if !strings.Contains(contentStr, "# comment 1") {
-			t.Error("Expected .gitignore to preserve comment 1")
-		}
-
-		if !strings.Contains(contentStr, ".windsor/") {
-			t.Error("Expected .gitignore to contain Windsor entry")
-		}
-	})
-}
-
-func TestComposer_normalizeGitignoreComment(t *testing.T) {
-	t.Run("SimpleCommentFormat", func(t *testing.T) {
-		// Given a simple comment line
-		line := "# .windsor/"
-
-		// When normalizing
-		result := normalizeGitignoreComment(line)
-
-		// Then result should be the uncommented entry
-		expected := ".windsor/"
-		if result != expected {
-			t.Errorf("Expected %s, got %s", expected, result)
-		}
-	})
-
-	t.Run("MultipleHashSymbols", func(t *testing.T) {
-		// Given a comment line with multiple hash symbols
-		line := "## .windsor/"
-
-		// When normalizing
-		result := normalizeGitignoreComment(line)
-
-		// Then result should be the uncommented entry
-		expected := ".windsor/"
-		if result != expected {
-			t.Errorf("Expected %s, got %s", expected, result)
-		}
-	})
-
-	t.Run("CommentWithLeadingWhitespace", func(t *testing.T) {
-		// Given a comment line with leading whitespace
-		line := "  # .windsor/"
-
-		// When normalizing
-		result := normalizeGitignoreComment(line)
-
-		// Then result should be the uncommented entry
-		expected := ".windsor/"
-		if result != expected {
-			t.Errorf("Expected %s, got %s", expected, result)
-		}
-	})
-
-	t.Run("CommentWithTrailingWhitespace", func(t *testing.T) {
-		// Given a comment line with trailing whitespace
-		line := "# .windsor/  "
-
-		// When normalizing
-		result := normalizeGitignoreComment(line)
-
-		// Then result should be the uncommented entry without trailing whitespace
-		expected := ".windsor/"
-		if result != expected {
-			t.Errorf("Expected %s, got %s", expected, result)
-		}
-	})
-
-	t.Run("NonCommentLine", func(t *testing.T) {
-		// Given a non-comment line
-		line := ".windsor/"
-
-		// When normalizing
-		result := normalizeGitignoreComment(line)
-
-		// Then result should be empty string
-		if result != "" {
-			t.Errorf("Expected empty string, got %s", result)
-		}
-	})
-
-	t.Run("OnlyHashSymbol", func(t *testing.T) {
-		// Given a line with only hash symbol
-		line := "#"
-
-		// When normalizing
-		result := normalizeGitignoreComment(line)
-
-		// Then result should be empty string
-		if result != "" {
-			t.Errorf("Expected empty string, got %s", result)
-		}
-	})
-
-	t.Run("CommentWithMultipleSpaces", func(t *testing.T) {
-		// Given a comment line with multiple spaces
-		line := "#   .windsor/  "
-
-		// When normalizing
-		result := normalizeGitignoreComment(line)
-
-		// Then result should be the uncommented entry
-		expected := ".windsor/"
-		if result != expected {
-			t.Errorf("Expected %s, got %s", expected, result)
+		if !strings.Contains(err.Error(), "failed to ensure .windsor directory") {
+			t.Errorf("Expected error about ensuring .windsor directory, got: %v", err)
 		}
 	})
 }

--- a/pkg/composer/composer_test.go
+++ b/pkg/composer/composer_test.go
@@ -810,7 +810,8 @@ func TestComposer_Generate(t *testing.T) {
 	})
 
 	t.Run("ErrorFromWriteLocalGitignores", func(t *testing.T) {
-		// Given mocks with writeLocalGitignores failing (simulated via file system error)
+		// Given mocks with writeLocalGitignores failing because ProjectRoot points
+		// inside a regular file (MkdirAll of any child path returns ENOTDIR on all OSes)
 		mocks := setupComposerMocks(t)
 		mocks.BlueprintHandler.LoadBlueprintFunc = func(...string) error {
 			return nil
@@ -821,7 +822,11 @@ func TestComposer_Generate(t *testing.T) {
 		mocks.TerraformResolver.ProcessModulesFunc = func() error {
 			return nil
 		}
-		mocks.Runtime.ProjectRoot = "/nonexistent/path/that/cannot/be/written"
+		blocker := filepath.Join(t.TempDir(), "blocker")
+		if err := os.WriteFile(blocker, []byte{}, 0644); err != nil {
+			t.Fatalf("Failed to create blocker file: %v", err)
+		}
+		mocks.Runtime.ProjectRoot = blocker
 		composer := createComposerWithMocks(mocks)
 
 		// When generating
@@ -1071,9 +1076,14 @@ func TestComposer_writeLocalGitignores(t *testing.T) {
 	})
 
 	t.Run("ErrorWhenWindsorParentUncreatable", func(t *testing.T) {
-		// Given a composer whose project root cannot be created (parent unwritable)
+		// Given a composer whose ProjectRoot points inside a regular file, so
+		// MkdirAll of any child path fails with ENOTDIR on every supported OS
 		mocks := setupComposerMocks(t)
-		mocks.Runtime.ProjectRoot = "/nonexistent/path/that/cannot/be/written"
+		blocker := filepath.Join(t.TempDir(), "blocker")
+		if err := os.WriteFile(blocker, []byte{}, 0644); err != nil {
+			t.Fatalf("Failed to create blocker file: %v", err)
+		}
+		mocks.Runtime.ProjectRoot = blocker
 		composer := createComposerWithMocks(mocks)
 
 		// When writing local gitignores


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> This PR touches the composer's gitignore strategy, which runs on every `windsor init` and affects how generated files are excluded from version control across all projects.
>
> **Overview**
>
> The change replaces a single project-root `.gitignore` mutator with a set of local, self-contained `.gitignore` files written into Windsor-owned directories (`.windsor/`, `.volumes/`, `contexts/<ctx>/`). The new approach is idempotent — existing files are never overwritten — and it stops Windsor from ever modifying the user's project-root `.gitignore`. The rewrite shrinks the implementation significantly and the test suite is updated to match, with a new integration test that explicitly verifies the project-root file is left untouched.
>
> One behavioral gap is worth tracking: the old implementation added `terraform/**/backend_override.tf` to the project-root `.gitignore`; the new implementation does not write this pattern anywhere. Existing projects retain the entry from prior Windsor runs, but fresh repositories initialized with this version will not have backend override files automatically ignored.
>
> Reviewed by Claude for commit `d9a158fb`.

<!-- /claude-code-review:summary -->
