### PR TITLE
feat(composer/blueprint): enhance UpgradeSourcesToLatest to resolve highest compatible OCI tags

### DIFF
--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -4,12 +4,14 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 
 	"github.com/Masterminds/semver/v3"
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/composer/artifact"
+	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/runtime"
 	runtimegit "github.com/windsorcli/cli/pkg/runtime/git"
 )
@@ -218,12 +220,14 @@ type SourceUpgrade struct {
 	To   string
 }
 
-// UpgradeSourcesToLatest moves each remote OCI source pinned to a semver to the latest stable tag
-// published in its repository, mutating the composed blueprint in memory (call Write to persist) and
-// returning the changes for reporting. Sources that are not OCI, not semver-pinned (a branch, a
-// mutable tag like :latest), or already at the latest are left untouched, as are prerelease tags. It
-// resolves directly to the latest — it does not step minor-by-minor. All tags are resolved before any
-// source is mutated, so a registry failure mid-resolution leaves the in-memory blueprint untouched.
+// UpgradeSourcesToLatest moves each remote OCI source pinned to a semver to the highest stable tag
+// published in its repository that this CLI is compatible with (per the tag's declared cliVersion
+// constraint — see resolveCompatibleTag), mutating the composed blueprint in memory (call Write to
+// persist) and returning the changes for reporting. Sources that are not OCI, not semver-pinned (a
+// branch, a mutable tag like :latest), or already at the latest compatible tag are left untouched,
+// as are prerelease tags and tags this CLI does not satisfy. It resolves directly to the latest
+// compatible tag — it does not step minor-by-minor. All tags are resolved before any source is
+// mutated, so a registry failure mid-resolution leaves the in-memory blueprint untouched.
 func (h *BaseBlueprintHandler) UpgradeSourcesToLatest() ([]SourceUpgrade, error) {
 	if h.composedBlueprint == nil {
 		return nil, fmt.Errorf("blueprint not loaded")
@@ -254,12 +258,16 @@ func (h *BaseBlueprintHandler) UpgradeSourcesToLatest() ([]SourceUpgrade, error)
 		if err != nil {
 			return nil, fmt.Errorf("failed to list tags for source %q: %w", src.Name, err)
 		}
-		latestTag, latest, ok := latestStableSemver(tags)
+		urlPrefix := strings.TrimSuffix(src.Url, ":"+info.Tag)
+		latestTag, latest, ok, err := resolveCompatibleTag(h.artifactBuilder, urlPrefix, tags)
+		if err != nil {
+			return nil, fmt.Errorf("failed to check CLI compatibility for source %q: %w", src.Name, err)
+		}
 		if !ok || !latest.GreaterThan(current) {
 			continue
 		}
 
-		newURL := strings.TrimSuffix(src.Url, ":"+info.Tag) + ":" + latestTag
+		newURL := urlPrefix + ":" + latestTag
 		planned = append(planned, plannedUpgrade{
 			index:  i,
 			newURL: newURL,
@@ -293,6 +301,44 @@ func latestStableSemver(tags []string) (string, *semver.Version, bool) {
 		}
 	}
 	return bestTag, best, best != nil
+}
+
+// resolveCompatibleTag walks tags newest-first (stable semver only, prereleases excluded) and
+// returns the highest one this CLI is compatible with, alongside its parsed version. urlPrefix is
+// the source URL without its tag (e.g. "oci://ghcr.io/windsorcli/core") — resolveCompatibleTag
+// appends ":<tag>" per candidate and checks its declared cliVersion constraint via
+// artifact.Artifact.GetCliVersionConstraint, a manifest-only fetch (no full Pull) — so checking N
+// candidates costs N small manifest reads, not N full artifact downloads. A candidate with no
+// declared constraint is treated as compatible, matching ValidateCliVersion's own
+// empty-constraint semantics: Windsor enforces what a tag declares, it does not infer
+// compatibility. Reports ok=false, not an error, when no stable semver tag is compatible.
+func resolveCompatibleTag(artifactBuilder artifact.Artifact, urlPrefix string, tags []string) (tag string, version *semver.Version, ok bool, err error) {
+	type candidate struct {
+		tag string
+		ver *semver.Version
+	}
+	var candidates []candidate
+	for _, t := range tags {
+		v, err := semver.NewVersion(t)
+		if err != nil || v.Prerelease() != "" {
+			continue
+		}
+		candidates = append(candidates, candidate{tag: t, ver: v})
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].ver.GreaterThan(candidates[j].ver)
+	})
+
+	for _, c := range candidates {
+		constraint, err := artifactBuilder.GetCliVersionConstraint(urlPrefix + ":" + c.tag)
+		if err != nil {
+			return "", nil, false, fmt.Errorf("failed to check compatibility for %s:%s: %w", urlPrefix, c.tag, err)
+		}
+		if artifact.ValidateCliVersion(constants.Version, constraint) == nil {
+			return c.tag, c.ver, true, nil
+		}
+	}
+	return "", nil, false, nil
 }
 
 // IsDowngrade reports whether targetURL pins an older stable semver than previousURL for the same

