### PR TITLE
fix(cmd): improve output formatting for deferred work commands

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -153,11 +153,13 @@ windsor up --blueprint=ghcr.io/myorg/blueprint:v1.0.0`,
 
 // printDeferredWork renders the end-of-run summary for items the apply skipped because they
 // require elevation Up() will not request. Required items render as halt sentences ("then
-// re-run 'windsor up'"); optional items render as outcome sentences below. An optional item
-// whose command matches a required item is folded into that required line ("Run 'X' to <outcome>,
-// then re-run 'windsor up'.") rather than repeated on its own line, so the same command is never
-// printed twice. Empty items produce no output. goos selects the OS-specific elevation
-// parenthetical: "(Administrator PowerShell)" on windows, "(asks for sudo)" elsewhere.
+// re-run 'windsor up'"); optional items render as outcome sentences below. Each required item
+// folds in the first not-yet-folded optional item that shares its command ("Run 'X' to <outcome>,
+// then re-run 'windsor up'.") so the same command is never printed twice for the same outcome.
+// Any optional item not folded into a required line — including a second outcome sharing a folded
+// command — still renders on its own line, so no outcome is silently dropped. Empty items produce
+// no output. goos selects the OS-specific elevation parenthetical: "(Administrator PowerShell)" on
+// windows, "(asks for sudo)" elsewhere.
 func printDeferredWork(w io.Writer, items []workstation.DeferredWorkItem, goos string) {
 	if len(items) == 0 {
 		return
@@ -166,20 +168,16 @@ func printDeferredWork(w io.Writer, items []workstation.DeferredWorkItem, goos s
 	if goos == "windows" {
 		paren = "(Administrator PowerShell)"
 	}
-	required := make(map[string]bool)
-	for _, item := range items {
-		if item.Required {
-			required[item.Command] = true
-		}
-	}
+	folded := make(map[int]bool)
 	for _, item := range items {
 		if !item.Required {
 			continue
 		}
 		outcome := ""
-		for _, other := range items {
-			if !other.Required && other.Command == item.Command && other.Outcome != "" {
+		for j, other := range items {
+			if !other.Required && !folded[j] && other.Command == item.Command && other.Outcome != "" {
 				outcome = other.Outcome
+				folded[j] = true
 				break
 			}
 		}
@@ -189,8 +187,8 @@ func printDeferredWork(w io.Writer, items []workstation.DeferredWorkItem, goos s
 			fmt.Fprintf(w, "Run '%s' %s, then re-run 'windsor up'.\n", item.Command, paren)
 		}
 	}
-	for _, item := range items {
-		if !item.Required && !required[item.Command] {
+	for j, item := range items {
+		if !item.Required && !folded[j] {
 			fmt.Fprintf(w, "Run '%s' %s to %s.\n", item.Command, paren, item.Outcome)
 		}
 	}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -153,11 +153,11 @@ windsor up --blueprint=ghcr.io/myorg/blueprint:v1.0.0`,
 
 // printDeferredWork renders the end-of-run summary for items the apply skipped because they
 // require elevation Up() will not request. Required items render as halt sentences ("then
