### PR TITLE
feat(cmd/upgrade): add --source flag for retargeting declared sources in upgrade command

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -3,11 +3,13 @@ package cmd
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/windsorcli/cli/pkg/composer"
 	"github.com/windsorcli/cli/pkg/constants"
+	"github.com/windsorcli/cli/pkg/project"
 	"github.com/windsorcli/cli/pkg/provisioner"
 	"github.com/windsorcli/cli/pkg/provisioner/stacklock"
 	"github.com/windsorcli/cli/pkg/runtime"
@@ -15,8 +17,9 @@ import (
 )
 
 var (
-	upgradeNodes []string
-	upgradeImage string
+	upgradeNodes   []string
+	upgradeImage   string
+	upgradeSources []string
 
 	upgradeNodeAddr    string
 	upgradeNodeImage   string
@@ -56,6 +59,16 @@ windsor upgrade cluster --nodes=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1
 		blueprint := proj.Composer.BlueprintHandler.Generate()
 		if blueprint == nil {
 			return fmt.Errorf("blueprint is not available")
+		}
+
+		if len(upgradeSources) > 0 {
+			if err := retargetSources(cmd, proj, upgradeSources); err != nil {
+				return err
+			}
+			blueprint = proj.Composer.BlueprintHandler.Generate()
+			if blueprint == nil {
+				return fmt.Errorf("blueprint is not available")
+			}
 		}
 
 		return stacklock.With(cmd.Context(), proj.Runtime, "upgrade", func() error {
@@ -209,10 +222,41 @@ windsor upgrade node --node=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.
 	},
 }
 
+// retargetSources applies each `name=url` spec to the context's declared sources, persists the bumps
+// to blueprint.yaml via the same writer init uses, and prints what changed for the operator to
+// commit. An unknown source name or malformed spec aborts before anything is written, so a failed
+// retarget never leaves blueprint.yaml half-edited.
+func retargetSources(cmd *cobra.Command, proj *project.Project, specs []string) error {
+	type change struct{ name, previous, target string }
+	changes := make([]change, 0, len(specs))
+	for _, spec := range specs {
+		name, url, ok := strings.Cut(spec, "=")
+		if !ok || name == "" || url == "" {
+			return fmt.Errorf("invalid --source %q; expected name=url", spec)
+		}
+		previous, err := proj.Composer.BlueprintHandler.RetargetSource(name, url)
+		if err != nil {
+			return err
+		}
+		changes = append(changes, change{name: name, previous: previous, target: url})
+	}
+
+	if err := proj.Composer.BlueprintHandler.Write(true); err != nil {
+		return fmt.Errorf("failed to persist source changes to blueprint.yaml: %w", err)
+	}
+
+	for _, c := range changes {
+		fmt.Fprintf(cmd.OutOrStdout(), "Retargeted %s from %s to %s\n", c.name, c.previous, c.target)
+	}
+	return nil
+}
+
 func init() {
 	rootCmd.AddCommand(upgradeCmd)
 	upgradeCmd.AddCommand(upgradeClusterCmd)
 	upgradeCmd.AddCommand(upgradeNodeCmd)
+
+	upgradeCmd.Flags().StringArrayVar(&upgradeSources, "source", nil, "Retarget a declared source to a new tagged URL (name=url); repeatable. Persisted to blueprint.yaml.")
 
 	upgradeClusterCmd.Flags().StringSliceVar(&upgradeNodes, "nodes", []string{}, "Node addresses to upgrade. Required.")
 	upgradeClusterCmd.Flags().StringVar(&upgradeImage, "image", "", "Talos image to upgrade to. Required.")

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -290,6 +290,111 @@ func TestUpgradeCmd(t *testing.T) {
 	})
 }
 
