### PR TITLE
feat(cmd): add unlock command to force-release stuck stack locks with --force flag

### DIFF
--- a/cmd/unlock.go
+++ b/cmd/unlock.go
@@ -47,20 +47,25 @@ windsor unlock --force`,
 			return err
 		}
 
-		holder, err := lock.Inspect(cmd.Context())
-		if err != nil {
-			return fmt.Errorf("error inspecting stack lock: %w", err)
-		}
-
 		contextName := proj.Runtime.ContextName
 		w := cmd.ErrOrStderr()
-		if holder == nil {
+
+		// A missing sidecar means nothing is held. A corrupt/unreadable one (e.g. a
+		// partial write from a killed holder) is exactly the debris unlock clears, so
+		// warn and proceed rather than treating it as "nothing to release".
+		holder, inspectErr := lock.Inspect(cmd.Context())
+		lockID := ""
+		switch {
+		case inspectErr != nil:
+			fmt.Fprintf(w, "Stack lock for context %q has unreadable holder info (%v); clearing it.\n", contextName, inspectErr)
+		case holder == nil:
 			fmt.Fprintf(w, "No stack lock held for context %q; nothing to release.\n", contextName)
 			return nil
+		default:
+			lockID = holder.ID
+			fmt.Fprintf(w, "Stack lock for context %q is held by %s (PID=%d, operation=%s, started=%s).\n",
+				contextName, holder.Who, holder.PID, holder.Operation, holder.Created.Format(time.RFC3339))
 		}
-
-		fmt.Fprintf(w, "Stack lock for context %q is held by %s (PID=%d, operation=%s, started=%s).\n",
-			contextName, holder.Who, holder.PID, holder.Operation, holder.Created.Format(time.RFC3339))
 
 		if !unlockForce {
 			desc := fmt.Sprintf("This will force-release the stack lock for context %q. Only proceed if no other windsor process is operating on it.", contextName)
@@ -69,7 +74,7 @@ windsor unlock --force`,
 			}
 		}
 
-		if err := lock.ForceRelease(cmd.Context(), holder.ID, "windsor unlock"); err != nil {
+		if err := lock.ForceRelease(cmd.Context(), lockID, "windsor unlock"); err != nil {
 			return fmt.Errorf("error releasing stack lock: %w", err)
 		}
 		fmt.Fprintf(w, "Released stack lock for context %q.\n", contextName)

--- a/cmd/unlock.go
+++ b/cmd/unlock.go
@@ -1,0 +1,85 @@
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/windsorcli/cli/pkg/provisioner/stacklock"
+	"github.com/windsorcli/cli/pkg/runtime/tools"
+)
+
+// =============================================================================
+// Unlock Command
+// =============================================================================
+
+var unlockForce bool
+
+var unlockCmd = &cobra.Command{
+	Use:   "unlock",
+	Short: "Release a stuck stack lock.",
+	Long: `Force-release a stuck stack lock for the current context.
+
+A holder killed before it could release (CI cancellation, OOM, crash) leaves the lock behind, so later commands block until timeout and then fail. This clears it. It does not check whether the holder is still alive, so only run it when no other windsor process is using this context.`,
+	Example: `# Clear a stuck lock interactively
+windsor unlock
+# → prompts: Type "local" to confirm:
+
+# Scripted recovery
+windsor unlock --force`,
+	Annotations: map[string]string{
+		"docs.seealso": "[`destroy`](destroy.md), [`up`](up.md)",
+		"docs.source":  "cmd/unlock.go",
+	},
+	Args:         cobra.NoArgs,
+	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// unlock only touches the local lock files; no terraform/k8s/docker tools are
+		// needed. Skip-validation so a deployed-but-misordered blueprint can't block
+		// the recovery path that exists precisely to unstick such a context.
+		proj, err := prepareProjectSkipValidation(cmd, tools.Requirements{})
+		if err != nil {
+			return err
+		}
+
+		lock, err := stacklock.ForRuntime(proj.Runtime)
+		if err != nil {
+			return err
+		}
+
+		holder, err := lock.Inspect(cmd.Context())
+		if err != nil {
+			return fmt.Errorf("error inspecting stack lock: %w", err)
+		}
+
+		contextName := proj.Runtime.ContextName
+		w := cmd.ErrOrStderr()
+		if holder == nil {
+			fmt.Fprintf(w, "No stack lock held for context %q; nothing to release.\n", contextName)
+			return nil
+		}
+
+		fmt.Fprintf(w, "Stack lock for context %q is held by %s (PID=%d, operation=%s, started=%s).\n",
+			contextName, holder.Who, holder.PID, holder.Operation, holder.Created.Format(time.RFC3339))
+
+		if !unlockForce {
+			desc := fmt.Sprintf("This will force-release the stack lock for context %q. Only proceed if no other windsor process is operating on it.", contextName)
+			if err := confirmDestroy(cmd.InOrStdin(), w, desc, contextName); err != nil {
+				return err
+			}
+		}
+
+		if err := lock.ForceRelease(cmd.Context(), holder.ID, "windsor unlock"); err != nil {
+			return fmt.Errorf("error releasing stack lock: %w", err)
+		}
+		fmt.Fprintf(w, "Released stack lock for context %q.\n", contextName)
+		return nil
+	},
+}
+
+// init registers the unlock command and its --force flag, which skips the
+// type-the-context confirmation for scripted recovery.
+func init() {
+	unlockCmd.Flags().BoolVar(&unlockForce, "force", false, "Skip the confirmation prompt (for scripted recovery).")
+	rootCmd.AddCommand(unlockCmd)
+}

