### PR TITLE
feat(show): Add support for listing all kustomizations and their tiers

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -1123,6 +1123,17 @@ func (b *Blueprint) AllKustomizations() []Kustomization {
 	return all
 }
 
+// TierNames returns the compiled Kustomization names this system produces (its install tier, if
+// any, followed by each resources variant), in compiled order.
+func (sys FluxSystem) TierNames() []string {
+	tiers := compileFluxSystemTiers(sys)
+	names := make([]string, len(tiers))
+	for i, t := range tiers {
+		names[i] = t.Name
+	}
+	return names
+}
+
 // compileFluxSystemTiers converts a pre-evaluated FluxSystem into its tier Kustomizations without
 // any expression evaluation. Install compiles to "<name>-install" at "<path>/install"; each
 // resources variant compiles to "<name>-resources[-<variant>]" at "<path>/resources".

--- a/api/v1alpha1/blueprint_types_test.go
+++ b/api/v1alpha1/blueprint_types_test.go
@@ -4694,3 +4694,51 @@ func TestBlueprint_UpsertFluxSystem(t *testing.T) {
 		}
 	})
 }
+
+func TestFluxSystem_TierNames(t *testing.T) {
+	t.Run("ReturnsInstallThenResourcesVariantNames", func(t *testing.T) {
+		sys := FluxSystem{
+			Name:    "cert-manager",
+			Install: &Kustomization{Components: []string{"helm-release"}},
+			Resources: []FluxVariant{
+				{Kustomization: Kustomization{Components: []string{"private-issuer/ca"}}},
+				{Kustomization: Kustomization{Name: "extra", Components: []string{"public-issuer"}}},
+			},
+		}
+
+		names := sys.TierNames()
+
+		want := []string{"cert-manager-install", "cert-manager-resources", "cert-manager-resources-extra"}
+		if len(names) != len(want) {
+			t.Fatalf("expected %v, got %v", want, names)
+		}
+		for i := range want {
+			if names[i] != want[i] {
+				t.Errorf("expected %v, got %v", want, names)
+				break
+			}
+		}
+	})
+
+	t.Run("ReturnsEmptyForSystemWithNoTiers", func(t *testing.T) {
+		sys := FluxSystem{Name: "empty-sys"}
+
+		if names := sys.TierNames(); len(names) != 0 {
+			t.Errorf("expected no tier names for a system with no install or resources, got %v", names)
+		}
+	})
+
+	t.Run("DoesNotLeakAnUnrelatedSystemsNamePrefixCollision", func(t *testing.T) {
+		// Given a system literally named "cert-manager-resources", distinct from "cert-manager"
+		sys := FluxSystem{
+			Name:    "cert-manager-resources",
+			Install: &Kustomization{Components: []string{"x"}},
+		}
+
+		names := sys.TierNames()
+
+		if len(names) != 1 || names[0] != "cert-manager-resources-install" {
+			t.Fatalf("expected only cert-manager-resources-install, got %v", names)
+		}
+	})
+}

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"strings"
 
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
 	"github.com/goccy/go-yaml"
@@ -75,10 +76,14 @@ windsor show blueprint --json`,
 }
 
 var showKustomizationCmd = &cobra.Command{
-	Use:   "kustomization <component-name>",
-	Short: "Display the Flux Kustomization resource for a component.",
-	Long:  `Print the Flux Kustomization resource for the named component, including blueprint-level ConfigMaps in postBuild.substituteFrom. The output matches what 'windsor apply' would write to the cluster. Defaults to YAML; use --json for JSON. Unresolved deferred values render as '<deferred>' by default; use --raw to keep the original expression text instead.`,
-	Example: `# Inspect the Flux Kustomization for one component
+	Use:     "kustomization [component-name]",
+	Aliases: []string{"kustomizations"},
+	Short:   "Display the Flux Kustomization resource for a component.",
+	Long:    `Print the Flux Kustomization resource for the named component, including blueprint-level ConfigMaps in postBuild.substituteFrom. The output matches what 'windsor apply' would write to the cluster. Omit the name to list every compiled component. Defaults to YAML; use --json for JSON. Unresolved deferred values render as '<deferred>' by default; use --raw to keep the original expression text instead.`,
+	Example: `# List every compiled component
+windsor show kustomization
+
+# Inspect the Flux Kustomization for one component
 windsor show kustomization dns
 
 # JSON for tooling
@@ -88,11 +93,9 @@ windsor show kustomization dns --json`,
 			"[Blueprint reference](../blueprint.md)",
 		"docs.source": "cmd/show.go",
 	},
