### PR TITLE
feat(runtime/env): add per-context .env file for provider credentials

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -28,7 +28,7 @@ system-managed and not covered here.
 | `cluster` | `object` | Kubernetes cluster configuration. Node-group sub-types (NodeGroupConfig) are authored in api/v1alpha1/cluster/cluster_config.go; expansion to full field detail is a planned follow-up. |
 | `dns` | `object` | DNS configuration. |
 | `docker` | `object` | Docker / container-registry configuration. |
-| `environment` | `map<string>` | Static environment variables exported into every command run in this context. Plain string-to-string map; no expression evaluation. |
+| `environment` | `map<string>` | Environment variables exported into every command run in this context. Values may contain `${...}` expressions, including `secret(...)` references. Declarative and version-controlled; see [`.env` files](contexts.md#env-files) for a git-ignored, lower-precedence alternative. |
 | `gcp` | `object` | GCP integration. |
 | `git` | `object` | Git / livereload configuration. |
 | `id` | `string` | Stable identifier for the context, distinct from its map key. Used for cross-context references where the key may change. |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -28,7 +28,7 @@ system-managed and not covered here.
 | `cluster` | `object` | Kubernetes cluster configuration. Node-group sub-types (NodeGroupConfig) are authored in api/v1alpha1/cluster/cluster_config.go; expansion to full field detail is a planned follow-up. |
 | `dns` | `object` | DNS configuration. |
 | `docker` | `object` | Docker / container-registry configuration. |
-| `environment` | `map<string>` | Environment variables exported into every command run in this context. Values may contain `${...}` expressions, including `secret(...)` references. Declarative and version-controlled; see [`.env` files](contexts.md#env-files) for a git-ignored, lower-precedence alternative. |
+| `environment` | `map<string>` | Environment variables exported into every command run in this context. Values may contain `${...}` expressions, including `secret(...)` references. This key is declarative and lives in version control; for local, git-ignored values instead, see [`.env` files](contexts.md#env-files). |
 | `gcp` | `object` | GCP integration. |
 | `git` | `object` | Git / livereload configuration. |
 | `id` | `string` | Stable identifier for the context, distinct from its map key. Used for cross-context references where the key may change. |

--- a/docs/reference/contexts.md
+++ b/docs/reference/contexts.md
@@ -23,6 +23,7 @@ contexts/
 └── <context-name>/                         per-context configuration and credentials
     ├── blueprint.yaml                      referential blueprint for this context
     ├── values.yaml                         user-set values that feed the schema
+    ├── .env                                git-ignored operator env vars (e.g. provider credentials)
     ├── terraform/<component-id>.tfvars     user-edited Terraform variable overrides
     ├── terraform/<component-id>.tfvars.json  JSON variant of the above
     ├── terraform/backend.tfvars            optional Terraform backend overrides
@@ -58,6 +59,7 @@ live under `contexts/<context-name>/`.
 | `terraform/<component-id>.tfvars` | HCL | Operator-authored variable overrides for a Terraform component. Read at plan/apply time. |
 | `terraform/<component-id>.tfvars.json` | JSON | JSON-formatted alternative to `.tfvars`. |
 | `terraform/backend.tfvars` | HCL | Optional overrides applied to the Terraform backend init. |
+| `.env` | dotenv | Operator-supplied environment variables, auto-git-ignored. See [`.env` files](#env-files) below. |
 | `.aws/config`, `.aws/credentials` | INI | AWS CLI files; the env hook sets `AWS_CONFIG_FILE` and `AWS_SHARED_CREDENTIALS_FILE` so `aws` commands inside the windsor shell write here instead of `~/.aws/`. |
 | `.azure/` | Directory | Azure CLI config; `AZURE_CONFIG_DIR` points `az` here. |
 | `.gcp/gcloud/` | Directory | gcloud CLI config; `CLOUDSDK_CONFIG` points `gcloud` here. |
@@ -70,6 +72,25 @@ Hidden subdirectories (`.aws/`, `.azure/`, `.gcp/`, `.kube/`,
 `.talos/`, `.omni/`) keep CLI state scoped to the context so that tools
 invoked through the windsor shell never touch the operator's global
 config under `~/`.
+
+## `.env` files
+
+`contexts/<context-name>/.env` is a per-context, git-ignored dotenv file for
+provider environment variables that windsor has no native config for — Hyper-V
+(`HYPERV_USER`, `HYPERV_PASSWORD`, `HYPERV_HOST`, …) and vSphere
+(`VSPHERE_USER`, `VSPHERE_PASSWORD`, `VSPHERE_SERVER`, …) are the motivating
+cases. Use it for credentials/local values; use the `environment:` key under
+`contexts.<name>` in `windsor.yaml` for declarative, version-controlled values
+shared with the team (see [Configuration reference](configuration.md)).
+
+- Standard `KEY=VALUE` lines, one per line; `#` starts a comment.
+- Values may reference secrets, e.g. `HYPERV_PASSWORD=${secret("op://vault/item/field")}`.
+- Loaded on every `windsor env` / `windsor exec` / shell hook invocation, with
+  the **lowest precedence** of any environment source — `windsor.yaml`'s
+  `environment:` key and every provider-specific printer (AWS, Azure, GCP,
+  Terraform, …) override a same-named `.env` key.
+- Windsor warns (without failing) if the file is readable by group or other;
+  restrict it to the owner (`chmod 600`).
 
 ## See also
 

--- a/integration/dotenv_test.go
+++ b/integration/dotenv_test.go
@@ -1,0 +1,106 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/windsorcli/cli/integration/helpers"
+)
+
+// =============================================================================
+// Integration Tests
+// =============================================================================
+
+// TestDotEnv_InjectsValueIntoWindsorEnv verifies that a plain KEY=VALUE line in
+// contexts/<ctx>/.env is exported by `windsor env`. Bare `windsor init` (used by
+// PrepareFixture) provisions the "local" context.
+func TestDotEnv_InjectsValueIntoWindsorEnv(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "default")
+
+	dotEnvPath := filepath.Join(dir, "contexts", "local", ".env")
+	if err := os.WriteFile(dotEnvPath, []byte("HYPERV_HOST=hyperv.local\n"), 0600); err != nil {
+		t.Fatalf("write .env fixture: %v", err)
+	}
+
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"env"}, env)
+	if err != nil {
+		t.Fatalf("env: %v\nstderr: %s", err, stderr)
+	}
+	if !strings.Contains(string(stdout), "HYPERV_HOST=hyperv.local") {
+		t.Errorf("expected HYPERV_HOST=hyperv.local in output, got:\n%s", stdout)
+	}
+}
+
+// TestDotEnv_AbsentFileDoesNotBreakWindsorEnv verifies that `windsor env` succeeds
+// normally when no contexts/<ctx>/.env file is present.
+func TestDotEnv_AbsentFileDoesNotBreakWindsorEnv(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "default")
+
+	_, stderr, err := helpers.RunCLI(dir, []string{"env"}, env)
+	if err != nil {
+		t.Fatalf("expected env to succeed with no .env file, got error: %v\nstderr: %s", err, stderr)
+	}
+}
+
+// TestDotEnv_ContextEnvironmentKeyOverridesDotEnv verifies that the declarative
+// contexts.<ctx>.environment key in windsor.yaml takes precedence over the same
+// key supplied via contexts/<ctx>/.env, matching the documented precedence where
+// .env is the lowest-precedence base layer.
+func TestDotEnv_ContextEnvironmentKeyOverridesDotEnv(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "default")
+
+	windsorYamlPath := filepath.Join(dir, "windsor.yaml")
+	windsorYaml := `version: v1alpha1
+contexts:
+  local:
+    environment:
+      SHARED_VAR: from-windsor-yaml
+`
+	if err := os.WriteFile(windsorYamlPath, []byte(windsorYaml), 0644); err != nil {
+		t.Fatalf("write windsor.yaml: %v", err)
+	}
+	helpers.MarkAsGitRepo(t, dir)
+	if _, stderr, err := helpers.RunCLI(dir, []string{"init"}, env); err != nil {
+		t.Fatalf("windsor init: %v\nstderr: %s", err, stderr)
+	}
+
+	dotEnvPath := filepath.Join(dir, "contexts", "local", ".env")
+	if err := os.WriteFile(dotEnvPath, []byte("SHARED_VAR=from-dotenv\n"), 0600); err != nil {
+		t.Fatalf("write .env fixture: %v", err)
+	}
+
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"env"}, env)
+	if err != nil {
+		t.Fatalf("env: %v\nstderr: %s", err, stderr)
+	}
+	if !strings.Contains(string(stdout), "SHARED_VAR=from-windsor-yaml") {
+		t.Errorf("expected the windsor.yaml environment key to win over .env, got:\n%s", stdout)
+	}
+	if strings.Contains(string(stdout), "from-dotenv") {
+		t.Errorf("expected .env value to be overridden, got:\n%s", stdout)
+	}
+}
+
+// TestDotEnv_ContextGitignoreCoversDotEnvFile verifies that `windsor init` writes
+// contexts/<ctx>/.gitignore covering .env so the file can never be committed.
+func TestDotEnv_ContextGitignoreCoversDotEnvFile(t *testing.T) {
+	t.Parallel()
+	dir, _ := helpers.PrepareFixture(t, "default")
+
+	gitignorePath := filepath.Join(dir, "contexts", "local", ".gitignore")
+	content, err := os.ReadFile(gitignorePath)
+	if err != nil {
+		t.Fatalf("expected contexts/local/.gitignore to exist: %v", err)
+	}
+	if !strings.Contains(string(content), ".env") {
+		t.Errorf("expected .gitignore to cover .env, got:\n%s", content)
+	}
+}

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -569,7 +569,7 @@ func TestInit_WritesLocalGitignoresAndLeavesProjectRootAlone(t *testing.T) {
 	if readErr != nil {
 		t.Fatalf("expected contexts/local/.gitignore at %s, got %v", contextIgnore, readErr)
 	}
-	expected := ".kube/\n.talos/\n.omni/\n.aws/\n.azure/\n.gcp/\n"
+	expected := ".kube/\n.talos/\n.omni/\n.aws/\n.azure/\n.gcp/\n.env\n"
 	if string(content) != expected {
 		t.Errorf("expected contexts/local/.gitignore to contain credential dirs, got: %q", string(content))
 	}

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/windsorcli/cli/pkg/composer/artifact"
 	"github.com/windsorcli/cli/pkg/composer/blueprint"
@@ -186,7 +187,7 @@ const windsorMarkerContent = "*\n"
 
 // contextIgnoreContent is written to contexts/<ctx>/.gitignore to keep
 // per-context credential and state directories out of version control.
-const contextIgnoreContent = ".kube/\n.talos/\n.omni/\n.aws/\n.azure/\n.gcp/\n"
+const contextIgnoreContent = ".kube/\n.talos/\n.omni/\n.aws/\n.azure/\n.gcp/\n.env\n"
 
 // writeLocalGitignores writes self-contained .gitignore files into Windsor-owned
 // folders so re-running Windsor never touches the project-root .gitignore.
@@ -224,11 +225,53 @@ func (r *Composer) writeLocalGitignores() error {
 			continue
 		}
 		target := filepath.Join(contextsDir, entry.Name(), ".gitignore")
-		if err := writeIfMissing(target, contextIgnoreContent); err != nil {
+		if err := writeOrMergeContextIgnore(target, contextIgnoreContent); err != nil {
 			return fmt.Errorf("failed to write contexts/%s/.gitignore: %w", entry.Name(), err)
 		}
 	}
 	return nil
+}
+
+// writeOrMergeContextIgnore writes desired's content fresh when target is
+// missing, or appends any of desired's lines that a pre-existing target lacks
+// (preserving the file's other content) so a contextIgnoreContent addition
+// still reaches contexts created by an earlier CLI version.
+func writeOrMergeContextIgnore(target, desired string) error {
+	if err := writeIfMissing(target, desired); err != nil {
+		return err
+	}
+
+	// #nosec G304 - target is composed from the project's own contexts/ directory listing, not user-supplied
+	existing, err := os.ReadFile(target)
+	if err != nil {
+		return err
+	}
+
+	present := make(map[string]bool)
+	for _, line := range strings.Split(string(existing), "\n") {
+		present[strings.TrimSpace(line)] = true
+	}
+
+	var missing strings.Builder
+	for _, line := range strings.Split(strings.TrimRight(desired, "\n"), "\n") {
+		if line != "" && !present[line] {
+			missing.WriteString(line)
+			missing.WriteString("\n")
+		}
+	}
+	if missing.Len() == 0 {
+		return nil
+	}
+
+	content := string(existing)
+	if content != "" && !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+	content += missing.String()
+
+	// #nosec G306 G703 - .gitignore files use standard 0644 permissions; target is
+	// composed from the project's own contexts/ directory listing, not user-supplied
+	return os.WriteFile(target, []byte(content), 0644)
 }
 
 // writeIfMissing writes content to path with 0644 perms only when the file