+func TestUpgradeCmd_Source(t *testing.T) {
+	createTestUpgradeCmd := func() *cobra.Command { return makeApplyTestCmd(upgradeCmd) }
+
+	suppressProcessStdout(t)
+	suppressProcessStderr(t)
+
+	t.Run("RetargetsPersistsAndUpgrades", func(t *testing.T) {
+		t.Cleanup(func() { upgradeSources = nil })
+		// Given a declared source being bumped to a new tag
+		mocks := setupApplyTest(t)
+		var gotName, gotURL string
+		persisted := false
+		mocks.BlueprintHandler.RetargetSourceFunc = func(name, url string) (string, error) {
+			gotName, gotURL = name, url
+			return "oci://ghcr.io/windsorcli/core:v0.3.0", nil
+		}
+		mocks.BlueprintHandler.WriteFunc = func(overwrite ...bool) error {
+			if len(overwrite) > 0 && overwrite[0] {
+				persisted = true
+			}
+			return nil
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When upgrading with --source
+		var out bytes.Buffer
+		cmd := createTestUpgradeCmd()
+		cmd.SetOut(&out)
+		cmd.SetArgs([]string{"--source", "core=oci://ghcr.io/windsorcli/core:v0.6.0"})
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the source is retargeted, persisted, reported, and the upgrade proceeds
+		if gotName != "core" || gotURL != "oci://ghcr.io/windsorcli/core:v0.6.0" {
+			t.Errorf("Expected retarget core to new URL, got %q=%q", gotName, gotURL)
+		}
+		if !persisted {
+			t.Error("Expected the bump to be persisted via Write(true)")
+		}
+		if !strings.Contains(out.String(), "Retargeted core") {
+			t.Errorf("Expected a retarget report, got: %q", out.String())
+		}
+	})
+
+	t.Run("UnknownSourceAbortsBeforeWrite", func(t *testing.T) {
+		t.Cleanup(func() { upgradeSources = nil })
+		// Given a source name that is not declared
+		mocks := setupApplyTest(t)
+		persisted := false
+		mocks.BlueprintHandler.RetargetSourceFunc = func(name, url string) (string, error) {
+			return "", fmt.Errorf("source %q is not declared in the blueprint", name)
+		}
+		mocks.BlueprintHandler.WriteFunc = func(overwrite ...bool) error {
+			if len(overwrite) > 0 && overwrite[0] {
+				persisted = true
+			}
+			return nil
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When upgrading with an undeclared --source
+		cmd := createTestUpgradeCmd()
+		cmd.SetArgs([]string{"--source", "addons=oci://ghcr.io/acme/addons:v0.5.0"})
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then it aborts with the error and never writes blueprint.yaml
+		if err == nil {
+			t.Fatal("Expected error for an undeclared source, got nil")
+		}
+		if !strings.Contains(err.Error(), "not declared") {
+			t.Errorf("Expected an undeclared-source error, got: %v", err)
+		}
+		if persisted {
+			t.Error("Expected no Write(true) when a retarget fails")
+		}
+	})
+
+	t.Run("MalformedSourceSpecIsRejected", func(t *testing.T) {
+		t.Cleanup(func() { upgradeSources = nil })
+		// Given a --source value missing the name=url separator
+		mocks := setupApplyTest(t)
+		proj := newApplyAllProject(mocks)
+
+		// When upgrading with the malformed spec
+		cmd := createTestUpgradeCmd()
+		cmd.SetArgs([]string{"--source", "coreonly"})
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then it is rejected with a format error
+		if err == nil {
+			t.Fatal("Expected error for a malformed --source, got nil")
+		}
+		if !strings.Contains(err.Error(), "name=url") {
+			t.Errorf("Expected a name=url format error, got: %v", err)
+		}
+	})
+}
+
 func TestUpgradeNodeCmd(t *testing.T) {
 	t.Cleanup(func() {
 		rootCmd.SetContext(stdcontext.Background())

--- a/docs/reference/commands/upgrade.md
+++ b/docs/reference/commands/upgrade.md
@@ -5,12 +5,18 @@ description: "Upgrade the blueprint, pruning kustomizations it no longer declare
 # windsor upgrade
 
 ```sh
-windsor upgrade
+windsor upgrade [flags]
 ```
 
 Apply terraform and the Flux blueprint, wait for kustomizations to be ready, then prune any kustomizations this context no longer declares. Pruning runs only after a successful wait, so resources are never deleted before the desired set has reconciled.
 
 Use the 'cluster' or 'node' subcommand to upgrade Talos nodes instead.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--source` | `[]` | Retarget a declared source to a new tagged URL (name=url); repeatable. Persisted to blueprint.yaml. |
 
 ## Subcommands
 

--- a/integration/upgrade_test.go
+++ b/integration/upgrade_test.go
@@ -50,6 +50,26 @@ func TestUpgrade_RunsBlueprintFlowInLocalContext(t *testing.T) {
 	}
 }
 
+func TestUpgrade_SourceRejectsUndeclaredSource(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
+	if _, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env); err != nil {
+		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
+	}
+	env = append(env, "WINDSOR_CONTEXT=local")
+
+	// --source must refuse a source the blueprint does not declare, before any cluster work —
+	// adding a source is a structural edit to blueprint.yaml, not a retarget.
+	_, stderr, err := helpers.RunCLI(dir, []string{"upgrade", "--source", "bogus=oci://ghcr.io/windsorcli/bogus:v1.0.0"}, env)
+	if err == nil {
+		t.Fatal("expected upgrade to reject an undeclared --source, got success")
+	}
+	if !strings.Contains(string(stderr), "not declared") {
+		t.Errorf("expected an undeclared-source error, got: %s", stderr)
+	}
+}
+
 // =============================================================================
 // Integration Tests — upgrade cluster
 // =============================================================================

--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -19,6 +19,7 @@ type BlueprintHandler interface {
 	LoadBlueprint(blueprintURL ...string) error
 	SetSkipValidation(skip bool)
 	Write(overwrite ...bool) error
+	RetargetSource(name, url string) (string, error)
 	GetTerraformComponents() []blueprintv1alpha1.TerraformComponent
 	GetLocalTemplateData() (map[string][]byte, error)
 	Generate() *blueprintv1alpha1.Blueprint
@@ -181,6 +182,30 @@ func (h *BaseBlueprintHandler) Write(overwrite ...bool) error {
 	h.setRepositoryDefaults()
 
 	return h.writer.Write(h.composedBlueprint, shouldOverwrite, h.initBlueprintURLs...)
+}
+
+// RetargetSource repoints an already-declared source to a new tagged OCI URL and returns the
+// source's previous URL for diff reporting. The new URL must include a version tag, validated via
+// OCI parsing; the tag is carried in the URL (the canonical source form), so any prior ref fields
+// are cleared. It errors when the source name is not declared, since adding or removing a source is
+// a structural edit to blueprint.yaml rather than a retarget. RetargetSource mutates the composed
+// blueprint in memory only; call Write to persist.
+func (h *BaseBlueprintHandler) RetargetSource(name, url string) (string, error) {
+	if h.composedBlueprint == nil {
+		return "", fmt.Errorf("blueprint not loaded")
+	}
+	if _, err := artifact.ParseOCIReference(url); err != nil {
+		return "", fmt.Errorf("invalid source url %q: %w", url, err)
+	}
+	for i := range h.composedBlueprint.Sources {
+		if h.composedBlueprint.Sources[i].Name == name {
+			previous := h.composedBlueprint.Sources[i].Url
+			h.composedBlueprint.Sources[i].Url = url
+			h.composedBlueprint.Sources[i].Ref = blueprintv1alpha1.Reference{}
+			return previous, nil
+		}
+	}
+	return "", fmt.Errorf("source %q is not declared in the blueprint; add it to blueprint.yaml before retargeting", name)
 }
 
 // GetTerraformComponents returns a copy of the composed blueprint's terraform components with

--- a/pkg/composer/blueprint/handler_test.go
+++ b/pkg/composer/blueprint/handler_test.go
@@ -2099,3 +2099,68 @@ func TestHandler_deriveConfigMapDeferredPaths(t *testing.T) {
 		}
 	})
 }
+
+func TestHandler_RetargetSource(t *testing.T) {
+	setup := func(t *testing.T) *BaseBlueprintHandler {
+		t.Helper()
+		mocks := setupHandlerMocks(t)
+		handler := NewBlueprintHandler(mocks.Runtime, mocks.ArtifactBuilder)
+		handler.composedBlueprint = &blueprintv1alpha1.Blueprint{
+			Sources: []blueprintv1alpha1.Source{
+				{Name: "core", Url: "oci://ghcr.io/windsorcli/core:v0.3.0", Ref: blueprintv1alpha1.Reference{SemVer: "v0.3.0"}},
+			},
+		}
+		return handler
+	}
+
+	t.Run("RepointsDeclaredSourceAndReturnsPrevious", func(t *testing.T) {
+		// Given a handler with a declared core source
+		handler := setup(t)
+
+		// When retargeting it to a newer tagged URL
+		previous, err := handler.RetargetSource("core", "oci://ghcr.io/windsorcli/core:v0.6.0")
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the previous URL is returned and the source carries the new URL with its ref cleared
+		if previous != "oci://ghcr.io/windsorcli/core:v0.3.0" {
+			t.Errorf("Expected previous URL, got %q", previous)
+		}
+		if handler.composedBlueprint.Sources[0].Url != "oci://ghcr.io/windsorcli/core:v0.6.0" {
+			t.Errorf("Expected URL repointed, got %q", handler.composedBlueprint.Sources[0].Url)
+		}
+		if handler.composedBlueprint.Sources[0].Ref != (blueprintv1alpha1.Reference{}) {
+			t.Errorf("Expected ref cleared (tag lives in URL), got %+v", handler.composedBlueprint.Sources[0].Ref)
+		}
+	})
+
+	t.Run("ErrorsOnUndeclaredSource", func(t *testing.T) {
+		// Given a handler without an 'addons' source
+		handler := setup(t)
+
+		// When retargeting an undeclared source, it errors rather than adding one
+		if _, err := handler.RetargetSource("addons", "oci://ghcr.io/acme/addons:v0.5.0"); err == nil {
+			t.Error("Expected an error for an undeclared source")
+		}
+	})
+
+	t.Run("ErrorsOnURLWithoutVersion", func(t *testing.T) {
+		// Given a handler with a declared source
+		handler := setup(t)
+
+		// When the new URL omits a version tag, it is rejected
+		if _, err := handler.RetargetSource("core", "oci://ghcr.io/windsorcli/core"); err == nil {
+			t.Error("Expected an error for a URL missing a version")
+		}
+	})
+
+	t.Run("ErrorsWhenBlueprintNotLoaded", func(t *testing.T) {
+		mocks := setupHandlerMocks(t)
+		handler := NewBlueprintHandler(mocks.Runtime, mocks.ArtifactBuilder)
+		handler.composedBlueprint = nil
+		if _, err := handler.RetargetSource("core", "oci://ghcr.io/windsorcli/core:v0.6.0"); err == nil {
+			t.Error("Expected an error when no blueprint is loaded")
+		}
+	})
+}

--- a/pkg/composer/blueprint/mock_blueprint_handler.go
+++ b/pkg/composer/blueprint/mock_blueprint_handler.go
@@ -9,6 +9,7 @@ type MockBlueprintHandler struct {
 	LoadBlueprintFunc          func(...string) error
 	SetSkipValidationFunc      func(skip bool)
 	WriteFunc                  func(overwrite ...bool) error
+	RetargetSourceFunc         func(name, url string) (string, error)
 	GetTerraformComponentsFunc func() []blueprintv1alpha1.TerraformComponent
 	GetLocalTemplateDataFunc   func() (map[string][]byte, error)
 	GenerateFunc               func() *blueprintv1alpha1.Blueprint
@@ -61,6 +62,14 @@ func (m *MockBlueprintHandler) Write(overwrite ...bool) error {
 		return m.WriteFunc(overwrite...)
 	}
 	return nil
+}
+
+// RetargetSource calls the mock RetargetSourceFunc if set, otherwise returns an empty previous URL.
+func (m *MockBlueprintHandler) RetargetSource(name, url string) (string, error) {
+	if m.RetargetSourceFunc != nil {
+		return m.RetargetSourceFunc(name, url)
+	}
+	return "", nil
 }
 
 // GetTerraformComponents calls the mock GetTerraformComponentsFunc if set, otherwise returns empty slice.


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> This is a new opt-in CLI flag that has no effect on existing `windsor upgrade` behavior; the code path is only entered when `--source` is explicitly passed.
>
> **Overview**
>
> The PR adds `--source name=url` to `windsor upgrade`, letting operators bump a declared OCI source to a new tagged URL in `blueprint.yaml` and immediately apply the change in a single command. `RetargetSource` is added to the `BlueprintHandler` interface and implemented on `BaseBlueprintHandler`; the command calls it for each spec, then calls `Write(true)` once to persist, and regenerates the blueprint before proceeding with the stack upgrade.
>
> One operational behavior to note: `blueprint.yaml` is written before the upgrade runs, so if the upgrade itself fails (connectivity, terraform error), the source bump remains on disk. This is intentional — it mirrors how `windsor init` treats blueprint mutations — but operators who roll back a failed upgrade should also revert the source change manually or re-run with the previous URL.

Reviewed by Claude for commit `92c3f23`.

<!-- /claude-code-review:summary -->
