### PR TITLE
feat(cmd/upgrade): implement upgrade to latest sources

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -67,8 +67,10 @@ windsor upgrade cluster --nodes=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1
 		}
 
 		if !upgradeYes {
+			msg := "upgrade rewrites blueprint.yaml and reconciles the cluster (apply, wait, prune); re-run with --yes to proceed, or use `windsor plan` to preview"
+			fmt.Fprintln(cmd.ErrOrStderr(), msg)
 			silenceErrorsOnAncestors(cmd)
-			return fmt.Errorf("upgrade rewrites blueprint.yaml and reconciles the cluster (apply, wait, prune); re-run with --yes to proceed, or use `windsor plan` to preview")
+			return fmt.Errorf("%s", msg)
 		}
 
 		if len(upgradeSources) > 0 {

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -30,12 +30,15 @@ var (
 
 var upgradeCmd = &cobra.Command{
 	Use:   "upgrade",
-	Short: "Upgrade the blueprint, pruning kustomizations it no longer declares.",
-	Long: `Apply terraform and the Flux blueprint, wait for kustomizations to be ready, then prune any kustomizations this context no longer declares. Pruning runs only after a successful wait, so resources are never deleted before the desired set has reconciled.
+	Short: "Move sources to their latest version and reconcile the blueprint.",
+	Long: `With no arguments, move every declared OCI source to its latest stable version, then reconcile: apply terraform and the Flux blueprint, wait, and prune kustomizations this context no longer declares. Use --source name=url to move named sources to specific versions instead. Prunes run only after a successful wait and are gated by --yes.
 
 Use the 'cluster' or 'node' subcommand to upgrade Talos nodes instead.`,
-	Example: `# Upgrade the blueprint and prune orphaned kustomizations
-windsor upgrade
+	Example: `# Move all sources to their latest stable version and reconcile
+windsor upgrade --yes
+
+# Move a specific source to a specific version
+windsor upgrade --source core=oci://ghcr.io/windsorcli/core:v0.6.0 --yes
 
 # Upgrade Talos nodes in parallel (see 'upgrade cluster')
 windsor upgrade cluster --nodes=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.0`,
@@ -67,10 +70,14 @@ windsor upgrade cluster --nodes=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1
 			if err := retargetSources(cmd, proj, upgradeSources); err != nil {
 				return err
 			}
-			blueprint = proj.Composer.BlueprintHandler.Generate()
-			if blueprint == nil {
-				return fmt.Errorf("blueprint is not available")
+		} else {
+			if err := upgradeToLatest(cmd, proj); err != nil {
+				return err
 			}
+		}
+		blueprint = proj.Composer.BlueprintHandler.Generate()
+		if blueprint == nil {
+			return fmt.Errorf("blueprint is not available")
 		}
 
 		return stacklock.With(cmd.Context(), proj.Runtime, "upgrade", func() error {
@@ -243,6 +250,27 @@ func confirmAndPrune(cmd *cobra.Command, proj *project.Project, blueprint *bluep
 	}
 	if err := proj.Provisioner.Prune(blueprint); err != nil {
 		return fmt.Errorf("error pruning orphaned kustomizations: %w", err)
+	}
+	return nil
+}
+
+// upgradeToLatest moves every remote OCI source pinned to a semver to its latest stable tag,
+// persists the bumps to blueprint.yaml, and prints what changed. Sources that are not OCI, not
+// semver-pinned, or already current are left untouched; it reports when nothing moved.
+func upgradeToLatest(cmd *cobra.Command, proj *project.Project) error {
+	upgrades, err := proj.Composer.BlueprintHandler.UpgradeSourcesToLatest()
+	if err != nil {
+		return fmt.Errorf("error resolving latest source versions: %w", err)
+	}
+	if len(upgrades) == 0 {
+		fmt.Fprintln(cmd.OutOrStdout(), "All sources are already at their latest version.")
+		return nil
+	}
+	if err := proj.Composer.BlueprintHandler.Write(true); err != nil {
+		return fmt.Errorf("failed to persist source upgrades to blueprint.yaml: %w", err)
+	}
+	for _, u := range upgrades {
+		fmt.Fprintf(cmd.OutOrStdout(), "Upgraded %s from %s to %s\n", u.Name, u.From, u.To)
 	}
 	return nil
 }

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -66,6 +66,11 @@ windsor upgrade cluster --nodes=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1
 			return fmt.Errorf("blueprint is not available")
 		}
 
+		if !upgradeYes {
+			silenceErrorsOnAncestors(cmd)
+			return fmt.Errorf("upgrade rewrites blueprint.yaml and reconciles the cluster (apply, wait, prune); re-run with --yes to proceed, or use `windsor plan` to preview")
+		}
+
 		if len(upgradeSources) > 0 {
 			if err := retargetSources(cmd, proj, upgradeSources); err != nil {
 				return err

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+	"github.com/windsorcli/cli/pkg/composer/blueprint"
 	"github.com/windsorcli/cli/pkg/provisioner/kubernetes"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 )
@@ -301,6 +302,98 @@ func TestUpgradeCmd(t *testing.T) {
 		// Then it is rejected — bare upgrade takes no positional args
 		if err == nil {
 			t.Error("Expected error for unexpected argument, got nil")
+		}
+	})
+}
+
+func TestUpgradeCmd_Latest(t *testing.T) {
+	createTestUpgradeCmd := func() *cobra.Command { return makeApplyTestCmd(upgradeCmd) }
+
+	suppressProcessStdout(t)
+	suppressProcessStderr(t)
+
+	t.Run("ResolvesLatestPersistsAndUpgrades", func(t *testing.T) {
+		// Given sources with a newer version available (implicit upgrade, no --source)
+		mocks := setupApplyTest(t)
+		mocks.BlueprintHandler.UpgradeSourcesToLatestFunc = func() ([]blueprint.SourceUpgrade, error) {
+			return []blueprint.SourceUpgrade{{
+				Name: "core",
+				From: "oci://ghcr.io/windsorcli/core:v0.5.0",
+				To:   "oci://ghcr.io/windsorcli/core:v0.6.0",
+			}}, nil
+		}
+		persisted := false
+		mocks.BlueprintHandler.WriteFunc = func(overwrite ...bool) error {
+			if len(overwrite) > 0 && overwrite[0] {
+				persisted = true
+			}
+			return nil
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When running bare upgrade
+		var out bytes.Buffer
+		cmd := createTestUpgradeCmd()
+		cmd.SetOut(&out)
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then it resolves latest, persists the bump, reports it, and proceeds
+		if !persisted {
+			t.Error("Expected the resolved versions to be persisted via Write(true)")
+		}
+		if !strings.Contains(out.String(), "Upgraded core") {
+			t.Errorf("Expected an upgrade report, got: %q", out.String())
+		}
+	})
+
+	t.Run("ReportsWhenAlreadyLatest", func(t *testing.T) {
+		// Given nothing newer is available
+		mocks := setupApplyTest(t)
+		mocks.BlueprintHandler.UpgradeSourcesToLatestFunc = func() ([]blueprint.SourceUpgrade, error) {
+			return nil, nil
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When running bare upgrade
+		var out bytes.Buffer
+		cmd := createTestUpgradeCmd()
+		cmd.SetOut(&out)
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then it reports already-latest and still reconciles
+		if !strings.Contains(out.String(), "already at their latest") {
+			t.Errorf("Expected an already-latest report, got: %q", out.String())
+		}
+	})
+
+	t.Run("ResolutionErrorAborts", func(t *testing.T) {
+		// Given resolving latest fails
+		mocks := setupApplyTest(t)
+		mocks.BlueprintHandler.UpgradeSourcesToLatestFunc = func() ([]blueprint.SourceUpgrade, error) {
+			return nil, fmt.Errorf("registry unreachable")
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When running bare upgrade
+		cmd := createTestUpgradeCmd()
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then it aborts with the resolution error
+		if err == nil {
+			t.Fatal("Expected an error when resolving latest fails, got nil")
+		}
+		if !strings.Contains(err.Error(), "resolving latest source versions") {
+			t.Errorf("Expected a resolution error, got: %v", err)
 		}
 	})
 }

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -20,9 +20,12 @@ func TestUpgradeCmd(t *testing.T) {
 	suppressProcessStdout(t)
 	suppressProcessStderr(t)
 
+	// These subtests exercise the executing path; upgrade requires --yes to mutate, so confirm it.
+	upgradeYes = true
+	t.Cleanup(func() { upgradeYes = false })
+
 	t.Run("PrunesAfterSuccessfulWait", func(t *testing.T) {
-		t.Cleanup(func() { upgradeYes = false })
-		// Given an upgrade with an orphaned kustomization, run with --yes
+		// Given an upgrade with an orphaned kustomization
 		mocks := setupApplyTest(t)
 		mocks.KubernetesManager.ListPrunableKustomizationsFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) ([]string, error) {
 			return []string{"old-thing"}, nil
@@ -131,7 +134,6 @@ func TestUpgradeCmd(t *testing.T) {
 	})
 
 	t.Run("LeavesInFlightMarkerWhenPruneFails", func(t *testing.T) {
-		t.Cleanup(func() { upgradeYes = false })
 		// Given an orphan to prune and a prune that fails after install and wait succeed
 		mocks := setupApplyTest(t)
 		mocks.KubernetesManager.ListPrunableKustomizationsFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) ([]string, error) {
@@ -195,7 +197,6 @@ func TestUpgradeCmd(t *testing.T) {
 	})
 
 	t.Run("ErrorPruneFails", func(t *testing.T) {
-		t.Cleanup(func() { upgradeYes = false })
 		// Given an orphan to prune and a prune step that fails after a successful wait
 		mocks := setupApplyTest(t)
 		mocks.KubernetesManager.ListPrunableKustomizationsFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) ([]string, error) {
@@ -312,6 +313,9 @@ func TestUpgradeCmd_Latest(t *testing.T) {
 	suppressProcessStdout(t)
 	suppressProcessStderr(t)
 
+	upgradeYes = true
+	t.Cleanup(func() { upgradeYes = false })
+
 	t.Run("ResolvesLatestPersistsAndUpgrades", func(t *testing.T) {
 		// Given sources with a newer version available (implicit upgrade, no --source)
 		mocks := setupApplyTest(t)
@@ -403,6 +407,9 @@ func TestUpgradeCmd_Source(t *testing.T) {
 
 	suppressProcessStdout(t)
 	suppressProcessStderr(t)
+
+	upgradeYes = true
+	t.Cleanup(func() { upgradeYes = false })
 
 	t.Run("RetargetsPersistsAndUpgrades", func(t *testing.T) {
 		t.Cleanup(func() { upgradeSources = nil })
@@ -503,18 +510,20 @@ func TestUpgradeCmd_Source(t *testing.T) {
 	})
 }
 
-func TestUpgradeCmd_PruneGate(t *testing.T) {
+func TestUpgradeCmd_Confirmation(t *testing.T) {
 	createTestUpgradeCmd := func() *cobra.Command { return makeApplyTestCmd(upgradeCmd) }
 
 	suppressProcessStdout(t)
 	suppressProcessStderr(t)
 
-	t.Run("RefusesPruneWithoutYes", func(t *testing.T) {
+	t.Run("RefusesWithoutYes", func(t *testing.T) {
 		t.Cleanup(func() { upgradeYes = false })
-		// Given a transition that would prune a kustomization
+		// Given an upgrade that would rewrite blueprint.yaml and reconcile
 		mocks := setupApplyTest(t)
-		mocks.KubernetesManager.ListPrunableKustomizationsFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) ([]string, error) {
-			return []string{"old-thing"}, nil
+		installed := false
+		mocks.KubernetesManager.ApplyBlueprintFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) error {
+			installed = true
+			return nil
 		}
 		pruned := false
 		mocks.KubernetesManager.PruneBlueprintFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) error {
@@ -529,21 +538,24 @@ func TestUpgradeCmd_PruneGate(t *testing.T) {
 		cmd.SetContext(ctx)
 		err := cmd.Execute()
 
-		// Then it refuses and never prunes
+		// Then it refuses up front and reconciles nothing
 		if err == nil {
-			t.Fatal("Expected refusal without --yes when a prune is pending, got nil")
+			t.Fatal("Expected refusal without --yes, got nil")
 		}
 		if !strings.Contains(err.Error(), "--yes") {
 			t.Errorf("Expected the message to point at --yes, got: %v", err)
 		}
+		if installed {
+			t.Error("Expected install to be skipped when the guard refuses")
+		}
 		if pruned {
-			t.Error("Expected prune to be skipped when the gate refuses")
+			t.Error("Expected prune to be skipped when the guard refuses")
 		}
 	})
 
 	t.Run("ProceedsWithYes", func(t *testing.T) {
 		t.Cleanup(func() { upgradeYes = false })
-		// Given the same pending prune
+		// Given a pending prune
 		mocks := setupApplyTest(t)
 		mocks.KubernetesManager.ListPrunableKustomizationsFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) ([]string, error) {
 			return []string{"old-thing"}, nil
@@ -567,28 +579,6 @@ func TestUpgradeCmd_PruneGate(t *testing.T) {
 		// Then the prune runs
 		if !pruned {
 			t.Error("Expected prune to run under --yes")
-		}
-	})
-
-	t.Run("ProceedsWhenNothingPrunable", func(t *testing.T) {
-		// Given a transition that prunes nothing
-		mocks := setupApplyTest(t)
-		listed := false
-		mocks.KubernetesManager.ListPrunableKustomizationsFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) ([]string, error) {
-			listed = true
-			return nil, nil
-		}
-		proj := newApplyAllProject(mocks)
-
-		// When upgrading, the gate runs and allows it through without --yes
-		cmd := createTestUpgradeCmd()
-		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
-		cmd.SetContext(ctx)
-		if err := cmd.Execute(); err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if !listed {
-			t.Error("Expected the prune gate to run")
 		}
 	})
 }

--- a/docs/reference/commands/upgrade.md
+++ b/docs/reference/commands/upgrade.md
@@ -1,6 +1,6 @@
 ---
 title: "windsor upgrade"
-description: "Upgrade the blueprint, pruning kustomizations it no longer declares."
+description: "Move sources to their latest version and reconcile the blueprint."
 ---
 # windsor upgrade
 
@@ -8,7 +8,7 @@ description: "Upgrade the blueprint, pruning kustomizations it no longer declare
 windsor upgrade [flags]
 ```
 
-Apply terraform and the Flux blueprint, wait for kustomizations to be ready, then prune any kustomizations this context no longer declares. Pruning runs only after a successful wait, so resources are never deleted before the desired set has reconciled.
+With no arguments, move every declared OCI source to its latest stable version, then reconcile: apply terraform and the Flux blueprint, wait, and prune kustomizations this context no longer declares. Use --source name=url to move named sources to specific versions instead. Prunes run only after a successful wait and are gated by --yes.
 
 Use the 'cluster' or 'node' subcommand to upgrade Talos nodes instead.
 
@@ -27,8 +27,11 @@ Use the 'cluster' or 'node' subcommand to upgrade Talos nodes instead.
 ## Examples
 
 ```sh
-# Upgrade the blueprint and prune orphaned kustomizations
-windsor upgrade
+# Move all sources to their latest stable version and reconcile
+windsor upgrade --yes
+
+# Move a specific source to a specific version
+windsor upgrade --source core=oci://ghcr.io/windsorcli/core:v0.6.0 --yes
 
 # Upgrade Talos nodes in parallel (see 'upgrade cluster')
 windsor upgrade cluster --nodes=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.0

--- a/integration/upgrade_test.go
+++ b/integration/upgrade_test.go
@@ -37,16 +37,36 @@ func TestUpgrade_RunsBlueprintFlowInLocalContext(t *testing.T) {
 	}
 	env = append(env, "WINDSOR_CONTEXT=local")
 
-	// Bare `upgrade` drives terraform + the blueprint install/wait/prune flow. With no live
+	// `upgrade --yes` drives terraform + the blueprint install/wait/prune flow. With no live
 	// cluster the install/wait phase fails, which proves the command reaches real
 	// provisioning rather than dispatching to the talos subcommands or printing help.
-	_, stderr, err := helpers.RunCLI(dir, []string{"upgrade"}, env)
+	_, stderr, err := helpers.RunCLI(dir, []string{"upgrade", "--yes"}, env)
 	if err == nil {
 		t.Fatal("expected upgrade to fail without a live cluster, got success")
 	}
 	out := string(stderr)
 	if strings.Contains(out, "unknown command") || strings.Contains(out, "Available Commands") {
-		t.Errorf("expected bare upgrade to run the blueprint flow, not print help, got: %s", out)
+		t.Errorf("expected upgrade to run the blueprint flow, not print help, got: %s", out)
+	}
+}
+
+func TestUpgrade_RefusesWithoutYes(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
+	if _, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env); err != nil {
+		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
+	}
+	env = append(env, "WINDSOR_CONTEXT=local")
+
+	// Bare `upgrade` rewrites blueprint.yaml and reconciles the cluster, so it must refuse up
+	// front without --yes and point the operator at the read-only preview.
+	_, stderr, err := helpers.RunCLI(dir, []string{"upgrade"}, env)
+	if err == nil {
+		t.Fatal("expected upgrade to refuse without --yes, got success")
+	}
+	if !strings.Contains(string(stderr), "--yes") {
+		t.Errorf("expected the refusal to point at --yes, got: %s", stderr)
 	}
 }
 
@@ -61,7 +81,7 @@ func TestUpgrade_SourceRejectsUndeclaredSource(t *testing.T) {
 
 	// --source must refuse a source the blueprint does not declare, before any cluster work —
 	// adding a source is a structural edit to blueprint.yaml, not a retarget.
-	_, stderr, err := helpers.RunCLI(dir, []string{"upgrade", "--source", "bogus=oci://ghcr.io/windsorcli/bogus:v1.0.0"}, env)
+	_, stderr, err := helpers.RunCLI(dir, []string{"upgrade", "--source", "bogus=oci://ghcr.io/windsorcli/bogus:v1.0.0", "--yes"}, env)
 	if err == nil {
 		t.Fatal("expected upgrade to reject an undeclared --source, got success")
 	}

--- a/pkg/composer/artifact/artifact.go
+++ b/pkg/composer/artifact/artifact.go
@@ -52,6 +52,7 @@ type Artifact interface {
 	ExtractModulePath(registry, repository, tag, modulePath string) (string, error)
 	ParseOCIRef(ociRef string) (registry, repository, tag string, err error)
 	GetCacheDir(registry, repository, tag string) (string, error)
+	ListTags(ociRef string) ([]string, error)
 }
 
 // =============================================================================
@@ -194,6 +195,25 @@ func (a *ArtifactBuilder) Write(outputPath string, tag string) (string, error) {
 // Validates OCI reference format and extracts registry, repository, and tag parts.
 // Requires OCI reference to follow the format "oci://registry/repository:tag".
 // Returns individual components for separate handling in OCI operations.
+// ListTags returns the tags published for the repository of an OCI reference (the tag in ociRef is
+// ignored). It is used to resolve the latest available version when upgrading a source. Returns an
+// error if the reference is malformed or the registry cannot be reached.
+func (a *ArtifactBuilder) ListTags(ociRef string) ([]string, error) {
+	registry, repository, _, err := a.ParseOCIRef(ociRef)
+	if err != nil {
+		return nil, err
+	}
+	repo, err := a.shims.NewRepository(registry + "/" + repository)
+	if err != nil {
+		return nil, fmt.Errorf("invalid repository %q/%q: %w", registry, repository, err)
+	}
+	tags, err := a.shims.RemoteList(repo, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list tags for %s/%s: %w", registry, repository, err)
+	}
+	return tags, nil
+}
+
 func (a *ArtifactBuilder) ParseOCIRef(ociRef string) (registry, repository, tag string, err error) {
 	if !strings.HasPrefix(ociRef, "oci://") {
 		return "", "", "", fmt.Errorf("invalid OCI reference format: %s", ociRef)

--- a/pkg/composer/artifact/artifact.go
+++ b/pkg/composer/artifact/artifact.go
@@ -195,25 +195,6 @@ func (a *ArtifactBuilder) Write(outputPath string, tag string) (string, error) {
 // Validates OCI reference format and extracts registry, repository, and tag parts.
 // Requires OCI reference to follow the format "oci://registry/repository:tag".
 // Returns individual components for separate handling in OCI operations.
-// ListTags returns the tags published for the repository of an OCI reference (the tag in ociRef is
-// ignored). It is used to resolve the latest available version when upgrading a source. Returns an
-// error if the reference is malformed or the registry cannot be reached.
-func (a *ArtifactBuilder) ListTags(ociRef string) ([]string, error) {
-	registry, repository, _, err := a.ParseOCIRef(ociRef)
-	if err != nil {
-		return nil, err
-	}
-	repo, err := a.shims.NewRepository(registry + "/" + repository)
-	if err != nil {
-		return nil, fmt.Errorf("invalid repository %q/%q: %w", registry, repository, err)
-	}
-	tags, err := a.shims.RemoteList(repo, remote.WithAuthFromKeychain(authn.DefaultKeychain))
-	if err != nil {
-		return nil, fmt.Errorf("failed to list tags for %s/%s: %w", registry, repository, err)
-	}
-	return tags, nil
-}
-
 func (a *ArtifactBuilder) ParseOCIRef(ociRef string) (registry, repository, tag string, err error) {
 	if !strings.HasPrefix(ociRef, "oci://") {
 		return "", "", "", fmt.Errorf("invalid OCI reference format: %s", ociRef)
@@ -238,6 +219,25 @@ func (a *ArtifactBuilder) ParseOCIRef(ociRef string) (registry, repository, tag 
 	repository = repoParts[1]
 
 	return registry, repository, tag, nil
+}
+
+// ListTags returns the tags published for the repository of an OCI reference (the tag in ociRef is
+// ignored). It is used to resolve the latest available version when upgrading a source. Returns an
+// error if the reference is malformed or the registry cannot be reached.
+func (a *ArtifactBuilder) ListTags(ociRef string) ([]string, error) {
+	registry, repository, _, err := a.ParseOCIRef(ociRef)
+	if err != nil {
+		return nil, err
+	}
+	repo, err := a.shims.NewRepository(registry + "/" + repository)
+	if err != nil {
+		return nil, fmt.Errorf("invalid repository %q/%q: %w", registry, repository, err)
+	}
+	tags, err := a.shims.RemoteList(repo, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil {
+		return nil, fmt.Errorf("failed to list tags for %s/%s: %w", registry, repository, err)
+	}
+	return tags, nil
 }
 
 // GetCacheDir returns the cache directory path for an OCI artifact identified by registry, repository, and tag.

--- a/pkg/composer/artifact/artifact_private_test.go
+++ b/pkg/composer/artifact/artifact_private_test.go
@@ -2803,3 +2803,54 @@ func (m *mockWriteCloser) Close() error {
 // =============================================================================
 // Test Helper Functions
 // =============================================================================
+
+func TestArtifactBuilder_ListTags(t *testing.T) {
+	setup := func(t *testing.T) *ArtifactBuilder {
+		t.Helper()
+		mocks := setupArtifactMocks(t)
+		builder := NewArtifactBuilder(mocks.Runtime)
+		builder.shims = mocks.Shims
+		return builder
+	}
+
+	t.Run("ReturnsTagsForRepository", func(t *testing.T) {
+		// Given a registry that lists two tags for the repository
+		builder := setup(t)
+		var listedRepo string
+		builder.shims.RemoteList = func(repo name.Repository, options ...remote.Option) ([]string, error) {
+			listedRepo = repo.String()
+			return []string{"v0.5.0", "v0.6.0"}, nil
+		}
+
+		// When listing tags for an OCI reference (the tag in the ref is ignored)
+		tags, err := builder.ListTags("oci://ghcr.io/windsorcli/core:v0.6.0")
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then it lists the repository's tags
+		if !strings.Contains(listedRepo, "ghcr.io/windsorcli/core") {
+			t.Errorf("Expected the repository to be listed, got %q", listedRepo)
+		}
+		if len(tags) != 2 || tags[1] != "v0.6.0" {
+			t.Errorf("Expected [v0.5.0 v0.6.0], got %v", tags)
+		}
+	})
+
+	t.Run("ErrorsOnMalformedReference", func(t *testing.T) {
+		builder := setup(t)
+		if _, err := builder.ListTags("not-an-oci-ref"); err == nil {
+			t.Error("Expected an error for a malformed OCI reference")
+		}
+	})
+
+	t.Run("PropagatesRegistryError", func(t *testing.T) {
+		builder := setup(t)
+		builder.shims.RemoteList = func(repo name.Repository, options ...remote.Option) ([]string, error) {
+			return nil, fmt.Errorf("registry down")
+		}
+		if _, err := builder.ListTags("oci://ghcr.io/windsorcli/core:v0.6.0"); err == nil {
+			t.Error("Expected the registry error to surface")
+		}
+	})
+}

--- a/pkg/composer/artifact/mock_artifact.go
+++ b/pkg/composer/artifact/mock_artifact.go
@@ -18,6 +18,7 @@ type MockArtifact struct {
 	ExtractModulePathFunc func(registry, repository, tag, modulePath string) (string, error)
 	ParseOCIRefFunc       func(ociRef string) (registry, repository, tag string, err error)
 	GetCacheDirFunc       func(registry, repository, tag string) (string, error)
+	ListTagsFunc          func(ociRef string) ([]string, error)
 }
 
 // =============================================================================
@@ -66,6 +67,14 @@ func (m *MockArtifact) Pull(ociRefs []string) (map[string]string, error) {
 		return m.PullFunc(ociRefs)
 	}
 	return make(map[string]string), nil
+}
+
+// ListTags calls the mock ListTagsFunc if set, otherwise returns an empty slice and nil error
+func (m *MockArtifact) ListTags(ociRef string) ([]string, error) {
+	if m.ListTagsFunc != nil {
+		return m.ListTagsFunc(ociRef)
+	}
+	return nil, nil
 }
 
 // ExtractModulePath calls the mock ExtractModulePathFunc if set, otherwise returns empty string and nil error

--- a/pkg/composer/artifact/shims.go
+++ b/pkg/composer/artifact/shims.go
@@ -64,6 +64,8 @@ type Shims struct {
 	RemoteGet         func(ref name.Reference, options ...remote.Option) (*remote.Descriptor, error)
 	RemoteWriteLayer  func(repo name.Repository, layer v1.Layer, options ...remote.Option) error
 	RemoteWrite       func(ref name.Reference, img v1.Image, options ...remote.Option) error
+	RemoteList        func(repo name.Repository, options ...remote.Option) ([]string, error)
+	NewRepository     func(repo string, opts ...name.Option) (name.Repository, error)
 	MkdirAll           func(path string, perm os.FileMode) error
 	NewBytesReader     func(b []byte) *bytes.Reader
 	NewTarReader       func(r io.Reader) TarReader
@@ -106,6 +108,8 @@ func NewShims() *Shims {
 		RemoteGet:        remote.Get,
 		RemoteWriteLayer: remote.WriteLayer,
 		RemoteWrite:      remote.Write,
+		RemoteList:       remote.List,
+		NewRepository:    func(repo string, opts ...name.Option) (name.Repository, error) { return name.NewRepository(repo, opts...) },
 		MkdirAll:          os.MkdirAll,
 		NewBytesReader:    func(b []byte) *bytes.Reader { return bytes.NewReader(b) },
 		NewTarReader:      func(r io.Reader) TarReader { return tar.NewReader(r) },

--- a/pkg/composer/artifact/shims.go
+++ b/pkg/composer/artifact/shims.go
@@ -66,13 +66,13 @@ type Shims struct {
 	RemoteWrite       func(ref name.Reference, img v1.Image, options ...remote.Option) error
 	RemoteList        func(repo name.Repository, options ...remote.Option) ([]string, error)
 	NewRepository     func(repo string, opts ...name.Option) (name.Repository, error)
-	MkdirAll           func(path string, perm os.FileMode) error
-	NewBytesReader     func(b []byte) *bytes.Reader
-	NewTarReader       func(r io.Reader) TarReader
-	Copy               func(dst io.Writer, src io.Reader) (int64, error)
-	Chmod              func(name string, mode os.FileMode) error
-	Rename             func(oldpath, newpath string) error
-	RemoveAll          func(path string) error
+	MkdirAll          func(path string, perm os.FileMode) error
+	NewBytesReader    func(b []byte) *bytes.Reader
+	NewTarReader      func(r io.Reader) TarReader
+	Copy              func(dst io.Writer, src io.Reader) (int64, error)
+	Chmod             func(name string, mode os.FileMode) error
+	Rename            func(oldpath, newpath string) error
+	RemoveAll         func(path string) error
 }
 
 // =============================================================================
@@ -84,17 +84,21 @@ func NewShims() *Shims {
 	return &Shims{
 		Stat: os.Stat,
 		// #nosec G304 - User-controlled output path is intentional for build artifact creation
-		Create:            func(name string) (io.WriteCloser, error) { return os.Create(name) },
-		ReadFile:          os.ReadFile,
-		Walk:              filepath.Walk,
-		NewGzipWriter:     gzip.NewWriter,
-		NewTarWriter:      func(w io.Writer) TarWriter { return tar.NewWriter(w) },
-		YamlUnmarshal:     yaml.Unmarshal,
-		FilepathRel:       filepath.Rel,
-		YamlMarshal:       yaml.Marshal,
-		ReadAll:           io.ReadAll,
-		ParseReference:    func(ref string, opts ...name.Option) (name.Reference, error) { return name.ParseReference(ref, opts...) },
-		RemoteImage:       func(ref name.Reference, options ...remote.Option) (v1.Image, error) { return remote.Image(ref, options...) },
+		Create:        func(name string) (io.WriteCloser, error) { return os.Create(name) },
+		ReadFile:      os.ReadFile,
+		Walk:          filepath.Walk,
+		NewGzipWriter: gzip.NewWriter,
+		NewTarWriter:  func(w io.Writer) TarWriter { return tar.NewWriter(w) },
+		YamlUnmarshal: yaml.Unmarshal,
+		FilepathRel:   filepath.Rel,
+		YamlMarshal:   yaml.Marshal,
+		ReadAll:       io.ReadAll,
+		ParseReference: func(ref string, opts ...name.Option) (name.Reference, error) {
+			return name.ParseReference(ref, opts...)
+		},
+		RemoteImage: func(ref name.Reference, options ...remote.Option) (v1.Image, error) {
+			return remote.Image(ref, options...)
+		},
 		ImageLayers:       func(img v1.Image) ([]v1.Layer, error) { return img.Layers() },
 		LayerUncompressed: func(layer v1.Layer) (io.ReadCloser, error) { return layer.Uncompressed() },
 		AppendLayers:      mutate.AppendLayers,
@@ -109,13 +113,15 @@ func NewShims() *Shims {
 		RemoteWriteLayer: remote.WriteLayer,
 		RemoteWrite:      remote.Write,
 		RemoteList:       remote.List,
-		NewRepository:    func(repo string, opts ...name.Option) (name.Repository, error) { return name.NewRepository(repo, opts...) },
-		MkdirAll:          os.MkdirAll,
-		NewBytesReader:    func(b []byte) *bytes.Reader { return bytes.NewReader(b) },
-		NewTarReader:      func(r io.Reader) TarReader { return tar.NewReader(r) },
-		Copy:              io.Copy,
-		Chmod:             os.Chmod,
-		Rename:            os.Rename,
-		RemoveAll:         os.RemoveAll,
+		NewRepository: func(repo string, opts ...name.Option) (name.Repository, error) {
+			return name.NewRepository(repo, opts...)
+		},
+		MkdirAll:       os.MkdirAll,
+		NewBytesReader: func(b []byte) *bytes.Reader { return bytes.NewReader(b) },
+		NewTarReader:   func(r io.Reader) TarReader { return tar.NewReader(r) },
+		Copy:           io.Copy,
+		Chmod:          os.Chmod,
+		Rename:         os.Rename,
+		RemoveAll:      os.RemoveAll,
 	}
 }

--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -221,15 +221,22 @@ type SourceUpgrade struct {
 // published in its repository, mutating the composed blueprint in memory (call Write to persist) and
 // returning the changes for reporting. Sources that are not OCI, not semver-pinned (a branch, a
 // mutable tag like :latest), or already at the latest are left untouched, as are prerelease tags. It
-// resolves directly to the latest — it does not step minor-by-minor.
+// resolves directly to the latest — it does not step minor-by-minor. All tags are resolved before any
+// source is mutated, so a registry failure mid-resolution leaves the in-memory blueprint untouched.
 func (h *BaseBlueprintHandler) UpgradeSourcesToLatest() ([]SourceUpgrade, error) {
 	if h.composedBlueprint == nil {
 		return nil, fmt.Errorf("blueprint not loaded")
 	}
 
-	var upgrades []SourceUpgrade
+	type plannedUpgrade struct {
+		index  int
+		newURL string
+		change SourceUpgrade
+	}
+
+	var planned []plannedUpgrade
 	for i := range h.composedBlueprint.Sources {
-		src := &h.composedBlueprint.Sources[i]
+		src := h.composedBlueprint.Sources[i]
 		if !strings.HasPrefix(src.Url, "oci://") {
 			continue
 		}
@@ -252,9 +259,18 @@ func (h *BaseBlueprintHandler) UpgradeSourcesToLatest() ([]SourceUpgrade, error)
 		}
 
 		newURL := strings.TrimSuffix(src.Url, ":"+info.Tag) + ":" + latestTag
-		upgrades = append(upgrades, SourceUpgrade{Name: src.Name, From: src.Url, To: newURL})
-		src.Url = newURL
-		src.Ref = blueprintv1alpha1.Reference{}
+		planned = append(planned, plannedUpgrade{
+			index:  i,
+			newURL: newURL,
+			change: SourceUpgrade{Name: src.Name, From: src.Url, To: newURL},
+		})
+	}
+
+	upgrades := make([]SourceUpgrade, 0, len(planned))
+	for _, p := range planned {
+		h.composedBlueprint.Sources[p.index].Url = p.newURL
+		h.composedBlueprint.Sources[p.index].Ref = blueprintv1alpha1.Reference{}
+		upgrades = append(upgrades, p.change)
 	}
 	return upgrades, nil
 }

--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/Masterminds/semver/v3"
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/composer/artifact"
 	"github.com/windsorcli/cli/pkg/runtime"
@@ -20,6 +21,7 @@ type BlueprintHandler interface {
 	SetSkipValidation(skip bool)
 	Write(overwrite ...bool) error
 	RetargetSource(name, url string) (string, error)
+	UpgradeSourcesToLatest() ([]SourceUpgrade, error)
 	GetTerraformComponents() []blueprintv1alpha1.TerraformComponent
 	GetLocalTemplateData() (map[string][]byte, error)
 	Generate() *blueprintv1alpha1.Blueprint
@@ -206,6 +208,74 @@ func (h *BaseBlueprintHandler) RetargetSource(name, url string) (string, error) 
 		}
 	}
 	return "", fmt.Errorf("source %q is not declared in the blueprint; add it to blueprint.yaml before retargeting", name)
+}
+
+// SourceUpgrade records one source moved to a newer version by UpgradeSourcesToLatest.
+type SourceUpgrade struct {
+	Name string
+	From string
+	To   string
+}
+
+// UpgradeSourcesToLatest moves each remote OCI source pinned to a semver to the latest stable tag
+// published in its repository, mutating the composed blueprint in memory (call Write to persist) and
+// returning the changes for reporting. Sources that are not OCI, not semver-pinned (a branch, a
+// mutable tag like :latest), or already at the latest are left untouched, as are prerelease tags. It
+// resolves directly to the latest — it does not step minor-by-minor.
+func (h *BaseBlueprintHandler) UpgradeSourcesToLatest() ([]SourceUpgrade, error) {
+	if h.composedBlueprint == nil {
+		return nil, fmt.Errorf("blueprint not loaded")
+	}
+
+	var upgrades []SourceUpgrade
+	for i := range h.composedBlueprint.Sources {
+		src := &h.composedBlueprint.Sources[i]
+		if !strings.HasPrefix(src.Url, "oci://") {
+			continue
+		}
+		info, err := artifact.ParseOCIReference(src.Url)
+		if err != nil || info == nil {
+			continue
+		}
+		current, err := semver.NewVersion(info.Tag)
+		if err != nil {
+			continue
+		}
+
+		tags, err := h.artifactBuilder.ListTags(src.Url)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list tags for source %q: %w", src.Name, err)
+		}
+		latestTag, latest, ok := latestStableSemver(tags)
+		if !ok || !latest.GreaterThan(current) {
+			continue
+		}
+
+		newURL := strings.TrimSuffix(src.Url, ":"+info.Tag) + ":" + latestTag
+		upgrades = append(upgrades, SourceUpgrade{Name: src.Name, From: src.Url, To: newURL})
+		src.Url = newURL
+		src.Ref = blueprintv1alpha1.Reference{}
+	}
+	return upgrades, nil
+}
+
+// latestStableSemver returns the highest non-prerelease semver among tags, alongside its original tag
+// string (preserving any "v" prefix) for rebuilding the URL. Non-semver and prerelease tags are
+// ignored. Reports false when no stable semver tag is present.
+func latestStableSemver(tags []string) (string, *semver.Version, bool) {
+	var best *semver.Version
+	var bestTag string
+	for _, t := range tags {
+		v, err := semver.NewVersion(t)
+		if err != nil || v.Prerelease() != "" {
+			continue
+		}
+		if best == nil || v.GreaterThan(best) {
+			best = v
+			bestTag = t
+		}
+	}
+	return bestTag, best, best != nil
 }
 
 // GetTerraformComponents returns a copy of the composed blueprint's terraform components with

--- a/pkg/composer/blueprint/handler_test.go
+++ b/pkg/composer/blueprint/handler_test.go
@@ -2274,4 +2274,31 @@ func TestHandler_UpgradeSourcesToLatest(t *testing.T) {
 			t.Error("Expected an error when no blueprint is loaded")
 		}
 	})
+
+	t.Run("LeavesBlueprintUntouchedWhenAListFailsMidway", func(t *testing.T) {
+		// Given a resolvable first source and a second source whose tag listing fails
+		handler, mock := setup(t,
+			[]blueprintv1alpha1.Source{
+				{Name: "core", Url: "oci://ghcr.io/windsorcli/core:v0.5.0"},
+				{Name: "addons", Url: "oci://ghcr.io/acme/addons:v0.5.0"},
+			},
+			nil,
+		)
+		mock.ListTagsFunc = func(ociRef string) ([]string, error) {
+			if ociRef == "oci://ghcr.io/acme/addons:v0.5.0" {
+				return nil, fmt.Errorf("registry unreachable")
+			}
+			return []string{"v0.6.0"}, nil
+		}
+
+		// When upgrading, the second source's failure aborts the whole operation
+		if _, err := handler.UpgradeSourcesToLatest(); err == nil {
+			t.Fatal("Expected an error when a source's tag listing fails")
+		}
+
+		// Then the first source is left untouched — no partial in-memory mutation
+		if handler.composedBlueprint.Sources[0].Url != "oci://ghcr.io/windsorcli/core:v0.5.0" {
+			t.Errorf("Expected the first source unmutated, got %q", handler.composedBlueprint.Sources[0].Url)
+		}
+	})
 }

--- a/pkg/composer/blueprint/handler_test.go
+++ b/pkg/composer/blueprint/handler_test.go
@@ -2164,3 +2164,114 @@ func TestHandler_RetargetSource(t *testing.T) {
 		}
 	})
 }
+
+func TestLatestStableSemver(t *testing.T) {
+	t.Run("PicksHighestStableSkippingPrereleases", func(t *testing.T) {
+		tag, v, ok := latestStableSemver([]string{"v0.5.0", "v0.6.0", "v0.7.0-rc.1", "not-a-version"})
+		if !ok {
+			t.Fatal("Expected a stable version to be found")
+		}
+		if tag != "v0.6.0" {
+			t.Errorf("Expected v0.6.0 (highest stable), got %q", tag)
+		}
+		if v == nil || v.String() != "0.6.0" {
+			t.Errorf("Expected parsed 0.6.0, got %v", v)
+		}
+	})
+
+	t.Run("FalseWhenOnlyPrereleasesOrJunk", func(t *testing.T) {
+		if _, _, ok := latestStableSemver([]string{"v1.0.0-rc.1", "garbage"}); ok {
+			t.Error("Expected no stable version among prereleases/junk")
+		}
+	})
+}
+
+func TestHandler_UpgradeSourcesToLatest(t *testing.T) {
+	setup := func(t *testing.T, sources []blueprintv1alpha1.Source, tags map[string][]string) (*BaseBlueprintHandler, *artifact.MockArtifact) {
+		t.Helper()
+		mocks := setupHandlerMocks(t)
+		mocks.ArtifactBuilder.ListTagsFunc = func(ociRef string) ([]string, error) {
+			return tags[ociRef], nil
+		}
+		handler := NewBlueprintHandler(mocks.Runtime, mocks.ArtifactBuilder)
+		handler.composedBlueprint = &blueprintv1alpha1.Blueprint{Sources: sources}
+		return handler, mocks.ArtifactBuilder
+	}
+
+	t.Run("BumpsOCISemverSourceToLatestStable", func(t *testing.T) {
+		// Given a core source at v0.5.0 with newer stable and prerelease tags available
+		handler, _ := setup(t,
+			[]blueprintv1alpha1.Source{{Name: "core", Url: "oci://ghcr.io/windsorcli/core:v0.5.0", Ref: blueprintv1alpha1.Reference{SemVer: "v0.5.0"}}},
+			map[string][]string{"oci://ghcr.io/windsorcli/core:v0.5.0": {"v0.5.0", "v0.6.0", "v0.7.0-rc.1"}},
+		)
+
+		// When upgrading sources to latest
+		upgrades, err := handler.UpgradeSourcesToLatest()
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then it moves to the latest stable (v0.6.0), skipping the rc, and clears the ref
+		if len(upgrades) != 1 || upgrades[0].Name != "core" {
+			t.Fatalf("Expected one core upgrade, got %v", upgrades)
+		}
+		if upgrades[0].To != "oci://ghcr.io/windsorcli/core:v0.6.0" {
+			t.Errorf("Expected target v0.6.0, got %q", upgrades[0].To)
+		}
+		if handler.composedBlueprint.Sources[0].Url != "oci://ghcr.io/windsorcli/core:v0.6.0" {
+			t.Errorf("Expected source URL bumped, got %q", handler.composedBlueprint.Sources[0].Url)
+		}
+		if handler.composedBlueprint.Sources[0].Ref != (blueprintv1alpha1.Reference{}) {
+			t.Errorf("Expected ref cleared, got %+v", handler.composedBlueprint.Sources[0].Ref)
+		}
+	})
+
+	t.Run("SkipsNonOCIAndNonSemverAndAlreadyLatest", func(t *testing.T) {
+		// Given a git source, a mutable-tag OCI source, and an already-latest OCI source
+		handler, _ := setup(t,
+			[]blueprintv1alpha1.Source{
+				{Name: "modules", Url: "github.com/org/modules", Ref: blueprintv1alpha1.Reference{Branch: "main"}},
+				{Name: "dev", Url: "oci://ghcr.io/acme/dev:latest"},
+				{Name: "core", Url: "oci://ghcr.io/windsorcli/core:v0.6.0", Ref: blueprintv1alpha1.Reference{SemVer: "v0.6.0"}},
+			},
+			map[string][]string{
+				"oci://ghcr.io/acme/dev:latest":        {"v9.9.9"},
+				"oci://ghcr.io/windsorcli/core:v0.6.0": {"v0.5.0", "v0.6.0"},
+			},
+		)
+
+		// When upgrading
+		upgrades, err := handler.UpgradeSourcesToLatest()
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then nothing is upgraded (git skipped, :latest not semver, core already latest)
+		if len(upgrades) != 0 {
+			t.Errorf("Expected no upgrades, got %v", upgrades)
+		}
+	})
+
+	t.Run("PropagatesListTagsError", func(t *testing.T) {
+		mocks := setupHandlerMocks(t)
+		mocks.ArtifactBuilder.ListTagsFunc = func(ociRef string) ([]string, error) {
+			return nil, fmt.Errorf("registry unreachable")
+		}
+		handler := NewBlueprintHandler(mocks.Runtime, mocks.ArtifactBuilder)
+		handler.composedBlueprint = &blueprintv1alpha1.Blueprint{
+			Sources: []blueprintv1alpha1.Source{{Name: "core", Url: "oci://ghcr.io/windsorcli/core:v0.5.0"}},
+		}
+		if _, err := handler.UpgradeSourcesToLatest(); err == nil {
+			t.Error("Expected an error when tag listing fails")
+		}
+	})
+
+	t.Run("ErrorsWhenBlueprintNotLoaded", func(t *testing.T) {
+		mocks := setupHandlerMocks(t)
+		handler := NewBlueprintHandler(mocks.Runtime, mocks.ArtifactBuilder)
+		handler.composedBlueprint = nil
+		if _, err := handler.UpgradeSourcesToLatest(); err == nil {
+			t.Error("Expected an error when no blueprint is loaded")
+		}
+	})
+}

--- a/pkg/composer/blueprint/mock_blueprint_handler.go
+++ b/pkg/composer/blueprint/mock_blueprint_handler.go
@@ -10,6 +10,7 @@ type MockBlueprintHandler struct {
 	SetSkipValidationFunc      func(skip bool)
 	WriteFunc                  func(overwrite ...bool) error
 	RetargetSourceFunc         func(name, url string) (string, error)
+	UpgradeSourcesToLatestFunc func() ([]SourceUpgrade, error)
 	GetTerraformComponentsFunc func() []blueprintv1alpha1.TerraformComponent
 	GetLocalTemplateDataFunc   func() (map[string][]byte, error)
 	GenerateFunc               func() *blueprintv1alpha1.Blueprint
@@ -70,6 +71,14 @@ func (m *MockBlueprintHandler) RetargetSource(name, url string) (string, error) 
 		return m.RetargetSourceFunc(name, url)
 	}
 	return "", nil
+}
+
+// UpgradeSourcesToLatest calls the mock UpgradeSourcesToLatestFunc if set, otherwise returns nil.
+func (m *MockBlueprintHandler) UpgradeSourcesToLatest() ([]SourceUpgrade, error) {
+	if m.UpgradeSourcesToLatestFunc != nil {
+		return m.UpgradeSourcesToLatestFunc()
+	}
+	return nil, nil
 }
 
 // GetTerraformComponents calls the mock GetTerraformComponentsFunc if set, otherwise returns empty slice.


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Medium Risk**
>
> The PR introduces a new default behavior for `windsor upgrade` that reaches out to OCI registries, bumps source versions in memory, and writes `blueprint.yaml` before the existing apply/wait/prune flow — a meaningful blast-radius expansion compared to the prior behavior where a bare `windsor upgrade` was a pure reconciliation with no file mutations.
>
> **Overview**
>
> This change converts bare `windsor upgrade` into an auto-upgrade step: it resolves the latest stable semver tag for each declared OCI source, persists the bumped URLs to `blueprint.yaml`, then runs the existing terraform apply and kustomization wait. The `--source name=url` pin path is unchanged. Three new pieces are introduced: `ListTags` on the artifact builder (backed by `remote.List`), `UpgradeSourcesToLatest` on the blueprint handler with `latestStableSemver` as a pure helper, and an `upgradeToLatest` glue function in the command layer. Tests cover the happy path and error cases at all three layers.
>
> The primary concerns are a doc-comment misattribution in `artifact.go` (the `ParseOCIRef` comment block flows into `ListTags` without a separator, stripping `ParseOCIRef` of its doc comment), partial in-memory blueprint mutation when a registry call fails mid-loop, and the unconditional `blueprint.yaml` write that is not gated by `--yes`.
>
> Reviewed by Claude for commit `e72d1ef`.

<!-- /claude-code-review:summary -->
