### PR TITLE
fix(provisioner): harden Kustomization wait loop against races and hung auth failures

### DIFF
--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -740,6 +740,7 @@ func (h *BaseBlueprintHandler) loadSources() error {
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	var errs []error
+	claimed := make(map[string]bool)
 
 	for _, source := range userBp.Sources {
 		if source.Name == "" {
@@ -747,10 +748,12 @@ func (h *BaseBlueprintHandler) loadSources() error {
 		}
 		mu.Lock()
 		_, exists := h.sourceBlueprintLoaders[source.Name]
-		mu.Unlock()
-		if exists {
+		if exists || claimed[source.Name] {
+			mu.Unlock()
 			continue
 		}
+		claimed[source.Name] = true
+		mu.Unlock()
 
 		wg.Add(1)
 		go func(src blueprintv1alpha1.Source) {

--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -745,7 +745,10 @@ func (h *BaseBlueprintHandler) loadSources() error {
 		if source.Name == "" {
 			continue
 		}
-		if _, exists := h.sourceBlueprintLoaders[source.Name]; exists {
+		mu.Lock()
+		_, exists := h.sourceBlueprintLoaders[source.Name]
+		mu.Unlock()
+		if exists {
 			continue
 		}
 

--- a/pkg/composer/blueprint/handler_test.go
+++ b/pkg/composer/blueprint/handler_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
@@ -586,6 +587,58 @@ metadata:
 		}
 		if len(handler.sourceBlueprintLoaders) < 2 {
 			t.Errorf("Expected at least 2 source loaders, got %d", len(handler.sourceBlueprintLoaders))
+		}
+	})
+
+	t.Run("DuplicateSourceNamesLoadOnlyOnce", func(t *testing.T) {
+		// Given a user blueprint listing the same source name twice
+		mocks := setupHandlerMocks(t)
+
+		userYaml := `kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: user
+sources:
+  - name: dup-source
+    url: oci://example.com/dup:v1.0.0
+  - name: dup-source
+    url: oci://example.com/dup:v1.0.0
+`
+		os.WriteFile(filepath.Join(mocks.Runtime.ConfigRoot, "blueprint.yaml"), []byte(userYaml), 0644)
+
+		sourceCacheDir := filepath.Join(mocks.Runtime.ProjectRoot, "dup-source-cache")
+		sourceTemplateDir := filepath.Join(sourceCacheDir, "_template")
+		os.MkdirAll(sourceTemplateDir, 0755)
+		sourceYaml := `kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: dup-source
+`
+		os.WriteFile(filepath.Join(sourceTemplateDir, "blueprint.yaml"), []byte(sourceYaml), 0644)
+
+		var pullMu sync.Mutex
+		pullCalls := 0
+		mocks.ArtifactBuilder.PullFunc = func(refs []string) (map[string]string, error) {
+			pullMu.Lock()
+			pullCalls++
+			pullMu.Unlock()
+			return map[string]string{"example.com/dup:v1.0.0": sourceCacheDir}, nil
+		}
+		mocks.ArtifactBuilder.ParseOCIRefFunc = func(ref string) (string, string, string, error) {
+			return "example.com", "dup", "v1.0.0", nil
+		}
+
+		handler := NewBlueprintHandler(mocks.Runtime, mocks.ArtifactBuilder)
+
+		// When loading blueprint
+		err := handler.LoadBlueprint()
+
+		// Then the duplicate entry is only loaded once, not raced by two concurrent goroutines
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if pullCalls != 1 {
+			t.Errorf("Expected exactly 1 Pull call for the duplicate source name, got %d", pullCalls)
 		}
 	})
 

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -82,9 +82,10 @@ type BaseKubernetesManager struct {
 	client        client.KubernetesClient
 	configHandler config.ConfigHandler
 
-	kustomizationWaitPollInterval time.Duration
-	kustomizationReconcileTimeout time.Duration
-	kustomizationReconcileSleep   time.Duration
+	kustomizationWaitPollInterval         time.Duration
+	kustomizationWaitMaxConsecutiveErrors int
+	kustomizationReconcileTimeout         time.Duration
+	kustomizationReconcileSleep           time.Duration
 
 	notReadyDescribeBudget time.Duration
 
@@ -103,15 +104,16 @@ func NewKubernetesManager(kubernetesClient client.KubernetesClient, configHandle
 	}
 
 	manager := &BaseKubernetesManager{
-		client:                        kubernetesClient,
-		configHandler:                 configHandler,
-		shims:                         NewShims(),
-		kustomizationWaitPollInterval: 2 * time.Second,
-		kustomizationReconcileTimeout: 5 * time.Minute,
-		kustomizationReconcileSleep:   2 * time.Second,
-		notReadyDescribeBudget:        10 * time.Second,
-		healthCheckPollInterval:       10 * time.Second,
-		nodeReadyPollInterval:         5 * time.Second,
+		client:                                kubernetesClient,
+		configHandler:                         configHandler,
+		shims:                                 NewShims(),
+		kustomizationWaitPollInterval:         2 * time.Second,
+		kustomizationWaitMaxConsecutiveErrors: 3,
+		kustomizationReconcileTimeout:         5 * time.Minute,
+		kustomizationReconcileSleep:           2 * time.Second,
+		notReadyDescribeBudget:                10 * time.Second,
+		healthCheckPollInterval:               10 * time.Second,
+		nodeReadyPollInterval:                 5 * time.Second,
 	}
 
 	return manager
@@ -328,7 +330,12 @@ func kustomizationReady(obj *unstructured.Unstructured) bool {
 // the total wait timeout being used before beginning polling. The wait also honors ctx:
 // a cancelled or deadline-exceeded context ends the wait immediately and returns ctx.Err(),
 // so a parent SIGTERM/Ctrl+C or command deadline can interrupt it (rather than requiring a
-// SIGKILL that bypasses the caller's defer cleanup).
+// SIGKILL that bypasses the caller's defer cleanup). A not-found GetResource error is treated
+// as not-ready-yet and keeps polling. Any other error (auth, connection, RBAC) counts toward
+// kustomizationWaitMaxConsecutiveErrors: a single transient blip (a brief apiserver restart, a
+// load-balancer failover) is tolerated and retried on the next tick, but a persistent failure
+// like broken cluster auth ends the wait immediately with the underlying error surfaced, rather
+// than silently retrying it for the full timeout budget.
 func (k *BaseKubernetesManager) WaitForKustomizations(ctx context.Context, message string, blueprint *blueprintv1alpha1.Blueprint) error {
 	if blueprint == nil {
 		return fmt.Errorf("blueprint not provided")
@@ -349,6 +356,8 @@ func (k *BaseKubernetesManager) WaitForKustomizations(ctx context.Context, messa
 	ticker := time.NewTicker(k.kustomizationWaitPollInterval)
 	defer ticker.Stop()
 
+	consecutiveErrors := 0
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -359,6 +368,7 @@ func (k *BaseKubernetesManager) WaitForKustomizations(ctx context.Context, messa
 			return fmt.Errorf("timeout waiting for kustomizations%s", k.describeNotReadyKustomizations(kustomizationNames, k.gitopsNamespace()))
 		case <-ticker.C:
 			allReady := true
+			var tickErr error
 			for _, name := range kustomizationNames {
 				gvr := schema.GroupVersionResource{
 					Group:    "kustomize.toolkit.fluxcd.io",
@@ -366,8 +376,13 @@ func (k *BaseKubernetesManager) WaitForKustomizations(ctx context.Context, messa
 					Resource: "kustomizations",
 				}
 				obj, err := k.client.GetResource(gvr, k.gitopsNamespace(), name)
+				if err != nil && isNotFoundError(err) {
+					allReady = false
+					break
+				}
 				if err != nil {
 					allReady = false
+					tickErr = fmt.Errorf("error checking kustomization %s: %w", name, err)
 					break
 				}
 				var kustomizationObj map[string]any
@@ -401,6 +416,15 @@ func (k *BaseKubernetesManager) WaitForKustomizations(ctx context.Context, messa
 					break
 				}
 			}
+			if tickErr != nil {
+				consecutiveErrors++
+				if consecutiveErrors >= k.kustomizationWaitMaxConsecutiveErrors {
+					tui.Fail()
+					return tickErr
+				}
+				continue
+			}
+			consecutiveErrors = 0
 			if allReady {
 				tui.Done()
 				return nil
@@ -976,10 +1000,10 @@ func (k *BaseKubernetesManager) ApplyBlueprint(blueprint *blueprintv1alpha1.Blue
 //     so DELETE blocks until every managed resource is fully gone from etcd. The chain
 //     for cloud resources is:
 //
-//         K8s DELETE → controller's finalizer holds the object in etcd
-//         → controller calls cloud API to release external state
-//         → finalizer lifts → object NotFound
-//         → WaitForTermination satisfied
+//     K8s DELETE → controller's finalizer holds the object in etcd
+//     → controller calls cloud API to release external state
+//     → finalizer lifts → object NotFound
+//     → WaitForTermination satisfied
 //
 //     This is what makes CSI volumes, LB Services, Ingresses, and cert-manager
 //     Certificates clean up cloud-side without the orchestrator ever calling a

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -514,6 +514,130 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 		}
 	})
 
+	t.Run("NotFoundKeepsPollingUntilReady", func(t *testing.T) {
+		// Given a kustomization that isn't created yet, then becomes Ready
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		calls := 0
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			calls++
+			if calls < 2 {
+				return nil, fmt.Errorf("kustomizations.kustomize.toolkit.fluxcd.io \"test-kustomization\" not found")
+			}
+			return &unstructured.Unstructured{
+				Object: map[string]any{
+					"status": map[string]any{
+						"conditions": []any{
+							map[string]any{"type": "Ready", "status": "True"},
+						},
+					},
+				},
+			}, nil
+		}
+		manager.client = kubernetesClient
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{
+					Name:    "test-kustomization",
+					Timeout: &blueprintv1alpha1.DurationString{Duration: 500 * time.Millisecond},
+				},
+			},
+		}
+
+		// When waiting for kustomizations
+		err := manager.WaitForKustomizations(context.Background(), "Waiting for kustomizations", blueprint)
+
+		// Then the wait succeeds once the resource appears, rather than treating not-found as fatal
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if calls < 2 {
+			t.Errorf("Expected GetResource to be polled at least twice, got %d calls", calls)
+		}
+	})
+
+	t.Run("PersistentErrorFailsFastInsteadOfBurningTimeout", func(t *testing.T) {
+		// Given GetResource returns a persistent, non-transient error (e.g. broken cluster auth)
+		// on every poll
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		calls := 0
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			calls++
+			return nil, fmt.Errorf("Unauthorized")
+		}
+		manager.client = kubernetesClient
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{
+					Name:    "test-kustomization",
+					Timeout: &blueprintv1alpha1.DurationString{Duration: 10 * time.Minute},
+				},
+			},
+		}
+
+		// When waiting for kustomizations
+		err := manager.WaitForKustomizations(context.Background(), "Waiting for kustomizations", blueprint)
+
+		// Then the wait ends after a few consecutive failures with the underlying error, instead of
+		// retrying silently for the full timeout budget
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "Unauthorized") {
+			t.Errorf("Expected error to surface the underlying failure, got: %v", err)
+		}
+		if strings.Contains(err.Error(), "timeout waiting for kustomizations") {
+			t.Errorf("Expected a fail-fast error, not the generic timeout error, got: %v", err)
+		}
+		if calls != manager.kustomizationWaitMaxConsecutiveErrors {
+			t.Errorf("Expected GetResource to be called exactly %d times before failing fast, got %d calls", manager.kustomizationWaitMaxConsecutiveErrors, calls)
+		}
+	})
+
+	t.Run("TransientErrorIsToleratedThenSucceeds", func(t *testing.T) {
+		// Given GetResource fails with a non-not-found error a couple of times (e.g. a brief
+		// apiserver restart) but recovers before hitting the consecutive-failure threshold
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		calls := 0
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			calls++
+			if calls <= manager.kustomizationWaitMaxConsecutiveErrors-1 {
+				return nil, fmt.Errorf("connection refused")
+			}
+			return &unstructured.Unstructured{
+				Object: map[string]any{
+					"status": map[string]any{
+						"conditions": []any{
+							map[string]any{"type": "Ready", "status": "True"},
+						},
+					},
+				},
+			}, nil
+		}
+		manager.client = kubernetesClient
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{
+					Name:    "test-kustomization",
+					Timeout: &blueprintv1alpha1.DurationString{Duration: 10 * time.Minute},
+				},
+			},
+		}
+
+		// When waiting for kustomizations
+		err := manager.WaitForKustomizations(context.Background(), "Waiting for kustomizations", blueprint)
+
+		// Then the transient errors are tolerated and the wait succeeds once the resource recovers
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
 	t.Run("ContextCancelledInterruptsWait", func(t *testing.T) {
 		// Given a kustomization that never becomes Ready and a long internal timeout
 		manager := setup(t)


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Two targeted correctness fixes in internal provisioner and composer logic; neither touches the CLI surface or any persistent state, so they are easily reversible.
>
> **Overview**
>
> The PR ships two independent bug fixes. The first adds a mutex-guarded read to the `loadSources` loop in the blueprint handler, preventing a data race when `sourceBlueprintLoaders` is checked concurrently. The second teaches `WaitForKustomizations` to distinguish not-found (resource not yet created — keep polling) from hard errors (auth failure, RBAC denial — fail fast after a configurable consecutive-error threshold of 3). Three new test cases cover the not-found polling path, the persistent-error fast-exit path, and transient-error tolerance.
>
> The kubernetes-manager change is the more behaviorally significant of the two: before this fix, a broken cluster credential would silently retry for the full five-minute timeout budget before surfacing any error; after it, the error surfaces within three poll intervals (≈6 seconds by default).
>
> Reviewed by Claude for commit `fead13a5`.

<!-- /claude-code-review:summary -->
