### PR TITLE
fix(secrets): include secret reference in error messages for better debugging

### DIFF
--- a/pkg/runtime/secrets/op_cli_provider.go
+++ b/pkg/runtime/secrets/op_cli_provider.go
@@ -57,7 +57,8 @@ func (s *OnePasswordCLIProvider) Resolve(ref SecretRef) (string, bool, error) {
 	cmd := s.shims.Command("op", args...)
 	output, err := s.shims.CmdOutput(cmd)
 	if err != nil {
-		return "", true, fmt.Errorf("failed to retrieve secret from 1Password: %w", err)
+		secretRef := fmt.Sprintf("op://%s/%s/%s", s.vault.Name, ref.Item, ref.Field)
+		return "", true, fmt.Errorf("failed to retrieve secret %q from 1Password: %w", secretRef, err)
 	}
 
 	value := strings.TrimSpace(string(output))

--- a/pkg/runtime/secrets/op_cli_provider_test.go
+++ b/pkg/runtime/secrets/op_cli_provider_test.go
@@ -106,6 +106,11 @@ func TestOnePasswordCLIProvider_Resolve(t *testing.T) {
 		if !handled || err == nil || !strings.Contains(err.Error(), "op command failed") {
 			t.Errorf("expected handled error, got handled=%v err=%v", handled, err)
 		}
+		// The error names the secret reference that failed so the operator knows
+		// which vault/item/field to check rather than only that some secret failed.
+		if err != nil && !strings.Contains(err.Error(), "op://My Vault/item/password") {
+			t.Errorf("expected error to name the secret reference, got: %v", err)
+		}
 	})
 
 	t.Run("TrimsWhitespaceFromOutput", func(t *testing.T) {

--- a/pkg/runtime/secrets/op_cli_provider_test.go
+++ b/pkg/runtime/secrets/op_cli_provider_test.go
@@ -108,7 +108,7 @@ func TestOnePasswordCLIProvider_Resolve(t *testing.T) {
 		}
 		// The error names the secret reference that failed so the operator knows
 		// which vault/item/field to check rather than only that some secret failed.
-		if err != nil && !strings.Contains(err.Error(), "op://My Vault/item/password") {
+		if err == nil || !strings.Contains(err.Error(), "op://My Vault/item/password") {
 			t.Errorf("expected error to name the secret reference, got: %v", err)
 		}
 	})

--- a/pkg/runtime/secrets/op_sdk_provider.go
+++ b/pkg/runtime/secrets/op_sdk_provider.go
@@ -94,7 +94,7 @@ func (s *OnePasswordSDKProvider) Resolve(ref SecretRef) (string, bool, error) {
 
 	value, err := s.shims.ResolveSecret(globalClient, globalCtx, secretRefURI)
 	if err != nil {
-		return "", true, fmt.Errorf("failed to resolve secret: %w", err)
+		return "", true, fmt.Errorf("failed to resolve secret %q: %w", secretRefURI, err)
 	}
 
 	return value, true, nil

--- a/pkg/runtime/secrets/op_sdk_provider_test.go
+++ b/pkg/runtime/secrets/op_sdk_provider_test.go
@@ -176,7 +176,7 @@ func TestOnePasswordSDKProvider_Resolve(t *testing.T) {
 		}
 		// The error names the secret reference that failed so the operator knows
 		// which vault/item/field to check rather than only that some secret failed.
-		if err != nil && !strings.Contains(err.Error(), "op://SDK Vault/item/field") {
+		if err == nil || !strings.Contains(err.Error(), "op://SDK Vault/item/field") {
 			t.Errorf("expected error to name the secret reference, got: %v", err)
 		}
 	})

--- a/pkg/runtime/secrets/op_sdk_provider_test.go
+++ b/pkg/runtime/secrets/op_sdk_provider_test.go
@@ -174,6 +174,11 @@ func TestOnePasswordSDKProvider_Resolve(t *testing.T) {
 		if !handled || err == nil || !strings.Contains(err.Error(), "resolve failed") {
 			t.Errorf("expected resolve error, got handled=%v err=%v", handled, err)
 		}
+		// The error names the secret reference that failed so the operator knows
+		// which vault/item/field to check rather than only that some secret failed.
+		if err != nil && !strings.Contains(err.Error(), "op://SDK Vault/item/field") {
+			t.Errorf("expected error to name the secret reference, got: %v", err)
+		}
 	})
 
 	t.Run("ReusesGlobalClientOnSecondCall", func(t *testing.T) {


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This change touches only the error message text in two 1Password secret providers and their tests, with no behavioral change on any success path.
>
> **Overview**
>
> The PR adds the secret reference URI (`op://vault/item/field`) to error messages produced by both the CLI and SDK 1Password providers when secret resolution fails. Previously these errors gave no indication of which specific secret triggered the failure, making it harder for operators to identify misconfigured vaults or missing items at a glance. Both providers are updated consistently, and each gains a test assertion verifying the reference string appears in the error.
>
> The one structural concern is in both test files: the new assertions use `err != nil &&` as a guard, which silently passes instead of failing when `err` is nil. Since the preceding check uses `t.Errorf` rather than `t.Fatalf`, execution reaches the new block even on a nil error, making the assertion a no-op in that case. Inline comments detail the fix.
>
> Reviewed by Claude for commit `78421f09`.

<!-- /claude-code-review:summary -->
