### PR TITLE
fix(runtime): add support for GitHub Actions OIDC in Azure kubelogin mode detection

### DIFF
--- a/pkg/runtime/env/azure_env.go
+++ b/pkg/runtime/env/azure_env.go
@@ -94,8 +94,9 @@ func (e *AzureEnvPrinter) GetEnvVars() (map[string]string, error) {
 // resolveKubeloginMode returns the kubelogin login mode for the AKS
 // kubeconfig, in precedence order: azure.kubelogin_mode (operator override,
 // the only path that handles managed-identity since MI has no env signal) →
-// AZURE_FEDERATED_TOKEN_FILE → workloadidentity → AZURE_CLIENT_SECRET /
-// AZURE_CLIENT_CERTIFICATE_PATH → spn → otherwise → azurecli.
+// AZURE_FEDERATED_TOKEN_FILE / GitHub Actions OIDC → workloadidentity →
+// AZURE_CLIENT_SECRET / AZURE_CLIENT_CERTIFICATE_PATH → spn → otherwise →
+// azurecli.
 func (e *AzureEnvPrinter) resolveKubeloginMode(config *v1alpha1.Context) string {
 	if config != nil && config.Azure != nil && config.Azure.KubeloginMode != nil {
 		if v := *config.Azure.KubeloginMode; v != "" {
@@ -103,6 +104,10 @@ func (e *AzureEnvPrinter) resolveKubeloginMode(config *v1alpha1.Context) string 
 		}
 	}
 	if os.Getenv("AZURE_FEDERATED_TOKEN_FILE") != "" {
+		return "workloadidentity"
+	}
+	if os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN") != "" &&
+		os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL") != "" {
 		return "workloadidentity"
 	}
 	if os.Getenv("AZURE_CLIENT_SECRET") != "" || os.Getenv("AZURE_CLIENT_CERTIFICATE_PATH") != "" {

--- a/pkg/runtime/env/azure_env_test.go
+++ b/pkg/runtime/env/azure_env_test.go
@@ -219,6 +219,8 @@ func TestAzureEnv_KubeloginMode(t *testing.T) {
 		t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "")
 		t.Setenv("AZURE_CLIENT_SECRET", "")
 		t.Setenv("AZURE_CLIENT_CERTIFICATE_PATH", "")
+		t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "")
+		t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "")
 	}
 
 	setupPrinter := func(t *testing.T, configStr string) (*AzureEnvPrinter, config.ConfigHandler) {
@@ -283,11 +285,59 @@ contexts:
 		}
 	})
 
