### PR TITLE
feat(runtime): add region support to AzureConfig and related tests

### DIFF
--- a/api/v1alpha1/azure/azure_config.go
+++ b/api/v1alpha1/azure/azure_config.go
@@ -12,6 +12,11 @@ type AzureConfig struct {
 	// Environment specifies the Azure cloud environment (e.g. "public", "usgovernment")
 	Environment *string `yaml:"environment,omitempty"`
 
+	// Region is the Azure location used for resource deployment, exported to terraform
+	// as TF_VAR_region so consuming modules (azure-aks, azure-vnet) honor it instead of
+	// falling back to their own variable defaults. Mirrors aws.region symmetrically.
+	Region *string `yaml:"region,omitempty"`
+
 	// KubeloginMode overrides the kubelogin login mode for AAD-enabled AKS kubeconfigs.
 	// Empty (default) auto-detects from the active credential chain. Set to "msi" on
 	// managed-identity runners; other values match kubelogin's own modes.
@@ -32,6 +37,9 @@ func (base *AzureConfig) Merge(overlay *AzureConfig) {
 	if overlay.Environment != nil {
 		base.Environment = overlay.Environment
 	}
+	if overlay.Region != nil {
+		base.Region = overlay.Region
+	}
 	if overlay.KubeloginMode != nil {
 		base.KubeloginMode = overlay.KubeloginMode
 	}
@@ -46,6 +54,7 @@ func (c *AzureConfig) Copy() *AzureConfig {
 		SubscriptionID: c.SubscriptionID,
 		TenantID:       c.TenantID,
 		Environment:    c.Environment,
+		Region:         c.Region,
 		KubeloginMode:  c.KubeloginMode,
 	}
 }

--- a/api/v1alpha1/azure/azure_config_test.go
+++ b/api/v1alpha1/azure/azure_config_test.go
@@ -18,18 +18,21 @@ func TestAzureConfig(t *testing.T) {
 					SubscriptionID: stringPtr("old-sub"),
 					TenantID:       stringPtr("old-tenant"),
 					Environment:    stringPtr("old-env"),
+					Region:         stringPtr("eastus"),
 					KubeloginMode:  stringPtr("azurecli"),
 				},
 				overlay: &AzureConfig{
 					SubscriptionID: stringPtr("new-sub"),
 					TenantID:       stringPtr("new-tenant"),
 					Environment:    stringPtr("new-env"),
+					Region:         stringPtr("eastus2"),
 					KubeloginMode:  stringPtr("workloadidentity"),
 				},
 				expected: &AzureConfig{
 					SubscriptionID: stringPtr("new-sub"),
 					TenantID:       stringPtr("new-tenant"),
 					Environment:    stringPtr("new-env"),
+					Region:         stringPtr("eastus2"),
 					KubeloginMode:  stringPtr("workloadidentity"),
 				},
 			},
@@ -39,6 +42,7 @@ func TestAzureConfig(t *testing.T) {
 					SubscriptionID: stringPtr("old-sub"),
 					TenantID:       stringPtr("old-tenant"),
 					Environment:    stringPtr("old-env"),
+					Region:         stringPtr("eastus"),
 				},
 				overlay: &AzureConfig{
 					KubeloginMode: stringPtr("msi"),
@@ -47,7 +51,22 @@ func TestAzureConfig(t *testing.T) {
 					SubscriptionID: stringPtr("old-sub"),
 					TenantID:       stringPtr("old-tenant"),
 					Environment:    stringPtr("old-env"),
+					Region:         stringPtr("eastus"),
 					KubeloginMode:  stringPtr("msi"),
+				},
+			},
+			{
+				name: "RegionOverlayOnly",
+				base: &AzureConfig{
+					SubscriptionID: stringPtr("old-sub"),
+					Region:         stringPtr("eastus"),
+				},
+				overlay: &AzureConfig{
+					Region: stringPtr("westus2"),
+				},
+				expected: &AzureConfig{
+					SubscriptionID: stringPtr("old-sub"),
+					Region:         stringPtr("westus2"),
 				},
 			},
 			{
@@ -56,12 +75,14 @@ func TestAzureConfig(t *testing.T) {
 					SubscriptionID: stringPtr("old-sub"),
 					TenantID:       stringPtr("old-tenant"),
 					Environment:    stringPtr("old-env"),
+					Region:         stringPtr("eastus"),
 				},
 				overlay: nil,
 				expected: &AzureConfig{
 					SubscriptionID: stringPtr("old-sub"),
 					TenantID:       stringPtr("old-tenant"),
 					Environment:    stringPtr("old-env"),
+					Region:         stringPtr("eastus"),
 				},
 			},
 		}
