### PR TITLE
feat(env): Support special case of .env injection for terraform execution only

### DIFF
--- a/docs/reference/contexts.md
+++ b/docs/reference/contexts.md
@@ -27,6 +27,7 @@ contexts/
     ├── terraform/<component-id>.tfvars     user-edited Terraform variable overrides
     ├── terraform/<component-id>.tfvars.json  JSON variant of the above
     ├── terraform/backend.tfvars            optional Terraform backend overrides
+    ├── terraform/.env                      git-ignored, Terraform-only env vars
     ├── .aws/{config,credentials}           AWS CLI config + credentials, scoped to this context
     ├── .azure/                             Azure CLI config, scoped to this context
     ├── .gcp/gcloud/                        gcloud CLI config, scoped to this context
@@ -59,6 +60,7 @@ live under `contexts/<context-name>/`.
 | `terraform/<component-id>.tfvars` | HCL | Operator-authored variable overrides for a Terraform component. Read at plan/apply time. |
 | `terraform/<component-id>.tfvars.json` | JSON | JSON-formatted alternative to `.tfvars`. |
 | `terraform/backend.tfvars` | HCL | Optional overrides applied to the Terraform backend init. |
+| `terraform/.env` | dotenv | Terraform-only operator env vars, auto-git-ignored. See [Terraform-scoped `.env`](#terraform-scoped-env) below. |
 | `.env` | dotenv | Operator-supplied environment variables, auto-git-ignored. See [`.env` files](#env-files) below. |
 | `.aws/config`, `.aws/credentials` | INI | AWS CLI files; the env hook sets `AWS_CONFIG_FILE` and `AWS_SHARED_CREDENTIALS_FILE` so `aws` commands inside the windsor shell write here instead of `~/.aws/`. |
 | `.azure/` | Directory | Azure CLI config; `AZURE_CONFIG_DIR` points `az` here. |
@@ -91,6 +93,42 @@ shared with the team (see [Configuration reference](configuration.md)).
   Terraform, …) override a same-named `.env` key.
 - Windsor warns (without failing) if the file is readable by group or other;
   restrict it to the owner (`chmod 600`).
+
+### Committing `.env` anyway
+
+A team that wants to share `.env` (or `terraform/.env`) through git — for
+example, a file whose values are all `secret(...)` references rather than
+raw credentials — can add a negation line to the end of
+`contexts/<context-name>/.gitignore`:
+
+```
+!.env
+```
+
+Don't delete the `.env` line itself to do this. Windsor re-adds any missing
+line from its managed set on every `windsor init`/`up` (so upgrading to a
+newer CLI still protects contexts created by an older one), and deleting the
+line would just have it silently reappear. Appending `!.env` after it is
+stable: the line is still present, so Windsor leaves the file alone, and
+git's own last-match-wins rule un-ignores the file anyway.
+
+## Terraform-scoped `.env`
+
+`contexts/<context-name>/terraform/.env` is a second, narrower dotenv file
+for variables that are only ever relevant to Terraform — most commonly
+provider credentials read directly from the environment, like Hyper-V or
+vSphere. Same format as the general `.env` above, including `secret(...)`
+support.
+
+The difference is *when* it loads. The general `.env` loads on every
+`windsor env` / shell hook invocation; `terraform/.env` loads only when
+Windsor is actually doing Terraform work — either the operator is `cd`'d
+into a `terraform/<component>/` directory, or a command like `windsor up`
+is running. A plain shell prompt elsewhere never touches it, so it never
+pays secret-resolution cost for content that isn't relevant right now. Move
+a variable here instead of the general `.env` once you notice it's
+Terraform-only and secret-resolution heavy enough to matter for prompt
+latency.
 
 ## See also
 

--- a/integration/fixtures/terraform-dotenv/contexts/_template/blueprint.yaml
+++ b/integration/fixtures/terraform-dotenv/contexts/_template/blueprint.yaml
@@ -1,0 +1,7 @@
+kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: terraform-dotenv
+  description: Terraform-scoped .env integration fixture with a minimal local terraform component
+terraform:
+  - path: "null"

--- a/integration/fixtures/terraform-dotenv/terraform/null/main.tf
+++ b/integration/fixtures/terraform-dotenv/terraform/null/main.tf
@@ -1,0 +1,1 @@
+terraform {}

--- a/integration/fixtures/terraform-dotenv/windsor.yaml
+++ b/integration/fixtures/terraform-dotenv/windsor.yaml
@@ -1,0 +1,3 @@
+version: v1alpha1
+contexts:
+  local: {}

--- a/integration/terraform_dotenv_test.go
+++ b/integration/terraform_dotenv_test.go
@@ -1,0 +1,68 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/windsorcli/cli/integration/helpers"
+)
+
+// =============================================================================
+// Integration Tests
+// =============================================================================
+
+// TestTerraformDotEnv_InjectedWhenCdIntoTerraformDirectory verifies that a value in
+// contexts/<ctx>/terraform/.env reaches `windsor env` when the operator is cd'd into
+// a Terraform component directory — the same TerraformProvider.GetEnvVars call that
+// `windsor up`/`apply`/`plan`/`destroy` use per component.
+func TestTerraformDotEnv_InjectedWhenCdIntoTerraformDirectory(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "terraform-dotenv")
+
+	dotEnvPath := filepath.Join(dir, "contexts", "local", "terraform", ".env")
+	if err := os.MkdirAll(filepath.Dir(dotEnvPath), 0750); err != nil {
+		t.Fatalf("mkdir terraform dir: %v", err)
+	}
+	if err := os.WriteFile(dotEnvPath, []byte("HYPERV_HOST=hyperv.local\n"), 0600); err != nil {
+		t.Fatalf("write terraform/.env fixture: %v", err)
+	}
+
+	componentDir := filepath.Join(dir, "terraform", "null")
+	stdout, stderr, err := helpers.RunCLI(componentDir, []string{"env"}, env)
+	if err != nil {
+		t.Fatalf("env: %v\nstderr: %s", err, stderr)
+	}
+	if !strings.Contains(string(stdout), "HYPERV_HOST=hyperv.local") {
+		t.Errorf("expected HYPERV_HOST=hyperv.local in output, got:\n%s", stdout)
+	}
+}
+
+// TestTerraformDotEnv_AbsentFromHookOutsideTerraformDirectory verifies that a value in
+// contexts/<ctx>/terraform/.env does NOT reach `windsor env` when the operator is not
+// cd'd into a Terraform directory — the core performance property: content that's only
+// relevant to Terraform work never touches the general interactive hook path.
+func TestTerraformDotEnv_AbsentFromHookOutsideTerraformDirectory(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "terraform-dotenv")
+
+	dotEnvPath := filepath.Join(dir, "contexts", "local", "terraform", ".env")
+	if err := os.MkdirAll(filepath.Dir(dotEnvPath), 0750); err != nil {
+		t.Fatalf("mkdir terraform dir: %v", err)
+	}
+	if err := os.WriteFile(dotEnvPath, []byte("HYPERV_HOST=hyperv.local\n"), 0600); err != nil {
+		t.Fatalf("write terraform/.env fixture: %v", err)
+	}
+
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"env"}, env)
+	if err != nil {
+		t.Fatalf("env: %v\nstderr: %s", err, stderr)
+	}
+	if strings.Contains(string(stdout), "hyperv.local") {
+		t.Errorf("expected HYPERV_HOST to be absent outside a Terraform directory, got:\n%s", stdout)
+	}
+}

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -310,7 +310,7 @@ func (s *TerraformStack) Up(blueprint *blueprintv1alpha1.Blueprint, onApply ...f
 				return fmt.Errorf("directory %s does not exist", component.FullPath)
 			}
 
