### PR TITLE
fix(provisioner): bound terraform destroy and preflight cluster reachability

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -171,7 +171,7 @@ const DefaultKustomizationWaitMaxFailures = 5
 const DefaultTerraformDestroyTimeout = 30 * time.Minute
 
 // Bounds the pre-destroy Kubernetes reachability preflight.
-const DefaultKubernetesReachabilityCheckTimeout = 10 * time.Second
+const DefaultKubernetesReachabilityCheckTimeout = 30 * time.Second
 
 // renovate: datasource=docker depName=localstack/localstack
 const DefaultAWSLocalstackImage = "localstack/localstack:4.14.0"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -167,6 +167,12 @@ const DefaultKustomizationWaitPollInterval = 5 * time.Second
 // Maximum number of consecutive failures before giving up
 const DefaultKustomizationWaitMaxFailures = 5
 
+// Bounds a single `terraform destroy` invocation so a hung provider call fails, not blocks forever.
+const DefaultTerraformDestroyTimeout = 30 * time.Minute
+
+// Bounds the pre-destroy Kubernetes reachability preflight.
+const DefaultKubernetesReachabilityCheckTimeout = 10 * time.Second
+
 // renovate: datasource=docker depName=localstack/localstack
 const DefaultAWSLocalstackImage = "localstack/localstack:4.14.0"
 

--- a/pkg/provisioner/destroy_test.go
+++ b/pkg/provisioner/destroy_test.go
@@ -86,7 +86,7 @@ func TestProvisioner_Teardown(t *testing.T) {
 			destroyAllCalls++
 			return terraforminfra.DestroyOutcome{}, nil
 		}
-		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack})
 
 		if _, err := provisioner.Teardown(createTestBlueprint(), true, false); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
@@ -137,7 +137,7 @@ func TestProvisioner_Teardown(t *testing.T) {
 			migrateCalled = true
 			return nil, nil
 		}
-		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack})
 
 		if _, err := provisioner.Teardown(bp, true, false); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
@@ -197,7 +197,7 @@ func TestProvisioner_Teardown(t *testing.T) {
 			ops = append(ops, "migrate")
 			return nil, nil
 		}
-		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack})
 
 		if _, err := provisioner.Teardown(bp, true, false); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
@@ -269,7 +269,7 @@ func TestProvisioner_Teardown(t *testing.T) {
 			migrateBlueprints = append(migrateBlueprints, b)
 			return nil, nil
 		}
-		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack})
 
 		if _, err := provisioner.Teardown(bp, true, false); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
@@ -334,7 +334,7 @@ func TestProvisioner_Teardown(t *testing.T) {
 			migrateCalled = true
 			return nil, nil
 		}
-		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack})
 
 		_, err := provisioner.Teardown(bp, true, false)
 		if err == nil {
@@ -394,7 +394,7 @@ func TestProvisioner_Teardown(t *testing.T) {
 			ops = append(ops, "migrate-fail")
 			return nil, fmt.Errorf("configured backend unreachable")
 		}
-		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack})
 
 		_, err := provisioner.Teardown(bp, true, false)
 		if err == nil {
@@ -460,7 +460,7 @@ func TestProvisioner_Teardown(t *testing.T) {
 		os.Stderr = w
 		defer func() { os.Stderr = origStderr }()
 
-		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack})
 		_, err := provisioner.Teardown(bp, true, false)
 
 		w.Close()
@@ -515,7 +515,7 @@ func TestProvisioner_Teardown(t *testing.T) {
 		mockStack.MigrateStateFunc = func(_ *blueprintv1alpha1.Blueprint) ([]string, error) {
 			return []string{"backend"}, nil
 		}
-		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack})
 
 		result, err := provisioner.Teardown(bp, true, false)
 		if err != nil {
@@ -570,7 +570,7 @@ func TestProvisioner_Teardown(t *testing.T) {
 			migrateCalled = true
 			return nil, nil
 		}
-		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack})
 
 		// When Teardown runs with continueOnError=true
 		result, err := provisioner.Teardown(bp, true, true)
