### PR TITLE
feat(test): Add comprehensive tests for Flux system and variant matching

### DIFF
--- a/integration/fixtures/facet-tiers/contexts/_template/facets/policy.yaml
+++ b/integration/fixtures/facet-tiers/contexts/_template/facets/policy.yaml
@@ -1,0 +1,21 @@
+kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: policy
+  description: A conditionally-gated flux system, and a resources variant gated by its own condition, to exercise expect.flux/exclude.flux assertions on flux system rendering.
+
+flux:
+
+- name: policy
+  when: (policy.enabled ?? false) == true
+  install:
+    components:
+    - kyverno
+    timeout: 5m
+    interval: 5m
+  resources:
+  - when: (policy.strict ?? false) == true
+    components:
+    - kyverno/strict-policies
+    timeout: 5m
+    interval: 5m

--- a/integration/fixtures/facet-tiers/contexts/_template/tests/tiers.test.yaml
+++ b/integration/fixtures/facet-tiers/contexts/_template/tests/tiers.test.yaml
@@ -1,0 +1,78 @@
+# flux: facet rendering assertions for the facet-tiers fixture.
+# Exercises expect.flux/exclude.flux against bp.FluxSystems directly, in the
+# author's own vocabulary, rather than requiring compiled tier names.
+
+cases:
+
+  # cert-manager (pki.yaml + pki-extra.yaml + addon-cert-manager-extra.yaml) merges
+  # install components across ordinals and merges same-ordinal unnamed resources
+  # variants into one entry, alongside a separately named variant.
+  - name: cert_manager_system_merges_across_facets
+    values: {}
+    expect:
+      flux:
+        - name: cert-manager
+          path: pki/cert-manager
+          install:
+            components:
+              - helm-release
+              - helm-release-extra-metrics
+          resources:
+            - components:
+                - private-issuer/ca
+                - private-issuer/wildcard
+            - name: extra
+              components:
+                - public-issuer
+      kustomize:
+        - name: cert-manager-resources
+          dependsOn:
+            - cert-manager-install
+
+  # policy's install tier renders and its resources variant is present when both
+  # when: conditions evaluate true.
+  - name: policy_system_and_strict_variant_included_when_enabled
+    values:
+      policy:
+        enabled: true
+        strict: true
+    expect:
+      flux:
+        - name: policy
+          install:
+            components:
+              - kyverno
+          resources:
+            - components:
+                - kyverno/strict-policies
+
+  # policy's install tier still renders when only the system is enabled, but its
+  # resources variant is gated off by its own when: -- install remaining present
+  # while one resources variant is absent is the realistic "addon disabled" shape.
+  - name: policy_strict_variant_excluded_when_its_own_condition_is_false
+    values:
+      policy:
+        enabled: true
+        strict: false
+    expect:
+      flux:
+        - name: policy
+          install:
+            components:
+              - kyverno
+    exclude:
+      flux:
+        - name: policy
+          resources:
+            - components:
+                - kyverno/strict-policies
+
+  # The whole policy system is absent -- not just its resources tier -- when the
+  # system's own when: is false.
+  - name: policy_system_excluded_entirely_when_disabled
+    values:
+      policy:
+        enabled: false
+    exclude:
+      flux:
+        - name: policy

--- a/integration/test_test.go
+++ b/integration/test_test.go
@@ -63,3 +63,22 @@ func TestWindsorTest_TerraformOutputUnregisteredFixture(t *testing.T) {
 		t.Errorf("expected PASS or ✓ in output: %s", out)
 	}
 }
+
+// TestWindsorTest_FluxSystemTiersFixture exercises expect.flux/exclude.flux against the
+// facet-tiers fixture's tiers.test.yaml: a system merged across facets (install components
+// accumulate, same-ordinal resources variants merge), and a when:-gated system whose install
+// tier and resources variant can be asserted present or absent independently, in the author's
+// own flux: vocabulary rather than compiled tier names.
+func TestWindsorTest_FluxSystemTiersFixture(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "facet-tiers")
+	env = append(env, "WINDSOR_CONTEXT=default")
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"test"}, env)
+	if err != nil {
+		t.Fatalf("windsor test: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
+	}
+	out := string(stdout) + string(stderr)
+	if !strings.Contains(out, "PASS") && !strings.Contains(out, "✓") {
+		t.Errorf("expected PASS or ✓ in output: %s", out)
+	}
+}

--- a/pkg/test/runner.go
+++ b/pkg/test/runner.go
@@ -520,8 +520,19 @@ func (r *TestRunner) matchBlueprint(bp *blueprintv1alpha1.Blueprint, expect *blu
 			continue
 		}
 
-		kustomizeDiffs := r.matchKustomization(found, expectK)
+		kustomizeDiffs := r.matchKustomization(found, expectK, expectK.Name)
 		diffs = append(diffs, kustomizeDiffs...)
+	}
+
+	for _, expectSys := range expect.FluxSystems {
+		found := r.findFluxSystem(bp, expectSys)
+		if found == nil {
+			diffs = append(diffs, fmt.Sprintf("flux system not found: %s", expectSys.Name))
+			continue
+		}
+
+		fluxDiffs := r.matchFluxSystem(found, expectSys)
+		diffs = append(diffs, fluxDiffs...)
 	}
 
 	for _, ref := range expect.Crds {
@@ -564,6 +575,18 @@ func (r *TestRunner) matchExclusions(bp *blueprintv1alpha1.Blueprint, exclude *b
 		}
 	}
 
