### PR TITLE
feat(composer): resolve bare dependsOn on controller-less flux systems to their resources tier

### DIFF
--- a/pkg/composer/blueprint/composer.go
+++ b/pkg/composer/blueprint/composer.go
@@ -909,19 +909,26 @@ func appendMissing(deps []string, additions []string) []string {
 	return deps
 }
 
-// resolveTierDependencies rewrites a dependsOn reference to a vendor's bare name into its install
-// tier when the vendor was authored with install/resources tiers. A facet that depends on
-// "cert-manager" resolves to "cert-manager-install" when no kustomization named "cert-manager"
-// exists but "cert-manager-install" does, so "depend on cert-manager" means "wait for its
-// controller". An exact name match always wins, so the legacy flat form is unaffected.
+// resolveTierDependencies rewrites a bare dependsOn on a tiered flux system to the tier that means
+// "X is ready to build on": its install tier (the controller) when it has one, otherwise its sole
+// resources tier for controller-less systems like gitops. So "depend on cert-manager" waits for its
+// controller, and "depend on gitops" waits for its resources. An exact kustomization-name match
+// always wins, so the legacy flat form and explicit tier names pass through untouched. A system with
+// several resources variants has no single terminal tier, so a bare dep on it is left for
+// validateDependencies to flag rather than resolved ambiguously.
 func (c *BaseBlueprintComposer) resolveTierDependencies(bp *blueprintv1alpha1.Blueprint) {
 	names := make(map[string]struct{}, len(bp.Kustomizations)+len(bp.FluxSystems))
 	for _, k := range bp.Kustomizations {
 		names[k.Name] = struct{}{}
 	}
+	resourcesEntry := make(map[string]string)
 	for _, sys := range bp.FluxSystems {
 		if sys.Install != nil {
 			names[sys.Name+"-install"] = struct{}{}
+			continue
+		}
+		if tiers := sys.TierNames(); len(tiers) == 1 {
+			resourcesEntry[sys.Name] = tiers[0]
 		}
 	}
 	resolve := func(deps []string) {
@@ -931,6 +938,10 @@ func (c *BaseBlueprintComposer) resolveTierDependencies(bp *blueprintv1alpha1.Bl
 			}
 			if _, ok := names[dep+"-install"]; ok {
 				deps[j] = dep + "-install"
+				continue
+			}
+			if resolved, ok := resourcesEntry[dep]; ok {
+				deps[j] = resolved
 			}
 		}
 	}

--- a/pkg/composer/blueprint/composer_test.go
+++ b/pkg/composer/blueprint/composer_test.go
@@ -1439,6 +1439,51 @@ func TestComposer_resolveTierDependencies(t *testing.T) {
 			t.Errorf("Expected unresolved dependency to be left untouched, got %v", depsOf(bp, "app"))
 		}
 	})
+
+	t.Run("RewritesBareNameToResourcesTierForControllerlessSystem", func(t *testing.T) {
+		// Given a controller-less (resources-only) flux system and a consumer depending on it by bare name
+		composer := &BaseBlueprintComposer{}
+		bp := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "app", DependsOn: []string{"gitops"}},
+			},
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{Name: "gitops", Resources: []blueprintv1alpha1.FluxVariant{{}}},
+			},
+		}
+
+		// When resolving tier dependencies
+		composer.resolveTierDependencies(bp)
+
+		// Then the bare name resolves to the resources tier, since there is no install tier to target
+		if !slices.Contains(depsOf(bp, "app"), "gitops-resources") {
+			t.Errorf("Expected app to depend on gitops-resources, got %v", depsOf(bp, "app"))
+		}
+	})
+
+	t.Run("LeavesAmbiguousMultiVariantResourcesSystemUntouched", func(t *testing.T) {
+		// Given a resources-only system with several named variants (no single terminal tier)
+		composer := &BaseBlueprintComposer{}
+		bp := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "app", DependsOn: []string{"multi"}},
+			},
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{Name: "multi", Resources: []blueprintv1alpha1.FluxVariant{
+					{Kustomization: blueprintv1alpha1.Kustomization{Name: "a"}},
+					{Kustomization: blueprintv1alpha1.Kustomization{Name: "b"}},
+				}},
+			},
+		}
+
+		// When resolving
+		composer.resolveTierDependencies(bp)
+
+		// Then the ambiguous bare dependency is left untouched (validateDependencies surfaces it later)
+		if !slices.Contains(depsOf(bp, "app"), "multi") {
+			t.Errorf("Expected ambiguous dependency left as multi, got %v", depsOf(bp, "app"))
+		}
+	})
 }
 
 func TestComposer_applyUserBlueprint(t *testing.T) {


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change is isolated to a single composer helper and is additive — it extends an existing resolution path rather than altering any existing behavior.
>
> **Overview**
>
> The PR extends `resolveTierDependencies` to resolve a bare `dependsOn` reference to the correct terminal tier for controller-less Flux systems (those without an install tier). Previously, a dep on `"gitops"` was left untouched if no `"gitops-install"` kustomization existed; now it resolves to `"gitops-resources"` when the system has exactly one resources variant. Systems with multiple resources variants are intentionally left unresolved and delegated to `validateDependencies` to surface as an error.
>
> The implementation adds a `continue` to the install-tier branch so a system cannot simultaneously populate both `names` and `resourcesEntry`, and a matching `continue` in the resolve closure to short-circuit after the install-tier rewrite. Two new unit tests cover the single-variant resolution and the multi-variant passthrough cases.
>
> Reviewed by Claude for commit `8e6cfd66`.

<!-- /claude-code-review:summary -->