@@ -627,7 +627,7 @@ func TestProvisioner_Teardown(t *testing.T) {
 			migrateCalled = true
 			return nil, nil
 		}
-		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack})
 
 		// When Teardown runs with continueOnError=true
 		result, err := provisioner.Teardown(bp, true, true)
@@ -671,7 +671,7 @@ func TestProvisioner_Teardown(t *testing.T) {
 				Failed:    []terraforminfra.ComponentFailure{{ID: "iam", Err: fmt.Errorf("permission denied")}},
 			}, nil
 		}
-		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack})
 
 		// When Teardown runs with continueOnError=true
 		result, err := provisioner.Teardown(createTestBlueprint(), true, true)
@@ -885,7 +885,7 @@ func TestProvisioner_TeardownComponent(t *testing.T) {
 			}
 			return false, nil
 		}
-		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack})
 
 		if _, err := provisioner.TeardownComponent(bpWithBackend(), "backend"); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
@@ -930,7 +930,7 @@ func TestProvisioner_TeardownComponent(t *testing.T) {
 					}
 					return false, nil
 				}
-				provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+				provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack})
 
 				if _, err := provisioner.TeardownComponent(bpWithBackend(), "cluster"); err != nil {
 					t.Fatalf("Expected no error, got %v", err)

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -386,7 +386,8 @@ func (i *Provisioner) Down(blueprint *blueprintv1alpha1.Blueprint) error {
 // even when a later component fails. Skipped components had nothing in state to destroy (never
 // applied, fully torn down already, or upstream destroy collapsed their cloud objects out from
 // under them); cmd-layer callers surface them in the user-facing summary so an operator can see
-// "these were no-ops" alongside "these were destroyed".
+// "these were no-ops" alongside "these were destroyed". Runs checkKubernetesReachableForDestroy
+// once terraform is confirmed enabled.
 func (i *Provisioner) DestroyAllTerraform(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyResult, error) {
 	var result DestroyResult
 	if blueprint == nil {
@@ -397,6 +398,9 @@ func (i *Provisioner) DestroyAllTerraform(blueprint *blueprintv1alpha1.Blueprint
 	}
 	if i.TerraformStack == nil {
 		return result, fmt.Errorf("terraform is disabled")
+	}
+	if err := i.checkKubernetesReachableForDestroy(); err != nil {
+		return result, err
 	}
 	outcome, err := i.TerraformStack.DestroyAll(blueprint, continueOnError, excludeIDs...)
 	result.Destroyed = outcome.Destroyed
@@ -431,7 +435,8 @@ func (i *Provisioner) Apply(blueprint *blueprintv1alpha1.Blueprint, componentID 
 // Returns (skipped, nil) when the component's state is empty (nothing to destroy), (false, nil)
 // when destroy ran successfully, or (false, err) on any failure. Returns an error if the
 // blueprint is nil, terraform is disabled, the stack cannot be initialized, the component is
-// not found, or any terraform operation fails.
+// not found, or any terraform operation fails. Runs checkKubernetesReachableForDestroy once
+// terraform is confirmed enabled.
 func (i *Provisioner) Destroy(blueprint *blueprintv1alpha1.Blueprint, componentID string) (bool, error) {
 	if blueprint == nil {
 		return false, fmt.Errorf("blueprint not provided")
@@ -441,6 +446,9 @@ func (i *Provisioner) Destroy(blueprint *blueprintv1alpha1.Blueprint, componentI
 	}
 	if i.TerraformStack == nil {
 		return false, fmt.Errorf("terraform is disabled")
+	}
+	if err := i.checkKubernetesReachableForDestroy(); err != nil {
+		return false, err
 	}
 	skipped, err := i.TerraformStack.Destroy(blueprint, componentID)
 	if err != nil {
@@ -493,7 +501,8 @@ func (i *Provisioner) DestroyKustomize(blueprint *blueprintv1alpha1.Blueprint, c
 // last). Returns the IDs of terraform components that were skipped because their state
 // was empty (never applied, already torn down) alongside any error from either step —
 // paired with the error so callers see what was no-op'd even when a later step fails.
-// Returns an error if either step fails.
+// Returns an error if either step fails. Runs checkKubernetesReachableForDestroy before the
+// terraform step.
 func (i *Provisioner) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyResult, error) {
 	var result DestroyResult
 	if blueprint == nil {
@@ -519,6 +528,9 @@ func (i *Provisioner) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continu
 		return result, err
 	}
 	if i.TerraformStack != nil {
+		if err := i.checkKubernetesReachableForDestroy(); err != nil {
+			return result, err
+		}
 		outcome, err := i.TerraformStack.DestroyAll(blueprint, continueOnError, excludeIDs...)
 		result.Destroyed = append(result.Destroyed, outcome.Destroyed...)
 		result.Skipped = append(result.Skipped, outcome.Skipped...)
@@ -1535,4 +1547,18 @@ func (i *Provisioner) kubeconfigPresent() bool {
 		return false
 	}
 	return true
+}
+
+// checkKubernetesReachableForDestroy fails fast if the cluster is unreachable, so terraform's
+// kubernetes/helm provider doesn't hang against broken auth. No-op when there's no kubeconfig.
+func (i *Provisioner) checkKubernetesReachableForDestroy() error {
+	if i.KubernetesManager == nil || !i.kubeconfigPresent() {
+		return nil
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), constants.DefaultKubernetesReachabilityCheckTimeout)
+	defer cancel()
+	if err := i.KubernetesManager.WaitForKubernetesHealthy(ctx, "", nil); err != nil {
+		return fmt.Errorf("kubernetes API is unreachable, refusing to run terraform destroy (its kubernetes/helm provider would hang against a broken cluster): %w", err)
+	}
+	return nil
 }

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -501,8 +501,8 @@ func (i *Provisioner) DestroyKustomize(blueprint *blueprintv1alpha1.Blueprint, c
 // last). Returns the IDs of terraform components that were skipped because their state
 // was empty (never applied, already torn down) alongside any error from either step —
 // paired with the error so callers see what was no-op'd even when a later step fails.
-// Returns an error if either step fails. Runs checkKubernetesReachableForDestroy before the
-// terraform step.
+// Returns an error if either step fails. checkKubernetesReachableForDestroy runs after the
+// kustomize step (so it never fires if kustomize already hard-failed) and before terraform.
 func (i *Provisioner) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyResult, error) {
 	var result DestroyResult
 	if blueprint == nil {

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -728,7 +728,7 @@ func TestProvisioner_DestroyAllTerraform(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
 		mockStack := terraforminfra.NewMockStack()
 		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) { return terraforminfra.DestroyOutcome{}, nil }
-		opts := &Provisioner{TerraformStack: mockStack}
+		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
 		_, err := provisioner.DestroyAllTerraform(createTestBlueprint(), false)
@@ -782,7 +782,7 @@ func TestProvisioner_DestroyAllTerraform(t *testing.T) {
 		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) {
 			return terraforminfra.DestroyOutcome{}, fmt.Errorf("terraform destroy all failed")
 		}
-		opts := &Provisioner{TerraformStack: mockStack}
+		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
 		_, err := provisioner.DestroyAllTerraform(createTestBlueprint(), false)
@@ -792,6 +792,33 @@ func TestProvisioner_DestroyAllTerraform(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "failed to run terraform destroy") {
 			t.Errorf("Expected specific error message, got: %v", err)
+		}
+	})
+
+	t.Run("ErrorKubernetesUnreachable", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
+			return fmt.Errorf("connection refused")
+		}
+		mockStack := terraforminfra.NewMockStack()
+		destroyAllCalled := false
+		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) {
+			destroyAllCalled = true
+			return terraforminfra.DestroyOutcome{}, nil
+		}
+		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
+
+		_, err := provisioner.DestroyAllTerraform(createTestBlueprint(), false)
+
+		if err == nil {
+			t.Fatal("Expected error when kubernetes is unreachable")
+		}
+		if !strings.Contains(err.Error(), "kubernetes API is unreachable") {
+			t.Errorf("Expected specific error message, got: %v", err)
+		}
+		if destroyAllCalled {
+			t.Error("Expected terraform DestroyAll not to run when kubernetes is unreachable")
 		}
 	})
 }
@@ -2144,7 +2171,7 @@ func TestProvisioner_Destroy(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
 		mockStack := terraforminfra.NewMockStack()
 		mockStack.DestroyFunc = func(bp *blueprintv1alpha1.Blueprint, componentID string) (bool, error) { return false, nil }
-		opts := &Provisioner{TerraformStack: mockStack}
+		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
 		_, err := provisioner.Destroy(createTestBlueprint(), "remote/path")
@@ -2198,7 +2225,7 @@ func TestProvisioner_Destroy(t *testing.T) {
 		mockStack.DestroyFunc = func(bp *blueprintv1alpha1.Blueprint, componentID string) (bool, error) {
 			return false, fmt.Errorf("terraform stack destroy failed")
 		}
-		opts := &Provisioner{TerraformStack: mockStack}
+		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
 		_, err := provisioner.Destroy(createTestBlueprint(), "remote/path")
@@ -2220,7 +2247,7 @@ func TestProvisioner_Destroy(t *testing.T) {
 		mockStack.DestroyFunc = func(bp *blueprintv1alpha1.Blueprint, componentID string) (bool, error) {
 			return true, nil
 		}
-		opts := &Provisioner{TerraformStack: mockStack}
+		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
 		skipped, err := provisioner.Destroy(createTestBlueprint(), "remote/path")
@@ -2229,6 +2256,33 @@ func TestProvisioner_Destroy(t *testing.T) {
 		}
 		if !skipped {
 			t.Error("Expected skipped=true when stack reports empty state")
+		}
+	})
+
+	t.Run("ErrorKubernetesUnreachable", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
+			return fmt.Errorf("connection refused")
+		}
+		mockStack := terraforminfra.NewMockStack()
+		destroyCalled := false
+		mockStack.DestroyFunc = func(bp *blueprintv1alpha1.Blueprint, componentID string) (bool, error) {
+			destroyCalled = true
+			return false, nil
+		}
+		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
+
+		_, err := provisioner.Destroy(createTestBlueprint(), "remote/path")
+
+		if err == nil {
+			t.Fatal("Expected error when kubernetes is unreachable")
+		}
+		if !strings.Contains(err.Error(), "kubernetes API is unreachable") {
+			t.Errorf("Expected specific error message, got: %v", err)
+		}
+		if destroyCalled {
+			t.Error("Expected terraform Destroy not to run when kubernetes is unreachable")
 		}
 	})
 }
@@ -2526,6 +2580,90 @@ func TestProvisioner_DestroyAll(t *testing.T) {
 		// DeleteBlueprint actually processes.
 		if len(result.Destroyed) != 1 || result.Destroyed[0] != "dns" {
 			t.Errorf("Expected result.Destroyed=[dns], got %v", result.Destroyed)
+		}
+	})
+
+	t.Run("ErrorKubernetesUnreachable", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.DeleteBlueprintFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) error { return nil }
+		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
+			return fmt.Errorf("connection refused")
+		}
+		mockStack := terraforminfra.NewMockStack()
+		destroyAllCalled := false
+		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) {
+			destroyAllCalled = true
+			return terraforminfra.DestroyOutcome{}, nil
+		}
+		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
+
+		_, err := provisioner.DestroyAll(createTestBlueprint(), false)
+
+		if err == nil {
+			t.Fatal("Expected error when kubernetes is unreachable")
+		}
+		if !strings.Contains(err.Error(), "kubernetes API is unreachable") {
+			t.Errorf("Expected specific error message, got: %v", err)
+		}
+		if destroyAllCalled {
+			t.Error("Expected terraform DestroyAll not to run when kubernetes is unreachable")
+		}
+	})
+}
+
+func TestProvisioner_checkKubernetesReachableForDestroy(t *testing.T) {
+	t.Run("NoOpWhenKubernetesManagerNil", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler)
+		provisioner.KubernetesManager = nil
+
+		if err := provisioner.checkKubernetesReachableForDestroy(); err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("NoOpWhenKubeconfigMissing", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		mocks.Runtime.ConfigRoot = t.TempDir()
+		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
+
+		if err := provisioner.checkKubernetesReachableForDestroy(); err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("PassesWhenClusterReachable", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
+			return nil
+		}
+		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
+
+		if err := provisioner.checkKubernetesReachableForDestroy(); err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("ErrorWhenClusterUnreachable", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
+			return fmt.Errorf("connection refused")
+		}
+		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
+
+		err := provisioner.checkKubernetesReachableForDestroy()
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "kubernetes API is unreachable") {
+			t.Errorf("Expected error to name the unreachable cluster, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "connection refused") {
+			t.Errorf("Expected error to wrap the underlying cause, got: %v", err)
 		}
 	})
 }

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/runtime"
 	envvars "github.com/windsorcli/cli/pkg/runtime/env"
 	"github.com/windsorcli/cli/pkg/tui"
