### PR TITLE
feat(constants): set default timeout for install tiers

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -1126,7 +1126,8 @@ func (sys FluxSystem) TierNames() []string {
 
 // compileFluxSystemTiers converts a pre-evaluated FluxSystem into its tier Kustomizations without
 // any expression evaluation. Install compiles to "<name>-install" at "<path>/install"; each
-// resources variant compiles to "<name>-resources[-<variant>]" at "<path>/resources".
+// resources variant compiles to "<name>-resources[-<variant>]" at "<path>/resources". A timeout-less
+// install tier falls back to DefaultFluxKustomizationInstallTimeout instead of the generic default.
 func compileFluxSystemTiers(sys FluxSystem) []Kustomization {
 	name := sys.Name
 	base := sys.Path
@@ -1144,6 +1145,9 @@ func compileFluxSystemTiers(sys FluxSystem) []Kustomization {
 		k.Path = path.Join(base, "install")
 		k.DependsOn = slices.Clone(sys.DependsOn)
 		applySystemTierDefaults(&k, sys)
+		if k.Timeout == nil {
+			k.Timeout = &DurationString{Duration: constants.DefaultFluxKustomizationInstallTimeout}
+		}
 		out = append(out, k)
 		installEmitted = true
 	}

--- a/api/v1alpha1/blueprint_types_test.go
+++ b/api/v1alpha1/blueprint_types_test.go
@@ -3156,31 +3156,36 @@ func TestKustomization_ToFluxKustomization(t *testing.T) {
 		}
 	})
 
