### PR TITLE
fix(provisioner): include synthesized CRD layers in bootstrap summary

### DIFF
--- a/pkg/provisioner/bootstrap.go
+++ b/pkg/provisioner/bootstrap.go
@@ -100,7 +100,9 @@ func (i *Provisioner) Bootstrap(blueprint *blueprintv1alpha1.Blueprint, onApply 
 
 // BuildBootstrapSummary constructs the operator-visible intent description for a bootstrap,
 // independent of any Provisioner instance so the project layer can render the plan before
-// committing to privileged work.
+// committing to privileged work. The CRD layers are materialized via withCrdLayer so the bootstrap
+// plan lists the synthesized "crds"/"crds-<source>" kustomizations the stack installs, matching what
+// `windsor plan` shows rather than hiding them until apply.
 func BuildBootstrapSummary(blueprint *blueprintv1alpha1.Blueprint, contextName, backendType string) *BootstrapSummary {
 	summary := &BootstrapSummary{
 		ContextName: contextName,
@@ -118,7 +120,7 @@ func BuildBootstrapSummary(blueprint *blueprintv1alpha1.Blueprint, contextName, 
 			Path:        c.Path,
 		})
 	}
-	for _, k := range blueprint.Kustomizations {
+	for _, k := range withCrdLayer(blueprint).Kustomizations {
 		summary.Kustomize = append(summary.Kustomize, k.Name)
 	}
 	return summary

--- a/pkg/provisioner/bootstrap_test.go
+++ b/pkg/provisioner/bootstrap_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 
@@ -657,6 +658,33 @@ func TestBuildBootstrapSummary(t *testing.T) {
 		}
 		if len(s.Kustomize) != 2 || s.Kustomize[0] != "argocd" || s.Kustomize[1] != "monitoring" {
 			t.Errorf("Expected kustomize [argocd, monitoring], got %#v", s.Kustomize)
+		}
+	})
+
+	t.Run("IncludesSynthesizedCrdLayers", func(t *testing.T) {
+		// Given a blueprint with local CRDs and an install source that vendors CRDs — the same layers
+		// `windsor plan` materializes via withCrdLayer
+		installed := true
+		bp := &blueprintv1alpha1.Blueprint{
+			Crds: []string{"cert-manager-1.16.2"},
+			Sources: []blueprintv1alpha1.Source{
+				{Name: "core", Install: &blueprintv1alpha1.BoolExpression{Value: &installed}, Crds: []string{"gateway-api-1.5.1"}},
+			},
+			Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "argocd"}},
+		}
+
+		s := BuildBootstrapSummary(bp, "local", "s3")
+
+		// Then the bootstrap plan lists the synthesized CRD kustomizations ahead of the stack, matching
+		// what `windsor plan` shows — operators see every CRD layer before confirming
+		if !slices.Contains(s.Kustomize, "crds") {
+			t.Errorf("expected synthesized 'crds' layer in bootstrap summary, got %#v", s.Kustomize)
+		}
+		if !slices.Contains(s.Kustomize, "crds-core") {
+			t.Errorf("expected synthesized 'crds-core' layer in bootstrap summary, got %#v", s.Kustomize)
+		}
+		if !slices.Contains(s.Kustomize, "argocd") {
+			t.Errorf("expected the regular kustomization retained, got %#v", s.Kustomize)
 		}
 	})
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> An isolated fix to the pre-bootstrap display summary with no effect on apply behavior.
>
> **Overview**
>
> `BuildBootstrapSummary` was iterating `blueprint.Kustomizations` directly, so the synthesized CRD layers (`crds`, `crds-<source>`) that `withCrdLayer` prepends before every apply, plan, and wait operation were absent from the summary operators see before confirming `windsor bootstrap`. The fix applies `withCrdLayer` at this call site, aligning the displayed intent with the actual execution path and matching what `windsor plan` already shows.
>
> The new test covers both a local CRD layer and a source-vendor CRD layer, and confirms the original kustomizations are retained alongside the synthesized ones.
>
> Reviewed by Claude for commit `e030edc7`.

<!-- /claude-code-review:summary -->