--- a/docs/reference/commands/unlock.md
+++ b/docs/reference/commands/unlock.md
@@ -1,0 +1,35 @@
+---
+title: "windsor unlock"
+description: "Release a stuck stack lock."
+---
+# windsor unlock
+
+```sh
+windsor unlock [flags]
+```
+
+Force-release a stuck stack lock for the current context.
+
+A holder killed before it could release (CI cancellation, OOM, crash) leaves the lock behind, so later commands block until timeout and then fail. This clears it. It does not check whether the holder is still alive, so only run it when no other windsor process is using this context.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--force` | `false` | Skip the confirmation prompt (for scripted recovery). |
+
+## Examples
+
+```sh
+# Clear a stuck lock interactively
+windsor unlock
+# → prompts: Type "local" to confirm:
+
+# Scripted recovery
+windsor unlock --force
+```
+
+## See also
+
+- [`destroy`](destroy.md), [`up`](up.md)
+- Source: [cmd/unlock.go](https://github.com/windsorcli/cli/blob/main/cmd/unlock.go)

--- a/integration/unlock_test.go
+++ b/integration/unlock_test.go
@@ -69,3 +69,41 @@ func TestUnlock_ReleasesOrphanedLock(t *testing.T) {
 		t.Errorf("expected sidecar removed, stat err=%v", statErr)
 	}
 }
+
+// TestUnlock_ClearsCorruptSidecar verifies that a torn/partial holder-info sidecar
+// (a holder killed mid-write) is treated as clearable debris — unlock --force warns
+// that the holder info is unreadable and still removes the lock files, rather than
+// reporting "nothing to release" and leaving the operator stuck.
+func TestUnlock_ClearsCorruptSidecar(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "default")
+	env = append(env, "WINDSOR_CONTEXT=default")
+
+	scratch := filepath.Join(dir, ".windsor", "contexts", "default")
+	if err := os.MkdirAll(scratch, 0o755); err != nil {
+		t.Fatalf("mkdir scratch: %v", err)
+	}
+	lockPath := filepath.Join(scratch, ".stacklock")
+	if err := os.WriteFile(lockPath, nil, 0o644); err != nil {
+		t.Fatalf("write lock file: %v", err)
+	}
+	// A partial JSON write — what a SIGKILL mid-sidecar-write leaves behind.
+	if err := os.WriteFile(lockPath+".info", []byte(`{"id":"orphan`), 0o644); err != nil {
+		t.Fatalf("write corrupt sidecar: %v", err)
+	}
+
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"unlock", "--force"}, env)
+	if err != nil {
+		t.Fatalf("unlock --force: %v\nstderr: %s", err, stderr)
+	}
+	out := string(stdout) + string(stderr)
+	if !strings.Contains(out, "unreadable") || !strings.Contains(out, "Released stack lock") {
+		t.Errorf("expected unreadable-holder warning and release confirmation, got:\n%s", out)
+	}
+	if _, statErr := os.Stat(lockPath); !os.IsNotExist(statErr) {
+		t.Errorf("expected lock file removed, stat err=%v", statErr)
+	}
+	if _, statErr := os.Stat(lockPath + ".info"); !os.IsNotExist(statErr) {
+		t.Errorf("expected corrupt sidecar removed, stat err=%v", statErr)
+	}
+}

