### PR TITLE
feat(provisioner): add Prune functionality to manage orphaned Kustomizations

### DIFF
--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -53,6 +53,7 @@ type KubernetesManager interface {
 	GetNodeReadyStatus(ctx context.Context, nodeNames []string) (map[string]bool, error)
 	ApplyBlueprint(blueprint *blueprintv1alpha1.Blueprint, namespace string) error
 	DeleteBlueprint(blueprint *blueprintv1alpha1.Blueprint, namespace string) error
+	PruneBlueprint(blueprint *blueprintv1alpha1.Blueprint, namespace string) error
 	ApplyVersionMarker(namespace string, marker VersionMarker) error
 }
 
@@ -1016,6 +1017,72 @@ func (k *BaseKubernetesManager) DeleteBlueprint(blueprint *blueprintv1alpha1.Blu
 	return nil
 }
 
+// PruneBlueprint deletes Kustomizations belonging to the current context that are no longer part of
+// the blueprint. It scopes strictly to this context — only objects carrying the
+// windsorcli.dev/context-id label for this context are considered, so kustomizations owned by other
+// contexts (or by no Windsor context) are never touched. Every non-DestroyOnly kustomization in the
+// blueprint is treated as desired; the live remainder is deleted in reverse-dependency order (read
+// from each object's live spec.dependsOn) so dependents tear down before their dependencies, each
+// honoring its own deletionPolicy. The caller passes the same prepared blueprint Install applied
+// (CRD layers included) so the synthesized crds/crds-<source> layers are recognized as desired and
+// not pruned. Deletion errors are collected and joined rather than aborting on the first.
+func (k *BaseKubernetesManager) PruneBlueprint(blueprint *blueprintv1alpha1.Blueprint, namespace string) error {
+	if blueprint == nil {
+		return fmt.Errorf("blueprint not provided")
+	}
+
+	contextID := k.configHandler.GetString("id")
+	if contextID == "" {
+		return fmt.Errorf("context id not set; cannot scope pruning to this context")
+	}
+
+	desired := make(map[string]bool, len(blueprint.Kustomizations))
+	for _, kustomization := range blueprint.Kustomizations {
+		if kustomization.DestroyOnly != nil && *kustomization.DestroyOnly {
+			continue
+		}
+		desired[kustomization.Name] = true
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    "kustomize.toolkit.fluxcd.io",
+		Version:  "v1",
+		Resource: "kustomizations",
+	}
+	list, err := k.client.ListResources(gvr, namespace)
+	if err != nil {
+		return fmt.Errorf("failed to list kustomizations for pruning: %w", err)
+	}
+
+	orphans := make([]blueprintv1alpha1.Kustomization, 0)
+	for i := range list.Items {
+		item := list.Items[i]
+		if item.GetLabels()["windsorcli.dev/context-id"] != contextID {
+			continue
+		}
+		name := item.GetName()
+		if desired[name] {
+			continue
+		}
+		orphans = append(orphans, blueprintv1alpha1.Kustomization{
+			Name:      name,
+			DependsOn: dependsOnFromObject(item),
+		})
+	}
+
+	if len(orphans) == 0 {
+		return nil
+	}
+
+	var errs []error
+	for _, orphan := range orderForDestroy(orphans, "prune") {
+		if err := k.DeleteKustomization(orphan.Name, namespace); err != nil {
+			errs = append(errs, fmt.Errorf("failed to prune kustomization %q: %w", orphan.Name, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
 // processDestroyOnlyKustomizations applies all destroy-only kustomizations, waits for all to become ready, then deletes all.
 // This approach ensures dependencies remain available while Flux reconciles dependent kustomizations.
 // Returns a slice of errors encountered during the process, which may be empty if no errors occurred.
@@ -1586,6 +1653,26 @@ func isNotFoundError(err error) bool {
 		strings.Contains(errMsg, "the server could not find the requested resource") ||
 		strings.Contains(errMsg, "\" not found")) &&
 		!strings.Contains(errMsg, "namespace not found")
+}
+
+// dependsOnFromObject extracts the dependency names from a live Kustomization's spec.dependsOn,
+// used to order pruned kustomizations so dependents are deleted before their dependencies.
+func dependsOnFromObject(obj unstructured.Unstructured) []string {
+	raw, found, err := unstructured.NestedSlice(obj.Object, "spec", "dependsOn")
+	if err != nil || !found {
+		return nil
+	}
+	deps := make([]string, 0, len(raw))
+	for _, entry := range raw {
+		entryMap, ok := entry.(map[string]any)
+		if !ok {
+			continue
+		}
+		if name, ok := entryMap["name"].(string); ok && name != "" {
+			deps = append(deps, name)
+		}
+	}
+	return deps
 }
 
 // orderForDestroy returns the input slice ordered for destroy: reverse-topological

--- a/pkg/provisioner/kubernetes/kustomization_prune_test.go
+++ b/pkg/provisioner/kubernetes/kustomization_prune_test.go
@@ -1,0 +1,160 @@
+package kubernetes
+
+import (
+	"fmt"
+	"testing"
+
+	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+	"github.com/windsorcli/cli/pkg/provisioner/kubernetes/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+func TestBaseKubernetesManager_PruneBlueprint(t *testing.T) {
+	setup := func(t *testing.T) *BaseKubernetesManager {
+		t.Helper()
+		mocks := setupKubernetesMocks(t)
+		manager := NewKubernetesManager(mocks.KubernetesClient, mocks.ConfigHandler)
+		manager.shims = mocks.Shims
+		manager.shims.ToUnstructured = func(obj any) (map[string]any, error) {
+			return runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+		}
+		manager.shims.FromUnstructured = func(obj map[string]any, target any) error {
+			return runtime.DefaultUnstructuredConverter.FromUnstructured(obj, target)
+		}
+		return manager
+	}
+
+	// kustomizationObj builds a live Kustomization list item with the given context-id label and dependsOn names.
+	kustomizationObj := func(name, contextID string, dependsOn ...string) unstructured.Unstructured {
+		spec := map[string]any{}
+		if len(dependsOn) > 0 {
+			deps := make([]any, 0, len(dependsOn))
+			for _, d := range dependsOn {
+				deps = append(deps, map[string]any{"name": d})
+			}
+			spec["dependsOn"] = deps
+		}
+		metadata := map[string]any{"name": name, "namespace": "system-gitops"}
+		if contextID != "" {
+			metadata["labels"] = map[string]any{"windsorcli.dev/context-id": contextID}
+		}
+		return unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+			"kind":       "Kustomization",
+			"metadata":   metadata,
+			"spec":       spec,
+		}}
+	}
+
+	// wire makes the manager list the given items and capture deletions in order; GetResource returns
+	// not-found so DeleteKustomization's termination wait completes immediately.
+	wire := func(manager *BaseKubernetesManager, items ...unstructured.Unstructured) *[]string {
+		deleted := []string{}
+		c := client.NewMockKubernetesClient()
+		c.ListResourcesFunc = func(gvr schema.GroupVersionResource, ns string) (*unstructured.UnstructuredList, error) {
+			return &unstructured.UnstructuredList{Items: items}, nil
+		}
+		c.DeleteResourceFunc = func(gvr schema.GroupVersionResource, ns, name string, opts metav1.DeleteOptions) error {
+			deleted = append(deleted, name)
+			return nil
+		}
+		c.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			return nil, fmt.Errorf("the server could not find the requested resource")
+		}
+		manager.client = c
+		return &deleted
+	}
+
+	t.Run("PrunesOrphansAndKeepsDesired", func(t *testing.T) {
+		// Given a context with a desired kustomization and an orphan, both owned by this context
+		manager := setup(t)
+		deleted := wire(manager,
+			kustomizationObj("app", "test-context-id"),
+			kustomizationObj("old-thing", "test-context-id"),
+		)
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "app"}},
+		}
+
+		// When pruning
+		if err := manager.PruneBlueprint(blueprint, "system-gitops"); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then only the orphan is deleted; the desired kustomization is kept
+		if len(*deleted) != 1 || (*deleted)[0] != "old-thing" {
+			t.Errorf("Expected only 'old-thing' pruned, got %v", *deleted)
+		}
+	})
+
+	t.Run("IgnoresOtherContextsAndUnlabeledKustomizations", func(t *testing.T) {
+		// Given orphan-shaped kustomizations owned by another context and by no context
+		manager := setup(t)
+		deleted := wire(manager,
+			kustomizationObj("other-orphan", "different-context-id"),
+			kustomizationObj("unmanaged", ""),
+		)
+		blueprint := &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{}}
+
+		// When pruning
+		if err := manager.PruneBlueprint(blueprint, "system-gitops"); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then nothing is deleted — pruning is scoped to this context's labeled objects
+		if len(*deleted) != 0 {
+			t.Errorf("Expected no deletions, got %v", *deleted)
+		}
+	})
+
+	t.Run("DeletesOrphansInReverseDependencyOrder", func(t *testing.T) {
+		// Given two orphans where 'leaf' dependsOn 'base'
+		manager := setup(t)
+		deleted := wire(manager,
+			kustomizationObj("base", "test-context-id"),
+			kustomizationObj("leaf", "test-context-id", "base"),
+		)
+		blueprint := &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{}}
+
+		// When pruning
+		if err := manager.PruneBlueprint(blueprint, "system-gitops"); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the dependent is deleted before its dependency
+		if len(*deleted) != 2 || (*deleted)[0] != "leaf" || (*deleted)[1] != "base" {
+			t.Errorf("Expected delete order [leaf base], got %v", *deleted)
+		}
+	})
+
+	t.Run("DestroyOnlyKustomizationsAreNotDesired", func(t *testing.T) {
+		// Given a live kustomization whose blueprint entry is DestroyOnly (never applied by Install)
+		manager := setup(t)
+		destroyOnly := true
+		deleted := wire(manager, kustomizationObj("backup", "test-context-id"))
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "backup", DestroyOnly: &destroyOnly}},
+		}
+
+		// When pruning
+		if err := manager.PruneBlueprint(blueprint, "system-gitops"); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then it is treated as an orphan and pruned (it is not part of the applied set)
+		if len(*deleted) != 1 || (*deleted)[0] != "backup" {
+			t.Errorf("Expected 'backup' pruned, got %v", *deleted)
+		}
+	})
+
+	t.Run("NilBlueprintReturnsError", func(t *testing.T) {
+		manager := setup(t)
+		wire(manager)
+		if err := manager.PruneBlueprint(nil, "system-gitops"); err == nil {
+			t.Error("Expected error for nil blueprint")
+		}
+	})
+}

