### PR TITLE
feat(composer): Enhance Flux system handling and integration in blueprint processing

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -1035,17 +1035,80 @@ func (b *Blueprint) RemoveKustomization(removal Kustomization) error {
 	return nil
 }
 
-// UpsertFluxSystem replaces the FluxSystem with the same Name if one exists in b.FluxSystems,
-// or appends it when none does.
+// UpsertFluxSystem merges sys into the FluxSystem with the same Name if one exists in
+// b.FluxSystems, or appends it when none does. On a match, DependsOn accumulates (union) and
+// Install/Resources deep-merge via MergeFluxInstall/MergeFluxVariants — the same field-level
+// semantics strategicMergeKustomization already gives same-name plain kustomize: entries — rather
+// than sys wholesale-replacing what is already there. This is the path StrategicMerge uses to
+// combine FluxSystems across sources (each source's facets already merged among themselves before
+// reaching here), so a same-name collision here must not silently drop one side's install/resources
+// tiers the way a blind replace would.
 func (b *Blueprint) UpsertFluxSystem(sys FluxSystem) error {
 	for i, existing := range b.FluxSystems {
 		if existing.Name == sys.Name {
-			b.FluxSystems[i] = sys
+			merged := existing
+			for _, dep := range sys.DependsOn {
+				if dep != "" && !slices.Contains(merged.DependsOn, dep) {
+					merged.DependsOn = append(merged.DependsOn, dep)
+				}
+			}
+			merged.Install = MergeFluxInstall(existing.Install, sys.Install)
+			merged.Resources = MergeFluxVariants(existing.Resources, sys.Resources)
+			b.FluxSystems[i] = merged
 			return nil
 		}
 	}
 	b.FluxSystems = append(b.FluxSystems, sys)
 	return nil
+}
+
+// MergeFluxInstall deep-merges new's Install tier into existing's via MergeKustomizationFields
+// (Components/DependsOn accumulate, other fields are overridden by new when set) rather than via
+// by-name Blueprint.Kustomizations matching, since Install carries no Name until tier compilation
+// and that by-name path is a no-op on an unnamed Kustomization. Either side being nil just takes
+// the other, matching how a facet or source with no Install opinion shouldn't erase one
+// contributed elsewhere.
+func MergeFluxInstall(existing, new *Kustomization) *Kustomization {
+	if new == nil {
+		return existing
+	}
+	if existing == nil {
+		return new
+	}
+	merged := MergeKustomizationFields(*existing, *new)
+	return &merged
+}
+
+// MergeFluxVariants combines two resources-variant lists keyed by variant name. A variant from new
+// deep-merges into the same-named variant in existing via MergeKustomizationFields (see
+// MergeFluxInstall for why by-name Blueprint.Kustomizations matching isn't used instead), and the
+// two When conditions combine with AND. A variant with a new name is appended in order. This keeps
+// a cross-facet or cross-source merge from emitting two Kustomizations with the same
+// "<system>-resources[-<name>]" identity.
+func MergeFluxVariants(existing, new []FluxVariant) []FluxVariant {
+	merged := slices.Clone(existing)
+	for _, nv := range new {
+		idx := slices.IndexFunc(merged, func(v FluxVariant) bool { return v.Name == nv.Name })
+		if idx == -1 {
+			merged = append(merged, nv)
+			continue
+		}
+
+		mergedK := MergeKustomizationFields(merged[idx].Kustomization, nv.Kustomization)
+
+		combinedWhen := merged[idx].When
+		switch {
+		case merged[idx].When != "" && nv.When != "":
+			combinedWhen = fmt.Sprintf("(%s) && (%s)", merged[idx].When, nv.When)
+		case nv.When != "":
+			combinedWhen = nv.When
+		}
+		merged[idx] = FluxVariant{
+			Kustomization: mergedK,
+			When:          combinedWhen,
+		}
+	}
+	return merged
 }
 
 // AllKustomizations returns a flat list of every compiled Kustomization — plain kustomize: entries

--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -1438,71 +1438,82 @@ func (b *Blueprint) strategicMergeKustomization(kustomization Kustomization) err
 
 	for i, existing := range b.Kustomizations {
 		if existing.Name == kustomization.Name {
-			for _, component := range kustomization.Components {
-				if component == "" || !slices.Contains(existing.Components, component) {
-					existing.Components = append(existing.Components, component)
-				}
-			}
-			slices.Sort(existing.Components)
-			for _, dep := range kustomization.DependsOn {
-				if dep != "" && !slices.Contains(existing.DependsOn, dep) {
-					existing.DependsOn = append(existing.DependsOn, dep)
-				}
-			}
-			if kustomization.Path != "" {
-				existing.Path = kustomization.Path
-			}
-			if kustomization.Source != "" {
-				existing.Source = kustomization.Source
-			}
-			if kustomization.Namespace != "" {
-				existing.Namespace = kustomization.Namespace
-			}
-			if kustomization.TargetNamespace != "" {
-				existing.TargetNamespace = kustomization.TargetNamespace
-			}
-			if kustomization.Destroy != nil {
-				existing.Destroy = kustomization.Destroy
-			}
-			if kustomization.Enabled != nil {
-				existing.Enabled = kustomization.Enabled
-			}
-			if kustomization.DestroyOnly != nil {
-				existing.DestroyOnly = kustomization.DestroyOnly
-			}
-			if kustomization.Interval != nil {
-				existing.Interval = kustomization.Interval
-			}
-			if kustomization.RetryInterval != nil {
-				existing.RetryInterval = kustomization.RetryInterval
-			}
-			if kustomization.Timeout != nil {
-				existing.Timeout = kustomization.Timeout
-			}
-			if kustomization.Wait != nil {
-				existing.Wait = kustomization.Wait
-			}
-			if kustomization.Force != nil {
-				existing.Force = kustomization.Force
-			}
-			if kustomization.Prune != nil {
-				existing.Prune = kustomization.Prune
-			}
-			if len(kustomization.Patches) > 0 {
-				existing.Patches = append(existing.Patches, kustomization.Patches...)
-			}
-			if len(kustomization.Substitutions) > 0 {
-				if existing.Substitutions == nil {
-					existing.Substitutions = make(map[string]string)
-				}
-				maps.Copy(existing.Substitutions, kustomization.Substitutions)
-			}
-			b.Kustomizations[i] = existing
+			b.Kustomizations[i] = MergeKustomizationFields(existing, kustomization)
 			return b.sortKustomize()
 		}
 	}
 	b.Kustomizations = append(b.Kustomizations, kustomization)
 	return b.sortKustomize()
+}
+
+// MergeKustomizationFields deep-merges overlay onto base and returns the result: Components and
+// DependsOn accumulate (deduplicated, Components sorted), Patches accumulate, Substitutions copy
+// in, and every other field is overridden by overlay when overlay sets it. Callers that need
+// by-name matching within a Blueprint's Kustomizations list use strategicMergeKustomization, which
+// calls this once a match is found; callers merging two already-matched Kustomization values
+// directly (e.g. FluxSystem tiers, which carry no Name until tier compilation) call this directly.
+func MergeKustomizationFields(base, overlay Kustomization) Kustomization {
+	existing := base
+	for _, component := range overlay.Components {
+		if component == "" || !slices.Contains(existing.Components, component) {
+			existing.Components = append(existing.Components, component)
+		}
+	}
+	slices.Sort(existing.Components)
+	for _, dep := range overlay.DependsOn {
+		if dep != "" && !slices.Contains(existing.DependsOn, dep) {
+			existing.DependsOn = append(existing.DependsOn, dep)
+		}
+	}
+	if overlay.Path != "" {
+		existing.Path = overlay.Path
+	}
+	if overlay.Source != "" {
+		existing.Source = overlay.Source
+	}
+	if overlay.Namespace != "" {
+		existing.Namespace = overlay.Namespace
+	}
+	if overlay.TargetNamespace != "" {
+		existing.TargetNamespace = overlay.TargetNamespace
+	}
+	if overlay.Destroy != nil {
+		existing.Destroy = overlay.Destroy
+	}
+	if overlay.Enabled != nil {
+		existing.Enabled = overlay.Enabled
+	}
+	if overlay.DestroyOnly != nil {
+		existing.DestroyOnly = overlay.DestroyOnly
+	}
+	if overlay.Interval != nil {
+		existing.Interval = overlay.Interval
+	}
+	if overlay.RetryInterval != nil {
+		existing.RetryInterval = overlay.RetryInterval
+	}
+	if overlay.Timeout != nil {
+		existing.Timeout = overlay.Timeout
+	}
+	if overlay.Wait != nil {
+		existing.Wait = overlay.Wait
+	}
+	if overlay.Force != nil {
+		existing.Force = overlay.Force
+	}
+	if overlay.Prune != nil {
+		existing.Prune = overlay.Prune
+	}
+	if len(overlay.Patches) > 0 {
+		existing.Patches = append(existing.Patches, overlay.Patches...)
+	}
+	if len(overlay.Substitutions) > 0 {
+		if existing.Substitutions == nil {
+			existing.Substitutions = make(map[string]string)
+		}
+		maps.Copy(existing.Substitutions, overlay.Substitutions)
+	}
+	return existing
 }
 
 // sortKustomize reorders the Blueprint's Kustomizations so that dependencies precede dependents.

--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -5,6 +5,7 @@ package v1alpha1
 import (
 	"fmt"
 	"maps"
+	"path"
 	"reflect"
 	"slices"
 	"strings"
@@ -891,6 +892,12 @@ func (b *Blueprint) StrategicMerge(overlays ...*Blueprint) error {
 			}
 		}
 