--- a/integration/unlock_test.go
+++ b/integration/unlock_test.go
@@ -1,0 +1,71 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/windsorcli/cli/integration/helpers"
+)
+
+// TestUnlock_NoLockHeld verifies that windsor unlock reports there is nothing to
+// release (and exits 0) when no stack lock is present for the context.
+func TestUnlock_NoLockHeld(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "default")
+	env = append(env, "WINDSOR_CONTEXT=default")
+
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"unlock"}, env)
+	if err != nil {
+		t.Fatalf("unlock: %v\nstderr: %s", err, stderr)
+	}
+	out := string(stdout) + string(stderr)
+	if !strings.Contains(out, "nothing to release") {
+		t.Errorf("expected 'nothing to release', got:\n%s", out)
+	}
+}
+
+// TestUnlock_ReleasesOrphanedLock verifies that windsor unlock --force clears a
+// stuck lock left behind by a holder that died without releasing: the lock file
+// and its holder-info sidecar are removed and the command reports success.
+func TestUnlock_ReleasesOrphanedLock(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "default")
+	env = append(env, "WINDSOR_CONTEXT=default")
+
+	// Plant an orphaned lock: lock file + a valid holder-info sidecar naming a PID
+	// that is no longer running, mirroring a SIGKILL'd holder.
+	scratch := filepath.Join(dir, ".windsor", "contexts", "default")
+	if err := os.MkdirAll(scratch, 0o755); err != nil {
+		t.Fatalf("mkdir scratch: %v", err)
+	}
+	lockPath := filepath.Join(scratch, ".stacklock")
+	if err := os.WriteFile(lockPath, nil, 0o644); err != nil {
+		t.Fatalf("write lock file: %v", err)
+	}
+	sidecar := `{"id":"orphan-1","operation":"bootstrap","mode":0,"who":"ci@runner","version":"0.0.0","project_id":"p","context":"default","created":"2026-06-08T03:02:31Z","pid":8016}`
+	if err := os.WriteFile(lockPath+".info", []byte(sidecar), 0o644); err != nil {
+		t.Fatalf("write sidecar: %v", err)
+	}
+
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"unlock", "--force"}, env)
+	if err != nil {
+		t.Fatalf("unlock --force: %v\nstderr: %s", err, stderr)
+	}
+	out := string(stdout) + string(stderr)
+	// The holder is named, and the release is reported.
+	if !strings.Contains(out, "bootstrap") || !strings.Contains(out, "Released stack lock") {
+		t.Errorf("expected holder detail and release confirmation, got:\n%s", out)
+	}
+	// Both lock files are gone afterward.
+	if _, statErr := os.Stat(lockPath); !os.IsNotExist(statErr) {
+		t.Errorf("expected lock file removed, stat err=%v", statErr)
+	}
+	if _, statErr := os.Stat(lockPath + ".info"); !os.IsNotExist(statErr) {
+		t.Errorf("expected sidecar removed, stat err=%v", statErr)
+	}
+}

