### PR TITLE
chore(tests): remove dead test stubs for GetTemplateData and sanitizeForK8s

### DIFF
--- a/pkg/composer/artifact/artifact_public_test.go
+++ b/pkg/composer/artifact/artifact_public_test.go
@@ -2696,14 +2696,6 @@ func TestArtifactBuilder_Bundle_EmitsArtifactManifest(t *testing.T) {
 	})
 }
 
-func TestArtifactBuilder_GetTemplateData_Removed(t *testing.T) {
-	t.Skip("GetTemplateData has been removed - functionality now handled by Pull + reading from cache directories")
-}
-
-func TestArtifactBuilder_GetTemplateData_Old_Removed(t *testing.T) {
-	t.Skip("GetTemplateData has been removed - entire test function removed")
-}
-
 func TestArtifactBuilder_GetCacheDir(t *testing.T) {
 	setup := func(t *testing.T) (*ArtifactBuilder, *ArtifactMocks) {
 		t.Helper()

--- a/pkg/composer/artifact/mock_artifact_test.go
+++ b/pkg/composer/artifact/mock_artifact_test.go
@@ -258,11 +258,6 @@ func TestMockArtifact_Pull(t *testing.T) {
 	})
 }
 
-// TestMockArtifact_GetTemplateData tests the GetTemplateData method of MockArtifact
-func TestMockArtifact_GetTemplateData_Removed(t *testing.T) {
-	t.Skip("GetTemplateData has been removed from MockArtifact")
-}
-
 // TestMockArtifact_ParseOCIRef tests the ParseOCIRef method of MockArtifact
 func TestMockArtifact_ParseOCIRef(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {

--- a/pkg/runtime/env/terraform_env_test.go
+++ b/pkg/runtime/env/terraform_env_test.go
@@ -850,62 +850,6 @@ func TestTerraformEnv_PostEnvHook(t *testing.T) {
 	})
 }
 
-func TestTerraformEnv_sanitizeForK8s(t *testing.T) {
-	tests := []struct {
-		name     string
-		input    string
-		expected string
-	}{
-		{
-			name:     "Lowercase and valid characters",
-			input:    "valid-name",
-			expected: "valid-name",
-		},
-		{
-			name:     "Uppercase characters",
-			input:    "VALID-NAME",
-			expected: "valid-name",
-		},
-		{
-			name:     "Underscores to hyphens",
-			input:    "valid_name",
-			expected: "valid-name",
-		},
-		{
-			name:     "Invalid characters",
-			input:    "valid@name!",
-			expected: "valid-name",
-		},
-		{
-			name:     "Consecutive hyphens",
-			input:    "valid--name",
-			expected: "valid-name",
-		},
-		{
-			name:     "Leading and trailing hyphens",
-			input:    "-valid-name-",
-			expected: "valid-name",
-		},
-		{
-			name:     "Exceeds max length",
-			input:    "a-very-long-name-that-exceeds-the-sixty-three-character-limit-should-be-truncated",
-			expected: "a-very-long-name-that-exceeds-the-sixty-three-character-limit-s",
-		},
-		{
-			name:     "Empty input",
-			input:    "",
-			expected: "",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			// Note: sanitizeForK8s is now in the terraform package, this test should be moved there
-			t.Skip("sanitizeForK8s moved to terraform package - test should be moved there")
-		})
-	}
-}
-
 // TestTerraformEnv_generateBackendOverrideTf - UPDATED
 // The generateBackendOverrideTf method has been moved to terraform.TerraformProvider.GenerateBackendOverride.
 // This test now verifies PostEnvHook which calls the provider's GenerateBackendOverride.


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This PR removes dead test stubs that were unconditionally skipped, touching only test files with no production code changes.
>
> **Overview**
>
> The change deletes four test functions across three files: two `t.Skip`-only stubs for `GetTemplateData` in `artifact_public_test.go` and `mock_artifact_test.go`, one stub for `GetTemplateData` on `MockArtifact`, and the `TestTerraformEnv_sanitizeForK8s` table-driven test whose every sub-case immediately called `t.Skip`. All removed functions were placeholders left behind after the corresponding production methods were relocated or deleted in earlier commits, providing no test coverage. The deletion is purely subtractive with no behavioral impact.
>
> Reviewed by Claude for commit `1745c287`.

<!-- /claude-code-review:summary -->
