### PR TITLE
feat(composer/artifact): add CLI version compatibility support

### DIFF
--- a/pkg/composer/artifact/artifact.go
+++ b/pkg/composer/artifact/artifact.go
@@ -39,6 +39,11 @@ import (
 
 const artifactTarFilename = "artifact.tar"
 
+// CliVersionAnnotationKey is the OCI manifest annotation key that mirrors an artifact's
+// cliVersion constraint (see BlueprintMetadataInput.CliVersion), letting a consumer check
+// compatibility with a manifest-only fetch instead of a full Pull. See GetCliVersionConstraint.
+const CliVersionAnnotationKey = "windsorcli.dev/cli-version"
+
 // =============================================================================
 // Interfaces
 // =============================================================================
@@ -53,6 +58,7 @@ type Artifact interface {
 	ParseOCIRef(ociRef string) (registry, repository, tag string, err error)
 	GetCacheDir(registry, repository, tag string) (string, error)
 	ListTags(ociRef string) ([]string, error)
+	GetCliVersionConstraint(ociRef string) (string, error)
 }
 
 // =============================================================================
@@ -168,7 +174,7 @@ func (a *ArtifactBuilder) Write(outputPath string, tag string) (string, error) {
 		return "", fmt.Errorf("failed to bundle files: %w", err)
 	}
 
-	finalName, finalVersion, metadata, err := a.parseTagAndResolveMetadata("", tag)
+	finalName, finalVersion, _, metadata, err := a.parseTagAndResolveMetadata("", tag)
 	if err != nil {
 		return "", err
 	}
@@ -240,6 +246,44 @@ func (a *ArtifactBuilder) ListTags(ociRef string) ([]string, error) {
 	return tags, nil
 }
 
+// GetCliVersionConstraint returns the cliVersion constraint an OCI artifact declares, read from
+// its CliVersionAnnotationKey manifest annotation (set at push time by createOCIArtifactImage).
+// It fetches only the image manifest — never the layer blob a full Pull would download and
+// extract — so checking a candidate tag's compatibility costs a small JSON round trip regardless
+// of artifact size. Returns an empty string, not an error, when the tag declares no constraint
+// (an older tag published before this annotation existed, or an artifact that never set
+// cliVersion): callers treat that the same way ValidateCliVersion treats an empty constraint —
+// unconstrained, not a failure.
+func (a *ArtifactBuilder) GetCliVersionConstraint(ociRef string) (string, error) {
+	registry, repository, tag, err := a.ParseOCIRef(ociRef)
+	if err != nil {
+		return "", err
+	}
+
+	ref := fmt.Sprintf("%s/%s:%s", registry, repository, tag)
+	parsedRef, err := a.shims.ParseReference(ref)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse reference %s: %w", ref, err)
+	}
+
+	img, err := a.shims.RemoteImage(parsedRef, remote.WithAuthFromKeychain(authn.DefaultKeychain))
+	if err != nil && IsAuthenticationError(err) {
+		if anonImg, anonErr := a.shims.RemoteImage(parsedRef, remote.WithAuth(authn.Anonymous)); anonErr == nil {
+			img, err = anonImg, nil
+		}
+	}
+	if err != nil {
+		return "", fmt.Errorf("failed to get image manifest for %s: %w", ref, err)
+	}
+
+	manifest, err := img.Manifest()
+	if err != nil {
+		return "", fmt.Errorf("failed to read manifest for %s: %w", ref, err)
+	}
+
+	return manifest.Annotations[CliVersionAnnotationKey], nil
+}
+
 // GetCacheDir returns the cache directory path for an OCI artifact identified by registry, repository, and tag.
 // The cache directory is located at <projectRoot>/.windsor/cache/oci/<extractionKey> where extractionKey
 // is the cacheKey with / and : replaced with _ for filesystem safety.
@@ -266,13 +310,14 @@ func (a *ArtifactBuilder) Push(registryBase string, repoName string, tag string)
 		return fmt.Errorf("failed to bundle files: %w", err)
 	}
 
-	finalName, tagName, metadata, err := a.parseTagAndResolveMetadata(repoName, tag)
+	finalName, tagName, cliVersionConstraint, metadata, err := a.parseTagAndResolveMetadata(repoName, tag)
 	if err != nil {
 		return err
 	}
 
 	a.metadata.Name = finalName
 	a.metadata.Version = tagName
