### PR TITLE
feat(cmd/apply): add --prune flag to remove unreferenced kustomizations

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
@@ -9,8 +10,8 @@ import (
 	"github.com/windsorcli/cli/pkg/runtime/tools"
 )
 
-var applyWaitFlag bool // Wait for kustomization resources to be ready after applying
-var applyYesFlag bool  // Proceed without confirmation when apply would prune kustomizations
+var applyWaitFlag bool  // Wait for kustomization resources to be ready after applying
+var applyPruneFlag bool // Remove kustomizations the blueprint no longer declares
 
 var applyCmd = &cobra.Command{
 	Use:   "apply",
@@ -19,9 +20,12 @@ var applyCmd = &cobra.Command{
 
 For workstation contexts, prefer 'windsor up' — it does the same work plus VM management.
 
-Pass --wait to block until kustomizations report ready.`,
+Pass --wait to block until kustomizations report ready. Pass --prune to also remove kustomizations the blueprint no longer declares, once the new set is Ready.`,
 	Example: `# Apply everything and block until ready
 windsor apply --wait
+
+# Apply and remove kustomizations no longer declared
+windsor apply --prune
 
 # Apply only the cluster terraform component
 windsor apply terraform cluster
@@ -82,19 +86,25 @@ windsor apply kustomize dns`,
 				return fmt.Errorf("error applying kustomize: %w", err)
 			}
 
-			// Reconcile removes kustomizations the blueprint no longer declares; wait for the
-			// desired set to be Ready before pruning so migrated resources are adopted first. A
-			// no-removal apply only waits when --wait is set.
+			// --prune removes kustomizations the blueprint no longer declares; wait for the
+			// desired set to be Ready first so migrated resources are adopted before a deletion.
+			// Without --prune, orphans are left in place and only reported.
 			prunable, err := proj.Provisioner.PrunableKustomizations(blueprint)
 			if err != nil {
 				return fmt.Errorf("error listing kustomizations to prune: %w", err)
 			}
-			if len(prunable) > 0 || applyWaitFlag {
+			if len(prunable) > 0 && !applyPruneFlag {
+				fmt.Fprintf(cmd.OutOrStdout(), "The following kustomizations are no longer declared; re-run with --prune to remove them:\n  %s\n", strings.Join(prunable, "\n  "))
+			}
+			if (len(prunable) > 0 && applyPruneFlag) || applyWaitFlag {
 				if err := proj.Provisioner.Wait(cmd.Context(), blueprint); err != nil {
 					return fmt.Errorf("error waiting for kustomizations: %w", err)
 				}
 			}
-			return confirmAndPrune(cmd, proj, blueprint, prunable, applyYesFlag)
+			if len(prunable) == 0 || !applyPruneFlag {
+				return nil
+			}
+			return pruneOrphaned(cmd, proj, blueprint, prunable)
 		})
 	},
 }
