### PR TITLE
feat(composer): Implement FluxSystem field-level removal

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -795,6 +795,11 @@ func (b *Blueprint) DeepCopy() *Blueprint {
 		}
 	}
 
+	fluxSystemsCopy := make([]FluxSystem, len(b.FluxSystems))
+	for i, sys := range b.FluxSystems {
+		fluxSystemsCopy[i] = *sys.DeepCopy()
+	}
+
 	return &Blueprint{
 		Kind:                b.Kind,
 		ApiVersion:          b.ApiVersion,
@@ -805,6 +810,7 @@ func (b *Blueprint) DeepCopy() *Blueprint {
 		TerraformComponents: terraformComponentsCopy,
 		Crds:                slices.Clone(b.Crds),
 		Kustomizations:      kustomizationsCopy,
+		FluxSystems:         fluxSystemsCopy,
 		Substitutions:       maps.Clone(b.Substitutions),
 		ConfigMaps:          configMapsCopy,
 	}
@@ -996,41 +1002,44 @@ func (b *Blueprint) RemoveTerraformComponent(removal TerraformComponent) error {
 func (b *Blueprint) RemoveKustomization(removal Kustomization) error {
 	for i, existing := range b.Kustomizations {
 		if existing.Name == removal.Name {
-			if len(removal.DependsOn) > 0 {
-				existing.DependsOn = slices.DeleteFunc(existing.DependsOn, func(dep string) bool {
-					return slices.Contains(removal.DependsOn, dep)
-				})
-			}
-
-			if len(removal.Components) > 0 {
-				existing.Components = slices.DeleteFunc(existing.Components, func(comp string) bool {
-					return slices.Contains(removal.Components, comp)
-				})
-			}
-
-			if len(removal.Patches) > 0 {
-				existing.Patches = slices.DeleteFunc(existing.Patches, func(patch BlueprintPatch) bool {
-					for _, removalPatch := range removal.Patches {
-						if removalPatch.Path != "" && patch.Path == removalPatch.Path {
-							return true
-						}
-						if removalPatch.Patch != "" && patch.Patch == removalPatch.Patch {
-							return true
-						}
-					}
-					return false
-				})
-			}
-
-			if len(removal.Substitutions) > 0 && existing.Substitutions != nil {
-				for key := range removal.Substitutions {
-					delete(existing.Substitutions, key)
-				}
-			}
-
-			b.Kustomizations[i] = existing
+			b.Kustomizations[i] = subtractKustomizationFields(existing, removal)
 			return b.sortKustomize()
 		}
+	}
+	return nil
+}
+
+// RemoveFluxSystem removes specified non-index fields from an existing FluxSystem. It finds a
+// system matching the same Name, then subtracts dependsOn entries and any install fields named in
+// removal.Install (reusing subtractKustomizationFields, since Install is itself a Kustomization
+// carrying no Name until tier compilation, so it cannot go through RemoveKustomization's by-Name
+// lookup), and drops any resources variant whose Name is named in removal.Resources (empty Name
+// matches the unnamed variant). A resources variant has no kustomize: analog — it compiles to its
+// own distinct Kustomization — so naming it is itself the field-level operation, not a whole-system
+// deletion. The index field (Name) is not affected. If no matching system exists, no action is taken.
+func (b *Blueprint) RemoveFluxSystem(removal FluxSystem) error {
+	for i, existing := range b.FluxSystems {
+		if existing.Name != removal.Name {
+			continue
+		}
+
+		existing.DependsOn = subtractStringSlice(existing.DependsOn, removal.DependsOn)
+
+		if removal.Install != nil && existing.Install != nil {
+			subtracted := subtractKustomizationFields(*existing.Install, *removal.Install)
+			existing.Install = &subtracted
+		}
+
+		if len(removal.Resources) > 0 {
+			existing.Resources = slices.DeleteFunc(existing.Resources, func(v FluxVariant) bool {
+				return slices.ContainsFunc(removal.Resources, func(rv FluxVariant) bool {
+					return rv.Name == v.Name
+				})
+			})
+		}
+
+		b.FluxSystems[i] = existing
+		return nil
 	}
 	return nil
 }
@@ -1233,6 +1242,61 @@ func (k *Kustomization) DeepCopy() *Kustomization {
 	}
 }
 
+// DeepCopy returns a deep copy of the FluxVariant, including its embedded Kustomization.
+func (v *FluxVariant) DeepCopy() *FluxVariant {
+	if v == nil {
+		return nil
+	}
+	return &FluxVariant{
+		Kustomization: *v.Kustomization.DeepCopy(),
+		When:          v.When,
+	}
+}
+
+// DeepCopy returns a deep copy of the FluxSystem, including its Install tier and Resources
+// variants (each deep-copied via Kustomization.DeepCopy/FluxVariant.DeepCopy).
+func (s *FluxSystem) DeepCopy() *FluxSystem {
+	if s == nil {
+		return nil
+	}
+
+	var enabledCopy *BoolExpression
+	if s.Enabled != nil {
+		enabledCopy = s.Enabled.DeepCopy()
+	}
+	var destroyCopy *BoolExpression
+	if s.Destroy != nil {
+		destroyCopy = s.Destroy.DeepCopy()
+	}
+	var ordinalCopy *int
+	if s.Ordinal != nil {
+		o := *s.Ordinal
+		ordinalCopy = &o
+	}
+	var installCopy *Kustomization
+	if s.Install != nil {
+		installCopy = s.Install.DeepCopy()
+	}
+	resourcesCopy := make([]FluxVariant, len(s.Resources))
+	for i, v := range s.Resources {
+		resourcesCopy[i] = *v.DeepCopy()
+	}
+
+	return &FluxSystem{
+		Name:      s.Name,
+		Path:      s.Path,
+		Source:    s.Source,
+		Enabled:   enabledCopy,
+		Destroy:   destroyCopy,
+		When:      s.When,
+		DependsOn: slices.Clone(s.DependsOn),
+		Strategy:  s.Strategy,
+		Ordinal:   ordinalCopy,
+		Install:   installCopy,
+		Resources: resourcesCopy,
+	}
+}
+
 // ToFluxKustomization converts a blueprint Kustomization to a Flux Kustomization.
 // It takes the default namespace for the kustomization (overridden per-kustomization
 // by k.Namespace when set), the default source name to use if no source is specified,
@@ -1412,6 +1476,50 @@ func (k *Kustomization) ToFluxKustomization(namespace string, defaultSourceName 
 // =============================================================================
 // Private Methods
 // =============================================================================
+
+// subtractStringSlice returns existing with every element also present in removal deleted.
+// Shared by subtractKustomizationFields (DependsOn, Components) and RemoveFluxSystem
+// (DependsOn), the two field-level removal entry points.
+func subtractStringSlice(existing, removal []string) []string {
+	if len(removal) == 0 {
+		return existing
+	}
+	return slices.DeleteFunc(existing, func(item string) bool {
+		return slices.Contains(removal, item)
+	})
+}
+
+// subtractKustomizationFields returns existing with the patches, components, dependencies, and
+// substitutions named in removal stripped out. Patches match by Path or Patch content equality;
+// everything else matches by value/key. Fields removal leaves empty are left untouched on
+// existing. The Name field is never touched, so this is safe to use on both indexed
+// (Blueprint.Kustomizations) and unindexed (a FluxSystem's Install tier) Kustomizations.
+func subtractKustomizationFields(existing, removal Kustomization) Kustomization {
+	existing.DependsOn = subtractStringSlice(existing.DependsOn, removal.DependsOn)
+	existing.Components = subtractStringSlice(existing.Components, removal.Components)
+
+	if len(removal.Patches) > 0 {
+		existing.Patches = slices.DeleteFunc(existing.Patches, func(patch BlueprintPatch) bool {
+			for _, removalPatch := range removal.Patches {
+				if removalPatch.Path != "" && patch.Path == removalPatch.Path {
+					return true
+				}
+				if removalPatch.Patch != "" && patch.Patch == removalPatch.Patch {
+					return true
+				}
+			}
+			return false
+		})
+	}
+
+	if len(removal.Substitutions) > 0 && existing.Substitutions != nil {
+		for key := range removal.Substitutions {
+			delete(existing.Substitutions, key)
+		}
+	}
+
+	return existing
+}
 
 // validateTerraformComponents validates that all terraform component IDs are unique.
 // Component IDs are either the Name (if provided) or Path (if no name).

--- a/api/v1alpha1/blueprint_types_test.go
+++ b/api/v1alpha1/blueprint_types_test.go
@@ -2304,6 +2304,211 @@ func TestBlueprint_RemoveKustomization(t *testing.T) {
 	})
 }
 
