### PR TITLE
fix(cmd/destroy): surface detailed error messages for failed kustomization deletions

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -437,7 +437,10 @@ func requireContinueScope(args []string) error {
 // returns a non-zero exit error when any component failed. Without --continue
 // the existing per-error abort already surfaces failures, so no extra output
 // is needed; this only fires when the operator opted into best-effort mode.
-// Returns nil when destroyContinue is false or when no failures were recorded.
+// After the summary, each failure's underlying error is printed so the operator
+// can diagnose the cause (e.g. a stuck kustomization finalizer) without re-running
+// under a debugger. Returns nil when destroyContinue is false or when no failures
+// were recorded.
 func finishContinueDestroy(w io.Writer, result provisioner.DestroyResult) error {
 	if !destroyContinue {
 		return nil
@@ -460,9 +463,6 @@ func finishContinueDestroy(w io.Writer, result provisioner.DestroyResult) error 
 	}
 	fmt.Fprintf(w, "windsor destroy: %s\n", strings.Join(parts, ", "))
 	if len(result.Failed) > 0 {
-		// The summary line names which components failed but not why. Print each
-		// underlying error so the operator can diagnose the failure (e.g. a stuck
-		// kustomization finalizer) without re-running under a debugger.
 		for _, f := range result.Failed {
 			if f.Err != nil {
 				fmt.Fprintf(w, "  %s: %v\n", f.ID, f.Err)

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -460,6 +460,14 @@ func finishContinueDestroy(w io.Writer, result provisioner.DestroyResult) error 
 	}
 	fmt.Fprintf(w, "windsor destroy: %s\n", strings.Join(parts, ", "))
 	if len(result.Failed) > 0 {
+		// The summary line names which components failed but not why. Print each
+		// underlying error so the operator can diagnose the failure (e.g. a stuck
+		// kustomization finalizer) without re-running under a debugger.
+		for _, f := range result.Failed {
+			if f.Err != nil {
+				fmt.Fprintf(w, "  %s: %v\n", f.ID, f.Err)
+			}
+		}
 		return fmt.Errorf("destroy completed with %d failure(s); rerun `windsor destroy --continue` after resolving them", len(result.Failed))
 	}
 	return nil

--- a/cmd/destroy_test.go
+++ b/cmd/destroy_test.go
@@ -691,6 +691,10 @@ func TestDestroyCmd(t *testing.T) {
 		if !strings.Contains(out, "1 failed (iam)") {
 			t.Errorf("Expected summary to name failed component, got: %q", out)
 		}
+		// The summary names the component; the operator also needs the reason.
+		if !strings.Contains(out, "iam: permission denied") {
+			t.Errorf("Expected failure detail to surface the underlying error, got: %q", out)
+		}
 	})
 
 	t.Run("NoSummaryWithoutContinueFlag", func(t *testing.T) {

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -177,18 +177,79 @@ func (k *BaseKubernetesManager) DeleteKustomization(name, namespace string) erro
 	}
 
 	timeout := time.Now().Add(k.kustomizationReconcileTimeout)
+	var lastObj *unstructured.Unstructured
 	for time.Now().Before(timeout) {
-		_, err := k.client.GetResource(gvr, namespace, name)
+		obj, err := k.client.GetResource(gvr, namespace, name)
 		if err != nil && isNotFoundError(err) {
 			return nil
 		}
 		if err != nil {
 			return fmt.Errorf("error checking kustomization deletion status: %w", err)
 		}
+		lastObj = obj
 		time.Sleep(k.kustomizationWaitPollInterval)
 	}
 
-	return fmt.Errorf("timeout waiting for kustomization %s/%s to be deleted; an inventory item is likely stuck on a cloud-controller finalizer — inspect with `kubectl get kustomization %s -n %s -o yaml` (status.conditions, status.inventory) and `kubectl get pvc,svc,ingress,certificate -A | grep Terminating` to find the stuck object", namespace, name, name, namespace)
+	reason := describeStuckKustomization(lastObj)
+	return fmt.Errorf("timeout waiting for kustomization %s/%s to be deleted%s; an inventory item is likely stuck on a cloud-controller finalizer — inspect with `kubectl get kustomization %s -n %s -o yaml` (status.conditions, status.inventory) and `kubectl get pvc,svc,ingress,certificate -A | grep Terminating` to find the stuck object", namespace, name, reason, name, namespace)
+}
+
+// describeStuckKustomization extracts the most diagnostic status condition from a
+// Kustomization that failed to delete in time, formatted as " (Type=Status Reason: message)"
+// for inline inclusion in the timeout error. Flux records the real failure cause
+// (prune failure, healthcheck failure, dependency-not-ready) in status.conditions,
+// so surfacing it here saves the operator a manual kubectl round-trip. Preference
+// order is Stalled, then non-True Ready, then any other non-True condition — these
+// carry the actionable reason; a bare Ready=True (rare during a stuck delete) is not
+// reported. Returns an empty string when no object was captured or no condition
+// carries a usable message, so the caller's sentence reads cleanly without it.
+func describeStuckKustomization(obj *unstructured.Unstructured) string {
+	if obj == nil {
+		return ""
+	}
+	conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if err != nil || !found {
+		return ""
+	}
+	var ready, stalled, other map[string]any
+	for _, c := range conditions {
+		cond, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		condType, _ := cond["type"].(string)
+		condStatus, _ := cond["status"].(string)
+		switch {
+		case condType == "Stalled" && condStatus == "True":
+			stalled = cond
+		case condType == "Ready" && condStatus != "True":
+			ready = cond
+		case condStatus != "True" && other == nil:
+			other = cond
+		}
+	}
+	pick := stalled
+	if pick == nil {
+		pick = ready
+	}
+	if pick == nil {
+		pick = other
+	}
+	if pick == nil {
+		return ""
+	}
+	condType, _ := pick["type"].(string)
+	condStatus, _ := pick["status"].(string)
+	reason, _ := pick["reason"].(string)
+	message, _ := pick["message"].(string)
+	message = strings.TrimSpace(message)
+	if message == "" {
+		return ""
+	}
+	if reason != "" {
+		return fmt.Sprintf(" (%s=%s %s: %s)", condType, condStatus, reason, message)
+	}
+	return fmt.Sprintf(" (%s=%s: %s)", condType, condStatus, message)
 }
 
 // WaitForKustomizations waits for kustomizations to be ready, calculating the timeout

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -242,7 +242,7 @@ func describeStuckKustomization(obj *unstructured.Unstructured) string {
 	condStatus, _ := pick["status"].(string)
 	reason, _ := pick["reason"].(string)
 	message, _ := pick["message"].(string)
-	message = strings.TrimSpace(message)
+	message = strings.ReplaceAll(strings.TrimSpace(message), "\n", " ")
 	if message == "" {
 		return ""
 	}

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -300,6 +300,48 @@ func TestBaseKubernetesManager_DeleteKustomization(t *testing.T) {
 		}
 	})
 
+	t.Run("TimeoutSurfacesStatusCondition", func(t *testing.T) {
+		// Given a kustomization that never disappears and whose status reports the
+		// real reason it is stuck (Flux records the prune failure in a condition)
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			return nil
+		}
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			return &unstructured.Unstructured{Object: map[string]any{
+				"status": map[string]any{
+					"conditions": []any{
+						map[string]any{
+							"type":    "Ready",
+							"status":  "False",
+							"reason":  "PruneFailed",
+							"message": "ServiceAccount/telemetry/collector still has finalizer",
+						},
+					},
+				},
+			}}, nil
+		}
+		manager.client = kubernetesClient
+		manager.kustomizationReconcileTimeout = 100 * time.Millisecond
+		manager.kustomizationWaitPollInterval = 50 * time.Millisecond
+
+		// When DeleteKustomization times out
+		err := manager.DeleteKustomization("test-kustomization", "test-namespace")
+
+		// Then the error surfaces the Flux condition reason and message inline so the
+		// operator sees why without a manual kubectl round-trip
+		if err == nil {
+			t.Fatal("Expected timeout error, got nil")
+		}
+		if !strings.Contains(err.Error(), "PruneFailed") {
+			t.Errorf("Expected error to surface the condition reason, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "still has finalizer") {
+			t.Errorf("Expected error to surface the condition message, got: %v", err)
+		}
+	})
+
 	t.Run("ErrorCheckingDeletionStatus", func(t *testing.T) {
 		manager := setup(t)
 		kubernetesClient := client.NewMockKubernetesClient()

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -342,6 +342,51 @@ func TestBaseKubernetesManager_DeleteKustomization(t *testing.T) {
 		}
 	})
 
+	t.Run("TimeoutFlattensMultilineConditionMessage", func(t *testing.T) {
+		// Given a stuck kustomization whose condition message spans multiple lines
+		// (Flux records YAML snippets and chained failures this way)
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			return nil
+		}
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			return &unstructured.Unstructured{Object: map[string]any{
+				"status": map[string]any{
+					"conditions": []any{
+						map[string]any{
+							"type":    "Stalled",
+							"status":  "True",
+							"reason":  "ReconciliationFailed",
+							"message": "prune failed:\nSecret/telemetry/token dependency not ready\nretrying",
+						},
+					},
+				},
+			}}, nil
+		}
+		manager.client = kubernetesClient
+		manager.kustomizationReconcileTimeout = 100 * time.Millisecond
+		manager.kustomizationWaitPollInterval = 50 * time.Millisecond
+
+		// When DeleteKustomization times out
+		err := manager.DeleteKustomization("test-kustomization", "test-namespace")
+
+		// Then the embedded newlines are flattened so the error stays on one line
+		if err == nil {
+			t.Fatal("Expected timeout error, got nil")
+		}
+		condPart := err.Error()
+		if i := strings.Index(condPart, "(Stalled"); i >= 0 {
+			condPart = condPart[i:]
+		}
+		if strings.Contains(condPart, "\n") {
+			t.Errorf("Expected condition detail to be single-line, got embedded newline: %q", err)
+		}
+		if !strings.Contains(err.Error(), "prune failed: Secret/telemetry/token dependency not ready retrying") {
+			t.Errorf("Expected flattened message, got: %v", err)
+		}
+	})
+
 	t.Run("ErrorCheckingDeletionStatus", func(t *testing.T) {
 		manager := setup(t)
 		kubernetesClient := client.NewMockKubernetesClient()


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This change is additive and isolated — it adds diagnostic output paths but does not alter any existing behavior or decision logic.
>
> **Overview**
>
> The PR surfaces two categories of diagnostic information that were previously silent. In `finishContinueDestroy`, each failed component now prints its underlying error before the summary return, so operators see `iam: permission denied` instead of only a count. In `DeleteKustomization`, the timeout error is enriched with the kustomization's Flux status condition (preferring Stalled, then non-True Ready, then any non-True condition), sparing operators a manual `kubectl get` round-trip to diagnose a stuck finalizer.
>
> The condition-priority logic and the nil-safety path (returning empty string when no object was captured) are sound. The one concrete concern is that Flux condition messages occasionally contain embedded newlines; without collapsing them the timeout error can split mid-sentence in terminal output.
>
> Reviewed by Claude for commit `ca46d89`.

<!-- /claude-code-review:summary -->