@@ -209,7 +219,7 @@ windsor apply kustomize dns --wait`,
 
 func init() {
 	applyCmd.Flags().BoolVar(&applyWaitFlag, "wait", false, "Wait for kustomization resources to be ready.")
-	applyCmd.Flags().BoolVar(&applyYesFlag, "yes", false, "Proceed without confirmation when the apply would prune kustomizations.")
+	applyCmd.Flags().BoolVar(&applyPruneFlag, "prune", false, "Remove kustomizations the blueprint no longer declares.")
 	applyKustomizeCmd.Flags().BoolVar(&applyWaitFlag, "wait", false, "Wait for kustomization resources to be ready.")
 	applyCmd.AddCommand(applyTerraformCmd)
 	applyCmd.AddCommand(applyKustomizeCmd)

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -201,8 +201,8 @@ func TestApplyCmd_Prune(t *testing.T) {
 		}
 	})
 
-	t.Run("RefusesPruneWithoutYes", func(t *testing.T) {
-		t.Cleanup(func() { applyYesFlag = false })
+	t.Run("ReportsOrphansWithoutPrune", func(t *testing.T) {
+		t.Cleanup(func() { applyPruneFlag = false })
 		// Given a reconcile that would prune a kustomization
 		mocks := setupApplyTest(t)
 		mocks.KubernetesManager.ListPrunableKustomizationsFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) ([]string, error) {
@@ -215,26 +215,28 @@ func TestApplyCmd_Prune(t *testing.T) {
 		}
 		proj := newApplyAllProject(mocks)
 
-		// When applying without --yes
+		// When applying without --prune
+		var stdout bytes.Buffer
 		cmd := createTestApplyCmd()
+		cmd.SetOut(&stdout)
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
 		cmd.SetContext(ctx)
 		err := cmd.Execute()
 
-		// Then it refuses and never prunes
-		if err == nil {
-			t.Fatal("Expected apply to refuse pruning without --yes, got nil")
+		// Then it succeeds, reports the orphan, and never prunes
+		if err != nil {
+			t.Fatalf("Expected apply to succeed without --prune, got %v", err)
 		}
-		if !strings.Contains(err.Error(), "--yes") {
-			t.Errorf("Expected the message to point at --yes, got: %v", err)
+		if !strings.Contains(stdout.String(), "--prune") {
+			t.Errorf("Expected the report to point at --prune, got: %q", stdout.String())
 		}
 		if pruned {
-			t.Error("Expected prune to be skipped when the gate refuses")
+			t.Error("Expected prune to be skipped without --prune")
 		}
 	})
 
-	t.Run("ProceedsWithYes", func(t *testing.T) {
-		t.Cleanup(func() { applyYesFlag = false })
+	t.Run("PrunesWithPruneFlag", func(t *testing.T) {
+		t.Cleanup(func() { applyPruneFlag = false })
 		// Given the same pending prune
 		mocks := setupApplyTest(t)
 		mocks.KubernetesManager.ListPrunableKustomizationsFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) ([]string, error) {
@@ -247,18 +249,18 @@ func TestApplyCmd_Prune(t *testing.T) {
 		}
 		proj := newApplyAllProject(mocks)
 
-		// When applying with --yes
+		// When applying with --prune
 		cmd := createTestApplyCmd()
-		cmd.SetArgs([]string{"--yes"})
+		cmd.SetArgs([]string{"--prune"})
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
 		cmd.SetContext(ctx)
 		if err := cmd.Execute(); err != nil {
-			t.Fatalf("Expected --yes to proceed, got %v", err)
+			t.Fatalf("Expected --prune to proceed, got %v", err)
 		}
 
 		// Then the prune runs
 		if !pruned {
-			t.Error("Expected prune to run under --yes")
+			t.Error("Expected prune to run under --prune")
 		}
 	})
 

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -332,7 +332,7 @@ func describePendingPrunes(cmd *cobra.Command, proj *project.Project, blueprint 
 	if err != nil || len(prunable) == 0 {
 		return
 	}
-	fmt.Fprintf(cmd.ErrOrStderr(), "These kustomizations are no longer declared and would be pruned by `windsor apply --yes` or `windsor upgrade --yes`:\n  %s\n", strings.Join(prunable, "\n  "))
+	fmt.Fprintf(cmd.ErrOrStderr(), "These kustomizations are no longer declared and would be pruned by `windsor apply --prune` or `windsor upgrade --yes`:\n  %s\n", strings.Join(prunable, "\n  "))
 }
 
 // blueprintHasTerraformComponent reports whether the blueprint contains an enabled Terraform component with the given ID.

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -33,7 +33,7 @@ var (
 var upgradeCmd = &cobra.Command{
 	Use:   "upgrade",
 	Short: "Move sources to their latest version and reconcile the blueprint.",
-	Long: `With no arguments, move every declared OCI source to its latest stable version, then reconcile: apply terraform and the Flux blueprint, wait, and prune kustomizations this context no longer declares. Use --source name=url to move named sources to specific versions instead. Prunes run only after a successful wait and are gated by --yes.
+	Long: `With no arguments, move every declared OCI source to its latest stable version, then reconcile: apply terraform and the Flux blueprint, wait, and prune kustomizations this context no longer declares. Use --source name=url to move named sources to specific versions instead. The whole reconcile — including the prune — is gated by --yes.
 
 Use the 'cluster' or 'node' subcommand to upgrade Talos nodes instead.`,
 	Example: `# Move all sources to their latest stable version and reconcile
@@ -134,7 +134,7 @@ windsor upgrade cluster --nodes=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1
 			if err != nil {
 				return fmt.Errorf("error listing kustomizations to prune: %w", err)
 			}
-			if err := confirmAndPrune(cmd, proj, blueprint, prunable, upgradeYes); err != nil {
+			if err := pruneOrphaned(cmd, proj, blueprint, prunable); err != nil {
 				return err
 			}
 
@@ -257,19 +257,15 @@ windsor upgrade node --node=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.
 	},
 }
 
-// confirmAndPrune prunes the kustomizations the blueprint no longer declares, after printing them
-// and requiring --yes. prunable is the already-computed prune set (empty → no-op). The caller must
-// have waited for the desired set to be Ready first, so any migrated resources are adopted before a
-// deletion. Shared by apply and upgrade, which reconcile identically.
-func confirmAndPrune(cmd *cobra.Command, proj *project.Project, blueprint *blueprintv1alpha1.Blueprint, prunable []string, yes bool) error {
+// pruneOrphaned deletes the kustomizations the blueprint no longer declares, after printing them.
+// prunable is the already-computed prune set (empty → no-op). The caller must have waited for the
+// desired set to be Ready first, so any migrated resources are adopted before a deletion. Shared by
+// apply (behind --prune) and upgrade (unconditional, since upgrade already required --yes to start).
+func pruneOrphaned(cmd *cobra.Command, proj *project.Project, blueprint *blueprintv1alpha1.Blueprint, prunable []string) error {
 	if len(prunable) == 0 {
 		return nil
 	}
-	fmt.Fprintf(cmd.OutOrStdout(), "The following kustomizations are no longer declared and will be pruned:\n  %s\n", strings.Join(prunable, "\n  "))
-	if !yes {
-		silenceErrorsOnAncestors(cmd)
-		return fmt.Errorf("this would prune %d kustomization(s); re-run with --yes to proceed", len(prunable))
-	}
+	fmt.Fprintf(cmd.OutOrStdout(), "Pruning kustomizations no longer declared:\n  %s\n", strings.Join(prunable, "\n  "))
 	if err := proj.Provisioner.Prune(blueprint); err != nil {
 		return fmt.Errorf("error pruning orphaned kustomizations: %w", err)
 	}

--- a/docs/reference/commands/apply.md
+++ b/docs/reference/commands/apply.md
@@ -12,14 +12,14 @@ Run Terraform components, then install the Flux blueprint. Use the 'terraform' o
 
 For workstation contexts, prefer 'windsor up' — it does the same work plus VM management.
 
-Pass --wait to block until kustomizations report ready.
+Pass --wait to block until kustomizations report ready. Pass --prune to also remove kustomizations the blueprint no longer declares, once the new set is Ready.
 
 ## Flags
 
 | Flag | Default | Description |
 |------|---------|-------------|
+| `--prune` | `false` | Remove kustomizations the blueprint no longer declares. |
 | `--wait` | `false` | Wait for kustomization resources to be ready. |
-| `--yes` | `false` | Proceed without confirmation when the apply would prune kustomizations. |
 
 ## Subcommands
 
@@ -31,6 +31,9 @@ Pass --wait to block until kustomizations report ready.
 ```sh
 # Apply everything and block until ready
 windsor apply --wait