+		for _, sys := range overlay.FluxSystems {
+			if err := b.UpsertFluxSystem(sys); err != nil {
+				return err
+			}
+		}
+
 		if overlay.Substitutions != nil {
 			if b.Substitutions == nil {
 				b.Substitutions = make(map[string]string)
@@ -1026,6 +1033,92 @@ func (b *Blueprint) RemoveKustomization(removal Kustomization) error {
 		}
 	}
 	return nil
+}
+
+// UpsertFluxSystem replaces the FluxSystem with the same Name if one exists in b.FluxSystems,
+// or appends it when none does.
+func (b *Blueprint) UpsertFluxSystem(sys FluxSystem) error {
+	for i, existing := range b.FluxSystems {
+		if existing.Name == sys.Name {
+			b.FluxSystems[i] = sys
+			return nil
+		}
+	}
+	b.FluxSystems = append(b.FluxSystems, sys)
+	return nil
+}
+
+// AllKustomizations returns a flat list of every compiled Kustomization — plain kustomize: entries
+// first, then the install and resources tiers compiled from each FluxSystem. Expressions on stored
+// FluxSystems are already evaluated; this method only performs name/path/dependency assembly.
+func (b *Blueprint) AllKustomizations() []Kustomization {
+	all := make([]Kustomization, 0, len(b.Kustomizations))
+	all = append(all, b.Kustomizations...)
+	for _, sys := range b.FluxSystems {
+		all = append(all, compileFluxSystemTiers(sys)...)
+	}
+	return all
+}
+
+// compileFluxSystemTiers converts a pre-evaluated FluxSystem into its tier Kustomizations without
+// any expression evaluation. Install compiles to "<name>-install" at "<path>/install"; each
+// resources variant compiles to "<name>-resources[-<variant>]" at "<path>/resources".
+func compileFluxSystemTiers(sys FluxSystem) []Kustomization {
+	name := sys.Name
+	base := sys.Path
+	if base == "" {
+		base = name
+	}
+	installName := name + "-install"
+
+	var out []Kustomization
+	installEmitted := false
+
+	if sys.Install != nil && len(sys.Install.Components) > 0 {
+		k := *sys.Install.DeepCopy()
+		k.Name = installName
+		k.Path = path.Join(base, "install")
+		k.DependsOn = slices.Clone(sys.DependsOn)
+		if k.Source == "" {
+			k.Source = sys.Source
+		}
+		if k.Enabled == nil {
+			k.Enabled = sys.Enabled
+		}
+		if k.Destroy == nil {
+			k.Destroy = sys.Destroy
+		}
+		k.Substitute = nil
+		out = append(out, k)
+		installEmitted = true
+	}
+
+	for _, v := range sys.Resources {
+		variantName := name + "-resources"
+		if v.Name != "" {
+			variantName += "-" + v.Name
+		}
+		k := *v.Kustomization.DeepCopy()
+		k.Name = variantName
+		k.Path = path.Join(base, "resources")
+		if installEmitted {
+			k.DependsOn = append([]string{installName}, v.DependsOn...)
+		} else {
+			k.DependsOn = append(slices.Clone(sys.DependsOn), v.DependsOn...)
+		}
+		if k.Source == "" {
+			k.Source = sys.Source
+		}
+		if k.Enabled == nil {
+			k.Enabled = sys.Enabled
+		}
+		if k.Destroy == nil {
+			k.Destroy = sys.Destroy
+		}
+		k.Substitute = nil
+		out = append(out, k)
+	}
+	return out
 }
 
 // DeepCopy creates a deep copy of the Kustomization object.

--- a/api/v1alpha1/blueprint_types_test.go
+++ b/api/v1alpha1/blueprint_types_test.go
@@ -1543,6 +1543,50 @@ func TestBlueprint_StrategicMerge(t *testing.T) {
 			t.Errorf("Expected base-only key to be preserved, got '%s'", base.Substitutions["keep_me"])
 		}
 	})
+
+	t.Run("MergesSameNameFluxSystemsAcrossSourcesInsteadOfReplacing", func(t *testing.T) {
+		// Given a base blueprint (one source's already-composed facets) with a cert-manager
+		// system carrying an install and one resources variant
+		base := &Blueprint{
+			FluxSystems: []FluxSystem{
+				{
+					Name:      "cert-manager",
+					Install:   &Kustomization{Components: []string{"helm-release"}},
+					Resources: []FluxVariant{{Kustomization: Kustomization{Components: []string{"private-issuer/ca"}}}},
+				},
+			},
+		}
+
+		// And an overlay (a second source's already-composed facets) contributing to the same
+		// system name with an extra install component and a new named resources variant
+		overlay := &Blueprint{
+			FluxSystems: []FluxSystem{
+				{
+					Name:      "cert-manager",
+					Install:   &Kustomization{Components: []string{"helm-release-extra-metrics"}},
+					Resources: []FluxVariant{{Kustomization: Kustomization{Name: "extra", Components: []string{"public-issuer"}}}},
+				},
+			},
+		}
+
+		// When strategic merging (the path composer.Compose uses to combine per-source blueprints)
+		if err := base.StrategicMerge(overlay); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Then the two sources' contributions merge into one system instead of the overlay's
+		// source wholesale-replacing the base source's install/resources
+		if len(base.FluxSystems) != 1 {
+			t.Fatalf("expected one merged cert-manager system, not two colliding sources' entries, got %+v", base.FluxSystems)
+		}
+		merged := base.FluxSystems[0]
+		if merged.Install == nil || !contains(merged.Install.Components, "helm-release") || !contains(merged.Install.Components, "helm-release-extra-metrics") {
+			t.Errorf("expected install components to union across sources, got %+v", merged.Install)
+		}
+		if len(merged.Resources) != 2 {
+			t.Fatalf("expected both sources' resources variants to survive, got %+v", merged.Resources)
+		}
+	})
 }
 
 func TestBlueprint_ReplaceTerraformComponent(t *testing.T) {
@@ -4588,6 +4632,65 @@ flux:
 		}
 		if len(bp.FluxSystems[0].Resources) != 1 {
 			t.Fatalf("expected one resources variant, got %+v", bp.FluxSystems[0].Resources)
+		}
+	})
+}
+
+func TestBlueprint_UpsertFluxSystem(t *testing.T) {
+	t.Run("AppendsWhenNoExistingSystemOfThatName", func(t *testing.T) {
+		// Given a blueprint with no cert-manager system yet
+		b := &Blueprint{}
+
+		// When a system is upserted
+		if err := b.UpsertFluxSystem(FluxSystem{Name: "cert-manager"}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Then it is appended
+		if len(b.FluxSystems) != 1 || b.FluxSystems[0].Name != "cert-manager" {
+			t.Fatalf("expected cert-manager appended, got %+v", b.FluxSystems)
+		}
+	})
+
+	t.Run("MergesInsteadOfReplacingOnNameCollision", func(t *testing.T) {
+		// Given a blueprint already carrying a cert-manager system with an install and one
+		// resources variant (as if written by one source's already-merged facets)
+		b := &Blueprint{
+			FluxSystems: []FluxSystem{
+				{
+					Name:      "cert-manager",
+					DependsOn: []string{"pki-base"},
+					Install:   &Kustomization{Components: []string{"helm-release"}},
+					Resources: []FluxVariant{{Kustomization: Kustomization{Components: []string{"private-issuer/ca"}}}},
+				},
+			},
+		}
+
+		// When a second same-named system (as if from another source) is upserted, contributing
+		// an additional install component, an extra dependsOn edge, and a new resources variant
+		if err := b.UpsertFluxSystem(FluxSystem{
+			Name:      "cert-manager",
+			DependsOn: []string{"lb-base"},
+			Install:   &Kustomization{Components: []string{"helm-release-extra-metrics"}},
+			Resources: []FluxVariant{{Kustomization: Kustomization{Name: "extra", Components: []string{"public-issuer"}}}},
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Then the two contributions merge into one entry instead of the second wholesale
+		// replacing the first
+		if len(b.FluxSystems) != 1 {
+			t.Fatalf("expected one merged cert-manager entry, not two colliding entries, got %+v", b.FluxSystems)
+		}
+		merged := b.FluxSystems[0]
+		if !contains(merged.DependsOn, "pki-base") || !contains(merged.DependsOn, "lb-base") {
+			t.Errorf("expected dependsOn to union, got %v", merged.DependsOn)
+		}
+		if merged.Install == nil || !contains(merged.Install.Components, "helm-release") || !contains(merged.Install.Components, "helm-release-extra-metrics") {
+			t.Errorf("expected install components to union across the collision, got %+v", merged.Install)
+		}
+		if len(merged.Resources) != 2 {
+			t.Fatalf("expected the original unnamed variant and the new named variant to both survive, got %+v", merged.Resources)
 		}
 	})
 }

--- a/integration/composer_test.go
+++ b/integration/composer_test.go
@@ -264,6 +264,139 @@ func TestShowBlueprint_InstallResourcesTiers(t *testing.T) {
 	}
 }
 
+// TestShowBlueprint_FluxSystemCrossFacetMerge verifies that two facets contributing to the same
+// flux: system name at different ordinals still merge under the default "merge" strategy instead
+// of the higher-ordinal facet wholesale-replacing the lower-ordinal one's install/resources: pki's
+// cert-manager install/resources (ordinal 0) and addon-cert-manager-extra's additional install
+// component and resources variant (ordinal 400, from the "addon-" filename prefix) must both
+// survive in the composed blueprint.
+func TestShowBlueprint_FluxSystemCrossFacetMerge(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "facet-tiers")
+	env = append(env, "WINDSOR_CONTEXT=default")
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"show", "blueprint"}, env)
+	if err != nil {
+		t.Fatalf("show blueprint: %v\nstderr: %s", err, stderr)
+	}
+
+	var bp struct {
+		Flux []struct {
+			Name    string `yaml:"name"`
+			Install struct {
+				Components []string `yaml:"components"`
+			} `yaml:"install"`
+			Resources []struct {
+				Name       string   `yaml:"name"`
+				Components []string `yaml:"components"`
+			} `yaml:"resources"`
+		} `yaml:"flux"`
+	}
+	if err := yaml.Unmarshal(stdout, &bp); err != nil {
+		t.Fatalf("parse blueprint YAML: %v\nstdout: %s", err, stdout)
+	}
+
+	var certMgr *struct {
+		Name    string `yaml:"name"`
+		Install struct {
+			Components []string `yaml:"components"`
+		} `yaml:"install"`
+		Resources []struct {
+			Name       string   `yaml:"name"`
+			Components []string `yaml:"components"`
+		} `yaml:"resources"`
+	}
+	for i := range bp.Flux {
+		if bp.Flux[i].Name == "cert-manager" {
+			certMgr = &bp.Flux[i]
+			break
+		}
+	}
+	if certMgr == nil {
+		t.Fatalf("expected cert-manager in flux:, got flux=%+v", bp.Flux)
+	}
+
+	if !slices.Contains(certMgr.Install.Components, "helm-release") || !slices.Contains(certMgr.Install.Components, "helm-release-extra-metrics") {
+		t.Errorf("expected install components to union across facets, got %v", certMgr.Install.Components)
+	}
+
+	var hasDefaultVariant, hasExtraVariant bool
+	for _, r := range certMgr.Resources {
+		if r.Name == "" && slices.Contains(r.Components, "private-issuer/ca") {
+			hasDefaultVariant = true
+		}
+		if r.Name == "extra" && slices.Contains(r.Components, "public-issuer") {
+			hasExtraVariant = true
+		}
+	}
+	if !hasDefaultVariant {
+		t.Errorf("expected the lower-ordinal facet's unnamed resources variant to survive, got %+v", certMgr.Resources)
+	}
+	if !hasExtraVariant {
+		t.Errorf("expected the higher-ordinal facet's resources variant to be added rather than replace the system, got %+v", certMgr.Resources)
+	}
+}
+
+// TestShowBlueprint_FluxSystemSameOrdinalVariantMerge verifies the original review-flagged
+// scenario: two facets at the SAME ordinal each contributing a resources variant under the same
+// key (both unnamed, so both would compile to "cert-manager-resources") merge into a single
+// variant instead of surviving as two colliding entries. pki's and pki-extra's unnamed variants
+// (both ordinal 0, since neither filename matches an ordinal-prefix rule) must union into one
+// resources entry carrying both facets' components, not appear as two separate list entries.
+func TestShowBlueprint_FluxSystemSameOrdinalVariantMerge(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "facet-tiers")
+	env = append(env, "WINDSOR_CONTEXT=default")
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"show", "blueprint"}, env)
+	if err != nil {
+		t.Fatalf("show blueprint: %v\nstderr: %s", err, stderr)
+	}
+
+	var bp struct {
+		Flux []struct {
+			Name      string `yaml:"name"`
+			Resources []struct {
+				Name       string   `yaml:"name"`
+				Components []string `yaml:"components"`
+			} `yaml:"resources"`
+		} `yaml:"flux"`
+	}
+	if err := yaml.Unmarshal(stdout, &bp); err != nil {
+		t.Fatalf("parse blueprint YAML: %v\nstdout: %s", err, stdout)
+	}
+
+	var certMgr *struct {
+		Name      string `yaml:"name"`
+		Resources []struct {
+			Name       string   `yaml:"name"`
+			Components []string `yaml:"components"`
+		} `yaml:"resources"`
+	}
+	for i := range bp.Flux {
+		if bp.Flux[i].Name == "cert-manager" {
+			certMgr = &bp.Flux[i]
+			break
+		}
+	}
+	if certMgr == nil {
+		t.Fatalf("expected cert-manager in flux:, got flux=%+v", bp.Flux)
+	}
+
+	var unnamedCount int
+	var unnamedComponents []string
+	for _, r := range certMgr.Resources {
+		if r.Name == "" {
+			unnamedCount++
+			unnamedComponents = r.Components
+		}
+	}
+	if unnamedCount != 1 {
+		t.Fatalf("expected pki's and pki-extra's same-key unnamed variant to merge into a single resources entry, got %d unnamed entries in %+v", unnamedCount, certMgr.Resources)
+	}
+	if !slices.Contains(unnamedComponents, "private-issuer/ca") || !slices.Contains(unnamedComponents, "private-issuer/wildcard") {
+		t.Errorf("expected the merged unnamed variant to union both facets' components, got %v", unnamedComponents)
+	}
+}
+
 // TestShowBlueprint_FacetRequires_Satisfied verifies the success path: when every required
 // path resolves to a present, non-empty value, ProcessFacets returns no error and the
 // blueprint renders normally.

