### PR TITLE
fix(provisioner): skip Kubernetes reachability check in Stage 2 after cluster destruction

### DIFF
--- a/pkg/provisioner/destroy.go
+++ b/pkg/provisioner/destroy.go
@@ -53,7 +53,12 @@ type DestroyResult struct {
 // collected rather than aborting the loop; the backend tier is only attempted
 // when Stage 1 produced zero failures, to avoid destroying the state store
 // while other components still depend on it. The tier-deferred flag on the
-// result signals when Stage 2 was skipped for this reason.
+// result signals when Stage 2 was skipped for this reason. Stage 2's tier
+// destroy skips the Kubernetes-reachability preflight: Stage 1 has, by
+// design, already destroyed the cluster (it is never a tier member), so an
+// unreachable API at this point is the expected state, not a broken-auth
+// signal, and the backend tier never has a kubernetes/helm provider
+// dependency for the check to protect.
 func (i *Provisioner) Teardown(blueprint *blueprintv1alpha1.Blueprint, terraformOnly bool, continueOnError bool) (DestroyResult, error) {
 	var result DestroyResult
 	backendType := i.configHandler.GetString("terraform.backend.type", "local")
@@ -94,7 +99,7 @@ func (i *Provisioner) Teardown(blueprint *blueprintv1alpha1.Blueprint, terraform
 		if err != nil {
 			return err
 		}
-		tierResult, destroyErr := i.DestroyAllTerraform(tierBP, continueOnError)
+		tierResult, destroyErr := i.destroyAllTerraform(tierBP, continueOnError, false)
 		result.Destroyed = append(result.Destroyed, tierResult.Destroyed...)
 		result.Skipped = mergeSkipped(result.Skipped, mergeSkipped(migrationSkipped, tierResult.Skipped))
 		result.Failed = append(result.Failed, tierResult.Failed...)

--- a/pkg/provisioner/destroy_test.go
+++ b/pkg/provisioner/destroy_test.go
@@ -1,6 +1,7 @@
 package provisioner
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"os"
@@ -225,6 +226,57 @@ func TestProvisioner_Teardown(t *testing.T) {
 		stage2Components := destroyAllBlueprints[1].TerraformComponents
 		if len(stage2Components) != 1 || stage2Components[0].Path != "backend" {
 			t.Errorf("Stage 2 DestroyAll should target tier [backend], got %#v", stage2Components)
+		}
+	})
+
+	t.Run("Stage2SkipsReachabilityCheckAfterClusterAlreadyDestroyed", func(t *testing.T) {
+		// Stage 1 destroys the cluster component itself (it is never a tier
+		// member), so by the time Stage 2 runs the kubeconfig on disk is stale
+		// and WaitForKubernetesHealthy fails against a host that no longer
+		// exists. That is the expected post-Stage-1 state, not broken auth —
+		// Stage 2's tier-only destroy must still proceed.
+		mocks := setupProvisionerMocks(t)
+		bp := &blueprintv1alpha1.Blueprint{
+			Backend:  "backend",
+			Metadata: blueprintv1alpha1.Metadata{Name: "test"},
+			TerraformComponents: []blueprintv1alpha1.TerraformComponent{
+				{Path: "backend"},
+				{Path: "cluster"},
+			},
+		}
+		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockCH.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "terraform.backend.type" {
+				return "s3"
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
+		mockCH.SetFunc = func(_ string, _ any) error { return nil }
+		destroyAllCalls := 0
+		mockStack := terraforminfra.NewMockStack()
+		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyOutcome, error) {
+			destroyAllCalls++
+			return terraforminfra.DestroyOutcome{}, nil
+		}
+		// Stage 1's own reachability check must still pass (the cluster is still up
+		// going into Stage 1); only once Stage 1's DestroyAll has torn it down does
+		// the kubeconfig on disk go stale, which is what Stage 2 must tolerate.
+		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
+			if destroyAllCalls == 0 {
+				return nil
+			}
+			return fmt.Errorf("dial tcp: lookup cluster-w0820el4.hcp.eastus.azmk8s.io: no such host")
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack})
+
+		if _, err := provisioner.Teardown(bp, true, false); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if destroyAllCalls != 2 {
+			t.Errorf("Expected Stage 1 + Stage 2 DestroyAll calls (2), got %d", destroyAllCalls)
 		}
 	})
 

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -389,6 +389,15 @@ func (i *Provisioner) Down(blueprint *blueprintv1alpha1.Blueprint) error {
 // "these were no-ops" alongside "these were destroyed". Runs checkKubernetesReachableForDestroy
 // once terraform is confirmed enabled.
 func (i *Provisioner) DestroyAllTerraform(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyResult, error) {
+	return i.destroyAllTerraform(blueprint, continueOnError, true, excludeIDs...)
+}
+
+// destroyAllTerraform is the shared implementation behind DestroyAllTerraform. checkReachability
+// is false only for Teardown's Stage 2 tier destroy: by the time Stage 2 runs, Stage 1 has
+// already destroyed the cluster by design, so an unreachable Kubernetes API is the expected state
+// rather than a signal of broken auth, and the backend tier never has a kubernetes/helm provider
+// dependency for the check to protect.
+func (i *Provisioner) destroyAllTerraform(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, checkReachability bool, excludeIDs ...string) (DestroyResult, error) {
 	var result DestroyResult
 	if blueprint == nil {
 		return result, fmt.Errorf("blueprint not provided")
@@ -399,8 +408,10 @@ func (i *Provisioner) DestroyAllTerraform(blueprint *blueprintv1alpha1.Blueprint
 	if i.TerraformStack == nil {
 		return result, fmt.Errorf("terraform is disabled")
 	}
-	if err := i.checkKubernetesReachableForDestroy(); err != nil {
-		return result, err
+	if checkReachability {
+		if err := i.checkKubernetesReachableForDestroy(); err != nil {
+			return result, err
+		}
 	}
 	outcome, err := i.TerraformStack.DestroyAll(blueprint, continueOnError, excludeIDs...)
 	result.Destroyed = outcome.Destroyed


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change touches only the provisioner's destroy path — a well-isolated teardown flow — and the fix is a narrowly scoped opt-out of a preflight check that is structurally guaranteed to fail in the affected call-site.
>
> **Overview**
>
> The PR fixes a spurious error in `Teardown`'s Stage 2 tier destroy: Stage 1 always destroys the cluster component first (it is never a tier member), which leaves the kubeconfig pointing at a host that no longer exists. The Kubernetes reachability preflight in `DestroyAllTerraform` then fails on this stale endpoint, aborting Stage 2 even though the failure is expected and harmless. The fix splits the public `DestroyAllTerraform` into a thin shim and a private `destroyAllTerraform` that accepts a `checkReachability` bool; Stage 2 passes `false`, all other callers continue to pass `true` via the shim.
>
> The new test accurately models the call sequence — reachability succeeds before Stage 1 runs and fails afterwards — and asserts that both DestroyAll calls are made, confirming Stage 2 is no longer blocked.
>
> Reviewed by Claude for commit `c4bba3be`.

<!-- /claude-code-review:summary -->
