### PR TITLE
feat(cmd): resolve compatible core tags for bootstrap and init

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -153,7 +153,7 @@ windsor bootstrap prod --yes`,
 			return fmt.Errorf("invalid configuration: %w", err)
 		}
 
-		blueprintURL, err := resolveBlueprintURL(bootstrapBlueprint, bootstrapPlatform, proj.Runtime.ContextName, proj.Runtime.TemplateRoot, true)
+		blueprintURL, err := resolveBlueprintURL(bootstrapBlueprint, bootstrapPlatform, proj.Runtime.ContextName, proj.Runtime.TemplateRoot, true, proj.Composer.ArtifactBuilder)
 		if err != nil {
 			return err
 		}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -163,7 +163,7 @@ windsor init staging --platform=aws --aws-profile=staging`,
 			return fmt.Errorf("invalid configuration: %w", err)
 		}
 
-		blueprintURL, err := resolveBlueprintURL(initBlueprint, initPlatform, contextName, rt.TemplateRoot, true)
+		blueprintURL, err := resolveBlueprintURL(initBlueprint, initPlatform, contextName, rt.TemplateRoot, true, proj.Composer.ArtifactBuilder)
 		if err != nil {
 			return err
 		}

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -74,7 +74,7 @@ windsor up --blueprint=ghcr.io/myorg/blueprint:v1.0.0`,
 			return fmt.Errorf("invalid configuration: %w", err)
 		}
 
-		blueprintURL, err := resolveBlueprintURL(upBlueprint, upPlatform, proj.Runtime.ContextName, proj.Runtime.TemplateRoot, false)
+		blueprintURL, err := resolveBlueprintURL(upBlueprint, upPlatform, proj.Runtime.ContextName, proj.Runtime.TemplateRoot, false, proj.Composer.ArtifactBuilder)
 		if err != nil {
 			return err
 		}

--- a/cmd/workstation_defaults.go
+++ b/cmd/workstation_defaults.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/Masterminds/semver/v3"
 	"github.com/windsorcli/cli/pkg/composer/artifact"
 	"github.com/windsorcli/cli/pkg/constants"
 )
@@ -110,15 +111,21 @@ func resolveBlueprintURL(blueprintFlag, platformFlag, contextName, templateRoot 
 
 // resolveEffectiveBlueprintURL returns the highest core tag this CLI is compatible with, falling
 // back to the build-time pin on any failure (nil builder, unreachable registry, no compatible
-// tag) — bootstrap must never block on the network.
+// tag) — bootstrap must never block on the network. Also falls back when the pin itself isn't a
+// concrete version (a dev build's mutable :latest): there's nothing to walk "newer than," and
+// substituting the highest tagged release for an unreleased :latest can resolve to older or
+// inconsistent content.
 func resolveEffectiveBlueprintURL(artifactBuilder artifact.Artifact) string {
 	pinned := constants.GetEffectiveBlueprintURL()
 	if artifactBuilder == nil {
 		return pinned
 	}
 
-	registry, repository, _, err := artifactBuilder.ParseOCIRef(pinned)
+	registry, repository, pinnedTag, err := artifactBuilder.ParseOCIRef(pinned)
 	if err != nil {
+		return pinned
+	}
+	if _, err := semver.NewVersion(pinnedTag); err != nil {
 		return pinned
 	}
 	urlPrefix := fmt.Sprintf("oci://%s/%s", registry, repository)
@@ -128,10 +135,10 @@ func resolveEffectiveBlueprintURL(artifactBuilder artifact.Artifact) string {
 		return pinned
 	}
 
-	tag, _, ok, err := artifact.ResolveCompatibleTag(artifactBuilder, urlPrefix, tags)
+	resolvedTag, _, ok, err := artifact.ResolveCompatibleTag(artifactBuilder, urlPrefix, tags)
 	if err != nil || !ok {
 		return pinned
 	}
 
-	return urlPrefix + ":" + tag
+	return urlPrefix + ":" + resolvedTag
 }

--- a/cmd/workstation_defaults.go
+++ b/cmd/workstation_defaults.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 
+	"github.com/windsorcli/cli/pkg/composer/artifact"
 	"github.com/windsorcli/cli/pkg/constants"
 )
 
@@ -75,8 +76,9 @@ func applyWorkstationFlagOverrides(overrides map[string]any, vmDriver, platform 
 // directory exists, but only when allowLocalBootstrap is true — init opts
 // in to bootstrap a fresh local context, while up must not silently pull
 // from the network on a bare invocation. Returns a nil slice when the
-// caller should use whatever blueprint state is already on disk.
-func resolveBlueprintURL(blueprintFlag, platformFlag, contextName, templateRoot string, allowLocalBootstrap bool) ([]string, error) {
+// caller should use whatever blueprint state is already on disk. artifactBuilder is passed to
+// resolveEffectiveBlueprintURL; nil (or a registry failure) falls back to the build-time pin.
+func resolveBlueprintURL(blueprintFlag, platformFlag, contextName, templateRoot string, allowLocalBootstrap bool, artifactBuilder artifact.Artifact) ([]string, error) {
 	if blueprintFlag != "" {
 		return []string{blueprintFlag}, nil
 	}
@@ -92,16 +94,44 @@ func resolveBlueprintURL(blueprintFlag, platformFlag, contextName, templateRoot 
 				return nil, fmt.Errorf("error checking template root: %w", err)
 			}
 		}
-		return []string{constants.GetEffectiveBlueprintURL()}, nil
+		return []string{resolveEffectiveBlueprintURL(artifactBuilder)}, nil
 	}
 	if !allowLocalBootstrap || contextName != "local" {
 		return nil, nil
 	}
 	if _, err := os.Stat(templateRoot); err != nil {
 		if os.IsNotExist(err) {
-			return []string{constants.GetEffectiveBlueprintURL()}, nil
+			return []string{resolveEffectiveBlueprintURL(artifactBuilder)}, nil
 		}
 		return nil, fmt.Errorf("error checking template root: %w", err)
 	}
 	return nil, nil
+}
+
+// resolveEffectiveBlueprintURL returns the highest core tag this CLI is compatible with, falling
+// back to the build-time pin on any failure (nil builder, unreachable registry, no compatible
+// tag) — bootstrap must never block on the network.
+func resolveEffectiveBlueprintURL(artifactBuilder artifact.Artifact) string {
+	pinned := constants.GetEffectiveBlueprintURL()
+	if artifactBuilder == nil {
+		return pinned
+	}
+
+	registry, repository, _, err := artifactBuilder.ParseOCIRef(pinned)
+	if err != nil {
+		return pinned
+	}
+	urlPrefix := fmt.Sprintf("oci://%s/%s", registry, repository)
+
+	tags, err := artifactBuilder.ListTags(pinned)
+	if err != nil {
+		return pinned
+	}
+
+	tag, _, ok, err := artifact.ResolveCompatibleTag(artifactBuilder, urlPrefix, tags)
+	if err != nil || !ok {
+		return pinned
+	}
+
+	return urlPrefix + ":" + tag
 }

--- a/cmd/workstation_defaults_test.go
+++ b/cmd/workstation_defaults_test.go
@@ -1,10 +1,14 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/windsorcli/cli/pkg/composer/artifact"
+	"github.com/windsorcli/cli/pkg/constants"
 )
 
 // =============================================================================
@@ -223,7 +227,7 @@ func TestApplyWorkstationFlagOverrides(t *testing.T) {
 func TestResolveBlueprintURL(t *testing.T) {
 	t.Run("ExplicitBlueprintWins", func(t *testing.T) {
 		// Given an explicit --blueprint value
-		urls, err := resolveBlueprintURL("oci://custom/blueprint:v1", "docker", "local", "/does/not/matter", true)
+		urls, err := resolveBlueprintURL("oci://custom/blueprint:v1", "docker", "local", "/does/not/matter", true, nil)
 
 		// Then the explicit URL is returned
 		if err != nil {
@@ -236,7 +240,7 @@ func TestResolveBlueprintURL(t *testing.T) {
 
 	t.Run("PlatformFallsBackToDefaultURL", func(t *testing.T) {
 		// Given --platform but no --blueprint
-		urls, err := resolveBlueprintURL("", "docker", "aws", "/does/not/matter", true)
+		urls, err := resolveBlueprintURL("", "docker", "aws", "/does/not/matter", true, nil)
 
 		// Then the default blueprint URL is returned
 		if err != nil {
@@ -260,7 +264,7 @@ func TestResolveBlueprintURL(t *testing.T) {
 			t.Fatalf("Failed to create template dir: %v", err)
 		}
 
-		urls, err := resolveBlueprintURL("", "aws", "aws", templateDir, true)
+		urls, err := resolveBlueprintURL("", "aws", "aws", templateDir, true, nil)
 
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
@@ -281,7 +285,7 @@ func TestResolveBlueprintURL(t *testing.T) {
 			t.Fatalf("Failed to create template dir: %v", err)
 		}
 
-		urls, err := resolveBlueprintURL("", "aws", "aws", templateDir, false)
+		urls, err := resolveBlueprintURL("", "aws", "aws", templateDir, false, nil)
 
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
@@ -296,7 +300,7 @@ func TestResolveBlueprintURL(t *testing.T) {
 		tmpDir := t.TempDir()
 		missingTemplate := filepath.Join(tmpDir, "contexts", "_template")
 
-		urls, err := resolveBlueprintURL("", "", "local", missingTemplate, true)
+		urls, err := resolveBlueprintURL("", "", "local", missingTemplate, true, nil)
 
 		// Then the default blueprint URL is returned
 		if err != nil {
@@ -312,7 +316,7 @@ func TestResolveBlueprintURL(t *testing.T) {
 		tmpDir := t.TempDir()
 		missingTemplate := filepath.Join(tmpDir, "contexts", "_template")
 
-		urls, err := resolveBlueprintURL("", "", "local", missingTemplate, false)
+		urls, err := resolveBlueprintURL("", "", "local", missingTemplate, false, nil)
 
 		// Then no URL is returned — up must not silently pull from OCI
 		if err != nil {
@@ -331,7 +335,7 @@ func TestResolveBlueprintURL(t *testing.T) {
 			t.Fatalf("Failed to create template dir: %v", err)
 		}
 
-		urls, err := resolveBlueprintURL("", "", "local", templateDir, true)
+		urls, err := resolveBlueprintURL("", "", "local", templateDir, true, nil)
 
 		// Then no URL is returned (use existing blueprint state on disk)
 		if err != nil {
@@ -344,7 +348,7 @@ func TestResolveBlueprintURL(t *testing.T) {
 
 	t.Run("NonLocalContextWithoutFlagsReturnsNil", func(t *testing.T) {
 		// Given context != local and no flags
-		urls, err := resolveBlueprintURL("", "", "aws", "/does/not/matter", true)
+		urls, err := resolveBlueprintURL("", "", "aws", "/does/not/matter", true, nil)
 
 		// Then no URL is returned
 		if err != nil {
@@ -360,7 +364,7 @@ func TestResolveBlueprintURL(t *testing.T) {
 		badPath := "\x00invalid"
 
 		// When bootstrap is disallowed, the stat is never reached
-		urls, err := resolveBlueprintURL("", "", "local", badPath, false)
+		urls, err := resolveBlueprintURL("", "", "local", badPath, false, nil)
 
 		// Then no error and no URL — stat short-circuited by the gate
 		if err != nil {
@@ -376,7 +380,7 @@ func TestResolveBlueprintURL(t *testing.T) {
 		// with a path containing an embedded NUL which os.Stat treats as invalid.
 		badPath := "\x00invalid"
 
-		_, err := resolveBlueprintURL("", "", "local", badPath, true)
+		_, err := resolveBlueprintURL("", "", "local", badPath, true, nil)
 
 		// Then a wrapped error is returned (not os.IsNotExist)
 		if err == nil {
@@ -384,6 +388,142 @@ func TestResolveBlueprintURL(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "error checking template root") {
 			t.Errorf("Expected wrapped 'error checking template root' error, got: %v", err)
+		}
+	})
+}
+
+func TestResolveEffectiveBlueprintURL(t *testing.T) {
+	t.Run("ReturnsPinWhenArtifactBuilderIsNil", func(t *testing.T) {
+		// Given no artifact builder (e.g. a caller that hasn't constructed one)
+		url := resolveEffectiveBlueprintURL(nil)
+
+		// Then it falls back to the build-time pin without attempting resolution
+		if url != constants.GetEffectiveBlueprintURL() {
+			t.Errorf("Expected the build-time pin, got %q", url)
+		}
+	})
+
+	t.Run("ReturnsPinWhenParseOCIRefFails", func(t *testing.T) {
+		mock := artifact.NewMockArtifact()
+		mock.ParseOCIRefFunc = func(ociRef string) (string, string, string, error) {
+			return "", "", "", fmt.Errorf("malformed ref")
+		}
+
+		url := resolveEffectiveBlueprintURL(mock)
+
+		if url != constants.GetEffectiveBlueprintURL() {
+			t.Errorf("Expected the build-time pin, got %q", url)
+		}
+	})
+
+	t.Run("ReturnsPinWhenListTagsFails", func(t *testing.T) {
+		// Given a registry that cannot be reached — bootstrap must never block on this
+		mock := artifact.NewMockArtifact()
+		mock.ParseOCIRefFunc = func(ociRef string) (string, string, string, error) {
+			return "ghcr.io", "windsorcli/core", "latest", nil
+		}
+		mock.ListTagsFunc = func(ociRef string) ([]string, error) {
+			return nil, fmt.Errorf("registry unreachable")
+		}
+
+		url := resolveEffectiveBlueprintURL(mock)
+
+		if url != constants.GetEffectiveBlueprintURL() {
+			t.Errorf("Expected the build-time pin on registry failure, got %q", url)
+		}
+	})
+
+	t.Run("ReturnsPinWhenNoCompatibleTagExists", func(t *testing.T) {
+		// ValidateCliVersion skips validation entirely for "dev"/"main"/"latest"/empty CLI
+		// versions (the default in a test binary), so this case needs a real semver override to
+		// actually exercise an incompatible constraint.
+		originalVersion := constants.Version
+		constants.Version = "0.1.0"
+		t.Cleanup(func() { constants.Version = originalVersion })
+
+		mock := artifact.NewMockArtifact()
+		mock.ParseOCIRefFunc = func(ociRef string) (string, string, string, error) {
+			return "ghcr.io", "windsorcli/core", "latest", nil
+		}
+		mock.ListTagsFunc = func(ociRef string) ([]string, error) {
+			return []string{"v0.5.0"}, nil
+		}
+		mock.GetCliVersionConstraintFunc = func(ociRef string) (string, error) {
+			return ">=99.0.0", nil
+		}
+
+		url := resolveEffectiveBlueprintURL(mock)
+
+		if url != constants.GetEffectiveBlueprintURL() {
+			t.Errorf("Expected the build-time pin when no tag is compatible, got %q", url)
+		}
+	})
+
+	t.Run("ReturnsPinWhenCompatibilityCheckErrors", func(t *testing.T) {
+		// Given a candidate tag whose compatibility cannot be checked (e.g. a registry hiccup
+		// mid-walk) — this is also swallowed, not surfaced as a bootstrap-blocking error
+		mock := artifact.NewMockArtifact()
+		mock.ParseOCIRefFunc = func(ociRef string) (string, string, string, error) {
+			return "ghcr.io", "windsorcli/core", "latest", nil
+		}
+		mock.ListTagsFunc = func(ociRef string) ([]string, error) {
+			return []string{"v0.5.0"}, nil
+		}
+		mock.GetCliVersionConstraintFunc = func(ociRef string) (string, error) {
+			return "", fmt.Errorf("registry hiccup")
+		}
+
+		url := resolveEffectiveBlueprintURL(mock)
+
+		if url != constants.GetEffectiveBlueprintURL() {
+			t.Errorf("Expected the build-time pin when compatibility cannot be checked, got %q", url)
+		}
+	})
+
+	t.Run("ReturnsHighestCompatibleTag", func(t *testing.T) {
+		// Given a reachable registry with a newer, compatible tag published since the CLI's
+		// build-time pin
+		mock := artifact.NewMockArtifact()
+		mock.ParseOCIRefFunc = func(ociRef string) (string, string, string, error) {
+			return "ghcr.io", "windsorcli/core", "latest", nil
+		}
+		mock.ListTagsFunc = func(ociRef string) ([]string, error) {
+			return []string{"v0.5.0", "v0.6.0"}, nil
+		}
+		mock.GetCliVersionConstraintFunc = func(ociRef string) (string, error) {
+			return "", nil
+		}
+
+		url := resolveEffectiveBlueprintURL(mock)
+
+		if url != "oci://ghcr.io/windsorcli/core:v0.6.0" {
+			t.Errorf("Expected the highest compatible tag, got %q", url)
+		}
+	})
+
+	t.Run("FallsBackToVerifyAndSkipsNewestWhenAnnotationAbsentAndIncompatible", func(t *testing.T) {
+		// Given the newest tag carries no cliVersion manifest annotation (an artifact published
+		// before that annotation existed) and its in-tarball metadata.yaml, checked via the
+		// fallback, turns out incompatible — the walk must not blindly trust the missing
+		// annotation as "compatible" and must fall through to the next candidate
+		mock := artifact.NewMockArtifact()
+		mock.ParseOCIRefFunc = func(ociRef string) (string, string, string, error) {
+			return "ghcr.io", "windsorcli/core", "latest", nil
+		}
+		mock.ListTagsFunc = func(ociRef string) ([]string, error) {
+			return []string{"v0.5.0", "v0.6.0"}, nil
+		}
+		mock.VerifyCliVersionCompatibilityFunc = func(ociRef string) error {
+			if ociRef == "oci://ghcr.io/windsorcli/core:v0.6.0" {
+				return fmt.Errorf("CLI version does not satisfy required constraint")
+			}
+			return nil
+		}
+
+		url := resolveEffectiveBlueprintURL(mock)
+
+		if url != "oci://ghcr.io/windsorcli/core:v0.5.0" {
+			t.Errorf("Expected v0.5.0 (newest rejected by the verify fallback), got %q", url)
 		}
 	})
 }

--- a/cmd/workstation_defaults_test.go
+++ b/cmd/workstation_defaults_test.go
@@ -416,11 +416,37 @@ func TestResolveEffectiveBlueprintURL(t *testing.T) {
 		}
 	})
 
+	t.Run("SkipsWalkWhenPinIsMutableTag", func(t *testing.T) {
+		// Given a build-time pin whose own tag isn't a concrete semver (a dev build's mutable
+		// :latest) — there's nothing to walk "newer than," so the walk must not run at all, even
+		// though ListTags/GetCliVersionConstraint are mocked to resolve to something else. This is
+		// the actual bug: substituting the highest tagged release for an unreleased :latest can
+		// resolve to older or inconsistent content.
+		mock := artifact.NewMockArtifact()
+		mock.ParseOCIRefFunc = func(ociRef string) (string, string, string, error) {
+			return "ghcr.io", "windsorcli/core", "latest", nil
+		}
+		listTagsCalled := false
+		mock.ListTagsFunc = func(ociRef string) ([]string, error) {
+			listTagsCalled = true
+			return []string{"v0.5.0", "v0.6.0"}, nil
+		}
+
+		url := resolveEffectiveBlueprintURL(mock)
+
+		if url != constants.GetEffectiveBlueprintURL() {
+			t.Errorf("Expected the build-time pin unchanged, got %q", url)
+		}
+		if listTagsCalled {
+			t.Error("Expected the walk not to run at all when the pin isn't a concrete version")
+		}
+	})
+
 	t.Run("ReturnsPinWhenListTagsFails", func(t *testing.T) {
 		// Given a registry that cannot be reached — bootstrap must never block on this
 		mock := artifact.NewMockArtifact()
 		mock.ParseOCIRefFunc = func(ociRef string) (string, string, string, error) {
-			return "ghcr.io", "windsorcli/core", "latest", nil
+			return "ghcr.io", "windsorcli/core", "v0.5.0", nil
 		}
 		mock.ListTagsFunc = func(ociRef string) ([]string, error) {
 			return nil, fmt.Errorf("registry unreachable")
@@ -443,7 +469,7 @@ func TestResolveEffectiveBlueprintURL(t *testing.T) {
 
 		mock := artifact.NewMockArtifact()
 		mock.ParseOCIRefFunc = func(ociRef string) (string, string, string, error) {
-			return "ghcr.io", "windsorcli/core", "latest", nil
+			return "ghcr.io", "windsorcli/core", "v0.5.0", nil
 		}
 		mock.ListTagsFunc = func(ociRef string) ([]string, error) {
 			return []string{"v0.5.0"}, nil
@@ -464,7 +490,7 @@ func TestResolveEffectiveBlueprintURL(t *testing.T) {
 		// mid-walk) — this is also swallowed, not surfaced as a bootstrap-blocking error
 		mock := artifact.NewMockArtifact()
 		mock.ParseOCIRefFunc = func(ociRef string) (string, string, string, error) {
-			return "ghcr.io", "windsorcli/core", "latest", nil
+			return "ghcr.io", "windsorcli/core", "v0.5.0", nil
 		}
 		mock.ListTagsFunc = func(ociRef string) ([]string, error) {
 			return []string{"v0.5.0"}, nil
@@ -485,7 +511,7 @@ func TestResolveEffectiveBlueprintURL(t *testing.T) {
 		// build-time pin
 		mock := artifact.NewMockArtifact()
 		mock.ParseOCIRefFunc = func(ociRef string) (string, string, string, error) {
-			return "ghcr.io", "windsorcli/core", "latest", nil
+			return "ghcr.io", "windsorcli/core", "v0.5.0", nil
 		}
 		mock.ListTagsFunc = func(ociRef string) ([]string, error) {
 			return []string{"v0.5.0", "v0.6.0"}, nil
@@ -508,7 +534,7 @@ func TestResolveEffectiveBlueprintURL(t *testing.T) {
 		// annotation as "compatible" and must fall through to the next candidate
 		mock := artifact.NewMockArtifact()
 		mock.ParseOCIRefFunc = func(ociRef string) (string, string, string, error) {
-			return "ghcr.io", "windsorcli/core", "latest", nil
+			return "ghcr.io", "windsorcli/core", "v0.5.0", nil
 		}
 		mock.ListTagsFunc = func(ociRef string) ([]string, error) {
 			return []string{"v0.5.0", "v0.6.0"}, nil

--- a/pkg/composer/artifact/artifact.go
+++ b/pkg/composer/artifact/artifact.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 
@@ -39,9 +40,8 @@ import (
 
 const artifactTarFilename = "artifact.tar"
 
-// CliVersionAnnotationKey is the OCI manifest annotation key that mirrors an artifact's
-// cliVersion constraint (see BlueprintMetadataInput.CliVersion), letting a consumer check
-// compatibility with a manifest-only fetch instead of a full Pull. See GetCliVersionConstraint.
+// CliVersionAnnotationKey mirrors BlueprintMetadataInput.CliVersion into the OCI manifest, so
+// GetCliVersionConstraint can check it without a full Pull.
 const CliVersionAnnotationKey = "windsorcli.dev/cli-version"
 
 // =============================================================================
@@ -59,6 +59,7 @@ type Artifact interface {
 	GetCacheDir(registry, repository, tag string) (string, error)
 	ListTags(ociRef string) ([]string, error)
 	GetCliVersionConstraint(ociRef string) (string, error)
+	VerifyCliVersionCompatibility(ociRef string) error
 }
 
 // =============================================================================
@@ -246,14 +247,8 @@ func (a *ArtifactBuilder) ListTags(ociRef string) ([]string, error) {
 	return tags, nil
 }
 
-// GetCliVersionConstraint returns the cliVersion constraint an OCI artifact declares, read from
-// its CliVersionAnnotationKey manifest annotation (set at push time by createOCIArtifactImage).
-// It fetches only the image manifest — never the layer blob a full Pull would download and
-// extract — so checking a candidate tag's compatibility costs a small JSON round trip regardless
-// of artifact size. Returns an empty string, not an error, when the tag declares no constraint
-// (an older tag published before this annotation existed, or an artifact that never set
-// cliVersion): callers treat that the same way ValidateCliVersion treats an empty constraint —
-// unconstrained, not a failure.
+// GetCliVersionConstraint returns ociRef's declared cliVersion constraint, via a manifest-only
+// fetch (no layer pull). Empty string, not an error, means no constraint declared.
 func (a *ArtifactBuilder) GetCliVersionConstraint(ociRef string) (string, error) {
 	registry, repository, tag, err := a.ParseOCIRef(ociRef)
 	if err != nil {
@@ -282,6 +277,81 @@ func (a *ArtifactBuilder) GetCliVersionConstraint(ociRef string) (string, error)
 	}
 
 	return manifest.Annotations[CliVersionAnnotationKey], nil
+}
+
+// VerifyCliVersionCompatibility pulls ociRef and validates its metadata.yaml cliVersion constraint
+// against the running CLI. Used as ResolveCompatibleTag's fallback when a candidate's manifest
+// annotation is absent. Returns nil if compatible or undeclared; any other error means "don't
+// trust this candidate."
+func (a *ArtifactBuilder) VerifyCliVersionCompatibility(ociRef string) error {
+	artifacts, err := a.Pull([]string{ociRef})
+	if err != nil {
+		return fmt.Errorf("failed to pull %s: %w", ociRef, err)
+	}
+	registry, repository, tag, err := a.ParseOCIRef(ociRef)
+	if err != nil {
+		return err
+	}
+	cacheKey := fmt.Sprintf("%s/%s:%s", registry, repository, tag)
+	cacheDir, ok := artifacts[cacheKey]
+	if !ok {
+		return fmt.Errorf("failed to retrieve cache directory for %s", ociRef)
+	}
+
+	metadataPath := filepath.Join(cacheDir, "metadata.yaml")
+	if _, err := a.shims.Stat(metadataPath); os.IsNotExist(err) {
+		return nil
+	}
+	data, err := a.shims.ReadFile(metadataPath)
+	if err != nil {
+		return fmt.Errorf("failed to read %s: %w", metadataPath, err)
+	}
+	var meta BlueprintMetadataInput
+	if err := a.shims.YamlUnmarshal(data, &meta); err != nil {
+		return fmt.Errorf("failed to parse %s: %w", metadataPath, err)
+	}
+	return ValidateCliVersion(constants.Version, meta.CliVersion)
+}
+
+// ResolveCompatibleTag walks tags newest-first (stable semver only) and returns the highest one
+// this CLI is compatible with. Checks the cheap manifest annotation first; falls back to
+// VerifyCliVersionCompatibility (a real pull) when the annotation is absent, since older tags
+// predate that annotation and can't be assumed compatible. Reports ok=false, not an error, when
+// nothing qualifies.
+func ResolveCompatibleTag(artifactBuilder Artifact, urlPrefix string, tags []string) (tag string, version *semver.Version, ok bool, err error) {
+	type candidate struct {
+		tag string
+		ver *semver.Version
+	}
+	var candidates []candidate
+	for _, t := range tags {
+		v, err := semver.NewVersion(t)
+		if err != nil || v.Prerelease() != "" {
+			continue
+		}
+		candidates = append(candidates, candidate{tag: t, ver: v})
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].ver.GreaterThan(candidates[j].ver)
+	})
+
+	for _, c := range candidates {
+		candidateRef := urlPrefix + ":" + c.tag
+		constraint, err := artifactBuilder.GetCliVersionConstraint(candidateRef)
+		if err != nil {
+			return "", nil, false, fmt.Errorf("failed to check compatibility for %s: %w", candidateRef, err)
+		}
+		if constraint != "" {
+			if ValidateCliVersion(constants.Version, constraint) == nil {
+				return c.tag, c.ver, true, nil
+			}
+			continue
+		}
+		if artifactBuilder.VerifyCliVersionCompatibility(candidateRef) == nil {
+			return c.tag, c.ver, true, nil
+		}
+	}
+	return "", nil, false, nil
 }
 
 // GetCacheDir returns the cache directory path for an OCI artifact identified by registry, repository, and tag.

--- a/pkg/composer/artifact/artifact.go
+++ b/pkg/composer/artifact/artifact.go
@@ -316,8 +316,8 @@ func (a *ArtifactBuilder) VerifyCliVersionCompatibility(ociRef string) error {
 // ResolveCompatibleTag walks tags newest-first (stable semver only) and returns the highest one
 // this CLI is compatible with. Checks the cheap manifest annotation first; falls back to
 // VerifyCliVersionCompatibility (a real pull) when the annotation is absent, since older tags
-// predate that annotation and can't be assumed compatible. Reports ok=false, not an error, when
-// nothing qualifies.
+// predate that annotation and can't be assumed compatible. A manifest-fetch error skips that
+// candidate instead of aborting the walk; it's only returned if no candidate ends up qualifying.
 func ResolveCompatibleTag(artifactBuilder Artifact, urlPrefix string, tags []string) (tag string, version *semver.Version, ok bool, err error) {
 	type candidate struct {
 		tag string
@@ -335,11 +335,13 @@ func ResolveCompatibleTag(artifactBuilder Artifact, urlPrefix string, tags []str
 		return candidates[i].ver.GreaterThan(candidates[j].ver)
 	})
 
+	var constraintCheckErr error
 	for _, c := range candidates {
 		candidateRef := urlPrefix + ":" + c.tag
 		constraint, err := artifactBuilder.GetCliVersionConstraint(candidateRef)
 		if err != nil {
-			return "", nil, false, fmt.Errorf("failed to check compatibility for %s: %w", candidateRef, err)
+			constraintCheckErr = fmt.Errorf("failed to check compatibility for %s: %w", candidateRef, err)
+			continue
 		}
 		if constraint != "" {
 			if ValidateCliVersion(constants.Version, constraint) == nil {
@@ -351,7 +353,7 @@ func ResolveCompatibleTag(artifactBuilder Artifact, urlPrefix string, tags []str
 			return c.tag, c.ver, true, nil
 		}
 	}
-	return "", nil, false, nil
+	return "", nil, false, constraintCheckErr
 }
 
 // GetCacheDir returns the cache directory path for an OCI artifact identified by registry, repository, and tag.

--- a/pkg/composer/artifact/artifact_public_test.go
+++ b/pkg/composer/artifact/artifact_public_test.go
@@ -3270,6 +3270,27 @@ func TestResolveCompatibleTag(t *testing.T) {
 		}
 	})
 
+	t.Run("SkipsCandidateOnConstraintCheckErrorInsteadOfAbortingWalk", func(t *testing.T) {
+		// Given a transient manifest-fetch error on only the newest candidate, with an older
+		// candidate that checks out fine
+		mock := NewMockArtifact()
+		mock.GetCliVersionConstraintFunc = func(ociRef string) (string, error) {
+			if ociRef == "oci://ghcr.io/windsorcli/core:v0.6.0" {
+				return "", fmt.Errorf("registry hiccup")
+			}
+			return "", nil
+		}
+
+		tag, _, ok, err := ResolveCompatibleTag(mock, "oci://ghcr.io/windsorcli/core", []string{"v0.5.0", "v0.6.0"})
+
+		if err != nil {
+			t.Fatalf("Expected no error — an older candidate resolved fine, got %v", err)
+		}
+		if !ok || tag != "v0.5.0" {
+			t.Errorf("Expected v0.5.0 (newest skipped on a check error, not an aborted walk), got tag=%q ok=%v", tag, ok)
+		}
+	})
+
 	t.Run("FalseWhenNoStableSemverTagPresent", func(t *testing.T) {
 		mock := NewMockArtifact()
 

--- a/pkg/composer/artifact/artifact_public_test.go
+++ b/pkg/composer/artifact/artifact_public_test.go
@@ -18,6 +18,7 @@ import (
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	"github.com/google/go-containerregistry/pkg/v1/types"
+	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/runtime"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
 )
@@ -2991,6 +2992,294 @@ func TestArtifactBuilder_ExtractModulePath(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), requestedModulePath) {
 			t.Errorf("Expected error to mention module path %s, got %v", requestedModulePath, err)
+		}
+	})
+}
+
+// setTestCliVersion temporarily overrides constants.Version for the duration of the calling test,
+// restoring the original value via t.Cleanup. constants.Version is process-global, not per-test
+// state — any test using this helper, and any sibling subtest in this package that reads
+// constants.Version, MUST NOT run under t.Parallel(); a parallel subtest would race this mutation
+// against concurrent reads (or another parallel mutation). This package has no t.Parallel() calls
+// today; if one is ever added, audit for this helper's callers first.
+func setTestCliVersion(t *testing.T, v string) {
+	t.Helper()
+	original := constants.Version
+	constants.Version = v
+	t.Cleanup(func() { constants.Version = original })
+}
+
+func TestArtifactBuilder_VerifyCliVersionCompatibility(t *testing.T) {
+	setup := func(t *testing.T, metadataYAML []byte) (*ArtifactBuilder, *ArtifactMocks) {
+		t.Helper()
+		mocks := setupArtifactMocks(t)
+		builder := NewArtifactBuilder(mocks.Runtime)
+		builder.shims = mocks.Shims
+
+		mocks.Shims.ParseReference = func(ref string, opts ...name.Option) (name.Reference, error) {
+			return nil, nil
+		}
+		mocks.Shims.RemoteImage = func(ref name.Reference, options ...remote.Option) (v1.Image, error) {
+			return nil, nil
+		}
+		mocks.Shims.ImageLayers = func(img v1.Image) ([]v1.Layer, error) {
+			return []v1.Layer{&mockLayer{}}, nil
+		}
+
+		files := map[string][]byte{"_template/test.yaml": []byte("test content")}
+		if metadataYAML != nil {
+			files["metadata.yaml"] = metadataYAML
+		}
+		testTarData := createTestTarGz(t, files)
+		mocks.Shims.LayerUncompressed = func(layer v1.Layer) (io.ReadCloser, error) {
+			return io.NopCloser(bytes.NewReader(testTarData)), nil
+		}
+		mocks.Shims.ReadAll = io.ReadAll
+
+		mocks.Shims.Stat = os.Stat
+		mocks.Shims.ReadFile = os.ReadFile
+		mocks.Shims.Create = func(name string) (io.WriteCloser, error) {
+			if err := os.MkdirAll(filepath.Dir(name), 0755); err != nil {
+				return nil, err
+			}
+			return os.Create(name)
+		}
+		// setupDefaultShims's YamlUnmarshal stub only ever sets Name/Version, ignoring actual
+		// content — VerifyCliVersionCompatibility needs the real cliVersion field, so parse for
+		// real here.
+		mocks.Shims.YamlUnmarshal = yaml.Unmarshal
+
+		return builder, mocks
+	}
+
+	t.Run("ReturnsNilWhenConstraintSatisfied", func(t *testing.T) {
+		setTestCliVersion(t, "1.0.0")
+		builder, _ := setup(t, []byte("name: test\nversion: v1.0.0\ncliVersion: \">=0.9.0\"\n"))
+
+		err := builder.VerifyCliVersionCompatibility("oci://registry.example.com/my-repo:v1.0.0")
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenConstraintNotSatisfied", func(t *testing.T) {
+		setTestCliVersion(t, "0.1.0")
+		builder, _ := setup(t, []byte("name: test\nversion: v1.0.0\ncliVersion: \">=0.9.0\"\n"))
+
+		err := builder.VerifyCliVersionCompatibility("oci://registry.example.com/my-repo:v1.0.0")
+
+		if err == nil {
+			t.Error("Expected an error for an unsatisfied constraint")
+		}
+	})
+
+	t.Run("ReturnsNilWhenNoMetadataFile", func(t *testing.T) {
+		builder, _ := setup(t, nil)
+
+		err := builder.VerifyCliVersionCompatibility("oci://registry.example.com/my-repo:v1.0.0")
+
+		if err != nil {
+			t.Errorf("Expected no error when metadata.yaml is absent, got %v", err)
+		}
+	})
+
+	t.Run("ReturnsNilWhenCliVersionFieldAbsent", func(t *testing.T) {
+		builder, _ := setup(t, []byte("name: test\nversion: v1.0.0\n"))
+
+		err := builder.VerifyCliVersionCompatibility("oci://registry.example.com/my-repo:v1.0.0")
+
+		if err != nil {
+			t.Errorf("Expected no error when cliVersion is undeclared, got %v", err)
+		}
+	})
+
+	t.Run("PropagatesPullError", func(t *testing.T) {
+		builder, mocks := setup(t, []byte("name: test\nversion: v1.0.0\n"))
+		mocks.Shims.RemoteImage = func(ref name.Reference, options ...remote.Option) (v1.Image, error) {
+			return nil, fmt.Errorf("registry unreachable")
+		}
+
+		err := builder.VerifyCliVersionCompatibility("oci://registry.example.com/my-repo:v1.0.0")
+
+		if err == nil || !strings.Contains(err.Error(), "failed to pull") {
+			t.Errorf("Expected a wrapped pull error, got %v", err)
+		}
+	})
+}
+
+func TestResolveCompatibleTag(t *testing.T) {
+	t.Run("PicksHighestCompatibleSkippingIncompatibleNewest", func(t *testing.T) {
+		setTestCliVersion(t, "0.8.1")
+		mock := NewMockArtifact()
+		mock.GetCliVersionConstraintFunc = func(ociRef string) (string, error) {
+			if ociRef == "oci://ghcr.io/windsorcli/core:v0.7.0" {
+				return ">=99.0.0", nil
+			}
+			return "", nil
+		}
+
+		tag, v, ok, err := ResolveCompatibleTag(mock, "oci://ghcr.io/windsorcli/core", []string{"v0.5.0", "v0.6.0", "v0.7.0"})
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !ok || tag != "v0.6.0" {
+			t.Fatalf("Expected v0.6.0 (skipping incompatible v0.7.0), got tag=%q ok=%v", tag, ok)
+		}
+		if v == nil || v.String() != "0.6.0" {
+			t.Errorf("Expected parsed 0.6.0, got %v", v)
+		}
+	})
+
+	t.Run("SkipsPrereleaseTagsEvenWhenCompatible", func(t *testing.T) {
+		setTestCliVersion(t, "0.8.1")
+		mock := NewMockArtifact()
+
+		tag, _, ok, err := ResolveCompatibleTag(mock, "oci://ghcr.io/windsorcli/core", []string{"v0.6.0", "v0.7.0-rc.1"})
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !ok || tag != "v0.6.0" {
+			t.Errorf("Expected v0.6.0 (prerelease excluded regardless of compatibility), got tag=%q ok=%v", tag, ok)
+		}
+	})
+
+	t.Run("FallsBackToVerifyWhenAnnotationAbsentAndAccepts", func(t *testing.T) {
+		// Given a candidate whose manifest carries no cliVersion annotation (an artifact
+		// published before that annotation existed) but whose in-tarball metadata.yaml, checked
+		// via the fallback, is actually compatible
+		mock := NewMockArtifact()
+		var verifiedRef string
+		mock.VerifyCliVersionCompatibilityFunc = func(ociRef string) error {
+			verifiedRef = ociRef
+			return nil
+		}
+
+		tag, _, ok, err := ResolveCompatibleTag(mock, "oci://ghcr.io/windsorcli/core", []string{"v0.6.0"})
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !ok || tag != "v0.6.0" {
+			t.Errorf("Expected the fallback-verified tag to be accepted, got tag=%q ok=%v", tag, ok)
+		}
+		if verifiedRef != "oci://ghcr.io/windsorcli/core:v0.6.0" {
+			t.Errorf("Expected VerifyCliVersionCompatibility to be called with the candidate ref, got %q", verifiedRef)
+		}
+	})
+
+	t.Run("FallsBackToVerifyWhenAnnotationAbsentAndRejectsThenTriesNext", func(t *testing.T) {
+		// Given the newest candidate has no annotation and fails verification, but an older
+		// candidate does carry a satisfied annotation
+		mock := NewMockArtifact()
+		mock.GetCliVersionConstraintFunc = func(ociRef string) (string, error) {
+			if ociRef == "oci://ghcr.io/windsorcli/core:v0.6.0" {
+				return "", nil // no annotation on the newest tag
+			}
+			return "", nil // no annotation on the older tag either — both fall back to verify
+		}
+		mock.VerifyCliVersionCompatibilityFunc = func(ociRef string) error {
+			if ociRef == "oci://ghcr.io/windsorcli/core:v0.6.0" {
+				return fmt.Errorf("CLI version does not satisfy required constraint")
+			}
+			return nil
+		}
+
+		tag, _, ok, err := ResolveCompatibleTag(mock, "oci://ghcr.io/windsorcli/core", []string{"v0.5.0", "v0.6.0"})
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !ok || tag != "v0.5.0" {
+			t.Errorf("Expected v0.5.0 (newest rejected by verify fallback), got tag=%q ok=%v", tag, ok)
+		}
+	})
+
+	t.Run("SkipsVerifyFallbackWhenAnnotationIsPresent", func(t *testing.T) {
+		// Given a candidate whose manifest DOES carry an annotation — the cheap path must stay
+		// cheap and never fall back to a pull-based verification
+		mock := NewMockArtifact()
+		mock.GetCliVersionConstraintFunc = func(ociRef string) (string, error) {
+			return ">=0.1.0", nil
+		}
+		verifyCalled := false
+		mock.VerifyCliVersionCompatibilityFunc = func(ociRef string) error {
+			verifyCalled = true
+			return nil
+		}
+		setTestCliVersion(t, "1.0.0")
+
+		tag, _, ok, err := ResolveCompatibleTag(mock, "oci://ghcr.io/windsorcli/core", []string{"v0.6.0"})
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !ok || tag != "v0.6.0" {
+			t.Errorf("Expected v0.6.0, got tag=%q ok=%v", tag, ok)
+		}
+		if verifyCalled {
+			t.Error("Expected VerifyCliVersionCompatibility not to be called when the annotation is present")
+		}
+	})
+
+	t.Run("FalseWhenAllCandidatesFailBothAnnotationAndVerifyFallback", func(t *testing.T) {
+		mock := NewMockArtifact()
+		mock.VerifyCliVersionCompatibilityFunc = func(ociRef string) error {
+			return fmt.Errorf("incompatible")
+		}
+
+		_, _, ok, err := ResolveCompatibleTag(mock, "oci://ghcr.io/windsorcli/core", []string{"v0.5.0", "v0.6.0"})
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok {
+			t.Error("Expected ok=false when every candidate fails both the annotation check and the verify fallback")
+		}
+	})
+
+	t.Run("FalseWhenNoTagIsCompatible", func(t *testing.T) {
+		setTestCliVersion(t, "0.1.0")
+		mock := NewMockArtifact()
+		mock.GetCliVersionConstraintFunc = func(ociRef string) (string, error) {
+			return ">=99.0.0", nil
+		}
+
+		_, _, ok, err := ResolveCompatibleTag(mock, "oci://ghcr.io/windsorcli/core", []string{"v0.5.0", "v0.6.0"})
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok {
+			t.Error("Expected ok=false when no tag is compatible")
+		}
+	})
+
+	t.Run("PropagatesConstraintCheckError", func(t *testing.T) {
+		mock := NewMockArtifact()
+		mock.GetCliVersionConstraintFunc = func(ociRef string) (string, error) {
+			return "", fmt.Errorf("registry unreachable")
+		}
+
+		_, _, _, err := ResolveCompatibleTag(mock, "oci://ghcr.io/windsorcli/core", []string{"v0.6.0"})
+
+		if err == nil {
+			t.Error("Expected the registry error to propagate")
+		}
+	})
+
+	t.Run("FalseWhenNoStableSemverTagPresent", func(t *testing.T) {
+		mock := NewMockArtifact()
+
+		_, _, ok, err := ResolveCompatibleTag(mock, "oci://ghcr.io/windsorcli/core", []string{"v1.0.0-rc.1", "garbage"})
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ok {
+			t.Error("Expected ok=false among prereleases/junk")
 		}
 	})
 }

--- a/pkg/composer/artifact/mock_artifact.go
+++ b/pkg/composer/artifact/mock_artifact.go
@@ -11,15 +11,16 @@ package artifact
 
 // MockArtifact is a mock implementation of the Artifact interface
 type MockArtifact struct {
-	BundleFunc                  func() error
-	WriteFunc                   func(outputPath string, tag string) (string, error)
-	PushFunc                    func(registryBase string, repoName string, tag string) error
-	PullFunc                    func(ociRefs []string) (map[string]string, error)
-	ExtractModulePathFunc       func(registry, repository, tag, modulePath string) (string, error)
-	ParseOCIRefFunc             func(ociRef string) (registry, repository, tag string, err error)
-	GetCacheDirFunc             func(registry, repository, tag string) (string, error)
-	ListTagsFunc                func(ociRef string) ([]string, error)
-	GetCliVersionConstraintFunc func(ociRef string) (string, error)
+	BundleFunc                        func() error
+	WriteFunc                         func(outputPath string, tag string) (string, error)
+	PushFunc                          func(registryBase string, repoName string, tag string) error
+	PullFunc                          func(ociRefs []string) (map[string]string, error)
+	ExtractModulePathFunc             func(registry, repository, tag, modulePath string) (string, error)
+	ParseOCIRefFunc                   func(ociRef string) (registry, repository, tag string, err error)
+	GetCacheDirFunc                   func(registry, repository, tag string) (string, error)
+	ListTagsFunc                      func(ociRef string) ([]string, error)
+	GetCliVersionConstraintFunc       func(ociRef string) (string, error)
+	VerifyCliVersionCompatibilityFunc func(ociRef string) error
 }
 
 // =============================================================================
@@ -84,6 +85,14 @@ func (m *MockArtifact) GetCliVersionConstraint(ociRef string) (string, error) {
 		return m.GetCliVersionConstraintFunc(ociRef)
 	}
 	return "", nil
+}
+
+// VerifyCliVersionCompatibility calls the mock VerifyCliVersionCompatibilityFunc if set, otherwise returns nil
+func (m *MockArtifact) VerifyCliVersionCompatibility(ociRef string) error {
+	if m.VerifyCliVersionCompatibilityFunc != nil {
+		return m.VerifyCliVersionCompatibilityFunc(ociRef)
+	}
+	return nil
 }
 
 // ExtractModulePath calls the mock ExtractModulePathFunc if set, otherwise returns empty string and nil error

--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -4,14 +4,12 @@ import (
 	"errors"
 	"fmt"
 	"path/filepath"
-	"sort"
 	"strings"
 	"sync"
 
 	"github.com/Masterminds/semver/v3"
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/composer/artifact"
-	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/runtime"
 	runtimegit "github.com/windsorcli/cli/pkg/runtime/git"
 )
@@ -221,13 +219,11 @@ type SourceUpgrade struct {
 }
 
 // UpgradeSourcesToLatest moves each remote OCI source pinned to a semver to the highest stable tag
-// published in its repository that this CLI is compatible with (per the tag's declared cliVersion
-// constraint — see resolveCompatibleTag), mutating the composed blueprint in memory (call Write to
-// persist) and returning the changes for reporting. Sources that are not OCI, not semver-pinned (a
-// branch, a mutable tag like :latest), or already at the latest compatible tag are left untouched,
-// as are prerelease tags and tags this CLI does not satisfy. It resolves directly to the latest
-// compatible tag — it does not step minor-by-minor. All tags are resolved before any source is
-// mutated, so a registry failure mid-resolution leaves the in-memory blueprint untouched.
+// this CLI is compatible with (see artifact.ResolveCompatibleTag), mutating the composed blueprint
+// in memory (call Write to persist) and returning the changes for reporting. Sources that are not
+// OCI, not semver-pinned, or already at the latest compatible tag are left untouched. All tags are
+// resolved before any source is mutated, so a registry failure mid-resolution leaves the in-memory
+// blueprint untouched.
 func (h *BaseBlueprintHandler) UpgradeSourcesToLatest() ([]SourceUpgrade, error) {
 	if h.composedBlueprint == nil {
 		return nil, fmt.Errorf("blueprint not loaded")
@@ -259,7 +255,7 @@ func (h *BaseBlueprintHandler) UpgradeSourcesToLatest() ([]SourceUpgrade, error)
 			return nil, fmt.Errorf("failed to list tags for source %q: %w", src.Name, err)
 		}
 		urlPrefix := strings.TrimSuffix(src.Url, ":"+info.Tag)
-		latestTag, latest, ok, err := resolveCompatibleTag(h.artifactBuilder, urlPrefix, tags)
+		latestTag, latest, ok, err := artifact.ResolveCompatibleTag(h.artifactBuilder, urlPrefix, tags)
 		if err != nil {
 			return nil, fmt.Errorf("failed to check CLI compatibility for source %q: %w", src.Name, err)
 		}
@@ -301,44 +297,6 @@ func latestStableSemver(tags []string) (string, *semver.Version, bool) {
 		}
 	}
 	return bestTag, best, best != nil
-}
-
-// resolveCompatibleTag walks tags newest-first (stable semver only, prereleases excluded) and
-// returns the highest one this CLI is compatible with, alongside its parsed version. urlPrefix is
-// the source URL without its tag (e.g. "oci://ghcr.io/windsorcli/core") — resolveCompatibleTag
-// appends ":<tag>" per candidate and checks its declared cliVersion constraint via
-// artifact.Artifact.GetCliVersionConstraint, a manifest-only fetch (no full Pull) — so checking N
-// candidates costs N small manifest reads, not N full artifact downloads. A candidate with no
-// declared constraint is treated as compatible, matching ValidateCliVersion's own
-// empty-constraint semantics: Windsor enforces what a tag declares, it does not infer
-// compatibility. Reports ok=false, not an error, when no stable semver tag is compatible.
-func resolveCompatibleTag(artifactBuilder artifact.Artifact, urlPrefix string, tags []string) (tag string, version *semver.Version, ok bool, err error) {
-	type candidate struct {
-		tag string
-		ver *semver.Version
-	}
-	var candidates []candidate
-	for _, t := range tags {
-		v, err := semver.NewVersion(t)
-		if err != nil || v.Prerelease() != "" {
-			continue
-		}
-		candidates = append(candidates, candidate{tag: t, ver: v})
-	}
-	sort.Slice(candidates, func(i, j int) bool {
-		return candidates[i].ver.GreaterThan(candidates[j].ver)
-	})
-
-	for _, c := range candidates {
-		constraint, err := artifactBuilder.GetCliVersionConstraint(urlPrefix + ":" + c.tag)
-		if err != nil {
-			return "", nil, false, fmt.Errorf("failed to check compatibility for %s:%s: %w", urlPrefix, c.tag, err)
-		}
-		if artifact.ValidateCliVersion(constants.Version, constraint) == nil {
-			return c.tag, c.ver, true, nil
-		}
-	}
-	return "", nil, false, nil
 }
 
 // IsDowngrade reports whether targetURL pins an older stable semver than previousURL for the same

--- a/pkg/composer/blueprint/handler_test.go
+++ b/pkg/composer/blueprint/handler_test.go
@@ -2258,102 +2258,6 @@ func TestLatestStableSemver(t *testing.T) {
 	})
 }
 
-func TestResolveCompatibleTag(t *testing.T) {
-	t.Run("PicksHighestCompatibleSkippingIncompatibleNewest", func(t *testing.T) {
-		setTestCliVersion(t, "0.8.1")
-		mock := artifact.NewMockArtifact()
-		mock.GetCliVersionConstraintFunc = func(ociRef string) (string, error) {
-			if ociRef == "oci://ghcr.io/windsorcli/core:v0.7.0" {
-				return ">=99.0.0", nil
-			}
-			return "", nil
-		}
-
-		tag, v, ok, err := resolveCompatibleTag(mock, "oci://ghcr.io/windsorcli/core", []string{"v0.5.0", "v0.6.0", "v0.7.0"})
-
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if !ok || tag != "v0.6.0" {
-			t.Fatalf("Expected v0.6.0 (skipping incompatible v0.7.0), got tag=%q ok=%v", tag, ok)
-		}
-		if v == nil || v.String() != "0.6.0" {
-			t.Errorf("Expected parsed 0.6.0, got %v", v)
-		}
-	})
-
-	t.Run("SkipsPrereleaseTagsEvenWhenCompatible", func(t *testing.T) {
-		setTestCliVersion(t, "0.8.1")
-		mock := artifact.NewMockArtifact()
-
-		tag, _, ok, err := resolveCompatibleTag(mock, "oci://ghcr.io/windsorcli/core", []string{"v0.6.0", "v0.7.0-rc.1"})
-
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if !ok || tag != "v0.6.0" {
-			t.Errorf("Expected v0.6.0 (prerelease excluded regardless of compatibility), got tag=%q ok=%v", tag, ok)
-		}
-	})
-
-	t.Run("TreatsUndeclaredConstraintAsCompatible", func(t *testing.T) {
-		setTestCliVersion(t, "0.1.0")
-		mock := artifact.NewMockArtifact()
-
-		tag, _, ok, err := resolveCompatibleTag(mock, "oci://ghcr.io/windsorcli/core", []string{"v0.6.0"})
-
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if !ok || tag != "v0.6.0" {
-			t.Errorf("Expected an undeclared constraint to be treated as compatible, got tag=%q ok=%v", tag, ok)
-		}
-	})
-
-	t.Run("FalseWhenNoTagIsCompatible", func(t *testing.T) {
-		setTestCliVersion(t, "0.1.0")
-		mock := artifact.NewMockArtifact()
-		mock.GetCliVersionConstraintFunc = func(ociRef string) (string, error) {
-			return ">=99.0.0", nil
-		}
-
-		_, _, ok, err := resolveCompatibleTag(mock, "oci://ghcr.io/windsorcli/core", []string{"v0.5.0", "v0.6.0"})
-
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if ok {
-			t.Error("Expected ok=false when no tag is compatible")
-		}
-	})
-
-	t.Run("PropagatesConstraintCheckError", func(t *testing.T) {
-		mock := artifact.NewMockArtifact()
-		mock.GetCliVersionConstraintFunc = func(ociRef string) (string, error) {
-			return "", fmt.Errorf("registry unreachable")
-		}
-
-		_, _, _, err := resolveCompatibleTag(mock, "oci://ghcr.io/windsorcli/core", []string{"v0.6.0"})
-
-		if err == nil {
-			t.Error("Expected the registry error to propagate")
-		}
-	})
-
-	t.Run("FalseWhenNoStableSemverTagPresent", func(t *testing.T) {
-		mock := artifact.NewMockArtifact()
-
-		_, _, ok, err := resolveCompatibleTag(mock, "oci://ghcr.io/windsorcli/core", []string{"v1.0.0-rc.1", "garbage"})
-
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if ok {
-			t.Error("Expected ok=false among prereleases/junk")
-		}
-	})
-}
-
 func TestIsDowngrade(t *testing.T) {
 	t.Run("TrueWhenTargetTagIsOlderInSameRepo", func(t *testing.T) {
 		// Given a target that pins an older semver than the previous ref of the same repository
@@ -2582,6 +2486,35 @@ func TestHandler_UpgradeSourcesToLatest(t *testing.T) {
 		}
 		if len(upgrades) != 0 {
 			t.Errorf("Expected no upgrades, got %v", upgrades)
+		}
+	})
+
+	t.Run("FallsBackToVerifyWhenNewestTagHasNoAnnotation", func(t *testing.T) {
+		// Given the newest tag carries no cliVersion manifest annotation (an artifact published
+		// before that annotation existed) but its in-tarball metadata.yaml, checked via the
+		// fallback, is compatible
+		handler, mock := setup(t,
+			[]blueprintv1alpha1.Source{{Name: "core", Url: "oci://ghcr.io/windsorcli/core:v0.5.0"}},
+			map[string][]string{"oci://ghcr.io/windsorcli/core:v0.5.0": {"v0.5.0", "v0.6.0"}},
+		)
+		var verifiedRef string
+		mock.VerifyCliVersionCompatibilityFunc = func(ociRef string) error {
+			verifiedRef = ociRef
+			return nil
+		}
+
+		// When upgrading sources to latest
+		upgrades, err := handler.UpgradeSourcesToLatest()
+
+		// Then it upgrades to the fallback-verified tag
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if len(upgrades) != 1 || upgrades[0].To != "oci://ghcr.io/windsorcli/core:v0.6.0" {
+			t.Fatalf("Expected upgrade to v0.6.0 via the verify fallback, got %v", upgrades)
+		}
+		if verifiedRef != "oci://ghcr.io/windsorcli/core:v0.6.0" {
+			t.Errorf("Expected the fallback to verify the resolved candidate, got %q", verifiedRef)
 		}
 	})
 

--- a/pkg/composer/blueprint/loader.go
+++ b/pkg/composer/blueprint/loader.go
@@ -324,15 +324,9 @@ func (l *BaseBlueprintLoader) normalizeOCISourceRefs(bp *blueprintv1alpha1.Bluep
 	}
 }
 
-// enforceCliVersionCompatibility returns an error when this source's pulled artifact declares a
-// cliVersion constraint (artifact.BlueprintMetadataInput.CliVersion) the running CLI does not
-// satisfy. Reads the same root metadata.yaml applyArtifactMetadataName already extracts. A missing
-// metadata.yaml is treated as no constraint declared, not a failure — Windsor enforces what an
-// artifact declares, it does not infer compatibility. A metadata.yaml that exists but cannot be
-// read or parsed is a different case and is NOT swallowed: silently skipping the gate on a
-// corrupted or unreadable cache would let a malformed artifact bypass the one check that exists to
-// catch it. Called before any other loading work so an incompatible source fails fast with a
-// named, actionable error instead of surfacing as a downstream schema or tier failure.
+// enforceCliVersionCompatibility errors if this source's pulled artifact declares a cliVersion
+// constraint the running CLI doesn't satisfy. A missing metadata.yaml means no constraint; a
+// read/parse failure is a real error, not swallowed, so a corrupted cache can't bypass the check.
 func (l *BaseBlueprintLoader) enforceCliVersionCompatibility(cacheDir, tag string) error {
 	metadataPath := filepath.Join(cacheDir, "metadata.yaml")
 	if _, err := l.shims.Stat(metadataPath); os.IsNotExist(err) {


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This change adds network calls to three startup commands and extends the `Artifact` interface with a new method, making it a moderate blast-radius refactor despite clean error handling.
>
> **Overview**
>
> The PR promotes `resolveCompatibleTag` from a package-private function in `blueprint/handler.go` to a public `artifact.ResolveCompatibleTag`, and wires it into the `bootstrap`, `init`, and `up` commands so they resolve the highest compatible core OCI tag at startup rather than always using the build-time pin. A new `VerifyCliVersionCompatibility` interface method (and implementation) is added as a fallback for older artifacts that predate the manifest annotation, performing a full pull to check `metadata.yaml`.
>
> The most notable behavioral shift is that pre-annotation OCI tags are no longer assumed compatible — they are now verified via a real pull. This affects both `UpgradeSourcesToLatest` and the new bootstrap resolution path. All registry failures in the startup path are swallowed and fall back to the build-time pin, so the commands remain offline-safe.
>
> Reviewed by Claude for commit `97dbe49a`.

<!-- /claude-code-review:summary -->