--- a/integration/composer_test.go
+++ b/integration/composer_test.go
@@ -174,9 +174,11 @@ func TestShowBlueprint_CrdsDriverSelection(t *testing.T) {
 	}
 }
 
-// TestShowBlueprint_InstallResourcesTiers verifies a tiered facet entry expands into separate
-// install and resources kustomizations sharing the entry's path, and that a consumer depending on
-// the vendor by its bare name resolves to the install tier.
+// TestShowBlueprint_InstallResourcesTiers verifies that flux: system entries appear in the
+// composed blueprint's flux: section (not kustomize:), that their tiers have correct paths and
+// components, that the implicit install→resources edge is encoded in the flux: structure, and
+// that a plain kustomize: consumer depending on the system by its bare name resolves to its
+// install tier.
 func TestShowBlueprint_InstallResourcesTiers(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.PrepareFixture(t, "facet-tiers")
@@ -187,56 +189,78 @@ func TestShowBlueprint_InstallResourcesTiers(t *testing.T) {
 	}
 
 	var bp struct {
+		Flux []struct {
+			Name    string `yaml:"name"`
+			Path    string `yaml:"path"`
+			Install struct {
+				Components []string `yaml:"components"`
+			} `yaml:"install"`
+			Resources []struct {
+				Components []string `yaml:"components"`
+			} `yaml:"resources"`
+		} `yaml:"flux"`
 		Kustomize []struct {
-			Name       string   `yaml:"name"`
-			Path       string   `yaml:"path"`
-			Components []string `yaml:"components"`
-			DependsOn  []string `yaml:"dependsOn"`
+			Name      string   `yaml:"name"`
+			DependsOn []string `yaml:"dependsOn"`
 		} `yaml:"kustomize"`
 	}
 	if err := yaml.Unmarshal(stdout, &bp); err != nil {
 		t.Fatalf("parse blueprint YAML: %v\nstdout: %s", err, stdout)
 	}
-	byName := map[string]struct {
-		path       string
-		components []string
-		dependsOn  []string
-	}{}
+
+	// cert-manager must be in flux:, not kustomize:.
+	var certMgr *struct {
+		Name    string `yaml:"name"`
+		Path    string `yaml:"path"`
+		Install struct {
+			Components []string `yaml:"components"`
+		} `yaml:"install"`
+		Resources []struct {
+			Components []string `yaml:"components"`
+		} `yaml:"resources"`
+	}
+	for i := range bp.Flux {
+		if bp.Flux[i].Name == "cert-manager" {
+			certMgr = &bp.Flux[i]
+			break
+		}
+	}
+	if certMgr == nil {
+		t.Fatalf("expected cert-manager in flux:, got flux=%+v", bp.Flux)
+	}
+	if certMgr.Path != "pki/cert-manager" {
+		t.Errorf("expected path pki/cert-manager, got %q", certMgr.Path)
+	}
+	if !slices.Contains(certMgr.Install.Components, "helm-release") {
+		t.Errorf("expected install components [helm-release], got %v", certMgr.Install.Components)
+	}
+	if len(certMgr.Resources) == 0 || !slices.Contains(certMgr.Resources[0].Components, "private-issuer/ca") {
+		t.Errorf("expected resources[0] components [private-issuer/ca], got %v", certMgr.Resources)
+	}
+
+	// cert-manager must NOT appear under kustomize:.
 	for _, k := range bp.Kustomize {
-		byName[k.Name] = struct {
-			path       string
-			components []string
-			dependsOn  []string
-		}{k.Path, k.Components, k.DependsOn}
+		if k.Name == "cert-manager-install" || k.Name == "cert-manager-resources" {
+			t.Errorf("flux system tier %q must not appear under kustomize:", k.Name)
+		}
 	}
 
-	install, ok := byName["cert-manager-install"]
-	if !ok {
-		t.Fatalf("expected cert-manager-install, got %+v", bp.Kustomize)
+	// Plain kustomize: consumer's bare-name dependency must resolve to the install tier.
+	var dns *struct {
+		Name      string   `yaml:"name"`
+		DependsOn []string `yaml:"dependsOn"`
 	}
-	res, ok := byName["cert-manager-resources"]
-	if !ok {
-		t.Fatalf("expected cert-manager-resources, got %+v", bp.Kustomize)
+	for i := range bp.Kustomize {
+		if bp.Kustomize[i].Name == "dns" {
+			dns = &bp.Kustomize[i]
+			break
+		}
 	}
-	if install.path != "pki/cert-manager/install" || res.path != "pki/cert-manager/resources" {
-		t.Errorf("expected tiers at pki/cert-manager/{install,resources}, got install=%q resources=%q", install.path, res.path)
+	if dns == nil {
+		t.Fatalf("expected dns in kustomize:, got %+v", bp.Kustomize)
 	}
-	if !slices.Contains(install.components, "helm-release") {
-		t.Errorf("expected install components [helm-release], got %v", install.components)
-	}
-	if !slices.Contains(res.components, "private-issuer/ca") {
-		t.Errorf("expected resources components [private-issuer/ca], got %v", res.components)
-	}
-	if !slices.Contains(res.dependsOn, "cert-manager-install") {
-		t.Errorf("expected resources to depend on cert-manager-install, got %v", res.dependsOn)
-	}
-
-	dns, ok := byName["dns"]
-	if !ok {
-		t.Fatalf("expected dns, got %+v", bp.Kustomize)
-	}
-	if !slices.Contains(dns.dependsOn, "cert-manager-install") {
-		t.Errorf("expected dns bare-name dependency to resolve to cert-manager-install, got %v", dns.dependsOn)
+	if !slices.Contains(dns.DependsOn, "cert-manager-install") {
+		t.Errorf("expected dns bare-name dependency to resolve to cert-manager-install, got %v", dns.DependsOn)
 	}
 }
 

--- a/integration/fixtures/facet-tiers/contexts/_template/facets/addon-cert-manager-extra.yaml
+++ b/integration/fixtures/facet-tiers/contexts/_template/facets/addon-cert-manager-extra.yaml
@@ -1,0 +1,18 @@
+kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: addon-cert-manager-extra
+  description: Higher-ordinal facet contributing to pki's cert-manager flux system, to exercise cross-ordinal merge (install components accumulate, an extra resources variant is added) rather than wholesale replacement.
+
+flux:
+
+- name: cert-manager
+  install:
+    components:
+    - helm-release-extra-metrics
+  resources:
+  - name: extra
+    components:
+    - public-issuer
+    timeout: 5m
+    interval: 5m

--- a/integration/fixtures/facet-tiers/contexts/_template/facets/pki-extra.yaml
+++ b/integration/fixtures/facet-tiers/contexts/_template/facets/pki-extra.yaml
@@ -1,0 +1,14 @@
+kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: pki-extra
+  description: Same-ordinal facet contributing an unnamed resources variant to pki's cert-manager flux system under the same implicit key, to exercise the original review-flagged scenario -- two facets, same ordinal, colliding variant key -- merging into one entry instead of compiling to two colliding Kustomization names.
+
+flux:
+
+- name: cert-manager
+  resources:
+  - components:
+    - private-issuer/wildcard
+    timeout: 5m
+    interval: 5m

--- a/pkg/composer/blueprint/composer.go
+++ b/pkg/composer/blueprint/composer.go
@@ -789,6 +789,11 @@ func (c *BaseBlueprintComposer) applyCrdLayerBarrier(bp *blueprintv1alpha1.Bluep
 			k.DependsOn = slices.Clone(names)
 		}
 	}
+	for i := range bp.FluxSystems {
+		if len(bp.FluxSystems[i].DependsOn) == 0 {
+			bp.FluxSystems[i].DependsOn = slices.Clone(names)
+		}
+	}
 }
 
 // resolveTierDependencies rewrites a dependsOn reference to a vendor's bare name into its install
@@ -797,19 +802,30 @@ func (c *BaseBlueprintComposer) applyCrdLayerBarrier(bp *blueprintv1alpha1.Bluep
 // exists but "cert-manager-install" does, so "depend on cert-manager" means "wait for its
 // controller". An exact name match always wins, so the legacy flat form is unaffected.
 func (c *BaseBlueprintComposer) resolveTierDependencies(bp *blueprintv1alpha1.Blueprint) {
-	names := make(map[string]struct{}, len(bp.Kustomizations))
+	names := make(map[string]struct{}, len(bp.Kustomizations)+len(bp.FluxSystems))
 	for _, k := range bp.Kustomizations {
 		names[k.Name] = struct{}{}
 	}
-	for i := range bp.Kustomizations {
-		for j, dep := range bp.Kustomizations[i].DependsOn {
+	for _, sys := range bp.FluxSystems {
+		if sys.Install != nil {
+			names[sys.Name+"-install"] = struct{}{}
+		}
+	}
+	resolve := func(deps []string) {
+		for j, dep := range deps {
 			if _, ok := names[dep]; ok {
 				continue
 			}
 			if _, ok := names[dep+"-install"]; ok {
-				bp.Kustomizations[i].DependsOn[j] = dep + "-install"
+				deps[j] = dep + "-install"
 			}
 		}
+	}
+	for i := range bp.Kustomizations {
+		resolve(bp.Kustomizations[i].DependsOn)
+	}
+	for i := range bp.FluxSystems {
+		resolve(bp.FluxSystems[i].DependsOn)
 	}
 }
 
@@ -855,8 +871,9 @@ func (c *BaseBlueprintComposer) validateDependencies(bp *blueprintv1alpha1.Bluep
 		tfIDs[tf.GetID()] = struct{}{}
 	}
 
-	kNames := make(map[string]struct{}, len(bp.Kustomizations)+len(bp.Sources)+1)
-	for _, k := range bp.Kustomizations {
+	allK := bp.AllKustomizations()
+	kNames := make(map[string]struct{}, len(allK)+len(bp.Sources)+1)
+	for _, k := range allK {
 		kNames[k.Name] = struct{}{}
 	}
 	for _, layer := range CrdLayers(bp) {
@@ -871,7 +888,7 @@ func (c *BaseBlueprintComposer) validateDependencies(bp *blueprintv1alpha1.Bluep
 		}
 	}
 
-	for _, k := range bp.Kustomizations {
+	for _, k := range allK {
 		for _, dep := range k.DependsOn {
 			if _, exists := kNames[dep]; !exists {
 				return fmt.Errorf("kustomization %q depends on non-existent kustomization %q", k.Name, dep)

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -1293,9 +1293,11 @@ func (p *BaseBlueprintProcessor) collectFluxSystems(facet blueprintv1alpha1.Face
 }
 
 // updateFluxSystemEntry merges a new FluxSystem into an existing entry in fluxSystemByName using
-// the same ordinal/strategy precedence rules as updateKustomizationEntry: higher ordinal wins;
-// equal ordinal uses strategy precedence (remove > replace > merge); equal ordinal+strategy merges
-// DependsOn (union), replaces Install when non-nil, and appends unique Resources variants.
+// the same ordinal/strategy precedence rules as updateKustomizationEntry: a higher ordinal still
+// runs applyFluxSystemEntryByStrategy (so a "merge" strategy keeps merging across ordinal bands
+// instead of wholesale-replacing) unless either side's strategy is "remove", in which case it wins
+// outright; equal ordinal falls back to strategy precedence (remove > replace > merge) before
+// merging at equal precedence.
 func (p *BaseBlueprintProcessor) updateFluxSystemEntry(name string, new *blueprintv1alpha1.FluxSystem, strategy string, entries map[string]*blueprintv1alpha1.FluxSystem) error {
 	existing := entries[name]
 	existingStrategy := existing.Strategy
@@ -1318,9 +1320,12 @@ func (p *BaseBlueprintProcessor) updateFluxSystemEntry(name string, new *bluepri
 	}
 
 	if newOrdinal > existingOrdinal {
-		new.Strategy = strategy
-		entries[name] = new
-		return nil
+		if existingStrategy == "remove" || strategy == "remove" {
+			new.Strategy = strategy
+			entries[name] = new
+			return nil
+		}
+		return p.applyFluxSystemEntryByStrategy(name, new, strategy, existing, entries)
 	}
 	if newOrdinal < existingOrdinal {
 		return nil
@@ -1336,6 +1341,16 @@ func (p *BaseBlueprintProcessor) updateFluxSystemEntry(name string, new *bluepri
 		return nil
 	}
 
+	return p.applyFluxSystemEntryByStrategy(name, new, strategy, existing, entries)
+}
+
+// applyFluxSystemEntryByStrategy applies new to existing's slot in entries per strategy, mirroring
+// applyKustomizationEntryByStrategy: "replace" swaps the whole entry, "remove" deletes it outright
+// (FluxSystem has no field-level removal the way RemoveKustomization strips individual
+// components/patches/dependsOn), and "merge" unions DependsOn and deep-merges both Install and
+// Resources variants via blueprintv1alpha1.MergeKustomizationFields — the same semantics same-name
+// Kustomizations get elsewhere — instead of replacing either wholesale.
+func (p *BaseBlueprintProcessor) applyFluxSystemEntryByStrategy(name string, new *blueprintv1alpha1.FluxSystem, strategy string, existing *blueprintv1alpha1.FluxSystem, entries map[string]*blueprintv1alpha1.FluxSystem) error {
 	switch strategy {
 	case "replace":
 		new.Strategy = strategy
@@ -1345,10 +1360,8 @@ func (p *BaseBlueprintProcessor) updateFluxSystemEntry(name string, new *bluepri
 	case "merge":
 		merged := *existing
 		merged.DependsOn = accumulateStringSlice(existing.DependsOn, new.DependsOn)
-		if new.Install != nil {
-			merged.Install = new.Install
-		}
-		merged.Resources = append(slices.Clone(existing.Resources), new.Resources...)
+		merged.Install = mergeFluxInstall(existing.Install, new.Install)
+		merged.Resources = mergeFluxVariants(existing.Resources, new.Resources)
 		merged.Ordinal = new.Ordinal
 		entries[name] = &merged
 	}
@@ -2401,6 +2414,55 @@ func deepMergeMap(base, overlay map[string]any) map[string]any {
 		result[k] = v
 	}
 	return result
+}
+
+// mergeFluxInstall deep-merges new's Install tier into existing's via
+// blueprintv1alpha1.MergeKustomizationFields (Components/DependsOn accumulate, other fields are
+// overridden by new when set) rather than Blueprint.StrategicMerge, since Install carries no Name
+// until tier compilation and StrategicMerge's by-name matching is a no-op on an unnamed
+// Kustomization. Either side being nil just takes the other, matching how a facet with no Install
+// opinion shouldn't erase one contributed earlier.
+func mergeFluxInstall(existing, new *blueprintv1alpha1.Kustomization) *blueprintv1alpha1.Kustomization {
+	if new == nil {
+		return existing
+	}
+	if existing == nil {
+		return new
+	}
+	merged := blueprintv1alpha1.MergeKustomizationFields(*existing, *new)
+	return &merged
+}
+
+// mergeFluxVariants combines two resources-variant lists keyed by variant name. A variant from new
+// deep-merges into the same-named variant in existing via
+// blueprintv1alpha1.MergeKustomizationFields (see mergeFluxInstall for why this is used instead of
+// Blueprint.StrategicMerge), and the two When conditions combine with AND. A variant with a new
+// name is appended in order. This keeps a cross-facet merge from emitting two Kustomizations with
+// the same "<system>-resources[-<name>]" identity.
+func mergeFluxVariants(existing, new []blueprintv1alpha1.FluxVariant) []blueprintv1alpha1.FluxVariant {
+	merged := slices.Clone(existing)
+	for _, nv := range new {
+		idx := slices.IndexFunc(merged, func(v blueprintv1alpha1.FluxVariant) bool { return v.Name == nv.Name })
+		if idx == -1 {
+			merged = append(merged, nv)
+			continue
+		}
+
+		mergedK := blueprintv1alpha1.MergeKustomizationFields(merged[idx].Kustomization, nv.Kustomization)
+
+		combinedWhen := merged[idx].When
+		switch {
+		case merged[idx].When != "" && nv.When != "":
+			combinedWhen = fmt.Sprintf("(%s) && (%s)", merged[idx].When, nv.When)
+		case nv.When != "":
+			combinedWhen = nv.When
+		}
+		merged[idx] = blueprintv1alpha1.FluxVariant{
+			Kustomization: mergedK,
+			When:          combinedWhen,
+		}
+	}
+	return merged
 }
 
 // accumulateStringSlice merges two string slices into a deduplicated, sorted slice.

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -1347,9 +1347,11 @@ func (p *BaseBlueprintProcessor) updateFluxSystemEntry(name string, new *bluepri
 // applyFluxSystemEntryByStrategy applies new to existing's slot in entries per strategy, mirroring
 // applyKustomizationEntryByStrategy: "replace" swaps the whole entry, "remove" deletes it outright
 // (FluxSystem has no field-level removal the way RemoveKustomization strips individual
-// components/patches/dependsOn), and "merge" unions DependsOn and deep-merges both Install and
-// Resources variants via blueprintv1alpha1.MergeKustomizationFields — the same semantics same-name
-// Kustomizations get elsewhere — instead of replacing either wholesale.
+// components/patches/dependsOn), and "merge" unions DependsOn and deep-merges both Install
+// (blueprintv1alpha1.MergeFluxInstall) and Resources variants (blueprintv1alpha1.MergeFluxVariants)
+// — the same semantics same-name Kustomizations get elsewhere, and the same helpers
+// Blueprint.UpsertFluxSystem uses to merge FluxSystems across sources — instead of replacing
+// either wholesale.
 func (p *BaseBlueprintProcessor) applyFluxSystemEntryByStrategy(name string, new *blueprintv1alpha1.FluxSystem, strategy string, existing *blueprintv1alpha1.FluxSystem, entries map[string]*blueprintv1alpha1.FluxSystem) error {
 	switch strategy {
 	case "replace":
@@ -1360,8 +1362,8 @@ func (p *BaseBlueprintProcessor) applyFluxSystemEntryByStrategy(name string, new
 	case "merge":
 		merged := *existing
 		merged.DependsOn = accumulateStringSlice(existing.DependsOn, new.DependsOn)
-		merged.Install = mergeFluxInstall(existing.Install, new.Install)
-		merged.Resources = mergeFluxVariants(existing.Resources, new.Resources)
+		merged.Install = blueprintv1alpha1.MergeFluxInstall(existing.Install, new.Install)
+		merged.Resources = blueprintv1alpha1.MergeFluxVariants(existing.Resources, new.Resources)
 		merged.Ordinal = new.Ordinal
 		entries[name] = &merged
 	}
@@ -2414,55 +2416,6 @@ func deepMergeMap(base, overlay map[string]any) map[string]any {
 		result[k] = v
 	}
 	return result
-}
-
-// mergeFluxInstall deep-merges new's Install tier into existing's via
-// blueprintv1alpha1.MergeKustomizationFields (Components/DependsOn accumulate, other fields are
-// overridden by new when set) rather than Blueprint.StrategicMerge, since Install carries no Name
-// until tier compilation and StrategicMerge's by-name matching is a no-op on an unnamed
-// Kustomization. Either side being nil just takes the other, matching how a facet with no Install
-// opinion shouldn't erase one contributed earlier.
-func mergeFluxInstall(existing, new *blueprintv1alpha1.Kustomization) *blueprintv1alpha1.Kustomization {
-	if new == nil {
-		return existing
-	}
-	if existing == nil {
-		return new
-	}
-	merged := blueprintv1alpha1.MergeKustomizationFields(*existing, *new)
-	return &merged
-}
-
-// mergeFluxVariants combines two resources-variant lists keyed by variant name. A variant from new
-// deep-merges into the same-named variant in existing via
-// blueprintv1alpha1.MergeKustomizationFields (see mergeFluxInstall for why this is used instead of
-// Blueprint.StrategicMerge), and the two When conditions combine with AND. A variant with a new
-// name is appended in order. This keeps a cross-facet merge from emitting two Kustomizations with
-// the same "<system>-resources[-<name>]" identity.
-func mergeFluxVariants(existing, new []blueprintv1alpha1.FluxVariant) []blueprintv1alpha1.FluxVariant {
-	merged := slices.Clone(existing)
-	for _, nv := range new {
-		idx := slices.IndexFunc(merged, func(v blueprintv1alpha1.FluxVariant) bool { return v.Name == nv.Name })
-		if idx == -1 {
-			merged = append(merged, nv)
-			continue
-		}
-
-		mergedK := blueprintv1alpha1.MergeKustomizationFields(merged[idx].Kustomization, nv.Kustomization)
-
-		combinedWhen := merged[idx].When
-		switch {
-		case merged[idx].When != "" && nv.When != "":
-			combinedWhen = fmt.Sprintf("(%s) && (%s)", merged[idx].When, nv.When)
-		case nv.When != "":
-			combinedWhen = nv.When
-		}
-		merged[idx] = blueprintv1alpha1.FluxVariant{
-			Kustomization: mergedK,
-			When:          combinedWhen,
-		}
-	}
-	return merged
 }
 
 // accumulateStringSlice merges two string slices into a deduplicated, sorted slice.

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -1295,9 +1295,13 @@ func (p *BaseBlueprintProcessor) collectFluxSystems(facet blueprintv1alpha1.Face
 // updateFluxSystemEntry merges a new FluxSystem into an existing entry in fluxSystemByName using
 // the same ordinal/strategy precedence rules as updateKustomizationEntry: a higher ordinal still
 // runs applyFluxSystemEntryByStrategy (so a "merge" strategy keeps merging across ordinal bands
-// instead of wholesale-replacing) unless either side's strategy is "remove", in which case it wins
-// outright; equal ordinal falls back to strategy precedence (remove > replace > merge) before
-// merging at equal precedence.
+// instead of wholesale-replacing) unless either side's strategy is "remove"; equal ordinal falls
+// back to strategy precedence (remove > replace > merge) before merging at equal precedence.
+// Whenever new's own strategy is "remove" and it wins, the outcome is always delete(entries, name),
+// never entries[name] = new: unlike Kustomization/Terraform entries, FluxSystem has no deferred
+// removal pass in applyCollectedComponents that later interprets a stored Strategy == "remove" —
+// the final write loop upserts every remaining map entry unconditionally, so a "remove"-tagged
+// FluxSystem left sitting in the map would be written to the target blueprint unchanged.
 func (p *BaseBlueprintProcessor) updateFluxSystemEntry(name string, new *blueprintv1alpha1.FluxSystem, strategy string, entries map[string]*blueprintv1alpha1.FluxSystem) error {
 	existing := entries[name]
 	existingStrategy := existing.Strategy
@@ -1320,7 +1324,11 @@ func (p *BaseBlueprintProcessor) updateFluxSystemEntry(name string, new *bluepri
 	}
 
 	if newOrdinal > existingOrdinal {
-		if existingStrategy == "remove" || strategy == "remove" {
+		if strategy == "remove" {
+			delete(entries, name)
+			return nil
+		}
+		if existingStrategy == "remove" {
 			new.Strategy = strategy
 			entries[name] = new
 			return nil
@@ -1333,6 +1341,10 @@ func (p *BaseBlueprintProcessor) updateFluxSystemEntry(name string, new *bluepri
 
 	existingStrategyPrec := strategyPrecedence[existingStrategy]
 	if newStrategyPrec > existingStrategyPrec {
+		if strategy == "remove" {
+			delete(entries, name)
+			return nil
+		}
 		new.Strategy = strategy
 		entries[name] = new
 		return nil

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -74,6 +74,14 @@ type facetRequirementMisses struct {
 	Misses []requirementBlockMiss
 }
 
+// collectedComponents holds the intermediate accumulation maps built during ProcessFacets before
+// they are written to the target blueprint by applyCollectedComponents.
+type collectedComponents struct {
+	terraformByID       map[string]*blueprintv1alpha1.ConditionalTerraformComponent
+	kustomizationByName map[string]*blueprintv1alpha1.ConditionalKustomization
+	fluxSystemByName    map[string]*blueprintv1alpha1.FluxSystem
+}
+
 // =============================================================================
 // Constructor
 // =============================================================================
@@ -179,8 +187,11 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 		return sortedFacets[i].Metadata.Name < sortedFacets[j].Metadata.Name
 	})
 
-	terraformByID := make(map[string]*blueprintv1alpha1.ConditionalTerraformComponent)
-	kustomizationByName := make(map[string]*blueprintv1alpha1.ConditionalKustomization)
+	collected := collectedComponents{
+		terraformByID:       make(map[string]*blueprintv1alpha1.ConditionalTerraformComponent),
+		kustomizationByName: make(map[string]*blueprintv1alpha1.ConditionalKustomization),
+		fluxSystemByName:    make(map[string]*blueprintv1alpha1.FluxSystem),
+	}
 	crdRefs := make(map[string]struct{})
 	scope := contextScope
 	var globalScope map[string]any
@@ -269,13 +280,13 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 				}
 			}
 		}
-		if err := p.collectTerraformComponents(facet, sourceName, terraformByID, scope); err != nil {
+		if err := p.collectTerraformComponents(facet, sourceName, collected.terraformByID, scope); err != nil {
 			return nil, err
 		}
-		if err := p.collectKustomizations(facet, sourceName, kustomizationByName, scope); err != nil {
+		if err := p.collectKustomizations(facet, sourceName, collected.kustomizationByName, scope); err != nil {
 			return nil, err
 		}
-		if err := p.collectFluxSystems(facet, sourceName, kustomizationByName, scope); err != nil {
+		if err := p.collectFluxSystems(facet, sourceName, collected.fluxSystemByName, scope); err != nil {
 			return nil, err
 		}
 		for _, ref := range facet.Crds {
@@ -319,7 +330,7 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 
 	setCrdLayer(target, crdRefs, resolveSourceName(sourceName))
 
-	if err := p.applyCollectedComponents(target, terraformByID, kustomizationByName, scope); err != nil {
+	if err := p.applyCollectedComponents(target, collected, scope); err != nil {
 		return nil, err
 	}
 	return globalScope, nil
@@ -1100,20 +1111,8 @@ func (p *BaseBlueprintProcessor) buildFluxSystemEntries(system blueprintv1alpha1
 		if k.Destroy == nil {
 			k.Destroy = system.Destroy
 		}
-		subs := mergeSubstitute(k)
-		k.Substitute = nil
-		k.Substitutions = nil
-		if len(subs) > 0 {
-			evaluated, deferredKeys, err := p.evaluateSubstitutions(subs, facet.Path, scope)
-			if err != nil {
-				return blueprintv1alpha1.ConditionalKustomization{}, err
-			}
-			k.Substitutions = evaluated
-			for key, isDeferred := range deferredKeys {
-				if isDeferred {
-					p.markDeferredPath("kustomize." + tierName + ".substitutions." + key)
-				}
-			}
+		if err := p.evalKustomizationSubstitutions(&k, facet.Path, "kustomize."+tierName+".substitutions.", scope); err != nil {
+			return blueprintv1alpha1.ConditionalKustomization{}, err
 		}
 		return blueprintv1alpha1.ConditionalKustomization{Kustomization: k, When: when}, nil
 	}
@@ -1179,10 +1178,13 @@ func (p *BaseBlueprintProcessor) buildFluxSystemEntries(system blueprintv1alpha1
 	return entries, nil
 }
 
-// collectFluxSystems compiles a facet's flux: system descriptors into their tier Kustomizations and
-// merges them into kustomizationByName, exactly as collectKustomizations does for plain entries —
-// so ToFluxKustomization and the merge/validation logic apply to the generated tiers unchanged.
-func (p *BaseBlueprintProcessor) collectFluxSystems(facet blueprintv1alpha1.Facet, sourceName []string, kustomizationByName map[string]*blueprintv1alpha1.ConditionalKustomization, facetScope map[string]any) error {
+// collectFluxSystems evaluates a facet's flux: system descriptors — resolving expressions on
+// DependsOn, Install components/substitutions, and each resources variant — and stores the result
+// in fluxSystemByName. Variants whose when condition is false or whose components evaluate to empty
+// are dropped; an install tier whose components prune to empty sets Install to nil. This preserves
+// the FluxSystem structure in the composed blueprint (for show blueprint and YAML output) while
+// keeping tier compilation deferred to AllKustomizations().
+func (p *BaseBlueprintProcessor) collectFluxSystems(facet blueprintv1alpha1.Facet, sourceName []string, fluxSystemByName map[string]*blueprintv1alpha1.FluxSystem, facetScope map[string]any) error {
 	for _, system := range facet.FluxSystems {
 		when := system.When
 		if when == "" && facet.When != "" {
@@ -1208,28 +1210,168 @@ func (p *BaseBlueprintProcessor) collectFluxSystems(facet blueprintv1alpha1.Face
 		if strategy == "" {
 			strategy = "merge"
 		}
-		sn := ""
-		if len(sourceName) > 0 {
-			sn = sourceName[0]
+
+		deps, err := p.evalDropEmpty(system.DependsOn, facet.Path, facetScope)
+		if err != nil {
+			return fmt.Errorf("error evaluating dependsOn for system '%s': %w", system.Name, err)
+		}
+		system.DependsOn = deps
+
+		if system.Install != nil {
+			comps, err := p.evalDropEmpty(system.Install.Components, facet.Path, facetScope)
+			if err != nil {
+				return fmt.Errorf("error evaluating install components for system '%s': %w", system.Name, err)
+			}
+			if len(comps) > 0 {
+				installCopy := *system.Install.DeepCopy()
+				installCopy.Components = comps
+				if err := p.evalKustomizationSubstitutions(&installCopy, facet.Path, "flux."+system.Name+".install.substitutions.", facetScope); err != nil {
+					return fmt.Errorf("error evaluating install substitutions for system '%s': %w", system.Name, err)
+				}
+				system.Install = &installCopy
+			} else {
+				system.Install = nil
+			}
 		}
 
-		entries, err := p.buildFluxSystemEntries(system, facet, facetScope)
-		if err != nil {
-			return err
-		}
-		for _, entry := range entries {
-			entry.Ordinal = &effectiveOrdinal
-			p.recordKustomizationTraces(entry.Name, entry.Components, entry.Substitutions, facet.Path, sn, effectiveOrdinal, strategy)
-			if _, exists := kustomizationByName[entry.Name]; !exists {
-				entry.Strategy = strategy
-				stored := new(blueprintv1alpha1.ConditionalKustomization)
-				*stored = entry
-				kustomizationByName[entry.Name] = stored
+		seenVariants := make(map[string]bool)
+		var evaluatedResources []blueprintv1alpha1.FluxVariant
+		for _, v := range system.Resources {
+			combined := combineWhen(system.When, v.When)
+			include, err := p.shouldIncludeComponent(combined, facet.Path, facetScope)
+			if err != nil {
+				return fmt.Errorf("error evaluating resources condition for system '%s': %w", system.Name, err)
+			}
+			if !include {
 				continue
 			}
-			if err := p.updateKustomizationEntry(entry.Name, &entry, strategy, kustomizationByName, facetScope); err != nil {
-				return err
+			comps, err := p.evalDropEmpty(v.Components, facet.Path, facetScope)
+			if err != nil {
+				return fmt.Errorf("error evaluating resources components for system '%s': %w", system.Name, err)
 			}
+			if len(comps) == 0 {
+				continue
+			}
+			variantKey := system.Name + "-resources"
+			if v.Name != "" {
+				variantKey += "-" + v.Name
+			}
+			if seenVariants[variantKey] {
+				return fmt.Errorf("duplicate resources variant %q in system %q; add a unique name: field to each variant", variantKey, system.Name)
+			}
+			seenVariants[variantKey] = true
+
+			evalV := blueprintv1alpha1.FluxVariant{Kustomization: *v.Kustomization.DeepCopy()}
+			evalV.Components = comps
+			evalV.When = ""
+
+			extraDeps, err := p.evalDropEmpty(v.DependsOn, facet.Path, facetScope)
+			if err != nil {
+				return fmt.Errorf("error evaluating resources dependsOn for system '%s': %w", system.Name, err)
+			}
+			evalV.DependsOn = extraDeps
+
+			if err := p.evalKustomizationSubstitutions(&evalV.Kustomization, facet.Path, "flux."+system.Name+".resources.substitutions.", facetScope); err != nil {
+				return fmt.Errorf("error evaluating resources substitutions for system '%s': %w", system.Name, err)
+			}
+			evaluatedResources = append(evaluatedResources, evalV)
+		}
+		system.Resources = evaluatedResources
+		system.Ordinal = &effectiveOrdinal
+		system.Strategy = strategy
+
+		if _, exists := fluxSystemByName[system.Name]; !exists {
+			stored := system
+			fluxSystemByName[system.Name] = &stored
+			continue
+		}
+		if err := p.updateFluxSystemEntry(system.Name, &system, strategy, fluxSystemByName); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// updateFluxSystemEntry merges a new FluxSystem into an existing entry in fluxSystemByName using
+// the same ordinal/strategy precedence rules as updateKustomizationEntry: higher ordinal wins;
+// equal ordinal uses strategy precedence (remove > replace > merge); equal ordinal+strategy merges
+// DependsOn (union), replaces Install when non-nil, and appends unique Resources variants.
+func (p *BaseBlueprintProcessor) updateFluxSystemEntry(name string, new *blueprintv1alpha1.FluxSystem, strategy string, entries map[string]*blueprintv1alpha1.FluxSystem) error {
+	existing := entries[name]
+	existingStrategy := existing.Strategy
+	if existingStrategy == "" {
+		existingStrategy = "merge"
+	}
+
+	newStrategyPrec, ok := strategyPrecedence[strategy]
+	if !ok {
+		return fmt.Errorf("invalid strategy '%s' for flux system '%s': must be 'remove', 'replace', or 'merge'", strategy, name)
+	}
+
+	newOrdinal := 0
+	if new.Ordinal != nil {
+		newOrdinal = *new.Ordinal
+	}
+	existingOrdinal := 0
+	if existing.Ordinal != nil {
+		existingOrdinal = *existing.Ordinal
+	}
+
+	if newOrdinal > existingOrdinal {
+		new.Strategy = strategy
+		entries[name] = new
+		return nil
+	}
+	if newOrdinal < existingOrdinal {
+		return nil
+	}
+
+	existingStrategyPrec := strategyPrecedence[existingStrategy]
+	if newStrategyPrec > existingStrategyPrec {
+		new.Strategy = strategy
+		entries[name] = new
+		return nil
+	}
+	if newStrategyPrec < existingStrategyPrec {
+		return nil
+	}
+
+	switch strategy {
+	case "replace":
+		new.Strategy = strategy
+		entries[name] = new
+	case "remove":
+		delete(entries, name)
+	case "merge":
+		merged := *existing
+		merged.DependsOn = accumulateStringSlice(existing.DependsOn, new.DependsOn)
+		if new.Install != nil {
+			merged.Install = new.Install
+		}
+		merged.Resources = append(slices.Clone(existing.Resources), new.Resources...)
+		merged.Ordinal = new.Ordinal
+		entries[name] = &merged
+	}
+	return nil
+}
+
+// evalKustomizationSubstitutions merges substitute into substitutions, clears substitute, evaluates
+// all substitution values, and marks any deferred keys under deferredPrefix.
+func (p *BaseBlueprintProcessor) evalKustomizationSubstitutions(k *blueprintv1alpha1.Kustomization, facetPath, deferredPrefix string, scope map[string]any) error {
+	subs := mergeSubstitute(*k)
+	k.Substitute = nil
+	k.Substitutions = nil
+	if len(subs) == 0 {
+		return nil
+	}
+	evaluated, deferredKeys, err := p.evaluateSubstitutions(subs, facetPath, scope)
+	if err != nil {
+		return err
+	}
+	k.Substitutions = evaluated
+	for key, isDeferred := range deferredKeys {
+		if isDeferred {
+			p.markDeferredPath(deferredPrefix + key)
 		}
 	}
 	return nil
@@ -1583,7 +1725,10 @@ func (p *BaseBlueprintProcessor) applyKustomizationEntryByStrategy(name string, 
 // blueprint in the documented order: replace operations first, then merge operations, then remove
 // operations last. This ensures that remove operations are applied after all merge/replace
 // operations, as documented. Returns an error if any application operation fails.
-func (p *BaseBlueprintProcessor) applyCollectedComponents(target *blueprintv1alpha1.Blueprint, terraformByID map[string]*blueprintv1alpha1.ConditionalTerraformComponent, kustomizationByName map[string]*blueprintv1alpha1.ConditionalKustomization, scope map[string]any) error {
+func (p *BaseBlueprintProcessor) applyCollectedComponents(target *blueprintv1alpha1.Blueprint, collected collectedComponents, scope map[string]any) error {
+	terraformByID := collected.terraformByID
+	kustomizationByName := collected.kustomizationByName
+	fluxSystemByName := collected.fluxSystemByName
 	for componentID, entry := range terraformByID {
 		if entry.When != "" {
 			shouldInclude, err := p.shouldIncludeComponent(entry.When, "", scope)
@@ -1700,6 +1845,20 @@ func (p *BaseBlueprintProcessor) applyCollectedComponents(target *blueprintv1alp
 	for _, removal := range kustomizationRemovals {
 		if err := target.RemoveKustomization(removal); err != nil {
 			return fmt.Errorf("error removing kustomization '%s': %w", removal.Name, err)
+		}
+	}
+
+	fluxKeys := make([]string, 0, len(fluxSystemByName))
+	for key := range fluxSystemByName {
+		fluxKeys = append(fluxKeys, key)
+	}
+	sort.Strings(fluxKeys)
+	for _, key := range fluxKeys {
+		sys := *fluxSystemByName[key]
+		sys.Strategy = ""
+		sys.Ordinal = nil
+		if err := target.UpsertFluxSystem(sys); err != nil {
+			return fmt.Errorf("error writing flux system '%s': %w", key, err)
 		}
 	}
 

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -2487,7 +2487,7 @@ func TestProcessor_ProcessFacets_Crds(t *testing.T) {
 
 func TestProcessor_ProcessFacets_Tiers(t *testing.T) {
 	find := func(bp *blueprintv1alpha1.Blueprint, name string) (blueprintv1alpha1.Kustomization, bool) {
-		for _, k := range bp.Kustomizations {
+		for _, k := range bp.AllKustomizations() {
 			if k.Name == name {
 				return k, true
 			}
@@ -2609,7 +2609,7 @@ func TestProcessor_ProcessFacets_Tiers(t *testing.T) {
 		})
 		res, ok := find(target, "issuers-resources")
 		if !ok {
-			t.Fatalf("expected issuers-resources, got %+v", target.Kustomizations)
+			t.Fatalf("expected issuers-resources, got %+v", target.AllKustomizations())
 		}
 		if !slices.Contains(res.DependsOn, "cert-manager-install") {
 			t.Errorf("expected system deps on the variant, got %v", res.DependsOn)
@@ -2677,7 +2677,7 @@ func TestProcessor_ProcessFacets_Tiers(t *testing.T) {
 		}
 		res, ok := find(target, "gateway-resources")
 		if !ok {
-			t.Fatalf("expected gateway-resources, got %+v", target.Kustomizations)
+			t.Fatalf("expected gateway-resources, got %+v", target.AllKustomizations())
 		}
 		if slices.Contains(res.DependsOn, "gateway-install") {
 			t.Errorf("expected no implicit install edge when install pruned away, got %v", res.DependsOn)
@@ -3492,7 +3492,7 @@ func TestProcessor_applyCollectedComponents(t *testing.T) {
 		}
 
 		// When applying collected components
-		err := processor.applyCollectedComponents(target, terraformByID, kustomizationByName, nil)
+		err := processor.applyCollectedComponents(target, collectedComponents{terraformByID: terraformByID, kustomizationByName: kustomizationByName}, nil)
 
 		// Then specified fields should be removed (removes are applied last)
 		if err != nil {
@@ -3528,7 +3528,7 @@ func TestProcessor_applyCollectedComponents(t *testing.T) {
 		}
 
 		// When applying collected components
-		err := processor.applyCollectedComponents(target, terraformByID, nil, nil)
+		err := processor.applyCollectedComponents(target, collectedComponents{terraformByID: terraformByID}, nil)
 
 		// Then component should be replaced
 		if err != nil {
@@ -3558,7 +3558,7 @@ func TestProcessor_applyCollectedComponents(t *testing.T) {
 		}
 
 		// When applying collected components
-		err := processor.applyCollectedComponents(target, terraformByID, nil, nil)
+		err := processor.applyCollectedComponents(target, collectedComponents{terraformByID: terraformByID}, nil)
 
 		// Then component should be merged
 		if err != nil {
@@ -3588,7 +3588,7 @@ func TestProcessor_applyCollectedComponents(t *testing.T) {
 		}
 
 		// When applying collected components
-		err := processor.applyCollectedComponents(target, terraformByID, nil, nil)
+		err := processor.applyCollectedComponents(target, collectedComponents{terraformByID: terraformByID}, nil)
 
 		// Then should default to merge
 		if err != nil {
@@ -3615,7 +3615,7 @@ func TestProcessor_applyCollectedComponents(t *testing.T) {
 		}
 
 		// When applying collected components
-		err := processor.applyCollectedComponents(target, nil, kustomizationByName, nil)
+		err := processor.applyCollectedComponents(target, collectedComponents{kustomizationByName: kustomizationByName}, nil)
 
 		// Then kustomization should be replaced
 		if err != nil {
@@ -3650,7 +3650,7 @@ func TestProcessor_applyCollectedComponents(t *testing.T) {
 		}
 
 		// When applying collected components
-		err := processor.applyCollectedComponents(target, terraformByID, nil, nil)
+		err := processor.applyCollectedComponents(target, collectedComponents{terraformByID: terraformByID}, nil)
 
 		// Then strategies should be applied correctly
 		if err != nil {
@@ -3683,7 +3683,7 @@ func TestProcessor_applyCollectedComponents(t *testing.T) {
 		}
 
 		// First apply merge
-		err := processor.applyCollectedComponents(target, terraformByID, nil, nil)
+		err := processor.applyCollectedComponents(target, collectedComponents{terraformByID: terraformByID}, nil)
 		if err != nil {
 			t.Fatalf("Expected no error on merge, got %v", err)
 		}
@@ -3695,7 +3695,7 @@ func TestProcessor_applyCollectedComponents(t *testing.T) {
 				TerraformComponent: blueprintv1alpha1.TerraformComponent{Path: "vpc", Inputs: map[string]any{"replaced": "value"}},
 			},
 		}
-		err = processor.applyCollectedComponents(target, terraformByID, nil, nil)
+		err = processor.applyCollectedComponents(target, collectedComponents{terraformByID: terraformByID}, nil)
 		if err != nil {
 			t.Fatalf("Expected no error on replace, got %v", err)
 		}
@@ -3707,7 +3707,7 @@ func TestProcessor_applyCollectedComponents(t *testing.T) {
 				TerraformComponent: blueprintv1alpha1.TerraformComponent{Path: "vpc", Inputs: map[string]any{"replaced": nil}},
 			},
 		}
-		err = processor.applyCollectedComponents(target, terraformByID, nil, nil)
+		err = processor.applyCollectedComponents(target, collectedComponents{terraformByID: terraformByID}, nil)
 		if err != nil {
 			t.Fatalf("Expected no error on remove, got %v", err)
 		}
@@ -5198,7 +5198,7 @@ func TestProcessor_PostProcessingConditionEvaluation(t *testing.T) {
 		}
 
 		// When applying collected components
-		err := processor.applyCollectedComponents(target, terraformByID, nil, nil)
+		err := processor.applyCollectedComponents(target, collectedComponents{terraformByID: terraformByID}, nil)
 
 		// Then component should be removed (condition is false)
 		if err != nil {
@@ -5229,7 +5229,7 @@ func TestProcessor_PostProcessingConditionEvaluation(t *testing.T) {
 		}
 
 		// When applying collected components
-		err := processor.applyCollectedComponents(target, nil, kustomizationByName, nil)
+		err := processor.applyCollectedComponents(target, collectedComponents{kustomizationByName: kustomizationByName}, nil)
 
 		// Then kustomization should be removed (condition is false)
 		if err != nil {
@@ -5260,7 +5260,7 @@ func TestProcessor_PostProcessingConditionEvaluation(t *testing.T) {
 		}
 
 		// When applying collected components
-		err := processor.applyCollectedComponents(target, terraformByID, nil, nil)
+		err := processor.applyCollectedComponents(target, collectedComponents{terraformByID: terraformByID}, nil)
 
 		// Then component should be preserved (condition is true)
 		if err != nil {
@@ -5297,7 +5297,7 @@ func TestProcessor_PostProcessingConditionEvaluation(t *testing.T) {
 		}
 
 		// When applying collected components
-		err := processor.applyCollectedComponents(target, terraformByID, nil, nil)
+		err := processor.applyCollectedComponents(target, collectedComponents{terraformByID: terraformByID}, nil)
 
 		// Then component should be removed (combined condition is false)
 		if err != nil {
@@ -5324,7 +5324,7 @@ func TestProcessor_PostProcessingConditionEvaluation(t *testing.T) {
 		}
 
 		// When applying collected components
-		err := processor.applyCollectedComponents(target, terraformByID, nil, nil)
+		err := processor.applyCollectedComponents(target, collectedComponents{terraformByID: terraformByID}, nil)
 
 		// Then should return error
 		if err == nil {

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -2702,6 +2702,117 @@ func TestProcessor_ProcessFacets_Tiers(t *testing.T) {
 			t.Fatal("expected error for duplicate unnamed resources variant, got nil")
 		}
 	})
+
+	t.Run("CrossFacetSameNamedVariantDeepMerges", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "gateway-a"},
+				FluxSystems: []blueprintv1alpha1.FluxSystem{{
+					Name:      "gateway",
+					Resources: []blueprintv1alpha1.FluxVariant{{Kustomization: blueprintv1alpha1.Kustomization{Name: "internal", Components: []string{"a"}}}},
+				}},
+			},
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "gateway-b"},
+				FluxSystems: []blueprintv1alpha1.FluxSystem{{
+					Name:      "gateway",
+					Resources: []blueprintv1alpha1.FluxVariant{{Kustomization: blueprintv1alpha1.Kustomization{Name: "internal", Components: []string{"b"}}}},
+				}},
+			},
+		}
+		target := &blueprintv1alpha1.Blueprint{}
+		if _, err := processor.ProcessFacets(target, facets); err != nil {
+			t.Fatalf("ProcessFacets: %v", err)
+		}
+		count := 0
+		var got blueprintv1alpha1.Kustomization
+		for _, k := range target.AllKustomizations() {
+			if k.Name == "gateway-resources-internal" {
+				count++
+				got = k
+			}
+		}
+		if count != 1 {
+			t.Fatalf("expected a single gateway-resources-internal after cross-facet merge, got %d", count)
+		}
+		if !slices.Contains(got.Components, "a") || !slices.Contains(got.Components, "b") {
+			t.Errorf("expected merged variant components to union [a b], got %v", got.Components)
+		}
+	})
+
+	t.Run("CrossOrdinalFacetsStillMergeFluxSystem", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		ordProvider := 200
+		ordAddon := 300
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "provider-gateway"},
+				Ordinal:  &ordProvider,
+				FluxSystems: []blueprintv1alpha1.FluxSystem{{
+					Name:      "gateway",
+					Install:   &blueprintv1alpha1.Kustomization{Components: []string{"envoy"}},
+					Resources: []blueprintv1alpha1.FluxVariant{{Kustomization: blueprintv1alpha1.Kustomization{Name: "internal", Components: []string{"internal"}}}},
+				}},
+			},
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "addon-gateway-external"},
+				Ordinal:  &ordAddon,
+				FluxSystems: []blueprintv1alpha1.FluxSystem{{
+					Name:      "gateway",
+					Resources: []blueprintv1alpha1.FluxVariant{{Kustomization: blueprintv1alpha1.Kustomization{Name: "external", Components: []string{"external"}}}},
+				}},
+			},
+		}
+		target := &blueprintv1alpha1.Blueprint{}
+		if _, err := processor.ProcessFacets(target, facets); err != nil {
+			t.Fatalf("ProcessFacets: %v", err)
+		}
+		install, ok := find(target, "gateway-install")
+		if !ok || !slices.Contains(install.Components, "envoy") {
+			t.Fatalf("expected the lower-ordinal facet's install to survive a higher-ordinal merge, got %+v", target.AllKustomizations())
+		}
+		if _, ok := find(target, "gateway-resources-internal"); !ok {
+			t.Errorf("expected the lower-ordinal facet's resources variant to survive, got %+v", target.AllKustomizations())
+		}
+		if _, ok := find(target, "gateway-resources-external"); !ok {
+			t.Errorf("expected the higher-ordinal facet's resources variant to be added rather than replace the system, got %+v", target.AllKustomizations())
+		}
+	})
+
+	t.Run("SameOrdinalInstallDeepMerges", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "gateway-a"},
+				FluxSystems: []blueprintv1alpha1.FluxSystem{{
+					Name:    "gateway",
+					Install: &blueprintv1alpha1.Kustomization{Components: []string{"envoy"}},
+				}},
+			},
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "gateway-b"},
+				FluxSystems: []blueprintv1alpha1.FluxSystem{{
+					Name:    "gateway",
+					Install: &blueprintv1alpha1.Kustomization{Components: []string{"cert-manager"}},
+				}},
+			},
+		}
+		target := &blueprintv1alpha1.Blueprint{}
+		if _, err := processor.ProcessFacets(target, facets); err != nil {
+			t.Fatalf("ProcessFacets: %v", err)
+		}
+		install, ok := find(target, "gateway-install")
+		if !ok {
+			t.Fatalf("expected gateway-install, got %+v", target.AllKustomizations())
+		}
+		if !slices.Contains(install.Components, "envoy") || !slices.Contains(install.Components, "cert-manager") {
+			t.Errorf("expected install components to union [cert-manager envoy], got %v", install.Components)
+		}
+	})
 }
 func TestProcessor_mergeHelpers(t *testing.T) {
 	t.Run("deepMergeMapMergesNestedMaps", func(t *testing.T) {

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -2813,6 +2813,76 @@ func TestProcessor_ProcessFacets_Tiers(t *testing.T) {
 			t.Errorf("expected install components to union [cert-manager envoy], got %v", install.Components)
 		}
 	})
+
+	t.Run("HigherOrdinalRemoveDeletesFluxSystem", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		ordProvider := 200
+		ordRemoval := 300
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "provider-gateway"},
+				Ordinal:  &ordProvider,
+				FluxSystems: []blueprintv1alpha1.FluxSystem{{
+					Name:    "gateway",
+					Install: &blueprintv1alpha1.Kustomization{Components: []string{"envoy"}},
+				}},
+			},
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "option-remove-gateway"},
+				Ordinal:  &ordRemoval,
+				FluxSystems: []blueprintv1alpha1.FluxSystem{{
+					Name:     "gateway",
+					Strategy: "remove",
+				}},
+			},
+		}
+		target := &blueprintv1alpha1.Blueprint{}
+		if _, err := processor.ProcessFacets(target, facets); err != nil {
+			t.Fatalf("ProcessFacets: %v", err)
+		}
+		if _, ok := find(target, "gateway-install"); ok {
+			t.Errorf("expected a higher-ordinal remove to delete the system, but gateway-install survived: %+v", target.AllKustomizations())
+		}
+		for _, sys := range target.FluxSystems {
+			if sys.Name == "gateway" {
+				t.Errorf("expected no gateway FluxSystem entry after a higher-ordinal remove, got %+v", sys)
+			}
+		}
+	})
+
+	t.Run("EqualOrdinalRemoveStrategyPrecedenceDeletesFluxSystem", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "gateway-a"},
+				FluxSystems: []blueprintv1alpha1.FluxSystem{{
+					Name:    "gateway",
+					Install: &blueprintv1alpha1.Kustomization{Components: []string{"envoy"}},
+				}},
+			},
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "gateway-b"},
+				FluxSystems: []blueprintv1alpha1.FluxSystem{{
+					Name:     "gateway",
+					Strategy: "remove",
+				}},
+			},
+		}
+		target := &blueprintv1alpha1.Blueprint{}
+		if _, err := processor.ProcessFacets(target, facets); err != nil {
+			t.Fatalf("ProcessFacets: %v", err)
+		}
+		if _, ok := find(target, "gateway-install"); ok {
+			t.Errorf("expected equal-ordinal remove (higher strategy precedence) to delete the system, but gateway-install survived: %+v", target.AllKustomizations())
+		}
+		for _, sys := range target.FluxSystems {
+			if sys.Name == "gateway" {
+				t.Errorf("expected no gateway FluxSystem entry after remove wins on strategy precedence, got %+v", sys)
+			}
+		}
+	})
 }
 func TestProcessor_mergeHelpers(t *testing.T) {
 	t.Run("deepMergeMapMergesNestedMaps", func(t *testing.T) {

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -461,7 +461,7 @@ func (i *Provisioner) DestroyKustomize(blueprint *blueprintv1alpha1.Blueprint, c
 	}
 
 	var found *blueprintv1alpha1.Kustomization
-	for _, k := range blueprint.Kustomizations {
+	for _, k := range blueprint.AllKustomizations() {
 		if k.Name == componentID {
 			kCopy := k
 			found = &kCopy
@@ -507,7 +507,7 @@ func (i *Provisioner) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continu
 			}
 			result.Failed = append(result.Failed, ComponentFailure{ID: KustomizeFailureID, Err: err})
 		} else {
-			for _, k := range blueprint.Kustomizations {
+			for _, k := range blueprint.AllKustomizations() {
 				if fluxinfra.KustomizationDestroyEligible(k) {
 					result.Destroyed = append(result.Destroyed, k.Name)
 				}
@@ -1415,17 +1415,10 @@ func (i *Provisioner) ensureClusterClient() error {
 	return nil
 }
 
-// withCrdLayer returns a blueprint whose Kustomizations include the synthesized CRD layers — the
-// "crds" layer for the blueprint's own (default/project) CRDs and a "crds-<source>" layer per install
-// source that vendors CRDs, each bound to that source so it reads the manifests from where they live
-// rather than defaulting to the project git source (blueprint.CrdLayers derives the set; the composer
-// wires the stack to the same names). A layer's components are its CRD references, pruning is disabled
-// (pruning a CRD deletes every custom resource of that kind cluster-wide), and wait is enabled so
-// dependents block until the CRDs are Established. The layers are prepended ahead of the stack. Each
-// layer's Path is the fixed catalog root CrdLayerName (which ToFluxKustomization expands to
-// kustomize/crds), so a layer's source must vendor its manifests at <source>/kustomize/crds/<ref>. The
-// provisioner materializes the layers here, at the point it applies, waits on, or plans the
-// kustomization set. Returns bp unchanged when it implies no CRD layers.
+// withCrdLayer returns a copy of the blueprint with synthesized CRD kustomizations prepended ahead of
+// the stack. Pruning is disabled (pruning a CRD deletes every custom resource of that kind cluster-wide)
+// and wait is enabled so dependents block until the CRDs are Established. Returns the blueprint unchanged
+// when it implies no CRD layers.
 func withCrdLayer(bp *blueprintv1alpha1.Blueprint) *blueprintv1alpha1.Blueprint {
 	if bp == nil {
 		return bp
@@ -1448,7 +1441,8 @@ func withCrdLayer(bp *blueprintv1alpha1.Blueprint) *blueprintv1alpha1.Blueprint 
 		})
 	}
 	out := *bp
-	out.Kustomizations = append(crds, bp.Kustomizations...)
+	out.Kustomizations = append(crds, bp.AllKustomizations()...)
+	out.FluxSystems = nil
 	return &out
 }
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This change restructures how Flux system definitions are accumulated and merged across blueprint facets — touching the core composition path used by every Windsor project that uses `flux:` entries.
>
> **Overview**
>
> The PR promotes FluxSystems from being immediately compiled to flat Kustomizations during `ProcessFacets` to being accumulated as structured `FluxSystem` objects that are compiled lazily via the new `AllKustomizations()` method. This allows same-name systems contributed by multiple facets (at the same or different ordinals) to deep-merge their `install` and `resources` tiers rather than the last writer silently overwriting the earlier one. `MergeKustomizationFields` is extracted from the existing `strategicMergeKustomization` inline logic and reused by the new merge helpers, keeping field-level semantics consistent.
>
> The ordinal/strategy precedence logic for FluxSystems is implemented in the new `updateFluxSystemEntry` / `applyFluxSystemEntryByStrategy` pair. The `remove` strategy case in `applyFluxSystemEntryByStrategy` correctly deletes from the accumulation map, but the early-exit shortcut in `updateFluxSystemEntry` (line 1323) that fires when the incoming entry has a higher ordinal and either side is `"remove"` unconditionally stores the entry rather than deleting it when `strategy == "remove"`, meaning a higher-ordinal `"remove"` facet would silently fail to remove the system from the composed blueprint.
>
> Reviewed by Claude for commit `0f7cfbf9`.

<!-- /claude-code-review:summary -->
