### PR TITLE
feat(shell): add ExecCaptureWithEnv for capturing command output without streaming

### DIFF
--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -1237,7 +1237,7 @@ func (s *TerraformStack) clearBackendPointer(terraformVars map[string]string) {
 func (s *TerraformStack) hasStateResources(component *blueprintv1alpha1.TerraformComponent, terraformVars map[string]string) (bool, error) {
 	terraformCommand := s.runtime.ToolsManager.GetTerraformCommand()
 	stateShowArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "show", "-json"}
-	stateJSON, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, selectTerraformCommandEnv(terraformVars, true), stateShowArgs...)
+	stateJSON, err := s.runtime.Shell.ExecCaptureWithEnv(terraformCommand, selectTerraformCommandEnv(terraformVars, true), stateShowArgs...)
 	if err != nil {
 		return false, fmt.Errorf("error reading terraform state JSON for %s: %w", component.Path, err)
 	}
@@ -1374,7 +1374,7 @@ func (s *TerraformStack) planOneTerraformSummary(component *blueprintv1alpha1.Te
 	planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan", "-json", "-no-color"}
 	planArgs = append(planArgs, terraformArgs.PlanArgs...)
 	planEnv := selectTerraformCommandEnv(terraformVars, true)
-	planOutput, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, planEnv, planArgs...)
+	planOutput, err := s.runtime.Shell.ExecCaptureWithEnv(terraformCommand, planEnv, planArgs...)
 	if err != nil {
 		result.Err = fmt.Errorf("error running terraform plan for %s: %w", component.Path, err)
 		return result
@@ -1428,7 +1428,7 @@ func (s *TerraformStack) planOneTerraformDestroySummary(component *blueprintv1al
 	planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan", "-json", "-no-color"}
 	planArgs = append(planArgs, terraformArgs.PlanDestroyArgs...)
 	planEnv := selectTerraformCommandEnv(terraformVars, true)
-	planOutput, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, planEnv, planArgs...)
+	planOutput, err := s.runtime.Shell.ExecCaptureWithEnv(terraformCommand, planEnv, planArgs...)
 	// terraform exits non-zero when any resource has prevent_destroy = true,
 	// but still emits the diagnostic events naming them. Look for those addresses
 	// regardless of exec error so the warning can surface them; otherwise the

--- a/pkg/runtime/shell/mock_shell.go
+++ b/pkg/runtime/shell/mock_shell.go
@@ -22,6 +22,7 @@ type MockShell struct {
 	ExecFunc                        func(command string, args ...string) (string, error)
 	ExecSilentFunc                  func(command string, args ...string) (string, error)
 	ExecSilentWithEnvFunc           func(command string, env map[string]string, args ...string) (string, error)
+	ExecCaptureWithEnvFunc          func(command string, env map[string]string, args ...string) (string, error)
 	ExecSilentWithTimeoutFunc       func(command string, args []string, timeout time.Duration) (string, error)
 	ExecSilentWithEnvAndTimeoutFunc func(command string, env map[string]string, args []string, timeout time.Duration) (string, error)
 	ExecProgressFunc                func(message string, command string, args ...string) (string, error)
@@ -101,6 +102,15 @@ func (s *MockShell) ExecSilentWithEnv(command string, env map[string]string, arg
 		return s.ExecSilentWithEnvFunc(command, env, args...)
 	}
 	return s.ExecSilent(command, args...)
+}
+
+// ExecCaptureWithEnv calls the custom ExecCaptureWithEnvFunc if provided, otherwise delegates to
+// ExecSilentWithEnv.
+func (s *MockShell) ExecCaptureWithEnv(command string, env map[string]string, args ...string) (string, error) {
+	if s.ExecCaptureWithEnvFunc != nil {
+		return s.ExecCaptureWithEnvFunc(command, env, args...)
+	}
+	return s.ExecSilentWithEnv(command, env, args...)
 }
 
 // ExecSilentWithTimeout calls the custom ExecSilentWithTimeoutFunc if provided, otherwise delegates to ExecSilent.

--- a/pkg/runtime/shell/shell.go
+++ b/pkg/runtime/shell/shell.go
@@ -55,6 +55,7 @@ type Shell interface {
 	Exec(command string, args ...string) (string, error)
 	ExecSilent(command string, args ...string) (string, error)
 	ExecSilentWithEnv(command string, env map[string]string, args ...string) (string, error)
+	ExecCaptureWithEnv(command string, env map[string]string, args ...string) (string, error)
 	ExecSilentWithTimeout(command string, args []string, timeout time.Duration) (string, error)
 	ExecSilentWithEnvAndTimeout(command string, env map[string]string, args []string, timeout time.Duration) (string, error)
 	ExecSudo(message string, command string, args ...string) (string, error)
@@ -247,6 +248,26 @@ func (s *DefaultShell) ExecSilentWithEnv(command string, env map[string]string, 
 		cmd.Stdout = &stdoutBuf
 		cmd.Stderr = &stderrBuf
 	}
+	if err := s.shims.CmdRun(cmd); err != nil {
+		return s.scrubString(stdoutBuf.String()), fmt.Errorf("command execution failed: %w\n%s", err, s.scrubString(stderrBuf.String()))
+	}
+	return s.scrubString(stdoutBuf.String()), nil
+}
+
+// ExecCaptureWithEnv runs a command with merged environment variables and captures its output,
+// never streaming to stdout or stderr even in verbose mode. Use it for internal, machine-only output
+// (e.g. `terraform show -json` state inspection) that is parsed rather than shown and may contain
+// sensitive material such as cluster PKI — unlike ExecSilentWithEnv, which echoes captured output
+// under verbose.
+func (s *DefaultShell) ExecCaptureWithEnv(command string, env map[string]string, args ...string) (string, error) {
+	var stdoutBuf, stderrBuf bytes.Buffer
+	cmd := s.shims.Command(command, args...)
+	if cmd == nil {
+		return "", fmt.Errorf("failed to create command")
+	}
+	cmd.Env = mergeEnvVars(s.shims.Environ(), env)
+	cmd.Stdout = &stdoutBuf
+	cmd.Stderr = &stderrBuf
 	if err := s.shims.CmdRun(cmd); err != nil {
 		return s.scrubString(stdoutBuf.String()), fmt.Errorf("command execution failed: %w\n%s", err, s.scrubString(stderrBuf.String()))
 	}

--- a/pkg/runtime/shell/shell_test.go
+++ b/pkg/runtime/shell/shell_test.go
@@ -1312,6 +1312,107 @@ func TestShell_ExecSilentWithEnv(t *testing.T) {
 	})
 }
 