--- a/pkg/provisioner/stacklock/stacklock.go
+++ b/pkg/provisioner/stacklock/stacklock.go
@@ -139,19 +139,31 @@ func NewLocalFlockLock(lockPath string) StackLock {
 // "apply", "destroy", "bootstrap", "plan") so concurrent operators see the
 // holder's intent in busy-error messages.
 func With(ctx context.Context, rt *runtime.Runtime, operation string, fn func() error) error {
-	if rt == nil {
-		return errors.New("stacklock: runtime is required")
+	lock, err := ForRuntime(rt)
+	if err != nil {
+		return err
 	}
-	if rt.WindsorScratchPath == "" {
-		return errors.New("stacklock: scratch path is empty (Configure must run first)")
-	}
-	lock := NewLocalFlockLock(filepath.Join(rt.WindsorScratchPath, stackLockFilename))
 	release, err := lock.Acquire(ctx, NewInfo(rt, operation), DefaultTimeout)
 	if err != nil {
 		return err
 	}
 	defer release()
 	return fn()
+}
+
+// ForRuntime returns the StackLock for the runtime's context — the same lock that
+// With acquires. It is exposed so operator-facing recovery (windsor unlock) can
+// inspect and force-release a stuck lock without duplicating the path derivation.
+// Returns an error when the runtime is nil or has not been configured yet (empty
+// scratch path).
+func ForRuntime(rt *runtime.Runtime) (StackLock, error) {
+	if rt == nil {
+		return nil, errors.New("stacklock: runtime is required")
+	}
+	if rt.WindsorScratchPath == "" {
+		return nil, errors.New("stacklock: scratch path is empty (Configure must run first)")
+	}
+	return NewLocalFlockLock(filepath.Join(rt.WindsorScratchPath, stackLockFilename)), nil
 }
 
 // NewInfo constructs the LockInfo persisted into the holder-info sidecar for a
@@ -175,11 +187,6 @@ func NewInfo(rt *runtime.Runtime, operation string) LockInfo {
 // =============================================================================
 // Private Methods
 // =============================================================================
-
-// errOperationNotSupported is returned by Inspect and ForceRelease, which are
-// reserved for the operator-facing `windsor stack lock --inspect`/`--force`
-// commands that are not yet wired up.
-var errOperationNotSupported = errors.New("stacklock: operation not supported")
 
 // localFlockLock is the single-host implementation of StackLock. The struct
 // itself owns no per-Acquire state — flk and the once-guard are scoped to each
@@ -230,16 +237,39 @@ func (s *localFlockLock) Acquire(ctx context.Context, info LockInfo, timeout tim
 	return makeRelease(flk, infoPath), nil
 }
 
-// Inspect is reserved for the operator-facing `windsor stack lock --inspect`
-// command; the CLI entry point is not yet wired up.
+// Inspect returns the current holder recorded in the sidecar, or (nil, nil) when
+// no lock is held (or the sidecar is absent/unreadable). It backs windsor unlock's
+// "who holds this?" report. The sidecar is diagnostic, so a missing file is not an
+// error — it simply means there is nothing to release.
 func (s *localFlockLock) Inspect(ctx context.Context) (*LockInfo, error) {
-	return nil, errOperationNotSupported
+	return readHolderInfo(s.path + stackLockInfoSuffix), nil
 }
 
-// ForceRelease is reserved for the operator-facing `windsor stack lock --force`
-// command; the CLI entry point is not yet wired up.
+// ForceRelease clears a stuck lock by removing the lock file and its holder-info
+// sidecar, so the next Acquire starts from a clean slate. It is the operator-facing
+// recovery path (windsor unlock) for a holder that died without releasing. When
+// lockID is non-empty it guards against a race: if a different holder has acquired
+// the lock since the caller inspected it, the release is refused rather than yanking
+// a lock that is now legitimately held. reason is included in any failure message
+// for diagnostics. Missing files are not an error — the lock is already clear.
 func (s *localFlockLock) ForceRelease(ctx context.Context, lockID string, reason string) error {
-	return errOperationNotSupported
+	infoPath := s.path + stackLockInfoSuffix
+	if lockID != "" {
+		if info := readHolderInfo(infoPath); info != nil && info.ID != lockID {
+			return fmt.Errorf("stacklock: refusing to force-release: lock is now held by a different holder (%q, not %q) — a new windsor process acquired it", info.ID, lockID)
+		}
+	}
+	var errs []error
+	if err := os.Remove(s.path); err != nil && !os.IsNotExist(err) {
+		errs = append(errs, err)
+	}
+	if err := os.Remove(infoPath); err != nil && !os.IsNotExist(err) {
+		errs = append(errs, err)
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("stacklock: force-release (%s): %w", reason, errors.Join(errs...))
+	}
+	return nil
 }
 
 // makeRelease returns the closure handed back from Acquire. flk, infoPath,

--- a/pkg/provisioner/stacklock/stacklock.go
+++ b/pkg/provisioner/stacklock/stacklock.go
@@ -237,12 +237,26 @@ func (s *localFlockLock) Acquire(ctx context.Context, info LockInfo, timeout tim
 	return makeRelease(flk, infoPath), nil
 }
 
-// Inspect returns the current holder recorded in the sidecar, or (nil, nil) when
-// no lock is held (or the sidecar is absent/unreadable). It backs windsor unlock's
-// "who holds this?" report. The sidecar is diagnostic, so a missing file is not an
-// error — it simply means there is nothing to release.
+// Inspect returns the current holder recorded in the sidecar. A missing sidecar
+// returns (nil, nil) — the normal clean state, nothing to release. A sidecar that
+// is present but unreadable or corrupt (e.g. a partial write from a killed holder)
+// returns an error: that is debris windsor unlock should still clear, so the caller
+// must not mistake it for "no lock held". It backs unlock's "who holds this?" report.
 func (s *localFlockLock) Inspect(ctx context.Context) (*LockInfo, error) {
-	return readHolderInfo(s.path + stackLockInfoSuffix), nil
+	infoPath := s.path + stackLockInfoSuffix
+	// #nosec G304 - infoPath is the lock's sidecar location configured by the runtime, not user-supplied
+	data, err := os.ReadFile(infoPath)
+	if errors.Is(err, os.ErrNotExist) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("stacklock: reading holder info at %s: %w", infoPath, err)
+	}
+	var info LockInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return nil, fmt.Errorf("stacklock: holder info at %s is corrupt: %w", infoPath, err)
+	}
+	return &info, nil
 }
 
 // ForceRelease clears a stuck lock by removing the lock file and its holder-info

--- a/pkg/provisioner/stacklock/stacklock_test.go
+++ b/pkg/provisioner/stacklock/stacklock_test.go
@@ -696,6 +696,26 @@ func TestLocalFlockLock_Inspect(t *testing.T) {
 			t.Fatalf("expected populated holder, got %+v", info)
 		}
 	})