-	Args:         cobra.ExactArgs(1),
+	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		componentName := args[0]
-
 		proj, blueprint, deferredPaths, validationErr := getBlueprint(cmd)
 		if blueprint == nil {
 			if validationErr != nil {
@@ -101,9 +104,20 @@ windsor show kustomization dns --json`,
 			return fmt.Errorf("failed to generate blueprint")
 		}
 
+		if len(args) == 0 {
+			if err := listKustomizations(blueprint, showKustomizationJSON); err != nil {
+				return err
+			}
+			if validationErr != nil {
+				fmt.Fprintf(os.Stderr, "\033[33mWarning: %v\033[0m\n", validationErr)
+			}
+			return nil
+		}
+
+		componentName := args[0]
 		kustomization := findKustomization(blueprint, componentName)
 		if kustomization == nil {
-			return errKustomizationNotFound(componentName)
+			return errKustomizationNotFound(blueprint, componentName)
 		}
 
 		namespace := proj.Runtime.ConfigHandler.GetString("gitops.namespace", constants.DefaultGitopsNamespace)
@@ -219,20 +233,54 @@ func outputResource(resource any, useJSON bool, resourceType string) error {
 	return nil
 }
 
-// findKustomization searches for a kustomization by name in the blueprint and returns a pointer
-// to it if found, or nil if not found.
+// findKustomization searches the blueprint's full compiled Kustomization set (plain kustomize:
+// entries plus every flux: system's install/resources tiers) for the given name.
 func findKustomization(blueprint *blueprintv1alpha1.Blueprint, name string) *blueprintv1alpha1.Kustomization {
-	for i := range blueprint.Kustomizations {
-		if blueprint.Kustomizations[i].Name == name {
-			return &blueprint.Kustomizations[i]
+	for _, k := range blueprint.AllKustomizations() {
+		if k.Name == name {
+			return &k
 		}
 	}
 	return nil
 }
 
-// errKustomizationNotFound returns a formatted error for when a kustomization is not found.
-func errKustomizationNotFound(name string) error {
+// errKustomizationNotFound returns a formatted error for when a kustomization is not found. If the
+// name instead matches a flux: system descriptor rather than one of its compiled tiers, the error
+// lists that system's tier names, since a system name (e.g. "cert-manager") is never itself a valid
+// argument.
+func errKustomizationNotFound(blueprint *blueprintv1alpha1.Blueprint, name string) error {
+	for _, sys := range blueprint.FluxSystems {
+		if sys.Name != name {
+			continue
+		}
+		tiers := sys.TierNames()
+		if len(tiers) == 0 {
+			return fmt.Errorf("%q is a flux system with no compiled install or resources tiers", name)
+		}
+		return fmt.Errorf("%q is a flux system, not a kustomization; use one of its tiers instead: %s",
+			name, strings.Join(tiers, ", "))
+	}
 	return fmt.Errorf("kustomization %q not found in blueprint", name)
+}
+
+// listKustomizations prints the name of every compiled Kustomization in the blueprint (plain
+// kustomize: entries plus every flux: system's install/resources tiers), one per line as plain
+// text, or as a JSON array when useJSON is true.
+func listKustomizations(blueprint *blueprintv1alpha1.Blueprint, useJSON bool) error {
+	all := blueprint.AllKustomizations()
+	names := make([]string, len(all))
+	for i, k := range all {
+		names[i] = k.Name
+	}
+
+	if useJSON {
+		return outputResource(names, true, "kustomization names")
+	}
+
+	for _, name := range names {
+		fmt.Println(name)
+	}
+	return nil
 }
 
 // getValues configures the project and returns the effective context values and loaded schema without

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -115,14 +115,14 @@ windsor show kustomization dns --json`,
 		}
 
 		componentName := args[0]
-		kustomization := findKustomization(blueprint, componentName)
-		if kustomization == nil {
+		kustomization, found := findKustomization(blueprint, componentName)
+		if !found {
 			return errKustomizationNotFound(blueprint, componentName)
 		}
 
 		namespace := proj.Runtime.ConfigHandler.GetString("gitops.namespace", constants.DefaultGitopsNamespace)
 		mode := constants.ParseGitopsMode(proj.Runtime.ConfigHandler.GetString("gitops.mode", ""))
-		fluxKustomization := buildFluxKustomization(blueprint, kustomization, namespace, mode)
+		fluxKustomization := buildFluxKustomization(blueprint, &kustomization, namespace, mode)
 		resource := blueprintcomposer.RenderDeferredPlaceholders(fluxKustomization, showKustomizationRaw, deferredPaths)
 
 		if err := outputResource(resource, showKustomizationJSON, "kustomization"); err != nil {
@@ -234,14 +234,15 @@ func outputResource(resource any, useJSON bool, resourceType string) error {
 }
 
 // findKustomization searches the blueprint's full compiled Kustomization set (plain kustomize:
-// entries plus every flux: system's install/resources tiers) for the given name.
-func findKustomization(blueprint *blueprintv1alpha1.Blueprint, name string) *blueprintv1alpha1.Kustomization {
+// entries plus every flux: system's install/resources tiers) for the given name. Returns a copy,
+// not a reference into the blueprint, since AllKustomizations() compiles tiers fresh on each call.
+func findKustomization(blueprint *blueprintv1alpha1.Blueprint, name string) (blueprintv1alpha1.Kustomization, bool) {
 	for _, k := range blueprint.AllKustomizations() {
 		if k.Name == name {
-			return &k
+			return k, true
 		}
 	}
-	return nil
+	return blueprintv1alpha1.Kustomization{}, false
 }
 
 // errKustomizationNotFound returns a formatted error for when a kustomization is not found. If the

--- a/cmd/show_test.go
+++ b/cmd/show_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"slices"
 	"strings"
 	"testing"
 
@@ -936,6 +937,221 @@ func TestShowKustomizationCmd(t *testing.T) {
 		}
 	})
 
+	t.Run("SuccessWithNoArgsListsNames", func(t *testing.T) {
+		mocks := setupShowTest(t)
+
+		comp := composer.NewComposer(mocks.Runtime)
+		comp.BlueprintHandler = mocks.BlueprintHandler
+
+		proj := project.NewProject("", &project.Project{
+			Runtime:  mocks.Runtime,
+			Composer: comp,
+		})
+
+		stdout, stderr, closePipes := setupOutput(t)
+
+		cmd := createTestCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{})
+		_ = cmd.Execute()
+
+		closePipes()
+
+		if got := strings.TrimSpace(stdout.String()); got != "test-kustomization" {
+			t.Errorf("Expected listing to contain 'test-kustomization', got %q", got)
+		}
+		if stderr.String() != "" {
+			t.Error("Expected empty stderr")
+		}
+	})
+
+	t.Run("SuccessWithNoArgsListsFluxSystemTiers", func(t *testing.T) {
+		mocks := setupShowTest(t)
+
+		mocks.BlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint {
+			return &blueprintv1alpha1.Blueprint{
+				Kustomizations: []blueprintv1alpha1.Kustomization{
+					{Name: "test-kustomization", Path: "test/path"},
+				},
+				FluxSystems: []blueprintv1alpha1.FluxSystem{
+					{
+						Name: "cert-manager",
+						Path: "pki/cert-manager",
+						Install: &blueprintv1alpha1.Kustomization{
+							Components: []string{"helm-release"},
+						},
+						Resources: []blueprintv1alpha1.FluxVariant{
+							{Kustomization: blueprintv1alpha1.Kustomization{Components: []string{"private-issuer/ca"}}},
+						},
+					},
+				},
+			}
+		}
+		mocks.BlueprintHandler.GetDeferredPathsFunc = func() map[string]bool { return nil }
+
+		comp := composer.NewComposer(mocks.Runtime)
+		comp.BlueprintHandler = mocks.BlueprintHandler
+
+		proj := project.NewProject("", &project.Project{
+			Runtime:  mocks.Runtime,
+			Composer: comp,
+		})
+
+		stdout, stderr, closePipes := setupOutput(t)
+
+		cmd := createTestCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"--json"})
+		_ = cmd.Execute()
+
+		closePipes()
+
+		var names []string
+		if err := json.Unmarshal(stdout.Bytes(), &names); err != nil {
+			t.Fatalf("Expected valid JSON array output, got error: %v\noutput: %s", err, stdout.String())
+		}
+		expected := []string{"test-kustomization", "cert-manager-install", "cert-manager-resources"}
+		if !slices.Equal(names, expected) {
+			t.Errorf("Expected names %v, got %v", expected, names)
+		}
+		if stderr.String() != "" {
+			t.Error("Expected empty stderr")
+		}
+	})
+
+	t.Run("SuccessWithFluxSystemTierLookup", func(t *testing.T) {
+		mocks := setupShowTest(t)
+
+		mocks.BlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint {
+			return &blueprintv1alpha1.Blueprint{
+				FluxSystems: []blueprintv1alpha1.FluxSystem{
+					{
+						Name: "cert-manager",
+						Path: "pki/cert-manager",
+						Install: &blueprintv1alpha1.Kustomization{
+							Components: []string{"helm-release"},
+						},
+					},
+				},
+			}
+		}
+		mocks.BlueprintHandler.GetDeferredPathsFunc = func() map[string]bool { return nil }
+
+		comp := composer.NewComposer(mocks.Runtime)
+		comp.BlueprintHandler = mocks.BlueprintHandler
+
+		proj := project.NewProject("", &project.Project{
+			Runtime:  mocks.Runtime,
+			Composer: comp,
+		})
+
+		stdout, stderr, closePipes := setupOutput(t)
+
+		cmd := createTestCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"cert-manager-install"})
+		_ = cmd.Execute()
+
+		closePipes()
+
+		var kustomization kustomizev1.Kustomization
+		if err := yaml.Unmarshal(stdout.Bytes(), &kustomization); err != nil {
+			t.Fatalf("Expected valid YAML output, got error: %v\noutput: %s", err, stdout.String())
+		}
+		if kustomization.Name != "cert-manager-install" {
+			t.Errorf("Expected kustomization name 'cert-manager-install', got %q", kustomization.Name)
+		}
+		if kustomization.Spec.Path != "kustomize/pki/cert-manager/install" {
+			t.Errorf("Expected path 'kustomize/pki/cert-manager/install', got %q", kustomization.Spec.Path)
+		}
+		if stderr.String() != "" {
+			t.Error("Expected empty stderr")
+		}
+	})
+
+	t.Run("FluxSystemNameReturnsTierList", func(t *testing.T) {
+		mocks := setupShowTest(t)
+
+		mocks.BlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint {
+			return &blueprintv1alpha1.Blueprint{
+				FluxSystems: []blueprintv1alpha1.FluxSystem{
+					{
+						Name: "cert-manager",
+						Path: "pki/cert-manager",
+						Install: &blueprintv1alpha1.Kustomization{
+							Components: []string{"helm-release"},
+						},
+						Resources: []blueprintv1alpha1.FluxVariant{
+							{Kustomization: blueprintv1alpha1.Kustomization{Components: []string{"private-issuer/ca"}}},
+						},
+					},
+				},
+			}
+		}
+		mocks.BlueprintHandler.GetDeferredPathsFunc = func() map[string]bool { return nil }
+
+		comp := composer.NewComposer(mocks.Runtime)
+		comp.BlueprintHandler = mocks.BlueprintHandler
+
+		proj := project.NewProject("", &project.Project{
+			Runtime:  mocks.Runtime,
+			Composer: comp,
+		})
+
+		cmd := createTestCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"cert-manager"})
+		err := cmd.Execute()
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "cert-manager-install") || !strings.Contains(err.Error(), "cert-manager-resources") {
+			t.Errorf("Expected error to list tier names, got: %v", err)
+		}
+	})
+
+	t.Run("FluxSystemWithNoTiersReturnsClearError", func(t *testing.T) {
+		mocks := setupShowTest(t)
+
+		mocks.BlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint {
+			return &blueprintv1alpha1.Blueprint{
+				FluxSystems: []blueprintv1alpha1.FluxSystem{
+					{Name: "empty-sys"},
+				},
+			}
+		}
+		mocks.BlueprintHandler.GetDeferredPathsFunc = func() map[string]bool { return nil }
+
+		comp := composer.NewComposer(mocks.Runtime)
+		comp.BlueprintHandler = mocks.BlueprintHandler
+
+		proj := project.NewProject("", &project.Project{
+			Runtime:  mocks.Runtime,
+			Composer: comp,
+		})
+
+		cmd := createTestCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{"empty-sys"})
+		err := cmd.Execute()
+
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "no compiled install or resources tiers") {
+			t.Errorf("Expected error to explain the system has no tiers, got: %v", err)
+		}
+		if strings.HasSuffix(err.Error(), ": ") {
+			t.Errorf("Expected error to not end with a dangling colon, got: %v", err)
+		}
+	})
+
 	t.Run("KustomizationNotFound", func(t *testing.T) {
 		mocks := setupShowTest(t)
 
@@ -1025,8 +1241,11 @@ func TestShowKustomizationCmd(t *testing.T) {
 	t.Run("CommandInitialization", func(t *testing.T) {
 		cmd := showKustomizationCmd
 
-		if cmd.Use != "kustomization <component-name>" {
-			t.Errorf("Expected Use to be 'kustomization <component-name>', got %q", cmd.Use)
+		if cmd.Use != "kustomization [component-name]" {
+			t.Errorf("Expected Use to be 'kustomization [component-name]', got %q", cmd.Use)
+		}
+		if len(cmd.Aliases) != 1 || cmd.Aliases[0] != "kustomizations" {
+			t.Errorf("Expected Aliases to be ['kustomizations'], got %v", cmd.Aliases)
 		}
 		if cmd.Short == "" {
 			t.Error("Expected non-empty Short description")

--- a/docs/reference/commands/show-kustomization.md
+++ b/docs/reference/commands/show-kustomization.md
@@ -5,10 +5,10 @@ description: "Display the Flux Kustomization resource for a component."
 # windsor show kustomization
 
 ```sh
-windsor show kustomization <component-name> [flags]
+windsor show kustomization [component-name] [flags]
 ```
 
-Print the Flux Kustomization resource for the named component, including blueprint-level ConfigMaps in postBuild.substituteFrom. The output matches what 'windsor apply' would write to the cluster. Defaults to YAML; use --json for JSON. Unresolved deferred values render as '<deferred>' by default; use --raw to keep the original expression text instead.
+Print the Flux Kustomization resource for the named component, including blueprint-level ConfigMaps in postBuild.substituteFrom. The output matches what 'windsor apply' would write to the cluster. Omit the name to list every compiled component. Defaults to YAML; use --json for JSON. Unresolved deferred values render as '<deferred>' by default; use --raw to keep the original expression text instead.
 
 ## Flags
 
@@ -20,6 +20,9 @@ Print the Flux Kustomization resource for the named component, including bluepri
 ## Examples
 
 ```sh
+# List every compiled component
+windsor show kustomization
+
 # Inspect the Flux Kustomization for one component
 windsor show kustomization dns
 

--- a/integration/show_test.go
+++ b/integration/show_test.go
@@ -4,6 +4,7 @@
 package integration
 
 import (
+	"slices"
 	"strings"
 	"testing"
 
@@ -92,6 +93,76 @@ func TestShowBlueprint_DefaultRendersDeferredPlaceholder(t *testing.T) {
 	}
 	if strings.Contains(string(stdout), "${terraform_output(") {
 		t.Fatalf("expected output to hide deferred expression text, got:\n%s", stdout)
+	}
+}
+
+func TestShowKustomization_PluralAliasBehavesIdentically(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "facet-tiers")
+	env = append(env, "WINDSOR_CONTEXT=default")
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"show", "kustomizations"}, env)
+	if err != nil {
+		t.Fatalf("show kustomizations: %v\nstderr: %s", err, stderr)
+	}
+	names := strings.Fields(string(stdout))
+	if !slices.Contains(names, "dns") || !slices.Contains(names, "cert-manager-install") {
+		t.Errorf("expected plural alias listing to contain dns and cert-manager-install, got %v", names)
+	}
+}
+
+func TestShowKustomization_NoArgsListsPlainAndFluxSystemTierNames(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "facet-tiers")
+	env = append(env, "WINDSOR_CONTEXT=default")
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"show", "kustomization"}, env)
+	if err != nil {
+		t.Fatalf("show kustomization: %v\nstderr: %s", err, stderr)
+	}
+	names := strings.Fields(string(stdout))
+	for _, want := range []string{"dns", "cert-manager-install", "cert-manager-resources", "cert-manager-resources-extra"} {
+		if !slices.Contains(names, want) {
+			t.Errorf("expected listing to contain %q, got %v", want, names)
+		}
+	}
+}
+
+func TestShowKustomization_TierNameRendersCompiledKustomization(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "facet-tiers")
+	env = append(env, "WINDSOR_CONTEXT=default")
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"show", "kustomization", "cert-manager-install"}, env)
+	if err != nil {
+		t.Fatalf("show kustomization cert-manager-install: %v\nstderr: %s", err, stderr)
+	}
+	var k struct {
+		Metadata struct {
+			Name string `yaml:"name"`
+		} `yaml:"metadata"`
+		Spec struct {
+			Path string `yaml:"path"`
+		} `yaml:"spec"`
+	}
+	if err := yaml.Unmarshal(stdout, &k); err != nil {
+		t.Fatalf("parse kustomization YAML: %v\nstdout: %s", err, stdout)
+	}
+	if k.Metadata.Name != "cert-manager-install" {
+		t.Errorf("expected metadata.name cert-manager-install, got %q", k.Metadata.Name)
+	}
+	if k.Spec.Path != "kustomize/pki/cert-manager/install" {
+		t.Errorf("expected spec.path kustomize/pki/cert-manager/install, got %q", k.Spec.Path)
+	}
+}
+
+func TestShowKustomization_SystemNameReturnsTierListError(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "facet-tiers")
+	env = append(env, "WINDSOR_CONTEXT=default")
+	_, stderr, err := helpers.RunCLI(dir, []string{"show", "kustomization", "cert-manager"}, env)
+	if err == nil {
+		t.Fatal("expected failure but command succeeded")
+	}
+	if !strings.Contains(string(stderr), "cert-manager-install") {
+		t.Errorf("expected stderr to list tier names, got: %s", stderr)
 	}
 }
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change is purely additive: it makes the `component-name` argument to `windsor show kustomization` optional and adds a `kustomizations` plural alias, both of which are backwards-compatible for existing callers.
>
> **Overview**
>
> The PR extends `show kustomization` with a no-args listing mode that prints every compiled kustomization name — both plain `kustomize:` entries and the install/resources tiers compiled from `flux:` systems. A new `TierNames()` helper on `FluxSystem` drives both the listing path and the improved error message that suggests valid tier names when a user accidentally passes a flux system name instead of one of its tiers. `findKustomization` is updated to search `AllKustomizations()` so flux-system tiers are discoverable by name, not just plain kustomizations.
>
> The change also adds a `kustomizations` plural alias, three new unit-test subtests, and four integration tests backed by a `facet-tiers` fixture.
>
> Reviewed by Claude for commit `fc58a459`.

<!-- /claude-code-review:summary -->
