### PR TITLE
feat(composer): Facets install & resources tiers

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -557,6 +557,19 @@ type Kustomization struct {
 	// All values are converted to strings as required by Flux variable substitution.
 	// These are used for generating ConfigMaps and are not written to the final context blueprint.yaml.
 	Substitutions map[string]string `yaml:"substitutions,omitempty"`
+
+	// Install lists the components of the install (controller/operator) tier. Like Components, each
+	// entry is a component path and may be a '${...}' expression that prunes to empty. When Install
+	// and/or Resources are set, the composer expands this entry into two kustomizations sharing this
+	// entry's Path: an install named after the entry carrying the Install components, and a resources
+	// kustomization (named "<name>-resources") carrying the Resources components and depending on the
+	// install, so the controller is reconciled before the custom resources it admits. When both are
+	// empty the entry stays a single flat kustomization built from Components. Tiers desugar during
+	// composition and never appear in the composed blueprint.
+	Install []string `yaml:"install,omitempty"`
+
+	// Resources lists the components of the custom-resource tier. See Install.
+	Resources []string `yaml:"resources,omitempty"`
 }
 
 // PostBuild is a post-build step to run after the kustomization is applied.
@@ -940,6 +953,8 @@ func (k *Kustomization) DeepCopy() *Kustomization {
 		DestroyOnly:     k.DestroyOnly,
 		Enabled:         enabledCopy,
 		Substitutions:   maps.Clone(k.Substitutions),
+		Install:         slices.Clone(k.Install),
+		Resources:       slices.Clone(k.Resources),
 	}
 }
 

--- a/api/v1alpha1/facet_types_test.go
+++ b/api/v1alpha1/facet_types_test.go
@@ -401,6 +401,35 @@ func TestConditionalKustomizationDeepCopy(t *testing.T) {
 			t.Error("Deep copy failed: requires message was not copied")
 		}
 	})
+
+	t.Run("CopiesInstallAndResourceTiersIndependently", func(t *testing.T) {
+		original := &ConditionalKustomization{
+			Kustomization: Kustomization{
+				Name:      "cert-manager",
+				Path:      "pki/cert-manager",
+				Install:   []string{"helm-release"},
+				Resources: []string{"private-issuer/ca"},
+			},
+		}
+
+		copy := original.DeepCopy()
+
+		if len(copy.Install) != 1 || copy.Install[0] != "helm-release" {
+			t.Fatalf("Expected install components copied, got %v", copy.Install)
+		}
+		if len(copy.Resources) != 1 || copy.Resources[0] != "private-issuer/ca" {
+			t.Fatalf("Expected resources components copied, got %v", copy.Resources)
+		}
+
+		original.Install[0] = "modified"
+		if copy.Install[0] == "modified" {
+			t.Error("Deep copy failed: install components slice was not copied")
+		}
+		original.Resources[0] = "modified"
+		if copy.Resources[0] == "modified" {
+			t.Error("Deep copy failed: resources components slice was not copied")
+		}
+	})
 }
 
 func TestConfigBlockDeepCopy(t *testing.T) {

--- a/docs/reference/blueprint.md
+++ b/docs/reference/blueprint.md
@@ -43,10 +43,12 @@ variable substitutions shared across them.
 | `destroyOnly` | `boolean` | When true, the kustomization only runs during destroy. Useful for teardown-only resources (e.g. cleanup jobs). |
 | `enabled` | `boolean / string` | Whether to include this kustomization in the final blueprint. Boolean or expression. Defaults to true. |
 | `force` | `boolean` | Force-apply resources Flux would otherwise refuse to update. |
+| `install` | `array<string>` | Components of the install (controller/operator) tier. Like components, each entry may be a '${...}' expression that prunes to empty. When install and/or resources are set, the entry expands into separate kustomizations sharing this path: '<name>-install' carrying these components and '<name>-resources' depending on it, so the controller is reconciled before the custom resources it admits. |
 | `interval` | `string` | Reconciliation interval, expressed as a Go duration string (e.g. '5m', '1h'). Defaults to a mode-appropriate value chosen by the provisioner (short poll for pull mode, long fallback for push). |
 | `namespace` | `string` | Namespace where the Flux Kustomization object itself lives. Defaults to the gitops namespace. DependsOn references always resolve in the gitops namespace; cross-namespace dependencies are not supported. |
 | `patches` | `array<object>` | Strategic-merge or Flux-style patches applied to the kustomization. Each entry is either a 'path:' to a patch file relative to the kustomization, or a 'patch:' inline YAML body with an optional 'target:' selector (kind / name / namespace). |
 | `prune` | `boolean` | Garbage-collect resources removed from the source. Defaults to true. |
+| `resources` | `array<string>` | Components of the custom-resource tier. See install. |
 | `retryInterval` | `string` | Duration to wait before retrying a failed reconciliation (e.g. '2m'). |
 | `source` | `string` | Name of the source (from the sources list) that provides this kustomization. Defaults to the blueprint's primary source when unset. |
 | `substitutions` | `map<string>` | PostBuild variable substitutions for this kustomization. Collected into a 'values-<name>' ConfigMap that Flux substitutes from. |

--- a/integration/composer_test.go
+++ b/integration/composer_test.go
@@ -172,6 +172,72 @@ func TestShowBlueprint_CrdsDriverSelection(t *testing.T) {
 	}
 }
 
