### PR TITLE
fix(tools): require terraform >= 1.12.2

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Install Terraform (integration tests)
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1 renovate: depName=hashicorp/setup-terraform
         with:
-          terraform_version: "1.9.8" # 1.9.x line: OpenTofu migration-compatible per OpenTofu docs; satisfies CLI min 1.7.0
+          terraform_version: "1.12.2" # satisfies CLI min 1.12.2
           terraform_wrapper: false
 
       - name: Install Docker CLI (macOS)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -203,7 +203,7 @@ const MinimumVersionLima = "1.0.0"
 // Lima 1.x can hang after "Terminal is not available"; 2.0.3+ is required for reliable colima+incus startup.
 const MinimumVersionLimaIncus = "2.0.3"
 
-const MinimumVersionTerraform = "1.7.0"
+const MinimumVersionTerraform = "1.12.2"
 
 const MinimumVersion1Password = "2.15.0"
 

--- a/pkg/runtime/tools/registry_test.go
+++ b/pkg/runtime/tools/registry_test.go
@@ -3,6 +3,8 @@ package tools
 import (
 	"strings"
 	"testing"
+
+	"github.com/windsorcli/cli/pkg/constants"
 )
 
 // =============================================================================
@@ -22,7 +24,7 @@ func TestMissingToolError(t *testing.T) {
 		// — the exact pieces operators need to resolve the failure via the vendor's own
 		// install instructions (which encode platform-specific nuance we don't replicate).
 		msg := err.Error()
-		expected := []string{"Terraform", "1.7.0", "https://developer.hashicorp.com/terraform/install", "not found on PATH"}
+		expected := []string{"Terraform", constants.MinimumVersionTerraform, "https://developer.hashicorp.com/terraform/install", "not found on PATH"}
 		for _, want := range expected {
 			if !strings.Contains(msg, want) {
 				t.Errorf("expected error to contain %q, got: %s", want, msg)


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Isolated constant update to a single version floor; affects only users running Terraform below 1.12.2, who were already broken by a deeper terraform-init error.
>
> **Overview**
>
> This PR raises the CLI's minimum required Terraform version from 1.7.0 to 1.12.2 to match the `required_version` constraint now declared in the upstream core modules. Without this change, `windsor up` would fail deep inside `terraform init` with an opaque "Unsupported Terraform Core version" message rather than a clear pre-flight error. The companion test change replaces a hardcoded version string with `constants.MinimumVersionTerraform`, eliminating the risk of the test drifting from the real floor in the future.
>
> Reviewed by Claude for commit `c2facf73`.

<!-- /claude-code-review:summary -->
