### PR TITLE
chore(ci): publish Claude review from files, not the model's own turn loop

### DIFF
--- a/.github/scripts/publish-review.sh
+++ b/.github/scripts/publish-review.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+# Publishes a Claude PR review that was written to files by the review step.
+# The model writes /tmp/summary-block.md (required) and, optionally,
+# /tmp/review-comments.json; this script does every GitHub write. Publishing
+# lives here — not in the model's sandbox — so it can never be permission-denied
+# mid-run, and the sticky summary is guaranteed to post even when the review
+# step errored, hit its turn cap, or produced nothing.
+#
+# Required env: GH_TOKEN, GH_REPO (owner/repo), PR_NUMBER, PR_HEAD_SHA.
+set -euo pipefail
+
+: "${GH_REPO:?}" "${PR_NUMBER:?}" "${PR_HEAD_SHA:?}"
+
+MARKER="<!-- claude-code-review:summary -->"
+END_MARKER="<!-- /claude-code-review:summary -->"
+SUMMARY=/tmp/summary-block.md
+COMMENTS=/tmp/review-comments.json
+STATUS=0
+
+# --- Sticky summary (always) ------------------------------------------------
+if [ ! -s "$SUMMARY" ]; then
+  # The review step produced no summary (errored, hit the turn cap, or a dead
+  # key). Post a visible stub and fail the job so the miss is a red X, not a
+  # silent green.
+  RUN_URL="${GITHUB_SERVER_URL:-https://github.com}/${GH_REPO}/actions/runs/${GITHUB_RUN_ID:-}"
+  {
+    echo "> [!WARNING]"
+    echo ">"
+    echo "> **Review did not complete**"
+    echo ">"
+    echo "> The automated review produced no summary. See the [run](${RUN_URL})."
+  } > "$SUMMARY"
+  STATUS=1
+fi
+
+{
+  echo "$MARKER"
+  echo
+  cat "$SUMMARY"
+  echo
+  echo "$END_MARKER"
+} > /tmp/summary-marked.md
+
+gh api "repos/${GH_REPO}/pulls/${PR_NUMBER}" --jq '.body // ""' > /tmp/pr-body.md || : > /tmp/pr-body.md
+
+STICKY_MARKER="$MARKER" END_MARKER="$END_MARKER" python3 - <<'PY'
+import os, re, pathlib
+marker = os.environ["STICKY_MARKER"]
+end    = os.environ["END_MARKER"]
+body   = pathlib.Path("/tmp/pr-body.md").read_text()
+block  = pathlib.Path("/tmp/summary-marked.md").read_text().rstrip() + "\n"
+pattern = re.compile(re.escape(marker) + r".*?" + re.escape(end) + r"\s*", re.DOTALL)
+body = pattern.sub("", body).rstrip()
+new  = (body + "\n\n" + block) if body else block
+pathlib.Path("/tmp/pr-body.new.md").write_text(new)
+PY
+
+gh api --method PATCH "repos/${GH_REPO}/pulls/${PR_NUMBER}" --field body=@/tmp/pr-body.new.md > /dev/null
+echo "Sticky summary upserted into PR #${PR_NUMBER}."
+
+# --- Inline comments (only when the model wrote findings) -------------------
+if [ -s "$COMMENTS" ] && [ "$(jq 'length' "$COMMENTS" 2>/dev/null || echo 0)" -gt 0 ]; then
+  # Resolve prior unresolved bot threads first, so a re-review doesn't stack
+  # duplicate inline comments on top of the old ones.
+  owner="${GH_REPO%/*}"
+  repo="${GH_REPO#*/}"
+  # shellcheck disable=SC2016  # $owner/$repo/$num are GraphQL variables, passed via -F
+  gh api graphql -f query='
+    query($owner:String!,$repo:String!,$num:Int!){
+      repository(owner:$owner,name:$repo){
+        pullRequest(number:$num){
+          reviewThreads(first:100){ nodes{ id isResolved
+            comments(first:1){ nodes{ author{ login } } } } } } } }' \
+    -F owner="$owner" -F repo="$repo" -F num="$PR_NUMBER" \
+    --jq '.data.repository.pullRequest.reviewThreads.nodes[]
+          | select(.isResolved==false)
+          | select(.comments.nodes[0].author.login | test("\\[bot\\]$|^github-actions|^claude$"))
+          | .id' 2>/dev/null | while read -r tid; do
+    [ -n "$tid" ] || continue
+    # shellcheck disable=SC2016  # $id is a GraphQL variable, passed via -F
+    gh api graphql -f query='
+      mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){ thread{ id } } }' \
+      -F id="$tid" > /dev/null || true
+  done
+
+  jq -n --arg sha "$PR_HEAD_SHA" --slurpfile c "$COMMENTS" \
+    '{commit_id:$sha, event:"COMMENT", comments:$c[0]}' > /tmp/review.json
+  if gh api -X POST "repos/${GH_REPO}/pulls/${PR_NUMBER}/reviews" --input /tmp/review.json > /dev/null; then
+    echo "Posted $(jq 'length' "$COMMENTS") inline comment(s)."
+  else
+    echo "::warning::Inline review POST failed (line anchors may be stale); summary still posted."
+  fi
+fi
+
+exit "$STATUS"

