### PR TITLE
fix(provisioner): ensure synthesized CRD layer is removed during uninstall process

### DIFF
--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -947,7 +947,9 @@ func (i *Provisioner) Wait(ctx context.Context, blueprint *blueprintv1alpha1.Blu
 }
 
 // Uninstall orchestrates the high-level kustomization teardown process from the blueprint.
-// It initializes the kubernetes manager and deletes all blueprint kustomizations.
+// It initializes the kubernetes manager and deletes all blueprint kustomizations, including the
+// synthesized CRD layer (withCrdLayer) so its Flux Kustomization objects are removed symmetrically
+// with apply; the layer keeps Prune disabled, so the vendored CRDs themselves are retained.
 // DeleteBlueprint emits its own per-Kustomization progress (Start/Done/Fail spinners),
 // so this method does not wrap the call in WithProgress — doing so would suppress the
 // inner per-Kustomization output and produce a single opaque "Removing blueprint
@@ -961,6 +963,8 @@ func (i *Provisioner) Uninstall(blueprint *blueprintv1alpha1.Blueprint) error {
 	if i.KubernetesManager == nil {
 		return fmt.Errorf("kubernetes manager not configured")
 	}
+
+	blueprint = withCrdLayer(blueprint)
 
 	if err := i.KubernetesManager.DeleteBlueprint(blueprint, i.fluxNamespace()); err != nil {
 		return fmt.Errorf("failed to delete blueprint: %w", err)

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -1608,6 +1608,42 @@ func TestProvisioner_Uninstall(t *testing.T) {
 		}
 	})
 
+	t.Run("MaterializesCrdLayerForDestroy", func(t *testing.T) {
+		// Given a blueprint whose crds: layer must be torn down with the stack
+		mocks := setupProvisionerMocks(t)
+		var deleted *blueprintv1alpha1.Blueprint
+		mocks.KubernetesManager.DeleteBlueprintFunc = func(blueprint *blueprintv1alpha1.Blueprint, namespace string) error {
+			deleted = blueprint
+			return nil
+		}
+		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Crds: []blueprintv1alpha1.CrdLayer{
+				{Source: "core", Refs: []string{"cert-manager-1.16.2"}},
+			},
+			Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "cert-manager", DependsOn: []string{"crds-core"}}},
+		}
+
+		// When uninstalling
+		if err := provisioner.Uninstall(blueprint); err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// Then the synthesized crds layer is part of the destroy walk so the Flux
+		// Kustomization object is removed, with pruning left disabled so the CRDs survive
+		if deleted == nil || len(deleted.Kustomizations) != 2 {
+			t.Fatalf("expected crds kustomization included in destroy, got %+v", deleted)
+		}
+		crd := deleted.Kustomizations[0]
+		if crd.Name != "crds-core" || crd.Source != "core" {
+			t.Errorf("expected crds-core bound to core, got name=%q source=%q", crd.Name, crd.Source)
+		}
+		if crd.Prune == nil || *crd.Prune != false {
+			t.Errorf("expected prune=false so CRDs are retained, got prune=%v", crd.Prune)
+		}
+	})
+
 	t.Run("ErrorNilBlueprint", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler)

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -1639,8 +1639,8 @@ func TestProvisioner_Uninstall(t *testing.T) {
 		if crd.Name != "crds-core" || crd.Source != "core" {
 			t.Errorf("expected crds-core bound to core, got name=%q source=%q", crd.Name, crd.Source)
 		}
-		if crd.Prune == nil || *crd.Prune != false {
-			t.Errorf("expected prune=false so CRDs are retained, got prune=%v", crd.Prune)
+		if crd.Prune == nil || *crd.Prune != false || crd.Wait == nil || *crd.Wait != true {
+			t.Errorf("expected prune=false wait=true, got prune=%v wait=%v", crd.Prune, crd.Wait)
 		}
 	})
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Isolated one-line fix to a single provisioner method with a focused test; the change is reversible and has no effect on Terraform or non-CRD kustomizations.
>
> **Overview**
>
> `Uninstall` previously skipped the `withCrdLayer` transformation that every other apply-path method (`Install`, `Wait`, `ApplyKustomize`) applies, so the synthesized Flux Kustomization object for CRD layers was never deleted during teardown. This PR adds the missing call, ensuring the Flux Kustomization object is cleaned up symmetrically. Because the synthesized kustomization keeps `Prune=false`, the actual CRD resources are never pruned — only the Kustomization CR itself is removed.
>
> One non-diff observation: `DestroyAll` populates `result.Destroyed` by iterating the original blueprint's `Kustomizations` slice after delegating to `Uninstall`, so the newly-deleted `crds-core` entry will not appear in that accounting. The teardown is correct, but callers expecting a complete inventory of what was removed will not see the synthesized layer.
>
> Reviewed by Claude for commit `c1a20537`.

<!-- /claude-code-review:summary -->