--- a/pkg/composer/composer_test.go
+++ b/pkg/composer/composer_test.go
@@ -1014,7 +1014,7 @@ func TestComposer_writeLocalGitignores(t *testing.T) {
 		}
 
 		// And each non-template context should have a .gitignore with cred dirs
-		expected := ".kube/\n.talos/\n.omni/\n.aws/\n.azure/\n.gcp/\n"
+		expected := ".kube/\n.talos/\n.omni/\n.aws/\n.azure/\n.gcp/\n.env\n"
 		for _, name := range []string{"local", "prod"} {
 			path := filepath.Join(root, "contexts", name, ".gitignore")
 			content, readErr := os.ReadFile(path)
@@ -1030,6 +1030,98 @@ func TestComposer_writeLocalGitignores(t *testing.T) {
 		templatePath := filepath.Join(root, "contexts", "_template", ".gitignore")
 		if _, err := os.Stat(templatePath); !os.IsNotExist(err) {
 			t.Errorf("Expected contexts/_template/.gitignore to not exist, got stat err: %v", err)
+		}
+	})
+
+	t.Run("BackfillsMissingLineIntoExistingContextGitignore", func(t *testing.T) {
+		// Given a context whose .gitignore predates the ".env" line addition
+		mocks := setupComposerMocks(t)
+		root := mocks.Runtime.ProjectRoot
+		contextDir := filepath.Join(root, "contexts", "local")
+		if err := os.MkdirAll(contextDir, 0750); err != nil {
+			t.Fatalf("Failed to create context dir: %v", err)
+		}
+		staleContent := ".kube/\n.talos/\n.omni/\n.aws/\n.azure/\n.gcp/\n"
+		path := filepath.Join(contextDir, ".gitignore")
+		if err := os.WriteFile(path, []byte(staleContent), 0644); err != nil {
+			t.Fatalf("Failed to seed stale .gitignore: %v", err)
+		}
+		composer := createComposerWithMocks(mocks)
+
+		// When writing local gitignores
+		err := composer.writeLocalGitignores()
+
+		// Then no error should occur
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// And the missing ".env" line should be appended
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatalf("Failed to read .gitignore: %v", readErr)
+		}
+		if string(content) != staleContent+".env\n" {
+			t.Errorf("Expected .env to be backfilled, got: %q", string(content))
+		}
+	})
+
+	t.Run("PreservesUserLinesWhenBackfillingContextGitignore", func(t *testing.T) {
+		// Given a context .gitignore with a user-added line and no ".env" line
+		mocks := setupComposerMocks(t)
+		root := mocks.Runtime.ProjectRoot
+		contextDir := filepath.Join(root, "contexts", "local")
+		if err := os.MkdirAll(contextDir, 0750); err != nil {
+			t.Fatalf("Failed to create context dir: %v", err)
+		}
+		staleContent := ".kube/\n.talos/\n.omni/\n.aws/\n.azure/\n.gcp/\n*.bak\n"
+		path := filepath.Join(contextDir, ".gitignore")
+		if err := os.WriteFile(path, []byte(staleContent), 0644); err != nil {
+			t.Fatalf("Failed to seed stale .gitignore: %v", err)
+		}
+		composer := createComposerWithMocks(mocks)
+
+		// When writing local gitignores
+		if err := composer.writeLocalGitignores(); err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// Then the user's line should be preserved and ".env" appended
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatalf("Failed to read .gitignore: %v", readErr)
+		}
+		if string(content) != staleContent+".env\n" {
+			t.Errorf("Expected user line preserved and .env appended, got: %q", string(content))
+		}
+	})
+
+	t.Run("IsIdempotentWhenEnvLineAlreadyPresent", func(t *testing.T) {
+		// Given a context .gitignore that already has every current line
+		mocks := setupComposerMocks(t)
+		root := mocks.Runtime.ProjectRoot
+		contextDir := filepath.Join(root, "contexts", "local")
+		if err := os.MkdirAll(contextDir, 0750); err != nil {
+			t.Fatalf("Failed to create context dir: %v", err)
+		}
+		path := filepath.Join(contextDir, ".gitignore")
+		if err := os.WriteFile(path, []byte(contextIgnoreContent), 0644); err != nil {
+			t.Fatalf("Failed to seed .gitignore: %v", err)
+		}
+		composer := createComposerWithMocks(mocks)
+
+		// When writing local gitignores
+		if err := composer.writeLocalGitignores(); err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// Then the file should be unchanged
+		content, readErr := os.ReadFile(path)
+		if readErr != nil {
+			t.Fatalf("Failed to read .gitignore: %v", readErr)
+		}
+		if string(content) != contextIgnoreContent {
+			t.Errorf("Expected .gitignore unchanged, got: %q", string(content))
 		}
 	})
 

