### PR TITLE
feat(cmd/upgrade): add downgrade guard and allow flag for source retargeting

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -297,6 +297,17 @@ func upgradeToLatest(cmd *cobra.Command, proj *project.Project) error {
 	return nil
 }
 
+// parseSourceSpec splits a `--source` value into its name and URL, rejecting any spec missing the
+// separator or either half. Both the downgrade gate and the retarget writer parse the same specs,
+// so they share this one parser to stay in lockstep on what a valid spec is.
+func parseSourceSpec(spec string) (name, url string, err error) {
+	name, url, ok := strings.Cut(spec, "=")
+	if !ok || name == "" || url == "" {
+		return "", "", fmt.Errorf("invalid --source %q; expected name=url", spec)
+	}
+	return name, url, nil
+}
+
 // retargetSources applies each `name=url` spec to the context's declared sources, persists the bumps
 // to blueprint.yaml via the same writer init uses, and prints what changed for the operator to
 // commit. An unknown source name or malformed spec aborts before anything is written, so a failed
@@ -306,9 +317,9 @@ func retargetSources(cmd *cobra.Command, proj *project.Project, specs []string) 
 	type change struct{ name, previous, target string }
 	changes := make([]change, 0, len(specs))
 	for _, spec := range specs {
-		name, url, ok := strings.Cut(spec, "=")
-		if !ok || name == "" || url == "" {
-			return fmt.Errorf("invalid --source %q; expected name=url", spec)
+		name, url, err := parseSourceSpec(spec)
+		if err != nil {
+			return err
 		}
 		previous, err := proj.Composer.BlueprintHandler.RetargetSource(name, url)
 		if err != nil {
@@ -337,9 +348,9 @@ func checkSourceDowngrades(cmd *cobra.Command, proj *project.Project, specs []st
 	type change struct{ name, previous, target string }
 	targets := make([]change, 0, len(specs))
 	for _, spec := range specs {
-		name, url, ok := strings.Cut(spec, "=")
-		if !ok || name == "" || url == "" {
-			return fmt.Errorf("invalid --source %q; expected name=url", spec)
+		name, url, err := parseSourceSpec(spec)
+		if err != nil {
+			return err
 		}
 		targets = append(targets, change{name: name, target: url})
 	}

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/composer"
+	"github.com/windsorcli/cli/pkg/composer/blueprint"
 	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/project"
 	"github.com/windsorcli/cli/pkg/provisioner"
@@ -18,10 +19,11 @@ import (
 )
 
 var (
-	upgradeNodes   []string
-	upgradeImage   string
-	upgradeSources []string
-	upgradeYes     bool
+	upgradeNodes          []string
+	upgradeImage          string
+	upgradeSources        []string
+	upgradeYes            bool
+	upgradeAllowDowngrade bool
 
 	upgradeNodeAddr    string
 	upgradeNodeImage   string
@@ -49,11 +51,31 @@ windsor upgrade cluster --nodes=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1
 	Args:         cobra.NoArgs,
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		// `windsor upgrade` runs the full blueprint — terraform components and Flux
-		// kustomizations both — so the tool surface is not statically narrowable; mirror
-		// `apply` and request AllRequirements(), letting the per-tool config gates decide.
-		proj, err := prepareProject(cmd, tools.AllRequirements())
+		// Configure the project but defer Initialize (compose) until after the confirmation and
+		// downgrade gates, so neither a missing --yes nor a refused downgrade pulls or composes
+		// any source. `windsor upgrade` runs the full blueprint — terraform components and Flux
+		// kustomizations both — so the tool surface is not statically narrowable; mirror `apply`
+		// and request AllRequirements(), letting the per-tool config gates decide.
+		proj, err := configureProject(cmd)
 		if err != nil {
+			return err
+		}
+
+		if !upgradeYes {
+			msg := "upgrade rewrites blueprint.yaml and reconciles the cluster (apply, wait, prune); re-run with --yes to proceed, or use `windsor plan` to preview"
+			fmt.Fprintln(cmd.ErrOrStderr(), msg)
+			silenceErrorsOnAncestors(cmd)
+			return fmt.Errorf("%s", msg)
+		}
+
+		if len(upgradeSources) > 0 {
+			if err := checkSourceDowngrades(cmd, proj, upgradeSources, upgradeAllowDowngrade); err != nil {
+				return err
+			}
+		}
+
+		proj.SetToolRequirements(tools.AllRequirements())
+		if err := proj.Initialize(false); err != nil {
 			return err
 		}
 
@@ -64,13 +86,6 @@ windsor upgrade cluster --nodes=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1
 		blueprint := proj.Composer.BlueprintHandler.Generate()
 		if blueprint == nil {
 			return fmt.Errorf("blueprint is not available")
-		}
-
-		if !upgradeYes {
-			msg := "upgrade rewrites blueprint.yaml and reconciles the cluster (apply, wait, prune); re-run with --yes to proceed, or use `windsor plan` to preview"
-			fmt.Fprintln(cmd.ErrOrStderr(), msg)
-			silenceErrorsOnAncestors(cmd)
-			return fmt.Errorf("%s", msg)
 		}
 
 		if len(upgradeSources) > 0 {
@@ -285,7 +300,8 @@ func upgradeToLatest(cmd *cobra.Command, proj *project.Project) error {
 // retargetSources applies each `name=url` spec to the context's declared sources, persists the bumps
 // to blueprint.yaml via the same writer init uses, and prints what changed for the operator to
 // commit. An unknown source name or malformed spec aborts before anything is written, so a failed
-// retarget never leaves blueprint.yaml half-edited.
+// retarget never leaves blueprint.yaml half-edited. Downgrades are refused earlier by
+// checkSourceDowngrades, before any source is composed.
 func retargetSources(cmd *cobra.Command, proj *project.Project, specs []string) error {
 	type change struct{ name, previous, target string }
 	changes := make([]change, 0, len(specs))
@@ -311,6 +327,54 @@ func retargetSources(cmd *cobra.Command, proj *project.Project, specs []string) 
 	return nil
 }
 
+// checkSourceDowngrades evaluates each `name=url` spec against the context's declared sources before
+// anything is composed or pulled, so a refused downgrade never triggers a registry round-trip. A
+// spec that moves a declared source to an older semver of the same repository is a downgrade: it is
+// refused unless allowDowngrade is set, since Windsor reverts infrastructure declaratively but does
+// not reverse application data. Specs naming an undeclared source are left for retargetSources to
+// reject; malformed specs are rejected here.
+func checkSourceDowngrades(cmd *cobra.Command, proj *project.Project, specs []string, allowDowngrade bool) error {
+	type change struct{ name, previous, target string }
+	targets := make([]change, 0, len(specs))
+	for _, spec := range specs {
+		name, url, ok := strings.Cut(spec, "=")
+		if !ok || name == "" || url == "" {
+			return fmt.Errorf("invalid --source %q; expected name=url", spec)
+		}
+		targets = append(targets, change{name: name, target: url})
+	}
+
+	declared, err := proj.Composer.BlueprintHandler.GetDeclaredSources()
+	if err != nil {
+		return fmt.Errorf("failed to read declared sources: %w", err)
+	}
+	declaredURL := make(map[string]string, len(declared))
+	for _, s := range declared {
+		declaredURL[s.Name] = s.Url
+	}
+
+	var downgrades []change
+	for _, t := range targets {
+		if prev, found := declaredURL[t.name]; found && blueprint.IsDowngrade(prev, t.target) {
+			downgrades = append(downgrades, change{name: t.name, previous: prev, target: t.target})
+		}
+	}
+	if len(downgrades) == 0 {
+		return nil
+	}
+	for _, d := range downgrades {
+		fmt.Fprintf(cmd.ErrOrStderr(), "Downgrading %s from %s to %s\n", d.name, d.previous, d.target)
+	}
+	if !allowDowngrade {
+		msg := fmt.Sprintf("refusing to downgrade %d source(s); recovery from a bad version is fix-forward (cut a higher version that reverts the change). To revert infrastructure anyway, re-run with --allow-downgrade — application data is NOT reversed", len(downgrades))
+		fmt.Fprintln(cmd.ErrOrStderr(), msg)
+		silenceErrorsOnAncestors(cmd)
+		return fmt.Errorf("%s", msg)
+	}
+	fmt.Fprintln(cmd.ErrOrStderr(), "Warning: downgrading reverts infrastructure declaratively but does NOT reverse application data; ensure you have backups.")
+	return nil
+}
+
 func init() {
 	rootCmd.AddCommand(upgradeCmd)
 	upgradeCmd.AddCommand(upgradeClusterCmd)
@@ -318,6 +382,7 @@ func init() {
 
 	upgradeCmd.Flags().StringArrayVar(&upgradeSources, "source", nil, "Retarget a declared source to a new tagged URL (name=url); repeatable. Persisted to blueprint.yaml.")
 	upgradeCmd.Flags().BoolVar(&upgradeYes, "yes", false, "Proceed without confirmation when the upgrade would prune kustomizations.")
+	upgradeCmd.Flags().BoolVar(&upgradeAllowDowngrade, "allow-downgrade", false, "Permit moving a source to an older version. Reverts infrastructure declaratively; does NOT reverse application data.")
 
 	upgradeClusterCmd.Flags().StringSliceVar(&upgradeNodes, "nodes", []string{}, "Node addresses to upgrade. Required.")
 	upgradeClusterCmd.Flags().StringVar(&upgradeImage, "image", "", "Talos image to upgrade to. Required.")

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -344,6 +344,12 @@ func retargetSources(cmd *cobra.Command, proj *project.Project, specs []string) 
 // refused unless allowDowngrade is set, since Windsor reverts infrastructure declaratively but does
 // not reverse application data. Specs naming an undeclared source are left for retargetSources to
 // reject; malformed specs are rejected here.
+//
+// The comparison baseline is the ref declared in blueprint.yaml, not the running version recorded in
+// the cluster marker — a deliberate trade-off that keeps this a cheap, offline pre-flight (the marker
+// would require a cluster read). The normal flow keeps declared and applied in lockstep; the gap is a
+// blueprint.yaml hand-edited below the running version, where a move that is forward relative to the
+// declared ref but still behind what is applied would not be flagged.
 func checkSourceDowngrades(cmd *cobra.Command, proj *project.Project, specs []string, allowDowngrade bool) error {
 	type change struct{ name, previous, target string }
 	targets := make([]change, 0, len(specs))

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -600,6 +600,57 @@ func TestUpgradeCmd_Source(t *testing.T) {
 			t.Error("Expected the downgrade to be persisted under --allow-downgrade")
 		}
 	})
+
+	t.Run("RefusesWholeOperationWhenAnySourceDowngrades", func(t *testing.T) {
+		t.Cleanup(func() { upgradeSources = nil; upgradeAllowDowngrade = false })
+		// Given two declared sources, one bumped forward and one moved back
+		mocks := setupApplyTest(t)
+		mocks.BlueprintHandler.GetDeclaredSourcesFunc = func() ([]blueprintv1alpha1.Source, error) {
+			return []blueprintv1alpha1.Source{
+				{Name: "core", Url: "oci://ghcr.io/windsorcli/core:v0.6.0"},
+				{Name: "addons", Url: "oci://ghcr.io/windsorcli/addons:v0.2.0"},
+			}, nil
+		}
+		retargeted := false
+		mocks.BlueprintHandler.RetargetSourceFunc = func(name, url string) (string, error) {
+			retargeted = true
+			return "", nil
+		}
+		persisted := false
+		mocks.BlueprintHandler.WriteFunc = func(overwrite ...bool) error {
+			if len(overwrite) > 0 && overwrite[0] {
+				persisted = true
+			}
+			return nil
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When one spec is a forward bump and the other is a downgrade, without --allow-downgrade
+		var errOut bytes.Buffer
+		cmd := createTestUpgradeCmd()
+		cmd.SetErr(&errOut)
+		cmd.SetArgs([]string{
+			"--source", "addons=oci://ghcr.io/windsorcli/addons:v0.3.0",
+			"--source", "core=oci://ghcr.io/windsorcli/core:v0.4.0",
+		})
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then the whole operation is refused before any source is retargeted or written
+		if err == nil {
+			t.Fatal("Expected the downgrade in one spec to refuse the whole operation, got nil")
+		}
+		if !strings.Contains(err.Error(), "--allow-downgrade") {
+			t.Errorf("Expected a downgrade refusal pointing at --allow-downgrade, got: %v", err)
+		}
+		if !strings.Contains(errOut.String(), "Downgrading core") {
+			t.Errorf("Expected the refused downgrade to name core, got: %q", errOut.String())
+		}
+		if retargeted || persisted {
+			t.Error("Expected no retarget or write when any spec is a refused downgrade")
+		}
+	})
 }
 
 func TestUpgradeCmd_Confirmation(t *testing.T) {

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -508,6 +508,98 @@ func TestUpgradeCmd_Source(t *testing.T) {
 			t.Errorf("Expected a name=url format error, got: %v", err)
 		}
 	})
+
+	t.Run("RefusesDowngradeWithoutAllowFlag", func(t *testing.T) {
+		t.Cleanup(func() { upgradeSources = nil; upgradeAllowDowngrade = false })
+		// Given a declared source currently pinned newer than the requested target
+		mocks := setupApplyTest(t)
+		mocks.BlueprintHandler.GetDeclaredSourcesFunc = func() ([]blueprintv1alpha1.Source, error) {
+			return []blueprintv1alpha1.Source{{Name: "core", Url: "oci://ghcr.io/windsorcli/core:v0.6.0"}}, nil
+		}
+		retargeted := false
+		mocks.BlueprintHandler.RetargetSourceFunc = func(name, url string) (string, error) {
+			retargeted = true
+			return "oci://ghcr.io/windsorcli/core:v0.6.0", nil
+		}
+		persisted := false
+		mocks.BlueprintHandler.WriteFunc = func(overwrite ...bool) error {
+			if len(overwrite) > 0 && overwrite[0] {
+				persisted = true
+			}
+			return nil
+		}
+		applied := false
+		mocks.KubernetesManager.ApplyBlueprintFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) error {
+			applied = true
+			return nil
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When retargeting to an older version without --allow-downgrade
+		var errOut bytes.Buffer
+		cmd := createTestUpgradeCmd()
+		cmd.SetErr(&errOut)
+		cmd.SetArgs([]string{"--source", "core=oci://ghcr.io/windsorcli/core:v0.3.0"})
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then it refuses before writing or reconciling, and points at --allow-downgrade
+		if err == nil {
+			t.Fatal("Expected a downgrade refusal, got nil")
+		}
+		if !strings.Contains(err.Error(), "downgrade") || !strings.Contains(err.Error(), "--allow-downgrade") {
+			t.Errorf("Expected a downgrade refusal pointing at --allow-downgrade, got: %v", err)
+		}
+		if retargeted {
+			t.Error("Expected no retarget on a refused downgrade — the gate runs before compose")
+		}
+		if persisted {
+			t.Error("Expected blueprint.yaml not to be written on a refused downgrade")
+		}
+		if applied {
+			t.Error("Expected no reconcile on a refused downgrade")
+		}
+	})
+
+	t.Run("ProceedsWithAllowDowngrade", func(t *testing.T) {
+		t.Cleanup(func() { upgradeSources = nil; upgradeAllowDowngrade = false })
+		// Given the same older target
+		mocks := setupApplyTest(t)
+		mocks.BlueprintHandler.GetDeclaredSourcesFunc = func() ([]blueprintv1alpha1.Source, error) {
+			return []blueprintv1alpha1.Source{{Name: "core", Url: "oci://ghcr.io/windsorcli/core:v0.6.0"}}, nil
+		}
+		mocks.BlueprintHandler.RetargetSourceFunc = func(name, url string) (string, error) {
+			return "oci://ghcr.io/windsorcli/core:v0.6.0", nil
+		}
+		persisted := false
+		mocks.BlueprintHandler.WriteFunc = func(overwrite ...bool) error {
+			if len(overwrite) > 0 && overwrite[0] {
+				persisted = true
+			}
+			return nil
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When retargeting to an older version with --allow-downgrade
+		var errOut bytes.Buffer
+		cmd := createTestUpgradeCmd()
+		cmd.SetErr(&errOut)
+		cmd.SetArgs([]string{"--source", "core=oci://ghcr.io/windsorcli/core:v0.3.0", "--allow-downgrade"})
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Expected --allow-downgrade to proceed, got %v", err)
+		}
+
+		// Then it warns about data, persists the bump, and proceeds
+		if !strings.Contains(errOut.String(), "does NOT reverse application data") {
+			t.Errorf("Expected a data-loss warning, got: %q", errOut.String())
+		}
+		if !persisted {
+			t.Error("Expected the downgrade to be persisted under --allow-downgrade")
+		}
+	})
 }
 
 func TestUpgradeCmd_Confirmation(t *testing.T) {

--- a/docs/reference/commands/upgrade.md
+++ b/docs/reference/commands/upgrade.md
@@ -16,6 +16,7 @@ Use the 'cluster' or 'node' subcommand to upgrade Talos nodes instead.
 
 | Flag | Default | Description |
 |------|---------|-------------|
+| `--allow-downgrade` | `false` | Permit moving a source to an older version. Reverts infrastructure declaratively; does NOT reverse application data. |
 | `--source` | `[]` | Retarget a declared source to a new tagged URL (name=url); repeatable. Persisted to blueprint.yaml. |
 | `--yes` | `false` | Proceed without confirmation when the upgrade would prune kustomizations. |
 

--- a/integration/fixtures/upgrade-source/contexts/_template/blueprint.yaml
+++ b/integration/fixtures/upgrade-source/contexts/_template/blueprint.yaml
@@ -1,0 +1,10 @@
+kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: upgrade-source
+  description: Upgrade fixture with a declared OCI source for downgrade-guard tests
+sources:
+  - name: core
+    url: oci://ghcr.io/windsorcli/core:v0.6.0
+terraform:
+  - path: "null"

--- a/integration/fixtures/upgrade-source/terraform/null/main.tf
+++ b/integration/fixtures/upgrade-source/terraform/null/main.tf
@@ -1,0 +1,1 @@
+terraform {}

--- a/integration/fixtures/upgrade-source/windsor.yaml
+++ b/integration/fixtures/upgrade-source/windsor.yaml
@@ -1,0 +1,3 @@
+version: v1alpha1
+contexts:
+  local: {}

--- a/integration/upgrade_test.go
+++ b/integration/upgrade_test.go
@@ -90,6 +90,48 @@ func TestUpgrade_SourceRejectsUndeclaredSource(t *testing.T) {
 	}
 }
 
+func TestUpgrade_RefusesDowngrade(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "upgrade-source")
+	helpers.MarkAsGitRepo(t, dir)
+	if _, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env); err != nil {
+		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
+	}
+	env = append(env, "WINDSOR_CONTEXT=local")
+
+	// Retargeting a declared source to an older semver of the same repository is forward-only by
+	// default: it must refuse before writing or reconciling and point at --allow-downgrade.
+	_, stderr, err := helpers.RunCLI(dir, []string{"upgrade", "--source", "core=oci://ghcr.io/windsorcli/core:v0.3.0", "--yes"}, env)
+	if err == nil {
+		t.Fatal("expected upgrade to refuse a downgrade, got success")
+	}
+	out := string(stderr)
+	if !strings.Contains(out, "downgrade") || !strings.Contains(out, "--allow-downgrade") {
+		t.Errorf("expected a downgrade refusal pointing at --allow-downgrade, got: %s", out)
+	}
+}
+
+func TestUpgrade_AllowsDowngradeWithFlag(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "upgrade-source")
+	helpers.MarkAsGitRepo(t, dir)
+	if _, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env); err != nil {
+		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
+	}
+	env = append(env, "WINDSOR_CONTEXT=local")
+
+	// With --allow-downgrade the guard is cleared: it warns that data is not reversed and proceeds
+	// past the refusal (reconcile then fails without a live cluster, which is expected here).
+	_, stderr, _ := helpers.RunCLI(dir, []string{"upgrade", "--source", "core=oci://ghcr.io/windsorcli/core:v0.3.0", "--yes", "--allow-downgrade"}, env)
+	out := string(stderr)
+	if strings.Contains(out, "refusing to downgrade") {
+		t.Errorf("expected --allow-downgrade to clear the refusal, got: %s", out)
+	}
+	if !strings.Contains(out, "does NOT reverse application data") {
+		t.Errorf("expected a data-loss warning under --allow-downgrade, got: %s", out)
+	}
+}
+
 func TestUpgrade_AcceptsYesFlag(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")

--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -22,6 +22,7 @@ type BlueprintHandler interface {
 	Write(overwrite ...bool) error
 	RetargetSource(name, url string) (string, error)
 	UpgradeSourcesToLatest() ([]SourceUpgrade, error)
+	GetDeclaredSources() ([]blueprintv1alpha1.Source, error)
 	GetTerraformComponents() []blueprintv1alpha1.TerraformComponent
 	GetLocalTemplateData() (map[string][]byte, error)
 	Generate() *blueprintv1alpha1.Blueprint
@@ -292,6 +293,50 @@ func latestStableSemver(tags []string) (string, *semver.Version, bool) {
 		}
 	}
 	return bestTag, best, best != nil
+}
+
+// IsDowngrade reports whether targetURL pins an older stable semver than previousURL for the same
+// OCI repository. It returns false when either URL is not a parseable OCI reference, when the two
+// reference different repositories (a re-source is not an ordered version change), or when either
+// tag is not a semver (a branch, mutable tag, or commit is not ordered) — in those cases a
+// regression cannot be asserted, so the caller must not treat the change as a downgrade.
+func IsDowngrade(previousURL, targetURL string) bool {
+	prev, err := artifact.ParseOCIReference(previousURL)
+	if err != nil || prev == nil {
+		return false
+	}
+	target, err := artifact.ParseOCIReference(targetURL)
+	if err != nil || target == nil {
+		return false
+	}
+	if strings.TrimSuffix(prev.URL, ":"+prev.Tag) != strings.TrimSuffix(target.URL, ":"+target.Tag) {
+		return false
+	}
+	from, err := semver.NewVersion(prev.Tag)
+	if err != nil {
+		return false
+	}
+	to, err := semver.NewVersion(target.Tag)
+	if err != nil {
+		return false
+	}
+	return to.LessThan(from)
+}
+
+// GetDeclaredSources loads only the context's blueprint.yaml (the user blueprint) and returns its
+// declared sources, without loading remote source content or composing. It is the cheap pre-flight
+// read upgrade uses to evaluate a --source change before pulling or composing anything, so a refused
+// downgrade never triggers a registry round-trip. Returns an empty slice when no blueprint.yaml or
+// no sources are declared.
+func (h *BaseBlueprintHandler) GetDeclaredSources() ([]blueprintv1alpha1.Source, error) {
+	if err := h.loadUser(); err != nil {
+		return nil, err
+	}
+	userBp := h.userBlueprintLoader.GetBlueprint()
+	if userBp == nil {
+		return nil, nil
+	}
+	return userBp.Sources, nil
 }
 
 // GetTerraformComponents returns a copy of the composed blueprint's terraform components with

--- a/pkg/composer/blueprint/handler_test.go
+++ b/pkg/composer/blueprint/handler_test.go
@@ -2186,6 +2186,65 @@ func TestLatestStableSemver(t *testing.T) {
 	})
 }
 
+func TestIsDowngrade(t *testing.T) {
+	t.Run("TrueWhenTargetTagIsOlderInSameRepo", func(t *testing.T) {
+		// Given a target that pins an older semver than the previous ref of the same repository
+		// When comparing them
+		// Then it is reported as a downgrade
+		if !IsDowngrade("oci://ghcr.io/windsorcli/core:v0.6.0", "oci://ghcr.io/windsorcli/core:v0.3.0") {
+			t.Error("Expected v0.3.0 after v0.6.0 to be a downgrade")
+		}
+	})
+
+	t.Run("FalseWhenTargetTagIsNewer", func(t *testing.T) {
+		// Given a target that pins a newer semver
+		// When comparing them
+		// Then it is not a downgrade
+		if IsDowngrade("oci://ghcr.io/windsorcli/core:v0.3.0", "oci://ghcr.io/windsorcli/core:v0.6.0") {
+			t.Error("Expected v0.6.0 after v0.3.0 to be an upgrade, not a downgrade")
+		}
+	})
+
+	t.Run("FalseWhenTagsAreEqual", func(t *testing.T) {
+		// Given identical tags
+		// When comparing them
+		// Then it is not a downgrade
+		if IsDowngrade("oci://ghcr.io/windsorcli/core:v0.6.0", "oci://ghcr.io/windsorcli/core:v0.6.0") {
+			t.Error("Expected an unchanged tag not to be a downgrade")
+		}
+	})
+
+	t.Run("FalseWhenRepositoriesDiffer", func(t *testing.T) {
+		// Given a target that points at a different repository, even at a lower tag
+		// When comparing them
+		// Then it is a re-source, not an ordered downgrade
+		if IsDowngrade("oci://ghcr.io/windsorcli/core:v0.6.0", "oci://ghcr.io/acme/core:v0.3.0") {
+			t.Error("Expected a different repository not to be treated as a downgrade")
+		}
+	})
+
+	t.Run("FalseWhenEitherTagIsNotSemver", func(t *testing.T) {
+		// Given a ref pinned to a branch or mutable tag rather than a semver
+		// When comparing them
+		// Then the change is not ordered and not a downgrade
+		if IsDowngrade("oci://ghcr.io/windsorcli/core:main", "oci://ghcr.io/windsorcli/core:v0.3.0") {
+			t.Error("Expected a non-semver previous ref not to be ordered")
+		}
+		if IsDowngrade("oci://ghcr.io/windsorcli/core:v0.6.0", "oci://ghcr.io/windsorcli/core:latest") {
+			t.Error("Expected a non-semver target ref not to be ordered")
+		}
+	})
+
+	t.Run("FalseWhenEitherURLIsNotOCI", func(t *testing.T) {
+		// Given a ref that is not a parseable OCI reference
+		// When comparing them
+		// Then no regression can be asserted
+		if IsDowngrade("https://example.com/core", "oci://ghcr.io/windsorcli/core:v0.3.0") {
+			t.Error("Expected a non-OCI previous ref not to be a downgrade")
+		}
+	})
+}
+
 func TestHandler_UpgradeSourcesToLatest(t *testing.T) {
 	setup := func(t *testing.T, sources []blueprintv1alpha1.Source, tags map[string][]string) (*BaseBlueprintHandler, *artifact.MockArtifact) {
 		t.Helper()

--- a/pkg/composer/blueprint/mock_blueprint_handler.go
+++ b/pkg/composer/blueprint/mock_blueprint_handler.go
@@ -11,6 +11,7 @@ type MockBlueprintHandler struct {
 	WriteFunc                  func(overwrite ...bool) error
 	RetargetSourceFunc         func(name, url string) (string, error)
 	UpgradeSourcesToLatestFunc func() ([]SourceUpgrade, error)
+	GetDeclaredSourcesFunc     func() ([]blueprintv1alpha1.Source, error)
 	GetTerraformComponentsFunc func() []blueprintv1alpha1.TerraformComponent
 	GetLocalTemplateDataFunc   func() (map[string][]byte, error)
 	GenerateFunc               func() *blueprintv1alpha1.Blueprint
@@ -77,6 +78,14 @@ func (m *MockBlueprintHandler) RetargetSource(name, url string) (string, error) 
 func (m *MockBlueprintHandler) UpgradeSourcesToLatest() ([]SourceUpgrade, error) {
 	if m.UpgradeSourcesToLatestFunc != nil {
 		return m.UpgradeSourcesToLatestFunc()
+	}
+	return nil, nil
+}
+
+// GetDeclaredSources calls the mock GetDeclaredSourcesFunc if set, otherwise returns nil.
+func (m *MockBlueprintHandler) GetDeclaredSources() ([]blueprintv1alpha1.Source, error) {
+	if m.GetDeclaredSourcesFunc != nil {
+		return m.GetDeclaredSourcesFunc()
 	}
 	return nil, nil
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This changes a default of `windsor upgrade` — it now refuses version downgrades — and restructures the command's startup sequence, which is why Medium rather than Low is appropriate.
>
> **Overview**
>
> `windsor upgrade --source` now refuses to move a declared source to an older stable semver of the same OCI repository, because Windsor reverts infrastructure declaratively but cannot reverse application data. The new `--allow-downgrade` flag overrides the refusal with an explicit data-loss warning, and implicit `upgrade` resolves to the latest version so it can never trip the guard.
>
> The downgrade check runs as a pre-flight against the declared source reference before the blueprint is composed or any artifact is pulled, so a refused downgrade costs no registry round-trip. The command was restructured to run the confirmation and downgrade gates between project configuration and initialization.
>
> Reviewed by Claude for commit `df3c048`.

<!-- /claude-code-review:summary -->