+func TestShell_ExecCaptureWithEnv(t *testing.T) {
+	setup := func(t *testing.T) (*DefaultShell, *ShellTestMocks) {
+		t.Helper()
+		mocks := setupShellMocks(t)
+		shell := NewDefaultShell()
+		shell.shims = mocks.Shims
+		return shell, mocks
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		// Given a shell with mocked command execution
+		shell, _ := setup(t)
+
+		// When capturing a command's output
+		out, err := shell.ExecCaptureWithEnv("test", map[string]string{"FOO": "bar"}, "arg")
+
+		// Then it succeeds and returns the captured output
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if out != "test\n" {
+			t.Errorf("Expected output 'test\n', got '%s'", out)
+		}
+	})
+
+	t.Run("NeverStreamsEvenInVerboseMode", func(t *testing.T) {
+		// Given a shell in verbose mode whose command emits sensitive machine output
+		shell, mocks := setup(t)
+		shell.SetVerbosity(true)
+		mocks.Shims.CmdRun = func(cmd *exec.Cmd) error {
+			if cmd.Stdout != nil {
+				if _, err := cmd.Stdout.Write([]byte("cluster-pki-secret\n")); err != nil {
+					return fmt.Errorf("failed to write: %v", err)
+				}
+			}
+			return nil
+		}
+
+		// Capture what reaches os.Stdout
+		oldStdout := os.Stdout
+		r, w, _ := os.Pipe()
+		os.Stdout = w
+
+		// When capturing the output in verbose mode
+		out, err := shell.ExecCaptureWithEnv("test", nil, "arg")
+
+		w.Close()
+		os.Stdout = oldStdout
+		streamed, _ := io.ReadAll(r)
+
+		// Then the output is returned to the caller but never echoed to the terminal
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if out != "cluster-pki-secret\n" {
+			t.Errorf("Expected captured output, got %q", out)
+		}
+		if strings.Contains(string(streamed), "cluster-pki-secret") {
+			t.Errorf("Expected nothing streamed to stdout in verbose mode, got %q", string(streamed))
+		}
+	})
+
+	t.Run("Error", func(t *testing.T) {
+		// Given a shell whose CmdRun returns an error
+		shell, mocks := setup(t)
+		mocks.Shims.CmdRun = func(cmd *exec.Cmd) error {
+			return fmt.Errorf("command failed")
+		}
+
+		// When capturing output
+		out, err := shell.ExecCaptureWithEnv("test", nil, "arg")
+
+		// Then an error is returned and output is empty
+		if err == nil || !strings.Contains(err.Error(), "command failed") {
+			t.Errorf("Expected 'command failed' error, got %v", err)
+		}
+		if out != "" {
+			t.Errorf("Expected empty output, got %q", out)
+		}
+	})
+
+	t.Run("CommandNil", func(t *testing.T) {
+		// Given a shell whose Command shim returns nil
+		shell, mocks := setup(t)
+		mocks.Shims.Command = func(name string, args ...string) *exec.Cmd {
+			return nil
+		}
+
+		// When capturing output
+		output, err := shell.ExecCaptureWithEnv("test", nil, "arg")
+
+		// Then an error about command creation is returned
+		if err == nil || !strings.Contains(err.Error(), "failed to create command") {
+			t.Errorf("Expected error about command creation, got: %v", err)
+		}
+		if output != "" {
+			t.Errorf("Expected empty output, got %q", output)
+		}
+	})
+}
+
 func TestShell_GetSessionToken(t *testing.T) {
 	setup := func(t *testing.T) (*DefaultShell, *ShellTestMocks) {
 		t.Helper()

--- a/pkg/runtime/shell/shell_test.go
+++ b/pkg/runtime/shell/shell_test.go
@@ -1352,7 +1352,10 @@ func TestShell_ExecCaptureWithEnv(t *testing.T) {
 
 		// Capture what reaches os.Stdout
 		oldStdout := os.Stdout
-		r, w, _ := os.Pipe()
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("failed to create pipe: %v", err)
+		}
 		os.Stdout = w
 
 		// When capturing the output in verbose mode


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> The change adds one new interface method and implementation, touches three call sites in a single file, and the new behavior is verified by a focused test. No existing callers are changed in a way that alters their observable output.
>
> **Overview**
>
> This PR introduces `ExecCaptureWithEnv` to the `Shell` interface, pairing it with a `DefaultShell` implementation that always captures stdout and stderr to in-memory buffers regardless of verbose mode. The motivation is concrete: `ExecSilentWithEnv` pipes command output through an `io.MultiWriter` to `os.Stdout`/`os.Stderr` when verbose is active, meaning `terraform show -json` state and `terraform plan -json` plan output were leaking to the terminal in verbose mode. Three call sites in the Terraform provisioner — state inspection and both plan-summary paths — are switched to the new method.
>
> The behavioral difference between the two methods is verified by reading `ExecSilentWithEnv`'s implementation at lines 242–250 of `shell.go`, which confirms the verbose-path `io.MultiWriter` that `ExecCaptureWithEnv` explicitly omits. Two low-severity test-reliability issues are noted inline: the mock fallback couples `ExecCaptureWithEnv` to `ExecSilentWithEnv` semantics, and the verbose-suppression test ignores the error return from `os.Pipe()`.
>
> Reviewed by Claude for commit `dfcedfc6`.

<!-- /claude-code-review:summary -->
