### PR TITLE
chore(ai): update skills documentation and add create-pr skill

### DIFF
--- a/.claude/skills/address-pr-feedback/SKILL.md
+++ b/.claude/skills/address-pr-feedback/SKILL.md
@@ -125,7 +125,7 @@ For each finding the author confirms, run this exact sequence:
    message (same rules as `create-pr` titles). One commit per finding
    unless the author asks to squash. Match the project's existing
    commit-message voice (sample `git log main --pretty=format:%s |
-   head -10`). End with the standard `Co-Authored-By` trailer.
+   head -10`). Do not add a `Co-Authored-By` trailer.
 
 9. **On author's request changes**: iterate. Don't move to the next
    finding until this one is committed-or-skipped.

--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: architecture
-description: Enforce Windsor CLI architecture boundaries and separation of concerns. Use when changes touch more than one layer (cmd, runtime, evaluator, secrets, terraform, composer), or when ownership of logic is unclear.
+description: Enforce Windsor CLI architecture boundaries and separation of concerns. Use when changes touch more than one layer (cmd, runtime, evaluator, secrets, provisioner, composer, workstation), or when ownership of logic is unclear.
 ---
 
 # Windsor Architecture
 
 ## Apply when
 - Changes touch more than one architectural layer.
-- Ownership is unclear between evaluator/secrets/terraform/runtime.
+- Ownership is unclear between evaluator/secrets/runtime/provisioner/composer/workstation — or between the three packages named "terraform" (see below).
 - New behavior could introduce cross-layer coupling.
 
 ## Do not apply when
@@ -22,16 +22,28 @@ description: Enforce Windsor CLI architecture boundaries and separation of conce
 | Runtime | `pkg/runtime/runtime.go` | Lifecycle orchestration and dependency wiring |
 | Evaluator | `pkg/runtime/evaluator/*` | Provider-agnostic expression evaluation and helper registration |
 | Secrets | `pkg/runtime/secrets/*` | Provider adapters and secret expression resolution |
-| Terraform | `pkg/runtime/terraform/*` | Terraform metadata introspection, env assembly, provider policy |
-| Composer | `pkg/composer/*` | Blueprint load/process/compose/write pipeline, module preparation |
+| Runtime Terraform | `pkg/runtime/terraform/*` | Terraform metadata introspection, env assembly, provider policy |
+| Composer | `pkg/composer/*` | Blueprint load/process/compose/write pipeline, source/module resolution |
+| Provisioner | `pkg/provisioner/*` | Infrastructure lifecycle: terraform execution, Kubernetes/Flux management, cluster clients, stack locking |
+| Workstation | `pkg/workstation/*` | Local VM and network provisioning (colima, docker-desktop, host networking) |
+
+### Three packages named "terraform" — do not conflate
+
+- `pkg/runtime/terraform/*` — metadata introspection, env var assembly, provider policy. No execution.
+- `pkg/composer/terraform/*` — resolves terraform module sources (OCI/git) during blueprint composition. No execution.
+- `pkg/provisioner/terraform/*` (`TerraformStack`) — the only one that actually runs `terraform init/plan/apply/destroy`.
+
+If a change needs to run terraform or change how/when it runs, it belongs in `pkg/provisioner/terraform`. If it needs to read terraform config/state shape without executing, it belongs in `pkg/runtime/terraform`. If it's about finding/fetching module source code before composition, it belongs in `pkg/composer/terraform`.
 
 ## Ownership rules
 
 - **Runtime orchestrates.** Coordinates initialization order and lifecycle transitions. Does not make provider-specific decisions.
 - **Evaluator evaluates.** Must not hardcode provider-specific branches.
 - **Secrets resolves.** Handles provider-specific retrieval. Does not orchestrate lifecycle.
-- **Terraform provider owns** terraform metadata and env var decisions.
+- **Runtime terraform owns** terraform metadata and env var decisions — not execution.
 - **Composer blueprint handler owns** blueprint pipelines and source/template composition.
+- **Provisioner owns** actually running infrastructure operations: `TerraformStack` (terraform exec), `KubernetesManager` (cluster/Flux operations), `ClusterClient` (cluster lifecycle), stack locking. The `Provisioner` struct in `pkg/provisioner/provisioner.go` is the orchestration entrypoint cmd/ calls into for apply/destroy/bootstrap.
+- **Workstation owns** local VM/network setup — colima, docker-desktop, host DNS/routes. Does not touch cloud or cluster infrastructure.
 - **CLI command layer owns** UX/policy decisions (hook/non-hook error behavior, output format).
 
 ## Proven patterns

--- a/.claude/skills/create-pr/SKILL.md
+++ b/.claude/skills/create-pr/SKILL.md
@@ -1,0 +1,141 @@
+---
+name: create-pr
+description: Push the current branch and open or update its pull request with a Conventional-Commits title. Does NOT author a PR description -- the claude-code-review workflow upserts the canonical summary into the body on every push, so this skill leaves the body empty for CI to fill and never touches an existing one. Run after committing and before announcing the PR. Use whenever the user asks to "open the PR", "push and PR", "create a branch and PR", or after the project's gates are green and the branch is ready.
+---
+
+# Create or Update PR
+
+Open a pull request for the current branch with a Conventional-Commits
+title and an empty body. The repo's `claude-code-review` workflow upserts
+the canonical summary into the PR body on every push, so this skill never
+authors a description: it creates the PR with no body and leaves the body
+for CI, and it never overwrites a body that already exists.
+
+## Apply when
+- The user says "open the PR", "push the branch and PR", "make a PR", or
+  similar after work is committed.
+- The project's gates (lint + tests) have passed locally and the branch
+  has commits ahead of `main`.
+- Skip if `git status -s` shows uncommitted changes that should be in the
+  PR -- ask the user to commit or stash first.
+
+## Inputs to gather
+1. `git rev-parse --abbrev-ref HEAD` — branch name.
+2. `git log main..HEAD --oneline` — commits the PR contains.
+3. `git diff main...HEAD --stat` — file-level shape of the change.
+4. `gh pr view --json number 2>/dev/null` — does a PR exist already?
+
+If `gh pr view` returns "no pull requests found", we'll create with an
+empty body. Otherwise the PR already exists and we leave its body alone.
+
+## Title rules
+
+Hard requirements:
+- **Conventional Commits shape**: `<type>(<scope>?): <description>`.
+- **Types**: `feat`, `fix`, `chore`, `docs`, `test`, `refactor`, `ci`,
+  `perf`, `build`. Pick from this fixed set.
+- **Scope** (optional, lowercase): the package or area touched, e.g. the
+  directory or component name, or `deps` for dependency bumps. Single
+  word; multi-word scopes are a smell. Sample existing scopes with
+  `git log main --pretty=format:%s | head -20`.
+- **Description**: lowercase first letter, imperative or descriptive,
+  no trailing punctuation.
+- **Length**: aim for ≤ 65 chars total. Hard cap at 72.
+- **Same shape as commit titles** in the project — sample
+  `git log main --pretty=format:%s | head -20` to verify.
+
+Examples that fit: `feat(api): inline default timeout`,
+`fix(server): bound request ctx with command timeout`,
+`chore(deps): bump some-dependency to v1.20`.
+
+Anti-patterns to avoid:
+- ALL CAPS prefixes ("M4: ..."): drop the milestone tag.
+- Multi-clause titles with "and" or `+`: pick the bigger half. If the
+  change really is two things, that's a sign it should be two PRs.
+- Verbose nouns ("complete the foo resource"): use the verb
+  ("complete foo").
+
+## Body
+
+Do not write a PR body. The repo's `claude-code-review` workflow upserts
+the canonical summary (a `> [!NOTE]` block delimited by
+`<!-- claude-code-review:summary -->` markers) into the PR description on
+every push, so authoring one here would only duplicate or fight with it.
+
+Create the PR with an empty body and let CI fill it. If a PR already
+exists, leave its body untouched — CI owns it, and a human may have added
+prose of their own that must not be clobbered.
+
+## Decision tree
+
+```
+Does a PR exist for this branch?
+├── No  → gh pr create with generated title and an empty body, then print URL.
+└── Yes → Leave the body alone (CI owns the summary; a human may have added
+          prose). Print URL only.
+```
+
+After the PR exists, **always check CI status** (see below). The point
+of opening a PR is to get the change reviewed and merged; surfacing a
+red check immediately lets the user fix it before they walk away.
+
+## Commands
+
+Push first, then create the PR with an empty body. Pass `--body ""`
+explicitly so `gh` does not drop into an interactive editor.
+
+```bash
+# 1. Push (set upstream on first push of this branch)
+git push -u origin "$(git rev-parse --abbrev-ref HEAD)"
+
+# 2. Detect existing PR
+PR_NUM=$(gh pr view --json number --jq '.number // empty' 2>/dev/null)
+
+# 3. Create with an empty body when none exists; never touch an existing body
+if [ -z "$PR_NUM" ]; then
+  gh pr create --title "<generated title>" --body ""
+  PR_NUM=$(gh pr view --json number --jq .number)
+else
+  echo "PR #$PR_NUM already exists; leaving its body to CI."
+fi
+gh pr view --json url --jq .url
+```
+
+If `gh` returns `HTTP 401: Bad credentials`, the operator has a stale
+`GITHUB_TOKEN` env var overriding the keychain. Prepend `unset GITHUB_TOKEN`
+to the failing command and retry.
+
+## CI status check
+
+After the PR exists (just created OR already-existed), run a quick
+status check. CI typically kicks off within a few seconds of the push,
+but most pipelines take 1-5 minutes to complete. Two modes:
+
+```bash
+# Snapshot: list current state of every check, no waiting.
+gh pr checks "$PR_NUM"
+```
+
+If any row shows `fail` or `failure`, surface those rows to the user
+verbatim and direct them to the failing job's URL (the rightmost
+column of `gh pr checks`). Don't try to diagnose the failure from the
+skill -- the failing job's logs are the source of truth.
+
+If every row shows `pending` or `queued`, that's expected on a fresh
+push. Print the URL with a "checks running" hint. Do NOT block the
+skill on completion -- the user can run `gh pr checks --watch` to
+follow them.
+
+If every row shows `pass`, say so explicitly. The user shouldn't have
+to scroll back to verify.
+
+## What NOT to do
+- Don't author a PR body. The `claude-code-review` workflow owns the
+  description; anything written here duplicates or fights with it.
+- Don't overwrite or edit the body of an existing PR.
+- Don't push to `main` directly. Always operate on a feature branch.
+- Don't run `git push --force` unless the user explicitly asked.
+
+## After posting
+
+Print the PR URL on its own line so the operator can click through.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -8,6 +8,8 @@ disable-model-invocation: true
 
 You are a senior Go engineer performing a pre-commit bug review on the Windsor CLI codebase. Your only job is to find real bugs. Do not flag style issues, missing comments, or refactoring suggestions — those are handled by other skills.
 
+Use this for staged, pre-commit changes in this repo — it's Windsor-specific (six fixed passes, including this repo's architecture boundaries). For a broader or cross-repo review, or one scoped to effort level rather than a fixed pass list, use the generic `code-review` skill instead.
+
 ## Diff under review
 
 ```
@@ -22,7 +24,7 @@ You are a senior Go engineer performing a pre-commit bug review on the Windsor C
 
 ## Review process
 
-Run all five passes **in parallel** using the Agent tool. Each pass is independent and focused on a single bug category. Spawn all five simultaneously, then aggregate their findings.
+Run all six passes **in parallel** using the Agent tool. Each pass is independent and focused on a single bug category. Spawn all six simultaneously, then aggregate their findings.
 
 ---
 

--- a/.claude/skills/test-engineer/SKILL.md
+++ b/.claude/skills/test-engineer/SKILL.md
@@ -59,20 +59,20 @@ func TestFoo_Bar(t *testing.T) {
 }
 ```
 
-## Mandatory TDD workflow
+## Test-writing workflow
 
-1. Present the full test suite structure as `t.Run` stubs first.
-2. Get explicit confirmation before implementing any case.
-3. Implement exactly **one** `t.Run` case at a time.
-4. Run tests after each case. Report pass/fail.
-5. Request confirmation before the next case.
+- Default: write the full set of `t.Run` cases for the behavior in one pass, then run the whole file (or `-run` the new test function) and report pass/fail. Don't stop to confirm each case individually — that ceremony has outlived its usefulness for routine test-writing.
+- Reserve stub-first-then-confirm for cases where the *shape* of coverage is itself a design decision worth checking before investing in it — e.g., scoping a brand-new package's test suite, or a case list long enough that getting it wrong wastes real effort. Propose the `t.Run` names, get a nod, then implement all of them.
+- Run tests after writing, not after every single case.
 
 ## Prohibited
 
-- Implementing multiple test cases in one step.
-- Table-driven or matrix-based tests.
 - Modifying source code during test-engineering-only tasks.
 - Using `testify` or any non-standard test library.
+
+## Table-driven tests
+
+Prefer `t.Run` BDD scenarios (Given/When/Then) for behavior-level tests — they name what's being verified and fail with a readable subtest name. Table-driven (`tests := []struct{...}`) is fine, and already used in this codebase, specifically for enumerating edge cases of pure logic (parsers, validators, format checks) where the cases are homogeneous and the table itself is the clearest representation — see `pkg/composer/terraform/oci_module_resolver_private_test.go`'s `HandlesEdgeCases` for a real example. Don't reach for it to cover heterogeneous behavior that reads better as named `t.Run` cases.
 
 ## Test commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,22 +1,24 @@
 # Windsor CLI — Claude Code Context
 
-Skills are defined in `.agent/skills/` and are discovered automatically by Claude Code, Cursor, and other adopting tools.
+Skills are defined in `.claude/skills/` and are discovered automatically by Claude Code, Cursor, and other adopting tools.
 
 ## Non-negotiable rules
 
 1. **Function comment placement** — behavior documentation belongs in function header comments, never inside function bodies.
 
-2. **Go testing** — use standard `go test` only. No `testify`. Follow the mandatory one-`t.Run` workflow from `test-engineer`.
+2. **Go testing** — use standard `go test` only. No `testify`. Follow `test-engineer` for test design and structure.
 
 3. **Style and organization** — follow STYLE.md and `go-style` for section headers, file layout, and naming.
 
-4. **Architecture boundaries** — follow `architecture` for runtime/evaluator/secrets/terraform ownership. Do not cross layer boundaries.
+4. **Architecture boundaries** — follow `architecture` for cmd/runtime/evaluator/secrets/provisioner/composer ownership. Do not cross layer boundaries.
 
 5. **Large cross-cutting work** — follow `large-pr` for phased implementation and change-map reporting.
 
-6. **Security and pre-commit review** — run `/review-pr` before every commit. It runs `task scan`, `go vet`, and five parallel bug passes automatically.
+6. **Security and pre-commit review** — run `/review-pr` before every commit; it runs `task scan`, `go vet`, and six parallel bug passes automatically. For a PR-level or cross-repo review instead, use the generic `code-review` skill.
 
 7. **Integration tests** — every new CLI command or flag requires an integration test. Follow `integration-tests`.
+
+8. **PRs** — use `create-pr` to push and open/update a PR, and `address-pr-feedback` to work through review comments and CI failures one finding at a time.
 
 ## Key commands
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This PR touches only AI-skill instruction files and `CLAUDE.md`; no production Go code, tests, or infrastructure is affected.
>
> **Overview**
>
> The change adds a new `create-pr` skill that encodes the project's Conventional-Commits PR-creation workflow (push branch, generate title, leave body empty for CI to fill), fixes a stale path reference in `CLAUDE.md` (`.agent/skills/` → `.claude/skills/`), and expands the `architecture` skill to document the `provisioner` and `workstation` layers and to disambiguate the three packages all named "terraform". Two smaller updates land alongside: `review-pr` corrects its pass count from five to six (Pass 6 — Architecture boundaries — already existed in the file), and `test-engineer` relaxes the mandatory per-case confirmation ceremony in favour of writing a full test suite in one pass.
>
> The removal of the `Co-Authored-By` trailer instruction from `address-pr-feedback` is the one behavioural change that affects commit output, and it is intentional.
>
> Reviewed by Claude for commit `1edb7499`.

<!-- /claude-code-review:summary -->
