### PR TITLE
feat(composer): add globalDependency inverse-dependency for flux systems

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -631,6 +631,14 @@ type FluxSystem struct {
 	// Ordinal overrides the facet's ordinal for this system's merge precedence.
 	Ordinal *int `yaml:"ordinal,omitempty"`
 
+	// GlobalDependency inverts the system's edges: when true, every kustomization and system outside
+	// this system's own dependency closure is wired to depend on its terminal tier — its resources tier
+	// if it has one, else its install tier. It lets a cluster-wide precondition (e.g. admission policies
+	// that must be enforcing before any workload lands) be declared once here rather than repeated as a
+	// dependsOn on every consumer. The closure exclusion keeps the system, and anything it depends on,
+	// from ordering after itself.
+	GlobalDependency bool `yaml:"globalDependency,omitempty"`
+
 	// Install is the controller/operator tier (at most one). Its Components/Substitute and operational
 	// fields flow to "<name>-install"; its Name/Path/DependsOn are derived by the composer.
 	Install *Kustomization `yaml:"install,omitempty"`
@@ -1245,17 +1253,18 @@ func (s *FluxSystem) DeepCopy() *FluxSystem {
 	}
 
 	return &FluxSystem{
-		Name:      s.Name,
-		Path:      s.Path,
-		Source:    s.Source,
-		Enabled:   s.Enabled.DeepCopy(),
-		Destroy:   s.Destroy.DeepCopy(),
-		When:      s.When,
-		DependsOn: slices.Clone(s.DependsOn),
-		Strategy:  s.Strategy,
-		Ordinal:   ordinalCopy,
-		Install:   s.Install.DeepCopy(),
-		Resources: resourcesCopy,
+		Name:             s.Name,
+		Path:             s.Path,
+		Source:           s.Source,
+		Enabled:          s.Enabled.DeepCopy(),
+		Destroy:          s.Destroy.DeepCopy(),
+		When:             s.When,
+		DependsOn:        slices.Clone(s.DependsOn),
+		Strategy:         s.Strategy,
+		Ordinal:          ordinalCopy,
+		GlobalDependency: s.GlobalDependency,
+		Install:          s.Install.DeepCopy(),
+		Resources:        resourcesCopy,
 	}
 }
 

--- a/pkg/composer/blueprint/composer.go
+++ b/pkg/composer/blueprint/composer.go
@@ -176,6 +176,7 @@ func (c *BaseBlueprintComposer) Compose(loaders []BlueprintLoader, initLoaderNam
 	c.resolveTierDependencies(result)
 	c.finalizeCrdLayers(result)
 	c.applyCrdLayerBarrier(result)
+	c.applyGlobalDependencyBarrier(result)
 	validationErr := errors.Join(c.validateSources(result), c.validateReservedNames(result), c.validateDependencies(result))
 	return result, validationErr
 }
@@ -795,6 +796,117 @@ func (c *BaseBlueprintComposer) applyCrdLayerBarrier(bp *blueprintv1alpha1.Bluep
 			bp.FluxSystems[i].DependsOn = slices.Clone(names)
 		}
 	}