+
+	t.Run("errors when the sidecar is present but corrupt", func(t *testing.T) {
+		// Given a sidecar with a partial/corrupt write (e.g. a holder killed mid-write)
+		path := filepath.Join(t.TempDir(), ".stacklock")
+		if err := os.WriteFile(path+stackLockInfoSuffix, []byte(`{"id":"orphan`), lockInfoPerm); err != nil {
+			t.Fatalf("write corrupt sidecar: %v", err)
+		}
+
+		// When inspecting
+		info, err := NewLocalFlockLock(path).Inspect(context.Background())
+
+		// Then it reports corruption rather than masquerading as "no lock held", so
+		// the caller can still clear the debris instead of short-circuiting.
+		if err == nil || !strings.Contains(err.Error(), "corrupt") {
+			t.Fatalf("expected corrupt-sidecar error, got info=%+v err=%v", info, err)
+		}
+		if info != nil {
+			t.Fatalf("expected nil holder on corrupt sidecar, got %+v", info)
+		}
+	})
 }
 
 // =============================================================================

--- a/pkg/provisioner/stacklock/stacklock_test.go
+++ b/pkg/provisioner/stacklock/stacklock_test.go
@@ -608,3 +608,158 @@ func TestHashProjectRoot(t *testing.T) {
 		}
 	})
 }