--- a/pkg/composer/blueprint/handler_test.go
+++ b/pkg/composer/blueprint/handler_test.go
@@ -81,6 +81,19 @@ func setupHandlerMocks(t *testing.T) *HandlerTestMocks {
 	return mocks
 }
 
+// setTestCliVersion temporarily overrides constants.Version for the duration of the calling test,
+// restoring the original value via t.Cleanup. constants.Version is process-global, not per-test
+// state — any test using this helper, and any sibling subtest in this package that reads
+// constants.Version, MUST NOT run under t.Parallel(); a parallel subtest would race this mutation
+// against concurrent reads (or another parallel mutation). This package has no t.Parallel() calls
+// today; if one is ever added, audit for this helper's callers first.
+func setTestCliVersion(t *testing.T, v string) {
+	t.Helper()
+	original := constants.Version
+	constants.Version = v
+	t.Cleanup(func() { constants.Version = original })
+}
+
 func TestEvaluateWithOrigins(t *testing.T) {
 	t.Run("UsesSubKeyOriginsForDeepMergedInputMaps", func(t *testing.T) {
 		facetPathByKey := make(map[string]string)
@@ -2246,15 +2259,8 @@ func TestLatestStableSemver(t *testing.T) {
 }
 
 func TestResolveCompatibleTag(t *testing.T) {
-	setVersion := func(t *testing.T, v string) {
-		t.Helper()
-		original := constants.Version
-		constants.Version = v
-		t.Cleanup(func() { constants.Version = original })
-	}
-
 	t.Run("PicksHighestCompatibleSkippingIncompatibleNewest", func(t *testing.T) {
-		setVersion(t, "0.8.1")
+		setTestCliVersion(t, "0.8.1")
 		mock := artifact.NewMockArtifact()
 		mock.GetCliVersionConstraintFunc = func(ociRef string) (string, error) {
 			if ociRef == "oci://ghcr.io/windsorcli/core:v0.7.0" {
@@ -2277,7 +2283,7 @@ func TestResolveCompatibleTag(t *testing.T) {
 	})
 
 	t.Run("SkipsPrereleaseTagsEvenWhenCompatible", func(t *testing.T) {
-		setVersion(t, "0.8.1")
+		setTestCliVersion(t, "0.8.1")
 		mock := artifact.NewMockArtifact()
 
 		tag, _, ok, err := resolveCompatibleTag(mock, "oci://ghcr.io/windsorcli/core", []string{"v0.6.0", "v0.7.0-rc.1"})
@@ -2291,7 +2297,7 @@ func TestResolveCompatibleTag(t *testing.T) {
 	})
 
 	t.Run("TreatsUndeclaredConstraintAsCompatible", func(t *testing.T) {
-		setVersion(t, "0.1.0")
+		setTestCliVersion(t, "0.1.0")
 		mock := artifact.NewMockArtifact()
 
 		tag, _, ok, err := resolveCompatibleTag(mock, "oci://ghcr.io/windsorcli/core", []string{"v0.6.0"})
@@ -2305,7 +2311,7 @@ func TestResolveCompatibleTag(t *testing.T) {
 	})
 
 	t.Run("FalseWhenNoTagIsCompatible", func(t *testing.T) {
-		setVersion(t, "0.1.0")
+		setTestCliVersion(t, "0.1.0")
 		mock := artifact.NewMockArtifact()
 		mock.GetCliVersionConstraintFunc = func(ociRef string) (string, error) {
 			return ">=99.0.0", nil
@@ -2526,9 +2532,7 @@ func TestHandler_UpgradeSourcesToLatest(t *testing.T) {
 	t.Run("SkipsIncompatibleNewestTagAndSelectsNextCompatible", func(t *testing.T) {
 		// Given a running CLI that the newest tag's declared cliVersion excludes, but an
 		// older-than-newest (still newer than current) tag admits
-		originalVersion := constants.Version
-		constants.Version = "0.8.1"
-		t.Cleanup(func() { constants.Version = originalVersion })
+		setTestCliVersion(t, "0.8.1")
 
 		handler, mock := setup(t,
 			[]blueprintv1alpha1.Source{{Name: "core", Url: "oci://ghcr.io/windsorcli/core:v0.5.0"}},
@@ -2555,9 +2559,7 @@ func TestHandler_UpgradeSourcesToLatest(t *testing.T) {
 
 	t.Run("SkipsSourceWhenNoNewerTagIsCompatible", func(t *testing.T) {
 		// Given every tag newer than current declares a cliVersion constraint this CLI fails
-		originalVersion := constants.Version
-		constants.Version = "0.8.1"
-		t.Cleanup(func() { constants.Version = originalVersion })
+		setTestCliVersion(t, "0.8.1")
 
 		handler, mock := setup(t,
 			[]blueprintv1alpha1.Source{{Name: "core", Url: "oci://ghcr.io/windsorcli/core:v0.5.0"}},

--- a/pkg/composer/blueprint/handler_test.go
+++ b/pkg/composer/blueprint/handler_test.go
@@ -10,6 +10,7 @@ import (
 
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/composer/artifact"
+	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/runtime"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	"github.com/windsorcli/cli/pkg/runtime/evaluator"
@@ -2244,6 +2245,109 @@ func TestLatestStableSemver(t *testing.T) {
 	})
 }
 
+func TestResolveCompatibleTag(t *testing.T) {
+	setVersion := func(t *testing.T, v string) {
+		t.Helper()
+		original := constants.Version
+		constants.Version = v
+		t.Cleanup(func() { constants.Version = original })
+	}
+
+	t.Run("PicksHighestCompatibleSkippingIncompatibleNewest", func(t *testing.T) {
+		setVersion(t, "0.8.1")
+		mock := artifact.NewMockArtifact()
+		mock.GetCliVersionConstraintFunc = func(ociRef string) (string, error) {
+			if ociRef == "oci://ghcr.io/windsorcli/core:v0.7.0" {
+				return ">=99.0.0", nil
+			}
+			return "", nil
+		}
+
+		tag, v, ok, err := resolveCompatibleTag(mock, "oci://ghcr.io/windsorcli/core", []string{"v0.5.0", "v0.6.0", "v0.7.0"})
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !ok || tag != "v0.6.0" {
+			t.Fatalf("Expected v0.6.0 (skipping incompatible v0.7.0), got tag=%q ok=%v", tag, ok)
+		}
+		if v == nil || v.String() != "0.6.0" {
+			t.Errorf("Expected parsed 0.6.0, got %v", v)
+		}
+	})
+
+	t.Run("SkipsPrereleaseTagsEvenWhenCompatible", func(t *testing.T) {
+		setVersion(t, "0.8.1")
+		mock := artifact.NewMockArtifact()
+
+		tag, _, ok, err := resolveCompatibleTag(mock, "oci://ghcr.io/windsorcli/core", []string{"v0.6.0", "v0.7.0-rc.1"})
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !ok || tag != "v0.6.0" {
+			t.Errorf("Expected v0.6.0 (prerelease excluded regardless of compatibility), got tag=%q ok=%v", tag, ok)
+		}
+	})
+
+	t.Run("TreatsUndeclaredConstraintAsCompatible", func(t *testing.T) {
+		setVersion(t, "0.1.0")
+		mock := artifact.NewMockArtifact()
+
+		tag, _, ok, err := resolveCompatibleTag(mock, "oci://ghcr.io/windsorcli/core", []string{"v0.6.0"})
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !ok || tag != "v0.6.0" {
+			t.Errorf("Expected an undeclared constraint to be treated as compatible, got tag=%q ok=%v", tag, ok)
+		}
+	})
+
+	t.Run("FalseWhenNoTagIsCompatible", func(t *testing.T) {
+		setVersion(t, "0.1.0")
+		mock := artifact.NewMockArtifact()
+		mock.GetCliVersionConstraintFunc = func(ociRef string) (string, error) {
+			return ">=99.0.0", nil
+		}
+
+		_, _, ok, err := resolveCompatibleTag(mock, "oci://ghcr.io/windsorcli/core", []string{"v0.5.0", "v0.6.0"})
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok {
+			t.Error("Expected ok=false when no tag is compatible")
+		}
+	})
+
+	t.Run("PropagatesConstraintCheckError", func(t *testing.T) {
+		mock := artifact.NewMockArtifact()
+		mock.GetCliVersionConstraintFunc = func(ociRef string) (string, error) {
+			return "", fmt.Errorf("registry unreachable")
+		}
+
+		_, _, _, err := resolveCompatibleTag(mock, "oci://ghcr.io/windsorcli/core", []string{"v0.6.0"})
+
+		if err == nil {
+			t.Error("Expected the registry error to propagate")
+		}
+	})
+
+	t.Run("FalseWhenNoStableSemverTagPresent", func(t *testing.T) {
+		mock := artifact.NewMockArtifact()
+
+		_, _, ok, err := resolveCompatibleTag(mock, "oci://ghcr.io/windsorcli/core", []string{"v1.0.0-rc.1", "garbage"})
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok {
+			t.Error("Expected ok=false among prereleases/junk")
+		}
+	})
+}
+
 func TestIsDowngrade(t *testing.T) {
 	t.Run("TrueWhenTargetTagIsOlderInSameRepo", func(t *testing.T) {
 		// Given a target that pins an older semver than the previous ref of the same repository
@@ -2416,6 +2520,82 @@ func TestHandler_UpgradeSourcesToLatest(t *testing.T) {
 		// Then the first source is left untouched — no partial in-memory mutation
 		if handler.composedBlueprint.Sources[0].Url != "oci://ghcr.io/windsorcli/core:v0.5.0" {
 			t.Errorf("Expected the first source unmutated, got %q", handler.composedBlueprint.Sources[0].Url)
+		}
+	})
+
+	t.Run("SkipsIncompatibleNewestTagAndSelectsNextCompatible", func(t *testing.T) {
+		// Given a running CLI that the newest tag's declared cliVersion excludes, but an
+		// older-than-newest (still newer than current) tag admits
+		originalVersion := constants.Version
+		constants.Version = "0.8.1"
+		t.Cleanup(func() { constants.Version = originalVersion })
+
+		handler, mock := setup(t,
+			[]blueprintv1alpha1.Source{{Name: "core", Url: "oci://ghcr.io/windsorcli/core:v0.5.0"}},
+			map[string][]string{"oci://ghcr.io/windsorcli/core:v0.5.0": {"v0.5.0", "v0.6.0", "v0.7.0"}},
+		)
+		mock.GetCliVersionConstraintFunc = func(ociRef string) (string, error) {
+			if ociRef == "oci://ghcr.io/windsorcli/core:v0.7.0" {
+				return ">=99.0.0", nil
+			}
+			return "", nil
+		}
+
+		// When upgrading sources to latest
+		upgrades, err := handler.UpgradeSourcesToLatest()
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then it skips v0.7.0 and moves to v0.6.0, the highest tag this CLI is compatible with
+		if len(upgrades) != 1 || upgrades[0].To != "oci://ghcr.io/windsorcli/core:v0.6.0" {
+			t.Fatalf("Expected upgrade to v0.6.0 (skipping incompatible v0.7.0), got %v", upgrades)
+		}
+	})
+
+	t.Run("SkipsSourceWhenNoNewerTagIsCompatible", func(t *testing.T) {
+		// Given every tag newer than current declares a cliVersion constraint this CLI fails
+		originalVersion := constants.Version
+		constants.Version = "0.8.1"
+		t.Cleanup(func() { constants.Version = originalVersion })
+
+		handler, mock := setup(t,
+			[]blueprintv1alpha1.Source{{Name: "core", Url: "oci://ghcr.io/windsorcli/core:v0.5.0"}},
+			map[string][]string{"oci://ghcr.io/windsorcli/core:v0.5.0": {"v0.5.0", "v0.6.0"}},
+		)
+		mock.GetCliVersionConstraintFunc = func(ociRef string) (string, error) {
+			if ociRef == "oci://ghcr.io/windsorcli/core:v0.6.0" {
+				return ">=99.0.0", nil
+			}
+			return "", nil
+		}
+
+		// When upgrading sources to latest
+		upgrades, err := handler.UpgradeSourcesToLatest()
+
+		// Then no upgrade happens — no compatible tag newer than current exists — and this is not
+		// treated as an error
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if len(upgrades) != 0 {
+			t.Errorf("Expected no upgrades, got %v", upgrades)
+		}
+	})
+
+	t.Run("PropagatesGetCliVersionConstraintError", func(t *testing.T) {
+		// Given a candidate tag whose compatibility cannot be checked (e.g. a registry hiccup)
+		handler, mock := setup(t,
+			[]blueprintv1alpha1.Source{{Name: "core", Url: "oci://ghcr.io/windsorcli/core:v0.5.0"}},
+			map[string][]string{"oci://ghcr.io/windsorcli/core:v0.5.0": {"v0.5.0", "v0.6.0"}},
+		)
+		mock.GetCliVersionConstraintFunc = func(ociRef string) (string, error) {
+			return "", fmt.Errorf("registry unreachable")
+		}
+
+		// When upgrading sources to latest
+		if _, err := handler.UpgradeSourcesToLatest(); err == nil {
+			t.Error("Expected an error when a candidate's compatibility cannot be checked")
 		}
 	})
 }

--- a/pkg/composer/blueprint/loader_test.go
+++ b/pkg/composer/blueprint/loader_test.go
@@ -9,7 +9,6 @@ import (
 
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/composer/artifact"
-	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/runtime"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
@@ -768,9 +767,7 @@ metadata:
 		// constraint the running CLI does not satisfy
 		mocks := setupLoaderMocks(t)
 
-		originalVersion := constants.Version
-		constants.Version = "0.8.1"
-		t.Cleanup(func() { constants.Version = originalVersion })
+		setTestCliVersion(t, "0.8.1")
 
 		cacheDir := filepath.Join(mocks.TmpDir, "cache")
 		templateDir := filepath.Join(cacheDir, "_template")
@@ -814,9 +811,7 @@ metadata:
 		// Given an OCI artifact whose declared cliVersion the running CLI satisfies
 		mocks := setupLoaderMocks(t)
 
-		originalVersion := constants.Version
-		constants.Version = "0.9.2"
-		t.Cleanup(func() { constants.Version = originalVersion })
+		setTestCliVersion(t, "0.9.2")
 
 		cacheDir := filepath.Join(mocks.TmpDir, "cache")
 		templateDir := filepath.Join(cacheDir, "_template")


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change narrows `UpgradeSourcesToLatest` to skip artifact tags incompatible with the running CLI version; the blast radius is limited to the blueprint upgrade path and the behavior is strictly more conservative than before.
>
> **Overview**
>
> The PR replaces the existing `latestStableSemver` call in `UpgradeSourcesToLatest` with a new `resolveCompatibleTag` helper that walks stable semver tags newest-first and returns the highest one whose declared `cliVersion` constraint the running CLI satisfies. Tags that declare no constraint remain unconditionally compatible, matching the semantics of `ValidateCliVersion`. Registry errors checking compatibility are surfaced as hard errors rather than silently skipped.
>
> The implementation performs one manifest read per candidate tag (short-circuits on the first compatible hit), and all compatibility checks complete before any source is mutated — so a mid-resolution registry failure leaves the in-memory blueprint unchanged. Test coverage is thorough, including the boundary cases for undeclared constraints, all-incompatible tag sets, and error propagation.
>
> Reviewed by Claude for commit `e376606`.

<!-- /claude-code-review:summary -->