+}
+
+// applyGlobalDependencyBarrier wires every kustomization and flux system outside a global-dependency
+// system's own dependency closure to depend on that system's terminal tier — its resources tier if it
+// has one, else its install tier. It is the inverse of dependsOn: a system declares itself required by
+// the whole cluster once (globalDependency: true) instead of every consumer naming it. The closure
+// exclusion keeps the system, and anything it transitively depends on, from ordering after itself — the
+// same way the crds layer sits ahead of the stack without depending on it. It runs after
+// applyCrdLayerBarrier so a global system rooted at the crds layer already carries that edge when its
+// closure is computed.
+func (c *BaseBlueprintComposer) applyGlobalDependencyBarrier(bp *blueprintv1alpha1.Blueprint) {
+	type barrier struct {
+		terminals []string
+		closure   map[string]struct{}
+	}
+
+	depsByName := make(map[string][]string)
+	for _, k := range bp.AllKustomizations() {
+		depsByName[k.Name] = k.DependsOn
+	}
+
+	var barriers []barrier
+	for _, sys := range bp.FluxSystems {
+		if !sys.GlobalDependency {
+			continue
+		}
+		terminals := terminalTierNames(sys)
+		if len(terminals) == 0 {
+			continue
+		}
+		barriers = append(barriers, barrier{
+			terminals: terminals,
+			closure:   dependencyClosure(sys.TierNames(), depsByName),
+		})
+	}
+	if len(barriers) == 0 {
+		return
+	}
+
+	for _, b := range barriers {
+		for i := range bp.Kustomizations {
+			if _, inClosure := b.closure[bp.Kustomizations[i].Name]; inClosure {
+				continue
+			}
+			bp.Kustomizations[i].DependsOn = appendMissing(bp.Kustomizations[i].DependsOn, b.terminals)
+		}
+		for i := range bp.FluxSystems {
+			if fluxSystemInClosure(bp.FluxSystems[i], b.closure) {
+				continue
+			}
+			bp.FluxSystems[i].DependsOn = appendMissing(bp.FluxSystems[i].DependsOn, b.terminals)
+		}
+	}
+}
+
+// terminalTierNames returns the compiled kustomization names at which a system is fully reconciled: its
+// resources tier names when it has a resources tier, otherwise its install tier. These are the targets a
+// globalDependency system's consumers wait on.
+func terminalTierNames(sys blueprintv1alpha1.FluxSystem) []string {
+	names := sys.TierNames()
+	if len(sys.Resources) == 0 {
+		return names
+	}
+	installName := sys.Name + "-install"
+	terminals := make([]string, 0, len(names))
+	for _, n := range names {
+		if n != installName {
+			terminals = append(terminals, n)
+		}
+	}
+	return terminals
+}
+
+// dependencyClosure returns the set of kustomization names reachable from seeds by following dependsOn
+// edges (seeds included), over the compiled dependency graph depsByName.
+func dependencyClosure(seeds []string, depsByName map[string][]string) map[string]struct{} {
+	closure := make(map[string]struct{})
+	queue := slices.Clone(seeds)
+	for len(queue) > 0 {
+		name := queue[0]
+		queue = queue[1:]
+		if _, seen := closure[name]; seen {
+			continue
+		}
+		closure[name] = struct{}{}
+		queue = append(queue, depsByName[name]...)
+	}
+	return closure
+}
+
+// fluxSystemInClosure reports whether any of a system's compiled tiers is in closure. It is how a
+// globalDependency barrier skips the system it depends on (wiring it would form a cycle), the global
+// system itself included, since a system's own tiers are always in its closure.
+func fluxSystemInClosure(sys blueprintv1alpha1.FluxSystem, closure map[string]struct{}) bool {
+	for _, name := range sys.TierNames() {
+		if _, ok := closure[name]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// appendMissing returns deps with each addition not already present appended in order, so the barrier
+// never duplicates an edge a consumer already declares.
+func appendMissing(deps []string, additions []string) []string {
+	for _, add := range additions {
+		if !slices.Contains(deps, add) {
+			deps = append(deps, add)
+		}
+	}
+	return deps
 }
 
 // resolveTierDependencies rewrites a dependsOn reference to a vendor's bare name into its install

--- a/pkg/composer/blueprint/composer_test.go
+++ b/pkg/composer/blueprint/composer_test.go
@@ -1089,6 +1089,147 @@ func TestComposer_applyCrdLayerBarrier(t *testing.T) {
 	})
 }
 
