### PR TITLE
feat(composer/blueprint): enforce CLI version compatibility for OCI artifacts

### DIFF
--- a/pkg/composer/blueprint/loader.go
+++ b/pkg/composer/blueprint/loader.go
@@ -326,11 +326,13 @@ func (l *BaseBlueprintLoader) normalizeOCISourceRefs(bp *blueprintv1alpha1.Bluep
 
 // enforceCliVersionCompatibility returns an error when this source's pulled artifact declares a
 // cliVersion constraint (artifact.BlueprintMetadataInput.CliVersion) the running CLI does not
-// satisfy. Reads the same root metadata.yaml applyArtifactMetadataName already extracts; missing
-// or unparsable metadata is treated as no constraint declared, not a failure — Windsor enforces
-// what an artifact declares, it does not infer compatibility. Called before any other loading work
-// so an incompatible source fails fast with a named, actionable error instead of surfacing as a
-// downstream schema or tier failure.
+// satisfy. Reads the same root metadata.yaml applyArtifactMetadataName already extracts. A missing
+// metadata.yaml is treated as no constraint declared, not a failure — Windsor enforces what an
+// artifact declares, it does not infer compatibility. A metadata.yaml that exists but cannot be
+// read or parsed is a different case and is NOT swallowed: silently skipping the gate on a
+// corrupted or unreadable cache would let a malformed artifact bypass the one check that exists to
+// catch it. Called before any other loading work so an incompatible source fails fast with a
+// named, actionable error instead of surfacing as a downstream schema or tier failure.
 func (l *BaseBlueprintLoader) enforceCliVersionCompatibility(cacheDir, tag string) error {
 	metadataPath := filepath.Join(cacheDir, "metadata.yaml")
 	if _, err := l.shims.Stat(metadataPath); os.IsNotExist(err) {
@@ -338,11 +340,11 @@ func (l *BaseBlueprintLoader) enforceCliVersionCompatibility(cacheDir, tag strin
 	}
 	data, err := l.shims.ReadFile(metadataPath)
 	if err != nil {
-		return nil
+		return fmt.Errorf("failed to read %s: %w", metadataPath, err)
 	}
 	var meta artifact.BlueprintMetadataInput
 	if err := l.shims.YamlUnmarshal(data, &meta); err != nil {
-		return nil
+		return fmt.Errorf("failed to parse %s: %w", metadataPath, err)
 	}
 	if err := artifact.ValidateCliVersion(constants.Version, meta.CliVersion); err != nil {
 		return fmt.Errorf("%s:%s is incompatible with this CLI (%w) — upgrade windsor or pin an older tag for this source in blueprint.yaml", l.sourceName, tag, err)

--- a/pkg/composer/blueprint/loader.go
+++ b/pkg/composer/blueprint/loader.go
@@ -8,6 +8,7 @@ import (
 
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/composer/artifact"
+	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/runtime"
 )
 
@@ -213,6 +214,10 @@ func (l *BaseBlueprintLoader) loadFromOCI() error {
 		return fmt.Errorf("failed to retrieve cache directory for %s", l.sourceURL)
 	}
 
+	if err := l.enforceCliVersionCompatibility(cacheDir, tag); err != nil {
+		return err
+	}
+
 	templateDir := filepath.Join(cacheDir, "_template")
 	if _, err := l.shims.Stat(templateDir); os.IsNotExist(err) {
 		templateDir = cacheDir
@@ -317,6 +322,32 @@ func (l *BaseBlueprintLoader) normalizeOCISourceRefs(bp *blueprintv1alpha1.Bluep
 			s.Ref = blueprintv1alpha1.Reference{}
 		}
 	}
+}
+
+// enforceCliVersionCompatibility returns an error when this source's pulled artifact declares a
+// cliVersion constraint (artifact.BlueprintMetadataInput.CliVersion) the running CLI does not
+// satisfy. Reads the same root metadata.yaml applyArtifactMetadataName already extracts; missing
+// or unparsable metadata is treated as no constraint declared, not a failure — Windsor enforces
+// what an artifact declares, it does not infer compatibility. Called before any other loading work
+// so an incompatible source fails fast with a named, actionable error instead of surfacing as a
+// downstream schema or tier failure.
+func (l *BaseBlueprintLoader) enforceCliVersionCompatibility(cacheDir, tag string) error {
+	metadataPath := filepath.Join(cacheDir, "metadata.yaml")
+	if _, err := l.shims.Stat(metadataPath); os.IsNotExist(err) {
+		return nil
+	}
+	data, err := l.shims.ReadFile(metadataPath)
+	if err != nil {
+		return nil
+	}
+	var meta artifact.BlueprintMetadataInput
+	if err := l.shims.YamlUnmarshal(data, &meta); err != nil {
+		return nil
+	}
+	if err := artifact.ValidateCliVersion(constants.Version, meta.CliVersion); err != nil {
+		return fmt.Errorf("%s:%s is incompatible with this CLI (%w) — upgrade windsor or pin an older tag for this source in blueprint.yaml", l.sourceName, tag, err)
+	}
+	return nil
 }
 
 // applyArtifactMetadataName sets the blueprint's Metadata.Name from the artifact's root

--- a/pkg/composer/blueprint/loader_test.go
+++ b/pkg/composer/blueprint/loader_test.go
@@ -886,6 +886,85 @@ metadata:
 		}
 	})
 
