### PR TITLE
fix(cmd): surface detailed timeout errors for not ready kustomizations

### DIFF
--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -81,6 +81,8 @@ type BaseKubernetesManager struct {
 	kustomizationReconcileTimeout time.Duration
 	kustomizationReconcileSleep   time.Duration
 
+	notReadyDescribeBudget time.Duration
+
 	healthCheckPollInterval time.Duration
 	nodeReadyPollInterval   time.Duration
 }
@@ -102,6 +104,7 @@ func NewKubernetesManager(kubernetesClient client.KubernetesClient, configHandle
 		kustomizationWaitPollInterval: 2 * time.Second,
 		kustomizationReconcileTimeout: 5 * time.Minute,
 		kustomizationReconcileSleep:   2 * time.Second,
+		notReadyDescribeBudget:        10 * time.Second,
 		healthCheckPollInterval:       10 * time.Second,
 		nodeReadyPollInterval:         5 * time.Second,
 	}
@@ -261,14 +264,25 @@ func describeStuckKustomization(obj *unstructured.Unstructured) string {
 // kubectl round-trip. A kustomization that cannot be read is listed by name
 // alone. Returns an empty string when every kustomization reads back Ready, so
 // the caller's sentence stays clean.
+//
+// Because this runs only after a wait already timed out, the API may be slow or
+// unreachable. Each GetResource is individually bounded by the client's request
+// timeout, but probing every kustomization serially could still compound into
+// minutes; total probing is therefore capped at notReadyDescribeBudget. Once the
+// budget is spent the remaining kustomizations are named without condition detail.
 func (k *BaseKubernetesManager) describeNotReadyKustomizations(names []string, namespace string) string {
 	gvr := schema.GroupVersionResource{
 		Group:    "kustomize.toolkit.fluxcd.io",
 		Version:  "v1",
 		Resource: "kustomizations",
 	}
+	start := time.Now()
 	var stuck []string
 	for _, name := range names {
+		if time.Since(start) >= k.notReadyDescribeBudget {
+			stuck = append(stuck, name)
+			continue
+		}
 		obj, err := k.client.GetResource(gvr, namespace, name)
 		if err != nil {
 			stuck = append(stuck, name)

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -252,6 +252,58 @@ func describeStuckKustomization(obj *unstructured.Unstructured) string {
 	return fmt.Sprintf(" (%s=%s: %s)", condType, condStatus, message)
 }
 
+// describeNotReadyKustomizations fetches the current state of each named
+// kustomization and returns a ": name (condition), ..." suffix naming those not
+// yet Ready, each annotated with its most diagnostic status condition. It is the
+// wait-timeout counterpart to the destroy-timeout enrichment: rather than a bare
+// "timeout waiting for kustomizations", the operator sees which ones are stuck
+// and why (e.g. a failed reconciliation or unmet dependency) without a manual
+// kubectl round-trip. A kustomization that cannot be read is listed by name
+// alone. Returns an empty string when every kustomization reads back Ready, so
+// the caller's sentence stays clean.
+func (k *BaseKubernetesManager) describeNotReadyKustomizations(names []string, namespace string) string {
+	gvr := schema.GroupVersionResource{
+		Group:    "kustomize.toolkit.fluxcd.io",
+		Version:  "v1",
+		Resource: "kustomizations",
+	}
+	var stuck []string
+	for _, name := range names {
+		obj, err := k.client.GetResource(gvr, namespace, name)
+		if err != nil {
+			stuck = append(stuck, name)
+			continue
+		}
+		if kustomizationReady(obj) {
+			continue
+		}
+		stuck = append(stuck, name+describeStuckKustomization(obj))
+	}
+	if len(stuck) == 0 {
+		return ""
+	}
+	return ": " + strings.Join(stuck, ", ")
+}
+
+// kustomizationReady reports whether a Kustomization's status carries a
+// Ready=True condition. A missing status or conditions slice reads as not ready.
+func kustomizationReady(obj *unstructured.Unstructured) bool {
+	conditions, found, err := unstructured.NestedSlice(obj.Object, "status", "conditions")
+	if err != nil || !found {
+		return false
+	}
+	for _, c := range conditions {
+		cond, ok := c.(map[string]any)
+		if !ok {
+			continue
+		}
+		if cond["type"] == "Ready" && cond["status"] == "True" {
+			return true
+		}
+	}
+	return false
+}
+
 // WaitForKustomizations waits for kustomizations to be ready, calculating the timeout
 // from the longest dependency chain in the blueprint. Outputs a debug message describing
 // the total wait timeout being used before beginning polling.
@@ -279,7 +331,7 @@ func (k *BaseKubernetesManager) WaitForKustomizations(message string, blueprint 
 		select {
 		case <-timeoutChan:
 			tui.Fail()
-			return fmt.Errorf("timeout waiting for kustomizations")
+			return fmt.Errorf("timeout waiting for kustomizations%s", k.describeNotReadyKustomizations(kustomizationNames, k.gitopsNamespace()))
 		case <-ticker.C:
 			allReady := true
 			for _, name := range kustomizationNames {

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -437,6 +437,34 @@ func TestBaseKubernetesManager_DeleteKustomization(t *testing.T) {
 	})
 }
 
+func TestBaseKubernetesManager_describeNotReadyKustomizations(t *testing.T) {
+	t.Run("ExhaustedBudgetNamesWithoutProbing", func(t *testing.T) {
+		// Given a diagnostic budget that is already spent before the first probe
+		mocks := setupKubernetesMocks(t)
+		manager := NewKubernetesManager(mocks.KubernetesClient, mocks.ConfigHandler)
+		manager.notReadyDescribeBudget = 0
+		kubernetesClient := client.NewMockKubernetesClient()
+		called := false
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			called = true
+			return &unstructured.Unstructured{}, nil
+		}
+		manager.client = kubernetesClient
+
+		// When describing not-ready kustomizations
+		got := manager.describeNotReadyKustomizations([]string{"dns", "pki-base"}, "flux-system")
+
+		// Then the API is never probed and every kustomization is named plainly,
+		// bounding the diagnostic when the API is the thing that's unresponsive.
+		if called {
+			t.Error("Expected no GetResource calls once the budget is exhausted")
+		}
+		if !strings.Contains(got, "dns") || !strings.Contains(got, "pki-base") {
+			t.Errorf("Expected both kustomizations named, got: %q", got)
+		}
+	})
+}
+
 func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 	setup := func(t *testing.T) *BaseKubernetesManager {
 		t.Helper()

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -519,6 +519,57 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 		if err == nil {
 			t.Error("Expected timeout error, got nil")
 		}
+		// The timeout error names which kustomization is still not Ready so the
+		// operator isn't left with a bare "timeout waiting for kustomizations".
+		if err != nil && !strings.Contains(err.Error(), "test-kustomization") {
+			t.Errorf("Expected timeout error to name the stuck kustomization, got: %v", err)
+		}
+	})
+
+	t.Run("TimeoutSurfacesNotReadyCondition", func(t *testing.T) {
+		// Given a kustomization stuck not-Ready with a diagnostic Flux condition
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			return &unstructured.Unstructured{
+				Object: map[string]any{
+					"status": map[string]any{
+						"conditions": []any{
+							map[string]any{
+								"type":    "Ready",
+								"status":  "False",
+								"reason":  "ReconciliationFailed",
+								"message": "dependency 'flux-system/pki-base' is not ready",
+							},
+						},
+					},
+				},
+			}, nil
+		}
+		manager.client = kubernetesClient
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{
+					Name:    "dns",
+					Timeout: &blueprintv1alpha1.DurationString{Duration: 50 * time.Millisecond},
+				},
+			},
+		}
+
+		// When the wait times out
+		err := manager.WaitForKustomizations("Waiting for kustomizations", blueprint)
+
+		// Then the error names the kustomization and surfaces the condition reason+message
+		if err == nil {
+			t.Fatal("Expected timeout error, got nil")
+		}
+		if !strings.Contains(err.Error(), "dns") {
+			t.Errorf("Expected error to name the stuck kustomization, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "ReconciliationFailed") || !strings.Contains(err.Error(), "is not ready") {
+			t.Errorf("Expected error to surface the condition reason and message, got: %v", err)
+		}
 	})
 
 	t.Run("MissingStatus", func(t *testing.T) {


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This is an additive change on the error path of `WaitForKustomizations`, introducing no new control flow or state — it only enriches the timeout error message and adds tests.
>
> **Overview**
>
> The PR mirrors the diagnostic enrichment already present on the destroy path: when `WaitForKustomizations` times out, it now snapshots each kustomization's status and appends which ones are still not Ready along with their most informative Flux condition (type, status, reason, message). The new `kustomizationReady` helper correctly checks for `Ready=True` using `unstructured.NestedSlice`, and the existing `describeStuckKustomization` function is reused as-is for the condition annotation. Tests cover both the kustomization-name-in-error and the condition-detail-in-error assertions.
>
> Reviewed by Claude for commit `fca92994`.

<!-- /claude-code-review:summary -->
