### PR TITLE
fix(provisioner): update Wait methods to honor context for better cancellation handling

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -72,7 +72,7 @@ windsor apply kustomize dns`,
 			}
 
 			if applyWaitFlag {
-				if err := proj.Provisioner.Wait(blueprint); err != nil {
+				if err := proj.Provisioner.Wait(cmd.Context(), blueprint); err != nil {
 					return fmt.Errorf("error waiting for kustomizations: %w", err)
 				}
 			}
@@ -180,7 +180,7 @@ windsor apply kustomize dns --wait`,
 			}
 
 			if applyWaitFlag {
-				if err := proj.Provisioner.Wait(waitBlueprint); err != nil {
+				if err := proj.Provisioner.Wait(cmd.Context(), waitBlueprint); err != nil {
 					return fmt.Errorf("error waiting for kustomizations: %w", err)
 				}
 			}

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -89,7 +89,7 @@ func setupApplyTest(t *testing.T, opts ...*SetupOptions) *ApplyMocks {
 
 	mockKubernetesManager := kubernetes.NewMockKubernetesManager()
 	mockKubernetesManager.ApplyBlueprintFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) error { return nil }
-	mockKubernetesManager.WaitForKustomizationsFunc = func(message string, blueprint *blueprintv1alpha1.Blueprint) error { return nil }
+	mockKubernetesManager.WaitForKustomizationsFunc = func(ctx context.Context, message string, blueprint *blueprintv1alpha1.Blueprint) error { return nil }
 
 	rt := runtime.NewRuntime(&runtime.Runtime{
 		Shell:         baseMocks.Shell,
@@ -285,7 +285,7 @@ func TestApplyCmd(t *testing.T) {
 		t.Cleanup(func() { applyWaitFlag = false })
 		// Given a kubernetes manager whose WaitForKustomizations fails
 		mocks := setupApplyTest(t)
-		mocks.KubernetesManager.WaitForKustomizationsFunc = func(message string, bp *blueprintv1alpha1.Blueprint) error {
+		mocks.KubernetesManager.WaitForKustomizationsFunc = func(ctx context.Context, message string, bp *blueprintv1alpha1.Blueprint) error {
 			return fmt.Errorf("wait failed")
 		}
 		proj := newApplyAllProject(mocks)
@@ -595,7 +595,7 @@ func TestApplyKustomizeCmd(t *testing.T) {
 		}
 		mocks.BlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint { return testBlueprint }
 		var waitedBlueprint *blueprintv1alpha1.Blueprint
-		mocks.KubernetesManager.WaitForKustomizationsFunc = func(message string, bp *blueprintv1alpha1.Blueprint) error {
+		mocks.KubernetesManager.WaitForKustomizationsFunc = func(ctx context.Context, message string, bp *blueprintv1alpha1.Blueprint) error {
 			waitedBlueprint = bp
 			return nil
 		}
@@ -630,7 +630,7 @@ func TestApplyKustomizeCmd(t *testing.T) {
 		}
 		mocks.BlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint { return testBlueprint }
 		var waitedBlueprint *blueprintv1alpha1.Blueprint
-		mocks.KubernetesManager.WaitForKustomizationsFunc = func(message string, bp *blueprintv1alpha1.Blueprint) error {
+		mocks.KubernetesManager.WaitForKustomizationsFunc = func(ctx context.Context, message string, bp *blueprintv1alpha1.Blueprint) error {
 			waitedBlueprint = bp
 			return nil
 		}
@@ -659,7 +659,7 @@ func TestApplyKustomizeCmd(t *testing.T) {
 		t.Cleanup(func() { applyWaitFlag = false })
 		// Given a kubernetes manager whose WaitForKustomizations fails
 		mocks := setupApplyTest(t)
-		mocks.KubernetesManager.WaitForKustomizationsFunc = func(message string, blueprint *blueprintv1alpha1.Blueprint) error {
+		mocks.KubernetesManager.WaitForKustomizationsFunc = func(ctx context.Context, message string, blueprint *blueprintv1alpha1.Blueprint) error {
 			return fmt.Errorf("wait for kustomizations failed")
 		}
 		testBlueprint := &blueprintv1alpha1.Blueprint{
@@ -690,7 +690,7 @@ func TestApplyKustomizeCmd(t *testing.T) {
 		t.Cleanup(func() { applyWaitFlag = false })
 		// Given a kubernetes manager whose WaitForKustomizations fails on a named kustomization
 		mocks := setupApplyTest(t)
-		mocks.KubernetesManager.WaitForKustomizationsFunc = func(message string, blueprint *blueprintv1alpha1.Blueprint) error {
+		mocks.KubernetesManager.WaitForKustomizationsFunc = func(ctx context.Context, message string, blueprint *blueprintv1alpha1.Blueprint) error {
 			return fmt.Errorf("wait for kustomizations failed")
 		}
 		testBlueprint := &blueprintv1alpha1.Blueprint{

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -229,7 +229,7 @@ windsor bootstrap prod --yes`,
 				return fmt.Errorf("error installing blueprint: %w", err)
 			}
 
-			if err := proj.Provisioner.Wait(blueprint); err != nil {
+			if err := proj.Provisioner.Wait(cmd.Context(), blueprint); err != nil {
 				return fmt.Errorf("error waiting for kustomizations: %w", err)
 			}
 			return nil

--- a/cmd/bootstrap_test.go
+++ b/cmd/bootstrap_test.go
@@ -98,7 +98,7 @@ func setupBootstrapTest(t *testing.T, opts ...*SetupOptions) *BootstrapMocks {
 
 	mockKubernetesManager := kubernetes.NewMockKubernetesManager()
 	mockKubernetesManager.ApplyBlueprintFunc = func(blueprint *blueprintv1alpha1.Blueprint, namespace string) error { return nil }
-	mockKubernetesManager.WaitForKustomizationsFunc = func(message string, blueprint *blueprintv1alpha1.Blueprint) error { return nil }
+	mockKubernetesManager.WaitForKustomizationsFunc = func(ctx context.Context, message string, blueprint *blueprintv1alpha1.Blueprint) error { return nil }
 
 	rt := runtime.NewRuntime(&runtime.Runtime{
 		Shell:         baseMocks.Shell,
@@ -175,7 +175,7 @@ func TestBootstrapCmd(t *testing.T) {
 			return nil
 		}
 		waitCalled := false
-		mocks.KubernetesManager.WaitForKustomizationsFunc = func(message string, blueprint *blueprintv1alpha1.Blueprint) error {
+		mocks.KubernetesManager.WaitForKustomizationsFunc = func(ctx context.Context, message string, blueprint *blueprintv1alpha1.Blueprint) error {
 			waitCalled = true
 			return nil
 		}

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -41,7 +41,7 @@ windsor install --wait`,
 		}
 
 		if installWaitFlag {
-			if err := proj.Provisioner.Wait(blueprint); err != nil {
+			if err := proj.Provisioner.Wait(cmd.Context(), blueprint); err != nil {
 				return fmt.Errorf("error waiting for kustomizations: %w", err)
 			}
 		}

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -104,7 +104,7 @@ func TestInstallCmd(t *testing.T) {
 
 		mockKubernetesManager := kubernetes.NewMockKubernetesManager()
 		mockKubernetesManager.ApplyBlueprintFunc = func(blueprint *blueprintv1alpha1.Blueprint, namespace string) error { return nil }
-		mockKubernetesManager.WaitForKustomizationsFunc = func(message string, blueprint *blueprintv1alpha1.Blueprint) error { return nil }
+		mockKubernetesManager.WaitForKustomizationsFunc = func(ctx context.Context, message string, blueprint *blueprintv1alpha1.Blueprint) error { return nil }
 
 		// Override ConfigHandler and ProjectRoot in runtime
 		mocks.Runtime.ConfigHandler = mockConfigHandler

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -134,7 +134,7 @@ windsor up --blueprint=ghcr.io/myorg/blueprint:v1.0.0`,
 			}
 
 			if waitFlag {
-				if err := proj.Provisioner.Wait(blueprint); err != nil {
+				if err := proj.Provisioner.Wait(cmd.Context(), blueprint); err != nil {
 					return fmt.Errorf("error waiting for kustomizations: %w", err)
 				}
 			}

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -97,7 +97,7 @@ func setupUpTest(t *testing.T, opts ...*SetupOptions) *UpMocks {
 	// Add kubernetes manager mock
 	mockKubernetesManager := kubernetes.NewMockKubernetesManager()
 	mockKubernetesManager.ApplyBlueprintFunc = func(blueprint *blueprintv1alpha1.Blueprint, namespace string) error { return nil }
-	mockKubernetesManager.WaitForKustomizationsFunc = func(message string, blueprint *blueprintv1alpha1.Blueprint) error { return nil }
+	mockKubernetesManager.WaitForKustomizationsFunc = func(ctx context.Context, message string, blueprint *blueprintv1alpha1.Blueprint) error { return nil }
 
 	// Create runtime with all mocked dependencies
 	rt := runtime.NewRuntime(&runtime.Runtime{
@@ -452,7 +452,7 @@ func TestUpCmd(t *testing.T) {
 	t.Run("ProvisionerWaitError", func(t *testing.T) {
 		// Given a kubernetes manager whose WaitForKustomizations fails
 		mocks := setupUpTest(t)
-		mocks.KubernetesManager.WaitForKustomizationsFunc = func(message string, blueprint *blueprintv1alpha1.Blueprint) error {
+		mocks.KubernetesManager.WaitForKustomizationsFunc = func(ctx context.Context, message string, blueprint *blueprintv1alpha1.Blueprint) error {
 			return fmt.Errorf("wait for kustomizations failed")
 		}
 		proj := newUpTestProject(mocks, true)

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -347,7 +347,7 @@ func (k *BaseKubernetesManager) WaitForKustomizations(ctx context.Context, messa
 	for {
 		select {
 		case <-ctx.Done():
-			tui.Fail()
+			tui.Pause()
 			return ctx.Err()
 		case <-timeoutChan:
 			tui.Fail()

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -37,7 +37,7 @@ import (
 type KubernetesManager interface {
 	ApplyKustomization(kustomization kustomizev1.Kustomization) error
 	DeleteKustomization(name, namespace string) error
-	WaitForKustomizations(message string, blueprint *blueprintv1alpha1.Blueprint) error
+	WaitForKustomizations(ctx context.Context, message string, blueprint *blueprintv1alpha1.Blueprint) error
 	CreateNamespace(name string) error
 	DeleteNamespace(name string) error
 	ApplyConfigMap(name, namespace string, data map[string]string) error
@@ -320,8 +320,11 @@ func kustomizationReady(obj *unstructured.Unstructured) bool {
 
 // WaitForKustomizations waits for kustomizations to be ready, calculating the timeout
 // from the longest dependency chain in the blueprint. Outputs a debug message describing
-// the total wait timeout being used before beginning polling.
-func (k *BaseKubernetesManager) WaitForKustomizations(message string, blueprint *blueprintv1alpha1.Blueprint) error {
+// the total wait timeout being used before beginning polling. The wait also honors ctx:
+// a cancelled or deadline-exceeded context ends the wait immediately and returns ctx.Err(),
+// so a parent SIGTERM/Ctrl+C or command deadline can interrupt it (rather than requiring a
+// SIGKILL that bypasses the caller's defer cleanup).
+func (k *BaseKubernetesManager) WaitForKustomizations(ctx context.Context, message string, blueprint *blueprintv1alpha1.Blueprint) error {
 	if blueprint == nil {
 		return fmt.Errorf("blueprint not provided")
 	}
@@ -343,6 +346,9 @@ func (k *BaseKubernetesManager) WaitForKustomizations(message string, blueprint 
 
 	for {
 		select {
+		case <-ctx.Done():
+			tui.Fail()
+			return ctx.Err()
 		case <-timeoutChan:
 			tui.Fail()
 			return fmt.Errorf("timeout waiting for kustomizations%s", k.describeNotReadyKustomizations(kustomizationNames, k.gitopsNamespace()))

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -507,9 +507,47 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 			},
 		}
 
-		err := manager.WaitForKustomizations("Waiting for kustomizations", blueprint)
+		err := manager.WaitForKustomizations(context.Background(), "Waiting for kustomizations", blueprint)
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("ContextCancelledInterruptsWait", func(t *testing.T) {
+		// Given a kustomization that never becomes Ready and a long internal timeout
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			return &unstructured.Unstructured{
+				Object: map[string]any{
+					"status": map[string]any{
+						"conditions": []any{
+							map[string]any{"type": "Ready", "status": "False"},
+						},
+					},
+				},
+			}, nil
+		}
+		manager.client = kubernetesClient
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{
+					Name:    "test-kustomization",
+					Timeout: &blueprintv1alpha1.DurationString{Duration: 10 * time.Minute},
+				},
+			},
+		}
+
+		// When the parent context is cancelled
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		// Then the wait returns promptly with the context error instead of blocking
+		// until the (long) internal timeout, so a caller's SIGTERM/deadline can end it.
+		err := manager.WaitForKustomizations(ctx, "Waiting for kustomizations", blueprint)
+		if err != context.Canceled {
+			t.Errorf("expected context.Canceled, got: %v", err)
 		}
 	})
 
@@ -543,7 +581,7 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 			},
 		}
 
-		err := manager.WaitForKustomizations("Waiting for kustomizations", blueprint)
+		err := manager.WaitForKustomizations(context.Background(), "Waiting for kustomizations", blueprint)
 		if err == nil {
 			t.Error("Expected timeout error, got nil")
 		}
@@ -586,7 +624,7 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 		}
 
 		// When the wait times out
-		err := manager.WaitForKustomizations("Waiting for kustomizations", blueprint)
+		err := manager.WaitForKustomizations(context.Background(), "Waiting for kustomizations", blueprint)
 
 		// Then the error names the kustomization and surfaces the condition reason+message
 		if err == nil {
@@ -621,7 +659,7 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 			},
 		}
 
-		err := manager.WaitForKustomizations("Waiting for kustomizations", blueprint)
+		err := manager.WaitForKustomizations(context.Background(), "Waiting for kustomizations", blueprint)
 		if err == nil {
 			t.Error("Expected timeout error, got nil")
 		}
@@ -661,7 +699,7 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 			},
 		}
 
-		err := manager.WaitForKustomizations("Waiting for kustomizations", blueprint)
+		err := manager.WaitForKustomizations(context.Background(), "Waiting for kustomizations", blueprint)
 		if err == nil {
 			t.Error("Expected timeout error, got nil")
 		}
@@ -690,7 +728,7 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 			},
 		}
 
-		err := manager.WaitForKustomizations("Waiting for kustomizations", blueprint)
+		err := manager.WaitForKustomizations(context.Background(), "Waiting for kustomizations", blueprint)
 		if err == nil {
 			t.Error("Expected timeout error, got nil")
 		}
@@ -726,7 +764,7 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 			},
 		}
 
-		err := manager.WaitForKustomizations("Waiting for kustomizations", blueprint)
+		err := manager.WaitForKustomizations(context.Background(), "Waiting for kustomizations", blueprint)
 		if err == nil {
 			t.Error("Expected timeout error, got nil")
 		}
@@ -762,7 +800,7 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 			},
 		}
 
-		err := manager.WaitForKustomizations("Waiting for kustomizations", blueprint)
+		err := manager.WaitForKustomizations(context.Background(), "Waiting for kustomizations", blueprint)
 		if err == nil {
 			t.Error("Expected timeout error, got nil")
 		}
@@ -807,7 +845,7 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 			},
 		}
 
-		err := manager.WaitForKustomizations("Waiting for kustomizations", blueprint)
+		err := manager.WaitForKustomizations(context.Background(), "Waiting for kustomizations", blueprint)
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -820,7 +858,7 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 
 	t.Run("WithBlueprintNilReturnsError", func(t *testing.T) {
 		manager := setup(t)
-		err := manager.WaitForKustomizations("Waiting for kustomizations", nil)
+		err := manager.WaitForKustomizations(context.Background(), "Waiting for kustomizations", nil)
 		if err == nil {
 			t.Error("Expected error for nil blueprint, got nil")
 		}
@@ -870,7 +908,7 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 			},
 		}
 
-		err := manager.WaitForKustomizations("Waiting for kustomizations", blueprint)
+		err := manager.WaitForKustomizations(context.Background(), "Waiting for kustomizations", blueprint)
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}

--- a/pkg/provisioner/kubernetes/mock_kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/mock_kubernetes_manager.go
@@ -21,7 +21,7 @@ import (
 type MockKubernetesManager struct {
 	ApplyKustomizationFunc              func(kustomization kustomizev1.Kustomization) error
 	DeleteKustomizationFunc             func(name, namespace string) error
-	WaitForKustomizationsFunc           func(message string, blueprint *blueprintv1alpha1.Blueprint) error
+	WaitForKustomizationsFunc           func(ctx context.Context, message string, blueprint *blueprintv1alpha1.Blueprint) error
 	GetKustomizationStatusFunc          func(names []string) (map[string]bool, error)
 	CreateNamespaceFunc                 func(name string) error
 	DeleteNamespaceFunc                 func(name string) error
@@ -68,9 +68,9 @@ func (m *MockKubernetesManager) DeleteKustomization(name, namespace string) erro
 }
 
 // WaitForKustomizations implements KubernetesManager interface
-func (m *MockKubernetesManager) WaitForKustomizations(message string, blueprint *blueprintv1alpha1.Blueprint) error {
+func (m *MockKubernetesManager) WaitForKustomizations(ctx context.Context, message string, blueprint *blueprintv1alpha1.Blueprint) error {
 	if m.WaitForKustomizationsFunc != nil {
-		return m.WaitForKustomizationsFunc(message, blueprint)
+		return m.WaitForKustomizationsFunc(ctx, message, blueprint)
 	}
 	return nil
 }

--- a/pkg/provisioner/kubernetes/mock_kubernetes_manager_test.go
+++ b/pkg/provisioner/kubernetes/mock_kubernetes_manager_test.go
@@ -79,8 +79,8 @@ func TestMockKubernetesManager_WaitForKustomizations(t *testing.T) {
 
 	t.Run("FuncSet", func(t *testing.T) {
 		manager := setup(t)
-		manager.WaitForKustomizationsFunc = func(m string, b *blueprintv1alpha1.Blueprint) error { return fmt.Errorf("err") }
-		err := manager.WaitForKustomizations(msg, nil)
+		manager.WaitForKustomizationsFunc = func(ctx context.Context, m string, b *blueprintv1alpha1.Blueprint) error { return fmt.Errorf("err") }
+		err := manager.WaitForKustomizations(context.Background(), msg, nil)
 		if err == nil || err.Error() != "err" {
 			t.Errorf("Expected error 'err', got %v", err)
 		}
@@ -88,7 +88,7 @@ func TestMockKubernetesManager_WaitForKustomizations(t *testing.T) {
 
 	t.Run("FuncNotSet", func(t *testing.T) {
 		manager := setup(t)
-		err := manager.WaitForKustomizations(msg, nil)
+		err := manager.WaitForKustomizations(context.Background(), msg, nil)
 		if err != nil {
 			t.Errorf("Expected nil, got %v", err)
 		}

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -920,9 +920,10 @@ func (i *Provisioner) Install(ctx context.Context, blueprint *blueprintv1alpha1.
 
 // Wait waits for kustomizations from the blueprint to be ready. It initializes the kubernetes manager
 // if needed and polls the status of all kustomizations until they are ready or a timeout occurs.
-// The timeout is calculated from the longest dependency chain in the blueprint. Returns an error if
-// the kubernetes manager is not configured, initialization fails, or waiting times out.
-func (i *Provisioner) Wait(blueprint *blueprintv1alpha1.Blueprint) error {
+// The timeout is calculated from the longest dependency chain in the blueprint. The wait honors ctx,
+// so a cancelled context (caller SIGTERM/Ctrl+C or command deadline) ends it promptly. Returns an
+// error if the kubernetes manager is not configured, initialization fails, or waiting times out.
+func (i *Provisioner) Wait(ctx context.Context, blueprint *blueprintv1alpha1.Blueprint) error {
 	if blueprint == nil {
 		return fmt.Errorf("blueprint not provided")
 	}
@@ -931,7 +932,7 @@ func (i *Provisioner) Wait(blueprint *blueprintv1alpha1.Blueprint) error {
 		return fmt.Errorf("kubernetes manager not configured")
 	}
 
-	if err := i.KubernetesManager.WaitForKustomizations("Waiting for kustomizations to be ready", blueprint); err != nil {
+	if err := i.KubernetesManager.WaitForKustomizations(ctx, "Waiting for kustomizations to be ready", blueprint); err != nil {
 		return fmt.Errorf("failed waiting for kustomizations: %w", err)
 	}
 

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -1276,7 +1276,7 @@ func TestProvisioner_Install(t *testing.T) {
 func TestProvisioner_Wait(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
-		mocks.KubernetesManager.WaitForKustomizationsFunc = func(message string, blueprint *blueprintv1alpha1.Blueprint) error {
+		mocks.KubernetesManager.WaitForKustomizationsFunc = func(ctx context.Context, message string, blueprint *blueprintv1alpha1.Blueprint) error {
 			return nil
 		}
 		opts := &Provisioner{
@@ -1285,7 +1285,7 @@ func TestProvisioner_Wait(t *testing.T) {
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
 		blueprint := createTestBlueprint()
-		err := provisioner.Wait(blueprint)
+		err := provisioner.Wait(context.Background(), blueprint)
 
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)
@@ -1296,7 +1296,7 @@ func TestProvisioner_Wait(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler)
 
-		err := provisioner.Wait(nil)
+		err := provisioner.Wait(context.Background(), nil)
 
 		if err == nil {
 			t.Error("Expected error for nil blueprint")
@@ -1313,7 +1313,7 @@ func TestProvisioner_Wait(t *testing.T) {
 		provisioner.KubernetesManager = nil
 
 		blueprint := createTestBlueprint()
-		err := provisioner.Wait(blueprint)
+		err := provisioner.Wait(context.Background(), blueprint)
 
 		if err == nil {
 			t.Error("Expected error for nil kubernetes manager")
@@ -1326,7 +1326,7 @@ func TestProvisioner_Wait(t *testing.T) {
 
 	t.Run("ErrorWaitForKustomizations", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
-		mocks.KubernetesManager.WaitForKustomizationsFunc = func(message string, blueprint *blueprintv1alpha1.Blueprint) error {
+		mocks.KubernetesManager.WaitForKustomizationsFunc = func(ctx context.Context, message string, blueprint *blueprintv1alpha1.Blueprint) error {
 			return fmt.Errorf("wait failed")
 		}
 		opts := &Provisioner{
@@ -1335,7 +1335,7 @@ func TestProvisioner_Wait(t *testing.T) {
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
 		blueprint := createTestBlueprint()
-		err := provisioner.Wait(blueprint)
+		err := provisioner.Wait(context.Background(), blueprint)
 
 		if err == nil {
 			t.Error("Expected error for wait for kustomizations failure")


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Context propagation through an internal polling loop — isolated to the provisioner and Kubernetes manager layers, with all four call sites updated consistently.
>
> **Overview**
>
> This PR threads a `context.Context` parameter through `Provisioner.Wait` and `KubernetesManager.WaitForKustomizations` so that a cancelled or deadline-exceeded context ends the kustomization wait immediately rather than requiring the internal timeout to expire. All four CLI commands (`apply`, `bootstrap`, `install`, `up`) now pass `cmd.Context()`, which Cobra wires to OS signal handling. The mock, interface, and test suite are updated uniformly.
>
> One gap worth noting: `TestProvisioner_Wait` has no case that passes a cancelled context to `Provisioner.Wait` and verifies the error propagates; the cancellation path is covered only at the `KubernetesManager` level by the new `ContextCancelledInterruptsWait` test.
>
> Reviewed by Claude for commit `8754f88`.

<!-- /claude-code-review:summary -->
