### PR TITLE
feat(composer): support flat entries under flux:

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -597,10 +597,10 @@ type Kustomization struct {
 }
 
 // FluxSystem is a system entry under a blueprint or facet's `flux:` list — a functional layer that
-// compiles to an install Kustomization plus zero or more resources-variant Kustomizations. The
-// descriptor carries identity, lifecycle, and merge fields; the Install/Resources tiers reuse the
-// Kustomization type and carry the Flux operational properties per tier. It holds no operational
-// properties itself — those belong on the tiers that produce Kustomization objects.
+// compiles to either a single flat Kustomization or an install Kustomization plus zero or more
+// resources-variant Kustomizations. The descriptor carries identity, lifecycle, and merge fields;
+// Flat/Install/Resources reuse the Kustomization type and carry the Flux operational properties.
+// A system with neither Install nor Resources compiles flat, from Flat.
 type FluxSystem struct {
 	// Name identifies the system; tiers compile to "<name>-install" / "<name>-resources[-<variant>]".
 	Name string `yaml:"name"`
@@ -645,6 +645,9 @@ type FluxSystem struct {
 
 	// Resources are the custom-resource tier variants, all sharing "<path>/resources".
 	Resources []FluxVariant `yaml:"resources,omitempty"`
+
+	// Flat carries a flat entry's operational properties inline; see HasFlatContent.
+	Flat *Kustomization `yaml:",inline"`
 }
 
 // FluxVariant is one resources-tier Kustomization of a system. It reuses Kustomization for its
@@ -999,9 +1002,9 @@ func (b *Blueprint) RemoveKustomization(removal Kustomization) error {
 }
 
 // RemoveFluxSystem removes specified non-index fields from an existing FluxSystem. It finds a
-// system matching the same Name, then subtracts dependsOn entries and any install fields named in
-// removal.Install (reusing subtractKustomizationFields, since Install is itself a Kustomization
-// carrying no Name until tier compilation, so it cannot go through RemoveKustomization's by-Name
+// system matching the same Name, then subtracts dependsOn entries and any install/flat fields named
+// in removal.Install/removal.Flat (reusing subtractKustomizationFields, since both are Kustomizations
+// carrying no Name until tier compilation, so neither can go through RemoveKustomization's by-Name
 // lookup), and drops any resources variant whose Name is named in removal.Resources (empty Name
 // matches the unnamed variant). A resources variant has no kustomize: analog — it compiles to its
 // own distinct Kustomization — so naming it is itself the field-level operation, not a whole-system
@@ -1017,6 +1020,11 @@ func (b *Blueprint) RemoveFluxSystem(removal FluxSystem) error {
 		if removal.Install != nil && existing.Install != nil {
 			subtracted := subtractKustomizationFields(*existing.Install, *removal.Install)
 			existing.Install = &subtracted
+		}
+
+		if removal.Flat != nil && existing.Flat != nil {
+			subtracted := subtractKustomizationFields(*existing.Flat, *removal.Flat)
+			existing.Flat = &subtracted
 		}
 
 		if len(removal.Resources) > 0 {
@@ -1035,12 +1043,12 @@ func (b *Blueprint) RemoveFluxSystem(removal FluxSystem) error {
 
 // UpsertFluxSystem merges sys into the FluxSystem with the same Name if one exists in
 // b.FluxSystems, or appends it when none does. On a match, DependsOn accumulates (union) and
-// Install/Resources deep-merge via MergeFluxInstall/MergeFluxVariants — the same field-level
+// Install/Resources/Flat deep-merge via MergeFluxInstall/MergeFluxVariants — the same field-level
 // semantics strategicMergeKustomization already gives same-name plain kustomize: entries — rather
 // than sys wholesale-replacing what is already there. This is the path StrategicMerge uses to
 // combine FluxSystems across sources (each source's facets already merged among themselves before
-// reaching here), so a same-name collision here must not silently drop one side's install/resources
-// tiers the way a blind replace would.
+// reaching here), so a same-name collision here must not silently drop one side's install/resources/
+// flat content the way a blind replace would.
 func (b *Blueprint) UpsertFluxSystem(sys FluxSystem) error {
 	for i, existing := range b.FluxSystems {
 		if existing.Name == sys.Name {
@@ -1052,6 +1060,7 @@ func (b *Blueprint) UpsertFluxSystem(sys FluxSystem) error {
 			}
 			merged.Install = MergeFluxInstall(existing.Install, sys.Install)
 			merged.Resources = MergeFluxVariants(existing.Resources, sys.Resources)
+			merged.Flat = MergeFluxInstall(existing.Flat, sys.Flat)
 			b.FluxSystems[i] = merged
 			return nil
 		}
@@ -1060,12 +1069,12 @@ func (b *Blueprint) UpsertFluxSystem(sys FluxSystem) error {
 	return nil
 }
 
-// MergeFluxInstall deep-merges overlay's Install tier into existing's via MergeKustomizationFields
-// (Components/DependsOn accumulate, other fields are overridden by overlay when set) rather than
-// via by-name Blueprint.Kustomizations matching, since Install carries no Name until tier
+// MergeFluxInstall deep-merges overlay into existing via MergeKustomizationFields (Components/
+// DependsOn accumulate, other fields are overridden by overlay when set) rather than via by-name
+// Blueprint.Kustomizations matching, since neither Install nor Flat carries a Name until tier
 // compilation and that by-name path is a no-op on an unnamed Kustomization. Either side being nil
-// just takes the other, matching how a facet or source with no Install opinion shouldn't erase one
-// contributed elsewhere.
+// just takes the other. Used for both FluxSystem.Install and FluxSystem.Flat — the merge semantics
+// are identical regardless of which tier the Kustomization represents.
 func MergeFluxInstall(existing, overlay *Kustomization) *Kustomization {
 	if overlay == nil {
 		return existing
@@ -1132,16 +1141,54 @@ func (sys FluxSystem) TierNames() []string {
 	return names
 }
 
-// compileFluxSystemTiers converts a pre-evaluated FluxSystem into its tier Kustomizations without
-// any expression evaluation. Install compiles to "<name>-install" at "<path>/install"; each
-// resources variant compiles to "<name>-resources[-<variant>]" at "<path>/resources". A timeout-less
-// install tier falls back to DefaultFluxKustomizationInstallTimeout instead of the generic default.
+// HasFlatContent reports whether Flat carries any field an author actually set. The YAML library
+// allocates Flat unconditionally on unmarshal (it is an inline field), so non-nilness alone is
+// never a valid "is this a flat entry" signal — every caller checking Flat's presence (validation,
+// test-fixture matching) must go through this method instead of `Flat != nil`.
+func (sys FluxSystem) HasFlatContent() bool {
+	k := sys.Flat
+	if k == nil {
+		return false
+	}
+	return len(k.Components) > 0 ||
+		len(k.Substitutions) > 0 ||
+		len(k.Substitute) > 0 ||
+		k.Interval != nil ||
+		k.RetryInterval != nil ||
+		k.Timeout != nil ||
+		len(k.Patches) > 0 ||
+		k.Wait != nil ||
+		k.Force != nil ||
+		k.Prune != nil ||
+		k.Namespace != "" ||
+		k.TargetNamespace != "" ||
+		k.DestroyOnly != nil
+}
+
+// compileFluxSystemTiers converts a pre-evaluated FluxSystem into its compiled Kustomizations.
+// A system with neither Install nor Resources compiles flat, from Flat, to one Kustomization
+// named exactly name — always emitted regardless of component count, unlike install:'s "empty
+// means none" rule. Otherwise Install compiles to "<name>-install" and each resources variant to
+// "<name>-resources[-<variant>]", both under "<path>/install" or "<path>/resources".
 func compileFluxSystemTiers(sys FluxSystem) []Kustomization {
 	name := sys.Name
 	base := sys.Path
 	if base == "" {
 		base = name
 	}
+
+	if sys.Install == nil && len(sys.Resources) == 0 {
+		var k Kustomization
+		if sys.Flat != nil {
+			k = *sys.Flat.DeepCopy()
+		}
+		k.Name = name
+		k.Path = base
+		k.DependsOn = slices.Clone(sys.DependsOn)
+		applySystemTierDefaults(&k, sys)
+		return []Kustomization{k}
+	}
+
 	installName := name + "-install"
 
 	var out []Kustomization
@@ -1265,6 +1312,7 @@ func (s *FluxSystem) DeepCopy() *FluxSystem {
 		GlobalDependency: s.GlobalDependency,
 		Install:          s.Install.DeepCopy(),
 		Resources:        resourcesCopy,
+		Flat:             s.Flat.DeepCopy(),
 	}
 }
 

--- a/api/v1alpha1/blueprint_types_test.go
+++ b/api/v1alpha1/blueprint_types_test.go
@@ -2359,6 +2359,33 @@ func TestBlueprint_RemoveFluxSystem(t *testing.T) {
 		}
 	})
 
+	t.Run("RemovesFlatComponentsFromExistingSystem", func(t *testing.T) {
+		base := &Blueprint{
+			FluxSystems: []FluxSystem{
+				{
+					Name: "gateway-cilium",
+					Flat: &Kustomization{Components: []string{"cilium", "cilium/gateway", "keep_component"}},
+				},
+			},
+		}
+
+		removal := FluxSystem{
+			Name: "gateway-cilium",
+			Flat: &Kustomization{Components: []string{"cilium", "cilium/gateway"}},
+		}
+
+		err := base.RemoveFluxSystem(removal)
+
+		if err != nil {
+			t.Errorf("Unexpected error: %v", err)
+		}
+
+		sys := base.FluxSystems[0]
+		if sys.Flat == nil || len(sys.Flat.Components) != 1 || sys.Flat.Components[0] != "keep_component" {
+			t.Errorf("Expected only 'keep_component' to remain, got %+v", sys.Flat)
+		}
+	})
+
 	t.Run("LeavesInstallUnchangedWhenRemovalHasNoInstall", func(t *testing.T) {
 		base := &Blueprint{
 			FluxSystems: []FluxSystem{
@@ -4975,6 +5002,70 @@ func TestBlueprint_UpsertFluxSystem(t *testing.T) {
 			t.Fatalf("expected the original unnamed variant and the new named variant to both survive, got %+v", merged.Resources)
 		}
 	})
+
+	t.Run("MergesFlatComponentsOnNameCollision", func(t *testing.T) {
+		// Given a blueprint already carrying a flat gateway-cilium system
+		b := &Blueprint{
+			FluxSystems: []FluxSystem{
+				{Name: "gateway-cilium", Flat: &Kustomization{Components: []string{"cilium"}}},
+			},
+		}
+
+		// When a second same-named system contributes an additional flat component
+		if err := b.UpsertFluxSystem(FluxSystem{
+			Name: "gateway-cilium",
+			Flat: &Kustomization{Components: []string{"cilium/gateway"}},
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Then the flat components union into one entry
+		if len(b.FluxSystems) != 1 {
+			t.Fatalf("expected one merged entry, got %+v", b.FluxSystems)
+		}
+		merged := b.FluxSystems[0]
+		if merged.Flat == nil || !contains(merged.Flat.Components, "cilium") || !contains(merged.Flat.Components, "cilium/gateway") {
+			t.Errorf("expected flat components to union across the collision, got %+v", merged.Flat)
+		}
+	})
+}
+
+func TestFluxSystem_HasFlatContent(t *testing.T) {
+	t.Run("ReturnsFalseWhenFlatIsNil", func(t *testing.T) {
+		sys := FluxSystem{Name: "cert-manager"}
+
+		if sys.HasFlatContent() {
+			t.Error("expected false for a nil Flat")
+		}
+	})
+
+	t.Run("ReturnsFalseForAnUnpopulatedFlat", func(t *testing.T) {
+		// The zero-value Kustomization the YAML library allocates unconditionally must not
+		// register as real flat content.
+		sys := FluxSystem{Name: "cert-manager", Flat: &Kustomization{}}
+
+		if sys.HasFlatContent() {
+			t.Error("expected false for an unpopulated Flat")
+		}
+	})
+
+	t.Run("ReturnsTrueWhenComponentsSet", func(t *testing.T) {
+		sys := FluxSystem{Flat: &Kustomization{Components: []string{"cilium"}}}
+
+		if !sys.HasFlatContent() {
+			t.Error("expected true when Components is set")
+		}
+	})
+
+	t.Run("ReturnsTrueForANonComponentFieldAlone", func(t *testing.T) {
+		// A stray operational field with no Components must still register as content —
+		// this is the case validateFluxFlatExclusivity and matchFluxSystem both rely on.
+		sys := FluxSystem{Flat: &Kustomization{Substitute: map[string]string{"cluster_name": "prod"}}}
+
+		if !sys.HasFlatContent() {
+			t.Error("expected true when a non-Components field is set")
+		}
+	})
 }
 
 func TestFluxSystem_TierNames(t *testing.T) {
@@ -5002,11 +5093,15 @@ func TestFluxSystem_TierNames(t *testing.T) {
 		}
 	})
 
-	t.Run("ReturnsEmptyForSystemWithNoTiers", func(t *testing.T) {
+	t.Run("ReturnsFlatNameForSystemWithNoTiers", func(t *testing.T) {
+		// A system with neither Install nor Resources compiles flat: one Kustomization named
+		// exactly after the system, matching a bare kustomize: entry with no components.
 		sys := FluxSystem{Name: "empty-sys"}
 
-		if names := sys.TierNames(); len(names) != 0 {
-			t.Errorf("expected no tier names for a system with no install or resources, got %v", names)
+		names := sys.TierNames()
+		want := []string{"empty-sys"}
+		if len(names) != len(want) || names[0] != want[0] {
+			t.Errorf("expected %v for a flat system with no tiers, got %v", want, names)
 		}
 	})
 
@@ -5021,6 +5116,122 @@ func TestFluxSystem_TierNames(t *testing.T) {
 
 		if len(names) != 1 || names[0] != "cert-manager-resources-install" {
 			t.Fatalf("expected only cert-manager-resources-install, got %v", names)
+		}
+	})
+}
+
+func TestFluxSystem_CompilesFlat(t *testing.T) {
+	t.Run("CompilesToOneKustomizationNamedExactlyTheSystem", func(t *testing.T) {
+		// Given a flat system — no install, no resources — with components and an operational field
+		bp := &Blueprint{
+			FluxSystems: []FluxSystem{
+				{
+					Name:      "gateway-cilium",
+					DependsOn: []string{"gateway-install"},
+					Flat: &Kustomization{
+						Components: []string{"cilium", "cilium/gateway"},
+						Timeout:    &DurationString{Duration: 5 * time.Minute},
+					},
+				},
+			},
+		}
+
+		all := bp.AllKustomizations()
+
+		// Then it compiles to exactly one Kustomization, named after the system with no suffix
+		if len(all) != 1 {
+			t.Fatalf("expected exactly one compiled kustomization, got %+v", all)
+		}
+		k := all[0]
+		if k.Name != "gateway-cilium" {
+			t.Errorf("expected name %q with no tier suffix, got %q", "gateway-cilium", k.Name)
+		}
+		if k.Path != "gateway-cilium" {
+			t.Errorf("expected path to default to name with no tier subfolder, got %q", k.Path)
+		}
+		if !contains(k.Components, "cilium") || !contains(k.Components, "cilium/gateway") {
+			t.Errorf("expected flat components to carry through, got %v", k.Components)
+		}
+		if k.Timeout == nil || k.Timeout.Duration != 5*time.Minute {
+			t.Errorf("expected flat timeout to carry through, got %+v", k.Timeout)
+		}
+		if !contains(k.DependsOn, "gateway-install") {
+			t.Errorf("expected the system's dependsOn to attach directly, got %v", k.DependsOn)
+		}
+	})
+
+	t.Run("UsesExplicitPathOverDefaultingToName", func(t *testing.T) {
+		bp := &Blueprint{
+			FluxSystems: []FluxSystem{
+				{Name: "dashboards", Path: "observability/dashboards", Flat: &Kustomization{Components: []string{"grafana-dashboards"}}},
+			},
+		}
+
+		all := bp.AllKustomizations()
+
+		if len(all) != 1 || all[0].Path != "observability/dashboards" {
+			t.Fatalf("expected explicit path to win, got %+v", all)
+		}
+	})
+
+	t.Run("FallsThroughToSystemSourceEnabledDestroyLikeATier", func(t *testing.T) {
+		// Given a flat system with no Source/Enabled/Destroy of its own but the descriptor sets them
+		enabled := &BoolExpression{Value: ptrBool(false)}
+		bp := &Blueprint{
+			FluxSystems: []FluxSystem{
+				{
+					Name:    "gateway-cilium",
+					Source:  "core",
+					Enabled: enabled,
+					Flat:    &Kustomization{Components: []string{"cilium"}},
+				},
+			},
+		}
+
+		all := bp.AllKustomizations()
+
+		if len(all) != 1 {
+			t.Fatalf("expected one compiled kustomization, got %+v", all)
+		}
+		k := all[0]
+		if k.Source != "core" {
+			t.Errorf("expected source to fall through from the system descriptor, got %q", k.Source)
+		}
+		if k.Enabled == nil || k.Enabled.Value == nil || *k.Enabled.Value != false {
+			t.Errorf("expected enabled to fall through from the system descriptor, got %+v", k.Enabled)
+		}
+	})
+
+	t.Run("EmitsAKustomizationEvenWithZeroComponents", func(t *testing.T) {
+		// A flat system with no components is still a legitimate minimal form, matching a bare
+		// kustomize: entry with no components — never dropped the way an empty install tier is.
+		bp := &Blueprint{FluxSystems: []FluxSystem{{Name: "flux-system"}}}
+
+		all := bp.AllKustomizations()
+
+		if len(all) != 1 || all[0].Name != "flux-system" {
+			t.Fatalf("expected one flat kustomization named flux-system, got %+v", all)
+		}
+	})
+
+	t.Run("PrefersTieredCompilationWhenInstallIsSet", func(t *testing.T) {
+		// Given a system with both Install and (mistakenly) Flat set
+		bp := &Blueprint{
+			FluxSystems: []FluxSystem{
+				{
+					Name:    "cert-manager",
+					Install: &Kustomization{Components: []string{"cert-manager"}},
+					Flat:    &Kustomization{Components: []string{"stray"}},
+				},
+			},
+		}
+
+		all := bp.AllKustomizations()
+
+		// Then it compiles tiered — Flat is structurally ignored (validation catches this case
+		// separately at the composer layer; this test only pins the compile-time precedence)
+		if len(all) != 1 || all[0].Name != "cert-manager-install" {
+			t.Fatalf("expected tiered compilation to win, got %+v", all)
 		}
 	})
 }

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -246,18 +246,16 @@ func findKustomization(blueprint *blueprintv1alpha1.Blueprint, name string) (blu
 }
 
 // kustomizationNotFoundError returns a formatted error for when a kustomization is not found. If the
-// name instead matches a flux: system descriptor rather than one of its compiled tiers, the error
-// lists that system's tier names, since a system name (e.g. "cert-manager") is never itself a valid
-// argument.
+// name instead matches a tiered flux: system descriptor rather than one of its compiled tiers, the
+// error lists that system's tier names, since a tiered system's own name (e.g. "cert-manager") is
+// never itself a valid argument. A flat system's name always resolves via findKustomization instead
+// (it compiles to exactly one Kustomization named after the system), so it never reaches this path.
 func kustomizationNotFoundError(blueprint *blueprintv1alpha1.Blueprint, name string) error {
 	for _, sys := range blueprint.FluxSystems {
 		if sys.Name != name {
 			continue
 		}
 		tiers := sys.TierNames()
-		if len(tiers) == 0 {
-			return fmt.Errorf("%q is a flux system with no compiled install or resources tiers", name)
-		}
 		return fmt.Errorf("%q is a flux system, not a kustomization; use one of its tiers instead: %s",
 			name, strings.Join(tiers, ", "))
 	}

--- a/cmd/show_test.go
+++ b/cmd/show_test.go
@@ -106,8 +106,8 @@ func setupShowTest(t *testing.T, opts ...*SetupOptions) *ShowMocks {
 	mockBlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint { return testBlueprint }
 	mockBlueprintHandler.GetDeferredPathsFunc = func() map[string]bool {
 		return map[string]bool{
-			"terraform.test-component.inputs.deferred":       true,
-			"kustomize.test-kustomization.path":              true,
+			"terraform.test-component.inputs.deferred":                     true,
+			"kustomize.test-kustomization.path":                            true,
 			"kustomize.test-kustomization.substitutions.DEFERRED_ENDPOINT": true,
 		}
 	}
@@ -1115,13 +1115,16 @@ func TestShowKustomizationCmd(t *testing.T) {
 		}
 	})
 
-	t.Run("FluxSystemWithNoTiersReturnsClearError", func(t *testing.T) {
+	t.Run("FlatFluxSystemNameReturnsItsCompiledKustomization", func(t *testing.T) {
+		// A flux: system with neither install nor resources compiles flat, to one Kustomization
+		// named exactly after the system — findKustomization resolves it directly, the same as
+		// any other compiled name; it never reaches kustomizationNotFoundError's system lookup.
 		mocks := setupShowTest(t)
 
 		mocks.BlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint {
 			return &blueprintv1alpha1.Blueprint{
 				FluxSystems: []blueprintv1alpha1.FluxSystem{
-					{Name: "empty-sys"},
+					{Name: "flat-sys", Flat: &blueprintv1alpha1.Kustomization{Components: []string{"cilium"}}},
 				},
 			}
 		}
@@ -1135,20 +1138,29 @@ func TestShowKustomizationCmd(t *testing.T) {
 			Composer: comp,
 		})
 
+		stdout, stderr, closePipes := setupOutput(t)
+
 		cmd := createTestCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
 		cmd.SetContext(ctx)
-		cmd.SetArgs([]string{"empty-sys"})
+		cmd.SetArgs([]string{"flat-sys"})
 		err := cmd.Execute()
 
-		if err == nil {
-			t.Fatal("Expected error, got nil")
+		closePipes()
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v\nstderr: %s", err, stderr.String())
 		}
-		if !strings.Contains(err.Error(), "no compiled install or resources tiers") {
-			t.Errorf("Expected error to explain the system has no tiers, got: %v", err)
+
+		var kustomization kustomizev1.Kustomization
+		if unmarshalErr := yaml.Unmarshal(stdout.Bytes(), &kustomization); unmarshalErr != nil {
+			t.Fatalf("Expected valid YAML output, got error: %v\noutput: %s", unmarshalErr, stdout.String())
 		}
-		if strings.HasSuffix(err.Error(), ": ") {
-			t.Errorf("Expected error to not end with a dangling colon, got: %v", err)
+		if kustomization.Name != "flat-sys" {
+			t.Errorf("Expected kustomization name 'flat-sys' with no tier suffix, got %q", kustomization.Name)
+		}
+		if stderr.String() != "" {
+			t.Error("Expected empty stderr")
 		}
 	})
 

--- a/integration/composer_test.go
+++ b/integration/composer_test.go
@@ -593,3 +593,91 @@ func TestShowBlueprint_FacetComponentRequires_ComponentExcludedSkipsRequires(t *
 		t.Errorf("expected kind Blueprint, got %v", bp["kind"])
 	}
 }
+
+// TestShowBlueprint_FlatFluxEntry verifies that a flux: system with no install:/resources: tiers
+// compiles output-neutrally with an equivalent kustomize: entry: same name (no tier suffix), same
+// components, and the same bare-name dependsOn resolution ("cert-manager" -> "cert-manager-install")
+// that plain kustomize: entries already get from resolveTierDependencies.
+func TestShowBlueprint_FlatFluxEntry(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "facet-tiers")
+	env = append(env, "WINDSOR_CONTEXT=default")
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"show", "blueprint"}, env)
+	if err != nil {
+		t.Fatalf("show blueprint: %v\nstderr: %s", err, stderr)
+	}
+
+	var bp struct {
+		Flux []struct {
+			Name       string   `yaml:"name"`
+			DependsOn  []string `yaml:"dependsOn"`
+			Components []string `yaml:"components"`
+		} `yaml:"flux"`
+		Kustomize []struct {
+			Name       string   `yaml:"name"`
+			DependsOn  []string `yaml:"dependsOn"`
+			Components []string `yaml:"components"`
+		} `yaml:"kustomize"`
+	}
+	if err := yaml.Unmarshal(stdout, &bp); err != nil {
+		t.Fatalf("parse blueprint YAML: %v\nstdout: %s", err, stdout)
+	}
+
+	var flat *struct {
+		Name       string   `yaml:"name"`
+		DependsOn  []string `yaml:"dependsOn"`
+		Components []string `yaml:"components"`
+	}
+	for i := range bp.Flux {
+		if bp.Flux[i].Name == "gateway-cilium" {
+			flat = &bp.Flux[i]
+		}
+	}
+	if flat == nil {
+		t.Fatalf("expected gateway-cilium under flux:, got flux=%+v", bp.Flux)
+	}
+
+	var legacy *struct {
+		Name       string   `yaml:"name"`
+		DependsOn  []string `yaml:"dependsOn"`
+		Components []string `yaml:"components"`
+	}
+	for i := range bp.Kustomize {
+		if bp.Kustomize[i].Name == "gateway-cilium-legacy" {
+			legacy = &bp.Kustomize[i]
+		}
+	}
+	if legacy == nil {
+		t.Fatalf("expected gateway-cilium-legacy under kustomize:, got kustomize=%+v", bp.Kustomize)
+	}
+
+	// The flat flux: entry compiles to exactly its own name -- no -install/-resources suffix.
+	if flat.Name != "gateway-cilium" {
+		t.Errorf("expected flat entry name gateway-cilium with no tier suffix, got %q", flat.Name)
+	}
+
+	// Both entries resolve the same bare-name dependency to the same install tier.
+	if !slices.Contains(flat.DependsOn, "cert-manager-install") {
+		t.Errorf("expected flat entry dependsOn to resolve bare cert-manager to cert-manager-install, got %v", flat.DependsOn)
+	}
+	if !slices.Contains(legacy.DependsOn, "cert-manager-install") {
+		t.Errorf("expected legacy kustomize entry dependsOn to resolve bare cert-manager to cert-manager-install, got %v", legacy.DependsOn)
+	}
+
+	// Both entries carry the identical component list.
+	if len(flat.Components) != len(legacy.Components) {
+		t.Fatalf("expected matching component counts, got flat=%v legacy=%v", flat.Components, legacy.Components)
+	}
+	for _, c := range legacy.Components {
+		if !slices.Contains(flat.Components, c) {
+			t.Errorf("expected flat entry components to match the legacy kustomize entry, got flat=%v legacy=%v", flat.Components, legacy.Components)
+		}
+	}
+
+	// Neither compiled name leaks a tier suffix into kustomize: (flat systems never appear there).
+	for _, k := range bp.Kustomize {
+		if k.Name == "gateway-cilium" {
+			t.Errorf("flat flux system %q must not also appear under kustomize:", k.Name)
+		}
+	}
+}

--- a/integration/fixtures/facet-tiers/contexts/_template/facets/gateway-cilium.yaml
+++ b/integration/fixtures/facet-tiers/contexts/_template/facets/gateway-cilium.yaml
@@ -1,0 +1,23 @@
+kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: gateway-cilium
+  description: A flat flux entry with no install/resources split, proving output-neutrality with an equivalent kustomize entry and that bare-name dependsOn resolution applies to flat flux entries the same way it does to kustomize entries.
+
+flux:
+
+- name: gateway-cilium
+  dependsOn:
+  - cert-manager
+  components:
+  - cilium
+  - cilium/gateway
+
+kustomize:
+
+- name: gateway-cilium-legacy
+  components:
+  - cilium
+  - cilium/gateway
+  dependsOn:
+  - cert-manager

--- a/integration/fixtures/facet-tiers/contexts/_template/tests/tiers.test.yaml
+++ b/integration/fixtures/facet-tiers/contexts/_template/tests/tiers.test.yaml
@@ -76,3 +76,24 @@ cases:
     exclude:
       flux:
         - name: policy
+
+  # gateway-cilium is a flat flux: entry (no install/resources) -- proving expect.flux and
+  # expect.kustomize agree on the same compiled Kustomization, and that its bare-name
+  # dependsOn on cert-manager resolves to cert-manager-install exactly like a kustomize: entry's would.
+  - name: flat_flux_entry_matches_via_both_flux_and_kustomize_assertions
+    values: {}
+    expect:
+      flux:
+        - name: gateway-cilium
+          dependsOn:
+            - cert-manager-install
+          components:
+            - cilium
+            - cilium/gateway
+      kustomize:
+        - name: gateway-cilium
+          dependsOn:
+            - cert-manager-install
+          components:
+            - cilium
+            - cilium/gateway

--- a/pkg/composer/blueprint/composer.go
+++ b/pkg/composer/blueprint/composer.go
@@ -177,7 +177,7 @@ func (c *BaseBlueprintComposer) Compose(loaders []BlueprintLoader, initLoaderNam
 	c.finalizeCrdLayers(result)
 	c.applyCrdLayerBarrier(result)
 	c.applyGlobalDependencyBarrier(result)
-	validationErr := errors.Join(c.validateSources(result), c.validateReservedNames(result), c.validateDependencies(result))
+	validationErr := errors.Join(c.validateSources(result), c.validateReservedNames(result), c.validateFluxFlatExclusivity(result), c.validateDependencies(result))
 	return result, validationErr
 }
 
@@ -971,6 +971,22 @@ func (c *BaseBlueprintComposer) validateReservedNames(bp *blueprintv1alpha1.Blue
 	for _, k := range bp.Kustomizations {
 		if blueprintv1alpha1.IsCrdLayerName(k.Name) {
 			return fmt.Errorf("kustomization name %q is reserved for the CRD layer; use the crds: section instead", k.Name)
+		}
+	}
+	return nil
+}
+
+// validateFluxFlatExclusivity rejects a flux: system that sets both flat fields and a tier
+// (install and/or resources). An author who sets both almost certainly meant one or the other;
+// compileFluxSystemTiers structurally prefers the tiered form when both are present, which would
+// silently discard the flat fields without this check.
+func (c *BaseBlueprintComposer) validateFluxFlatExclusivity(bp *blueprintv1alpha1.Blueprint) error {
+	for _, sys := range bp.FluxSystems {
+		if !sys.HasFlatContent() {
+			continue
+		}
+		if sys.Install != nil || len(sys.Resources) > 0 {
+			return fmt.Errorf("flux system %q sets both flat fields and install/resources; a system is either flat or tiered, not both", sys.Name)
 		}
 	}
 	return nil

--- a/pkg/composer/blueprint/composer_test.go
+++ b/pkg/composer/blueprint/composer_test.go
@@ -3355,6 +3355,119 @@ func TestComposer_validateReservedNames(t *testing.T) {
 	})
 }
 
+func TestComposer_validateFluxFlatExclusivity(t *testing.T) {
+	t.Run("RejectsFlatComponentsAlongsideInstall", func(t *testing.T) {
+		// Given a system that sets both flat components and an install tier
+		mocks := setupComposerMocks(t)
+		composer := NewBlueprintComposer(mocks.Runtime)
+		bp := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{{
+				Name:    "cert-manager",
+				Install: &blueprintv1alpha1.Kustomization{Components: []string{"cert-manager"}},
+				Flat:    &blueprintv1alpha1.Kustomization{Components: []string{"stray"}},
+			}},
+		}
+
+		// When validating
+		err := composer.validateFluxFlatExclusivity(bp)
+
+		// Then it is rejected
+		if err == nil || !strings.Contains(err.Error(), "cert-manager") || !strings.Contains(err.Error(), "flat fields and install/resources") {
+			t.Errorf("expected flat/tiered exclusivity error, got %v", err)
+		}
+	})
+
+	t.Run("RejectsFlatComponentsAlongsideResources", func(t *testing.T) {
+		// Given a system that sets both flat components and a resources variant
+		mocks := setupComposerMocks(t)
+		composer := NewBlueprintComposer(mocks.Runtime)
+		bp := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{{
+				Name:      "policy",
+				Resources: []blueprintv1alpha1.FluxVariant{{Kustomization: blueprintv1alpha1.Kustomization{Components: []string{"kyverno/policies"}}}},
+				Flat:      &blueprintv1alpha1.Kustomization{Components: []string{"stray"}},
+			}},
+		}
+
+		// When validating
+		err := composer.validateFluxFlatExclusivity(bp)
+
+		// Then it is rejected
+		if err == nil || !strings.Contains(err.Error(), "policy") {
+			t.Errorf("expected flat/tiered exclusivity error, got %v", err)
+		}
+	})
+
+	t.Run("AllowsFlatOnly", func(t *testing.T) {
+		mocks := setupComposerMocks(t)
+		composer := NewBlueprintComposer(mocks.Runtime)
+		bp := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{{
+				Name: "gateway-cilium",
+				Flat: &blueprintv1alpha1.Kustomization{Components: []string{"cilium"}},
+			}},
+		}
+
+		if err := composer.validateFluxFlatExclusivity(bp); err != nil {
+			t.Errorf("expected no error for a flat-only system, got %v", err)
+		}
+	})
+
+	t.Run("AllowsTieredOnly", func(t *testing.T) {
+		mocks := setupComposerMocks(t)
+		composer := NewBlueprintComposer(mocks.Runtime)
+		bp := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{{
+				Name:    "cert-manager",
+				Install: &blueprintv1alpha1.Kustomization{Components: []string{"cert-manager"}},
+			}},
+		}
+
+		if err := composer.validateFluxFlatExclusivity(bp); err != nil {
+			t.Errorf("expected no error for a tiered-only system, got %v", err)
+		}
+	})
+
+	t.Run("AllowsInstallWithAnUnpopulatedFlatField", func(t *testing.T) {
+		// Flat is always non-nil after YAML unmarshal (goccy allocates inline structs
+		// unconditionally); an empty Components list must not be mistaken for a real flat entry.
+		mocks := setupComposerMocks(t)
+		composer := NewBlueprintComposer(mocks.Runtime)
+		bp := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{{
+				Name:    "cert-manager",
+				Install: &blueprintv1alpha1.Kustomization{Components: []string{"cert-manager"}},
+				Flat:    &blueprintv1alpha1.Kustomization{},
+			}},
+		}
+
+		if err := composer.validateFluxFlatExclusivity(bp); err != nil {
+			t.Errorf("expected no error when Flat carries no components, got %v", err)
+		}
+	})
+
+	t.Run("RejectsStrayNonComponentFlatFieldAlongsideInstall", func(t *testing.T) {
+		// A stray flat-only field other than Components (e.g. a mistaken top-level substitute:
+		// left alongside install:) must still be caught -- not just Components, which was the
+		// original, narrower presence signal before HasFlatContent broadened it.
+		mocks := setupComposerMocks(t)
+		composer := NewBlueprintComposer(mocks.Runtime)
+		bp := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{{
+				Name:    "cert-manager",
+				Install: &blueprintv1alpha1.Kustomization{Components: []string{"cert-manager"}},
+				Flat:    &blueprintv1alpha1.Kustomization{Substitute: map[string]string{"cluster_name": "prod"}},
+			}},
+		}
+
+		err := composer.validateFluxFlatExclusivity(bp)
+
+		if err == nil || !strings.Contains(err.Error(), "cert-manager") {
+			t.Errorf("expected flat/tiered exclusivity error for a stray substitute field, got %v", err)
+		}
+	})
+}
+
 func TestComposer_validateDependencies(t *testing.T) {
 	t.Run("ReturnsNilForValidTerraformDependencies", func(t *testing.T) {
 		mocks := setupComposerMocks(t)

--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -503,6 +503,18 @@ func (h *BaseBlueprintHandler) resolveDeferredSubstitutions() error {
 				sys.Install.Substitutions[key] = str
 			}
 		}
+		if sys.Flat != nil {
+			for key, value := range sys.Flat.Substitutions {
+				if !deferred["flux."+sys.Name+".substitutions."+key] {
+					continue
+				}
+				str, err := h.resolveDeferred(value)
+				if err != nil {
+					return fmt.Errorf("flux.%s.substitutions.%s: %w", sys.Name, key, err)
+				}
+				sys.Flat.Substitutions[key] = str
+			}
+		}
 		for j := range sys.Resources {
 			v := &sys.Resources[j]
 			resourcesPrefix := fluxResourcesSubstitutionPrefix(sys.Name, v.Name)

--- a/pkg/composer/blueprint/handler_test.go
+++ b/pkg/composer/blueprint/handler_test.go
@@ -1344,6 +1344,43 @@ func TestHandler_GenerateResolved(t *testing.T) {
 			t.Errorf("Expected 'external' variant's already-resolved substitution left untouched, got %q", sys.Resources[1].Substitutions["gateway_lb_ip"])
 		}
 	})
+
+	t.Run("ResolvesFlatFluxSystemSubstitutions", func(t *testing.T) {
+		mocks := setupHandlerMocks(t)
+		mocks.Runtime.Evaluator = &evaluator.MockExpressionEvaluator{
+			EvaluateFunc: func(expr string, _ string, _ map[string]any, _ bool) (any, error) {
+				return "resolved-value", nil
+			},
+		}
+		handler := NewBlueprintHandler(mocks.Runtime, mocks.ArtifactBuilder)
+		handler.composedBlueprint = &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name: "gateway-cilium",
+					Flat: &blueprintv1alpha1.Kustomization{
+						Substitutions: map[string]string{
+							"gateway_ip": "${terraform_output('network', 'gateway_ip') ?? ''}",
+						},
+					},
+				},
+			},
+		}
+		handler.deferredPaths = map[string]bool{
+			"flux.gateway-cilium.substitutions.gateway_ip": true,
+		}
+
+		// When calling GenerateResolved
+		resolved, err := handler.GenerateResolved()
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the deferred flat substitution is resolved
+		sys := resolved.FluxSystems[0]
+		if sys.Flat.Substitutions["gateway_ip"] != "resolved-value" {
+			t.Errorf("Expected flat substitution resolved, got %q", sys.Flat.Substitutions["gateway_ip"])
+		}
+	})
 }
 
 func TestHandler_getConfigValues(t *testing.T) {

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -1049,14 +1049,15 @@ func (p *BaseBlueprintProcessor) evalDropEmpty(raw []string, facetPath string, s
 }
 
 // collectFluxSystems evaluates a facet's flux: system descriptors — resolving expressions on
-// DependsOn, Install components/substitutions, and each resources variant — and stores the result
-// in fluxSystemByName. A resources variant is dropped only when its own when condition (combined
-// with the system's) is false — never merely because its components prune to empty, matching how
-// a plain kustomize: entry is always emitted regardless of its resolved component count; a
-// dependsOn reference to it stays valid whether or not the variant's own components ended up
-// empty. An install tier whose components prune to empty sets Install to nil, since install is
-// optional per system (a system may have none at all) and an empty install is equivalent to none
-// declared.
+// DependsOn, Install components/substitutions, Flat components/substitutions, and each resources
+// variant — and stores the result in fluxSystemByName. A resources variant is dropped only when its
+// own when condition (combined with the system's) is false — never merely because its components
+// prune to empty, matching how a plain kustomize: entry is always emitted regardless of its
+// resolved component count; a dependsOn reference to it stays valid whether or not the variant's
+// own components ended up empty. An install tier whose components prune to empty sets Install to
+// nil, since install is optional per system (a system may have none at all) and an empty install is
+// equivalent to none declared. Flat's components are evaluated the same way a resources variant's
+// are (no dropping, never nils Flat out) since Flat is the kustomize: equivalent, not install:'s.
 func (p *BaseBlueprintProcessor) collectFluxSystems(facet blueprintv1alpha1.Facet, sourceName []string, fluxSystemByName map[string]*blueprintv1alpha1.FluxSystem, facetScope map[string]any) error {
 	for _, system := range facet.FluxSystems {
 		when := system.When
@@ -1102,6 +1103,21 @@ func (p *BaseBlueprintProcessor) collectFluxSystems(facet blueprintv1alpha1.Face
 			} else {
 				system.Install = nil
 			}
+		}
+
+		if system.Flat != nil {
+			flatCopy := *system.Flat.DeepCopy()
+			if len(flatCopy.Components) > 0 {
+				evaluated, err := p.evaluateStringSlice(flatCopy.Components, facet.Path, facetScope)
+				if err != nil {
+					return fmt.Errorf("error evaluating flat components for system '%s': %w", system.Name, err)
+				}
+				flatCopy.Components = evaluated
+			}
+			if err := p.evalKustomizationSubstitutions(&flatCopy, facet.Path, "flux."+system.Name+".substitutions.", facetScope); err != nil {
+				return fmt.Errorf("error evaluating flat substitutions for system '%s': %w", system.Name, err)
+			}
+			system.Flat = &flatCopy
 		}
 
 		seenVariants := make(map[string]bool)
@@ -1219,10 +1235,11 @@ func (p *BaseBlueprintProcessor) updateFluxSystemEntry(name string, new *bluepri
 // applyKustomizationEntryByStrategy: "replace" swaps the whole entry, "remove" accumulates a
 // combined removal descriptor via accumulateFluxSystemRemovals (field-level, matching
 // RemoveKustomization's semantics for plain kustomize: entries — never a whole-system deletion),
-// and "merge" unions DependsOn and deep-merges both Install (blueprintv1alpha1.MergeFluxInstall)
-// and Resources variants (blueprintv1alpha1.MergeFluxVariants) — the same semantics same-name
-// Kustomizations get elsewhere, and the same helpers Blueprint.UpsertFluxSystem uses to merge
-// FluxSystems across sources — instead of replacing either wholesale.
+// and "merge" unions DependsOn and deep-merges Install, Flat (both via blueprintv1alpha1.
+// MergeFluxInstall, which operates on any *Kustomization), and Resources variants
+// (blueprintv1alpha1.MergeFluxVariants) — the same semantics same-name Kustomizations get
+// elsewhere, and the same helpers Blueprint.UpsertFluxSystem uses to merge FluxSystems across
+// sources — instead of replacing either wholesale.
 func (p *BaseBlueprintProcessor) applyFluxSystemEntryByStrategy(name string, new *blueprintv1alpha1.FluxSystem, strategy string, existing *blueprintv1alpha1.FluxSystem, entries map[string]*blueprintv1alpha1.FluxSystem) error {
 	switch strategy {
 	case "replace":
@@ -1238,6 +1255,7 @@ func (p *BaseBlueprintProcessor) applyFluxSystemEntryByStrategy(name string, new
 		merged.DependsOn = accumulateStringSlice(existing.DependsOn, new.DependsOn)
 		merged.Install = blueprintv1alpha1.MergeFluxInstall(existing.Install, new.Install)
 		merged.Resources = blueprintv1alpha1.MergeFluxVariants(existing.Resources, new.Resources)
+		merged.Flat = blueprintv1alpha1.MergeFluxInstall(existing.Flat, new.Flat)
 		merged.Ordinal = new.Ordinal
 		merged.GlobalDependency = existing.GlobalDependency || new.GlobalDependency
 		entries[name] = &merged
@@ -1806,10 +1824,11 @@ func (p *BaseBlueprintProcessor) accumulateKustomizationRemovals(existing, new b
 // facets into one combined descriptor, mirroring accumulateKustomizationRemovals: DependsOn
 // accumulates via accumulateStringSlice, and Resources concatenates removal-descriptor variants
 // (each identified by Name; Blueprint.RemoveFluxSystem drops the named variant outright, so
-// duplicates surviving accumulation are harmless). Install's removable fields accumulate via
-// accumulateKustomizationRemovals itself, treating a nil Install on either side as a zero-value
-// Kustomization{} — Install carries no Name until tier compilation, so the same field-level union
-// accumulateKustomizationRemovals gives two facets' top-level removal descriptors applies here.
+// duplicates surviving accumulation are harmless). Install's and Flat's removable fields accumulate
+// via accumulateKustomizationRemovals itself, treating a nil Install/Flat on either side as a
+// zero-value Kustomization{} — neither carries a Name until tier compilation, so the same
+// field-level union accumulateKustomizationRemovals gives two facets' top-level removal
+// descriptors applies to both.
 func (p *BaseBlueprintProcessor) accumulateFluxSystemRemovals(existing, new blueprintv1alpha1.FluxSystem) blueprintv1alpha1.FluxSystem {
 	accumulated := blueprintv1alpha1.FluxSystem{
 		Name: existing.Name,
@@ -1820,6 +1839,11 @@ func (p *BaseBlueprintProcessor) accumulateFluxSystemRemovals(existing, new blue
 	if existing.Install != nil || new.Install != nil {
 		mergedInstall := p.accumulateKustomizationRemovals(kustomizationOrZero(existing.Install), kustomizationOrZero(new.Install))
 		accumulated.Install = &mergedInstall
+	}
+
+	if existing.Flat != nil || new.Flat != nil {
+		mergedFlat := p.accumulateKustomizationRemovals(kustomizationOrZero(existing.Flat), kustomizationOrZero(new.Flat))
+		accumulated.Flat = &mergedFlat
 	}
 
 	accumulated.Resources = append(accumulated.Resources, existing.Resources...)

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -2579,6 +2579,73 @@ func TestProcessor_ProcessFacets_Tiers(t *testing.T) {
 		}
 	})
 
+	t.Run("CompilesFlatEntryAtTheSystemNameAndPathWithNoSubfolder", func(t *testing.T) {
+		target := process(t, blueprintv1alpha1.FluxSystem{
+			Name: "gateway-cilium",
+			Path: "gateway/cilium",
+			Flat: &blueprintv1alpha1.Kustomization{Components: []string{"cilium", "cilium/gateway"}},
+		})
+		k, ok := find(target, "gateway-cilium")
+		if !ok || k.Path != "gateway/cilium" {
+			t.Fatalf("expected gateway-cilium at gateway/cilium with no tier subfolder, got %+v", k)
+		}
+		if !slices.Contains(k.Components, "cilium") || !slices.Contains(k.Components, "cilium/gateway") {
+			t.Errorf("expected flat components to carry through, got %v", k.Components)
+		}
+		if _, ok := find(target, "gateway-cilium-install"); ok {
+			t.Error("expected no -install suffixed kustomization for a flat entry")
+		}
+	})
+
+	t.Run("FlatSubstituteFlowsToTheCompiledKustomization", func(t *testing.T) {
+		target := process(t, blueprintv1alpha1.FluxSystem{
+			Name: "dashboards",
+			Flat: &blueprintv1alpha1.Kustomization{Components: []string{"grafana-dashboards"}, Substitute: map[string]string{"grafana_namespace": "system-observability"}},
+		})
+		k, ok := find(target, "dashboards")
+		if !ok || k.Substitutions["grafana_namespace"] != "system-observability" {
+			t.Fatalf("expected flat substitute merged into substitutions, got %+v", k)
+		}
+	})
+
+	t.Run("FlatComponentsEvaluateExpressionsWithoutDroppingEmptyResults", func(t *testing.T) {
+		// Unlike install:, a flat entry's empty-string placeholders survive evaluation —
+		// matching kustomize:'s conditional-slot convention, not install:'s "empty means none".
+		target := process(t, blueprintv1alpha1.FluxSystem{
+			Name: "gateway-cilium",
+			Flat: &blueprintv1alpha1.Kustomization{Components: []string{"cilium", "${false ? 'cilium/gateway' : ''}"}},
+		})
+		k, ok := find(target, "gateway-cilium")
+		if !ok {
+			t.Fatalf("expected gateway-cilium to be compiled, got %+v", target.AllKustomizations())
+		}
+		if len(k.Components) != 2 || k.Components[1] != "" {
+			t.Errorf("expected the empty-string placeholder to survive evaluation, got %v", k.Components)
+		}
+	})
+
+	t.Run("FlatKeptEvenWhenAllComponentsPruneToEmpty", func(t *testing.T) {
+		target := process(t, blueprintv1alpha1.FluxSystem{
+			Name: "gateway-cilium",
+			Flat: &blueprintv1alpha1.Kustomization{Components: []string{"${false ? 'cilium' : ''}"}},
+		})
+		if _, ok := find(target, "gateway-cilium"); !ok {
+			t.Fatalf("expected gateway-cilium to be kept even with pruned-empty components, got %+v", target.AllKustomizations())
+		}
+	})
+
+	t.Run("SystemDependsOnAttachesDirectlyToTheFlatKustomization", func(t *testing.T) {
+		target := process(t, blueprintv1alpha1.FluxSystem{
+			Name:      "gateway-cilium",
+			DependsOn: []string{"pki-install"},
+			Flat:      &blueprintv1alpha1.Kustomization{Components: []string{"cilium"}},
+		})
+		k, ok := find(target, "gateway-cilium")
+		if !ok || !slices.Contains(k.DependsOn, "pki-install") {
+			t.Fatalf("expected the system's dependsOn to attach directly to the flat kustomization, got %+v", k)
+		}
+	})
+
 	t.Run("SystemDependsOnAttachesToInstallAndResourcesReachItTransitively", func(t *testing.T) {
 		target := process(t, blueprintv1alpha1.FluxSystem{
 			Name:      "gateway",
@@ -2827,6 +2894,75 @@ func TestProcessor_ProcessFacets_Tiers(t *testing.T) {
 		}
 		if !slices.Contains(install.Components, "envoy") || !slices.Contains(install.Components, "cert-manager") {
 			t.Errorf("expected install components to union [cert-manager envoy], got %v", install.Components)
+		}
+	})
+
+	t.Run("SameOrdinalFlatDeepMerges", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "gateway-cilium-a"},
+				FluxSystems: []blueprintv1alpha1.FluxSystem{{
+					Name: "gateway-cilium",
+					Flat: &blueprintv1alpha1.Kustomization{Components: []string{"cilium"}},
+				}},
+			},
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "gateway-cilium-b"},
+				FluxSystems: []blueprintv1alpha1.FluxSystem{{
+					Name: "gateway-cilium",
+					Flat: &blueprintv1alpha1.Kustomization{Components: []string{"cilium/gateway"}},
+				}},
+			},
+		}
+		target := &blueprintv1alpha1.Blueprint{}
+		if _, err := processor.ProcessFacets(target, facets); err != nil {
+			t.Fatalf("ProcessFacets: %v", err)
+		}
+		k, ok := find(target, "gateway-cilium")
+		if !ok {
+			t.Fatalf("expected gateway-cilium, got %+v", target.AllKustomizations())
+		}
+		if !slices.Contains(k.Components, "cilium") || !slices.Contains(k.Components, "cilium/gateway") {
+			t.Errorf("expected flat components to union [cilium cilium/gateway], got %v", k.Components)
+		}
+	})
+
+	t.Run("RemoveStripsFlatComponentsFromPreexistingSystem", func(t *testing.T) {
+		mocks := setupProcessorMocks(t)
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "option-remove-gateway-cilium-variant"},
+				FluxSystems: []blueprintv1alpha1.FluxSystem{{
+					Name:     "gateway-cilium",
+					Strategy: "remove",
+					Flat:     &blueprintv1alpha1.Kustomization{Components: []string{"cilium/gateway"}},
+				}},
+			},
+		}
+		// A pre-existing FluxSystem, standing in for one already declared in the loader's parsed
+		// blueprint.yaml before facets are layered on, so the remove-strategy facet above has a
+		// real entry to subtract from — see EqualOrdinalRemoveFacetsAccumulateAndStripFieldsFromPreexistingSystem.
+		target := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{{
+				Name: "gateway-cilium",
+				Flat: &blueprintv1alpha1.Kustomization{Components: []string{"cilium", "cilium/gateway"}},
+			}},
+		}
+		if _, err := processor.ProcessFacets(target, facets); err != nil {
+			t.Fatalf("ProcessFacets: %v", err)
+		}
+		k, ok := find(target, "gateway-cilium")
+		if !ok {
+			t.Fatalf("expected gateway-cilium to remain (only a component was removed), got %+v", target.AllKustomizations())
+		}
+		if slices.Contains(k.Components, "cilium/gateway") {
+			t.Errorf("expected cilium/gateway removed, got %v", k.Components)
+		}
+		if !slices.Contains(k.Components, "cilium") {
+			t.Errorf("expected cilium to remain, got %v", k.Components)
 		}
 	})
 