+
+// =============================================================================
+// Test ForRuntime
+// =============================================================================
+
+func TestForRuntime(t *testing.T) {
+	t.Run("returns a usable lock for a configured runtime", func(t *testing.T) {
+		// Given a runtime with a scratch path
+		rt := newTestRuntime(t)
+
+		// When deriving the lock
+		lock, err := ForRuntime(rt)
+
+		// Then a usable lock is returned
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if lock == nil {
+			t.Fatal("expected non-nil StackLock")
+		}
+	})
+
+	t.Run("errors when the runtime is nil", func(t *testing.T) {
+		// When deriving a lock from a nil runtime
+		_, err := ForRuntime(nil)
+
+		// Then it reports the missing runtime
+		if err == nil || !strings.Contains(err.Error(), "runtime is required") {
+			t.Fatalf("expected runtime-required error, got %v", err)
+		}
+	})
+
+	t.Run("errors when the scratch path is empty", func(t *testing.T) {
+		// Given a runtime that has not been configured yet
+		rt := &runtime.Runtime{}
+
+		// When deriving the lock
+		_, err := ForRuntime(rt)
+
+		// Then it reports the unconfigured scratch path
+		if err == nil || !strings.Contains(err.Error(), "scratch path is empty") {
+			t.Fatalf("expected scratch-path error, got %v", err)
+		}
+	})
+}
+
+// =============================================================================
+// Test Inspect
+// =============================================================================
+
+func TestLocalFlockLock_Inspect(t *testing.T) {
+	t.Run("returns nil when no lock is held", func(t *testing.T) {
+		// Given a fresh lock path with no sidecar
+		path := filepath.Join(t.TempDir(), ".stacklock")
+		sl := NewLocalFlockLock(path)
+
+		// When inspecting
+		info, err := sl.Inspect(context.Background())
+
+		// Then there is no holder and no error
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if info != nil {
+			t.Fatalf("expected nil holder, got %+v", info)
+		}
+	})
+
+	t.Run("returns the holder recorded in the sidecar", func(t *testing.T) {
+		// Given a sidecar describing the current holder
+		path := filepath.Join(t.TempDir(), ".stacklock")
+		holder := newTestLockInfo()
+		holder.Who = "ci@runner-9"
+		holder.Operation = "bootstrap"
+		holder.PID = 4242
+		writeHolderInfo(path+stackLockInfoSuffix, holder)
+
+		// When inspecting
+		info, err := NewLocalFlockLock(path).Inspect(context.Background())
+
+		// Then the recorded holder is returned
+		if err != nil {
+			t.Fatalf("expected nil error, got %v", err)
+		}
+		if info == nil || info.PID != 4242 || info.Operation != "bootstrap" {
+			t.Fatalf("expected populated holder, got %+v", info)
+		}
+	})
+}
+
+// =============================================================================
+// Test ForceRelease
+// =============================================================================
+
+func TestLocalFlockLock_ForceRelease(t *testing.T) {
+	// orphanedLock writes a lock file and sidecar with no process holding the flock,
+	// mirroring a holder that was SIGKILL'd before it could release. Files are created
+	// directly (not via Acquire) so no open fd lingers — os.Remove of an fd-held file
+	// fails on Windows, and the recovery scenario is precisely a dead holder.
+	orphanedLock := func(t *testing.T, info LockInfo) string {
+		t.Helper()
+		path := filepath.Join(t.TempDir(), ".stacklock")
+		if err := os.WriteFile(path, nil, lockInfoPerm); err != nil {
+			t.Fatalf("write lock file: %v", err)
+		}
+		writeHolderInfo(path+stackLockInfoSuffix, info)
+		return path
+	}
+
+	t.Run("removes the lock file and sidecar", func(t *testing.T) {
+		// Given an orphaned lock with both files present
+		path := orphanedLock(t, newTestLockInfo())
+
+		// When force-releasing without an ID guard
+		if err := NewLocalFlockLock(path).ForceRelease(context.Background(), "", "test recovery"); err != nil {
+			t.Fatalf("force-release: %v", err)
+		}
+
+		// Then both the lock file and the sidecar are gone
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Fatalf("expected lock file removed, stat err=%v", err)
+		}
+		if _, err := os.Stat(path + stackLockInfoSuffix); !os.IsNotExist(err) {
+			t.Fatalf("expected sidecar removed, stat err=%v", err)
+		}
+	})
+
+	t.Run("is a no-op when no lock files exist", func(t *testing.T) {
+		// Given a path with no lock files
+		path := filepath.Join(t.TempDir(), ".stacklock")
+
+		// When force-releasing, then it succeeds (already clear)
+		if err := NewLocalFlockLock(path).ForceRelease(context.Background(), "", "test"); err != nil {
+			t.Fatalf("expected nil error for absent files, got %v", err)
+		}
+	})
+
+	t.Run("refuses when a different holder has acquired the lock", func(t *testing.T) {
+		// Given a lock now held by a holder whose ID differs from the caller's target
+		current := newTestLockInfo()
+		current.ID = "new-holder-id"
+		path := orphanedLock(t, current)
+
+		// When force-releasing against a stale target ID
+		err := NewLocalFlockLock(path).ForceRelease(context.Background(), "stale-target-id", "test")
+
+		// Then it refuses and leaves the files intact
+		if err == nil || !strings.Contains(err.Error(), "different holder") {
+			t.Fatalf("expected refusal error, got %v", err)
+		}
+		if _, statErr := os.Stat(path); statErr != nil {
+			t.Fatalf("expected lock file preserved on refusal, got %v", statErr)
+		}
+	})
+}


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This change adds a single isolated recovery command and wires up two previously stubbed-out methods in the stacklock package; it does not touch existing command behavior or shared infrastructure.
>
> **Overview**
>
> The PR introduces `windsor unlock` to let operators force-release a stuck stack lock left behind by a killed process. It extracts `ForRuntime` from `With` to eliminate duplicated path-derivation logic, then provides real implementations of `Inspect` and `ForceRelease` on `localFlockLock`, both of which previously returned an unsupported-operation error. The ID guard in `ForceRelease` is a best-effort check against a concurrent legitimate acquirer, explicitly documented as advisory for an operator-facing tool.
>
> One behavioral gap is noted inline: if the sidecar file is present but corrupt, `Inspect` returns `(nil, nil)` rather than an error, causing the command to report "nothing to release" even when lock-file debris exists on disk. This is the only finding of consequence.
>
> Reviewed by Claude for commit `5dcfa709`.

<!-- /claude-code-review:summary -->
