### PR TITLE
chore(ci): stop allowedTools patterns from splitting on spaces

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -202,7 +202,7 @@ jobs:
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 80
-            --allowedTools Read,Grep,Glob,Bash(git:*),Bash(gh pr view:*),Bash(gh pr edit:*),Bash(gh pr diff:*),Bash(gh api:*),Bash(jq:*),Bash(cat:*),Bash(tee:*),Bash(mktemp:*),Bash(head:*),Bash(xargs:*),Bash(python3:*),Bash(task scan:*),Bash(go vet:*),Write
+            --allowedTools Read,Grep,Glob,Bash(git:*),Bash(gh:*),Bash(jq:*),Bash(cat:*),Bash(tee:*),Bash(mktemp:*),Bash(head:*),Bash(xargs:*),Bash(python3:*),Bash(task:*),Bash(go:*),Write
             --disallowedTools WebSearch,WebFetch
 
   review-on-dispatch:
@@ -385,7 +385,7 @@ jobs:
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 80
-            --allowedTools Read,Grep,Glob,Bash(git:*),Bash(gh pr view:*),Bash(gh pr edit:*),Bash(gh pr diff:*),Bash(gh api:*),Bash(jq:*),Bash(cat:*),Bash(tee:*),Bash(mktemp:*),Bash(head:*),Bash(xargs:*),Bash(python3:*),Bash(task scan:*),Bash(go vet:*),Write
+            --allowedTools Read,Grep,Glob,Bash(git:*),Bash(gh:*),Bash(jq:*),Bash(cat:*),Bash(tee:*),Bash(mktemp:*),Bash(head:*),Bash(xargs:*),Bash(python3:*),Bash(task:*),Bash(go:*),Write
             --disallowedTools WebSearch,WebFetch
 
   resolve-threads:
@@ -479,5 +479,5 @@ jobs:
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 15
-            --allowedTools Read,Bash(gh api:*),Bash(cat:*),Bash(jq:*)
+            --allowedTools Read,Bash(gh:*),Bash(cat:*),Bash(jq:*)
             --disallowedTools WebSearch,WebFetch


### PR DESCRIPTION
## Summary

The Claude Code Review workflow posts nothing on real PRs because its `--allowedTools` list contains permission patterns with spaces, and the action tokenizes `claude_args` on whitespace.

Patterns like `Bash(gh pr view:*)`, `Bash(gh api:*)`, `Bash(task scan:*)`, and `Bash(go vet:*)` get split into invalid fragments. From the actual SDK options logged on a recent run, the parsed `allowedTools` was:

```
"Bash(git:*)", "Bash(gh", "pr", "view:*)", "edit:*)", "diff:*)", "api:*)", ... "Bash(task", "scan:*)", "Bash(go", "vet:*)", "Write"
```

No valid `gh` matcher survived, so every `gh api` / `gh pr` call the reviewer made — querying review threads, posting the review, upserting the sticky summary — was permission-denied. The run "succeeded" (`is_error: false`, `num_turns: 6`, `permission_denials_count: 3`) while posting nothing.

## Fix

Widen the space-containing patterns to space-free prefixes so they survive whitespace tokenization, in all three review jobs (`review`, `review-on-dispatch`, `resolve-threads`):

- `Bash(gh pr view:*),Bash(gh pr edit:*),Bash(gh pr diff:*),Bash(gh api:*)` → `Bash(gh:*)`
- `Bash(task scan:*)` → `Bash(task:*)`
- `Bash(go vet:*)` → `Bash(go:*)`

## Notes

Renovate/dependency PRs are skipped by the workflow's `if:` conditions, which is why this went unnoticed — it only breaks on the substantive PRs that actually need a review.