+	for _, excludeSys := range exclude.FluxSystems {
+		found := r.findFluxSystem(bp, excludeSys)
+		if found == nil {
+			continue
+		}
+		if excludeSys.Install == nil && len(excludeSys.Resources) == 0 {
+			diffs = append(diffs, fmt.Sprintf("flux system should not exist: %s", excludeSys.Name))
+			continue
+		}
+		diffs = append(diffs, r.matchFluxSystemExclusions(found, excludeSys)...)
+	}
+
 	for _, ref := range exclude.Crds {
 		if blueprintInstallsCrd(bp, ref) {
 			diffs = append(diffs, fmt.Sprintf("crd reference should not exist: %s", ref))
@@ -592,17 +615,63 @@ func (r *TestRunner) findTerraformComponent(bp *blueprintv1alpha1.Blueprint, exp
 }
 
 // findKustomization searches the blueprint's Kustomizations for a kustomization matching the expected
-// kustomization's name. It performs a linear search through all Kustomizations, comparing names exactly.
-// Returns a pointer to the matching kustomization if found, or nil if no kustomization with the
-// specified name exists in the blueprint.
+// kustomization's name, across both plain kustomize: entries and the install/resources tiers compiled
+// from flux: systems. It performs a linear search over AllKustomizations, comparing names exactly.
+// Returns a pointer to a copy of the matching kustomization if found, or nil if no kustomization with
+// the specified name exists in the blueprint.
 func (r *TestRunner) findKustomization(bp *blueprintv1alpha1.Blueprint, expect blueprintv1alpha1.Kustomization) *blueprintv1alpha1.Kustomization {
-	for i := range bp.Kustomizations {
-		k := &bp.Kustomizations[i]
+	for _, k := range bp.AllKustomizations() {
 		if k.Name == expect.Name {
-			return k
+			match := k
+			return &match
 		}
 	}
 	return nil
+}
+
+// findFluxSystem searches the blueprint's FluxSystems for a system matching the expected system's name.
+// bp.FluxSystems holds each system after facet merging and when-expression evaluation but before tier
+// compilation, so this is the author's own flux: shape rather than the compiled Kustomization output.
+// Returns a pointer to the matching system if found, or nil if no system with that name exists.
+func (r *TestRunner) findFluxSystem(bp *blueprintv1alpha1.Blueprint, expect blueprintv1alpha1.FluxSystem) *blueprintv1alpha1.FluxSystem {
+	for i := range bp.FluxSystems {
+		if bp.FluxSystems[i].Name == expect.Name {
+			return &bp.FluxSystems[i]
+		}
+	}
+	return nil
+}
+
+// findFluxVariant searches actual for a resources variant matching expect: by Name when the expectation
+// sets one, otherwise by expect.Components being a subset of a variant's Components so an unnamed or
+// facet-merged variant can still be identified. When expect gives neither a name nor components and
+// actual holds exactly one variant, that variant is returned. Returns nil if no variant matches.
+func (r *TestRunner) findFluxVariant(actual []blueprintv1alpha1.FluxVariant, expect blueprintv1alpha1.FluxVariant) *blueprintv1alpha1.FluxVariant {
+	for i := range actual {
+		v := &actual[i]
+		if expect.Name != "" {
+			if v.Name == expect.Name {
+				return v
+			}
+			continue
+		}
+		if len(expect.Components) > 0 && containsAll(v.Components, expect.Components) {
+			return v
+		}
+	}
+	if expect.Name == "" && len(expect.Components) == 0 && len(actual) == 1 {
+		return &actual[0]
+	}
+	return nil
+}
+
+// fluxVariantIdentifier returns a human-readable label for a resources variant expectation, for use in
+// diff messages: the variant's Name when set, otherwise its Components joined for display.
+func fluxVariantIdentifier(v blueprintv1alpha1.FluxVariant) string {
+	if v.Name != "" {
+		return v.Name
+	}
+	return strings.Join(v.Components, ",")
 }
 
 // matchTerraformComponent compares an actual Terraform component against expected properties and returns
@@ -655,24 +724,24 @@ func (r *TestRunner) matchTerraformComponent(actual *blueprintv1alpha1.Terraform
 // are validated. The function checks path, source, dependsOn, components, and substitutions fields. For
 // dependsOn and components, it verifies that all expected items are present in the actual kustomization's
 // lists. For substitutions, it performs strict value equality checking - each expected key must exist with
-// the exact expected value. Returns an empty slice if all specified properties match, or a list of
-// formatted difference messages describing mismatches, with each message prefixed by the kustomization
-// name for clarity.
-func (r *TestRunner) matchKustomization(actual *blueprintv1alpha1.Kustomization, expect blueprintv1alpha1.Kustomization) []string {
+// the exact expected value. label prefixes each diff message so callers nested under a flux system (Install,
+// a Resources variant) can identify the field's origin without borrowing the kustomization's own Name.
+// Returns an empty slice if all specified properties match.
+func (r *TestRunner) matchKustomization(actual *blueprintv1alpha1.Kustomization, expect blueprintv1alpha1.Kustomization, label string) []string {
 	var diffs []string
 
 	if expect.Path != "" && actual.Path != expect.Path {
-		diffs = append(diffs, fmt.Sprintf("kustomize[%s].path: expected %q, got %q", expect.Name, expect.Path, actual.Path))
+		diffs = append(diffs, fmt.Sprintf("kustomize[%s].path: expected %q, got %q", label, expect.Path, actual.Path))
 	}
 
 	if expect.Source != "" && actual.Source != expect.Source {
-		diffs = append(diffs, fmt.Sprintf("kustomize[%s].source: expected %q, got %q", expect.Name, expect.Source, actual.Source))
+		diffs = append(diffs, fmt.Sprintf("kustomize[%s].source: expected %q, got %q", label, expect.Source, actual.Source))
 	}
 
 	if len(expect.DependsOn) > 0 {
 		for _, dep := range expect.DependsOn {
 			if !contains(actual.DependsOn, dep) {
-				diffs = append(diffs, fmt.Sprintf("kustomize[%s].dependsOn: missing %q", expect.Name, dep))
+				diffs = append(diffs, fmt.Sprintf("kustomize[%s].dependsOn: missing %q", label, dep))
 			}
 		}
 	}
@@ -680,7 +749,7 @@ func (r *TestRunner) matchKustomization(actual *blueprintv1alpha1.Kustomization,
 	if len(expect.Components) > 0 {
 		for _, comp := range expect.Components {
 			if !contains(actual.Components, comp) {
-				diffs = append(diffs, fmt.Sprintf("kustomize[%s].components: missing %q", expect.Name, comp))
+				diffs = append(diffs, fmt.Sprintf("kustomize[%s].components: missing %q", label, comp))
 			}
 		}
 	}
@@ -689,12 +758,111 @@ func (r *TestRunner) matchKustomization(actual *blueprintv1alpha1.Kustomization,
 		for key, expectedValue := range expect.Substitutions {
 			actualValue, exists := actual.Substitutions[key]
 			if !exists {
-				diffs = append(diffs, fmt.Sprintf("kustomize[%s].substitutions[%s]: key not found", expect.Name, key))
+				diffs = append(diffs, fmt.Sprintf("kustomize[%s].substitutions[%s]: key not found", label, key))
 				continue
 			}
 			if expectedValue != actualValue {
-				diffs = append(diffs, fmt.Sprintf("kustomize[%s].substitutions[%s]: expected %q, got %q", expect.Name, key, expectedValue, actualValue))
+				diffs = append(diffs, fmt.Sprintf("kustomize[%s].substitutions[%s]: expected %q, got %q", label, key, expectedValue, actualValue))
 			}
+		}
+	}
+
+	return diffs
+}
+
+// matchFluxSystem compares an actual FluxSystem (from bp.FluxSystems, post facet-merge and
+// when-expression evaluation) against expected properties and returns a list of differences. It uses
+// partial matching: only properties set in the expect system are validated. Path, source, when, strategy,
+// and dependsOn are compared as the author wrote them (dependsOn is the system's own cross-layer edges,
+// not a composer-computed one). Ordinal and globalDependency compare when the expectation sets them;
+// globalDependency only asserts the true direction, since false is indistinguishable from unset. Install
+// and each Resources variant delegate to matchKustomization for their Kustomization fields. Enabled and
+// Destroy are not compared: neither is evaluated during composition, so they carry only the raw authored
+// expression at this stage, not a rendering outcome. Returns an empty slice if all specified properties
+// match.
+func (r *TestRunner) matchFluxSystem(actual *blueprintv1alpha1.FluxSystem, expect blueprintv1alpha1.FluxSystem) []string {
+	var diffs []string
+	name := expect.Name
+
+	if expect.Path != "" && actual.Path != expect.Path {
+		diffs = append(diffs, fmt.Sprintf("flux[%s].path: expected %q, got %q", name, expect.Path, actual.Path))
+	}
+
+	if expect.Source != "" && actual.Source != expect.Source {
+		diffs = append(diffs, fmt.Sprintf("flux[%s].source: expected %q, got %q", name, expect.Source, actual.Source))
+	}
+
+	if expect.When != "" && actual.When != expect.When {
+		diffs = append(diffs, fmt.Sprintf("flux[%s].when: expected %q, got %q", name, expect.When, actual.When))
+	}
+
+	if expect.Strategy != "" && actual.Strategy != expect.Strategy {
+		diffs = append(diffs, fmt.Sprintf("flux[%s].strategy: expected %q, got %q", name, expect.Strategy, actual.Strategy))
+	}
+
+	if len(expect.DependsOn) > 0 {
+		for _, dep := range expect.DependsOn {
+			if !contains(actual.DependsOn, dep) {
+				diffs = append(diffs, fmt.Sprintf("flux[%s].dependsOn: missing %q", name, dep))
+			}
+		}
+	}
+
+	if expect.Ordinal != nil {
+		switch {
+		case actual.Ordinal == nil:
+			diffs = append(diffs, fmt.Sprintf("flux[%s].ordinal: expected %d, got unset", name, *expect.Ordinal))
+		case *actual.Ordinal != *expect.Ordinal:
+			diffs = append(diffs, fmt.Sprintf("flux[%s].ordinal: expected %d, got %d", name, *expect.Ordinal, *actual.Ordinal))
+		}
+	}
+
+	if expect.GlobalDependency && !actual.GlobalDependency {
+		diffs = append(diffs, fmt.Sprintf("flux[%s].globalDependency: expected true, got false", name))
+	}
+
+	if expect.Install != nil {
+		if actual.Install == nil {
+			diffs = append(diffs, fmt.Sprintf("flux[%s].install: expected present, got absent", name))
+		} else {
+			diffs = append(diffs, r.matchKustomization(actual.Install, *expect.Install, name+".install")...)
+		}
+	}
+
+	for _, expectVariant := range expect.Resources {
+		identifier := fluxVariantIdentifier(expectVariant)
+		actualVariant := r.findFluxVariant(actual.Resources, expectVariant)
+		if actualVariant == nil {
+			diffs = append(diffs, fmt.Sprintf("flux[%s].resources: variant not found: %s", name, identifier))
+			continue
+		}
+		if expectVariant.When != "" && actualVariant.When != expectVariant.When {
+			diffs = append(diffs, fmt.Sprintf("flux[%s].resources[%s].when: expected %q, got %q", name, identifier, expectVariant.When, actualVariant.When))
+		}
+		label := fmt.Sprintf("%s.resources[%s]", name, identifier)
+		diffs = append(diffs, r.matchKustomization(&actualVariant.Kustomization, expectVariant.Kustomization, label)...)
+	}
+
+	return diffs
+}
+
+// matchFluxSystemExclusions verifies that specific parts of an actual FluxSystem (found by name) are
+// absent: the install tier when exclude.Install is set, and each named/matched resources variant in
+// exclude.Resources. Used when a fixture wants to assert a system is still partially present (e.g. its
+// install tier remains while one resources variant is gated off) rather than absent entirely, which
+// matchExclusions handles by name lookup alone before calling this. Returns an empty slice if every
+// excluded part is absent.
+func (r *TestRunner) matchFluxSystemExclusions(actual *blueprintv1alpha1.FluxSystem, exclude blueprintv1alpha1.FluxSystem) []string {
+	var diffs []string
+	name := exclude.Name
+
+	if exclude.Install != nil && actual.Install != nil {
+		diffs = append(diffs, fmt.Sprintf("flux[%s].install: should not exist", name))
+	}
+
+	for _, excludeVariant := range exclude.Resources {
+		if r.findFluxVariant(actual.Resources, excludeVariant) != nil {
+			diffs = append(diffs, fmt.Sprintf("flux[%s].resources: variant should not exist: %s", name, fluxVariantIdentifier(excludeVariant)))
 		}
 	}
 
@@ -965,6 +1133,16 @@ func contains(slice []string, item string) bool {
 		}
 	}
 	return false
+}
+
+// containsAll reports whether every item in needles is present in haystack, via contains.
+func containsAll(haystack []string, needles []string) bool {
+	for _, n := range needles {
+		if !contains(haystack, n) {
+			return false
+		}
+	}
+	return true
 }
 
 // blueprintInstallsCrd reports whether the composed blueprint installs ref — either from its own

--- a/pkg/test/runner_test.go
+++ b/pkg/test/runner_test.go
@@ -1141,6 +1141,125 @@ func TestTestRunner_matchBlueprint(t *testing.T) {
 			t.Errorf("Expected no diffs when expect is empty, got: %v", diffs)
 		}
 	})
+
+	t.Run("ReturnsDiffsWhenFluxSystemNotFound", func(t *testing.T) {
+		// Given a blueprint missing the expected flux: system
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{}
+
+		expect := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{Name: "missing-system"},
+			},
+		}
+
+		// When matching the blueprint
+		diffs := runner.matchBlueprint(blueprint, expect)
+
+		// Then diffs should indicate the missing system
+		if len(diffs) != 1 || !strings.Contains(diffs[0], "flux system not found: missing-system") {
+			t.Errorf("Expected flux system not found diff, got: %v", diffs)
+		}
+	})
+
+	t.Run("MatchesFluxSystemInstallAndNamedResourcesVariant", func(t *testing.T) {
+		// Given a composed blueprint carrying a flux: system with an install tier and a named resources variant
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name:      "cert-manager",
+					DependsOn: []string{"policy-resources"},
+					Install:   &blueprintv1alpha1.Kustomization{Components: []string{"cert-manager"}},
+					Resources: []blueprintv1alpha1.FluxVariant{
+						{Kustomization: blueprintv1alpha1.Kustomization{Name: "wildcard", Components: []string{"private-issuer/wildcard"}}},
+					},
+				},
+			},
+		}
+
+		// When the expectation asserts the system in the author's own vocabulary — name, dependsOn,
+		// install components, and a named resources variant's components
+		expect := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name:      "cert-manager",
+					DependsOn: []string{"policy-resources"},
+					Install:   &blueprintv1alpha1.Kustomization{Components: []string{"cert-manager"}},
+					Resources: []blueprintv1alpha1.FluxVariant{
+						{Kustomization: blueprintv1alpha1.Kustomization{Name: "wildcard", Components: []string{"private-issuer/wildcard"}}},
+					},
+				},
+			},
+		}
+
+		// Then no diffs should be returned
+		diffs := runner.matchBlueprint(blueprint, expect)
+		if len(diffs) != 0 {
+			t.Errorf("Expected no diffs, got: %v", diffs)
+		}
+	})
+
+	t.Run("ReturnsDiffsWhenFluxSystemInstallAbsent", func(t *testing.T) {
+		// Given a flux: system whose install tier was excluded by a when: condition
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{Name: "cert-manager"},
+			},
+		}
+
+		expect := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{Name: "cert-manager", Install: &blueprintv1alpha1.Kustomization{}},
+			},
+		}
+
+		// When matching the blueprint
+		diffs := runner.matchBlueprint(blueprint, expect)
+
+		// Then diffs should indicate the install tier is absent
+		if len(diffs) != 1 || !strings.Contains(diffs[0], "flux[cert-manager].install: expected present, got absent") {
+			t.Errorf("Expected install-absent diff, got: %v", diffs)
+		}
+	})
+
+	t.Run("ReturnsDiffsWhenFluxSystemResourcesVariantNotFound", func(t *testing.T) {
+		// Given a flux: system whose expected resources variant was gated off by when:
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{Name: "cert-manager"},
+			},
+		}
+
+		expect := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name: "cert-manager",
+					Resources: []blueprintv1alpha1.FluxVariant{
+						{Kustomization: blueprintv1alpha1.Kustomization{Components: []string{"private-issuer/ca"}}},
+					},
+				},
+			},
+		}
+
+		// When matching the blueprint
+		diffs := runner.matchBlueprint(blueprint, expect)
+
+		// Then diffs should indicate the variant is missing
+		if len(diffs) != 1 || !strings.Contains(diffs[0], "flux[cert-manager].resources: variant not found") {
+			t.Errorf("Expected variant-not-found diff, got: %v", diffs)
+		}
+	})
 }
 
 func TestTestRunner_matchExclusions(t *testing.T) {
@@ -1264,6 +1383,124 @@ func TestTestRunner_matchExclusions(t *testing.T) {
 			t.Errorf("Expected 1 diff, got: %d", len(diffs))
 		}
 	})
