### PR TITLE
feat(cmd/plan): add describePlanMode function to indicate version transition status

### DIFF
--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	composerblueprint "github.com/windsorcli/cli/pkg/composer/blueprint"
+	"github.com/windsorcli/cli/pkg/project"
 	"github.com/windsorcli/cli/pkg/provisioner"
 	fluxinfra "github.com/windsorcli/cli/pkg/provisioner/flux"
 	"github.com/windsorcli/cli/pkg/provisioner/stacklock"
@@ -74,6 +75,7 @@ windsor plan terraform cluster`,
 				if planJSON {
 					return tuiplan.SummaryJSON(os.Stdout, summary.Terraform, summary.Kustomize)
 				}
+				describePlanMode(cmd, proj, blueprint)
 				tuiplan.Summary(os.Stdout, summary.Terraform, summary.Kustomize, summary.Hints, planNoColor || os.Getenv("NO_COLOR") != "")
 				return nil
 			})
@@ -300,6 +302,24 @@ func init() {
 	planCmd.AddCommand(planTerraformCmd)
 	planCmd.AddCommand(planKustomizeCmd)
 	rootCmd.AddCommand(planCmd)
+}
+
+// describePlanMode prints to stderr whether `plan` is previewing in-version content drift or a
+// pending version transition, so the operator knows the path forward is apply or upgrade. It is
+// best-effort: a legacy or unreadable marker prints nothing and lets the content plan speak for
+// itself. The transition's content delta is the plan shown below; this only labels which mode the
+// operator is in.
+func describePlanMode(cmd *cobra.Command, proj *project.Project, blueprint *blueprintv1alpha1.Blueprint) {
+	gate, err := proj.Provisioner.CheckVersionGate(blueprint)
+	if err != nil || !gate.MarkerFound {
+		return
+	}
+	switch {
+	case gate.InFlight:
+		fmt.Fprintln(cmd.ErrOrStderr(), "An upgrade is in progress for this context. Run `windsor upgrade` to resume it; the plan below shows the current content delta.")
+	case !gate.VersionMatch:
+		fmt.Fprintln(cmd.ErrOrStderr(), "The blueprint targets a different version than what is applied. The plan below shows the content delta; run `windsor upgrade` to transition versions.")
+	}
 }
 
 // blueprintHasTerraformComponent reports whether the blueprint contains an enabled Terraform component with the given ID.

--- a/cmd/plan_test.go
+++ b/cmd/plan_test.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -15,6 +18,7 @@ import (
 	"github.com/windsorcli/cli/pkg/project"
 	"github.com/windsorcli/cli/pkg/provisioner"
 	fluxinfra "github.com/windsorcli/cli/pkg/provisioner/flux"
+	"github.com/windsorcli/cli/pkg/provisioner/kubernetes"
 	terraforminfra "github.com/windsorcli/cli/pkg/provisioner/terraform"
 	"github.com/windsorcli/cli/pkg/runtime"
 	"github.com/windsorcli/cli/pkg/runtime/config"
@@ -211,6 +215,94 @@ func TestPlanCmd(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "not found in blueprint") {
 			t.Errorf("expected not-found error, got: %v", err)
+		}
+	})
+}
+
+func TestDescribePlanMode(t *testing.T) {
+	// projectWithMarker wires a seeded kubeconfig (so the version gate engages) and a mock
+	// kubernetes manager returning the given marker into a plan project.
+	projectWithMarker := func(t *testing.T, getFn func(string) (kubernetes.VersionMarker, bool, error)) *project.Project {
+		t.Helper()
+		mocks := setupPlanTest(t)
+		root := t.TempDir()
+		if err := os.MkdirAll(filepath.Join(root, ".kube"), 0755); err != nil {
+			t.Fatalf("seed kubeconfig dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(root, ".kube", "config"), []byte("apiVersion: v1\nkind: Config\n"), 0644); err != nil {
+			t.Fatalf("seed kubeconfig: %v", err)
+		}
+		mocks.Runtime.ConfigRoot = root
+		km := kubernetes.NewMockKubernetesManager()
+		km.GetVersionMarkerFunc = getFn
+		comp := composer.NewComposer(mocks.Runtime)
+		comp.BlueprintHandler = mocks.BlueprintHandler
+		prov := provisioner.NewProvisioner(mocks.Runtime, comp.BlueprintHandler, &provisioner.Provisioner{
+			TerraformStack:    mocks.TerraformStack,
+			KubernetesManager: km,
+		})
+		return project.NewProject("", &project.Project{Runtime: mocks.Runtime, Composer: comp, Provisioner: prov})
+	}
+
+	// The bare test blueprint has no sources, so its derived source set is empty; a marker with a
+	// non-empty applied set is therefore a version mismatch.
+	blueprint := &blueprintv1alpha1.Blueprint{Metadata: blueprintv1alpha1.Metadata{Name: "test"}}
+
+	run := func(proj *project.Project) string {
+		var buf bytes.Buffer
+		cmd := &cobra.Command{}
+		cmd.SetErr(&buf)
+		describePlanMode(cmd, proj, blueprint)
+		return buf.String()
+	}
+
+	t.Run("AnnouncesPendingTransitionWhenVersionDiffers", func(t *testing.T) {
+		proj := projectWithMarker(t, func(string) (kubernetes.VersionMarker, bool, error) {
+			return kubernetes.VersionMarker{
+				Phase:          kubernetes.VersionMarkerPhaseIdle,
+				AppliedSources: map[string]kubernetes.SourceRef{"core": {URL: "oci://example/core", Ref: "v1.0.0"}},
+			}, true, nil
+		})
+		out := run(proj)
+		if !strings.Contains(out, "targets a different version") || !strings.Contains(out, "upgrade") {
+			t.Errorf("Expected a version-transition notice, got: %q", out)
+		}
+	})
+
+	t.Run("AnnouncesInFlightUpgrade", func(t *testing.T) {
+		proj := projectWithMarker(t, func(string) (kubernetes.VersionMarker, bool, error) {
+			return kubernetes.VersionMarker{Phase: kubernetes.VersionMarkerPhaseUpgrading}, true, nil
+		})
+		out := run(proj)
+		if !strings.Contains(out, "in progress") || !strings.Contains(out, "upgrade") {
+			t.Errorf("Expected an in-flight upgrade notice, got: %q", out)
+		}
+	})
+
+	t.Run("SilentWhenVersionMatches", func(t *testing.T) {
+		proj := projectWithMarker(t, func(string) (kubernetes.VersionMarker, bool, error) {
+			return kubernetes.VersionMarker{Phase: kubernetes.VersionMarkerPhaseIdle}, true, nil
+		})
+		if out := run(proj); out != "" {
+			t.Errorf("Expected no notice when the version matches, got: %q", out)
+		}
+	})
+
+	t.Run("SilentForLegacyContextWithNoMarker", func(t *testing.T) {
+		proj := projectWithMarker(t, func(string) (kubernetes.VersionMarker, bool, error) {
+			return kubernetes.VersionMarker{}, false, nil
+		})
+		if out := run(proj); out != "" {
+			t.Errorf("Expected no notice for a legacy context, got: %q", out)
+		}
+	})
+
+	t.Run("SilentWhenMarkerReadFails", func(t *testing.T) {
+		proj := projectWithMarker(t, func(string) (kubernetes.VersionMarker, bool, error) {
+			return kubernetes.VersionMarker{}, false, fmt.Errorf("connection refused")
+		})
+		if out := run(proj); out != "" {
+			t.Errorf("Expected best-effort silence when the marker cannot be read, got: %q", out)
 		}
 	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This change adds a single read-only diagnostic to the non-JSON plan path, writing at most one line to stderr — no shared state is modified.
>
> **Overview**
>
> The PR adds `describePlanMode`, a small function that checks the version gate marker after a plan runs and tells the operator whether they are looking at in-version content drift or a pending version upgrade. The function is intentionally best-effort: errors and absent markers both produce silent returns, so legacy contexts continue working unchanged. The call is guarded by the existing `planJSON` check, keeping structured output clean.
>
> The test suite exercises all four meaningful states — in-flight upgrade, version mismatch, version match, absent marker, and read failure — through the full project stack down to a mocked `KubernetesManager`, matching the project's integration-style test convention.
>
> Reviewed by Claude for commit `24db3041`.

<!-- /claude-code-review:summary -->