+func TestBlueprint_RemoveFluxSystem(t *testing.T) {
+	t.Run("RemovesDependsOnFromExistingSystem", func(t *testing.T) {
+		base := &Blueprint{
+			FluxSystems: []FluxSystem{
+				{
+					Name:      "gateway",
+					DependsOn: []string{"pki-install", "lb-install", "keep_dep"},
+				},
+			},
+		}
+
+		removal := FluxSystem{
+			Name:      "gateway",
+			DependsOn: []string{"pki-install", "lb-install"},
+		}
+
+		err := base.RemoveFluxSystem(removal)
+
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		sys := base.FluxSystems[0]
+		if len(sys.DependsOn) != 1 || sys.DependsOn[0] != "keep_dep" {
+			t.Errorf("Expected only 'keep_dep' to remain, got %v", sys.DependsOn)
+		}
+	})
+
+	t.Run("RemovesInstallComponentsFromExistingSystem", func(t *testing.T) {
+		base := &Blueprint{
+			FluxSystems: []FluxSystem{
+				{
+					Name:    "gateway",
+					Install: &Kustomization{Components: []string{"envoy", "envoy/prometheus", "keep_component"}},
+				},
+			},
+		}
+
+		removal := FluxSystem{
+			Name:    "gateway",
+			Install: &Kustomization{Components: []string{"envoy", "envoy/prometheus"}},
+		}
+
+		err := base.RemoveFluxSystem(removal)
+
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		sys := base.FluxSystems[0]
+		if sys.Install == nil || len(sys.Install.Components) != 1 || sys.Install.Components[0] != "keep_component" {
+			t.Errorf("Expected only 'keep_component' to remain, got %+v", sys.Install)
+		}
+	})
+
+	t.Run("LeavesInstallUnchangedWhenRemovalHasNoInstall", func(t *testing.T) {
+		base := &Blueprint{
+			FluxSystems: []FluxSystem{
+				{
+					Name:    "gateway",
+					Install: &Kustomization{Components: []string{"envoy"}},
+				},
+			},
+		}
+
+		removal := FluxSystem{
+			Name:      "gateway",
+			DependsOn: []string{"pki-install"},
+		}
+
+		err := base.RemoveFluxSystem(removal)
+
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		sys := base.FluxSystems[0]
+		if sys.Install == nil || len(sys.Install.Components) != 1 || sys.Install.Components[0] != "envoy" {
+			t.Errorf("Expected install to be unchanged, got %+v", sys.Install)
+		}
+	})
+
+	t.Run("DropsNamedResourcesVariant", func(t *testing.T) {
+		base := &Blueprint{
+			FluxSystems: []FluxSystem{
+				{
+					Name: "gateway",
+					Resources: []FluxVariant{
+						{Kustomization: Kustomization{Name: "internal", Components: []string{"internal"}}},
+						{Kustomization: Kustomization{Name: "external", Components: []string{"external"}}},
+					},
+				},
+			},
+		}
+
+		removal := FluxSystem{
+			Name:      "gateway",
+			Resources: []FluxVariant{{Kustomization: Kustomization{Name: "internal"}}},
+		}
+
+		err := base.RemoveFluxSystem(removal)
+
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		sys := base.FluxSystems[0]
+		if len(sys.Resources) != 1 || sys.Resources[0].Name != "external" {
+			t.Errorf("Expected only 'external' variant to remain, got %+v", sys.Resources)
+		}
+	})
+
+	t.Run("DropsUnnamedResourcesVariant", func(t *testing.T) {
+		base := &Blueprint{
+			FluxSystems: []FluxSystem{
+				{
+					Name: "dns",
+					Resources: []FluxVariant{
+						{Kustomization: Kustomization{Components: []string{"coredns"}}},
+					},
+				},
+			},
+		}
+
+		removal := FluxSystem{
+			Name:      "dns",
+			Resources: []FluxVariant{{}},
+		}
+
+		err := base.RemoveFluxSystem(removal)
+
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		sys := base.FluxSystems[0]
+		if len(sys.Resources) != 0 {
+			t.Errorf("Expected the unnamed variant to be dropped, got %+v", sys.Resources)
+		}
+	})
+
+	t.Run("NoOpWhenSystemNotFound", func(t *testing.T) {
+		base := &Blueprint{
+			FluxSystems: []FluxSystem{
+				{
+					Name:    "existing",
+					Install: &Kustomization{Components: []string{"component1"}},
+				},
+			},
+		}
+
+		removal := FluxSystem{
+			Name:    "non-existent",
+			Install: &Kustomization{Components: []string{"component1"}},
+		}
+
+		err := base.RemoveFluxSystem(removal)
+
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+		if len(base.FluxSystems) != 1 {
+			t.Errorf("Expected 1 system unchanged, got %d", len(base.FluxSystems))
+		}
+		if len(base.FluxSystems[0].Install.Components) != 1 {
+			t.Errorf("Expected existing system to be unchanged")
+		}
+	})
+
+	t.Run("PreservesIndexField", func(t *testing.T) {
+		base := &Blueprint{
+			FluxSystems: []FluxSystem{
+				{
+					Name:    "gateway",
+					Path:    "original-path",
+					Source:  "original-source",
+					Install: &Kustomization{Components: []string{"envoy"}},
+				},
+			},
+		}
+
+		removal := FluxSystem{
+			Name:    "gateway",
+			Install: &Kustomization{Components: []string{"envoy"}},
+		}
+
+		err := base.RemoveFluxSystem(removal)
+
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		sys := base.FluxSystems[0]
+		if sys.Name != "gateway" {
+			t.Errorf("Expected Name to be preserved, got '%s'", sys.Name)
+		}
+		if sys.Path != "original-path" {
+			t.Errorf("Expected Path to be preserved, got '%s'", sys.Path)
+		}
+		if sys.Source != "original-source" {
+			t.Errorf("Expected Source to be preserved, got '%s'", sys.Source)
+		}
+	})
+}
+
 func TestBlueprint_DeepCopy(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		blueprint := &Blueprint{
@@ -4294,6 +4499,47 @@ func TestBlueprint_DeepCopy_WithNewFields(t *testing.T) {
 		}
 		if blueprint.Sources[0].Crds[0] != "gateway-api-1.5.1" {
 			t.Error("Expected original source crds untouched after mutating copy")
+		}
+	})
+
+	t.Run("CopiesFluxSystemsDeeply", func(t *testing.T) {
+		blueprint := &Blueprint{
+			FluxSystems: []FluxSystem{
+				{
+					Name:      "gateway",
+					DependsOn: []string{"pki-install"},
+					Install:   &Kustomization{Components: []string{"envoy"}},
+					Resources: []FluxVariant{
+						{Kustomization: Kustomization{Name: "internal", Components: []string{"internal"}}},
+					},
+				},
+			},
+		}
+
+		copy := blueprint.DeepCopy()
+		if len(copy.FluxSystems) != 1 {
+			t.Fatalf("Expected 1 flux system, got %d", len(copy.FluxSystems))
+		}
+		sys := copy.FluxSystems[0]
+		if sys.Install == nil || len(sys.Install.Components) != 1 || sys.Install.Components[0] != "envoy" {
+			t.Fatalf("Expected install copied, got %+v", sys.Install)
+		}
+		if len(sys.Resources) != 1 || sys.Resources[0].Name != "internal" {
+			t.Fatalf("Expected resources copied, got %+v", sys.Resources)
+		}
+
+		// Mutating the copy must not touch the original (deep copy, not aliased)
+		copy.FluxSystems[0].DependsOn[0] = "mutated"
+		copy.FluxSystems[0].Install.Components[0] = "mutated"
+		copy.FluxSystems[0].Resources[0].Components[0] = "mutated"
+		if blueprint.FluxSystems[0].DependsOn[0] != "pki-install" {
+			t.Error("Expected original dependsOn untouched after mutating copy")
+		}
+		if blueprint.FluxSystems[0].Install.Components[0] != "envoy" {
+			t.Error("Expected original install untouched after mutating copy")
+		}
+		if blueprint.FluxSystems[0].Resources[0].Components[0] != "internal" {
+			t.Error("Expected original resources untouched after mutating copy")
 		}
 	})
 

