### PR TITLE
fix(terraform): add -input=false to init for non-interactive execution

### DIFF
--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -36,7 +36,13 @@ import (
 // surfaces as a clear refusal rather than silently auto-copying state. MigrateState and
 // MigrateComponentState pass `-migrate-state -force-copy` explicitly when migration is
 // the requested operation; see migrateOneComponent.
-var defaultInitFlags = []string{"-upgrade"}
+//
+// -input=false runs init non-interactively. ExecSilentWithEnv never sets cmd.Stdin, so a
+// terraform prompt (e.g. the backend-migration confirmation triggered on the next init after
+// destroy clears state) would read EOF from a closed stdin and abort with an opaque "Error
+// asking for confirmation: EOF". -input=false makes that surface as a clear, fail-fast error
+// instead of a stdin read against nothing.
+var defaultInitFlags = []string{"-upgrade", "-input=false"}
 
 // =============================================================================
 // Types

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -720,6 +720,37 @@ func TestStack_Up(t *testing.T) {
 			t.Error("Expected Up's init not to include -force-copy; the flag belongs only on the explicit state-migration path")
 		}
 	})
+
+	t.Run("PassesInputFalseFlag", func(t *testing.T) {
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+
+		var inputFalseSeen bool
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == "init" {
+				for _, a := range args {
+					if a == "-input=false" {
+						inputFalseSeen = true
+					}
+				}
+			}
+			if command == "terraform" && len(args) >= 3 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[]}}}`, nil
+			}
+			return "", nil
+		}
+
+		// When Up runs
+		if _, err := stack.Up(blueprint); err != nil {
+			t.Fatalf("Expected Up to succeed, got %v", err)
+		}
+
+		// Then init ran non-interactively so a backend-migration prompt after destroy
+		// fails fast with a clear error instead of reading EOF from a closed stdin
+		if !inputFalseSeen {
+			t.Error("Expected Up's init to include -input=false so terraform never blocks on an interactive prompt")
+		}
+	})
 }
 
 func TestStack_MigrateState(t *testing.T) {


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This is a single-flag addition to an internal constant, isolated to the apply/plan/destroy init path with a focused regression test.
>
> **Overview**
>
> The PR adds `-input=false` to `defaultInitFlags` so that `terraform init` never attempts interactive prompting when run through `ExecSilentWithEnv`, which never sets `cmd.Stdin`. Without this flag, terraform's backend-migration prompt reads EOF from a closed stdin and surfaces an opaque "Error asking for confirmation: EOF" rather than a clear failure.
>
> The fix is correctly scoped: `MigrateState` already suppresses the migration prompt via `-force-copy` and is not affected. The new `PassesInputFalseFlag` test mirrors the established pattern for this test file and fails before the change, passes after.
>
> Reviewed by Claude for commit `b7d3188`.

<!-- /claude-code-review:summary -->