-	t.Run("PushModeUsesLongDefaultInterval", func(t *testing.T) {
+	t.Run("DefaultIntervalIsSameRegardlessOfGitopsMode", func(t *testing.T) {
 		// Given a kustomization with no explicit Interval (leans on the default)
 		kustomization := &Kustomization{Name: "k", Path: "p"}
 
-		// When converted under push mode
-		result := kustomization.ToFluxKustomization("ns", "src", []Source{}, constants.GitopsModePush)
+		// When converted under both pull and push mode
+		pullResult := kustomization.ToFluxKustomization("ns", "src", []Source{}, constants.GitopsModePull)
+		pushResult := kustomization.ToFluxKustomization("ns", "src", []Source{}, constants.GitopsModePush)
 
-		// Then the rendered Interval matches the push-mode default so flux polls
-		// on a long cadence and Windsor's annotation is the primary trigger
-		if result.Spec.Interval.Duration != constants.DefaultFluxKustomizationIntervalPush {
-			t.Errorf("Expected push-mode interval %v, got %v", constants.DefaultFluxKustomizationIntervalPush, result.Spec.Interval.Duration)
+		// Then both render the same default interval: flux content here is pinned and
+		// explicitly re-triggered by the notifier regardless of mode, so the backstop
+		// poll cadence has no reason to differ between them
+		if pullResult.Spec.Interval.Duration != constants.DefaultFluxKustomizationInterval {
+			t.Errorf("Expected pull-mode interval %v, got %v", constants.DefaultFluxKustomizationInterval, pullResult.Spec.Interval.Duration)
+		}
+		if pushResult.Spec.Interval.Duration != constants.DefaultFluxKustomizationInterval {
+			t.Errorf("Expected push-mode interval %v, got %v", constants.DefaultFluxKustomizationInterval, pushResult.Spec.Interval.Duration)
 		}
 	})
 
-	t.Run("BlueprintIntervalOverrideBeatsPushDefault", func(t *testing.T) {
+	t.Run("BlueprintIntervalOverrideBeatsDefault", func(t *testing.T) {
 		// Given a kustomization that explicitly sets a short Interval
 		override := DurationString{Duration: 2 * time.Minute}
 		kustomization := &Kustomization{Name: "k", Path: "p", Interval: &override}
 
-		// When converted under push mode
-		result := kustomization.ToFluxKustomization("ns", "src", []Source{}, constants.GitopsModePush)
+		// When converted
+		result := kustomization.ToFluxKustomization("ns", "src", []Source{}, constants.GitopsModePull)
 
-		// Then the user's explicit Interval wins over the push-mode default
+		// Then the user's explicit Interval wins over the default
 		if result.Spec.Interval.Duration != override.Duration {
-			t.Errorf("Expected explicit interval %v to override push default, got %v", override.Duration, result.Spec.Interval.Duration)
+			t.Errorf("Expected explicit interval %v to override default, got %v", override.Duration, result.Spec.Interval.Duration)
 		}
 	})
 }

--- a/api/v1alpha1/blueprint_types_test.go
+++ b/api/v1alpha1/blueprint_types_test.go
@@ -4988,3 +4988,61 @@ func TestFluxSystem_TierNames(t *testing.T) {
 		}
 	})
 }
+
+func TestBlueprint_AllKustomizations_InstallTierTimeoutDefault(t *testing.T) {
+	t.Run("InstallTierFallsBackToInstallTimeoutDefaultWhenUnset", func(t *testing.T) {
+		// Given a flux system whose install tier sets no timeout of its own
+		bp := &Blueprint{
+			FluxSystems: []FluxSystem{
+				{
+					Name:      "cert-manager",
+					Install:   &Kustomization{Components: []string{"helm-release"}},
+					Resources: []FluxVariant{{Kustomization: Kustomization{Components: []string{"private-issuer/ca"}}}},
+				},
+			},
+		}
+
+		all := bp.AllKustomizations()
+
+		// Then the compiled install tier gets the install-specific default timeout
+		install := findKustomization(all, "cert-manager-install")
+		if install == nil || install.Timeout == nil || install.Timeout.Duration != constants.DefaultFluxKustomizationInstallTimeout {
+			t.Fatalf("expected cert-manager-install timeout %v, got %+v", constants.DefaultFluxKustomizationInstallTimeout, install)
+		}
+
+		// And the resources tier is left to ToFluxKustomization's own generic default
+		resources := findKustomization(all, "cert-manager-resources")
+		if resources == nil || resources.Timeout != nil {
+			t.Fatalf("expected cert-manager-resources timeout unset, got %+v", resources)
+		}
+	})
+
+	t.Run("ExplicitInstallTimeoutOverridesTheDefault", func(t *testing.T) {
+		// Given a flux system whose install tier sets its own timeout
+		bp := &Blueprint{
+			FluxSystems: []FluxSystem{
+				{
+					Name:    "lb",
+					Install: &Kustomization{Components: []string{"aws-lb-controller"}, Timeout: &DurationString{Duration: 20 * time.Minute}},
+				},
+			},
+		}
+
+		all := bp.AllKustomizations()
+
+		// Then the explicit value wins over the install-tier default
+		install := findKustomization(all, "lb-install")
+		if install == nil || install.Timeout == nil || install.Timeout.Duration != 20*time.Minute {
+			t.Fatalf("expected lb-install timeout 20m, got %+v", install)
+		}
+	})
+}
+
+func findKustomization(all []Kustomization, name string) *Kustomization {
+	for i := range all {
+		if all[i].Name == name {
+			return &all[i]
+		}
+	}
+	return nil
+}

--- a/docs/reference/blueprint.md
+++ b/docs/reference/blueprint.md
@@ -67,7 +67,7 @@ variable substitutions shared across them.
 | `substitute` | `map<string>` | PostBuild substitutions (preferred spelling); merges with substitutions. |
 | `substitutions` | `map<string>` | PostBuild variable substitutions for this tier. |
 | `targetNamespace` | `string` | Populates spec.targetNamespace, overriding the namespace of reconciled resources. |
-| `timeout` | `string` | Maximum duration for a single reconciliation attempt (e.g. '10m'). |
+| `timeout` | `string` | Maximum duration for a single reconciliation attempt. Defaults to 10m. |
 | `wait` | `boolean` | Wait for resources to settle before declaring reconciliation complete. |
 
 #### flux[].install.patches[]

--- a/docs/reference/blueprint.md
+++ b/docs/reference/blueprint.md
@@ -122,7 +122,7 @@ variable substitutions shared across them.
 | `destroyOnly` | `boolean` | When true, the kustomization only runs during destroy. Useful for teardown-only resources (e.g. cleanup jobs). |
 | `enabled` | `boolean / string` | Whether to include this kustomization in the final blueprint. Boolean or expression. Defaults to true. |
 | `force` | `boolean` | Force-apply resources Flux would otherwise refuse to update. |
-| `interval` | `string` | Reconciliation interval, expressed as a Go duration string (e.g. '5m', '1h'). Defaults to a mode-appropriate value chosen by the provisioner (short poll for pull mode, long fallback for push). |
+| `interval` | `string` | Reconciliation interval, expressed as a Go duration string (e.g. '5m', '1h'). Defaults to 1h, a backstop cadence for content that is pinned and explicitly re-triggered rather than continuously tracked. |
 | `namespace` | `string` | Namespace where the Flux Kustomization object itself lives. Defaults to the gitops namespace. DependsOn references always resolve in the gitops namespace; cross-namespace dependencies are not supported. |
 | `patches` | `array<object>` | Strategic-merge or Flux-style patches applied to the kustomization. Each entry is either a 'path:' to a patch file relative to the kustomization, or a 'patch:' inline YAML body with an optional 'target:' selector (kind / name / namespace). |
 | `prune` | `boolean` | Garbage-collect resources removed from the source. Defaults to true. |

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -64,7 +64,8 @@ const DefaultWorkerMemory = 8
 
 const DefaultGitopsNamespace = "system-gitops"
 
-const DefaultFluxKustomizationInterval = 1 * time.Minute
+// DefaultFluxKustomizationInterval is the reconciliation interval for Kustomizations in pull mode.
+const DefaultFluxKustomizationInterval = 5 * time.Minute
 
 // DefaultFluxKustomizationIntervalPush is the reconciliation interval for
 // Kustomizations when gitops.mode is "push". It is intentionally long because
@@ -82,7 +83,14 @@ const DefaultFluxKustomizationForce = false
 
 const DefaultFluxKustomizationTimeout = 5 * time.Minute
 
-const DefaultFluxSourceInterval = 1 * time.Minute
+// DefaultFluxKustomizationInstallTimeout is the timeout for a flux system's install tier
+// when the facet sets none; install tiers install controllers and need more headroom
+// than plain resources.
+const DefaultFluxKustomizationInstallTimeout = 10 * time.Minute
+
+// DefaultFluxSourceInterval is the reconciliation interval for flux Sources in pull mode.
+// Kept equal to DefaultFluxKustomizationInterval so the two stay in step.
+const DefaultFluxSourceInterval = 5 * time.Minute
 
 // DefaultFluxSourceIntervalPush is the reconciliation interval for flux Sources
 // (GitRepository / OCIRepository) when gitops.mode is "push". Matches the

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -64,14 +64,12 @@ const DefaultWorkerMemory = 8
 
 const DefaultGitopsNamespace = "system-gitops"
 
-// DefaultFluxKustomizationInterval is the reconciliation interval for Kustomizations in pull mode.
-const DefaultFluxKustomizationInterval = 5 * time.Minute
-
-// DefaultFluxKustomizationIntervalPush is the reconciliation interval for
-// Kustomizations when gitops.mode is "push". It is intentionally long because
-// Windsor annotates sources on every install/apply to trigger reconcile; flux's
-// own poll becomes a fallback rather than the primary path.
-const DefaultFluxKustomizationIntervalPush = 1 * time.Hour
+// DefaultFluxKustomizationInterval is the reconciliation interval for Kustomizations. Flux
+// content here is pinned and explicitly triggered (the notifier re-fetches sources on every
+// apply/up/bootstrap) rather than continuously tracked, so this is an eventual-consistency
+// backstop, not the primary propagation path. A Kustomization that genuinely wants fast,
+// continuously-polled GitOps behavior should set its own interval override.
+const DefaultFluxKustomizationInterval = 1 * time.Hour
 
 const DefaultFluxKustomizationPrune = true
 
@@ -88,21 +86,15 @@ const DefaultFluxKustomizationTimeout = 5 * time.Minute
 // than plain resources.
 const DefaultFluxKustomizationInstallTimeout = 10 * time.Minute
 
-// DefaultFluxSourceInterval is the reconciliation interval for flux Sources in pull mode.
-// Kept equal to DefaultFluxKustomizationInterval so the two stay in step.
-const DefaultFluxSourceInterval = 5 * time.Minute
+// DefaultFluxSourceInterval is the reconciliation interval for flux Sources. Same rationale
+// as DefaultFluxKustomizationInterval: sources are pinned and explicitly re-fetched by the
+// notifier, so this is a backstop rather than the propagation path.
+const DefaultFluxSourceInterval = 1 * time.Hour
 
-// DefaultFluxSourceIntervalPush is the reconciliation interval for flux Sources
-// (GitRepository / OCIRepository) when gitops.mode is "push". Matches the
-// Kustomization push interval so the two layers stay in step.
-const DefaultFluxSourceIntervalPush = 1 * time.Hour
-
-// GitopsMode controls whether Windsor or flux drives reconciliation cadence.
-// In "pull" mode (default) flux polls sources on short intervals so changes
-// propagate without CLI involvement. In "push" mode Windsor triggers reconcile
-// via annotation during install/apply, so polling becomes a long-interval
-// fallback rather than the primary path. Unknown and empty values resolve to
-// "pull" via ParseGitopsMode so an unset config key keeps today's behaviour.
+// GitopsMode is accepted by FluxKustomizationInterval/FluxSourceInterval for call-site
+// stability but no longer changes their result: the notifier re-fetches sources on every
+// apply/up/bootstrap regardless of mode, so pull and push need the same backstop cadence.
+// Unknown and empty values resolve to "pull" via ParseGitopsMode.
 type GitopsMode string
 
 const (
@@ -120,24 +112,17 @@ func ParseGitopsMode(s string) GitopsMode {
 	return GitopsModePull
 }
 
-// FluxKustomizationInterval returns the default reconciliation interval for
-// Kustomizations under the given mode. Blueprint-level Interval overrides take
-// precedence over both defaults; this only affects Kustomizations that leave
-// Interval unset.
+// FluxKustomizationInterval returns the default reconciliation interval for Kustomizations.
+// Blueprint-level Interval overrides take precedence; this only affects Kustomizations that
+// leave Interval unset. mode is accepted but unused (see GitopsMode).
 func FluxKustomizationInterval(mode GitopsMode) time.Duration {
-	if mode == GitopsModePush {
-		return DefaultFluxKustomizationIntervalPush
-	}
 	return DefaultFluxKustomizationInterval
 }
 
-// FluxSourceInterval returns the default reconciliation interval for flux
-// Sources (GitRepository / OCIRepository) under the given mode. As with
-// FluxKustomizationInterval, blueprint-level overrides win when present.
+// FluxSourceInterval returns the default reconciliation interval for flux Sources
+// (GitRepository / OCIRepository). Blueprint-level overrides win when present. mode is
+// accepted but unused (see GitopsMode).
 func FluxSourceInterval(mode GitopsMode) time.Duration {
-	if mode == GitopsModePush {
-		return DefaultFluxSourceIntervalPush
-	}
 	return DefaultFluxSourceInterval
 }
 

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -5265,81 +5265,95 @@ func TestBaseKubernetesManager_ApplyBlueprint(t *testing.T) {
 		}
 	})
 