+	a.metadata.CliVersion = cliVersionConstraint
 	if err := a.refreshArtifactManifest(); err != nil {
 		return err
 	}
@@ -284,7 +329,7 @@ func (a *ArtifactBuilder) Push(registryBase string, repoName string, tag string)
 
 	layer := static.NewLayer(tarballContent, types.DockerLayer)
 
-	img, err := a.createOCIArtifactImage(layer, finalName, tagName)
+	img, err := a.createOCIArtifactImage(layer, finalName, tagName, cliVersionConstraint)
 	if err != nil {
 		return fmt.Errorf("failed to create OCI image: %w", err)
 	}
@@ -803,8 +848,9 @@ func (a *ArtifactBuilder) shouldSkipTerraformFile(filename string) bool {
 // For Push method (repoName provided): tag is version only, repoName is used as fallback name
 // Loads existing metadata.yaml from files if present and parses it as BlueprintMetadataInput.
 // Tag parameter takes precedence over metadata file values for version and/or name.
-// Returns final name, version, and complete marshaled metadata ready for embedding in artifacts.
-func (a *ArtifactBuilder) parseTagAndResolveMetadata(repoName, tag string) (string, string, []byte, error) {
+// Returns final name, version, the cliVersion constraint (empty if none declared), and complete
+// marshaled metadata ready for embedding in artifacts.
+func (a *ArtifactBuilder) parseTagAndResolveMetadata(repoName, tag string) (string, string, string, []byte, error) {
 	var tagName, tagVersion string
 
 	if repoName == "" {
@@ -812,7 +858,7 @@ func (a *ArtifactBuilder) parseTagAndResolveMetadata(repoName, tag string) (stri
 			if strings.Contains(tag, ":") {
 				parts := strings.Split(tag, ":")
 				if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
-					return "", "", nil, fmt.Errorf("tag must be in format 'name:version', got: %s", tag)
+					return "", "", "", nil, fmt.Errorf("tag must be in format 'name:version', got: %s", tag)
 				}
 				tagName = parts[0]
 				tagVersion = parts[1]
@@ -831,10 +877,10 @@ func (a *ArtifactBuilder) parseTagAndResolveMetadata(repoName, tag string) (stri
 
 	if hasMetadata {
 		if err := a.shims.YamlUnmarshal(metadataFileInfo.Content, &input); err != nil {
-			return "", "", nil, fmt.Errorf("failed to parse metadata.yaml: %w", err)
+			return "", "", "", nil, fmt.Errorf("failed to parse metadata.yaml: %w", err)
 		}
 		if err := ValidateCliVersion(constants.Version, input.CliVersion); err != nil {
-			return "", "", nil, err
+			return "", "", "", nil, err
 		}
 	}
 
@@ -854,21 +900,21 @@ func (a *ArtifactBuilder) parseTagAndResolveMetadata(repoName, tag string) (stri
 
 	if finalName == "" {
 		if repoName == "" {
-			return "", "", nil, fmt.Errorf("name is required: provide via tag parameter or metadata.yaml")
+			return "", "", "", nil, fmt.Errorf("name is required: provide via tag parameter or metadata.yaml")
 		} else {
-			return "", "", nil, fmt.Errorf("name is required: provide via metadata.yaml")
+			return "", "", "", nil, fmt.Errorf("name is required: provide via metadata.yaml")
 		}
 	}
 	if finalVersion == "" {
-		return "", "", nil, fmt.Errorf("version is required: provide via tag parameter or metadata.yaml")
+		return "", "", "", nil, fmt.Errorf("version is required: provide via tag parameter or metadata.yaml")
 	}
 
 	metadata, err := a.generateMetadata(input, finalName, finalVersion)
 	if err != nil {
-		return "", "", nil, fmt.Errorf("failed to generate metadata: %w", err)
+		return "", "", "", nil, fmt.Errorf("failed to generate metadata: %w", err)
 	}
 
-	return finalName, finalVersion, metadata, nil
+	return finalName, finalVersion, input.CliVersion, metadata, nil
 }
 
 // generateMetadata creates enriched metadata by merging input metadata with generated values.
@@ -1003,8 +1049,10 @@ func (a *ArtifactBuilder) createTarballToDisk(outputPath string, metadata []byte
 // Sets architecture to amd64 and OS to linux for compatibility with container runtimes.
 // Uses standard OCI media types with optional artifactType for tool-specific identification.
 // Adds comprehensive OCI annotations including creation time, source, revision, title, and version.
+// When cliVersionConstraint is non-empty, also sets CliVersionAnnotationKey so a consumer can check
+// CLI compatibility for this tag via GetCliVersionConstraint's manifest-only fetch, without a full Pull.
 // Returns a complete OCI image ready for pushing to any OCI 1.1 compatible registry.
-func (a *ArtifactBuilder) createOCIArtifactImage(layer v1.Layer, repoName, tagName string) (v1.Image, error) {
+func (a *ArtifactBuilder) createOCIArtifactImage(layer v1.Layer, repoName, tagName, cliVersionConstraint string) (v1.Image, error) {
 	gitProvenance, err := a.getGitProvenance()
 	if err != nil {
 		gitProvenance = GitProvenance{}
@@ -1059,6 +1107,9 @@ func (a *ArtifactBuilder) createOCIArtifactImage(layer v1.Layer, repoName, tagNa
 		"org.opencontainers.image.revision": revision,
 		"org.opencontainers.image.title":    repoName,
 		"org.opencontainers.image.version":  tagName,
+	}
+	if cliVersionConstraint != "" {
+		annotations[CliVersionAnnotationKey] = cliVersionConstraint
 	}
 
 	img = a.shims.Annotations(img, annotations)

--- a/pkg/composer/artifact/artifact_private_test.go
+++ b/pkg/composer/artifact/artifact_private_test.go
@@ -879,7 +879,7 @@ func TestArtifactBuilder_createOCIArtifactImage(t *testing.T) {
 		layer := static.NewLayer([]byte("test"), types.DockerLayer)
 
 		// When creating OCI artifact image
-		img, err := builder.createOCIArtifactImage(layer, "test-repo", "v1.0.0")
+		img, err := builder.createOCIArtifactImage(layer, "test-repo", "v1.0.0", "")
 
 		// Then should succeed
 		if err != nil {
@@ -887,6 +887,74 @@ func TestArtifactBuilder_createOCIArtifactImage(t *testing.T) {
 		}
 		if img == nil {
 			t.Error("Expected non-nil image")
+		}
+	})
+
+	t.Run("SetsCliVersionAnnotationWhenDeclared", func(t *testing.T) {
+		// Given a builder pushing an artifact whose _template/metadata.yaml declares cliVersion
+		builder, mocks := setup(t)
+
+		mockImage := &mockImage{}
+		mocks.Shims.EmptyImage = func() v1.Image { return mockImage }
+		mocks.Shims.AppendLayers = func(base v1.Image, layers ...v1.Layer) (v1.Image, error) {
+			return mockImage, nil
+		}
+		mocks.Shims.ConfigFile = func(img v1.Image, cfg *v1.ConfigFile) (v1.Image, error) {
+			return mockImage, nil
+		}
+		mocks.Shims.MediaType = func(img v1.Image, mt types.MediaType) v1.Image { return mockImage }
+		mocks.Shims.ConfigMediaType = func(img v1.Image, mt types.MediaType) v1.Image { return mockImage }
+
+		var capturedAnnotations map[string]string
+		mocks.Shims.Annotations = func(img v1.Image, anns map[string]string) v1.Image {
+			capturedAnnotations = anns
+			return mockImage
+		}
+
+		layer := static.NewLayer([]byte("test"), types.DockerLayer)
+
+		// When creating OCI artifact image with a declared constraint
+		if _, err := builder.createOCIArtifactImage(layer, "test-repo", "v1.0.0", ">=0.9.0"); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the manifest annotation mirrors the same constraint metadata.yaml carries
+		if capturedAnnotations[CliVersionAnnotationKey] != ">=0.9.0" {
+			t.Errorf("Expected %s annotation %q, got %q", CliVersionAnnotationKey, ">=0.9.0", capturedAnnotations[CliVersionAnnotationKey])
+		}
+	})
+
+	t.Run("OmitsCliVersionAnnotationWhenNotDeclared", func(t *testing.T) {
+		// Given a builder pushing an artifact with no cliVersion declared
+		builder, mocks := setup(t)
+
+		mockImage := &mockImage{}
+		mocks.Shims.EmptyImage = func() v1.Image { return mockImage }
+		mocks.Shims.AppendLayers = func(base v1.Image, layers ...v1.Layer) (v1.Image, error) {
+			return mockImage, nil
+		}
+		mocks.Shims.ConfigFile = func(img v1.Image, cfg *v1.ConfigFile) (v1.Image, error) {
+			return mockImage, nil
+		}
+		mocks.Shims.MediaType = func(img v1.Image, mt types.MediaType) v1.Image { return mockImage }
+		mocks.Shims.ConfigMediaType = func(img v1.Image, mt types.MediaType) v1.Image { return mockImage }
+
+		var capturedAnnotations map[string]string
+		mocks.Shims.Annotations = func(img v1.Image, anns map[string]string) v1.Image {
+			capturedAnnotations = anns
+			return mockImage
+		}
+
+		layer := static.NewLayer([]byte("test"), types.DockerLayer)
+
+		// When creating OCI artifact image with an empty constraint
+		if _, err := builder.createOCIArtifactImage(layer, "test-repo", "v1.0.0", ""); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then no cli-version annotation key is written at all
+		if _, ok := capturedAnnotations[CliVersionAnnotationKey]; ok {
+			t.Errorf("Expected no %s annotation when cliVersion is undeclared, got %q", CliVersionAnnotationKey, capturedAnnotations[CliVersionAnnotationKey])
 		}
 	})
 
@@ -911,7 +979,7 @@ func TestArtifactBuilder_createOCIArtifactImage(t *testing.T) {
 		layer := static.NewLayer([]byte("test"), types.DockerLayer)
 
 		// When creating OCI artifact image
-		_, err := builder.createOCIArtifactImage(layer, "test-repo", "v1.0.0")
+		_, err := builder.createOCIArtifactImage(layer, "test-repo", "v1.0.0", "")
 
 		// Then should return error
 		if err == nil {
@@ -942,7 +1010,7 @@ func TestArtifactBuilder_createOCIArtifactImage(t *testing.T) {
 		layer := static.NewLayer([]byte("test"), types.DockerLayer)
 
 		// When creating OCI artifact image
-		_, err := builder.createOCIArtifactImage(layer, "test-repo", "v1.0.0")
+		_, err := builder.createOCIArtifactImage(layer, "test-repo", "v1.0.0", "")
 
 		// Then should return error
 		if err == nil {
@@ -988,7 +1056,7 @@ func TestArtifactBuilder_createOCIArtifactImage(t *testing.T) {
 		layer := static.NewLayer([]byte("test"), types.DockerLayer)
 
 		// When creating OCI artifact image
-		img, err := builder.createOCIArtifactImage(layer, "test-repo", "v1.0.0")
+		img, err := builder.createOCIArtifactImage(layer, "test-repo", "v1.0.0", "")
 
 		// Then should succeed with fallback values
 		if err != nil {
@@ -1042,7 +1110,7 @@ func TestArtifactBuilder_createOCIArtifactImage(t *testing.T) {
 		layer := static.NewLayer([]byte("test"), types.DockerLayer)
 
 		// When creating OCI artifact image
-		img, err := builder.createOCIArtifactImage(layer, "test-repo", "v1.0.0")
+		img, err := builder.createOCIArtifactImage(layer, "test-repo", "v1.0.0", "")
 
 		// Then should succeed
 		if err != nil {
@@ -2851,6 +2919,158 @@ func TestArtifactBuilder_ListTags(t *testing.T) {
 		}
 		if _, err := builder.ListTags("oci://ghcr.io/windsorcli/core:v0.6.0"); err == nil {
 			t.Error("Expected the registry error to surface")
+		}
+	})
+}
+
+func TestArtifactBuilder_GetCliVersionConstraint(t *testing.T) {
+	setup := func(t *testing.T) *ArtifactBuilder {
+		t.Helper()
+		mocks := setupArtifactMocks(t)
+		builder := NewArtifactBuilder(mocks.Runtime)
+		builder.shims = mocks.Shims
+		return builder
+	}
+
+	t.Run("ReturnsDeclaredConstraint", func(t *testing.T) {
+		// Given a registry whose manifest carries the cli-version annotation. ImageLayers is
+		// deliberately left unset (nil) — a call to it panics, proving GetCliVersionConstraint
+		// never touches the layer blob the way a full Pull would.
+		builder := setup(t)
+		builder.shims.ParseReference = func(ref string, opts ...name.Option) (name.Reference, error) {
+			return nil, nil
+		}
+		builder.shims.RemoteImage = func(ref name.Reference, options ...remote.Option) (v1.Image, error) {
+			return &mockImageWithManifest{
+				manifestFunc: func() (*v1.Manifest, error) {
+					return &v1.Manifest{Annotations: map[string]string{CliVersionAnnotationKey: ">=0.9.0"}}, nil
+				},
+			}, nil
+		}
+
+		// When reading the constraint for a candidate tag
+		constraint, err := builder.GetCliVersionConstraint("oci://ghcr.io/windsorcli/core:v0.9.2")
+
+		// Then it returns the declared constraint, manifest-only
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if constraint != ">=0.9.0" {
+			t.Errorf("Expected constraint >=0.9.0, got %q", constraint)
+		}
+	})
+
+	t.Run("ReturnsEmptyWhenAnnotationAbsent", func(t *testing.T) {
+		// Given a manifest with no cli-version annotation (an older tag published before this
+		// annotation existed, or an artifact that never declared cliVersion)
+		builder := setup(t)
+		builder.shims.ParseReference = func(ref string, opts ...name.Option) (name.Reference, error) {
+			return nil, nil
+		}
+		builder.shims.RemoteImage = func(ref name.Reference, options ...remote.Option) (v1.Image, error) {
+			return &mockImageWithManifest{
+				manifestFunc: func() (*v1.Manifest, error) {
+					return &v1.Manifest{Annotations: map[string]string{}}, nil
+				},
+			}, nil
+		}
+
+		// When reading the constraint
+		constraint, err := builder.GetCliVersionConstraint("oci://ghcr.io/windsorcli/core:v0.5.0")
+
+		// Then it returns empty, not an error — unconstrained, same as ValidateCliVersion treats
+		// an empty constraint
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if constraint != "" {
+			t.Errorf("Expected empty constraint, got %q", constraint)
+		}
+	})
+
+	t.Run("ErrorsOnMalformedReference", func(t *testing.T) {
+		builder := setup(t)
+		if _, err := builder.GetCliVersionConstraint("not-an-oci-ref"); err == nil {
+			t.Error("Expected an error for a malformed OCI reference")
+		}
+	})
+
+	t.Run("ErrorWhenParseReferenceFails", func(t *testing.T) {
+		builder := setup(t)
+		builder.shims.ParseReference = func(ref string, opts ...name.Option) (name.Reference, error) {
+			return nil, fmt.Errorf("parse error")
+		}
+
+		_, err := builder.GetCliVersionConstraint("oci://ghcr.io/windsorcli/core:v0.9.2")
+		if err == nil || !strings.Contains(err.Error(), "failed to parse reference") {
+			t.Errorf("Expected parse reference error, got %v", err)
+		}
+	})
+
+	t.Run("ErrorWhenRemoteImageFails", func(t *testing.T) {
+		builder := setup(t)
+		builder.shims.ParseReference = func(ref string, opts ...name.Option) (name.Reference, error) {
+			return nil, nil
+		}
+		builder.shims.RemoteImage = func(ref name.Reference, options ...remote.Option) (v1.Image, error) {
+			return nil, fmt.Errorf("remote error")
+		}
+
+		_, err := builder.GetCliVersionConstraint("oci://ghcr.io/windsorcli/core:v0.9.2")
+		if err == nil || !strings.Contains(err.Error(), "failed to get image manifest") {
+			t.Errorf("Expected image manifest error, got %v", err)
+		}
+	})
+
+	t.Run("ErrorWhenManifestReadFails", func(t *testing.T) {
+		builder := setup(t)
+		builder.shims.ParseReference = func(ref string, opts ...name.Option) (name.Reference, error) {
+			return nil, nil
+		}
+		builder.shims.RemoteImage = func(ref name.Reference, options ...remote.Option) (v1.Image, error) {
+			return &mockImageWithManifest{
+				manifestFunc: func() (*v1.Manifest, error) {
+					return nil, fmt.Errorf("manifest read error")
+				},
+			}, nil
+		}
+
+		_, err := builder.GetCliVersionConstraint("oci://ghcr.io/windsorcli/core:v0.9.2")
+		if err == nil || !strings.Contains(err.Error(), "failed to read manifest") {
+			t.Errorf("Expected manifest read error, got %v", err)
+		}
+	})
+
+	t.Run("RetriesAnonymouslyWhenKeychainRejectedByRegistry", func(t *testing.T) {
+		// Given a registry that rejects keychain credentials but accepts anonymous access,
+		// mirroring downloadOCIArtifact's identical fallback behavior
+		builder := setup(t)
+		builder.shims.ParseReference = func(ref string, opts ...name.Option) (name.Reference, error) {
+			return nil, nil
+		}
+		callCount := 0
+		builder.shims.RemoteImage = func(ref name.Reference, options ...remote.Option) (v1.Image, error) {
+			callCount++
+			if callCount == 1 {
+				return nil, &transport.Error{StatusCode: http.StatusForbidden, Errors: []transport.Diagnostic{{Code: transport.DeniedErrorCode}}}
+			}
+			return &mockImageWithManifest{
+				manifestFunc: func() (*v1.Manifest, error) {
+					return &v1.Manifest{Annotations: map[string]string{CliVersionAnnotationKey: ">=0.9.0"}}, nil
+				},
+			}, nil
+		}
+
+		constraint, err := builder.GetCliVersionConstraint("oci://ghcr.io/windsorcli/core:v0.9.2")
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if constraint != ">=0.9.0" {
+			t.Errorf("Expected constraint >=0.9.0, got %q", constraint)
+		}
+		if callCount != 2 {
+			t.Errorf("Expected 2 RemoteImage calls (keychain then anonymous), got %d", callCount)
 		}
 	})
 }

--- a/pkg/composer/artifact/artifact_public_test.go
+++ b/pkg/composer/artifact/artifact_public_test.go
@@ -1071,6 +1071,56 @@ func TestArtifactBuilder_Push(t *testing.T) {
 		}
 	})
 
+	t.Run("PropagatesCliVersionConstraintToManifestAnnotation", func(t *testing.T) {
+		// Given a builder whose _template/metadata.yaml declares a cliVersion constraint. The
+		// package default YamlUnmarshal stub (setupDefaultShims) ignores file content and only
+		// ever sets Name/Version, so CliVersion needs its own override here.
+		builder, mocks := setup(t)
+
+		mocks.Shims.YamlUnmarshal = func(data []byte, v any) error {
+			input := v.(*BlueprintMetadataInput)
+			input.Name = "test"
+			input.Version = "1.0.0"
+			input.CliVersion = ">=0.9.0"
+			return nil
+		}
+
+		mockImg := &mockImage{}
+		mocks.Shims.EmptyImage = func() v1.Image { return mockImg }
+		mocks.Shims.AppendLayers = func(base v1.Image, layers ...v1.Layer) (v1.Image, error) {
+			return mockImg, nil
+		}
+		mocks.Shims.ConfigFile = func(img v1.Image, cfg *v1.ConfigFile) (v1.Image, error) {
+			return mockImg, nil
+		}
+		mocks.Shims.MediaType = func(img v1.Image, mt types.MediaType) v1.Image { return mockImg }
+		mocks.Shims.ConfigMediaType = func(img v1.Image, mt types.MediaType) v1.Image { return mockImg }
+
+		var capturedAnnotations map[string]string
+		mocks.Shims.Annotations = func(img v1.Image, anns map[string]string) v1.Image {
+			capturedAnnotations = anns
+			return &mockImageWithManifest{
+				manifestFunc: func() (*v1.Manifest, error) {
+					return nil, fmt.Errorf("stop after annotations captured")
+				},
+			}
+		}
+
+		builder.addFile("_template/metadata.yaml", []byte("name: test\nversion: 1.0.0\ncliVersion: \">=0.9.0\""), 0644)
+
+		// When pushing
+		err := builder.Push("registry.example.com", "myapp", "2.0.0")
+
+		// Then execution reached the manifest step (proving OCI image creation completed) and the
+		// constraint declared in metadata.yaml was mirrored into the manifest annotation
+		if err == nil || !strings.Contains(err.Error(), "stop after annotations captured") {
+			t.Fatalf("Expected to reach manifest step, got: %v", err)
+		}
+		if capturedAnnotations[CliVersionAnnotationKey] != ">=0.9.0" {
+			t.Errorf("Expected %s annotation %q, got %q", CliVersionAnnotationKey, ">=0.9.0", capturedAnnotations[CliVersionAnnotationKey])
+		}
+	})
+
 	t.Run("SuccessWithInMemoryOperation", func(t *testing.T) {
 		// Given a builder with valid metadata
 		builder, mocks := setup(t)

--- a/pkg/composer/artifact/mock_artifact.go
+++ b/pkg/composer/artifact/mock_artifact.go
@@ -11,14 +11,15 @@ package artifact
 
 // MockArtifact is a mock implementation of the Artifact interface
 type MockArtifact struct {
-	BundleFunc            func() error
-	WriteFunc             func(outputPath string, tag string) (string, error)
-	PushFunc              func(registryBase string, repoName string, tag string) error
-	PullFunc              func(ociRefs []string) (map[string]string, error)
-	ExtractModulePathFunc func(registry, repository, tag, modulePath string) (string, error)
-	ParseOCIRefFunc       func(ociRef string) (registry, repository, tag string, err error)
-	GetCacheDirFunc       func(registry, repository, tag string) (string, error)
-	ListTagsFunc          func(ociRef string) ([]string, error)
+	BundleFunc                  func() error
+	WriteFunc                   func(outputPath string, tag string) (string, error)
+	PushFunc                    func(registryBase string, repoName string, tag string) error
+	PullFunc                    func(ociRefs []string) (map[string]string, error)
+	ExtractModulePathFunc       func(registry, repository, tag, modulePath string) (string, error)
+	ParseOCIRefFunc             func(ociRef string) (registry, repository, tag string, err error)
+	GetCacheDirFunc             func(registry, repository, tag string) (string, error)
+	ListTagsFunc                func(ociRef string) ([]string, error)
+	GetCliVersionConstraintFunc func(ociRef string) (string, error)
 }
 
 // =============================================================================
@@ -75,6 +76,14 @@ func (m *MockArtifact) ListTags(ociRef string) ([]string, error) {
 		return m.ListTagsFunc(ociRef)
 	}
 	return nil, nil
+}
+
+// GetCliVersionConstraint calls the mock GetCliVersionConstraintFunc if set, otherwise returns empty string and nil error
+func (m *MockArtifact) GetCliVersionConstraint(ociRef string) (string, error) {
+	if m.GetCliVersionConstraintFunc != nil {
+		return m.GetCliVersionConstraintFunc(ociRef)
+	}
+	return "", nil
 }
 
 // ExtractModulePath calls the mock ExtractModulePathFunc if set, otherwise returns empty string and nil error


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change adds a manifest-only OCI annotation fetch to the artifact package — a net-new, additive code path with no mutations to existing behavior and full backward compatibility for older tags.
>
> **Overview**
>
> The PR adds `GetCliVersionConstraint`, a new `Artifact` interface method that reads a single OCI manifest (no layer download) to surface the `windsorcli.dev/cli-version` semver constraint for a candidate tag. On the push side, `parseTagAndResolveMetadata` now returns the `cliVersion` field from `metadata.yaml` as an explicit return value; `Push` carries it through to both `a.metadata.CliVersion` and a new OCI annotation via `createOCIArtifactImage`, while `Write` intentionally discards it since local tarballs carry the constraint through the embedded metadata. The mock and interface are updated in sync.
>
> Tags published before this change carry no annotation and the method returns an empty string — matching the unconstrained treatment `ValidateCliVersion` already applies to an empty field.
>
> Reviewed by Claude for commit `097e844d`.

<!-- /claude-code-review:summary -->
