### PR TITLE
feat(cmd/apply): implement version gate enforcement for apply command with --force option

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -5,11 +5,13 @@ import (
 
 	"github.com/spf13/cobra"
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+	"github.com/windsorcli/cli/pkg/project"
 	"github.com/windsorcli/cli/pkg/provisioner/stacklock"
 	"github.com/windsorcli/cli/pkg/runtime/tools"
 )
 
-var applyWaitFlag bool // Wait for kustomization resources to be ready after applying
+var applyWaitFlag bool  // Wait for kustomization resources to be ready after applying
+var applyForceFlag bool // Apply even when the blueprint version differs from what is applied
 
 var applyCmd = &cobra.Command{
 	Use:   "apply",
@@ -50,6 +52,10 @@ windsor apply kustomize dns`,
 		blueprint := proj.Composer.BlueprintHandler.Generate()
 		if blueprint == nil {
 			return fmt.Errorf("blueprint is not available")
+		}
+
+		if err := enforceApplyVersionGate(cmd, proj, blueprint, applyForceFlag); err != nil {
+			return err
 		}
 
 		return stacklock.With(cmd.Context(), proj.Runtime, "apply", func() error {
@@ -190,8 +196,42 @@ windsor apply kustomize dns --wait`,
 	},
 }
 
+// enforceApplyVersionGate enforces the version-equality seam for `apply`: apply reconciles the
+// currently-applied blueprint version and refuses to cross a version boundary, which belongs to
+// `upgrade`. A context with no readable marker (pre-bootstrap, no cluster, or legacy) is allowed —
+// there is nothing applied to cross. An in-flight upgrade is refused so a half-finished transition
+// is resumed with `upgrade`, never reconciled by `apply`; --force does not override this, since
+// applying over a live transition risks corrupting it. A version mismatch is refused and redirected
+// to `upgrade`, unless --force is set, in which case it warns and proceeds. A marker read failure
+// (cluster unreachable) is best-effort: it warns and proceeds rather than blocking terraform-based
+// recovery, since apply's later steps would surface a genuinely-unreachable cluster anyway.
+func enforceApplyVersionGate(cmd *cobra.Command, proj *project.Project, blueprint *blueprintv1alpha1.Blueprint, force bool) error {
+	gate, err := proj.Provisioner.CheckVersionGate(blueprint)
+	if err != nil {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: could not verify the applied blueprint version (%v); proceeding without the version gate.\n", err)
+		return nil
+	}
+	if !gate.MarkerFound {
+		return nil
+	}
+	if gate.InFlight {
+		silenceErrorsOnAncestors(cmd)
+		return fmt.Errorf("an upgrade is in progress for this context; run `windsor upgrade` to resume it. apply cannot reconcile a half-finished version transition")
+	}
+	if !gate.VersionMatch {
+		if force {
+			fmt.Fprintln(cmd.ErrOrStderr(), "Warning: the blueprint version differs from what is applied; applying anyway because --force was set.")
+			return nil
+		}
+		silenceErrorsOnAncestors(cmd)
+		return fmt.Errorf("the blueprint version differs from what is applied; run `windsor upgrade` to transition versions, or re-run with --force to apply against the current version anyway")
+	}
+	return nil
+}
+
 func init() {
 	applyCmd.Flags().BoolVar(&applyWaitFlag, "wait", false, "Wait for kustomization resources to be ready.")
+	applyCmd.Flags().BoolVar(&applyForceFlag, "force", false, "Apply even if the blueprint version differs from what is applied (skips the upgrade version gate).")
 	applyKustomizeCmd.Flags().BoolVar(&applyWaitFlag, "wait", false, "Wait for kustomization resources to be ready.")
 	applyCmd.AddCommand(applyTerraformCmd)
 	applyCmd.AddCommand(applyKustomizeCmd)

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -120,6 +120,9 @@ windsor apply tf cluster`,
 		}
 
 		blueprint := proj.Composer.BlueprintHandler.Generate()
+		if err := enforceApplyVersionGate(cmd, proj, blueprint, applyForceFlag); err != nil {
+			return err
+		}
 		return stacklock.With(cmd.Context(), proj.Runtime, "apply", func() error {
 			if err := proj.Provisioner.Apply(blueprint, componentID); err != nil {
 				return fmt.Errorf("error applying terraform for %s: %w", componentID, err)
@@ -160,6 +163,9 @@ windsor apply kustomize dns --wait`,
 		blueprint := proj.Composer.BlueprintHandler.Generate()
 		if blueprint == nil {
 			return fmt.Errorf("blueprint is not available")
+		}
+		if err := enforceApplyVersionGate(cmd, proj, blueprint, applyForceFlag); err != nil {
+			return err
 		}
 		waitBlueprint := blueprint
 
@@ -230,9 +236,12 @@ func enforceApplyVersionGate(cmd *cobra.Command, proj *project.Project, blueprin
 }
 
 func init() {
+	const forceUsage = "Apply even if the blueprint version differs from what is applied (skips the upgrade version gate)."
 	applyCmd.Flags().BoolVar(&applyWaitFlag, "wait", false, "Wait for kustomization resources to be ready.")
-	applyCmd.Flags().BoolVar(&applyForceFlag, "force", false, "Apply even if the blueprint version differs from what is applied (skips the upgrade version gate).")
+	applyCmd.Flags().BoolVar(&applyForceFlag, "force", false, forceUsage)
 	applyKustomizeCmd.Flags().BoolVar(&applyWaitFlag, "wait", false, "Wait for kustomization resources to be ready.")
+	applyKustomizeCmd.Flags().BoolVar(&applyForceFlag, "force", false, forceUsage)
+	applyTerraformCmd.Flags().BoolVar(&applyForceFlag, "force", false, forceUsage)
 	applyCmd.AddCommand(applyTerraformCmd)
 	applyCmd.AddCommand(applyKustomizeCmd)
 	rootCmd.AddCommand(applyCmd)

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -282,6 +282,85 @@ func TestApplyCmd_VersionGate(t *testing.T) {
 			t.Errorf("Expected apply to proceed when the marker cannot be read, got %v", err)
 		}
 	})