+// TestShowBlueprint_InstallResourcesTiers verifies a tiered facet entry expands into separate
+// install and resources kustomizations sharing the entry's path, and that a consumer depending on
+// the vendor by its bare name resolves to the install tier.
+func TestShowBlueprint_InstallResourcesTiers(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "facet-tiers")
+	env = append(env, "WINDSOR_CONTEXT=default")
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"show", "blueprint"}, env)
+	if err != nil {
+		t.Fatalf("show blueprint: %v\nstderr: %s", err, stderr)
+	}
+
+	var bp struct {
+		Kustomize []struct {
+			Name       string   `yaml:"name"`
+			Path       string   `yaml:"path"`
+			Components []string `yaml:"components"`
+			DependsOn  []string `yaml:"dependsOn"`
+		} `yaml:"kustomize"`
+	}
+	if err := yaml.Unmarshal(stdout, &bp); err != nil {
+		t.Fatalf("parse blueprint YAML: %v\nstdout: %s", err, stdout)
+	}
+	byName := map[string]struct {
+		path       string
+		components []string
+		dependsOn  []string
+	}{}
+	for _, k := range bp.Kustomize {
+		byName[k.Name] = struct {
+			path       string
+			components []string
+			dependsOn  []string
+		}{k.Path, k.Components, k.DependsOn}
+	}
+
+	install, ok := byName["cert-manager-install"]
+	if !ok {
+		t.Fatalf("expected cert-manager-install, got %+v", bp.Kustomize)
+	}
+	res, ok := byName["cert-manager-resources"]
+	if !ok {
+		t.Fatalf("expected cert-manager-resources, got %+v", bp.Kustomize)
+	}
+	if install.path != "pki/cert-manager" || res.path != "pki/cert-manager" {
+		t.Errorf("expected both tiers at pki/cert-manager, got install=%q resources=%q", install.path, res.path)
+	}
+	if !slices.Contains(install.components, "helm-release") {
+		t.Errorf("expected install components [helm-release], got %v", install.components)
+	}
+	if !slices.Contains(res.components, "private-issuer/ca") {
+		t.Errorf("expected resources components [private-issuer/ca], got %v", res.components)
+	}
+	if !slices.Contains(res.dependsOn, "cert-manager-install") {
+		t.Errorf("expected resources to depend on cert-manager-install, got %v", res.dependsOn)
+	}
+
+	dns, ok := byName["dns"]
+	if !ok {
+		t.Fatalf("expected dns, got %+v", bp.Kustomize)
+	}
+	if !slices.Contains(dns.dependsOn, "cert-manager-install") {
+		t.Errorf("expected dns bare-name dependency to resolve to cert-manager-install, got %v", dns.dependsOn)
+	}
+}
+
 // TestShowBlueprint_FacetRequires_Satisfied verifies the success path: when every required
 // path resolves to a present, non-empty value, ProcessFacets returns no error and the
 // blueprint renders normally.

--- a/integration/fixtures/facet-tiers/contexts/_template/blueprint.yaml
+++ b/integration/fixtures/facet-tiers/contexts/_template/blueprint.yaml
@@ -1,0 +1,5 @@
+kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: facet-tiers
+  description: Install/resources tier expansion integration fixture

--- a/integration/fixtures/facet-tiers/contexts/_template/facets/dns.yaml
+++ b/integration/fixtures/facet-tiers/contexts/_template/facets/dns.yaml
@@ -1,0 +1,16 @@
+kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: dns
+  description: Depends on cert-manager by its bare name to exercise install-tier resolution
+
+kustomize:
+
+- name: dns
+  path: dns
+  components:
+  - coredns
+  dependsOn:
+  - cert-manager
+  timeout: 5m
+  interval: 5m

--- a/integration/fixtures/facet-tiers/contexts/_template/facets/pki.yaml
+++ b/integration/fixtures/facet-tiers/contexts/_template/facets/pki.yaml
@@ -1,0 +1,16 @@
+kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: pki
+  description: cert-manager split into install and resources tiers
+
+kustomize:
+
+- name: cert-manager
+  path: pki/cert-manager
+  install:
+  - helm-release
+  resources:
+  - private-issuer/ca
+  timeout: 5m
+  interval: 5m

