### PR TITLE
fix(runtime/shell): enhance secret redaction and add tests for scrubbingWriter

### DIFF
--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -267,11 +267,6 @@ func (s *TerraformStack) PostApply(fns ...func(id string) error) {
 // onApply hooks run inside each spinner; PostApply hooks run after each Done line and are
 // consumed (not retained across calls).
 //
-// The pre-apply plan is run through ExecCaptureWithEnv rather than a streaming exec: its output
-// is discarded (it only gates apply), and streaming it under --verbose would echo provider-generated
-// cluster PKI that the secret scrubber cannot mask because it was never registered. apply re-renders
-// the plan and a failing plan still surfaces terraform's stderr through the wrapped error.
-//
 // Returns (halted bool, err error). halted=true means a hook signaled that the component
 // apply succeeded but subsequent components should not be applied (e.g. cluster reachability
 // needs a host-side configuration step the operator hasn't done yet). halted is reported as
@@ -337,7 +332,7 @@ func (s *TerraformStack) Up(blueprint *blueprintv1alpha1.Blueprint, onApply ...f
 			planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan", "-refresh=false"}
 			planArgs = append(planArgs, terraformArgs.PlanArgs...)
 			planEnv := selectTerraformCommandEnv(terraformVars, true)
-			if _, err = s.runtime.Shell.ExecCaptureWithEnv(terraformCommand, planEnv, planArgs...); err != nil {
+			if _, err = s.runtime.Shell.ExecSilentWithEnv(terraformCommand, planEnv, planArgs...); err != nil {
 				return fmt.Errorf("error running terraform plan for %s: %w", component.Path, err)
 			}
 
@@ -817,8 +812,7 @@ func (s *TerraformStack) PlanAllJSON(blueprint *blueprintv1alpha1.Blueprint) err
 // Apply runs terraform init, plan, and apply for a single component identified by componentID.
 // It resolves the component from the blueprint, sets up the environment, and executes
 // init, plan, then apply in sequence. Returns an error if the component is not found,
-// the directory does not exist, or any terraform operation fails. As in Up, the pre-apply plan
-// uses ExecCaptureWithEnv so its discarded output cannot leak provider-generated PKI under --verbose.
+// the directory does not exist, or any terraform operation fails.
 func (s *TerraformStack) Apply(blueprint *blueprintv1alpha1.Blueprint, componentID string) error {
 	if blueprint == nil {
 		return fmt.Errorf("blueprint not provided")
@@ -847,7 +841,7 @@ func (s *TerraformStack) Apply(blueprint *blueprintv1alpha1.Blueprint, component
 		planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan", "-refresh=false"}
 		planArgs = append(planArgs, terraformArgs.PlanArgs...)
 		planEnv := selectTerraformCommandEnv(terraformVars, true)
-		if _, err := s.runtime.Shell.ExecCaptureWithEnv(terraformCommand, planEnv, planArgs...); err != nil {
+		if _, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, planEnv, planArgs...); err != nil {
 			return fmt.Errorf("error running terraform plan for %s: %w", component.Path, err)
 		}
 

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -267,6 +267,11 @@ func (s *TerraformStack) PostApply(fns ...func(id string) error) {
 // onApply hooks run inside each spinner; PostApply hooks run after each Done line and are
 // consumed (not retained across calls).
 //
+// The pre-apply plan is run through ExecCaptureWithEnv rather than a streaming exec: its output
+// is discarded (it only gates apply), and streaming it under --verbose would echo provider-generated
+// cluster PKI that the secret scrubber cannot mask because it was never registered. apply re-renders
+// the plan and a failing plan still surfaces terraform's stderr through the wrapped error.
+//
 // Returns (halted bool, err error). halted=true means a hook signaled that the component
 // apply succeeded but subsequent components should not be applied (e.g. cluster reachability
 // needs a host-side configuration step the operator hasn't done yet). halted is reported as
@@ -812,7 +817,8 @@ func (s *TerraformStack) PlanAllJSON(blueprint *blueprintv1alpha1.Blueprint) err
 // Apply runs terraform init, plan, and apply for a single component identified by componentID.
 // It resolves the component from the blueprint, sets up the environment, and executes
 // init, plan, then apply in sequence. Returns an error if the component is not found,
-// the directory does not exist, or any terraform operation fails.
+// the directory does not exist, or any terraform operation fails. As in Up, the pre-apply plan
+// uses ExecCaptureWithEnv so its discarded output cannot leak provider-generated PKI under --verbose.
 func (s *TerraformStack) Apply(blueprint *blueprintv1alpha1.Blueprint, componentID string) error {
 	if blueprint == nil {
 		return fmt.Errorf("blueprint not provided")

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -332,7 +332,7 @@ func (s *TerraformStack) Up(blueprint *blueprintv1alpha1.Blueprint, onApply ...f
 			planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan", "-refresh=false"}
 			planArgs = append(planArgs, terraformArgs.PlanArgs...)
 			planEnv := selectTerraformCommandEnv(terraformVars, true)
-			if _, err = s.runtime.Shell.ExecSilentWithEnv(terraformCommand, planEnv, planArgs...); err != nil {
+			if _, err = s.runtime.Shell.ExecCaptureWithEnv(terraformCommand, planEnv, planArgs...); err != nil {
 				return fmt.Errorf("error running terraform plan for %s: %w", component.Path, err)
 			}
 
@@ -841,7 +841,7 @@ func (s *TerraformStack) Apply(blueprint *blueprintv1alpha1.Blueprint, component
 		planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan", "-refresh=false"}
 		planArgs = append(planArgs, terraformArgs.PlanArgs...)
 		planEnv := selectTerraformCommandEnv(terraformVars, true)
-		if _, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, planEnv, planArgs...); err != nil {
+		if _, err := s.runtime.Shell.ExecCaptureWithEnv(terraformCommand, planEnv, planArgs...); err != nil {
 			return fmt.Errorf("error running terraform plan for %s: %w", component.Path, err)
 		}
 

--- a/pkg/runtime/shell/scrubbing_writer.go
+++ b/pkg/runtime/shell/scrubbing_writer.go
@@ -37,10 +37,11 @@ var pemInlinePattern = regexp.MustCompile(`-----BEGIN [A-Z0-9 ]+-----.*?-----END
 // secretFieldPattern matches a secret-bearing field name followed by a long base64 value,
 // masking the value while leaving the field name and separator visible. The field name matches
 // either an identifier carrying a secret word (covering terraform attributes like ca_certificate
-// and client_key as well as YAML keys like secret/token) or the bare ca/id keys from Talos machine
-// config. The 40-character floor keeps ordinary identifiers intact while still catching machine-secret
-// blobs, CA bundles, and private keys.
-var secretFieldPattern = regexp.MustCompile(`(?i)([A-Za-z0-9_.-]*(?:token|key|crt|cert|secret|serviceaccount)[A-Za-z0-9_.-]*|\b(?:ca|id)\b)(\s*[:=]\s*["']?)([A-Za-z0-9+/]{40,}={0,2})(["']?)`)
+// and client_key as well as YAML keys like secret/token) or the bare ca key from Talos machine
+// config. The bare id key is deliberately excluded: id is a ubiquitous terraform output field
+// and masking a long opaque id is not worth the false positives. The 40-character floor keeps
+// ordinary identifiers intact while still catching machine-secret blobs, CA bundles, and private keys.
+var secretFieldPattern = regexp.MustCompile(`(?i)([A-Za-z0-9_.-]*(?:token|key|crt|cert|secret|serviceaccount)[A-Za-z0-9_.-]*|\bca\b)(\s*[:=]\s*["']?)([A-Za-z0-9+/]{40,}={0,2})(["']?)`)
 
 // talosTokenPattern matches the Talos bootstrap-token shape (six base32 chars, a dot, then
 // sixteen) following a token field, masking the value.

--- a/pkg/runtime/shell/scrubbing_writer.go
+++ b/pkg/runtime/shell/scrubbing_writer.go
@@ -3,59 +3,30 @@ package shell
 import (
 	"bytes"
 	"io"
-	"regexp"
-	"strings"
 )
 
 // =============================================================================
 // Types
 // =============================================================================
 
-// scrubbingWriter wraps an io.Writer and removes sensitive material from streamed
-// output before it reaches the terminal. It applies two layers: scrubFunc masks
-// values registered via RegisterSecret (a denylist of known secrets), and redactSecrets
-// masks structurally-recognised material — PEM blocks and base64 key/cert/token fields —
-// that terraform and other tools emit without windsor ever registering them. Output is
-// buffered by line so multi-write secrets are masked as a unit; Flush must be called once
-// the source command completes to emit any trailing partial line.
+// scrubbingWriter wraps an io.Writer and masks values registered via RegisterSecret before
+// writing streamed output to the terminal. Output is buffered by line so a secret split
+// across multiple Write calls (e.g. at a buffer boundary) is still matched as a whole
+// value; Flush must be called once the source command completes to emit any trailing
+// partial line.
 type scrubbingWriter struct {
 	writer    io.Writer
 	scrubFunc func(string) string
 	pending   []byte
-	inPEM     bool
 }
-
-// =============================================================================
-// Patterns
-// =============================================================================
-
-// pemInlinePattern matches a complete PEM block rendered on a single physical line.
-// Terraform prints embedded keys and certificates with escaped "\n", so the whole block
-// lands on one line; the surrounding real newlines are handled by the multi-line path.
-var pemInlinePattern = regexp.MustCompile(`-----BEGIN [A-Z0-9 ]+-----.*?-----END [A-Z0-9 ]+-----`)
-
-// secretFieldPattern matches a secret-bearing field name followed by a long base64 value,
-// masking the value while leaving the field name and separator visible. The field name matches
-// either an identifier carrying a secret word (covering terraform attributes like ca_certificate
-// and client_key as well as YAML keys like secret/token) or the bare ca key from Talos machine
-// config. The bare id key is deliberately excluded: id is a ubiquitous terraform output field
-// and masking a long opaque id is not worth the false positives. The 40-character floor keeps
-// ordinary identifiers intact while still catching machine-secret blobs, CA bundles, and private keys.
-var secretFieldPattern = regexp.MustCompile(`(?i)([A-Za-z0-9_.-]*(?:token|key|crt|cert|secret|serviceaccount)[A-Za-z0-9_.-]*|\bca\b)(\s*[:=]\s*["']?)([A-Za-z0-9+/]{40,}={0,2})(["']?)`)
-
-// talosTokenPattern matches the Talos bootstrap-token shape (six base32 chars, a dot, then
-// sixteen) following a token field, masking the value.
-var talosTokenPattern = regexp.MustCompile(`(?i)(\btoken\b\s*[:=]\s*["']?)([a-z0-9]{6}\.[a-z0-9]{16})(["']?)`)
 
 // =============================================================================
 // Methods
 // =============================================================================
 
 // Write buffers incoming bytes and emits complete lines once their newline arrives, holding
-// any trailing partial line until the next Write or Flush. Buffering by line lets redaction
-// reason about whole values rather than arbitrary chunk boundaries and lets a PEM block that
-// spans several writes be masked as a single unit. The full length of p is always reported
-// consumed so the writer composes cleanly under io.MultiWriter.
+// any trailing partial line until the next Write or Flush. The full length of p is always
+// reported consumed so the writer composes cleanly under io.MultiWriter.
 func (sw *scrubbingWriter) Write(p []byte) (n int, err error) {
 	sw.pending = append(sw.pending, p...)
 	for {
@@ -73,8 +44,7 @@ func (sw *scrubbingWriter) Write(p []byte) (n int, err error) {
 }
 
 // Flush emits any buffered partial line. It is called after the source command finishes so a
-// final line without a trailing newline is not dropped. An unterminated PEM block in progress
-// is masked rather than passed through.
+// final line without a trailing newline is not dropped.
 func (sw *scrubbingWriter) Flush() error {
 	if len(sw.pending) == 0 {
 		return nil
@@ -84,37 +54,8 @@ func (sw *scrubbingWriter) Flush() error {
 	return sw.emit(line)
 }
 
-// emit writes a single line after redaction. While inside a multi-line PEM block it suppresses
-// the body and emits a single masked placeholder at the END marker. Otherwise it masks any
-// structurally-recognised secret, then applies the registered-secret denylist, before writing.
+// emit applies the registered-secret denylist to a line and writes the result.
 func (sw *scrubbingWriter) emit(line string) error {
-	if sw.inPEM {
-		if strings.Contains(line, "-----END ") {
-			sw.inPEM = false
-			_, err := sw.writer.Write([]byte(sw.scrubFunc("********\n")))
-			return err
-		}
-		return nil
-	}
-	if strings.Contains(line, "-----BEGIN ") && !strings.Contains(line, "-----END ") {
-		sw.inPEM = true
-		return nil
-	}
-	_, err := sw.writer.Write([]byte(sw.scrubFunc(redactSecrets(line))))
+	_, err := sw.writer.Write([]byte(sw.scrubFunc(line)))
 	return err
-}
-
-// =============================================================================
-// Functions
-// =============================================================================
-
-// redactSecrets masks structurally-recognised sensitive material in a line: inline PEM blocks,
-// base64 values bound to secret-bearing field names, and Talos bootstrap tokens. It is a
-// best-effort backstop for secrets that were generated downstream (e.g. by terraform providers)
-// and therefore never passed through RegisterSecret.
-func redactSecrets(line string) string {
-	line = pemInlinePattern.ReplaceAllString(line, "********")
-	line = talosTokenPattern.ReplaceAllString(line, "${1}********${3}")
-	line = secretFieldPattern.ReplaceAllString(line, "${1}${2}********${4}")
-	return line
 }

--- a/pkg/runtime/shell/scrubbing_writer.go
+++ b/pkg/runtime/shell/scrubbing_writer.go
@@ -1,37 +1,119 @@
 package shell
 
-import "io"
+import (
+	"bytes"
+	"io"
+	"regexp"
+	"strings"
+)
 
-// scrubbingWriter wraps an io.Writer and scrubs secrets from content before writing
+// =============================================================================
+// Types
+// =============================================================================
+
+// scrubbingWriter wraps an io.Writer and removes sensitive material from streamed
+// output before it reaches the terminal. It applies two layers: scrubFunc masks
+// values registered via RegisterSecret (a denylist of known secrets), and redactSecrets
+// masks structurally-recognised material — PEM blocks and base64 key/cert/token fields —
+// that terraform and other tools emit without windsor ever registering them. Output is
+// buffered by line so multi-write secrets are masked as a unit; Flush must be called once
+// the source command completes to emit any trailing partial line.
 type scrubbingWriter struct {
 	writer    io.Writer
 	scrubFunc func(string) string
+	pending   []byte
+	inPEM     bool
 }
 
-// Write scrubs secrets from content and writes to the underlying writer.
-// If scrubbing changes the content length, it pads with spaces or truncates
-// to maintain the original byte length for consistent output formatting.
+// =============================================================================
+// Patterns
+// =============================================================================
+
+// pemInlinePattern matches a complete PEM block rendered on a single physical line.
+// Terraform prints embedded keys and certificates with escaped "\n", so the whole block
+// lands on one line; the surrounding real newlines are handled by the multi-line path.
+var pemInlinePattern = regexp.MustCompile(`-----BEGIN [A-Z0-9 ]+-----.*?-----END [A-Z0-9 ]+-----`)
+
+// secretFieldPattern matches a secret-bearing field name followed by a long base64 value,
+// masking the value while leaving the field name and separator visible. The field name matches
+// either an identifier carrying a secret word (covering terraform attributes like ca_certificate
+// and client_key as well as YAML keys like secret/token) or the bare ca/id keys from Talos machine
+// config. The 40-character floor keeps ordinary identifiers intact while still catching machine-secret
+// blobs, CA bundles, and private keys.
+var secretFieldPattern = regexp.MustCompile(`(?i)([A-Za-z0-9_.-]*(?:token|key|crt|cert|secret|serviceaccount)[A-Za-z0-9_.-]*|\b(?:ca|id)\b)(\s*[:=]\s*["']?)([A-Za-z0-9+/]{40,}={0,2})(["']?)`)
+
+// talosTokenPattern matches the Talos bootstrap-token shape (six base32 chars, a dot, then
+// sixteen) following a token field, masking the value.
+var talosTokenPattern = regexp.MustCompile(`(?i)(\btoken\b\s*[:=]\s*["']?)([a-z0-9]{6}\.[a-z0-9]{16})(["']?)`)
+
+// =============================================================================
+// Methods
+// =============================================================================
+
+// Write buffers incoming bytes and emits complete lines once their newline arrives, holding
+// any trailing partial line until the next Write or Flush. Buffering by line lets redaction
+// reason about whole values rather than arbitrary chunk boundaries and lets a PEM block that
+// spans several writes be masked as a single unit. The full length of p is always reported
+// consumed so the writer composes cleanly under io.MultiWriter.
 func (sw *scrubbingWriter) Write(p []byte) (n int, err error) {
-	original := string(p)
-	scrubbed := sw.scrubFunc(original)
-
-	if scrubbed != original {
-		scrubbedBytes := []byte(scrubbed)
-		originalLen := len(p)
-		scrubbedLen := len(scrubbedBytes)
-
-		if scrubbedLen < originalLen {
-			padding := make([]byte, originalLen-scrubbedLen)
-			for i := range padding {
-				padding[i] = ' '
-			}
-			scrubbedBytes = append(scrubbedBytes, padding...)
-		} else if scrubbedLen > originalLen {
-			scrubbedBytes = scrubbedBytes[:originalLen]
+	sw.pending = append(sw.pending, p...)
+	for {
+		i := bytes.IndexByte(sw.pending, '\n')
+		if i < 0 {
+			break
 		}
-
-		return sw.writer.Write(scrubbedBytes)
+		line := string(sw.pending[:i+1])
+		sw.pending = sw.pending[i+1:]
+		if err := sw.emit(line); err != nil {
+			return 0, err
+		}
 	}
+	return len(p), nil
+}
 
-	return sw.writer.Write(p)
+// Flush emits any buffered partial line. It is called after the source command finishes so a
+// final line without a trailing newline is not dropped. An unterminated PEM block in progress
+// is masked rather than passed through.
+func (sw *scrubbingWriter) Flush() error {
+	if len(sw.pending) == 0 {
+		return nil
+	}
+	line := string(sw.pending)
+	sw.pending = nil
+	return sw.emit(line)
+}
+
+// emit writes a single line after redaction. While inside a multi-line PEM block it suppresses
+// the body and emits a single masked placeholder at the END marker. Otherwise it masks any
+// structurally-recognised secret, then applies the registered-secret denylist, before writing.
+func (sw *scrubbingWriter) emit(line string) error {
+	if sw.inPEM {
+		if strings.Contains(line, "-----END ") {
+			sw.inPEM = false
+			_, err := sw.writer.Write([]byte(sw.scrubFunc("********\n")))
+			return err
+		}
+		return nil
+	}
+	if strings.Contains(line, "-----BEGIN ") && !strings.Contains(line, "-----END ") {
+		sw.inPEM = true
+		return nil
+	}
+	_, err := sw.writer.Write([]byte(sw.scrubFunc(redactSecrets(line))))
+	return err
+}
+
+// =============================================================================
+// Functions
+// =============================================================================
+
+// redactSecrets masks structurally-recognised sensitive material in a line: inline PEM blocks,
+// base64 values bound to secret-bearing field names, and Talos bootstrap tokens. It is a
+// best-effort backstop for secrets that were generated downstream (e.g. by terraform providers)
+// and therefore never passed through RegisterSecret.
+func redactSecrets(line string) string {
+	line = pemInlinePattern.ReplaceAllString(line, "********")
+	line = talosTokenPattern.ReplaceAllString(line, "${1}********${3}")
+	line = secretFieldPattern.ReplaceAllString(line, "${1}${2}********${4}")
+	return line
 }

--- a/pkg/runtime/shell/scrubbing_writer_test.go
+++ b/pkg/runtime/shell/scrubbing_writer_test.go
@@ -1,0 +1,185 @@
+package shell
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestRedactSecrets(t *testing.T) {
+	t.Run("MasksInlinePEMBlock", func(t *testing.T) {
+		// Given a line carrying a PEM block rendered with escaped newlines, as terraform prints it
+		input := `ca_certificate = "-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAOZ\n-----END CERTIFICATE-----\n"`
+
+		// When the line is redacted
+		result := redactSecrets(input)
+
+		// Then no PEM material survives
+		if strings.Contains(result, "BEGIN CERTIFICATE") || strings.Contains(result, "MIIBkTCB") {
+			t.Errorf("Expected PEM block to be masked, got %q", result)
+		}
+		if !strings.Contains(result, "********") {
+			t.Errorf("Expected mask marker in output, got %q", result)
+		}
+	})
+
+	t.Run("MasksBase64SecretField", func(t *testing.T) {
+		// Given a secret-bearing field name followed by a long base64 value
+		input := `        secret: dGhpc2lzYXZlcnlsb25nYmFzZTY0c2VjcmV0dmFsdWVhYmNkZWZn`
+
+		// When the line is redacted
+		result := redactSecrets(input)
+
+		// Then the value is masked while the field name remains visible
+		if strings.Contains(result, "dGhpc2lzYXZlcnlsb25n") {
+			t.Errorf("Expected base64 value to be masked, got %q", result)
+		}
+		if !strings.Contains(result, "secret:") || !strings.Contains(result, "********") {
+			t.Errorf("Expected field name kept and value masked, got %q", result)
+		}
+	})
+
+	t.Run("MasksTerraformAttributeNames", func(t *testing.T) {
+		// Given terraform plan lines for Talos PKI attributes whose names embed the secret word
+		for _, input := range []string{
+			`        ca_certificate     = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tQUFBQUFBQUFBQUFB"`,
+			`        client_key         = "LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLUFBQUFBQUFB"`,
+		} {
+			// When the line is redacted
+			result := redactSecrets(input)
+
+			// Then the base64 value is masked
+			if strings.Contains(result, "LS0tLS1") {
+				t.Errorf("Expected attribute value masked, got %q", result)
+			}
+			if !strings.Contains(result, "********") {
+				t.Errorf("Expected mask marker, got %q", result)
+			}
+		}
+	})
+
+	t.Run("MasksTalosBootstrapToken", func(t *testing.T) {
+		// Given a Talos bootstrap-token field
+		input := `token: abcdef.0123456789abcdef`
+
+		// When the line is redacted
+		result := redactSecrets(input)
+
+		// Then the token value is masked
+		if strings.Contains(result, "0123456789abcdef") {
+			t.Errorf("Expected token to be masked, got %q", result)
+		}
+	})
+
+	t.Run("LeavesOrdinaryOutputUntouched", func(t *testing.T) {
+		// Given a line with a short identifier that is not a secret
+		input := `id = "abc123"`
+
+		// When the line is redacted
+		result := redactSecrets(input)
+
+		// Then the line is unchanged
+		if result != input {
+			t.Errorf("Expected unchanged line, got %q", result)
+		}
+	})
+}
+
+func TestScrubbingWriter_Write(t *testing.T) {
+	// setup builds a scrubbingWriter over a buffer with the given registered secrets.
+	setup := func(secrets ...string) (*scrubbingWriter, *bytes.Buffer) {
+		var sink bytes.Buffer
+		scrub := func(in string) string {
+			out := in
+			for _, sec := range secrets {
+				out = strings.ReplaceAll(out, sec, "********")
+			}
+			return out
+		}
+		return &scrubbingWriter{writer: &sink, scrubFunc: scrub}, &sink
+	}
+
+	t.Run("MasksMultiLinePEMBlockAsSingleUnit", func(t *testing.T) {
+		// Given a real multi-line PEM block split across writes
+		sw, sink := setup()
+
+		// When the block is written line by line
+		for _, line := range []string{
+			"machine config:\n",
+			"-----BEGIN RSA PRIVATE KEY-----\n",
+			"MIIEpAIBAAKCAQEA1234567890\n",
+			"abcdefghijklmnopqrstuvwxyz\n",
+			"-----END RSA PRIVATE KEY-----\n",
+			"done\n",
+		} {
+			if _, err := sw.Write([]byte(line)); err != nil {
+				t.Fatalf("unexpected write error: %v", err)
+			}
+		}
+
+		// Then no key material reaches the sink and the surrounding lines survive
+		out := sink.String()
+		if strings.Contains(out, "BEGIN RSA PRIVATE KEY") || strings.Contains(out, "MIIEpAIBAAKCAQEA") {
+			t.Errorf("Expected PEM body to be masked, got %q", out)
+		}
+		if !strings.Contains(out, "machine config:") || !strings.Contains(out, "done") {
+			t.Errorf("Expected surrounding lines preserved, got %q", out)
+		}
+		if !strings.Contains(out, "********") {
+			t.Errorf("Expected mask marker, got %q", out)
+		}
+	})
+
+	t.Run("BuffersPartialLineUntilFlush", func(t *testing.T) {
+		// Given a line delivered without a trailing newline
+		sw, sink := setup()
+
+		// When a partial line is written
+		if _, err := sw.Write([]byte("no newline yet")); err != nil {
+			t.Fatalf("unexpected write error: %v", err)
+		}
+
+		// Then nothing is emitted until Flush
+		if sink.Len() != 0 {
+			t.Errorf("Expected no output before flush, got %q", sink.String())
+		}
+		if err := sw.Flush(); err != nil {
+			t.Fatalf("unexpected flush error: %v", err)
+		}
+		if sink.String() != "no newline yet" {
+			t.Errorf("Expected flushed content, got %q", sink.String())
+		}
+	})
+
+	t.Run("AppliesRegisteredSecretDenylist", func(t *testing.T) {
+		// Given a writer with a registered secret
+		sw, sink := setup("s3cr3t")
+
+		// When a line containing the secret is written
+		if _, err := sw.Write([]byte("value is s3cr3t here\n")); err != nil {
+			t.Fatalf("unexpected write error: %v", err)
+		}
+
+		// Then the registered secret is masked
+		if strings.Contains(sink.String(), "s3cr3t") {
+			t.Errorf("Expected registered secret masked, got %q", sink.String())
+		}
+	})
+
+	t.Run("ReportsFullInputConsumed", func(t *testing.T) {
+		// Given a writer whose redaction shortens the content
+		sw, _ := setup()
+		input := []byte(`key: ` + strings.Repeat("A", 60) + "\n")
+
+		// When the input is written
+		n, err := sw.Write(input)
+
+		// Then the writer reports the full input length consumed despite masking
+		if err != nil {
+			t.Fatalf("unexpected write error: %v", err)
+		}
+		if n != len(input) {
+			t.Errorf("Expected %d bytes consumed, got %d", len(input), n)
+		}
+	})
+}

--- a/pkg/runtime/shell/scrubbing_writer_test.go
+++ b/pkg/runtime/shell/scrubbing_writer_test.go
@@ -83,6 +83,19 @@ func TestRedactSecrets(t *testing.T) {
 			t.Errorf("Expected unchanged line, got %q", result)
 		}
 	})
+
+	t.Run("LeavesLongOpaqueIdUntouched", func(t *testing.T) {
+		// Given a non-secret id whose value runs past the base64 length floor
+		input := `id = "` + strings.Repeat("A", 48) + `"`
+
+		// When the line is redacted
+		result := redactSecrets(input)
+
+		// Then the id is left intact: id is a ubiquitous terraform field, not a secret
+		if result != input {
+			t.Errorf("Expected long id left unchanged, got %q", result)
+		}
+	})
 }
 
 func TestScrubbingWriter_Write(t *testing.T) {

--- a/pkg/runtime/shell/scrubbing_writer_test.go
+++ b/pkg/runtime/shell/scrubbing_writer_test.go
@@ -6,98 +6,6 @@ import (
 	"testing"
 )
 
-func TestRedactSecrets(t *testing.T) {
-	t.Run("MasksInlinePEMBlock", func(t *testing.T) {
-		// Given a line carrying a PEM block rendered with escaped newlines, as terraform prints it
-		input := `ca_certificate = "-----BEGIN CERTIFICATE-----\nMIIBkTCB+wIJAOZ\n-----END CERTIFICATE-----\n"`
-
-		// When the line is redacted
-		result := redactSecrets(input)
-
-		// Then no PEM material survives
-		if strings.Contains(result, "BEGIN CERTIFICATE") || strings.Contains(result, "MIIBkTCB") {
-			t.Errorf("Expected PEM block to be masked, got %q", result)
-		}
-		if !strings.Contains(result, "********") {
-			t.Errorf("Expected mask marker in output, got %q", result)
-		}
-	})
-
-	t.Run("MasksBase64SecretField", func(t *testing.T) {
-		// Given a secret-bearing field name followed by a long base64 value
-		input := `        secret: dGhpc2lzYXZlcnlsb25nYmFzZTY0c2VjcmV0dmFsdWVhYmNkZWZn`
-
-		// When the line is redacted
-		result := redactSecrets(input)
-
-		// Then the value is masked while the field name remains visible
-		if strings.Contains(result, "dGhpc2lzYXZlcnlsb25n") {
-			t.Errorf("Expected base64 value to be masked, got %q", result)
-		}
-		if !strings.Contains(result, "secret:") || !strings.Contains(result, "********") {
-			t.Errorf("Expected field name kept and value masked, got %q", result)
-		}
-	})
-
-	t.Run("MasksTerraformAttributeNames", func(t *testing.T) {
-		// Given terraform plan lines for Talos PKI attributes whose names embed the secret word
-		for _, input := range []string{
-			`        ca_certificate     = "LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tQUFBQUFBQUFBQUFB"`,
-			`        client_key         = "LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLUFBQUFBQUFB"`,
-		} {
-			// When the line is redacted
-			result := redactSecrets(input)
-
-			// Then the base64 value is masked
-			if strings.Contains(result, "LS0tLS1") {
-				t.Errorf("Expected attribute value masked, got %q", result)
-			}
-			if !strings.Contains(result, "********") {
-				t.Errorf("Expected mask marker, got %q", result)
-			}
-		}
-	})
-
-	t.Run("MasksTalosBootstrapToken", func(t *testing.T) {
-		// Given a Talos bootstrap-token field
-		input := `token: abcdef.0123456789abcdef`
-
-		// When the line is redacted
-		result := redactSecrets(input)
-
-		// Then the token value is masked
-		if strings.Contains(result, "0123456789abcdef") {
-			t.Errorf("Expected token to be masked, got %q", result)
-		}
-	})
-
-	t.Run("LeavesOrdinaryOutputUntouched", func(t *testing.T) {
-		// Given a line with a short identifier that is not a secret
-		input := `id = "abc123"`
-
-		// When the line is redacted
-		result := redactSecrets(input)
-
-		// Then the line is unchanged
-		if result != input {
-			t.Errorf("Expected unchanged line, got %q", result)
-		}
-	})
-
-	t.Run("LeavesLongOpaqueIdUntouched", func(t *testing.T) {
-		// Given a non-secret id whose value runs past the base64 length floor
-		input := `id = "` + strings.Repeat("A", 48) + `"`
-
-		// When the line is redacted
-		result := redactSecrets(input)
-
-		// Then the id is left intact: id is a ubiquitous terraform field, not a secret
-		if result != input {
-			t.Errorf("Expected long id left unchanged, got %q", result)
-		}
-	})
-}
-
 func TestScrubbingWriter_Write(t *testing.T) {
 	// setup builds a scrubbingWriter over a buffer with the given registered secrets.
 	setup := func(secrets ...string) (*scrubbingWriter, *bytes.Buffer) {
@@ -111,37 +19,6 @@ func TestScrubbingWriter_Write(t *testing.T) {
 		}
 		return &scrubbingWriter{writer: &sink, scrubFunc: scrub}, &sink
 	}
-
-	t.Run("MasksMultiLinePEMBlockAsSingleUnit", func(t *testing.T) {
-		// Given a real multi-line PEM block split across writes
-		sw, sink := setup()
-
-		// When the block is written line by line
-		for _, line := range []string{
-			"machine config:\n",
-			"-----BEGIN RSA PRIVATE KEY-----\n",
-			"MIIEpAIBAAKCAQEA1234567890\n",
-			"abcdefghijklmnopqrstuvwxyz\n",
-			"-----END RSA PRIVATE KEY-----\n",
-			"done\n",
-		} {
-			if _, err := sw.Write([]byte(line)); err != nil {
-				t.Fatalf("unexpected write error: %v", err)
-			}
-		}
-
-		// Then no key material reaches the sink and the surrounding lines survive
-		out := sink.String()
-		if strings.Contains(out, "BEGIN RSA PRIVATE KEY") || strings.Contains(out, "MIIEpAIBAAKCAQEA") {
-			t.Errorf("Expected PEM body to be masked, got %q", out)
-		}
-		if !strings.Contains(out, "machine config:") || !strings.Contains(out, "done") {
-			t.Errorf("Expected surrounding lines preserved, got %q", out)
-		}
-		if !strings.Contains(out, "********") {
-			t.Errorf("Expected mask marker, got %q", out)
-		}
-	})
 
 	t.Run("BuffersPartialLineUntilFlush", func(t *testing.T) {
 		// Given a line delivered without a trailing newline
@@ -164,6 +41,24 @@ func TestScrubbingWriter_Write(t *testing.T) {
 		}
 	})
 
+	t.Run("MasksSecretSplitAcrossWrites", func(t *testing.T) {
+		// Given a registered secret delivered across two separate Write calls
+		sw, sink := setup("s3cr3t")
+
+		// When the line is written in two chunks that split the secret
+		if _, err := sw.Write([]byte("value is s3")); err != nil {
+			t.Fatalf("unexpected write error: %v", err)
+		}
+		if _, err := sw.Write([]byte("cr3t here\n")); err != nil {
+			t.Fatalf("unexpected write error: %v", err)
+		}
+
+		// Then the secret is still masked once the full line is assembled
+		if strings.Contains(sink.String(), "s3cr3t") {
+			t.Errorf("Expected registered secret masked, got %q", sink.String())
+		}
+	})
+
 	t.Run("AppliesRegisteredSecretDenylist", func(t *testing.T) {
 		// Given a writer with a registered secret
 		sw, sink := setup("s3cr3t")
@@ -179,20 +74,24 @@ func TestScrubbingWriter_Write(t *testing.T) {
 		}
 	})
 
-	t.Run("ReportsFullInputConsumed", func(t *testing.T) {
-		// Given a writer whose redaction shortens the content
-		sw, _ := setup()
-		input := []byte(`key: ` + strings.Repeat("A", 60) + "\n")
+	t.Run("ReportsFullInputConsumedEvenWhenMaskingChangesLength", func(t *testing.T) {
+		// Given a writer with a registered secret shorter than its mask
+		sw, sink := setup("hi")
+		input := []byte("value is hi here\n")
 
 		// When the input is written
 		n, err := sw.Write(input)
 
-		// Then the writer reports the full input length consumed despite masking
+		// Then the writer reports the full input length consumed even though the masked
+		// output written to the sink is a different length
 		if err != nil {
 			t.Fatalf("unexpected write error: %v", err)
 		}
 		if n != len(input) {
 			t.Errorf("Expected %d bytes consumed, got %d", len(input), n)
+		}
+		if sink.Len() == len(input) {
+			t.Errorf("expected masked output length to differ from input length, got equal %q", sink.String())
 		}
 	})
 }

--- a/pkg/runtime/shell/shell.go
+++ b/pkg/runtime/shell/shell.go
@@ -184,8 +184,8 @@ func (s *DefaultShell) Exec(command string, args ...string) (string, error) {
 
 	scrubbingStdoutWriter := &scrubbingWriter{writer: os.Stdout, scrubFunc: s.scrubString}
 	scrubbingStderrWriter := &scrubbingWriter{writer: os.Stderr, scrubFunc: s.scrubString}
-	defer scrubbingStdoutWriter.Flush()
-	defer scrubbingStderrWriter.Flush()
+	defer func() { _ = scrubbingStdoutWriter.Flush() }()
+	defer func() { _ = scrubbingStderrWriter.Flush() }()
 
 	cmd.Stdout = io.MultiWriter(scrubbingStdoutWriter, &stdoutBuf)
 	cmd.Stderr = io.MultiWriter(scrubbingStderrWriter, &stderrBuf)
@@ -244,8 +244,8 @@ func (s *DefaultShell) ExecSilentWithEnv(command string, env map[string]string, 
 	if s.verbose {
 		scrubbingStdoutWriter := &scrubbingWriter{writer: os.Stdout, scrubFunc: s.scrubString}
 		scrubbingStderrWriter := &scrubbingWriter{writer: os.Stderr, scrubFunc: s.scrubString}
-		defer scrubbingStdoutWriter.Flush()
-		defer scrubbingStderrWriter.Flush()
+		defer func() { _ = scrubbingStdoutWriter.Flush() }()
+		defer func() { _ = scrubbingStderrWriter.Flush() }()
 		cmd.Stdout = io.MultiWriter(scrubbingStdoutWriter, &stdoutBuf)
 		cmd.Stderr = io.MultiWriter(scrubbingStderrWriter, &stderrBuf)
 	} else {
@@ -390,8 +390,8 @@ func (s *DefaultShell) ExecProgressWithEnv(message string, command string, env m
 		var stdoutBuf, stderrBuf bytes.Buffer
 		scrubbingStdoutWriter := &scrubbingWriter{writer: os.Stdout, scrubFunc: s.scrubString}
 		scrubbingStderrWriter := &scrubbingWriter{writer: os.Stderr, scrubFunc: s.scrubString}
-		defer scrubbingStdoutWriter.Flush()
-		defer scrubbingStderrWriter.Flush()
+		defer func() { _ = scrubbingStdoutWriter.Flush() }()
+		defer func() { _ = scrubbingStderrWriter.Flush() }()
 		cmd.Stdout = io.MultiWriter(scrubbingStdoutWriter, &stdoutBuf)
 		cmd.Stderr = io.MultiWriter(scrubbingStderrWriter, &stderrBuf)
 		cmd.Env = mergeEnvVars(s.shims.Environ(), env)

--- a/pkg/runtime/shell/shell.go
+++ b/pkg/runtime/shell/shell.go
@@ -184,6 +184,8 @@ func (s *DefaultShell) Exec(command string, args ...string) (string, error) {
 
 	scrubbingStdoutWriter := &scrubbingWriter{writer: os.Stdout, scrubFunc: s.scrubString}
 	scrubbingStderrWriter := &scrubbingWriter{writer: os.Stderr, scrubFunc: s.scrubString}
+	defer scrubbingStdoutWriter.Flush()
+	defer scrubbingStderrWriter.Flush()
 
 	cmd.Stdout = io.MultiWriter(scrubbingStdoutWriter, &stdoutBuf)
 	cmd.Stderr = io.MultiWriter(scrubbingStderrWriter, &stderrBuf)
@@ -242,6 +244,8 @@ func (s *DefaultShell) ExecSilentWithEnv(command string, env map[string]string, 
 	if s.verbose {
 		scrubbingStdoutWriter := &scrubbingWriter{writer: os.Stdout, scrubFunc: s.scrubString}
 		scrubbingStderrWriter := &scrubbingWriter{writer: os.Stderr, scrubFunc: s.scrubString}
+		defer scrubbingStdoutWriter.Flush()
+		defer scrubbingStderrWriter.Flush()
 		cmd.Stdout = io.MultiWriter(scrubbingStdoutWriter, &stdoutBuf)
 		cmd.Stderr = io.MultiWriter(scrubbingStderrWriter, &stderrBuf)
 	} else {
@@ -386,6 +390,8 @@ func (s *DefaultShell) ExecProgressWithEnv(message string, command string, env m
 		var stdoutBuf, stderrBuf bytes.Buffer
 		scrubbingStdoutWriter := &scrubbingWriter{writer: os.Stdout, scrubFunc: s.scrubString}
 		scrubbingStderrWriter := &scrubbingWriter{writer: os.Stderr, scrubFunc: s.scrubString}
+		defer scrubbingStdoutWriter.Flush()
+		defer scrubbingStderrWriter.Flush()
 		cmd.Stdout = io.MultiWriter(scrubbingStdoutWriter, &stdoutBuf)
 		cmd.Stderr = io.MultiWriter(scrubbingStderrWriter, &stderrBuf)
 		cmd.Env = mergeEnvVars(s.shims.Environ(), env)

--- a/pkg/runtime/shell/shell_test.go
+++ b/pkg/runtime/shell/shell_test.go
@@ -4103,11 +4103,11 @@ func TestScrubbingWriter(t *testing.T) {
 		shell, buf := setup(t)
 		writer := &scrubbingWriter{writer: buf, scrubFunc: shell.scrubString}
 
-		// When writing content that contains registered secrets to the scrubbing writer
-		testContent := "This contains secret123 and other text"
+		// When writing a complete line that contains registered secrets to the scrubbing writer
+		testContent := "This contains secret123 and other text\n"
 		n, err := writer.Write([]byte(testContent))
 
-		// Then the secrets should be scrubbed from the output while maintaining byte count consistency
+		// Then the secret should be scrubbed from the emitted line
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)
 		}
@@ -4116,17 +4116,12 @@ func TestScrubbingWriter(t *testing.T) {
 		if strings.Contains(output, "secret123") {
 			t.Errorf("Expected secret to be scrubbed, but found in output: %s", output)
 		}
-		// Should replace with fixed ******** and pad to maintain length
 		if !strings.Contains(output, "********") {
 			t.Errorf("Expected scrubbed output to contain ********, got: %s", output)
 		}
-		// Byte counts should match due to padding
+		// The writer reports the full input consumed even though the emitted line is shorter
 		if n != len(testContent) {
 			t.Errorf("Expected bytes written to match content length %d, got %d", len(testContent), n)
-		}
-		// Output length should match input length due to padding
-		if len(output) != len(testContent) {
-			t.Errorf("Expected output length %d to match input length %d", len(output), len(testContent))
 		}
 	})
 
@@ -4136,11 +4131,11 @@ func TestScrubbingWriter(t *testing.T) {
 		shell.RegisterSecret("password456")
 		writer := &scrubbingWriter{writer: buf, scrubFunc: shell.scrubString}
 
-		// When writing content that contains multiple different secrets
-		testContent := "User secret123 has password456 for access"
+		// When writing a complete line that contains multiple different secrets
+		testContent := "User secret123 has password456 for access\n"
 		_, err := writer.Write([]byte(testContent))
 
-		// Then all secrets should be scrubbed while maintaining output length consistency
+		// Then all secrets should be scrubbed from the emitted line
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)
 		}
@@ -4149,13 +4144,8 @@ func TestScrubbingWriter(t *testing.T) {
 		if strings.Contains(output, "secret123") || strings.Contains(output, "password456") {
 			t.Errorf("Expected all secrets to be scrubbed, got: %s", output)
 		}
-		// Should contain fixed ******** replacements
 		if !strings.Contains(output, "********") {
 			t.Errorf("Expected scrubbed output to contain ********, got: %s", output)
-		}
-		// Output length should match input due to padding
-		if len(output) != len(testContent) {
-			t.Errorf("Expected output length %d to match input length %d", len(output), len(testContent))
 		}
 	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> The `scrubbingWriter` is shared infrastructure that processes every command's output, and the rewrite adds line-buffering as a new behavioral invariant that all call sites must accommodate via `Flush`.
>
> **Overview**
>
> The PR rewrites `scrubbingWriter` to buffer output by line and apply two redaction layers: structural pattern matching for PEM blocks, base64-encoded key/cert fields, and Talos bootstrap tokens; and the existing registered-secret denylist. `Flush` is now required after each command to drain any trailing partial line, and three call sites in `shell.go` add it via `defer`. Two `terraform plan` calls in `Up` and `Apply` are switched from `ExecSilentWithEnv` to `ExecCaptureWithEnv`, silencing their verbose-mode output entirely rather than streaming it through the scrubber.
>
> The line-buffering design cleanly solves the multi-write boundary problem, and the PEM state machine is correct for the common Terraform output shape. The most notable behavioral change — silent suppression of pre-flight plan output in verbose mode — is the main open question.
>
> Reviewed by Claude for commit `f7bc53fb`.

<!-- /claude-code-review:summary -->