+
+# Apply and remove kustomizations no longer declared
+windsor apply --prune
 
 # Apply only the cluster terraform component
 windsor apply terraform cluster

--- a/docs/reference/commands/upgrade.md
+++ b/docs/reference/commands/upgrade.md
@@ -8,7 +8,7 @@ description: "Move sources to their latest version and reconcile the blueprint."
 windsor upgrade [flags]
 ```
 
-With no arguments, move every declared OCI source to its latest stable version, then reconcile: apply terraform and the Flux blueprint, wait, and prune kustomizations this context no longer declares. Use --source name=url to move named sources to specific versions instead. Prunes run only after a successful wait and are gated by --yes.
+With no arguments, move every declared OCI source to its latest stable version, then reconcile: apply terraform and the Flux blueprint, wait, and prune kustomizations this context no longer declares. Use --source name=url to move named sources to specific versions instead. The whole reconcile — including the prune — is gated by --yes.
 
 Use the 'cluster' or 'node' subcommand to upgrade Talos nodes instead.
 

--- a/integration/apply_test.go
+++ b/integration/apply_test.go
@@ -100,7 +100,7 @@ func TestApply_AcceptsWaitFlag(t *testing.T) {
 	_ = err // may fail due to infrastructure not being available; flag must be accepted
 }
 
-func TestApply_AcceptsYesFlag(t *testing.T) {
+func TestApply_AcceptsPruneFlag(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
 	helpers.MarkAsGitRepo(t, dir)
@@ -109,9 +109,9 @@ func TestApply_AcceptsYesFlag(t *testing.T) {
 		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
 	}
 	env = append(env, "WINDSOR_CONTEXT=local")
-	_, stderr, err = helpers.RunCLI(dir, []string{"apply", "--yes"}, env)
+	_, stderr, err = helpers.RunCLI(dir, []string{"apply", "--prune"}, env)
 	if strings.Contains(string(stderr), "unknown flag") {
-		t.Errorf("--yes should be a recognised flag on apply, got: %s", stderr)
+		t.Errorf("--prune should be a recognised flag on apply, got: %s", stderr)
 	}
 	_ = err // may fail due to infrastructure not being available; the flag must be accepted
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change alters a single CLI flag and its behavioural contract on `apply`; all affected paths are well-tested and the default is now safer (no pruning without explicit opt-in).
>
> **Overview**
>
> The PR replaces the `--yes` confirmation gate on `windsor apply` with a new `--prune` flag. Previously, if orphaned kustomizations existed, `apply` would fail with an error directing the user to re-run with `--yes`; now it succeeds and prints an advisory message pointing at `--prune`. Pruning itself only happens when `--prune` is explicitly passed, which also triggers the pre-prune `Wait`. On `upgrade`, the private helper `confirmAndPrune` (which carried the `yes bool` parameter) is renamed to `pruneOrphaned` and the per-prune confirmation is dropped, since the entire upgrade reconcile is already gated by `--yes` at a higher level.
>
> The net effect is a strictly safer default: orphaned kustomizations are never silently removed by `apply`, and the `upgrade` path is unchanged for users who already pass `--yes`.
>
> Reviewed by Claude for commit `934b97d9`.

<!-- /claude-code-review:summary -->
