### PR TITLE
feat(cmd): Collapse apply and upgrade functionality

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -53,6 +53,13 @@ windsor apply kustomize dns`,
 			return fmt.Errorf("blueprint is not available")
 		}
 
+		// apply reconciles to the declared blueprint and never refuses on version, but an
+		// interrupted upgrade leaves the marker mid-transition; surface that (best-effort) so the
+		// operator can finish it with `upgrade` rather than silently reconciling past it.
+		if gate, gateErr := proj.Provisioner.CheckVersionGate(blueprint); gateErr == nil && gate.InFlight {
+			fmt.Fprintln(cmd.ErrOrStderr(), "Warning: an upgrade is in progress or was interrupted for this context. apply will reconcile to the declared blueprint; run `windsor upgrade` to complete the version transition.")
+		}
+
 		return stacklock.With(cmd.Context(), proj.Runtime, "apply", func() error {
 			// 'apply' doesn't run the workstation prep that registers MakeApplyHook, so no
 			// onApply hooks fire and the halted return is always false. Ignore it.

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -5,13 +5,12 @@ import (
 
 	"github.com/spf13/cobra"
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
-	"github.com/windsorcli/cli/pkg/project"
 	"github.com/windsorcli/cli/pkg/provisioner/stacklock"
 	"github.com/windsorcli/cli/pkg/runtime/tools"
 )
 
-var applyWaitFlag bool  // Wait for kustomization resources to be ready after applying
-var applyForceFlag bool // Apply even when the blueprint version differs from what is applied
+var applyWaitFlag bool // Wait for kustomization resources to be ready after applying
+var applyYesFlag bool  // Proceed without confirmation when apply would prune kustomizations
 
 var applyCmd = &cobra.Command{
 	Use:   "apply",
@@ -54,10 +53,6 @@ windsor apply kustomize dns`,
 			return fmt.Errorf("blueprint is not available")
 		}
 