@@ -73,6 +94,7 @@ func TestAzureConfig(t *testing.T) {
 				assertStringPtrEq(t, "SubscriptionID", tt.base.SubscriptionID, tt.expected.SubscriptionID)
 				assertStringPtrEq(t, "TenantID", tt.base.TenantID, tt.expected.TenantID)
 				assertStringPtrEq(t, "Environment", tt.base.Environment, tt.expected.Environment)
+				assertStringPtrEq(t, "Region", tt.base.Region, tt.expected.Region)
 				assertStringPtrEq(t, "KubeloginMode", tt.base.KubeloginMode, tt.expected.KubeloginMode)
 			})
 		}
@@ -89,12 +111,14 @@ func TestAzureConfig(t *testing.T) {
 					SubscriptionID: stringPtr("sub"),
 					TenantID:       stringPtr("tenant"),
 					Environment:    stringPtr("env"),
+					Region:         stringPtr("eastus2"),
 					KubeloginMode:  stringPtr("azurecli"),
 				},
 			},
 			{
 				name: "SomeFields",
 				original: &AzureConfig{
+					Region:        stringPtr("westeurope"),
 					KubeloginMode: stringPtr("workloadidentity"),
 				},
 			},
@@ -126,6 +150,7 @@ func TestAzureConfig(t *testing.T) {
 				assertStringPtrEq(t, "SubscriptionID", copy.SubscriptionID, tt.original.SubscriptionID)
 				assertStringPtrEq(t, "TenantID", copy.TenantID, tt.original.TenantID)
 				assertStringPtrEq(t, "Environment", copy.Environment, tt.original.Environment)
+				assertStringPtrEq(t, "Region", copy.Region, tt.original.Region)
 				assertStringPtrEq(t, "KubeloginMode", copy.KubeloginMode, tt.original.KubeloginMode)
 			})
 		}