--- a/pkg/composer/blueprint/render.go
+++ b/pkg/composer/blueprint/render.go
@@ -97,6 +97,13 @@ func applyDeferredPathsToBlueprint(bp *blueprintv1alpha1.Blueprint, deferredPath
 				}
 			}
 		}
+		if sys.Flat != nil {
+			for key := range sys.Flat.Substitutions {
+				if deferredPaths["flux."+sys.Name+".substitutions."+key] {
+					sys.Flat.Substitutions[key] = deferredPlaceholder
+				}
+			}
+		}
 		for j := range sys.Resources {
 			resourcesPrefix := fluxResourcesSubstitutionPrefix(sys.Name, sys.Resources[j].Name)
 			for key := range sys.Resources[j].Substitutions {

--- a/pkg/composer/blueprint/render_test.go
+++ b/pkg/composer/blueprint/render_test.go
@@ -139,6 +139,36 @@ func TestRenderDeferredPlaceholders(t *testing.T) {
 		}
 	})
 
+	t.Run("RewritesDeferredFlatFluxSystemSubstitutionsToPlaceholder", func(t *testing.T) {
+		bp := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name: "gateway-cilium",
+					Flat: &blueprintv1alpha1.Kustomization{
+						Substitutions: map[string]string{
+							"gateway_ip":   "${terraform_output('network', 'gateway_ip')}",
+							"resolved_key": "already-resolved",
+						},
+					},
+				},
+			},
+		}
+		deferredPaths := map[string]bool{
+			"flux.gateway-cilium.substitutions.gateway_ip": true,
+		}
+
+		result := RenderDeferredPlaceholders(bp, false, deferredPaths)
+
+		got := result.(*blueprintv1alpha1.Blueprint)
+		sys := got.FluxSystems[0]
+		if sys.Flat.Substitutions["gateway_ip"] != deferredPlaceholder {
+			t.Errorf("Expected deferred flat substitution to be '%s', got '%s'", deferredPlaceholder, sys.Flat.Substitutions["gateway_ip"])
+		}
+		if sys.Flat.Substitutions["resolved_key"] != "already-resolved" {
+			t.Errorf("Expected resolved flat substitution unchanged, got '%s'", sys.Flat.Substitutions["resolved_key"])
+		}
+	})
+
 	t.Run("DoesNotMutateOriginalBlueprint", func(t *testing.T) {
 		// Given a blueprint with a deferred substitution
 		bp := &blueprintv1alpha1.Blueprint{

--- a/pkg/runtime/config/schemas/artifacts/blueprint.yaml
+++ b/pkg/runtime/config/schemas/artifacts/blueprint.yaml
@@ -290,9 +290,14 @@ properties:
   flux:
     type: array
     description: |
-      System entries — functional layers that each compile to an install
-      Kustomization plus one or more resources-variant Kustomizations. Distinct
-      from 'kustomize:', which is a 1:1 Kustomization passthrough.
+      System entries — functional layers that each compile to either a single
+      flat Kustomization or an install Kustomization plus one or more
+      resources-variant Kustomizations. A system with neither 'install:' nor
+      'resources:' compiles flat, from its own components/operational fields
+      (below) — the flux: equivalent of a 'kustomize:' entry. 'kustomize:'
+      remains a 1:1 Kustomization passthrough and is not being removed; new
+      entries should prefer 'flux:' so every Kustomization-producing entry
+      lives in one section.
     items:
       type: object
       required:
@@ -301,10 +306,16 @@ properties:
       properties:
         name:
           type: string
-          description: System identifier; tiers compile to '<name>-install' and '<name>-resources[-<variant>]'.
+          description: |
+            System identifier. A flat system (no install/resources) compiles
+            to a Kustomization named exactly this; a tiered system compiles
+            to '<name>-install' and '<name>-resources[-<variant>]'.
         path:
           type: string
-          description: Base path; tiers reconcile from '<path>/install' and '<path>/resources'. Defaults to name.
+          description: |
+            Base path. A flat system reconciles from this path directly; a
+            tiered system's tiers reconcile from '<path>/install' and
+            '<path>/resources'. Defaults to name.
         source:
           type: string
           description: Name of the source that provides the tier bases.
@@ -324,7 +335,8 @@ properties:
           description: |
             Cross-layer edges to other systems (a bare '<other>' resolves to
             '<other>-install'). Attached to the install tier when present
-            (resources reach them transitively), otherwise to each variant.
+            (resources reach them transitively), or to the flat Kustomization
+            directly for a flat system, otherwise to each resources variant.
         strategy:
           type: string
           enum:
@@ -335,6 +347,74 @@ properties:
         ordinal:
           type: integer
           description: Overrides the facet ordinal for this system's merge precedence.
+        namespace:
+          type: string
+          description: |
+            Flat entry only: namespace where the Flux Kustomization object
+            itself lives. Defaults to the gitops namespace.
+        targetNamespace:
+          type: string
+          description: |
+            Flat entry only: populates spec.targetNamespace, overriding the
+            namespace of reconciled resources.
+        interval:
+          type: string
+          description: |
+            Flat entry only: reconciliation interval as a Go duration string
+            (e.g. '5m', '1h').
+        retryInterval:
+          type: string
+          description: Flat entry only. Duration to wait before retrying a failed reconciliation (e.g. '2m').
+        timeout:
+          type: string
+          description: Flat entry only. Maximum duration for a single reconciliation attempt (e.g. '10m').
+        patches:
+          type: array
+          description: Flat entry only. Strategic-merge or Flux-style patches applied to the kustomization.
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              path:
+                type: string
+              patch:
+                type: string
+              target:
+                type: object
+                additionalProperties: true
+        wait:
+          type: boolean
+          description: Flat entry only. Wait for resources to settle before declaring reconciliation complete.
+        force:
+          type: boolean
+          description: Flat entry only. Force-apply resources Flux would otherwise refuse to update.
+        prune:
+          type: boolean
+          description: Flat entry only. Garbage-collect resources removed from the source. Defaults to true.
+        components:
+          type: array
+          items:
+            type: string
+          description: |
+            Flat entry only: kustomize components to compose into this
+            system's single Kustomization. Setting this alongside 'install:'
+            or 'resources:' is an error — a system is either flat or tiered,
+            not both.
+        substitute:
+          type: object
+          additionalProperties:
+            type: string
+          description: Flat entry only. Preferred spelling of substitutions (matching Flux postBuild.substitute); both merge into the same map.
+        substitutions:
+          type: object
+          additionalProperties:
+            type: string
+          description: Flat entry only. PostBuild variable substitutions for this system's Kustomization.
+        destroyOnly:
+          type: boolean
+          description: |
+            Flat entry only. When true, the Kustomization only runs during
+            destroy operations.
         install:
           type: object
           additionalProperties: false

--- a/pkg/test/runner.go
+++ b/pkg/test/runner.go
@@ -580,7 +580,7 @@ func (r *TestRunner) matchExclusions(bp *blueprintv1alpha1.Blueprint, exclude *b
 		if found == nil {
 			continue
 		}
-		if excludeSys.Install == nil && len(excludeSys.Resources) == 0 {
+		if excludeSys.Install == nil && len(excludeSys.Resources) == 0 && !excludeSys.HasFlatContent() {
 			diffs = append(diffs, fmt.Sprintf("flux system should not exist: %s", excludeSys.Name))
 			continue
 		}
@@ -771,15 +771,11 @@ func (r *TestRunner) matchKustomization(actual *blueprintv1alpha1.Kustomization,
 }
 
 // matchFluxSystem compares an actual FluxSystem (from bp.FluxSystems, post facet-merge and
-// when-expression evaluation) against expected properties and returns a list of differences. It uses
-// partial matching: only properties set in the expect system are validated. Path, source, when, strategy,
-// and dependsOn are compared as the author wrote them (dependsOn is the system's own cross-layer edges,
-// not a composer-computed one). Ordinal and globalDependency compare when the expectation sets them;
-// globalDependency only asserts the true direction, since false is indistinguishable from unset. Install
-// and each Resources variant delegate to matchKustomization for their Kustomization fields. Enabled and
-// Destroy are not compared: neither is evaluated during composition, so they carry only the raw authored
-// expression at this stage, not a rendering outcome. Returns an empty slice if all specified properties
-// match.
+// when-expression evaluation) against expected properties and returns a list of differences. It
+// uses partial matching: only properties set in the expect system are validated (Flat's presence
+// is HasFlatContent, not non-nilness). Install, Flat, and each Resources variant delegate to
+// matchKustomization. Enabled and Destroy are not compared: neither is evaluated during
+// composition, so they carry only the raw authored expression, not a rendering outcome.
 func (r *TestRunner) matchFluxSystem(actual *blueprintv1alpha1.FluxSystem, expect blueprintv1alpha1.FluxSystem) []string {
 	var diffs []string
 	name := expect.Name
@@ -829,6 +825,14 @@ func (r *TestRunner) matchFluxSystem(actual *blueprintv1alpha1.FluxSystem, expec
 		}
 	}
 
+	if expect.HasFlatContent() {
+		if !actual.HasFlatContent() {
+			diffs = append(diffs, fmt.Sprintf("flux[%s].flat: expected present, got absent", name))
+		} else {
+			diffs = append(diffs, r.matchKustomization(actual.Flat, *expect.Flat, name)...)
+		}
+	}
+
 	for _, expectVariant := range expect.Resources {
 		identifier := fluxVariantIdentifier(expectVariant)
 		actualVariant := r.findFluxVariant(actual.Resources, expectVariant)
@@ -847,17 +851,20 @@ func (r *TestRunner) matchFluxSystem(actual *blueprintv1alpha1.FluxSystem, expec
 }
 
 // matchFluxSystemExclusions verifies that specific parts of an actual FluxSystem (found by name) are
-// absent: the install tier when exclude.Install is set, and each named/matched resources variant in
-// exclude.Resources. Used when a fixture wants to assert a system is still partially present (e.g. its
-// install tier remains while one resources variant is gated off) rather than absent entirely, which
-// matchExclusions handles by name lookup alone before calling this. Returns an empty slice if every
-// excluded part is absent.
+// absent: the install tier, the flat form (via HasFlatContent), and each named/matched resources
+// variant in exclude.Resources. Used when a system stays partially present (e.g. install remains
+// while one resources variant is gated off), rather than absent entirely, which matchExclusions
+// handles by name lookup alone before calling this.
 func (r *TestRunner) matchFluxSystemExclusions(actual *blueprintv1alpha1.FluxSystem, exclude blueprintv1alpha1.FluxSystem) []string {
 	var diffs []string
 	name := exclude.Name
 
 	if exclude.Install != nil && actual.Install != nil {
 		diffs = append(diffs, fmt.Sprintf("flux[%s].install: should not exist", name))
+	}
+
+	if exclude.HasFlatContent() && actual.HasFlatContent() {
+		diffs = append(diffs, fmt.Sprintf("flux[%s].flat: should not exist", name))
 	}
 
 	for _, excludeVariant := range exclude.Resources {

--- a/pkg/test/runner_test.go
+++ b/pkg/test/runner_test.go
@@ -1501,6 +1501,35 @@ func TestTestRunner_matchExclusions(t *testing.T) {
 			t.Errorf("Expected variant-level exclusion diff, got: %v", diffs)
 		}
 	})
+
+	t.Run("ReturnsDiffsWhenExcludedFlatComponentsExistWithinPresentSystem", func(t *testing.T) {
+		// Given a flat system that exists, matching an exclude.flux entry that only sets
+		// components — this must be treated as a partial (flat) exclusion, not a whole-system
+		// one, even though exclude.Install and exclude.Resources are both unset (Install is
+		// simply nil for a flat exclude; Resources is simply empty).
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{Name: "gateway-cilium", Flat: &blueprintv1alpha1.Kustomization{Components: []string{"cilium"}}},
+			},
+		}
+
+		exclude := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{Name: "gateway-cilium", Flat: &blueprintv1alpha1.Kustomization{Components: []string{"cilium"}}},
+			},
+		}
+
+		// When matching exclusions
+		diffs := runner.matchExclusions(blueprint, exclude)
+
+		// Then diffs should identify the flat form specifically, not report a whole-system exclusion
+		if len(diffs) != 1 || !strings.Contains(diffs[0], "flux[gateway-cilium].flat: should not exist") {
+			t.Errorf("Expected flat-level exclusion diff, got: %v", diffs)
+		}
+	})
 }
 
 func TestTestRunner_findTerraformComponent(t *testing.T) {
@@ -2400,6 +2429,89 @@ func TestTestRunner_matchFluxSystem(t *testing.T) {
 			t.Errorf("Expected variant when: mismatch diff, got: %v", diffs)
 		}
 	})
