### PR TITLE
feat(provisioner): implement version transition marker management for upgrades

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -74,6 +74,10 @@ windsor upgrade cluster --nodes=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1
 				return fmt.Errorf("resolved blueprint is not available")
 			}
 
+			if err := proj.Provisioner.BeginVersionTransition(blueprint); err != nil {
+				return fmt.Errorf("error recording version transition: %w", err)
+			}
+
 			if err := proj.Provisioner.Install(cmd.Context(), blueprint); err != nil {
 				return fmt.Errorf("error installing blueprint: %w", err)
 			}
@@ -84,6 +88,10 @@ windsor upgrade cluster --nodes=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1
 
 			if err := proj.Provisioner.Prune(blueprint); err != nil {
 				return fmt.Errorf("error pruning orphaned kustomizations: %w", err)
+			}
+
+			if err := proj.Provisioner.WriteVersionMarker(blueprint); err != nil {
+				return fmt.Errorf("error recording applied version: %w", err)
 			}
 
 			return nil

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -96,6 +96,62 @@ func TestUpgradeCmd(t *testing.T) {
 		}
 	})
 
+	t.Run("LeavesInFlightMarkerWhenInstallFails", func(t *testing.T) {
+		// Given an install that fails after the transition has been recorded
+		mocks := setupApplyTest(t)
+		mocks.KubernetesManager.ApplyBlueprintFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) error {
+			return fmt.Errorf("install failed")
+		}
+		var phases []string
+		mocks.KubernetesManager.ApplyVersionMarkerFunc = func(namespace string, marker kubernetes.VersionMarker) error {
+			phases = append(phases, marker.Phase)
+			return nil
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When executing the upgrade command
+		cmd := createTestUpgradeCmd()
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then the failure surfaces and the marker is never settled
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if len(phases) != 1 || phases[0] != kubernetes.VersionMarkerPhaseUpgrading {
+			t.Errorf("Expected only the in-flight marker write, got %v", phases)
+		}
+	})
+
+	t.Run("LeavesInFlightMarkerWhenPruneFails", func(t *testing.T) {
+		// Given a prune that fails after install and wait succeed
+		mocks := setupApplyTest(t)
+		mocks.KubernetesManager.PruneBlueprintFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) error {
+			return fmt.Errorf("prune failed")
+		}
+		var phases []string
+		mocks.KubernetesManager.ApplyVersionMarkerFunc = func(namespace string, marker kubernetes.VersionMarker) error {
+			phases = append(phases, marker.Phase)
+			return nil
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When executing the upgrade command
+		cmd := createTestUpgradeCmd()
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then the failure surfaces and the marker is never settled
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if len(phases) != 1 || phases[0] != kubernetes.VersionMarkerPhaseUpgrading {
+			t.Errorf("Expected only the in-flight marker write, got %v", phases)
+		}
+	})
+
 	t.Run("WaitFailureSkipsPrune", func(t *testing.T) {
 		// Given a wait that fails before the desired set has reconciled
 		mocks := setupApplyTest(t)

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+	"github.com/windsorcli/cli/pkg/provisioner/kubernetes"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 )
 
@@ -40,6 +41,58 @@ func TestUpgradeCmd(t *testing.T) {
 		}
 		if !pruned {
 			t.Error("Expected upgrade to prune orphaned kustomizations")
+		}
+	})
+
+	t.Run("WritesInFlightMarkerThenSettledMarker", func(t *testing.T) {
+		// Given an upgrade whose every step succeeds
+		mocks := setupApplyTest(t)
+		var phases []string
+		mocks.KubernetesManager.ApplyVersionMarkerFunc = func(namespace string, marker kubernetes.VersionMarker) error {
+			phases = append(phases, marker.Phase)
+			return nil
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When executing the bare upgrade command
+		cmd := createTestUpgradeCmd()
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then it records the in-flight marker first, then settles it to idle on success
+		if len(phases) != 2 || phases[0] != kubernetes.VersionMarkerPhaseUpgrading || phases[1] != kubernetes.VersionMarkerPhaseIdle {
+			t.Errorf("Expected marker writes [upgrading idle], got %v", phases)
+		}
+	})
+
+	t.Run("LeavesInFlightMarkerWhenWaitFails", func(t *testing.T) {
+		// Given a wait that fails after the transition has been recorded
+		mocks := setupApplyTest(t)
+		mocks.KubernetesManager.WaitForKustomizationsFunc = func(ctx stdcontext.Context, message string, bp *blueprintv1alpha1.Blueprint) error {
+			return fmt.Errorf("wait failed")
+		}
+		var phases []string
+		mocks.KubernetesManager.ApplyVersionMarkerFunc = func(namespace string, marker kubernetes.VersionMarker) error {
+			phases = append(phases, marker.Phase)
+			return nil
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When executing the upgrade command
+		cmd := createTestUpgradeCmd()
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then the failure surfaces and the marker is left in-flight (never settled) so apply refuses
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if len(phases) != 1 || phases[0] != kubernetes.VersionMarkerPhaseUpgrading {
+			t.Errorf("Expected only the in-flight marker write, got %v", phases)
 		}
 	})
 

--- a/pkg/provisioner/kubernetes/version_marker.go
+++ b/pkg/provisioner/kubernetes/version_marker.go
@@ -28,6 +28,10 @@ const (
 
 	// VersionMarkerPhaseIdle marks a context with no upgrade in flight.
 	VersionMarkerPhaseIdle = "idle"
+
+	// VersionMarkerPhaseUpgrading is the phase of a context with an upgrade in flight. apply's
+	// version gate refuses any non-idle phase, so an interrupted upgrade is resumed, not reconciled.
+	VersionMarkerPhaseUpgrading = "upgrading"
 )
 
 // =============================================================================
@@ -50,6 +54,7 @@ type VersionMarker struct {
 	SchemaVersion  int                  `json:"schemaVersion"`
 	Phase          string               `json:"phase"`
 	AppliedSources map[string]SourceRef `json:"appliedSources,omitempty"`
+	TargetSources  map[string]SourceRef `json:"targetSources,omitempty"`
 }
 
 // =============================================================================
@@ -97,6 +102,22 @@ func BuildVersionMarker(blueprint *blueprintv1alpha1.Blueprint) (VersionMarker, 
 		}
 	}
 	return marker, nil
+}
+
+// BuildTransitionMarker returns an in-flight marker for an upgrade toward blueprint: the applied
+// source set (empty for a legacy context) plus the blueprint's set as the target, under the
+// upgrading phase. WriteVersionMarker replaces it with a settled marker once the upgrade succeeds.
+func BuildTransitionMarker(applied map[string]SourceRef, blueprint *blueprintv1alpha1.Blueprint) (VersionMarker, error) {
+	target, err := BuildVersionMarker(blueprint)
+	if err != nil {
+		return VersionMarker{}, err
+	}
+	return VersionMarker{
+		SchemaVersion:  versionMarkerSchemaVersion,
+		Phase:          VersionMarkerPhaseUpgrading,
+		AppliedSources: applied,
+		TargetSources:  target.AppliedSources,
+	}, nil
 }
 
 // ToConfigMapData encodes the marker as ConfigMap data (a single JSON document).