+	t.Run("ReturnsErrorWhenMetadataUnreadable", func(t *testing.T) {
+		// Given a metadata.yaml path that exists but cannot be read as a file — a directory in its
+		// place is a portable stand-in for a permissions/I-O failure across platforms
+		mocks := setupLoaderMocks(t)
+
+		cacheDir := filepath.Join(mocks.TmpDir, "cache")
+		templateDir := filepath.Join(cacheDir, "_template")
+		os.MkdirAll(templateDir, 0755)
+
+		blueprintYaml := `kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: oci-blueprint
+`
+		os.WriteFile(filepath.Join(templateDir, "blueprint.yaml"), []byte(blueprintYaml), 0644)
+		os.MkdirAll(filepath.Join(cacheDir, "metadata.yaml"), 0755)
+
+		mocks.ArtifactBuilder.PullFunc = func(refs []string) (map[string]string, error) {
+			return map[string]string{
+				"ghcr.io/windsorcli/core:v0.9.2": cacheDir,
+			}, nil
+		}
+		mocks.ArtifactBuilder.ParseOCIRefFunc = func(ref string) (string, string, string, error) {
+			return "ghcr.io", "windsorcli/core", "v0.9.2", nil
+		}
+
+		loader := NewBlueprintLoader(mocks.Runtime, mocks.ArtifactBuilder)
+
+		// When loading
+		err := loader.Load("core", "oci://ghcr.io/windsorcli/core:v0.9.2")
+
+		// Then the read failure propagates instead of silently skipping the compatibility gate
+		if err == nil {
+			t.Fatal("Expected an error when metadata.yaml cannot be read")
+		}
+		if !strings.Contains(err.Error(), "failed to read") {
+			t.Errorf("Expected a read-failure error, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenMetadataUnparsable", func(t *testing.T) {
+		// Given metadata.yaml exists and is readable but is not valid YAML
+		mocks := setupLoaderMocks(t)
+
+		cacheDir := filepath.Join(mocks.TmpDir, "cache")
+		templateDir := filepath.Join(cacheDir, "_template")
+		os.MkdirAll(templateDir, 0755)
+
+		blueprintYaml := `kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: oci-blueprint
+`
+		os.WriteFile(filepath.Join(templateDir, "blueprint.yaml"), []byte(blueprintYaml), 0644)
+		os.WriteFile(filepath.Join(cacheDir, "metadata.yaml"), []byte("not: [valid: yaml"), 0644)
+
+		mocks.ArtifactBuilder.PullFunc = func(refs []string) (map[string]string, error) {
+			return map[string]string{
+				"ghcr.io/windsorcli/core:v0.9.2": cacheDir,
+			}, nil
+		}
+		mocks.ArtifactBuilder.ParseOCIRefFunc = func(ref string) (string, string, string, error) {
+			return "ghcr.io", "windsorcli/core", "v0.9.2", nil
+		}
+
+		loader := NewBlueprintLoader(mocks.Runtime, mocks.ArtifactBuilder)
+
+		// When loading
+		err := loader.Load("core", "oci://ghcr.io/windsorcli/core:v0.9.2")
+
+		// Then the parse failure propagates instead of silently skipping the compatibility gate
+		if err == nil {
+			t.Fatal("Expected an error when metadata.yaml is not valid YAML")
+		}
+		if !strings.Contains(err.Error(), "failed to parse") {
+			t.Errorf("Expected a parse-failure error, got: %v", err)
+		}
+	})
+
 	t.Run("ReturnsErrorWhenOCIPullFails", func(t *testing.T) {
 		// Given a loader where OCI pull fails
 		mocks := setupLoaderMocks(t)

--- a/pkg/composer/blueprint/loader_test.go
+++ b/pkg/composer/blueprint/loader_test.go
@@ -9,6 +9,7 @@ import (
 
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/composer/artifact"
+	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/runtime"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
@@ -759,6 +760,129 @@ metadata:
 		}
 		if loader.blueprint.Metadata.Name != "oci-blueprint" {
 			t.Errorf("Expected name='oci-blueprint', got '%s'", loader.blueprint.Metadata.Name)
+		}
+	})
+
+	t.Run("RefusesIncompatibleCliVersionFromOCIArtifact", func(t *testing.T) {
+		// Given an OCI artifact whose root metadata.yaml declares a cliVersion
+		// constraint the running CLI does not satisfy
+		mocks := setupLoaderMocks(t)
+
+		originalVersion := constants.Version
+		constants.Version = "0.8.1"
+		t.Cleanup(func() { constants.Version = originalVersion })
+
+		cacheDir := filepath.Join(mocks.TmpDir, "cache")
+		templateDir := filepath.Join(cacheDir, "_template")
+		os.MkdirAll(templateDir, 0755)
+
+		blueprintYaml := `kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: oci-blueprint
+`
+		os.WriteFile(filepath.Join(templateDir, "blueprint.yaml"), []byte(blueprintYaml), 0644)
+		os.WriteFile(filepath.Join(cacheDir, "metadata.yaml"), []byte("name: windsorcli/core\ncliVersion: \">=0.9.0\"\n"), 0644)
+
+		mocks.ArtifactBuilder.PullFunc = func(refs []string) (map[string]string, error) {
+			return map[string]string{
+				"ghcr.io/windsorcli/core:v0.9.2": cacheDir,
+			}, nil
+		}
+		mocks.ArtifactBuilder.ParseOCIRefFunc = func(ref string) (string, string, string, error) {
+			return "ghcr.io", "windsorcli/core", "v0.9.2", nil
+		}
+
+		loader := NewBlueprintLoader(mocks.Runtime, mocks.ArtifactBuilder)
+
+		// When loading
+		err := loader.Load("core", "oci://ghcr.io/windsorcli/core:v0.9.2")
+
+		// Then it fails with a named, actionable error before any other loading work
+		if err == nil {
+			t.Fatal("Expected an error for an incompatible cliVersion constraint")
+		}
+		if !strings.Contains(err.Error(), "core:v0.9.2") {
+			t.Errorf("Expected error to name the source and tag, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "0.8.1") || !strings.Contains(err.Error(), ">=0.9.0") {
+			t.Errorf("Expected error to name the running CLI version and the declared constraint, got: %v", err)
+		}
+	})
+
+	t.Run("AllowsCompatibleCliVersionFromOCIArtifact", func(t *testing.T) {
+		// Given an OCI artifact whose declared cliVersion the running CLI satisfies
+		mocks := setupLoaderMocks(t)
+
+		originalVersion := constants.Version
+		constants.Version = "0.9.2"
+		t.Cleanup(func() { constants.Version = originalVersion })
+
+		cacheDir := filepath.Join(mocks.TmpDir, "cache")
+		templateDir := filepath.Join(cacheDir, "_template")
+		os.MkdirAll(templateDir, 0755)
+
+		blueprintYaml := `kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: oci-blueprint
+`
+		os.WriteFile(filepath.Join(templateDir, "blueprint.yaml"), []byte(blueprintYaml), 0644)
+		os.WriteFile(filepath.Join(cacheDir, "metadata.yaml"), []byte("name: windsorcli/core\ncliVersion: \">=0.9.0\"\n"), 0644)
+
+		mocks.ArtifactBuilder.PullFunc = func(refs []string) (map[string]string, error) {
+			return map[string]string{
+				"ghcr.io/windsorcli/core:v0.9.2": cacheDir,
+			}, nil
+		}
+		mocks.ArtifactBuilder.ParseOCIRefFunc = func(ref string) (string, string, string, error) {
+			return "ghcr.io", "windsorcli/core", "v0.9.2", nil
+		}
+
+		loader := NewBlueprintLoader(mocks.Runtime, mocks.ArtifactBuilder)
+
+		// When loading
+		err := loader.Load("core", "oci://ghcr.io/windsorcli/core:v0.9.2")
+
+		// Then it succeeds
+		if err != nil {
+			t.Fatalf("Expected no error for a satisfied cliVersion constraint, got %v", err)
+		}
+	})
+
+	t.Run("AllowsMissingCliVersionFieldFromOCIArtifact", func(t *testing.T) {
+		// Given an OCI artifact whose metadata.yaml declares no cliVersion at all
+		mocks := setupLoaderMocks(t)
+
+		cacheDir := filepath.Join(mocks.TmpDir, "cache")
+		templateDir := filepath.Join(cacheDir, "_template")
+		os.MkdirAll(templateDir, 0755)
+
+		blueprintYaml := `kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: oci-blueprint
+`
+		os.WriteFile(filepath.Join(templateDir, "blueprint.yaml"), []byte(blueprintYaml), 0644)
+		os.WriteFile(filepath.Join(cacheDir, "metadata.yaml"), []byte("name: windsorcli/core\n"), 0644)
+
+		mocks.ArtifactBuilder.PullFunc = func(refs []string) (map[string]string, error) {
+			return map[string]string{
+				"ghcr.io/windsorcli/core:v0.9.2": cacheDir,
+			}, nil
+		}
+		mocks.ArtifactBuilder.ParseOCIRefFunc = func(ref string) (string, string, string, error) {
+			return "ghcr.io", "windsorcli/core", "v0.9.2", nil
+		}
+
+		loader := NewBlueprintLoader(mocks.Runtime, mocks.ArtifactBuilder)
+
+		// When loading — undeclared means unconstrained, not a failure
+		err := loader.Load("core", "oci://ghcr.io/windsorcli/core:v0.9.2")
+
+		// Then it succeeds
+		if err != nil {
+			t.Fatalf("Expected no error when cliVersion is undeclared, got %v", err)
 		}
 	})
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change adds a new compatibility gate to OCI artifact loading; it only affects users who pull artifacts that declare a `cliVersion` constraint in `metadata.yaml`, and has no effect on the existing code path for artifacts that omit or cannot provide that field.
>
> **Overview**
>
> The PR introduces `enforceCliVersionCompatibility` in the blueprint loader, which reads the root `metadata.yaml` from the OCI artifact cache and calls the existing `artifact.ValidateCliVersion` before any template or schema loading begins. If the running CLI version does not satisfy the declared semver constraint, loading fails immediately with an actionable error naming the source, tag, running version, and constraint. Three test cases cover the reject, allow, and undeclared-constraint paths.
>
> Missing or unreadable metadata is treated as "no constraint declared" rather than a failure, so the gate is purely additive: artifacts that do not declare `cliVersion` continue to load without change.
>
> Reviewed by Claude for commit `a0eb95b2`.

<!-- /claude-code-review:summary -->
