### PR TITLE
fix(provisioner): resume kustomizations before delete so finalizer prunes inventory

### DIFF
--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -984,13 +984,17 @@ func (k *BaseKubernetesManager) DeleteBlueprint(blueprint *blueprintv1alpha1.Blu
 		eligible = append(eligible, kustomization)
 	}
 	for _, kustomization := range eligible {
-		if err := k.suspendKustomization(kustomization.Name, namespace); err != nil {
+		if err := k.setKustomizationSuspend(kustomization.Name, namespace, true); err != nil {
 			return fmt.Errorf("destroy aborted: failed to suspend kustomization %q: %w", kustomization.Name, err)
 		}
 	}
 
 	for _, kustomization := range orderForDestroy(eligible, "destroy") {
 		tui.Start(fmt.Sprintf("Destroying kustomization %s", kustomization.Name))
+		if err := k.setKustomizationSuspend(kustomization.Name, namespace, false); err != nil {
+			tui.Fail()
+			return fmt.Errorf("destroy aborted: failed to resume kustomization %q before delete: %w", kustomization.Name, err)
+		}
 		if err := k.DeleteKustomization(kustomization.Name, namespace); err != nil {
 			tui.Fail()
 			return fmt.Errorf("destroy aborted: failed to delete kustomization %q: %w (further deletions skipped to avoid cascading orphans)", kustomization.Name, err)
@@ -1191,24 +1195,27 @@ func (k *BaseKubernetesManager) applyBlueprintSource(source blueprintv1alpha1.So
 	return k.applyBlueprintGitRepository(source, namespace)
 }
 
-// suspendKustomization sets spec.suspend=true so the kustomize-controller stops
-// reconciling the Kustomization. DeleteBlueprint suspends every eligible
-// Kustomization before the ordered delete walk: an un-deleted Kustomization that
-// keeps reconciling can re-create a (often cluster-scoped) resource that another
-// component's Helm uninstall is mid-way through deleting, deadlocking it — Helm
-// waits for the resource to disappear while Flux restores it, so the HelmRelease
-// never drops its finalizers.fluxcd.io finalizer and the namespace hangs in
-// Terminating until destroy times out. Suspension does not block the later
-// delete: the controller's deletion branch runs ahead of the suspend
-// short-circuit, so the finalizer still prunes (WaitForTermination) when the
-// Kustomization is removed. A NotFound Kustomization is treated as success.
-func (k *BaseKubernetesManager) suspendKustomization(name, namespace string) error {
+// setKustomizationSuspend patches spec.suspend on a Kustomization. DeleteBlueprint
+// suspends every eligible Kustomization up front to freeze reconciliation: an
+// un-deleted Kustomization that keeps reconciling can re-create a (often
+// cluster-scoped) resource that another component's Helm uninstall is mid-way
+// through deleting, deadlocking it — Helm waits for the resource to disappear while
+// Flux restores it, so the HelmRelease never drops its finalizers.fluxcd.io
+// finalizer and the namespace hangs in Terminating until destroy times out. The
+// frozen Kustomizations are then resumed (suspend=false) one at a time, each
+// immediately before its own delete: the kustomize-controller's finalizer prunes
+// managed inventory only when the object is NOT suspended, so deleting a still-
+// suspended Kustomization strips its finalizer without garbage-collecting its
+// resources, orphaning them and letting destroy race ahead. Resuming just before
+// delete keeps every other Kustomization frozen while letting the one being deleted
+// prune. A NotFound Kustomization is treated as success.
+func (k *BaseKubernetesManager) setKustomizationSuspend(name, namespace string, suspend bool) error {
 	gvr := schema.GroupVersionResource{
 		Group:    "kustomize.toolkit.fluxcd.io",
 		Version:  "v1",
 		Resource: "kustomizations",
 	}
-	patch := []byte(`{"spec":{"suspend":true}}`)
+	patch := fmt.Appendf(nil, `{"spec":{"suspend":%t}}`, suspend)
 	opts := metav1.PatchOptions{FieldManager: "windsor-cli"}
 	if _, err := k.client.PatchResource(context.Background(), gvr, namespace, name, types.MergePatchType, patch, opts); err != nil {
 		if isNotFoundError(err) {

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -3127,6 +3127,83 @@ func TestBaseKubernetesManager_DeleteBlueprint(t *testing.T) {
 		}
 	})
 
+	t.Run("ResumesEachKustomizationImmediatelyBeforeDeletingIt", func(t *testing.T) {
+		// Given a blueprint with two eligible kustomizations and a client that
+		// records the ordered sequence of suspend/resume patches and deletes
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+
+		var events []string
+		kubernetesClient.PatchResourceFunc = func(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*unstructured.Unstructured, error) {
+			switch string(data) {
+			case `{"spec":{"suspend":true}}`:
+				events = append(events, "suspend:"+name)
+			case `{"spec":{"suspend":false}}`:
+				events = append(events, "resume:"+name)
+			}
+			return nil, nil
+		}
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			events = append(events, "delete:"+name)
+			return nil
+		}
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			return nil, fmt.Errorf("the server could not find the requested resource")
+		}
+		manager.client = kubernetesClient
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Metadata: blueprintv1alpha1.Metadata{Name: "test-blueprint"},
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "test-kustomization-1"},
+				{Name: "test-kustomization-2"},
+			},
+		}
+
+		// When the blueprint is deleted
+		err := manager.DeleteBlueprint(blueprint, "test-namespace")
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then every eligible kustomization is suspended before any delete starts
+		// (the freeze that prevents a still-active kustomization from re-creating
+		// resources mid-teardown), and each is resumed immediately before its own
+		// delete so the Flux finalizer prunes its inventory rather than orphaning it
+		firstResume, lastSuspend := -1, -1
+		for i, e := range events {
+			if strings.HasPrefix(e, "suspend:") {
+				lastSuspend = i
+			}
+			if strings.HasPrefix(e, "resume:") && firstResume == -1 {
+				firstResume = i
+			}
+		}
+		if lastSuspend == -1 || firstResume == -1 {
+			t.Fatalf("Expected both suspend and resume patches, got events %v", events)
+		}
+		if lastSuspend >= firstResume {
+			t.Fatalf("Expected all suspends before any resume (freeze-all-first), got events %v", events)
+		}
+		for _, name := range []string{"test-kustomization-1", "test-kustomization-2"} {
+			resumeIdx, deleteIdx := -1, -1
+			for i, e := range events {
+				switch e {
+				case "resume:" + name:
+					resumeIdx = i
+				case "delete:" + name:
+					deleteIdx = i
+				}
+			}
+			if resumeIdx == -1 || deleteIdx == -1 {
+				t.Fatalf("Expected %q to be both resumed and deleted, got events %v", name, events)
+			}
+			if resumeIdx != deleteIdx-1 {
+				t.Fatalf("Expected resume of %q immediately before its delete, got events %v", name, events)
+			}
+		}
+	})
+
 	t.Run("SuccessWithDestroyOnlyKustomizations", func(t *testing.T) {
 		manager := setup(t)
 		kubernetesClient := client.NewMockKubernetesClient()


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> This PR modifies the irreversible destroy sequence of `DeleteBlueprint`, a change that warrants attention even though the fix is clearly correct.
>
> **Overview**
>
> The PR fixes a bug where suspending a Flux Kustomization before deleting it caused the `kustomize-controller` finalizer to skip inventory pruning, orphaning cloud resources (load balancers, volumes, DNS records) and letting cluster teardown race ahead. The fix keeps the freeze-all-first pattern — which prevents a live controller from recreating resources that another Helm uninstall is mid-way through deleting — but resumes each Kustomization individually, immediately before its own delete, so the finalizer runs cleanup correctly.
>
> If a delete call fails mid-loop after a successful resume, one Kustomization is left unsuspended while siblings remain frozen. A retry of `DeleteBlueprint` re-suspends it in the first pass, so the recovery path is correct, but operators inspecting cluster state during a failed destroy may observe this asymmetric suspension state. The unit test correctly asserts the freeze-all-first ordering and that each resume is immediately adjacent to its own delete.
>
> Reviewed by Claude for commit `5e35623`.

<!-- /claude-code-review:summary -->