--- a/integration/composer_test.go
+++ b/integration/composer_test.go
@@ -264,6 +264,74 @@ func TestShowBlueprint_InstallResourcesTiers(t *testing.T) {
 	}
 }
 
+// TestShowBlueprint_FluxSystemFieldRemoval verifies that a facet's "strategy: remove" flux: entry
+// subtracts only the named dependsOn/install.components/resources[].name fields from a flux system
+// already declared in the base blueprint.yaml, leaving the rest of the system (and any resources
+// variant not named in the removal) intact -- Blueprint.RemoveFluxSystem's field-level semantics,
+// matching how kustomize:'s "remove" strategy already behaves, rather than deleting the system.
+func TestShowBlueprint_FluxSystemFieldRemoval(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "facet-tiers-remove")
+	env = append(env, "WINDSOR_CONTEXT=default")
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"show", "blueprint"}, env)
+	if err != nil {
+		t.Fatalf("show blueprint: %v\nstderr: %s", err, stderr)
+	}
+
+	var bp struct {
+		Flux []struct {
+			Name      string   `yaml:"name"`
+			DependsOn []string `yaml:"dependsOn"`
+			Install   struct {
+				Components []string `yaml:"components"`
+			} `yaml:"install"`
+			Resources []struct {
+				Name       string   `yaml:"name"`
+				Components []string `yaml:"components"`
+			} `yaml:"resources"`
+		} `yaml:"flux"`
+	}
+	if err := yaml.Unmarshal(stdout, &bp); err != nil {
+		t.Fatalf("parse blueprint YAML: %v\nstdout: %s", err, stdout)
+	}
+
+	var gateway *struct {
+		Name      string   `yaml:"name"`
+		DependsOn []string `yaml:"dependsOn"`
+		Install   struct {
+			Components []string `yaml:"components"`
+		} `yaml:"install"`
+		Resources []struct {
+			Name       string   `yaml:"name"`
+			Components []string `yaml:"components"`
+		} `yaml:"resources"`
+	}
+	for i := range bp.Flux {
+		if bp.Flux[i].Name == "gateway" {
+			gateway = &bp.Flux[i]
+			break
+		}
+	}
+	if gateway == nil {
+		t.Fatalf("expected gateway to survive field-level removal, got flux=%+v", bp.Flux)
+	}
+
+	if slices.Contains(gateway.DependsOn, "pki-install") {
+		t.Errorf("expected pki-install to be removed from dependsOn, got %v", gateway.DependsOn)
+	}
+
+	if slices.Contains(gateway.Install.Components, "envoy-metrics") {
+		t.Errorf("expected envoy-metrics to be removed from install components, got %v", gateway.Install.Components)
+	}
+	if !slices.Contains(gateway.Install.Components, "envoy") {
+		t.Errorf("expected envoy to remain in install components, got %v", gateway.Install.Components)
+	}
+
+	if len(gateway.Resources) != 1 || gateway.Resources[0].Name != "external" {
+		t.Errorf("expected only the 'external' resources variant to remain, got %+v", gateway.Resources)
+	}
+}
+
 // TestShowBlueprint_FluxSystemCrossFacetMerge verifies that two facets contributing to the same
 // flux: system name at different ordinals still merge under the default "merge" strategy instead
 // of the higher-ordinal facet wholesale-replacing the lower-ordinal one's install/resources: pki's

--- a/integration/fixtures/facet-tiers-remove/contexts/_template/blueprint.yaml
+++ b/integration/fixtures/facet-tiers-remove/contexts/_template/blueprint.yaml
@@ -1,0 +1,30 @@
+kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: facet-tiers-remove
+  description: "Field-level flux: strategy remove integration fixture"
+
+kustomize:
+
+- name: pki-install
+  path: pki
+  components:
+  - cert-manager
+
+flux:
+
+- name: gateway
+  path: gateway
+  dependsOn:
+  - pki-install
+  install:
+    components:
+    - envoy
+    - envoy-metrics
+  resources:
+  - name: internal
+    components:
+    - internal
+  - name: external
+    components:
+    - external

--- a/integration/fixtures/facet-tiers-remove/contexts/_template/facets/remove-gateway-fields.yaml
+++ b/integration/fixtures/facet-tiers-remove/contexts/_template/facets/remove-gateway-fields.yaml
@@ -1,0 +1,17 @@
+kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: remove-gateway-fields
+  description: Strips specific dependsOn/install/resources fields from the base blueprint's gateway flux system, leaving the rest of the system intact.
+
+flux:
+
+- name: gateway
+  strategy: remove
+  dependsOn:
+  - pki-install
+  install:
+    components:
+    - envoy-metrics
+  resources:
+  - name: internal

--- a/integration/fixtures/facet-tiers-remove/windsor.yaml
+++ b/integration/fixtures/facet-tiers-remove/windsor.yaml
@@ -1,0 +1,3 @@
+version: v1alpha1
+contexts:
+  default: {}