--- a/pkg/provisioner/kubernetes/kustomization_prune_test.go
+++ b/pkg/provisioner/kubernetes/kustomization_prune_test.go
@@ -6,6 +6,7 @@ import (
 
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/provisioner/kubernetes/client"
+	"github.com/windsorcli/cli/pkg/runtime/config"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -155,6 +156,41 @@ func TestBaseKubernetesManager_PruneBlueprint(t *testing.T) {
 		wire(manager)
 		if err := manager.PruneBlueprint(nil, "system-gitops"); err == nil {
 			t.Error("Expected error for nil blueprint")
+		}
+	})
+
+	t.Run("EmptyContextIDReturnsError", func(t *testing.T) {
+		// Given a manager whose config handler reports no context id
+		mocks := setupKubernetesMocks(t, func(m *KubernetesTestMocks) {
+			m.ConfigHandler.(*config.MockConfigHandler).GetStringFunc = func(key string, defaultValue ...string) string {
+				if len(defaultValue) > 0 {
+					return defaultValue[0]
+				}
+				return ""
+			}
+		})
+		manager := NewKubernetesManager(mocks.KubernetesClient, mocks.ConfigHandler)
+		blueprint := &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{}}
+
+		// When pruning without a context id, the guard rejects it before listing anything
+		if err := manager.PruneBlueprint(blueprint, "system-gitops"); err == nil {
+			t.Error("Expected error when context id is not set")
+		}
+	})
+
+	t.Run("ListResourcesErrorIsPropagated", func(t *testing.T) {
+		// Given a client whose kustomization list fails
+		manager := setup(t)
+		c := client.NewMockKubernetesClient()
+		c.ListResourcesFunc = func(gvr schema.GroupVersionResource, ns string) (*unstructured.UnstructuredList, error) {
+			return nil, fmt.Errorf("api server unreachable")
+		}
+		manager.client = c
+		blueprint := &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{}}
+
+		// When pruning, the list failure is surfaced rather than swallowed
+		if err := manager.PruneBlueprint(blueprint, "system-gitops"); err == nil {
+			t.Error("Expected error when listing kustomizations fails")
 		}
 	})
 }

