### PR TITLE
feat(cmd/upgrade): enhance upgrade command to prune orphaned kustomizations after successful execution

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -9,7 +9,9 @@ import (
 	"github.com/windsorcli/cli/pkg/composer"
 	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/provisioner"
+	"github.com/windsorcli/cli/pkg/provisioner/stacklock"
 	"github.com/windsorcli/cli/pkg/runtime"
+	"github.com/windsorcli/cli/pkg/runtime/tools"
 )
 
 var (
@@ -23,13 +25,67 @@ var (
 
 var upgradeCmd = &cobra.Command{
 	Use:   "upgrade",
-	Short: "Upgrade cluster components.",
-	Long:  `Upgrade cluster components. Currently supports Talos node upgrades via the 'cluster' (parallel) and 'node' (one-at-a-time, with health verification) subcommands.`,
+	Short: "Upgrade the blueprint, pruning kustomizations it no longer declares.",
+	Long: `Apply terraform and the Flux blueprint, wait for kustomizations to be ready, then prune any kustomizations this context no longer declares. Pruning runs only after a successful wait, so resources are never deleted before the desired set has reconciled.
+
+Use the 'cluster' or 'node' subcommand to upgrade Talos nodes instead.`,
+	Example: `# Upgrade the blueprint and prune orphaned kustomizations
+windsor upgrade
+
+# Upgrade Talos nodes in parallel (see 'upgrade cluster')
+windsor upgrade cluster --nodes=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.0`,
 	Annotations: map[string]string{
-		"docs.seealso": "[`check node-health`](check-node-health.md)",
+		"docs.seealso": "[`apply`](apply.md), [`bootstrap`](bootstrap.md), [`plan`](plan.md)",
 		"docs.source":  "cmd/upgrade.go",
 	},
+	Args:         cobra.NoArgs,
 	SilenceUsage: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		// `windsor upgrade` runs the full blueprint — terraform components and Flux
+		// kustomizations both — so the tool surface is not statically narrowable; mirror
+		// `apply` and request AllRequirements(), letting the per-tool config gates decide.
+		proj, err := prepareProject(cmd, tools.AllRequirements())
+		if err != nil {
+			return err
+		}
+
+		if err := requireCloudAuth(cmd, proj); err != nil {
+			return err
+		}
+
+		blueprint := proj.Composer.BlueprintHandler.Generate()
+		if blueprint == nil {
+			return fmt.Errorf("blueprint is not available")
+		}
+
+		return stacklock.With(cmd.Context(), proj.Runtime, "upgrade", func() error {
+			if _, err := proj.Provisioner.Up(blueprint); err != nil {
+				return fmt.Errorf("error applying terraform: %w", err)
+			}
+
+			// Re-generate with deferred substitutions resolved now that terraform
+			// outputs are available from the Up step above.
+			var resolveErr error
+			blueprint, resolveErr = proj.Composer.BlueprintHandler.GenerateResolved()
+			if resolveErr != nil {
+				return fmt.Errorf("error resolving blueprint substitutions: %w", resolveErr)
+			}
+
+			if err := proj.Provisioner.Install(cmd.Context(), blueprint); err != nil {
+				return fmt.Errorf("error installing blueprint: %w", err)
+			}
+
+			if err := proj.Provisioner.Wait(cmd.Context(), blueprint); err != nil {
+				return fmt.Errorf("error waiting for kustomizations: %w", err)
+			}
+
+			if err := proj.Provisioner.Prune(blueprint); err != nil {
+				return fmt.Errorf("error pruning orphaned kustomizations: %w", err)
+			}
+
+			return nil
+		})
+	},
 }
 
 var upgradeClusterCmd = &cobra.Command{

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -70,6 +70,9 @@ windsor upgrade cluster --nodes=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1
 			if resolveErr != nil {
 				return fmt.Errorf("error resolving blueprint substitutions: %w", resolveErr)
 			}
+			if blueprint == nil {
+				return fmt.Errorf("resolved blueprint is not available")
+			}
 
 			if err := proj.Provisioner.Install(cmd.Context(), blueprint); err != nil {
 				return fmt.Errorf("error installing blueprint: %w", err)

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -118,6 +118,27 @@ func TestUpgradeCmd(t *testing.T) {
 		}
 	})
 
+	t.Run("ErrorNilResolvedBlueprint", func(t *testing.T) {
+		// Given a handler whose resolved blueprint comes back nil after terraform runs
+		mocks := setupApplyTest(t)
+		mocks.BlueprintHandler.GenerateResolvedFunc = func() (*blueprintv1alpha1.Blueprint, error) { return nil, nil }
+		proj := newApplyAllProject(mocks)
+
+		// When executing the upgrade command
+		cmd := createTestUpgradeCmd()
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then it reports the missing resolved blueprint rather than feeding nil downstream
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "resolved blueprint is not available") {
+			t.Errorf("Expected resolved-blueprint error, got: %v", err)
+		}
+	})
+
 	t.Run("ErrorTerraformFails", func(t *testing.T) {
 		// Given a terraform stack whose Up fails
 		mocks := setupApplyTest(t)

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -3,11 +3,162 @@ package cmd
 import (
 	"bytes"
 	stdcontext "context"
+	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/spf13/cobra"
+	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 )
+
+func TestUpgradeCmd(t *testing.T) {
+	createTestUpgradeCmd := func() *cobra.Command { return makeApplyTestCmd(upgradeCmd) }
+
+	suppressProcessStdout(t)
+	suppressProcessStderr(t)
+
+	t.Run("PrunesAfterSuccessfulWait", func(t *testing.T) {
+		// Given an upgrade command whose terraform, install, and wait all succeed
+		mocks := setupApplyTest(t)
+		pruned := false
+		mocks.KubernetesManager.PruneBlueprintFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) error {
+			pruned = true
+			return nil
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When executing the bare upgrade command
+		cmd := createTestUpgradeCmd()
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then it completes and prunes orphaned kustomizations
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if !pruned {
+			t.Error("Expected upgrade to prune orphaned kustomizations")
+		}
+	})
+
+	t.Run("WaitFailureSkipsPrune", func(t *testing.T) {
+		// Given a wait that fails before the desired set has reconciled
+		mocks := setupApplyTest(t)
+		mocks.KubernetesManager.WaitForKustomizationsFunc = func(ctx stdcontext.Context, message string, bp *blueprintv1alpha1.Blueprint) error {
+			return fmt.Errorf("wait failed")
+		}
+		pruned := false
+		mocks.KubernetesManager.PruneBlueprintFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) error {
+			pruned = true
+			return nil
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When executing the upgrade command
+		cmd := createTestUpgradeCmd()
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then the wait error surfaces and prune never runs — no deletion before adoption
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "error waiting for kustomizations") {
+			t.Errorf("Expected wait error, got: %v", err)
+		}
+		if pruned {
+			t.Error("Expected prune to be skipped when the wait fails")
+		}
+	})
+
+	t.Run("ErrorPruneFails", func(t *testing.T) {
+		// Given a prune step that fails after a successful wait
+		mocks := setupApplyTest(t)
+		mocks.KubernetesManager.PruneBlueprintFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) error {
+			return fmt.Errorf("delete kustomization failed")
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When executing the upgrade command
+		cmd := createTestUpgradeCmd()
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then the prune error surfaces
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "error pruning orphaned kustomizations") {
+			t.Errorf("Expected prune error, got: %v", err)
+		}
+	})
+
+	t.Run("ErrorNilBlueprint", func(t *testing.T) {
+		// Given a blueprint handler that returns nil
+		mocks := setupApplyTest(t)
+		mocks.BlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint { return nil }
+		proj := newApplyAllProject(mocks)
+
+		// When executing the upgrade command
+		cmd := createTestUpgradeCmd()
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then it reports the missing blueprint
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "blueprint is not available") {
+			t.Errorf("Expected blueprint error, got: %v", err)
+		}
+	})
+
+	t.Run("ErrorTerraformFails", func(t *testing.T) {
+		// Given a terraform stack whose Up fails
+		mocks := setupApplyTest(t)
+		mocks.TerraformStack.UpFunc = func(bp *blueprintv1alpha1.Blueprint, onApply ...func(id string) (bool, error)) (bool, error) {
+			return false, fmt.Errorf("terraform up failed")
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When executing the upgrade command
+		cmd := createTestUpgradeCmd()
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then the terraform error surfaces before any kustomization work
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "error applying terraform") {
+			t.Errorf("Expected terraform error, got: %v", err)
+		}
+	})
+
+	t.Run("RejectsUnexpectedArgs", func(t *testing.T) {
+		// Given a bare upgrade command with a stray positional argument
+		mocks := setupApplyTest(t)
+		proj := newApplyAllProject(mocks)
+
+		// When executing with an unexpected argument
+		cmd := createTestUpgradeCmd()
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"bogus"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then it is rejected — bare upgrade takes no positional args
+		if err == nil {
+			t.Error("Expected error for unexpected argument, got nil")
+		}
+	})
+}
 
 func TestUpgradeNodeCmd(t *testing.T) {
 	t.Cleanup(func() {

--- a/docs/reference/commands/upgrade.md
+++ b/docs/reference/commands/upgrade.md
@@ -1,6 +1,6 @@
 ---
 title: "windsor upgrade"
-description: "Upgrade cluster components."
+description: "Upgrade the blueprint, pruning kustomizations it no longer declares."
 ---
 # windsor upgrade
 
@@ -8,14 +8,26 @@ description: "Upgrade cluster components."
 windsor upgrade
 ```
 
-Upgrade cluster components. Currently supports Talos node upgrades via the 'cluster' (parallel) and 'node' (one-at-a-time, with health verification) subcommands.
+Apply terraform and the Flux blueprint, wait for kustomizations to be ready, then prune any kustomizations this context no longer declares. Pruning runs only after a successful wait, so resources are never deleted before the desired set has reconciled.
+
+Use the 'cluster' or 'node' subcommand to upgrade Talos nodes instead.
 
 ## Subcommands
 
 - [`windsor upgrade cluster`](upgrade-cluster.md) — Upgrade cluster nodes in parallel.
 - [`windsor upgrade node`](upgrade-node.md) — Upgrade a single cluster node and wait for it to rejoin.
 
+## Examples
+
+```sh
+# Upgrade the blueprint and prune orphaned kustomizations
+windsor upgrade
+
+# Upgrade Talos nodes in parallel (see 'upgrade cluster')
+windsor upgrade cluster --nodes=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.0
+```
+
 ## See also
 
-- [`check node-health`](check-node-health.md)
+- [`apply`](apply.md), [`bootstrap`](bootstrap.md), [`plan`](plan.md)
 - Source: [cmd/upgrade.go](https://github.com/windsorcli/cli/blob/main/cmd/upgrade.go)

--- a/integration/upgrade_test.go
+++ b/integration/upgrade_test.go
@@ -11,6 +11,46 @@ import (
 )
 
 // =============================================================================
+// Integration Tests — upgrade (blueprint)
+// =============================================================================
+
+func TestUpgrade_FailsWhenNotInTrustedDirectory(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	// Bare `upgrade` now runs the blueprint flow, so it must enforce the trusted-directory
+	// gate. A no-op parent would have printed help and exited 0 instead.
+	_, stderr, err := helpers.RunCLI(dir, []string{"upgrade"}, env)
+	if err == nil {
+		t.Fatal("expected failure but command succeeded")
+	}
+	if !strings.Contains(string(stderr), "trusted") {
+		t.Errorf("expected stderr to mention 'trusted', got: %s", stderr)
+	}
+}
+
+func TestUpgrade_RunsBlueprintFlowInLocalContext(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
+	if _, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env); err != nil {
+		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
+	}
+	env = append(env, "WINDSOR_CONTEXT=local")
+
+	// Bare `upgrade` drives terraform + the blueprint install/wait/prune flow. With no live
+	// cluster the install/wait phase fails, which proves the command reaches real
+	// provisioning rather than dispatching to the talos subcommands or printing help.
+	_, stderr, err := helpers.RunCLI(dir, []string{"upgrade"}, env)
+	if err == nil {
+		t.Fatal("expected upgrade to fail without a live cluster, got success")
+	}
+	out := string(stderr)
+	if strings.Contains(out, "unknown command") || strings.Contains(out, "Available Commands") {
+		t.Errorf("expected bare upgrade to run the blueprint flow, not print help, got: %s", out)
+	}
+}
+
+// =============================================================================
 // Integration Tests — upgrade cluster
 // =============================================================================
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> This PR changes `windsor upgrade` from a help-printing no-op into a live provisioning command that applies terraform, installs Flux kustomizations, waits for readiness, and prunes orphaned kustomizations — the destructive prune step makes the risk medium.
>
> **Overview**
>
> The PR wires a `RunE` handler into `upgradeCmd`, following the same terraform-then-blueprint flow used by `apply`. Pruning runs only after a successful wait, so the desired set must reconcile before any kustomization is removed. Unit tests cover the key orderings (prune-after-wait, skip-prune-on-wait-failure), and two integration tests verify that the trusted-directory gate fires and that the command reaches real provisioning rather than falling through to subcommand help.
>
> One correctness gap: `GenerateResolved()` is called after `Up()` to pick up fresh terraform outputs, but the result is not nil-checked before being passed to `Install`, `Wait`, and `Prune`. The earlier `Generate()` call does carry a nil guard; the same guard is missing here.
>
> Reviewed by Claude for commit `0b35d14`.

<!-- /claude-code-review:summary -->