--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -18,6 +18,15 @@ permissions:
   pull-requests: write
   issues: write
   id-token: write
+
+# The review step only READS the diff and WRITES two files:
+#   /tmp/summary-block.md      — sticky summary body (required)
+#   /tmp/review-comments.json  — inline findings, JSON array (optional)
+# A deterministic "Publish review" step then does every GitHub write via
+# .github/scripts/publish-review.sh. Publishing lives outside the model's
+# tool sandbox, so it can never be permission-denied or silently skipped
+# mid-run, and the summary is guaranteed to post even if the review step
+# errors, hits its turn cap, or finishes early without posting anything.
 jobs:
   review:
     name: Full Review
@@ -41,169 +50,82 @@ jobs:
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
           BASE_REF: ${{ github.base_ref }}
           GH_REPO: ${{ github.repository }}
-          STICKY_MARKER: "<!-- claude-code-review:summary -->"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           prompt: |
-            Run the `review-pr` skill against this pull request and publish
-            findings as a GitHub pull request review with **inline, line-anchored
-            comments** plus a single **sticky summary** in the PR description.
+            Review this pull request and produce two output files. Do NOT post
+            anything to GitHub yourself — a later CI step publishes what you
+            write. Your only job is to write the files.
 
-            Scope strictly to the diff. Do NOT read files outside the changed
-            set unless flagging a specific, concrete concern. Skip style nits
-            and focus on correctness, security, and blast-radius issues.
+            Scope strictly to the diff. Read the changed set with
+            `git diff "origin/$BASE_REF"...HEAD` (full history is checked out).
+            Do NOT read files outside the changed set unless flagging a
+            specific, concrete concern. Skip style nits; focus on correctness,
+            security, and blast radius.
 
-            ## Tone and format
+            ## Output 1 — /tmp/summary-block.md (REQUIRED, always write it)
 