+
+	t.Run("ReturnsNoDiffsWhenFlatComponentsMatch", func(t *testing.T) {
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		actual := &blueprintv1alpha1.FluxSystem{
+			Name: "gateway-cilium",
+			Flat: &blueprintv1alpha1.Kustomization{Components: []string{"cilium", "cilium/gateway"}},
+		}
+		expect := blueprintv1alpha1.FluxSystem{
+			Name: "gateway-cilium",
+			Flat: &blueprintv1alpha1.Kustomization{Components: []string{"cilium"}},
+		}
+
+		diffs := runner.matchFluxSystem(actual, expect)
+
+		if len(diffs) != 0 {
+			t.Errorf("Expected no diffs, got: %v", diffs)
+		}
+	})
+
+	t.Run("DelegatesFlatMismatchesToMatchKustomization", func(t *testing.T) {
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		actual := &blueprintv1alpha1.FluxSystem{
+			Name: "gateway-cilium",
+			Flat: &blueprintv1alpha1.Kustomization{Components: []string{"cilium"}},
+		}
+		expect := blueprintv1alpha1.FluxSystem{
+			Name: "gateway-cilium",
+			Flat: &blueprintv1alpha1.Kustomization{Components: []string{"cilium", "cilium/gateway"}},
+		}
+
+		diffs := runner.matchFluxSystem(actual, expect)
+
+		if len(diffs) != 1 || !strings.Contains(diffs[0], "kustomize[gateway-cilium].components") {
+			t.Errorf("Expected labeled flat component diff, got: %v", diffs)
+		}
+	})
+
+	t.Run("ReturnsDiffWhenFlatExpectedButSystemCompiledTiered", func(t *testing.T) {
+		// Given the actual system compiled tiered (its Flat field carries no components)
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		actual := &blueprintv1alpha1.FluxSystem{
+			Name:    "cert-manager",
+			Install: &blueprintv1alpha1.Kustomization{Components: []string{"cert-manager"}},
+		}
+		expect := blueprintv1alpha1.FluxSystem{
+			Name: "cert-manager",
+			Flat: &blueprintv1alpha1.Kustomization{Components: []string{"cert-manager"}},
+		}
+
+		diffs := runner.matchFluxSystem(actual, expect)
+
+		if len(diffs) != 1 || !strings.Contains(diffs[0], "flux[cert-manager].flat: expected present, got absent") {
+			t.Errorf("Expected flat-absent diff, got: %v", diffs)
+		}
+	})
+
+	t.Run("ReturnsNoDiffWhenExpectFlatHasNoComponents", func(t *testing.T) {
+		// expect.Flat is always non-nil after unmarshal; an empty Components list must not be
+		// mistaken for a real assertion.
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		actual := &blueprintv1alpha1.FluxSystem{
+			Name:    "cert-manager",
+			Install: &blueprintv1alpha1.Kustomization{Components: []string{"cert-manager"}},
+		}
+		expect := blueprintv1alpha1.FluxSystem{
+			Name: "cert-manager",
+			Flat: &blueprintv1alpha1.Kustomization{},
+		}
+
+		diffs := runner.matchFluxSystem(actual, expect)
+
+		if len(diffs) != 0 {
+			t.Errorf("Expected no diffs when expect.Flat carries no components, got: %v", diffs)
+		}
+	})
 }
 
 func TestTestRunner_matchFluxSystemExclusions(t *testing.T) {
@@ -2452,6 +2564,46 @@ func TestTestRunner_matchFluxSystemExclusions(t *testing.T) {
 
 		if len(diffs) != 1 || !strings.Contains(diffs[0], "flux[pki].resources: variant should not exist: ca") {
 			t.Errorf("Expected variant-should-not-exist diff, got: %v", diffs)
+		}
+	})
+
+	t.Run("ReturnsDiffWhenExcludedFlatComponentsExist", func(t *testing.T) {
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		actual := &blueprintv1alpha1.FluxSystem{
+			Name: "gateway-cilium",
+			Flat: &blueprintv1alpha1.Kustomization{Components: []string{"cilium"}},
+		}
+		exclude := blueprintv1alpha1.FluxSystem{
+			Name: "gateway-cilium",
+			Flat: &blueprintv1alpha1.Kustomization{Components: []string{"cilium"}},
+		}
+
+		diffs := runner.matchFluxSystemExclusions(actual, exclude)
+
+		if len(diffs) != 1 || !strings.Contains(diffs[0], "flux[gateway-cilium].flat: should not exist") {
+			t.Errorf("Expected flat-should-not-exist diff, got: %v", diffs)
+		}
+	})
+
+	t.Run("ReturnsNoDiffWhenExcludeFlatHasNoComponents", func(t *testing.T) {
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		actual := &blueprintv1alpha1.FluxSystem{
+			Name: "gateway-cilium",
+			Flat: &blueprintv1alpha1.Kustomization{Components: []string{"cilium"}},
+		}
+		exclude := blueprintv1alpha1.FluxSystem{
+			Name: "gateway-cilium",
+			Flat: &blueprintv1alpha1.Kustomization{},
+		}
+
+		diffs := runner.matchFluxSystemExclusions(actual, exclude)
+
+		if len(diffs) != 0 {
+			t.Errorf("Expected no diffs when exclude.Flat carries no components, got: %v", diffs)
 		}
 	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change is additive and self-contained within the Flux composition pipeline; the new `Flat` inline field and its supporting methods are well-guarded and the compile path is covered by thorough tests.
>
> **Overview**
>
> The PR introduces "flat entry" support for `flux:` system descriptors: a system with neither `install:` nor `resources:` now compiles to a single Kustomization named exactly after the system — the `flux:` equivalent of a plain `kustomize:` entry. Eight files are touched, but most of the diff is tests; the core type addition is a single inline `*Kustomization` field on `FluxSystem`, guarded by a `HasFlatContent()` sentinel that compensates for the YAML library allocating inline structs unconditionally. A new `validateFluxFlatExclusivity` validation step prevents authors from mixing flat and tiered properties on the same system.
>
> The `TierNames()` method now returns `[name]` for tier-less systems instead of an empty slice, and the `kustomizationNotFoundError` branch that guarded against an empty tier list has been removed; both callers in the diff correctly account for this change.
>
> Reviewed by Claude for commit `310e7d7f`.

<!-- /claude-code-review:summary -->