-		if err := enforceApplyVersionGate(cmd, proj, blueprint, applyForceFlag); err != nil {
-			return err
-		}
-
 		return stacklock.With(cmd.Context(), proj.Runtime, "apply", func() error {
 			// 'apply' doesn't run the workstation prep that registers MakeApplyHook, so no
 			// onApply hooks fire and the halted return is always false. Ignore it.
@@ -72,18 +67,27 @@ windsor apply kustomize dns`,
 			if resolveErr != nil {
 				return fmt.Errorf("error resolving blueprint substitutions: %w", resolveErr)
 			}
+			if blueprint == nil {
+				return fmt.Errorf("resolved blueprint is not available")
+			}
 
 			if err := proj.Provisioner.Install(cmd.Context(), blueprint); err != nil {
 				return fmt.Errorf("error applying kustomize: %w", err)
 			}
 
-			if applyWaitFlag {
+			// Reconcile removes kustomizations the blueprint no longer declares; wait for the
+			// desired set to be Ready before pruning so migrated resources are adopted first. A
+			// no-removal apply only waits when --wait is set.
+			prunable, err := proj.Provisioner.PrunableKustomizations(blueprint)
+			if err != nil {
+				return fmt.Errorf("error listing kustomizations to prune: %w", err)
+			}
+			if len(prunable) > 0 || applyWaitFlag {
 				if err := proj.Provisioner.Wait(cmd.Context(), blueprint); err != nil {
 					return fmt.Errorf("error waiting for kustomizations: %w", err)
 				}
 			}
-
-			return nil
+			return confirmAndPrune(cmd, proj, blueprint, prunable, applyYesFlag)
 		})
 	},
 }
@@ -120,9 +124,6 @@ windsor apply tf cluster`,
 		}
 
 		blueprint := proj.Composer.BlueprintHandler.Generate()
-		if err := enforceApplyVersionGate(cmd, proj, blueprint, applyForceFlag); err != nil {
-			return err
-		}
 		return stacklock.With(cmd.Context(), proj.Runtime, "apply", func() error {
 			if err := proj.Provisioner.Apply(blueprint, componentID); err != nil {
 				return fmt.Errorf("error applying terraform for %s: %w", componentID, err)
@@ -164,9 +165,6 @@ windsor apply kustomize dns --wait`,
 		if blueprint == nil {
 			return fmt.Errorf("blueprint is not available")
 		}
-		if err := enforceApplyVersionGate(cmd, proj, blueprint, applyForceFlag); err != nil {
-			return err
-		}
 		waitBlueprint := blueprint
 
 		return stacklock.With(cmd.Context(), proj.Runtime, "apply", func() error {
@@ -202,46 +200,10 @@ windsor apply kustomize dns --wait`,
 	},
 }
 
-// enforceApplyVersionGate enforces the version-equality seam for `apply`: apply reconciles the
-// currently-applied blueprint version and refuses to cross a version boundary, which belongs to
-// `upgrade`. A context with no readable marker (pre-bootstrap, no cluster, or legacy) is allowed —
-// there is nothing applied to cross. An in-flight upgrade is refused so a half-finished transition
-// is resumed with `upgrade`, never reconciled by `apply`; --force does not override this, since
-// applying over a live transition risks corrupting it. A version mismatch is refused and redirected
-// to `upgrade`, unless --force is set, in which case it warns and proceeds. A marker read failure
-// (cluster unreachable) is best-effort: it warns and proceeds rather than blocking terraform-based
-// recovery, since apply's later steps would surface a genuinely-unreachable cluster anyway.
-func enforceApplyVersionGate(cmd *cobra.Command, proj *project.Project, blueprint *blueprintv1alpha1.Blueprint, force bool) error {
-	gate, err := proj.Provisioner.CheckVersionGate(blueprint)
-	if err != nil {
-		fmt.Fprintf(cmd.ErrOrStderr(), "Warning: could not verify the applied blueprint version (%v); proceeding without the version gate.\n", err)
-		return nil
-	}
-	if !gate.MarkerFound {
-		return nil
-	}
-	if gate.InFlight {
-		silenceErrorsOnAncestors(cmd)
-		return fmt.Errorf("an upgrade is in progress for this context; run `windsor upgrade` to resume it. apply cannot reconcile a half-finished version transition")
-	}
-	if !gate.VersionMatch {
-		if force {
-			fmt.Fprintln(cmd.ErrOrStderr(), "Warning: the blueprint version differs from what is applied; applying anyway because --force was set.")
-			return nil
-		}
-		silenceErrorsOnAncestors(cmd)
-		return fmt.Errorf("the blueprint version differs from what is applied; run `windsor upgrade` to transition versions, or re-run with --force to apply against the current version anyway")
-	}
-	return nil
-}
-
 func init() {
-	const forceUsage = "Apply even if the blueprint version differs from what is applied (skips the upgrade version gate)."
 	applyCmd.Flags().BoolVar(&applyWaitFlag, "wait", false, "Wait for kustomization resources to be ready.")
-	applyCmd.Flags().BoolVar(&applyForceFlag, "force", false, forceUsage)
+	applyCmd.Flags().BoolVar(&applyYesFlag, "yes", false, "Proceed without confirmation when the apply would prune kustomizations.")
 	applyKustomizeCmd.Flags().BoolVar(&applyWaitFlag, "wait", false, "Wait for kustomization resources to be ready.")
-	applyKustomizeCmd.Flags().BoolVar(&applyForceFlag, "force", false, forceUsage)
-	applyTerraformCmd.Flags().BoolVar(&applyForceFlag, "force", false, forceUsage)
 	applyCmd.AddCommand(applyTerraformCmd)
 	applyCmd.AddCommand(applyKustomizeCmd)
 	rootCmd.AddCommand(applyCmd)

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -153,212 +151,102 @@ func makeApplyTestCmd(source *cobra.Command) *cobra.Command {
 // Test Cases
 // =============================================================================
 
-// seedKubeconfig points the runtime's config root at a temp dir holding a kubeconfig so the
-// version gate's kubeconfigPresent() probe engages (the apply harness leaves ConfigRoot empty,
-// which short-circuits the gate). Returns the config root.
-func seedKubeconfig(t *testing.T, mocks *ApplyMocks) string {
-	t.Helper()
-	root := t.TempDir()
-	if err := os.MkdirAll(filepath.Join(root, ".kube"), 0755); err != nil {
-		t.Fatalf("seed kubeconfig dir: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(root, ".kube", "config"), []byte("apiVersion: v1\nkind: Config\n"), 0644); err != nil {
-		t.Fatalf("seed kubeconfig: %v", err)
-	}
-	mocks.Runtime.ConfigRoot = root
-	return root
-}
-
-func TestApplyCmd_VersionGate(t *testing.T) {
+func TestApplyCmd_Prune(t *testing.T) {
 	createTestApplyCmd := func() *cobra.Command { return makeApplyTestCmd(applyCmd) }
 
 	suppressProcessStdout(t)
 	suppressProcessStderr(t)
 
-	run := func(t *testing.T, proj *project.Project, args ...string) error {
-		t.Helper()
+	t.Run("RefusesPruneWithoutYes", func(t *testing.T) {
+		t.Cleanup(func() { applyYesFlag = false })
+		// Given a reconcile that would prune a kustomization
+		mocks := setupApplyTest(t)
+		mocks.KubernetesManager.ListPrunableKustomizationsFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) ([]string, error) {
+			return []string{"old-thing"}, nil
+		}
+		pruned := false
+		mocks.KubernetesManager.PruneBlueprintFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) error {
+			pruned = true
+			return nil
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When applying without --yes
 		cmd := createTestApplyCmd()
-		cmd.SetArgs(args)
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
 		cmd.SetContext(ctx)
-		return cmd.Execute()
-	}
+		err := cmd.Execute()
 
-	t.Run("RefusesWhenVersionDiffers", func(t *testing.T) {
-		t.Cleanup(func() { applyForceFlag = false })
-		// Given a cluster whose applied marker differs from the blueprint
-		mocks := setupApplyTest(t)
-		seedKubeconfig(t, mocks)
-		mocks.KubernetesManager.GetVersionMarkerFunc = func(namespace string) (kubernetes.VersionMarker, bool, error) {
-			return kubernetes.VersionMarker{
-				SchemaVersion:  1,
-				Phase:          kubernetes.VersionMarkerPhaseIdle,
-				AppliedSources: map[string]kubernetes.SourceRef{"core": {URL: "oci://example/core", Ref: "v1.0.0"}},
-			}, true, nil
-		}
-		proj := newApplyAllProject(mocks)
-
-		// When applying without --force
-		err := run(t, proj)
-
-		// Then apply refuses and points at upgrade
+		// Then it refuses and never prunes
 		if err == nil {
-			t.Fatal("Expected apply to refuse a version mismatch, got nil")
+			t.Fatal("Expected apply to refuse pruning without --yes, got nil")
 		}
-		if !strings.Contains(err.Error(), "upgrade") {
-			t.Errorf("Expected redirect to upgrade, got: %v", err)
+		if !strings.Contains(err.Error(), "--yes") {
+			t.Errorf("Expected the message to point at --yes, got: %v", err)
+		}
+		if pruned {
+			t.Error("Expected prune to be skipped when the gate refuses")
 		}
 	})
 
-	t.Run("ForceAppliesAcrossVersionMismatch", func(t *testing.T) {
-		t.Cleanup(func() { applyForceFlag = false })
-		// Given the same version mismatch
+	t.Run("ProceedsWithYes", func(t *testing.T) {
+		t.Cleanup(func() { applyYesFlag = false })
+		// Given the same pending prune
 		mocks := setupApplyTest(t)
-		seedKubeconfig(t, mocks)
-		mocks.KubernetesManager.GetVersionMarkerFunc = func(namespace string) (kubernetes.VersionMarker, bool, error) {
-			return kubernetes.VersionMarker{
-				SchemaVersion:  1,
-				Phase:          kubernetes.VersionMarkerPhaseIdle,
-				AppliedSources: map[string]kubernetes.SourceRef{"core": {URL: "oci://example/core", Ref: "v1.0.0"}},
-			}, true, nil
+		mocks.KubernetesManager.ListPrunableKustomizationsFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) ([]string, error) {
+			return []string{"old-thing"}, nil
+		}
+		pruned := false
+		mocks.KubernetesManager.PruneBlueprintFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) error {
+			pruned = true
+			return nil
 		}
 		proj := newApplyAllProject(mocks)
 
-		// When applying with --force
-		err := run(t, proj, "--force")
-
-		// Then the gate is overridden and apply proceeds
-		if err != nil {
-			t.Errorf("Expected --force to apply across a mismatch, got %v", err)
-		}
-	})
-
-	t.Run("RefusesWhenUpgradeInFlight", func(t *testing.T) {
-		t.Cleanup(func() { applyForceFlag = false })
-		// Given a marker mid-transition
-		mocks := setupApplyTest(t)
-		seedKubeconfig(t, mocks)
-		mocks.KubernetesManager.GetVersionMarkerFunc = func(namespace string) (kubernetes.VersionMarker, bool, error) {
-			return kubernetes.VersionMarker{SchemaVersion: 1, Phase: "migrating"}, true, nil
-		}
-		proj := newApplyAllProject(mocks)
-
-		// When applying, even with --force, an in-flight transition is refused
-		err := run(t, proj, "--force")
-		if err == nil {
-			t.Fatal("Expected apply to refuse during an in-flight upgrade, got nil")
-		}
-		if !strings.Contains(err.Error(), "upgrade") {
-			t.Errorf("Expected an in-flight upgrade message, got: %v", err)
-		}
-	})
-
-	t.Run("ProceedsForLegacyContextWithNoMarker", func(t *testing.T) {
-		// Given a cluster with no marker recorded
-		mocks := setupApplyTest(t)
-		seedKubeconfig(t, mocks)
-		mocks.KubernetesManager.GetVersionMarkerFunc = func(namespace string) (kubernetes.VersionMarker, bool, error) {
-			return kubernetes.VersionMarker{}, false, nil
-		}
-		proj := newApplyAllProject(mocks)
-
-		// When applying, the legacy context is allowed through
-		if err := run(t, proj); err != nil {
-			t.Errorf("Expected apply to proceed for a legacy context, got %v", err)
-		}
-	})
-
-	t.Run("ProceedsBestEffortWhenMarkerReadFails", func(t *testing.T) {
-		// Given a marker read that fails (cluster unreachable)
-		mocks := setupApplyTest(t)
-		seedKubeconfig(t, mocks)
-		mocks.KubernetesManager.GetVersionMarkerFunc = func(namespace string) (kubernetes.VersionMarker, bool, error) {
-			return kubernetes.VersionMarker{}, false, fmt.Errorf("connection refused")
-		}
-		proj := newApplyAllProject(mocks)
-
-		// When applying, the gate is best-effort and does not block recovery
-		if err := run(t, proj); err != nil {
-			t.Errorf("Expected apply to proceed when the marker cannot be read, got %v", err)
-		}
-	})
-
-	// mismatchMarker returns a marker whose source set cannot match the bare test blueprint
-	// (which has no sources), so the gate always sees a version mismatch.
-	mismatchMarker := func(namespace string) (kubernetes.VersionMarker, bool, error) {
-		return kubernetes.VersionMarker{
-			SchemaVersion:  1,
-			Phase:          kubernetes.VersionMarkerPhaseIdle,
-			AppliedSources: map[string]kubernetes.SourceRef{"core": {URL: "oci://example/core", Ref: "v1.0.0"}},
-		}, true, nil
-	}
-
-	runCmd := func(t *testing.T, source *cobra.Command, proj *project.Project, args ...string) error {
-		t.Helper()
-		cmd := makeApplyTestCmd(source)
-		cmd.SetArgs(args)
+		// When applying with --yes
+		cmd := createTestApplyCmd()
+		cmd.SetArgs([]string{"--yes"})
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
 		cmd.SetContext(ctx)
-		return cmd.Execute()
-	}
-
-	t.Run("RefusesOnApplyTerraformSubcommand", func(t *testing.T) {
-		t.Cleanup(func() { applyForceFlag = false })
-		// Given a version mismatch, the apply terraform subcommand must also gate
-		mocks := setupApplyTest(t)
-		seedKubeconfig(t, mocks)
-		mocks.KubernetesManager.GetVersionMarkerFunc = mismatchMarker
-		proj := newApplyAllProject(mocks)
-
-		err := runCmd(t, applyTerraformCmd, proj, "cluster")
-		if err == nil {
-			t.Fatal("Expected apply terraform to refuse a version mismatch, got nil")
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Expected --yes to proceed, got %v", err)
 		}
-		if !strings.Contains(err.Error(), "upgrade") {
-			t.Errorf("Expected redirect to upgrade, got: %v", err)
+
+		// Then the prune runs
+		if !pruned {
+			t.Error("Expected prune to run under --yes")
 		}
 	})
 
-	t.Run("ForceOnApplyTerraformSubcommand", func(t *testing.T) {
-		t.Cleanup(func() { applyForceFlag = false })
-		// Given the same mismatch, --force must be honored on the subcommand
+	t.Run("NoWaitOrPruneWhenNothingOrphaned", func(t *testing.T) {
+		// Given a reconcile that prunes nothing, with --wait unset
 		mocks := setupApplyTest(t)
-		seedKubeconfig(t, mocks)
-		mocks.KubernetesManager.GetVersionMarkerFunc = mismatchMarker
+		listed := false
+		mocks.KubernetesManager.ListPrunableKustomizationsFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) ([]string, error) {
+			listed = true
+			return nil, nil
+		}
+		waited := false
+		mocks.KubernetesManager.WaitForKustomizationsFunc = func(ctx context.Context, message string, bp *blueprintv1alpha1.Blueprint) error {
+			waited = true
+			return nil
+		}
 		proj := newApplyAllProject(mocks)
 
-		if err := runCmd(t, applyTerraformCmd, proj, "cluster", "--force"); err != nil {
-			t.Errorf("Expected --force to apply terraform across a mismatch, got %v", err)
+		// When applying
+		cmd := createTestApplyCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
 		}
-	})
 
-	t.Run("RefusesOnApplyKustomizeSubcommand", func(t *testing.T) {
-		t.Cleanup(func() { applyForceFlag = false })
-		// Given a version mismatch, the apply kustomize subcommand must also gate
-		mocks := setupApplyTest(t)
-		seedKubeconfig(t, mocks)
-		mocks.KubernetesManager.GetVersionMarkerFunc = mismatchMarker
-		proj := newApplyAllProject(mocks)
-
-		err := runCmd(t, applyKustomizeCmd, proj)
-		if err == nil {
-			t.Fatal("Expected apply kustomize to refuse a version mismatch, got nil")
+		// Then it checked for prunes but did not wait (fast no-op apply)
+		if !listed {
+			t.Error("Expected apply to check for prunable kustomizations")
 		}
-		if !strings.Contains(err.Error(), "upgrade") {
-			t.Errorf("Expected redirect to upgrade, got: %v", err)
-		}
-	})
-
-	t.Run("ForceOnApplyKustomizeSubcommand", func(t *testing.T) {
-		t.Cleanup(func() { applyForceFlag = false })
-		// Given the same mismatch, --force must be honored on the subcommand
-		mocks := setupApplyTest(t)
-		seedKubeconfig(t, mocks)
-		mocks.KubernetesManager.GetVersionMarkerFunc = mismatchMarker
-		proj := newApplyAllProject(mocks)
-
-		if err := runCmd(t, applyKustomizeCmd, proj, "--force"); err != nil {
-			t.Errorf("Expected --force to apply kustomize across a mismatch, got %v", err)
+		if waited {
+			t.Error("Expected apply not to wait when nothing is orphaned and --wait is unset")
 		}
 	})
 }

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -1,9 +1,12 @@
 package cmd
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -151,11 +154,52 @@ func makeApplyTestCmd(source *cobra.Command) *cobra.Command {
 // Test Cases
 // =============================================================================
 
+// seedKubeconfig points the runtime's config root at a temp dir holding a kubeconfig so the marker
+// read in apply's in-flight check engages (the apply harness leaves ConfigRoot empty, which makes
+// CheckVersionGate short-circuit to "no marker").
+func seedKubeconfig(t *testing.T, mocks *ApplyMocks) {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, ".kube"), 0755); err != nil {
+		t.Fatalf("seed kubeconfig dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, ".kube", "config"), []byte("apiVersion: v1\nkind: Config\n"), 0644); err != nil {
+		t.Fatalf("seed kubeconfig: %v", err)
+	}
+	mocks.Runtime.ConfigRoot = root
+}
+
 func TestApplyCmd_Prune(t *testing.T) {
 	createTestApplyCmd := func() *cobra.Command { return makeApplyTestCmd(applyCmd) }
 
 	suppressProcessStdout(t)
 	suppressProcessStderr(t)
+
+	t.Run("WarnsButProceedsWhenUpgradeInFlight", func(t *testing.T) {
+		// Given an interrupted upgrade (marker mid-transition)
+		mocks := setupApplyTest(t)
+		seedKubeconfig(t, mocks)
+		mocks.KubernetesManager.GetVersionMarkerFunc = func(namespace string) (kubernetes.VersionMarker, bool, error) {
+			return kubernetes.VersionMarker{SchemaVersion: 1, Phase: "upgrading"}, true, nil
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When applying
+		var stderr bytes.Buffer
+		cmd := createTestApplyCmd()
+		cmd.SetErr(&stderr)
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then it warns but does not refuse — apply reconciles regardless
+		if err != nil {
+			t.Errorf("Expected apply to proceed during an in-flight upgrade, got %v", err)
+		}
+		if !strings.Contains(stderr.String(), "upgrade is in progress") {
+			t.Errorf("Expected an in-flight warning on stderr, got: %q", stderr.String())
+		}
+	})
 
 	t.Run("RefusesPruneWithoutYes", func(t *testing.T) {
 		t.Cleanup(func() { applyYesFlag = false })

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -332,7 +332,7 @@ func describePendingPrunes(cmd *cobra.Command, proj *project.Project, blueprint 
 	if err != nil || len(prunable) == 0 {
 		return
 	}
-	fmt.Fprintf(cmd.ErrOrStderr(), "These kustomizations are no longer declared and would be pruned by `windsor upgrade`:\n  %s\n", strings.Join(prunable, "\n  "))
+	fmt.Fprintf(cmd.ErrOrStderr(), "These kustomizations are no longer declared and would be pruned by `windsor apply --yes` or `windsor upgrade --yes`:\n  %s\n", strings.Join(prunable, "\n  "))
 }
 
 // blueprintHasTerraformComponent reports whether the blueprint contains an enabled Terraform component with the given ID.

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
@@ -76,6 +77,7 @@ windsor plan terraform cluster`,
 					return tuiplan.SummaryJSON(os.Stdout, summary.Terraform, summary.Kustomize)
 				}
 				describePlanMode(cmd, proj, blueprint)
+				describePendingPrunes(cmd, proj, blueprint)
 				tuiplan.Summary(os.Stdout, summary.Terraform, summary.Kustomize, summary.Hints, planNoColor || os.Getenv("NO_COLOR") != "")
 				return nil
 			})
@@ -320,6 +322,17 @@ func describePlanMode(cmd *cobra.Command, proj *project.Project, blueprint *blue
 	case !gate.VersionMatch:
 		fmt.Fprintln(cmd.ErrOrStderr(), "The blueprint targets a different version than what is applied. The plan below shows the content delta; run `windsor upgrade` to transition versions.")
 	}
+}
+
+// describePendingPrunes prints to stderr the kustomizations a `windsor upgrade` would prune — those
+// this context still has live but the blueprint no longer declares — so a pending removal is visible
+// before it happens. It is best-effort: a legacy/unreachable cluster or no orphans prints nothing.
+func describePendingPrunes(cmd *cobra.Command, proj *project.Project, blueprint *blueprintv1alpha1.Blueprint) {
+	prunable, err := proj.Provisioner.PrunableKustomizations(blueprint)
+	if err != nil || len(prunable) == 0 {
+		return
+	}
+	fmt.Fprintf(cmd.ErrOrStderr(), "These kustomizations are no longer declared and would be pruned by `windsor upgrade`:\n  %s\n", strings.Join(prunable, "\n  "))
 }
 
 // blueprintHasTerraformComponent reports whether the blueprint contains an enabled Terraform component with the given ID.

--- a/cmd/plan_test.go
+++ b/cmd/plan_test.go
@@ -307,6 +307,60 @@ func TestDescribePlanMode(t *testing.T) {
 	})
 }
 
+func TestDescribePendingPrunes(t *testing.T) {
+	projectWithPrunable := func(t *testing.T, listFn func(*blueprintv1alpha1.Blueprint, string) ([]string, error)) *project.Project {
+		t.Helper()
+		mocks := setupPlanTest(t)
+		km := kubernetes.NewMockKubernetesManager()
+		km.ListPrunableKustomizationsFunc = listFn
+		comp := composer.NewComposer(mocks.Runtime)
+		comp.BlueprintHandler = mocks.BlueprintHandler
+		prov := provisioner.NewProvisioner(mocks.Runtime, comp.BlueprintHandler, &provisioner.Provisioner{
+			TerraformStack:    mocks.TerraformStack,
+			KubernetesManager: km,
+		})
+		return project.NewProject("", &project.Project{Runtime: mocks.Runtime, Composer: comp, Provisioner: prov})
+	}
+
+	blueprint := &blueprintv1alpha1.Blueprint{Metadata: blueprintv1alpha1.Metadata{Name: "test"}}
+
+	run := func(proj *project.Project) string {
+		var buf bytes.Buffer
+		cmd := &cobra.Command{}
+		cmd.SetErr(&buf)
+		describePendingPrunes(cmd, proj, blueprint)
+		return buf.String()
+	}
+
+	t.Run("ListsPendingPrunes", func(t *testing.T) {
+		proj := projectWithPrunable(t, func(*blueprintv1alpha1.Blueprint, string) ([]string, error) {
+			return []string{"old-thing", "stale-app"}, nil
+		})
+		out := run(proj)
+		if !strings.Contains(out, "would be pruned") || !strings.Contains(out, "old-thing") || !strings.Contains(out, "stale-app") {
+			t.Errorf("Expected a prune preview listing the orphans, got: %q", out)
+		}
+	})
+
+	t.Run("SilentWhenNothingPrunable", func(t *testing.T) {
+		proj := projectWithPrunable(t, func(*blueprintv1alpha1.Blueprint, string) ([]string, error) {
+			return nil, nil
+		})
+		if out := run(proj); out != "" {
+			t.Errorf("Expected no output when nothing is prunable, got: %q", out)
+		}
+	})
+
+	t.Run("SilentWhenListingFails", func(t *testing.T) {
+		proj := projectWithPrunable(t, func(*blueprintv1alpha1.Blueprint, string) ([]string, error) {
+			return nil, fmt.Errorf("cluster unreachable")
+		})
+		if out := run(proj); out != "" {
+			t.Errorf("Expected best-effort silence on error, got: %q", out)
+		}
+	})
+}
+
 func TestPlanTerraformCmd(t *testing.T) {
 	createTestPlanTerraformCmd := func() *cobra.Command {
 		cmd := &cobra.Command{

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/composer"
 	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/project"
@@ -104,16 +105,8 @@ windsor upgrade cluster --nodes=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1
 			if err != nil {
 				return fmt.Errorf("error listing kustomizations to prune: %w", err)
 			}
-			if len(prunable) > 0 {
-				fmt.Fprintf(cmd.OutOrStdout(), "The following kustomizations are no longer declared and will be pruned:\n  %s\n", strings.Join(prunable, "\n  "))
-				if !upgradeYes {
-					silenceErrorsOnAncestors(cmd)
-					return fmt.Errorf("upgrade would prune %d kustomization(s); re-run with --yes to proceed", len(prunable))
-				}
-			}
-
-			if err := proj.Provisioner.Prune(blueprint); err != nil {
-				return fmt.Errorf("error pruning orphaned kustomizations: %w", err)
+			if err := confirmAndPrune(cmd, proj, blueprint, prunable, upgradeYes); err != nil {
+				return err
 			}
 
 			if err := proj.Provisioner.WriteVersionMarker(blueprint); err != nil {
@@ -233,6 +226,25 @@ windsor upgrade node --node=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.
 
 		return nil
 	},
+}
+
+// confirmAndPrune prunes the kustomizations the blueprint no longer declares, after printing them
+// and requiring --yes. prunable is the already-computed prune set (empty → no-op). The caller must
+// have waited for the desired set to be Ready first, so any migrated resources are adopted before a
+// deletion. Shared by apply and upgrade, which reconcile identically.
+func confirmAndPrune(cmd *cobra.Command, proj *project.Project, blueprint *blueprintv1alpha1.Blueprint, prunable []string, yes bool) error {
+	if len(prunable) == 0 {
+		return nil
+	}
+	fmt.Fprintf(cmd.OutOrStdout(), "The following kustomizations are no longer declared and will be pruned:\n  %s\n", strings.Join(prunable, "\n  "))
+	if !yes {
+		silenceErrorsOnAncestors(cmd)
+		return fmt.Errorf("this would prune %d kustomization(s); re-run with --yes to proceed", len(prunable))
+	}
+	if err := proj.Provisioner.Prune(blueprint); err != nil {
+		return fmt.Errorf("error pruning orphaned kustomizations: %w", err)
+	}
+	return nil
 }
 
 // retargetSources applies each `name=url` spec to the context's declared sources, persists the bumps

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -20,6 +20,7 @@ var (
 	upgradeNodes   []string
 	upgradeImage   string
 	upgradeSources []string
+	upgradeYes     bool
 
 	upgradeNodeAddr    string
 	upgradeNodeImage   string
@@ -97,6 +98,18 @@ windsor upgrade cluster --nodes=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1
 
 			if err := proj.Provisioner.Wait(cmd.Context(), blueprint); err != nil {
 				return fmt.Errorf("error waiting for kustomizations: %w", err)
+			}
+
+			prunable, err := proj.Provisioner.PrunableKustomizations(blueprint)
+			if err != nil {
+				return fmt.Errorf("error listing kustomizations to prune: %w", err)
+			}
+			if len(prunable) > 0 {
+				fmt.Fprintf(cmd.OutOrStdout(), "The following kustomizations are no longer declared and will be pruned:\n  %s\n", strings.Join(prunable, "\n  "))
+				if !upgradeYes {
+					silenceErrorsOnAncestors(cmd)
+					return fmt.Errorf("upgrade would prune %d kustomization(s); re-run with --yes to proceed", len(prunable))
+				}
 			}
 
 			if err := proj.Provisioner.Prune(blueprint); err != nil {
@@ -257,6 +270,7 @@ func init() {
 	upgradeCmd.AddCommand(upgradeNodeCmd)
 
 	upgradeCmd.Flags().StringArrayVar(&upgradeSources, "source", nil, "Retarget a declared source to a new tagged URL (name=url); repeatable. Persisted to blueprint.yaml.")
+	upgradeCmd.Flags().BoolVar(&upgradeYes, "yes", false, "Proceed without confirmation when the upgrade would prune kustomizations.")
 
 	upgradeClusterCmd.Flags().StringSliceVar(&upgradeNodes, "nodes", []string{}, "Node addresses to upgrade. Required.")
 	upgradeClusterCmd.Flags().StringVar(&upgradeImage, "image", "", "Talos image to upgrade to. Required.")

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -20,8 +20,12 @@ func TestUpgradeCmd(t *testing.T) {
 	suppressProcessStderr(t)
 
 	t.Run("PrunesAfterSuccessfulWait", func(t *testing.T) {
-		// Given an upgrade command whose terraform, install, and wait all succeed
+		t.Cleanup(func() { upgradeYes = false })
+		// Given an upgrade with an orphaned kustomization, run with --yes
 		mocks := setupApplyTest(t)
+		mocks.KubernetesManager.ListPrunableKustomizationsFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) ([]string, error) {
+			return []string{"old-thing"}, nil
+		}
 		pruned := false
 		mocks.KubernetesManager.PruneBlueprintFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) error {
 			pruned = true
@@ -29,8 +33,9 @@ func TestUpgradeCmd(t *testing.T) {
 		}
 		proj := newApplyAllProject(mocks)
 
-		// When executing the bare upgrade command
+		// When executing the bare upgrade command with --yes
 		cmd := createTestUpgradeCmd()
+		cmd.SetArgs([]string{"--yes"})
 		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
 		cmd.SetContext(ctx)
 		err := cmd.Execute()
@@ -125,8 +130,12 @@ func TestUpgradeCmd(t *testing.T) {
 	})
 
 	t.Run("LeavesInFlightMarkerWhenPruneFails", func(t *testing.T) {
-		// Given a prune that fails after install and wait succeed
+		t.Cleanup(func() { upgradeYes = false })
+		// Given an orphan to prune and a prune that fails after install and wait succeed
 		mocks := setupApplyTest(t)
+		mocks.KubernetesManager.ListPrunableKustomizationsFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) ([]string, error) {
+			return []string{"old-thing"}, nil
+		}
 		mocks.KubernetesManager.PruneBlueprintFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) error {
 			return fmt.Errorf("prune failed")
 		}
@@ -137,8 +146,9 @@ func TestUpgradeCmd(t *testing.T) {
 		}
 		proj := newApplyAllProject(mocks)
 
-		// When executing the upgrade command
+		// When executing the upgrade command with --yes
 		cmd := createTestUpgradeCmd()
+		cmd.SetArgs([]string{"--yes"})
 		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
 		cmd.SetContext(ctx)
 		err := cmd.Execute()
@@ -184,15 +194,20 @@ func TestUpgradeCmd(t *testing.T) {
 	})
 
 	t.Run("ErrorPruneFails", func(t *testing.T) {
-		// Given a prune step that fails after a successful wait
+		t.Cleanup(func() { upgradeYes = false })
+		// Given an orphan to prune and a prune step that fails after a successful wait
 		mocks := setupApplyTest(t)
+		mocks.KubernetesManager.ListPrunableKustomizationsFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) ([]string, error) {
+			return []string{"old-thing"}, nil
+		}
 		mocks.KubernetesManager.PruneBlueprintFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) error {
 			return fmt.Errorf("delete kustomization failed")
 		}
 		proj := newApplyAllProject(mocks)
 
-		// When executing the upgrade command
+		// When executing the upgrade command with --yes
 		cmd := createTestUpgradeCmd()
+		cmd.SetArgs([]string{"--yes"})
 		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
 		cmd.SetContext(ctx)
 		err := cmd.Execute()

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -395,6 +395,96 @@ func TestUpgradeCmd_Source(t *testing.T) {
 	})
 }
 
+func TestUpgradeCmd_PruneGate(t *testing.T) {
+	createTestUpgradeCmd := func() *cobra.Command { return makeApplyTestCmd(upgradeCmd) }
+
+	suppressProcessStdout(t)
+	suppressProcessStderr(t)
+
+	t.Run("RefusesPruneWithoutYes", func(t *testing.T) {
+		t.Cleanup(func() { upgradeYes = false })
+		// Given a transition that would prune a kustomization
+		mocks := setupApplyTest(t)
+		mocks.KubernetesManager.ListPrunableKustomizationsFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) ([]string, error) {
+			return []string{"old-thing"}, nil
+		}
+		pruned := false
+		mocks.KubernetesManager.PruneBlueprintFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) error {
+			pruned = true
+			return nil
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When upgrading without --yes
+		cmd := createTestUpgradeCmd()
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then it refuses and never prunes
+		if err == nil {
+			t.Fatal("Expected refusal without --yes when a prune is pending, got nil")
+		}
+		if !strings.Contains(err.Error(), "--yes") {
+			t.Errorf("Expected the message to point at --yes, got: %v", err)
+		}
+		if pruned {
+			t.Error("Expected prune to be skipped when the gate refuses")
+		}
+	})
+
+	t.Run("ProceedsWithYes", func(t *testing.T) {
+		t.Cleanup(func() { upgradeYes = false })
+		// Given the same pending prune
+		mocks := setupApplyTest(t)
+		mocks.KubernetesManager.ListPrunableKustomizationsFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) ([]string, error) {
+			return []string{"old-thing"}, nil
+		}
+		pruned := false
+		mocks.KubernetesManager.PruneBlueprintFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) error {
+			pruned = true
+			return nil
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When upgrading with --yes
+		cmd := createTestUpgradeCmd()
+		cmd.SetArgs([]string{"--yes"})
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Expected --yes to proceed, got %v", err)
+		}
+
+		// Then the prune runs
+		if !pruned {
+			t.Error("Expected prune to run under --yes")
+		}
+	})
+
+	t.Run("ProceedsWhenNothingPrunable", func(t *testing.T) {
+		// Given a transition that prunes nothing
+		mocks := setupApplyTest(t)
+		listed := false
+		mocks.KubernetesManager.ListPrunableKustomizationsFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) ([]string, error) {
+			listed = true
+			return nil, nil
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When upgrading, the gate runs and allows it through without --yes
+		cmd := createTestUpgradeCmd()
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !listed {
+			t.Error("Expected the prune gate to run")
+		}
+	})
+}
+
 func TestUpgradeNodeCmd(t *testing.T) {
 	t.Cleanup(func() {
 		rootCmd.SetContext(stdcontext.Background())

--- a/docs/reference/commands/apply-kustomize.md
+++ b/docs/reference/commands/apply-kustomize.md
@@ -16,7 +16,6 @@ When a name is supplied with --wait, the wait scope is narrowed to only that kus
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--force` | `false` | Apply even if the blueprint version differs from what is applied (skips the upgrade version gate). |
 | `--wait` | `false` | Wait for kustomization resources to be ready. |
 
 ## Examples

--- a/docs/reference/commands/apply-terraform.md
+++ b/docs/reference/commands/apply-terraform.md
@@ -5,16 +5,10 @@ description: "Apply Terraform changes for a single component."
 # windsor apply terraform
 
 ```sh
-windsor apply terraform <component> [flags]
+windsor apply terraform <component>
 ```
 
 Run terraform apply for a single component. The <component> argument is required and must match a terraform component declared in the blueprint.
-
-## Flags
-
-| Flag | Default | Description |
-|------|---------|-------------|
-| `--force` | `false` | Apply even if the blueprint version differs from what is applied (skips the upgrade version gate). |
 
 ## Examples
 

--- a/docs/reference/commands/apply.md
+++ b/docs/reference/commands/apply.md
@@ -18,8 +18,8 @@ Pass --wait to block until kustomizations report ready.
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--force` | `false` | Apply even if the blueprint version differs from what is applied (skips the upgrade version gate). |
 | `--wait` | `false` | Wait for kustomization resources to be ready. |
+| `--yes` | `false` | Proceed without confirmation when the apply would prune kustomizations. |
 
 ## Subcommands
 

--- a/docs/reference/commands/upgrade.md
+++ b/docs/reference/commands/upgrade.md
@@ -17,6 +17,7 @@ Use the 'cluster' or 'node' subcommand to upgrade Talos nodes instead.
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--source` | `[]` | Retarget a declared source to a new tagged URL (name=url); repeatable. Persisted to blueprint.yaml. |
+| `--yes` | `false` | Proceed without confirmation when the upgrade would prune kustomizations. |
 
 ## Subcommands
 

--- a/integration/apply_test.go
+++ b/integration/apply_test.go
@@ -100,7 +100,7 @@ func TestApply_AcceptsWaitFlag(t *testing.T) {
 	_ = err // may fail due to infrastructure not being available; flag must be accepted
 }
 
-func TestApply_AcceptsForceFlag(t *testing.T) {
+func TestApply_AcceptsYesFlag(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
 	helpers.MarkAsGitRepo(t, dir)
@@ -109,41 +109,9 @@ func TestApply_AcceptsForceFlag(t *testing.T) {
 		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
 	}
 	env = append(env, "WINDSOR_CONTEXT=local")
-	_, stderr, err = helpers.RunCLI(dir, []string{"apply", "--force"}, env)
+	_, stderr, err = helpers.RunCLI(dir, []string{"apply", "--yes"}, env)
 	if strings.Contains(string(stderr), "unknown flag") {
-		t.Errorf("--force should be a recognised flag on apply, got: %s", stderr)
-	}
-	_ = err // may fail due to infrastructure not being available; the flag must be accepted
-}
-
-func TestApplyTerraform_AcceptsForceFlag(t *testing.T) {
-	t.Parallel()
-	dir, env := helpers.CopyFixtureOnly(t, "plan")
-	helpers.MarkAsGitRepo(t, dir)
-	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
-	if err != nil {
-		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
-	}
-	env = append(env, "WINDSOR_CONTEXT=local")
-	_, stderr, err = helpers.RunCLI(dir, []string{"apply", "terraform", "null", "--force"}, env)
-	if strings.Contains(string(stderr), "unknown flag") {
-		t.Errorf("--force should be a recognised flag on apply terraform, got: %s", stderr)
-	}
-	_ = err // may fail due to infrastructure not being available; the flag must be accepted
-}
-
-func TestApplyKustomize_AcceptsForceFlag(t *testing.T) {
-	t.Parallel()
-	dir, env := helpers.CopyFixtureOnly(t, "plan")
-	helpers.MarkAsGitRepo(t, dir)
-	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
-	if err != nil {
-		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
-	}
-	env = append(env, "WINDSOR_CONTEXT=local")
-	_, stderr, err = helpers.RunCLI(dir, []string{"apply", "kustomize", "--force"}, env)
-	if strings.Contains(string(stderr), "unknown flag") {
-		t.Errorf("--force should be a recognised flag on apply kustomize, got: %s", stderr)
+		t.Errorf("--yes should be a recognised flag on apply, got: %s", stderr)
 	}
 	_ = err // may fail due to infrastructure not being available; the flag must be accepted
 }

--- a/integration/upgrade_test.go
+++ b/integration/upgrade_test.go
@@ -70,6 +70,21 @@ func TestUpgrade_SourceRejectsUndeclaredSource(t *testing.T) {
 	}
 }
 
+func TestUpgrade_AcceptsYesFlag(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
+	if _, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env); err != nil {
+		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
+	}
+	env = append(env, "WINDSOR_CONTEXT=local")
+	_, stderr, err := helpers.RunCLI(dir, []string{"upgrade", "--yes"}, env)
+	if strings.Contains(string(stderr), "unknown flag") {
+		t.Errorf("--yes should be a recognised flag on upgrade, got: %s", stderr)
+	}
+	_ = err // fails without a live cluster; the flag must be accepted
+}
+
 // =============================================================================
 // Integration Tests — upgrade cluster
 // =============================================================================

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -54,6 +54,7 @@ type KubernetesManager interface {
 	ApplyBlueprint(blueprint *blueprintv1alpha1.Blueprint, namespace string) error
 	DeleteBlueprint(blueprint *blueprintv1alpha1.Blueprint, namespace string) error
 	PruneBlueprint(blueprint *blueprintv1alpha1.Blueprint, namespace string) error
+	ListPrunableKustomizations(blueprint *blueprintv1alpha1.Blueprint, namespace string) ([]string, error)
 	ApplyVersionMarker(namespace string, marker VersionMarker) error
 	GetVersionMarker(namespace string) (VersionMarker, bool, error)
 }
@@ -1059,9 +1060,33 @@ func (k *BaseKubernetesManager) PruneBlueprint(blueprint *blueprintv1alpha1.Blue
 		return fmt.Errorf("blueprint not provided")
 	}
 
+	orphans, err := k.contextOrphanKustomizations(blueprint, namespace)
+	if err != nil {
+		return err
+	}
+
+	if len(orphans) == 0 {
+		return nil
+	}
+
+	var errs []error
+	for _, orphan := range orderForDestroy(orphans, "prune") {
+		if err := k.DeleteKustomization(orphan.Name, namespace); err != nil {
+			errs = append(errs, fmt.Errorf("failed to prune kustomization %q: %w", orphan.Name, err))
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// contextOrphanKustomizations lists the live Kustomizations belonging to this context (by the
+// windsorcli.dev/context-id label) that the blueprint no longer declares — the set Prune deletes and
+// ListPrunableKustomizations reports. It scopes strictly to this context, so kustomizations owned by
+// other contexts (or by no Windsor context) are never returned. DestroyOnly entries are not desired.
+// Each orphan carries its live spec.dependsOn for reverse-dependency ordering.
+func (k *BaseKubernetesManager) contextOrphanKustomizations(blueprint *blueprintv1alpha1.Blueprint, namespace string) ([]blueprintv1alpha1.Kustomization, error) {
 	contextID := k.configHandler.GetString("id")
 	if contextID == "" {
-		return fmt.Errorf("context id not set; cannot scope pruning to this context")
+		return nil, fmt.Errorf("context id not set; cannot scope pruning to this context")
 	}
 
 	desired := make(map[string]bool, len(blueprint.Kustomizations))
@@ -1079,7 +1104,7 @@ func (k *BaseKubernetesManager) PruneBlueprint(blueprint *blueprintv1alpha1.Blue
 	}
 	list, err := k.client.ListResources(gvr, namespace)
 	if err != nil {
-		return fmt.Errorf("failed to list kustomizations for pruning: %w", err)
+		return nil, fmt.Errorf("failed to list kustomizations: %w", err)
 	}
 
 	orphans := make([]blueprintv1alpha1.Kustomization, 0)
@@ -1097,18 +1122,27 @@ func (k *BaseKubernetesManager) PruneBlueprint(blueprint *blueprintv1alpha1.Blue
 			DependsOn: dependsOnFromObject(item),
 		})
 	}
+	return orphans, nil
+}
 
-	if len(orphans) == 0 {
-		return nil
+// ListPrunableKustomizations returns the names of this context's Kustomizations that the blueprint no
+// longer declares — exactly what PruneBlueprint would delete, in reverse-dependency order. It is the
+// read-only input to plan's prune preview and upgrade's confirmation gate; it deletes nothing.
+func (k *BaseKubernetesManager) ListPrunableKustomizations(blueprint *blueprintv1alpha1.Blueprint, namespace string) ([]string, error) {
+	if blueprint == nil {
+		return nil, fmt.Errorf("blueprint not provided")
 	}
 
-	var errs []error
+	orphans, err := k.contextOrphanKustomizations(blueprint, namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	names := make([]string, 0, len(orphans))
 	for _, orphan := range orderForDestroy(orphans, "prune") {
-		if err := k.DeleteKustomization(orphan.Name, namespace); err != nil {
-			errs = append(errs, fmt.Errorf("failed to prune kustomization %q: %w", orphan.Name, err))
-		}
+		names = append(names, orphan.Name)
 	}
-	return errors.Join(errs...)
+	return names, nil
 }
 
 // processDestroyOnlyKustomizations applies all destroy-only kustomizations, waits for all to become ready, then deletes all.

--- a/pkg/provisioner/kubernetes/kustomization_prune_test.go
+++ b/pkg/provisioner/kubernetes/kustomization_prune_test.go
@@ -194,3 +194,73 @@ func TestBaseKubernetesManager_PruneBlueprint(t *testing.T) {
 		}
 	})
 }
+
+func TestBaseKubernetesManager_ListPrunableKustomizations(t *testing.T) {
+	setup := func(t *testing.T) *BaseKubernetesManager {
+		t.Helper()
+		mocks := setupKubernetesMocks(t)
+		manager := NewKubernetesManager(mocks.KubernetesClient, mocks.ConfigHandler)
+		manager.shims = mocks.Shims
+		return manager
+	}
+
+	ctxItem := func(name string) unstructured.Unstructured {
+		return unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+			"kind":       "Kustomization",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": "system-gitops",
+				"labels":    map[string]any{"windsorcli.dev/context-id": "test-context-id"},
+			},
+		}}
+	}
+
+	wire := func(manager *BaseKubernetesManager, items ...unstructured.Unstructured) {
+		c := client.NewMockKubernetesClient()
+		c.ListResourcesFunc = func(gvr schema.GroupVersionResource, ns string) (*unstructured.UnstructuredList, error) {
+			return &unstructured.UnstructuredList{Items: items}, nil
+		}
+		manager.client = c
+	}
+
+	t.Run("ReturnsOrphanNames", func(t *testing.T) {
+		// Given a desired kustomization and an orphan, both owned by this context
+		manager := setup(t)
+		wire(manager, ctxItem("app"), ctxItem("old-thing"))
+		blueprint := &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "app"}}}
+
+		// When listing prunable kustomizations
+		got, err := manager.ListPrunableKustomizations(blueprint, "system-gitops")
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then only the orphan is reported
+		if len(got) != 1 || got[0] != "old-thing" {
+			t.Errorf("Expected [old-thing], got %v", got)
+		}
+	})
+
+	t.Run("EmptyWhenNothingOrphaned", func(t *testing.T) {
+		manager := setup(t)
+		wire(manager, ctxItem("app"))
+		blueprint := &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "app"}}}
+
+		got, err := manager.ListPrunableKustomizations(blueprint, "system-gitops")
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if len(got) != 0 {
+			t.Errorf("Expected no prunable kustomizations, got %v", got)
+		}
+	})
+
+	t.Run("NilBlueprintReturnsError", func(t *testing.T) {
+		manager := setup(t)
+		wire(manager)
+		if _, err := manager.ListPrunableKustomizations(nil, "system-gitops"); err == nil {
+			t.Error("Expected error for nil blueprint")
+		}
+	})
+}

--- a/pkg/provisioner/kubernetes/mock_kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/mock_kubernetes_manager.go
@@ -39,6 +39,7 @@ type MockKubernetesManager struct {
 	ApplyBlueprintFunc                  func(blueprint *blueprintv1alpha1.Blueprint, namespace string) error
 	DeleteBlueprintFunc                 func(blueprint *blueprintv1alpha1.Blueprint, namespace string) error
 	PruneBlueprintFunc                  func(blueprint *blueprintv1alpha1.Blueprint, namespace string) error
+	ListPrunableKustomizationsFunc      func(blueprint *blueprintv1alpha1.Blueprint, namespace string) ([]string, error)
 }
 
 // =============================================================================
@@ -214,6 +215,14 @@ func (m *MockKubernetesManager) PruneBlueprint(blueprint *blueprintv1alpha1.Blue
 		return m.PruneBlueprintFunc(blueprint, namespace)
 	}
 	return nil
+}
+
+// ListPrunableKustomizations implements KubernetesManager interface
+func (m *MockKubernetesManager) ListPrunableKustomizations(blueprint *blueprintv1alpha1.Blueprint, namespace string) ([]string, error) {
+	if m.ListPrunableKustomizationsFunc != nil {
+		return m.ListPrunableKustomizationsFunc(blueprint, namespace)
+	}
+	return nil, nil
 }
 
 // =============================================================================

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -1034,6 +1034,27 @@ func (i *Provisioner) Prune(blueprint *blueprintv1alpha1.Blueprint) error {
 	return nil
 }
 
+// PrunableKustomizations returns the names of this context's Kustomizations that the blueprint no
+// longer declares — exactly what Prune would delete. It is the read-only input to plan's prune
+// preview and upgrade's confirmation gate; it deletes nothing. It prepares the blueprint with the
+// synthesized CRD layers so the desired set matches what Prune deletes against.
+func (i *Provisioner) PrunableKustomizations(blueprint *blueprintv1alpha1.Blueprint) ([]string, error) {
+	if blueprint == nil {
+		return nil, fmt.Errorf("blueprint not provided")
+	}
+	if i.KubernetesManager == nil {
+		return nil, fmt.Errorf("kubernetes manager not configured")
+	}
+
+	blueprint = withCrdLayer(blueprint)
+
+	names, err := i.KubernetesManager.ListPrunableKustomizations(blueprint, i.fluxNamespace())
+	if err != nil {
+		return nil, fmt.Errorf("failed to list prunable kustomizations: %w", err)
+	}
+	return names, nil
+}
+
 // GetVersionMarker reads the applied-version marker for this context's gitops namespace, reporting
 // false when no marker exists (a pre-bootstrap, no-cluster, or legacy context). apply and plan read
 // the marker to gate on the blueprint version; only bootstrap and upgrade write it. Returns false

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -1333,6 +1333,50 @@ func TestProvisioner_Prune(t *testing.T) {
 	})
 }
 
+func TestProvisioner_PrunableKustomizations(t *testing.T) {
+	t.Run("DelegatesAndReturnsNames", func(t *testing.T) {
+		// Given a manager that reports an orphan kustomization
+		mocks := setupProvisionerMocks(t)
+		var capturedNamespace string
+		mocks.KubernetesManager.ListPrunableKustomizationsFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) ([]string, error) {
+			capturedNamespace = namespace
+			return []string{"old-thing"}, nil
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+
+		// When listing prunable kustomizations
+		got, err := provisioner.PrunableKustomizations(createTestBlueprint())
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then it delegates against the gitops namespace and returns the names
+		if capturedNamespace != provisioner.fluxNamespace() {
+			t.Errorf("Expected namespace %q, got %q", provisioner.fluxNamespace(), capturedNamespace)
+		}
+		if len(got) != 1 || got[0] != "old-thing" {
+			t.Errorf("Expected [old-thing], got %v", got)
+		}
+	})
+
+	t.Run("NilBlueprintReturnsError", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+		if _, err := provisioner.PrunableKustomizations(nil); err == nil {
+			t.Error("Expected error for nil blueprint")
+		}
+	})
+
+	t.Run("NilManagerReturnsError", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+		provisioner.KubernetesManager = nil
+		if _, err := provisioner.PrunableKustomizations(createTestBlueprint()); err == nil {
+			t.Error("Expected error for nil kubernetes manager")
+		}
+	})
+}
+
 func TestProvisioner_GetVersionMarker(t *testing.T) {
 	t.Run("DelegatesToManagerWhenKubeconfigPresent", func(t *testing.T) {
 		// Given a manager that returns a marker and a context with a kubeconfig


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> This PR removes a shared infrastructure boundary (`enforceApplyVersionGate`) and expands `apply`'s reconciliation scope to include kustomization pruning — a capability previously exclusive to `upgrade`. Any operator automation or runbook that relied on the gate to prevent `apply` from running during a version transition is now unguarded.
>
> **Overview**
>
> The change collapses the apply/upgrade seam by removing the version-equality gate from `apply` and introducing a shared `--yes` confirmation gate that both commands require before pruning orphaned kustomizations. A new read-only `PrunableKustomizations` method is added at the provisioner and KubernetesManager layers to power the confirmation prompt and the prune preview added to `windsor plan`.
>
> The most load-bearing behavioral change is that `apply` now silently proceeds when an upgrade is in flight. The old gate explicitly refused `apply` during a live version transition and was non-bypassable even with `--force`. That protection is not replaced by the `--yes` gate, which only fires on orphaned kustomizations.
>
> Reviewed by Claude for commit `6edb98d2`.

<!-- /claude-code-review:summary -->