--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -436,7 +436,8 @@ func (h *BaseBlueprintHandler) GetDeferredPaths() map[string]bool {
 // so that helpers like terraform_output() resolve using outputs available at generate time
 // (after terraform apply). Only substitutions marked as deferred during composition are
 // re-evaluated; already-resolved substitutions are left untouched. Covers global substitutions,
-// blueprint-level ConfigMaps, and per-kustomization substitutions.
+// blueprint-level ConfigMaps, per-kustomization substitutions, and flux: systems' install/
+// resources tier substitutions.
 //
 // Returns the first evaluation error encountered (with the substitution path named, e.g.
 // "kustomize.dns.substitutions.external_dns_tenant_id") so the operator sees exactly which
@@ -491,6 +492,35 @@ func (h *BaseBlueprintHandler) resolveDeferredSubstitutions() error {
 				return fmt.Errorf("kustomize.%s.substitutions.%s: %w", k.Name, key, err)
 			}
 			k.Substitutions[key] = str
+		}
+	}
+
+	for i := range bp.FluxSystems {
+		sys := &bp.FluxSystems[i]
+		if sys.Install != nil {
+			for key, value := range sys.Install.Substitutions {
+				if !deferred["flux."+sys.Name+".install.substitutions."+key] {
+					continue
+				}
+				str, err := h.resolveDeferred(value)
+				if err != nil {
+					return fmt.Errorf("flux.%s.install.substitutions.%s: %w", sys.Name, key, err)
+				}
+				sys.Install.Substitutions[key] = str
+			}
+		}
+		for j := range sys.Resources {
+			v := &sys.Resources[j]
+			for key, value := range v.Substitutions {
+				if !deferred["flux."+sys.Name+".resources.substitutions."+key] {
+					continue
+				}
+				str, err := h.resolveDeferred(value)
+				if err != nil {
+					return fmt.Errorf("flux.%s.resources.substitutions.%s: %w", sys.Name, key, err)
+				}
+				v.Substitutions[key] = str
+			}
 		}
 	}
 