--- a/pkg/provisioner/kubernetes/mock_kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/mock_kubernetes_manager.go
@@ -37,6 +37,7 @@ type MockKubernetesManager struct {
 	GetNodeReadyStatusFunc              func(ctx context.Context, nodeNames []string) (map[string]bool, error)
 	ApplyBlueprintFunc                  func(blueprint *blueprintv1alpha1.Blueprint, namespace string) error
 	DeleteBlueprintFunc                 func(blueprint *blueprintv1alpha1.Blueprint, namespace string) error
+	PruneBlueprintFunc                  func(blueprint *blueprintv1alpha1.Blueprint, namespace string) error
 }
 
 // =============================================================================
@@ -194,6 +195,14 @@ func (m *MockKubernetesManager) ApplyBlueprint(blueprint *blueprintv1alpha1.Blue
 func (m *MockKubernetesManager) DeleteBlueprint(blueprint *blueprintv1alpha1.Blueprint, namespace string) error {
 	if m.DeleteBlueprintFunc != nil {
 		return m.DeleteBlueprintFunc(blueprint, namespace)
+	}
+	return nil
+}
+
+// PruneBlueprint implements KubernetesManager interface
+func (m *MockKubernetesManager) PruneBlueprint(blueprint *blueprintv1alpha1.Blueprint, namespace string) error {
+	if m.PruneBlueprintFunc != nil {
+		return m.PruneBlueprintFunc(blueprint, namespace)
 	}
 	return nil
 }

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -970,6 +970,28 @@ func (i *Provisioner) WriteVersionMarker(blueprint *blueprintv1alpha1.Blueprint)
 	return nil
 }
 