-            Calm, specific, prose-first. No emojis. No bulleted laundry lists
-            in the summary. No "Test plan" checklists. Write in short
-            paragraphs. Readers should scan the summary in ~15 seconds and
-            know the shape of the change and the risk.
-
-            ## Step 1 — Resolve stale inline comments from earlier runs
-
-            Before posting new comments, resolve threads whose concerns are
-            no longer present in the current HEAD. Query via GraphQL:
-
-              gh api graphql -f query='
-                query($owner:String!,$repo:String!,$num:Int!){
-                  repository(owner:$owner,name:$repo){
-                    pullRequest(number:$num){
-                      reviewThreads(first:100){
-                        nodes{
-                          id isResolved isOutdated
-                          comments(first:1){ nodes{ author{login} path line body } }
-                        }
-                      }
-                    }
-                  }
-                }' -F owner="${GH_REPO%/*}" -F repo="${GH_REPO#*/}" -F num="$PR_NUMBER" \
-                > /tmp/threads.json
-
-            For each unresolved thread authored by the bot (login ending in
-            `[bot]`, `github-actions`, or `claude`), resolve when:
-            - GitHub reports `isOutdated: true`
-            - The specific issue is no longer present at HEAD
-
-            Do NOT resolve threads where a human has replied. Resolve via:
-
-              gh api graphql -f query='
-                mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){ thread{ id } } }' \
-                -F id="<threadId>"
-
-            ## Step 2 — Post inline comments as a single PR review
-
-            Stage the diff for review:
-
-              git diff "origin/$BASE_REF"...HEAD --name-only | xargs -r git add -N
-              git add -u
-
-            Post one review with all new findings. Use `event: "COMMENT"`.
-
-            Each inline comment body MUST follow this structure:
-
-              **{One-line title describing the problem}**
-
-              _{Low|Medium|High} Severity_ · `{path}:{line}`
-
-              {1-3 sentences of prose explaining what's wrong and the
-              concrete consequence. No bullet lists. If a fix is obvious,
-              weave it into the prose.}
-
-            Title: imperative or declarative, 4-10 words, no trailing
-            punctuation. Severity: Low for maintainability, Medium for
-            latent bugs, High for correctness/security/data-loss.
-
-            De-duplicate against existing unresolved threads — skip if a
-            new finding matches an existing open comment on the same
-            path/line with the same concern.
-
-            `line` must appear in the PR's current diff against the base
-            — otherwise the API rejects it. For multi-line findings use
-            `start_line` + `line` + `start_side` + `side`.
-
-            Post via:
-
-              gh api -X POST "repos/$GH_REPO/pulls/$PR_NUMBER/reviews" --input /tmp/review.json
-
-            If there are no new inline findings, skip this step.
-
-            ## Step 3 — Upsert the sticky summary into the PR description
-
-            The summary lives in the **PR body**, not as a separate
-            comment. Preserve the author's prose; append/update only a
-            marked block delimited by `$STICKY_MARKER` and
-            `<!-- /claude-code-review:summary -->`.
-
-            The marked block shape:
+            A sticky summary of the whole PR as it stands now. Write ONLY the
+            callout body — no HTML comment markers, the publish step adds them.
+            Exact shape:
 
               > [!NOTE]
               >
               > **{Low|Medium|High} Risk**
               >
-              > {One sentence: what the change affects and why this risk
-              > level is appropriate.}
+              > {One sentence: what the change affects and why this risk level
+              > is appropriate.}
               >
               > **Overview**
               >
-              > {2-3 sentences on what the PR does at the highest level.}
+              > {2-3 sentences on what the PR does at the highest level — the
+              > shape of the change, not a file list.}
               >
-              > {Optional second paragraph on notable behavioral or
-              > structural detail.}
+              > {Optional second paragraph: the most notable behavioral or
+              > structural detail — a rename, a new default, a migration.}
               >
               > Reviewed by Claude for commit `<short SHA of PR_HEAD_SHA>`.
 