+
+	// mismatchMarker returns a marker whose source set cannot match the bare test blueprint
+	// (which has no sources), so the gate always sees a version mismatch.
+	mismatchMarker := func(namespace string) (kubernetes.VersionMarker, bool, error) {
+		return kubernetes.VersionMarker{
+			SchemaVersion:  1,
+			Phase:          kubernetes.VersionMarkerPhaseIdle,
+			AppliedSources: map[string]kubernetes.SourceRef{"core": {URL: "oci://example/core", Ref: "v1.0.0"}},
+		}, true, nil
+	}
+
+	runCmd := func(t *testing.T, source *cobra.Command, proj *project.Project, args ...string) error {
+		t.Helper()
+		cmd := makeApplyTestCmd(source)
+		cmd.SetArgs(args)
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		return cmd.Execute()
+	}
+
+	t.Run("RefusesOnApplyTerraformSubcommand", func(t *testing.T) {
+		t.Cleanup(func() { applyForceFlag = false })
+		// Given a version mismatch, the apply terraform subcommand must also gate
+		mocks := setupApplyTest(t)
+		seedKubeconfig(t, mocks)
+		mocks.KubernetesManager.GetVersionMarkerFunc = mismatchMarker
+		proj := newApplyAllProject(mocks)
+
+		err := runCmd(t, applyTerraformCmd, proj, "cluster")
+		if err == nil {
+			t.Fatal("Expected apply terraform to refuse a version mismatch, got nil")
+		}
+		if !strings.Contains(err.Error(), "upgrade") {
+			t.Errorf("Expected redirect to upgrade, got: %v", err)
+		}
+	})
+
+	t.Run("ForceOnApplyTerraformSubcommand", func(t *testing.T) {
+		t.Cleanup(func() { applyForceFlag = false })
+		// Given the same mismatch, --force must be honored on the subcommand
+		mocks := setupApplyTest(t)
+		seedKubeconfig(t, mocks)
+		mocks.KubernetesManager.GetVersionMarkerFunc = mismatchMarker
+		proj := newApplyAllProject(mocks)
+
+		if err := runCmd(t, applyTerraformCmd, proj, "cluster", "--force"); err != nil {
+			t.Errorf("Expected --force to apply terraform across a mismatch, got %v", err)
+		}
+	})
+
+	t.Run("RefusesOnApplyKustomizeSubcommand", func(t *testing.T) {
+		t.Cleanup(func() { applyForceFlag = false })
+		// Given a version mismatch, the apply kustomize subcommand must also gate
+		mocks := setupApplyTest(t)
+		seedKubeconfig(t, mocks)
+		mocks.KubernetesManager.GetVersionMarkerFunc = mismatchMarker
+		proj := newApplyAllProject(mocks)
+
+		err := runCmd(t, applyKustomizeCmd, proj)
+		if err == nil {
+			t.Fatal("Expected apply kustomize to refuse a version mismatch, got nil")
+		}
+		if !strings.Contains(err.Error(), "upgrade") {
+			t.Errorf("Expected redirect to upgrade, got: %v", err)
+		}
+	})
+
+	t.Run("ForceOnApplyKustomizeSubcommand", func(t *testing.T) {
+		t.Cleanup(func() { applyForceFlag = false })
+		// Given the same mismatch, --force must be honored on the subcommand
+		mocks := setupApplyTest(t)
+		seedKubeconfig(t, mocks)
+		mocks.KubernetesManager.GetVersionMarkerFunc = mismatchMarker
+		proj := newApplyAllProject(mocks)
+
+		if err := runCmd(t, applyKustomizeCmd, proj, "--force"); err != nil {
+			t.Errorf("Expected --force to apply kustomize across a mismatch, got %v", err)
+		}
+	})
 }
 
 func TestApplyCmd(t *testing.T) {

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -150,6 +152,137 @@ func makeApplyTestCmd(source *cobra.Command) *cobra.Command {
 // =============================================================================
 // Test Cases
 // =============================================================================
+
+// seedKubeconfig points the runtime's config root at a temp dir holding a kubeconfig so the
+// version gate's kubeconfigPresent() probe engages (the apply harness leaves ConfigRoot empty,
+// which short-circuits the gate). Returns the config root.
+func seedKubeconfig(t *testing.T, mocks *ApplyMocks) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".kube"), 0755); err != nil {
+		t.Fatalf("seed kubeconfig dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".kube", "config"), []byte("apiVersion: v1\nkind: Config\n"), 0644); err != nil {
+		t.Fatalf("seed kubeconfig: %v", err)
+	}
+	mocks.Runtime.ConfigRoot = root
+	return root
+}
+
+func TestApplyCmd_VersionGate(t *testing.T) {
+	createTestApplyCmd := func() *cobra.Command { return makeApplyTestCmd(applyCmd) }
+
+	suppressProcessStdout(t)
+	suppressProcessStderr(t)
+
+	run := func(t *testing.T, proj *project.Project, args ...string) error {
+		t.Helper()
+		cmd := createTestApplyCmd()
+		cmd.SetArgs(args)
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		return cmd.Execute()
+	}
+
+	t.Run("RefusesWhenVersionDiffers", func(t *testing.T) {
+		t.Cleanup(func() { applyForceFlag = false })
+		// Given a cluster whose applied marker differs from the blueprint
+		mocks := setupApplyTest(t)
+		seedKubeconfig(t, mocks)
+		mocks.KubernetesManager.GetVersionMarkerFunc = func(namespace string) (kubernetes.VersionMarker, bool, error) {
+			return kubernetes.VersionMarker{
+				SchemaVersion:  1,
+				Phase:          kubernetes.VersionMarkerPhaseIdle,
+				AppliedSources: map[string]kubernetes.SourceRef{"core": {URL: "oci://example/core", Ref: "v1.0.0"}},
+			}, true, nil
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When applying without --force
+		err := run(t, proj)
+
+		// Then apply refuses and points at upgrade
+		if err == nil {
+			t.Fatal("Expected apply to refuse a version mismatch, got nil")
+		}
+		if !strings.Contains(err.Error(), "upgrade") {
+			t.Errorf("Expected redirect to upgrade, got: %v", err)
+		}
+	})
+
+	t.Run("ForceAppliesAcrossVersionMismatch", func(t *testing.T) {
+		t.Cleanup(func() { applyForceFlag = false })
+		// Given the same version mismatch
+		mocks := setupApplyTest(t)
+		seedKubeconfig(t, mocks)
+		mocks.KubernetesManager.GetVersionMarkerFunc = func(namespace string) (kubernetes.VersionMarker, bool, error) {
+			return kubernetes.VersionMarker{
+				SchemaVersion:  1,
+				Phase:          kubernetes.VersionMarkerPhaseIdle,
+				AppliedSources: map[string]kubernetes.SourceRef{"core": {URL: "oci://example/core", Ref: "v1.0.0"}},
+			}, true, nil
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When applying with --force
+		err := run(t, proj, "--force")
+
+		// Then the gate is overridden and apply proceeds
+		if err != nil {
+			t.Errorf("Expected --force to apply across a mismatch, got %v", err)
+		}
+	})
+
+	t.Run("RefusesWhenUpgradeInFlight", func(t *testing.T) {
+		t.Cleanup(func() { applyForceFlag = false })
+		// Given a marker mid-transition
+		mocks := setupApplyTest(t)
+		seedKubeconfig(t, mocks)
+		mocks.KubernetesManager.GetVersionMarkerFunc = func(namespace string) (kubernetes.VersionMarker, bool, error) {
+			return kubernetes.VersionMarker{SchemaVersion: 1, Phase: "migrating"}, true, nil
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When applying, even with --force, an in-flight transition is refused
+		err := run(t, proj, "--force")
+		if err == nil {
+			t.Fatal("Expected apply to refuse during an in-flight upgrade, got nil")
+		}
+		if !strings.Contains(err.Error(), "upgrade") {
+			t.Errorf("Expected an in-flight upgrade message, got: %v", err)
+		}
+	})
+
+	t.Run("ProceedsForLegacyContextWithNoMarker", func(t *testing.T) {
+		// Given a cluster with no marker recorded
+		mocks := setupApplyTest(t)
+		seedKubeconfig(t, mocks)
+		mocks.KubernetesManager.GetVersionMarkerFunc = func(namespace string) (kubernetes.VersionMarker, bool, error) {
+			return kubernetes.VersionMarker{}, false, nil
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When applying, the legacy context is allowed through
+		if err := run(t, proj); err != nil {
+			t.Errorf("Expected apply to proceed for a legacy context, got %v", err)
+		}
+	})
+
+	t.Run("ProceedsBestEffortWhenMarkerReadFails", func(t *testing.T) {
+		// Given a marker read that fails (cluster unreachable)
+		mocks := setupApplyTest(t)
+		seedKubeconfig(t, mocks)
+		mocks.KubernetesManager.GetVersionMarkerFunc = func(namespace string) (kubernetes.VersionMarker, bool, error) {
+			return kubernetes.VersionMarker{}, false, fmt.Errorf("connection refused")
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When applying, the gate is best-effort and does not block recovery
+		if err := run(t, proj); err != nil {
+			t.Errorf("Expected apply to proceed when the marker cannot be read, got %v", err)
+		}
+	})
+}
 
 func TestApplyCmd(t *testing.T) {
 	createTestApplyCmd := func() *cobra.Command { return makeApplyTestCmd(applyCmd) }

--- a/docs/reference/commands/apply-kustomize.md
+++ b/docs/reference/commands/apply-kustomize.md
@@ -16,6 +16,7 @@ When a name is supplied with --wait, the wait scope is narrowed to only that kus
 
 | Flag | Default | Description |
 |------|---------|-------------|
+| `--force` | `false` | Apply even if the blueprint version differs from what is applied (skips the upgrade version gate). |
 | `--wait` | `false` | Wait for kustomization resources to be ready. |
 
 ## Examples

--- a/docs/reference/commands/apply-terraform.md
+++ b/docs/reference/commands/apply-terraform.md
@@ -5,10 +5,16 @@ description: "Apply Terraform changes for a single component."
 # windsor apply terraform
 
 ```sh
-windsor apply terraform <component>
+windsor apply terraform <component> [flags]
 ```
 
 Run terraform apply for a single component. The <component> argument is required and must match a terraform component declared in the blueprint.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--force` | `false` | Apply even if the blueprint version differs from what is applied (skips the upgrade version gate). |
 
 ## Examples
 

--- a/docs/reference/commands/apply.md
+++ b/docs/reference/commands/apply.md
@@ -18,6 +18,7 @@ Pass --wait to block until kustomizations report ready.
 
 | Flag | Default | Description |
 |------|---------|-------------|
+| `--force` | `false` | Apply even if the blueprint version differs from what is applied (skips the upgrade version gate). |
 | `--wait` | `false` | Wait for kustomization resources to be ready. |
 
 ## Subcommands

--- a/integration/apply_test.go
+++ b/integration/apply_test.go
@@ -100,6 +100,22 @@ func TestApply_AcceptsWaitFlag(t *testing.T) {
 	_ = err // may fail due to infrastructure not being available; flag must be accepted
 }
 
+func TestApply_AcceptsForceFlag(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
+	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
+	if err != nil {
+		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
+	}
+	env = append(env, "WINDSOR_CONTEXT=local")
+	_, stderr, err = helpers.RunCLI(dir, []string{"apply", "--force"}, env)
+	if strings.Contains(string(stderr), "unknown flag") {
+		t.Errorf("--force should be a recognised flag on apply, got: %s", stderr)
+	}
+	_ = err // may fail due to infrastructure not being available; the flag must be accepted
+}
+
 // TestApplyTerraform_MissingBinary_ShowsActionableError verifies the registry-formatted
 // missing-tool error reaches the user end-to-end: when an `apply terraform` preflight
 // fails because terraform is not on PATH, stderr must include the vendor download URL

--- a/integration/apply_test.go
+++ b/integration/apply_test.go
@@ -116,6 +116,38 @@ func TestApply_AcceptsForceFlag(t *testing.T) {
 	_ = err // may fail due to infrastructure not being available; the flag must be accepted
 }
 
+func TestApplyTerraform_AcceptsForceFlag(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
+	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
+	if err != nil {
+		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
+	}
+	env = append(env, "WINDSOR_CONTEXT=local")
+	_, stderr, err = helpers.RunCLI(dir, []string{"apply", "terraform", "null", "--force"}, env)
+	if strings.Contains(string(stderr), "unknown flag") {
+		t.Errorf("--force should be a recognised flag on apply terraform, got: %s", stderr)
+	}
+	_ = err // may fail due to infrastructure not being available; the flag must be accepted
+}
+
+func TestApplyKustomize_AcceptsForceFlag(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
+	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
+	if err != nil {
+		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
+	}
+	env = append(env, "WINDSOR_CONTEXT=local")
+	_, stderr, err = helpers.RunCLI(dir, []string{"apply", "kustomize", "--force"}, env)
+	if strings.Contains(string(stderr), "unknown flag") {
+		t.Errorf("--force should be a recognised flag on apply kustomize, got: %s", stderr)
+	}
+	_ = err // may fail due to infrastructure not being available; the flag must be accepted
+}
+
 // TestApplyTerraform_MissingBinary_ShowsActionableError verifies the registry-formatted
 // missing-tool error reaches the user end-to-end: when an `apply terraform` preflight
 // fails because terraform is not on PATH, stderr must include the vendor download URL

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -55,6 +55,7 @@ type KubernetesManager interface {
 	DeleteBlueprint(blueprint *blueprintv1alpha1.Blueprint, namespace string) error
 	PruneBlueprint(blueprint *blueprintv1alpha1.Blueprint, namespace string) error
 	ApplyVersionMarker(namespace string, marker VersionMarker) error
+	GetVersionMarker(namespace string) (VersionMarker, bool, error)
 }
 
 // InventoryEntry identifies one resource Flux is tracking for a Kustomization,
@@ -499,6 +500,33 @@ func (k *BaseKubernetesManager) ApplyVersionMarker(namespace string, marker Vers
 		return fmt.Errorf("failed to encode version marker: %w", err)
 	}
 	return k.ApplyConfigMap(VersionMarkerConfigMapName, namespace, data)
+}
+
+// GetVersionMarker reads the applied-version marker ConfigMap from the namespace, reporting false
+// when no marker is present — a missing ConfigMap (pre-bootstrap context) or one without marker data
+// (legacy cluster). It returns an error only on a real read or decode failure, so callers can tell
+// "no marker yet" (proceed as legacy) apart from "could not read the marker" (cluster unreachable).
+func (k *BaseKubernetesManager) GetVersionMarker(namespace string) (VersionMarker, bool, error) {
+	gvr := schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "configmaps",
+	}
+	obj, err := k.client.GetResource(gvr, namespace, VersionMarkerConfigMapName)
+	if err != nil {
+		if isNotFoundError(err) {
+			return VersionMarker{}, false, nil
+		}
+		return VersionMarker{}, false, fmt.Errorf("failed to read version marker: %w", err)
+	}
+	data, found, err := unstructured.NestedStringMap(obj.Object, "data")
+	if err != nil {
+		return VersionMarker{}, false, fmt.Errorf("failed to read version marker data: %w", err)
+	}
+	if !found {
+		return VersionMarker{}, false, nil
+	}
+	return ParseVersionMarker(data)
 }
 
 // GetHelmReleasesForKustomization gets HelmReleases associated with a Kustomization

--- a/pkg/provisioner/kubernetes/mock_kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/mock_kubernetes_manager.go
@@ -27,6 +27,7 @@ type MockKubernetesManager struct {
 	DeleteNamespaceFunc                 func(name string) error
 	ApplyConfigMapFunc                  func(name, namespace string, data map[string]string) error
 	ApplyVersionMarkerFunc              func(namespace string, marker VersionMarker) error
+	GetVersionMarkerFunc                func(namespace string) (VersionMarker, bool, error)
 	GetHelmReleasesForKustomizationFunc func(name, namespace string) ([]helmv2.HelmRelease, error)
 	ApplyGitRepositoryFunc              func(repo *sourcev1.GitRepository) error
 	ApplyOCIRepositoryFunc              func(repo *sourcev1.OCIRepository) error
@@ -115,6 +116,14 @@ func (m *MockKubernetesManager) ApplyVersionMarker(namespace string, marker Vers
 		return m.ApplyVersionMarkerFunc(namespace, marker)
 	}
 	return nil
+}
+
+// GetVersionMarker implements KubernetesManager interface
+func (m *MockKubernetesManager) GetVersionMarker(namespace string) (VersionMarker, bool, error) {
+	if m.GetVersionMarkerFunc != nil {
+		return m.GetVersionMarkerFunc(namespace)
+	}
+	return VersionMarker{}, false, nil
 }
 
 // GetHelmReleasesForKustomization implements KubernetesManager interface

--- a/pkg/provisioner/kubernetes/version_marker.go
+++ b/pkg/provisioner/kubernetes/version_marker.go
@@ -124,6 +124,23 @@ func ParseVersionMarker(data map[string]string) (VersionMarker, bool, error) {
 	return marker, true, nil
 }
 
+// SourcesEqual reports whether two applied-source sets are identical: the same source names, each
+// carrying the same URL and resolved ref. It is the version-equality test the apply gate uses —
+// equal sets mean the blueprint matches what is applied, so apply may reconcile in place rather than
+// redirect to upgrade. SourceRef is a plain comparable struct, so values compare by field.
+func SourcesEqual(a, b map[string]SourceRef) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for name, ref := range a {
+		other, ok := b[name]
+		if !ok || other != ref {
+			return false
+		}
+	}
+	return true
+}
+
 // effectiveRef resolves a reference in priority order Commit → SemVer → Tag → Branch, matching the
 // composer and terraform provisioner; it returns an empty string when none are set.
 func effectiveRef(ref blueprintv1alpha1.Reference) string {

--- a/pkg/provisioner/kubernetes/version_marker_test.go
+++ b/pkg/provisioner/kubernetes/version_marker_test.go
@@ -163,6 +163,145 @@ func TestVersionMarker_ConfigMapRoundTrip(t *testing.T) {
 	})
 }
 
+func TestSourcesEqual(t *testing.T) {
+	base := map[string]SourceRef{"core": {URL: "u", Ref: "v1"}}
+
+	t.Run("EqualForIdenticalSets", func(t *testing.T) {
+		if !SourcesEqual(base, map[string]SourceRef{"core": {URL: "u", Ref: "v1"}}) {
+			t.Error("Expected identical sets to be equal")
+		}
+	})
+
+	t.Run("UnequalWhenRefDiffers", func(t *testing.T) {
+		if SourcesEqual(base, map[string]SourceRef{"core": {URL: "u", Ref: "v2"}}) {
+			t.Error("Expected differing refs to be unequal")
+		}
+	})
+
+	t.Run("UnequalWhenKeyMissing", func(t *testing.T) {
+		if SourcesEqual(base, map[string]SourceRef{"other": {URL: "u", Ref: "v1"}}) {
+			t.Error("Expected sets with different keys to be unequal")
+		}
+	})
+
+	t.Run("UnequalWhenLengthDiffers", func(t *testing.T) {
+		if SourcesEqual(base, map[string]SourceRef{"core": {URL: "u", Ref: "v1"}, "extra": {URL: "x", Ref: "v1"}}) {
+			t.Error("Expected sets of different sizes to be unequal")
+		}
+	})
+}
+
+func TestBaseKubernetesManager_GetVersionMarker(t *testing.T) {
+	setup := func(t *testing.T) *BaseKubernetesManager {
+		t.Helper()
+		mocks := setupKubernetesMocks(t)
+		return NewKubernetesManager(mocks.KubernetesClient, mocks.ConfigHandler)
+	}
+
+	t.Run("ReturnsParsedMarkerWhenPresent", func(t *testing.T) {
+		// Given a marker ConfigMap present in the gitops namespace
+		manager := setup(t)
+		marker := VersionMarker{
+			SchemaVersion:  versionMarkerSchemaVersion,
+			Phase:          VersionMarkerPhaseIdle,
+			AppliedSources: map[string]SourceRef{"core": {URL: "oci://example/core", Ref: "v1.0.0"}},
+		}
+		data, err := marker.ToConfigMapData()
+		if err != nil {
+			t.Fatalf("encode marker: %v", err)
+		}
+		c := client.NewMockKubernetesClient()
+		c.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			d := map[string]any{}
+			for k, v := range data {
+				d[k] = v
+			}
+			return &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata":   map[string]any{"name": name, "namespace": ns},
+				"data":       d,
+			}}, nil
+		}
+		manager.client = c
+
+		// When the marker is read
+		got, found, err := manager.GetVersionMarker("system-gitops")
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then it is found and decoded
+		if !found {
+			t.Fatal("Expected marker to be found")
+		}
+		if got.AppliedSources["core"].Ref != "v1.0.0" {
+			t.Errorf("Expected core ref 'v1.0.0', got %q", got.AppliedSources["core"].Ref)
+		}
+	})
+
+	t.Run("ReportsAbsentWhenConfigMapNotFound", func(t *testing.T) {
+		// Given no marker ConfigMap (pre-bootstrap context)
+		manager := setup(t)
+		c := client.NewMockKubernetesClient()
+		c.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			return nil, fmt.Errorf("configmaps %q not found", name)
+		}
+		manager.client = c
+
+		// When the marker is read
+		_, found, err := manager.GetVersionMarker("system-gitops")
+
+		// Then it reports absent without error
+		if err != nil {
+			t.Fatalf("Expected no error for a missing marker, got %v", err)
+		}
+		if found {
+			t.Error("Expected found=false when the ConfigMap is absent")
+		}
+	})
+
+	t.Run("ReportsAbsentWhenConfigMapHasNoData", func(t *testing.T) {
+		// Given a marker ConfigMap that carries no data (legacy)
+		manager := setup(t)
+		c := client.NewMockKubernetesClient()
+		c.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			return &unstructured.Unstructured{Object: map[string]any{
+				"apiVersion": "v1",
+				"kind":       "ConfigMap",
+				"metadata":   map[string]any{"name": name, "namespace": ns},
+			}}, nil
+		}
+		manager.client = c
+
+		// When the marker is read
+		_, found, err := manager.GetVersionMarker("system-gitops")
+
+		// Then it reports absent without error
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if found {
+			t.Error("Expected found=false when the ConfigMap carries no data")
+		}
+	})
+
+	t.Run("ErrorsOnReadFailure", func(t *testing.T) {
+		// Given a cluster that is unreachable
+		manager := setup(t)
+		c := client.NewMockKubernetesClient()
+		c.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			return nil, fmt.Errorf("connection refused")
+		}
+		manager.client = c
+
+		// When the marker is read, the failure surfaces rather than being mistaken for "absent"
+		if _, _, err := manager.GetVersionMarker("system-gitops"); err == nil {
+			t.Error("Expected an error when the marker read fails")
+		}
+	})
+}
+
 func TestBaseKubernetesManager_ApplyVersionMarker(t *testing.T) {
 	setup := func(t *testing.T) *BaseKubernetesManager {
 		t.Helper()

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -83,6 +83,17 @@ type DestroyPlanSummary struct {
 	Kustomize []fluxinfra.KustomizePlan
 }
 
+// VersionGate describes how the blueprint a command is about to apply relates to the version marker
+// recorded in the cluster. It is the input to apply's version-equality seam: apply may reconcile in
+// place only when a settled marker matches the blueprint it would apply. Any other state — a version
+// mismatch or an in-flight transition — belongs to upgrade. The caller decides policy (proceed,
+// refuse, or honor --force); this struct only reports the relation.
+type VersionGate struct {
+	MarkerFound  bool // a marker exists for this context (false = pre-bootstrap, no cluster, or legacy)
+	InFlight     bool // an upgrade is mid-transition (marker phase is not idle)
+	VersionMatch bool // the blueprint's resolved source-ref set equals the applied set
+}
+
 // NodeHealthCheckOptions contains options for node health checking.
 type NodeHealthCheckOptions struct {
 	Nodes               []string
@@ -990,6 +1001,53 @@ func (i *Provisioner) Prune(blueprint *blueprintv1alpha1.Blueprint) error {
 	}
 
 	return nil
+}
+
+// GetVersionMarker reads the applied-version marker for this context's gitops namespace, reporting
+// false when no marker exists (a pre-bootstrap, no-cluster, or legacy context). apply and plan read
+// the marker to gate on the blueprint version; only bootstrap and upgrade write it. Returns false
+// without consulting the cluster when no context-scoped kubeconfig is present — there is no cluster,
+// so nothing is applied and there is no version to read.
+func (i *Provisioner) GetVersionMarker() (kubernetes.VersionMarker, bool, error) {
+	if i.KubernetesManager == nil {
+		return kubernetes.VersionMarker{}, false, fmt.Errorf("kubernetes manager not configured")
+	}
+	if !i.kubeconfigPresent() {
+		return kubernetes.VersionMarker{}, false, nil
+	}
+	return i.KubernetesManager.GetVersionMarker(i.fluxNamespace())
+}
+
+// CheckVersionGate reads the version marker and reports how the given blueprint relates to it,
+// without deciding policy. A missing marker (pre-bootstrap, no cluster, or legacy) yields
+// MarkerFound=false so callers treat it as "nothing applied yet — proceed". When a marker exists,
+// InFlight reflects a non-idle phase and VersionMatch compares the blueprint's resolved source-ref
+// set against the applied set. Returns an error only on a real read/decode failure or when the
+// blueprint's sources cannot be reduced to an unambiguous set; callers may treat a read failure as
+// best-effort (cluster unreachable) rather than a hard stop.
+func (i *Provisioner) CheckVersionGate(blueprint *blueprintv1alpha1.Blueprint) (VersionGate, error) {
+	if blueprint == nil {
+		return VersionGate{}, fmt.Errorf("blueprint not provided")
+	}
+
+	marker, found, err := i.GetVersionMarker()
+	if err != nil {
+		return VersionGate{}, err
+	}
+	if !found {
+		return VersionGate{MarkerFound: false}, nil
+	}
+
+	target, err := kubernetes.BuildVersionMarker(blueprint)
+	if err != nil {
+		return VersionGate{}, fmt.Errorf("failed to derive blueprint version: %w", err)
+	}
+
+	return VersionGate{
+		MarkerFound:  true,
+		InFlight:     marker.Phase != "" && marker.Phase != kubernetes.VersionMarkerPhaseIdle,
+		VersionMatch: kubernetes.SourcesEqual(marker.AppliedSources, target.AppliedSources),
+	}, nil
 }
 
 // Uninstall orchestrates the high-level kustomization teardown process from the blueprint.

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -1333,6 +1333,200 @@ func TestProvisioner_Prune(t *testing.T) {
 	})
 }
 
+func TestProvisioner_GetVersionMarker(t *testing.T) {
+	t.Run("DelegatesToManagerWhenKubeconfigPresent", func(t *testing.T) {
+		// Given a manager that returns a marker and a context with a kubeconfig
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.GetVersionMarkerFunc = func(namespace string) (kubernetes.VersionMarker, bool, error) {
+			return kubernetes.VersionMarker{Phase: kubernetes.VersionMarkerPhaseIdle}, true, nil
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+
+		// When the marker is read
+		_, found, err := provisioner.GetVersionMarker()
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !found {
+			t.Error("Expected the marker to be found")
+		}
+	})
+
+	t.Run("ReturnsAbsentWithoutClusterWhenNoKubeconfig", func(t *testing.T) {
+		// Given a context whose config root has no kubeconfig (no cluster)
+		mocks := setupProvisionerMocks(t)
+		mocks.Runtime.ConfigRoot = t.TempDir()
+		called := false
+		mocks.KubernetesManager.GetVersionMarkerFunc = func(namespace string) (kubernetes.VersionMarker, bool, error) {
+			called = true
+			return kubernetes.VersionMarker{}, false, fmt.Errorf("should not be called")
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+
+		// When the marker is read
+		_, found, err := provisioner.GetVersionMarker()
+
+		// Then it reports absent without consulting the cluster
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if found {
+			t.Error("Expected found=false when no kubeconfig is present")
+		}
+		if called {
+			t.Error("Expected the cluster not to be consulted when no kubeconfig is present")
+		}
+	})
+
+	t.Run("NilManagerReturnsError", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+		provisioner.KubernetesManager = nil
+		if _, _, err := provisioner.GetVersionMarker(); err == nil {
+			t.Error("Expected error for nil kubernetes manager")
+		}
+	})
+}
+
+func TestProvisioner_CheckVersionGate(t *testing.T) {
+	// matchingMarker returns a settled marker whose source set equals the test blueprint's.
+	matchingMarker := func() kubernetes.VersionMarker {
+		target, err := kubernetes.BuildVersionMarker(createTestBlueprint())
+		if err != nil {
+			t.Fatalf("build target marker: %v", err)
+		}
+		return target
+	}
+
+	t.Run("MarkerNotFoundIsTreatedAsLegacy", func(t *testing.T) {
+		// Given no marker recorded for the context
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.GetVersionMarkerFunc = func(namespace string) (kubernetes.VersionMarker, bool, error) {
+			return kubernetes.VersionMarker{}, false, nil
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+
+		// When the gate is checked
+		gate, err := provisioner.CheckVersionGate(createTestBlueprint())
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then it reports no marker — the caller proceeds as a legacy/pre-bootstrap context
+		if gate.MarkerFound {
+			t.Error("Expected MarkerFound=false when no marker is recorded")
+		}
+	})
+
+	t.Run("VersionMatchesWhenSourceSetEqualsApplied", func(t *testing.T) {
+		// Given a settled marker whose source set matches the blueprint
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.GetVersionMarkerFunc = func(namespace string) (kubernetes.VersionMarker, bool, error) {
+			return matchingMarker(), true, nil
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+
+		// When the gate is checked
+		gate, err := provisioner.CheckVersionGate(createTestBlueprint())
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then it reports a settled, matching version
+		if !gate.MarkerFound || gate.InFlight || !gate.VersionMatch {
+			t.Errorf("Expected found+match+settled, got %+v", gate)
+		}
+	})
+
+	t.Run("VersionDiffersWhenSourceRefChanged", func(t *testing.T) {
+		// Given a marker whose source ref differs from the blueprint
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.GetVersionMarkerFunc = func(namespace string) (kubernetes.VersionMarker, bool, error) {
+			marker := matchingMarker()
+			for name, ref := range marker.AppliedSources {
+				ref.Ref = "different"
+				marker.AppliedSources[name] = ref
+			}
+			return marker, true, nil
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+
+		// When the gate is checked
+		gate, err := provisioner.CheckVersionGate(createTestBlueprint())
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the version does not match — apply must redirect to upgrade
+		if !gate.MarkerFound || gate.VersionMatch {
+			t.Errorf("Expected found with VersionMatch=false, got %+v", gate)
+		}
+	})
+
+	t.Run("InFlightWhenMarkerPhaseNotIdle", func(t *testing.T) {
+		// Given a marker mid-transition
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.GetVersionMarkerFunc = func(namespace string) (kubernetes.VersionMarker, bool, error) {
+			marker := matchingMarker()
+			marker.Phase = "migrating"
+			return marker, true, nil
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+
+		// When the gate is checked
+		gate, err := provisioner.CheckVersionGate(createTestBlueprint())
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then it reports an in-flight transition
+		if !gate.InFlight {
+			t.Errorf("Expected InFlight=true for a non-idle phase, got %+v", gate)
+		}
+	})
+
+	t.Run("NoKubeconfigShortCircuitsToLegacy", func(t *testing.T) {
+		// Given a context with no kubeconfig (no cluster)
+		mocks := setupProvisionerMocks(t)
+		mocks.Runtime.ConfigRoot = t.TempDir()
+		mocks.KubernetesManager.GetVersionMarkerFunc = func(namespace string) (kubernetes.VersionMarker, bool, error) {
+			return kubernetes.VersionMarker{}, false, fmt.Errorf("should not be called")
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+
+		// When the gate is checked, it short-circuits to "nothing applied"
+		gate, err := provisioner.CheckVersionGate(createTestBlueprint())
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if gate.MarkerFound {
+			t.Error("Expected MarkerFound=false with no kubeconfig")
+		}
+	})
+
+	t.Run("ReadFailurePropagates", func(t *testing.T) {
+		// Given a marker read that fails (cluster unreachable)
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.GetVersionMarkerFunc = func(namespace string) (kubernetes.VersionMarker, bool, error) {
+			return kubernetes.VersionMarker{}, false, fmt.Errorf("connection refused")
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+
+		// When the gate is checked, the error surfaces for the caller to treat as best-effort
+		if _, err := provisioner.CheckVersionGate(createTestBlueprint()); err == nil {
+			t.Error("Expected an error when the marker read fails")
+		}
+	})
+
+	t.Run("NilBlueprintReturnsError", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+		if _, err := provisioner.CheckVersionGate(nil); err == nil {
+			t.Error("Expected error for nil blueprint")
+		}
+	})
+}
+
 func TestProvisioner_Install(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> This adds shared enforcement logic to a core CLI command path, and the gate is missing from two of the three invocation paths the change is meant to protect.
>
> **Overview**
>
> The PR introduces a version gate on `windsor apply` that reads a ConfigMap marker written by `upgrade` and refuses to let `apply` cross a version boundary. An `--force` flag overrides version-mismatch refusals but not in-flight upgrade refusals, which is the correct asymmetry. The gate short-circuits to "proceed" when no kubeconfig is present and treats cluster-read failures as best-effort, both reasonable defaults for recovery scenarios.
>
> The gate is wired only into `applyCmd.RunE`. Because Cobra dispatches `windsor apply terraform` and `windsor apply kustomize` directly to their own `RunE` — bypassing the parent's — both subcommands skip the version check entirely, undermining the invariant the change is adding.
>
> Reviewed by Claude for commit `fa1a385f`.

<!-- /claude-code-review:summary -->