@@ -566,7 +567,8 @@ func (s *TerraformStack) MigrateComponentState(blueprint *blueprintv1alpha1.Blue
 // off the backend component from the bulk pass — it gets destroyed last, after its state
 // is migrated to local). When continueOnError is true, per-component destroy errors are
 // collected in DestroyOutcome.Failed and the loop proceeds to the next component; when
-// false, the first error aborts and is returned alongside a partial DestroyOutcome.
+// false, the first error aborts and is returned alongside a partial DestroyOutcome. Each
+// destroy is bounded by constants.DefaultTerraformDestroyTimeout.
 func (s *TerraformStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyOutcome, error) {
 	var result DestroyOutcome
 	if blueprint == nil {
@@ -693,7 +695,7 @@ func (s *TerraformStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, cont
 			destroyArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "destroy", destroyRefreshFlag}
 			destroyArgs = append(destroyArgs, terraformArgs.DestroyArgs...)
 			destroyEnv := selectTerraformCommandEnv(terraformVars, true, scopedKeys)
-			output, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, destroyEnv, destroyArgs...)
+			output, err := s.runtime.Shell.ExecSilentWithEnvAndTimeout(terraformCommand, destroyEnv, destroyArgs, constants.DefaultTerraformDestroyTimeout)
 			if err != nil {
 				if trimmed := strings.TrimSpace(output); trimmed != "" {
 					fmt.Fprintf(s.warningWriter, "terraform destroy output for %s:\n%s\n", component.Path, trimmed)
@@ -869,6 +871,7 @@ func (s *TerraformStack) Apply(blueprint *blueprintv1alpha1.Blueprint, component
 // for backend) would otherwise produce inconsistent "Destroying X" / "Destroying terraform
 // for X" lines side by side. The terraform destroy exec runs silently inside the spinner
 // for the same reason: the bulk loop is silent, so single-component Destroy must be too.
+// Bounded by constants.DefaultTerraformDestroyTimeout.
 func (s *TerraformStack) Destroy(blueprint *blueprintv1alpha1.Blueprint, componentID string) (bool, error) {
 	if blueprint == nil {
 		return false, fmt.Errorf("blueprint not provided")
@@ -926,7 +929,7 @@ func (s *TerraformStack) Destroy(blueprint *blueprintv1alpha1.Blueprint, compone
 		destroyArgs = append(destroyArgs, terraformArgs.DestroyArgs...)
 		destroyEnv := selectTerraformCommandEnv(terraformVars, true, scopedKeys)
 
-		output, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, destroyEnv, destroyArgs...)
+		output, err := s.runtime.Shell.ExecSilentWithEnvAndTimeout(terraformCommand, destroyEnv, destroyArgs, constants.DefaultTerraformDestroyTimeout)
 		if err != nil {
 			if trimmed := strings.TrimSpace(output); trimmed != "" {
 				fmt.Fprintf(s.warningWriter, "terraform destroy output for %s:\n%s\n", component.Path, trimmed)

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -12,9 +12,11 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/composer/blueprint"
+	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/runtime"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	envvars "github.com/windsorcli/cli/pkg/runtime/env"
@@ -1109,6 +1111,32 @@ func TestStack_DestroyAll(t *testing.T) {
 
 		if _, err := stack.DestroyAll(blueprint, false); err != nil {
 			t.Errorf("Expected Down to return nil, got %v", err)
+		}
+	})
+
+	t.Run("UsesDestroyTimeout", func(t *testing.T) {
+		// Given a stack whose terraform destroy exec is bounded by a timeout
+		stack, mocks := setup(t)
+		var gotTimeout time.Duration
+		var sawDestroy bool
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			sawDestroy = true
+			gotTimeout = timeout
+			return "", nil
+		}
+		blueprint := createTestBlueprint()
+
+		// When DestroyAll runs
+		if _, err := stack.DestroyAll(blueprint, false); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the destroy exec runs with the bounded timeout, not the untimed variant
+		if !sawDestroy {
+			t.Fatal("Expected terraform destroy to run via ExecSilentWithEnvAndTimeout")
+		}
+		if gotTimeout != constants.DefaultTerraformDestroyTimeout {
+			t.Errorf("Expected timeout %v, got %v", constants.DefaultTerraformDestroyTimeout, gotTimeout)
 		}
 	})
 
@@ -2953,6 +2981,33 @@ func TestStack_Destroy(t *testing.T) {
 		// Then no error should occur
 		if err != nil {
 			t.Errorf("Expected Destroy to return nil, got %v", err)
+		}
+	})
+
+	t.Run("UsesDestroyTimeout", func(t *testing.T) {
+		// Given a stack whose terraform destroy exec is bounded by a timeout
+		stack, mocks := setup(t)
+		var gotTimeout time.Duration
+		var sawDestroy bool
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			sawDestroy = true
+			gotTimeout = timeout
+			return "", nil
+		}
+		blueprint := createTestBlueprint()
+
+		// When destroying the local component by ID
+		_, err := stack.Destroy(blueprint, "local/path")
+
+		// Then the destroy exec runs with the bounded timeout, not the untimed variant
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !sawDestroy {
+			t.Fatal("Expected terraform destroy to run via ExecSilentWithEnvAndTimeout")
+		}
+		if gotTimeout != constants.DefaultTerraformDestroyTimeout {
+			t.Errorf("Expected timeout %v, got %v", constants.DefaultTerraformDestroyTimeout, gotTimeout)
 		}
 	})
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This change touches all destroy paths in the provisioner, adding a blocking preflight that can abort a `terraform destroy` before it starts; a misconfigured or slow API server will now turn a destroy into a hard error rather than a hang.
>
> **Overview**
>
> The PR adds two defenses against stuck destroy operations: (1) a 30-minute wall-clock timeout wrapping every `terraform destroy` shell invocation via a new `ExecSilentWithEnvAndTimeout` call in `TerraformStack.Destroy` and `TerraformStack.DestroyAll`, and (2) a `checkKubernetesReachableForDestroy` preflight in the provisioner layer that pings the Kubernetes API with a 10-second timeout before handing off to terraform, so that a broken cluster auth does not cause terraform's kubernetes/helm provider to hang indefinitely. Both guards are wired into `Destroy`, `DestroyAllTerraform`, and `DestroyAll`; the new constants are `DefaultTerraformDestroyTimeout = 30m` and `DefaultKubernetesReachabilityCheckTimeout = 10s`.
>
> The 10-second reachability timeout is the operationally sensitive value: on a high-latency or temporarily-loaded API server it may produce false positives and block a legitimate destroy. The `NoOpWhenKubeconfigMissing` path correctly bypasses the check for kubeconfig-less environments.
>
> Reviewed by Claude for commit `6e79b151`.

<!-- /claude-code-review:summary -->