-// re-run 'windsor up'"); optional items render as outcome sentences below. When both are
-// present the operator sees the halt instruction first, then any optional follow-up outcomes
-// the same command will also produce — they don't disappear just because a halt is in flight.
-// Empty items produce no output. goos selects the OS-specific elevation parenthetical:
-// "(Administrator PowerShell)" on windows, "(asks for sudo)" elsewhere.
+// re-run 'windsor up'"); optional items render as outcome sentences below. An optional item
+// whose command matches a required item is folded into that required line ("Run 'X' to <outcome>,
+// then re-run 'windsor up'.") rather than repeated on its own line, so the same command is never
+// printed twice. Empty items produce no output. goos selects the OS-specific elevation
+// parenthetical: "(Administrator PowerShell)" on windows, "(asks for sudo)" elsewhere.
 func printDeferredWork(w io.Writer, items []workstation.DeferredWorkItem, goos string) {
 	if len(items) == 0 {
 		return
@@ -166,13 +166,31 @@ func printDeferredWork(w io.Writer, items []workstation.DeferredWorkItem, goos s
 	if goos == "windows" {
 		paren = "(Administrator PowerShell)"
 	}
+	required := make(map[string]bool)
 	for _, item := range items {
 		if item.Required {
-			fmt.Fprintf(w, "Run '%s' %s, then re-run 'windsor up'.\n", item.Command, paren)
+			required[item.Command] = true
 		}
 	}
 	for _, item := range items {
 		if !item.Required {
+			continue
+		}
+		outcome := ""
+		for _, other := range items {
+			if !other.Required && other.Command == item.Command && other.Outcome != "" {
+				outcome = other.Outcome
+				break
+			}
+		}
+		if outcome != "" {
+			fmt.Fprintf(w, "Run '%s' %s to %s, then re-run 'windsor up'.\n", item.Command, paren, outcome)
+		} else {
+			fmt.Fprintf(w, "Run '%s' %s, then re-run 'windsor up'.\n", item.Command, paren)
+		}
+	}
+	for _, item := range items {
+		if !item.Required && !required[item.Command] {
 			fmt.Fprintf(w, "Run '%s' %s to %s.\n", item.Command, paren, item.Outcome)
 		}
 	}

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -716,6 +716,23 @@ func TestPrintDeferredWork(t *testing.T) {
 		}
 	})
 
+	t.Run("SecondOptionalOutcomeSharingRequiredCommandStillRenders", func(t *testing.T) {
+		// Given a required halt plus TWO optional outcomes sharing its command — only the first
+		// folds into the halt line; the second must still render on its own line rather than
+		// being silently dropped.
+		var buf strings.Builder
+		printDeferredWork(&buf, []workstation.DeferredWorkItem{
+			{Required: true, Command: "windsor configure network"},
+			{Required: false, Command: "windsor configure network", Outcome: "use *.local.test in your browser"},
+			{Required: false, Command: "windsor configure network", Outcome: "reach the cluster ingress"},
+		}, "darwin")
+		want := "Run 'windsor configure network' (asks for sudo) to use *.local.test in your browser, then re-run 'windsor up'.\n" +
+			"Run 'windsor configure network' (asks for sudo) to reach the cluster ingress.\n"
+		if buf.String() != want {
+			t.Errorf("Expected second outcome preserved %q, got %q", want, buf.String())
+		}
+	})
+
 	t.Run("MultipleOptionalItemsEachRenderOnTheirOwnLine", func(t *testing.T) {
 		var buf strings.Builder
 		printDeferredWork(&buf, []workstation.DeferredWorkItem{

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -687,20 +687,32 @@ func TestPrintDeferredWork(t *testing.T) {
 		}
 	})
 
-	t.Run("RequiredItemEmitsHaltSentenceFirstThenOptionalOutcomes", func(t *testing.T) {
-		// Given a halt (cluster-privilege) paired with an optional outcome (DNS hint) — the
-		// typical first-run colima case where 'configure network' will produce both. The
-		// operator must see BOTH: the halt instruction (with re-run guidance) AND the
-		// follow-up outcome they'll get from the same command.
+	t.Run("RequiredItemFoldsMatchingOptionalOutcomeIntoSingleLine", func(t *testing.T) {
+		// Given a halt (cluster-privilege) paired with an optional outcome (DNS hint) sharing
+		// the same command — the typical first-run colima case where 'configure network' will
+		// produce both. The operator must see one line that names the outcome AND the re-run
+		// guidance, not the same command printed twice.
 		var buf strings.Builder
 		printDeferredWork(&buf, []workstation.DeferredWorkItem{
 			{Required: false, Command: "windsor configure network", Outcome: "use *.local.test in your browser"},
 			{Required: true, Command: "windsor configure network"},
 		}, "darwin")
-		want := "Run 'windsor configure network' (asks for sudo), then re-run 'windsor up'.\n" +
-			"Run 'windsor configure network' (asks for sudo) to use *.local.test in your browser.\n"
+		want := "Run 'windsor configure network' (asks for sudo) to use *.local.test in your browser, then re-run 'windsor up'.\n"
 		if buf.String() != want {
-			t.Errorf("Expected halt + optional output %q, got %q", want, buf.String())
+			t.Errorf("Expected folded output %q, got %q", want, buf.String())
+		}
+	})
+
+	t.Run("OptionalItemWithDistinctCommandStillRendersSeparatelyAlongsideHalt", func(t *testing.T) {
+		var buf strings.Builder
+		printDeferredWork(&buf, []workstation.DeferredWorkItem{
+			{Required: true, Command: "windsor configure network"},
+			{Required: false, Command: "windsor configure network --revert", Outcome: "remove host configuration"},
+		}, "darwin")
+		want := "Run 'windsor configure network' (asks for sudo), then re-run 'windsor up'.\n" +
+			"Run 'windsor configure network --revert' (asks for sudo) to remove host configuration.\n"
+		if buf.String() != want {
+			t.Errorf("Expected halt + distinct optional %q, got %q", want, buf.String())
 		}
 	})
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,128 @@
+---
+title: Installation
+description: Install the Windsor CLI on macOS, Windows, or Linux.
+---
+
+<!--
+  Rendered by windsorcli.github.io with a custom OS-tabbed layout. Per-OS
+  sections are delimited by HTML comments of the form `os:NAME` (macos /
+  windows / linux); everything before the first one is shared preamble. The
+  tokens VERSION and RELEASES (each in double curly braces) are substituted by
+  the site with the pinned CLI version and the GitHub releases URL.
+-->
+
+This page covers installing the Windsor CLI binary and verifying it runs. Choose your OS below for package manager, install script, and manual options.
+
+<!-- os:macos -->
+
+### Homebrew
+
+```sh
+brew update
+brew tap windsorcli/cli
+brew install windsor
+```
+
+### Install script
+
+```sh
+curl -fsSL https://windsorcli.dev/install.sh | sh
+```
+
+Restart your shell or run `source ~/.zshrc` (or `~/.bashrc`) so `windsor` is on your PATH.
+
+### Manual (ARM64)
+
+```sh
+curl -L -o windsor_{{VERSION}}_darwin_arm64.tar.gz {{RELEASES}}/download/v{{VERSION}}/windsor_{{VERSION}}_darwin_arm64.tar.gz
+tar -xzf windsor_{{VERSION}}_darwin_arm64.tar.gz -C /usr/local/bin
+chmod +x /usr/local/bin/windsor
+```
+
+### Manual (AMD64)
+
+```sh
+curl -L -o windsor_{{VERSION}}_darwin_amd64.tar.gz {{RELEASES}}/download/v{{VERSION}}/windsor_{{VERSION}}_darwin_amd64.tar.gz
+tar -xzf windsor_{{VERSION}}_darwin_amd64.tar.gz -C /usr/local/bin
+chmod +x /usr/local/bin/windsor
+```
+
+## Verify
+
+```sh
+windsor version
+```
+
+**Shell hook (optional).** You don't need this to install blueprints or run `windsor bootstrap`, and `windsor exec -- <command>` runs any one-off command with the right environment. It's mainly for developing Terraform on top of a blueprint: add `eval "$(windsor hook bash)"` (or `zsh`) to your shell profile so your context's variables — `KUBECONFIG`, cloud profile, Talos config — stay current on every prompt. See [Environment injection](/contexts/environment-injection).
+
+<!-- os:windows -->
+
+### Chocolatey
+
+Run in PowerShell as Administrator:
+
+```powershell
+choco install windsor
+```
+
+### Install script (PowerShell)
+
+```powershell
+irm https://windsorcli.dev/install.ps1 | iex
+```
+
+### Manual (PowerShell as Administrator)
+
+```powershell
+$installDir = "C:\Program Files\Windsor"
+New-Item -Path $installDir -ItemType Directory -Force
+Invoke-WebRequest -Uri "{{RELEASES}}/download/v{{VERSION}}/windsor_{{VERSION}}_windows_amd64.zip" -Headers @{"Accept"="application/octet-stream"} -OutFile "windsor_{{VERSION}}_windows_amd64.zip"
+Expand-Archive -Path "windsor_{{VERSION}}_windows_amd64.zip" -DestinationPath $installDir -Force
+$currentPath = [Environment]::GetEnvironmentVariable("Path", "Machine")
+if ($currentPath -notlike "*$installDir*") {
+  [Environment]::SetEnvironmentVariable("Path", "$currentPath;$installDir", "Machine")
+  $env:Path += ";$installDir"
+}
+```
+
+## Verify
+
+```powershell
+windsor version
+```
+
+**Shell hook (optional).** You don't need this to install blueprints or run `windsor bootstrap`, and `windsor exec -- <command>` runs any one-off command with the right environment. It's mainly for developing Terraform on top of a blueprint: add `Invoke-Expression (& windsor hook powershell)` to your PowerShell profile so your context's variables stay current on every prompt. See [Environment injection](/contexts/environment-injection).
+
+<!-- os:linux -->
+
+### Install script
+
+```sh
+curl -fsSL https://windsorcli.dev/install.sh | sh
+```
+
+Restart your shell or run `source ~/.bashrc` (or your profile) so `windsor` is on your PATH.
+
+### Manual (ARM64)
+
+```sh
+curl -L -o windsor_{{VERSION}}_linux_arm64.tar.gz {{RELEASES}}/download/v{{VERSION}}/windsor_{{VERSION}}_linux_arm64.tar.gz
+sudo tar -xzf windsor_{{VERSION}}_linux_arm64.tar.gz -C /usr/local/bin
+sudo chmod +x /usr/local/bin/windsor
+```
+
+### Manual (AMD64)
+
+```sh
+curl -L -o windsor_{{VERSION}}_linux_amd64.tar.gz {{RELEASES}}/download/v{{VERSION}}/windsor_{{VERSION}}_linux_amd64.tar.gz
+sudo tar -xzf windsor_{{VERSION}}_linux_amd64.tar.gz -C /usr/local/bin
+sudo chmod +x /usr/local/bin/windsor
+```
+
+## Verify
+
+```sh
+windsor version
+```
+
+**Shell hook (optional).** You don't need this to install blueprints or run `windsor bootstrap`, and `windsor exec -- <command>` runs any one-off command with the right environment. It's mainly for developing Terraform on top of a blueprint: add `eval "$(windsor hook bash)"` (or `zsh`) to your shell profile so your context's variables — `KUBECONFIG`, cloud profile, Talos config — stay current on every prompt. See [Environment injection](/contexts/environment-injection).


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This change is isolated to a single CLI output function and a new documentation file, with no effect on persistent state or shared infrastructure.
>
> **Overview**
>
> The PR fixes a duplicate-command problem in `printDeferredWork`: when a required and an optional `DeferredWorkItem` share the same command string, the optional outcome is now folded into the required line ("Run 'X' to Y, then re-run 'windsor up'.") rather than printed as a separate follow-up. Optional items whose command does not match any required item continue to render on their own line. The commit also adds a new `docs/installation.md` covering Homebrew, install-script, and manual binary options for macOS, Windows, and Linux.
>
> The one latent concern is that the inner fold loop breaks on the first matching optional outcome, and the third loop then suppresses all optional items sharing that command — so a second optional outcome for the same command would be silently dropped. A test covering that case would close the gap.
>
> Reviewed by Claude for commit `a7d28b67`.

<!-- /claude-code-review:summary -->