+func TestComposer_applyGlobalDependencyBarrier(t *testing.T) {
+	kDeps := func(bp *blueprintv1alpha1.Blueprint, name string) []string {
+		for _, k := range bp.Kustomizations {
+			if k.Name == name {
+				return k.DependsOn
+			}
+		}
+		return nil
+	}
+	sysDeps := func(bp *blueprintv1alpha1.Blueprint, name string) []string {
+		for _, s := range bp.FluxSystems {
+			if s.Name == name {
+				return s.DependsOn
+			}
+		}
+		return nil
+	}
+	install := func(components ...string) *blueprintv1alpha1.Kustomization {
+		return &blueprintv1alpha1.Kustomization{Components: components}
+	}
+	resources := func(components ...string) []blueprintv1alpha1.FluxVariant {
+		return []blueprintv1alpha1.FluxVariant{{Kustomization: blueprintv1alpha1.Kustomization{Components: components}}}
+	}
+
+	t.Run("WiresOutsideSystemsAndKustomizationsToTheResourcesTier", func(t *testing.T) {
+		// Given a globalDependency system with a resources tier, an unrelated system, and a flat kustomization
+		composer := &BaseBlueprintComposer{}
+		bp := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{Name: "policy", GlobalDependency: true, Install: install("kyverno"), Resources: resources("kyverno/policies")},
+				{Name: "telemetry", Install: install("prometheus")},
+			},
+			Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "gitops-webhook", Path: "gitops/flux"}},
+		}
+
+		composer.applyGlobalDependencyBarrier(bp)
+
+		// Then everything outside policy waits on its resources tier, and policy does not order after itself
+		if !slices.Contains(sysDeps(bp, "telemetry"), "policy-resources") {
+			t.Errorf("expected telemetry wired to policy-resources, got %v", sysDeps(bp, "telemetry"))
+		}
+		if !slices.Contains(kDeps(bp, "gitops-webhook"), "policy-resources") {
+			t.Errorf("expected gitops-webhook wired to policy-resources, got %v", kDeps(bp, "gitops-webhook"))
+		}
+		if slices.Contains(sysDeps(bp, "policy"), "policy-resources") {
+			t.Errorf("expected policy not wired to its own tier, got %v", sysDeps(bp, "policy"))
+		}
+	})
+
+	t.Run("ExcludesSystemsInTheGlobalSystemsClosure", func(t *testing.T) {
+		// Given policy depends on telemetry's install tier, so telemetry is in policy's closure
+		composer := &BaseBlueprintComposer{}
+		bp := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{Name: "policy", GlobalDependency: true, DependsOn: []string{"telemetry-install"}, Install: install("kyverno"), Resources: resources("kyverno/policies")},
+				{Name: "telemetry", Install: install("prometheus")},
+			},
+		}
+
+		composer.applyGlobalDependencyBarrier(bp)
+
+		// Then telemetry is not wired back to policy-resources (that would be a cycle)
+		if slices.Contains(sysDeps(bp, "telemetry"), "policy-resources") {
+			t.Errorf("expected telemetry (in policy's closure) left unwired, got %v", sysDeps(bp, "telemetry"))
+		}
+	})
+
+	t.Run("TargetsInstallTierWhenNoResources", func(t *testing.T) {
+		// Given a globalDependency system with only an install tier
+		composer := &BaseBlueprintComposer{}
+		bp := &blueprintv1alpha1.Blueprint{
+			FluxSystems:    []blueprintv1alpha1.FluxSystem{{Name: "cni", GlobalDependency: true, Install: install("cilium")}},
+			Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "app", Path: "app"}},
+		}
+
+		composer.applyGlobalDependencyBarrier(bp)
+
+		if !slices.Equal(kDeps(bp, "app"), []string{"cni-install"}) {
+			t.Errorf("expected app wired to cni-install, got %v", kDeps(bp, "app"))
+		}
+	})
+
+	t.Run("DoesNotDuplicateAnExistingEdge", func(t *testing.T) {
+		// Given a consumer that already depends on the terminal tier
+		composer := &BaseBlueprintComposer{}
+		bp := &blueprintv1alpha1.Blueprint{
+			FluxSystems:    []blueprintv1alpha1.FluxSystem{{Name: "policy", GlobalDependency: true, Install: install("kyverno"), Resources: resources("kyverno/policies")}},
+			Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "app", Path: "app", DependsOn: []string{"policy-resources"}}},
+		}
+
+		composer.applyGlobalDependencyBarrier(bp)
+
+		if !slices.Equal(kDeps(bp, "app"), []string{"policy-resources"}) {
+			t.Errorf("expected app to keep a single policy-resources edge, got %v", kDeps(bp, "app"))
+		}
+	})
+
+	t.Run("ComposesWithTheCrdLayerBarrierWithoutACycle", func(t *testing.T) {
+		// Given a crds layer plus a globalDependency policy system and a consumer, both roots
+		composer := &BaseBlueprintComposer{}
+		bp := &blueprintv1alpha1.Blueprint{
+			Crds: []string{"kyverno-crds-1.0.0"},
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{Name: "policy", GlobalDependency: true, Install: install("kyverno"), Resources: resources("kyverno/policies")},
+				{Name: "telemetry", Install: install("prometheus")},
+			},
+		}
+
+		composer.applyCrdLayerBarrier(bp)
+		composer.applyGlobalDependencyBarrier(bp)
+
+		// Then policy roots at the crds layer and is not wired to itself
+		if !slices.Equal(sysDeps(bp, "policy"), []string{"crds"}) {
+			t.Errorf("expected policy to root at crds only, got %v", sysDeps(bp, "policy"))
+		}
+		// And telemetry waits on both the crds layer (barrier) and policy-resources (global), no duplicate
+		if !slices.Equal(sysDeps(bp, "telemetry"), []string{"crds", "policy-resources"}) {
+			t.Errorf("expected telemetry wired to crds then policy-resources, got %v", sysDeps(bp, "telemetry"))
+		}
+		// And the composed graph has no dangling dependency
+		if err := composer.validateDependencies(bp); err != nil {
+			t.Errorf("expected a valid dependency graph, got %v", err)
+		}
+	})
+
+	t.Run("NoopWithoutAGlobalDependencySystem", func(t *testing.T) {
+		// Given a system with the same shape but globalDependency unset
+		composer := &BaseBlueprintComposer{}
+		bp := &blueprintv1alpha1.Blueprint{
+			FluxSystems:    []blueprintv1alpha1.FluxSystem{{Name: "policy", Install: install("kyverno"), Resources: resources("kyverno/policies")}},
+			Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "app", Path: "app"}},
+		}
+
+		composer.applyGlobalDependencyBarrier(bp)
+
+		if len(kDeps(bp, "app")) != 0 {
+			t.Errorf("expected no barrier without a globalDependency system, got %v", kDeps(bp, "app"))
+		}
+	})
+}
+
 func sourceByName(bp *blueprintv1alpha1.Blueprint, name string) blueprintv1alpha1.Source {
 	for _, s := range bp.Sources {
 		if s.Name == name {

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -1239,6 +1239,7 @@ func (p *BaseBlueprintProcessor) applyFluxSystemEntryByStrategy(name string, new
 		merged.Install = blueprintv1alpha1.MergeFluxInstall(existing.Install, new.Install)
 		merged.Resources = blueprintv1alpha1.MergeFluxVariants(existing.Resources, new.Resources)
 		merged.Ordinal = new.Ordinal
+		merged.GlobalDependency = existing.GlobalDependency || new.GlobalDependency
 		entries[name] = &merged
 	}
 	return nil


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This adds an opt-in `globalDependency` flag to `FluxSystem` that only activates when explicitly set; existing blueprints with no `globalDependency: true` systems hit a one-pass no-op and are unaffected.
>
> **Overview**
>
> The PR introduces `GlobalDependency bool` on `FluxSystem` and a new compose pass (`applyGlobalDependencyBarrier`) that inverts the normal dependency declaration pattern: instead of every consumer naming a prerequisite system in its `dependsOn`, the prerequisite system declares itself cluster-wide once. The barrier wires every kustomization and flux system outside the global system's transitive dependency closure to wait on that system's terminal tier (resources tier if present, otherwise install tier).
>
> The merge rule in the processor uses logical OR, so `globalDependency` is sticky across blueprint layers — any layer asserting it wins. The compose pass runs after `applyCrdLayerBarrier`, so a global system already rooted at the CRDs layer carries that edge into its closure computation, preventing cycles. Six unit tests cover the terminal-tier selection, closure exclusion, deduplication, CRD-layer composition, and the no-op path.
>
> Reviewed by Claude for commit `d58a0a66`.

<!-- /claude-code-review:summary -->