--- a/pkg/provisioner/kubernetes/version_marker_test.go
+++ b/pkg/provisioner/kubernetes/version_marker_test.go
@@ -110,11 +110,12 @@ func TestBuildVersionMarker(t *testing.T) {
 
 func TestVersionMarker_ConfigMapRoundTrip(t *testing.T) {
 	t.Run("EncodesAndDecodesToTheSameMarker", func(t *testing.T) {
-		// Given a marker
+		// Given an in-flight marker carrying both applied and target source sets
 		original := VersionMarker{
 			SchemaVersion:  versionMarkerSchemaVersion,
-			Phase:          VersionMarkerPhaseIdle,
+			Phase:          VersionMarkerPhaseUpgrading,
 			AppliedSources: map[string]SourceRef{"core": {URL: "oci://example/core", Ref: "v1.0.0"}},
+			TargetSources:  map[string]SourceRef{"core": {URL: "oci://example/core", Ref: "v2.0.0"}},
 		}
 
 		// When it is encoded to ConfigMap data and parsed back
@@ -127,11 +128,11 @@ func TestVersionMarker_ConfigMapRoundTrip(t *testing.T) {
 			t.Fatalf("Expected no parse error, got %v", err)
 		}
 
-		// Then the round-trip preserves the marker
+		// Then the round-trip preserves the phase and both source sets
 		if !ok {
 			t.Fatal("Expected marker to be present")
 		}
-		if parsed.Phase != original.Phase || parsed.AppliedSources["core"] != original.AppliedSources["core"] {
+		if parsed.Phase != original.Phase || parsed.AppliedSources["core"] != original.AppliedSources["core"] || parsed.TargetSources["core"] != original.TargetSources["core"] {
 			t.Errorf("Round-trip mismatch: got %+v, want %+v", parsed, original)
 		}
 	})
@@ -159,6 +160,48 @@ func TestVersionMarker_ConfigMapRoundTrip(t *testing.T) {
 		// Then it errors rather than returning silently zero-valued fields from an unrecognized schema
 		if err == nil {
 			t.Error("Expected an error for an unsupported schema version")
+		}
+	})
+}
+
+func TestBuildTransitionMarker(t *testing.T) {
+	t.Run("PreservesAppliedAndRecordsTargetUnderUpgradingPhase", func(t *testing.T) {
+		// Given the currently-applied source set and a blueprint pinned to a newer ref
+		applied := map[string]SourceRef{"core": {URL: "oci://example/core", Ref: "v1.0.0"}}
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Metadata: blueprintv1alpha1.Metadata{Name: "bp"},
+			Sources:  []blueprintv1alpha1.Source{{Name: "core", Url: "oci://example/core", Ref: blueprintv1alpha1.Reference{SemVer: "v2.0.0"}}},
+		}
+
+		// When the transition marker is built
+		marker, err := BuildTransitionMarker(applied, blueprint)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then it is in-flight, preserves the applied ref, and records the target ref
+		if marker.Phase != VersionMarkerPhaseUpgrading {
+			t.Errorf("Expected phase %q, got %q", VersionMarkerPhaseUpgrading, marker.Phase)
+		}
+		if marker.AppliedSources["core"].Ref != "v1.0.0" {
+			t.Errorf("Expected applied ref 'v1.0.0', got %q", marker.AppliedSources["core"].Ref)
+		}
+		if marker.TargetSources["core"].Ref != "v2.0.0" {
+			t.Errorf("Expected target ref 'v2.0.0', got %q", marker.TargetSources["core"].Ref)
+		}
+	})
+
+	t.Run("PropagatesBlueprintReductionError", func(t *testing.T) {
+		// Given a blueprint whose repository name collides with a declared source
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Metadata:   blueprintv1alpha1.Metadata{Name: "core"},
+			Repository: blueprintv1alpha1.Repository{Url: "http://git.test/core", Ref: blueprintv1alpha1.Reference{Branch: "main"}},
+			Sources:    []blueprintv1alpha1.Source{{Name: "core", Url: "oci://example/core", Ref: blueprintv1alpha1.Reference{SemVer: "v2.0.0"}}},
+		}
+
+		// When the transition marker is built, the underlying reduction error surfaces
+		if _, err := BuildTransitionMarker(nil, blueprint); err == nil {
+			t.Error("Expected an error when the blueprint cannot be reduced to an unambiguous set")
 		}
 	})
 }

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -90,7 +90,7 @@ type DestroyPlanSummary struct {
 // refuse, or honor --force); this struct only reports the relation.
 type VersionGate struct {
 	MarkerFound  bool // a marker exists for this context (false = pre-bootstrap, no cluster, or legacy)
-	InFlight     bool // an upgrade is mid-transition (marker phase is not idle)
+	InFlight     bool // the marker phase is not idle (an upgrade is in flight)
 	VersionMatch bool // the blueprint's resolved source-ref set equals the applied set
 }
 
@@ -978,6 +978,37 @@ func (i *Provisioner) WriteVersionMarker(blueprint *blueprintv1alpha1.Blueprint)
 		return fmt.Errorf("failed to write version marker: %w", err)
 	}
 
