### PR TITLE
feat(composer): Refactor Flux system handling in blueprint processor

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -317,8 +317,12 @@ type Blueprint struct {
 	// materializes these into the "crds" kustomization, bound to the default source, ahead of the stack.
 	Crds []string `yaml:"crds,omitempty"`
 
-	// Kustomizations are kustomization configs in the blueprint.
+	// Kustomizations are plain Flux Kustomization configs (the kustomize: passthrough).
 	Kustomizations []Kustomization `yaml:"kustomize,omitempty"`
+
+	// FluxSystems are system entries (the flux: collection): each compiles to an install plus
+	// resources-variant Kustomizations. Distinct from Kustomizations, which are 1:1 passthroughs.
+	FluxSystems []FluxSystem `yaml:"flux,omitempty"`
 
 	// Substitutions are top-level key/value pairs evaluated with facet scope and injected into
 	// values-common, making them available to all kustomizations via PostBuild substitution.
@@ -328,27 +332,6 @@ type Blueprint struct {
 	// ConfigMaps are standalone ConfigMaps to be created, not tied to specific kustomizations.
 	// These ConfigMaps are referenced by all kustomizations in PostBuild substitution.
 	ConfigMaps map[string]map[string]string `yaml:"configMaps,omitempty"`
-}
-
-// UnmarshalYAML accepts `flux:` as an alias for `kustomize:`, mirroring Facet. Both keys
-// deserialize into Kustomizations; `flux:` is the preferred spelling and `kustomize:` a permanent
-// backward-compatible alias. The aliased type carries no UnmarshalYAML of its own, so decoding it
-// does not recurse.
-func (b *Blueprint) UnmarshalYAML(unmarshal func(any) error) error {
-	type alias Blueprint
-	var a alias
-	if err := unmarshal(&a); err != nil {
-		return err
-	}
-	*b = Blueprint(a)
-	var aux struct {
-		Flux []Kustomization `yaml:"flux,omitempty"`
-	}
-	if err := unmarshal(&aux); err != nil {
-		return err
-	}
-	b.Kustomizations = append(b.Kustomizations, aux.Flux...)
-	return nil
 }
 
 // CrdKustomizationName returns the name of the kustomization the provisioner synthesizes for a CRD
@@ -621,18 +604,63 @@ type Kustomization struct {
 	// These are used for generating ConfigMaps and are not written to the final context blueprint.yaml.
 	Substitutions map[string]string `yaml:"substitutions,omitempty"`
 
-	// Install lists the components of the install (controller/operator) tier. Like Components, each
-	// entry is a component path and may be a '${...}' expression that prunes to empty. When Install
-	// and/or Resources are set, the composer expands this entry into two kustomizations sharing this
-	// entry's Path: an install named after the entry carrying the Install components, and a resources
-	// kustomization (named "<name>-resources") carrying the Resources components and depending on the
-	// install, so the controller is reconciled before the custom resources it admits. When both are
-	// empty the entry stays a single flat kustomization built from Components. Tiers desugar during
-	// composition and never appear in the composed blueprint.
-	Install []string `yaml:"install,omitempty"`
+	// Substitute is the preferred spelling of Substitutions; both keys merge into Substitutions
+	// during composition. It exists so `flux:` system tiers and `kustomize:` entries can spell
+	// postBuild substitutions the same short way (matching Flux's `postBuild.substitute`).
+	Substitute map[string]string `yaml:"substitute,omitempty"`
+}
 
-	// Resources lists the components of the custom-resource tier. See Install.
-	Resources []string `yaml:"resources,omitempty"`
+// FluxSystem is a system entry under a blueprint or facet's `flux:` list — a functional layer that
+// compiles to an install Kustomization plus zero or more resources-variant Kustomizations. The
+// descriptor carries identity, lifecycle, and merge fields; the Install/Resources tiers reuse the
+// Kustomization type and carry the Flux operational properties per tier. It holds no operational
+// properties itself — those belong on the tiers that produce Kustomization objects.
+type FluxSystem struct {
+	// Name identifies the system; tiers compile to "<name>-install" / "<name>-resources[-<variant>]".
+	Name string `yaml:"name"`
+
+	// Path is the base; tiers reconcile from "<path>/install" and "<path>/resources". Defaults to Name.
+	Path string `yaml:"path,omitempty"`
+
+	// Source is the blueprint source that provides the tier bases.
+	Source string `yaml:"source,omitempty"`
+
+	// Enabled includes or excludes the whole system. Defaults to true.
+	Enabled *BoolExpression `yaml:"enabled,omitempty"`
+
+	// Destroy governs whether the system's kustomizations are removed on teardown. Defaults to true.
+	Destroy *BoolExpression `yaml:"destroy,omitempty"`
+
+	// When gates the system; combined (AND) with each resources variant's own condition.
+	When string `yaml:"when,omitempty"`
+
+	// DependsOn are cross-layer edges to other systems, attached to the install tier when present
+	// (resources reach them transitively) or to each resources variant otherwise. It never names the
+	// intra-system install edge — that edge is implicit.
+	DependsOn []string `yaml:"dependsOn,omitempty"`
+
+	// Strategy governs how a system with this Name merges across facets (merge | replace | remove).
+	Strategy string `yaml:"strategy,omitempty"`
+
+	// Ordinal overrides the facet's ordinal for this system's merge precedence.
+	Ordinal *int `yaml:"ordinal,omitempty"`
+
+	// Install is the controller/operator tier (at most one). Its Components/Substitute and operational
+	// fields flow to "<name>-install"; its Name/Path/DependsOn are derived by the composer.
+	Install *Kustomization `yaml:"install,omitempty"`
+
+	// Resources are the custom-resource tier variants, all sharing "<path>/resources".
+	Resources []FluxVariant `yaml:"resources,omitempty"`
+}
+
+// FluxVariant is one resources-tier Kustomization of a system. It reuses Kustomization for its
+// components, substitutions, and operational properties; the authored `name` becomes the variant
+// suffix ("<system>-resources-<name>") and `dependsOn` is appended to the implicit install edge.
+type FluxVariant struct {
+	Kustomization `yaml:",inline"`
+
+	// When gates this variant; combined (AND) with the system's own condition.
+	When string `yaml:"when,omitempty"`
 }
 
 // PostBuild is a post-build step to run after the kustomization is applied.
@@ -1034,8 +1062,7 @@ func (k *Kustomization) DeepCopy() *Kustomization {
 		DestroyOnly:     k.DestroyOnly,
 		Enabled:         enabledCopy,
 		Substitutions:   maps.Clone(k.Substitutions),
-		Install:         slices.Clone(k.Install),
-		Resources:       slices.Clone(k.Resources),
+		Substitute:      maps.Clone(k.Substitute),
 	}
 }
 

--- a/api/v1alpha1/blueprint_types_test.go
+++ b/api/v1alpha1/blueprint_types_test.go
@@ -4559,67 +4559,35 @@ terraform:
 }
 
 // The `flux:` key is a preferred alias of `kustomize:` on the blueprint, mirroring Facet.
