### PR TITLE
feat(provisioner): enhance CRD handling in Wait method and add tests for CRD layer processing

### DIFF
--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -918,11 +918,13 @@ func (i *Provisioner) Install(ctx context.Context, blueprint *blueprintv1alpha1.
 	return nil
 }
 
-// Wait waits for kustomizations from the blueprint to be ready. It initializes the kubernetes manager
-// if needed and polls the status of all kustomizations until they are ready or a timeout occurs.
-// The timeout is calculated from the longest dependency chain in the blueprint. The wait honors ctx,
-// so a cancelled context (caller SIGTERM/Ctrl+C or command deadline) ends it promptly. Returns an
-// error if the kubernetes manager is not configured, initialization fails, or waiting times out.
+// Wait waits for kustomizations from the blueprint to be ready, polling status until ready or a
+// timeout calculated from the longest dependency chain. When the blueprint carries a CRD layer it
+// waits for those kustomizations first under their own progress line ("Waiting for CRDs to be
+// ready"), then the rest — matching the dependsOn barrier that brings the CRDs up ahead of the
+// stack; blueprints with no CRD layer wait in a single phase as before. The wait honors ctx, so a
+// cancelled context (caller SIGTERM/Ctrl+C or command deadline) ends it promptly. Returns an error
+// if the kubernetes manager is not configured or waiting times out.
 func (i *Provisioner) Wait(ctx context.Context, blueprint *blueprintv1alpha1.Blueprint) error {
 	if blueprint == nil {
 		return fmt.Errorf("blueprint not provided")
@@ -932,7 +934,17 @@ func (i *Provisioner) Wait(ctx context.Context, blueprint *blueprintv1alpha1.Blu
 		return fmt.Errorf("kubernetes manager not configured")
 	}
 
-	if err := i.KubernetesManager.WaitForKustomizations(ctx, "Waiting for kustomizations to be ready", blueprint); err != nil {
+	crds, rest := splitCrdLayer(blueprint)
+	if crds != nil {
+		if err := i.KubernetesManager.WaitForKustomizations(ctx, "Waiting for CRDs to be ready", crds); err != nil {
+			return fmt.Errorf("failed waiting for CRDs: %w", err)
+		}
+		if len(rest.Kustomizations) == 0 {
+			return nil
+		}
+	}
+
+	if err := i.KubernetesManager.WaitForKustomizations(ctx, "Waiting for kustomizations to be ready", rest); err != nil {
 		return fmt.Errorf("failed waiting for kustomizations: %w", err)
 	}
 
@@ -1246,6 +1258,29 @@ func (i *Provisioner) ensureClusterClient() error {
 		return fmt.Errorf("no cluster client found; ensure cluster.driver is configured")
 	}
 	return nil
+}
+
+// splitCrdLayer partitions a blueprint's kustomizations into the CRD layer and the rest, returning
+// shallow blueprint copies that share everything but the kustomization slice. When the blueprint has
+// no CRD-layer kustomization, crds is nil and rest is the original blueprint untouched, so callers
+// fall back to single-phase handling.
+func splitCrdLayer(blueprint *blueprintv1alpha1.Blueprint) (crds, rest *blueprintv1alpha1.Blueprint) {
+	var crdK, restK []blueprintv1alpha1.Kustomization
+	for _, k := range blueprint.Kustomizations {
+		if k.IsCrdLayer() {
+			crdK = append(crdK, k)
+		} else {
+			restK = append(restK, k)
+		}
+	}
+	if len(crdK) == 0 {
+		return nil, blueprint
+	}
+	crdsCopy := *blueprint
+	crdsCopy.Kustomizations = crdK
+	restCopy := *blueprint
+	restCopy.Kustomizations = restK
+	return &crdsCopy, &restCopy
 }
 
 // versionFromImage extracts the Talos version from an image URI tag.

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -1343,6 +1344,121 @@ func TestProvisioner_Wait(t *testing.T) {
 
 		if !strings.Contains(err.Error(), "failed waiting for kustomizations") {
 			t.Errorf("Expected specific error message, got: %v", err)
+		}
+	})
+
+	t.Run("WaitsForCrdLayerFirstUnderItsOwnMessage", func(t *testing.T) {
+		// Given a blueprint with a CRD-layer kustomization and a regular one
+		mocks := setupProvisionerMocks(t)
+		type call struct {
+			message string
+			names   []string
+		}
+		var calls []call
+		mocks.KubernetesManager.WaitForKustomizationsFunc = func(ctx context.Context, message string, blueprint *blueprintv1alpha1.Blueprint) error {
+			names := make([]string, 0, len(blueprint.Kustomizations))
+			for _, k := range blueprint.Kustomizations {
+				names = append(names, k.Name)
+			}
+			calls = append(calls, call{message, names})
+			return nil
+		}
+		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "cert-manager-1.16.2", Path: "crds/cert-manager-1.16.2"},
+				{Name: "cert-manager", Path: "pki/cert-manager"},
+			},
+		}
+
+		// When waiting
+		if err := provisioner.Wait(context.Background(), blueprint); err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// Then the CRD layer is waited first under its own message, then the rest
+		if len(calls) != 2 {
+			t.Fatalf("expected 2 wait phases, got %d: %+v", len(calls), calls)
+		}
+		if calls[0].message != "Waiting for CRDs to be ready" || !slices.Equal(calls[0].names, []string{"cert-manager-1.16.2"}) {
+			t.Errorf("expected CRD phase first, got %+v", calls[0])
+		}
+		if calls[1].message != "Waiting for kustomizations to be ready" || !slices.Equal(calls[1].names, []string{"cert-manager"}) {
+			t.Errorf("expected stack phase second, got %+v", calls[1])
+		}
+	})
+
+	t.Run("SkipsEmptyStackPhaseWhenAllCrds", func(t *testing.T) {
+		// Given a blueprint whose only kustomizations are CRD-layer entries
+		mocks := setupProvisionerMocks(t)
+		var messages []string
+		mocks.KubernetesManager.WaitForKustomizationsFunc = func(ctx context.Context, message string, blueprint *blueprintv1alpha1.Blueprint) error {
+			messages = append(messages, message)
+			return nil
+		}
+		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "cert-manager-1.16.2", Path: "crds/cert-manager-1.16.2"},
+			},
+		}
+
+		// When waiting
+		if err := provisioner.Wait(context.Background(), blueprint); err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// Then only the CRD phase runs — no empty stack-phase line
+		if !slices.Equal(messages, []string{"Waiting for CRDs to be ready"}) {
+			t.Errorf("expected only the CRD phase, got %v", messages)
+		}
+	})
+
+	t.Run("SinglePhaseWhenNoCrdLayer", func(t *testing.T) {
+		// Given a blueprint with no CRD-layer kustomization
+		mocks := setupProvisionerMocks(t)
+		var messages []string
+		mocks.KubernetesManager.WaitForKustomizationsFunc = func(ctx context.Context, message string, blueprint *blueprintv1alpha1.Blueprint) error {
+			messages = append(messages, message)
+			return nil
+		}
+		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
+
+		// When waiting
+		if err := provisioner.Wait(context.Background(), createTestBlueprint()); err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// Then it waits in a single phase under the original message
+		if !slices.Equal(messages, []string{"Waiting for kustomizations to be ready"}) {
+			t.Errorf("expected single stack phase, got %v", messages)
+		}
+	})
+
+	t.Run("ErrorWaitingForCrdLayer", func(t *testing.T) {
+		// Given the CRD-layer wait fails
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.WaitForKustomizationsFunc = func(ctx context.Context, message string, blueprint *blueprintv1alpha1.Blueprint) error {
+			return fmt.Errorf("crd wait failed")
+		}
+		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "cert-manager-1.16.2", Path: "crds/cert-manager-1.16.2"},
+				{Name: "cert-manager", Path: "pki/cert-manager"},
+			},
+		}
+
+		// When waiting
+		err := provisioner.Wait(context.Background(), blueprint)
+
+		// Then the failure is surfaced as a CRD wait error
+		if err == nil || !strings.Contains(err.Error(), "failed waiting for CRDs") {
+			t.Errorf("expected CRD wait error, got: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> This change touches the `Wait` method's sequencing logic for CRD-layer kustomizations, which executes against a live Kubernetes cluster; incorrect timeout derivation or unhandled dangling dependency references could silently shorten the allowed wait window.
>
> **Overview**
>
> The PR introduces two-phase waiting in `Wait`: CRD-layer kustomizations are now waited for separately under a dedicated progress message before the rest of the blueprint proceeds, matching the `dependsOn` barrier that the blueprint renderer establishes. A new `splitCrdLayer` helper partitions kustomizations by `IsCrdLayer()` and returns shallow blueprint copies so each phase sees only its own slice. The early-return path when all kustomizations are CRDs prevents an empty second-phase call.
>
> Four new test cases cover the split, the all-CRD early exit, the no-CRD single-phase fallback, and CRD-phase error propagation. The main open questions are whether `WaitForKustomizations` tolerates dangling cross-phase `dependsOn` references in the rest blueprint, and whether per-phase timeout derivation is equivalent to the original single-phase budget.
>
> Reviewed by Claude for commit `57a389a1`.

<!-- /claude-code-review:summary -->