+
+	t.Run("CatchesExcludedComponentCompiledFromFluxSystem", func(t *testing.T) {
+		// Given a resources tier compiled from a flux: system carries the component a fixture excludes —
+		// this is the scenario that silently passed before findKustomization searched AllKustomizations()
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name: "pki",
+					Resources: []blueprintv1alpha1.FluxVariant{
+						{Kustomization: blueprintv1alpha1.Kustomization{Components: []string{"private-issuer/ca"}}},
+					},
+				},
+			},
+		}
+
+		exclude := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "pki-resources", Components: []string{"private-issuer/ca"}},
+			},
+		}
+
+		// When matching exclusions
+		diffs := runner.matchExclusions(blueprint, exclude)
+
+		// Then a diff must be reported, not silently pass
+		if len(diffs) != 1 || !strings.Contains(diffs[0], "kustomization should not exist: pki-resources") {
+			t.Errorf("Expected excluded compiled kustomization diff, got: %v", diffs)
+		}
+	})
+
+	t.Run("ReturnsNoDiffsWhenExcludedFluxSystemAbsent", func(t *testing.T) {
+		// Given a blueprint without the excluded flux: system at all
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{}
+
+		exclude := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{Name: "should-not-exist"},
+			},
+		}
+
+		// When matching exclusions
+		diffs := runner.matchExclusions(blueprint, exclude)
+
+		// Then no diffs should be returned
+		if len(diffs) != 0 {
+			t.Errorf("Expected no diffs, got: %v", diffs)
+		}
+	})
+
+	t.Run("ReturnsDiffsWhenExcludedFluxSystemExistsEntirely", func(t *testing.T) {
+		// Given a blueprint carrying a flux: system a fixture asserts must not exist at all
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{Name: "should-not-exist"},
+			},
+		}
+
+		exclude := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{Name: "should-not-exist"},
+			},
+		}
+
+		// When matching exclusions
+		diffs := runner.matchExclusions(blueprint, exclude)
+
+		// Then diffs should indicate the whole system should not exist
+		if len(diffs) != 1 || !strings.Contains(diffs[0], "flux system should not exist: should-not-exist") {
+			t.Errorf("Expected whole-system exclusion diff, got: %v", diffs)
+		}
+	})
+
+	t.Run("ReturnsDiffsWhenExcludedResourcesVariantExistsWithinPresentSystem", func(t *testing.T) {
+		// Given a flux: system whose install tier legitimately remains while one resources variant
+		// should have been gated off by when: — the system itself must not be reported as excludable
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name:    "pki",
+					Install: &blueprintv1alpha1.Kustomization{Components: []string{"trust-manager"}},
+					Resources: []blueprintv1alpha1.FluxVariant{
+						{Kustomization: blueprintv1alpha1.Kustomization{Components: []string{"private-issuer/ca"}}},
+					},
+				},
+			},
+		}
+
+		exclude := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name: "pki",
+					Resources: []blueprintv1alpha1.FluxVariant{
+						{Kustomization: blueprintv1alpha1.Kustomization{Components: []string{"private-issuer/ca"}}},
+					},
+				},
+			},
+		}
+
+		// When matching exclusions
+		diffs := runner.matchExclusions(blueprint, exclude)
+
+		// Then diffs should identify the variant, not the whole system
+		if len(diffs) != 1 || !strings.Contains(diffs[0], "flux[pki].resources: variant should not exist") {
+			t.Errorf("Expected variant-level exclusion diff, got: %v", diffs)
+		}
+	})
 }
 
 func TestTestRunner_findTerraformComponent(t *testing.T) {
@@ -1358,6 +1595,61 @@ func TestTestRunner_findKustomization(t *testing.T) {
 		// Then nil should be returned
 		if found != nil {
 			t.Error("Expected nil for nonexistent kustomization")
+		}
+	})
+
+	t.Run("FindsInstallTierCompiledFromFluxSystem", func(t *testing.T) {
+		// Given a blueprint whose only kustomization comes from a flux: system's install tier
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name:    "cert-manager",
+					Install: &blueprintv1alpha1.Kustomization{Components: []string{"cert-manager"}},
+				},
+			},
+		}
+
+		// When finding the compiled install tier by name
+		found := runner.findKustomization(blueprint, blueprintv1alpha1.Kustomization{Name: "cert-manager-install"})
+
+		// Then the compiled kustomization should be found
+		if found == nil {
+			t.Fatal("Expected compiled install tier to be found")
+		}
+		if !contains(found.Components, "cert-manager") {
+			t.Errorf("Expected compiled install tier to carry components, got %v", found.Components)
+		}
+	})
+
+	t.Run("FindsResourcesTierCompiledFromFluxSystem", func(t *testing.T) {
+		// Given a blueprint whose flux: system has both an install and a resources tier
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name:    "cert-manager",
+					Install: &blueprintv1alpha1.Kustomization{Components: []string{"cert-manager"}},
+					Resources: []blueprintv1alpha1.FluxVariant{
+						{Kustomization: blueprintv1alpha1.Kustomization{Components: []string{"private-issuer/ca"}}},
+					},
+				},
+			},
+		}
+
+		// When finding the compiled resources tier by name
+		found := runner.findKustomization(blueprint, blueprintv1alpha1.Kustomization{Name: "cert-manager-resources"})
+
+		// Then the compiled kustomization should be found, depending on the install tier
+		if found == nil {
+			t.Fatal("Expected compiled resources tier to be found")
+		}
+		if !contains(found.DependsOn, "cert-manager-install") {
+			t.Errorf("Expected compiled resources tier to depend on install tier, got %v", found.DependsOn)
 		}
 	})
 }