-              <!-- /claude-code-review:summary -->
+            Tone: calm, specific, prose-first. No emojis, no bullet lists, no
+            "Test plan", under ~150 words. Risk level: Low for isolated,
+            reversible changes; Medium for shared infra/CLI/workflows or
+            changes to defaults; High for security, data-loss, or cross-cutting
+            changes. Write this file even when the PR is clean (say it's clean).
 
-            Hard rules: prose paragraphs only, no bullet lists, no file
-            enumerations, under ~150 words.
+            ## Output 2 — /tmp/review-comments.json (optional)
 
-            Risk level: Low for isolated, reversible changes; Medium for
-            shared infra/CLI/workflows or changes to defaults; High for
-            security, data-loss, or cross-cutting changes.
+            Inline, line-anchored findings as a JSON array. Omit the file, or
+            write `[]`, if there are no line-anchored findings. Each element:
 
-            Upsert logic (preserve author prose, replace only the block):
+              {
+                "path": "relative/path.ext",
+                "line": 42,
+                "side": "RIGHT",
+                "body": "**{title}**\n\n_{Low|Medium|High} Severity_ · `path:line`\n\n{1-3 sentences on what's wrong and the concrete consequence}"
+              }
 
-              gh pr view "$PR_NUMBER" --json body --jq .body > /tmp/pr-body.md
+            `line` must be a line present in the PR's current diff or GitHub
+            rejects the comment. For a multi-line span add `"start_line"` and
+            `"start_side": "RIGHT"`. Title: 4-10 words, imperative or
+            declarative, no trailing punctuation. Prefer a few high-signal
+            findings over many nits; if a finding can't be line-anchored, fold
+            it into the summary instead.
 
-              python3 - <<'PY'
-              import os, re, pathlib
-              marker = os.environ["STICKY_MARKER"]
-              end    = "<!-- /claude-code-review:summary -->"
-              body   = pathlib.Path("/tmp/pr-body.md").read_text()
-              block  = pathlib.Path("/tmp/summary-block.md").read_text().rstrip() + "\n"
-              pattern = re.compile(
-                  re.escape(marker) + r".*?" + re.escape(end) + r"\s*",
-                  re.DOTALL,
-              )
-              body = pattern.sub("", body).rstrip()
-              new  = (body + "\n\n" + block) if body else block
-              pathlib.Path("/tmp/pr-body.new.md").write_text(new)
-              PY
-
-              gh pr edit "$PR_NUMBER" --body-file /tmp/pr-body.new.md
-
-            Clean up any legacy sticky comment from earlier runs:
-
-              LEGACY_ID=$(gh api --paginate "repos/$GH_REPO/issues/$PR_NUMBER/comments" \
-                --jq ".[] | select(.body | contains(\"$STICKY_MARKER\")) | .id" \
-                | head -n1)
-              if [ -n "$LEGACY_ID" ]; then
-                gh api -X DELETE "repos/$GH_REPO/issues/comments/$LEGACY_ID"
-              fi
-
-            ## Notes
-            - The PR body is the only summary surface. Do NOT post a
-              separate top-level conversation comment.
-            - Never overwrite the author's prose.
-            - Prefer fewer, higher-signal inline comments over many nits.
-            - If a finding cannot be line-anchored, include it in the
-              sticky summary instead.
+            Write the two files and stop. Do not run `gh`, do not post, do not
+            edit the PR.
           claude_args: |
             --model claude-sonnet-4-6
-            --max-turns 80
-            --allowedTools Read,Grep,Glob,Bash(git:*),Bash(gh:*),Bash(jq:*),Bash(cat:*),Bash(tee:*),Bash(mktemp:*),Bash(head:*),Bash(xargs:*),Bash(python3:*),Bash(task:*),Bash(go:*),Write
+            --max-turns 40
+            --allowedTools Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Write
             --disallowedTools WebSearch,WebFetch
+      - name: Publish review
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: bash .github/scripts/publish-review.sh
 
   review-on-dispatch:
     name: Full Review (on-demand)
@@ -223,170 +145,83 @@ jobs:
           PR_HEAD_SHA: ${{ inputs.head_sha }}
           BASE_REF: ${{ inputs.base_ref }}
           GH_REPO: ${{ github.repository }}
-          STICKY_MARKER: "<!-- claude-code-review:summary -->"
         with:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           allowed_bots: github-actions
           prompt: |
-            Run the `review-pr` skill against this pull request and publish
-            findings as a GitHub pull request review with **inline, line-anchored
-            comments** plus a single **sticky summary** in the PR description.
+            Review this pull request and produce two output files. Do NOT post
+            anything to GitHub yourself — a later CI step publishes what you
+            write. Your only job is to write the files.
 
-            Scope strictly to the diff. Do NOT read files outside the changed
-            set unless flagging a specific, concrete concern. Skip style nits
-            and focus on correctness, security, and blast-radius issues.
+            Scope strictly to the diff. Read the changed set with
+            `git diff "origin/$BASE_REF"...HEAD` (full history is checked out).
+            Do NOT read files outside the changed set unless flagging a
+            specific, concrete concern. Skip style nits; focus on correctness,
+            security, and blast radius.
 
-            ## Tone and format
+            ## Output 1 — /tmp/summary-block.md (REQUIRED, always write it)
 
-            Calm, specific, prose-first. No emojis. No bulleted laundry lists
-            in the summary. No "Test plan" checklists. Write in short
-            paragraphs. Readers should scan the summary in ~15 seconds and
-            know the shape of the change and the risk.
-
-            ## Step 1 — Resolve stale inline comments from earlier runs
-
-            Before posting new comments, resolve threads whose concerns are
-            no longer present in the current HEAD. Query via GraphQL:
-
-              gh api graphql -f query='
-                query($owner:String!,$repo:String!,$num:Int!){
-                  repository(owner:$owner,name:$repo){
-                    pullRequest(number:$num){
-                      reviewThreads(first:100){
-                        nodes{
-                          id isResolved isOutdated
-                          comments(first:1){ nodes{ author{login} path line body } }
-                        }
-                      }
-                    }
-                  }
-                }' -F owner="${GH_REPO%/*}" -F repo="${GH_REPO#*/}" -F num="$PR_NUMBER" \
-                > /tmp/threads.json
-
-            For each unresolved thread authored by the bot (login ending in
-            `[bot]`, `github-actions`, or `claude`), resolve when:
-            - GitHub reports `isOutdated: true`
-            - The specific issue is no longer present at HEAD
-
-            Do NOT resolve threads where a human has replied. Resolve via:
-
-              gh api graphql -f query='
-                mutation($id:ID!){ resolveReviewThread(input:{threadId:$id}){ thread{ id } } }' \
-                -F id="<threadId>"
-
-            ## Step 2 — Post inline comments as a single PR review
-
-            Stage the diff for review:
-
-              git diff "origin/$BASE_REF"...HEAD --name-only | xargs -r git add -N
-              git add -u
-
-            Post one review with all new findings. Use `event: "COMMENT"`.
-
-            Each inline comment body MUST follow this structure:
-
-              **{One-line title describing the problem}**
-
-              _{Low|Medium|High} Severity_ · `{path}:{line}`
-
-              {1-3 sentences of prose explaining what's wrong and the
-              concrete consequence. No bullet lists. If a fix is obvious,
-              weave it into the prose.}
-
-            Title: imperative or declarative, 4-10 words, no trailing
-            punctuation. Severity: Low for maintainability, Medium for
-            latent bugs, High for correctness/security/data-loss.
-
-            De-duplicate against existing unresolved threads — skip if a
-            new finding matches an existing open comment on the same
-            path/line with the same concern.
-
-            `line` must appear in the PR's current diff against the base
-            — otherwise the API rejects it. For multi-line findings use
-            `start_line` + `line` + `start_side` + `side`.
-
-            Post via:
-
-              gh api -X POST "repos/$GH_REPO/pulls/$PR_NUMBER/reviews" --input /tmp/review.json
-
-            If there are no new inline findings, skip this step.
-
-            ## Step 3 — Upsert the sticky summary into the PR description
-
-            The summary lives in the **PR body**, not as a separate
-            comment. Preserve the author's prose; append/update only a
-            marked block delimited by `$STICKY_MARKER` and
-            `<!-- /claude-code-review:summary -->`.
-
-            The marked block shape:
+            A sticky summary of the whole PR as it stands now. Write ONLY the
+            callout body — no HTML comment markers, the publish step adds them.
+            Exact shape:
 
               > [!NOTE]
               >
               > **{Low|Medium|High} Risk**
               >
-              > {One sentence: what the change affects and why this risk
-              > level is appropriate.}
+              > {One sentence: what the change affects and why this risk level
+              > is appropriate.}
               >
               > **Overview**
               >
-              > {2-3 sentences on what the PR does at the highest level.}
+              > {2-3 sentences on what the PR does at the highest level — the
+              > shape of the change, not a file list.}
               >
-              > {Optional second paragraph on notable behavioral or
-              > structural detail.}
+              > {Optional second paragraph: the most notable behavioral or
+              > structural detail — a rename, a new default, a migration.}
               >
               > Reviewed by Claude for commit `<short SHA of PR_HEAD_SHA>`.
 
-              <!-- /claude-code-review:summary -->
+            Tone: calm, specific, prose-first. No emojis, no bullet lists, no
+            "Test plan", under ~150 words. Risk level: Low for isolated,
+            reversible changes; Medium for shared infra/CLI/workflows or
+            changes to defaults; High for security, data-loss, or cross-cutting
+            changes. Write this file even when the PR is clean (say it's clean).
 
-            Hard rules: prose paragraphs only, no bullet lists, no file
-            enumerations, under ~150 words.
+            ## Output 2 — /tmp/review-comments.json (optional)
 
-            Risk level: Low for isolated, reversible changes; Medium for
-            shared infra/CLI/workflows or changes to defaults; High for
-            security, data-loss, or cross-cutting changes.
+            Inline, line-anchored findings as a JSON array. Omit the file, or
+            write `[]`, if there are no line-anchored findings. Each element:
 
-            Upsert logic (preserve author prose, replace only the block):
+              {
+                "path": "relative/path.ext",
+                "line": 42,
+                "side": "RIGHT",
+                "body": "**{title}**\n\n_{Low|Medium|High} Severity_ · `path:line`\n\n{1-3 sentences on what's wrong and the concrete consequence}"
+              }
 
-              gh pr view "$PR_NUMBER" --json body --jq .body > /tmp/pr-body.md
+            `line` must be a line present in the PR's current diff or GitHub
+            rejects the comment. For a multi-line span add `"start_line"` and
+            `"start_side": "RIGHT"`. Title: 4-10 words, imperative or
+            declarative, no trailing punctuation. Prefer a few high-signal
+            findings over many nits; if a finding can't be line-anchored, fold
+            it into the summary instead.
 
-              python3 - <<'PY'
-              import os, re, pathlib
-              marker = os.environ["STICKY_MARKER"]
-              end    = "<!-- /claude-code-review:summary -->"
-              body   = pathlib.Path("/tmp/pr-body.md").read_text()
-              block  = pathlib.Path("/tmp/summary-block.md").read_text().rstrip() + "\n"
-              pattern = re.compile(
-                  re.escape(marker) + r".*?" + re.escape(end) + r"\s*",
-                  re.DOTALL,
-              )
-              body = pattern.sub("", body).rstrip()
-              new  = (body + "\n\n" + block) if body else block
-              pathlib.Path("/tmp/pr-body.new.md").write_text(new)
-              PY
-
-              gh pr edit "$PR_NUMBER" --body-file /tmp/pr-body.new.md
-
-            Clean up any legacy sticky comment from earlier runs:
-
-              LEGACY_ID=$(gh api --paginate "repos/$GH_REPO/issues/$PR_NUMBER/comments" \
-                --jq ".[] | select(.body | contains(\"$STICKY_MARKER\")) | .id" \
-                | head -n1)
-              if [ -n "$LEGACY_ID" ]; then
-                gh api -X DELETE "repos/$GH_REPO/issues/comments/$LEGACY_ID"
-              fi
-
-            ## Notes
-            - The PR body is the only summary surface. Do NOT post a
-              separate top-level conversation comment.
-            - Never overwrite the author's prose.
-            - Prefer fewer, higher-signal inline comments over many nits.
-            - If a finding cannot be line-anchored, include it in the
-              sticky summary instead.
+            Write the two files and stop. Do not run `gh`, do not post, do not
+            edit the PR.
           claude_args: |
             --model claude-sonnet-4-6
-            --max-turns 80
-            --allowedTools Read,Grep,Glob,Bash(git:*),Bash(gh:*),Bash(jq:*),Bash(cat:*),Bash(tee:*),Bash(mktemp:*),Bash(head:*),Bash(xargs:*),Bash(python3:*),Bash(task:*),Bash(go:*),Write
+            --max-turns 40
+            --allowedTools Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Write
             --disallowedTools WebSearch,WebFetch
+      - name: Publish review
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ inputs.pr_number }}
+          PR_HEAD_SHA: ${{ inputs.head_sha }}
+        run: bash .github/scripts/publish-review.sh
 
   resolve-threads:
     name: Resolve Threads


