### PR TITLE
fix(provisioner): split Kustomization primary-source interval from Source's

### DIFF
--- a/api/v1alpha1/blueprint_types_test.go
+++ b/api/v1alpha1/blueprint_types_test.go
@@ -2682,7 +2682,7 @@ func TestKustomization_ToFluxKustomization(t *testing.T) {
 		if result.Spec.Path != "kustomize/test/path" {
 			t.Errorf("Expected path 'kustomize/test/path', got '%s'", result.Spec.Path)
 		}
-		if result.Spec.Interval.Duration != constants.DefaultFluxPrimaryRepositoryInterval {
+		if result.Spec.Interval.Duration != constants.DefaultFluxPrimaryKustomizationInterval {
 			t.Errorf("Expected primary-repository default interval (no explicit source set), got %v", result.Spec.Interval.Duration)
 		}
 		// PostBuild should have component-specific ConfigMap when substitutions exist
@@ -3001,7 +3001,7 @@ func TestKustomization_ToFluxKustomization(t *testing.T) {
 
 		result := kustomization.ToFluxKustomization("test-namespace", "default-source", []Source{}, constants.GitopsModePull)
 
-		if result.Spec.Interval.Duration != constants.DefaultFluxPrimaryRepositoryInterval {
+		if result.Spec.Interval.Duration != constants.DefaultFluxPrimaryKustomizationInterval {
 			t.Errorf("Expected primary-repository default interval (no explicit source set), got %v", result.Spec.Interval.Duration)
 		}
 	})
@@ -3168,11 +3168,11 @@ func TestKustomization_ToFluxKustomization(t *testing.T) {
 		// Then both render the same default interval: the notifier re-triggers reconciliation
 		// on every apply/up/bootstrap regardless of mode, so the interval has no reason to
 		// differ between them
-		if pullResult.Spec.Interval.Duration != constants.DefaultFluxPrimaryRepositoryInterval {
-			t.Errorf("Expected pull-mode interval %v, got %v", constants.DefaultFluxPrimaryRepositoryInterval, pullResult.Spec.Interval.Duration)
+		if pullResult.Spec.Interval.Duration != constants.DefaultFluxPrimaryKustomizationInterval {
+			t.Errorf("Expected pull-mode interval %v, got %v", constants.DefaultFluxPrimaryKustomizationInterval, pullResult.Spec.Interval.Duration)
 		}
-		if pushResult.Spec.Interval.Duration != constants.DefaultFluxPrimaryRepositoryInterval {
-			t.Errorf("Expected push-mode interval %v, got %v", constants.DefaultFluxPrimaryRepositoryInterval, pushResult.Spec.Interval.Duration)
+		if pushResult.Spec.Interval.Duration != constants.DefaultFluxPrimaryKustomizationInterval {
+			t.Errorf("Expected push-mode interval %v, got %v", constants.DefaultFluxPrimaryKustomizationInterval, pushResult.Spec.Interval.Duration)
 		}
 	})
 
@@ -3186,8 +3186,8 @@ func TestKustomization_ToFluxKustomization(t *testing.T) {
 
 		// Then it gets the short, continuously-polled primary-repository default: this content
 		// is presumed live and actively pushed, not a pinned vendor dependency
-		if result.Spec.Interval.Duration != constants.DefaultFluxPrimaryRepositoryInterval {
-			t.Errorf("Expected primary-repository interval %v, got %v", constants.DefaultFluxPrimaryRepositoryInterval, result.Spec.Interval.Duration)
+		if result.Spec.Interval.Duration != constants.DefaultFluxPrimaryKustomizationInterval {
+			t.Errorf("Expected primary-repository interval %v, got %v", constants.DefaultFluxPrimaryKustomizationInterval, result.Spec.Interval.Duration)
 		}
 	})
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -92,12 +92,26 @@ const DefaultFluxKustomizationInstallTimeout = 10 * time.Minute
 const DefaultFluxSourceInterval = 1 * time.Hour
 
 // DefaultFluxPrimaryRepositoryInterval is the reconciliation interval for the blueprint's own
-// repository (the top-level "repository:" field) and any Kustomization that resolves to it by
-// default (no explicit source: set). Unlike a named vendor source, the primary repository is
-// typically a live, actively-pushed branch rather than a pinned release, and a change can land
-// there without any windsor command running (a teammate's push, a CI merge) — so flux's own
-// poll is the propagation path here, not just a backstop.
+// repository (the top-level "repository:" field) as a flux Source. Unlike a named vendor
+// source, the primary repository is typically a live, actively-pushed branch rather than a
+// pinned release, and a change can land there without any windsor command running (a
+// teammate's push, a CI merge) — so flux's own Source poll is the propagation path here, not
+// just a backstop. See DefaultFluxPrimaryKustomizationInterval for why a Kustomization that
+// resolves to this same repository doesn't need the same cadence.
 const DefaultFluxPrimaryRepositoryInterval = 1 * time.Minute
+
+// DefaultFluxPrimaryKustomizationInterval is the reconciliation interval for a Kustomization
+// that resolves, explicitly or by default, to the blueprint's own repository rather than a
+// named vendor source. Unlike the Source object itself (DefaultFluxPrimaryRepositoryInterval),
+// a Kustomization's own poll is not the propagation path: kustomize-controller reconciles
+// dependent Kustomizations via a watch on the Source's revision, which the notifier keeps
+// fresh on every apply/up/bootstrap regardless of this interval — so this is purely a backstop
+// for drift correction, retrying failed reconciliations, and dependency-readiness rechecks.
+// A short interval here mainly causes needless churn: Flux's dependency-readiness check is a
+// point-in-time Ready read with no hysteresis, so a Kustomization on a 1m interval briefly
+// flipping to Reconciling can cascade DependencyNotReady retries through everything that
+// depends on it, directly or transitively.
+const DefaultFluxPrimaryKustomizationInterval = 5 * time.Minute
 
 // GitopsMode is accepted by ToFluxKustomization and friends for call-site stability but no
 // longer changes reconciliation cadence: the notifier re-fetches sources on every
@@ -123,11 +137,11 @@ func ParseGitopsMode(s string) GitopsMode {
 // FluxKustomizationInterval returns the default reconciliation interval for a Kustomization.
 // isPrimarySource is true when the Kustomization resolves, explicitly or by falling back to
 // the blueprint's default source, to the blueprint's own repository rather than a named vendor
-// source (see DefaultFluxPrimaryRepositoryInterval). Blueprint-level Interval overrides take
+// source (see DefaultFluxPrimaryKustomizationInterval). Blueprint-level Interval overrides take
 // precedence over either default.
 func FluxKustomizationInterval(isPrimarySource bool) time.Duration {
 	if isPrimarySource {
-		return DefaultFluxPrimaryRepositoryInterval
+		return DefaultFluxPrimaryKustomizationInterval
 	}
 	return DefaultFluxKustomizationInterval
 }

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -5344,8 +5344,8 @@ func TestBaseKubernetesManager_ApplyBlueprint(t *testing.T) {
 		if appliedKust == nil {
 			t.Fatal("Expected Kustomization to be applied")
 		}
-		if appliedKust.Spec.Interval.Duration != constants.DefaultFluxPrimaryRepositoryInterval {
-			t.Errorf("Expected kustomization interval %v, got %v", constants.DefaultFluxPrimaryRepositoryInterval, appliedKust.Spec.Interval.Duration)
+		if appliedKust.Spec.Interval.Duration != constants.DefaultFluxPrimaryKustomizationInterval {
+			t.Errorf("Expected kustomization interval %v, got %v", constants.DefaultFluxPrimaryKustomizationInterval, appliedKust.Spec.Interval.Duration)
 		}
 	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change splits a single constant into two, decoupling the Flux Source reconciliation interval from the Kustomization reconciliation interval for primary-repository resources — an isolated, well-reasoned default adjustment with no structural refactoring.
>
> **Overview**
>
> The PR introduces `DefaultFluxPrimaryKustomizationInterval` (5 minutes) alongside the existing `DefaultFluxPrimaryRepositoryInterval` (1 minute), which now exclusively governs Source objects. `FluxKustomizationInterval` and all tests are updated to use the new Kustomization constant. The change is purely additive in the constants layer; no call-site logic changes.
>
> The rationale is sound: a Kustomization's own poll is not the propagation path for primary-source changes — kustomize-controller watches the Source's revision, and the notifier triggers reconciliation on every `apply`/`up`/`bootstrap`. A 1-minute Kustomization interval was causing unnecessary churn and could cascade `DependencyNotReady` retries. The 5-minute value becomes the backstop for drift correction and failed-reconciliation retries only. Existing deployments will silently move to the longer interval on upgrade, which is the intended outcome.
>
> Reviewed by Claude for commit `4eaa6e82`.

<!-- /claude-code-review:summary -->