+// Prune removes Kustomizations belonging to this context that are no longer present in the
+// blueprint, leaving every still-declared kustomization (platform and user) and any other
+// context's kustomizations untouched. It prepares the blueprint with the synthesized CRD layers —
+// matching what Install applied — so those layers are recognized as desired and not pruned.
+func (i *Provisioner) Prune(blueprint *blueprintv1alpha1.Blueprint) error {
+	if blueprint == nil {
+		return fmt.Errorf("blueprint not provided")
+	}
+
+	if i.KubernetesManager == nil {
+		return fmt.Errorf("kubernetes manager not configured")
+	}
+
+	blueprint = withCrdLayer(blueprint)
+
+	if err := i.KubernetesManager.PruneBlueprint(blueprint, i.fluxNamespace()); err != nil {
+		return fmt.Errorf("failed to prune blueprint: %w", err)
+	}
+
+	return nil
+}
+
 // Uninstall orchestrates the high-level kustomization teardown process from the blueprint.
 // It initializes the kubernetes manager and deletes all blueprint kustomizations, including the
 // synthesized CRD layer (withCrdLayer) so its Flux Kustomization objects are removed symmetrically

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -1282,8 +1282,12 @@ func TestProvisioner_Prune(t *testing.T) {
 		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
+		// And a blueprint that vendors CRDs, so Prune must synthesize the CRD layer
+		blueprint := createTestBlueprint()
+		blueprint.Crds = []string{"example.com_widgets"}
+
 		// When pruning
-		if err := provisioner.Prune(createTestBlueprint()); err != nil {
+		if err := provisioner.Prune(blueprint); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
@@ -1291,8 +1295,23 @@ func TestProvisioner_Prune(t *testing.T) {
 		if capturedNamespace != provisioner.fluxNamespace() {
 			t.Errorf("Expected namespace %q, got %q", provisioner.fluxNamespace(), capturedNamespace)
 		}
+
+		// And the captured blueprint carries the synthesized CRD layer, proving withCrdLayer
+		// was applied so the CRD kustomizations stay in the desired set and are never pruned
 		if capturedBlueprint == nil {
-			t.Error("Expected a blueprint to be passed to the manager")
+			t.Fatal("Expected a blueprint to be passed to the manager")
+		}
+		crdName := blueprintv1alpha1.CrdKustomizationName("")
+		found := false
+		names := make([]string, 0, len(capturedBlueprint.Kustomizations))
+		for _, k := range capturedBlueprint.Kustomizations {
+			names = append(names, k.Name)
+			if k.Name == crdName {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("Expected synthesized CRD kustomization %q in pruned blueprint, got %v", crdName, names)
 		}
 	})
 

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -1268,6 +1268,52 @@ func TestProvisioner_WriteVersionMarker(t *testing.T) {
 	})
 }
 