### PR DESCRIPTION
## What happened on #2917

The review action ran to `success` and posted nothing. The actual run log:

```
is_error: false
duration_ms: 8986
num_turns: 4
total_cost_usd: 0.065
permission_denials_count: 0
```

4 of the 80 allotted turns, 9 seconds, no errors, no permission denials. This is **not** turn-budget exhaustion (an earlier theory floated for this PR pointed at that, and at two branches — \`ci-raise-resolve-threads-turn-budget\` and \`fix/ccr-review-on-comment-trigger\` — as prior art; neither holds up: the first is a stale, never-PR'd branch from three weeks ago that only touches the unrelated \`resolve-threads\` job, the second is @rmvangun's own pre-existing, unrelated PR #2876 about the \`/review\`-comment dispatch trigger). The model simply stopped short of the GitHub-writing steps the prompt asks it to do inline — no thread resolution, no inline comments, no PR-body summary upsert.

## The fix

Same restructuring already shipped and verified in \`windsorcli/core\` ([core#2131](https://github.com/windsorcli/core/pull/2131)): split reading from writing.

- The review step now only reads the diff and **writes two files** — \`/tmp/summary-block.md\` (required) and optional \`/tmp/review-comments.json\` — with \`Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Write\` only.
- A ported \`.github/scripts/publish-review.sh\`, run in a plain step **outside** the model's tool loop under \`always()\`, does every GitHub write: upserts the sticky summary (preserving author prose), resolves prior bot threads, posts inline comments from the JSON.
- If no summary was produced, it posts a stub and **exits non-zero** — a no-op run becomes a red X, not a silent, costless green.

Applied to both \`review\` (on-open) and \`review-on-dispatch\` (on-demand). \`resolve-threads\` is untouched — not implicated in this failure.

## Cost

Turn cap dropped **80 → 40** to match core's number. The model's job is now trivially "read diff, write two files" — no GraphQL thread listing, no PR-body fetch/python-transform, no git staging. That work moves to bash, so per-run cost should land at or below the historical baseline, not above it.

## Validation

\`yamllint\`/YAML-parse clean, \`actionlint\` clean (one pre-existing \`SC2016:info\` note in the untouched \`resolve-threads\` GraphQL query — a false positive, GraphQL variables in single quotes), \`shellcheck\` clean on the ported script.

Marking ready-for-review so the fixed \`review\` job exercises itself on this PR before merge.

<!-- claude-code-review:summary -->

> [!WARNING]
>
> **Review did not complete**
>
> The automated review produced no summary. See the [run](https://github.com/windsorcli/cli/actions/runs/28742608760).

<!-- /claude-code-review:summary -->
