### PR TITLE
feat(blueprint): skip PostBuild for CRD layer in ToFluxKustomization

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -21,7 +21,9 @@ import (
 // =============================================================================
 
 // CrdLayerName is the name of the synthesized kustomization that installs the vendored CRD layer
-// (its components are the blueprint's crds: references). The stack depends on it by this name.
+// (its components are the blueprint's crds: references). The stack depends on it by this name, and
+// ToFluxKustomization keys its PostBuild skip on it — so it is reserved: the composer rejects any
+// user-authored kustomization that claims this name.
 const CrdLayerName = "crds"
 
 // =============================================================================

--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -991,7 +991,9 @@ func (k *Kustomization) DeepCopy() *Kustomization {
 // level Interval overrides still win over both mode defaults.
 // An optional configMaps argument (blueprint-level ConfigMaps such as values-common) is added to
 // postBuild.substituteFrom so they are available to all kustomizations, matching what the provisioner applies.
-// PostBuild is constructed based on the kustomization's Substitutions field.
+// PostBuild is constructed from the kustomization's Substitutions field, except for the synthesized CRD layer
+// (k.Name == CrdLayerName), which skips PostBuild entirely: vendored CRDs need no substitution and their
+// ${...} description text would otherwise fail envsubst (e.g. fluent-operator's ${record.to_json}).
 func (k *Kustomization) ToFluxKustomization(namespace string, defaultSourceName string, sources []Source, mode constants.GitopsMode, configMaps ...map[string]map[string]string) kustomizev1.Kustomization {
 	dependsOn := make([]kustomizev1.DependencyReference, len(k.DependsOn))
 	for idx, dep := range k.DependsOn {
@@ -1091,30 +1093,32 @@ func (k *Kustomization) ToFluxKustomization(namespace string, defaultSourceName 
 	}
 
 	var postBuild *kustomizev1.PostBuild
-	if len(k.Substitutions) > 0 {
-		configMapName := fmt.Sprintf("values-%s", k.Name)
-		postBuild = &kustomizev1.PostBuild{
-			SubstituteFrom: []kustomizev1.SubstituteReference{
-				{
-					Kind:     "ConfigMap",
-					Name:     configMapName,
-					Optional: false,
-				},
-			},
-		}
-	}
-	if len(configMaps) > 0 && len(configMaps[0]) > 0 {
-		if postBuild == nil {
+	if k.Name != CrdLayerName {
+		if len(k.Substitutions) > 0 {
+			configMapName := fmt.Sprintf("values-%s", k.Name)
 			postBuild = &kustomizev1.PostBuild{
-				SubstituteFrom: make([]kustomizev1.SubstituteReference, 0),
+				SubstituteFrom: []kustomizev1.SubstituteReference{
+					{
+						Kind:     "ConfigMap",
+						Name:     configMapName,
+						Optional: false,
+					},
+				},
 			}
 		}
-		for name := range configMaps[0] {
-			postBuild.SubstituteFrom = append(postBuild.SubstituteFrom, kustomizev1.SubstituteReference{
-				Kind:     "ConfigMap",
-				Name:     name,
-				Optional: false,
-			})
+		if len(configMaps) > 0 && len(configMaps[0]) > 0 {
+			if postBuild == nil {
+				postBuild = &kustomizev1.PostBuild{
+					SubstituteFrom: make([]kustomizev1.SubstituteReference, 0),
+				}
+			}
+			for name := range configMaps[0] {
+				postBuild.SubstituteFrom = append(postBuild.SubstituteFrom, kustomizev1.SubstituteReference{
+					Kind:     "ConfigMap",
+					Name:     name,
+					Optional: false,
+				})
+			}
 		}
 	}
 

--- a/api/v1alpha1/blueprint_types_test.go
+++ b/api/v1alpha1/blueprint_types_test.go
@@ -2481,6 +2481,24 @@ func TestKustomization_ToFluxKustomization(t *testing.T) {
 		}
 	})
 
+	t.Run("CrdLayerSkipsPostBuildEvenWithConfigMaps", func(t *testing.T) {
+		configMaps := map[string]map[string]string{"values-common": {"key": "value"}}
+
+		// A normal kustomization picks up the global ConfigMaps via PostBuild.
+		normal := (&Kustomization{Name: "telemetry-base", Path: "telemetry/base"}).
+			ToFluxKustomization("test-namespace", "default-source", []Source{}, constants.GitopsModePull, configMaps)
+		if normal.Spec.PostBuild == nil {
+			t.Fatal("Expected PostBuild on a normal kustomization with global ConfigMaps")
+		}
+
+		// The CRD layer skips PostBuild entirely.
+		crds := (&Kustomization{Name: CrdLayerName, Path: CrdLayerName}).
+			ToFluxKustomization("test-namespace", "default-source", []Source{}, constants.GitopsModePull, configMaps)
+		if crds.Spec.PostBuild != nil {
+			t.Errorf("Expected nil PostBuild for the %q layer, got %v", CrdLayerName, crds.Spec.PostBuild)
+		}
+	})
+
 	t.Run("WithOCISource", func(t *testing.T) {
 		kustomization := &Kustomization{
 			Name:   "test-kustomization",

--- a/pkg/composer/blueprint/composer.go
+++ b/pkg/composer/blueprint/composer.go
@@ -166,7 +166,7 @@ func (c *BaseBlueprintComposer) Compose(loaders []BlueprintLoader, initLoaderNam
 	c.dropEmptyCompositionFragments(result)
 	c.resolveTierDependencies(result)
 	c.applyCrdLayerBarrier(result)
-	validationErr := errors.Join(c.validateSources(result), c.validateDependencies(result))
+	validationErr := errors.Join(c.validateSources(result), c.validateReservedNames(result), c.validateDependencies(result))
 	return result, validationErr
 }
 
@@ -731,6 +731,19 @@ func (c *BaseBlueprintComposer) validateSources(bp *blueprintv1alpha1.Blueprint)
 		}
 		if !strings.HasPrefix(s.Url, "oci://") {
 			return fmt.Errorf("source %q has install: true but URL %q is not an OCI source (oci://); install is only supported for OCI sources", s.Name, s.Url)
+		}
+	}
+	return nil
+}
+
+// validateReservedNames rejects a user-authored kustomization that takes the name reserved for the
+// synthesized CRD layer. That name is owned by the crds: layer the provisioner materializes; allowing
+// a kustomize: entry to claim it would collide with the synthesized entry and silently change how its
+// PostBuild is built, so it is an error rather than a silent override.
+func (c *BaseBlueprintComposer) validateReservedNames(bp *blueprintv1alpha1.Blueprint) error {
+	for _, k := range bp.Kustomizations {
+		if k.Name == blueprintv1alpha1.CrdLayerName {
+			return fmt.Errorf("kustomization name %q is reserved for the CRD layer; use the crds: section instead", blueprintv1alpha1.CrdLayerName)
 		}
 	}
 	return nil

--- a/pkg/composer/blueprint/composer_test.go
+++ b/pkg/composer/blueprint/composer_test.go
@@ -2997,6 +2997,40 @@ func TestComposer_validateSources(t *testing.T) {
 // Test validateDependencies
 // =============================================================================
 
+func TestComposer_validateReservedNames(t *testing.T) {
+	t.Run("RejectsUserKustomizationNamedCrds", func(t *testing.T) {
+		// Given a user-authored kustomization that claims the reserved CRD-layer name
+		mocks := setupComposerMocks(t)
+		composer := NewBlueprintComposer(mocks.Runtime)
+		bp := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{{Name: blueprintv1alpha1.CrdLayerName, Path: "crds"}},
+		}
+
+		// When validating
+		err := composer.validateReservedNames(bp)
+
+		// Then it is rejected as reserved
+		if err == nil || !strings.Contains(err.Error(), "reserved for the CRD layer") {
+			t.Errorf("expected reserved-name error, got %v", err)
+		}
+	})
+
+	t.Run("AllowsTheCrdsSectionItself", func(t *testing.T) {
+		// Given the CRD layer expressed through the crds: section (not a kustomization)
+		mocks := setupComposerMocks(t)
+		composer := NewBlueprintComposer(mocks.Runtime)
+		bp := &blueprintv1alpha1.Blueprint{
+			Crds:           []string{"cert-manager-1.16.2"},
+			Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "cert-manager", Path: "pki/cert-manager"}},
+		}
+
+		// When validating
+		if err := composer.validateReservedNames(bp); err != nil {
+			t.Errorf("expected no error for crds: section, got %v", err)
+		}
+	})
+}
+
 func TestComposer_validateDependencies(t *testing.T) {
 	t.Run("ReturnsNilForValidTerraformDependencies", func(t *testing.T) {
 		mocks := setupComposerMocks(t)


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This change touches only the CRD-layer path in `ToFluxKustomization`, an isolated function with a targeted guard. The rest of the PostBuild logic is unchanged and the behavioral difference affects only the synthesized "crds" kustomization.
>
> **Overview**
>
> The PR prevents `PostBuild` (Flux envsubst) from being applied to the synthesized CRD kustomization layer. Vendored CRDs contain literal `${...}` expressions in their YAML (e.g., fluent-operator's `${record.to_json}`) that are not substitution variables and would cause Flux to error if envsubst ran over them.
>
> The fix is a name-based guard wrapping the existing PostBuild construction block, with a matching test that confirms both normal kustomizations still receive PostBuild from global ConfigMaps and the CRD layer does not.
>
> Reviewed by Claude for commit `af09418`.

<!-- /claude-code-review:summary -->
