### PR TITLE
fix(cmd): enhance timeout error handling to surface underlying health-check failures

### DIFF
--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -790,7 +790,7 @@ func (k *BaseKubernetesManager) WaitForKubernetesHealthy(ctx context.Context, en
 			return healthyTimeoutError(lastErr)
 		default:
 			if err := k.client.CheckHealth(ctx, endpoint); err != nil {
-				lastErr = fmt.Errorf("API endpoint %s unreachable: %w", endpoint, err)
+				lastErr = fmt.Errorf("health check for API endpoint %s failed: %w", endpoint, err)
 				select {
 				case <-ctx.Done():
 					return healthyTimeoutError(lastErr)
@@ -820,8 +820,8 @@ func (k *BaseKubernetesManager) WaitForKubernetesHealthy(ctx context.Context, en
 
 // healthyTimeoutError builds the WaitForKubernetesHealthy timeout error. When a
 // health-check or node-readiness failure was seen on the final attempt it is
-// appended so the operator learns why the wait gave up (an unreachable API
-// endpoint, or specific nodes that never reached Ready) rather than only that it
+// appended so the operator learns why the wait gave up (a failed API health
+// check, or specific nodes that never reached Ready) rather than only that it
 // did. Falls back to the bare message when no underlying cause was recorded.
 func healthyTimeoutError(lastErr error) error {
 	if lastErr == nil {

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -783,15 +783,17 @@ func (k *BaseKubernetesManager) WaitForKubernetesHealthy(ctx context.Context, en
 		pollInterval = 10 * time.Second
 	}
 
+	var lastErr error
 	for time.Now().Before(deadline) {
 		select {
 		case <-ctx.Done():
-			return fmt.Errorf("timeout waiting for Kubernetes API to be healthy")
+			return healthyTimeoutError(lastErr)
 		default:
 			if err := k.client.CheckHealth(ctx, endpoint); err != nil {
+				lastErr = fmt.Errorf("API endpoint %s unreachable: %w", endpoint, err)
 				select {
 				case <-ctx.Done():
-					return fmt.Errorf("timeout waiting for Kubernetes API to be healthy")
+					return healthyTimeoutError(lastErr)
 				case <-time.After(pollInterval):
 					continue
 				}
@@ -799,9 +801,10 @@ func (k *BaseKubernetesManager) WaitForKubernetesHealthy(ctx context.Context, en
 
 			if len(nodeNames) > 0 {
 				if err := k.waitForNodesReady(ctx, nodeNames, outputFunc); err != nil {
+					lastErr = err
 					select {
 					case <-ctx.Done():
-						return fmt.Errorf("timeout waiting for Kubernetes API to be healthy")
+						return healthyTimeoutError(lastErr)
 					case <-time.After(pollInterval):
 						continue
 					}
@@ -812,7 +815,19 @@ func (k *BaseKubernetesManager) WaitForKubernetesHealthy(ctx context.Context, en
 		}
 	}
 
-	return fmt.Errorf("timeout waiting for Kubernetes API to be healthy")
+	return healthyTimeoutError(lastErr)
+}
+
+// healthyTimeoutError builds the WaitForKubernetesHealthy timeout error. When a
+// health-check or node-readiness failure was seen on the final attempt it is
+// appended so the operator learns why the wait gave up (an unreachable API
+// endpoint, or specific nodes that never reached Ready) rather than only that it
+// did. Falls back to the bare message when no underlying cause was recorded.
+func healthyTimeoutError(lastErr error) error {
+	if lastErr == nil {
+		return fmt.Errorf("timeout waiting for Kubernetes API to be healthy")
+	}
+	return fmt.Errorf("timeout waiting for Kubernetes API to be healthy: %w", lastErr)
 }
 
 // GetNodeReadyStatus returns a map of node names to their Ready condition status.

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -2524,6 +2524,46 @@ func TestBaseKubernetesManager_WaitForKubernetesHealthy(t *testing.T) {
 		if !strings.Contains(err.Error(), "timeout waiting for Kubernetes API to be healthy") {
 			t.Errorf("Expected timeout error, got: %v", err)
 		}
+		// The timeout surfaces the underlying health-check failure and the endpoint
+		// so the operator isn't left guessing why the API never came up.
+		if !strings.Contains(err.Error(), "health check failed") || !strings.Contains(err.Error(), "test-endpoint:6443") {
+			t.Errorf("Expected timeout error to surface the underlying cause, got: %v", err)
+		}
+	})
+
+	t.Run("TimeoutDistinguishesNodeReadinessPhase", func(t *testing.T) {
+		// Given an API that is healthy but a node that never reaches Ready
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.CheckHealthFunc = func(ctx context.Context, endpoint string) error {
+			return nil
+		}
+		kubernetesClient.GetNodeReadyStatusFunc = func(ctx context.Context, nodeNames []string) (map[string]bool, error) {
+			return map[string]bool{"worker-1": false}, nil
+		}
+		manager.client = kubernetesClient
+
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+
+		// When the wait times out on node readiness
+		err := manager.WaitForKubernetesHealthy(ctx, "https://test-endpoint:6443", nil, "worker-1")
+
+		// Then the error attributes the failure to node readiness rather than the
+		// API endpoint, so a healthy-API-but-stuck-nodes timeout is distinguishable
+		// from an unreachable endpoint (both were previously the same bare message).
+		if err == nil {
+			t.Fatal("Expected timeout error, got nil")
+		}
+		if !strings.Contains(err.Error(), "timeout waiting for Kubernetes API to be healthy") {
+			t.Errorf("Expected health timeout error, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "nodes") {
+			t.Errorf("Expected error to attribute the failure to node readiness, got: %v", err)
+		}
+		if strings.Contains(err.Error(), "endpoint") {
+			t.Errorf("Did not expect the node-phase failure to mention the API endpoint, got: %v", err)
+		}
 	})
 
 	t.Run("SuccessWithNodeNames", func(t *testing.T) {


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> The change affects only the error messages emitted from a single Kubernetes health-check polling loop; the polling logic itself is unchanged.
>
> **Overview**
>
> This PR improves the timeout error returned by `WaitForKubernetesHealthy` so operators can see why the wait gave up — whether an API endpoint was unreachable or specific nodes never reached Ready — instead of receiving a generic message in every case. A new `healthyTimeoutError` helper wraps the most recent failure when one was recorded, and two new test cases verify the enriched messages for each failure phase.
>
> Reviewed by Claude for commit `3f05f85d`.

<!-- /claude-code-review:summary -->
