### PR TITLE
fix(ci): fetch publish-review.sh from main, not the PR's own tree

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -125,7 +125,14 @@ jobs:
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-        run: bash .github/scripts/publish-review.sh
+        run: |
+          # The publish script is CI infrastructure that lives on main, not in the
+          # PR's own tree — a PR branch opened or last pushed before this script was
+          # added won't have it. Always run main's copy regardless of what commit
+          # the checkout step left in the working directory.
+          git fetch --depth=1 origin main
+          git show origin/main:.github/scripts/publish-review.sh > /tmp/publish-review.sh
+          bash /tmp/publish-review.sh
 
   review-on-dispatch:
     name: Full Review (on-demand)
@@ -221,7 +228,14 @@ jobs:
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ inputs.pr_number }}
           PR_HEAD_SHA: ${{ inputs.head_sha }}
-        run: bash .github/scripts/publish-review.sh
+        run: |
+          # The publish script is CI infrastructure that lives on main, not in the
+          # PR's own tree — a PR branch opened or last pushed before this script was
+          # added won't have it. Always run main's copy regardless of what commit
+          # the checkout step left in the working directory.
+          git fetch --depth=1 origin main
+          git show origin/main:.github/scripts/publish-review.sh > /tmp/publish-review.sh
+          bash /tmp/publish-review.sh
 
   resolve-threads:
     name: Resolve Threads


### PR DESCRIPTION
## What happened

After #2918 merged, I re-dispatched \`Full Review\` onto #2917 to confirm it now posts. The model ran for real this time — 22 turns, \$0.61, \`is_error: false\` — but the **publish step itself crashed**:

\`\`\`
bash: .github/scripts/publish-review.sh: No such file or directory
##[error]Process completed with exit code 127.
\`\`\`

Nothing posted, not even the fail-loud stub — because the script that posts the stub is the thing missing.

## Root cause

\`review-on-dispatch\` checks out \`ref: ${{ inputs.head_sha }}\` — the PR's own commit, not \`main\`. \`.github/scripts/publish-review.sh\` only exists as of #2918's merge, so any PR branch opened or last pushed before that (i.e. #2917, and every other currently-open PR) checks out a tree that simply doesn't contain it. Same exposure exists in the \`review\` job for any PR branch that predates the merge and hasn't rebased.

## Fix

The publish script is CI infrastructure, not PR content — it shouldn't depend on which commit the checkout step left in the working directory. Both \`Publish review\` steps now fetch and run **main's** copy explicitly:

\`\`\`bash
git fetch --depth=1 origin main
git show origin/main:.github/scripts/publish-review.sh > /tmp/publish-review.sh
bash /tmp/publish-review.sh
\`\`\`

This also means future fixes to the publish script automatically apply to in-flight PRs without requiring a rebase.

## Validation

Same constraint as #2918: this PR modifies the review workflow itself, so \`anthropics/claude-code-action\`'s own "workflow must match default branch" guard means I can't observe the *new* prompt/publish path succeed on this PR pre-merge — only a post-merge re-dispatch (as I did for #2918) gives a real result. YAML/actionlint clean; the fix itself is a small, mechanical location correction, not a logic change to the already-proven read/write split.

<!-- claude-code-review:summary -->

> [!WARNING]
>
> **Review did not complete**
>
> The automated review produced no summary. See the [run](https://github.com/windsorcli/cli/actions/runs/28742957473).

<!-- /claude-code-review:summary -->
