### PR TITLE
fix: support registry ports in ParseOCIRef

### DIFF
--- a/pkg/composer/artifact/artifact.go
+++ b/pkg/composer/artifact/artifact.go
@@ -199,9 +199,10 @@ func (a *ArtifactBuilder) Write(outputPath string, tag string) (string, error) {
 }
 
 // ParseOCIRef parses an OCI reference into registry, repository, and tag components.
-// Validates OCI reference format and extracts registry, repository, and tag parts.
-// Requires OCI reference to follow the format "oci://registry/repository:tag".
-// Returns individual components for separate handling in OCI operations.
+// Requires the format "oci://registry/repository:tag". The registry may itself contain a
+// colon (an explicit port, e.g. "localhost:5000/repo:tag"), so registry/repository are split
+// on the first "/" before the tag is found at the last ":" — a repository containing a colon
+// (e.g. "repo:tag:extra") is rejected rather than silently misparsed.
 func (a *ArtifactBuilder) ParseOCIRef(ociRef string) (registry, repository, tag string, err error) {
 	if !strings.HasPrefix(ociRef, "oci://") {
 		return "", "", "", fmt.Errorf("invalid OCI reference format: %s", ociRef)
@@ -209,21 +210,22 @@ func (a *ArtifactBuilder) ParseOCIRef(ociRef string) (registry, repository, tag 
 
 	ref := strings.TrimPrefix(ociRef, "oci://")
 
-	parts := strings.Split(ref, ":")
-	if len(parts) != 2 {
+	firstSlash := strings.Index(ref, "/")
+	if firstSlash <= 0 {
 		return "", "", "", fmt.Errorf("invalid OCI reference format, expected registry/repository:tag: %s", ociRef)
 	}
+	registry = ref[:firstSlash]
+	repoAndTag := ref[firstSlash+1:]
 
-	repoWithRegistry := parts[0]
-	tag = parts[1]
-
-	repoParts := strings.SplitN(repoWithRegistry, "/", 2)
-	if len(repoParts) != 2 {
+	lastColon := strings.LastIndex(repoAndTag, ":")
+	if lastColon <= 0 || lastColon == len(repoAndTag)-1 {
 		return "", "", "", fmt.Errorf("invalid OCI reference format, expected registry/repository:tag: %s", ociRef)
 	}
-
-	registry = repoParts[0]
-	repository = repoParts[1]
+	repository = repoAndTag[:lastColon]
+	tag = repoAndTag[lastColon+1:]
+	if strings.Contains(repository, ":") {
+		return "", "", "", fmt.Errorf("invalid OCI reference format, expected registry/repository:tag: %s", ociRef)
+	}
 
 	return registry, repository, tag, nil
 }

--- a/pkg/composer/artifact/artifact_private_test.go
+++ b/pkg/composer/artifact/artifact_private_test.go
@@ -1234,6 +1234,30 @@ func TestArtifactBuilder_ParseOCIRef(t *testing.T) {
 			t.Errorf("expected tag 'v1.0.0', got %s", tag)
 		}
 	})
+
+	t.Run("RegistryWithPort", func(t *testing.T) {
+		// Given an ArtifactBuilder
+		builder, _ := setup(t)
+
+		// When ParseOCIRef is called with a registry host that includes an explicit port
+		registry, repository, tag, err := builder.ParseOCIRef("oci://localhost:5050/my-repo:v1.0.0")
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		// And the port is retained as part of the registry, not mistaken for the tag separator
+		if registry != "localhost:5050" {
+			t.Errorf("expected registry 'localhost:5050', got %s", registry)
+		}
+		if repository != "my-repo" {
+			t.Errorf("expected repository 'my-repo', got %s", repository)
+		}
+		if tag != "v1.0.0" {
+			t.Errorf("expected tag 'v1.0.0', got %s", tag)
+		}
+	})
 }
 
 func TestArtifactBuilder_downloadOCIArtifact(t *testing.T) {

--- a/pkg/composer/artifact/artifact_private_test.go
+++ b/pkg/composer/artifact/artifact_private_test.go
@@ -1258,6 +1258,30 @@ func TestArtifactBuilder_ParseOCIRef(t *testing.T) {
 			t.Errorf("expected tag 'v1.0.0', got %s", tag)
 		}
 	})
+
+	t.Run("RegistryWithPortAndNestedRepositoryPath", func(t *testing.T) {
+		// Given an ArtifactBuilder
+		builder, _ := setup(t)
+
+		// When ParseOCIRef is called with both a port and a multi-segment repository path
+		registry, repository, tag, err := builder.ParseOCIRef("oci://localhost:5050/org/project/repo:v1.0.0")
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		// And the port and full nested path are both parsed correctly
+		if registry != "localhost:5050" {
+			t.Errorf("expected registry 'localhost:5050', got %s", registry)
+		}
+		if repository != "org/project/repo" {
+			t.Errorf("expected repository 'org/project/repo', got %s", repository)
+		}
+		if tag != "v1.0.0" {
+			t.Errorf("expected tag 'v1.0.0', got %s", tag)
+		}
+	})
 }
 
 func TestArtifactBuilder_downloadOCIArtifact(t *testing.T) {


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change is isolated to a single OCI reference parsing function with no effect on any other code path.
>
> **Overview**
>
> The PR fixes `ParseOCIRef` to handle registry hostnames that include an explicit port (e.g. `localhost:5050/repo:tag`). The old implementation split on `:` first, so a port in the registry host produced three segments and caused an immediate format error. The new implementation splits on the first `/` to isolate the registry (preserving any port), then uses the last `:` in the remaining string to separate repository from tag.
>
> A guard rejects repository strings that themselves contain a colon (e.g. `repo:extra:tag`) to prevent silent mis-parsing. A single new `t.Run("RegistryWithPort", …)` test exercises the happy path for the added format.
>
> Reviewed by Claude for commit `ff705daf`.

<!-- /claude-code-review:summary -->