--- a/api/v1alpha2/config/providers/azure/azure.go
+++ b/api/v1alpha2/config/providers/azure/azure.go
@@ -12,6 +12,11 @@ type AzureConfig struct {
 	// Environment specifies the Azure cloud environment (e.g. "public", "usgovernment")
 	Environment *string `yaml:"environment,omitempty"`
 
+	// Region is the Azure location used for resource deployment, exported to terraform
+	// as TF_VAR_region so consuming modules (azure-aks, azure-vnet) honor it instead of
+	// falling back to their own variable defaults. Mirrors aws.region symmetrically.
+	Region *string `yaml:"region,omitempty"`
+
 	// KubeloginMode overrides the kubelogin login mode for AAD-enabled AKS kubeconfigs.
 	// Empty (default) auto-detects from the active credential chain. Set to "msi" on
 	// managed-identity runners; other values match kubelogin's own modes.
@@ -31,6 +36,9 @@ func (base *AzureConfig) Merge(overlay *AzureConfig) {
 	}
 	if overlay.Environment != nil {
 		base.Environment = overlay.Environment
+	}
+	if overlay.Region != nil {
+		base.Region = overlay.Region
 	}
 	if overlay.KubeloginMode != nil {
 		base.KubeloginMode = overlay.KubeloginMode
@@ -55,6 +63,10 @@ func (c *AzureConfig) DeepCopy() *AzureConfig {
 	if c.Environment != nil {
 		environmentCopy := *c.Environment
 		copied.Environment = &environmentCopy
+	}
+	if c.Region != nil {
+		regionCopy := *c.Region
+		copied.Region = &regionCopy
 	}
 	if c.KubeloginMode != nil {
 		kubeloginModeCopy := *c.KubeloginMode

--- a/api/v1alpha2/config/providers/azure/azure_test.go
+++ b/api/v1alpha2/config/providers/azure/azure_test.go
@@ -11,12 +11,14 @@ func TestAzureConfig_Merge(t *testing.T) {
 			SubscriptionID: stringPtr("old-sub"),
 			TenantID:       stringPtr("old-tenant"),
 			Environment:    stringPtr("old-env"),
+			Region:         stringPtr("eastus"),
 			KubeloginMode:  stringPtr("old-mode"),
 		}
 		overlay := &AzureConfig{
 			SubscriptionID: stringPtr("new-sub"),
 			TenantID:       stringPtr("new-tenant"),
 			Environment:    stringPtr("new-env"),
+			Region:         stringPtr("eastus2"),
 			KubeloginMode:  stringPtr("msi"),
 		}
 
@@ -31,6 +33,9 @@ func TestAzureConfig_Merge(t *testing.T) {
 		if base.Environment == nil || *base.Environment != "new-env" {
 			t.Errorf("Expected Environment to be 'new-env', got %v", base.Environment)
 		}
+		if base.Region == nil || *base.Region != "eastus2" {
+			t.Errorf("Expected Region to be 'eastus2', got %v", base.Region)
+		}
 		if base.KubeloginMode == nil || *base.KubeloginMode != "msi" {
 			t.Errorf("Expected KubeloginMode to be 'msi', got %v", base.KubeloginMode)
 		}
@@ -41,6 +46,7 @@ func TestAzureConfig_Merge(t *testing.T) {
 			SubscriptionID: stringPtr("old-sub"),
 			TenantID:       stringPtr("old-tenant"),
 			Environment:    stringPtr("old-env"),
+			Region:         stringPtr("eastus"),
 			KubeloginMode:  stringPtr("old-mode"),
 		}
 		overlay := &AzureConfig{
@@ -58,8 +64,30 @@ func TestAzureConfig_Merge(t *testing.T) {
 		if base.Environment == nil || *base.Environment != "old-env" {
 			t.Errorf("Expected Environment to remain 'old-env', got %v", base.Environment)
 		}
+		if base.Region == nil || *base.Region != "eastus" {
+			t.Errorf("Expected Region to remain 'eastus', got %v", base.Region)
+		}
 		if base.KubeloginMode == nil || *base.KubeloginMode != "old-mode" {
 			t.Errorf("Expected KubeloginMode to remain 'old-mode', got %v", base.KubeloginMode)
+		}
+	})
+
+	t.Run("MergeRegionOnlyOverlay", func(t *testing.T) {
+		base := &AzureConfig{
+			SubscriptionID: stringPtr("old-sub"),
+			Region:         stringPtr("eastus"),
+		}
+		overlay := &AzureConfig{
+			Region: stringPtr("westus2"),
+		}
+
+		base.Merge(overlay)
+
+		if base.SubscriptionID == nil || *base.SubscriptionID != "old-sub" {
+			t.Errorf("Expected SubscriptionID to remain 'old-sub', got %v", base.SubscriptionID)
+		}
+		if base.Region == nil || *base.Region != "westus2" {
+			t.Errorf("Expected Region to be 'westus2', got %v", base.Region)
 		}
 	})
 
@@ -68,6 +96,7 @@ func TestAzureConfig_Merge(t *testing.T) {
 			SubscriptionID: stringPtr("old-sub"),
 			TenantID:       stringPtr("old-tenant"),
 			Environment:    stringPtr("old-env"),
+			Region:         stringPtr("eastus"),
 			KubeloginMode:  stringPtr("old-mode"),
 		}
 		original := base.DeepCopy()
@@ -83,6 +112,9 @@ func TestAzureConfig_Merge(t *testing.T) {
 		if base.Environment == nil || *base.Environment != *original.Environment {
 			t.Errorf("Expected Environment to remain unchanged")
 		}
+		if base.Region == nil || *base.Region != *original.Region {
+			t.Errorf("Expected Region to remain unchanged")
+		}
 		if base.KubeloginMode == nil || *base.KubeloginMode != *original.KubeloginMode {
 			t.Errorf("Expected KubeloginMode to remain unchanged")
 		}
@@ -96,6 +128,7 @@ func TestAzureConfig_Copy(t *testing.T) {
 			SubscriptionID: stringPtr("sub"),
 			TenantID:       stringPtr("tenant"),
 			Environment:    stringPtr("env"),
+			Region:         stringPtr("eastus2"),
 			KubeloginMode:  stringPtr("msi"),
 		}
 
@@ -116,6 +149,12 @@ func TestAzureConfig_Copy(t *testing.T) {
 		if copy.Environment == nil || *copy.Environment != *original.Environment {
 			t.Errorf("Expected Environment to be copied correctly")
 		}
+		if copy.Region == nil || *copy.Region != *original.Region {
+			t.Errorf("Expected Region to be copied correctly")
+		}
+		if copy.Region == original.Region {
+			t.Error("Expected Region pointer to be a new allocation")
+		}
 		if copy.KubeloginMode == nil || *copy.KubeloginMode != *original.KubeloginMode {
 			t.Errorf("Expected KubeloginMode to be copied correctly")
 		}
@@ -127,6 +166,7 @@ func TestAzureConfig_Copy(t *testing.T) {
 	t.Run("CopySomeFields", func(t *testing.T) {
 		original := &AzureConfig{
 			TenantID: stringPtr("tenant"),
+			Region:   stringPtr("westeurope"),
 		}
 
 		copy := original.DeepCopy()
@@ -136,6 +176,9 @@ func TestAzureConfig_Copy(t *testing.T) {
 		}
 		if copy.TenantID == nil || *copy.TenantID != *original.TenantID {
 			t.Errorf("Expected TenantID to be copied correctly")
+		}
+		if copy.Region == nil || *copy.Region != *original.Region {
+			t.Errorf("Expected Region to be copied correctly")
 		}
 		if copy.SubscriptionID != nil {
 			t.Error("Expected SubscriptionID to be nil")

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -587,3 +587,28 @@ func TestInit_WritesLocalGitignoresAndLeavesProjectRootAlone(t *testing.T) {
 		t.Errorf("project-root .gitignore was modified; before=%q after=%q", userRootContent, string(rootAfter))
 	}
 }
+
+// TestInit_AzureRegionPersistsAcrossInit verifies that `--set azure.region=...`
+// flows through init and lands in values.yaml as azure.region. The runtime
+// env printer reads this key to emit TF_VAR_region for terraform's
+// azure-aks / azure-vnet modules — the parity surface that matches aws.region.
+func TestInit_AzureRegionPersistsAcrossInit(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "default")
+	helpers.MarkAsGitRepo(t, dir)
+
+	_, stderr, err := helpers.RunCLI(dir, []string{"init", "azure-test", "--platform", "azure", "--set", "azure.region=eastus2", "--set", "dns.enabled=false"}, env)
+	if err != nil {
+		t.Fatalf("init azure-test --set azure.region=eastus2: %v\nstderr: %s", err, stderr)
+	}
+
+	valuesPath := filepath.Join(dir, "contexts", "azure-test", "values.yaml")
+	values := readYAMLFile(t, valuesPath)
+	region, ok := getPathValue(values, "azure", "region")
+	if !ok {
+		t.Fatalf("expected azure.region in values.yaml, got nothing\nvalues=%v", values)
+	}
+	if region != "eastus2" {
+		t.Errorf("expected azure.region=eastus2 in values.yaml, got %v", region)
+	}
+}

--- a/pkg/runtime/env/azure_env.go
+++ b/pkg/runtime/env/azure_env.go
@@ -50,10 +50,12 @@ func NewAzureEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler) *
 // In project mode AZURE_CONFIG_DIR always points at the context's .azure dir,
 // matching how the AWS env printer scopes AWS_CONFIG_FILE — keeps `az login`
 // from contaminating the operator's global ~/.azure. In global mode it is not
-// emitted; ARM_SUBSCRIPTION_ID / ARM_TENANT_ID / ARM_ENVIRONMENT and
-// TF_VAR_kubelogin_mode are emitted in both modes — the ARM_* vars describe
-// the target account/tenant and TF_VAR_kubelogin_mode feeds terraform, which
-// runs from global shells too.
+// emitted; ARM_SUBSCRIPTION_ID / ARM_TENANT_ID / ARM_ENVIRONMENT,
+// TF_VAR_region (when set), and TF_VAR_kubelogin_mode are emitted in both
+// modes — the ARM_* vars describe the target account/tenant and the TF_VAR_*
+// vars feed terraform, which runs from global shells too. TF_VAR_region is
+// omitted when azure.region is unset so consuming modules fall back to their
+// own variable defaults rather than receiving an empty string.
 func (e *AzureEnvPrinter) GetEnvVars() (map[string]string, error) {
 	envVars := make(map[string]string)
 	global := e.shell.IsGlobal()
@@ -78,6 +80,9 @@ func (e *AzureEnvPrinter) GetEnvVars() (map[string]string, error) {
 		}
 		if config.Azure.Environment != nil {
 			envVars["ARM_ENVIRONMENT"] = *config.Azure.Environment
+		}
+		if config.Azure.Region != nil {
+			envVars["TF_VAR_region"] = *config.Azure.Region
 		}
 	}
 

--- a/pkg/runtime/env/azure_env_test.go
+++ b/pkg/runtime/env/azure_env_test.go
@@ -416,3 +416,115 @@ contexts:
 		}
 	})
 }
+
+// TestAzureEnv_Region pins how azure.region flows into TF_VAR_region, the
+// variable consumed by core's azure-aks / azure-vnet terraform modules.
+// Mirrors the aws.region → AWS_REGION surface so config keys stay symmetric.
+func TestAzureEnv_Region(t *testing.T) {
+	setupPrinter := func(t *testing.T, configStr string) *AzureEnvPrinter {
+		t.Helper()
+		baseMocks := setupEnvMocks(t)
+		mocks := setupAzureEnvMocks(t, &EnvTestMocks{
+			ConfigHandler: config.NewConfigHandler(baseMocks.Shell),
+		})
+		mocks.ConfigHandler.SetContext("test-context")
+		if err := mocks.ConfigHandler.LoadConfigString(configStr); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+		printer := NewAzureEnvPrinter(mocks.Shell, mocks.ConfigHandler)
+		printer.shims = mocks.Shims
+		return printer
+	}
+
+	t.Run("EmittedWhenAzureRegionSet", func(t *testing.T) {
+		// Given azure.region=eastus2 in values.yaml
+		printer := setupPrinter(t, `
+version: v1alpha1
+contexts:
+  test-context:
+    azure:
+      region: eastus2
+`)
+
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars: %v", err)
+		}
+
+		// Then TF_VAR_region carries the value verbatim
+		if got := envVars["TF_VAR_region"]; got != "eastus2" {
+			t.Errorf("TF_VAR_region = %q, want %q", got, "eastus2")
+		}
+	})
+
+	t.Run("OmittedWhenAzureRegionUnset", func(t *testing.T) {
+		// Given an azure block with no region key
+		printer := setupPrinter(t, `
+version: v1alpha1
+contexts:
+  test-context:
+    azure:
+      tenant_id: 11111111-2222-3333-4444-555555555555
+`)
+
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars: %v", err)
+		}
+
+		// Then TF_VAR_region is not emitted at all — consuming modules fall back to
+		// their own var defaults rather than receiving an empty string
+		if got, ok := envVars["TF_VAR_region"]; ok {
+			t.Errorf("TF_VAR_region should be absent when azure.region unset, got %q", got)
+		}
+	})
+
+	t.Run("OmittedWhenAzureBlockAbsent", func(t *testing.T) {
+		// Given a context with no azure block at all
+		printer := setupPrinter(t, `
+version: v1alpha1
+contexts:
+  test-context: {}
+`)
+
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars: %v", err)
+		}
+
+		if got, ok := envVars["TF_VAR_region"]; ok {
+			t.Errorf("TF_VAR_region should be absent when azure: block missing, got %q", got)
+		}
+	})
+
+	t.Run("EmittedInGlobalMode", func(t *testing.T) {
+		// Given azure.region=westeurope and global mode — TF_VAR_region must still
+		// flow through because terraform runs from global shells too
+		baseMocks := setupEnvMocks(t)
+		mocks := setupAzureEnvMocks(t, &EnvTestMocks{
+			ConfigHandler: config.NewConfigHandler(baseMocks.Shell),
+		})
+		mocks.ConfigHandler.SetContext("test-context")
+		if err := mocks.ConfigHandler.LoadConfigString(`
+version: v1alpha1
+contexts:
+  test-context:
+    azure:
+      region: westeurope
+`); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+		mocks.Shell.IsGlobalFunc = func() bool { return true }
+		printer := NewAzureEnvPrinter(mocks.Shell, mocks.ConfigHandler)
+		printer.shims = mocks.Shims
+
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars: %v", err)
+		}
+
+		if got := envVars["TF_VAR_region"]; got != "westeurope" {
+			t.Errorf("TF_VAR_region = %q, want %q (global mode must still emit)", got, "westeurope")
+		}
+	})
+}


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> The change is additive: `azure.region` defaults to nil/absent, so all existing configs are unaffected. Users who explicitly set the field will now see `TF_VAR_region` emitted in their shell, which is the intended effect.
>
> **Overview**
>
> This PR adds `azure.region` as an optional field to both `v1alpha1` and `v1alpha2` `AzureConfig`, wires it through `Merge`/`Copy`/`DeepCopy`, and emits it as `TF_VAR_region` inside `GetEnvVars()` when the value is present. The variable is emitted in both project and global shell modes, mirroring how `TF_VAR_kubelogin_mode` behaves today, and is intentionally omitted when unset so downstream terraform modules retain their own defaults.
>
> `TF_VAR_region` is unique to the Azure env printer — there is no collision with the AWS printer. The integration test validates init-to-YAML persistence; `GetEnvVars` emission is covered at unit-test level by four dedicated sub-tests including a global-mode case.
>
> Reviewed by Claude for commit `2e1d1955`.

<!-- /claude-code-review:summary -->