+	return nil
+}
+
+// BeginVersionTransition writes the in-flight marker for an upgrade toward blueprint: it preserves
+// the applied source set from the existing marker (empty for a legacy context) and records the
+// blueprint's set as the target under the upgrading phase. apply's version gate refuses while the
+// marker is non-idle; WriteVersionMarker settles it to idle on success.
+func (i *Provisioner) BeginVersionTransition(blueprint *blueprintv1alpha1.Blueprint) error {
+	if blueprint == nil {
+		return fmt.Errorf("blueprint not provided")
+	}
+	if i.KubernetesManager == nil {
+		return fmt.Errorf("kubernetes manager not configured")
+	}
+
+	current, found, err := i.GetVersionMarker()
+	if err != nil {
+		return fmt.Errorf("failed to read current version marker: %w", err)
+	}
+	var applied map[string]kubernetes.SourceRef
+	if found {
+		applied = current.AppliedSources
+	}
+
+	marker, err := kubernetes.BuildTransitionMarker(applied, blueprint)
+	if err != nil {
+		return fmt.Errorf("failed to build transition marker: %w", err)
+	}
+	if err := i.KubernetesManager.ApplyVersionMarker(i.fluxNamespace(), marker); err != nil {
+		return fmt.Errorf("failed to write transition marker: %w", err)
+	}
 	return nil
 }
 

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -1388,6 +1388,100 @@ func TestProvisioner_GetVersionMarker(t *testing.T) {
 	})
 }
 
