### PR TITLE
fix(provisioner): Destroy only timeout surfaces conditions

### DIFF
--- a/api/v1alpha1/docker/docker_config.go
+++ b/api/v1alpha1/docker/docker_config.go
@@ -3,7 +3,7 @@ package docker
 // DockerConfig represents the Docker configuration
 type DockerConfig struct {
 	// Enabled toggles the internal workstation (docker-compose). Deprecated: defaults to false;
-	// use provider and workstation.runtime for workstation mode. When false, omit from config (not written to windsor.yaml).
+	// use platform and workstation.runtime for workstation mode. When false, omit from config (not written to windsor.yaml).
 	Enabled     *bool                     `yaml:"enabled,omitempty"`
 	RegistryURL string                    `yaml:"registry_url,omitempty"`
 	Registries  map[string]RegistryConfig `yaml:"registries,omitempty"`

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -1074,7 +1074,7 @@ waitLoop:
 	if !allReady {
 		tui.Fail()
 		if !statusCheckFailed {
-			errors = append(errors, fmt.Errorf("destroy-only kustomizations did not become ready within timeout - cleanup may not have completed"))
+			errors = append(errors, fmt.Errorf("destroy-only kustomizations did not become ready within timeout - cleanup may not have completed%s", k.describeNotReadyKustomizations(kustomizationNames, k.gitopsNamespace())))
 		}
 		for i := len(kustomizations) - 1; i >= 0; i-- {
 			kustomization := kustomizations[i]

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -3148,6 +3148,11 @@ func TestBaseKubernetesManager_DeleteBlueprint(t *testing.T) {
 		if !strings.Contains(err.Error(), "did not become ready within timeout") {
 			t.Errorf("Expected timeout error, got %v", err)
 		}
+		// The timeout names which destroy-only kustomization is still not Ready
+		// rather than leaving the operator with a bare "cleanup may not have completed".
+		if !strings.Contains(err.Error(), "cleanup may not have completed: destroy-only") {
+			t.Errorf("Expected timeout error to name the stuck kustomization, got: %v", err)
+		}
 	})
 
 	t.Run("DestroyOnlyWithSubstitutions", func(t *testing.T) {


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> A narrow, isolated fix that mirrors an existing pattern; no shared infrastructure is touched.
>
> **Overview**
>
> This PR extends the destroy-only kustomization timeout error to include per-kustomization status detail, mirroring the enrichment already added to the regular wait path in #2778. The changed line calls `describeNotReadyKustomizations`, which returns either an empty string (all kustomizations read back Ready by the time of the post-timeout probe) or a `: name (condition), ...` suffix naming the stuck resources — exactly the contract the function documents at its return site (`return ": " + strings.Join(stuck, ", ")`). A companion test assertion verifies that the suffix appears in the rendered error.
>
> The comment change in `docker_config.go` corrects "provider" to "platform" and is cosmetic only.
>
> Reviewed by Claude for commit `af17743b`.
<!-- /claude-code-review:summary -->