+	t.Run("DetectsWorkloadIdentityFromGitHubActionsOIDC", func(t *testing.T) {
+		// Given a hosted GitHub Actions runner with id-token: write — kubelogin
+		// fetches the federated token from the Actions endpoint, so no
+		// AZURE_FEDERATED_TOKEN_FILE exists.
+		clearAmbient(t)
+		t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "actions-oidc-bearer")
+		t.Setenv("ACTIONS_ID_TOKEN_REQUEST_URL", "https://pipelines.actions.githubusercontent.com/...")
+		printer, _ := setupPrinter(t, `
+version: v1alpha1
+contexts:
+  test-context:
+    azure:
+      tenant_id: 11111111-2222-3333-4444-555555555555
+`)
+
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars: %v", err)
+		}
+
+		// Then TF_VAR_kubelogin_mode = workloadidentity (kubelogin pulls the token from Actions)
+		if got := envVars["TF_VAR_kubelogin_mode"]; got != "workloadidentity" {
+			t.Errorf("TF_VAR_kubelogin_mode = %q, want %q under GitHub Actions OIDC", got, "workloadidentity")
+		}
+	})
+
+	t.Run("IgnoresPartialGitHubActionsOIDC", func(t *testing.T) {
+		// Given only the Actions OIDC token without the request URL — kubelogin
+		// can't fetch a token, so this is not a workload-identity runner.
+		clearAmbient(t)
+		t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "actions-oidc-bearer")
+		printer, _ := setupPrinter(t, `
+version: v1alpha1
+contexts:
+  test-context:
+    azure:
+      tenant_id: 11111111-2222-3333-4444-555555555555
+`)
+
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars: %v", err)
+		}
+
+		if got := envVars["TF_VAR_kubelogin_mode"]; got != "azurecli" {
+			t.Errorf("TF_VAR_kubelogin_mode = %q, want %q when only ACTIONS_ID_TOKEN_REQUEST_TOKEN is set", got, "azurecli")
+		}
+	})
+
 	t.Run("DetectsSpnFromClientSecret", func(t *testing.T) {
 		// Given a CI runner with SPN secret env
-		t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "")
+		clearAmbient(t)
 		t.Setenv("AZURE_CLIENT_SECRET", "spn-secret-value")
-		t.Setenv("AZURE_CLIENT_CERTIFICATE_PATH", "")
 		printer, _ := setupPrinter(t, `
 version: v1alpha1
 contexts:
@@ -308,8 +358,7 @@ contexts:
 
 	t.Run("DetectsSpnFromCertificatePath", func(t *testing.T) {
 		// Given a runner with SPN cert auth — same kubelogin mode as secret-based SPN
-		t.Setenv("AZURE_FEDERATED_TOKEN_FILE", "")
-		t.Setenv("AZURE_CLIENT_SECRET", "")
+		clearAmbient(t)
 		t.Setenv("AZURE_CLIENT_CERTIFICATE_PATH", "/secrets/spn.pem")
 		printer, _ := setupPrinter(t, `
 version: v1alpha1

--- a/pkg/runtime/env/azure_env_test.go
+++ b/pkg/runtime/env/azure_env_test.go
@@ -312,11 +312,23 @@ contexts:
 	})
 
 	t.Run("IgnoresPartialGitHubActionsOIDC", func(t *testing.T) {
-		// Given only the Actions OIDC token without the request URL — kubelogin
-		// can't fetch a token, so this is not a workload-identity runner.
-		clearAmbient(t)
-		t.Setenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN", "actions-oidc-bearer")
-		printer, _ := setupPrinter(t, `
+		// Given only one half of the Actions OIDC pair — kubelogin can't fetch a
+		// token from the endpoint, so neither direction is a workload-identity
+		// runner. Both single-var cases must fall through to azurecli; this also
+		// guards the && in resolveKubeloginMode against a regression to ||.
+		partial := []struct {
+			name  string
+			key   string
+			value string
+		}{
+			{"TokenWithoutUrl", "ACTIONS_ID_TOKEN_REQUEST_TOKEN", "actions-oidc-bearer"},
+			{"UrlWithoutToken", "ACTIONS_ID_TOKEN_REQUEST_URL", "https://pipelines.actions.githubusercontent.com/..."},
+		}
+		for _, tc := range partial {
+			t.Run(tc.name, func(t *testing.T) {
+				clearAmbient(t)
+				t.Setenv(tc.key, tc.value)
+				printer, _ := setupPrinter(t, `
 version: v1alpha1
 contexts:
   test-context:
@@ -324,13 +336,15 @@ contexts:
       tenant_id: 11111111-2222-3333-4444-555555555555
 `)
 
-		envVars, err := printer.GetEnvVars()
-		if err != nil {
-			t.Fatalf("GetEnvVars: %v", err)
-		}
+				envVars, err := printer.GetEnvVars()
+				if err != nil {
+					t.Fatalf("GetEnvVars: %v", err)
+				}
 
-		if got := envVars["TF_VAR_kubelogin_mode"]; got != "azurecli" {
-			t.Errorf("TF_VAR_kubelogin_mode = %q, want %q when only ACTIONS_ID_TOKEN_REQUEST_TOKEN is set", got, "azurecli")
+				if got := envVars["TF_VAR_kubelogin_mode"]; got != "azurecli" {
+					t.Errorf("TF_VAR_kubelogin_mode = %q, want %q when only %s is set", got, "azurecli", tc.key)
+				}
+			})
 		}
 	})
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This change is isolated to environment-variable detection logic within a single function and adds no new data flow paths beyond the existing workload-identity mode.
>
> **Overview**
>
> The PR teaches `resolveKubeloginMode` to recognize GitHub Actions OIDC federation as a workload-identity signal. When both `ACTIONS_ID_TOKEN_REQUEST_TOKEN` and `ACTIONS_ID_TOKEN_REQUEST_URL` are present, kubelogin can fetch an Azure AD token directly from the Actions endpoint without a pre-materialized `AZURE_FEDERATED_TOKEN_FILE`, so returning `workloadidentity` here is correct. The existing `AZURE_FEDERATED_TOKEN_FILE` branch retains priority over the OIDC path. The new tests cover the happy path and the TOKEN-only partial case; the URL-only partial case is the one coverage gap, flagged inline.
>
> Reviewed by Claude for commit `2e6401ce`.

<!-- /claude-code-review:summary -->