-func TestBlueprint_FluxAlias(t *testing.T) {
-	t.Run("FluxKeyPopulatesKustomizations", func(t *testing.T) {
-		// Given a blueprint authored with the flux: key
-		src := `kind: Blueprint
-flux:
-  - name: x
-    path: x
-`
-		// When it is unmarshaled
-		var b Blueprint
-		if err := yaml.Unmarshal([]byte(src), &b); err != nil {
-			t.Fatalf("unmarshal: %v", err)
-		}
-
-		// Then the entry lands in Kustomizations
-		if len(b.Kustomizations) != 1 || b.Kustomizations[0].Name != "x" {
-			t.Fatalf("flux entry not merged into Kustomizations: %+v", b.Kustomizations)
-		}
-	})
-
-	t.Run("KustomizeKeyStillWorksAndBothMerge", func(t *testing.T) {
-		// Given both keys
+// flux: on a blueprint is a distinct FluxSystems collection, separate from kustomize:.
+func TestBlueprint_FluxSystems(t *testing.T) {
+	t.Run("FluxKeyParsesSystemEntriesSeparateFromKustomize", func(t *testing.T) {
 		src := `kind: Blueprint
 kustomize:
-  - name: a
-    path: a
+  - name: plain
+    path: plain
 flux:
-  - name: b
-    path: b
+  - name: dns
+    install:
+      components: [coredns-controller]
+    resources:
+      - components: [coredns, external-dns]
 `
-		// When it is unmarshaled
-		var b Blueprint
-		if err := yaml.Unmarshal([]byte(src), &b); err != nil {
+		var bp Blueprint
+		if err := yaml.Unmarshal([]byte(src), &bp); err != nil {
 			t.Fatalf("unmarshal: %v", err)
 		}
-
-		// Then both are present
-		if len(b.Kustomizations) != 2 {
-			t.Fatalf("expected both entries, got %+v", b.Kustomizations)
+		if len(bp.Kustomizations) != 1 || bp.Kustomizations[0].Name != "plain" {
+			t.Fatalf("kustomize entry wrong: %+v", bp.Kustomizations)
 		}
-	})
-
-	t.Run("SameNameUnderBothKeysAreBothKept", func(t *testing.T) {
-		// Given the same name under both keys
-		src := `kind: Blueprint
-kustomize:
-  - name: foo
-    path: from-kustomize
-flux:
-  - name: foo
-    path: from-flux
-`
-		// When it is unmarshaled
-		var b Blueprint
-		if err := yaml.Unmarshal([]byte(src), &b); err != nil {
-			t.Fatalf("unmarshal: %v", err)
+		if len(bp.FluxSystems) != 1 || bp.FluxSystems[0].Name != "dns" {
+			t.Fatalf("expected one flux system dns, got %+v", bp.FluxSystems)
 		}
-
-		// Then the alias appends both without dedup — a pure spelling merge, same as Facet
-		if len(b.Kustomizations) != 2 {
-			t.Fatalf("expected the alias to append both same-name entries, got %+v", b.Kustomizations)
+		if bp.FluxSystems[0].Install == nil || bp.FluxSystems[0].Install.Components[0] != "coredns-controller" {
+			t.Fatalf("install wrong: %+v", bp.FluxSystems[0].Install)
+		}
+		if len(bp.FluxSystems[0].Resources) != 1 {
+			t.Fatalf("expected one resources variant, got %+v", bp.FluxSystems[0].Resources)
 		}
 	})
 }

--- a/api/v1alpha1/facet_types.go
+++ b/api/v1alpha1/facet_types.go
@@ -101,6 +101,10 @@ type Facet struct {
 	// Kustomizations are kustomization configs in the facet.
 	Kustomizations []ConditionalKustomization `yaml:"kustomize,omitempty"`
 
+	// FluxSystems are system entries (the flux: collection) contributed by this facet; each compiles
+	// to an install plus resources-variant Kustomizations.
+	FluxSystems []FluxSystem `yaml:"flux,omitempty"`
+
 	// Crds lists references into the vendored CRD catalog (e.g. "cert-manager-1.16.2").
 	// The composer emits one deduped kustomization per reference at kustomize/crds/<ref>
 	// and makes every kustomization in this facet depend on it.
@@ -110,28 +114,6 @@ type Facet struct {
 	// values-common, making them available to all kustomizations via PostBuild substitution.
 	// Values may use expression syntax (e.g. "${dns.domain}") resolved against facet config blocks.
 	Substitutions map[string]string `yaml:"substitutions,omitempty"`
-}
-
-// UnmarshalYAML accepts `flux:` as an alias for `kustomize:`. Both keys deserialize into
-// Kustomizations; a file may use either (or, transitionally, both). `flux:` is the preferred
-// spelling — every entry compiles to a Flux Kustomization — with `kustomize:` kept as a permanent
-// backward-compatible alias. The aliased type carries no UnmarshalYAML of its own, so decoding it
-// does not recurse.
-func (f *Facet) UnmarshalYAML(unmarshal func(any) error) error {
-	type alias Facet
-	var a alias
-	if err := unmarshal(&a); err != nil {
-		return err
-	}
-	*f = Facet(a)
-	var aux struct {
-		Flux []ConditionalKustomization `yaml:"flux,omitempty"`
-	}
-	if err := unmarshal(&aux); err != nil {
-		return err
-	}
-	f.Kustomizations = append(f.Kustomizations, aux.Flux...)
-	return nil
 }
 
 // ConditionalTerraformComponent extends TerraformComponent with conditional logic support.

--- a/api/v1alpha1/facet_types_test.go
+++ b/api/v1alpha1/facet_types_test.go
@@ -402,32 +402,23 @@ func TestConditionalKustomizationDeepCopy(t *testing.T) {
 		}
 	})
 
-	t.Run("CopiesInstallAndResourceTiersIndependently", func(t *testing.T) {
+	t.Run("CopiesSubstituteIndependently", func(t *testing.T) {
 		original := &ConditionalKustomization{
 			Kustomization: Kustomization{
-				Name:      "cert-manager",
-				Path:      "pki/cert-manager",
-				Install:   []string{"helm-release"},
-				Resources: []string{"private-issuer/ca"},
+				Name:       "cert-manager",
+				Path:       "pki/cert-manager",
+				Substitute: map[string]string{"region": "us-east-1"},
 			},
 		}
 
 		copy := original.DeepCopy()
 
-		if len(copy.Install) != 1 || copy.Install[0] != "helm-release" {
-			t.Fatalf("Expected install components copied, got %v", copy.Install)
+		if copy.Substitute["region"] != "us-east-1" {
+			t.Fatalf("Expected substitute copied, got %v", copy.Substitute)
 		}
-		if len(copy.Resources) != 1 || copy.Resources[0] != "private-issuer/ca" {
-			t.Fatalf("Expected resources components copied, got %v", copy.Resources)
-		}
-
-		original.Install[0] = "modified"
-		if copy.Install[0] == "modified" {
-			t.Error("Deep copy failed: install components slice was not copied")
-		}
-		original.Resources[0] = "modified"
-		if copy.Resources[0] == "modified" {
-			t.Error("Deep copy failed: resources components slice was not copied")
+		original.Substitute["region"] = "modified"
+		if copy.Substitute["region"] == "modified" {
+			t.Error("Deep copy failed: substitute map was not copied")
 		}
 	})
 }
@@ -893,110 +884,52 @@ kustomize:
 	})
 }
 
-// The `flux:` key is a preferred alias of `kustomize:`; both deserialize into Kustomizations and a
-// file may use either or, transitionally, both.
-func TestFacet_FluxAlias(t *testing.T) {
-	t.Run("FluxKeyPopulatesKustomizations", func(t *testing.T) {
-		// Given a facet authored with the flux: key
-		src := `kind: Facet
-flux:
-  - name: pki-install
-    path: pki/install
-`
-		// When it is unmarshaled
-		var f Facet
-		if err := yaml.Unmarshal([]byte(src), &f); err != nil {
-			t.Fatalf("unmarshal: %v", err)
-		}
-
-		// Then the entry lands in Kustomizations, indistinguishable from a kustomize: entry
-		if len(f.Kustomizations) != 1 || f.Kustomizations[0].Name != "pki-install" || f.Kustomizations[0].Path != "pki/install" {
-			t.Fatalf("flux entry not merged into Kustomizations: %+v", f.Kustomizations)
-		}
-	})
-
-	t.Run("KustomizeKeyStillWorks", func(t *testing.T) {
-		// Given the legacy kustomize: key
+// flux: is a distinct collection of system entries; kustomize: remains the plain-Kustomization
+// passthrough. The two do not merge.
+func TestFacet_FluxSystems(t *testing.T) {
+	t.Run("FluxKeyParsesSystemEntriesSeparateFromKustomize", func(t *testing.T) {
 		src := `kind: Facet
 kustomize:
-  - name: legacy
-    path: legacy
-`
-		// When it is unmarshaled
-		var f Facet
-		if err := yaml.Unmarshal([]byte(src), &f); err != nil {
-			t.Fatalf("unmarshal: %v", err)
-		}
-
-		// Then it parses exactly as before
-		if len(f.Kustomizations) != 1 || f.Kustomizations[0].Name != "legacy" {
-			t.Fatalf("kustomize entry regressed: %+v", f.Kustomizations)
-		}
-	})
-
-	t.Run("BothKeysMerge", func(t *testing.T) {
-		// Given a file using both keys during a transition
-		src := `kind: Facet
-kustomize:
-  - name: a
-    path: a
+  - name: gateway-cilium
+    path: gateway/cilium
+    components: [base]
 flux:
-  - name: b
-    path: b
+  - name: gateway
+    dependsOn: [pki]
+    install:
+      components: [envoy]
+      substitute: {cluster: prod}
+    resources:
+      - name: internal
+        when: "${x}"
+        components: [internal]
 `
-		// When it is unmarshaled
 		var f Facet
 		if err := yaml.Unmarshal([]byte(src), &f); err != nil {
 			t.Fatalf("unmarshal: %v", err)
 		}
-
-		// Then both contribute to Kustomizations
-		if len(f.Kustomizations) != 2 {
-			t.Fatalf("expected both kustomize: and flux: entries, got %+v", f.Kustomizations)
+		// kustomize: stays in Kustomizations; flux: lands in FluxSystems; they are disjoint
+		if len(f.Kustomizations) != 1 || f.Kustomizations[0].Name != "gateway-cilium" {
+			t.Fatalf("kustomize entry wrong: %+v", f.Kustomizations)
 		}
-	})
-
-	t.Run("SameNameUnderBothKeysAreBothKept", func(t *testing.T) {
-		// Given the same name declared under both keys (an authoring overlap during migration)
-		src := `kind: Facet
-kustomize:
-  - name: foo
-    path: from-kustomize
-flux:
-  - name: foo
-    path: from-flux
-`
-		// When it is unmarshaled
-		var f Facet
-		if err := yaml.Unmarshal([]byte(src), &f); err != nil {
-			t.Fatalf("unmarshal: %v", err)
+		if len(f.FluxSystems) != 1 {
+			t.Fatalf("expected one flux system, got %+v", f.FluxSystems)
 		}
-
-		// Then the alias layer appends both without dedup: it is a pure spelling merge. Collapsing a
-		// same-name overlap is composition's job (updateKustomizationEntry merges facet kustomizations
-		// by name), not the parser's, so both entries survive here.
-		if len(f.Kustomizations) != 2 {
-			t.Fatalf("expected the alias to append both same-name entries, got %+v", f.Kustomizations)
+		sys := f.FluxSystems[0]
+		if sys.Name != "gateway" || len(sys.DependsOn) != 1 || sys.DependsOn[0] != "pki" {
+			t.Fatalf("system descriptor wrong: %+v", sys)
 		}
-	})
-
-	t.Run("ConditionalFieldsSurviveTheAlias", func(t *testing.T) {
-		// Given a flux entry carrying conditional fields
-		src := `kind: Facet
-flux:
-  - name: dns
-    path: dns
-    when: "dns.enabled == true"
-`
-		// When it is unmarshaled
-		var f Facet
-		if err := yaml.Unmarshal([]byte(src), &f); err != nil {
-			t.Fatalf("unmarshal: %v", err)
+		if sys.Install == nil || len(sys.Install.Components) != 1 || sys.Install.Components[0] != "envoy" {
+			t.Fatalf("install tier wrong: %+v", sys.Install)
 		}
-
-		// Then the conditional fields are preserved (it decodes as a ConditionalKustomization)
-		if len(f.Kustomizations) != 1 || f.Kustomizations[0].When != "dns.enabled == true" {
-			t.Fatalf("conditional fields lost through the alias: %+v", f.Kustomizations)
+		if sys.Install.Substitute["cluster"] != "prod" {
+			t.Fatalf("install substitute wrong: %+v", sys.Install.Substitute)
+		}
+		if len(sys.Resources) != 1 || sys.Resources[0].Name != "internal" || sys.Resources[0].When != "${x}" {
+			t.Fatalf("resources variant wrong: %+v", sys.Resources)
+		}
+		if len(sys.Resources[0].Components) != 1 || sys.Resources[0].Components[0] != "internal" {
+			t.Fatalf("variant components wrong: %+v", sys.Resources[0])
 		}
 	})
 }

--- a/docs/reference/blueprint.md
+++ b/docs/reference/blueprint.md
@@ -53,18 +53,62 @@ variable substitutions shared across them.
 
 | Field | Type | Description |
 |------|------|-------------|
-| `components` | `array<string>` |  |
-| `substitute` | `map<string>` |  |
+| `components` | `array<string>` | Kustomize components to compose into the install tier. |
+| `destroy` | `boolean / string` | Whether to delete this tier during 'windsor down'. Boolean or expression. Defaults to true. |
+| `destroyOnly` | `boolean` | When true, this tier only runs during destroy operations. |
+| `enabled` | `boolean / string` | Whether to include this tier in the final blueprint. Boolean or expression. Defaults to true. |
+| `force` | `boolean` | Force-apply resources Flux would otherwise refuse to update. |
+| `interval` | `string` | Reconciliation interval as a Go duration string (e.g. '5m', '1h'). |
+| `namespace` | `string` | Namespace where the Flux Kustomization object lives. Defaults to the gitops namespace. |
+| `patches` | `array<object>` | Strategic-merge or Flux-style patches applied to this tier. |
+| `prune` | `boolean` | Garbage-collect resources removed from the source. Defaults to true. |
+| `retryInterval` | `string` | Duration to wait before retrying a failed reconciliation (e.g. '2m'). |
+| `source` | `string` | Source override for this tier. Defaults to the system source. |
+| `substitute` | `map<string>` | PostBuild substitutions (preferred spelling); merges with substitutions. |
+| `substitutions` | `map<string>` | PostBuild variable substitutions for this tier. |
+| `targetNamespace` | `string` | Populates spec.targetNamespace, overriding the namespace of reconciled resources. |
+| `timeout` | `string` | Maximum duration for a single reconciliation attempt (e.g. '10m'). |
+| `wait` | `boolean` | Wait for resources to settle before declaring reconciliation complete. |
+
+#### flux[].install.patches[]
+
+| Field | Type | Description |
+|------|------|-------------|
+| `patch` | `string` |  |
+| `path` | `string` |  |
+| `target` | `object` |  |
 
 ### flux[].resources[]
 
 | Field | Type | Description |
 |------|------|-------------|
-| `components` | `array<string>` |  |
+| `components` | `array<string>` | Kustomize components to compose into this variant. |
 | `dependsOn` | `array<string>` | Extra cross-layer edges, appended to the implicit install edge. |
+| `destroy` | `boolean / string` | Whether to delete this variant during 'windsor down'. Boolean or expression. Defaults to true. |
+| `destroyOnly` | `boolean` | When true, this variant only runs during destroy operations. |
+| `enabled` | `boolean / string` | Whether to include this variant in the final blueprint. Boolean or expression. Defaults to true. |
+| `force` | `boolean` | Force-apply resources Flux would otherwise refuse to update. |
+| `interval` | `string` | Reconciliation interval as a Go duration string (e.g. '5m', '1h'). |
 | `name` | `string` | Variant suffix ('<system>-resources-<name>'); omit for a single unnamed variant. |
-| `substitute` | `map<string>` |  |
+| `namespace` | `string` | Namespace where the Flux Kustomization object lives. Defaults to the gitops namespace. |
+| `patches` | `array<object>` | Strategic-merge or Flux-style patches applied to this variant. |
+| `prune` | `boolean` | Garbage-collect resources removed from the source. Defaults to true. |
+| `retryInterval` | `string` | Duration to wait before retrying a failed reconciliation (e.g. '2m'). |
+| `source` | `string` | Source override for this variant. Defaults to the system source. |
+| `substitute` | `map<string>` | PostBuild substitutions (preferred spelling); merges with substitutions. |
+| `substitutions` | `map<string>` | PostBuild variable substitutions for this variant. |
+| `targetNamespace` | `string` | Populates spec.targetNamespace, overriding the namespace of reconciled resources. |
+| `timeout` | `string` | Maximum duration for a single reconciliation attempt (e.g. '10m'). |
+| `wait` | `boolean` | Wait for resources to settle before declaring reconciliation complete. |
 | `when` | `string` | Gates the variant; combined (AND) with the system's condition. |
+
+#### flux[].resources[].patches[]
+
+| Field | Type | Description |
+|------|------|-------------|
+| `patch` | `string` |  |
+| `path` | `string` |  |
+| `target` | `object` |  |
 
 ## kustomize[]
 

--- a/docs/reference/blueprint.md
+++ b/docs/reference/blueprint.md
@@ -19,8 +19,8 @@ variable substitutions shared across them.
 | `backend` | `string` | Names the terraform component that terminates the backend tier. When set, 'windsor bootstrap' applies the backend component (and every component declared before it) against local state first, then migrates state to the configured remote backend before applying the rest of the graph. |
 | `configMaps` | `map<object>` | Standalone ConfigMaps to create. Each top-level key is a ConfigMap name; its map-of-string value is the .data payload. These are referenced by every kustomization in PostBuild substitution. |
 | `crds` | `array<string>` | The flat list of vendored CRD references installed from the default/project source (e.g. 'cert-manager-1.16.2'), authored as a bare scalar list — the same form facets use. CRDs carried by an OCI source are not listed here: they ride with that source (see sources[].crds) and install in the background when it is install:true. The provisioner materializes this list into the 'crds' kustomization — pruning disabled, wait enabled — applied ahead of the kustomize: layer so every kustomization sees its CRDs Established first. |
-| `flux` | `array<object>` | Flux Kustomizations included in the blueprint — the preferred spelling of 'kustomize:' (every entry compiles to a Flux Kustomization). 'kustomize:' remains accepted as a backward-compatible alias; both keys merge into one list. |
-| `kustomize` | `array<object>` | Flux kustomizations included in the blueprint. Each entry maps to a Kustomization resource the provisioner applies to the cluster, in topologically sorted dependsOn order. Deprecated alias of 'flux:'; both keys are accepted and merge into the same list. |
+| `flux` | `array<object>` | System entries — functional layers that each compile to an install Kustomization plus one or more resources-variant Kustomizations. Distinct from 'kustomize:', which is a 1:1 Kustomization passthrough. |
+| `kustomize` | `array<object>` | Plain Flux kustomizations included in the blueprint — a 1:1 passthrough: each entry maps to one Kustomization the provisioner applies, in topologically sorted dependsOn order. System entries (install/resources tiers) live under 'flux:' instead. |
 | `repository` | `object` | Source repository this blueprint was bootstrapped from. |
 | `sources` | `array<object>` | External resources referenced by the blueprint. Each source is an OCI blueprint artifact or a Git repository that contributes Terraform modules and/or kustomize bases consumable by the components below. |
 | `substitutions` | `map<string>` | Blueprint-level substitutions injected into 'values-common' and made available to every kustomization via PostBuild substitution. Values may use expression syntax (e.g. '${dns.domain}') resolved against facet config blocks. |
@@ -37,34 +37,34 @@ variable substitutions shared across them.
 
 | Field | Type | Description |
 |------|------|-------------|
-| `name` | `string` | Identifier for the kustomization; referenced by dependsOn. **(required)** |
-| `path` | `string` | Path within the source containing the kustomize base. **(required)** |
-| `components` | `array<string>` | Kustomize components to compose into this kustomization. |
-| `dependsOn` | `array<string>` | Names of kustomizations that must reconcile before this one. |
-| `destroy` | `boolean / string` | Whether to delete this kustomization during 'windsor down' / 'windsor destroy'. Boolean or expression. Defaults to true. |
-| `destroyOnly` | `boolean` | When true, the kustomization only runs during destroy. Useful for teardown-only resources (e.g. cleanup jobs). |
-| `enabled` | `boolean / string` | Whether to include this kustomization in the final blueprint. Boolean or expression. Defaults to true. |
-| `force` | `boolean` | Force-apply resources Flux would otherwise refuse to update. |
-| `install` | `array<string>` | Components of the install (controller/operator) tier. Like components, each entry may be a '${...}' expression that prunes to empty. When install and/or resources are set, the entry expands into separate kustomizations sharing this path: '<name>-install' carrying these components and '<name>-resources' depending on it, so the controller is reconciled before the custom resources it admits. |
-| `interval` | `string` | Reconciliation interval, expressed as a Go duration string (e.g. '5m', '1h'). Defaults to a mode-appropriate value chosen by the provisioner (short poll for pull mode, long fallback for push). |
-| `namespace` | `string` | Namespace where the Flux Kustomization object itself lives. Defaults to the gitops namespace. DependsOn references always resolve in the gitops namespace; cross-namespace dependencies are not supported. |
-| `patches` | `array<object>` | Strategic-merge or Flux-style patches applied to the kustomization. Each entry is either a 'path:' to a patch file relative to the kustomization, or a 'patch:' inline YAML body with an optional 'target:' selector (kind / name / namespace). |
-| `prune` | `boolean` | Garbage-collect resources removed from the source. Defaults to true. |
-| `resources` | `array<string>` | Components of the custom-resource tier. See install. |
-| `retryInterval` | `string` | Duration to wait before retrying a failed reconciliation (e.g. '2m'). |
-| `source` | `string` | Name of the source (from the sources list) that provides this kustomization. Defaults to the blueprint's primary source when unset. |
-| `substitutions` | `map<string>` | PostBuild variable substitutions for this kustomization. Collected into a 'values-<name>' ConfigMap that Flux substitutes from. |
-| `targetNamespace` | `string` | Populates spec.targetNamespace, instructing Flux to override the namespace of every resource reconciled by this kustomization. |
-| `timeout` | `string` | Maximum duration for a single reconciliation attempt (e.g. '10m'). |
-| `wait` | `boolean` | Wait for resources to settle before declaring reconciliation complete. |
+| `name` | `string` | System identifier; tiers compile to '<name>-install' and '<name>-resources[-<variant>]'. **(required)** |
+| `dependsOn` | `array<string>` | Cross-layer edges to other systems (a bare '<other>' resolves to '<other>-install'). Attached to the install tier when present (resources reach them transitively), otherwise to each variant. |
+| `destroy` | `boolean / string` | Whether the system's kustomizations are removed on teardown. Defaults to true. |
+| `enabled` | `boolean / string` | Include or exclude the whole system. Defaults to true. |
+| `install` | `object` | Controller/operator tier. Reuses the Kustomization shape — its components/substitute and operational properties (interval, timeout, wait, prune, patches, namespace, …) flow to '<name>-install'; its name/path/dependsOn are derived. When every component prunes to empty, no install Kustomization is emitted. |
+| `ordinal` | `integer` | Overrides the facet ordinal for this system's merge precedence. |
+| `path` | `string` | Base path; tiers reconcile from '<path>/install' and '<path>/resources'. Defaults to name. |
+| `resources` | `array<object>` | Custom-resource tier variants, all sharing '<path>/resources'. |
+| `source` | `string` | Name of the source that provides the tier bases. |
+| `strategy` | `string` | How a system with this name merges across facets. Defaults to merge. One of: `merge`, `replace`, `remove`. |
+| `when` | `string` | Gates the system; combined (AND) with each resources variant's condition. |
 
-### flux[].patches[]
+### flux[].install
 
 | Field | Type | Description |
 |------|------|-------------|
-| `patch` | `string` | Inline patch body as YAML (Flux format). |
-| `path` | `string` | Path to a patch file relative to the kustomization (blueprint format). |
-| `target` | `object` | Selector for the patch (Flux format). Used with 'patch:'. |
+| `components` | `array<string>` |  |
+| `substitute` | `map<string>` |  |
+
+### flux[].resources[]
+
+| Field | Type | Description |
+|------|------|-------------|
+| `components` | `array<string>` |  |
+| `dependsOn` | `array<string>` | Extra cross-layer edges, appended to the implicit install edge. |
+| `name` | `string` | Variant suffix ('<system>-resources-<name>'); omit for a single unnamed variant. |
+| `substitute` | `map<string>` |  |
+| `when` | `string` | Gates the variant; combined (AND) with the system's condition. |
 
 ## kustomize[]
 
@@ -78,14 +78,13 @@ variable substitutions shared across them.
 | `destroyOnly` | `boolean` | When true, the kustomization only runs during destroy. Useful for teardown-only resources (e.g. cleanup jobs). |
 | `enabled` | `boolean / string` | Whether to include this kustomization in the final blueprint. Boolean or expression. Defaults to true. |
 | `force` | `boolean` | Force-apply resources Flux would otherwise refuse to update. |
-| `install` | `array<string>` | Components of the install (controller/operator) tier. Like components, each entry may be a '${...}' expression that prunes to empty. When install and/or resources are set, the entry expands into separate kustomizations sharing this path: '<name>-install' carrying these components and '<name>-resources' depending on it, so the controller is reconciled before the custom resources it admits. |
 | `interval` | `string` | Reconciliation interval, expressed as a Go duration string (e.g. '5m', '1h'). Defaults to a mode-appropriate value chosen by the provisioner (short poll for pull mode, long fallback for push). |
 | `namespace` | `string` | Namespace where the Flux Kustomization object itself lives. Defaults to the gitops namespace. DependsOn references always resolve in the gitops namespace; cross-namespace dependencies are not supported. |
 | `patches` | `array<object>` | Strategic-merge or Flux-style patches applied to the kustomization. Each entry is either a 'path:' to a patch file relative to the kustomization, or a 'patch:' inline YAML body with an optional 'target:' selector (kind / name / namespace). |
 | `prune` | `boolean` | Garbage-collect resources removed from the source. Defaults to true. |
-| `resources` | `array<string>` | Components of the custom-resource tier. See install. |
 | `retryInterval` | `string` | Duration to wait before retrying a failed reconciliation (e.g. '2m'). |
 | `source` | `string` | Name of the source (from the sources list) that provides this kustomization. Defaults to the blueprint's primary source when unset. |
+| `substitute` | `map<string>` | Preferred spelling of substitutions (matching Flux postBuild.substitute); both merge into the same map. |
 | `substitutions` | `map<string>` | PostBuild variable substitutions for this kustomization. Collected into a 'values-<name>' ConfigMap that Flux substitutes from. |
 | `targetNamespace` | `string` | Populates spec.targetNamespace, instructing Flux to override the namespace of every resource reconciled by this kustomization. |
 | `timeout` | `string` | Maximum duration for a single reconciliation attempt (e.g. '10m'). |

--- a/docs/reference/facets.md
+++ b/docs/reference/facets.md
@@ -21,7 +21,7 @@ and are composed in ordinal order (lower-priority first).
 | `backend` | `string` | Contributes to Blueprint.backend (the terraform component that terminates the backend tier). The composer merges this across active facets by ordinal precedence; the highest-ordinal non-empty value wins. |
 | `config` | `array<object>` | Named configuration blocks exposed at scope root. Terraform inputs and kustomize substitutions reference '<name>' (scalar/list values) or '<name>.<key>' (map values), e.g. 'talos.controlplanes'. |
 | `crds` | `array<string>` | References into the vendored CRD catalog, version-pinned (e.g. 'cert-manager-1.16.2'). The composer collects these across all enabled facets and dedups them; a facet's CRDs install from the source that carries it — the blueprint's own (default/project) crds: list, or that source's crds when it comes from an install:true OCI source. The provisioner installs each ahead of the kustomize layer, so every kustomization sees its CRDs Established without a facet author naming a CRD in dependsOn. Entries may use '${...}' expressions that resolve against the facet scope and prune to empty — e.g. "${gateway.driver == 'envoy' ? 'envoy-gateway-1.7.1' : ''}" — so one facet can select different CRDs per driver. Each resolved reference must be a single path segment; values containing '/', '\', or '..' are rejected at composition time because they would escape the crds/ catalog directory. |
-| `flux` | `array<object>` | Flux Kustomizations contributed by this facet — the preferred spelling of 'kustomize:' (every entry compiles to a Flux Kustomization object). Each entry extends the blueprint's Kustomization shape with conditional fields (when, strategy, ordinal, requires). 'kustomize:' remains accepted as a backward-compatible alias; both keys merge into the same list. |
+| `flux` | `array<object>` | System entries contributed by this facet — functional layers that each compile to an install Kustomization plus resources-variant Kustomizations. Distinct from 'kustomize:' (1:1 passthrough). See the flux: shape in the [Blueprint reference](blueprint.md): name (required), path, source, enabled, destroy, when, dependsOn, strategy, ordinal, install, resources. |
 | `kustomize` | `array<object>` | Kustomizations contributed by this facet. Each entry extends the blueprint's Kustomization shape with conditional fields (when, strategy, ordinal, requires). Deprecated alias of 'flux:'; both keys are accepted and merge into the same list. |
 | `ordinal` | `integer` | Merge precedence relative to other facets. Higher ordinal wins on conflict (processed later). When unset, the loader derives an ordinal from the file basename: 'config-*' = 100; 'provider-*' or 'platform-*' with '-base' in the name = 199; other 'provider-*' / 'platform-*' = 200; 'option-*' / 'options-*' = 300; 'addon-*' / 'addons-*' = 400; no match = 0. |
 | `requires` | `array<object>` | Input-requirement blocks for the facet as a whole. When the facet is active and a block's optional 'when' holds, every path in that block must resolve to a present, non-empty value in the merged scope. Unsatisfied paths across every active facet are aggregated into a single user-facing error. |
@@ -48,23 +48,6 @@ and are composed in ordinal order (lower-priority first).
 | `when` | `string` | Optional expression that gates this block. Empty means the block is always evaluated when the parent facet is active. |
 
 ### config[].requires[]
-
-| Field | Type | Description |
-|------|------|-------------|
-| `paths` | `array<string>` | Dotted scope keys whose values must be present and non-empty. Required; the parser rejects an empty list. **(required)** |
-| `message` | `string` | Optional author-supplied context surfaced under this block's heading in the aggregated error. |
-| `when` | `string` | Optional expression gating this requirement. Empty means the paths are required whenever the parent (facet, config block, or component) is active. |
-
-## flux[]
-
-| Field | Type | Description |
-|------|------|-------------|
-| `ordinal` | `integer` | Per-kustomization override of the facet's ordinal for merge precedence. |
-| `requires` | `array<object>` | Requirement blocks scoped to this kustomization. Evaluated only when the parent facet is active and this kustomization's 'when' holds. |
-| `strategy` | `string` | How this kustomization is merged into the blueprint. 'merge' (default) deep-merges with existing kustomizations matching the same Name; 'replace' overwrites; 'remove' deletes the matching existing kustomization's non-index fields. Remove operations are always applied last. One of: `merge`, `replace`, `remove`. |
-| `when` | `string` | Expression that gates this kustomization. Empty means the kustomization is always applied when the parent facet matches. |
-
-### flux[].requires[]
 
 | Field | Type | Description |
 |------|------|-------------|

--- a/integration/composer_test.go
+++ b/integration/composer_test.go
@@ -218,8 +218,8 @@ func TestShowBlueprint_InstallResourcesTiers(t *testing.T) {
 	if !ok {
 		t.Fatalf("expected cert-manager-resources, got %+v", bp.Kustomize)
 	}
-	if install.path != "pki/cert-manager" || res.path != "pki/cert-manager" {
-		t.Errorf("expected both tiers at pki/cert-manager, got install=%q resources=%q", install.path, res.path)
+	if install.path != "pki/cert-manager/install" || res.path != "pki/cert-manager/resources" {
+		t.Errorf("expected tiers at pki/cert-manager/{install,resources}, got install=%q resources=%q", install.path, res.path)
 	}
 	if !slices.Contains(install.components, "helm-release") {
 		t.Errorf("expected install components [helm-release], got %v", install.components)

--- a/integration/fixtures/facet-tiers/contexts/_template/facets/pki.yaml
+++ b/integration/fixtures/facet-tiers/contexts/_template/facets/pki.yaml
@@ -2,15 +2,19 @@ kind: Facet
 apiVersion: blueprints.windsorcli.dev/v1alpha1
 metadata:
   name: pki
-  description: cert-manager split into install and resources tiers
+  description: cert-manager as a flux system entry with install and resources tiers
 
-kustomize:
+flux:
 
 - name: cert-manager
   path: pki/cert-manager
   install:
-  - helm-release
+    components:
+    - helm-release
+    timeout: 5m
+    interval: 5m
   resources:
-  - private-issuer/ca
-  timeout: 5m
-  interval: 5m
+  - components:
+    - private-issuer/ca
+    timeout: 5m
+    interval: 5m

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -1120,6 +1120,7 @@ func (p *BaseBlueprintProcessor) buildFluxSystemEntries(system blueprintv1alpha1
 
 	var entries []blueprintv1alpha1.ConditionalKustomization
 	installEmitted := false
+	seenVariants := make(map[string]bool)
 	if system.Install != nil {
 		comps, err := p.evalDropEmpty(system.Install.Components, facet.Path, scope)
 		if err != nil {
@@ -1155,6 +1156,10 @@ func (p *BaseBlueprintProcessor) buildFluxSystemEntries(system blueprintv1alpha1
 		if v.Name != "" {
 			variantName += "-" + v.Name
 		}
+		if seenVariants[variantName] {
+			return nil, fmt.Errorf("duplicate resources variant %q in system %q; add a unique name: field to each variant", variantName, name)
+		}
+		seenVariants[variantName] = true
 		extraDeps, err := p.evalDropEmpty(v.DependsOn, facet.Path, scope)
 		if err != nil {
 			return nil, fmt.Errorf("error evaluating resources dependsOn for system '%s': %w", name, err)

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -3,6 +3,7 @@ package blueprint
 import (
 	"fmt"
 	"maps"
+	"path"
 	"reflect"
 	"slices"
 	"sort"
@@ -272,6 +273,9 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 			return nil, err
 		}
 		if err := p.collectKustomizations(facet, sourceName, kustomizationByName, scope); err != nil {
+			return nil, err
+		}
+		if err := p.collectFluxSystems(facet, sourceName, kustomizationByName, scope); err != nil {
 			return nil, err
 		}
 		for _, ref := range facet.Crds {
@@ -900,6 +904,10 @@ func (p *BaseBlueprintProcessor) collectKustomizations(facet blueprintv1alpha1.F
 
 		processed := k
 		processed.When = componentWhen
+		if len(processed.Substitute) > 0 {
+			processed.Substitutions = mergeSubstitute(processed.Kustomization)
+			processed.Substitute = nil
+		}
 		if processed.Substitutions != nil {
 			evaluated, deferredKeys, err := p.evaluateSubstitutions(processed.Substitutions, facet.Path, facetScope)
 			if err != nil {
@@ -941,15 +949,6 @@ func (p *BaseBlueprintProcessor) collectKustomizations(facet blueprintv1alpha1.F
 			}
 			processed.Components = evaluated
 		}
-		installComponents, err := p.evaluateTierComponents(processed.Install, facet.Path, facetScope)
-		if err != nil {
-			return fmt.Errorf("error evaluating install for kustomization '%s': %w", processed.Name, err)
-		}
-		resourceComponents, err := p.evaluateTierComponents(processed.Resources, facet.Path, facetScope)
-		if err != nil {
-			return fmt.Errorf("error evaluating resources for kustomization '%s': %w", processed.Name, err)
-		}
-		tiered := len(installComponents) > 0 || len(resourceComponents) > 0
 		if processed.Destroy != nil && processed.Destroy.IsExpr {
 			evaluated, err := p.evaluateBooleanExpression(processed.Destroy.Expr, facet.Path, facetScope)
 			if err != nil {
@@ -989,16 +988,6 @@ func (p *BaseBlueprintProcessor) collectKustomizations(facet blueprintv1alpha1.F
 			return p.updateKustomizationEntry(entry.Name, &entry, strategy, kustomizationByName, facetScope)
 		}
 
-		if tiered {
-			for _, entry := range buildTierEntries(processed, installComponents, resourceComponents) {
-				p.recordKustomizationTraces(entry.Name, entry.Components, entry.Substitutions, facet.Path, sn, effectiveOrdinal, strategy)
-				if err := addEntry(entry); err != nil {
-					return err
-				}
-			}
-			continue
-		}
-
 		p.recordKustomizationTraces(processed.Name, k.Components, k.Substitutions, facet.Path, sn, effectiveOrdinal, strategy)
 		if err := addEntry(processed); err != nil {
 			return err
@@ -1035,37 +1024,210 @@ func validateCrdRef(ref string) error {
 // explicit dependencies; resources reaches those transitively through the install tier. The CRD
 // layer is ordered ahead of everything by the provisioner phase, not by per-entry dependsOn. Each
 // entry gets its own Substitutions copy and clears the tier fields.
-func buildTierEntries(processed blueprintv1alpha1.ConditionalKustomization, install, resources []string) []blueprintv1alpha1.ConditionalKustomization {
-	name := processed.Name
-	explicit := slices.Clone(processed.DependsOn)
-	installName := name + "-install"
-	resourcesName := name + "-resources"
+// mergeSubstitute returns k's Substitutions with its Substitute alias merged in (substitute wins on
+// key conflict). Returns nil when both are empty.
+func mergeSubstitute(k blueprintv1alpha1.Kustomization) map[string]string {
+	if len(k.Substitute) == 0 {
+		return k.Substitutions
+	}
+	out := maps.Clone(k.Substitutions)
+	if out == nil {
+		out = make(map[string]string, len(k.Substitute))
+	}
+	maps.Copy(out, k.Substitute)
+	return out
+}
 
-	mk := func(tierName string, components, dependsOn []string) blueprintv1alpha1.ConditionalKustomization {
-		entry := *processed.DeepCopy()
-		entry.Name = tierName
-		entry.Components = components
-		entry.DependsOn = dependsOn
-		entry.Install = nil
-		entry.Resources = nil
-		return entry
+// combineWhen ANDs two condition expressions, dropping empties. A system entry's own condition is
+// combined with each resources variant's.
+func combineWhen(a, b string) string {
+	switch {
+	case a != "" && b != "":
+		return fmt.Sprintf("(%s) && (%s)", a, b)
+	case a != "":
+		return a
+	default:
+		return b
+	}
+}
+
+// evalDropEmpty evaluates a slice of expressions against the facet scope and drops entries that
+// resolved to empty.
+func (p *BaseBlueprintProcessor) evalDropEmpty(raw []string, facetPath string, scope map[string]any) ([]string, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	evaluated, err := p.evaluateStringSlice(raw, facetPath, scope)
+	if err != nil {
+		return nil, err
+	}
+	return slices.DeleteFunc(evaluated, func(s string) bool { return s == "" }), nil
+}
+
+// buildFluxSystemEntries expands a flux: system descriptor into its Flux Kustomizations:
+// "<name>-install" at "<path>/install" from the install tier, and one
+// "<name>-resources[-<variant>]" per resources variant at "<path>/resources". Each resources
+// variant depends on "<name>-install" when an install tier is emitted (the controller-liveness
+// edge); otherwise it carries the system's cross-layer dependsOn directly. Install and variants
+// reuse the Kustomization type for their operational properties; the system supplies identity, path
+// base, lifecycle (source/enabled/destroy), and its cross-layer dependsOn. Components,
+// substitutions, and per-variant when/dependsOn are evaluated against the facet scope; a tier whose
+// components prune to empty, or a variant whose when is false, is dropped.
+func (p *BaseBlueprintProcessor) buildFluxSystemEntries(system blueprintv1alpha1.FluxSystem, facet blueprintv1alpha1.Facet, scope map[string]any) ([]blueprintv1alpha1.ConditionalKustomization, error) {
+	name := system.Name
+	base := system.Path
+	if base == "" {
+		base = name
+	}
+	installName := name + "-install"
+	systemDeps, err := p.evalDropEmpty(system.DependsOn, facet.Path, scope)
+	if err != nil {
+		return nil, fmt.Errorf("error evaluating dependsOn for system '%s': %w", name, err)
+	}
+
+	mk := func(tier blueprintv1alpha1.Kustomization, tierName, tierSegment string, components, dependsOn []string, when string) (blueprintv1alpha1.ConditionalKustomization, error) {
+		k := *tier.DeepCopy()
+		k.Name = tierName
+		k.Path = path.Join(base, tierSegment)
+		k.Components = components
+		k.DependsOn = dependsOn
+		if k.Source == "" {
+			k.Source = system.Source
+		}
+		if k.Enabled == nil {
+			k.Enabled = system.Enabled
+		}
+		if k.Destroy == nil {
+			k.Destroy = system.Destroy
+		}
+		subs := mergeSubstitute(k)
+		k.Substitute = nil
+		k.Substitutions = nil
+		if len(subs) > 0 {
+			evaluated, deferredKeys, err := p.evaluateSubstitutions(subs, facet.Path, scope)
+			if err != nil {
+				return blueprintv1alpha1.ConditionalKustomization{}, err
+			}
+			k.Substitutions = evaluated
+			for key, isDeferred := range deferredKeys {
+				if isDeferred {
+					p.markDeferredPath("kustomize." + tierName + ".substitutions." + key)
+				}
+			}
+		}
+		return blueprintv1alpha1.ConditionalKustomization{Kustomization: k, When: when}, nil
 	}
 
 	var entries []blueprintv1alpha1.ConditionalKustomization
-	if len(processed.Components) > 0 {
-		entries = append(entries, mk(name, slices.Clone(processed.Components), slices.Clone(explicit)))
-	}
-	if len(install) > 0 {
-		entries = append(entries, mk(installName, install, slices.Clone(explicit)))
-	}
-	if len(resources) > 0 {
-		if len(install) > 0 {
-			entries = append(entries, mk(resourcesName, resources, []string{installName}))
-		} else {
-			entries = append(entries, mk(resourcesName, resources, slices.Clone(explicit)))
+	installEmitted := false
+	if system.Install != nil {
+		comps, err := p.evalDropEmpty(system.Install.Components, facet.Path, scope)
+		if err != nil {
+			return nil, fmt.Errorf("error evaluating install components for system '%s': %w", name, err)
+		}
+		if len(comps) > 0 {
+			entry, err := mk(*system.Install, installName, "install", comps, systemDeps, system.When)
+			if err != nil {
+				return nil, fmt.Errorf("error building install tier for system '%s': %w", name, err)
+			}
+			entries = append(entries, entry)
+			installEmitted = true
 		}
 	}
-	return entries
+
+	for _, v := range system.Resources {
+		when := combineWhen(system.When, v.When)
+		include, err := p.shouldIncludeComponent(when, facet.Path, scope)
+		if err != nil {
+			return nil, fmt.Errorf("error evaluating resources condition for system '%s': %w", name, err)
+		}
+		if !include {
+			continue
+		}
+		comps, err := p.evalDropEmpty(v.Components, facet.Path, scope)
+		if err != nil {
+			return nil, fmt.Errorf("error evaluating resources components for system '%s': %w", name, err)
+		}
+		if len(comps) == 0 {
+			continue
+		}
+		variantName := name + "-resources"
+		if v.Name != "" {
+			variantName += "-" + v.Name
+		}
+		extraDeps, err := p.evalDropEmpty(v.DependsOn, facet.Path, scope)
+		if err != nil {
+			return nil, fmt.Errorf("error evaluating resources dependsOn for system '%s': %w", name, err)
+		}
+		var deps []string
+		if installEmitted {
+			deps = append([]string{installName}, extraDeps...)
+		} else {
+			deps = append(slices.Clone(systemDeps), extraDeps...)
+		}
+		entry, err := mk(v.Kustomization, variantName, "resources", comps, deps, when)
+		if err != nil {
+			return nil, fmt.Errorf("error building resources tier for system '%s': %w", name, err)
+		}
+		entries = append(entries, entry)
+	}
+	return entries, nil
+}
+
+// collectFluxSystems compiles a facet's flux: system descriptors into their tier Kustomizations and
+// merges them into kustomizationByName, exactly as collectKustomizations does for plain entries —
+// so ToFluxKustomization and the merge/validation logic apply to the generated tiers unchanged.
+func (p *BaseBlueprintProcessor) collectFluxSystems(facet blueprintv1alpha1.Facet, sourceName []string, kustomizationByName map[string]*blueprintv1alpha1.ConditionalKustomization, facetScope map[string]any) error {
+	for _, system := range facet.FluxSystems {
+		when := system.When
+		if when == "" && facet.When != "" {
+			when = facet.When
+		}
+		shouldInclude, err := p.shouldIncludeComponent(when, facet.Path, facetScope)
+		if err != nil {
+			return fmt.Errorf("error evaluating flux system condition: %w", err)
+		}
+		if !shouldInclude {
+			continue
+		}
+		system.When = when
+		if system.Source == "" {
+			system.Source = resolveSourceName(sourceName)
+		}
+
+		effectiveOrdinal := resolvedFacetOrdinal(facet)
+		if system.Ordinal != nil {
+			effectiveOrdinal = *system.Ordinal
+		}
+		strategy := system.Strategy
+		if strategy == "" {
+			strategy = "merge"
+		}
+		sn := ""
+		if len(sourceName) > 0 {
+			sn = sourceName[0]
+		}
+
+		entries, err := p.buildFluxSystemEntries(system, facet, facetScope)
+		if err != nil {
+			return err
+		}
+		for _, entry := range entries {
+			entry.Ordinal = &effectiveOrdinal
+			p.recordKustomizationTraces(entry.Name, entry.Components, entry.Substitutions, facet.Path, sn, effectiveOrdinal, strategy)
+			if _, exists := kustomizationByName[entry.Name]; !exists {
+				entry.Strategy = strategy
+				stored := new(blueprintv1alpha1.ConditionalKustomization)
+				*stored = entry
+				kustomizationByName[entry.Name] = stored
+				continue
+			}
+			if err := p.updateKustomizationEntry(entry.Name, &entry, strategy, kustomizationByName, facetScope); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // setCrdLayer records the deduped, sorted CRD references for sourceName. Refs from the default/project
@@ -1692,20 +1854,6 @@ func (p *BaseBlueprintProcessor) evaluateStringSlice(slice []string, facetPath s
 	}
 
 	return result, nil
-}
-
-// evaluateTierComponents evaluates a tier's component list (install or resources) the same way as
-// Components, then prunes entries that resolved to empty so a "${...}" expression that selects no
-// component leaves the tier — and the decision to emit it — empty.
-func (p *BaseBlueprintProcessor) evaluateTierComponents(components []string, facetPath string, scope map[string]any) ([]string, error) {
-	if len(components) == 0 {
-		return nil, nil
-	}
-	evaluated, err := p.evaluateStringSlice(components, facetPath, scope)
-	if err != nil {
-		return nil, err
-	}
-	return slices.DeleteFunc(evaluated, func(s string) bool { return s == "" }), nil
 }
 
 // evaluateBooleanExpression evaluates a boolean expression string. When scope is non-nil, it is

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -2683,6 +2683,25 @@ func TestProcessor_ProcessFacets_Tiers(t *testing.T) {
 			t.Errorf("expected no implicit install edge when install pruned away, got %v", res.DependsOn)
 		}
 	})
+
+	t.Run("DuplicateUnnamedVariantsReturnsError", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		facets := []blueprintv1alpha1.Facet{{
+			Metadata: blueprintv1alpha1.Metadata{Name: "gateway"},
+			FluxSystems: []blueprintv1alpha1.FluxSystem{{
+				Name: "gateway",
+				Resources: []blueprintv1alpha1.FluxVariant{
+					{Kustomization: blueprintv1alpha1.Kustomization{Components: []string{"a"}}},
+					{Kustomization: blueprintv1alpha1.Kustomization{Components: []string{"b"}}},
+				},
+			}},
+		}}
+		_, err := processor.ProcessFacets(&blueprintv1alpha1.Blueprint{}, facets)
+		if err == nil {
+			t.Fatal("expected error for duplicate unnamed resources variant, got nil")
+		}
+	})
 }
 func TestProcessor_mergeHelpers(t *testing.T) {
 	t.Run("deepMergeMapMergesNestedMaps", func(t *testing.T) {

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -2494,209 +2494,196 @@ func TestProcessor_ProcessFacets_Tiers(t *testing.T) {
 		}
 		return blueprintv1alpha1.Kustomization{}, false
 	}
-
-	t.Run("ExpandsInstallAndResourcesSharingThePath", func(t *testing.T) {
-		// Given an entry that partitions a vendor's components into install and resources tiers
+	process := func(t *testing.T, system blueprintv1alpha1.FluxSystem) *blueprintv1alpha1.Blueprint {
+		t.Helper()
 		mocks := setupProcessorMocks(t)
 		processor := NewBlueprintProcessor(mocks.Runtime)
-		facets := []blueprintv1alpha1.Facet{
-			{
-				Metadata: blueprintv1alpha1.Metadata{Name: "pki"},
-				Kustomizations: []blueprintv1alpha1.ConditionalKustomization{
-					{Kustomization: blueprintv1alpha1.Kustomization{
-						Name:      "cert-manager",
-						Path:      "pki/cert-manager",
-						Install:   []string{"helm-release"},
-						Resources: []string{"private-issuer/ca"},
-					}},
-				},
-			},
-		}
-
-		// When processing facets
+		facets := []blueprintv1alpha1.Facet{{
+			Metadata:    blueprintv1alpha1.Metadata{Name: system.Name},
+			FluxSystems: []blueprintv1alpha1.FluxSystem{system},
+		}}
 		target := &blueprintv1alpha1.Blueprint{}
-		_, err := processor.ProcessFacets(target, facets)
-
-		// Then two kustomizations are emitted at the same path, resources depending on install
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
+		if _, err := processor.ProcessFacets(target, facets); err != nil {
+			t.Fatalf("ProcessFacets: %v", err)
 		}
+		return target
+	}
+
+	t.Run("CompilesInstallAndResourcesTiersAtTierPaths", func(t *testing.T) {
+		target := process(t, blueprintv1alpha1.FluxSystem{
+			Name:      "cert-manager",
+			Path:      "pki/cert-manager",
+			Install:   &blueprintv1alpha1.Kustomization{Components: []string{"helm-release"}},
+			Resources: []blueprintv1alpha1.FluxVariant{{Kustomization: blueprintv1alpha1.Kustomization{Components: []string{"private-issuer/ca"}}}},
+		})
 		install, ok := find(target, "cert-manager-install")
-		if !ok {
-			t.Fatalf("Expected cert-manager-install, got %+v", target.Kustomizations)
+		if !ok || install.Path != "pki/cert-manager/install" {
+			t.Fatalf("expected cert-manager-install at pki/cert-manager/install, got %+v", install)
 		}
 		res, ok := find(target, "cert-manager-resources")
-		if !ok {
-			t.Fatalf("Expected cert-manager-resources, got %+v", target.Kustomizations)
+		if !ok || res.Path != "pki/cert-manager/resources" {
+			t.Fatalf("expected cert-manager-resources at pki/cert-manager/resources, got %+v", res)
 		}
-		if _, ok := find(target, "cert-manager"); ok {
-			t.Errorf("Did not expect a bare cert-manager kustomization without components")
-		}
-		if install.Path != "pki/cert-manager" || res.Path != "pki/cert-manager" {
-			t.Errorf("Expected both tiers at pki/cert-manager, got install=%q resources=%q", install.Path, res.Path)
-		}
-		if !slices.Contains(install.Components, "helm-release") {
-			t.Errorf("Expected install components [helm-release], got %v", install.Components)
-		}
-		if !slices.Contains(res.Components, "private-issuer/ca") {
-			t.Errorf("Expected resources components [private-issuer/ca], got %v", res.Components)
+		if !slices.Contains(install.Components, "helm-release") || !slices.Contains(res.Components, "private-issuer/ca") {
+			t.Errorf("tier components wrong: install=%v resources=%v", install.Components, res.Components)
 		}
 		if !slices.Contains(res.DependsOn, "cert-manager-install") {
-			t.Errorf("Expected resources to depend on cert-manager-install, got %v", res.DependsOn)
+			t.Errorf("expected resources to depend on cert-manager-install, got %v", res.DependsOn)
 		}
 	})
 
-	t.Run("EmitsLegacyComponentsAlongsideTiers", func(t *testing.T) {
-		// Given an entry that sets components AND install AND resources
-		mocks := setupProcessorMocks(t)
-		processor := NewBlueprintProcessor(mocks.Runtime)
-		facets := []blueprintv1alpha1.Facet{
-			{
-				Metadata: blueprintv1alpha1.Metadata{Name: "vendor"},
-				Kustomizations: []blueprintv1alpha1.ConditionalKustomization{
-					{Kustomization: blueprintv1alpha1.Kustomization{
-						Name:       "vendor",
-						Path:       "vendor",
-						Components: []string{"legacy"},
-						Install:    []string{"helm-release"},
-						Resources:  []string{"cr"},
-					}},
-				},
+	t.Run("PathDefaultsToName", func(t *testing.T) {
+		target := process(t, blueprintv1alpha1.FluxSystem{
+			Name:    "dns",
+			Install: &blueprintv1alpha1.Kustomization{Components: []string{"coredns-controller"}},
+		})
+		install, ok := find(target, "dns-install")
+		if !ok || install.Path != "dns/install" {
+			t.Fatalf("expected dns-install at dns/install (path defaults to name), got %+v", install)
+		}
+	})
+
+	t.Run("NamedResourcesVariantsShareThePathWithOwnSubstitutions", func(t *testing.T) {
+		target := process(t, blueprintv1alpha1.FluxSystem{
+			Name:    "gateway",
+			Path:    "gateway",
+			Install: &blueprintv1alpha1.Kustomization{Components: []string{"envoy"}},
+			Resources: []blueprintv1alpha1.FluxVariant{
+				{Kustomization: blueprintv1alpha1.Kustomization{Name: "internal", Components: []string{"internal"}, Substitute: map[string]string{"gateway_name": "internal"}}},
+				{Kustomization: blueprintv1alpha1.Kustomization{Name: "external", Components: []string{"external"}, Substitute: map[string]string{"gateway_name": "external"}}},
 			},
+		})
+		in, ok := find(target, "gateway-resources-internal")
+		if !ok || in.Path != "gateway/resources" || in.Substitutions["gateway_name"] != "internal" {
+			t.Fatalf("internal variant wrong: %+v", in)
 		}
-
-		// When processing facets
-		target := &blueprintv1alpha1.Blueprint{}
-		_, err := processor.ProcessFacets(target, facets)
-
-		// Then all three kustomizations exist
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
+		ex, ok := find(target, "gateway-resources-external")
+		if !ok || ex.Path != "gateway/resources" || ex.Substitutions["gateway_name"] != "external" {
+			t.Fatalf("external variant wrong: %+v", ex)
 		}
-		for _, name := range []string{"vendor", "vendor-install", "vendor-resources"} {
-			if _, ok := find(target, name); !ok {
-				t.Errorf("Expected kustomization %q, got %+v", name, target.Kustomizations)
+		for _, v := range []blueprintv1alpha1.Kustomization{in, ex} {
+			if !slices.Contains(v.DependsOn, "gateway-install") {
+				t.Errorf("expected %s to depend on gateway-install, got %v", v.Name, v.DependsOn)
 			}
 		}
 	})
 
-	t.Run("InstallOnlyEmitsSingleTier", func(t *testing.T) {
-		// Given an entry with only an install tier
-		mocks := setupProcessorMocks(t)
-		processor := NewBlueprintProcessor(mocks.Runtime)
-		facets := []blueprintv1alpha1.Facet{
-			{
-				Metadata: blueprintv1alpha1.Metadata{Name: "metallb"},
-				Kustomizations: []blueprintv1alpha1.ConditionalKustomization{
-					{Kustomization: blueprintv1alpha1.Kustomization{Name: "metallb", Path: "lb/metallb", Install: []string{"helm-release"}}},
-				},
-			},
-		}
-
-		// When processing facets
-		target := &blueprintv1alpha1.Blueprint{}
-		_, err := processor.ProcessFacets(target, facets)
-
-		// Then only the install tier is emitted
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if _, ok := find(target, "metallb-install"); !ok {
-			t.Fatalf("Expected metallb-install, got %+v", target.Kustomizations)
-		}
-		if _, ok := find(target, "metallb-resources"); ok {
-			t.Errorf("Did not expect a resources tier")
+	t.Run("InstallSubstituteFlowsToInstallKustomization", func(t *testing.T) {
+		target := process(t, blueprintv1alpha1.FluxSystem{
+			Name:    "lb",
+			Install: &blueprintv1alpha1.Kustomization{Components: []string{"aws-lb-controller"}, Substitute: map[string]string{"cluster_name": "prod"}},
+		})
+		install, ok := find(target, "lb-install")
+		if !ok || install.Substitutions["cluster_name"] != "prod" {
+			t.Fatalf("expected install substitute merged into substitutions, got %+v", install)
 		}
 	})
 
-	t.Run("ResourcesOnlyHasNoInstallDependency", func(t *testing.T) {
-		// Given an entry with only a resources tier
-		mocks := setupProcessorMocks(t)
-		processor := NewBlueprintProcessor(mocks.Runtime)
-		facets := []blueprintv1alpha1.Facet{
-			{
-				Metadata: blueprintv1alpha1.Metadata{Name: "issuers"},
-				Kustomizations: []blueprintv1alpha1.ConditionalKustomization{
-					{Kustomization: blueprintv1alpha1.Kustomization{Name: "issuers", Path: "pki/issuers", Resources: []string{"public-issuer"}}},
-				},
-			},
+	t.Run("SystemDependsOnAttachesToInstallAndResourcesReachItTransitively", func(t *testing.T) {
+		target := process(t, blueprintv1alpha1.FluxSystem{
+			Name:      "gateway",
+			Path:      "gateway",
+			DependsOn: []string{"pki-install", "lb-install"},
+			Install:   &blueprintv1alpha1.Kustomization{Components: []string{"envoy"}},
+			Resources: []blueprintv1alpha1.FluxVariant{{Kustomization: blueprintv1alpha1.Kustomization{Components: []string{"internal"}}}},
+		})
+		install, _ := find(target, "gateway-install")
+		if !slices.Contains(install.DependsOn, "pki-install") || !slices.Contains(install.DependsOn, "lb-install") {
+			t.Errorf("expected system deps on install, got %v", install.DependsOn)
 		}
-
-		// When processing facets
-		target := &blueprintv1alpha1.Blueprint{}
-		_, err := processor.ProcessFacets(target, facets)
-
-		// Then the resources tier exists and depends on no install tier
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
+		res, _ := find(target, "gateway-resources")
+		if slices.Contains(res.DependsOn, "pki-install") {
+			t.Errorf("expected resources to reach cross-layer deps transitively via install, got %v", res.DependsOn)
 		}
+		if !slices.Contains(res.DependsOn, "gateway-install") {
+			t.Errorf("expected resources -> gateway-install, got %v", res.DependsOn)
+		}
+	})
+
+	t.Run("NoInstallAttachesSystemDependsOnToEachVariant", func(t *testing.T) {
+		target := process(t, blueprintv1alpha1.FluxSystem{
+			Name:      "issuers",
+			Path:      "pki/issuers",
+			DependsOn: []string{"cert-manager-install"},
+			Resources: []blueprintv1alpha1.FluxVariant{{Kustomization: blueprintv1alpha1.Kustomization{Components: []string{"public-issuer"}}}},
+		})
 		res, ok := find(target, "issuers-resources")
 		if !ok {
-			t.Fatalf("Expected issuers-resources, got %+v", target.Kustomizations)
+			t.Fatalf("expected issuers-resources, got %+v", target.Kustomizations)
+		}
+		if !slices.Contains(res.DependsOn, "cert-manager-install") {
+			t.Errorf("expected system deps on the variant, got %v", res.DependsOn)
 		}
 		if slices.Contains(res.DependsOn, "issuers-install") {
-			t.Errorf("Expected no install dependency, got %v", res.DependsOn)
+			t.Errorf("did not expect an implicit install edge without an install tier: %v", res.DependsOn)
 		}
 	})
 
-	t.Run("TierEntriesDoNotSharePatchesBacking", func(t *testing.T) {
-		// Given a tiered entry that carries a patch
-		processed := blueprintv1alpha1.ConditionalKustomization{
-			Kustomization: blueprintv1alpha1.Kustomization{
-				Name:    "cert-manager",
-				Path:    "pki/cert-manager",
-				Patches: []blueprintv1alpha1.BlueprintPatch{{Patch: "original"}},
-			},
-		}
-
-		// When the entry is expanded into install and resources tiers
-		entries := buildTierEntries(processed, []string{"helm-release"}, []string{"ca"})
-		if len(entries) != 2 {
-			t.Fatalf("Expected install and resources entries, got %d", len(entries))
-		}
-
-		// Then mutating one tier's patches leaves the other tier untouched
-		entries[0].Patches[0].Patch = "mutated"
-		entries[0].Patches = append(entries[0].Patches, blueprintv1alpha1.BlueprintPatch{Patch: "added"})
-		if entries[1].Patches[0].Patch != "original" || len(entries[1].Patches) != 1 {
-			t.Errorf("Expected resources tier patches independent, got %+v", entries[1].Patches)
+	t.Run("VariantDependsOnIsAppended", func(t *testing.T) {
+		target := process(t, blueprintv1alpha1.FluxSystem{
+			Name:      "gateway",
+			Path:      "gateway",
+			Install:   &blueprintv1alpha1.Kustomization{Components: []string{"envoy"}},
+			Resources: []blueprintv1alpha1.FluxVariant{{Kustomization: blueprintv1alpha1.Kustomization{Components: []string{"internal"}, DependsOn: []string{"dns"}}}},
+		})
+		res, _ := find(target, "gateway-resources")
+		if !slices.Contains(res.DependsOn, "gateway-install") || !slices.Contains(res.DependsOn, "dns") {
+			t.Errorf("expected [gateway-install, dns], got %v", res.DependsOn)
 		}
 	})
 
-	t.Run("PrunesConditionalTierToNothing", func(t *testing.T) {
-		// Given a tier whose only component is a false expression
-		mocks := setupProcessorMocks(t)
-		processor := NewBlueprintProcessor(mocks.Runtime)
-		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
-			return map[string]any{"gateway": map[string]any{"driver": "cilium"}}, nil
+	t.Run("InstallOnlyEmitsSingleTier", func(t *testing.T) {
+		target := process(t, blueprintv1alpha1.FluxSystem{
+			Name:    "metallb",
+			Path:    "lb/metallb",
+			Install: &blueprintv1alpha1.Kustomization{Components: []string{"helm-release"}},
+		})
+		install, ok := find(target, "metallb-install")
+		if !ok || install.Path != "lb/metallb/install" {
+			t.Fatalf("expected metallb-install at lb/metallb/install, got %+v", install)
 		}
-		facets := []blueprintv1alpha1.Facet{
-			{
-				Metadata: blueprintv1alpha1.Metadata{Name: "gateway"},
-				Kustomizations: []blueprintv1alpha1.ConditionalKustomization{
-					{Kustomization: blueprintv1alpha1.Kustomization{
-						Name:    "gateway-envoy",
-						Path:    "gateway/envoy",
-						Install: []string{"${gateway.driver == 'envoy' ? 'helm-release' : ''}"},
-					}},
-				},
+		if _, ok := find(target, "metallb-resources"); ok {
+			t.Error("did not expect a resources tier")
+		}
+	})
+
+	t.Run("VariantWhenFalseIsDropped", func(t *testing.T) {
+		target := process(t, blueprintv1alpha1.FluxSystem{
+			Name:    "gateway",
+			Path:    "gateway",
+			Install: &blueprintv1alpha1.Kustomization{Components: []string{"envoy"}},
+			Resources: []blueprintv1alpha1.FluxVariant{
+				{Kustomization: blueprintv1alpha1.Kustomization{Name: "internal", Components: []string{"internal"}}, When: "false"},
+				{Kustomization: blueprintv1alpha1.Kustomization{Name: "external", Components: []string{"external"}}, When: "true"},
 			},
+		})
+		if _, ok := find(target, "gateway-resources-internal"); ok {
+			t.Error("expected the when:false variant to be dropped")
 		}
-
-		// When processing facets with a non-matching driver
-		target := &blueprintv1alpha1.Blueprint{}
-		_, err := processor.ProcessFacets(target, facets)
-
-		// Then the install tier prunes to empty and is not emitted
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
+		if _, ok := find(target, "gateway-resources-external"); !ok {
+			t.Error("expected the when:true variant to be kept")
 		}
-		if _, ok := find(target, "gateway-envoy-install"); ok {
-			t.Errorf("Expected no install tier when its components prune to empty, got %+v", target.Kustomizations)
+	})
+
+	t.Run("InstallPrunesToNothingWhenComponentsEmpty", func(t *testing.T) {
+		target := process(t, blueprintv1alpha1.FluxSystem{
+			Name:      "gateway",
+			Path:      "gateway",
+			Install:   &blueprintv1alpha1.Kustomization{Components: []string{"${false ? 'helm-release' : ''}"}},
+			Resources: []blueprintv1alpha1.FluxVariant{{Kustomization: blueprintv1alpha1.Kustomization{Components: []string{"internal"}}}},
+		})
+		if _, ok := find(target, "gateway-install"); ok {
+			t.Error("expected no install tier when its components prune to empty")
+		}
+		res, ok := find(target, "gateway-resources")
+		if !ok {
+			t.Fatalf("expected gateway-resources, got %+v", target.Kustomizations)
+		}
+		if slices.Contains(res.DependsOn, "gateway-install") {
+			t.Errorf("expected no implicit install edge when install pruned away, got %v", res.DependsOn)
 		}
 	})
 }
-
 func TestProcessor_mergeHelpers(t *testing.T) {
 	t.Run("deepMergeMapMergesNestedMaps", func(t *testing.T) {
 		base := map[string]any{"a": 1, "b": map[string]any{"x": 10}}

--- a/pkg/runtime/config/schemas/artifacts/blueprint.yaml
+++ b/pkg/runtime/config/schemas/artifacts/blueprint.yaml
@@ -168,11 +168,11 @@ properties:
   kustomize:
     type: array
     description: |
-      Flux kustomizations included in the blueprint. Each entry maps to a
-      Kustomization resource the provisioner applies to the cluster, in
-      topologically sorted dependsOn order. Deprecated alias of 'flux:'; both
-      keys are accepted and merge into the same list.
-    items: &blueprintKustomizationItems
+      Plain Flux kustomizations included in the blueprint — a 1:1 passthrough:
+      each entry maps to one Kustomization the provisioner applies, in
+      topologically sorted dependsOn order. System entries (install/resources
+      tiers) live under 'flux:' instead.
+    items:
       type: object
       required:
         - name
@@ -251,22 +251,13 @@ properties:
           items:
             type: string
           description: Kustomize components to compose into this kustomization.
-        install:
-          type: array
-          items:
+        substitute:
+          type: object
+          additionalProperties:
             type: string
           description: |
-            Components of the install (controller/operator) tier. Like
-            components, each entry may be a '${...}' expression that prunes to
-            empty. When install and/or resources are set, the entry expands into
-            separate kustomizations sharing this path: '<name>-install' carrying
-            these components and '<name>-resources' depending on it, so the
-            controller is reconciled before the custom resources it admits.
-        resources:
-          type: array
-          items:
-            type: string
-          description: Components of the custom-resource tier. See install.
+            Preferred spelling of substitutions (matching Flux
+            postBuild.substitute); both merge into the same map.
         destroy:
           type: [boolean, string]
           description: |
@@ -292,11 +283,95 @@ properties:
   flux:
     type: array
     description: |
-      Flux Kustomizations included in the blueprint — the preferred spelling of
-      'kustomize:' (every entry compiles to a Flux Kustomization). 'kustomize:'
-      remains accepted as a backward-compatible alias; both keys merge into one
-      list.
-    items: *blueprintKustomizationItems
+      System entries — functional layers that each compile to an install
+      Kustomization plus one or more resources-variant Kustomizations. Distinct
+      from 'kustomize:', which is a 1:1 Kustomization passthrough.
+    items:
+      type: object
+      required:
+        - name
+      additionalProperties: false
+      properties:
+        name:
+          type: string
+          description: System identifier; tiers compile to '<name>-install' and '<name>-resources[-<variant>]'.
+        path:
+          type: string
+          description: Base path; tiers reconcile from '<path>/install' and '<path>/resources'. Defaults to name.
+        source:
+          type: string
+          description: Name of the source that provides the tier bases.
+        enabled:
+          type: [boolean, string]
+          description: Include or exclude the whole system. Defaults to true.
+        destroy:
+          type: [boolean, string]
+          description: Whether the system's kustomizations are removed on teardown. Defaults to true.
+        when:
+          type: string
+          description: Gates the system; combined (AND) with each resources variant's condition.
+        dependsOn:
+          type: array
+          items:
+            type: string
+          description: |
+            Cross-layer edges to other systems (a bare '<other>' resolves to
+            '<other>-install'). Attached to the install tier when present
+            (resources reach them transitively), otherwise to each variant.
+        strategy:
+          type: string
+          enum:
+            - merge
+            - replace
+            - remove
+          description: How a system with this name merges across facets. Defaults to merge.
+        ordinal:
+          type: integer
+          description: Overrides the facet ordinal for this system's merge precedence.
+        install:
+          type: object
+          additionalProperties: true
+          description: |
+            Controller/operator tier. Reuses the Kustomization shape — its
+            components/substitute and operational properties (interval, timeout,
+            wait, prune, patches, namespace, …) flow to '<name>-install'; its
+            name/path/dependsOn are derived. When every component prunes to empty,
+            no install Kustomization is emitted.
+          properties:
+            components:
+              type: array
+              items:
+                type: string
+            substitute:
+              type: object
+              additionalProperties:
+                type: string
+        resources:
+          type: array
+          description: Custom-resource tier variants, all sharing '<path>/resources'.
+          items:
+            type: object
+            additionalProperties: true
+            properties:
+              name:
+                type: string
+                description: Variant suffix ('<system>-resources-<name>'); omit for a single unnamed variant.
+              when:
+                type: string
+                description: Gates the variant; combined (AND) with the system's condition.
+              dependsOn:
+                type: array
+                items:
+                  type: string
+                description: Extra cross-layer edges, appended to the implicit install edge.
+              components:
+                type: array
+                items:
+                  type: string
+              substitute:
+                type: object
+                additionalProperties:
+                  type: string
   substitutions:
     type: object
     additionalProperties:

--- a/pkg/runtime/config/schemas/artifacts/blueprint.yaml
+++ b/pkg/runtime/config/schemas/artifacts/blueprint.yaml
@@ -330,7 +330,7 @@ properties:
           description: Overrides the facet ordinal for this system's merge precedence.
         install:
           type: object
-          additionalProperties: true
+          additionalProperties: false
           description: |
             Controller/operator tier. Reuses the Kustomization shape — its
             components/substitute and operational properties (interval, timeout,
@@ -338,20 +338,77 @@ properties:
             name/path/dependsOn are derived. When every component prunes to empty,
             no install Kustomization is emitted.
           properties:
+            source:
+              type: string
+              description: Source override for this tier. Defaults to the system source.
+            namespace:
+              type: string
+              description: Namespace where the Flux Kustomization object lives. Defaults to the gitops namespace.
+            targetNamespace:
+              type: string
+              description: Populates spec.targetNamespace, overriding the namespace of reconciled resources.
+            interval:
+              type: string
+              description: Reconciliation interval as a Go duration string (e.g. '5m', '1h').
+            retryInterval:
+              type: string
+              description: Duration to wait before retrying a failed reconciliation (e.g. '2m').
+            timeout:
+              type: string
+              description: Maximum duration for a single reconciliation attempt (e.g. '10m').
+            patches:
+              type: array
+              description: Strategic-merge or Flux-style patches applied to this tier.
+              items:
+                type: object
+                additionalProperties: false
+                properties:
+                  path:
+                    type: string
+                  patch:
+                    type: string
+                  target:
+                    type: object
+                    additionalProperties: true
+            wait:
+              type: boolean
+              description: Wait for resources to settle before declaring reconciliation complete.
+            force:
+              type: boolean
+              description: Force-apply resources Flux would otherwise refuse to update.
+            prune:
+              type: boolean
+              description: Garbage-collect resources removed from the source. Defaults to true.
             components:
               type: array
               items:
                 type: string
+              description: Kustomize components to compose into the install tier.
             substitute:
               type: object
               additionalProperties:
                 type: string
+              description: PostBuild substitutions (preferred spelling); merges with substitutions.
+            substitutions:
+              type: object
+              additionalProperties:
+                type: string
+              description: PostBuild variable substitutions for this tier.
+            destroy:
+              type: [boolean, string]
+              description: Whether to delete this tier during 'windsor down'. Boolean or expression. Defaults to true.
+            destroyOnly:
+              type: boolean
+              description: When true, this tier only runs during destroy operations.
+            enabled:
+              type: [boolean, string]
+              description: Whether to include this tier in the final blueprint. Boolean or expression. Defaults to true.
         resources:
           type: array
           description: Custom-resource tier variants, all sharing '<path>/resources'.
           items:
             type: object
-            additionalProperties: true
+            additionalProperties: false
             properties:
               name:
                 type: string
@@ -359,19 +416,76 @@ properties:
               when:
                 type: string
                 description: Gates the variant; combined (AND) with the system's condition.
+              source:
+                type: string
+                description: Source override for this variant. Defaults to the system source.
+              namespace:
+                type: string
+                description: Namespace where the Flux Kustomization object lives. Defaults to the gitops namespace.
+              targetNamespace:
+                type: string
+                description: Populates spec.targetNamespace, overriding the namespace of reconciled resources.
               dependsOn:
                 type: array
                 items:
                   type: string
                 description: Extra cross-layer edges, appended to the implicit install edge.
+              interval:
+                type: string
+                description: Reconciliation interval as a Go duration string (e.g. '5m', '1h').
+              retryInterval:
+                type: string
+                description: Duration to wait before retrying a failed reconciliation (e.g. '2m').
+              timeout:
+                type: string
+                description: Maximum duration for a single reconciliation attempt (e.g. '10m').
+              patches:
+                type: array
+                description: Strategic-merge or Flux-style patches applied to this variant.
+                items:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    path:
+                      type: string
+                    patch:
+                      type: string
+                    target:
+                      type: object
+                      additionalProperties: true
+              wait:
+                type: boolean
+                description: Wait for resources to settle before declaring reconciliation complete.
+              force:
+                type: boolean
+                description: Force-apply resources Flux would otherwise refuse to update.
+              prune:
+                type: boolean
+                description: Garbage-collect resources removed from the source. Defaults to true.
               components:
                 type: array
                 items:
                   type: string
+                description: Kustomize components to compose into this variant.
               substitute:
                 type: object
                 additionalProperties:
                   type: string
+                description: PostBuild substitutions (preferred spelling); merges with substitutions.
+              substitutions:
+                type: object
+                additionalProperties:
+                  type: string
+                description: PostBuild variable substitutions for this variant.
+              destroy:
+                type: [boolean, string]
+                description: Whether to delete this variant during 'windsor down'. Boolean or expression. Defaults to true.
+              destroyOnly:
+                type: boolean
+                description: When true, this variant only runs during destroy operations.
+              enabled:
+                type: [boolean, string]
+                description: Whether to include this variant in the final blueprint. Boolean or expression. Defaults to true.
   substitutions:
     type: object
     additionalProperties:

--- a/pkg/runtime/config/schemas/artifacts/facets.yaml
+++ b/pkg/runtime/config/schemas/artifacts/facets.yaml
@@ -98,13 +98,16 @@ properties:
   flux:
     type: array
     description: |
-      Flux Kustomizations contributed by this facet — the preferred spelling of
-      'kustomize:' (every entry compiles to a Flux Kustomization object). Each
-      entry extends the blueprint's Kustomization shape with conditional fields
-      (when, strategy, ordinal, requires). 'kustomize:' remains accepted as a
-      backward-compatible alias; both keys merge into the same list.
+      System entries contributed by this facet — functional layers that each
+      compile to an install Kustomization plus resources-variant Kustomizations.
+      Distinct from 'kustomize:' (1:1 passthrough). See the flux: shape in the
+      [Blueprint reference](blueprint.md): name (required), path, source, enabled,
+      destroy, when, dependsOn, strategy, ordinal, install, resources.
     items:
-      $ref: '#/$defs/conditionalKustomization'
+      type: object
+      required:
+        - name
+      additionalProperties: true
   crds:
     type: array
     description: |
@@ -252,10 +255,10 @@ $defs:
     description: |
       Inherits every field from the blueprint's Kustomization shape (name,
       path, source, namespace, targetNamespace, dependsOn, interval,
-      retryInterval, timeout, patches, wait, force, prune, components, install,
-      resources, destroy, destroyOnly, enabled, substitutions) and adds the
-      conditional fields below. See the [Blueprint reference](blueprint.md) for
-      the inherited fields.
+      retryInterval, timeout, patches, wait, force, prune, components, destroy,
+      destroyOnly, enabled, substitutions, substitute) and adds the conditional
+      fields below. See the [Blueprint reference](blueprint.md) for the inherited
+      fields.
     properties:
       when:
         type: string


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This PR replaces the `flux:` alias (which previously merged flat `kustomize:` entries) with a distinct `FluxSystem` structured type, and removes the `install`/`resources` tier fields from `Kustomization`. The path change — tiers now reconcile from `<path>/install` and `<path>/resources` instead of the shared `<path>` — will orphan any Flux Kustomization objects already in-cluster that were created under the old layout.
>
> **Overview**
>
> `flux:` in blueprints and facets is promoted from a spelling alias of `kustomize:` to its own structured type (`FluxSystem`), which compiles to an install Kustomization plus zero or more named resources-variant Kustomizations. The `kustomize:` key becomes a strict 1:1 passthrough; `flux:` carries identity, lifecycle, and tier fields. The old `UnmarshalYAML` alias logic is removed entirely, as are the `install` and `resources` slice fields on `Kustomization`.
>
> The integration fixture is updated to confirm the new syntax, and all tier-related tests are rewritten against the `FluxSystem` API. Existing YAML authored with `flux:` as a flat kustomize alias (merged in the previous commit) must be rewritten to the new `install:` / `resources:` sub-object shape.
>
> Reviewed by Claude for commit `5f206788`.

<!-- /claude-code-review:summary -->
