### PR TITLE
feat(provisioner/kubernetes): add context ownership labels to Kustomization objects

### DIFF
--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -850,8 +850,9 @@ func (k *BaseKubernetesManager) GetNodeReadyStatus(ctx context.Context, nodeName
 // It creates the target namespace, applies all blueprint source repositories (Git and OCI),
 // applies all individual sources, applies any standalone ConfigMaps, and finally applies
 // all kustomizations and their associated ConfigMaps. This orchestrates a complete
-// blueprint installation following the intended order. CommonMetadata labels are added to all
-// kustomizations for resource provenance tracking using context info from the config handler.
+// blueprint installation following the intended order. Context ownership labels are stamped on
+// each Kustomization's ObjectMeta (so the objects are selectable by context) and propagated to
+// managed resources via CommonMetadata, using context info from the config handler.
 // Returns an error if any step fails.
 func (k *BaseKubernetesManager) ApplyBlueprint(blueprint *blueprintv1alpha1.Blueprint, namespace string) error {
 	if err := k.CreateNamespace(namespace); err != nil {
@@ -907,11 +908,9 @@ func (k *BaseKubernetesManager) ApplyBlueprint(blueprint *blueprintv1alpha1.Blue
 		}
 		fluxKustomization := kustomization.ToFluxKustomization(namespace, defaultSourceName, blueprint.Sources, mode, blueprint.ConfigMaps)
 
+		fluxKustomization.Labels = k.ownershipLabels()
 		fluxKustomization.Spec.CommonMetadata = &kustomizev1.CommonMetadata{
-			Labels: map[string]string{
-				"windsorcli.dev/context":    k.configHandler.GetContext(),
-				"windsorcli.dev/context-id": k.configHandler.GetString("id"),
-			},
+			Labels: k.ownershipLabels(),
 		}
 
 		if err := k.ApplyKustomization(fluxKustomization); err != nil {
@@ -1036,11 +1035,9 @@ func (k *BaseKubernetesManager) processDestroyOnlyKustomizations(kustomizations 
 
 		fluxKustomization := kustomization.ToFluxKustomization(namespace, defaultSourceName, blueprint.Sources, mode, blueprint.ConfigMaps)
 
+		fluxKustomization.Labels = k.ownershipLabels()
 		fluxKustomization.Spec.CommonMetadata = &kustomizev1.CommonMetadata{
-			Labels: map[string]string{
-				"windsorcli.dev/context":    k.configHandler.GetContext(),
-				"windsorcli.dev/context-id": k.configHandler.GetString("id"),
-			},
+			Labels: k.ownershipLabels(),
 		}
 
 		filteredDependsOn := make([]kustomizev1.DependencyReference, 0)
@@ -1139,6 +1136,15 @@ waitLoop:
 // gitopsNamespace returns the configured gitops namespace, defaulting to DefaultGitopsNamespace.
 func (k *BaseKubernetesManager) gitopsNamespace() string {
 	return k.configHandler.GetString("gitops.namespace", constants.DefaultGitopsNamespace)
+}
+
+// ownershipLabels returns the Windsor context labels stamped on each Kustomization object (so the
+// objects are selectable by context) and propagated to its managed resources via CommonMetadata.
+func (k *BaseKubernetesManager) ownershipLabels() map[string]string {
+	return map[string]string{
+		"windsorcli.dev/context":    k.configHandler.GetContext(),
+		"windsorcli.dev/context-id": k.configHandler.GetString("id"),
+	}
 }
 
 // applyWithRetry applies a resource using SSA with minimal logic

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -4282,6 +4282,13 @@ func TestBaseKubernetesManager_DeleteBlueprint(t *testing.T) {
 		if contextIDLabel != "test-context-id" {
 			t.Errorf("Expected 'windsorcli.dev/context-id' label to be 'test-context-id', got '%s'", contextIDLabel)
 		}
+
+		if appliedKustomization.Labels["windsorcli.dev/context"] != "test-context" {
+			t.Errorf("Expected ObjectMeta 'windsorcli.dev/context' label 'test-context', got '%s'", appliedKustomization.Labels["windsorcli.dev/context"])
+		}
+		if appliedKustomization.Labels["windsorcli.dev/context-id"] != "test-context-id" {
+			t.Errorf("Expected ObjectMeta 'windsorcli.dev/context-id' label 'test-context-id', got '%s'", appliedKustomization.Labels["windsorcli.dev/context-id"])
+		}
 	})
 }
 
@@ -5215,6 +5222,46 @@ func TestBaseKubernetesManager_ApplyBlueprint(t *testing.T) {
 		}
 		if contextIDLabel != "test-context-id" {
 			t.Errorf("Expected 'windsorcli.dev/context-id' label to be 'test-context-id', got '%s'", contextIDLabel)
+		}
+	})
+
+	t.Run("RegularKustomizationHasObjectMetaOwnershipLabels", func(t *testing.T) {
+		// Given a manager applying a blueprint with one kustomization
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+
+		var appliedKustomization kustomizev1.Kustomization
+		kubernetesClient.ApplyResourceFunc = func(gvr schema.GroupVersionResource, obj *unstructured.Unstructured, opts metav1.ApplyOptions) (*unstructured.Unstructured, error) {
+			if gvr.Resource == "kustomizations" {
+				if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &appliedKustomization); err != nil {
+					t.Fatalf("Failed to convert kustomization: %v", err)
+				}
+			}
+			return obj, nil
+		}
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			return nil, fmt.Errorf("not found")
+		}
+		manager.client = kubernetesClient
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Metadata: blueprintv1alpha1.Metadata{Name: "test-blueprint"},
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "test-kustomization", Path: "test/path"},
+			},
+		}
+
+		// When the blueprint is applied
+		if err := manager.ApplyBlueprint(blueprint, "test-namespace"); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the Kustomization object itself carries the context ownership labels (selectable by context)
+		if appliedKustomization.Labels["windsorcli.dev/context"] != "test-context" {
+			t.Errorf("Expected ObjectMeta 'windsorcli.dev/context' label 'test-context', got '%s'", appliedKustomization.Labels["windsorcli.dev/context"])
+		}
+		if appliedKustomization.Labels["windsorcli.dev/context-id"] != "test-context-id" {
+			t.Errorf("Expected ObjectMeta 'windsorcli.dev/context-id' label 'test-context-id', got '%s'", appliedKustomization.Labels["windsorcli.dev/context-id"])
 		}
 	})
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This change adds context ownership labels to Kustomization objects themselves, enabling label-based selection in the cluster while continuing to propagate those labels to managed resources via CommonMetadata — an additive, backward-compatible behavior change.
>
> **Overview**
>
> The PR extracts a repeated inline map literal into a private `ownershipLabels()` helper that returns the Windsor context labels (`windsorcli.dev/context` and `windsorcli.dev/context-id`). Those labels are now stamped on both the Kustomization object's own `ObjectMeta.Labels` and its `Spec.CommonMetadata.Labels`, making the Kustomization itself selectable by context (e.g., `kubectl get kustomizations -l windsorcli.dev/context=<name>`) while preserving the existing label propagation to managed resources.
>
> The refactor touches two code paths (`ApplyBlueprint` and `processDestroyOnlyKustomizations`) and adds tests for both. `ToFluxKustomization` sets no ObjectMeta labels, so the direct assignment introduces no overwrite risk. No correctness or security concerns were identified.
>
> Reviewed by Claude for commit `478ee9e2`.

<!-- /claude-code-review:summary -->
