### PR TITLE
feat(plan): add support for synthesized CRD layers as valid component targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,9 @@ age.public.key
 # Investigation/spike artifacts
 docs/spikes/
 
+# Architecture decision records (kept local for now)
+docs/adrs/
+
 # managed by windsor cli
 .windsor/
 .volumes/

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -319,13 +319,20 @@ func blueprintHasTerraformComponent(blueprint *blueprintv1alpha1.Blueprint, comp
 	return false
 }
 
-// blueprintHasKustomization reports whether the blueprint contains a Kustomization with the given name.
+// blueprintHasKustomization reports whether the blueprint contains a Kustomization with the given
+// name, including the synthesized CRD layers (crds / crds-<source>) the provisioner materializes
+// from crds: at plan time — so those layers are valid `windsor plan <name>` targets.
 func blueprintHasKustomization(blueprint *blueprintv1alpha1.Blueprint, componentID string) bool {
 	if blueprint == nil {
 		return false
 	}
 	for _, k := range blueprint.Kustomizations {
 		if k.Name == componentID {
+			return true
+		}
+	}
+	for _, layer := range blueprint.Crds {
+		if layer.KustomizationName() == componentID {
 			return true
 		}
 	}

--- a/cmd/plan_test.go
+++ b/cmd/plan_test.go
@@ -139,6 +139,82 @@ func newKustomizePlanProject(mocks *PlanMocks, fluxStack *fluxinfra.MockStack) *
 // Test Cases
 // =============================================================================
 
+func TestPlanCmd(t *testing.T) {
+	createTestPlanCmd := func() *cobra.Command {
+		cmd := &cobra.Command{
+			Use:  "plan",
+			RunE: planCmd.RunE,
+		}
+		planCmd.PersistentFlags().VisitAll(func(flag *pflag.Flag) {
+			cmd.Flags().AddFlag(flag)
+		})
+		cmd.Args = planCmd.Args
+		cmd.SilenceUsage = true
+		cmd.SilenceErrors = true
+		cmd.SetOut(io.Discard)
+		cmd.SetErr(io.Discard)
+		return cmd
+	}
+
+	suppressProcessStdout(t)
+	suppressProcessStderr(t)
+
+	t.Run("CrdLayerIsAValidComponentTarget", func(t *testing.T) {
+		// Given a blueprint whose only kustomize layer is the synthesized crds layer
+		mocks := setupPlanTest(t)
+		mocks.BlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint {
+			return &blueprintv1alpha1.Blueprint{
+				Metadata: blueprintv1alpha1.Metadata{Name: "test"},
+				Crds:     []blueprintv1alpha1.CrdLayer{{Refs: []string{"cert-manager-1.16.2"}}},
+			}
+		}
+		fluxStack := fluxinfra.NewMockStack()
+		planned := ""
+		fluxStack.PlanFunc = func(bp *blueprintv1alpha1.Blueprint, componentID string) error {
+			planned = componentID
+			return nil
+		}
+		proj := newKustomizePlanProject(mocks, fluxStack)
+
+		// When planning the crds layer by name
+		cmd := createTestPlanCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"crds"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then the command routes to the kustomize layer rather than failing the existence check
+		if err != nil {
+			t.Fatalf("expected crds to be a valid plan target, got: %v", err)
+		}
+		if planned != "crds" {
+			t.Errorf("expected the crds layer to be planned, got %q", planned)
+		}
+	})
+
+	t.Run("UnknownComponentIsRejected", func(t *testing.T) {
+		// Given a blueprint with no component matching the requested name
+		mocks := setupPlanTest(t)
+		fluxStack := fluxinfra.NewMockStack()
+		proj := newKustomizePlanProject(mocks, fluxStack)
+
+		// When planning a component that exists in neither layer
+		cmd := createTestPlanCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"nonexistent"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then the existence check rejects it
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "not found in blueprint") {
+			t.Errorf("expected not-found error, got: %v", err)
+		}
+	})
+}
+
 func TestPlanTerraformCmd(t *testing.T) {
 	createTestPlanTerraformCmd := func() *cobra.Command {
 		cmd := &cobra.Command{

--- a/integration/plan_test.go
+++ b/integration/plan_test.go
@@ -238,6 +238,27 @@ func TestPlanKustomize_FailsWhenKustomizationNotInBlueprint(t *testing.T) {
 	}
 }
 
+// TestPlan_CrdLayerIsAValidComponentTarget confirms that the synthesized CRD layer
+// is reachable by name: `windsor plan crds` routes to the kustomize layer rather than
+// failing the cmd-level existence check with "not found in blueprint". The facet-crds
+// fixture's pki facet declares a vendored CRD, which composes into the default-source
+// "crds" layer.
+func TestPlan_CrdLayerIsAValidComponentTarget(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "facet-crds")
+	env = append(env, "WINDSOR_CONTEXT=default")
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"plan", "crds", "--summary"}, env)
+	if err != nil {
+		t.Fatalf("plan crds --summary: %v\nstderr: %s", err, stderr)
+	}
+	if strings.Contains(string(stderr), "not found in blueprint") {
+		t.Errorf("expected crds to route to the kustomize layer, got not-found: %s", stderr)
+	}
+	if !strings.Contains(string(stdout), "crds") {
+		t.Errorf("expected the crds layer in the plan summary, got: %s", stdout)
+	}
+}
+
 // TestPlan_FooterHintAppearsForNewComponents confirms that the operator-facing
 // "drill in for full diffs" hint surfaces in the summary whenever a component
 // represents pending work. The plan fixture's `null` component has never been


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Isolated cmd-layer fix with no shared infrastructure changes; fully reversible with no data-loss surface.
>
> **Overview**
>
> The PR extends `blueprintHasKustomization` in `cmd/plan.go` to also scan `blueprint.Crds` when checking whether a component name is a valid plan target. Before this change, `windsor plan crds` always failed the existence guard with "not found in blueprint" even though the provisioner's `withCrdLayer` would successfully materialize and route the request — a gap between the guard and the execution path.
>
> The fix adds a five-line loop that mirrors the `KustomizationName()` logic already used in `withCrdLayer`, closing the gap without touching the provisioner. Test coverage includes a unit test for both the happy path and rejection case, plus an integration test against the `facet-crds` fixture.
>
> Reviewed by Claude for commit `f8d9210`.

<!-- /claude-code-review:summary -->
