### PR TITLE
feat(runtime): add support for Hetzner platform

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -373,7 +373,7 @@ func confirmBootstrapIfContextExists(in io.Reader, configRoot, contextName strin
 }
 
 func init() {
-	bootstrapCmd.Flags().StringVar(&bootstrapPlatform, "platform", "", "Target platform: none, metal, docker, aws, azure, gcp, hyperv, vsphere.")
+	bootstrapCmd.Flags().StringVar(&bootstrapPlatform, "platform", "", "Target platform: none, docker, incus, metal, hetzner, aws, azure, gcp, hyperv, vsphere.")
 	bootstrapCmd.Flags().StringVar(&bootstrapBlueprint, "blueprint", "", "Blueprint OCI reference. Accepts oci://host/org/repo:tag, host/org/repo:tag, or org/repo:tag (host defaults to ghcr.io). Tag is required.")
 	bootstrapCmd.Flags().StringSliceVar(&bootstrapSetFlags, "set", []string{}, "Override config values, e.g. --set dns.enabled=false. May be repeated.")
 	bootstrapCmd.Flags().BoolVarP(&bootstrapYes, "yes", "y", false, "Skip all confirmation prompts.")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -205,7 +205,7 @@ func init() {
 	initCmd.Flags().StringVar(&initArch, "vm-arch", "", "CPU architecture for the workstation VM.")
 	initCmd.Flags().BoolVar(&initDocker, "docker", false, "Enable Docker.")
 	initCmd.Flags().BoolVar(&initGitLivereload, "git-livereload", false, "Enable git livereload.")
-	initCmd.Flags().StringVar(&initPlatform, "platform", "", "Target platform: none, metal, docker, aws, azure, gcp, hyperv, vsphere.")
+	initCmd.Flags().StringVar(&initPlatform, "platform", "", "Target platform: none, docker, incus, metal, hetzner, aws, azure, gcp, hyperv, vsphere.")
 	initCmd.Flags().StringVar(&initBlueprint, "blueprint", "", "Blueprint OCI reference or local path.")
 	initCmd.Flags().StringVar(&initEndpoint, "endpoint", "", "Kubernetes API endpoint.")
 	initCmd.Flags().StringSliceVar(&initSetFlags, "set", []string{}, "Override config values, e.g. --set dns.enabled=false. May be repeated.")

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -214,7 +214,7 @@ func buildUpFlagOverrides() (map[string]any, error) {
 func init() {
 	upCmd.Flags().BoolVar(&waitFlag, "wait", false, "Wait for kustomization resources to be ready.")
 	upCmd.Flags().StringVar(&upVmDriver, "vm-driver", "", "VM driver: colima, colima-incus, docker-desktop, docker.")
-	upCmd.Flags().StringVar(&upPlatform, "platform", "", "Target platform: none, metal, docker, aws, azure, gcp, hyperv, vsphere.")
+	upCmd.Flags().StringVar(&upPlatform, "platform", "", "Target platform: none, docker, incus, metal, hetzner, aws, azure, gcp, hyperv, vsphere.")
 	upCmd.Flags().StringVar(&upBlueprint, "blueprint", "", "Blueprint OCI reference or local path.")
 	upCmd.Flags().StringSliceVar(&upSetFlags, "set", []string{}, "Override config values, e.g. --set dns.enabled=false. May be repeated.")
 	rootCmd.AddCommand(upCmd)

--- a/cmd/workstation_defaults.go
+++ b/cmd/workstation_defaults.go
@@ -22,8 +22,8 @@ import (
 //
 //   - aws   → s3       (S3 is the canonical state store on AWS)
 //   - azure → azurerm  (Azure Blob Storage via the azurerm backend)
-//   - metal, docker, incus → kubernetes  (the cluster IS the state store;
-//     each component's state lives as a Secret in the cluster it manages)
+//   - metal, docker, incus, hetzner → kubernetes  (the cluster IS the state
+//     store; each component's state lives as a Secret in the cluster it manages)
 //
 // The default only kicks in when terraform.backend.type is absent from
 // overrides, so explicit --set values (which are merged into the same map by
@@ -60,7 +60,7 @@ func applyWorkstationFlagOverrides(overrides map[string]any, vmDriver, platform 
 			overrides["terraform.backend.type"] = "s3"
 		case "azure":
 			overrides["terraform.backend.type"] = "azurerm"
-		case "metal", "docker", "incus":
+		case "metal", "docker", "incus", "hetzner":
 			overrides["terraform.backend.type"] = "kubernetes"
 		}
 	}

--- a/cmd/workstation_defaults.go
+++ b/cmd/workstation_defaults.go
@@ -20,10 +20,16 @@ import (
 // fills in a sensible default for terraform.backend.type when one isn't already
 // set in the override map:
 //
-//   - aws   → s3       (S3 is the canonical state store on AWS)
-//   - azure → azurerm  (Azure Blob Storage via the azurerm backend)
-//   - metal, docker, incus, hetzner → kubernetes  (the cluster IS the state
-//     store; each component's state lives as a Secret in the cluster it manages)
+//   - aws     → s3       (S3 is the canonical state store on AWS)
+//   - hetzner → s3       (Hetzner Object Storage is S3-API-compatible;
+//     avoids the kubernetes backend's bootstrap-ordering complexity, since
+//     state lives in a bucket rather than the cluster being provisioned.
+//     The endpoint override, S3Backend compatibility flags, and Object
+//     Storage credentials still require operator/facet configuration —
+//     this default only selects the backend type)
+//   - azure   → azurerm  (Azure Blob Storage via the azurerm backend)
+//   - metal, docker, incus → kubernetes  (the cluster IS the state store;
+//     each component's state lives as a Secret in the cluster it manages)
 //
 // The default only kicks in when terraform.backend.type is absent from
 // overrides, so explicit --set values (which are merged into the same map by
@@ -56,11 +62,11 @@ func applyWorkstationFlagOverrides(overrides map[string]any, vmDriver, platform 
 
 	if _, set := overrides["terraform.backend.type"]; !set {
 		switch overrides["platform"] {
-		case "aws":
+		case "aws", "hetzner":
 			overrides["terraform.backend.type"] = "s3"
 		case "azure":
 			overrides["terraform.backend.type"] = "azurerm"
-		case "metal", "docker", "incus", "hetzner":
+		case "metal", "docker", "incus":
 			overrides["terraform.backend.type"] = "kubernetes"
 		}
 	}

--- a/cmd/workstation_defaults_test.go
+++ b/cmd/workstation_defaults_test.go
@@ -186,6 +186,21 @@ func TestApplyWorkstationFlagOverrides(t *testing.T) {
 		}
 	})
 
+	t.Run("HetznerPlatformDefaultsBackendToKubernetes", func(t *testing.T) {
+		// Given --platform hetzner, same kubernetes-backend default applies as
+		// metal/docker/incus — Hetzner Cloud has no managed Kubernetes offering,
+		// so the Talos cluster Windsor provisions is also the state store.
+		overrides := map[string]any{}
+
+		// When the helper is applied
+		applyWorkstationFlagOverrides(overrides, "", "hetzner")
+
+		// Then terraform.backend.type defaults to "kubernetes"
+		if overrides["terraform.backend.type"] != "kubernetes" {
+			t.Errorf("Expected terraform.backend.type=kubernetes, got %v", overrides["terraform.backend.type"])
+		}
+	})
+
 	t.Run("VmDriverInferenceFlowsThroughToBackendDefault", func(t *testing.T) {
 		// Given --vm-driver docker-desktop with no --platform, the helper infers
 		// platform=docker, and the backend default must then key off that inferred

--- a/cmd/workstation_defaults_test.go
+++ b/cmd/workstation_defaults_test.go
@@ -186,18 +186,21 @@ func TestApplyWorkstationFlagOverrides(t *testing.T) {
 		}
 	})
 
-	t.Run("HetznerPlatformDefaultsBackendToKubernetes", func(t *testing.T) {
-		// Given --platform hetzner, same kubernetes-backend default applies as
-		// metal/docker/incus — Hetzner Cloud has no managed Kubernetes offering,
-		// so the Talos cluster Windsor provisions is also the state store.
+	t.Run("HetznerPlatformDefaultsBackendToS3", func(t *testing.T) {
+		// Given --platform hetzner and no explicit terraform.backend.type override.
+		// Hetzner Object Storage is S3-API-compatible, so "s3" is the default rather
+		// than "kubernetes" — this avoids the in-cluster backend's bootstrap-ordering
+		// complexity. The endpoint override, S3Backend compatibility flags, and
+		// Object Storage credentials still require operator/facet configuration;
+		// this default only selects the backend type.
 		overrides := map[string]any{}
 
 		// When the helper is applied
 		applyWorkstationFlagOverrides(overrides, "", "hetzner")
 
-		// Then terraform.backend.type defaults to "kubernetes"
-		if overrides["terraform.backend.type"] != "kubernetes" {
-			t.Errorf("Expected terraform.backend.type=kubernetes, got %v", overrides["terraform.backend.type"])
+		// Then terraform.backend.type defaults to "s3"
+		if overrides["terraform.backend.type"] != "s3" {
+			t.Errorf("Expected terraform.backend.type=s3, got %v", overrides["terraform.backend.type"])
 		}
 	})
 

--- a/docs/reference/commands/bootstrap.md
+++ b/docs/reference/commands/bootstrap.md
@@ -25,7 +25,7 @@ Re-running on an existing context prompts for confirmation. Pass --yes (or -y) t
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--blueprint` | `""` | Blueprint OCI reference. Accepts oci://host/org/repo:tag, host/org/repo:tag, or org/repo:tag (host defaults to ghcr.io). Tag is required. |
-| `--platform` | `""` | Target platform: none, metal, docker, aws, azure, gcp, hyperv, vsphere. |
+| `--platform` | `""` | Target platform: none, docker, incus, metal, hetzner, aws, azure, gcp, hyperv, vsphere. |
 | `--set` | `[]` | Override config values, e.g. --set dns.enabled=false. May be repeated. |
 | `-y`, `--yes` | `false` | Skip all confirmation prompts. |
 

--- a/docs/reference/commands/init.md
+++ b/docs/reference/commands/init.md
@@ -25,7 +25,7 @@ The directory must be a git repository — init refuses to run in an empty or no
 | `--docker` | `false` | Enable Docker. |
 | `--endpoint` | `""` | Kubernetes API endpoint. |
 | `--git-livereload` | `false` | Enable git livereload. |
-| `--platform` | `""` | Target platform: none, metal, docker, aws, azure, gcp, hyperv, vsphere. |
+| `--platform` | `""` | Target platform: none, docker, incus, metal, hetzner, aws, azure, gcp, hyperv, vsphere. |
 | `--reset` | `false` | Overwrite existing files and clean .terraform. |
 | `--set` | `[]` | Override config values, e.g. --set dns.enabled=false. May be repeated. |
 | `--vm-arch` | `""` | CPU architecture for the workstation VM. |

--- a/docs/reference/commands/up.md
+++ b/docs/reference/commands/up.md
@@ -19,7 +19,7 @@ If any host-side network or DNS configuration was deferred (because it requires 
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--blueprint` | `""` | Blueprint OCI reference or local path. |
-| `--platform` | `""` | Target platform: none, metal, docker, aws, azure, gcp, hyperv, vsphere. |
+| `--platform` | `""` | Target platform: none, docker, incus, metal, hetzner, aws, azure, gcp, hyperv, vsphere. |
 | `--set` | `[]` | Override config values, e.g. --set dns.enabled=false. May be repeated. |
 | `--vm-driver` | `""` | VM driver: colima, colima-incus, docker-desktop, docker. |
 | `--wait` | `false` | Wait for kustomization resources to be ready. |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -33,7 +33,7 @@ system-managed and not covered here.
 | `git` | `object` | Git / livereload configuration. |
 | `id` | `string` | Stable identifier for the context, distinct from its map key. Used for cross-context references where the key may change. |
 | `network` | `object` | Cluster network configuration. |
-| `platform` | `string` | Target deployment platform. Selects platform-specific facets and drives backend type inference. One of: `none`, `docker`, `incus`, `metal`, `aws`, `azure`, `gcp`, `hyperv`, `vsphere`. |
+| `platform` | `string` | Target deployment platform. Selects platform-specific facets and drives backend type inference. One of: `none`, `docker`, `incus`, `metal`, `hetzner`, `aws`, `azure`, `gcp`, `hyperv`, `vsphere`. |
 | `provider` | `string` | Deprecated alias for 'platform'. New configs should use 'platform'; the loader still reads 'provider' for backwards compatibility. |
 | `secrets` | `object` | Secrets provider configuration. Currently 1Password is the only supported provider. |
 | `terraform` | `object` | Per-context Terraform settings (state backend, lock policy, timeout). The runtime-validator sub-types (BackendConfig, LockConfig) are authored in api/v1alpha1/terraform/terraform_config.go; expansion to full field detail is a planned follow-up. |

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -509,6 +509,29 @@ func TestInit_PlatformMetalDefaultsBackendTypeToKubernetes(t *testing.T) {
 	}
 }
 
+// TestInit_PlatformHetznerDefaultsBackendTypeToKubernetes mirrors the metal test for the
+// hetzner platform. Hetzner Cloud has no managed Kubernetes offering, so the Talos cluster
+// Windsor provisions is also the natural state store, same as metal/docker/incus.
+func TestInit_PlatformHetznerDefaultsBackendTypeToKubernetes(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"init", "hetzner-test", "--platform", "hetzner", "--set", "dns.enabled=false"}, env)
+	if err != nil {
+		t.Logf("init exited: %v (tolerated)\nstdout: %s\nstderr: %s", err, stdout, stderr)
+	}
+
+	valuesPath := filepath.Join(dir, "contexts", "hetzner-test", "values.yaml")
+	data, readErr := os.ReadFile(valuesPath)
+	if readErr != nil {
+		t.Fatalf("expected values.yaml at %s, got %v\nstdout: %s\nstderr: %s", valuesPath, readErr, stdout, stderr)
+	}
+	body := string(data)
+	if !strings.Contains(body, "terraform:") || !strings.Contains(body, "type: kubernetes") {
+		t.Errorf("expected terraform.backend.type=kubernetes persisted for --platform hetzner, got values.yaml:\n%s", body)
+	}
+}
+
 // TestInit_UnmappedPlatformDoesNotDefaultBackendType confirms that platforms
 // outside the supported default mapping (currently gcp, pending GCS schema work)
 // leave terraform.backend.type unset in values.yaml — operators must configure

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -509,10 +509,12 @@ func TestInit_PlatformMetalDefaultsBackendTypeToKubernetes(t *testing.T) {
 	}
 }
 
-// TestInit_PlatformHetznerDefaultsBackendTypeToKubernetes mirrors the metal test for the
-// hetzner platform. Hetzner Cloud has no managed Kubernetes offering, so the Talos cluster
-// Windsor provisions is also the natural state store, same as metal/docker/incus.
-func TestInit_PlatformHetznerDefaultsBackendTypeToKubernetes(t *testing.T) {
+// TestInit_PlatformHetznerDefaultsBackendTypeToS3 confirms --platform hetzner defaults
+// terraform.backend.type to "s3" rather than "kubernetes". Hetzner Object Storage is
+// S3-API-compatible, and using it avoids the in-cluster backend's bootstrap-ordering
+// complexity; the endpoint override, S3Backend compatibility flags, and Object Storage
+// credentials still require operator/facet configuration beyond this default.
+func TestInit_PlatformHetznerDefaultsBackendTypeToS3(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
 	helpers.MarkAsGitRepo(t, dir)
@@ -527,8 +529,8 @@ func TestInit_PlatformHetznerDefaultsBackendTypeToKubernetes(t *testing.T) {
 		t.Fatalf("expected values.yaml at %s, got %v\nstdout: %s\nstderr: %s", valuesPath, readErr, stdout, stderr)
 	}
 	body := string(data)
-	if !strings.Contains(body, "terraform:") || !strings.Contains(body, "type: kubernetes") {
-		t.Errorf("expected terraform.backend.type=kubernetes persisted for --platform hetzner, got values.yaml:\n%s", body)
+	if !strings.Contains(body, "terraform:") || !strings.Contains(body, "type: s3") {
+		t.Errorf("expected terraform.backend.type=s3 persisted for --platform hetzner, got values.yaml:\n%s", body)
 	}
 }
 

--- a/pkg/runtime/config/resolve.go
+++ b/pkg/runtime/config/resolve.go
@@ -63,7 +63,7 @@ func (c *configHandler) applyPlatformDerivedDefaults(values map[string]any) {
 	}
 
 	switch platform {
-	case "docker", "incus", "metal", "omni", "hyperv", "vsphere":
+	case "docker", "incus", "metal", "hetzner", "omni", "hyperv", "vsphere":
 		c.setDerivedValueIfMissing(values, "cluster.driver", "talos")
 	case "aws":
 		c.setDerivedValueIfMissing(values, "cluster.driver", "eks")

--- a/pkg/runtime/config/resolve_test.go
+++ b/pkg/runtime/config/resolve_test.go
@@ -285,6 +285,26 @@ func TestConfigHandler_GetContextValues_Resolve(t *testing.T) {
 		}
 	})
 
+	t.Run("DerivesTalosDriverFromHetznerPlatform", func(t *testing.T) {
+		handler, _ := setupPrivateTestHandler(t)
+		if err := handler.Set("platform", "hetzner"); err != nil {
+			t.Fatalf("Expected no error setting platform, got %v", err)
+		}
+
+		values, err := handler.GetContextValues()
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		clusterValues, ok := values["cluster"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected cluster map, got %T", values["cluster"])
+		}
+		if clusterValues["driver"] != "talos" {
+			t.Errorf("Expected cluster.driver=talos, got %v", clusterValues["driver"])
+		}
+	})
+
 	t.Run("DerivesCloudDriverFromPlatform", func(t *testing.T) {
 		handler, _ := setupPrivateTestHandler(t)
 		if err := handler.Set("platform", "azure"); err != nil {

--- a/pkg/runtime/config/schemas/artifacts/configuration.yaml
+++ b/pkg/runtime/config/schemas/artifacts/configuration.yaml
@@ -58,6 +58,7 @@ $defs:
           - docker
           - incus
           - metal
+          - hetzner
           - aws
           - azure
           - gcp

--- a/pkg/runtime/config/schemas/common.yaml
+++ b/pkg/runtime/config/schemas/common.yaml
@@ -8,6 +8,7 @@ properties:
       - docker
       - incus
       - metal
+      - hetzner
       - aws
       - azure
       - gcp

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1633,7 +1633,7 @@ func TestRuntime_ApplyConfigDefaults(t *testing.T) {
 	})
 
 	t.Run("SkipsWorkstationRuntimeDefaultWhenPlatformIsNonWorkstationViaFlagOverride", func(t *testing.T) {
-		for _, platform := range []string{"aws", "azure", "gcp", "metal", "none", "hyperv"} {
+		for _, platform := range []string{"aws", "azure", "gcp", "metal", "hetzner", "none", "hyperv"} {
 			t.Run(platform, func(t *testing.T) {
 				mocks := setupRuntimeMocks(t)
 				rt := mocks.Runtime
@@ -1668,7 +1668,7 @@ func TestRuntime_ApplyConfigDefaults(t *testing.T) {
 	})
 
 	t.Run("SkipsWorkstationRuntimeDefaultWhenPlatformIsNonWorkstationViaSavedConfig", func(t *testing.T) {
-		for _, platform := range []string{"aws", "azure", "gcp", "metal", "none", "hyperv"} {
+		for _, platform := range []string{"aws", "azure", "gcp", "metal", "hetzner", "none", "hyperv"} {
 			t.Run(platform, func(t *testing.T) {
 				mocks := setupRuntimeMocks(t)
 				rt := mocks.Runtime


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Adds `hetzner` as a supported `--platform` value; the change is purely additive and does not affect any existing platform.
>
> **Overview**
>
> The PR registers Hetzner Cloud as a first-class platform alongside `metal`, `docker`, and `incus`. It wires up the two key defaults for that platform: `cluster.driver=talos` (in `pkg/runtime/config/resolve.go`) and `terraform.backend.type=kubernetes` (in `cmd/workstation_defaults.go`), reflecting that Hetzner has no managed Kubernetes offering and the provisioned Talos cluster doubles as the state store. Flag help text, reference docs, and both YAML schemas are updated consistently, and the change is covered by new unit tests in `workstation_defaults_test.go` and `resolve_test.go` plus an integration test in `integration/init_test.go`.
>
> Reviewed by Claude for commit `f20c6f1a`.

<!-- /claude-code-review:summary -->