--- a/pkg/runtime/config/schemas/artifacts/configuration.yaml
+++ b/pkg/runtime/config/schemas/artifacts/configuration.yaml
@@ -77,9 +77,11 @@ $defs:
         additionalProperties:
           type: string
         description: |
-          Static environment variables exported into every command run in
-          this context. Plain string-to-string map; no expression
-          evaluation.
+          Environment variables exported into every command run in this
+          context. Values may contain `${...}` expressions, including
+          `secret(...)` references. This key is declarative and lives in
+          version control; for local, git-ignored values instead, see
+          [`.env` files](contexts.md#env-files).
       secrets:
         $ref: '#/$defs/secrets'
       aws:

--- a/pkg/runtime/env/dotenv_env.go
+++ b/pkg/runtime/env/dotenv_env.go
@@ -115,7 +115,12 @@ func (e *DotEnvEnvPrinter) GetEnvVars() (map[string]string, error) {
 
 // warnOnLoosePermissions writes a non-fatal warning to warningWriter when path is
 // group- or world-accessible rather than restricted to the owner (0600-equivalent).
+// A no-op on Windows: NTFS has no owner/group/other model, so Go's FileMode bits
+// there don't reflect real ACL restrictiveness and chmod has no equivalent.
 func (e *DotEnvEnvPrinter) warnOnLoosePermissions(path string, mode os.FileMode) {
+	if e.shims.Goos() == "windows" {
+		return
+	}
 	if mode.Perm()&0077 != 0 {
 		fmt.Fprintf(e.warningWriter, "\033[33mWarning: %s is readable by group/other; it may contain credentials. Consider running: chmod 600 %s\033[0m\n", path, path)
 	}

--- a/pkg/runtime/env/dotenv_env.go
+++ b/pkg/runtime/env/dotenv_env.go
@@ -1,0 +1,160 @@
+// The DotEnvEnvPrinter is a specialized component that manages per-context .env environment configuration.
+// It provides a lightweight, portable mechanism for operators to supply provider environment variables.
+// The DotEnvEnvPrinter reads contexts/<context>/.env, resolves secret(...) and other evaluator
+// expressions, and registers loaded values for output scrubbing since the file may hold credentials.
+
+package env
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/windsorcli/cli/pkg/runtime/config"
+	"github.com/windsorcli/cli/pkg/runtime/evaluator"
+	"github.com/windsorcli/cli/pkg/runtime/secrets"
+	"github.com/windsorcli/cli/pkg/runtime/shell"
+)
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+// dotEnvFileName is the name of the per-context environment file.
+const dotEnvFileName = ".env"
+
+// =============================================================================
+// Types
+// =============================================================================
+
+// DotEnvEnvPrinter is a struct that implements per-context .env environment configuration
+type DotEnvEnvPrinter struct {
+	BaseEnvPrinter
+	evaluator     evaluator.ExpressionEvaluator
+	warningWriter io.Writer
+}
+
+// =============================================================================
+// Constructor
+// =============================================================================
+
+// NewDotEnvEnvPrinter creates a new DotEnvEnvPrinter instance
+func NewDotEnvEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler, eval evaluator.ExpressionEvaluator) *DotEnvEnvPrinter {
+	if shell == nil {
+		panic("shell is required")
+	}
+	if configHandler == nil {
+		panic("config handler is required")
+	}
+
+	return &DotEnvEnvPrinter{
+		BaseEnvPrinter: *NewBaseEnvPrinter(shell, configHandler),
+		evaluator:      eval,
+		warningWriter:  os.Stderr,
+	}
+}
+
+// =============================================================================
+// Public Methods
+// =============================================================================
+
+// GetEnvVars loads contexts/<context>/.env, evaluating secret(...) expressions and
+// registering every value with the shell for output scrubbing. A key already cached in
+// the shell is omitted rather than re-evaluated. Returns an empty map when the file is
+// absent, and warns (without failing) when the file has group- or world-readable permissions.
+func (e *DotEnvEnvPrinter) GetEnvVars() (map[string]string, error) {
+	envVars := make(map[string]string)
+
+	configRoot, err := e.configHandler.GetConfigRoot()
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving config root: %w", err)
+	}
+
+	dotEnvPath := filepath.Join(configRoot, dotEnvFileName)
+
+	info, err := e.shims.Stat(dotEnvPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return envVars, nil
+		}
+		return nil, fmt.Errorf("error checking %s: %w", dotEnvPath, err)
+	}
+
+	e.warnOnLoosePermissions(dotEnvPath, info.Mode())
+
+	data, err := e.shims.ReadFile(dotEnvPath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading %s: %w", dotEnvPath, err)
+	}
+
+	for k, v := range parseDotEnv(string(data)) {
+		e.SetManagedEnv(k)
+
+		normalizedValue := secrets.NormalizeLegacyBraces(v)
+
+		if e.evaluator != nil && evaluator.ContainsExpression(normalizedValue) {
+			if existingValue, exists := e.shims.LookupEnv(k); exists &&
+				e.shouldUseCache() && !strings.Contains(existingValue, "<ERROR") {
+				continue
+			}
+			envVars[k] = evaluateExpressionValue(e.evaluator, normalizedValue)
+		} else {
+			envVars[k] = normalizedValue
+		}
+		e.shell.RegisterSecret(envVars[k])
+	}
+
+	return envVars, nil
+}
+
+// =============================================================================
+// Private Methods
+// =============================================================================
+
+// warnOnLoosePermissions writes a non-fatal warning to warningWriter when path is
+// group- or world-accessible rather than restricted to the owner (0600-equivalent).
+func (e *DotEnvEnvPrinter) warnOnLoosePermissions(path string, mode os.FileMode) {
+	if mode.Perm()&0077 != 0 {
+		fmt.Fprintf(e.warningWriter, "\033[33mWarning: %s is readable by group/other; it may contain credentials. Consider running: chmod 600 %s\033[0m\n", path, path)
+	}
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+// parseDotEnv parses standard dotenv content (KEY=VALUE lines, # comments, blank
+// lines) into a map. Lines without a top-level "=" are skipped silently.
+func parseDotEnv(content string) map[string]string {
+	result := make(map[string]string)
+
+	for line := range strings.SplitSeq(content, "\n") {
+		line = strings.TrimSpace(strings.TrimSuffix(line, "\r"))
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		key, value, found := strings.Cut(line, "=")
+		if !found {
+			continue
+		}
+
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+
+		result[key] = strings.TrimSpace(value)
+	}
+
+	return result
+}
+
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
+// Ensure DotEnvEnvPrinter implements the EnvPrinter interface
+var _ EnvPrinter = (*DotEnvEnvPrinter)(nil)

--- a/pkg/runtime/env/dotenv_env_test.go
+++ b/pkg/runtime/env/dotenv_env_test.go
@@ -1,0 +1,382 @@
+package env
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/windsorcli/cli/pkg/runtime/evaluator"
+)
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+func setupDotEnvEnvMocks(t *testing.T, overrides ...*EnvTestMocks) *EnvTestMocks {
+	t.Helper()
+	mocks := setupEnvMocks(t, overrides...)
+
+	mocks.Shims.LookupEnv = func(key string) (string, bool) {
+		return os.LookupEnv(key)
+	}
+
+	return mocks
+}
+
+// writeDotEnvFixture writes content to contexts/<context>/.env for the mock's config
+// root and points Stat/ReadFile at the real filesystem so permission bits are honored.
+func writeDotEnvFixture(t *testing.T, mocks *EnvTestMocks, content string, perm os.FileMode) string {
+	t.Helper()
+
+	configRoot, err := mocks.ConfigHandler.GetConfigRoot()
+	if err != nil {
+		t.Fatalf("Failed to get config root: %v", err)
+	}
+	if err := os.MkdirAll(configRoot, 0750); err != nil {
+		t.Fatalf("Failed to create config root: %v", err)
+	}
+
+	path := filepath.Join(configRoot, ".env")
+	if err := os.WriteFile(path, []byte(content), perm); err != nil {
+		t.Fatalf("Failed to write .env fixture: %v", err)
+	}
+
+	mocks.Shims.Stat = os.Stat
+	mocks.Shims.ReadFile = os.ReadFile
+
+	return path
+}
+
+func setupDotEnvPrinter(t *testing.T, eval evaluator.ExpressionEvaluator) (*DotEnvEnvPrinter, *EnvTestMocks) {
+	t.Helper()
+	mocks := setupDotEnvEnvMocks(t)
+	printer := NewDotEnvEnvPrinter(mocks.Shell, mocks.ConfigHandler, eval)
+	printer.shims = mocks.Shims
+	return printer, mocks
+}
+
+// =============================================================================
+// Test Constructor
+// =============================================================================
+
+func TestNewDotEnvEnvPrinter(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Given valid shell and config handler
+		mocks := setupDotEnvEnvMocks(t)
+
+		// When creating a new DotEnvEnvPrinter
+		printer := NewDotEnvEnvPrinter(mocks.Shell, mocks.ConfigHandler, nil)
+
+		// Then it should be created successfully
+		if printer == nil {
+			t.Error("Expected printer to be created")
+		}
+	})
+
+	t.Run("PanicsWithNilShell", func(t *testing.T) {
+		// Given a nil shell
+		mocks := setupDotEnvEnvMocks(t)
+
+		// When creating a new DotEnvEnvPrinter
+		defer func() {
+			// Then it should panic
+			if r := recover(); r == nil {
+				t.Error("Expected panic, got none")
+			}
+		}()
+		NewDotEnvEnvPrinter(nil, mocks.ConfigHandler, nil)
+	})
+
+	t.Run("PanicsWithNilConfigHandler", func(t *testing.T) {
+		// Given a nil config handler
+		mocks := setupDotEnvEnvMocks(t)
+
+		// When creating a new DotEnvEnvPrinter
+		defer func() {
+			// Then it should panic
+			if r := recover(); r == nil {
+				t.Error("Expected panic, got none")
+			}
+		}()
+		NewDotEnvEnvPrinter(mocks.Shell, nil, nil)
+	})
+}
+
+// =============================================================================
+// Test Public Methods
+// =============================================================================
+
+func TestDotEnvEnvPrinter_GetEnvVars(t *testing.T) {
+	t.Run("ReturnsEmptyMapWhenFileMissing", func(t *testing.T) {
+		// Given a DotEnvEnvPrinter with no .env file on disk
+		printer, mocks := setupDotEnvPrinter(t, nil)
+		mocks.Shims.Stat = func(string) (os.FileInfo, error) { return nil, os.ErrNotExist }
+
+		// When GetEnvVars is called
+		envVars, err := printer.GetEnvVars()
+
+		// Then no error should be returned and the map should be empty
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if len(envVars) != 0 {
+			t.Errorf("Expected empty envVars, got %v", envVars)
+		}
+	})
+
+	t.Run("LoadsPlainKeyValuePairsAndTracksManagedEnv", func(t *testing.T) {
+		// Given a DotEnvEnvPrinter with a plain .env file
+		printer, mocks := setupDotEnvPrinter(t, nil)
+		writeDotEnvFixture(t, mocks, "HYPERV_USER=admin\nHYPERV_HOST=hyperv.local\n", 0600)
+
+		// When GetEnvVars is called
+		envVars, err := printer.GetEnvVars()
+
+		// Then the values should be loaded
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if envVars["HYPERV_USER"] != "admin" {
+			t.Errorf("Expected HYPERV_USER=admin, got %q", envVars["HYPERV_USER"])
+		}
+		if envVars["HYPERV_HOST"] != "hyperv.local" {
+			t.Errorf("Expected HYPERV_HOST=hyperv.local, got %q", envVars["HYPERV_HOST"])
+		}
+
+		// And both keys should be tracked as managed
+		managed := printer.GetManagedEnv()
+		for _, key := range []string{"HYPERV_USER", "HYPERV_HOST"} {
+			found := false
+			for _, m := range managed {
+				if m == key {
+					found = true
+				}
+			}
+			if !found {
+				t.Errorf("Expected %s to be tracked in managed env, got %v", key, managed)
+			}
+		}
+	})
+
+	t.Run("SkipsCommentsBlankLinesAndMalformedLines", func(t *testing.T) {
+		// Given a .env file with comments, blank lines, and a malformed line
+		printer, mocks := setupDotEnvPrinter(t, nil)
+		writeDotEnvFixture(t, mocks, "# a comment\n\nVALID=yes\nNOEQUALSIGN\n", 0600)
+
+		// When GetEnvVars is called
+		envVars, err := printer.GetEnvVars()
+
+		// Then only the valid key should be loaded
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if len(envVars) != 1 || envVars["VALID"] != "yes" {
+			t.Errorf("Expected only VALID=yes, got %v", envVars)
+		}
+	})
+
+	t.Run("EvaluatesExpressionValues", func(t *testing.T) {
+		// Given a .env file with a secret expression and a mock evaluator
+		mockEval := evaluator.NewMockExpressionEvaluator()
+		mockEval.EvaluateFunc = func(expression string, facetPath string, scope map[string]any, evaluateDeferred bool) (any, error) {
+			if strings.Contains(expression, "secret(") {
+				return "resolved-secret", nil
+			}
+			return expression, nil
+		}
+		printer, mocks := setupDotEnvPrinter(t, mockEval)
+		writeDotEnvFixture(t, mocks, `HYPERV_PASSWORD=${secret("op://vault/item/field")}`+"\n", 0600)
+
+		// When GetEnvVars is called
+		envVars, err := printer.GetEnvVars()
+
+		// Then the expression should be resolved through the evaluator
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if envVars["HYPERV_PASSWORD"] != "resolved-secret" {
+			t.Errorf("Expected resolved-secret, got %q", envVars["HYPERV_PASSWORD"])
+		}
+	})
+
+	t.Run("OmitsCachedKeyWhenAlreadyPresentInShell", func(t *testing.T) {
+		// Given a cached shell value for a secret key and caching enabled
+		mockEval := evaluator.NewMockExpressionEvaluator()
+		evaluateCalled := false
+		mockEval.EvaluateFunc = func(expression string, facetPath string, scope map[string]any, evaluateDeferred bool) (any, error) {
+			evaluateCalled = true
+			return "freshly-resolved", nil
+		}
+		printer, mocks := setupDotEnvPrinter(t, mockEval)
+		writeDotEnvFixture(t, mocks, `HYPERV_PASSWORD=${secret("op://vault/item/field")}`+"\n", 0600)
+
+		t.Setenv("NO_CACHE", "0")
+		t.Setenv("HYPERV_PASSWORD", "cached-value")
+
+		// When GetEnvVars is called
+		envVars, err := printer.GetEnvVars()
+
+		// Then the key should be omitted and the evaluator should not be called
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if _, exists := envVars["HYPERV_PASSWORD"]; exists {
+			t.Errorf("Expected HYPERV_PASSWORD to be omitted from envVars, got %v", envVars)
+		}
+		if evaluateCalled {
+			t.Error("Expected evaluator not to be called when a cached value exists")
+		}
+	})
+
+	t.Run("ReEvaluatesWhenNoCacheSet", func(t *testing.T) {
+		// Given a cached shell value but NO_CACHE set
+		mockEval := evaluator.NewMockExpressionEvaluator()
+		mockEval.EvaluateFunc = func(expression string, facetPath string, scope map[string]any, evaluateDeferred bool) (any, error) {
+			return "freshly-resolved", nil
+		}
+		printer, mocks := setupDotEnvPrinter(t, mockEval)
+		writeDotEnvFixture(t, mocks, `HYPERV_PASSWORD=${secret("op://vault/item/field")}`+"\n", 0600)
+
+		t.Setenv("NO_CACHE", "1")
+		t.Setenv("HYPERV_PASSWORD", "cached-value")
+
+		// When GetEnvVars is called
+		envVars, err := printer.GetEnvVars()
+
+		// Then the value should be freshly evaluated
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if envVars["HYPERV_PASSWORD"] != "freshly-resolved" {
+			t.Errorf("Expected freshly-resolved, got %q", envVars["HYPERV_PASSWORD"])
+		}
+	})
+
+	t.Run("RegistersLoadedValuesForScrubbing", func(t *testing.T) {
+		// Given a .env file with a plain value
+		printer, mocks := setupDotEnvPrinter(t, nil)
+		writeDotEnvFixture(t, mocks, "HYPERV_USER=admin\n", 0600)
+
+		var registered []string
+		mocks.Shell.RegisterSecretFunc = func(value string) {
+			registered = append(registered, value)
+		}
+
+		// When GetEnvVars is called
+		if _, err := printer.GetEnvVars(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the loaded value should be registered for scrubbing
+		found := false
+		for _, v := range registered {
+			if v == "admin" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("Expected 'admin' to be registered for scrubbing, got %v", registered)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenConfigRootFails", func(t *testing.T) {
+		// Given a config handler that fails to resolve the config root
+		mocks := setupDotEnvEnvMocks(t)
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return "", fmt.Errorf("mock error getting project root")
+		}
+		printer := NewDotEnvEnvPrinter(mocks.Shell, mocks.ConfigHandler, nil)
+		printer.shims = mocks.Shims
+
+		// When GetEnvVars is called
+		_, err := printer.GetEnvVars()
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "error retrieving config root") {
+			t.Errorf("Unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenStatFailsForNonMissingReason", func(t *testing.T) {
+		// Given Stat failing with a non-NotExist error
+		printer, mocks := setupDotEnvPrinter(t, nil)
+		mocks.Shims.Stat = func(string) (os.FileInfo, error) {
+			return nil, fmt.Errorf("mock permission denied")
+		}
+
+		// When GetEnvVars is called
+		_, err := printer.GetEnvVars()
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "error checking") {
+			t.Errorf("Unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenReadFileFails", func(t *testing.T) {
+		// Given a .env file that exists but fails to read
+		printer, mocks := setupDotEnvPrinter(t, nil)
+		writeDotEnvFixture(t, mocks, "VALID=yes\n", 0600)
+		mocks.Shims.ReadFile = func(string) ([]byte, error) {
+			return nil, fmt.Errorf("mock read error")
+		}
+
+		// When GetEnvVars is called
+		_, err := printer.GetEnvVars()
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "error reading") {
+			t.Errorf("Unexpected error message: %v", err)
+		}
+	})
+
+	t.Run("WarnsToStderrOnLoosePermissions", func(t *testing.T) {
+		// Given a .env file with group/world-readable permissions
+		printer, mocks := setupDotEnvPrinter(t, nil)
+		writeDotEnvFixture(t, mocks, "VALID=yes\n", 0644)
+
+		var stderr bytes.Buffer
+		printer.warningWriter = &stderr
+
+		// When GetEnvVars is called
+		if _, err := printer.GetEnvVars(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then a warning should be written
+		if !strings.Contains(stderr.String(), "Warning") {
+			t.Errorf("Expected a permission warning, got %q", stderr.String())
+		}
+	})
+
+	t.Run("NoWarningWhenPermissionsAreRestricted", func(t *testing.T) {
+		// Given a .env file restricted to the owner
+		printer, mocks := setupDotEnvPrinter(t, nil)
+		writeDotEnvFixture(t, mocks, "VALID=yes\n", 0600)
+
+		var stderr bytes.Buffer
+		printer.warningWriter = &stderr
+
+		// When GetEnvVars is called
+		if _, err := printer.GetEnvVars(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then no warning should be written
+		if stderr.String() != "" {
+			t.Errorf("Expected no warning, got %q", stderr.String())
+		}
+	})
+}

--- a/pkg/runtime/env/dotenv_env_test.go
+++ b/pkg/runtime/env/dotenv_env_test.go
@@ -343,9 +343,10 @@ func TestDotEnvEnvPrinter_GetEnvVars(t *testing.T) {
 	})
 
 	t.Run("WarnsToStderrOnLoosePermissions", func(t *testing.T) {
-		// Given a .env file with group/world-readable permissions
+		// Given a .env file with group/world-readable permissions on a POSIX-like OS
 		printer, mocks := setupDotEnvPrinter(t, nil)
 		writeDotEnvFixture(t, mocks, "VALID=yes\n", 0644)
+		mocks.Shims.Goos = func() string { return "linux" }
 
 		var stderr bytes.Buffer
 		printer.warningWriter = &stderr
@@ -362,9 +363,10 @@ func TestDotEnvEnvPrinter_GetEnvVars(t *testing.T) {
 	})
 
 	t.Run("NoWarningWhenPermissionsAreRestricted", func(t *testing.T) {
-		// Given a .env file restricted to the owner
+		// Given a .env file restricted to the owner on a POSIX-like OS
 		printer, mocks := setupDotEnvPrinter(t, nil)
 		writeDotEnvFixture(t, mocks, "VALID=yes\n", 0600)
+		mocks.Shims.Goos = func() string { return "linux" }
 
 		var stderr bytes.Buffer
 		printer.warningWriter = &stderr
@@ -377,6 +379,27 @@ func TestDotEnvEnvPrinter_GetEnvVars(t *testing.T) {
 		// Then no warning should be written
 		if stderr.String() != "" {
 			t.Errorf("Expected no warning, got %q", stderr.String())
+		}
+	})
+
+	t.Run("NoWarningOnWindowsRegardlessOfPermissions", func(t *testing.T) {
+		// Given a .env file that would trip the loose-permissions check, on Windows
+		printer, mocks := setupDotEnvPrinter(t, nil)
+		writeDotEnvFixture(t, mocks, "VALID=yes\n", 0644)
+		mocks.Shims.Goos = func() string { return "windows" }
+
+		var stderr bytes.Buffer
+		printer.warningWriter = &stderr
+
+		// When GetEnvVars is called
+		if _, err := printer.GetEnvVars(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then no warning should be written, since Windows has no owner/group/other
+		// permission model for the check (or chmod) to act on
+		if stderr.String() != "" {
+			t.Errorf("Expected no warning on Windows, got %q", stderr.String())
 		}
 	})
 }

--- a/pkg/runtime/env/dotenv_env_test.go
+++ b/pkg/runtime/env/dotenv_env_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/windsorcli/cli/pkg/runtime/evaluator"
 )
@@ -46,6 +47,38 @@ func writeDotEnvFixture(t *testing.T, mocks *EnvTestMocks, content string, perm 
 
 	mocks.Shims.Stat = os.Stat
 	mocks.Shims.ReadFile = os.ReadFile
+
+	return path
+}
+
+// fakePermFileInfo is a minimal os.FileInfo with a caller-controlled Mode, used
+// to test permission-bit behavior independent of the host OS's real file
+// semantics (a real Stat on Windows never reports a POSIX-restrictive mode,
+// regardless of what os.WriteFile was asked for).
+type fakePermFileInfo struct {
+	mode os.FileMode
+}
+
+func (f fakePermFileInfo) Name() string       { return ".env" }
+func (f fakePermFileInfo) Size() int64        { return 0 }
+func (f fakePermFileInfo) Mode() os.FileMode  { return f.mode }
+func (f fakePermFileInfo) ModTime() time.Time { return time.Time{} }
+func (f fakePermFileInfo) IsDir() bool        { return false }
+func (f fakePermFileInfo) Sys() any           { return nil }
+
+// writeDotEnvFixtureWithMode writes a real .env file (so ReadFile returns real
+// content) but stubs Stat to report a caller-controlled FileMode, decoupling
+// permission-bit assertions from the host OS's actual file semantics.
+func writeDotEnvFixtureWithMode(t *testing.T, mocks *EnvTestMocks, content string, mode os.FileMode) string {
+	t.Helper()
+
+	path := writeDotEnvFixture(t, mocks, content, 0600)
+	mocks.Shims.Stat = func(name string) (os.FileInfo, error) {
+		if name == path {
+			return fakePermFileInfo{mode: mode}, nil
+		}
+		return os.Stat(name)
+	}
 
 	return path
 }
@@ -345,7 +378,7 @@ func TestDotEnvEnvPrinter_GetEnvVars(t *testing.T) {
 	t.Run("WarnsToStderrOnLoosePermissions", func(t *testing.T) {
 		// Given a .env file with group/world-readable permissions on a POSIX-like OS
 		printer, mocks := setupDotEnvPrinter(t, nil)
-		writeDotEnvFixture(t, mocks, "VALID=yes\n", 0644)
+		writeDotEnvFixtureWithMode(t, mocks, "VALID=yes\n", 0644)
 		mocks.Shims.Goos = func() string { return "linux" }
 
 		var stderr bytes.Buffer
@@ -365,7 +398,7 @@ func TestDotEnvEnvPrinter_GetEnvVars(t *testing.T) {
 	t.Run("NoWarningWhenPermissionsAreRestricted", func(t *testing.T) {
 		// Given a .env file restricted to the owner on a POSIX-like OS
 		printer, mocks := setupDotEnvPrinter(t, nil)
-		writeDotEnvFixture(t, mocks, "VALID=yes\n", 0600)
+		writeDotEnvFixtureWithMode(t, mocks, "VALID=yes\n", 0600)
 		mocks.Shims.Goos = func() string { return "linux" }
 
 		var stderr bytes.Buffer
@@ -385,7 +418,7 @@ func TestDotEnvEnvPrinter_GetEnvVars(t *testing.T) {
 	t.Run("NoWarningOnWindowsRegardlessOfPermissions", func(t *testing.T) {
 		// Given a .env file that would trip the loose-permissions check, on Windows
 		printer, mocks := setupDotEnvPrinter(t, nil)
-		writeDotEnvFixture(t, mocks, "VALID=yes\n", 0644)
+		writeDotEnvFixtureWithMode(t, mocks, "VALID=yes\n", 0644)
 		mocks.Shims.Goos = func() string { return "windows" }
 
 		var stderr bytes.Buffer

--- a/pkg/runtime/env/env.go
+++ b/pkg/runtime/env/env.go
@@ -6,9 +6,11 @@
 package env
 
 import (
+	"fmt"
 	"slices"
 
 	"github.com/windsorcli/cli/pkg/runtime/config"
+	"github.com/windsorcli/cli/pkg/runtime/evaluator"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
 )
 
@@ -108,4 +110,33 @@ func (e *BaseEnvPrinter) Reset() {
 	e.managedEnv = make([]string, 0)
 	e.managedAlias = make([]string, 0)
 	e.shell.Reset()
+}
+
+// =============================================================================
+// Private Methods
+// =============================================================================
+
+// shouldUseCache determines if the cache should be used based on NO_CACHE environment variable.
+// Cache is enabled by default and can be disabled by setting NO_CACHE=1 or NO_CACHE=true.
+func (e *BaseEnvPrinter) shouldUseCache() bool {
+	noCache, _ := e.shims.LookupEnv("NO_CACHE")
+	return noCache == "" || noCache == "0" || noCache == "false" || noCache == "False"
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+// evaluateExpressionValue evaluates value through eval with deferred evaluation
+// enabled so secrets resolve immediately. Formats a resolution error inline as
+// "<ERROR: ...>" and normalizes a nil result to the empty string.
+func evaluateExpressionValue(eval evaluator.ExpressionEvaluator, value string) string {
+	result, err := eval.Evaluate(value, "", nil, true)
+	if err != nil {
+		return fmt.Sprintf("<ERROR: %s>", err)
+	}
+	if result == nil {
+		return ""
+	}
+	return fmt.Sprint(result)
 }

--- a/pkg/runtime/env/windsor_env.go
+++ b/pkg/runtime/env/windsor_env.go
@@ -173,21 +173,7 @@ func (e *WindsorEnvPrinter) evaluateEnvValue(value string) string {
 	if e.evaluator == nil {
 		return value
 	}
-	result, err := e.evaluator.Evaluate(value, "", nil, true)
-	if err != nil {
-		return fmt.Sprintf("<ERROR: %s>", err)
-	}
-	if result == nil {
-		return ""
-	}
-	return fmt.Sprint(result)
-}
-
-// shouldUseCache determines if the cache should be used based on NO_CACHE environment variable.
-// Cache is enabled by default and can be disabled by setting NO_CACHE=1 or NO_CACHE=true.
-func (e *WindsorEnvPrinter) shouldUseCache() bool {
-	noCache, _ := e.shims.LookupEnv("NO_CACHE")
-	return noCache == "" || noCache == "0" || noCache == "false" || noCache == "False"
+	return evaluateExpressionValue(e.evaluator, value)
 }
 
 // getBuildID retrieves the current build ID from the .windsor/.build-id file.

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -56,6 +56,7 @@ type Runtime struct {
 
 	// EnvPrinters contains environment printers for various providers and tools
 	EnvPrinters struct {
+		DotEnvEnv    env.EnvPrinter
 		AwsEnv       env.EnvPrinter
 		AzureEnv     env.EnvPrinter
 		GcpEnv       env.EnvPrinter
@@ -132,6 +133,9 @@ func NewRuntime(opts ...*Runtime) *Runtime {
 		}
 		if overrides.Resolver != nil {
 			rt.Resolver = overrides.Resolver
+		}
+		if overrides.EnvPrinters.DotEnvEnv != nil {
+			rt.EnvPrinters.DotEnvEnv = overrides.EnvPrinters.DotEnvEnv
 		}
 		if overrides.EnvPrinters.AwsEnv != nil {
 			rt.EnvPrinters.AwsEnv = overrides.EnvPrinters.AwsEnv
@@ -733,6 +737,9 @@ func (rt *Runtime) initializeEnvPrinters() {
 	hasGCPConfig := configData != nil && configData.GCP != nil
 	hasVSphereConfig := configData != nil && configData.VSphere != nil
 
+	if rt.EnvPrinters.DotEnvEnv == nil {
+		rt.EnvPrinters.DotEnvEnv = env.NewDotEnvEnvPrinter(rt.Shell, rt.ConfigHandler, rt.Evaluator)
+	}
 	if rt.EnvPrinters.AwsEnv == nil && (hasAWSConfig || platform == "aws") {
 		rt.EnvPrinters.AwsEnv = env.NewAwsEnvPrinter(rt.Shell, rt.ConfigHandler)
 	}
@@ -882,10 +889,12 @@ func (rt *Runtime) registerSecretHelper() {
 }
 
 // getAllEnvPrinters returns all environment printers in a consistent order.
-// This ensures that environment variables are processed in a predictable sequence
-// with WindsorEnv being processed last to take precedence.
+// This ensures that environment variables are processed in a predictable sequence,
+// with DotEnvEnv processed first (lowest precedence, an operator-supplied base layer)
+// and WindsorEnv processed last to take precedence.
 func (rt *Runtime) getAllEnvPrinters() []env.EnvPrinter {
 	return []env.EnvPrinter{
+		rt.EnvPrinters.DotEnvEnv,
 		rt.EnvPrinters.AwsEnv,
 		rt.EnvPrinters.AzureEnv,
 		rt.EnvPrinters.GcpEnv,

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -2972,4 +2972,59 @@ func TestRuntime_initializeEnvPrinters(t *testing.T) {
 			t.Error("Expected WindsorEnv to be initialized with Resolver")
 		}
 	})
+
+	t.Run("AlwaysInitializesDotEnvEnv", func(t *testing.T) {
+		// Given a runtime with no platform-specific configuration at all
+		mocks := setupRuntimeMocks(t)
+		rt := mocks.Runtime
+
+		// When initializeEnvPrinters is called
+		rt.initializeEnvPrinters()
+
+		// Then DotEnvEnv should be initialized unconditionally
+		if rt.EnvPrinters.DotEnvEnv == nil {
+			t.Error("Expected DotEnvEnv to always be initialized")
+		}
+	})
+
+	t.Run("DoesNotOverrideExistingDotEnvEnv", func(t *testing.T) {
+		// Given a runtime with an existing DotEnvEnv printer
+		mocks := setupRuntimeMocks(t)
+		rt := mocks.Runtime
+
+		existingDotEnvEnv := env.NewMockEnvPrinter()
+		rt.EnvPrinters.DotEnvEnv = existingDotEnvEnv
+
+		// When initializeEnvPrinters is called
+		rt.initializeEnvPrinters()
+
+		// Then the existing printer should be preserved
+		if rt.EnvPrinters.DotEnvEnv != existingDotEnvEnv {
+			t.Error("Expected existing DotEnvEnv to be preserved")
+		}
+	})
+}
+
+// TestRuntime_getAllEnvPrinters tests the ordering returned by getAllEnvPrinters.
+func TestRuntime_getAllEnvPrinters(t *testing.T) {
+	t.Run("DotEnvEnvIsFirst", func(t *testing.T) {
+		// Given a runtime with all env printers initialized
+		mocks := setupRuntimeMocks(t)
+		rt := mocks.Runtime
+		rt.initializeEnvPrinters()
+
+		// When getAllEnvPrinters is called
+		printers := rt.getAllEnvPrinters()
+
+		// Then DotEnvEnv should be first (lowest precedence) and WindsorEnv last
+		if len(printers) == 0 {
+			t.Fatal("Expected at least one printer")
+		}
+		if printers[0] != rt.EnvPrinters.DotEnvEnv {
+			t.Error("Expected DotEnvEnv to be first in getAllEnvPrinters")
+		}
+		if printers[len(printers)-1] != rt.EnvPrinters.WindsorEnv {
+			t.Error("Expected WindsorEnv to be last in getAllEnvPrinters")
+		}
+	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This PR adds a new environment-variable input layer (`contexts/<ctx>/.env`) that is always active and sits at the lowest precedence in the env-printer chain, touching credential loading and output-scrubbing paths.
>
> **Overview**
>
> The change introduces `DotEnvEnvPrinter`, a new env printer that reads a per-context `.env` file, evaluates `${secret(...)}` expressions, and registers every loaded value with the shell's output scrubber. The composer is extended with a `writeOrMergeContextIgnore` helper that backfills the `.env` entry into existing context `.gitignore` files created by older CLI versions. Helper functions `shouldUseCache` and `evaluateExpressionValue` are lifted from `WindsorEnvPrinter` into the shared base, eliminating duplication.
>
> The new printer is unconditionally initialized (unlike cloud-provider printers, which are gated on config) and placed first in `getAllEnvPrinters`, making it the base layer that all other printers can override. Documentation and integration tests cover the precedence contract, the absent-file no-op path, and the gitignore backfill.
>
> Reviewed by Claude for commit `750b3127`.

<!-- /claude-code-review:summary -->
