### PR TITLE
feat(provisioner): implement version marker management for blueprints

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -478,6 +478,6 @@ jobs:
             description. Be fast.
           claude_args: |
             --model claude-sonnet-4-6
-            --max-turns 15
+            --max-turns 40
             --allowedTools Read,Bash(gh:*),Bash(cat:*),Bash(jq:*)
             --disallowedTools WebSearch,WebFetch

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -232,6 +232,10 @@ windsor bootstrap prod --yes`,
 			if err := proj.Provisioner.Wait(cmd.Context(), blueprint); err != nil {
 				return fmt.Errorf("error waiting for kustomizations: %w", err)
 			}
+
+			if err := proj.Provisioner.WriteVersionMarker(blueprint); err != nil {
+				return fmt.Errorf("error writing version marker: %w", err)
+			}
 			return nil
 		}); err != nil {
 			return err

--- a/cmd/bootstrap_test.go
+++ b/cmd/bootstrap_test.go
@@ -200,6 +200,33 @@ func TestBootstrapCmd(t *testing.T) {
 		}
 	})
 
+	t.Run("WritesVersionMarkerAfterInstall", func(t *testing.T) {
+		// Given a successful bootstrap
+		mocks := setupBootstrapTest(t)
+		proj := newBootstrapTestProject(mocks)
+
+		markerWritten := false
+		mocks.KubernetesManager.ApplyVersionMarkerFunc = func(namespace string, marker kubernetes.VersionMarker) error {
+			markerWritten = true
+			return nil
+		}
+
+		cmd := createTestBootstrapCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--yes"})
+		cmd.SetContext(ctx)
+
+		// When executing bootstrap
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Expected success, got %v", err)
+		}
+
+		// Then the applied-version marker is written for the context
+		if !markerWritten {
+			t.Error("Expected the version marker to be written on successful bootstrap")
+		}
+	})
+
 	t.Run("HaltedBootstrapSkipsBlueprintInstallAndSuccessLine", func(t *testing.T) {
 		// Given a terraform stack that halts after a component (the apply hook needed host
 		// configuration the operator hasn't done yet)

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -53,6 +53,7 @@ type KubernetesManager interface {
 	GetNodeReadyStatus(ctx context.Context, nodeNames []string) (map[string]bool, error)
 	ApplyBlueprint(blueprint *blueprintv1alpha1.Blueprint, namespace string) error
 	DeleteBlueprint(blueprint *blueprintv1alpha1.Blueprint, namespace string) error
+	ApplyVersionMarker(namespace string, marker VersionMarker) error
 }
 
 // InventoryEntry identifies one resource Flux is tracking for a Kustomization,
@@ -486,6 +487,17 @@ func (k *BaseKubernetesManager) ApplyConfigMap(name, namespace string, data map[
 	}
 
 	return k.applyWithRetry(gvr, obj, opts)
+}
+
+// ApplyVersionMarker writes the applied-version marker ConfigMap to the namespace, recording which
+// blueprint version the context is running. The marker is stored as JSON in a single ConfigMap so
+// its encoding can evolve without churning Kustomization labels.
+func (k *BaseKubernetesManager) ApplyVersionMarker(namespace string, marker VersionMarker) error {
+	data, err := marker.ToConfigMapData()
+	if err != nil {
+		return fmt.Errorf("failed to encode version marker: %w", err)
+	}
+	return k.ApplyConfigMap(VersionMarkerConfigMapName, namespace, data)
 }
 
 // GetHelmReleasesForKustomization gets HelmReleases associated with a Kustomization

--- a/pkg/provisioner/kubernetes/mock_kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/mock_kubernetes_manager.go
@@ -26,6 +26,7 @@ type MockKubernetesManager struct {
 	CreateNamespaceFunc                 func(name string) error
 	DeleteNamespaceFunc                 func(name string) error
 	ApplyConfigMapFunc                  func(name, namespace string, data map[string]string) error
+	ApplyVersionMarkerFunc              func(namespace string, marker VersionMarker) error
 	GetHelmReleasesForKustomizationFunc func(name, namespace string) ([]helmv2.HelmRelease, error)
 	ApplyGitRepositoryFunc              func(repo *sourcev1.GitRepository) error
 	ApplyOCIRepositoryFunc              func(repo *sourcev1.OCIRepository) error
@@ -103,6 +104,14 @@ func (m *MockKubernetesManager) DeleteNamespace(name string) error {
 func (m *MockKubernetesManager) ApplyConfigMap(name, namespace string, data map[string]string) error {
 	if m.ApplyConfigMapFunc != nil {
 		return m.ApplyConfigMapFunc(name, namespace, data)
+	}
+	return nil
+}
+
+// ApplyVersionMarker implements KubernetesManager interface
+func (m *MockKubernetesManager) ApplyVersionMarker(namespace string, marker VersionMarker) error {
+	if m.ApplyVersionMarkerFunc != nil {
+		return m.ApplyVersionMarkerFunc(namespace, marker)
 	}
 	return nil
 }

--- a/pkg/provisioner/kubernetes/version_marker.go
+++ b/pkg/provisioner/kubernetes/version_marker.go
@@ -1,0 +1,124 @@
+// Package kubernetes provides Kubernetes resource management functionality.
+// This file defines the applied-version marker: the authoritative record of which
+// blueprint version a context is currently running, stored as a ConfigMap in the
+// gitops namespace. bootstrap and upgrade write it; apply and plan only read it.
+
+package kubernetes
+
+import (
+	"encoding/json"
+
+	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+)
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const (
+	// VersionMarkerConfigMapName is the ConfigMap, in the gitops namespace, that holds the marker.
+	VersionMarkerConfigMapName = "windsor-version-marker"
+
+	// versionMarkerDataKey is the ConfigMap data key the marker JSON is stored under.
+	versionMarkerDataKey = "marker"
+
+	// versionMarkerSchemaVersion is the current marker encoding version.
+	versionMarkerSchemaVersion = 1
+
+	// VersionMarkerPhaseIdle marks a context with no upgrade in flight.
+	VersionMarkerPhaseIdle = "idle"
+)
+
+// =============================================================================
+// Types
+// =============================================================================
+
+// SourceRef records one blueprint source as applied: its URL and resolved human reference
+// (tag/branch/semver/commit). The resolved digest is recorded later, when the version gate
+// that consumes it is built.
+type SourceRef struct {
+	URL string `json:"url,omitempty"`
+	Ref string `json:"ref,omitempty"`
+}
+
+// VersionMarker is the authoritative record of the blueprint version a context is running.
+// Because a context can carry several independently-versioned sources, the "version" is the
+// set of source refs, not a single string. Phase tracks an in-flight upgrade (idle for a
+// settled context); the target source set is recorded by upgrade and is absent at bootstrap.
+type VersionMarker struct {
+	SchemaVersion  int                  `json:"schemaVersion"`
+	Phase          string               `json:"phase"`
+	AppliedSources map[string]SourceRef `json:"appliedSources,omitempty"`
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+// BuildVersionMarker captures a settled (idle) marker from the applied blueprint: the repository
+// source (keyed by the blueprint name) and every declared remote source, each with its resolved
+// reference. Local template sources are skipped — they track the working tree and have no version.
+func BuildVersionMarker(blueprint *blueprintv1alpha1.Blueprint) VersionMarker {
+	marker := VersionMarker{
+		SchemaVersion:  versionMarkerSchemaVersion,
+		Phase:          VersionMarkerPhaseIdle,
+		AppliedSources: map[string]SourceRef{},
+	}
+	if blueprint == nil {
+		return marker
+	}
+	if blueprint.Repository.Url != "" {
+		marker.AppliedSources[blueprint.Metadata.Name] = SourceRef{
+			URL: blueprint.Repository.Url,
+			Ref: effectiveRef(blueprint.Repository.Ref),
+		}
+	}
+	for _, source := range blueprint.Sources {
+		if blueprintv1alpha1.IsLocalTemplateSource(source) {
+			continue
+		}
+		marker.AppliedSources[source.Name] = SourceRef{
+			URL: source.Url,
+			Ref: effectiveRef(source.Ref),
+		}
+	}
+	return marker
+}
+
+// ToConfigMapData encodes the marker as ConfigMap data (a single JSON document).
+func (m VersionMarker) ToConfigMapData() (map[string]string, error) {
+	encoded, err := json.Marshal(m)
+	if err != nil {
+		return nil, err
+	}
+	return map[string]string{versionMarkerDataKey: string(encoded)}, nil
+}
+
+// ParseVersionMarker decodes a marker from ConfigMap data, reporting false when no marker is present.
+func ParseVersionMarker(data map[string]string) (VersionMarker, bool, error) {
+	raw, ok := data[versionMarkerDataKey]
+	if !ok {
+		return VersionMarker{}, false, nil
+	}
+	var marker VersionMarker
+	if err := json.Unmarshal([]byte(raw), &marker); err != nil {
+		return VersionMarker{}, false, err
+	}
+	return marker, true, nil
+}
+
+// effectiveRef resolves a reference in priority order Commit → SemVer → Tag → Branch, matching the
+// composer and terraform provisioner; it returns an empty string when none are set.
+func effectiveRef(ref blueprintv1alpha1.Reference) string {
+	switch {
+	case ref.Commit != "":
+		return ref.Commit
+	case ref.SemVer != "":
+		return ref.SemVer
+	case ref.Tag != "":
+		return ref.Tag
+	case ref.Branch != "":
+		return ref.Branch
+	}
+	return ""
+}

--- a/pkg/provisioner/kubernetes/version_marker.go
+++ b/pkg/provisioner/kubernetes/version_marker.go
@@ -118,6 +118,9 @@ func ParseVersionMarker(data map[string]string) (VersionMarker, bool, error) {
 	if err := json.Unmarshal([]byte(raw), &marker); err != nil {
 		return VersionMarker{}, false, err
 	}
+	if marker.SchemaVersion != versionMarkerSchemaVersion {
+		return VersionMarker{}, false, fmt.Errorf("unsupported version marker schema version %d (supported %d)", marker.SchemaVersion, versionMarkerSchemaVersion)
+	}
 	return marker, true, nil
 }
 

--- a/pkg/provisioner/kubernetes/version_marker.go
+++ b/pkg/provisioner/kubernetes/version_marker.go
@@ -7,6 +7,7 @@ package kubernetes
 
 import (
 	"encoding/json"
+	"fmt"
 
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 )
@@ -58,31 +59,44 @@ type VersionMarker struct {
 // BuildVersionMarker captures a settled (idle) marker from the applied blueprint: the repository
 // source (keyed by the blueprint name) and every declared remote source, each with its resolved
 // reference. Local template sources are skipped — they track the working tree and have no version.
-func BuildVersionMarker(blueprint *blueprintv1alpha1.Blueprint) VersionMarker {
+// It errors on a source-name collision (two sources sharing a name, or a source matching the
+// repository's blueprint name) rather than silently overwriting and misrepresenting what was applied.
+func BuildVersionMarker(blueprint *blueprintv1alpha1.Blueprint) (VersionMarker, error) {
 	marker := VersionMarker{
 		SchemaVersion:  versionMarkerSchemaVersion,
 		Phase:          VersionMarkerPhaseIdle,
 		AppliedSources: map[string]SourceRef{},
 	}
 	if blueprint == nil {
-		return marker
+		return marker, nil
+	}
+	addSource := func(name string, ref SourceRef) error {
+		if _, exists := marker.AppliedSources[name]; exists {
+			return fmt.Errorf("duplicate source name %q; cannot record an unambiguous version marker", name)
+		}
+		marker.AppliedSources[name] = ref
+		return nil
 	}
 	if blueprint.Repository.Url != "" {
-		marker.AppliedSources[blueprint.Metadata.Name] = SourceRef{
+		if err := addSource(blueprint.Metadata.Name, SourceRef{
 			URL: blueprint.Repository.Url,
 			Ref: effectiveRef(blueprint.Repository.Ref),
+		}); err != nil {
+			return VersionMarker{}, err
 		}
 	}
 	for _, source := range blueprint.Sources {
 		if blueprintv1alpha1.IsLocalTemplateSource(source) {
 			continue
 		}
-		marker.AppliedSources[source.Name] = SourceRef{
+		if err := addSource(source.Name, SourceRef{
 			URL: source.Url,
 			Ref: effectiveRef(source.Ref),
+		}); err != nil {
+			return VersionMarker{}, err
 		}
 	}
-	return marker
+	return marker, nil
 }
 
 // ToConfigMapData encodes the marker as ConfigMap data (a single JSON document).

--- a/pkg/provisioner/kubernetes/version_marker_test.go
+++ b/pkg/provisioner/kubernetes/version_marker_test.go
@@ -1,0 +1,188 @@
+package kubernetes
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+	"github.com/windsorcli/cli/pkg/provisioner/kubernetes/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestBuildVersionMarker(t *testing.T) {
+	t.Run("CapturesRepositoryAndRemoteSourcesWithResolvedRefs", func(t *testing.T) {
+		// Given a blueprint with a repository, a remote source, and a local template source
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Metadata:   blueprintv1alpha1.Metadata{Name: "local"},
+			Repository: blueprintv1alpha1.Repository{Url: "http://git.test/git/core", Ref: blueprintv1alpha1.Reference{Branch: "main"}},
+			Sources: []blueprintv1alpha1.Source{
+				{Name: "core", Url: "oci://ghcr.io/windsorcli/core:v0.6.0", Ref: blueprintv1alpha1.Reference{SemVer: "v0.6.0"}},
+				{Name: "template"},
+			},
+		}
+
+		// When the marker is built
+		marker := BuildVersionMarker(blueprint)
+
+		// Then it is idle, schema-versioned, and records the repository and remote source (not the local template)
+		if marker.Phase != VersionMarkerPhaseIdle {
+			t.Errorf("Expected phase %q, got %q", VersionMarkerPhaseIdle, marker.Phase)
+		}
+		if marker.SchemaVersion != versionMarkerSchemaVersion {
+			t.Errorf("Expected schema version %d, got %d", versionMarkerSchemaVersion, marker.SchemaVersion)
+		}
+		repo, ok := marker.AppliedSources["local"]
+		if !ok || repo.URL != "http://git.test/git/core" || repo.Ref != "main" {
+			t.Errorf("Expected repository source 'local' url+ref, got %+v (present=%v)", repo, ok)
+		}
+		core, ok := marker.AppliedSources["core"]
+		if !ok || core.Ref != "v0.6.0" {
+			t.Errorf("Expected source 'core' ref 'v0.6.0', got %+v (present=%v)", core, ok)
+		}
+		if _, ok := marker.AppliedSources["template"]; ok {
+			t.Error("Expected local template source to be skipped")
+		}
+	})
+
+	t.Run("ResolvesRefInCommitSemverTagBranchPriority", func(t *testing.T) {
+		// Given a source pinned by both a commit and a tag
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Metadata: blueprintv1alpha1.Metadata{Name: "bp"},
+			Sources: []blueprintv1alpha1.Source{
+				{Name: "s", Url: "oci://example/s", Ref: blueprintv1alpha1.Reference{Tag: "v1", Commit: "abc123"}},
+			},
+		}
+
+		// When the marker is built
+		marker := BuildVersionMarker(blueprint)
+
+		// Then the commit wins over the tag
+		if marker.AppliedSources["s"].Ref != "abc123" {
+			t.Errorf("Expected ref 'abc123' (commit priority), got %q", marker.AppliedSources["s"].Ref)
+		}
+	})
+
+	t.Run("NilBlueprintYieldsIdleMarkerWithNoSources", func(t *testing.T) {
+		// When the marker is built from a nil blueprint
+		marker := BuildVersionMarker(nil)
+
+		// Then it is idle with an empty source set
+		if marker.Phase != VersionMarkerPhaseIdle {
+			t.Errorf("Expected idle phase, got %q", marker.Phase)
+		}
+		if len(marker.AppliedSources) != 0 {
+			t.Errorf("Expected no sources, got %d", len(marker.AppliedSources))
+		}
+	})
+}
+
+func TestVersionMarker_ConfigMapRoundTrip(t *testing.T) {
+	t.Run("EncodesAndDecodesToTheSameMarker", func(t *testing.T) {
+		// Given a marker
+		original := VersionMarker{
+			SchemaVersion:  versionMarkerSchemaVersion,
+			Phase:          VersionMarkerPhaseIdle,
+			AppliedSources: map[string]SourceRef{"core": {URL: "oci://example/core", Ref: "v1.0.0"}},
+		}
+
+		// When it is encoded to ConfigMap data and parsed back
+		data, err := original.ToConfigMapData()
+		if err != nil {
+			t.Fatalf("Expected no encode error, got %v", err)
+		}
+		parsed, ok, err := ParseVersionMarker(data)
+		if err != nil {
+			t.Fatalf("Expected no parse error, got %v", err)
+		}
+
+		// Then the round-trip preserves the marker
+		if !ok {
+			t.Fatal("Expected marker to be present")
+		}
+		if parsed.Phase != original.Phase || parsed.AppliedSources["core"] != original.AppliedSources["core"] {
+			t.Errorf("Round-trip mismatch: got %+v, want %+v", parsed, original)
+		}
+	})
+
+	t.Run("ParseReportsAbsentWhenNoMarkerKey", func(t *testing.T) {
+		// When parsing ConfigMap data without the marker key
+		_, ok, err := ParseVersionMarker(map[string]string{"other": "value"})
+
+		// Then it reports absent without error
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok {
+			t.Error("Expected ok=false for data without a marker key")
+		}
+	})
+}
+
+func TestBaseKubernetesManager_ApplyVersionMarker(t *testing.T) {
+	setup := func(t *testing.T) *BaseKubernetesManager {
+		t.Helper()
+		mocks := setupKubernetesMocks(t)
+		manager := NewKubernetesManager(mocks.KubernetesClient, mocks.ConfigHandler)
+		manager.shims = mocks.Shims
+		manager.shims.ToUnstructured = func(obj any) (map[string]any, error) {
+			return runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+		}
+		manager.shims.FromUnstructured = func(obj map[string]any, target any) error {
+			return runtime.DefaultUnstructuredConverter.FromUnstructured(obj, target)
+		}
+		return manager
+	}
+
+	t.Run("WritesMarkerConfigMapWithEncodedMarker", func(t *testing.T) {
+		// Given a manager capturing applied ConfigMaps
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+
+		var appliedName, appliedNamespace string
+		var appliedData map[string]string
+		kubernetesClient.ApplyResourceFunc = func(gvr schema.GroupVersionResource, obj *unstructured.Unstructured, opts metav1.ApplyOptions) (*unstructured.Unstructured, error) {
+			if gvr.Resource == "configmaps" {
+				appliedName = obj.GetName()
+				appliedNamespace = obj.GetNamespace()
+				if d, ok := obj.Object["data"].(map[string]string); ok {
+					appliedData = d
+				}
+			}
+			return obj, nil
+		}
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			return nil, fmt.Errorf("not found")
+		}
+		manager.client = kubernetesClient
+
+		marker := VersionMarker{
+			SchemaVersion:  versionMarkerSchemaVersion,
+			Phase:          VersionMarkerPhaseIdle,
+			AppliedSources: map[string]SourceRef{"core": {URL: "oci://example/core", Ref: "v1.0.0"}},
+		}
+
+		// When the marker is applied
+		if err := manager.ApplyVersionMarker("system-gitops", marker); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the well-known marker ConfigMap is written with the encoded marker
+		if appliedName != VersionMarkerConfigMapName {
+			t.Errorf("Expected ConfigMap name %q, got %q", VersionMarkerConfigMapName, appliedName)
+		}
+		if appliedNamespace != "system-gitops" {
+			t.Errorf("Expected namespace 'system-gitops', got %q", appliedNamespace)
+		}
+		var decoded VersionMarker
+		if err := json.Unmarshal([]byte(appliedData[versionMarkerDataKey]), &decoded); err != nil {
+			t.Fatalf("Expected marker data to be valid JSON, got error %v", err)
+		}
+		if decoded.AppliedSources["core"].Ref != "v1.0.0" {
+			t.Errorf("Expected applied marker to record core ref 'v1.0.0', got %q", decoded.AppliedSources["core"].Ref)
+		}
+	})
+}

--- a/pkg/provisioner/kubernetes/version_marker_test.go
+++ b/pkg/provisioner/kubernetes/version_marker_test.go
@@ -148,6 +148,19 @@ func TestVersionMarker_ConfigMapRoundTrip(t *testing.T) {
 			t.Error("Expected ok=false for data without a marker key")
 		}
 	})
+
+	t.Run("RejectsUnknownSchemaVersion", func(t *testing.T) {
+		// Given ConfigMap data holding a marker written under a newer, unknown schema version
+		data := map[string]string{versionMarkerDataKey: `{"schemaVersion":999,"phase":"idle"}`}
+
+		// When parsing it
+		_, _, err := ParseVersionMarker(data)
+
+		// Then it errors rather than returning silently zero-valued fields from an unrecognized schema
+		if err == nil {
+			t.Error("Expected an error for an unsupported schema version")
+		}
+	})
 }
 
 func TestBaseKubernetesManager_ApplyVersionMarker(t *testing.T) {

--- a/pkg/provisioner/kubernetes/version_marker_test.go
+++ b/pkg/provisioner/kubernetes/version_marker_test.go
@@ -26,7 +26,10 @@ func TestBuildVersionMarker(t *testing.T) {
 		}
 
 		// When the marker is built
-		marker := BuildVersionMarker(blueprint)
+		marker, err := BuildVersionMarker(blueprint)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
 
 		// Then it is idle, schema-versioned, and records the repository and remote source (not the local template)
 		if marker.Phase != VersionMarkerPhaseIdle {
@@ -58,7 +61,10 @@ func TestBuildVersionMarker(t *testing.T) {
 		}
 
 		// When the marker is built
-		marker := BuildVersionMarker(blueprint)
+		marker, err := BuildVersionMarker(blueprint)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
 
 		// Then the commit wins over the tag
 		if marker.AppliedSources["s"].Ref != "abc123" {
@@ -66,9 +72,31 @@ func TestBuildVersionMarker(t *testing.T) {
 		}
 	})
 
+	t.Run("ErrorsOnDuplicateSourceName", func(t *testing.T) {
+		// Given a blueprint whose repository name collides with a declared source name
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Metadata:   blueprintv1alpha1.Metadata{Name: "core"},
+			Repository: blueprintv1alpha1.Repository{Url: "http://git.test/git/core", Ref: blueprintv1alpha1.Reference{Branch: "main"}},
+			Sources: []blueprintv1alpha1.Source{
+				{Name: "core", Url: "oci://ghcr.io/windsorcli/core:v0.6.0", Ref: blueprintv1alpha1.Reference{SemVer: "v0.6.0"}},
+			},
+		}
+
+		// When the marker is built
+		_, err := BuildVersionMarker(blueprint)
+
+		// Then it errors rather than silently overwriting the colliding entry
+		if err == nil {
+			t.Error("Expected an error on a duplicate source name")
+		}
+	})
+
 	t.Run("NilBlueprintYieldsIdleMarkerWithNoSources", func(t *testing.T) {
 		// When the marker is built from a nil blueprint
-		marker := BuildVersionMarker(nil)
+		marker, err := BuildVersionMarker(nil)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
 
 		// Then it is idle with an empty source set
 		if marker.Phase != VersionMarkerPhaseIdle {

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -946,6 +946,27 @@ func (i *Provisioner) Wait(ctx context.Context, blueprint *blueprintv1alpha1.Blu
 	return nil
 }
 
+// WriteVersionMarker records the blueprint version applied to this context as a marker ConfigMap
+// in the gitops namespace, capturing the resolved reference of each applied source. Only bootstrap
+// and upgrade write the marker; apply and plan only read it, so the marker stays an authoritative
+// record of what was deliberately rolled out rather than drifting with every reconcile.
+func (i *Provisioner) WriteVersionMarker(blueprint *blueprintv1alpha1.Blueprint) error {
+	if blueprint == nil {
+		return fmt.Errorf("blueprint not provided")
+	}
+
+	if i.KubernetesManager == nil {
+		return fmt.Errorf("kubernetes manager not configured")
+	}
+
+	marker := kubernetes.BuildVersionMarker(blueprint)
+	if err := i.KubernetesManager.ApplyVersionMarker(i.fluxNamespace(), marker); err != nil {
+		return fmt.Errorf("failed to write version marker: %w", err)
+	}
+
+	return nil
+}
+
 // Uninstall orchestrates the high-level kustomization teardown process from the blueprint.
 // It initializes the kubernetes manager and deletes all blueprint kustomizations, including the
 // synthesized CRD layer (withCrdLayer) so its Flux Kustomization objects are removed symmetrically

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -959,7 +959,10 @@ func (i *Provisioner) WriteVersionMarker(blueprint *blueprintv1alpha1.Blueprint)
 		return fmt.Errorf("kubernetes manager not configured")
 	}
 
-	marker := kubernetes.BuildVersionMarker(blueprint)
+	marker, err := kubernetes.BuildVersionMarker(blueprint)
+	if err != nil {
+		return fmt.Errorf("failed to build version marker: %w", err)
+	}
 	if err := i.KubernetesManager.ApplyVersionMarker(i.fluxNamespace(), marker); err != nil {
 		return fmt.Errorf("failed to write version marker: %w", err)
 	}

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -1222,6 +1222,52 @@ func TestProvisioner_ApplyKustomizeAll(t *testing.T) {
 	})
 }
 
+func TestProvisioner_WriteVersionMarker(t *testing.T) {
+	t.Run("WritesMarkerToGitopsNamespaceFromBlueprintSources", func(t *testing.T) {
+		// Given a provisioner capturing the version marker write
+		mocks := setupProvisionerMocks(t)
+		var capturedNamespace string
+		var capturedMarker kubernetes.VersionMarker
+		mocks.KubernetesManager.ApplyVersionMarkerFunc = func(namespace string, marker kubernetes.VersionMarker) error {
+			capturedNamespace = namespace
+			capturedMarker = marker
+			return nil
+		}
+		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
+
+		// When writing the marker for a blueprint with one remote source
+		if err := provisioner.WriteVersionMarker(createTestBlueprint()); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then it is written to the gitops namespace recording the source's resolved ref
+		if capturedNamespace != provisioner.fluxNamespace() {
+			t.Errorf("Expected namespace %q, got %q", provisioner.fluxNamespace(), capturedNamespace)
+		}
+		if capturedMarker.AppliedSources["source1"].Ref != "main" {
+			t.Errorf("Expected source1 ref 'main', got %q", capturedMarker.AppliedSources["source1"].Ref)
+		}
+	})
+
+	t.Run("NilBlueprintReturnsError", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+		if err := provisioner.WriteVersionMarker(nil); err == nil {
+			t.Error("Expected error for nil blueprint")
+		}
+	})
+
+	t.Run("NilManagerReturnsError", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+		provisioner.KubernetesManager = nil
+		if err := provisioner.WriteVersionMarker(createTestBlueprint()); err == nil {
+			t.Error("Expected error for nil kubernetes manager")
+		}
+	})
+}
+
 func TestProvisioner_Install(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> This PR introduces shared infrastructure (a new ConfigMap written on every bootstrap) and two forward-compatibility gaps in the marker's read path that will become correctness bugs when the schema evolves.
>
> **Overview**
>
> The PR adds a version marker — a ConfigMap named `windsor-version-marker` in the gitops namespace — that records which blueprint sources (repository + remote OCI sources) were applied during bootstrap. The marker captures source URLs and resolved refs (Commit > SemVer > Tag > Branch priority), serialized as a single JSON document. `WriteVersionMarker` is called in `cmd/bootstrap.go` immediately after a successful `Wait`, so a marker write failure surfaces as a bootstrap error rather than silently succeeding.
>
> Two correctness gaps in the new `version_marker.go` are worth addressing before the upgrade path consumes this marker. `ParseVersionMarker` does not validate `SchemaVersion` after unmarshaling, so a newer binary's marker is silently misread by old code. `BuildVersionMarker` silently overwrites a source entry if two blueprint sources share the same name, or if a source name collides with `blueprint.Metadata.Name`, producing a marker that misrepresents what was applied.
>
> Reviewed by Claude for commit `937987b`.

<!-- /claude-code-review:summary -->
