### PR TITLE
feat: add vSphere platform support

### DIFF
--- a/api/v1alpha1/config_types.go
+++ b/api/v1alpha1/config_types.go
@@ -12,6 +12,7 @@ import (
 	"github.com/windsorcli/cli/api/v1alpha1/secrets"
 	"github.com/windsorcli/cli/api/v1alpha1/terraform"
 	"github.com/windsorcli/cli/api/v1alpha1/vm"
+	"github.com/windsorcli/cli/api/v1alpha1/vsphere"
 )
 
 // RootTerraformConfig represents the root-level terraform configuration
@@ -37,6 +38,7 @@ type Context struct {
 	AWS         *aws.AWSConfig             `yaml:"aws,omitempty"`
 	Azure       *azure.AzureConfig         `yaml:"azure,omitempty"`
 	GCP         *gcp.GCPConfig             `yaml:"gcp,omitempty"`
+	VSphere     *vsphere.VSphereConfig     `yaml:"vsphere,omitempty"`
 	Docker      *docker.DockerConfig       `yaml:"docker,omitempty"`
 	Git         *git.GitConfig             `yaml:"git,omitempty"`
 	Terraform   *terraform.TerraformConfig `yaml:"terraform,omitempty"`
@@ -91,6 +93,12 @@ func (base *Context) Merge(overlay *Context) {
 			base.GCP = &gcp.GCPConfig{}
 		}
 		base.GCP.Merge(overlay.GCP)
+	}
+	if overlay.VSphere != nil {
+		if base.VSphere == nil {
+			base.VSphere = &vsphere.VSphereConfig{}
+		}
+		base.VSphere.Merge(overlay.VSphere)
 	}
 	if overlay.Docker != nil {
 		if base.Docker == nil {
@@ -157,6 +165,7 @@ func (c *Context) DeepCopy() *Context {
 		AWS:         c.AWS.Copy(),
 		Azure:       c.Azure.Copy(),
 		GCP:         c.GCP.Copy(),
+		VSphere:     c.VSphere.Copy(),
 		Docker:      c.Docker.Copy(),
 		Git:         c.Git.Copy(),
 		Terraform:   c.Terraform.Copy(),

--- a/api/v1alpha1/vsphere/vsphere_config.go
+++ b/api/v1alpha1/vsphere/vsphere_config.go
@@ -1,0 +1,85 @@
+package vsphere
+
+// VSphereConfig represents the vSphere configuration. vSphere integration activates whenever this
+// block is present in a context (or when platform is "vsphere"); no separate enabled flag.
+type VSphereConfig struct {
+	// Server is the vCenter server hostname or IP address, exported as VSPHERE_SERVER.
+	Server *string `yaml:"server,omitempty"`
+
+	// User is the vCenter username, exported as VSPHERE_USER.
+	User *string `yaml:"user,omitempty"`
+
+	// Datacenter is the vSphere datacenter name for resource provisioning.
+	Datacenter *string `yaml:"datacenter,omitempty"`
+
+	// Cluster is the vSphere compute cluster name where VMs are scheduled.
+	Cluster *string `yaml:"cluster,omitempty"`
+
+	// Datastore is the vSphere datastore or datastore cluster name for VM disk placement.
+	Datastore *string `yaml:"datastore,omitempty"`
+
+	// Network is the default vSphere network/port group for VM interfaces.
+	Network *string `yaml:"network,omitempty"`
+
+	// ResourcePool is the default vSphere resource pool for VM placement.
+	ResourcePool *string `yaml:"resource_pool,omitempty"`
+
+	// Folder is the default vSphere folder path for VM inventory placement.
+	Folder *string `yaml:"folder,omitempty"`
+
+	// Insecure disables TLS certificate verification when connecting to vCenter.
+	// Exported as VSPHERE_ALLOW_UNVERIFIED_SSL.
+	Insecure *bool `yaml:"insecure,omitempty"`
+}
+
+// Merge performs a deep merge of the current VSphereConfig with another VSphereConfig.
+func (base *VSphereConfig) Merge(overlay *VSphereConfig) {
+	if overlay == nil {
+		return
+	}
+	if overlay.Server != nil {
+		base.Server = overlay.Server
+	}
+	if overlay.User != nil {
+		base.User = overlay.User
+	}
+	if overlay.Datacenter != nil {
+		base.Datacenter = overlay.Datacenter
+	}
+	if overlay.Cluster != nil {
+		base.Cluster = overlay.Cluster
+	}
+	if overlay.Datastore != nil {
+		base.Datastore = overlay.Datastore
+	}
+	if overlay.Network != nil {
+		base.Network = overlay.Network
+	}
+	if overlay.ResourcePool != nil {
+		base.ResourcePool = overlay.ResourcePool
+	}
+	if overlay.Folder != nil {
+		base.Folder = overlay.Folder
+	}
+	if overlay.Insecure != nil {
+		base.Insecure = overlay.Insecure
+	}
+}
+
+// Copy creates a deep copy of the VSphereConfig object.
+func (c *VSphereConfig) Copy() *VSphereConfig {
+	if c == nil {
+		return nil
+	}
+	return &VSphereConfig{
+		Server:       c.Server,
+		User:         c.User,
+		Datacenter:   c.Datacenter,
+		Cluster:      c.Cluster,
+		Datastore:    c.Datastore,
+		Network:      c.Network,
+		ResourcePool: c.ResourcePool,
+		Folder:       c.Folder,
+		Insecure:     c.Insecure,
+	}
+}

--- a/api/v1alpha1/vsphere/vsphere_config_test.go
+++ b/api/v1alpha1/vsphere/vsphere_config_test.go
@@ -1,0 +1,217 @@
+package vsphere
+
+import (
+	"testing"
+)
+
+// =============================================================================
+// Test Public Methods
+// =============================================================================
+
+func TestVSphereConfig_Merge(t *testing.T) {
+	t.Run("MergeWithAllFields", func(t *testing.T) {
+		// Given a base and overlay both with all fields set
+		base := &VSphereConfig{
+			Server:       ptrString("vcenter-base.example.com"),
+			User:         ptrString("base-user"),
+			Datacenter:   ptrString("base-dc"),
+			Cluster:      ptrString("base-cluster"),
+			Datastore:    ptrString("base-ds"),
+			Network:      ptrString("base-net"),
+			ResourcePool: ptrString("base-pool"),
+			Folder:       ptrString("base-folder"),
+			Insecure:     ptrBool(false),
+		}
+		overlay := &VSphereConfig{
+			Server:       ptrString("vcenter-overlay.example.com"),
+			User:         ptrString("overlay-user"),
+			Datacenter:   ptrString("overlay-dc"),
+			Cluster:      ptrString("overlay-cluster"),
+			Datastore:    ptrString("overlay-ds"),
+			Network:      ptrString("overlay-net"),
+			ResourcePool: ptrString("overlay-pool"),
+			Folder:       ptrString("overlay-folder"),
+			Insecure:     ptrBool(true),
+		}
+
+		// When Merge is called
+		base.Merge(overlay)
+
+		// Then all fields take overlay values
+		if *base.Server != "vcenter-overlay.example.com" {
+			t.Errorf("Server mismatch: expected vcenter-overlay.example.com, got %s", *base.Server)
+		}
+		if *base.User != "overlay-user" {
+			t.Errorf("User mismatch: expected overlay-user, got %s", *base.User)
+		}
+		if *base.Datacenter != "overlay-dc" {
+			t.Errorf("Datacenter mismatch: expected overlay-dc, got %s", *base.Datacenter)
+		}
+		if *base.Cluster != "overlay-cluster" {
+			t.Errorf("Cluster mismatch: expected overlay-cluster, got %s", *base.Cluster)
+		}
+		if *base.Datastore != "overlay-ds" {
+			t.Errorf("Datastore mismatch: expected overlay-ds, got %s", *base.Datastore)
+		}
+		if *base.Network != "overlay-net" {
+			t.Errorf("Network mismatch: expected overlay-net, got %s", *base.Network)
+		}
+		if *base.ResourcePool != "overlay-pool" {
+			t.Errorf("ResourcePool mismatch: expected overlay-pool, got %s", *base.ResourcePool)
+		}
+		if *base.Folder != "overlay-folder" {
+			t.Errorf("Folder mismatch: expected overlay-folder, got %s", *base.Folder)
+		}
+		if *base.Insecure != true {
+			t.Errorf("Insecure mismatch: expected true, got %v", *base.Insecure)
+		}
+	})
+
+	t.Run("MergeWithNilOverlay", func(t *testing.T) {
+		// Given a base config with all fields set
+		base := &VSphereConfig{
+			Server: ptrString("vcenter.example.com"),
+			User:   ptrString("admin"),
+		}
+		original := base.Copy()
+
+		// When Merge is called with a nil overlay
+		base.Merge(nil)
+
+		// Then base remains unchanged
+		if *base.Server != *original.Server {
+			t.Errorf("Server should be unchanged after nil merge")
+		}
+		if *base.User != *original.User {
+			t.Errorf("User should be unchanged after nil merge")
+		}
+	})
+
+	t.Run("MergeWithPartialOverlay", func(t *testing.T) {
+		// Given a fully populated base and an overlay with only Server
+		base := &VSphereConfig{
+			Server:     ptrString("vcenter-base.example.com"),
+			User:       ptrString("base-user"),
+			Datacenter: ptrString("base-dc"),
+		}
+		overlay := &VSphereConfig{
+			Server: ptrString("vcenter-new.example.com"),
+		}
+
+		// When Merge is called
+		base.Merge(overlay)
+
+		// Then only Server changes; other fields remain from base
+		if *base.Server != "vcenter-new.example.com" {
+			t.Errorf("Server mismatch: expected vcenter-new.example.com, got %s", *base.Server)
+		}
+		if *base.User != "base-user" {
+			t.Errorf("User should remain unchanged, got %s", *base.User)
+		}
+		if *base.Datacenter != "base-dc" {
+			t.Errorf("Datacenter should remain unchanged, got %s", *base.Datacenter)
+		}
+	})
+
+	t.Run("MergeWithAllNils", func(t *testing.T) {
+		// Given two configs with all nil fields
+		base := &VSphereConfig{}
+		overlay := &VSphereConfig{}
+
+		// When Merge is called
+		base.Merge(overlay)
+
+		// Then base remains all nil
+		if base.Server != nil || base.User != nil || base.Datacenter != nil ||
+			base.Cluster != nil || base.Datastore != nil || base.Network != nil ||
+			base.ResourcePool != nil || base.Folder != nil || base.Insecure != nil {
+			t.Error("All fields should remain nil after merging two empty configs")
+		}
+	})
+}
+
+func TestVSphereConfig_Copy(t *testing.T) {
+	t.Run("CopyWithAllFields", func(t *testing.T) {
+		// Given a fully populated config
+		original := &VSphereConfig{
+			Server:       ptrString("vcenter.example.com"),
+			User:         ptrString("admin"),
+			Datacenter:   ptrString("DC0"),
+			Cluster:      ptrString("cluster-01"),
+			Datastore:    ptrString("datastore1"),
+			Network:      ptrString("VM Network"),
+			ResourcePool: ptrString("Resources"),
+			Folder:       ptrString("/DC0/vm"),
+			Insecure:     ptrBool(true),
+		}
+
+		// When Copy is called
+		cp := original.Copy()
+
+		// Then all fields match and the copy is independent
+		if *cp.Server != *original.Server {
+			t.Errorf("Server mismatch: expected %s, got %s", *original.Server, *cp.Server)
+		}
+		if *cp.User != *original.User {
+			t.Errorf("User mismatch: expected %s, got %s", *original.User, *cp.User)
+		}
+		if *cp.Datacenter != *original.Datacenter {
+			t.Errorf("Datacenter mismatch")
+		}
+		if *cp.Cluster != *original.Cluster {
+			t.Errorf("Cluster mismatch")
+		}
+		if *cp.Datastore != *original.Datastore {
+			t.Errorf("Datastore mismatch")
+		}
+		if *cp.Network != *original.Network {
+			t.Errorf("Network mismatch")
+		}
+		if *cp.ResourcePool != *original.ResourcePool {
+			t.Errorf("ResourcePool mismatch")
+		}
+		if *cp.Folder != *original.Folder {
+			t.Errorf("Folder mismatch")
+		}
+		if *cp.Insecure != *original.Insecure {
+			t.Errorf("Insecure mismatch")
+		}
+	})
+
+	t.Run("CopyNil", func(t *testing.T) {
+		// Given a nil config pointer
+		var original *VSphereConfig
+
+		// When Copy is called
+		cp := original.Copy()
+
+		// Then the result is nil
+		if cp != nil {
+			t.Error("Expected nil copy for nil config")
+		}
+	})
+
+	t.Run("CopyWithPartialFields", func(t *testing.T) {
+		// Given a config with only some fields set
+		original := &VSphereConfig{
+			Server: ptrString("vcenter.example.com"),
+		}
+
+		// When Copy is called
+		cp := original.Copy()
+
+		// Then only the set field is copied; others are nil
+		if cp.Server == nil || *cp.Server != *original.Server {
+			t.Errorf("Server mismatch: expected %s", *original.Server)
+		}
+		if cp.User != nil {
+			t.Error("Expected User to be nil in copy")
+		}
+		if cp.Datacenter != nil {
+			t.Error("Expected Datacenter to be nil in copy")
+		}
+	})
+}
+
+func ptrString(s string) *string { return &s }
+func ptrBool(b bool) *bool       { return &b }

--- a/api/v1alpha2/config/providers/providers.go
+++ b/api/v1alpha2/config/providers/providers.go
@@ -4,13 +4,15 @@ import (
 	"github.com/windsorcli/cli/api/v1alpha2/config/providers/aws"
 	"github.com/windsorcli/cli/api/v1alpha2/config/providers/azure"
 	"github.com/windsorcli/cli/api/v1alpha2/config/providers/gcp"
+	"github.com/windsorcli/cli/api/v1alpha2/config/providers/vsphere"
 )
 
 // ProvidersConfig represents the configuration for all cloud providers
 type ProvidersConfig struct {
-	AWS   *aws.AWSConfig     `yaml:"aws,omitempty"`
-	Azure *azure.AzureConfig `yaml:"azure,omitempty"`
-	GCP   *gcp.GCPConfig     `yaml:"gcp,omitempty"`
+	AWS     *aws.AWSConfig         `yaml:"aws,omitempty"`
+	Azure   *azure.AzureConfig     `yaml:"azure,omitempty"`
+	GCP     *gcp.GCPConfig         `yaml:"gcp,omitempty"`
+	VSphere *vsphere.VSphereConfig `yaml:"vsphere,omitempty"`
 }
 
 // Merge performs a deep merge of the current ProvidersConfig with another ProvidersConfig.
@@ -36,6 +38,12 @@ func (base *ProvidersConfig) Merge(overlay *ProvidersConfig) {
 		}
 		base.GCP.Merge(overlay.GCP)
 	}
+	if overlay.VSphere != nil {
+		if base.VSphere == nil {
+			base.VSphere = &vsphere.VSphereConfig{}
+		}
+		base.VSphere.Merge(overlay.VSphere)
+	}
 }
 
 // DeepCopy creates a deep copy of the ProvidersConfig object
@@ -53,6 +61,9 @@ func (c *ProvidersConfig) DeepCopy() *ProvidersConfig {
 	}
 	if c.GCP != nil {
 		copied.GCP = c.GCP.DeepCopy()
+	}
+	if c.VSphere != nil {
+		copied.VSphere = c.VSphere.DeepCopy()
 	}
 
 	return copied

--- a/api/v1alpha2/config/providers/schema.yaml
+++ b/api/v1alpha2/config/providers/schema.yaml
@@ -61,4 +61,37 @@ properties:
         description: Project to use for quota and billing
     additionalProperties: false
 
+  vsphere:
+    type: object
+    description: vSphere provider configuration. vSphere integration activates whenever this block is present in a context (or when platform is "vsphere"); there is no separate enabled flag.
+    properties:
+      server:
+        type: string
+        description: vCenter server hostname or IP address, exported as VSPHERE_SERVER
+      user:
+        type: string
+        description: vCenter username, exported as VSPHERE_USER
+      datacenter:
+        type: string
+        description: vSphere datacenter name (exact inventory match, e.g. "dc-prod")
+      cluster:
+        type: string
+        description: vSphere compute cluster name where VMs are scheduled (e.g. "cluster-01")
+      datastore:
+        type: string
+        description: Datastore or datastore cluster name for VM disk placement
+      network:
+        type: string
+        description: Port group name the VM primary NIC attaches to
+      resource_pool:
+        type: string
+        description: Resource pool path relative to the compute cluster. Defaults to the cluster root pool.
+      folder:
+        type: string
+        description: VM folder path relative to the datacenter VM folder root. Defaults to the datacenter root.
+      insecure:
+        type: boolean
+        description: Disable TLS certificate verification when connecting to vCenter, exported as VSPHERE_ALLOW_UNVERIFIED_SSL
+    additionalProperties: false
+
 additionalProperties: false

--- a/api/v1alpha2/config/providers/vsphere/vsphere.go
+++ b/api/v1alpha2/config/providers/vsphere/vsphere.go
@@ -1,0 +1,114 @@
+package vsphere
+
+// VSphereConfig represents the vSphere configuration. vSphere integration activates whenever this
+// block is present in a context (or when platform is "vsphere"); no separate enabled flag.
+type VSphereConfig struct {
+	// Server is the vCenter server hostname or IP address, exported as VSPHERE_SERVER.
+	Server *string `yaml:"server,omitempty"`
+
+	// User is the vCenter username, exported as VSPHERE_USER.
+	User *string `yaml:"user,omitempty"`
+
+	// Datacenter is the vSphere datacenter name for resource provisioning.
+	Datacenter *string `yaml:"datacenter,omitempty"`
+
+	// Cluster is the vSphere compute cluster name where VMs are scheduled.
+	Cluster *string `yaml:"cluster,omitempty"`
+
+	// Datastore is the vSphere datastore or datastore cluster name for VM disk placement.
+	Datastore *string `yaml:"datastore,omitempty"`
+
+	// Network is the default vSphere network/port group for VM interfaces.
+	Network *string `yaml:"network,omitempty"`
+
+	// ResourcePool is the default vSphere resource pool for VM placement.
+	ResourcePool *string `yaml:"resource_pool,omitempty"`
+
+	// Folder is the default vSphere folder path for VM inventory placement.
+	Folder *string `yaml:"folder,omitempty"`
+
+	// Insecure disables TLS certificate verification when connecting to vCenter.
+	// Exported as VSPHERE_ALLOW_UNVERIFIED_SSL.
+	Insecure *bool `yaml:"insecure,omitempty"`
+}
+
+// Merge performs a deep merge of the current VSphereConfig with another VSphereConfig.
+func (base *VSphereConfig) Merge(overlay *VSphereConfig) {
+	if overlay == nil {
+		return
+	}
+	if overlay.Server != nil {
+		base.Server = overlay.Server
+	}
+	if overlay.User != nil {
+		base.User = overlay.User
+	}
+	if overlay.Datacenter != nil {
+		base.Datacenter = overlay.Datacenter
+	}
+	if overlay.Cluster != nil {
+		base.Cluster = overlay.Cluster
+	}
+	if overlay.Datastore != nil {
+		base.Datastore = overlay.Datastore
+	}
+	if overlay.Network != nil {
+		base.Network = overlay.Network
+	}
+	if overlay.ResourcePool != nil {
+		base.ResourcePool = overlay.ResourcePool
+	}
+	if overlay.Folder != nil {
+		base.Folder = overlay.Folder
+	}
+	if overlay.Insecure != nil {
+		base.Insecure = overlay.Insecure
+	}
+}
+
+// DeepCopy creates a deep copy of the VSphereConfig object.
+func (c *VSphereConfig) DeepCopy() *VSphereConfig {
+	if c == nil {
+		return nil
+	}
+	copied := &VSphereConfig{}
+
+	if c.Server != nil {
+		serverCopy := *c.Server
+		copied.Server = &serverCopy
+	}
+	if c.User != nil {
+		userCopy := *c.User
+		copied.User = &userCopy
+	}
+	if c.Datacenter != nil {
+		datacenterCopy := *c.Datacenter
+		copied.Datacenter = &datacenterCopy
+	}
+	if c.Cluster != nil {
+		clusterCopy := *c.Cluster
+		copied.Cluster = &clusterCopy
+	}
+	if c.Datastore != nil {
+		datastoreCopy := *c.Datastore
+		copied.Datastore = &datastoreCopy
+	}
+	if c.Network != nil {
+		networkCopy := *c.Network
+		copied.Network = &networkCopy
+	}
+	if c.ResourcePool != nil {
+		resourcePoolCopy := *c.ResourcePool
+		copied.ResourcePool = &resourcePoolCopy
+	}
+	if c.Folder != nil {
+		folderCopy := *c.Folder
+		copied.Folder = &folderCopy
+	}
+	if c.Insecure != nil {
+		insecureCopy := *c.Insecure
+		copied.Insecure = &insecureCopy
+	}
+
+	return copied
+}

--- a/api/v1alpha2/config/providers/vsphere/vsphere_test.go
+++ b/api/v1alpha2/config/providers/vsphere/vsphere_test.go
@@ -1,0 +1,223 @@
+package vsphere
+
+import (
+	"testing"
+)
+
+// =============================================================================
+// Test Public Methods
+// =============================================================================
+
+func TestVSphereConfig_Merge(t *testing.T) {
+	t.Run("MergeWithAllFields", func(t *testing.T) {
+		// Given base and overlay both fully populated
+		base := &VSphereConfig{
+			Server:       ptrString("vcenter-base.example.com"),
+			User:         ptrString("base-user"),
+			Datacenter:   ptrString("base-dc"),
+			Cluster:      ptrString("base-cluster"),
+			Datastore:    ptrString("base-ds"),
+			Network:      ptrString("base-net"),
+			ResourcePool: ptrString("base-pool"),
+			Folder:       ptrString("base-folder"),
+			Insecure:     ptrBool(false),
+		}
+		overlay := &VSphereConfig{
+			Server:       ptrString("vcenter-overlay.example.com"),
+			User:         ptrString("overlay-user"),
+			Datacenter:   ptrString("overlay-dc"),
+			Cluster:      ptrString("overlay-cluster"),
+			Datastore:    ptrString("overlay-ds"),
+			Network:      ptrString("overlay-net"),
+			ResourcePool: ptrString("overlay-pool"),
+			Folder:       ptrString("overlay-folder"),
+			Insecure:     ptrBool(true),
+		}
+
+		// When Merge is called
+		base.Merge(overlay)
+
+		// Then all fields take overlay values
+		if *base.Server != "vcenter-overlay.example.com" {
+			t.Errorf("Server mismatch: got %s", *base.Server)
+		}
+		if *base.User != "overlay-user" {
+			t.Errorf("User mismatch: got %s", *base.User)
+		}
+		if *base.Datacenter != "overlay-dc" {
+			t.Errorf("Datacenter mismatch: got %s", *base.Datacenter)
+		}
+		if *base.Cluster != "overlay-cluster" {
+			t.Errorf("Cluster mismatch: got %s", *base.Cluster)
+		}
+		if *base.Datastore != "overlay-ds" {
+			t.Errorf("Datastore mismatch: got %s", *base.Datastore)
+		}
+		if *base.Network != "overlay-net" {
+			t.Errorf("Network mismatch: got %s", *base.Network)
+		}
+		if *base.ResourcePool != "overlay-pool" {
+			t.Errorf("ResourcePool mismatch: got %s", *base.ResourcePool)
+		}
+		if *base.Folder != "overlay-folder" {
+			t.Errorf("Folder mismatch: got %s", *base.Folder)
+		}
+		if *base.Insecure != true {
+			t.Errorf("Insecure mismatch: got %v", *base.Insecure)
+		}
+	})
+
+	t.Run("MergeWithNilOverlay", func(t *testing.T) {
+		// Given a base config
+		base := &VSphereConfig{
+			Server: ptrString("vcenter.example.com"),
+			User:   ptrString("admin"),
+		}
+		original := base.DeepCopy()
+
+		// When Merge is called with nil
+		base.Merge(nil)
+
+		// Then base is unchanged
+		if *base.Server != *original.Server {
+			t.Error("Server should be unchanged after nil merge")
+		}
+		if *base.User != *original.User {
+			t.Error("User should be unchanged after nil merge")
+		}
+	})
+
+	t.Run("MergeWithPartialOverlay", func(t *testing.T) {
+		// Given a fully populated base and a partial overlay
+		base := &VSphereConfig{
+			Server:     ptrString("vcenter-base.example.com"),
+			User:       ptrString("base-user"),
+			Datacenter: ptrString("base-dc"),
+		}
+		overlay := &VSphereConfig{
+			Server: ptrString("vcenter-new.example.com"),
+		}
+
+		// When Merge is called
+		base.Merge(overlay)
+
+		// Then only Server is updated
+		if *base.Server != "vcenter-new.example.com" {
+			t.Errorf("Server mismatch: got %s", *base.Server)
+		}
+		if *base.User != "base-user" {
+			t.Errorf("User should remain unchanged, got %s", *base.User)
+		}
+		if *base.Datacenter != "base-dc" {
+			t.Errorf("Datacenter should remain unchanged, got %s", *base.Datacenter)
+		}
+	})
+
+	t.Run("MergeWithAllNils", func(t *testing.T) {
+		// Given two empty configs
+		base := &VSphereConfig{}
+		overlay := &VSphereConfig{}
+
+		// When Merge is called
+		base.Merge(overlay)
+
+		// Then all fields remain nil
+		if base.Server != nil || base.User != nil || base.Datacenter != nil ||
+			base.Cluster != nil || base.Datastore != nil || base.Network != nil ||
+			base.ResourcePool != nil || base.Folder != nil || base.Insecure != nil {
+			t.Error("All fields should remain nil after merging two empty configs")
+		}
+	})
+}
+
+func TestVSphereConfig_DeepCopy(t *testing.T) {
+	t.Run("DeepCopyWithAllFields", func(t *testing.T) {
+		// Given a fully populated config
+		original := &VSphereConfig{
+			Server:       ptrString("vcenter.example.com"),
+			User:         ptrString("admin"),
+			Datacenter:   ptrString("DC0"),
+			Cluster:      ptrString("cluster-01"),
+			Datastore:    ptrString("datastore1"),
+			Network:      ptrString("VM Network"),
+			ResourcePool: ptrString("Resources"),
+			Folder:       ptrString("/DC0/vm"),
+			Insecure:     ptrBool(true),
+		}
+
+		// When DeepCopy is called
+		cp := original.DeepCopy()
+
+		// Then all fields match
+		if *cp.Server != *original.Server {
+			t.Errorf("Server mismatch: got %s", *cp.Server)
+		}
+		if *cp.User != *original.User {
+			t.Errorf("User mismatch: got %s", *cp.User)
+		}
+		if *cp.Datacenter != *original.Datacenter {
+			t.Errorf("Datacenter mismatch")
+		}
+		if *cp.Cluster != *original.Cluster {
+			t.Errorf("Cluster mismatch")
+		}
+		if *cp.Datastore != *original.Datastore {
+			t.Errorf("Datastore mismatch")
+		}
+		if *cp.Network != *original.Network {
+			t.Errorf("Network mismatch")
+		}
+		if *cp.ResourcePool != *original.ResourcePool {
+			t.Errorf("ResourcePool mismatch")
+		}
+		if *cp.Folder != *original.Folder {
+			t.Errorf("Folder mismatch")
+		}
+		if *cp.Insecure != *original.Insecure {
+			t.Errorf("Insecure mismatch")
+		}
+
+		// And the copy is independent
+		*original.Server = "changed.example.com"
+		if *cp.Server == "changed.example.com" {
+			t.Error("DeepCopy should produce an independent copy")
+		}
+	})
+
+	t.Run("DeepCopyNil", func(t *testing.T) {
+		// Given a nil config pointer
+		var original *VSphereConfig
+
+		// When DeepCopy is called
+		cp := original.DeepCopy()
+
+		// Then the result is nil
+		if cp != nil {
+			t.Error("Expected nil DeepCopy for nil config")
+		}
+	})
+
+	t.Run("DeepCopyWithPartialFields", func(t *testing.T) {
+		// Given a config with only Server set
+		original := &VSphereConfig{
+			Server: ptrString("vcenter.example.com"),
+		}
+
+		// When DeepCopy is called
+		cp := original.DeepCopy()
+
+		// Then Server is copied and other fields are nil
+		if cp.Server == nil || *cp.Server != *original.Server {
+			t.Errorf("Server mismatch: expected %s", *original.Server)
+		}
+		if cp.User != nil {
+			t.Error("Expected User to be nil in copy")
+		}
+		if cp.Insecure != nil {
+			t.Error("Expected Insecure to be nil in copy")
+		}
+	})
+}
+
+func ptrString(s string) *string { return &s }
+func ptrBool(b bool) *bool       { return &b }

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -373,7 +373,7 @@ func confirmBootstrapIfContextExists(in io.Reader, configRoot, contextName strin
 }
 
 func init() {
-	bootstrapCmd.Flags().StringVar(&bootstrapPlatform, "platform", "", "Target platform: none, metal, docker, aws, azure, gcp, hyperv.")
+	bootstrapCmd.Flags().StringVar(&bootstrapPlatform, "platform", "", "Target platform: none, metal, docker, aws, azure, gcp, hyperv, vsphere.")
 	bootstrapCmd.Flags().StringVar(&bootstrapBlueprint, "blueprint", "", "Blueprint OCI reference. Accepts oci://host/org/repo:tag, host/org/repo:tag, or org/repo:tag (host defaults to ghcr.io). Tag is required.")
 	bootstrapCmd.Flags().StringSliceVar(&bootstrapSetFlags, "set", []string{}, "Override config values, e.g. --set dns.enabled=false. May be repeated.")
 	bootstrapCmd.Flags().BoolVarP(&bootstrapYes, "yes", "y", false, "Skip all confirmation prompts.")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -205,7 +205,7 @@ func init() {
 	initCmd.Flags().StringVar(&initArch, "vm-arch", "", "CPU architecture for the workstation VM.")
 	initCmd.Flags().BoolVar(&initDocker, "docker", false, "Enable Docker.")
 	initCmd.Flags().BoolVar(&initGitLivereload, "git-livereload", false, "Enable git livereload.")
-	initCmd.Flags().StringVar(&initPlatform, "platform", "", "Target platform: none, metal, docker, aws, azure, gcp, hyperv.")
+	initCmd.Flags().StringVar(&initPlatform, "platform", "", "Target platform: none, metal, docker, aws, azure, gcp, hyperv, vsphere.")
 	initCmd.Flags().StringVar(&initBlueprint, "blueprint", "", "Blueprint OCI reference or local path.")
 	initCmd.Flags().StringVar(&initEndpoint, "endpoint", "", "Kubernetes API endpoint.")
 	initCmd.Flags().StringSliceVar(&initSetFlags, "set", []string{}, "Override config values, e.g. --set dns.enabled=false. May be repeated.")

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -214,7 +214,7 @@ func buildUpFlagOverrides() (map[string]any, error) {
 func init() {
 	upCmd.Flags().BoolVar(&waitFlag, "wait", false, "Wait for kustomization resources to be ready.")
 	upCmd.Flags().StringVar(&upVmDriver, "vm-driver", "", "VM driver: colima, colima-incus, docker-desktop, docker.")
-	upCmd.Flags().StringVar(&upPlatform, "platform", "", "Target platform: none, metal, docker, aws, azure, gcp, hyperv.")
+	upCmd.Flags().StringVar(&upPlatform, "platform", "", "Target platform: none, metal, docker, aws, azure, gcp, hyperv, vsphere.")
 	upCmd.Flags().StringVar(&upBlueprint, "blueprint", "", "Blueprint OCI reference or local path.")
 	upCmd.Flags().StringSliceVar(&upSetFlags, "set", []string{}, "Override config values, e.g. --set dns.enabled=false. May be repeated.")
 	rootCmd.AddCommand(upCmd)

--- a/docs/reference/commands/bootstrap.md
+++ b/docs/reference/commands/bootstrap.md
@@ -25,7 +25,7 @@ Re-running on an existing context prompts for confirmation. Pass --yes (or -y) t
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--blueprint` | `""` | Blueprint OCI reference. Accepts oci://host/org/repo:tag, host/org/repo:tag, or org/repo:tag (host defaults to ghcr.io). Tag is required. |
-| `--platform` | `""` | Target platform: none, metal, docker, aws, azure, gcp, hyperv. |
+| `--platform` | `""` | Target platform: none, metal, docker, aws, azure, gcp, hyperv, vsphere. |
 | `--set` | `[]` | Override config values, e.g. --set dns.enabled=false. May be repeated. |
 | `-y`, `--yes` | `false` | Skip all confirmation prompts. |
 

--- a/docs/reference/commands/init.md
+++ b/docs/reference/commands/init.md
@@ -25,7 +25,7 @@ The directory must be a git repository — init refuses to run in an empty or no
 | `--docker` | `false` | Enable Docker. |
 | `--endpoint` | `""` | Kubernetes API endpoint. |
 | `--git-livereload` | `false` | Enable git livereload. |
-| `--platform` | `""` | Target platform: none, metal, docker, aws, azure, gcp, hyperv. |
+| `--platform` | `""` | Target platform: none, metal, docker, aws, azure, gcp, hyperv, vsphere. |
 | `--reset` | `false` | Overwrite existing files and clean .terraform. |
 | `--set` | `[]` | Override config values, e.g. --set dns.enabled=false. May be repeated. |
 | `--vm-arch` | `""` | CPU architecture for the workstation VM. |

--- a/docs/reference/commands/up.md
+++ b/docs/reference/commands/up.md
@@ -19,7 +19,7 @@ If any host-side network or DNS configuration was deferred (because it requires 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--blueprint` | `""` | Blueprint OCI reference or local path. |
-| `--platform` | `""` | Target platform: none, metal, docker, aws, azure, gcp, hyperv. |
+| `--platform` | `""` | Target platform: none, metal, docker, aws, azure, gcp, hyperv, vsphere. |
 | `--set` | `[]` | Override config values, e.g. --set dns.enabled=false. May be repeated. |
 | `--vm-driver` | `""` | VM driver: colima, colima-incus, docker-desktop, docker. |
 | `--wait` | `false` | Wait for kustomization resources to be ready. |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -33,11 +33,12 @@ system-managed and not covered here.
 | `git` | `object` | Git / livereload configuration. |
 | `id` | `string` | Stable identifier for the context, distinct from its map key. Used for cross-context references where the key may change. |
 | `network` | `object` | Cluster network configuration. |
-| `platform` | `string` | Target deployment platform. Selects platform-specific facets and drives backend type inference. One of: `none`, `docker`, `incus`, `metal`, `aws`, `azure`, `gcp`, `hyperv`. |
+| `platform` | `string` | Target deployment platform. Selects platform-specific facets and drives backend type inference. One of: `none`, `docker`, `incus`, `metal`, `aws`, `azure`, `gcp`, `hyperv`, `vsphere`. |
 | `provider` | `string` | Deprecated alias for 'platform'. New configs should use 'platform'; the loader still reads 'provider' for backwards compatibility. |
 | `secrets` | `object` | Secrets provider configuration. Currently 1Password is the only supported provider. |
 | `terraform` | `object` | Per-context Terraform settings (state backend, lock policy, timeout). The runtime-validator sub-types (BackendConfig, LockConfig) are authored in api/v1alpha1/terraform/terraform_config.go; expansion to full field detail is a planned follow-up. |
 | `vm` | `object` | Workstation VM settings. Applies to colima / colima-incus / docker- desktop driver choices; ignored when the workstation runs directly on Docker without a VM. |
+| `vsphere` | `object` | vSphere integration. Activates whenever this block is present (or when platform is 'vsphere'); there is no separate 'enabled' flag. Connection credentials (server, user, password) are env-var driven by the Terraform provider (VSPHERE_SERVER, VSPHERE_USER, VSPHERE_PASSWORD, VSPHERE_ALLOW_UNVERIFIED_SSL). Server and user may optionally be set here so the CLI can export them into the shell; password must come from secrets or the ambient environment and is never written to this file. Inventory pointers (datacenter, cluster, datastore, network) are wired as Terraform variable inputs by the vsphere platform facet. |
 
 ### contexts{}.aws
 
@@ -185,6 +186,20 @@ system-managed and not covered here.
 | `driver` | `string` | VM driver. One of 'colima', 'colima-incus', 'docker-desktop', 'docker'. |
 | `memory` | `integer` | Memory in GB. |
 | `runtime` | `string` | Container runtime inside the VM (typically 'docker'). |
+
+### contexts{}.vsphere
+
+| Field | Type | Description |
+|------|------|-------------|
+| `cluster` | `string` | vSphere compute cluster name where VMs are scheduled (e.g. "cluster-01"). |
+| `datacenter` | `string` | vSphere datacenter name (exact inventory match, e.g. "dc-prod"). |
+| `datastore` | `string` | Datastore or datastore cluster name for VM disk placement. |
+| `folder` | `string` | VM folder path relative to the datacenter VM folder root. Defaults to the datacenter root. |
+| `insecure` | `boolean` | Disable TLS certificate verification when connecting to vCenter. Exported as VSPHERE_ALLOW_UNVERIFIED_SSL. |
+| `network` | `string` | Port group name the VM primary NIC attaches to. |
+| `resource_pool` | `string` | Resource pool path relative to the compute cluster. Defaults to the cluster root pool. |
+| `server` | `string` | vCenter server hostname or IP address. Exported as VSPHERE_SERVER. |
+| `user` | `string` | vCenter username. Exported as VSPHERE_USER. |
 
 ## terraform
 

--- a/pkg/runtime/config/resolve.go
+++ b/pkg/runtime/config/resolve.go
@@ -63,7 +63,7 @@ func (c *configHandler) applyPlatformDerivedDefaults(values map[string]any) {
 	}
 
 	switch platform {
-	case "docker", "incus", "metal", "omni", "hyperv":
+	case "docker", "incus", "metal", "omni", "hyperv", "vsphere":
 		c.setDerivedValueIfMissing(values, "cluster.driver", "talos")
 	case "aws":
 		c.setDerivedValueIfMissing(values, "cluster.driver", "eks")

--- a/pkg/runtime/config/resolve_test.go
+++ b/pkg/runtime/config/resolve_test.go
@@ -265,6 +265,26 @@ func TestConfigHandler_GetContextValues_Resolve(t *testing.T) {
 		}
 	})
 
+	t.Run("DerivesTalosDriverFromVspherePlatform", func(t *testing.T) {
+		handler, _ := setupPrivateTestHandler(t)
+		if err := handler.Set("platform", "vsphere"); err != nil {
+			t.Fatalf("Expected no error setting platform, got %v", err)
+		}
+
+		values, err := handler.GetContextValues()
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		clusterValues, ok := values["cluster"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected cluster map, got %T", values["cluster"])
+		}
+		if clusterValues["driver"] != "talos" {
+			t.Errorf("Expected cluster.driver=talos, got %v", clusterValues["driver"])
+		}
+	})
+
 	t.Run("DerivesCloudDriverFromPlatform", func(t *testing.T) {
 		handler, _ := setupPrivateTestHandler(t)
 		if err := handler.Set("platform", "azure"); err != nil {

--- a/pkg/runtime/config/schemas/artifacts/configuration.yaml
+++ b/pkg/runtime/config/schemas/artifacts/configuration.yaml
@@ -62,6 +62,7 @@ $defs:
           - azure
           - gcp
           - hyperv
+          - vsphere
         description: |
           Target deployment platform. Selects platform-specific facets and
           drives backend type inference.
@@ -87,6 +88,8 @@ $defs:
         $ref: '#/$defs/azure'
       gcp:
         $ref: '#/$defs/gcp'
+      vsphere:
+        $ref: '#/$defs/vsphere'
       docker:
         $ref: '#/$defs/docker'
       git:
@@ -197,6 +200,47 @@ $defs:
       quota_project:
         type: string
         description: Project to bill quota usage against.
+  vsphere:
+    type: object
+    additionalProperties: false
+    description: |
+      vSphere integration. Activates whenever this block is present (or when
+      platform is 'vsphere'); there is no separate 'enabled' flag.
+      Connection credentials (server, user, password) are env-var driven by the
+      Terraform provider (VSPHERE_SERVER, VSPHERE_USER, VSPHERE_PASSWORD,
+      VSPHERE_ALLOW_UNVERIFIED_SSL). Server and user may optionally be set here
+      so the CLI can export them into the shell; password must come from secrets
+      or the ambient environment and is never written to this file.
+      Inventory pointers (datacenter, cluster, datastore, network) are wired as
+      Terraform variable inputs by the vsphere platform facet.
+    properties:
+      server:
+        type: string
+        description: vCenter server hostname or IP address. Exported as VSPHERE_SERVER.
+      user:
+        type: string
+        description: vCenter username. Exported as VSPHERE_USER.
+      datacenter:
+        type: string
+        description: vSphere datacenter name (exact inventory match, e.g. "dc-prod").
+      cluster:
+        type: string
+        description: vSphere compute cluster name where VMs are scheduled (e.g. "cluster-01").
+      datastore:
+        type: string
+        description: Datastore or datastore cluster name for VM disk placement.
+      network:
+        type: string
+        description: Port group name the VM primary NIC attaches to.
+      resource_pool:
+        type: string
+        description: Resource pool path relative to the compute cluster. Defaults to the cluster root pool.
+      folder:
+        type: string
+        description: VM folder path relative to the datacenter VM folder root. Defaults to the datacenter root.
+      insecure:
+        type: boolean
+        description: Disable TLS certificate verification when connecting to vCenter. Exported as VSPHERE_ALLOW_UNVERIFIED_SSL.
   docker:
     type: object
     additionalProperties: false

--- a/pkg/runtime/config/schemas/common.yaml
+++ b/pkg/runtime/config/schemas/common.yaml
@@ -12,6 +12,7 @@ properties:
       - azure
       - gcp
       - hyperv
+      - vsphere
 
   workstation:
     type: object

--- a/pkg/runtime/env/vsphere_env.go
+++ b/pkg/runtime/env/vsphere_env.go
@@ -1,0 +1,79 @@
+// The VsphereEnvPrinter is a specialized component that manages vSphere environment configuration.
+// It provides vSphere-specific environment variable management so that Terraform and other tools
+// can connect to vCenter without requiring inline credential flags.
+
+package env
+
+import (
+	"strconv"
+
+	"github.com/windsorcli/cli/pkg/runtime/config"
+	"github.com/windsorcli/cli/pkg/runtime/shell"
+)
+
+// =============================================================================
+// Types
+// =============================================================================
+
+// VsphereEnvPrinter is a struct that implements vSphere environment configuration
+type VsphereEnvPrinter struct {
+	BaseEnvPrinter
+}
+
+// =============================================================================
+// Constructor
+// =============================================================================
+
+// NewVsphereEnvPrinter creates a new VsphereEnvPrinter instance
+func NewVsphereEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler) *VsphereEnvPrinter {
+	if shell == nil {
+		panic("shell is required")
+	}
+	if configHandler == nil {
+		panic("config handler is required")
+	}
+
+	return &VsphereEnvPrinter{
+		BaseEnvPrinter: *NewBaseEnvPrinter(shell, configHandler),
+	}
+}
+
+// =============================================================================
+// Public Methods
+// =============================================================================
+
+// GetEnvVars retrieves the environment variables for the vSphere environment.
+// Only the three env vars consumed by the HashiCorp vSphere Terraform provider are
+// emitted: VSPHERE_SERVER, VSPHERE_USER, and VSPHERE_ALLOW_UNVERIFIED_SSL.
+// Inventory pointers (datacenter, cluster, datastore, network, etc.) are Terraform
+// variable inputs wired by the facet — they are not read from the environment.
+// VSPHERE_PASSWORD must be supplied via secrets or the ambient environment; plaintext
+// passwords are never written to the shell config file.
+func (e *VsphereEnvPrinter) GetEnvVars() (map[string]string, error) {
+	envVars := make(map[string]string)
+
+	cfg := e.configHandler.GetConfig()
+	if cfg == nil || cfg.VSphere == nil {
+		return envVars, nil
+	}
+
+	v := cfg.VSphere
+	if v.Server != nil {
+		envVars["VSPHERE_SERVER"] = *v.Server
+	}
+	if v.User != nil {
+		envVars["VSPHERE_USER"] = *v.User
+	}
+	if v.Insecure != nil {
+		envVars["VSPHERE_ALLOW_UNVERIFIED_SSL"] = strconv.FormatBool(*v.Insecure)
+	}
+
+	return envVars, nil
+}
+
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
+// Ensure VsphereEnvPrinter implements the EnvPrinter interface
+var _ EnvPrinter = (*VsphereEnvPrinter)(nil)

--- a/pkg/runtime/env/vsphere_env_test.go
+++ b/pkg/runtime/env/vsphere_env_test.go
@@ -1,0 +1,220 @@
+package env
+
+import (
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/windsorcli/cli/api/v1alpha1"
+	"github.com/windsorcli/cli/pkg/runtime/config"
+)
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+func setupVsphereEnvMocks(t *testing.T, overrides ...*EnvTestMocks) *EnvTestMocks {
+	t.Helper()
+
+	mocks := setupEnvMocks(t, overrides...)
+
+	if _, ok := mocks.ConfigHandler.(*config.MockConfigHandler); !ok {
+		mocks.ConfigHandler = config.NewMockConfigHandler()
+	}
+
+	mockConfigHandler := mocks.ConfigHandler.(*config.MockConfigHandler)
+
+	loadedConfigs := make(map[string]*v1alpha1.Context)
+	currentContext := "test-context"
+
+	mockConfigHandler.GetContextFunc = func() string {
+		return currentContext
+	}
+
+	mockConfigHandler.SetContextFunc = func(context string) error {
+		currentContext = context
+		return nil
+	}
+
+	mockConfigHandler.LoadConfigStringFunc = func(content string) error {
+		var cfg v1alpha1.Config
+		if err := yaml.Unmarshal([]byte(content), &cfg); err != nil {
+			return err
+		}
+		for name, ctx := range cfg.Contexts {
+			if ctx != nil {
+				ctxCopy := *ctx
+				loadedConfigs[name] = &ctxCopy
+			} else {
+				loadedConfigs[name] = &v1alpha1.Context{}
+			}
+		}
+		return nil
+	}
+
+	mockConfigHandler.GetConfigFunc = func() *v1alpha1.Context {
+		if ctx, ok := loadedConfigs[currentContext]; ok {
+			return ctx
+		}
+		return &v1alpha1.Context{}
+	}
+
+	if len(overrides) == 0 || overrides[0] == nil || overrides[0].ConfigHandler == nil {
+		defaultConfigStr := `
+version: v1alpha1
+contexts:
+  test-context:
+    vsphere:
+      server: "vcenter.example.com"
+      user: "administrator@vsphere.local"
+      datacenter: "DC0"
+      cluster: "cluster-01"
+      datastore: "datastore1"
+      network: "VM Network"
+      resource_pool: "Resources"
+      folder: "/DC0/vm"
+      insecure: true
+`
+		if err := mocks.ConfigHandler.LoadConfigString(defaultConfigStr); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+	}
+
+	if err := mocks.ConfigHandler.SetContext("test-context"); err != nil {
+		t.Fatalf("Failed to set context: %v", err)
+	}
+
+	return mocks
+}
+
+// =============================================================================
+// Test Public Methods
+// =============================================================================
+
+func TestVsphereEnv_GetEnvVars(t *testing.T) {
+	setup := func(t *testing.T, overrides ...*EnvTestMocks) (*VsphereEnvPrinter, *EnvTestMocks) {
+		t.Helper()
+		mocks := setupVsphereEnvMocks(t, overrides...)
+		printer := NewVsphereEnvPrinter(mocks.Shell, mocks.ConfigHandler)
+		printer.shims = mocks.Shims
+		return printer, mocks
+	}
+
+	t.Run("SuccessWithAllConfig", func(t *testing.T) {
+		// Given a full vSphere configuration
+		printer, _ := setup(t)
+
+		// When GetEnvVars is called
+		envVars, err := printer.GetEnvVars()
+
+		// Then only the three Terraform vSphere provider env vars are emitted.
+		// Inventory pointers (datacenter, cluster, datastore, etc.) are Terraform
+		// variable inputs wired by the facet — they are never emitted as env vars.
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if envVars["VSPHERE_SERVER"] != "vcenter.example.com" {
+			t.Errorf("VSPHERE_SERVER = %q, want %q", envVars["VSPHERE_SERVER"], "vcenter.example.com")
+		}
+		if envVars["VSPHERE_USER"] != "administrator@vsphere.local" {
+			t.Errorf("VSPHERE_USER = %q, want %q", envVars["VSPHERE_USER"], "administrator@vsphere.local")
+		}
+		if envVars["VSPHERE_ALLOW_UNVERIFIED_SSL"] != "true" {
+			t.Errorf("VSPHERE_ALLOW_UNVERIFIED_SSL = %q, want %q", envVars["VSPHERE_ALLOW_UNVERIFIED_SSL"], "true")
+		}
+		if len(envVars) != 3 {
+			t.Errorf("Expected exactly 3 env vars (provider credentials only), got %d: %v", len(envVars), envVars)
+		}
+	})
+
+	t.Run("SuccessWithMinimalConfig", func(t *testing.T) {
+		// Given a minimal vSphere configuration (server only)
+		mocks := setupVsphereEnvMocks(t)
+		configStr := `
+version: v1alpha1
+contexts:
+  test-context:
+    vsphere:
+      server: "vcenter.example.com"
+`
+		if err := mocks.ConfigHandler.LoadConfigString(configStr); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+		printer := NewVsphereEnvPrinter(mocks.Shell, mocks.ConfigHandler)
+		printer.shims = mocks.Shims
+
+		// When GetEnvVars is called
+		envVars, err := printer.GetEnvVars()
+
+		// Then only VSPHERE_SERVER is set
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if envVars["VSPHERE_SERVER"] != "vcenter.example.com" {
+			t.Errorf("VSPHERE_SERVER = %q, want vcenter.example.com", envVars["VSPHERE_SERVER"])
+		}
+		if _, ok := envVars["VSPHERE_USER"]; ok {
+			t.Error("VSPHERE_USER should not be set when user is not configured")
+		}
+		if _, ok := envVars["VSPHERE_ALLOW_UNVERIFIED_SSL"]; ok {
+			t.Error("VSPHERE_ALLOW_UNVERIFIED_SSL should not be set when insecure is not configured")
+		}
+		if len(envVars) != 1 {
+			t.Errorf("Expected 1 environment variable, got %d: %v", len(envVars), envVars)
+		}
+	})
+
+	t.Run("MissingConfiguration", func(t *testing.T) {
+		// Given a context with no vsphere block
+		mocks := setupVsphereEnvMocks(t)
+		configStr := `
+version: v1alpha1
+contexts:
+  test-context: {}
+`
+		if err := mocks.ConfigHandler.LoadConfigString(configStr); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+		printer := NewVsphereEnvPrinter(mocks.Shell, mocks.ConfigHandler)
+		printer.shims = mocks.Shims
+
+		// When GetEnvVars is called
+		envVars, err := printer.GetEnvVars()
+
+		// Then no env vars are emitted and no error is returned
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if len(envVars) != 0 {
+			t.Errorf("Expected empty env vars for missing vsphere config, got %v", envVars)
+		}
+	})
+
+	t.Run("InsecureFalseEmitted", func(t *testing.T) {
+		// Given a config with insecure explicitly set to false
+		mocks := setupVsphereEnvMocks(t)
+		configStr := `
+version: v1alpha1
+contexts:
+  test-context:
+    vsphere:
+      server: "vcenter.example.com"
+      insecure: false
+`
+		if err := mocks.ConfigHandler.LoadConfigString(configStr); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+		printer := NewVsphereEnvPrinter(mocks.Shell, mocks.ConfigHandler)
+		printer.shims = mocks.Shims
+
+		// When GetEnvVars is called
+		envVars, err := printer.GetEnvVars()
+
+		// Then VSPHERE_ALLOW_UNVERIFIED_SSL is "false" (explicit, not omitted)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if envVars["VSPHERE_ALLOW_UNVERIFIED_SSL"] != "false" {
+			t.Errorf("VSPHERE_ALLOW_UNVERIFIED_SSL = %q, want %q", envVars["VSPHERE_ALLOW_UNVERIFIED_SSL"], "false")
+		}
+	})
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -59,6 +59,7 @@ type Runtime struct {
 		AwsEnv       env.EnvPrinter
 		AzureEnv     env.EnvPrinter
 		GcpEnv       env.EnvPrinter
+		VsphereEnv   env.EnvPrinter
 		DockerEnv    env.EnvPrinter
 		KubeEnv      env.EnvPrinter
 		TalosEnv     env.EnvPrinter
@@ -140,6 +141,9 @@ func NewRuntime(opts ...*Runtime) *Runtime {
 		}
 		if overrides.EnvPrinters.GcpEnv != nil {
 			rt.EnvPrinters.GcpEnv = overrides.EnvPrinters.GcpEnv
+		}
+		if overrides.EnvPrinters.VsphereEnv != nil {
+			rt.EnvPrinters.VsphereEnv = overrides.EnvPrinters.VsphereEnv
 		}
 		if overrides.EnvPrinters.DockerEnv != nil {
 			rt.EnvPrinters.DockerEnv = overrides.EnvPrinters.DockerEnv
@@ -727,6 +731,7 @@ func (rt *Runtime) initializeEnvPrinters() {
 	hasAWSConfig := configData != nil && configData.AWS != nil
 	hasAzureConfig := configData != nil && configData.Azure != nil
 	hasGCPConfig := configData != nil && configData.GCP != nil
+	hasVSphereConfig := configData != nil && configData.VSphere != nil
 
 	if rt.EnvPrinters.AwsEnv == nil && (hasAWSConfig || platform == "aws") {
 		rt.EnvPrinters.AwsEnv = env.NewAwsEnvPrinter(rt.Shell, rt.ConfigHandler)
@@ -736,6 +741,9 @@ func (rt *Runtime) initializeEnvPrinters() {
 	}
 	if rt.EnvPrinters.GcpEnv == nil && gcpEnabled && hasGCPConfig {
 		rt.EnvPrinters.GcpEnv = env.NewGcpEnvPrinter(rt.Shell, rt.ConfigHandler)
+	}
+	if rt.EnvPrinters.VsphereEnv == nil && (hasVSphereConfig || platform == "vsphere") {
+		rt.EnvPrinters.VsphereEnv = env.NewVsphereEnvPrinter(rt.Shell, rt.ConfigHandler)
 	}
 	if rt.EnvPrinters.DockerEnv == nil && needsDocker {
 		rt.EnvPrinters.DockerEnv = env.NewVirtEnvPrinter(rt.Shell, rt.ConfigHandler)
@@ -881,6 +889,7 @@ func (rt *Runtime) getAllEnvPrinters() []env.EnvPrinter {
 		rt.EnvPrinters.AwsEnv,
 		rt.EnvPrinters.AzureEnv,
 		rt.EnvPrinters.GcpEnv,
+		rt.EnvPrinters.VsphereEnv,
 		rt.EnvPrinters.DockerEnv,
 		rt.EnvPrinters.KubeEnv,
 		rt.EnvPrinters.TalosEnv,


### PR DESCRIPTION
<!-- claude-code-review:summary -->
> [!NOTE]
>
> **Low Risk**
>
> Purely additive. No existing platform, config path, or env var is modified. The only change to shared code is a one-token addition to the Talos driver switch case and the `vsphere` enum entry already present in both schema files.
>
> **Overview**
>
> Adds `vsphere` as a supported platform alongside `hyperv`, following the same patterns established for Hyper-V and the cloud providers.
>
> **Config types** — `VSphereConfig` is introduced in both `api/v1alpha1/vsphere` and `api/v1alpha2/config/providers/vsphere` with fields for the two distinct concerns the core schema separates: provider credentials (`server`, `user`, `insecure`) and vSphere inventory pointers (`datacenter`, `cluster`, `datastore`, `network`, `folder`, `resource_pool`). The `cluster` field (compute cluster name) matches the required field in `../core/contexts/_template/schema.yaml` and the `compute/vsphere` Terraform module's `var.cluster` input. `VSphereConfig` is wired into `v1alpha1.Context` and `v1alpha2.ProvidersConfig` with the standard `Merge`/`Copy`/`DeepCopy` methods.
>
> **Env printer** — `VsphereEnvPrinter` emits only the three environment variables the HashiCorp vSphere Terraform provider reads from the environment: `VSPHERE_SERVER`, `VSPHERE_USER`, and `VSPHERE_ALLOW_UNVERIFIED_SSL`. Inventory pointers are intentionally excluded — they reach the Terraform module as `TF_VAR_*` inputs wired by the `platform-vsphere` facet expressions (`${vsphere_effective.datacenter}` etc.), not as env vars. `VSPHERE_PASSWORD` is left to secrets or the ambient environment; plaintext passwords are never written to the shell config file.
>
> **Driver derivation** — `vsphere` is added to the `"docker", "incus", "metal", "omni", "hyperv"` case in `resolve.go`, deriving `cluster.driver = talos`. This matches the Talos-on-vSphere deployment model used by `../core`.
>
> **CLI flags** — `--platform` help text in `init`, `bootstrap`, and `up` commands is updated to include `vsphere`.
>
> **Schemas** — `vsphere` was already present in both platform enums (`configuration.yaml` and `common.yaml`). This PR adds the full `$defs/vsphere` block to `configuration.yaml` and the `vsphere` object to `api/v1alpha2/config/providers/schema.yaml`, with descriptions aligned to the `../core` schema comments.
>
> Reviewed by Claude for commit `33c632d4`.

<!-- /claude-code-review:summary -->