### PR TITLE
chore(composer): Flux system cleanup

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -491,23 +491,8 @@ func (t *TerraformComponent) DeepCopy() *TerraformComponent {
 		return nil
 	}
 
-	inputsCopy := maps.Clone(t.Inputs)
-
 	dependsOnCopy := make([]string, len(t.DependsOn))
 	copy(dependsOnCopy, t.DependsOn)
-
-	var destroyCopy *BoolExpression
-	if t.Destroy != nil {
-		destroyCopy = t.Destroy.DeepCopy()
-	}
-	var parallelismCopy *IntExpression
-	if t.Parallelism != nil {
-		parallelismCopy = t.Parallelism.DeepCopy()
-	}
-	var enabledCopy *BoolExpression
-	if t.Enabled != nil {
-		enabledCopy = t.Enabled.DeepCopy()
-	}
 
 	return &TerraformComponent{
 		Name:         t.Name,
@@ -515,10 +500,10 @@ func (t *TerraformComponent) DeepCopy() *TerraformComponent {
 		Path:         t.Path,
 		FullPath:     t.FullPath,
 		DependsOn:    dependsOnCopy,
-		Inputs:       inputsCopy,
-		Destroy:      destroyCopy,
-		Parallelism:  parallelismCopy,
-		Enabled:      enabledCopy,
+		Inputs:       maps.Clone(t.Inputs),
+		Destroy:      t.Destroy.DeepCopy(),
+		Parallelism:  t.Parallelism.DeepCopy(),
+		Enabled:      t.Enabled.DeepCopy(),
 		InputOrigins: maps.Clone(t.InputOrigins),
 	}
 }