-	t.Run("PushModeWritesLongIntervalsOnSourceAndKustomization", func(t *testing.T) {
-		// Given an ApplyBlueprint run with gitops.mode=push
-		mocks := setupKubernetesMocks(t)
-		mocks.ConfigHandler.(*config.MockConfigHandler).GetStringFunc = func(key string, defaultValue ...string) string {
-			switch key {
-			case "id":
-				return "test-context-id"
-			case "gitops.mode":
-				return "push"
-			}
-			if len(defaultValue) > 0 {
-				return defaultValue[0]
-			}
-			return ""
-		}
-		manager := NewKubernetesManager(mocks.KubernetesClient, mocks.ConfigHandler)
-		manager.shims = mocks.Shims
-		manager.shims.ToUnstructured = func(obj any) (map[string]any, error) {
-			return runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
-		}
-		manager.shims.FromUnstructured = func(obj map[string]any, target any) error {
-			return runtime.DefaultUnstructuredConverter.FromUnstructured(obj, target)
-		}
-
-		var appliedRepo *sourcev1.GitRepository
-		var appliedKust *kustomizev1.Kustomization
-		kc := client.NewMockKubernetesClient()
-		kc.ApplyResourceFunc = func(gvr schema.GroupVersionResource, obj *unstructured.Unstructured, opts metav1.ApplyOptions) (*unstructured.Unstructured, error) {
-			switch gvr.Resource {
-			case "gitrepositories":
-				var repo sourcev1.GitRepository
-				if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &repo); err == nil {
-					appliedRepo = &repo
+	t.Run("SourceAndKustomizationIntervalIsSameRegardlessOfGitopsMode", func(t *testing.T) {
+		// applyUnderMode runs ApplyBlueprint with gitops.mode set to mode and returns the
+		// GitRepository/Kustomization objects actually written to the client.
+		applyUnderMode := func(t *testing.T, mode string) (*sourcev1.GitRepository, *kustomizev1.Kustomization) {
+			mocks := setupKubernetesMocks(t)
+			mocks.ConfigHandler.(*config.MockConfigHandler).GetStringFunc = func(key string, defaultValue ...string) string {
+				switch key {
+				case "id":
+					return "test-context-id"
+				case "gitops.mode":
+					return mode
 				}
-			case "kustomizations":
-				var k kustomizev1.Kustomization
-				if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &k); err == nil {
-					appliedKust = &k
+				if len(defaultValue) > 0 {
+					return defaultValue[0]
 				}
+				return ""
 			}
-			return obj, nil
-		}
-		kc.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
-			return nil, fmt.Errorf("not found")
-		}
-		manager.client = kc
+			manager := NewKubernetesManager(mocks.KubernetesClient, mocks.ConfigHandler)
+			manager.shims = mocks.Shims
+			manager.shims.ToUnstructured = func(obj any) (map[string]any, error) {
+				return runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+			}
+			manager.shims.FromUnstructured = func(obj map[string]any, target any) error {
+				return runtime.DefaultUnstructuredConverter.FromUnstructured(obj, target)
+			}
 
-		blueprint := &blueprintv1alpha1.Blueprint{
-			Metadata: blueprintv1alpha1.Metadata{Name: "test-blueprint"},
-			Sources: []blueprintv1alpha1.Source{
-				{Name: "test-source", Url: "https://github.com/example/repo.git", Ref: blueprintv1alpha1.Reference{Branch: "main"}},
-			},
-			Kustomizations: []blueprintv1alpha1.Kustomization{
-				{Name: "test-kustomization"},
-			},
+			var appliedRepo *sourcev1.GitRepository
+			var appliedKust *kustomizev1.Kustomization
+			kc := client.NewMockKubernetesClient()
+			kc.ApplyResourceFunc = func(gvr schema.GroupVersionResource, obj *unstructured.Unstructured, opts metav1.ApplyOptions) (*unstructured.Unstructured, error) {
+				switch gvr.Resource {
+				case "gitrepositories":
+					var repo sourcev1.GitRepository
+					if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &repo); err == nil {
+						appliedRepo = &repo
+					}
+				case "kustomizations":
+					var k kustomizev1.Kustomization
+					if err := runtime.DefaultUnstructuredConverter.FromUnstructured(obj.Object, &k); err == nil {
+						appliedKust = &k
+					}
+				}
+				return obj, nil
+			}
+			kc.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+				return nil, fmt.Errorf("not found")
+			}
+			manager.client = kc
+
+			blueprint := &blueprintv1alpha1.Blueprint{
+				Metadata: blueprintv1alpha1.Metadata{Name: "test-blueprint"},
+				Sources: []blueprintv1alpha1.Source{
+					{Name: "test-source", Url: "https://github.com/example/repo.git", Ref: blueprintv1alpha1.Reference{Branch: "main"}},
+				},
+				Kustomizations: []blueprintv1alpha1.Kustomization{
+					{Name: "test-kustomization"},
+				},
+			}
+
+			if err := manager.ApplyBlueprint(blueprint, "test-namespace"); err != nil {
+				t.Fatalf("Expected no error, got %v", err)
+			}
+			return appliedRepo, appliedKust
 		}
 
-		// When the blueprint is applied
-		if err := manager.ApplyBlueprint(blueprint, "test-namespace"); err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
+		// Given ApplyBlueprint runs under both pull and push mode
+		pullRepo, pullKust := applyUnderMode(t, "pull")
+		pushRepo, pushKust := applyUnderMode(t, "push")
 
-		// Then both source and kustomization carry the push-mode long interval,
-		// matching the expectation that Windsor's annotation is the primary trigger
-		if appliedRepo == nil {
-			t.Fatal("Expected GitRepository to be applied")
+		// Then both modes write the same default interval on the source and kustomization:
+		// flux content here is pinned and explicitly re-triggered by the notifier regardless
+		// of mode, so the backstop poll cadence has no reason to differ
+		if pullRepo == nil || pushRepo == nil {
+			t.Fatal("Expected GitRepository to be applied in both modes")
 		}
-		if appliedRepo.Spec.Interval.Duration != constants.DefaultFluxSourceIntervalPush {
-			t.Errorf("Expected GitRepository interval %v in push mode, got %v", constants.DefaultFluxSourceIntervalPush, appliedRepo.Spec.Interval.Duration)
+		if pullRepo.Spec.Interval.Duration != constants.DefaultFluxSourceInterval {
+			t.Errorf("Expected pull-mode GitRepository interval %v, got %v", constants.DefaultFluxSourceInterval, pullRepo.Spec.Interval.Duration)
 		}
-		if appliedKust == nil {
-			t.Fatal("Expected Kustomization to be applied")
+		if pushRepo.Spec.Interval.Duration != constants.DefaultFluxSourceInterval {
+			t.Errorf("Expected push-mode GitRepository interval %v, got %v", constants.DefaultFluxSourceInterval, pushRepo.Spec.Interval.Duration)
 		}
-		if appliedKust.Spec.Interval.Duration != constants.DefaultFluxKustomizationIntervalPush {
-			t.Errorf("Expected Kustomization interval %v in push mode, got %v", constants.DefaultFluxKustomizationIntervalPush, appliedKust.Spec.Interval.Duration)
+		if pullKust == nil || pushKust == nil {
+			t.Fatal("Expected Kustomization to be applied in both modes")
+		}
+		if pullKust.Spec.Interval.Duration != constants.DefaultFluxKustomizationInterval {
+			t.Errorf("Expected pull-mode Kustomization interval %v, got %v", constants.DefaultFluxKustomizationInterval, pullKust.Spec.Interval.Duration)
+		}
+		if pushKust.Spec.Interval.Duration != constants.DefaultFluxKustomizationInterval {
+			t.Errorf("Expected push-mode Kustomization interval %v, got %v", constants.DefaultFluxKustomizationInterval, pushKust.Spec.Interval.Duration)
 		}
 	})
 }

--- a/pkg/runtime/config/schemas/artifacts/blueprint.yaml
+++ b/pkg/runtime/config/schemas/artifacts/blueprint.yaml
@@ -355,7 +355,7 @@ properties:
               description: Duration to wait before retrying a failed reconciliation (e.g. '2m').
             timeout:
               type: string
-              description: Maximum duration for a single reconciliation attempt (e.g. '10m').
+              description: Maximum duration for a single reconciliation attempt. Defaults to 10m.
             patches:
               type: array
               description: Strategic-merge or Flux-style patches applied to this tier.

--- a/pkg/runtime/config/schemas/artifacts/blueprint.yaml
+++ b/pkg/runtime/config/schemas/artifacts/blueprint.yaml
@@ -208,8 +208,9 @@ properties:
           type: string
           description: |
             Reconciliation interval, expressed as a Go duration string
-            (e.g. '5m', '1h'). Defaults to a mode-appropriate value chosen by
-            the provisioner (short poll for pull mode, long fallback for push).
+            (e.g. '5m', '1h'). Defaults to 1h, a backstop cadence for content
+            that is pinned and explicitly re-triggered rather than
+            continuously tracked.
         retryInterval:
           type: string
           description: Duration to wait before retrying a failed reconciliation (e.g. '2m').


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This PR touches shared default constants used by all pull-mode Flux deployments, so the interval changes carry a broad blast radius even though the core feature is isolated.
>
> **Overview**
>
> The PR introduces `DefaultFluxKustomizationInstallTimeout` (10 minutes) and wires it into `compileFluxSystemTiers` so that install-tier Kustomizations without an explicit timeout get a longer default than the generic 5-minute value. Tests cover both the fallback path and the explicit-override path. Documentation and the YAML schema are updated to match.
>
> Bundled with the timeout feature, `DefaultFluxKustomizationInterval` and `DefaultFluxSourceInterval` are both raised from 1 minute to 5 minutes. This is a 5× reduction in reconciliation frequency for all pull-mode clusters using the default, which could slow drift detection. The change is intentional (the added comment explains alignment) but is not called out in the commit message and deserves explicit validation in upgrade notes.
>
> Reviewed by Claude for commit `113db8d`.

<!-- /claude-code-review:summary -->