+func TestProvisioner_Prune(t *testing.T) {
+	t.Run("DelegatesToManagerWithGitopsNamespace", func(t *testing.T) {
+		// Given a provisioner capturing the prune call
+		mocks := setupProvisionerMocks(t)
+		var capturedNamespace string
+		var capturedBlueprint *blueprintv1alpha1.Blueprint
+		mocks.KubernetesManager.PruneBlueprintFunc = func(blueprint *blueprintv1alpha1.Blueprint, namespace string) error {
+			capturedNamespace = namespace
+			capturedBlueprint = blueprint
+			return nil
+		}
+		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
+
+		// When pruning
+		if err := provisioner.Prune(createTestBlueprint()); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then it delegates to the manager against the gitops namespace
+		if capturedNamespace != provisioner.fluxNamespace() {
+			t.Errorf("Expected namespace %q, got %q", provisioner.fluxNamespace(), capturedNamespace)
+		}
+		if capturedBlueprint == nil {
+			t.Error("Expected a blueprint to be passed to the manager")
+		}
+	})
+
+	t.Run("NilBlueprintReturnsError", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+		if err := provisioner.Prune(nil); err == nil {
+			t.Error("Expected error for nil blueprint")
+		}
+	})
+
+	t.Run("NilManagerReturnsError", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+		provisioner.KubernetesManager = nil
+		if err := provisioner.Prune(createTestBlueprint()); err == nil {
+			t.Error("Expected error for nil kubernetes manager")
+		}
+	})
+}
+
 func TestProvisioner_Install(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> This PR introduces a new deletion operation — `Prune` — into the Kubernetes provisioner, guarded by a context-id label scope. The label scoping is a sound safety measure, but any defect in context-ID lookup or blueprint preparation could silently delete the wrong set of objects.
>
> **Overview**
>
> The PR adds `PruneBlueprint` to the `KubernetesManager` interface and a thin `Prune` wrapper to `Provisioner`. The implementation lists live Flux Kustomizations in the target namespace, filters to those carrying this context's `windsorcli.dev/context-id` label, drops any that appear in the blueprint's desired set, and deletes the remainder in reverse-dependency order. DestroyOnly entries are deliberately excluded from "desired" so they are also pruned. `Prune` is not yet wired into any call site; this PR establishes the mechanism in isolation.
>
> Reviewed by Claude for commit `9b2c37c`.

<!-- /claude-code-review:summary -->
