### PR TITLE
fix(provisioner): suspend eligible kustomizations before deletion to prevent deadlocks

### DIFF
--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -27,6 +27,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // =============================================================================
@@ -982,6 +983,12 @@ func (k *BaseKubernetesManager) DeleteBlueprint(blueprint *blueprintv1alpha1.Blu
 		}
 		eligible = append(eligible, kustomization)
 	}
+	for _, kustomization := range eligible {
+		if err := k.suspendKustomization(kustomization.Name, namespace); err != nil {
+			return fmt.Errorf("destroy aborted: failed to suspend kustomization %q before teardown: %w (suspension keeps a still-active kustomization from re-creating a resource that another component's Helm uninstall is mid-way through deleting, which would deadlock the uninstall on its fluxcd finalizer)", kustomization.Name, err)
+		}
+	}
+
 	for _, kustomization := range orderForDestroy(eligible, "destroy") {
 		tui.Start(fmt.Sprintf("Destroying kustomization %s", kustomization.Name))
 		if err := k.DeleteKustomization(kustomization.Name, namespace); err != nil {
@@ -1184,9 +1191,33 @@ func (k *BaseKubernetesManager) applyBlueprintSource(source blueprintv1alpha1.So
 	return k.applyBlueprintGitRepository(source, namespace)
 }
 
-// =============================================================================
-// Private Methods
-// =============================================================================
+// suspendKustomization sets spec.suspend=true so the kustomize-controller stops
+// reconciling the Kustomization. DeleteBlueprint suspends every eligible
+// Kustomization before the ordered delete walk: an un-deleted Kustomization that
+// keeps reconciling can re-create a (often cluster-scoped) resource that another
+// component's Helm uninstall is mid-way through deleting, deadlocking it — Helm
+// waits for the resource to disappear while Flux restores it, so the HelmRelease
+// never drops its finalizers.fluxcd.io finalizer and the namespace hangs in
+// Terminating until destroy times out. Suspension does not block the later
+// delete: the controller's deletion branch runs ahead of the suspend
+// short-circuit, so the finalizer still prunes (WaitForTermination) when the
+// Kustomization is removed. A NotFound Kustomization is treated as success.
+func (k *BaseKubernetesManager) suspendKustomization(name, namespace string) error {
+	gvr := schema.GroupVersionResource{
+		Group:    "kustomize.toolkit.fluxcd.io",
+		Version:  "v1",
+		Resource: "kustomizations",
+	}
+	patch := []byte(`{"spec":{"suspend":true}}`)
+	opts := metav1.PatchOptions{FieldManager: "windsor-cli"}
+	if _, err := k.client.PatchResource(context.Background(), gvr, namespace, name, types.MergePatchType, patch, opts); err != nil {
+		if isNotFoundError(err) {
+			return nil
+		}
+		return err
+	}
+	return nil
+}
 
 // gitopsMode returns the configured gitops mode, defaulting to pull. Centralising
 // the "gitops.mode" config read here keeps the several call sites below in sync:

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -985,7 +985,7 @@ func (k *BaseKubernetesManager) DeleteBlueprint(blueprint *blueprintv1alpha1.Blu
 	}
 	for _, kustomization := range eligible {
 		if err := k.suspendKustomization(kustomization.Name, namespace); err != nil {
-			return fmt.Errorf("destroy aborted: failed to suspend kustomization %q before teardown: %w (suspension keeps a still-active kustomization from re-creating a resource that another component's Helm uninstall is mid-way through deleting, which would deadlock the uninstall on its fluxcd finalizer)", kustomization.Name, err)
+			return fmt.Errorf("destroy aborted: failed to suspend kustomization %q: %w", kustomization.Name, err)
 		}
 	}
 

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -3045,19 +3045,23 @@ func TestBaseKubernetesManager_DeleteBlueprint(t *testing.T) {
 		}
 
 		firstDelete := -1
+		lastSuspend := -1
 		for i, e := range events {
-			if len(e) >= 7 && e[:7] == "delete:" {
+			switch {
+			case strings.HasPrefix(e, "delete:") && firstDelete == -1:
 				firstDelete = i
-				break
+			case strings.HasPrefix(e, "suspend:"):
+				lastSuspend = i
 			}
 		}
 		if firstDelete == -1 {
 			t.Fatalf("Expected at least one delete, got events %v", events)
 		}
-		for _, e := range events[:firstDelete] {
-			if len(e) >= 7 && e[:7] == "delete:" {
-				t.Fatalf("Expected all suspends before any delete, got events %v", events)
-			}
+		if lastSuspend == -1 {
+			t.Fatalf("Expected at least one suspend, got events %v", events)
+		}
+		if lastSuspend >= firstDelete {
+			t.Fatalf("Expected all suspends before any delete, got events %v", events)
 		}
 	})
 

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -20,6 +20,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // KubernetesTestMocks contains all the mock dependencies for testing the KubernetesManager
@@ -2994,6 +2995,131 @@ func TestBaseKubernetesManager_DeleteBlueprint(t *testing.T) {
 		}
 		if deleteCalls[0] != "test-kustomization-2" {
 			t.Errorf("Expected delete call for 'test-kustomization-2', got %s", deleteCalls[0])
+		}
+	})
+
+	t.Run("SuspendsEligibleKustomizationsBeforeDeleting", func(t *testing.T) {
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+
+		var events []string
+		var suspendPatches []string
+		kubernetesClient.PatchResourceFunc = func(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*unstructured.Unstructured, error) {
+			if string(data) == `{"spec":{"suspend":true}}` {
+				suspendPatches = append(suspendPatches, name)
+				events = append(events, "suspend:"+name)
+			}
+			return nil, nil
+		}
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			events = append(events, "delete:"+name)
+			return nil
+		}
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			return nil, fmt.Errorf("the server could not find the requested resource")
+		}
+		manager.client = kubernetesClient
+
+		destroyFalse := false
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Metadata: blueprintv1alpha1.Metadata{Name: "test-blueprint"},
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "test-kustomization-1"},
+				{Name: "test-kustomization-2"},
+				{Name: "pinned-keep", Destroy: &blueprintv1alpha1.BoolExpression{Value: &destroyFalse, IsExpr: false}},
+			},
+		}
+
+		err := manager.DeleteBlueprint(blueprint, "test-namespace")
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		if len(suspendPatches) != 2 {
+			t.Fatalf("Expected 2 suspend patches, got %d (%v)", len(suspendPatches), suspendPatches)
+		}
+		for _, name := range suspendPatches {
+			if name == "pinned-keep" {
+				t.Errorf("Expected destroy=false kustomization not to be suspended, but %q was", name)
+			}
+		}
+
+		firstDelete := -1
+		for i, e := range events {
+			if len(e) >= 7 && e[:7] == "delete:" {
+				firstDelete = i
+				break
+			}
+		}
+		if firstDelete == -1 {
+			t.Fatalf("Expected at least one delete, got events %v", events)
+		}
+		for _, e := range events[:firstDelete] {
+			if len(e) >= 7 && e[:7] == "delete:" {
+				t.Fatalf("Expected all suspends before any delete, got events %v", events)
+			}
+		}
+	})
+
+	t.Run("AbortsWhenSuspendFails", func(t *testing.T) {
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+
+		var deleteCalls []string
+		kubernetesClient.PatchResourceFunc = func(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*unstructured.Unstructured, error) {
+			return nil, fmt.Errorf("connection refused")
+		}
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			deleteCalls = append(deleteCalls, name)
+			return nil
+		}
+		manager.client = kubernetesClient
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Metadata:       blueprintv1alpha1.Metadata{Name: "test-blueprint"},
+			Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "test-kustomization-1"}},
+		}
+
+		err := manager.DeleteBlueprint(blueprint, "test-namespace")
+		if err == nil {
+			t.Fatal("Expected error when suspend fails, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to suspend kustomization") {
+			t.Errorf("Expected suspend-failure error, got %v", err)
+		}
+		if len(deleteCalls) != 0 {
+			t.Errorf("Expected no delete calls when suspend fails, got %v", deleteCalls)
+		}
+	})
+
+	t.Run("ToleratesNotFoundOnSuspend", func(t *testing.T) {
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+
+		var deleteCalls []string
+		kubernetesClient.PatchResourceFunc = func(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*unstructured.Unstructured, error) {
+			return nil, fmt.Errorf("the server could not find the requested resource")
+		}
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			deleteCalls = append(deleteCalls, name)
+			return nil
+		}
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			return nil, fmt.Errorf("the server could not find the requested resource")
+		}
+		manager.client = kubernetesClient
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Metadata:       blueprintv1alpha1.Metadata{Name: "test-blueprint"},
+			Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "test-kustomization-1"}},
+		}
+
+		err := manager.DeleteBlueprint(blueprint, "test-namespace")
+		if err != nil {
+			t.Fatalf("Expected NotFound on suspend to be tolerated, got %v", err)
+		}
+		if len(deleteCalls) != 1 {
+			t.Errorf("Expected 1 delete call, got %v", deleteCalls)
 		}
 	})
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> This fix modifies the blueprint destruction path by inserting a pre-delete suspension step; a network error or RBAC gap during suspension will now abort the entire destroy rather than proceeding, which is a behavioral change to an existing workflow.
>
> **Overview**
>
> The PR adds a `suspendKustomization` private method and calls it for every eligible Kustomization before the ordered delete walk in `DeleteBlueprint`. Suspension sets `spec.suspend=true` via a MergePatch, preventing the Flux kustomize-controller from re-creating cluster-scoped resources that a concurrent Helm uninstall is mid-way through deleting — a scenario that previously caused HelmRelease finalizers to deadlock until destroy timed out.
>
> Two issues are worth addressing before merge: the user-facing error on a suspension failure embeds a 150-word inline explanation (should be a comment), and the ordering assertion in `SuspendsEligibleKustomizationsBeforeDeleting` is tautologically vacuous — `events[:firstDelete]` can never contain a delete by construction, so the assertion cannot catch an interleaved implementation.
>
> Reviewed by Claude for commit `a16eb320`.

<!-- /claude-code-review:summary -->