-			terraformVars, terraformArgs, err := s.setupTerraformEnvironment(component)
+			terraformVars, scopedKeys, terraformArgs, err := s.setupTerraformEnvironment(component)
 			backendOverridePath := filepath.Join(component.FullPath, "backend_override.tf")
 			if _, statErr := s.shims.Stat(backendOverridePath); statErr == nil {
 				backendOverridePaths = append(backendOverridePaths, backendOverridePath)
@@ -320,25 +320,25 @@ func (s *TerraformStack) Up(blueprint *blueprintv1alpha1.Blueprint, onApply ...f
 			}
 			terraformVars["TF_VAR_operation"] = "apply"
 
-			if err := s.runTerraformInit(&component, terraformVars, terraformArgs, defaultInitFlags...); err != nil {
+			if err := s.runTerraformInit(&component, terraformVars, scopedKeys, terraformArgs, defaultInitFlags...); err != nil {
 				return err
 			}
 
-			if err := s.refreshIfStateNonEmpty(&component, terraformVars, terraformArgs); err != nil {
+			if err := s.refreshIfStateNonEmpty(&component, terraformVars, scopedKeys, terraformArgs); err != nil {
 				return err
 			}
 
 			terraformCommand := s.runtime.ToolsManager.GetTerraformCommand()
 			planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan", "-refresh=false"}
 			planArgs = append(planArgs, terraformArgs.PlanArgs...)
-			planEnv := selectTerraformCommandEnv(terraformVars, true)
+			planEnv := selectTerraformCommandEnv(terraformVars, true, scopedKeys)
 			if _, err = s.runtime.Shell.ExecSilentWithEnv(terraformCommand, planEnv, planArgs...); err != nil {
 				return fmt.Errorf("error running terraform plan for %s: %w", component.Path, err)
 			}
 
 			applyArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "apply"}
 			applyArgs = append(applyArgs, terraformArgs.ApplyArgs...)
-			applyEnv := selectTerraformCommandEnv(terraformVars, false)
+			applyEnv := selectTerraformCommandEnv(terraformVars, false, scopedKeys)
 			if _, err = s.runtime.Shell.ExecProgressWithEnv(fmt.Sprintf("Applying Terraform changes in %s", component.Path), terraformCommand, applyEnv, applyArgs...); err != nil {
 				return fmt.Errorf("error running terraform apply for %s: %w", component.Path, err)
 			}
@@ -385,27 +385,27 @@ func (s *TerraformStack) Up(blueprint *blueprintv1alpha1.Blueprint, onApply ...f
 // state in the currently-configured backend. Runs init + `terraform show
 // -json`; callers must invoke before any in-memory backend override.
 func (s *TerraformStack) HasRemoteState(blueprint *blueprintv1alpha1.Blueprint, componentID string) (bool, error) {
-	component, terraformVars, terraformArgs, cleanup, err := s.prepareComponentOp(blueprint, componentID)
+	component, terraformVars, scopedKeys, terraformArgs, cleanup, err := s.prepareComponentOp(blueprint, componentID)
 	if err != nil {
 		return false, err
 	}
 	defer cleanup()
 
-	if err := s.runTerraformInit(component, terraformVars, terraformArgs, defaultInitFlags...); err != nil {
+	if err := s.runTerraformInit(component, terraformVars, scopedKeys, terraformArgs, defaultInitFlags...); err != nil {
 		return false, err
 	}
-	return s.hasStateResources(component, terraformVars)
+	return s.hasStateResources(component, terraformVars, scopedKeys)
 }
 
 // InitComponent runs `terraform init` for one component using the currently-
 // configured backend; no -migrate-state, no plan, no apply.
 func (s *TerraformStack) InitComponent(blueprint *blueprintv1alpha1.Blueprint, componentID string) error {
-	component, terraformVars, terraformArgs, cleanup, err := s.prepareComponentOp(blueprint, componentID)
+	component, terraformVars, scopedKeys, terraformArgs, cleanup, err := s.prepareComponentOp(blueprint, componentID)
 	if err != nil {
 		return err
 	}
 	defer cleanup()
-	return s.runTerraformInit(component, terraformVars, terraformArgs, defaultInitFlags...)
+	return s.runTerraformInit(component, terraformVars, scopedKeys, terraformArgs, defaultInitFlags...)
 }
 
 // HasLocalStateWithResources reports whether the per-component local state
@@ -619,7 +619,7 @@ func (s *TerraformStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, cont
 			continue
 		}
 
-		terraformVars, terraformArgs, err := s.setupTerraformEnvironment(component)
+		terraformVars, scopedKeys, terraformArgs, err := s.setupTerraformEnvironment(component)
 		backendOverridePath := filepath.Join(component.FullPath, "backend_override.tf")
 		if _, statErr := s.shims.Stat(backendOverridePath); statErr == nil {
 			backendOverridePaths = append(backendOverridePaths, backendOverridePath)
@@ -636,13 +636,13 @@ func (s *TerraformStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, cont
 		if err := tui.WithProgress(fmt.Sprintf("Destroying %s", component.Path), func() error {
 			terraformVars["TF_VAR_operation"] = "destroy"
 
-			if err := s.runTerraformInit(&component, terraformVars, terraformArgs, defaultInitFlags...); err != nil {
+			if err := s.runTerraformInit(&component, terraformVars, scopedKeys, terraformArgs, defaultInitFlags...); err != nil {
 				return err
 			}
 
 			// Skip refresh if state is already empty: refresh can only drop resources, never
 			// add them, and downstream data sources may fail against torn-down upstreams.
-			hasResourcesPre, err := s.hasStateResources(&component, terraformVars)
+			hasResourcesPre, err := s.hasStateResources(&component, terraformVars, scopedKeys)
 			if err != nil {
 				return err
 			}
@@ -662,7 +662,7 @@ func (s *TerraformStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, cont
 			// — without it, a recurring credential or connectivity issue is invisible until
 			// destroy errors out, and a successful fallback leaves no trace at all.
 			refreshFailed := false
-			if err := s.refreshComponentState(&component, terraformVars, terraformArgs); err != nil {
+			if err := s.refreshComponentState(&component, terraformVars, scopedKeys, terraformArgs); err != nil {
 				refreshFailed = true
 				fmt.Fprintf(s.warningWriter, "warning: terraform refresh failed for %s; falling through to destroy -refresh=true (terraform will retry refresh during destroy): %v\n", component.Path, err)
 			}
@@ -672,7 +672,7 @@ func (s *TerraformStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, cont
 			// check would be redundant; if refresh succeeded but reconciliation dropped every
 			// resource, we still want the skip path.
 			if !refreshFailed {
-				hasResources, err := s.hasStateResources(&component, terraformVars)
+				hasResources, err := s.hasStateResources(&component, terraformVars, scopedKeys)
 				if err != nil {
 					return err
 				}
@@ -692,7 +692,7 @@ func (s *TerraformStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, cont
 			}
 			destroyArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "destroy", destroyRefreshFlag}
 			destroyArgs = append(destroyArgs, terraformArgs.DestroyArgs...)
-			destroyEnv := selectTerraformCommandEnv(terraformVars, true)
+			destroyEnv := selectTerraformCommandEnv(terraformVars, true, scopedKeys)
 			output, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, destroyEnv, destroyArgs...)
 			if err != nil {
 				if trimmed := strings.TrimSpace(output); trimmed != "" {
@@ -732,21 +732,21 @@ func (s *TerraformStack) Plan(blueprint *blueprintv1alpha1.Blueprint, componentI
 		return fmt.Errorf("component ID not provided")
 	}
 
-	component, terraformVars, terraformArgs, cleanup, err := s.prepareComponentOp(blueprint, componentID)
+	component, terraformVars, scopedKeys, terraformArgs, cleanup, err := s.prepareComponentOp(blueprint, componentID)
 	if err != nil {
 		return err
 	}
 	defer cleanup()
 	terraformVars["TF_VAR_operation"] = "apply"
 
-	if err := s.runTerraformInit(component, terraformVars, terraformArgs, defaultInitFlags...); err != nil {
+	if err := s.runTerraformInit(component, terraformVars, scopedKeys, terraformArgs, defaultInitFlags...); err != nil {
 		return err
 	}
 
 	terraformCommand := s.runtime.ToolsManager.GetTerraformCommand()
 	planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan"}
 	planArgs = append(planArgs, terraformArgs.PlanArgs...)
-	planEnv := selectTerraformCommandEnv(terraformVars, true)
+	planEnv := selectTerraformCommandEnv(terraformVars, true, scopedKeys)
 	planOutput, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, planEnv, planArgs...)
 	if err != nil {
 		return fmt.Errorf("error running terraform plan for %s: %w", component.Path, err)
@@ -776,21 +776,21 @@ func (s *TerraformStack) PlanJSON(blueprint *blueprintv1alpha1.Blueprint, compon
 		return fmt.Errorf("component ID not provided")
 	}
 
-	component, terraformVars, terraformArgs, cleanup, err := s.prepareComponentOp(blueprint, componentID)
+	component, terraformVars, scopedKeys, terraformArgs, cleanup, err := s.prepareComponentOp(blueprint, componentID)
 	if err != nil {
 		return err
 	}
 	defer cleanup()
 	terraformVars["TF_VAR_operation"] = "apply"
 
-	if err := s.runTerraformInit(component, terraformVars, terraformArgs, defaultInitFlags...); err != nil {
+	if err := s.runTerraformInit(component, terraformVars, scopedKeys, terraformArgs, defaultInitFlags...); err != nil {
 		return err
 	}
 
 	terraformCommand := s.runtime.ToolsManager.GetTerraformCommand()
 	planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan", "-json", "-no-color"}
 	planArgs = append(planArgs, terraformArgs.PlanArgs...)
-	planEnv := selectTerraformCommandEnv(terraformVars, true)
+	planEnv := selectTerraformCommandEnv(terraformVars, true, scopedKeys)
 	planOutput, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, planEnv, planArgs...)
 	if err != nil {
 		return fmt.Errorf("error running terraform plan for %s: %w", component.Path, err)
@@ -821,7 +821,7 @@ func (s *TerraformStack) Apply(blueprint *blueprintv1alpha1.Blueprint, component
 		return fmt.Errorf("component ID not provided")
 	}
 
-	component, terraformVars, terraformArgs, cleanup, err := s.prepareComponentOp(blueprint, componentID)
+	component, terraformVars, scopedKeys, terraformArgs, cleanup, err := s.prepareComponentOp(blueprint, componentID)
 	if err != nil {
 		return err
 	}
@@ -829,25 +829,25 @@ func (s *TerraformStack) Apply(blueprint *blueprintv1alpha1.Blueprint, component
 	terraformVars["TF_VAR_operation"] = "apply"
 
 	return tui.WithProgress(fmt.Sprintf("Applying %s", component.Path), func() error {
-		if err := s.runTerraformInit(component, terraformVars, terraformArgs, defaultInitFlags...); err != nil {
+		if err := s.runTerraformInit(component, terraformVars, scopedKeys, terraformArgs, defaultInitFlags...); err != nil {
 			return err
 		}
 
-		if err := s.refreshIfStateNonEmpty(component, terraformVars, terraformArgs); err != nil {
+		if err := s.refreshIfStateNonEmpty(component, terraformVars, scopedKeys, terraformArgs); err != nil {
 			return err
 		}
 
 		terraformCommand := s.runtime.ToolsManager.GetTerraformCommand()
 		planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan", "-refresh=false"}
 		planArgs = append(planArgs, terraformArgs.PlanArgs...)
-		planEnv := selectTerraformCommandEnv(terraformVars, true)
+		planEnv := selectTerraformCommandEnv(terraformVars, true, scopedKeys)
 		if _, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, planEnv, planArgs...); err != nil {
 			return fmt.Errorf("error running terraform plan for %s: %w", component.Path, err)
 		}
 
 		applyArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "apply"}
 		applyArgs = append(applyArgs, terraformArgs.ApplyArgs...)
-		applyEnv := selectTerraformCommandEnv(terraformVars, false)
+		applyEnv := selectTerraformCommandEnv(terraformVars, false, scopedKeys)
 		if _, err := s.runtime.Shell.ExecProgressWithEnv(fmt.Sprintf("Applying Terraform changes in %s", component.Path), terraformCommand, applyEnv, applyArgs...); err != nil {
 			return fmt.Errorf("error running terraform apply for %s: %w", component.Path, err)
 		}
@@ -877,7 +877,7 @@ func (s *TerraformStack) Destroy(blueprint *blueprintv1alpha1.Blueprint, compone
 		return false, fmt.Errorf("component ID not provided")
 	}
 
-	component, terraformVars, terraformArgs, cleanup, err := s.prepareComponentOp(blueprint, componentID)
+	component, terraformVars, scopedKeys, terraformArgs, cleanup, err := s.prepareComponentOp(blueprint, componentID)
 	if err != nil {
 		return false, err
 	}
@@ -887,11 +887,11 @@ func (s *TerraformStack) Destroy(blueprint *blueprintv1alpha1.Blueprint, compone
 
 	skipped := false
 	if err := tui.WithProgress(fmt.Sprintf("Destroying %s", component.Path), func() error {
-		if err := s.runTerraformInit(component, terraformVars, terraformArgs, defaultInitFlags...); err != nil {
+		if err := s.runTerraformInit(component, terraformVars, scopedKeys, terraformArgs, defaultInitFlags...); err != nil {
 			return err
 		}
 
-		hasResourcesPre, err := s.hasStateResources(component, terraformVars)
+		hasResourcesPre, err := s.hasStateResources(component, terraformVars, scopedKeys)
 		if err != nil {
 			return err
 		}
@@ -901,13 +901,13 @@ func (s *TerraformStack) Destroy(blueprint *blueprintv1alpha1.Blueprint, compone
 		}
 
 		refreshFailed := false
-		if err := s.refreshComponentState(component, terraformVars, terraformArgs); err != nil {
+		if err := s.refreshComponentState(component, terraformVars, scopedKeys, terraformArgs); err != nil {
 			refreshFailed = true
 			fmt.Fprintf(s.warningWriter, "warning: terraform refresh failed for %s; falling through to destroy -refresh=true (terraform will retry refresh during destroy): %v\n", component.Path, err)
 		}
 
 		if !refreshFailed {
-			hasResources, err := s.hasStateResources(component, terraformVars)
+			hasResources, err := s.hasStateResources(component, terraformVars, scopedKeys)
 			if err != nil {
 				return err
 			}
@@ -924,7 +924,7 @@ func (s *TerraformStack) Destroy(blueprint *blueprintv1alpha1.Blueprint, compone
 		}
 		destroyArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "destroy", destroyRefreshFlag}
 		destroyArgs = append(destroyArgs, terraformArgs.DestroyArgs...)
-		destroyEnv := selectTerraformCommandEnv(terraformVars, true)
+		destroyEnv := selectTerraformCommandEnv(terraformVars, true, scopedKeys)
 
 		output, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, destroyEnv, destroyArgs...)
 		if err != nil {
@@ -1087,7 +1087,7 @@ func (s *TerraformStack) migrateOneComponent(component *blueprintv1alpha1.Terraf
 		return false, fmt.Errorf("error checking component directory %s: %w", component.FullPath, statErr)
 	}
 
-	terraformVars, terraformArgs, err := s.setupTerraformEnvironment(*component)
+	terraformVars, scopedKeys, terraformArgs, err := s.setupTerraformEnvironment(*component)
 	backendOverridePath := filepath.Join(component.FullPath, "backend_override.tf")
 	if _, statErr := s.shims.Stat(backendOverridePath); statErr == nil {
 		*backendOverridePaths = append(*backendOverridePaths, backendOverridePath)
@@ -1096,7 +1096,7 @@ func (s *TerraformStack) migrateOneComponent(component *blueprintv1alpha1.Terraf
 		return false, err
 	}
 
-	if err := s.runTerraformInit(component, terraformVars, terraformArgs, "-migrate-state", "-force-copy"); err != nil {
+	if err := s.runTerraformInit(component, terraformVars, scopedKeys, terraformArgs, "-migrate-state", "-force-copy"); err != nil {
 		return false, err
 	}
 	return true, nil
@@ -1136,13 +1136,13 @@ func (s *TerraformStack) planComponents(blueprint *blueprintv1alpha1.Blueprint, 
 
 		fmt.Fprintf(os.Stderr, "\n%s\n", tui.SectionHeader("Terraform: "+component.Path))
 
-		terraformVars, terraformArgs, cleanup, err := s.prepareComponentEnv(component)
+		terraformVars, scopedKeys, terraformArgs, cleanup, err := s.prepareComponentEnv(component)
 		if err != nil {
 			return err
 		}
 		terraformVars["TF_VAR_operation"] = "apply"
 
-		if err := s.runTerraformInit(component, terraformVars, terraformArgs, defaultInitFlags...); err != nil {
+		if err := s.runTerraformInit(component, terraformVars, scopedKeys, terraformArgs, defaultInitFlags...); err != nil {
 			cleanup()
 			return err
 		}
@@ -1153,7 +1153,7 @@ func (s *TerraformStack) planComponents(blueprint *blueprintv1alpha1.Blueprint, 
 			planArgs = append(planArgs, "-json", "-no-color")
 		}
 		planArgs = append(planArgs, terraformArgs.PlanArgs...)
-		planEnv := selectTerraformCommandEnv(terraformVars, true)
+		planEnv := selectTerraformCommandEnv(terraformVars, true, scopedKeys)
 		planOutput, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, planEnv, planArgs...)
 		cleanup()
 		if err != nil {
@@ -1176,15 +1176,15 @@ func (s *TerraformStack) planComponents(blueprint *blueprintv1alpha1.Blueprint, 
 // itself failing is propagated; callers can't safely proceed without knowing whether state is
 // empty. Used by Up and Apply; Destroy retains its own refresh handling because its fallback
 // (-refresh=true on destroy) is destroy-specific.
-func (s *TerraformStack) refreshIfStateNonEmpty(component *blueprintv1alpha1.TerraformComponent, terraformVars map[string]string, terraformArgs *envvars.TerraformArgs) error {
-	hasResources, err := s.hasStateResources(component, terraformVars)
+func (s *TerraformStack) refreshIfStateNonEmpty(component *blueprintv1alpha1.TerraformComponent, terraformVars map[string]string, scopedKeys []string, terraformArgs *envvars.TerraformArgs) error {
+	hasResources, err := s.hasStateResources(component, terraformVars, scopedKeys)
 	if err != nil {
 		return err
 	}
 	if !hasResources {
 		return nil
 	}
-	if err := s.refreshComponentState(component, terraformVars, terraformArgs); err != nil {
+	if err := s.refreshComponentState(component, terraformVars, scopedKeys, terraformArgs); err != nil {
 		fmt.Fprintf(s.warningWriter, "warning: terraform refresh failed for %s; continuing with plan against the last-known state (plan runs with -refresh=false; any persistent state divergence will surface as a plan error): %v\n", component.Path, err)
 	}
 	return nil
@@ -1194,11 +1194,11 @@ func (s *TerraformStack) refreshIfStateNonEmpty(component *blueprintv1alpha1.Ter
 // Errors are returned to the caller. Destroy callers tolerate refresh failures for non-
 // empty-state components by falling through to `terraform destroy -refresh=true`; see
 // Destroy / DestroyAll for the rationale.
-func (s *TerraformStack) refreshComponentState(component *blueprintv1alpha1.TerraformComponent, terraformVars map[string]string, terraformArgs *envvars.TerraformArgs) error {
+func (s *TerraformStack) refreshComponentState(component *blueprintv1alpha1.TerraformComponent, terraformVars map[string]string, scopedKeys []string, terraformArgs *envvars.TerraformArgs) error {
 	terraformCommand := s.runtime.ToolsManager.GetTerraformCommand()
 	refreshArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "refresh"}
 	refreshArgs = append(refreshArgs, terraformArgs.RefreshArgs...)
-	refreshEnv := selectTerraformCommandEnv(terraformVars, true)
+	refreshEnv := selectTerraformCommandEnv(terraformVars, true, scopedKeys)
 	if _, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, refreshEnv, refreshArgs...); err != nil {
 		return fmt.Errorf("error refreshing terraform state for %s: %w", component.Path, err)
 	}
@@ -1240,10 +1240,10 @@ func (s *TerraformStack) clearBackendPointer(terraformVars map[string]string) {
 // depth in the module tree. Used by destroy to short-circuit already-destroyed components,
 // and by plan to classify never-applied components as IsNew (so plan is skipped rather than
 // running against empty state, which fails when dependent layers reference upstream state).
-func (s *TerraformStack) hasStateResources(component *blueprintv1alpha1.TerraformComponent, terraformVars map[string]string) (bool, error) {
+func (s *TerraformStack) hasStateResources(component *blueprintv1alpha1.TerraformComponent, terraformVars map[string]string, scopedKeys []string) (bool, error) {
 	terraformCommand := s.runtime.ToolsManager.GetTerraformCommand()
 	stateShowArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "show", "-json"}
-	stateJSON, err := s.runtime.Shell.ExecCaptureWithEnv(terraformCommand, selectTerraformCommandEnv(terraformVars, true), stateShowArgs...)
+	stateJSON, err := s.runtime.Shell.ExecCaptureWithEnv(terraformCommand, selectTerraformCommandEnv(terraformVars, true, scopedKeys), stateShowArgs...)
 	if err != nil {
 		return false, fmt.Errorf("error reading terraform state JSON for %s: %w", component.Path, err)
 	}
@@ -1350,7 +1350,7 @@ func (s *TerraformStack) resolveComponentPaths(blueprint *blueprintv1alpha1.Blue
 func (s *TerraformStack) planOneTerraformSummary(component *blueprintv1alpha1.TerraformComponent) TerraformComponentPlan {
 	result := TerraformComponentPlan{ComponentID: component.GetID(), Path: component.Path}
 
-	terraformVars, terraformArgs, cleanup, err := s.prepareComponentEnv(component)
+	terraformVars, scopedKeys, terraformArgs, cleanup, err := s.prepareComponentEnv(component)
 	if err != nil {
 		result.Err = err
 		return result
@@ -1358,12 +1358,12 @@ func (s *TerraformStack) planOneTerraformSummary(component *blueprintv1alpha1.Te
 	defer cleanup()
 	terraformVars["TF_VAR_operation"] = "apply"
 
-	if err := s.runTerraformInit(component, terraformVars, terraformArgs, defaultInitFlags...); err != nil {
+	if err := s.runTerraformInit(component, terraformVars, scopedKeys, terraformArgs, defaultInitFlags...); err != nil {
 		result.Err = err
 		return result
 	}
 
-	hasState, err := s.hasStateResources(component, terraformVars)
+	hasState, err := s.hasStateResources(component, terraformVars, scopedKeys)
 	if err != nil {
 		result.Err = err
 		return result
@@ -1379,7 +1379,7 @@ func (s *TerraformStack) planOneTerraformSummary(component *blueprintv1alpha1.Te
 	// is required by terraform alongside -json.
 	planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan", "-json", "-no-color"}
 	planArgs = append(planArgs, terraformArgs.PlanArgs...)
-	planEnv := selectTerraformCommandEnv(terraformVars, true)
+	planEnv := selectTerraformCommandEnv(terraformVars, true, scopedKeys)
 	planOutput, err := s.runtime.Shell.ExecCaptureWithEnv(terraformCommand, planEnv, planArgs...)
 	if err != nil {
 		result.Err = fmt.Errorf("error running terraform plan for %s: %w", component.Path, err)
@@ -1407,7 +1407,7 @@ func (s *TerraformStack) planOneTerraformSummary(component *blueprintv1alpha1.Te
 func (s *TerraformStack) planOneTerraformDestroySummary(component *blueprintv1alpha1.TerraformComponent) TerraformComponentPlan {
 	result := TerraformComponentPlan{ComponentID: component.GetID(), Path: component.Path}
 
-	terraformVars, terraformArgs, cleanup, err := s.prepareComponentEnv(component)
+	terraformVars, scopedKeys, terraformArgs, cleanup, err := s.prepareComponentEnv(component)
 	if err != nil {
 		result.Err = err
 		return result
@@ -1415,12 +1415,12 @@ func (s *TerraformStack) planOneTerraformDestroySummary(component *blueprintv1al
 	defer cleanup()
 	terraformVars["TF_VAR_operation"] = "destroy"
 
-	if err := s.runTerraformInit(component, terraformVars, terraformArgs, defaultInitFlags...); err != nil {
+	if err := s.runTerraformInit(component, terraformVars, scopedKeys, terraformArgs, defaultInitFlags...); err != nil {
 		result.Err = err
 		return result
 	}
 
-	hasState, err := s.hasStateResources(component, terraformVars)
+	hasState, err := s.hasStateResources(component, terraformVars, scopedKeys)
 	if err != nil {
 		result.Err = err
 		return result
@@ -1433,7 +1433,7 @@ func (s *TerraformStack) planOneTerraformDestroySummary(component *blueprintv1al
 	terraformCommand := s.runtime.ToolsManager.GetTerraformCommand()
 	planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan", "-json", "-no-color"}
 	planArgs = append(planArgs, terraformArgs.PlanDestroyArgs...)
-	planEnv := selectTerraformCommandEnv(terraformVars, true)
+	planEnv := selectTerraformCommandEnv(terraformVars, true, scopedKeys)
 	planOutput, err := s.runtime.Shell.ExecCaptureWithEnv(terraformCommand, planEnv, planArgs...)
 	// terraform exits non-zero when any resource has prevent_destroy = true,
 	// but still emits the diagnostic events naming them. Look for those addresses
@@ -1478,15 +1478,16 @@ func componentDestroyEnabled(component *blueprintv1alpha1.TerraformComponent) bo
 // prepareComponentEnv saves the current directory, validates the component's directory exists,
 // sets up the terraform environment, and returns a cleanup func that restores the working directory
 // and removes any backend_override.tf. It is the shared setup used by planComponents,
-// planOneTerraformSummary, and prepareComponentOp.
-func (s *TerraformStack) prepareComponentEnv(component *blueprintv1alpha1.TerraformComponent) (map[string]string, *envvars.TerraformArgs, func(), error) {
+// planOneTerraformSummary, and prepareComponentOp. scopedKeys names the
+// contexts/<context>/terraform/.env keys selectTerraformCommandEnv must pass through.
+func (s *TerraformStack) prepareComponentEnv(component *blueprintv1alpha1.TerraformComponent) (map[string]string, []string, *envvars.TerraformArgs, func(), error) {
 	currentDir, err := s.shims.Getwd()
 	if err != nil {
-		return nil, nil, func() {}, fmt.Errorf("error getting current directory: %w", err)
+		return nil, nil, nil, func() {}, fmt.Errorf("error getting current directory: %w", err)
 	}
 
 	if _, err := s.shims.Stat(component.FullPath); os.IsNotExist(err) {
-		return nil, nil, func() {}, fmt.Errorf("directory %s does not exist", component.FullPath)
+		return nil, nil, nil, func() {}, fmt.Errorf("directory %s does not exist", component.FullPath)
 	}
 
 	removeBackendOverride := func() {
@@ -1496,10 +1497,10 @@ func (s *TerraformStack) prepareComponentEnv(component *blueprintv1alpha1.Terraf
 		}
 	}
 
-	terraformVars, terraformArgs, err := s.setupTerraformEnvironment(*component)
+	terraformVars, scopedKeys, terraformArgs, err := s.setupTerraformEnvironment(*component)
 	if err != nil {
 		removeBackendOverride()
-		return nil, nil, func() {}, err
+		return nil, nil, nil, func() {}, err
 	}
 
 	cleanup := func() {
@@ -1507,7 +1508,7 @@ func (s *TerraformStack) prepareComponentEnv(component *blueprintv1alpha1.Terraf
 		removeBackendOverride()
 	}
 
-	return terraformVars, terraformArgs, cleanup, nil
+	return terraformVars, scopedKeys, terraformArgs, cleanup, nil
 }
 
 // prepareComponentOp validates inputs, resolves the named component from the blueprint, saves/restores
@@ -1516,13 +1517,14 @@ func (s *TerraformStack) prepareComponentEnv(component *blueprintv1alpha1.Terraf
 func (s *TerraformStack) prepareComponentOp(blueprint *blueprintv1alpha1.Blueprint, componentID string) (
 	*blueprintv1alpha1.TerraformComponent,
 	map[string]string,
+	[]string,
 	*envvars.TerraformArgs,
 	func(),
 	error,
 ) {
 	projectRoot := s.runtime.ProjectRoot
 	if projectRoot == "" {
-		return nil, nil, nil, func() {}, fmt.Errorf("error getting project root: project root is empty")
+		return nil, nil, nil, nil, func() {}, fmt.Errorf("error getting project root: project root is empty")
 	}
 
 	components := s.resolveTerraformComponents(blueprint, projectRoot)
@@ -1534,15 +1536,15 @@ func (s *TerraformStack) prepareComponentOp(blueprint *blueprintv1alpha1.Bluepri
 		}
 	}
 	if component == nil {
-		return nil, nil, nil, func() {}, fmt.Errorf("terraform component %q not found", componentID)
+		return nil, nil, nil, nil, func() {}, fmt.Errorf("terraform component %q not found", componentID)
 	}
 
-	terraformVars, terraformArgs, cleanup, err := s.prepareComponentEnv(component)
+	terraformVars, scopedKeys, terraformArgs, cleanup, err := s.prepareComponentEnv(component)
 	if err != nil {
-		return nil, nil, nil, func() {}, err
+		return nil, nil, nil, nil, func() {}, err
 	}
 
-	return component, terraformVars, terraformArgs, cleanup, nil
+	return component, terraformVars, scopedKeys, terraformArgs, cleanup, nil
 }
 
 // runTerraformInit executes terraform init for the given component, inserting
@@ -1552,7 +1554,7 @@ func (s *TerraformStack) prepareComponentOp(blueprint *blueprintv1alpha1.Bluepri
 // cached. On cache miss without -migrate-state, clearStaleBackendPointer
 // drops a stale pointer file before init runs. Dedup assumes sequential
 // callers; parallel iteration would need per-key sync.Once.
-func (s *TerraformStack) runTerraformInit(component *blueprintv1alpha1.TerraformComponent, terraformVars map[string]string, terraformArgs *envvars.TerraformArgs, extraFlags ...string) error {
+func (s *TerraformStack) runTerraformInit(component *blueprintv1alpha1.TerraformComponent, terraformVars map[string]string, scopedKeys []string, terraformArgs *envvars.TerraformArgs, extraFlags ...string) error {
 	migrateState := slices.Contains(extraFlags, "-migrate-state")
 	key := initCacheKey{
 		componentID:  component.GetID(),
@@ -1573,7 +1575,7 @@ func (s *TerraformStack) runTerraformInit(component *blueprintv1alpha1.Terraform
 	initArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "init"}
 	initArgs = append(initArgs, extraFlags...)
 	initArgs = append(initArgs, terraformArgs.InitArgs...)
-	initEnv := selectTerraformCommandEnv(terraformVars, false)
+	initEnv := selectTerraformCommandEnv(terraformVars, false, scopedKeys)
 	_, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, initEnv, initArgs...)
 	if err != nil {
 		return fmt.Errorf("error running terraform init for %s: %w", component.Path, err)
@@ -1635,22 +1637,30 @@ func (s *TerraformStack) clearStaleBackendPointer(terraformVars map[string]strin
 }
 
 // setupTerraformEnvironment computes Terraform-specific environment values and args for a component.
-func (s *TerraformStack) setupTerraformEnvironment(component blueprintv1alpha1.TerraformComponent) (map[string]string, *envvars.TerraformArgs, error) {
+// setupTerraformEnvironment computes Terraform-specific environment values and args for a
+// component, plus the contexts/<context>/terraform/.env key names (scopedKeys) that
+// selectTerraformCommandEnv must pass through unconditionally regardless of includeTFVars.
+func (s *TerraformStack) setupTerraformEnvironment(component blueprintv1alpha1.TerraformComponent) (map[string]string, []string, *envvars.TerraformArgs, error) {
 	terraformEnv := s.getTerraformEnv()
 	if terraformEnv == nil {
-		return nil, nil, fmt.Errorf("terraform environment printer not available")
+		return nil, nil, nil, fmt.Errorf("terraform environment printer not available")
 	}
 
 	terraformVars, terraformArgs, err := s.runtime.TerraformProvider.GetEnvVars(component.GetID(), false)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error getting terraform env vars: %w", err)
+		return nil, nil, nil, fmt.Errorf("error getting terraform env vars: %w", err)
+	}
+
+	scopedKeys, err := s.runtime.TerraformProvider.TerraformScopedEnvKeys()
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("error getting terraform-scoped env keys: %w", err)
 	}
 
 	if err := terraformEnv.PostEnvHook(component.FullPath); err != nil {
-		return nil, nil, fmt.Errorf("error creating backend override file for %s: %w", component.Path, err)
+		return nil, nil, nil, fmt.Errorf("error creating backend override file for %s: %w", component.Path, err)
 	}
 
-	return terraformVars, terraformArgs, nil
+	return terraformVars, scopedKeys, terraformArgs, nil
 }
 
 // getTerraformEnv returns the terraform environment printer, checking the runtime if not set on the stack.
@@ -1837,8 +1847,14 @@ func stripModuleMain(addr string) string {
 	return strings.TrimPrefix(addr, "module.main.")
 }
 
-// selectTerraformCommandEnv builds per-command env overrides without mutating process-wide environment.
-func selectTerraformCommandEnv(terraformVars map[string]string, includeTFVars bool) map[string]string {
+// selectTerraformCommandEnv builds per-command env overrides without mutating process-wide
+// environment. TF_CLI_ARGS_* always reset to blank; TF_DATA_DIR and, when includeTFVars is
+// true, TF_VAR_* pass through from terraformVars. scopedKeys names the additional keys to pass
+// through unconditionally (contexts/<context>/terraform/.env content — see
+// TerraformProvider.TerraformScopedEnvKeys): provider credentials are needed on every terraform
+// invocation regardless of includeTFVars. Any other key in terraformVars is dropped, preserving
+// isolation from unrelated process state.
+func selectTerraformCommandEnv(terraformVars map[string]string, includeTFVars bool, scopedKeys []string) map[string]string {
 	selected := make(map[string]string)
 	for _, key := range []string{
 		"TF_CLI_ARGS",
@@ -1856,6 +1872,11 @@ func selectTerraformCommandEnv(terraformVars map[string]string, includeTFVars bo
 			selected[key] = value
 		}
 		if includeTFVars && strings.HasPrefix(key, "TF_VAR_") {
+			selected[key] = value
+		}
+	}
+	for _, key := range scopedKeys {
+		if value, exists := terraformVars[key]; exists {
 			selected[key] = value
 		}
 	}

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -1646,14 +1646,9 @@ func (s *TerraformStack) setupTerraformEnvironment(component blueprintv1alpha1.T
 		return nil, nil, nil, fmt.Errorf("terraform environment printer not available")
 	}
 
-	terraformVars, terraformArgs, err := s.runtime.TerraformProvider.GetEnvVars(component.GetID(), false)
+	terraformVars, scopedKeys, terraformArgs, err := s.runtime.TerraformProvider.GetEnvVars(component.GetID(), false)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("error getting terraform env vars: %w", err)
-	}
-
-	scopedKeys, err := s.runtime.TerraformProvider.TerraformScopedEnvKeys()
-	if err != nil {
-		return nil, nil, nil, fmt.Errorf("error getting terraform-scoped env keys: %w", err)
 	}
 
 	if err := terraformEnv.PostEnvHook(component.FullPath); err != nil {

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -2017,7 +2017,7 @@ func TestTerraformStack_setupTerraformEnvironment(t *testing.T) {
 			_ = os.Unsetenv("TF_VAR_talos_version")
 		}()
 
-		terraformVars, terraformArgs, err := stack.setupTerraformEnvironment(component)
+		terraformVars, _, terraformArgs, err := stack.setupTerraformEnvironment(component)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
@@ -2046,7 +2046,7 @@ func TestTerraformStack_setupTerraformEnvironment(t *testing.T) {
 			FullPath: filepath.Join(os.Getenv("WINDSOR_PROJECT_ROOT"), "terraform", "test", "path"),
 		}
 
-		_, _, err := stack.setupTerraformEnvironment(component)
+		_, _, _, err := stack.setupTerraformEnvironment(component)
 		if err == nil {
 			t.Fatal("Expected error when terraformEnv is nil")
 		}
@@ -2066,7 +2066,7 @@ func TestTerraformStack_setupTerraformEnvironment(t *testing.T) {
 
 		mocks.ConfigHandler.Set("terraform.backend.type", "unsupported")
 
-		_, _, err := stack.setupTerraformEnvironment(component)
+		_, _, _, err := stack.setupTerraformEnvironment(component)
 		if err == nil {
 			t.Fatal("Expected error when GenerateTerraformArgs fails")
 		}
@@ -2082,7 +2082,7 @@ func TestTerraformStack_setupTerraformEnvironment(t *testing.T) {
 			"TF_DATA_DIR":         "/tmp/data",
 			"TF_VAR_context_path": "/tmp/context",
 			"OTHER":               "ignored",
-		}, false)
+		}, false, nil)
 
 		if selected["TF_DATA_DIR"] != "/tmp/data" {
 			t.Error("Expected TF_DATA_DIR to be included")
@@ -2091,7 +2091,7 @@ func TestTerraformStack_setupTerraformEnvironment(t *testing.T) {
 			t.Error("Expected TF_VAR_context_path to be omitted when includeTFVars is false")
 		}
 		if _, ok := selected["OTHER"]; ok {
-			t.Error("Expected non-TF keys to be omitted")
+			t.Error("Expected keys not named in scopedKeys to be omitted")
 		}
 		if val, ok := selected["TF_CLI_ARGS_apply"]; !ok || val != "" {
 			t.Error("Expected TF_CLI_ARGS_apply to be explicitly cleared")
@@ -2105,9 +2105,31 @@ func TestTerraformStack_setupTerraformEnvironment(t *testing.T) {
 		selected := selectTerraformCommandEnv(map[string]string{
 			"TF_DATA_DIR":         "/tmp/data",
 			"TF_VAR_context_path": "/tmp/context",
-		}, true)
+		}, true, nil)
 		if selected["TF_VAR_context_path"] == "" {
 			t.Error("Expected TF_VAR_context_path to be included when includeTFVars is true")
+		}
+	})
+
+	t.Run("SelectCommandEnvPassesThroughScopedKeysRegardlessOfIncludeTFVars", func(t *testing.T) {
+		// Given a terraform-scoped key (e.g. from contexts/<ctx>/terraform/.env) and an
+		// unrelated key that was never declared as scoped
+		terraformVars := map[string]string{
+			"TF_DATA_DIR": "/tmp/data",
+			"HYPERV_HOST": "hyperv.local",
+			"UNRELATED":   "should-not-leak",
+		}
+
+		// When selecting the command env with includeTFVars false (e.g. init/apply)
+		selected := selectTerraformCommandEnv(terraformVars, false, []string{"HYPERV_HOST"})
+
+		// Then the scoped key passes through regardless of includeTFVars
+		if selected["HYPERV_HOST"] != "hyperv.local" {
+			t.Error("Expected HYPERV_HOST to pass through as a declared scoped key")
+		}
+		// And an unrelated key not named in scopedKeys is still dropped
+		if _, ok := selected["UNRELATED"]; ok {
+			t.Error("Expected UNRELATED to be omitted since it isn't in scopedKeys")
 		}
 	})
 }
@@ -2556,6 +2578,52 @@ func TestStack_Apply(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "project root is empty") {
 			t.Errorf("Expected project root error, got: %v", err)
+		}
+	})
+
+	t.Run("TerraformScopedDotEnvValueReachesSubprocessExec", func(t *testing.T) {
+		// Given a contexts/<ctx>/terraform/.env file declaring a provider credential
+		stack, mocks := setup(t)
+		configRoot, err := mocks.ConfigHandler.GetConfigRoot()
+		if err != nil {
+			t.Fatalf("Failed to get config root: %v", err)
+		}
+		dotEnvDir := filepath.Join(configRoot, "terraform")
+		if err := os.MkdirAll(dotEnvDir, 0750); err != nil {
+			t.Fatalf("Failed to create terraform/.env directory: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(dotEnvDir, ".env"), []byte("HYPERV_HOST=hyperv.local\n"), 0600); err != nil {
+			t.Fatalf("Failed to write terraform/.env fixture: %v", err)
+		}
+		blueprint := createTestBlueprint()
+
+		var capturedEnvs []map[string]string
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			capturedEnvs = append(capturedEnvs, env)
+			if command == "terraform" && len(args) >= 3 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[]}}}`, nil
+			}
+			return "", nil
+		}
+		mocks.Shell.ExecProgressWithEnvFunc = func(message string, command string, env map[string]string, args ...string) (string, error) {
+			capturedEnvs = append(capturedEnvs, env)
+			return "", nil
+		}
+
+		// When applying the local component
+		if err := stack.Apply(blueprint, "local/path"); err != nil {
+			t.Fatalf("Expected Apply to return nil, got %v", err)
+		}
+
+		// Then every actual terraform subprocess invocation should have received the
+		// terraform/.env value — not just the in-process terraformVars map
+		if len(capturedEnvs) == 0 {
+			t.Fatal("Expected at least one captured subprocess env")
+		}
+		for i, env := range capturedEnvs {
+			if env["HYPERV_HOST"] != "hyperv.local" {
+				t.Errorf("Exec call %d: expected HYPERV_HOST=hyperv.local in subprocess env, got %v", i, env["HYPERV_HOST"])
+			}
 		}
 	})
 

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -1842,11 +1842,11 @@ func TestStack_DestroyAll(t *testing.T) {
 
 		// Inject a TerraformProvider whose GetEnvVars fails for "broken" only.
 		mocks.Runtime.TerraformProvider = &terraformRuntime.MockTerraformProvider{
-			GetEnvVarsFunc: func(componentID string, interactive bool) (map[string]string, *terraformRuntime.TerraformArgs, error) {
+			GetEnvVarsFunc: func(componentID string, interactive bool) (map[string]string, []string, *terraformRuntime.TerraformArgs, error) {
 				if strings.Contains(componentID, "broken") {
-					return nil, nil, fmt.Errorf("mock setup failure for %s", componentID)
+					return nil, nil, nil, fmt.Errorf("mock setup failure for %s", componentID)
 				}
-				return map[string]string{}, &terraformRuntime.TerraformArgs{}, nil
+				return map[string]string{}, nil, &terraformRuntime.TerraformArgs{}, nil
 			},
 		}
 
@@ -3122,8 +3122,8 @@ func TestStack_Destroy(t *testing.T) {
 		// Given a stack whose provider returns RefreshArgs containing a var-file flag
 		stack, mocks := setup(t)
 		mocks.Runtime.TerraformProvider = &terraformRuntime.MockTerraformProvider{
-			GetEnvVarsFunc: func(componentID string, interactive bool) (map[string]string, *terraformRuntime.TerraformArgs, error) {
-				return map[string]string{}, &terraformRuntime.TerraformArgs{
+			GetEnvVarsFunc: func(componentID string, interactive bool) (map[string]string, []string, *terraformRuntime.TerraformArgs, error) {
+				return map[string]string{}, nil, &terraformRuntime.TerraformArgs{
 					RefreshArgs: []string{"-var-file=secrets.tfvars"},
 				}, nil
 			},

--- a/pkg/runtime/dotenv/dotenv.go
+++ b/pkg/runtime/dotenv/dotenv.go
@@ -1,0 +1,81 @@
+// The dotenv package provides shared, dependency-light helpers for loading standard
+// dotenv-format files. It parses KEY=VALUE content, resolves ${...} expressions through
+// an injected evaluator, and implements the NO_CACHE-gated reuse rule so a fresh shell
+// session doesn't re-pay resolution cost.
+
+package dotenv
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/windsorcli/cli/pkg/runtime/evaluator"
+)
+
+// =============================================================================
+// Public Methods
+// =============================================================================
+
+// Parse parses standard dotenv content (KEY=VALUE lines, # comments, blank
+// lines) into a map. Lines without a top-level "=" are skipped silently.
+func Parse(content string) map[string]string {
+	result := make(map[string]string)
+
+	for line := range strings.SplitSeq(content, "\n") {
+		line = strings.TrimSpace(strings.TrimSuffix(line, "\r"))
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		key, value, found := strings.Cut(line, "=")
+		if !found {
+			continue
+		}
+
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+
+		result[key] = strings.TrimSpace(value)
+	}
+
+	return result
+}
+
+// ShouldUseCache reports whether a cached value should be reused rather than
+// re-evaluated, based on the NO_CACHE environment variable (read via lookupEnv).
+// Cache is enabled by default and disabled by setting NO_CACHE=1 or NO_CACHE=true.
+func ShouldUseCache(lookupEnv func(string) (string, bool)) bool {
+	noCache, _ := lookupEnv("NO_CACHE")
+	return noCache == "" || noCache == "0" || noCache == "false" || noCache == "False"
+}
+
+// EvaluateExpressionValue evaluates value through eval with deferred evaluation
+// enabled so secrets resolve immediately. Formats a resolution error inline as
+// "<ERROR: ...>" and normalizes a nil result to the empty string.
+func EvaluateExpressionValue(eval evaluator.ExpressionEvaluator, value string) string {
+	result, err := eval.Evaluate(value, "", nil, true)
+	if err != nil {
+		return fmt.Sprintf("<ERROR: %s>", err)
+	}
+	if result == nil {
+		return ""
+	}
+	return fmt.Sprint(result)
+}
+
+// WarnOnLoosePermissions writes a non-fatal warning to w when path's mode is
+// group- or world-accessible rather than restricted to the owner (0600-equivalent).
+// A no-op when goos is "windows": NTFS has no owner/group/other model, so FileMode
+// bits there don't reflect real ACL restrictiveness and chmod has no equivalent.
+func WarnOnLoosePermissions(w io.Writer, goos, path string, mode os.FileMode) {
+	if goos == "windows" {
+		return
+	}
+	if mode.Perm()&0077 != 0 {
+		fmt.Fprintf(w, "\033[33mWarning: %s is readable by group/other; it may contain credentials. Consider running: chmod 600 %s\033[0m\n", path, path)
+	}
+}

--- a/pkg/runtime/dotenv/dotenv_test.go
+++ b/pkg/runtime/dotenv/dotenv_test.go
@@ -1,0 +1,194 @@
+package dotenv
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/windsorcli/cli/pkg/runtime/evaluator"
+)
+
+// =============================================================================
+// Test Public Methods
+// =============================================================================
+
+func TestParse(t *testing.T) {
+	t.Run("ParsesPlainKeyValuePairs", func(t *testing.T) {
+		// Given standard dotenv content
+		content := "HYPERV_USER=admin\nHYPERV_HOST=hyperv.local\n"
+
+		// When Parse is called
+		result := Parse(content)
+
+		// Then both keys should be present
+		if result["HYPERV_USER"] != "admin" {
+			t.Errorf("Expected HYPERV_USER=admin, got %q", result["HYPERV_USER"])
+		}
+		if result["HYPERV_HOST"] != "hyperv.local" {
+			t.Errorf("Expected HYPERV_HOST=hyperv.local, got %q", result["HYPERV_HOST"])
+		}
+	})
+
+	t.Run("SkipsCommentsBlankLinesAndMalformedLines", func(t *testing.T) {
+		// Given content with comments, blank lines, and a malformed line
+		content := "# a comment\n\nVALID=yes\nNOEQUALSIGN\n"
+
+		// When Parse is called
+		result := Parse(content)
+
+		// Then only the valid key should be present
+		if len(result) != 1 || result["VALID"] != "yes" {
+			t.Errorf("Expected only VALID=yes, got %v", result)
+		}
+	})
+
+	t.Run("TrimsWhitespaceAroundKeysAndValues", func(t *testing.T) {
+		// Given content with surrounding whitespace
+		content := "  SPACED_KEY  =  spaced value  \n"
+
+		// When Parse is called
+		result := Parse(content)
+
+		// Then the key and value should be trimmed
+		if _, exists := result["SPACED_KEY"]; !exists {
+			t.Fatalf("Expected SPACED_KEY to be present, got %v", result)
+		}
+		if result["SPACED_KEY"] != "spaced value" {
+			t.Errorf("Expected trimmed value 'spaced value', got %q", result["SPACED_KEY"])
+		}
+	})
+}
+
+func TestShouldUseCache(t *testing.T) {
+	t.Run("TrueWhenUnset", func(t *testing.T) {
+		// Given NO_CACHE is unset
+		lookupEnv := func(string) (string, bool) { return "", false }
+
+		// When ShouldUseCache is called
+		result := ShouldUseCache(lookupEnv)
+
+		// Then it should return true
+		if !result {
+			t.Error("Expected true when NO_CACHE is unset")
+		}
+	})
+
+	t.Run("TrueWhenZero", func(t *testing.T) {
+		// Given NO_CACHE is "0"
+		lookupEnv := func(string) (string, bool) { return "0", true }
+
+		// When ShouldUseCache is called
+		result := ShouldUseCache(lookupEnv)
+
+		// Then it should return true
+		if !result {
+			t.Error("Expected true when NO_CACHE=0")
+		}
+	})
+
+	t.Run("FalseWhenOne", func(t *testing.T) {
+		// Given NO_CACHE is "1"
+		lookupEnv := func(string) (string, bool) { return "1", true }
+
+		// When ShouldUseCache is called
+		result := ShouldUseCache(lookupEnv)
+
+		// Then it should return false
+		if result {
+			t.Error("Expected false when NO_CACHE=1")
+		}
+	})
+}
+
+func TestEvaluateExpressionValue(t *testing.T) {
+	t.Run("ReturnsEvaluatedResult", func(t *testing.T) {
+		// Given an evaluator that resolves an expression
+		mockEval := evaluator.NewMockExpressionEvaluator()
+		mockEval.EvaluateFunc = func(expression string, facetPath string, scope map[string]any, evaluateDeferred bool) (any, error) {
+			return "resolved-value", nil
+		}
+
+		// When EvaluateExpressionValue is called
+		result := EvaluateExpressionValue(mockEval, `${secret("op://vault/item/field")}`)
+
+		// Then the resolved value should be returned
+		if result != "resolved-value" {
+			t.Errorf("Expected resolved-value, got %q", result)
+		}
+	})
+
+	t.Run("ReturnsErrorMarkerOnEvaluationError", func(t *testing.T) {
+		// Given an evaluator that fails
+		mockEval := evaluator.NewMockExpressionEvaluator()
+		mockEval.EvaluateFunc = func(expression string, facetPath string, scope map[string]any, evaluateDeferred bool) (any, error) {
+			return nil, fmt.Errorf("resolution failed")
+		}
+
+		// When EvaluateExpressionValue is called
+		result := EvaluateExpressionValue(mockEval, "${bad}")
+
+		// Then an inline error marker should be returned
+		if !strings.Contains(result, "<ERROR") {
+			t.Errorf("Expected an <ERROR marker, got %q", result)
+		}
+	})
+
+	t.Run("ReturnsEmptyStringForNilResult", func(t *testing.T) {
+		// Given an evaluator that resolves to nil
+		mockEval := evaluator.NewMockExpressionEvaluator()
+		mockEval.EvaluateFunc = func(expression string, facetPath string, scope map[string]any, evaluateDeferred bool) (any, error) {
+			return nil, nil
+		}
+
+		// When EvaluateExpressionValue is called
+		result := EvaluateExpressionValue(mockEval, "${nil_expr}")
+
+		// Then an empty string should be returned
+		if result != "" {
+			t.Errorf("Expected empty string, got %q", result)
+		}
+	})
+}
+
+func TestWarnOnLoosePermissions(t *testing.T) {
+	t.Run("WarnsOnLoosePermissionsOnNonWindows", func(t *testing.T) {
+		// Given a group/world-readable file on a POSIX-like OS
+		var buf bytes.Buffer
+
+		// When WarnOnLoosePermissions is called
+		WarnOnLoosePermissions(&buf, "linux", "/path/.env", os.FileMode(0644))
+
+		// Then a warning should be written
+		if !strings.Contains(buf.String(), "Warning") {
+			t.Errorf("Expected a warning, got %q", buf.String())
+		}
+	})
+
+	t.Run("NoWarningOnRestrictedPermissions", func(t *testing.T) {
+		// Given an owner-only file on a POSIX-like OS
+		var buf bytes.Buffer
+
+		// When WarnOnLoosePermissions is called
+		WarnOnLoosePermissions(&buf, "linux", "/path/.env", os.FileMode(0600))
+
+		// Then no warning should be written
+		if buf.String() != "" {
+			t.Errorf("Expected no warning, got %q", buf.String())
+		}
+	})
+
+	t.Run("NoWarningOnWindowsRegardlessOfPermissions", func(t *testing.T) {
+		// Given a file that would trip the check, on Windows
+		var buf bytes.Buffer
+
+		// When WarnOnLoosePermissions is called
+		WarnOnLoosePermissions(&buf, "windows", "/path/.env", os.FileMode(0644))
+
+		// Then no warning should be written
+		if buf.String() != "" {
+			t.Errorf("Expected no warning on Windows, got %q", buf.String())
+		}
+	})
+}

--- a/pkg/runtime/env/dotenv_env.go
+++ b/pkg/runtime/env/dotenv_env.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 
 	"github.com/windsorcli/cli/pkg/runtime/config"
+	"github.com/windsorcli/cli/pkg/runtime/dotenv"
 	"github.com/windsorcli/cli/pkg/runtime/evaluator"
 	"github.com/windsorcli/cli/pkg/runtime/secrets"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
@@ -89,7 +90,7 @@ func (e *DotEnvEnvPrinter) GetEnvVars() (map[string]string, error) {
 		return nil, fmt.Errorf("error reading %s: %w", dotEnvPath, err)
 	}
 
-	for k, v := range parseDotEnv(string(data)) {
+	for k, v := range dotenv.Parse(string(data)) {
 		e.SetManagedEnv(k)
 
 		normalizedValue := secrets.NormalizeLegacyBraces(v)
@@ -97,6 +98,7 @@ func (e *DotEnvEnvPrinter) GetEnvVars() (map[string]string, error) {
 		if e.evaluator != nil && evaluator.ContainsExpression(normalizedValue) {
 			if existingValue, exists := e.shims.LookupEnv(k); exists &&
 				e.shouldUseCache() && !strings.Contains(existingValue, "<ERROR") {
+				e.shell.RegisterSecret(existingValue)
 				continue
 			}
 			envVars[k] = evaluateExpressionValue(e.evaluator, normalizedValue)
@@ -118,43 +120,7 @@ func (e *DotEnvEnvPrinter) GetEnvVars() (map[string]string, error) {
 // A no-op on Windows: NTFS has no owner/group/other model, so Go's FileMode bits
 // there don't reflect real ACL restrictiveness and chmod has no equivalent.
 func (e *DotEnvEnvPrinter) warnOnLoosePermissions(path string, mode os.FileMode) {
-	if e.shims.Goos() == "windows" {
-		return
-	}
-	if mode.Perm()&0077 != 0 {
-		fmt.Fprintf(e.warningWriter, "\033[33mWarning: %s is readable by group/other; it may contain credentials. Consider running: chmod 600 %s\033[0m\n", path, path)
-	}
-}
-
-// =============================================================================
-// Helpers
-// =============================================================================
-
-// parseDotEnv parses standard dotenv content (KEY=VALUE lines, # comments, blank
-// lines) into a map. Lines without a top-level "=" are skipped silently.
-func parseDotEnv(content string) map[string]string {
-	result := make(map[string]string)
-
-	for line := range strings.SplitSeq(content, "\n") {
-		line = strings.TrimSpace(strings.TrimSuffix(line, "\r"))
-		if line == "" || strings.HasPrefix(line, "#") {
-			continue
-		}
-
-		key, value, found := strings.Cut(line, "=")
-		if !found {
-			continue
-		}
-
-		key = strings.TrimSpace(key)
-		if key == "" {
-			continue
-		}
-
-		result[key] = strings.TrimSpace(value)
-	}
-
-	return result
+	dotenv.WarnOnLoosePermissions(e.warningWriter, e.shims.Goos(), path, mode)
 }
 
 // =============================================================================

--- a/pkg/runtime/env/env.go
+++ b/pkg/runtime/env/env.go
@@ -6,10 +6,10 @@
 package env
 
 import (
-	"fmt"
 	"slices"
 
 	"github.com/windsorcli/cli/pkg/runtime/config"
+	"github.com/windsorcli/cli/pkg/runtime/dotenv"
 	"github.com/windsorcli/cli/pkg/runtime/evaluator"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
 )
@@ -119,8 +119,7 @@ func (e *BaseEnvPrinter) Reset() {
 // shouldUseCache determines if the cache should be used based on NO_CACHE environment variable.
 // Cache is enabled by default and can be disabled by setting NO_CACHE=1 or NO_CACHE=true.
 func (e *BaseEnvPrinter) shouldUseCache() bool {
-	noCache, _ := e.shims.LookupEnv("NO_CACHE")
-	return noCache == "" || noCache == "0" || noCache == "false" || noCache == "False"
+	return dotenv.ShouldUseCache(e.shims.LookupEnv)
 }
 
 // =============================================================================
@@ -131,12 +130,5 @@ func (e *BaseEnvPrinter) shouldUseCache() bool {
 // enabled so secrets resolve immediately. Formats a resolution error inline as
 // "<ERROR: ...>" and normalizes a nil result to the empty string.
 func evaluateExpressionValue(eval evaluator.ExpressionEvaluator, value string) string {
-	result, err := eval.Evaluate(value, "", nil, true)
-	if err != nil {
-		return fmt.Sprintf("<ERROR: %s>", err)
-	}
-	if result == nil {
-		return ""
-	}
-	return fmt.Sprint(result)
+	return dotenv.EvaluateExpressionValue(eval, value)
 }

--- a/pkg/runtime/env/terraform_env.go
+++ b/pkg/runtime/env/terraform_env.go
@@ -84,12 +84,12 @@ func (e *TerraformEnvPrinter) GetEnvVars() (map[string]string, error) {
 		return e.getEmptyEnvVars(), nil
 	}
 
-	terraformVars, _, err := e.terraformProvider.GetEnvVars(projectPath, true)
+	terraformVars, scopedKeys, _, err := e.terraformProvider.GetEnvVars(projectPath, true)
 	for key := range terraformVars {
 		e.SetManagedEnv(key)
 	}
 
-	if scopedKeys, keysErr := e.terraformProvider.TerraformScopedEnvKeys(); keysErr == nil && len(scopedKeys) > 0 {
+	if len(scopedKeys) > 0 {
 		if terraformVars == nil {
 			terraformVars = make(map[string]string)
 		}

--- a/pkg/runtime/env/terraform_env.go
+++ b/pkg/runtime/env/terraform_env.go
@@ -61,9 +61,18 @@ func NewTerraformEnvPrinter(shell shell.Shell, configHandler config.ConfigHandle
 // Public Methods
 // =============================================================================
 
+// terraformScopedEnvKeysVar is the managed env var recording which keys the current
+// contexts/<context>/terraform/.env last exported, so getEmptyEnvVars can unset exactly
+// those keys on a later invocation even if the file has since changed or been removed.
+const terraformScopedEnvKeysVar = "WINDSOR_MANAGED_TERRAFORM_ENV"
+
 // GetEnvVars returns a map of environment variables for Terraform operations.
-// If not in a Terraform project directory, it unsets managed TF_ variables present in the environment.
-// Otherwise, it generates Terraform arguments for the current project.
+// If not in a Terraform project directory, it unsets managed variables present in the environment.
+// Otherwise, it generates Terraform arguments for the current project, merged with any
+// contexts/<context>/terraform/.env content. Every returned key is tracked as managed so it
+// is unset cleanly when the operator leaves the directory; the terraform/.env key names are
+// additionally recorded in WINDSOR_MANAGED_TERRAFORM_ENV so getEmptyEnvVars can still unset
+// them later even if the file's contents change or the file is removed in the meantime.
 // Returns the environment variable map or an error if resolution fails.
 func (e *TerraformEnvPrinter) GetEnvVars() (map[string]string, error) {
 	projectPath, err := e.terraformProvider.FindRelativeProjectPath()
@@ -77,10 +86,17 @@ func (e *TerraformEnvPrinter) GetEnvVars() (map[string]string, error) {
 
 	terraformVars, _, err := e.terraformProvider.GetEnvVars(projectPath, true)
 	for key := range terraformVars {
-		if key == "TF_DATA_DIR" || strings.HasPrefix(key, "TF_CLI_ARGS_") || strings.HasPrefix(key, "TF_VAR_") {
-			e.SetManagedEnv(key)
-		}
+		e.SetManagedEnv(key)
 	}
+
+	if scopedKeys, keysErr := e.terraformProvider.TerraformScopedEnvKeys(); keysErr == nil && len(scopedKeys) > 0 {
+		if terraformVars == nil {
+			terraformVars = make(map[string]string)
+		}
+		terraformVars[terraformScopedEnvKeysVar] = strings.Join(scopedKeys, ",")
+		e.SetManagedEnv(terraformScopedEnvKeysVar)
+	}
+
 	return terraformVars, err
 }
 
@@ -119,7 +135,12 @@ func (e *TerraformEnvPrinter) restoreEnvVar(key, originalValue string) {
 	}
 }
 
-// getEmptyEnvVars returns env vars for unsetting managed variables when not in a terraform project.
+// getEmptyEnvVars returns env vars for unsetting managed variables when not in a terraform
+// project, including any keys the last-visited contexts/<context>/terraform/.env exported.
+// Those key names come from WINDSOR_MANAGED_TERRAFORM_ENV (recorded by GetEnvVars when the
+// keys were actually exported) rather than re-reading the current terraform/.env: the file
+// may have changed or been removed since, and re-reading it would miss keys it no longer
+// declares, leaking them in the shell indefinitely.
 func (e *TerraformEnvPrinter) getEmptyEnvVars() map[string]string {
 	envVars := make(map[string]string)
 	managedVars := []string{
@@ -135,6 +156,7 @@ func (e *TerraformEnvPrinter) getEmptyEnvVars() map[string]string {
 		"TF_VAR_context_id",
 		"TF_VAR_os_type",
 		"TF_VAR_operation",
+		terraformScopedEnvKeysVar,
 	}
 	if managedEnv := e.shims.Getenv("WINDSOR_MANAGED_ENV"); managedEnv != "" {
 		for _, key := range strings.Split(managedEnv, ",") {
@@ -143,6 +165,13 @@ func (e *TerraformEnvPrinter) getEmptyEnvVars() map[string]string {
 				continue
 			}
 			if strings.HasPrefix(key, "TF_VAR_") || strings.HasPrefix(key, "TF_CLI_ARGS_") || key == "TF_DATA_DIR" {
+				managedVars = append(managedVars, key)
+			}
+		}
+	}
+	if scoped := e.shims.Getenv(terraformScopedEnvKeysVar); scoped != "" {
+		for _, key := range strings.Split(scoped, ",") {
+			if key = strings.TrimSpace(key); key != "" {
 				managedVars = append(managedVars, key)
 			}
 		}

--- a/pkg/runtime/env/terraform_env_test.go
+++ b/pkg/runtime/env/terraform_env_test.go
@@ -153,7 +153,7 @@ func setupMockTerraformProvider(mocks *EnvTestMocks) *terraform.MockTerraformPro
 			}
 			return realProvider.GenerateTerraformArgs(componentID, interactive)
 		},
-		GetEnvVarsFunc: func(componentID string, interactive bool) (map[string]string, *terraform.TerraformArgs, error) {
+		GetEnvVarsFunc: func(componentID string, interactive bool) (map[string]string, []string, *terraform.TerraformArgs, error) {
 			// Ensure the real provider uses the test's mocked functions
 			rv := reflect.ValueOf(realProvider)
 			if rv.Kind() == reflect.Ptr {
@@ -500,12 +500,12 @@ func TestTerraformEnv_GetEnvVars(t *testing.T) {
 		mockProvider.FindRelativeProjectPathFunc = func(directory ...string) (string, error) {
 			return "cluster", nil
 		}
-		mockProvider.GetEnvVarsFunc = func(componentID string, withOutputs bool) (map[string]string, *terraform.TerraformArgs, error) {
+		mockProvider.GetEnvVarsFunc = func(componentID string, withOutputs bool) (map[string]string, []string, *terraform.TerraformArgs, error) {
 			return map[string]string{
 				"TF_DATA_DIR":             "/tmp/data",
 				"TF_CLI_ARGS_refresh":     "-var-file=/tmp/cluster.tfvars",
 				"TF_VAR_cluster_endpoint": "https://10.0.0.1:6443",
-			}, &terraform.TerraformArgs{}, nil
+			}, nil, &terraform.TerraformArgs{}, nil
 		}
 		printer = setupTerraformEnvPrinter(t, mocks, mockProvider)
 
@@ -534,14 +534,11 @@ func TestTerraformEnv_GetEnvVars(t *testing.T) {
 		mockProvider.FindRelativeProjectPathFunc = func(directory ...string) (string, error) {
 			return "cluster", nil
 		}
-		mockProvider.GetEnvVarsFunc = func(componentID string, withOutputs bool) (map[string]string, *terraform.TerraformArgs, error) {
+		mockProvider.GetEnvVarsFunc = func(componentID string, withOutputs bool) (map[string]string, []string, *terraform.TerraformArgs, error) {
 			return map[string]string{
 				"TF_DATA_DIR": "/tmp/data",
 				"HYPERV_HOST": "hyperv.local",
-			}, &terraform.TerraformArgs{}, nil
-		}
-		mockProvider.TerraformScopedEnvKeysFunc = func() ([]string, error) {
-			return []string{"HYPERV_HOST"}, nil
+			}, []string{"HYPERV_HOST"}, &terraform.TerraformArgs{}, nil
 		}
 		printer = setupTerraformEnvPrinter(t, mocks, mockProvider)
 
@@ -1474,7 +1471,7 @@ func TestTerraformProvider_GetEnvVars(t *testing.T) {
 		printer = setupTerraformEnvPrinter(t, mocks, mockProvider)
 
 		// When generating terraform args without parallelism for interactive regular injection
-		_, args, err := printer.terraformProvider.GetEnvVars("test/path", true)
+		_, _, args, err := printer.terraformProvider.GetEnvVars("test/path", true)
 
 		// Then no error should be returned
 		if err != nil {
@@ -1494,7 +1491,7 @@ func TestTerraformProvider_GetEnvVars(t *testing.T) {
 		}
 
 		// And environment variables should not contain parallelism
-		envVars, args, err := printer.terraformProvider.GetEnvVars("test/path", true)
+		envVars, _, args, err := printer.terraformProvider.GetEnvVars("test/path", true)
 		if err != nil {
 			t.Fatalf("Error getting env vars: %v", err)
 		}
@@ -1584,10 +1581,10 @@ terraform:
 				BackendConfig:   strings.Join(backendConfigArgs, " "),
 			}, nil
 		}
-		mockProvider.GetEnvVarsFunc = func(componentID string, interactive bool) (map[string]string, *terraform.TerraformArgs, error) {
+		mockProvider.GetEnvVarsFunc = func(componentID string, interactive bool) (map[string]string, []string, *terraform.TerraformArgs, error) {
 			args, err := mockProvider.GenerateTerraformArgsFunc(componentID, interactive)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 			envVars := make(map[string]string)
 			envVars["TF_DATA_DIR"] = args.TFDataDir
@@ -1595,12 +1592,12 @@ terraform:
 			envVars["TF_CLI_ARGS_plan"] = strings.Join(args.PlanArgs, " ")
 			envVars["TF_CLI_ARGS_apply"] = strings.Join(args.ApplyArgs, " ")
 			envVars["TF_CLI_ARGS_destroy"] = strings.Join(args.DestroyArgs, " ")
-			return envVars, args, nil
+			return envVars, nil, args, nil
 		}
 		printer = setupTerraformEnvPrinter(t, mocks, mockProvider)
 
 		// When generating terraform args with parallelism for interactive regular injection
-		_, args, err := printer.terraformProvider.GetEnvVars("test/path", true)
+		_, _, args, err := printer.terraformProvider.GetEnvVars("test/path", true)
 
 		// Then no error should be returned
 		if err != nil {
@@ -1626,7 +1623,7 @@ terraform:
 		}
 
 		// And environment variables should contain parallelism
-		envVars, args, err := printer.terraformProvider.GetEnvVars("test/path", true)
+		envVars, _, args, err := printer.terraformProvider.GetEnvVars("test/path", true)
 		if err != nil {
 			t.Fatalf("Error getting env vars: %v", err)
 		}
@@ -1671,7 +1668,7 @@ terraform:
 		printer = setupTerraformEnvPrinter(t, mocks, mockProvider)
 
 		// When generating terraform args for component without parallelism for interactive regular injection
-		_, args, err := printer.terraformProvider.GetEnvVars("test/path", true)
+		_, _, args, err := printer.terraformProvider.GetEnvVars("test/path", true)
 
 		// Then no error should be returned
 		if err != nil {
@@ -1686,7 +1683,7 @@ terraform:
 		}
 
 		// And environment variables should not contain parallelism
-		envVars, args, err := printer.terraformProvider.GetEnvVars("test/path", true)
+		envVars, _, args, err := printer.terraformProvider.GetEnvVars("test/path", true)
 		if err != nil {
 			t.Fatalf("Error getting env vars: %v", err)
 		}
@@ -1707,7 +1704,7 @@ terraform:
 		printer = setupTerraformEnvPrinter(t, mocks, mockProvider)
 
 		// When generating terraform args without blueprint.yaml file for interactive regular injection
-		_, args, err := printer.terraformProvider.GetEnvVars("test/path", true)
+		_, _, args, err := printer.terraformProvider.GetEnvVars("test/path", true)
 
 		// Then no error should be returned
 		if err != nil {
@@ -1789,7 +1786,7 @@ terraform:
 		}
 		printer = setupTerraformEnvPrinter(t, mocks, mockProvider)
 
-		envVars, _, err := printer.terraformProvider.GetEnvVars(componentName, true)
+		envVars, _, _, err := printer.terraformProvider.GetEnvVars(componentName, true)
 		if err != nil {
 			t.Fatalf("Error getting env vars: %v", err)
 		}
@@ -1836,7 +1833,7 @@ terraform:
 		}
 		printer = setupTerraformEnvPrinter(t, mocks, mockProvider)
 
-		_, args, err := printer.terraformProvider.GetEnvVars("test/path", true)
+		_, _, args, err := printer.terraformProvider.GetEnvVars("test/path", true)
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
@@ -1846,7 +1843,7 @@ terraform:
 			t.Errorf("Expected TFDataDir to be %s, got %s", expectedTFDataDir, args.TFDataDir)
 		}
 
-		envVars, args, err := printer.terraformProvider.GetEnvVars("test/path", true)
+		envVars, _, args, err := printer.terraformProvider.GetEnvVars("test/path", true)
 		if err != nil {
 			t.Fatalf("Error getting env vars: %v", err)
 		}
@@ -1878,7 +1875,7 @@ terraform:
 		printer = setupTerraformEnvPrinter(t, mocks, mockProvider)
 
 		expectedTfstatePath := filepath.ToSlash(filepath.Join(windsorScratchPath, ".tfstate", "test/path", "terraform.tfstate"))
-		envVars, _, err := printer.terraformProvider.GetEnvVars("test/path", true)
+		envVars, _, _, err := printer.terraformProvider.GetEnvVars("test/path", true)
 		if err != nil {
 			t.Fatalf("Error getting env vars: %v", err)
 		}
@@ -1918,13 +1915,13 @@ terraform:
 			}
 			return &terraform.TerraformArgs{}, nil
 		}
-		mockProvider.GetEnvVarsFunc = func(componentID string, interactive bool) (map[string]string, *terraform.TerraformArgs, error) {
+		mockProvider.GetEnvVarsFunc = func(componentID string, interactive bool) (map[string]string, []string, *terraform.TerraformArgs, error) {
 			_, err := mockProvider.GenerateTerraformArgsFunc(componentID, interactive)
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		printer = setupTerraformEnvPrinter(t, mocks, mockProvider)
 
-		_, _, err := printer.terraformProvider.GetEnvVars("test/path", true)
+		_, _, _, err := printer.terraformProvider.GetEnvVars("test/path", true)
 		if err == nil {
 			t.Error("Expected error when GetTFDataDir fails")
 			return
@@ -2011,10 +2008,10 @@ terraform:
 				BackendConfig:   strings.Join(backendConfigArgs, " "),
 			}, nil
 		}
-		mockProvider.GetEnvVarsFunc = func(componentID string, interactive bool) (map[string]string, *terraform.TerraformArgs, error) {
+		mockProvider.GetEnvVarsFunc = func(componentID string, interactive bool) (map[string]string, []string, *terraform.TerraformArgs, error) {
 			args, err := mockProvider.GenerateTerraformArgsFunc(componentID, interactive)
 			if err != nil {
-				return nil, nil, err
+				return nil, nil, nil, err
 			}
 			envVars := make(map[string]string)
 			envVars["TF_DATA_DIR"] = args.TFDataDir
@@ -2022,12 +2019,12 @@ terraform:
 			envVars["TF_CLI_ARGS_plan"] = strings.Join(args.PlanArgs, " ")
 			envVars["TF_CLI_ARGS_apply"] = strings.Join(args.ApplyArgs, " ")
 			envVars["TF_CLI_ARGS_destroy"] = strings.Join(args.DestroyArgs, " ")
-			return envVars, args, nil
+			return envVars, nil, args, nil
 		}
 		printer = setupTerraformEnvPrinter(t, mocks, mockProvider)
 
 		// When generating terraform args for interactive regular injection
-		_, args, err := printer.terraformProvider.GetEnvVars("test/path", true)
+		_, _, args, err := printer.terraformProvider.GetEnvVars("test/path", true)
 
 		// Then no error should be returned
 		if err != nil {

--- a/pkg/runtime/env/terraform_env_test.go
+++ b/pkg/runtime/env/terraform_env_test.go
@@ -416,6 +416,83 @@ func TestTerraformEnv_GetEnvVars(t *testing.T) {
 		}
 	})
 
+	t.Run("UnsetsTerraformScopedDotEnvKeysWhenNoProjectPathFound", func(t *testing.T) {
+		// Given a terraform/.env key that is currently set in the shell, recorded by a
+		// prior GetEnvVars call in WINDSOR_MANAGED_TERRAFORM_ENV
+		printer, mocks := setup(t)
+
+		mocks.Shims.Getenv = func(key string) string {
+			if key == "WINDSOR_MANAGED_TERRAFORM_ENV" {
+				return "HYPERV_HOST"
+			}
+			return ""
+		}
+		mocks.Shims.LookupEnv = func(key string) (string, bool) {
+			if key == "HYPERV_HOST" {
+				return "hyperv.local", true
+			}
+			return "", false
+		}
+
+		mockProvider := setupMockTerraformProvider(mocks)
+		mockProvider.FindRelativeProjectPathFunc = func(directory ...string) (string, error) {
+			return "", nil
+		}
+		printer = setupTerraformEnvPrinter(t, mocks, mockProvider)
+
+		// When GetEnvVars is called outside a Terraform directory
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		// Then the terraform/.env key should be unset
+		if val, exists := envVars["HYPERV_HOST"]; !exists || val != "" {
+			t.Errorf("Expected HYPERV_HOST to be unset, got %v", val)
+		}
+	})
+
+	t.Run("UnsetsTerraformScopedDotEnvKeyEvenAfterFileNoLongerDeclaresIt", func(t *testing.T) {
+		// Given HYPERV_HOST was exported on a prior visit (recorded in
+		// WINDSOR_MANAGED_TERRAFORM_ENV) but terraform/.env has since been edited to no
+		// longer declare it — TerraformScopedEnvKeysFunc reflects the current, changed file
+		printer, mocks := setup(t)
+
+		mocks.Shims.Getenv = func(key string) string {
+			if key == "WINDSOR_MANAGED_TERRAFORM_ENV" {
+				return "HYPERV_HOST"
+			}
+			return ""
+		}
+		mocks.Shims.LookupEnv = func(key string) (string, bool) {
+			if key == "HYPERV_HOST" {
+				return "hyperv.local", true
+			}
+			return "", false
+		}
+
+		mockProvider := setupMockTerraformProvider(mocks)
+		mockProvider.FindRelativeProjectPathFunc = func(directory ...string) (string, error) {
+			return "", nil
+		}
+		mockProvider.TerraformScopedEnvKeysFunc = func() ([]string, error) {
+			return nil, nil
+		}
+		printer = setupTerraformEnvPrinter(t, mocks, mockProvider)
+
+		// When GetEnvVars is called outside a Terraform directory
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		// Then HYPERV_HOST should still be unset, since the durable record (not the
+		// live file) drives what gets cleaned up
+		if val, exists := envVars["HYPERV_HOST"]; !exists || val != "" {
+			t.Errorf("Expected HYPERV_HOST to still be unset, got %v", val)
+		}
+	})
+
 	t.Run("TrackManagedTFVarsWhenProjectPathFound", func(t *testing.T) {
 		printer, mocks := setup(t)
 
@@ -446,6 +523,46 @@ func TestTerraformEnv_GetEnvVars(t *testing.T) {
 		}
 		if !slices.Contains(managed, "TF_VAR_cluster_endpoint") {
 			t.Errorf("Expected TF_VAR_cluster_endpoint to be tracked in managed env, got %v", managed)
+		}
+	})
+
+	t.Run("TracksTerraformScopedDotEnvKeysAsManaged", func(t *testing.T) {
+		// Given a component whose env vars include a non-TF_-prefixed key from terraform/.env
+		printer, mocks := setup(t)
+
+		mockProvider := setupMockTerraformProvider(mocks)
+		mockProvider.FindRelativeProjectPathFunc = func(directory ...string) (string, error) {
+			return "cluster", nil
+		}
+		mockProvider.GetEnvVarsFunc = func(componentID string, withOutputs bool) (map[string]string, *terraform.TerraformArgs, error) {
+			return map[string]string{
+				"TF_DATA_DIR": "/tmp/data",
+				"HYPERV_HOST": "hyperv.local",
+			}, &terraform.TerraformArgs{}, nil
+		}
+		mockProvider.TerraformScopedEnvKeysFunc = func() ([]string, error) {
+			return []string{"HYPERV_HOST"}, nil
+		}
+		printer = setupTerraformEnvPrinter(t, mocks, mockProvider)
+
+		// When GetEnvVars is called
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		// Then the non-TF_-prefixed key should also be tracked as managed
+		managed := printer.GetManagedEnv()
+		if !slices.Contains(managed, "HYPERV_HOST") {
+			t.Errorf("Expected HYPERV_HOST to be tracked in managed env, got %v", managed)
+		}
+
+		// And the durable record of which keys came from terraform/.env should be set and managed
+		if envVars["WINDSOR_MANAGED_TERRAFORM_ENV"] != "HYPERV_HOST" {
+			t.Errorf("Expected WINDSOR_MANAGED_TERRAFORM_ENV=HYPERV_HOST, got %q", envVars["WINDSOR_MANAGED_TERRAFORM_ENV"])
+		}
+		if !slices.Contains(managed, "WINDSOR_MANAGED_TERRAFORM_ENV") {
+			t.Errorf("Expected WINDSOR_MANAGED_TERRAFORM_ENV to be tracked in managed env, got %v", managed)
 		}
 	})
 

--- a/pkg/runtime/terraform/mock_provider.go
+++ b/pkg/runtime/terraform/mock_provider.go
@@ -19,7 +19,7 @@ type MockTerraformProvider struct {
 	GetTFDataDirFunc            func(componentID string) (string, error)
 	GetStatePathFunc            func(componentID string) (string, error)
 	BackendConfigCompleteFunc   func() bool
-	GetEnvVarsFunc              func(componentID string, interactive bool) (map[string]string, *TerraformArgs, error)
+	GetEnvVarsFunc              func(componentID string, interactive bool) (map[string]string, []string, *TerraformArgs, error)
 	FormatArgsForEnvFunc        func(args []string) string
 	ClearCacheFunc              func()
 	TerraformScopedEnvKeysFunc  func() ([]string, error)
@@ -130,11 +130,11 @@ func (m *MockTerraformProvider) BackendConfigComplete() bool {
 }
 
 // GetEnvVars implements TerraformProvider.
-func (m *MockTerraformProvider) GetEnvVars(componentID string, interactive bool) (map[string]string, *TerraformArgs, error) {
+func (m *MockTerraformProvider) GetEnvVars(componentID string, interactive bool) (map[string]string, []string, *TerraformArgs, error) {
 	if m.GetEnvVarsFunc != nil {
 		return m.GetEnvVarsFunc(componentID, interactive)
 	}
-	return make(map[string]string), &TerraformArgs{}, nil
+	return make(map[string]string), nil, &TerraformArgs{}, nil
 }
 
 // FormatArgsForEnv implements TerraformProvider.

--- a/pkg/runtime/terraform/mock_provider.go
+++ b/pkg/runtime/terraform/mock_provider.go
@@ -22,6 +22,7 @@ type MockTerraformProvider struct {
 	GetEnvVarsFunc              func(componentID string, interactive bool) (map[string]string, *TerraformArgs, error)
 	FormatArgsForEnvFunc        func(args []string) string
 	ClearCacheFunc              func()
+	TerraformScopedEnvKeysFunc  func() ([]string, error)
 }
 
 // FindRelativeProjectPath implements TerraformProvider.
@@ -149,6 +150,14 @@ func (m *MockTerraformProvider) ClearCache() {
 	if m.ClearCacheFunc != nil {
 		m.ClearCacheFunc()
 	}
+}
+
+// TerraformScopedEnvKeys implements TerraformProvider.
+func (m *MockTerraformProvider) TerraformScopedEnvKeys() ([]string, error) {
+	if m.TerraformScopedEnvKeysFunc != nil {
+		return m.TerraformScopedEnvKeysFunc()
+	}
+	return nil, nil
 }
 
 // =============================================================================

--- a/pkg/runtime/terraform/provider.go
+++ b/pkg/runtime/terraform/provider.go
@@ -6,6 +6,7 @@ package terraform
 
 import (
 	"fmt"
+	"io"
 	"maps"
 	"os"
 	"path/filepath"
@@ -38,6 +39,7 @@ type terraformProvider struct {
 	cache         map[string]map[string]any
 	components    []blueprintv1alpha1.TerraformComponent
 	configScope   map[string]any
+	warningWriter io.Writer
 	mu            sync.RWMutex
 }
 
@@ -84,7 +86,7 @@ type TerraformProvider interface {
 	GetTFDataDir(componentID string) (string, error)
 	GetStatePath(componentID string) (string, error)
 	BackendConfigComplete() bool
-	GetEnvVars(componentID string, interactive bool) (map[string]string, *TerraformArgs, error)
+	GetEnvVars(componentID string, interactive bool) (map[string]string, []string, *TerraformArgs, error)
 	FormatArgsForEnv(args []string) string
 	ClearCache()
 	TerraformScopedEnvKeys() ([]string, error)
@@ -122,6 +124,7 @@ func NewTerraformProvider(
 		evaluator:     evaluator,
 		Shims:         NewShims(),
 		cache:         make(map[string]map[string]any),
+		warningWriter: os.Stderr,
 	}
 
 	provider.registerTerraformOutputHelper(evaluator)
@@ -439,29 +442,30 @@ func (p *terraformProvider) GetTFDataDir(componentID string) (string, error) {
 	return tfDataDir, nil
 }
 
-// GetEnvVars constructs the environment variables required for Terraform execution for the specified component ID.
-// It generates TerraformArgs internally and sets up base environment variables including TF_DATA_DIR,
-// TF_CLI_ARGS_*, and TF_VAR_context_* variables. Component inputs are evaluated to populate the cache via
-// terraform_output() calls, and resulting TF_VAR_* environment variables are populated from the evaluated
-// inputs of the current component only. Outputs from other components are used solely to evaluate inputs and
-// are not included as separate TF_VAR_* variables. Complex output values are JSON-encoded.
-// Returns the generated environment variables map, the TerraformArgs struct, or an error if processing fails.
-func (p *terraformProvider) GetEnvVars(componentID string, interactive bool) (map[string]string, *TerraformArgs, error) {
+// GetEnvVars constructs the environment variables required for Terraform execution for the specified
+// component ID: base vars (TF_DATA_DIR, TF_CLI_ARGS_*, TF_VAR_context_*), contexts/<context>/terraform/.env
+// content, and TF_VAR_* from the component's own inputs (evaluated via terraform_output(); outputs from
+// other components are used only to evaluate inputs, never emitted as separate TF_VAR_* variables).
+// Returns the environment variables map, the terraform/.env key names (for callers that must pass them
+// through a narrower allowlist or track them for later cleanup), the TerraformArgs struct, and any error.
+func (p *terraformProvider) GetEnvVars(componentID string, interactive bool) (map[string]string, []string, *TerraformArgs, error) {
 	terraformArgs, err := p.GenerateTerraformArgs(componentID, interactive)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error generating terraform args: %w", err)
+		return nil, nil, nil, fmt.Errorf("error generating terraform args: %w", err)
 	}
 
 	envVars, err := p.getBaseEnvVarsForComponent(terraformArgs)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	scopedEnvVars, err := p.loadTerraformScopedEnv()
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, nil, err
 	}
+	scopedKeys := make([]string, 0, len(scopedEnvVars))
 	for k, v := range scopedEnvVars {
+		scopedKeys = append(scopedKeys, k)
 		if _, exists := envVars[k]; !exists {
 			envVars[k] = v
 		}
@@ -481,7 +485,7 @@ func (p *terraformProvider) GetEnvVars(componentID string, interactive bool) (ma
 					p.mu.RUnlock()
 					nonDeferred, err := p.evaluator.EvaluateMap(map[string]any{key: value}, "", evalScope, false)
 					if err != nil {
-						return nil, nil, fmt.Errorf("error evaluating input '%s' for component %s: %w", key, componentID, err)
+						return nil, nil, nil, fmt.Errorf("error evaluating input '%s' for component %s: %w", key, componentID, err)
 					}
 					nonDeferredValue, exists := nonDeferred[key]
 					if !exists {
@@ -502,7 +506,7 @@ func (p *terraformProvider) GetEnvVars(componentID string, interactive bool) (ma
 					}
 					evaluated, err := p.evaluator.EvaluateMap(map[string]any{key: value}, "", evalScope, true)
 					if err != nil {
-						return nil, nil, fmt.Errorf("error evaluating input '%s' for component %s: %w", key, componentID, err)
+						return nil, nil, nil, fmt.Errorf("error evaluating input '%s' for component %s: %w", key, componentID, err)
 					}
 					evaluatedValue, exists := evaluated[key]
 					if !exists {
@@ -530,7 +534,7 @@ func (p *terraformProvider) GetEnvVars(componentID string, interactive bool) (ma
 		}
 	}
 
-	return envVars, terraformArgs, nil
+	return envVars, scopedKeys, terraformArgs, nil
 }
 
 // TerraformScopedEnvKeys returns the key names declared in contexts/<context>/terraform/.env,
@@ -899,7 +903,7 @@ func (p *terraformProvider) loadTerraformScopedEnv() (map[string]string, error) 
 		return nil, fmt.Errorf("error checking %s: %w", dotEnvPath, err)
 	}
 
-	dotenv.WarnOnLoosePermissions(os.Stderr, p.Shims.Goos(), dotEnvPath, info.Mode())
+	dotenv.WarnOnLoosePermissions(p.warningWriter, p.Shims.Goos(), dotEnvPath, info.Mode())
 
 	data, err := p.Shims.ReadFile(dotEnvPath)
 	if err != nil {

--- a/pkg/runtime/terraform/provider.go
+++ b/pkg/runtime/terraform/provider.go
@@ -17,6 +17,7 @@ import (
 
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/runtime/config"
+	"github.com/windsorcli/cli/pkg/runtime/dotenv"
 	"github.com/windsorcli/cli/pkg/runtime/evaluator"
 	secretsRuntime "github.com/windsorcli/cli/pkg/runtime/secrets"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
@@ -86,6 +87,7 @@ type TerraformProvider interface {
 	GetEnvVars(componentID string, interactive bool) (map[string]string, *TerraformArgs, error)
 	FormatArgsForEnv(args []string) string
 	ClearCache()
+	TerraformScopedEnvKeys() ([]string, error)
 }
 
 // =============================================================================
@@ -455,6 +457,16 @@ func (p *terraformProvider) GetEnvVars(componentID string, interactive bool) (ma
 		return nil, nil, err
 	}
 
+	scopedEnvVars, err := p.loadTerraformScopedEnv()
+	if err != nil {
+		return nil, nil, err
+	}
+	for k, v := range scopedEnvVars {
+		if _, exists := envVars[k]; !exists {
+			envVars[k] = v
+		}
+	}
+
 	if componentID != "" && p.evaluator != nil {
 		component := p.GetTerraformComponent(componentID)
 		if component != nil && component.Inputs != nil && len(component.Inputs) > 0 {
@@ -519,6 +531,34 @@ func (p *terraformProvider) GetEnvVars(componentID string, interactive bool) (ma
 	}
 
 	return envVars, terraformArgs, nil
+}
+
+// TerraformScopedEnvKeys returns the key names declared in contexts/<context>/terraform/.env,
+// without resolving any values or paying secret-resolution cost. Used to identify which
+// environment variables to unset when leaving a Terraform directory.
+func (p *terraformProvider) TerraformScopedEnvKeys() ([]string, error) {
+	configRoot, err := p.configHandler.GetConfigRoot()
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving config root: %w", err)
+	}
+
+	dotEnvPath := filepath.Join(configRoot, "terraform", ".env")
+
+	data, err := p.Shims.ReadFile(dotEnvPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("error reading %s: %w", dotEnvPath, err)
+	}
+
+	parsed := dotenv.Parse(string(data))
+	keys := make([]string, 0, len(parsed))
+	for k := range parsed {
+		keys = append(keys, k)
+	}
+
+	return keys, nil
 }
 
 // FormatArgsForEnv formats CLI arguments for use in environment variables.
@@ -830,6 +870,56 @@ func (p *terraformProvider) getBaseEnvVarsForComponent(terraformArgs *TerraformA
 		envVars["TF_VAR_os_type"] = "windows"
 	} else {
 		envVars["TF_VAR_os_type"] = "unix"
+	}
+
+	return envVars, nil
+}
+
+// loadTerraformScopedEnv reads contexts/<context>/terraform/.env, resolving secret(...)
+// expressions and registering every value with the shell for output scrubbing. A key
+// already cached in the shell is omitted rather than re-evaluated. Returns an empty map
+// when the file is absent, and warns (without failing) on loose file permissions. Reused
+// by both the interactive shell hook and windsor up/apply/plan/destroy, since both paths
+// call GetEnvVars per component.
+func (p *terraformProvider) loadTerraformScopedEnv() (map[string]string, error) {
+	envVars := make(map[string]string)
+
+	configRoot, err := p.configHandler.GetConfigRoot()
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving config root: %w", err)
+	}
+
+	dotEnvPath := filepath.Join(configRoot, "terraform", ".env")
+
+	info, err := p.Shims.Stat(dotEnvPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return envVars, nil
+		}
+		return nil, fmt.Errorf("error checking %s: %w", dotEnvPath, err)
+	}
+
+	dotenv.WarnOnLoosePermissions(os.Stderr, p.Shims.Goos(), dotEnvPath, info.Mode())
+
+	data, err := p.Shims.ReadFile(dotEnvPath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading %s: %w", dotEnvPath, err)
+	}
+
+	for k, v := range dotenv.Parse(string(data)) {
+		normalizedValue := secretsRuntime.NormalizeLegacyBraces(v)
+
+		if p.evaluator != nil && evaluator.ContainsExpression(normalizedValue) {
+			if existingValue, exists := p.Shims.LookupEnv(k); exists &&
+				dotenv.ShouldUseCache(p.Shims.LookupEnv) && !strings.Contains(existingValue, "<ERROR") {
+				p.shell.RegisterSecret(existingValue)
+				continue
+			}
+			envVars[k] = dotenv.EvaluateExpressionValue(p.evaluator, normalizedValue)
+		} else {
+			envVars[k] = normalizedValue
+		}
+		p.shell.RegisterSecret(envVars[k])
 	}
 
 	return envVars, nil

--- a/pkg/runtime/terraform/provider_public_test.go
+++ b/pkg/runtime/terraform/provider_public_test.go
@@ -1,6 +1,7 @@
 package terraform
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
 	"os"
@@ -17,16 +18,18 @@ import (
 	"github.com/windsorcli/cli/pkg/runtime/tools"
 )
 
-// fakeFileInfo is a minimal os.FileInfo with a fixed, owner-only Mode, used where a
+// fakeFileInfo is a minimal os.FileInfo with a caller-controlled Mode, used where a
 // Stat mock must return a real FileInfo (callers that call .Mode()) rather than nil.
-type fakeFileInfo struct{}
+type fakeFileInfo struct {
+	mode os.FileMode
+}
 
-func (fakeFileInfo) Name() string       { return ".env" }
-func (fakeFileInfo) Size() int64        { return 0 }
-func (fakeFileInfo) Mode() os.FileMode  { return os.FileMode(0600) }
-func (fakeFileInfo) ModTime() time.Time { return time.Time{} }
-func (fakeFileInfo) IsDir() bool        { return false }
-func (fakeFileInfo) Sys() any           { return nil }
+func (f fakeFileInfo) Name() string       { return ".env" }
+func (f fakeFileInfo) Size() int64        { return 0 }
+func (f fakeFileInfo) Mode() os.FileMode  { return f.mode }
+func (f fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (f fakeFileInfo) IsDir() bool        { return false }
+func (f fakeFileInfo) Sys() any           { return nil }
 
 // =============================================================================
 // Test Setup
@@ -2908,7 +2911,7 @@ terraform:
 		}
 
 		// When getting env vars
-		envVars, _, err := mocks.Provider.GetEnvVars("cluster", false)
+		envVars, _, _, err := mocks.Provider.GetEnvVars("cluster", false)
 		if err != nil {
 			t.Fatalf("Expected no error, got: %v", err)
 		}
@@ -2994,7 +2997,7 @@ terraform:
 			return "", nil
 		}
 
-		envVars, _, err := mocks.Provider.GetEnvVars("cluster", false)
+		envVars, _, _, err := mocks.Provider.GetEnvVars("cluster", false)
 		if err != nil {
 			t.Fatalf("Expected no error, got: %v", err)
 		}
@@ -3066,7 +3069,7 @@ terraform:
 		mocks.Provider.evaluator = mockEvaluator
 
 		// When getting env vars
-		envVars, _, err := mocks.Provider.GetEnvVars("cluster", false)
+		envVars, _, _, err := mocks.Provider.GetEnvVars("cluster", false)
 
 		// Then inputs with expressions should be evaluated
 		if err != nil {
@@ -3091,7 +3094,7 @@ terraform:
 		mocks := setupMocks(t, &SetupOptions{BlueprintYAML: blueprintYAML, BackendType: "none"})
 
 		// When getting env vars
-		envVars, _, err := mocks.Provider.GetEnvVars("cluster", false)
+		envVars, _, _, err := mocks.Provider.GetEnvVars("cluster", false)
 
 		// Then non-expression inputs should not be emitted as TF_VAR_*
 		if err != nil {
@@ -3114,7 +3117,7 @@ terraform:
 			return "/my/project", nil
 		}
 
-		envVars, _, err := mocks.Provider.GetEnvVars("nonexistent", false)
+		envVars, _, _, err := mocks.Provider.GetEnvVars("nonexistent", false)
 		if err != nil {
 			t.Fatalf("Expected no error, got: %v", err)
 		}
@@ -3132,7 +3135,7 @@ terraform:
 		mocks := setupMocks(t, &SetupOptions{BackendType: "none"})
 
 		// When getting env vars for nonexistent component
-		envVars, _, err := mocks.Provider.GetEnvVars("nonexistent", false)
+		envVars, _, _, err := mocks.Provider.GetEnvVars("nonexistent", false)
 
 		// Then it should return empty env vars without error
 		if err != nil {
@@ -3152,7 +3155,7 @@ terraform:
 		}
 
 		// When getting env vars for nonexistent component
-		_, _, err := mocks.Provider.GetEnvVars("nonexistent", false)
+		_, _, _, err := mocks.Provider.GetEnvVars("nonexistent", false)
 
 		// Then it should return an error
 		if err == nil {
@@ -3177,7 +3180,7 @@ terraform:
 		mocks.Provider.evaluator = mockEvaluator
 
 		// When getting env vars
-		_, _, err := mocks.Provider.GetEnvVars("cluster", false)
+		_, _, _, err := mocks.Provider.GetEnvVars("cluster", false)
 
 		// Then it should return an error
 		if err == nil {
@@ -3212,7 +3215,7 @@ terraform:
 		}
 
 		// When getting env vars
-		envVars, _, err := mocks.Provider.GetEnvVars("cluster", false)
+		envVars, _, _, err := mocks.Provider.GetEnvVars("cluster", false)
 
 		// Then non-string values should be JSON marshaled
 		if err != nil {
@@ -3251,7 +3254,7 @@ terraform:
 		}
 
 		// When getting env vars
-		envVars, _, err := mocks.Provider.GetEnvVars("cluster", false)
+		envVars, _, _, err := mocks.Provider.GetEnvVars("cluster", false)
 
 		// Then marshal error should be skipped and var not set
 		if err != nil {
@@ -3276,7 +3279,7 @@ terraform:
 			return "", errors.New("scratch path error")
 		}
 
-		_, _, err := mocks.Provider.GetEnvVars("cluster", false)
+		_, _, _, err := mocks.Provider.GetEnvVars("cluster", false)
 
 		if err == nil {
 			t.Fatal("Expected error when GenerateTerraformArgs fails")
@@ -3304,7 +3307,7 @@ terraform:
 			return "", errors.New("config root error")
 		}
 
-		_, _, err := mocks.Provider.GetEnvVars("cluster", false)
+		_, _, _, err := mocks.Provider.GetEnvVars("cluster", false)
 
 		if err == nil {
 			t.Fatal("Expected error when getBaseEnvVarsForComponent fails")
@@ -3329,7 +3332,7 @@ terraform:
 		}
 		mocks.Provider.evaluator = mockEvaluator
 
-		envVars, _, err := mocks.Provider.GetEnvVars("cluster", false)
+		envVars, _, _, err := mocks.Provider.GetEnvVars("cluster", false)
 
 		if err != nil {
 			t.Fatalf("Expected no error, got: %v", err)
@@ -3375,7 +3378,7 @@ terraform:
 		mocks.Provider.SetTerraformComponents([]blueprintv1alpha1.TerraformComponent{component})
 
 		// When getting env vars
-		envVars, _, err := mocks.Provider.GetEnvVars("cluster", false)
+		envVars, _, _, err := mocks.Provider.GetEnvVars("cluster", false)
 
 		// Then non-runtime expressions should remain tfvars-only and not emit TF_VAR
 		if err != nil {
@@ -3401,7 +3404,7 @@ terraform:
 		mocks.Provider.SetTerraformComponents([]blueprintv1alpha1.TerraformComponent{component})
 
 		// When getting env vars
-		envVars, _, err := mocks.Provider.GetEnvVars("cluster", false)
+		envVars, _, _, err := mocks.Provider.GetEnvVars("cluster", false)
 
 		// Then non-expression input should remain tfvars-only and not emit TF_VAR
 		if err != nil {
@@ -3421,7 +3424,7 @@ terraform:
       talos_version: "${config.kubernetes.version}"`
 
 		mocks := setupMocks(t, &SetupOptions{BlueprintYAML: blueprintYAML, BackendType: "none"})
-		envVars, _, err := mocks.Provider.GetEnvVars("cluster", false)
+		envVars, _, _, err := mocks.Provider.GetEnvVars("cluster", false)
 		if err != nil {
 			t.Fatalf("Expected no error, got: %v", err)
 		}
@@ -3448,7 +3451,7 @@ terraform:
 		}
 		mocks.Provider.evaluator = mockEvaluator
 
-		envVars, _, err := mocks.Provider.GetEnvVars("cluster", false)
+		envVars, _, _, err := mocks.Provider.GetEnvVars("cluster", false)
 		if err != nil {
 			t.Fatalf("Expected no error, got: %v", err)
 		}
@@ -3483,7 +3486,7 @@ terraform:
 		}
 		mocks.Provider.evaluator = mockEvaluator
 
-		envVars, _, err := mocks.Provider.GetEnvVars("cluster", false)
+		envVars, _, _, err := mocks.Provider.GetEnvVars("cluster", false)
 		if err != nil {
 			t.Fatalf("Expected no error, got: %v", err)
 		}
@@ -3533,7 +3536,7 @@ terraform:
 		mocks.Provider.evaluator = mockEvaluator
 
 		// When GetEnvVars is called
-		envVars, _, err := mocks.Provider.GetEnvVars("compute", false)
+		envVars, _, _, err := mocks.Provider.GetEnvVars("compute", false)
 		if err != nil {
 			t.Fatalf("Expected no error, got: %v", err)
 		}
@@ -3550,7 +3553,7 @@ terraform:
 		dotEnvPath := filepath.Join("/test/config", "terraform", ".env")
 		mocks.Provider.Shims.Stat = func(path string) (os.FileInfo, error) {
 			if path == dotEnvPath {
-				return fakeFileInfo{}, nil
+				return fakeFileInfo{mode: 0600}, nil
 			}
 			return nil, os.ErrNotExist
 		}
@@ -3562,7 +3565,7 @@ terraform:
 		}
 
 		// When GetEnvVars is called
-		envVars, _, err := mocks.Provider.GetEnvVars("compute", false)
+		envVars, _, _, err := mocks.Provider.GetEnvVars("compute", false)
 		if err != nil {
 			t.Fatalf("Expected no error, got: %v", err)
 		}
@@ -3573,13 +3576,75 @@ terraform:
 		}
 	})
 
+	t.Run("WarnsOnLooseTerraformScopedDotEnvPermissions", func(t *testing.T) {
+		// Given a contexts/<ctx>/terraform/.env file with group/world-readable permissions
+		mocks := setupMocks(t, &SetupOptions{BackendType: "none"})
+		dotEnvPath := filepath.Join("/test/config", "terraform", ".env")
+		mocks.Provider.Shims.Stat = func(path string) (os.FileInfo, error) {
+			if path == dotEnvPath {
+				return fakeFileInfo{mode: 0644}, nil
+			}
+			return nil, os.ErrNotExist
+		}
+		mocks.Provider.Shims.ReadFile = func(path string) ([]byte, error) {
+			if path == dotEnvPath {
+				return []byte("HYPERV_HOST=hyperv.local\n"), nil
+			}
+			return nil, os.ErrNotExist
+		}
+		mocks.Provider.Shims.Goos = func() string { return "linux" }
+		var stderr bytes.Buffer
+		mocks.Provider.warningWriter = &stderr
+
+		// When GetEnvVars is called
+		if _, _, _, err := mocks.Provider.GetEnvVars("compute", false); err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// Then a warning should be written to the injected writer
+		if !strings.Contains(stderr.String(), "Warning") {
+			t.Errorf("Expected a permission warning, got %q", stderr.String())
+		}
+	})
+
+	t.Run("NoWarningOnRestrictedTerraformScopedDotEnvPermissions", func(t *testing.T) {
+		// Given a contexts/<ctx>/terraform/.env file restricted to the owner
+		mocks := setupMocks(t, &SetupOptions{BackendType: "none"})
+		dotEnvPath := filepath.Join("/test/config", "terraform", ".env")
+		mocks.Provider.Shims.Stat = func(path string) (os.FileInfo, error) {
+			if path == dotEnvPath {
+				return fakeFileInfo{mode: 0600}, nil
+			}
+			return nil, os.ErrNotExist
+		}
+		mocks.Provider.Shims.ReadFile = func(path string) ([]byte, error) {
+			if path == dotEnvPath {
+				return []byte("HYPERV_HOST=hyperv.local\n"), nil
+			}
+			return nil, os.ErrNotExist
+		}
+		mocks.Provider.Shims.Goos = func() string { return "linux" }
+		var stderr bytes.Buffer
+		mocks.Provider.warningWriter = &stderr
+
+		// When GetEnvVars is called
+		if _, _, _, err := mocks.Provider.GetEnvVars("compute", false); err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// Then no warning should be written
+		if stderr.String() != "" {
+			t.Errorf("Expected no warning, got %q", stderr.String())
+		}
+	})
+
 	t.Run("ResolvesSecretExpressionInTerraformScopedDotEnv", func(t *testing.T) {
 		// Given a terraform/.env file with a secret expression and a mock evaluator
 		mocks := setupMocks(t, &SetupOptions{BackendType: "none"})
 		dotEnvPath := filepath.Join("/test/config", "terraform", ".env")
 		mocks.Provider.Shims.Stat = func(path string) (os.FileInfo, error) {
 			if path == dotEnvPath {
-				return fakeFileInfo{}, nil
+				return fakeFileInfo{mode: 0600}, nil
 			}
 			return nil, os.ErrNotExist
 		}
@@ -3599,7 +3664,7 @@ terraform:
 		mocks.Provider.evaluator = mockEvaluator
 
 		// When GetEnvVars is called
-		envVars, _, err := mocks.Provider.GetEnvVars("compute", false)
+		envVars, _, _, err := mocks.Provider.GetEnvVars("compute", false)
 		if err != nil {
 			t.Fatalf("Expected no error, got: %v", err)
 		}
@@ -3616,7 +3681,7 @@ terraform:
 		dotEnvPath := filepath.Join("/test/config", "terraform", ".env")
 		mocks.Provider.Shims.Stat = func(path string) (os.FileInfo, error) {
 			if path == dotEnvPath {
-				return fakeFileInfo{}, nil
+				return fakeFileInfo{mode: 0600}, nil
 			}
 			return nil, os.ErrNotExist
 		}
@@ -3628,7 +3693,7 @@ terraform:
 		}
 
 		// When GetEnvVars is called
-		_, _, err := mocks.Provider.GetEnvVars("compute", false)
+		_, _, _, err := mocks.Provider.GetEnvVars("compute", false)
 
 		// Then an error should be returned
 		if err == nil {

--- a/pkg/runtime/terraform/provider_public_test.go
+++ b/pkg/runtime/terraform/provider_public_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	terraformcfg "github.com/windsorcli/cli/api/v1alpha1/terraform"
@@ -15,6 +16,17 @@ import (
 	"github.com/windsorcli/cli/pkg/runtime/shell"
 	"github.com/windsorcli/cli/pkg/runtime/tools"
 )
+
+// fakeFileInfo is a minimal os.FileInfo with a fixed, owner-only Mode, used where a
+// Stat mock must return a real FileInfo (callers that call .Mode()) rather than nil.
+type fakeFileInfo struct{}
+
+func (fakeFileInfo) Name() string       { return ".env" }
+func (fakeFileInfo) Size() int64        { return 0 }
+func (fakeFileInfo) Mode() os.FileMode  { return os.FileMode(0600) }
+func (fakeFileInfo) ModTime() time.Time { return time.Time{} }
+func (fakeFileInfo) IsDir() bool        { return false }
+func (fakeFileInfo) Sys() any           { return nil }
 
 // =============================================================================
 // Test Setup
@@ -3529,6 +3541,176 @@ terraform:
 		// Then TF_VAR_network_cidr must not be set (not even to the string "null")
 		if val, exists := envVars["TF_VAR_network_cidr"]; exists {
 			t.Errorf("Expected TF_VAR_network_cidr to be absent when dependency is not applied, got %q", val)
+		}
+	})
+
+	t.Run("MergesTerraformScopedDotEnvValues", func(t *testing.T) {
+		// Given a contexts/<ctx>/terraform/.env file with a plain value
+		mocks := setupMocks(t, &SetupOptions{BackendType: "none"})
+		dotEnvPath := filepath.Join("/test/config", "terraform", ".env")
+		mocks.Provider.Shims.Stat = func(path string) (os.FileInfo, error) {
+			if path == dotEnvPath {
+				return fakeFileInfo{}, nil
+			}
+			return nil, os.ErrNotExist
+		}
+		mocks.Provider.Shims.ReadFile = func(path string) ([]byte, error) {
+			if path == dotEnvPath {
+				return []byte("HYPERV_HOST=hyperv.local\n"), nil
+			}
+			return nil, os.ErrNotExist
+		}
+
+		// When GetEnvVars is called
+		envVars, _, err := mocks.Provider.GetEnvVars("compute", false)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// Then the terraform/.env value should be present
+		if envVars["HYPERV_HOST"] != "hyperv.local" {
+			t.Errorf("Expected HYPERV_HOST=hyperv.local, got %q", envVars["HYPERV_HOST"])
+		}
+	})
+
+	t.Run("ResolvesSecretExpressionInTerraformScopedDotEnv", func(t *testing.T) {
+		// Given a terraform/.env file with a secret expression and a mock evaluator
+		mocks := setupMocks(t, &SetupOptions{BackendType: "none"})
+		dotEnvPath := filepath.Join("/test/config", "terraform", ".env")
+		mocks.Provider.Shims.Stat = func(path string) (os.FileInfo, error) {
+			if path == dotEnvPath {
+				return fakeFileInfo{}, nil
+			}
+			return nil, os.ErrNotExist
+		}
+		mocks.Provider.Shims.ReadFile = func(path string) ([]byte, error) {
+			if path == dotEnvPath {
+				return []byte(`HYPERV_PASSWORD=${secret("op://vault/item/field")}` + "\n"), nil
+			}
+			return nil, os.ErrNotExist
+		}
+		mockEvaluator := evaluator.NewMockExpressionEvaluator()
+		mockEvaluator.EvaluateFunc = func(expression string, facetPath string, scope map[string]any, evaluateDeferred bool) (any, error) {
+			if strings.Contains(expression, "secret(") {
+				return "resolved-secret", nil
+			}
+			return expression, nil
+		}
+		mocks.Provider.evaluator = mockEvaluator
+
+		// When GetEnvVars is called
+		envVars, _, err := mocks.Provider.GetEnvVars("compute", false)
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// Then the expression should be resolved through the evaluator
+		if envVars["HYPERV_PASSWORD"] != "resolved-secret" {
+			t.Errorf("Expected resolved-secret, got %q", envVars["HYPERV_PASSWORD"])
+		}
+	})
+
+	t.Run("ReturnsErrorWhenTerraformScopedDotEnvReadFails", func(t *testing.T) {
+		// Given a terraform/.env file that exists but fails to read
+		mocks := setupMocks(t, &SetupOptions{BackendType: "none"})
+		dotEnvPath := filepath.Join("/test/config", "terraform", ".env")
+		mocks.Provider.Shims.Stat = func(path string) (os.FileInfo, error) {
+			if path == dotEnvPath {
+				return fakeFileInfo{}, nil
+			}
+			return nil, os.ErrNotExist
+		}
+		mocks.Provider.Shims.ReadFile = func(path string) ([]byte, error) {
+			if path == dotEnvPath {
+				return nil, fmt.Errorf("mock read error")
+			}
+			return nil, os.ErrNotExist
+		}
+
+		// When GetEnvVars is called
+		_, _, err := mocks.Provider.GetEnvVars("compute", false)
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "error reading") {
+			t.Errorf("Unexpected error message: %v", err)
+		}
+	})
+}
+
+// TestTerraformProvider_TerraformScopedEnvKeys tests the TerraformScopedEnvKeys method.
+func TestTerraformProvider_TerraformScopedEnvKeys(t *testing.T) {
+	t.Run("ReturnsKeyNamesWithoutResolvingValues", func(t *testing.T) {
+		// Given a terraform/.env file with a secret expression and an evaluator that must not be called
+		mocks := setupMocks(t, &SetupOptions{BackendType: "none"})
+		dotEnvPath := filepath.Join("/test/config", "terraform", ".env")
+		mocks.Provider.Shims.ReadFile = func(path string) ([]byte, error) {
+			if path == dotEnvPath {
+				return []byte(`HYPERV_PASSWORD=${secret("op://vault/item/field")}` + "\nHYPERV_HOST=hyperv.local\n"), nil
+			}
+			return nil, os.ErrNotExist
+		}
+		evaluateCalled := false
+		mockEvaluator := evaluator.NewMockExpressionEvaluator()
+		mockEvaluator.EvaluateFunc = func(expression string, facetPath string, scope map[string]any, evaluateDeferred bool) (any, error) {
+			evaluateCalled = true
+			return "resolved", nil
+		}
+		mocks.Provider.evaluator = mockEvaluator
+
+		// When TerraformScopedEnvKeys is called
+		keys, err := mocks.Provider.TerraformScopedEnvKeys()
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// Then both key names should be returned and the evaluator never invoked
+		if len(keys) != 2 {
+			t.Fatalf("Expected 2 keys, got %v", keys)
+		}
+		if evaluateCalled {
+			t.Error("Expected evaluator not to be called")
+		}
+	})
+
+	t.Run("ReturnsEmptyWhenFileAbsent", func(t *testing.T) {
+		// Given no terraform/.env file
+		mocks := setupMocks(t, &SetupOptions{BackendType: "none"})
+
+		// When TerraformScopedEnvKeys is called
+		keys, err := mocks.Provider.TerraformScopedEnvKeys()
+
+		// Then no error and no keys should be returned
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if len(keys) != 0 {
+			t.Errorf("Expected no keys, got %v", keys)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenReadFailsForOtherReason", func(t *testing.T) {
+		// Given a terraform/.env file that fails to read for a non-NotExist reason
+		mocks := setupMocks(t, &SetupOptions{BackendType: "none"})
+		dotEnvPath := filepath.Join("/test/config", "terraform", ".env")
+		mocks.Provider.Shims.ReadFile = func(path string) ([]byte, error) {
+			if path == dotEnvPath {
+				return nil, fmt.Errorf("mock permission denied")
+			}
+			return nil, os.ErrNotExist
+		}
+
+		// When TerraformScopedEnvKeys is called
+		_, err := mocks.Provider.TerraformScopedEnvKeys()
+
+		// Then an error should be returned
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "error reading") {
+			t.Errorf("Unexpected error message: %v", err)
 		}
 	})
 }

--- a/pkg/runtime/terraform/shims.go
+++ b/pkg/runtime/terraform/shims.go
@@ -39,6 +39,7 @@ type Shims struct {
 	HclParseConfig func([]byte, string, hcl.Pos) (*hclwrite.File, hcl.Diagnostics)
 	Goos           func() string
 	Sleep          func(time.Duration)
+	LookupEnv      func(string) (string, bool)
 }
 
 // =============================================================================
@@ -64,5 +65,6 @@ func NewShims() *Shims {
 		HclParseConfig: hclwrite.ParseConfig,
 		Goos:           func() string { return runtime.GOOS },
 		Sleep:          time.Sleep,
+		LookupEnv:      os.LookupEnv,
 	}
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This PR adds a new `contexts/<context>/terraform/.env` file loaded only during Terraform operations, touching a shared provider interface (`TerraformProvider`), threading a new return value (`scopedKeys`) through every Terraform operation call chain, and broadening the set of env vars tracked as managed from TF_-prefixed only to all keys returned by `GetEnvVars`.
>
> **Overview**
>
> The change introduces a Terraform-scoped dotenv file (`terraform/.env` inside a context directory) whose values are injected into subprocess environments only when Terraform is actually executing, not on every shell hook invocation. A new `pkg/runtime/dotenv` package consolidates previously duplicated helpers (`Parse`, `ShouldUseCache`, `EvaluateExpressionValue`, `WarnOnLoosePermissions`). The new `TerraformScopedEnvKeys()` method on `TerraformProvider` returns the declared key names without resolving secrets, and `WINDSOR_MANAGED_TERRAFORM_ENV` records which keys to unset when the operator leaves a Terraform directory.
>
> The `selectTerraformCommandEnv` filtering function gains a `scopedKeys` parameter so provider credentials (arbitrary names like `HYPERV_HOST`) pass through to every terraform subprocess alongside the usual `TF_*` variables. Unit and integration tests cover injection, cleanup, the cache-hit path, and the "file removed since last export" unset scenario.
>
> Reviewed by Claude for commit `9ff966be`.

<!-- /claude-code-review:summary -->