@@ -757,10 +742,6 @@ func (b *Blueprint) DeepCopy() *Blueprint {
 
 	sourcesCopy := make([]Source, len(b.Sources))
 	for i, source := range b.Sources {
-		var installCopy *BoolExpression
-		if source.Install != nil {
-			installCopy = source.Install.DeepCopy()
-		}
 		sourcesCopy[i] = Source{
 			Name:       source.Name,
 			Url:        source.Url,
@@ -773,7 +754,7 @@ func (b *Blueprint) DeepCopy() *Blueprint {
 				Commit: source.Ref.Commit,
 			},
 			SecretName: source.SecretName,
-			Install:    installCopy,
+			Install:    source.Install.DeepCopy(),
 			Crds:       slices.Clone(source.Crds),
 		}
 	}
@@ -1071,32 +1052,32 @@ func (b *Blueprint) UpsertFluxSystem(sys FluxSystem) error {
 	return nil
 }
 
-// MergeFluxInstall deep-merges new's Install tier into existing's via MergeKustomizationFields
-// (Components/DependsOn accumulate, other fields are overridden by new when set) rather than via
-// by-name Blueprint.Kustomizations matching, since Install carries no Name until tier compilation
-// and that by-name path is a no-op on an unnamed Kustomization. Either side being nil just takes
-// the other, matching how a facet or source with no Install opinion shouldn't erase one
+// MergeFluxInstall deep-merges overlay's Install tier into existing's via MergeKustomizationFields
+// (Components/DependsOn accumulate, other fields are overridden by overlay when set) rather than
+// via by-name Blueprint.Kustomizations matching, since Install carries no Name until tier
+// compilation and that by-name path is a no-op on an unnamed Kustomization. Either side being nil
+// just takes the other, matching how a facet or source with no Install opinion shouldn't erase one
 // contributed elsewhere.
-func MergeFluxInstall(existing, new *Kustomization) *Kustomization {
-	if new == nil {
+func MergeFluxInstall(existing, overlay *Kustomization) *Kustomization {
+	if overlay == nil {
 		return existing
 	}
 	if existing == nil {
-		return new
+		return overlay
 	}
-	merged := MergeKustomizationFields(*existing, *new)
+	merged := MergeKustomizationFields(*existing, *overlay)
 	return &merged
 }
 
-// MergeFluxVariants combines two resources-variant lists keyed by variant name. A variant from new
-// deep-merges into the same-named variant in existing via MergeKustomizationFields (see
+// MergeFluxVariants combines two resources-variant lists keyed by variant name. A variant from
+// overlay deep-merges into the same-named variant in existing via MergeKustomizationFields (see
 // MergeFluxInstall for why by-name Blueprint.Kustomizations matching isn't used instead), and the
 // two When conditions combine with AND. A variant with a new name is appended in order. This keeps
 // a cross-facet or cross-source merge from emitting two Kustomizations with the same
 // "<system>-resources[-<name>]" identity.
-func MergeFluxVariants(existing, new []FluxVariant) []FluxVariant {
+func MergeFluxVariants(existing, overlay []FluxVariant) []FluxVariant {
 	merged := slices.Clone(existing)
-	for _, nv := range new {
+	for _, nv := range overlay {
 		idx := slices.IndexFunc(merged, func(v FluxVariant) bool { return v.Name == nv.Name })
 		if idx == -1 {
 			merged = append(merged, nv)
@@ -1162,16 +1143,7 @@ func compileFluxSystemTiers(sys FluxSystem) []Kustomization {
 		k.Name = installName
 		k.Path = path.Join(base, "install")
 		k.DependsOn = slices.Clone(sys.DependsOn)
-		if k.Source == "" {
-			k.Source = sys.Source
-		}
-		if k.Enabled == nil {
-			k.Enabled = sys.Enabled
-		}
-		if k.Destroy == nil {
-			k.Destroy = sys.Destroy
-		}
-		k.Substitute = nil
+		applySystemTierDefaults(&k, sys)
 		out = append(out, k)
 		installEmitted = true
 	}
@@ -1189,34 +1161,32 @@ func compileFluxSystemTiers(sys FluxSystem) []Kustomization {
 		} else {
 			k.DependsOn = append(slices.Clone(sys.DependsOn), v.DependsOn...)
 		}
-		if k.Source == "" {
-			k.Source = sys.Source
-		}
-		if k.Enabled == nil {
-			k.Enabled = sys.Enabled
-		}
-		if k.Destroy == nil {
-			k.Destroy = sys.Destroy
-		}
-		k.Substitute = nil
+		applySystemTierDefaults(&k, sys)
 		out = append(out, k)
 	}
 	return out
+}
+
+// applySystemTierDefaults fills a compiled tier Kustomization's Source/Enabled/Destroy from the
+// owning FluxSystem when the tier didn't set its own, and clears Substitute (already merged into
+// Substitutions during collection, so it carries no further meaning on the compiled tier).
+func applySystemTierDefaults(k *Kustomization, sys FluxSystem) {
+	if k.Source == "" {
+		k.Source = sys.Source
+	}
+	if k.Enabled == nil {
+		k.Enabled = sys.Enabled
+	}
+	if k.Destroy == nil {
+		k.Destroy = sys.Destroy
+	}
+	k.Substitute = nil
 }
 
 // DeepCopy creates a deep copy of the Kustomization object.
 func (k *Kustomization) DeepCopy() *Kustomization {
 	if k == nil {
 		return nil
-	}
-
-	var destroyCopy *BoolExpression
-	if k.Destroy != nil {
-		destroyCopy = k.Destroy.DeepCopy()
-	}
-	var enabledCopy *BoolExpression
-	if k.Enabled != nil {
-		enabledCopy = k.Enabled.DeepCopy()
 	}
 
 	return &Kustomization{
@@ -1234,9 +1204,9 @@ func (k *Kustomization) DeepCopy() *Kustomization {
 		Force:           k.Force,
 		Prune:           k.Prune,
 		Components:      slices.Clone(k.Components),
-		Destroy:         destroyCopy,
+		Destroy:         k.Destroy.DeepCopy(),
 		DestroyOnly:     k.DestroyOnly,
-		Enabled:         enabledCopy,
+		Enabled:         k.Enabled.DeepCopy(),
 		Substitutions:   maps.Clone(k.Substitutions),
 		Substitute:      maps.Clone(k.Substitute),
 	}
@@ -1260,22 +1230,10 @@ func (s *FluxSystem) DeepCopy() *FluxSystem {
 		return nil
 	}
 
-	var enabledCopy *BoolExpression
-	if s.Enabled != nil {
-		enabledCopy = s.Enabled.DeepCopy()
-	}
-	var destroyCopy *BoolExpression
-	if s.Destroy != nil {
-		destroyCopy = s.Destroy.DeepCopy()
-	}
 	var ordinalCopy *int
 	if s.Ordinal != nil {
 		o := *s.Ordinal
 		ordinalCopy = &o
-	}
-	var installCopy *Kustomization
-	if s.Install != nil {
-		installCopy = s.Install.DeepCopy()
 	}
 	resourcesCopy := make([]FluxVariant, len(s.Resources))
 	for i, v := range s.Resources {
@@ -1286,13 +1244,13 @@ func (s *FluxSystem) DeepCopy() *FluxSystem {
 		Name:      s.Name,
 		Path:      s.Path,
 		Source:    s.Source,
-		Enabled:   enabledCopy,
-		Destroy:   destroyCopy,
+		Enabled:   s.Enabled.DeepCopy(),
+		Destroy:   s.Destroy.DeepCopy(),
 		When:      s.When,
 		DependsOn: slices.Clone(s.DependsOn),
 		Strategy:  s.Strategy,
 		Ordinal:   ordinalCopy,
-		Install:   installCopy,
+		Install:   s.Install.DeepCopy(),
 		Resources: resourcesCopy,
 	}
 }

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -117,7 +117,7 @@ windsor show kustomization dns --json`,
 		componentName := args[0]
 		kustomization, found := findKustomization(blueprint, componentName)
 		if !found {
-			return errKustomizationNotFound(blueprint, componentName)
+			return kustomizationNotFoundError(blueprint, componentName)
 		}
 
 		namespace := proj.Runtime.ConfigHandler.GetString("gitops.namespace", constants.DefaultGitopsNamespace)
@@ -245,11 +245,11 @@ func findKustomization(blueprint *blueprintv1alpha1.Blueprint, name string) (blu
 	return blueprintv1alpha1.Kustomization{}, false
 }
 
-// errKustomizationNotFound returns a formatted error for when a kustomization is not found. If the
+// kustomizationNotFoundError returns a formatted error for when a kustomization is not found. If the
 // name instead matches a flux: system descriptor rather than one of its compiled tiers, the error
 // lists that system's tier names, since a system name (e.g. "cert-manager") is never itself a valid
 // argument.
-func errKustomizationNotFound(blueprint *blueprintv1alpha1.Blueprint, name string) error {
+func kustomizationNotFoundError(blueprint *blueprintv1alpha1.Blueprint, name string) error {
 	for _, sys := range blueprint.FluxSystems {
 		if sys.Name != name {
 			continue

--- a/pkg/composer/blueprint/composer.go
+++ b/pkg/composer/blueprint/composer.go
@@ -769,11 +769,12 @@ func claimCrdRefs(refs []string, claimed map[string]struct{}) []string {
 }
 
 // applyCrdLayerBarrier orders the vendored CRD layers ahead of the whole stack: when the blueprint
-// implies CRD layers, every root kustomization (one with no dependsOn of its own) is made to depend on
-// every synthesized CRD kustomization. Dependents of those roots reach the layers transitively, so the
-// stack reconciles after the CRDs are Established — without any facet author naming a CRD in dependsOn,
-// and without the provisioner waiting: Flux honors the edges on every reconcile. The CRD kustomizations
-// themselves are materialized by the provisioner from the same CrdLayers derivation.
+// implies CRD layers, every root — a plain kustomize: entry or flux: system with no dependsOn of its
+// own — is made to depend on every synthesized CRD kustomization. Dependents of those roots reach the
+// layers transitively, so the stack reconciles after the CRDs are Established — without any facet
+// author naming a CRD in dependsOn, and without the provisioner waiting: Flux honors the edges on
+// every reconcile. The CRD kustomizations themselves are materialized by the provisioner from the
+// same CrdLayers derivation.
 func (c *BaseBlueprintComposer) applyCrdLayerBarrier(bp *blueprintv1alpha1.Blueprint) {
 	layers := CrdLayers(bp)
 	if len(layers) == 0 {

--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -505,11 +505,7 @@ func (h *BaseBlueprintHandler) resolveDeferredSubstitutions() error {
 		}
 		for j := range sys.Resources {
 			v := &sys.Resources[j]
-			resourcesPrefix := "flux." + sys.Name + ".resources"
-			if v.Name != "" {
-				resourcesPrefix += "-" + v.Name
-			}
-			resourcesPrefix += ".substitutions."
+			resourcesPrefix := fluxResourcesSubstitutionPrefix(sys.Name, v.Name)
 			for key, value := range v.Substitutions {
 				if !deferred[resourcesPrefix+key] {
 					continue

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -3,7 +3,6 @@ package blueprint
 import (
 	"fmt"
 	"maps"
-	"path"
 	"reflect"
 	"slices"
 	"sort"
@@ -1027,14 +1026,6 @@ func validateCrdRef(ref string) error {
 	return nil
 }
 
-// buildTierEntries expands a processed kustomization that declares install/resources component
-// groups into separate entries sharing the entry's path: "<name>-install" carries the install
-// components and "<name>-resources" carries the resources components and depends on the install,
-// so the controller is reconciled before the custom resources it admits. A legacy "<name>" entry
-// is emitted when Components is also set. The install (and legacy) entries carry the entry's
-// explicit dependencies; resources reaches those transitively through the install tier. The CRD
-// layer is ordered ahead of everything by the provisioner phase, not by per-entry dependsOn. Each
-// entry gets its own Substitutions copy and clears the tier fields.
 // mergeSubstitute returns k's Substitutions with its Substitute alias merged in (substitute wins on
 // key conflict). Returns nil when both are empty.
 func mergeSubstitute(k blueprintv1alpha1.Kustomization) map[string]string {
@@ -1047,6 +1038,17 @@ func mergeSubstitute(k blueprintv1alpha1.Kustomization) map[string]string {
 	}
 	maps.Copy(out, k.Substitute)
 	return out
+}
+
+// fluxResourcesSubstitutionPrefix returns the deferred-path prefix for a flux system's resources
+// tier substitutions, scoped per resources variant (empty variantName for the unnamed variant) so
+// two variants sharing a substitution key name don't collide on the same deferred-path entry.
+func fluxResourcesSubstitutionPrefix(systemName, variantName string) string {
+	prefix := "flux." + systemName + ".resources"
+	if variantName != "" {
+		prefix += "-" + variantName
+	}
+	return prefix + ".substitutions."
 }
 
 // combineWhen ANDs two condition expressions, dropping empties. A system entry's own condition is
@@ -1073,109 +1075,6 @@ func (p *BaseBlueprintProcessor) evalDropEmpty(raw []string, facetPath string, s
 		return nil, err
 	}
 	return slices.DeleteFunc(evaluated, func(s string) bool { return s == "" }), nil
-}
-
-// buildFluxSystemEntries expands a flux: system descriptor into its Flux Kustomizations:
-// "<name>-install" at "<path>/install" from the install tier, and one
-// "<name>-resources[-<variant>]" per resources variant at "<path>/resources". Each resources
-// variant depends on "<name>-install" when an install tier is emitted (the controller-liveness
-// edge); otherwise it carries the system's cross-layer dependsOn directly. Install and variants
-// reuse the Kustomization type for their operational properties; the system supplies identity, path
-// base, lifecycle (source/enabled/destroy), and its cross-layer dependsOn. Components,
-// substitutions, and per-variant when/dependsOn are evaluated against the facet scope; a tier whose
-// components prune to empty, or a variant whose when is false, is dropped.
-func (p *BaseBlueprintProcessor) buildFluxSystemEntries(system blueprintv1alpha1.FluxSystem, facet blueprintv1alpha1.Facet, scope map[string]any) ([]blueprintv1alpha1.ConditionalKustomization, error) {
-	name := system.Name
-	base := system.Path
-	if base == "" {
-		base = name
-	}
-	installName := name + "-install"
-	systemDeps, err := p.evalDropEmpty(system.DependsOn, facet.Path, scope)
-	if err != nil {
-		return nil, fmt.Errorf("error evaluating dependsOn for system '%s': %w", name, err)
-	}
-
-	mk := func(tier blueprintv1alpha1.Kustomization, tierName, tierSegment string, components, dependsOn []string, when string) (blueprintv1alpha1.ConditionalKustomization, error) {
-		k := *tier.DeepCopy()
-		k.Name = tierName
-		k.Path = path.Join(base, tierSegment)
-		k.Components = components
-		k.DependsOn = dependsOn
-		if k.Source == "" {
-			k.Source = system.Source
-		}
-		if k.Enabled == nil {
-			k.Enabled = system.Enabled
-		}
-		if k.Destroy == nil {
-			k.Destroy = system.Destroy
-		}
-		if err := p.evalKustomizationSubstitutions(&k, facet.Path, "kustomize."+tierName+".substitutions.", scope); err != nil {
-			return blueprintv1alpha1.ConditionalKustomization{}, err
-		}
-		return blueprintv1alpha1.ConditionalKustomization{Kustomization: k, When: when}, nil
-	}
-
-	var entries []blueprintv1alpha1.ConditionalKustomization
-	installEmitted := false
-	seenVariants := make(map[string]bool)
-	if system.Install != nil {
-		comps, err := p.evalDropEmpty(system.Install.Components, facet.Path, scope)
-		if err != nil {
-			return nil, fmt.Errorf("error evaluating install components for system '%s': %w", name, err)
-		}
-		if len(comps) > 0 {
-			entry, err := mk(*system.Install, installName, "install", comps, systemDeps, system.When)
-			if err != nil {
-				return nil, fmt.Errorf("error building install tier for system '%s': %w", name, err)
-			}
-			entries = append(entries, entry)
-			installEmitted = true
-		}
-	}
-
-	for _, v := range system.Resources {
-		when := combineWhen(system.When, v.When)
-		include, err := p.shouldIncludeComponent(when, facet.Path, scope)
-		if err != nil {
-			return nil, fmt.Errorf("error evaluating resources condition for system '%s': %w", name, err)
-		}
-		if !include {
-			continue
-		}
-		comps, err := p.evalDropEmpty(v.Components, facet.Path, scope)
-		if err != nil {
-			return nil, fmt.Errorf("error evaluating resources components for system '%s': %w", name, err)
-		}
-		if len(comps) == 0 {
-			continue
-		}
-		variantName := name + "-resources"
-		if v.Name != "" {
-			variantName += "-" + v.Name
-		}
-		if seenVariants[variantName] {
-			return nil, fmt.Errorf("duplicate resources variant %q in system %q; add a unique name: field to each variant", variantName, name)
-		}
-		seenVariants[variantName] = true
-		extraDeps, err := p.evalDropEmpty(v.DependsOn, facet.Path, scope)
-		if err != nil {
-			return nil, fmt.Errorf("error evaluating resources dependsOn for system '%s': %w", name, err)
-		}
-		var deps []string
-		if installEmitted {
-			deps = append([]string{installName}, extraDeps...)
-		} else {
-			deps = append(slices.Clone(systemDeps), extraDeps...)
-		}
-		entry, err := mk(v.Kustomization, variantName, "resources", comps, deps, when)
-		if err != nil {
-			return nil, fmt.Errorf("error building resources tier for system '%s': %w", name, err)
-		}
-		entries = append(entries, entry)
-	}
-	return entries, nil
 }
 
 // collectFluxSystems evaluates a facet's flux: system descriptors — resolving expressions on
@@ -1274,11 +1173,7 @@ func (p *BaseBlueprintProcessor) collectFluxSystems(facet blueprintv1alpha1.Face
 			}
 			evalV.DependsOn = extraDeps
 
-			resourcesDeferredPrefix := "flux." + system.Name + ".resources"
-			if v.Name != "" {
-				resourcesDeferredPrefix += "-" + v.Name
-			}
-			resourcesDeferredPrefix += ".substitutions."
+			resourcesDeferredPrefix := fluxResourcesSubstitutionPrefix(system.Name, v.Name)
 			if err := p.evalKustomizationSubstitutions(&evalV.Kustomization, facet.Path, resourcesDeferredPrefix, facetScope); err != nil {
 				return fmt.Errorf("error evaluating resources substitutions for system '%s': %w", system.Name, err)
 			}

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -522,15 +522,9 @@ func (p *BaseBlueprintProcessor) mergeConfigBlocks(scope map[string]any, existin
 		if strategy != "merge" && strategy != "replace" && strategy != "remove" {
 			return nil, nil, fmt.Errorf("invalid strategy %q for config block %q: must be 'merge', 'replace', or 'remove'", strategy, name)
 		}
-		incOrdinal := 0
-		if inc.Ordinal != nil {
-			incOrdinal = *inc.Ordinal
-		}
+		incOrdinal := ordinalOrZero(inc.Ordinal)
 		if prev, hasPrev := merged[name]; hasPrev {
-			prevOrdinal := 0
-			if prev.Ordinal != nil {
-				prevOrdinal = *prev.Ordinal
-			}
+			prevOrdinal := ordinalOrZero(prev.Ordinal)
 			prevStrategy := prev.Strategy
 			if prevStrategy == "" {
 				prevStrategy = "merge"
@@ -824,11 +818,7 @@ func (p *BaseBlueprintProcessor) collectTerraformComponents(
 			processed.Source = resolveSourceName(sourceName)
 		}
 
-		facetOrd := resolvedFacetOrdinal(facet)
-		effectiveOrdinal := facetOrd
-		if processed.Ordinal != nil {
-			effectiveOrdinal = *processed.Ordinal
-		}
+		effectiveOrdinal := resolveOrdinal(facet, processed.Ordinal)
 		processed.Ordinal = &effectiveOrdinal
 
 		strategy := processed.Strategy
@@ -914,21 +904,8 @@ func (p *BaseBlueprintProcessor) collectKustomizations(facet blueprintv1alpha1.F
 
 		processed := k
 		processed.When = componentWhen
-		if len(processed.Substitute) > 0 {
-			processed.Substitutions = mergeSubstitute(processed.Kustomization)
-			processed.Substitute = nil
-		}
-		if processed.Substitutions != nil {
-			evaluated, deferredKeys, err := p.evaluateSubstitutions(processed.Substitutions, facet.Path, facetScope)
-			if err != nil {
-				return fmt.Errorf("error evaluating substitutions for kustomization '%s': %w", processed.Name, err)
-			}
-			processed.Substitutions = evaluated
-			for key, isDeferred := range deferredKeys {
-				if isDeferred {
-					p.markDeferredPath("kustomize." + processed.Name + ".substitutions." + key)
-				}
-			}
+		if err := p.evalKustomizationSubstitutions(&processed.Kustomization, facet.Path, "kustomize."+processed.Name+".substitutions.", facetScope); err != nil {
+			return fmt.Errorf("error evaluating substitutions for kustomization '%s': %w", processed.Name, err)
 		}
 		if evaluator.ContainsExpression(processed.Path) {
 			evaluatedPath, err := p.evaluator.Evaluate(processed.Path, facet.Path, facetScope, false)
@@ -945,13 +922,11 @@ func (p *BaseBlueprintProcessor) collectKustomizations(facet blueprintv1alpha1.F
 				processed.Path = fmt.Sprintf("%v", evaluatedPath)
 			}
 		}
-		if len(processed.DependsOn) > 0 {
-			evaluated, err := p.evaluateStringSlice(processed.DependsOn, facet.Path, facetScope)
-			if err != nil {
-				return fmt.Errorf("error evaluating dependsOn for kustomization '%s': %w", processed.Name, err)
-			}
-			processed.DependsOn = slices.DeleteFunc(evaluated, func(s string) bool { return s == "" })
+		dependsOn, err := p.evalDropEmpty(processed.DependsOn, facet.Path, facetScope)
+		if err != nil {
+			return fmt.Errorf("error evaluating dependsOn for kustomization '%s': %w", processed.Name, err)
 		}
+		processed.DependsOn = dependsOn
 		if len(processed.Components) > 0 {
 			evaluated, err := p.evaluateStringSlice(processed.Components, facet.Path, facetScope)
 			if err != nil {
@@ -970,11 +945,7 @@ func (p *BaseBlueprintProcessor) collectKustomizations(facet blueprintv1alpha1.F
 			processed.Source = resolveSourceName(sourceName)
 		}
 
-		facetOrd := resolvedFacetOrdinal(facet)
-		effectiveOrdinal := facetOrd
-		if processed.Ordinal != nil {
-			effectiveOrdinal = *processed.Ordinal
-		}
+		effectiveOrdinal := resolveOrdinal(facet, processed.Ordinal)
 		processed.Ordinal = &effectiveOrdinal
 
 		strategy := processed.Strategy
@@ -1104,10 +1075,7 @@ func (p *BaseBlueprintProcessor) collectFluxSystems(facet blueprintv1alpha1.Face
 			system.Source = resolveSourceName(sourceName)
 		}
 
-		effectiveOrdinal := resolvedFacetOrdinal(facet)
-		if system.Ordinal != nil {
-			effectiveOrdinal = *system.Ordinal
-		}
+		effectiveOrdinal := resolveOrdinal(facet, system.Ordinal)
 		strategy := system.Strategy
 		if strategy == "" {
 			strategy = "merge"
@@ -1222,14 +1190,8 @@ func (p *BaseBlueprintProcessor) updateFluxSystemEntry(name string, new *bluepri
 		return fmt.Errorf("invalid strategy '%s' for flux system '%s': must be 'remove', 'replace', or 'merge'", strategy, name)
 	}
 
-	newOrdinal := 0
-	if new.Ordinal != nil {
-		newOrdinal = *new.Ordinal
-	}
-	existingOrdinal := 0
-	if existing.Ordinal != nil {
-		existingOrdinal = *existing.Ordinal
-	}
+	newOrdinal := ordinalOrZero(new.Ordinal)
+	existingOrdinal := ordinalOrZero(existing.Ordinal)
 
 	if newOrdinal > existingOrdinal {
 		if existingStrategy == "remove" || strategy == "remove" {
@@ -1431,14 +1393,8 @@ func (p *BaseBlueprintProcessor) updateTerraformComponentEntry(
 		return fmt.Errorf("invalid strategy '%s' for terraform component '%s': must be 'remove', 'replace', or 'merge'", strategy, componentID)
 	}
 
-	newOrdinal := 0
-	if new.Ordinal != nil {
-		newOrdinal = *new.Ordinal
-	}
-	existingOrdinal := 0
-	if existing.Ordinal != nil {
-		existingOrdinal = *existing.Ordinal
-	}
+	newOrdinal := ordinalOrZero(new.Ordinal)
+	existingOrdinal := ordinalOrZero(existing.Ordinal)
 
 	if newOrdinal > existingOrdinal {
 		if strategy == "replace" {
@@ -1565,14 +1521,8 @@ func (p *BaseBlueprintProcessor) updateKustomizationEntry(name string, new *blue
 		return fmt.Errorf("invalid strategy '%s' for kustomization '%s': must be 'remove', 'replace', or 'merge'", strategy, name)
 	}
 
-	newOrdinal := 0
-	if new.Ordinal != nil {
-		newOrdinal = *new.Ordinal
-	}
-	existingOrdinal := 0
-	if existing.Ordinal != nil {
-		existingOrdinal = *existing.Ordinal
-	}
+	newOrdinal := ordinalOrZero(new.Ordinal)
+	existingOrdinal := ordinalOrZero(existing.Ordinal)
 
 	if newOrdinal > existingOrdinal {
 		if existingStrategy == "remove" || strategy == "remove" {
@@ -2209,6 +2159,25 @@ func resolvedFacetOrdinal(f blueprintv1alpha1.Facet) int {
 		return *f.Ordinal
 	}
 	return OrdinalFromFacetPath(f.Path)
+}
+
+// ordinalOrZero dereferences ordinal, or returns 0 when it is nil. Shared by every ordinal
+// precedence comparison across terraform/kustomization/flux-system entry merging and config-block
+// merging.
+func ordinalOrZero(ordinal *int) int {
+	if ordinal == nil {
+		return 0
+	}
+	return *ordinal
+}
+
+// resolveOrdinal returns ordinal's value when set, or facet's own default ordinal otherwise.
+// Shared by each collect* function's per-entry ordinal resolution.
+func resolveOrdinal(facet blueprintv1alpha1.Facet, ordinal *int) int {
+	if ordinal != nil {
+		return *ordinal
+	}
+	return resolvedFacetOrdinal(facet)
 }
 
 // deepCopyMapStringAny returns a deep copy of m so that trace records hold a snapshot of the

--- a/pkg/composer/blueprint/render.go
+++ b/pkg/composer/blueprint/render.go
@@ -98,11 +98,7 @@ func applyDeferredPathsToBlueprint(bp *blueprintv1alpha1.Blueprint, deferredPath
 			}
 		}
 		for j := range sys.Resources {
-			resourcesPrefix := "flux." + sys.Name + ".resources"
-			if sys.Resources[j].Name != "" {
-				resourcesPrefix += "-" + sys.Resources[j].Name
-			}
-			resourcesPrefix += ".substitutions."
+			resourcesPrefix := fluxResourcesSubstitutionPrefix(sys.Name, sys.Resources[j].Name)
 			for key := range sys.Resources[j].Substitutions {
 				if deferredPaths[resourcesPrefix+key] {
 					sys.Resources[j].Substitutions[key] = deferredPlaceholder


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This is a pure cleanup PR within the blueprint composer package; no behavior changes are introduced and the affected paths are well-covered by existing tests.
>
> **Overview**
>
> The PR extracts four small helpers (`ordinalOrZero`, `resolveOrdinal`, `fluxResourcesSubstitutionPrefix`, `applySystemTierDefaults`) to eliminate repeated inline patterns across `processor.go`, `handler.go`, and `render.go`. It simplifies the `DeepCopy` methods in `blueprint_types.go` by removing intermediate nil-check variables, relying on the nil-receiver pattern already present on every `DeepCopy` implementation in the file. The `buildFluxSystemEntries` function (103 lines) is deleted, having been superseded by the `collectFluxSystems`/`compileFluxSystemTiers` path introduced in the preceding FluxSystem field-level removal PR.
>
> Two naming cleanups round out the change: `errKustomizationNotFound` is renamed to `kustomizationNotFoundError` to follow Go conventions, and the `new` parameter in `MergeFluxInstall`/`MergeFluxVariants` is renamed to `overlay` to avoid shadowing the built-in.
>
> Reviewed by Claude for commit `5ab090e2`.

<!-- /claude-code-review:summary -->