+func TestProvisioner_BeginVersionTransition(t *testing.T) {
+	t.Run("PreservesAppliedAndRecordsTargetUnderUpgradingPhase", func(t *testing.T) {
+		// Given a context already running an older version
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.GetVersionMarkerFunc = func(namespace string) (kubernetes.VersionMarker, bool, error) {
+			return kubernetes.VersionMarker{
+				Phase:          kubernetes.VersionMarkerPhaseIdle,
+				AppliedSources: map[string]kubernetes.SourceRef{"source1": {URL: "old", Ref: "v0"}},
+			}, true, nil
+		}
+		var captured kubernetes.VersionMarker
+		mocks.KubernetesManager.ApplyVersionMarkerFunc = func(namespace string, marker kubernetes.VersionMarker) error {
+			captured = marker
+			return nil
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+
+		// When beginning a transition toward the blueprint
+		if err := provisioner.BeginVersionTransition(createTestBlueprint()); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the written marker is in-flight, preserves the old applied set, and records the new target
+		if captured.Phase != kubernetes.VersionMarkerPhaseUpgrading {
+			t.Errorf("Expected phase %q, got %q", kubernetes.VersionMarkerPhaseUpgrading, captured.Phase)
+		}
+		if captured.AppliedSources["source1"].Ref != "v0" {
+			t.Errorf("Expected applied ref preserved as 'v0', got %q", captured.AppliedSources["source1"].Ref)
+		}
+		target, _ := kubernetes.BuildVersionMarker(createTestBlueprint())
+		if !kubernetes.SourcesEqual(captured.TargetSources, target.AppliedSources) {
+			t.Errorf("Expected target to equal the blueprint source set, got %+v", captured.TargetSources)
+		}
+	})
+
+	t.Run("EmptyAppliedForLegacyContext", func(t *testing.T) {
+		// Given a legacy/first-upgrade context with no recorded marker
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.GetVersionMarkerFunc = func(namespace string) (kubernetes.VersionMarker, bool, error) {
+			return kubernetes.VersionMarker{}, false, nil
+		}
+		var captured kubernetes.VersionMarker
+		mocks.KubernetesManager.ApplyVersionMarkerFunc = func(namespace string, marker kubernetes.VersionMarker) error {
+			captured = marker
+			return nil
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+
+		// When beginning a transition
+		if err := provisioner.BeginVersionTransition(createTestBlueprint()); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then there is no applied set to preserve, but the target is still recorded
+		if len(captured.AppliedSources) != 0 {
+			t.Errorf("Expected empty applied set for a legacy context, got %+v", captured.AppliedSources)
+		}
+		if len(captured.TargetSources) == 0 {
+			t.Error("Expected the target set to be recorded")
+		}
+	})
+
+	t.Run("ReadFailurePropagates", func(t *testing.T) {
+		// Given a marker read that fails
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.GetVersionMarkerFunc = func(namespace string) (kubernetes.VersionMarker, bool, error) {
+			return kubernetes.VersionMarker{}, false, fmt.Errorf("connection refused")
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+
+		// When beginning a transition, the read error surfaces rather than writing a wrong marker
+		if err := provisioner.BeginVersionTransition(createTestBlueprint()); err == nil {
+			t.Error("Expected an error when the current marker cannot be read")
+		}
+	})
+
+	t.Run("NilBlueprintReturnsError", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+		if err := provisioner.BeginVersionTransition(nil); err == nil {
+			t.Error("Expected error for nil blueprint")
+		}
+	})
+
+	t.Run("NilManagerReturnsError", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+		provisioner.KubernetesManager = nil
+		if err := provisioner.BeginVersionTransition(createTestBlueprint()); err == nil {
+			t.Error("Expected error for nil kubernetes manager")
+		}
+	})
+}
+
 func TestProvisioner_CheckVersionGate(t *testing.T) {
 	// matchingMarker returns a settled marker whose source set equals the test blueprint's.
 	matchingMarker := func() kubernetes.VersionMarker {


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> The PR adds two new Kubernetes API calls to the upgrade command path, meaning any cluster-side failure between them leaves the version marker in a non-idle state and blocks `apply` until upgrade is retried.
>
> **Overview**
>
> This PR completes the upgrade-side of the version marker lifecycle introduced alongside the `apply` version gate. Before calling `Install`, the upgrade command now writes an in-flight "upgrading" marker that preserves the current applied source set and records the blueprint's source set as the target. After all cluster work succeeds (`Install`, `WaitForKustomizations`, `PruneOrphans`), `WriteVersionMarker` settles the marker to "idle". Any failure mid-upgrade intentionally leaves the marker in-flight, forcing the user to re-run upgrade rather than letting `apply` proceed on a potentially inconsistent cluster.
>
> `BuildTransitionMarker` delegates to `BuildVersionMarker` and maps the result's `AppliedSources` into `TargetSources` — the indirection is correct but ties the transition builder to `BuildVersionMarker`'s field naming convention. The one test gap worth addressing: only `WaitForKustomizations` failure is exercised as an in-flight path; an `Install`-fails case would complete the correctness matrix for this invariant.
>
> Reviewed by Claude for commit `870604f`.

<!-- /claude-code-review:summary -->
