### PR TITLE
fix(composer): enhance kustomization validation for flux systems and resources variants

### DIFF
--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -1050,13 +1050,13 @@ func (p *BaseBlueprintProcessor) evalDropEmpty(raw []string, facetPath string, s
 
 // collectFluxSystems evaluates a facet's flux: system descriptors — resolving expressions on
 // DependsOn, Install components/substitutions, and each resources variant — and stores the result
-// in fluxSystemByName. Variants whose when condition is false or whose components evaluate to empty
-// are dropped; an install tier whose components prune to empty sets Install to nil. This preserves
-// the FluxSystem structure in the composed blueprint (for show blueprint and YAML output) while
-// keeping tier compilation deferred to AllKustomizations(). The empty-components pruning is skipped
-// for strategy == "remove": a removal descriptor's resources variants are identified by Name alone,
-// not by a non-empty Components list, so dropping a variant with no evaluated components (as merge/
-// replace do) would erase the very variant name a removal is naming.
+// in fluxSystemByName. A resources variant is dropped only when its own when condition (combined
+// with the system's) is false — never merely because its components prune to empty, matching how
+// a plain kustomize: entry is always emitted regardless of its resolved component count; a
+// dependsOn reference to it stays valid whether or not the variant's own components ended up
+// empty. An install tier whose components prune to empty sets Install to nil, since install is
+// optional per system (a system may have none at all) and an empty install is equivalent to none
+// declared.
 func (p *BaseBlueprintProcessor) collectFluxSystems(facet blueprintv1alpha1.Facet, sourceName []string, fluxSystemByName map[string]*blueprintv1alpha1.FluxSystem, facetScope map[string]any) error {
 	for _, system := range facet.FluxSystems {
 		when := system.When
@@ -1118,9 +1118,6 @@ func (p *BaseBlueprintProcessor) collectFluxSystems(facet blueprintv1alpha1.Face
 			comps, err := p.evalDropEmpty(v.Components, facet.Path, facetScope)
 			if err != nil {
 				return fmt.Errorf("error evaluating resources components for system '%s': %w", system.Name, err)
-			}
-			if len(comps) == 0 && strategy != "remove" {
-				continue
 			}
 			variantKey := system.Name + "-resources"
 			if v.Name != "" {

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -2684,6 +2684,22 @@ func TestProcessor_ProcessFacets_Tiers(t *testing.T) {
 		}
 	})
 
+	t.Run("ResourcesVariantKeptWhenComponentsPruneToEmpty", func(t *testing.T) {
+		target := process(t, blueprintv1alpha1.FluxSystem{
+			Name:      "policy",
+			Path:      "policy",
+			Install:   &blueprintv1alpha1.Kustomization{Components: []string{"kyverno"}},
+			Resources: []blueprintv1alpha1.FluxVariant{{Kustomization: blueprintv1alpha1.Kustomization{Components: []string{"${false ? 'resource-limits' : ''}"}}}},
+		})
+		res, ok := find(target, "policy-resources")
+		if !ok {
+			t.Fatalf("expected policy-resources to be kept even with no components, got %+v", target.AllKustomizations())
+		}
+		if len(res.Components) != 0 {
+			t.Errorf("expected empty components, got %v", res.Components)
+		}
+	})
+
 	t.Run("DuplicateUnnamedVariantsReturnsError", func(t *testing.T) {
 		mocks := setupProcessorMocks(t)
 		processor := NewBlueprintProcessor(mocks.Runtime)

--- a/pkg/test/runner.go
+++ b/pkg/test/runner.go
@@ -739,14 +739,14 @@ func (r *TestRunner) validateDuplicateTerraformComponents(bp *blueprintv1alpha1.
 }
 
 // validateDuplicateKustomizations checks for duplicate Kustomizations in the blueprint by comparing
-// kustomization names. It maintains a set of seen names and reports an error for each duplicate
-// encountered. Duplicate kustomizations indicate a composition error where multiple facets contributed
-// the same kustomization without proper merging or replacement. Returns a slice of error messages,
-// one for each duplicate found.
+// kustomization names across both plain kustomize: entries and the tiers compiled from flux: systems.
+// It maintains a set of seen names and reports an error for each duplicate encountered. Duplicate
+// kustomizations indicate a composition error where multiple facets contributed the same kustomization
+// without proper merging or replacement. Returns a slice of error messages, one for each duplicate found.
 func (r *TestRunner) validateDuplicateKustomizations(bp *blueprintv1alpha1.Blueprint) []string {
 	var errs []string
 	names := make(map[string]struct{})
-	for _, k := range bp.Kustomizations {
+	for _, k := range bp.AllKustomizations() {
 		if _, exists := names[k.Name]; exists {
 			errs = append(errs, fmt.Sprintf("duplicate kustomization name: %s", k.Name))
 		}
@@ -756,12 +756,13 @@ func (r *TestRunner) validateDuplicateKustomizations(bp *blueprintv1alpha1.Bluep
 }
 
 // validateDuplicateKustomizationComponents checks for duplicate component references within each
-// Kustomization's Components list. Empty strings are placeholders (e.g. conditional slot with no
-// component) and may appear multiple times; only non-empty duplicate component names are reported.
-// Returns a slice of error messages, one for each duplicate found.
+// Kustomization's Components list, across both plain kustomize: entries and the tiers compiled from
+// flux: systems. Empty strings are placeholders (e.g. conditional slot with no component) and may
+// appear multiple times; only non-empty duplicate component names are reported. Returns a slice of
+// error messages, one for each duplicate found.
 func (r *TestRunner) validateDuplicateKustomizationComponents(bp *blueprintv1alpha1.Blueprint) []string {
 	var errs []string
-	for _, k := range bp.Kustomizations {
+	for _, k := range bp.AllKustomizations() {
 		components := make(map[string]struct{})
 		for _, comp := range k.Components {
 			if comp == "" {
@@ -779,9 +780,11 @@ func (r *TestRunner) validateDuplicateKustomizationComponents(bp *blueprintv1alp
 // validateCircularDependencies checks for circular dependency chains in both Terraform components
 // and Kustomizations. It builds dependency graphs for each component type and uses depth-first search
 // to detect cycles. Circular dependencies would cause infinite loops or undefined ordering during
-// blueprint application, so they must be caught and reported. The function validates Terraform
-// components separately from Kustomizations, as they have independent dependency graphs. Returns a
-// slice of error messages describing each circular dependency found, including the full cycle path.
+// blueprint application, so they must be caught and reported. The Kustomization graph covers both
+// plain kustomize: entries and the tiers compiled from flux: systems, since dependsOn edges can
+// target or originate from either. The function validates Terraform components separately from
+// Kustomizations, as they have independent dependency graphs. Returns a slice of error messages
+// describing each circular dependency found, including the full cycle path.
 func (r *TestRunner) validateCircularDependencies(bp *blueprintv1alpha1.Blueprint) []string {
 	var errs []string
 
@@ -796,7 +799,7 @@ func (r *TestRunner) validateCircularDependencies(bp *blueprintv1alpha1.Blueprin
 
 	kGraph := make(map[string][]string)
 	kNames := make(map[string]struct{})
-	for _, k := range bp.Kustomizations {
+	for _, k := range bp.AllKustomizations() {
 		kNames[k.Name] = struct{}{}
 		kGraph[k.Name] = k.DependsOn
 	}
@@ -821,8 +824,9 @@ func (r *TestRunner) validateInvalidDependencies(bp *blueprintv1alpha1.Blueprint
 		tfIDs[tf.GetID()] = struct{}{}
 	}
 
-	kNames := make(map[string]struct{})
-	for _, k := range bp.Kustomizations {
+	allK := bp.AllKustomizations()
+	kNames := make(map[string]struct{}, len(allK))
+	for _, k := range allK {
 		kNames[k.Name] = struct{}{}
 	}
 	for _, layer := range blueprint.CrdLayers(bp) {
@@ -837,7 +841,7 @@ func (r *TestRunner) validateInvalidDependencies(bp *blueprintv1alpha1.Blueprint
 		}
 	}
 
-	for _, k := range bp.Kustomizations {
+	for _, k := range allK {
 		for _, dep := range k.DependsOn {
 			if _, exists := kNames[dep]; !exists {
 				errs = append(errs, fmt.Sprintf("kustomization %q depends on non-existent kustomization %q", k.Name, dep))

--- a/pkg/test/runner_test.go
+++ b/pkg/test/runner_test.go
@@ -1845,6 +1845,36 @@ func TestTestRunner_validateBlueprint(t *testing.T) {
 		}
 	})
 
+	t.Run("DetectsDuplicateKustomizationAgainstFluxCompiledTier", func(t *testing.T) {
+		// Given a plain kustomization whose name collides with a flux: system's compiled tier name
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "policy-install", Path: "app"},
+			},
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name:    "policy",
+					Path:    "policy",
+					Install: &blueprintv1alpha1.Kustomization{Components: []string{"kyverno"}},
+				},
+			},
+		}
+
+		// When validating
+		errors := runner.validateBlueprint(blueprint)
+
+		// Then the collision is caught even though one side is compiled from a flux: system
+		if len(errors) == 0 {
+			t.Error("Expected error for duplicate kustomization name against flux-compiled tier")
+		}
+		if !strings.Contains(errors[0], "duplicate kustomization name") {
+			t.Errorf("Expected duplicate kustomization error, got: %v", errors)
+		}
+	})
+
 	t.Run("DetectsDuplicateKustomizationComponents", func(t *testing.T) {
 		mocks := setupTestRunnerMocks(t)
 		runner := createRunnerWithMockGenerator(mocks)
@@ -1911,6 +1941,37 @@ func TestTestRunner_validateBlueprint(t *testing.T) {
 		}
 	})
 
+	t.Run("DetectsCircularDependencyAcrossFluxTiers", func(t *testing.T) {
+		// Given a plain kustomization and a flux: system install tier depending on each other
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "a", Path: "a", DependsOn: []string{"policy-install"}},
+			},
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name:      "policy",
+					Path:      "policy",
+					DependsOn: []string{"a"},
+					Install:   &blueprintv1alpha1.Kustomization{Components: []string{"kyverno"}},
+				},
+			},
+		}
+
+		// When validating
+		errors := runner.validateBlueprint(blueprint)
+
+		// Then the cycle is caught even though it spans a plain kustomization and a compiled flux tier
+		if len(errors) == 0 {
+			t.Error("Expected error for circular dependency across flux tiers")
+		}
+		if !strings.Contains(errors[0], "circular dependency") {
+			t.Errorf("Expected circular dependency error, got: %v", errors)
+		}
+	})
+
 	t.Run("DetectsInvalidTerraformDependencies", func(t *testing.T) {
 		mocks := setupTestRunnerMocks(t)
 		runner := createRunnerWithMockGenerator(mocks)
@@ -1951,6 +2012,35 @@ func TestTestRunner_validateBlueprint(t *testing.T) {
 		}
 	})
 
+	t.Run("DetectsInvalidDependencyFromFluxResourcesVariant", func(t *testing.T) {
+		// Given a flux: system resources variant depending on a nonexistent kustomization
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name: "policy",
+					Path: "policy",
+					Resources: []blueprintv1alpha1.FluxVariant{
+						{Kustomization: blueprintv1alpha1.Kustomization{Components: []string{"resource-limits"}, DependsOn: []string{"nonexistent"}}},
+					},
+				},
+			},
+		}
+
+		// When validating
+		errors := runner.validateBlueprint(blueprint)
+
+		// Then the invalid dependency is caught even though it originates from a compiled flux tier
+		if len(errors) == 0 {
+			t.Error("Expected error for invalid dependency from flux resources variant")
+		}
+		if !strings.Contains(errors[0], "depends on non-existent kustomization") {
+			t.Errorf("Expected invalid dependency error, got: %v", errors)
+		}
+	})
+
 	t.Run("AcceptsCrdLayerDependency", func(t *testing.T) {
 		// Given a blueprint with a crds: layer and a root wired to it by the barrier
 		mocks := setupTestRunnerMocks(t)
@@ -1969,6 +2059,33 @@ func TestTestRunner_validateBlueprint(t *testing.T) {
 		// Then the synthesized crds layer is a valid dependency target, not flagged as missing
 		if len(errors) != 0 {
 			t.Errorf("Expected no errors for crds dependency, got: %v", errors)
+		}
+	})
+
+	t.Run("AcceptsDependencyOnFluxCompiledTier", func(t *testing.T) {
+		// Given a plain kustomization depending on a name compiled from a flux: system
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name:    "policy",
+					Path:    "policy",
+					Install: &blueprintv1alpha1.Kustomization{Components: []string{"kyverno"}},
+				},
+			},
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "app", Path: "app", DependsOn: []string{"policy-install"}},
+			},
+		}
+
+		// When validating
+		errors := runner.validateBlueprint(blueprint)
+
+		// Then the compiled flux tier name is a valid dependency target, not flagged as missing
+		if len(errors) != 0 {
+			t.Errorf("Expected no errors for dependency on flux-compiled tier, got: %v", errors)
 		}
 	})
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change is isolated to the composer subsystem's Flux system handling and its internal test-runner validators; it is a correctness fix with no interface changes.
>
> **Overview**
>
> The PR removes an overly aggressive pruning guard in `collectFluxSystems` that was dropping resources variants whose components evaluated to an empty list (after expression evaluation). The old behavior was inconsistent with how plain `kustomize:` entries are always emitted regardless of component count, and it silently broke `dependsOn` references that targeted those variant names. Alongside this, the blueprint test-runner's four validation passes — duplicate names, duplicate components, circular dependencies, and invalid dependency targets — are updated to iterate over `AllKustomizations()` instead of `bp.Kustomizations`, so compiled Flux install and resources tiers are fully visible to each check.
>
> Each behavioral change is paired with a targeted test: `ResourcesVariantKeptWhenComponentsPruneToEmpty` in the processor suite, and four new cases in the runner suite covering duplicate-name collision, cross-tier circular dependency, invalid dependency from a compiled resources tier, and a positive acceptance case for a dependency on a compiled install tier.
>
> Reviewed by Claude for commit `2769e9d`.

<!-- /claude-code-review:summary -->