--- a/integration/fixtures/facet-tiers/windsor.yaml
+++ b/integration/fixtures/facet-tiers/windsor.yaml
@@ -1,0 +1,3 @@
+version: v1alpha1
+contexts:
+  default: {}

--- a/pkg/composer/blueprint/composer.go
+++ b/pkg/composer/blueprint/composer.go
@@ -164,6 +164,7 @@ func (c *BaseBlueprintComposer) Compose(loaders []BlueprintLoader, initLoaderNam
 		return nil, fmt.Errorf("failed to apply per-kustomization substitutions: %w", err)
 	}
 	c.dropEmptyCompositionFragments(result)
+	c.resolveTierDependencies(result)
 	validationErr := errors.Join(c.validateSources(result), c.validateDependencies(result))
 	return result, validationErr
 }
@@ -672,6 +673,28 @@ func (c *BaseBlueprintComposer) applyPerKustomizationSubstitutions(blueprint *bl
 	}
 
 	return nil
+}
+
+// resolveTierDependencies rewrites a dependsOn reference to a vendor's bare name into its install
+// tier when the vendor was authored with install/resources tiers. A facet that depends on
+// "cert-manager" resolves to "cert-manager-install" when no kustomization named "cert-manager"
+// exists but "cert-manager-install" does, so "depend on cert-manager" means "wait for its
+// controller". An exact name match always wins, so the legacy flat form is unaffected.
+func (c *BaseBlueprintComposer) resolveTierDependencies(bp *blueprintv1alpha1.Blueprint) {
+	names := make(map[string]struct{}, len(bp.Kustomizations))
+	for _, k := range bp.Kustomizations {
+		names[k.Name] = struct{}{}
+	}
+	for i := range bp.Kustomizations {
+		for j, dep := range bp.Kustomizations[i].DependsOn {
+			if _, ok := names[dep]; ok {
+				continue
+			}
+			if _, ok := names[dep+"-install"]; ok {
+				bp.Kustomizations[i].DependsOn[j] = dep + "-install"
+			}
+		}
+	}
 }
 
 // validateSources checks that install is only used on OCI sources. Git and other non-OCI sources

--- a/pkg/composer/blueprint/composer_test.go
+++ b/pkg/composer/blueprint/composer_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -996,6 +997,75 @@ func TestComposer_setContextMetadata(t *testing.T) {
 		// Then metadata should remain unchanged
 		if bp.Metadata.Name != "original" {
 			t.Errorf("Expected name 'original', got '%s'", bp.Metadata.Name)
+		}
+	})
+}
+
+func TestComposer_resolveTierDependencies(t *testing.T) {
+	depsOf := func(bp *blueprintv1alpha1.Blueprint, name string) []string {
+		for _, k := range bp.Kustomizations {
+			if k.Name == name {
+				return k.DependsOn
+			}
+		}
+		return nil
+	}
+
+	t.Run("RewritesBareVendorNameToInstallTier", func(t *testing.T) {
+		// Given a consumer that depends on a vendor by its bare name, where the vendor was tiered
+		composer := &BaseBlueprintComposer{}
+		bp := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "cert-manager-install"},
+				{Name: "cert-manager-resources", DependsOn: []string{"cert-manager-install"}},
+				{Name: "dns", DependsOn: []string{"cert-manager"}},
+			},
+		}
+
+		// When resolving tier dependencies
+		composer.resolveTierDependencies(bp)
+
+		// Then the bare-name dependency points at the install tier
+		if !slices.Contains(depsOf(bp, "dns"), "cert-manager-install") {
+			t.Errorf("Expected dns to depend on cert-manager-install, got %v", depsOf(bp, "dns"))
+		}
+	})
+
+	t.Run("ExactNameMatchWins", func(t *testing.T) {
+		// Given both a flat "foo" and a "foo-install" exist
+		composer := &BaseBlueprintComposer{}
+		bp := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "foo"},
+				{Name: "foo-install"},
+				{Name: "bar", DependsOn: []string{"foo"}},
+			},
+		}
+
+		// When resolving
+		composer.resolveTierDependencies(bp)
+
+		// Then the exact flat name is preserved (legacy form unaffected)
+		if !slices.Contains(depsOf(bp, "bar"), "foo") || slices.Contains(depsOf(bp, "bar"), "foo-install") {
+			t.Errorf("Expected bar to keep dependency on foo, got %v", depsOf(bp, "bar"))
+		}
+	})
+
+	t.Run("LeavesUnresolvableDependencyUntouched", func(t *testing.T) {
+		// Given a dependency with neither an exact nor an install-tier match
+		composer := &BaseBlueprintComposer{}
+		bp := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "app", DependsOn: []string{"missing"}},
+			},
+		}
+
+		// When resolving
+		composer.resolveTierDependencies(bp)
+
+		// Then the dependency is left as-is (validateDependencies surfaces the error later)
+		if !slices.Contains(depsOf(bp, "app"), "missing") {
+			t.Errorf("Expected unresolved dependency to be left untouched, got %v", depsOf(bp, "app"))
 		}
 	})
 }