--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -391,14 +391,11 @@ func (h *BaseBlueprintHandler) Generate() *blueprintv1alpha1.Blueprint {
 // Generate() instead to preserve deferred placeholders.
 //
 // Returns an error when a deferred substitution cannot be resolved (e.g. terraform_output()
-// references a missing key, or terraform itself errors during the lookup). The previous behavior
-// was to swallow these errors and leave the raw `${...}` source in the substitution map — which
-// then leaked into Flux ConfigMaps and downstream Helm renders, where the literal expression
-// text was treated as a config value (e.g. external-dns reading "${terraform_output('cluster',
-// 'tenant_id') ?? ''}" as the tenant ID and crashlooping with "invalid tenantID"). The contract
-// is now: an unresolved expression must never reach a ConfigMap. Operators see the failure at
-// blueprint-resolution time with the offending key + path called out by name, instead of via a
-// downstream pod crashloop minutes later.
+// references a missing key, or terraform itself errors during the lookup), named by the
+// offending substitution path (e.g. "kustomize.dns.substitutions.external_dns_tenant_id") so
+// operators see the failure at blueprint-resolution time rather than via a downstream pod
+// crashloop. An unresolved expression must never reach a ConfigMap: raw `${...}` source text
+// left in place would be treated as a literal config value by downstream Helm renders.
 func (h *BaseBlueprintHandler) GenerateResolved() (*blueprintv1alpha1.Blueprint, error) {
 	bp := h.Generate()
 	if bp == nil {
@@ -439,12 +436,9 @@ func (h *BaseBlueprintHandler) GetDeferredPaths() map[string]bool {
 // blueprint-level ConfigMaps, per-kustomization substitutions, and flux: systems' install/
 // resources tier substitutions.
 //
-// Returns the first evaluation error encountered (with the substitution path named, e.g.
-// "kustomize.dns.substitutions.external_dns_tenant_id") so the operator sees exactly which
-// expression failed. Leaving an unresolved expression in place — the previous behavior — let
-// raw `${terraform_output(...)}` source text leak into Flux ConfigMaps; downstream Helm
-// renders then treated the literal expression as a config value. Failing here surfaces the
-// problem at blueprint-resolution time, before anything is written to the cluster.
+// Returns the first evaluation error encountered, with the substitution path named (e.g.
+// "kustomize.dns.substitutions.external_dns_tenant_id"), surfacing the problem at
+// blueprint-resolution time, before anything is written to the cluster.
 func (h *BaseBlueprintHandler) resolveDeferredSubstitutions() error {
 	if h.runtime == nil || h.runtime.Evaluator == nil || h.composedBlueprint == nil {
 		return nil
@@ -511,13 +505,18 @@ func (h *BaseBlueprintHandler) resolveDeferredSubstitutions() error {
 		}
 		for j := range sys.Resources {
 			v := &sys.Resources[j]
+			resourcesPrefix := "flux." + sys.Name + ".resources"
+			if v.Name != "" {
+				resourcesPrefix += "-" + v.Name
+			}
+			resourcesPrefix += ".substitutions."
 			for key, value := range v.Substitutions {
-				if !deferred["flux."+sys.Name+".resources.substitutions."+key] {
+				if !deferred[resourcesPrefix+key] {
 					continue
 				}
 				str, err := h.resolveDeferred(value)
 				if err != nil {
-					return fmt.Errorf("flux.%s.resources.substitutions.%s: %w", sys.Name, key, err)
+					return fmt.Errorf("%s%s: %w", resourcesPrefix, key, err)
 				}
 				v.Substitutions[key] = str
 			}
@@ -530,12 +529,9 @@ func (h *BaseBlueprintHandler) resolveDeferredSubstitutions() error {
 // resolveDeferred evaluates a single expression with evaluateDeferred=true using the composed
 // scope. Returns the resolved string on success, or an error when the expression cannot be
 // evaluated (e.g. terraform_output() references a missing module output, or terraform itself
-// errors). The previous behavior — swallowing the error and returning a sentinel that callers
-// interpreted as "leave the original raw expression in place" — is the bug that lets unresolved
-// `${terraform_output(...)}` text leak into ConfigMaps. Operators with a legitimately-optional
-// reference should write `?? <fallback>` in the expression itself; nil from the evaluator
-// (with no coalesce) renders as the empty string here, which is the operator's explicit choice
-// rather than a silent failure.
+// errors). Operators with a legitimately-optional reference should write `?? <fallback>` in the
+// expression itself; nil from the evaluator (with no coalesce) renders as the empty string here,
+// which is the operator's explicit choice rather than a silent failure.
 func (h *BaseBlueprintHandler) resolveDeferred(expr string) (string, error) {
 	resolved, err := h.runtime.Evaluator.Evaluate(expr, "", h.composedScope, true)
 	if err != nil {

--- a/pkg/composer/blueprint/handler_test.go
+++ b/pkg/composer/blueprint/handler_test.go
@@ -1239,13 +1239,8 @@ func TestHandler_GenerateResolved(t *testing.T) {
 	})
 
 	t.Run("PropagatesEvaluatorErrorWithSubstitutionPath", func(t *testing.T) {
-		// Given a handler with a deferred substitution whose underlying expression errors
-		// during the deferred-resolution pass — e.g. a terraform_output() that references a
-		// missing module key, or a terraform shell failure. Previously the handler would
-		// swallow the error and leave the raw `${...}` source string in the substitution
-		// map, which then leaked into Flux ConfigMaps and downstream Helm renders. Now the
-		// error must surface here, named by its substitution path, so the operator sees the
-		// failure at blueprint-resolution time instead of via a downstream pod crashloop.
+		// A deferred substitution whose expression errors (e.g. terraform_output() referencing
+		// a missing module key) surfaces the error here, named by its substitution path.
 		mocks := setupHandlerMocks(t)
 		mocks.Runtime.Evaluator = &evaluator.MockExpressionEvaluator{
 			EvaluateFunc: func(expr string, _ string, _ map[string]any, _ bool) (any, error) {
@@ -1288,11 +1283,7 @@ func TestHandler_GenerateResolved(t *testing.T) {
 	})
 
 	t.Run("ResolvesFluxSystemInstallAndResourcesSubstitutions", func(t *testing.T) {
-		// Given a handler with deferred substitutions on a flux: system's install and resources
-		// tiers. Blueprint.DeepCopy() previously always dropped FluxSystems, which masked the
-		// fact that resolveDeferredSubstitutions never walked them either — a deferred
-		// terraform_output() under flux: would reach a cluster ConfigMap unresolved. Now that
-		// DeepCopy carries FluxSystems, this path must actually resolve them.
+		// Two resources variants share a substitution key name; only "internal"'s is deferred.
 		mocks := setupHandlerMocks(t)
 		mocks.Runtime.Evaluator = &evaluator.MockExpressionEvaluator{
 			EvaluateFunc: func(expr string, _ string, _ map[string]any, _ bool) (any, error) {
@@ -1314,7 +1305,15 @@ func TestHandler_GenerateResolved(t *testing.T) {
 							Kustomization: blueprintv1alpha1.Kustomization{
 								Name: "internal",
 								Substitutions: map[string]string{
-									"gateway_lb_ip": "${terraform_output('network', 'lb_ip') ?? ''}",
+									"gateway_lb_ip": "${terraform_output('network', 'internal_lb_ip') ?? ''}",
+								},
+							},
+						},
+						{
+							Kustomization: blueprintv1alpha1.Kustomization{
+								Name: "external",
+								Substitutions: map[string]string{
+									"gateway_lb_ip": "already-resolved",
 								},
 							},
 						},
@@ -1323,8 +1322,8 @@ func TestHandler_GenerateResolved(t *testing.T) {
 			},
 		}
 		handler.deferredPaths = map[string]bool{
-			"flux.gateway.install.substitutions.cluster_name":    true,
-			"flux.gateway.resources.substitutions.gateway_lb_ip": true,
+			"flux.gateway.install.substitutions.cluster_name":             true,
+			"flux.gateway.resources-internal.substitutions.gateway_lb_ip": true,
 		}
 
 		// When calling GenerateResolved
@@ -1333,13 +1332,16 @@ func TestHandler_GenerateResolved(t *testing.T) {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
-		// Then both the install and resources deferred substitutions are resolved
+		// Then only the deferred substitutions are resolved
 		sys := resolved.FluxSystems[0]
 		if sys.Install.Substitutions["cluster_name"] != "resolved-value" {
 			t.Errorf("Expected install substitution resolved, got %q", sys.Install.Substitutions["cluster_name"])
 		}
 		if sys.Resources[0].Substitutions["gateway_lb_ip"] != "resolved-value" {
-			t.Errorf("Expected resources substitution resolved, got %q", sys.Resources[0].Substitutions["gateway_lb_ip"])
+			t.Errorf("Expected 'internal' variant's deferred substitution resolved, got %q", sys.Resources[0].Substitutions["gateway_lb_ip"])
+		}
+		if sys.Resources[1].Substitutions["gateway_lb_ip"] != "already-resolved" {
+			t.Errorf("Expected 'external' variant's already-resolved substitution left untouched, got %q", sys.Resources[1].Substitutions["gateway_lb_ip"])
 		}
 	})
 }

--- a/pkg/composer/blueprint/handler_test.go
+++ b/pkg/composer/blueprint/handler_test.go
@@ -1286,6 +1286,62 @@ func TestHandler_GenerateResolved(t *testing.T) {
 			t.Error("Expected nil blueprint on resolve failure (no partial results to consume)")
 		}
 	})
+
+	t.Run("ResolvesFluxSystemInstallAndResourcesSubstitutions", func(t *testing.T) {
+		// Given a handler with deferred substitutions on a flux: system's install and resources
+		// tiers. Blueprint.DeepCopy() previously always dropped FluxSystems, which masked the
+		// fact that resolveDeferredSubstitutions never walked them either — a deferred
+		// terraform_output() under flux: would reach a cluster ConfigMap unresolved. Now that
+		// DeepCopy carries FluxSystems, this path must actually resolve them.
+		mocks := setupHandlerMocks(t)
+		mocks.Runtime.Evaluator = &evaluator.MockExpressionEvaluator{
+			EvaluateFunc: func(expr string, _ string, _ map[string]any, _ bool) (any, error) {
+				return "resolved-value", nil
+			},
+		}
+		handler := NewBlueprintHandler(mocks.Runtime, mocks.ArtifactBuilder)
+		handler.composedBlueprint = &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name: "gateway",
+					Install: &blueprintv1alpha1.Kustomization{
+						Substitutions: map[string]string{
+							"cluster_name": "${terraform_output('cluster', 'cluster_name') ?? ''}",
+						},
+					},
+					Resources: []blueprintv1alpha1.FluxVariant{
+						{
+							Kustomization: blueprintv1alpha1.Kustomization{
+								Name: "internal",
+								Substitutions: map[string]string{
+									"gateway_lb_ip": "${terraform_output('network', 'lb_ip') ?? ''}",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		handler.deferredPaths = map[string]bool{
+			"flux.gateway.install.substitutions.cluster_name":    true,
+			"flux.gateway.resources.substitutions.gateway_lb_ip": true,
+		}
+
+		// When calling GenerateResolved
+		resolved, err := handler.GenerateResolved()
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then both the install and resources deferred substitutions are resolved
+		sys := resolved.FluxSystems[0]
+		if sys.Install.Substitutions["cluster_name"] != "resolved-value" {
+			t.Errorf("Expected install substitution resolved, got %q", sys.Install.Substitutions["cluster_name"])
+		}
+		if sys.Resources[0].Substitutions["gateway_lb_ip"] != "resolved-value" {
+			t.Errorf("Expected resources substitution resolved, got %q", sys.Resources[0].Substitutions["gateway_lb_ip"])
+		}
+	})
 }
 
 func TestHandler_getConfigValues(t *testing.T) {

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -1183,7 +1183,10 @@ func (p *BaseBlueprintProcessor) buildFluxSystemEntries(system blueprintv1alpha1
 // in fluxSystemByName. Variants whose when condition is false or whose components evaluate to empty
 // are dropped; an install tier whose components prune to empty sets Install to nil. This preserves
 // the FluxSystem structure in the composed blueprint (for show blueprint and YAML output) while
-// keeping tier compilation deferred to AllKustomizations().
+// keeping tier compilation deferred to AllKustomizations(). The empty-components pruning is skipped
+// for strategy == "remove": a removal descriptor's resources variants are identified by Name alone,
+// not by a non-empty Components list, so dropping a variant with no evaluated components (as merge/
+// replace do) would erase the very variant name a removal is naming.
 func (p *BaseBlueprintProcessor) collectFluxSystems(facet blueprintv1alpha1.Facet, sourceName []string, fluxSystemByName map[string]*blueprintv1alpha1.FluxSystem, facetScope map[string]any) error {
 	for _, system := range facet.FluxSystems {
 		when := system.When
@@ -1222,7 +1225,7 @@ func (p *BaseBlueprintProcessor) collectFluxSystems(facet blueprintv1alpha1.Face
 			if err != nil {
 				return fmt.Errorf("error evaluating install components for system '%s': %w", system.Name, err)
 			}
-			if len(comps) > 0 {
+			if len(comps) > 0 || strategy == "remove" {
 				installCopy := *system.Install.DeepCopy()
 				installCopy.Components = comps
 				if err := p.evalKustomizationSubstitutions(&installCopy, facet.Path, "flux."+system.Name+".install.substitutions.", facetScope); err != nil {
@@ -1249,7 +1252,7 @@ func (p *BaseBlueprintProcessor) collectFluxSystems(facet blueprintv1alpha1.Face
 			if err != nil {
 				return fmt.Errorf("error evaluating resources components for system '%s': %w", system.Name, err)
 			}
-			if len(comps) == 0 {
+			if len(comps) == 0 && strategy != "remove" {
 				continue
 			}
 			variantKey := system.Name + "-resources"
@@ -1295,13 +1298,18 @@ func (p *BaseBlueprintProcessor) collectFluxSystems(facet blueprintv1alpha1.Face
 // updateFluxSystemEntry merges a new FluxSystem into an existing entry in fluxSystemByName using
 // the same ordinal/strategy precedence rules as updateKustomizationEntry: a higher ordinal still
 // runs applyFluxSystemEntryByStrategy (so a "merge" strategy keeps merging across ordinal bands
-// instead of wholesale-replacing) unless either side's strategy is "remove"; equal ordinal falls
-// back to strategy precedence (remove > replace > merge) before merging at equal precedence.
-// Whenever new's own strategy is "remove" and it wins, the outcome is always delete(entries, name),
-// never entries[name] = new: unlike Kustomization/Terraform entries, FluxSystem has no deferred
-// removal pass in applyCollectedComponents that later interprets a stored Strategy == "remove" —
-// the final write loop upserts every remaining map entry unconditionally, so a "remove"-tagged
-// FluxSystem left sitting in the map would be written to the target blueprint unchanged.
+// instead of wholesale-replacing) unless either side's strategy is "remove", in which case new
+// wins outright (entries[name] = new, tagged with strategy); equal ordinal falls back to strategy
+// precedence (remove > replace > merge) before merging at equal precedence. A winning "remove"
+// is never deleted from entries here — like Kustomization/Terraform entries, it is carried as a
+// Strategy == "remove" descriptor into applyCollectedComponents's deferred removal pass, which
+// accumulates it there and applies Blueprint.RemoveFluxSystem after all merges/replaces write.
+// Note this map-level "new wins outright" replacement is itself wholesale, same as
+// updateKustomizationEntry: if a lower-ordinal (or lower-precedence) facet had already merged
+// real Install/Resources content into this map slot, a winning "remove" discards it from the map
+// before RemoveFluxSystem ever runs — RemoveFluxSystem's field-level subtraction only has
+// something to act on when the target blueprint already has a matching entry (e.g. declared
+// directly in blueprint.yaml) independent of this collection pass.
 func (p *BaseBlueprintProcessor) updateFluxSystemEntry(name string, new *blueprintv1alpha1.FluxSystem, strategy string, entries map[string]*blueprintv1alpha1.FluxSystem) error {
 	existing := entries[name]
 	existingStrategy := existing.Strategy
@@ -1324,11 +1332,7 @@ func (p *BaseBlueprintProcessor) updateFluxSystemEntry(name string, new *bluepri
 	}
 
 	if newOrdinal > existingOrdinal {
-		if strategy == "remove" {
-			delete(entries, name)
-			return nil
-		}
-		if existingStrategy == "remove" {
+		if existingStrategy == "remove" || strategy == "remove" {
 			new.Strategy = strategy
 			entries[name] = new
 			return nil
@@ -1341,10 +1345,6 @@ func (p *BaseBlueprintProcessor) updateFluxSystemEntry(name string, new *bluepri
 
 	existingStrategyPrec := strategyPrecedence[existingStrategy]
 	if newStrategyPrec > existingStrategyPrec {
-		if strategy == "remove" {
-			delete(entries, name)
-			return nil
-		}
 		new.Strategy = strategy
 		entries[name] = new
 		return nil
@@ -1357,20 +1357,23 @@ func (p *BaseBlueprintProcessor) updateFluxSystemEntry(name string, new *bluepri
 }
 
 // applyFluxSystemEntryByStrategy applies new to existing's slot in entries per strategy, mirroring
-// applyKustomizationEntryByStrategy: "replace" swaps the whole entry, "remove" deletes it outright
-// (FluxSystem has no field-level removal the way RemoveKustomization strips individual
-// components/patches/dependsOn), and "merge" unions DependsOn and deep-merges both Install
-// (blueprintv1alpha1.MergeFluxInstall) and Resources variants (blueprintv1alpha1.MergeFluxVariants)
-// — the same semantics same-name Kustomizations get elsewhere, and the same helpers
-// Blueprint.UpsertFluxSystem uses to merge FluxSystems across sources — instead of replacing
-// either wholesale.
+// applyKustomizationEntryByStrategy: "replace" swaps the whole entry, "remove" accumulates a
+// combined removal descriptor via accumulateFluxSystemRemovals (field-level, matching
+// RemoveKustomization's semantics for plain kustomize: entries — never a whole-system deletion),
+// and "merge" unions DependsOn and deep-merges both Install (blueprintv1alpha1.MergeFluxInstall)
+// and Resources variants (blueprintv1alpha1.MergeFluxVariants) — the same semantics same-name
+// Kustomizations get elsewhere, and the same helpers Blueprint.UpsertFluxSystem uses to merge
+// FluxSystems across sources — instead of replacing either wholesale.
 func (p *BaseBlueprintProcessor) applyFluxSystemEntryByStrategy(name string, new *blueprintv1alpha1.FluxSystem, strategy string, existing *blueprintv1alpha1.FluxSystem, entries map[string]*blueprintv1alpha1.FluxSystem) error {
 	switch strategy {
 	case "replace":
 		new.Strategy = strategy
 		entries[name] = new
 	case "remove":
-		delete(entries, name)
+		accumulated := p.accumulateFluxSystemRemovals(*existing, *new)
+		accumulated.Strategy = "remove"
+		accumulated.Ordinal = new.Ordinal
+		entries[name] = &accumulated
 	case "merge":
 		merged := *existing
 		merged.DependsOn = accumulateStringSlice(existing.DependsOn, new.DependsOn)
@@ -1875,6 +1878,8 @@ func (p *BaseBlueprintProcessor) applyCollectedComponents(target *blueprintv1alp
 		}
 	}
 
+	var fluxRemovals []blueprintv1alpha1.FluxSystem
+
 	fluxKeys := make([]string, 0, len(fluxSystemByName))
 	for key := range fluxSystemByName {
 		fluxKeys = append(fluxKeys, key)
@@ -1882,10 +1887,25 @@ func (p *BaseBlueprintProcessor) applyCollectedComponents(target *blueprintv1alp
 	sort.Strings(fluxKeys)
 	for _, key := range fluxKeys {
 		sys := *fluxSystemByName[key]
+		strategy := sys.Strategy
+		if strategy == "" {
+			strategy = "merge"
+		}
 		sys.Strategy = ""
 		sys.Ordinal = nil
+
+		if strategy == "remove" {
+			fluxRemovals = append(fluxRemovals, sys)
+			continue
+		}
 		if err := target.UpsertFluxSystem(sys); err != nil {
 			return fmt.Errorf("error writing flux system '%s': %w", key, err)
+		}
+	}
+
+	for _, removal := range fluxRemovals {
+		if err := target.RemoveFluxSystem(removal); err != nil {
+			return fmt.Errorf("error removing flux system '%s': %w", removal.Name, err)
 		}
 	}
 
@@ -1932,6 +1952,40 @@ func (p *BaseBlueprintProcessor) accumulateKustomizationRemovals(existing, new b
 	accumulated.Substitutions = accumulateMapKeys(existing.Substitutions, new.Substitutions)
 
 	return accumulated
+}
+
+// accumulateFluxSystemRemovals unions two removal-strategy FluxSystem descriptors from different
+// facets into one combined descriptor, mirroring accumulateKustomizationRemovals: DependsOn
+// accumulates via accumulateStringSlice, and Resources concatenates removal-descriptor variants
+// (each identified by Name; Blueprint.RemoveFluxSystem drops the named variant outright, so
+// duplicates surviving accumulation are harmless). Install's removable fields accumulate via
+// accumulateKustomizationRemovals itself, treating a nil Install on either side as a zero-value
+// Kustomization{} — Install carries no Name until tier compilation, so the same field-level union
+// accumulateKustomizationRemovals gives two facets' top-level removal descriptors applies here.
+func (p *BaseBlueprintProcessor) accumulateFluxSystemRemovals(existing, new blueprintv1alpha1.FluxSystem) blueprintv1alpha1.FluxSystem {
+	accumulated := blueprintv1alpha1.FluxSystem{
+		Name: existing.Name,
+	}
+
+	accumulated.DependsOn = accumulateStringSlice(existing.DependsOn, new.DependsOn)
+
+	if existing.Install != nil || new.Install != nil {
+		mergedInstall := p.accumulateKustomizationRemovals(kustomizationOrZero(existing.Install), kustomizationOrZero(new.Install))
+		accumulated.Install = &mergedInstall
+	}
+
+	accumulated.Resources = append(accumulated.Resources, existing.Resources...)
+	accumulated.Resources = append(accumulated.Resources, new.Resources...)
+
+	return accumulated
+}
+
+// kustomizationOrZero dereferences k, or returns a zero-value Kustomization when k is nil.
+func kustomizationOrZero(k *blueprintv1alpha1.Kustomization) blueprintv1alpha1.Kustomization {
+	if k == nil {
+		return blueprintv1alpha1.Kustomization{}
+	}
+	return *k
 }
 
 // evaluateCondition uses the expression evaluator to evaluate a 'when' condition string against

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -1274,7 +1274,12 @@ func (p *BaseBlueprintProcessor) collectFluxSystems(facet blueprintv1alpha1.Face
 			}
 			evalV.DependsOn = extraDeps
 
-			if err := p.evalKustomizationSubstitutions(&evalV.Kustomization, facet.Path, "flux."+system.Name+".resources.substitutions.", facetScope); err != nil {
+			resourcesDeferredPrefix := "flux." + system.Name + ".resources"
+			if v.Name != "" {
+				resourcesDeferredPrefix += "-" + v.Name
+			}
+			resourcesDeferredPrefix += ".substitutions."
+			if err := p.evalKustomizationSubstitutions(&evalV.Kustomization, facet.Path, resourcesDeferredPrefix, facetScope); err != nil {
 				return fmt.Errorf("error evaluating resources substitutions for system '%s': %w", system.Name, err)
 			}
 			evaluatedResources = append(evaluatedResources, evalV)

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -2883,6 +2883,62 @@ func TestProcessor_ProcessFacets_Tiers(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("EqualOrdinalRemoveFacetsAccumulateAndStripFieldsFromPreexistingSystem", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "remove-install-component"},
+				FluxSystems: []blueprintv1alpha1.FluxSystem{{
+					Name:     "gateway",
+					Strategy: "remove",
+					Install:  &blueprintv1alpha1.Kustomization{Components: []string{"envoy"}},
+				}},
+			},
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "remove-resources-variant"},
+				FluxSystems: []blueprintv1alpha1.FluxSystem{{
+					Name:      "gateway",
+					Strategy:  "remove",
+					Resources: []blueprintv1alpha1.FluxVariant{{Kustomization: blueprintv1alpha1.Kustomization{Name: "internal"}}},
+				}},
+			},
+		}
+		// A pre-existing FluxSystem, standing in for one already declared in the loader's parsed
+		// blueprint.yaml (bp := loader.GetBlueprint() in handler.go's processLoader) before facets
+		// are layered on, so the two remove-strategy facets above have a real entry to subtract from.
+		target := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{{
+				Name:    "gateway",
+				Install: &blueprintv1alpha1.Kustomization{Components: []string{"envoy", "keep_component"}},
+				Resources: []blueprintv1alpha1.FluxVariant{
+					{Kustomization: blueprintv1alpha1.Kustomization{Name: "internal", Components: []string{"internal"}}},
+					{Kustomization: blueprintv1alpha1.Kustomization{Name: "external", Components: []string{"external"}}},
+				},
+			}},
+		}
+		if _, err := processor.ProcessFacets(target, facets); err != nil {
+			t.Fatalf("ProcessFacets: %v", err)
+		}
+
+		var sys blueprintv1alpha1.FluxSystem
+		found := false
+		for _, s := range target.FluxSystems {
+			if s.Name == "gateway" {
+				sys, found = s, true
+			}
+		}
+		if !found {
+			t.Fatalf("expected the gateway FluxSystem to survive field-level removal, got %+v", target.FluxSystems)
+		}
+		if sys.Install == nil || len(sys.Install.Components) != 1 || sys.Install.Components[0] != "keep_component" {
+			t.Errorf("expected only 'keep_component' to remain on install, got %+v", sys.Install)
+		}
+		if len(sys.Resources) != 1 || sys.Resources[0].Name != "external" {
+			t.Errorf("expected only the 'external' resources variant to remain, got %+v", sys.Resources)
+		}
+	})
 }
 func TestProcessor_mergeHelpers(t *testing.T) {
 	t.Run("deepMergeMapMergesNestedMaps", func(t *testing.T) {

--- a/pkg/composer/blueprint/render.go
+++ b/pkg/composer/blueprint/render.go
@@ -88,6 +88,23 @@ func applyDeferredPathsToBlueprint(bp *blueprintv1alpha1.Blueprint, deferredPath
 			}
 		}
 	}
+	for i := range bp.FluxSystems {
+		sys := &bp.FluxSystems[i]
+		if sys.Install != nil {
+			for key := range sys.Install.Substitutions {
+				if deferredPaths["flux."+sys.Name+".install.substitutions."+key] {
+					sys.Install.Substitutions[key] = deferredPlaceholder
+				}
+			}
+		}
+		for j := range sys.Resources {
+			for key := range sys.Resources[j].Substitutions {
+				if deferredPaths["flux."+sys.Name+".resources.substitutions."+key] {
+					sys.Resources[j].Substitutions[key] = deferredPlaceholder
+				}
+			}
+		}
+	}
 }
 
 // applyDeferredPathsToFluxKustomization rewrites deferred fields on flux kustomization output.

--- a/pkg/composer/blueprint/render.go
+++ b/pkg/composer/blueprint/render.go
@@ -98,8 +98,13 @@ func applyDeferredPathsToBlueprint(bp *blueprintv1alpha1.Blueprint, deferredPath
 			}
 		}
 		for j := range sys.Resources {
+			resourcesPrefix := "flux." + sys.Name + ".resources"
+			if sys.Resources[j].Name != "" {
+				resourcesPrefix += "-" + sys.Resources[j].Name
+			}
+			resourcesPrefix += ".substitutions."
 			for key := range sys.Resources[j].Substitutions {
-				if deferredPaths["flux."+sys.Name+".resources.substitutions."+key] {
+				if deferredPaths[resourcesPrefix+key] {
 					sys.Resources[j].Substitutions[key] = deferredPlaceholder
 				}
 			}

--- a/pkg/composer/blueprint/render_test.go
+++ b/pkg/composer/blueprint/render_test.go
@@ -81,6 +81,58 @@ func TestRenderDeferredPlaceholders(t *testing.T) {
 		}
 	})
 
+	t.Run("RewritesDeferredFluxSystemInstallAndResourcesSubstitutionsToPlaceholder", func(t *testing.T) {
+		// Given a blueprint with deferred substitutions on a flux: system's install and
+		// resources tiers. Blueprint.DeepCopy() previously always dropped FluxSystems, which
+		// masked the fact that applyDeferredPathsToBlueprint never walked them either — a
+		// deferred flux install/resources substitution would render its raw expression text
+		// instead of '<deferred>'. Now that DeepCopy carries FluxSystems, this path must
+		// actually render the placeholder.
+		bp := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name: "gateway",
+					Install: &blueprintv1alpha1.Kustomization{
+						Substitutions: map[string]string{
+							"cluster_name": "${terraform_output('cluster', 'cluster_name')}",
+							"resolved_key": "already-resolved",
+						},
+					},
+					Resources: []blueprintv1alpha1.FluxVariant{
+						{
+							Kustomization: blueprintv1alpha1.Kustomization{
+								Name: "internal",
+								Substitutions: map[string]string{
+									"gateway_lb_ip": "${terraform_output('network', 'lb_ip')}",
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		deferredPaths := map[string]bool{
+			"flux.gateway.install.substitutions.cluster_name":    true,
+			"flux.gateway.resources.substitutions.gateway_lb_ip": true,
+		}
+
+		// When rendering deferred placeholders
+		result := RenderDeferredPlaceholders(bp, false, deferredPaths)
+
+		// Then the deferred install/resources keys become <deferred>, unrelated keys are unchanged
+		got := result.(*blueprintv1alpha1.Blueprint)
+		sys := got.FluxSystems[0]
+		if sys.Install.Substitutions["cluster_name"] != deferredPlaceholder {
+			t.Errorf("Expected deferred install substitution to be '%s', got '%s'", deferredPlaceholder, sys.Install.Substitutions["cluster_name"])
+		}
+		if sys.Install.Substitutions["resolved_key"] != "already-resolved" {
+			t.Errorf("Expected resolved install substitution unchanged, got '%s'", sys.Install.Substitutions["resolved_key"])
+		}
+		if sys.Resources[0].Substitutions["gateway_lb_ip"] != deferredPlaceholder {
+			t.Errorf("Expected deferred resources substitution to be '%s', got '%s'", deferredPlaceholder, sys.Resources[0].Substitutions["gateway_lb_ip"])
+		}
+	})
+
 	t.Run("DoesNotMutateOriginalBlueprint", func(t *testing.T) {
 		// Given a blueprint with a deferred substitution
 		bp := &blueprintv1alpha1.Blueprint{

--- a/pkg/composer/blueprint/render_test.go
+++ b/pkg/composer/blueprint/render_test.go
@@ -82,12 +82,7 @@ func TestRenderDeferredPlaceholders(t *testing.T) {
 	})
 
 	t.Run("RewritesDeferredFluxSystemInstallAndResourcesSubstitutionsToPlaceholder", func(t *testing.T) {
-		// Given a blueprint with deferred substitutions on a flux: system's install and
-		// resources tiers. Blueprint.DeepCopy() previously always dropped FluxSystems, which
-		// masked the fact that applyDeferredPathsToBlueprint never walked them either — a
-		// deferred flux install/resources substitution would render its raw expression text
-		// instead of '<deferred>'. Now that DeepCopy carries FluxSystems, this path must
-		// actually render the placeholder.
+		// Two resources variants share a substitution key name; only "internal"'s is deferred.
 		bp := &blueprintv1alpha1.Blueprint{
 			FluxSystems: []blueprintv1alpha1.FluxSystem{
 				{
@@ -103,7 +98,15 @@ func TestRenderDeferredPlaceholders(t *testing.T) {
 							Kustomization: blueprintv1alpha1.Kustomization{
 								Name: "internal",
 								Substitutions: map[string]string{
-									"gateway_lb_ip": "${terraform_output('network', 'lb_ip')}",
+									"gateway_lb_ip": "${terraform_output('network', 'internal_lb_ip')}",
+								},
+							},
+						},
+						{
+							Kustomization: blueprintv1alpha1.Kustomization{
+								Name: "external",
+								Substitutions: map[string]string{
+									"gateway_lb_ip": "already-resolved",
 								},
 							},
 						},
@@ -112,8 +115,8 @@ func TestRenderDeferredPlaceholders(t *testing.T) {
 			},
 		}
 		deferredPaths := map[string]bool{
-			"flux.gateway.install.substitutions.cluster_name":    true,
-			"flux.gateway.resources.substitutions.gateway_lb_ip": true,
+			"flux.gateway.install.substitutions.cluster_name":             true,
+			"flux.gateway.resources-internal.substitutions.gateway_lb_ip": true,
 		}
 
 		// When rendering deferred placeholders
@@ -129,7 +132,10 @@ func TestRenderDeferredPlaceholders(t *testing.T) {
 			t.Errorf("Expected resolved install substitution unchanged, got '%s'", sys.Install.Substitutions["resolved_key"])
 		}
 		if sys.Resources[0].Substitutions["gateway_lb_ip"] != deferredPlaceholder {
-			t.Errorf("Expected deferred resources substitution to be '%s', got '%s'", deferredPlaceholder, sys.Resources[0].Substitutions["gateway_lb_ip"])
+			t.Errorf("Expected deferred 'internal' resources substitution to be '%s', got '%s'", deferredPlaceholder, sys.Resources[0].Substitutions["gateway_lb_ip"])
+		}
+		if sys.Resources[1].Substitutions["gateway_lb_ip"] != "already-resolved" {
+			t.Errorf("Expected 'external' resources substitution unchanged, got '%s'", sys.Resources[1].Substitutions["gateway_lb_ip"])
 		}
 	})
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This PR changes the existing `strategy: remove` semantics for FluxSystems from whole-system deletion to field-level subtraction, which is a behavioral break for any facet that used `strategy: remove` to delete a FluxSystem introduced by another facet rather than stripping fields from a blueprint.yaml-declared system.
>
> **Overview**
>
> The PR adds `FluxSystem.DeepCopy()` and `FluxVariant.DeepCopy()` (previously missing, causing FluxSystems to be silently dropped from blueprint copies), implements `Blueprint.RemoveFluxSystem()` for field-level removal mirroring `RemoveKustomization()`, and extends deferred-substitution rendering and resolution to cover flux system install and resources tiers. The processor's "remove" strategy for FluxSystems is reworked from immediately deleting the map entry to accumulating a removal descriptor that `applyCollectedComponents` applies via `RemoveFluxSystem` after all upserts complete.
>
> The behavioral change is intentional and documented in the updated function comments: a winning "remove" descriptor now only subtracts named fields (dependsOn, install components/patches, named resources variants) from a pre-existing target-blueprint entry; it no longer removes a FluxSystem that was contributed solely by a lower-ordinal facet. The test suite — unit, processor, handler, render, and a new integration fixture — covers the happy paths well, though cross-variant key collisions in the deferred-path key space are not exercised.
>
> Reviewed by Claude for commit `1e48ba56`.

<!-- /claude-code-review:summary -->
