### PR TITLE
feat(api): default path to name when unset and update related documentation

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -527,8 +527,8 @@ type Kustomization struct {
 	// Name of the kustomization.
 	Name string `yaml:"name"`
 
-	// Path of the kustomization.
-	Path string `yaml:"path"`
+	// Path of the kustomization. Defaults to Name.
+	Path string `yaml:"path,omitempty"`
 
 	// Source of the kustomization.
 	Source string `yaml:"source,omitempty"`
@@ -1259,6 +1259,7 @@ func (s *FluxSystem) DeepCopy() *FluxSystem {
 // It takes the default namespace for the kustomization (overridden per-kustomization
 // by k.Namespace when set), the default source name to use if no source is specified,
 // and the list of sources to determine the source kind (GitRepository or OCIRepository).
+// A Path-less k defaults to k.Name, matching FluxSystem's own path-defaulting.
 // k.TargetNamespace is passed through to spec.targetNamespace so Flux rewrites the
 // namespace of every reconciled resource. DependsOn references are always resolved
 // in the default namespace.
@@ -1305,12 +1306,11 @@ func (k *Kustomization) ToFluxKustomization(namespace string, defaultSourceName 
 
 	path := k.Path
 	if path == "" {
-		path = "kustomize"
-	} else {
-		path = strings.ReplaceAll(path, "\\", "/")
-		if path != "kustomize" && !strings.HasPrefix(path, "kustomize/") {
-			path = "kustomize/" + path
-		}
+		path = k.Name
+	}
+	path = strings.ReplaceAll(path, "\\", "/")
+	if path != "kustomize" && !strings.HasPrefix(path, "kustomize/") {
+		path = "kustomize/" + path
 	}
 
 	interval := metav1.Duration{Duration: constants.FluxKustomizationInterval(mode)}

--- a/api/v1alpha1/blueprint_types_test.go
+++ b/api/v1alpha1/blueprint_types_test.go
@@ -2885,8 +2885,8 @@ func TestKustomization_ToFluxKustomization(t *testing.T) {
 
 		result := kustomization.ToFluxKustomization("test-namespace", "default-source", []Source{}, constants.GitopsModePull)
 
-		if result.Spec.Path != "kustomize" {
-			t.Errorf("Expected path 'kustomize', got '%s'", result.Spec.Path)
+		if result.Spec.Path != "kustomize/test-kustomization" {
+			t.Errorf("Expected path 'kustomize/test-kustomization', got '%s'", result.Spec.Path)
 		}
 	})
 

--- a/docs/reference/blueprint.md
+++ b/docs/reference/blueprint.md
@@ -115,7 +115,6 @@ variable substitutions shared across them.
 | Field | Type | Description |
 |------|------|-------------|
 | `name` | `string` | Identifier for the kustomization; referenced by dependsOn. **(required)** |
-| `path` | `string` | Path within the source containing the kustomize base. **(required)** |
 | `components` | `array<string>` | Kustomize components to compose into this kustomization. |
 | `dependsOn` | `array<string>` | Names of kustomizations that must reconcile before this one. |
 | `destroy` | `boolean / string` | Whether to delete this kustomization during 'windsor down' / 'windsor destroy'. Boolean or expression. Defaults to true. |
@@ -125,6 +124,7 @@ variable substitutions shared across them.
 | `interval` | `string` | Reconciliation interval, expressed as a Go duration string (e.g. '5m', '1h'). Defaults to a mode-appropriate value chosen by the provisioner (short poll for pull mode, long fallback for push). |
 | `namespace` | `string` | Namespace where the Flux Kustomization object itself lives. Defaults to the gitops namespace. DependsOn references always resolve in the gitops namespace; cross-namespace dependencies are not supported. |
 | `patches` | `array<object>` | Strategic-merge or Flux-style patches applied to the kustomization. Each entry is either a 'path:' to a patch file relative to the kustomization, or a 'patch:' inline YAML body with an optional 'target:' selector (kind / name / namespace). |
+| `path` | `string` | Path within the source containing the kustomize base. Defaults to name. |
 | `prune` | `boolean` | Garbage-collect resources removed from the source. Defaults to true. |
 | `retryInterval` | `string` | Duration to wait before retrying a failed reconciliation (e.g. '2m'). |
 | `source` | `string` | Name of the source (from the sources list) that provides this kustomization. Defaults to the blueprint's primary source when unset. |

--- a/integration/fixtures/facet-tiers/contexts/_template/facets/dns.yaml
+++ b/integration/fixtures/facet-tiers/contexts/_template/facets/dns.yaml
@@ -2,12 +2,11 @@ kind: Facet
 apiVersion: blueprints.windsorcli.dev/v1alpha1
 metadata:
   name: dns
-  description: Depends on cert-manager by its bare name to exercise install-tier resolution
+  description: Depends on cert-manager by its bare name to exercise install-tier resolution; omits path to exercise path-defaults-to-name
 
 kustomize:
 
 - name: dns
-  path: dns
   components:
   - coredns
   dependsOn:

--- a/integration/show_test.go
+++ b/integration/show_test.go
@@ -153,6 +153,27 @@ func TestShowKustomization_TierNameRendersCompiledKustomization(t *testing.T) {
 	}
 }
 
+func TestShowKustomization_PathDefaultsToNameWhenUnset(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "facet-tiers")
+	env = append(env, "WINDSOR_CONTEXT=default")
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"show", "kustomization", "dns"}, env)
+	if err != nil {
+		t.Fatalf("show kustomization dns: %v\nstderr: %s", err, stderr)
+	}
+	var k struct {
+		Spec struct {
+			Path string `yaml:"path"`
+		} `yaml:"spec"`
+	}
+	if err := yaml.Unmarshal(stdout, &k); err != nil {
+		t.Fatalf("parse kustomization YAML: %v\nstdout: %s", err, stdout)
+	}
+	if k.Spec.Path != "kustomize/dns" {
+		t.Errorf("expected spec.path kustomize/dns, got %q", k.Spec.Path)
+	}
+}
+
 func TestShowKustomization_SystemNameReturnsTierListError(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.PrepareFixture(t, "facet-tiers")

--- a/pkg/runtime/config/schemas/artifacts/blueprint.yaml
+++ b/pkg/runtime/config/schemas/artifacts/blueprint.yaml
@@ -176,7 +176,6 @@ properties:
       type: object
       required:
         - name
-        - path
       additionalProperties: false
       properties:
         name:
@@ -184,7 +183,7 @@ properties:
           description: Identifier for the kustomization; referenced by dependsOn.
         path:
           type: string
-          description: Path within the source containing the kustomize base.
+          description: Path within the source containing the kustomize base. Defaults to name.
         source:
           type: string
           description: Name of the source (from the sources list) that provides this kustomization. Defaults to the blueprint's primary source when unset.


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change makes `path` optional on `Kustomization` entries and is isolated to the blueprint type, its test, the YAML schema, and supporting docs — all consistently updated together.
>
> **Overview**
>
> The PR removes `path` from the required field list in both the Go struct (adding `omitempty`) and the JSON schema, then changes `ToFluxKustomization` so that an absent path defaults to the kustomization's `name` rather than the literal string `"kustomize"`. Path normalization (backslash replacement and the `kustomize/` prefix) now runs unconditionally rather than only in the non-empty branch, which is correct since the defaulted name needs the same treatment. Documentation, schema description, and the integration fixture are all updated in lockstep.
>
> The old fallback (`"kustomize"`) was only reachable when `path` was programmatically empty, since the schema previously required the field; valid existing blueprints that provided an explicit path are unaffected.
>
> Reviewed by Claude for commit `0075d199`.

<!-- /claude-code-review:summary -->