@@ -2498,9 +2568,9 @@ func TestComposer_dropEmptyCompositionFragments(t *testing.T) {
 		composer := NewBlueprintComposer(mocks.Runtime)
 		blueprint := &blueprintv1alpha1.Blueprint{
 			Substitutions: map[string]string{
-				"keep":        "10.0.0.1",
-				"drop_empty":  "",
-				"":            "empty-key",
+				"keep":       "10.0.0.1",
+				"drop_empty": "",
+				"":           "empty-key",
 			},
 		}
 

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -858,6 +858,31 @@ func (p *BaseBlueprintProcessor) collectTerraformComponents(
 // is ordinal (higher wins), then strategy precedence (remove > replace > merge) when ordinals are equal.
 // If a kustomization has an empty 'when' condition, it inherits the facet-level condition.
 // Returns an error if condition evaluation or substitution processing fails.
+// recordKustomizationTraces records substitution and component provenance for a composed
+// kustomization so `windsor explain` can attribute each value to its facet, source, and line.
+func (p *BaseBlueprintProcessor) recordKustomizationTraces(name string, rawComponents []string, rawSubstitutions map[string]string, facetPath, sourceName string, ordinal int, strategy string) {
+	for sk, sv := range rawSubstitutions {
+		p.recordTrace("kustomize."+name+".substitutions."+sk, TraceContribution{
+			FacetPath:  facetPath,
+			SourceName: sourceName,
+			Ordinal:    ordinal,
+			Strategy:   strategy,
+			Line:       yamlNodeLine(facetPath, "kustomize", namedItem(name), "substitutions", sk),
+			RawValue:   deepCopyValue(sv),
+		})
+	}
+	if len(rawComponents) > 0 {
+		p.recordTrace("kustomize."+name+".components", TraceContribution{
+			FacetPath:     facetPath,
+			SourceName:    sourceName,
+			Ordinal:       ordinal,
+			Strategy:      strategy,
+			Line:          yamlNodeLine(facetPath, "kustomize", namedItem(name), "components"),
+			RawComponents: slices.Clone(rawComponents),
+		})
+	}
+}
+
 func (p *BaseBlueprintProcessor) collectKustomizations(facet blueprintv1alpha1.Facet, sourceName []string, kustomizationByName map[string]*blueprintv1alpha1.ConditionalKustomization, facetScope map[string]any) error {
 	for _, k := range facet.Kustomizations {
 		componentWhen := k.When
@@ -916,7 +941,18 @@ func (p *BaseBlueprintProcessor) collectKustomizations(facet blueprintv1alpha1.F
 			}
 			processed.Components = evaluated
 		}
-		processed.DependsOn = appendCrdDependencies(processed.DependsOn, facet.Crds, processed.Name)
+		installComponents, err := p.evaluateTierComponents(processed.Install, facet.Path, facetScope)
+		if err != nil {
+			return fmt.Errorf("error evaluating install for kustomization '%s': %w", processed.Name, err)
+		}
+		resourceComponents, err := p.evaluateTierComponents(processed.Resources, facet.Path, facetScope)
+		if err != nil {
+			return fmt.Errorf("error evaluating resources for kustomization '%s': %w", processed.Name, err)
+		}
+		tiered := len(installComponents) > 0 || len(resourceComponents) > 0
+		if !tiered {
+			processed.DependsOn = appendCrdDependencies(processed.DependsOn, facet.Crds, processed.Name)
+		}
 		if processed.Destroy != nil && processed.Destroy.IsExpr {
 			evaluated, err := p.evaluateBooleanExpression(processed.Destroy.Expr, facet.Path, facetScope)
 			if err != nil {
@@ -944,38 +980,31 @@ func (p *BaseBlueprintProcessor) collectKustomizations(facet blueprintv1alpha1.F
 		if len(sourceName) > 0 {
 			sn = sourceName[0]
 		}
-		for sk, sv := range k.Substitutions {
-			composedPath := "kustomize." + processed.Name + ".substitutions." + sk
-			p.recordTrace(composedPath, TraceContribution{
-				FacetPath:  facet.Path,
-				SourceName: sn,
-				Ordinal:    effectiveOrdinal,
-				Strategy:   strategy,
-				Line:       yamlNodeLine(facet.Path, "kustomize", namedItem(processed.Name), "substitutions", sk),
-				RawValue:   deepCopyValue(sv),
-			})
-		}
-		if len(k.Components) > 0 {
-			componentsPath := "kustomize." + processed.Name + ".components"
-			p.recordTrace(componentsPath, TraceContribution{
-				FacetPath:     facet.Path,
-				SourceName:    sn,
-				Ordinal:       effectiveOrdinal,
-				Strategy:      strategy,
-				Line:          yamlNodeLine(facet.Path, "kustomize", namedItem(processed.Name), "components"),
-				RawComponents: slices.Clone(k.Components),
-			})
+
+		addEntry := func(entry blueprintv1alpha1.ConditionalKustomization) error {
+			if _, exists := kustomizationByName[entry.Name]; !exists {
+				entry.Strategy = strategy
+				stored := new(blueprintv1alpha1.ConditionalKustomization)
+				*stored = entry
+				kustomizationByName[entry.Name] = stored
+				return nil
+			}
+			return p.updateKustomizationEntry(entry.Name, &entry, strategy, kustomizationByName, facetScope)
 		}
 
-		if _, exists := kustomizationByName[processed.Name]; !exists {
-			processed.Strategy = strategy
-			entry := new(blueprintv1alpha1.ConditionalKustomization)
-			*entry = processed
-			kustomizationByName[processed.Name] = entry
-		} else {
-			if err := p.updateKustomizationEntry(processed.Name, &processed, strategy, kustomizationByName, facetScope); err != nil {
-				return err
+		if tiered {
+			for _, entry := range buildTierEntries(processed, installComponents, resourceComponents, facet.Crds) {
+				p.recordKustomizationTraces(entry.Name, entry.Components, entry.Substitutions, facet.Path, sn, effectiveOrdinal, strategy)
+				if err := addEntry(entry); err != nil {
+					return err
+				}
 			}
+			continue
+		}
+
+		p.recordKustomizationTraces(processed.Name, k.Components, k.Substitutions, facet.Path, sn, effectiveOrdinal, strategy)
+		if err := addEntry(processed); err != nil {
+			return err
 		}
 	}
 	return nil
@@ -1012,6 +1041,47 @@ func appendCrdDependencies(dependsOn []string, crds []string, self string) []str
 		dependsOn = append(dependsOn, ref)
 	}
 	return dependsOn
+}
+
+// buildTierEntries expands a processed kustomization that declares install/resources component
+// groups into separate entries sharing the entry's path: "<name>-install" carries the install
+// components and "<name>-resources" carries the resources components and depends on the install,
+// so the controller is reconciled before the custom resources it admits. A legacy "<name>" entry
+// is emitted when Components is also set. The install (and legacy) entries carry the entry's
+// explicit dependencies plus the facet's CRD references; resources reaches those transitively
+// through the install tier. Each entry gets its own Substitutions copy and clears the tier fields.
+func buildTierEntries(processed blueprintv1alpha1.ConditionalKustomization, install, resources, crds []string) []blueprintv1alpha1.ConditionalKustomization {
+	name := processed.Name
+	explicit := slices.Clone(processed.DependsOn)
+	installName := name + "-install"
+	resourcesName := name + "-resources"
+
+	mk := func(tierName string, components, dependsOn []string) blueprintv1alpha1.ConditionalKustomization {
+		entry := processed
+		entry.Name = tierName
+		entry.Components = components
+		entry.DependsOn = dependsOn
+		entry.Install = nil
+		entry.Resources = nil
+		entry.Substitutions = maps.Clone(processed.Substitutions)
+		return entry
+	}
+
+	var entries []blueprintv1alpha1.ConditionalKustomization
+	if len(processed.Components) > 0 {
+		entries = append(entries, mk(name, slices.Clone(processed.Components), appendCrdDependencies(slices.Clone(explicit), crds, name)))
+	}
+	if len(install) > 0 {
+		entries = append(entries, mk(installName, install, appendCrdDependencies(slices.Clone(explicit), crds, installName)))
+	}
+	if len(resources) > 0 {
+		if len(install) > 0 {
+			entries = append(entries, mk(resourcesName, resources, []string{installName}))
+		} else {
+			entries = append(entries, mk(resourcesName, resources, appendCrdDependencies(slices.Clone(explicit), crds, resourcesName)))
+		}
+	}
+	return entries
 }
 
 // addCrdKustomizations injects one synthesized kustomization per unique CRD reference into the
@@ -1633,6 +1703,20 @@ func (p *BaseBlueprintProcessor) evaluateStringSlice(slice []string, facetPath s
 	}
 
 	return result, nil
+}
+
+// evaluateTierComponents evaluates a tier's component list (install or resources) the same way as
+// Components, then prunes entries that resolved to empty so a "${...}" expression that selects no
+// component leaves the tier — and the decision to emit it — empty.
+func (p *BaseBlueprintProcessor) evaluateTierComponents(components []string, facetPath string, scope map[string]any) ([]string, error) {
+	if len(components) == 0 {
+		return nil, nil
+	}
+	evaluated, err := p.evaluateStringSlice(components, facetPath, scope)
+	if err != nil {
+		return nil, err
+	}
+	return slices.DeleteFunc(evaluated, func(s string) bool { return s == "" }), nil
 }
 
 // evaluateBooleanExpression evaluates a boolean expression string. When scope is non-nil, it is

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -1057,13 +1057,12 @@ func buildTierEntries(processed blueprintv1alpha1.ConditionalKustomization, inst
 	resourcesName := name + "-resources"
 
 	mk := func(tierName string, components, dependsOn []string) blueprintv1alpha1.ConditionalKustomization {
-		entry := processed
+		entry := *processed.DeepCopy()
 		entry.Name = tierName
 		entry.Components = components
 		entry.DependsOn = dependsOn
 		entry.Install = nil
 		entry.Resources = nil
-		entry.Substitutions = maps.Clone(processed.Substitutions)
 		return entry
 	}
 

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -2553,6 +2553,231 @@ func TestProcessor_ProcessFacets_Crds(t *testing.T) {
 	})
 }
 
+func TestProcessor_ProcessFacets_Tiers(t *testing.T) {
+	find := func(bp *blueprintv1alpha1.Blueprint, name string) (blueprintv1alpha1.Kustomization, bool) {
+		for _, k := range bp.Kustomizations {
+			if k.Name == name {
+				return k, true
+			}
+		}
+		return blueprintv1alpha1.Kustomization{}, false
+	}
+
+	t.Run("ExpandsInstallAndResourcesSharingThePath", func(t *testing.T) {
+		// Given an entry that partitions a vendor's components into install and resources tiers
+		mocks := setupProcessorMocks(t)
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "pki"},
+				Kustomizations: []blueprintv1alpha1.ConditionalKustomization{
+					{Kustomization: blueprintv1alpha1.Kustomization{
+						Name:      "cert-manager",
+						Path:      "pki/cert-manager",
+						Install:   []string{"helm-release"},
+						Resources: []string{"private-issuer/ca"},
+					}},
+				},
+			},
+		}
+
+		// When processing facets
+		target := &blueprintv1alpha1.Blueprint{}
+		_, err := processor.ProcessFacets(target, facets)
+
+		// Then two kustomizations are emitted at the same path, resources depending on install
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		install, ok := find(target, "cert-manager-install")
+		if !ok {
+			t.Fatalf("Expected cert-manager-install, got %+v", target.Kustomizations)
+		}
+		res, ok := find(target, "cert-manager-resources")
+		if !ok {
+			t.Fatalf("Expected cert-manager-resources, got %+v", target.Kustomizations)
+		}
+		if _, ok := find(target, "cert-manager"); ok {
+			t.Errorf("Did not expect a bare cert-manager kustomization without components")
+		}
+		if install.Path != "pki/cert-manager" || res.Path != "pki/cert-manager" {
+			t.Errorf("Expected both tiers at pki/cert-manager, got install=%q resources=%q", install.Path, res.Path)
+		}
+		if !slices.Contains(install.Components, "helm-release") {
+			t.Errorf("Expected install components [helm-release], got %v", install.Components)
+		}
+		if !slices.Contains(res.Components, "private-issuer/ca") {
+			t.Errorf("Expected resources components [private-issuer/ca], got %v", res.Components)
+		}
+		if !slices.Contains(res.DependsOn, "cert-manager-install") {
+			t.Errorf("Expected resources to depend on cert-manager-install, got %v", res.DependsOn)
+		}
+	})
+
+	t.Run("WiresCrdsToInstallNotResources", func(t *testing.T) {
+		// Given a tiered facet that also declares a CRD reference
+		mocks := setupProcessorMocks(t)
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "pki"},
+				Crds:     []string{"cert-manager-1.16.2"},
+				Kustomizations: []blueprintv1alpha1.ConditionalKustomization{
+					{Kustomization: blueprintv1alpha1.Kustomization{
+						Name:      "cert-manager",
+						Path:      "pki/cert-manager",
+						Install:   []string{"helm-release"},
+						Resources: []string{"private-issuer/ca"},
+					}},
+				},
+			},
+		}
+
+		// When processing facets
+		target := &blueprintv1alpha1.Blueprint{}
+		_, err := processor.ProcessFacets(target, facets)
+
+		// Then the CRD dep lands on install only; resources reaches it through install
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		install, _ := find(target, "cert-manager-install")
+		res, _ := find(target, "cert-manager-resources")
+		if !slices.Contains(install.DependsOn, "cert-manager-1.16.2") {
+			t.Errorf("Expected install to depend on the CRD, got %v", install.DependsOn)
+		}
+		if slices.Contains(res.DependsOn, "cert-manager-1.16.2") {
+			t.Errorf("Expected resources NOT to depend on the CRD directly, got %v", res.DependsOn)
+		}
+	})
+
+	t.Run("EmitsLegacyComponentsAlongsideTiers", func(t *testing.T) {
+		// Given an entry that sets components AND install AND resources
+		mocks := setupProcessorMocks(t)
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "vendor"},
+				Kustomizations: []blueprintv1alpha1.ConditionalKustomization{
+					{Kustomization: blueprintv1alpha1.Kustomization{
+						Name:       "vendor",
+						Path:       "vendor",
+						Components: []string{"legacy"},
+						Install:    []string{"helm-release"},
+						Resources:  []string{"cr"},
+					}},
+				},
+			},
+		}
+
+		// When processing facets
+		target := &blueprintv1alpha1.Blueprint{}
+		_, err := processor.ProcessFacets(target, facets)
+
+		// Then all three kustomizations exist
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		for _, name := range []string{"vendor", "vendor-install", "vendor-resources"} {
+			if _, ok := find(target, name); !ok {
+				t.Errorf("Expected kustomization %q, got %+v", name, target.Kustomizations)
+			}
+		}
+	})
+
+	t.Run("InstallOnlyEmitsSingleTier", func(t *testing.T) {
+		// Given an entry with only an install tier
+		mocks := setupProcessorMocks(t)
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "metallb"},
+				Kustomizations: []blueprintv1alpha1.ConditionalKustomization{
+					{Kustomization: blueprintv1alpha1.Kustomization{Name: "metallb", Path: "lb/metallb", Install: []string{"helm-release"}}},
+				},
+			},
+		}
+
+		// When processing facets
+		target := &blueprintv1alpha1.Blueprint{}
+		_, err := processor.ProcessFacets(target, facets)
+
+		// Then only the install tier is emitted
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if _, ok := find(target, "metallb-install"); !ok {
+			t.Fatalf("Expected metallb-install, got %+v", target.Kustomizations)
+		}
+		if _, ok := find(target, "metallb-resources"); ok {
+			t.Errorf("Did not expect a resources tier")
+		}
+	})
+
+	t.Run("ResourcesOnlyHasNoInstallDependency", func(t *testing.T) {
+		// Given an entry with only a resources tier
+		mocks := setupProcessorMocks(t)
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "issuers"},
+				Kustomizations: []blueprintv1alpha1.ConditionalKustomization{
+					{Kustomization: blueprintv1alpha1.Kustomization{Name: "issuers", Path: "pki/issuers", Resources: []string{"public-issuer"}}},
+				},
+			},
+		}
+
+		// When processing facets
+		target := &blueprintv1alpha1.Blueprint{}
+		_, err := processor.ProcessFacets(target, facets)
+
+		// Then the resources tier exists and depends on no install tier
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		res, ok := find(target, "issuers-resources")
+		if !ok {
+			t.Fatalf("Expected issuers-resources, got %+v", target.Kustomizations)
+		}
+		if slices.Contains(res.DependsOn, "issuers-install") {
+			t.Errorf("Expected no install dependency, got %v", res.DependsOn)
+		}
+	})
+
+	t.Run("PrunesConditionalTierToNothing", func(t *testing.T) {
+		// Given a tier whose only component is a false expression
+		mocks := setupProcessorMocks(t)
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"gateway": map[string]any{"driver": "cilium"}}, nil
+		}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "gateway"},
+				Kustomizations: []blueprintv1alpha1.ConditionalKustomization{
+					{Kustomization: blueprintv1alpha1.Kustomization{
+						Name:    "gateway-envoy",
+						Path:    "gateway/envoy",
+						Install: []string{"${gateway.driver == 'envoy' ? 'helm-release' : ''}"},
+					}},
+				},
+			},
+		}
+
+		// When processing facets with a non-matching driver
+		target := &blueprintv1alpha1.Blueprint{}
+		_, err := processor.ProcessFacets(target, facets)
+
+		// Then the install tier prunes to empty and is not emitted
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if _, ok := find(target, "gateway-envoy-install"); ok {
+			t.Errorf("Expected no install tier when its components prune to empty, got %+v", target.Kustomizations)
+		}
+	})
+}
+
 func TestProcessor_mergeHelpers(t *testing.T) {
 	t.Run("deepMergeMapMergesNestedMaps", func(t *testing.T) {
 		base := map[string]any{"a": 1, "b": map[string]any{"x": 10}}

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -2744,6 +2744,30 @@ func TestProcessor_ProcessFacets_Tiers(t *testing.T) {
 		}
 	})
 
+	t.Run("TierEntriesDoNotSharePatchesBacking", func(t *testing.T) {
+		// Given a tiered entry that carries a patch
+		processed := blueprintv1alpha1.ConditionalKustomization{
+			Kustomization: blueprintv1alpha1.Kustomization{
+				Name:    "cert-manager",
+				Path:    "pki/cert-manager",
+				Patches: []blueprintv1alpha1.BlueprintPatch{{Patch: "original"}},
+			},
+		}
+
+		// When the entry is expanded into install and resources tiers
+		entries := buildTierEntries(processed, []string{"helm-release"}, []string{"ca"}, nil)
+		if len(entries) != 2 {
+			t.Fatalf("Expected install and resources entries, got %d", len(entries))
+		}
+
+		// Then mutating one tier's patches leaves the other tier untouched
+		entries[0].Patches[0].Patch = "mutated"
+		entries[0].Patches = append(entries[0].Patches, blueprintv1alpha1.BlueprintPatch{Patch: "added"})
+		if entries[1].Patches[0].Patch != "original" || len(entries[1].Patches) != 1 {
+			t.Errorf("Expected resources tier patches independent, got %+v", entries[1].Patches)
+		}
+	})
+
 	t.Run("PrunesConditionalTierToNothing", func(t *testing.T) {
 		// Given a tier whose only component is a false expression
 		mocks := setupProcessorMocks(t)

--- a/pkg/runtime/config/schemas/artifacts/blueprint.yaml
+++ b/pkg/runtime/config/schemas/artifacts/blueprint.yaml
@@ -227,6 +227,22 @@ properties:
           items:
             type: string
           description: Kustomize components to compose into this kustomization.
+        install:
+          type: array
+          items:
+            type: string
+          description: |
+            Components of the install (controller/operator) tier. Like
+            components, each entry may be a '${...}' expression that prunes to
+            empty. When install and/or resources are set, the entry expands into
+            separate kustomizations sharing this path: '<name>-install' carrying
+            these components and '<name>-resources' depending on it, so the
+            controller is reconciled before the custom resources it admits.
+        resources:
+          type: array
+          items:
+            type: string
+          description: Components of the custom-resource tier. See install.
         destroy:
           type: [boolean, string]
           description: |

--- a/pkg/runtime/config/schemas/artifacts/facets.yaml
+++ b/pkg/runtime/config/schemas/artifacts/facets.yaml
@@ -240,10 +240,10 @@ $defs:
     description: |
       Inherits every field from the blueprint's Kustomization shape (name,
       path, source, namespace, targetNamespace, dependsOn, interval,
-      retryInterval, timeout, patches, wait, force, prune, components,
-      destroy, destroyOnly, enabled, substitutions) and adds the conditional
-      fields below. See the [Blueprint reference](blueprint.md) for the
-      inherited fields.
+      retryInterval, timeout, patches, wait, force, prune, components, install,
+      resources, destroy, destroyOnly, enabled, substitutions) and adds the
+      conditional fields below. See the [Blueprint reference](blueprint.md) for
+      the inherited fields.
     properties:
       when:
         type: string


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> This change extends the core blueprint composition pipeline with a new two-tier expansion pattern, making the risk level Medium.
>
> **Overview**
>
> The PR adds `install` and `resources` fields to `Kustomization`. When either is set, the processor expands the entry into `<name>-install` (carrying install components) and `<name>-resources` (carrying resource components and depending on install), so the controller is reconciled before the custom resources it admits. A post-composition pass rewrites bare-name `dependsOn` references to the install tier when no exact match exists, preserving backward compatibility with non-tiered vendors.
>
> The change is well-factored and well-tested across unit, integration, and fixture layers. One structural issue stands out: `buildTierEntries` uses a bare value copy for tier entries and manually clones only `Substitutions`, leaving `Patches`, `Enabled`, and `Destroy` as aliased references across sibling tiers. The existing `ConditionalKustomization.DeepCopy()` method covers all of these fields and should be used instead to prevent potential aliasing when two facets contribute to the same tiered entry.
>
> Reviewed by Claude for commit `827188d5`.

<!-- /claude-code-review:summary -->
