### PR TITLE
ci(review): trigger on-demand review from /review comment

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -2,17 +2,8 @@ name: Claude Code Review
 on:
   pull_request:
     types: [opened, ready_for_review, synchronize]
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        required: true
-        type: string
-      head_sha:
-        required: true
-        type: string
-      base_ref:
-        required: true
-        type: string
+  issue_comment:
+    types: [created]
 permissions:
   contents: read
   pull-requests: write
@@ -144,24 +135,41 @@ jobs:
           git show origin/main:.github/scripts/publish-review.sh > /tmp/publish-review.sh
           bash /tmp/publish-review.sh
 
-  review-on-dispatch:
+  review-on-comment:
     name: Full Review (on-demand)
     runs-on: ubuntu-latest
     timeout-minutes: 30
-    if: github.event_name == 'workflow_dispatch'
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    if: >-
+      github.event_name == 'issue_comment' &&
+      github.event.issue.pull_request &&
+      contains(github.event.comment.body, '/review')
     steps:
+      - name: Get PR details
+        id: pr
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_JSON=$(gh api repos/${{ github.repository }}/pulls/${{ github.event.issue.number }})
+          echo "head_sha=$(echo "$PR_JSON" | jq -r .head.sha)" >> "$GITHUB_OUTPUT"
+          echo "base_ref=$(echo "$PR_JSON" | jq -r .base.ref)" >> "$GITHUB_OUTPUT"
+          echo "head_ref=$(echo "$PR_JSON" | jq -r .head.ref)" >> "$GITHUB_OUTPUT"
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ inputs.head_sha }}
+          ref: ${{ steps.pr.outputs.head_ref }}
           fetch-depth: 0
       - name: Fetch base ref
-        run: git fetch --depth=1 origin ${{ inputs.base_ref }}
+        run: git fetch --depth=1 origin ${{ steps.pr.outputs.base_ref }}
       - uses: anthropics/claude-code-action@be7b93b1907a4abad570368f3c74b6fe3807510b # v1.0.183
         continue-on-error: true
         env:
-          PR_NUMBER: ${{ inputs.pr_number }}
-          PR_HEAD_SHA: ${{ inputs.head_sha }}
-          BASE_REF: ${{ inputs.base_ref }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          PR_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
+          BASE_REF: ${{ steps.pr.outputs.base_ref }}
           GH_REPO: ${{ github.repository }}
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
@@ -235,8 +243,8 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
-          PR_NUMBER: ${{ inputs.pr_number }}
-          PR_HEAD_SHA: ${{ inputs.head_sha }}
+          PR_NUMBER: ${{ github.event.issue.number }}
+          PR_HEAD_SHA: ${{ steps.pr.outputs.head_sha }}
         run: |
           # The publish script is CI infrastructure that lives on main, not in the
           # PR's own tree — a PR branch opened or last pushed before this script was


### PR DESCRIPTION
## What

Replaces the on-demand review trigger in `claude-code-review.yaml` — `workflow_dispatch` → an `issue_comment` gated on a **`/review`** comment, matching `windsorcli/core`.

## Why

On-demand re-review should fire the same way in every repo that uses Claude review. Today only `core` responds to a `/review` PR comment; the other repos require a manual `workflow_dispatch`. This makes `/review` work everywhere.

## Behavior (unchanged safety property)

- **Full Review** still runs only on PR `opened` / `ready_for_review` — never on push.
- **Pushes** still trigger only the lightweight **Resolve Threads** job.
- **`/review` comment** now triggers an on-demand Full Review (was `workflow_dispatch`).

The review prompt, `claude_args`, and pinned action SHAs are untouched.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` → OK
- `actionlint` → exit 0