@@ -1596,7 +1888,7 @@ func TestTestRunner_matchKustomization(t *testing.T) {
 		}
 
 		// When matching
-		diffs := runner.matchKustomization(actual, expect)
+		diffs := runner.matchKustomization(actual, expect, expect.Name)
 
 		// Then no diffs should be returned
 		if len(diffs) != 0 {
@@ -1620,7 +1912,7 @@ func TestTestRunner_matchKustomization(t *testing.T) {
 		}
 
 		// When matching
-		diffs := runner.matchKustomization(actual, expect)
+		diffs := runner.matchKustomization(actual, expect, expect.Name)
 
 		// Then diffs should indicate path mismatch
 		if len(diffs) != 1 {
@@ -1644,7 +1936,7 @@ func TestTestRunner_matchKustomization(t *testing.T) {
 		}
 
 		// When matching
-		diffs := runner.matchKustomization(actual, expect)
+		diffs := runner.matchKustomization(actual, expect, expect.Name)
 
 		// Then diffs should indicate source mismatch
 		if len(diffs) != 1 {
@@ -1668,7 +1960,7 @@ func TestTestRunner_matchKustomization(t *testing.T) {
 		}
 
 		// When matching
-		diffs := runner.matchKustomization(actual, expect)
+		diffs := runner.matchKustomization(actual, expect, expect.Name)
 
 		// Then diffs should indicate missing dependency
 		if len(diffs) != 1 {
@@ -1692,7 +1984,7 @@ func TestTestRunner_matchKustomization(t *testing.T) {
 		}
 
 		// When matching
-		diffs := runner.matchKustomization(actual, expect)
+		diffs := runner.matchKustomization(actual, expect, expect.Name)
 
 		// Then diffs should indicate missing component
 		if len(diffs) != 1 {
@@ -1721,7 +2013,7 @@ func TestTestRunner_matchKustomization(t *testing.T) {
 		}
 
 		// When matching
-		diffs := runner.matchKustomization(actual, expect)
+		diffs := runner.matchKustomization(actual, expect, expect.Name)
 
 		// Then no diffs should be returned
 		if len(diffs) != 0 {
@@ -1749,7 +2041,7 @@ func TestTestRunner_matchKustomization(t *testing.T) {
 		}
 
 		// When matching
-		diffs := runner.matchKustomization(actual, expect)
+		diffs := runner.matchKustomization(actual, expect, expect.Name)
 
 		// Then diffs should indicate value mismatch
 		if len(diffs) != 1 {
@@ -1775,11 +2067,391 @@ func TestTestRunner_matchKustomization(t *testing.T) {
 		}
 
 		// When matching
-		diffs := runner.matchKustomization(actual, expect)
+		diffs := runner.matchKustomization(actual, expect, expect.Name)
 
 		// Then diffs should indicate missing key
 		if len(diffs) != 1 {
 			t.Errorf("Expected 1 diff, got: %d", len(diffs))
+		}
+	})
+}
+
+func TestTestRunner_findFluxSystem(t *testing.T) {
+	t.Run("FindsByName", func(t *testing.T) {
+		// Given a blueprint with a flux: system
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{Name: "cert-manager"},
+			},
+		}
+
+		// When finding by name
+		found := runner.findFluxSystem(blueprint, blueprintv1alpha1.FluxSystem{Name: "cert-manager"})
+
+		// Then the system should be found
+		if found == nil {
+			t.Error("Expected flux system to be found")
+		}
+	})
+
+	t.Run("ReturnsNilWhenNotFound", func(t *testing.T) {
+		// Given a blueprint without the named system
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{}
+
+		// When finding a nonexistent system
+		found := runner.findFluxSystem(blueprint, blueprintv1alpha1.FluxSystem{Name: "nonexistent"})
+
+		// Then nil should be returned
+		if found != nil {
+			t.Error("Expected nil for nonexistent flux system")
+		}
+	})
+}
+
+func TestTestRunner_findFluxVariant(t *testing.T) {
+	t.Run("FindsByName", func(t *testing.T) {
+		// Given actual variants including one with a matching name
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		actual := []blueprintv1alpha1.FluxVariant{
+			{Kustomization: blueprintv1alpha1.Kustomization{Name: "wildcard", Components: []string{"private-issuer/wildcard"}}},
+			{Kustomization: blueprintv1alpha1.Kustomization{Name: "ca", Components: []string{"private-issuer/ca"}}},
+		}
+
+		// When finding by name
+		found := runner.findFluxVariant(actual, blueprintv1alpha1.FluxVariant{Kustomization: blueprintv1alpha1.Kustomization{Name: "ca"}})
+
+		// Then the matching variant should be found
+		if found == nil || found.Name != "ca" {
+			t.Errorf("Expected to find variant \"ca\", got: %+v", found)
+		}
+	})
+
+	t.Run("FindsByComponentSubsetWhenNameUnset", func(t *testing.T) {
+		// Given multiple unnamed/merged variants distinguished only by their components
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		actual := []blueprintv1alpha1.FluxVariant{
+			{Kustomization: blueprintv1alpha1.Kustomization{Components: []string{"kyverno/policies", "kyverno/extra"}}},
+			{Kustomization: blueprintv1alpha1.Kustomization{Components: []string{"private-issuer/ca"}}},
+		}
+
+		// When finding by a component subset
+		found := runner.findFluxVariant(actual, blueprintv1alpha1.FluxVariant{Kustomization: blueprintv1alpha1.Kustomization{Components: []string{"kyverno/policies"}}})
+
+		// Then the variant containing that component should be found
+		if found == nil || !contains(found.Components, "kyverno/extra") {
+			t.Errorf("Expected to find the kyverno variant, got: %+v", found)
+		}
+	})
+
+	t.Run("FallsBackToSoleVariantWhenNeitherNameNorComponentsGiven", func(t *testing.T) {
+		// Given exactly one actual variant and an expectation identifying it by neither name nor components
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		actual := []blueprintv1alpha1.FluxVariant{
+			{Kustomization: blueprintv1alpha1.Kustomization{Components: []string{"private-issuer/ca"}}},
+		}
+
+		// When finding with an empty expectation
+		found := runner.findFluxVariant(actual, blueprintv1alpha1.FluxVariant{})
+
+		// Then the sole variant should be returned
+		if found == nil {
+			t.Error("Expected the sole variant to be returned")
+		}
+	})
+
+	t.Run("ReturnsNilWhenNoVariantMatches", func(t *testing.T) {
+		// Given actual variants that share nothing with the expectation
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		actual := []blueprintv1alpha1.FluxVariant{
+			{Kustomization: blueprintv1alpha1.Kustomization{Name: "ca", Components: []string{"private-issuer/ca"}}},
+		}
+
+		// When finding by a name that doesn't exist
+		found := runner.findFluxVariant(actual, blueprintv1alpha1.FluxVariant{Kustomization: blueprintv1alpha1.Kustomization{Name: "wildcard"}})
+
+		// Then nil should be returned
+		if found != nil {
+			t.Error("Expected nil when no variant matches")
+		}
+	})
+}
+
+func TestTestRunner_matchFluxSystem(t *testing.T) {
+	t.Run("ReturnsNoDiffsWhenAllFieldsMatch", func(t *testing.T) {
+		// Given an actual system matching every asserted field
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		ordinal := 5
+		actual := &blueprintv1alpha1.FluxSystem{
+			Name:      "policy",
+			Path:      "policy",
+			Source:    "core",
+			When:      "${cluster.driver == 'talos'}",
+			Strategy:  "merge",
+			DependsOn: []string{"telemetry-install"},
+			Ordinal:   &ordinal,
+		}
+
+		expect := blueprintv1alpha1.FluxSystem{
+			Name:      "policy",
+			Path:      "policy",
+			Source:    "core",
+			When:      "${cluster.driver == 'talos'}",
+			Strategy:  "merge",
+			DependsOn: []string{"telemetry-install"},
+			Ordinal:   &ordinal,
+		}
+
+		// When matching
+		diffs := runner.matchFluxSystem(actual, expect)
+
+		// Then no diffs should be returned
+		if len(diffs) != 0 {
+			t.Errorf("Expected no diffs, got: %v", diffs)
+		}
+	})
+
+	t.Run("ReturnsDiffWhenPathMismatches", func(t *testing.T) {
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		actual := &blueprintv1alpha1.FluxSystem{Name: "policy", Path: "wrong"}
+		expect := blueprintv1alpha1.FluxSystem{Name: "policy", Path: "expected"}
+
+		diffs := runner.matchFluxSystem(actual, expect)
+
+		if len(diffs) != 1 {
+			t.Errorf("Expected 1 diff, got: %d", len(diffs))
+		}
+	})
+
+	t.Run("ReturnsDiffWhenSourceMismatches", func(t *testing.T) {
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		actual := &blueprintv1alpha1.FluxSystem{Name: "policy", Source: "wrong"}
+		expect := blueprintv1alpha1.FluxSystem{Name: "policy", Source: "expected"}
+
+		diffs := runner.matchFluxSystem(actual, expect)
+
+		if len(diffs) != 1 {
+			t.Errorf("Expected 1 diff, got: %d", len(diffs))
+		}
+	})
+
+	t.Run("ReturnsDiffWhenWhenMismatches", func(t *testing.T) {
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		actual := &blueprintv1alpha1.FluxSystem{Name: "policy", When: "wrong"}
+		expect := blueprintv1alpha1.FluxSystem{Name: "policy", When: "expected"}
+
+		diffs := runner.matchFluxSystem(actual, expect)
+
+		if len(diffs) != 1 {
+			t.Errorf("Expected 1 diff, got: %d", len(diffs))
+		}
+	})
+
+	t.Run("ReturnsDiffWhenStrategyMismatches", func(t *testing.T) {
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		actual := &blueprintv1alpha1.FluxSystem{Name: "policy", Strategy: "merge"}
+		expect := blueprintv1alpha1.FluxSystem{Name: "policy", Strategy: "remove"}
+
+		diffs := runner.matchFluxSystem(actual, expect)
+
+		if len(diffs) != 1 {
+			t.Errorf("Expected 1 diff, got: %d", len(diffs))
+		}
+	})
+
+	t.Run("ReturnsDiffWhenDependsOnMissing", func(t *testing.T) {
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		actual := &blueprintv1alpha1.FluxSystem{Name: "policy", DependsOn: []string{"telemetry-install"}}
+		expect := blueprintv1alpha1.FluxSystem{Name: "policy", DependsOn: []string{"telemetry-install", "csi"}}
+
+		diffs := runner.matchFluxSystem(actual, expect)
+
+		if len(diffs) != 1 {
+			t.Errorf("Expected 1 diff, got: %d", len(diffs))
+		}
+	})
+
+	t.Run("ReturnsDiffWhenOrdinalUnset", func(t *testing.T) {
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		ordinal := 3
+		actual := &blueprintv1alpha1.FluxSystem{Name: "policy"}
+		expect := blueprintv1alpha1.FluxSystem{Name: "policy", Ordinal: &ordinal}
+
+		diffs := runner.matchFluxSystem(actual, expect)
+
+		if len(diffs) != 1 {
+			t.Errorf("Expected 1 diff, got: %d", len(diffs))
+		}
+	})
+
+	t.Run("ReturnsDiffWhenOrdinalMismatches", func(t *testing.T) {
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		actualOrdinal, expectOrdinal := 1, 2
+		actual := &blueprintv1alpha1.FluxSystem{Name: "policy", Ordinal: &actualOrdinal}
+		expect := blueprintv1alpha1.FluxSystem{Name: "policy", Ordinal: &expectOrdinal}
+
+		diffs := runner.matchFluxSystem(actual, expect)
+
+		if len(diffs) != 1 {
+			t.Errorf("Expected 1 diff, got: %d", len(diffs))
+		}
+	})
+
+	t.Run("ReturnsDiffWhenGlobalDependencyExpectedTrueButActualFalse", func(t *testing.T) {
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		actual := &blueprintv1alpha1.FluxSystem{Name: "policy", GlobalDependency: false}
+		expect := blueprintv1alpha1.FluxSystem{Name: "policy", GlobalDependency: true}
+
+		diffs := runner.matchFluxSystem(actual, expect)
+
+		if len(diffs) != 1 {
+			t.Errorf("Expected 1 diff, got: %d", len(diffs))
+		}
+	})
+
+	t.Run("ReturnsNoDiffWhenGlobalDependencyNotAsserted", func(t *testing.T) {
+		// The zero value (false) is indistinguishable from "not asserted" — a documented limitation
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		actual := &blueprintv1alpha1.FluxSystem{Name: "policy", GlobalDependency: true}
+		expect := blueprintv1alpha1.FluxSystem{Name: "policy"}
+
+		diffs := runner.matchFluxSystem(actual, expect)
+
+		if len(diffs) != 0 {
+			t.Errorf("Expected no diffs, got: %v", diffs)
+		}
+	})
+
+	t.Run("DelegatesInstallMismatchesToMatchKustomization", func(t *testing.T) {
+		// Given an install tier missing an expected component
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		actual := &blueprintv1alpha1.FluxSystem{
+			Name:    "cert-manager",
+			Install: &blueprintv1alpha1.Kustomization{Components: []string{"cert-manager"}},
+		}
+		expect := blueprintv1alpha1.FluxSystem{
+			Name:    "cert-manager",
+			Install: &blueprintv1alpha1.Kustomization{Components: []string{"cert-manager", "cert-manager/prometheus"}},
+		}
+
+		diffs := runner.matchFluxSystem(actual, expect)
+
+		if len(diffs) != 1 || !strings.Contains(diffs[0], "kustomize[cert-manager.install].components") {
+			t.Errorf("Expected labeled install component diff, got: %v", diffs)
+		}
+	})
+
+	t.Run("ReturnsDiffWhenResourcesVariantWhenMismatches", func(t *testing.T) {
+		// Given a matched resources variant whose when: differs from expectation
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		actual := &blueprintv1alpha1.FluxSystem{
+			Name: "pki",
+			Resources: []blueprintv1alpha1.FluxVariant{
+				{Kustomization: blueprintv1alpha1.Kustomization{Name: "ca", Components: []string{"private-issuer/ca"}}, When: "${addons.private_ca.enabled}"},
+			},
+		}
+		expect := blueprintv1alpha1.FluxSystem{
+			Name: "pki",
+			Resources: []blueprintv1alpha1.FluxVariant{
+				{Kustomization: blueprintv1alpha1.Kustomization{Name: "ca"}, When: "${private_ca.enabled}"},
+			},
+		}
+
+		diffs := runner.matchFluxSystem(actual, expect)
+
+		if len(diffs) != 1 || !strings.Contains(diffs[0], "flux[pki].resources[ca].when") {
+			t.Errorf("Expected variant when: mismatch diff, got: %v", diffs)
+		}
+	})
+}
+
+func TestTestRunner_matchFluxSystemExclusions(t *testing.T) {
+	t.Run("ReturnsNoDiffsWhenNeitherInstallNorResourcesPresent", func(t *testing.T) {
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		actual := &blueprintv1alpha1.FluxSystem{Name: "pki"}
+		exclude := blueprintv1alpha1.FluxSystem{Name: "pki", Install: &blueprintv1alpha1.Kustomization{}}
+
+		diffs := runner.matchFluxSystemExclusions(actual, exclude)
+
+		if len(diffs) != 0 {
+			t.Errorf("Expected no diffs, got: %v", diffs)
+		}
+	})
+
+	t.Run("ReturnsDiffWhenExcludedInstallExists", func(t *testing.T) {
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		actual := &blueprintv1alpha1.FluxSystem{Name: "pki", Install: &blueprintv1alpha1.Kustomization{Components: []string{"cert-manager"}}}
+		exclude := blueprintv1alpha1.FluxSystem{Name: "pki", Install: &blueprintv1alpha1.Kustomization{}}
+
+		diffs := runner.matchFluxSystemExclusions(actual, exclude)
+
+		if len(diffs) != 1 || !strings.Contains(diffs[0], "flux[pki].install: should not exist") {
+			t.Errorf("Expected install-should-not-exist diff, got: %v", diffs)
+		}
+	})
+
+	t.Run("ReturnsDiffWhenExcludedResourcesVariantExists", func(t *testing.T) {
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		actual := &blueprintv1alpha1.FluxSystem{
+			Name: "pki",
+			Resources: []blueprintv1alpha1.FluxVariant{
+				{Kustomization: blueprintv1alpha1.Kustomization{Name: "ca", Components: []string{"private-issuer/ca"}}},
+			},
+		}
+		exclude := blueprintv1alpha1.FluxSystem{
+			Name: "pki",
+			Resources: []blueprintv1alpha1.FluxVariant{
+				{Kustomization: blueprintv1alpha1.Kustomization{Name: "ca"}},
+			},
+		}
+
+		diffs := runner.matchFluxSystemExclusions(actual, exclude)
+
+		if len(diffs) != 1 || !strings.Contains(diffs[0], "flux[pki].resources: variant should not exist: ca") {
+			t.Errorf("Expected variant-should-not-exist diff, got: %v", diffs)
 		}
 	})
 }
@@ -2529,6 +3201,47 @@ func TestContains(t *testing.T) {
 		// Then false should be returned
 		if result {
 			t.Error("Expected false for empty slice")
+		}
+	})
+}
+
+func TestContainsAll(t *testing.T) {
+	t.Run("ReturnsTrueWhenEveryNeedleIsPresent", func(t *testing.T) {
+		// Given a haystack containing every needle
+		haystack := []string{"a", "b", "c"}
+
+		// When checking a subset
+		result := containsAll(haystack, []string{"a", "c"})
+
+		// Then true should be returned
+		if !result {
+			t.Error("Expected true when every needle is present")
+		}
+	})
+
+	t.Run("ReturnsFalseWhenAnyNeedleIsMissing", func(t *testing.T) {
+		// Given a haystack missing one needle
+		haystack := []string{"a", "b"}
+
+		// When checking a set including the missing item
+		result := containsAll(haystack, []string{"a", "c"})
+
+		// Then false should be returned
+		if result {
+			t.Error("Expected false when a needle is missing")
+		}
+	})
+
+	t.Run("ReturnsTrueForEmptyNeedles", func(t *testing.T) {
+		// Given an empty set of needles
+		haystack := []string{"a"}
+
+		// When checking with no needles
+		result := containsAll(haystack, []string{})
+
+		// Then true should be returned vacuously
+		if !result {
+			t.Error("Expected true for empty needles")
 		}
 	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This PR extends the test runner's assertion vocabulary for Flux systems and fixes a pre-existing silent-pass bug in exclusion matching; no production CLI behavior changes.
>
> **Overview**
>
> The change adds `expect.flux` and `exclude.flux` as first-class assertion types in Windsor's YAML test framework, allowing fixtures to assert the pre-compilation shape of Flux systems (post facet-merge, post `when:` evaluation) independently from the compiled Kustomization names. Four new functions handle matching (`matchFluxSystem`, `matchFluxSystemExclusions`, `findFluxSystem`, `findFluxVariant`) and a helper (`containsAll`). A `label` parameter is threaded through `matchKustomization` so diff messages from nested flux contexts are unambiguous.
>
> The fix to `findKustomization` — switching from `bp.Kustomizations` to `bp.AllKustomizations()` — is a correctness improvement: `exclude.kustomize` entries referencing tier-compiled names (e.g. `pki-resources`) previously returned `nil` and silently passed; they now correctly detect and report the unwanted component. A new integration test and a policy fixture with `when:`-gated systems cover the end-to-end path.
>
> Reviewed by Claude for commit `b4b93bf2`.

<!-- /claude-code-review:summary -->
