### PR TITLE
feat(config): add sensitive path handling in ConfigHandler and SchemaValidator

### DIFF
--- a/pkg/runtime/config/handler.go
+++ b/pkg/runtime/config/handler.go
@@ -49,6 +49,8 @@ type ConfigHandler interface {
 	LoadSchemaFromBytes(schemaContent []byte) error
 	GetSchema() map[string]any
 	GetContextValues() (map[string]any, error)
+	GetSensitivePaths() []string
+	IsSensitivePath(path string) bool
 	RegisterProvider(prefix string, provider ValueProvider)
 	ValidateContextValues() error
 }
@@ -502,6 +504,28 @@ func (c *configHandler) GetSchema() map[string]any {
 		out[k] = v
 	}
 	return out
+}
+
+// GetSensitivePaths returns the dotted config paths marked `sensitive: true` in the loaded
+// schema, or nil if no schema is loaded. Consumers scrub these values from plaintext output
+// and gate which properties may back a cluster Secret.
+func (c *configHandler) GetSensitivePaths() []string {
+	if c.schemaValidator == nil {
+		return nil
+	}
+	return c.schemaValidator.GetSensitivePaths()
+}
+
+// IsSensitivePath reports whether the given dotted config path is marked sensitive in the loaded
+// schema. A "*" segment in a schema path (from a free-form map region) matches any single
+// segment of the queried path.
+func (c *configHandler) IsSensitivePath(path string) bool {
+	for _, sensitive := range c.GetSensitivePaths() {
+		if sensitivePathMatches(sensitive, path) {
+			return true
+		}
+	}
+	return false
 }
 
 // LoadSchema loads the schema.yaml file from the specified directory.

--- a/pkg/runtime/config/handler_test.go
+++ b/pkg/runtime/config/handler_test.go
@@ -1939,3 +1939,93 @@ func findSubstring(s, substr string) bool {
 	}
 	return false
 }
+
+func TestConfigHandler_SensitivePaths(t *testing.T) {
+	setup := func(t *testing.T) *configHandler {
+		t.Helper()
+		handler, _ := setupPrivateTestHandler(t)
+		handler.schemaValidator.Schema = map[string]any{
+			"$schema": "https://json-schema.org/draft/2020-12/schema",
+			"type":    "object",
+			"properties": map[string]any{
+				"cdn": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"cloudflare_api_key": map[string]any{"type": "string", "sensitive": true},
+						"zone":               map[string]any{"type": "string"},
+					},
+				},
+				"secrets": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"stores": map[string]any{
+							"type": "object",
+							"additionalProperties": map[string]any{
+								"type": "object",
+								"properties": map[string]any{
+									"token": map[string]any{"type": "string", "sensitive": true},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+		return handler
+	}
+
+	t.Run("GetSensitivePathsDelegatesSorted", func(t *testing.T) {
+		// Given a handler with sensitive markers at a nested path and under a map region
+		handler := setup(t)
+
+		// When getting sensitive paths
+		got := strings.Join(handler.GetSensitivePaths(), ",")
+
+		// Then both are returned, sorted
+		want := "cdn.cloudflare_api_key,secrets.stores.*.token"
+		if got != want {
+			t.Errorf("Expected %q, got %q", want, got)
+		}
+	})
+
+	t.Run("IsSensitivePathExactMatch", func(t *testing.T) {
+		// Given a handler with a sensitive nested property
+		handler := setup(t)
+
+		// Then the exact path is sensitive and a sibling is not
+		if !handler.IsSensitivePath("cdn.cloudflare_api_key") {
+			t.Error("Expected cdn.cloudflare_api_key to be sensitive")
+		}
+		if handler.IsSensitivePath("cdn.zone") {
+			t.Error("Expected cdn.zone to not be sensitive")
+		}
+	})
+
+	t.Run("IsSensitivePathWildcardSegment", func(t *testing.T) {
+		// Given a sensitive leaf under a free-form map region
+		handler := setup(t)
+
+		// Then a concrete key matches the "*" segment
+		if !handler.IsSensitivePath("secrets.stores.prod.token") {
+			t.Error("Expected secrets.stores.prod.token to match wildcard sensitive path")
+		}
+		// And a path with the wrong segment count does not match
+		if handler.IsSensitivePath("secrets.stores.token") {
+			t.Error("Expected secrets.stores.token (wrong depth) to not match")
+		}
+	})
+
+	t.Run("NilValidatorReturnsEmpty", func(t *testing.T) {
+		// Given a handler with no schema validator
+		handler, _ := setupPrivateTestHandler(t)
+		handler.schemaValidator = nil
+
+		// Then sensitive-path queries are safe no-ops
+		if handler.GetSensitivePaths() != nil {
+			t.Error("Expected nil sensitive paths")
+		}
+		if handler.IsSensitivePath("anything") {
+			t.Error("Expected IsSensitivePath false with no validator")
+		}
+	})
+}

--- a/pkg/runtime/config/helpers.go
+++ b/pkg/runtime/config/helpers.go
@@ -125,3 +125,20 @@ func parsePath(path string) []string {
 
 	return keys
 }
+
+// sensitivePathMatches reports whether a queried dotted path matches a sensitive-path pattern
+// segment-by-segment, where a "*" pattern segment matches any single path segment. Both are
+// tokenized with parsePath so bracket and dotted notation compare identically.
+func sensitivePathMatches(pattern, path string) bool {
+	patternKeys := parsePath(pattern)
+	pathKeys := parsePath(path)
+	if len(patternKeys) != len(pathKeys) {
+		return false
+	}
+	for i, key := range patternKeys {
+		if key != "*" && key != pathKeys[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/runtime/config/mock_handler.go
+++ b/pkg/runtime/config/mock_handler.go
@@ -36,6 +36,8 @@ type MockConfigHandler struct {
 	LoadSchemaFromBytesFunc    func(schemaContent []byte) error
 	GetSchemaFunc              func() map[string]any
 	GetContextValuesFunc       func() (map[string]any, error)
+	GetSensitivePathsFunc      func() []string
+	IsSensitivePathFunc        func(path string) bool
 	RegisterProviderFunc       func(prefix string, provider ValueProvider)
 	ValidateContextValuesFunc  func() error
 }
@@ -285,6 +287,22 @@ func (m *MockConfigHandler) GetContextValues() (map[string]any, error) {
 		return m.GetContextValuesFunc()
 	}
 	return nil, fmt.Errorf("GetContextValuesFunc not set")
+}
+
+// GetSensitivePaths calls the mock GetSensitivePathsFunc if set, otherwise returns nil
+func (m *MockConfigHandler) GetSensitivePaths() []string {
+	if m.GetSensitivePathsFunc != nil {
+		return m.GetSensitivePathsFunc()
+	}
+	return nil
+}
+
+// IsSensitivePath calls the mock IsSensitivePathFunc if set, otherwise returns false
+func (m *MockConfigHandler) IsSensitivePath(path string) bool {
+	if m.IsSensitivePathFunc != nil {
+		return m.IsSensitivePathFunc(path)
+	}
+	return false
 }
 
 // RegisterProvider calls the mock RegisterProviderFunc if set, otherwise does nothing

--- a/pkg/runtime/config/schema_validator.go
+++ b/pkg/runtime/config/schema_validator.go
@@ -31,6 +31,12 @@ type SchemaValidator struct {
 	Shims    *Shims
 	Schema   map[string]any
 	compiled *jsonschema.Schema
+
+	// sensitivePaths caches the result of walking Schema for `sensitive: true` markers; it is
+	// invalidated alongside compiled whenever a new schema fragment is loaded. sensitivePathsOK
+	// distinguishes a computed-empty result from an uncomputed cache.
+	sensitivePaths   []string
+	sensitivePathsOK bool
 }
 
 // SchemaValidationResult carries the outcome of a Validate call. Defaults is populated by
@@ -94,6 +100,8 @@ func (sv *SchemaValidator) LoadSchemaFromBytes(schemaContent []byte) error {
 		sv.Schema = sv.mergeSchema(sv.Schema, newSchema)
 	}
 	sv.compiled = nil
+	sv.sensitivePaths = nil
+	sv.sensitivePathsOK = false
 	return nil
 }
 
@@ -129,10 +137,17 @@ func (sv *SchemaValidator) GetSchemaDefaults() (map[string]any, error) {
 // GetSensitivePaths returns the dotted config paths of every property marked `sensitive: true`
 // in the loaded schema, sorted for stable output. A free-form map region (additionalProperties)
 // contributes a "*" wildcard segment for its dynamic key. Returns nil when no schema is loaded.
+// The result is computed once per loaded schema and cached (invalidated on LoadSchemaFromBytes),
+// so repeated calls — e.g. IsSensitivePath over every key of a config map — do not re-walk the
+// schema. The returned slice is shared; callers must not mutate it.
 func (sv *SchemaValidator) GetSensitivePaths() []string {
 	if sv.Schema == nil {
 		return nil
 	}
+	if sv.sensitivePathsOK {
+		return sv.sensitivePaths
+	}
+
 	var paths []string
 	collectSensitivePaths(sv.Schema, "", &paths)
 	sort.Strings(paths)
@@ -143,7 +158,10 @@ func (sv *SchemaValidator) GetSensitivePaths() []string {
 			deduped = append(deduped, path)
 		}
 	}
-	return deduped
+
+	sv.sensitivePaths = deduped
+	sv.sensitivePathsOK = true
+	return sv.sensitivePaths
 }
 
 // =============================================================================

--- a/pkg/runtime/config/schema_validator.go
+++ b/pkg/runtime/config/schema_validator.go
@@ -3,6 +3,7 @@ package config
 import (
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/goccy/go-yaml"
@@ -125,6 +126,19 @@ func (sv *SchemaValidator) GetSchemaDefaults() (map[string]any, error) {
 	return extractDefaults(sv.Schema), nil
 }
 
+// GetSensitivePaths returns the dotted config paths of every property marked `sensitive: true`
+// in the loaded schema, sorted for stable output. A free-form map region (additionalProperties)
+// contributes a "*" wildcard segment for its dynamic key. Returns nil when no schema is loaded.
+func (sv *SchemaValidator) GetSensitivePaths() []string {
+	if sv.Schema == nil {
+		return nil
+	}
+	var paths []string
+	collectSensitivePaths(sv.Schema, "", &paths)
+	sort.Strings(paths)
+	return paths
+}
+
 // =============================================================================
 // Private Methods
 // =============================================================================
@@ -214,6 +228,41 @@ func extractDefaults(schema map[string]any) map[string]any {
 		}
 	}
 	return defaults
+}
+
+// collectSensitivePaths walks a schema node, appending the dotted path of every property that
+// carries a truthy `sensitive` keyword. It mirrors extractDefaults' recursion over `properties`
+// and additionally descends `additionalProperties` subschemas with a "*" segment, so sensitive
+// leaves under free-form maps (e.g. secrets.<provider>.<store>) remain reachable.
+func collectSensitivePaths(schema map[string]any, prefix string, out *[]string) {
+	joinPath := func(segment string) string {
+		if prefix == "" {
+			return segment
+		}
+		return prefix + "." + segment
+	}
+
+	if properties, ok := schema["properties"].(map[string]any); ok {
+		for propName, propSchema := range properties {
+			propSchemaMap, ok := propSchema.(map[string]any)
+			if !ok {
+				continue
+			}
+			path := joinPath(propName)
+			if propSchemaMap["sensitive"] == true {
+				*out = append(*out, path)
+			}
+			collectSensitivePaths(propSchemaMap, path, out)
+		}
+	}
+
+	if additional, ok := schema["additionalProperties"].(map[string]any); ok {
+		path := joinPath("*")
+		if additional["sensitive"] == true {
+			*out = append(*out, path)
+		}
+		collectSensitivePaths(additional, path, out)
+	}
 }
 
 // collectErrors flattens a kaptinlin EvaluationResult into one error string per leaf,

--- a/pkg/runtime/config/schema_validator.go
+++ b/pkg/runtime/config/schema_validator.go
@@ -136,7 +136,14 @@ func (sv *SchemaValidator) GetSensitivePaths() []string {
 	var paths []string
 	collectSensitivePaths(sv.Schema, "", &paths)
 	sort.Strings(paths)
-	return paths
+
+	deduped := paths[:0]
+	for i, path := range paths {
+		if i == 0 || path != paths[i-1] {
+			deduped = append(deduped, path)
+		}
+	}
+	return deduped
 }
 
 // =============================================================================
@@ -231,9 +238,12 @@ func extractDefaults(schema map[string]any) map[string]any {
 }
 
 // collectSensitivePaths walks a schema node, appending the dotted path of every property that
-// carries a truthy `sensitive` keyword. It mirrors extractDefaults' recursion over `properties`
-// and additionally descends `additionalProperties` subschemas with a "*" segment, so sensitive
-// leaves under free-form maps (e.g. secrets.<provider>.<store>) remain reachable.
+// carries a truthy `sensitive` keyword. It mirrors extractDefaults' recursion over `properties`,
+// descends `additionalProperties`/`patternProperties` map regions with a "*" segment (their keys
+// are dynamic), and follows `allOf`/`anyOf`/`oneOf` composition branches at the same path prefix
+// (they constrain the same instance location). It does not resolve `$ref`; a sensitive leaf reached
+// only through a `$ref` is not enumerated. Duplicate paths from multiple branches are removed by
+// the caller.
 func collectSensitivePaths(schema map[string]any, prefix string, out *[]string) {
 	joinPath := func(segment string) string {
 		if prefix == "" {
@@ -256,12 +266,43 @@ func collectSensitivePaths(schema map[string]any, prefix string, out *[]string) 
 		}
 	}
 
-	if additional, ok := schema["additionalProperties"].(map[string]any); ok {
-		path := joinPath("*")
-		if additional["sensitive"] == true {
-			*out = append(*out, path)
+	for _, mapKeyword := range []string{"additionalProperties", "patternProperties"} {
+		region, ok := schema[mapKeyword].(map[string]any)
+		if !ok {
+			continue
 		}
-		collectSensitivePaths(additional, path, out)
+		path := joinPath("*")
+		if mapKeyword == "additionalProperties" {
+			if region["sensitive"] == true {
+				*out = append(*out, path)
+			}
+			collectSensitivePaths(region, path, out)
+			continue
+		}
+		// patternProperties maps each regex pattern to its own subschema; all dynamic keys
+		// collapse onto the same "*" segment.
+		for _, patternSchema := range region {
+			patternSchemaMap, ok := patternSchema.(map[string]any)
+			if !ok {
+				continue
+			}
+			if patternSchemaMap["sensitive"] == true {
+				*out = append(*out, path)
+			}
+			collectSensitivePaths(patternSchemaMap, path, out)
+		}
+	}
+
+	for _, composition := range []string{"allOf", "anyOf", "oneOf"} {
+		branches, ok := schema[composition].([]any)
+		if !ok {
+			continue
+		}
+		for _, branch := range branches {
+			if branchMap, ok := branch.(map[string]any); ok {
+				collectSensitivePaths(branchMap, prefix, out)
+			}
+		}
 	}
 }
 

--- a/pkg/runtime/config/schema_validator_test.go
+++ b/pkg/runtime/config/schema_validator_test.go
@@ -2900,3 +2900,103 @@ func TestSchemaValidator_mergeItemsSchema(t *testing.T) {
 		}
 	})
 }
+
+func TestSchemaValidator_GetSensitivePaths(t *testing.T) {
+	t.Run("NilWhenNoSchemaLoaded", func(t *testing.T) {
+		// Given a schema validator with no schema loaded
+		validator := NewSchemaValidator(shell.NewMockShell())
+
+		// When collecting sensitive paths
+		paths := validator.GetSensitivePaths()
+
+		// Then it returns nil
+		if paths != nil {
+			t.Errorf("Expected nil, got: %v", paths)
+		}
+	})
+
+	t.Run("CollectsAtEveryDepthAndSorts", func(t *testing.T) {
+		// Given a schema with sensitive markers at depth 1 and depth 2, plus non-sensitive siblings
+		validator := NewSchemaValidator(shell.NewMockShell())
+		validator.Schema = map[string]any{
+			"$schema": "https://json-schema.org/draft/2020-12/schema",
+			"type":    "object",
+			"properties": map[string]any{
+				"token": map[string]any{"type": "string", "sensitive": true},
+				"name":  map[string]any{"type": "string"},
+				"cdn": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"cloudflare_api_key": map[string]any{"type": "string", "sensitive": true},
+						"zone":               map[string]any{"type": "string"},
+					},
+				},
+			},
+		}
+
+		// When collecting sensitive paths
+		got := strings.Join(validator.GetSensitivePaths(), ",")
+
+		// Then both sensitive leaves appear, sorted, and non-sensitive siblings do not
+		want := "cdn.cloudflare_api_key,token"
+		if got != want {
+			t.Errorf("Expected %q, got %q", want, got)
+		}
+	})
+
+	t.Run("DescendsAdditionalPropertiesWithWildcard", func(t *testing.T) {
+		// Given a sensitive leaf under a free-form map region (additionalProperties)
+		validator := NewSchemaValidator(shell.NewMockShell())
+		validator.Schema = map[string]any{
+			"$schema": "https://json-schema.org/draft/2020-12/schema",
+			"type":    "object",
+			"properties": map[string]any{
+				"secrets": map[string]any{
+					"type": "object",
+					"properties": map[string]any{
+						"stores": map[string]any{
+							"type": "object",
+							"additionalProperties": map[string]any{
+								"type": "object",
+								"properties": map[string]any{
+									"token": map[string]any{"type": "string", "sensitive": true},
+									"url":   map[string]any{"type": "string"},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		// When collecting sensitive paths
+		got := strings.Join(validator.GetSensitivePaths(), ",")
+
+		// Then the dynamic key contributes a "*" wildcard segment
+		want := "secrets.stores.*.token"
+		if got != want {
+			t.Errorf("Expected %q, got %q", want, got)
+		}
+	})
+
+	t.Run("FalseAndAbsentYieldNoPath", func(t *testing.T) {
+		// Given properties with sensitive:false and no sensitive marker
+		validator := NewSchemaValidator(shell.NewMockShell())
+		validator.Schema = map[string]any{
+			"$schema": "https://json-schema.org/draft/2020-12/schema",
+			"type":    "object",
+			"properties": map[string]any{
+				"public":       map[string]any{"type": "string"},
+				"notSensitive": map[string]any{"type": "string", "sensitive": false},
+			},
+		}
+
+		// When collecting sensitive paths
+		paths := validator.GetSensitivePaths()
+
+		// Then nothing is flagged sensitive
+		if len(paths) != 0 {
+			t.Errorf("Expected no paths, got: %v", paths)
+		}
+	})
+}

--- a/pkg/runtime/config/schema_validator_test.go
+++ b/pkg/runtime/config/schema_validator_test.go
@@ -3095,4 +3095,50 @@ func TestSchemaValidator_GetSensitivePaths(t *testing.T) {
 			t.Errorf("Expected [token], got %v", paths)
 		}
 	})
+
+	t.Run("CachesResultAndInvalidatesOnSchemaLoad", func(t *testing.T) {
+		// Given a loaded schema with one sensitive property
+		validator := NewSchemaValidator(shell.NewMockShell())
+		first := []byte(`
+$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+properties:
+  token:
+    type: string
+    sensitive: true
+`)
+		if err := validator.LoadSchemaFromBytes(first); err != nil {
+			t.Fatalf("Failed to load first schema: %v", err)
+		}
+
+		// When collecting sensitive paths twice, the cached result is returned
+		if got := strings.Join(validator.GetSensitivePaths(), ","); got != "token" {
+			t.Fatalf("Expected token, got %q", got)
+		}
+		if !validator.sensitivePathsOK {
+			t.Error("Expected sensitive paths to be cached after first call")
+		}
+		if got := strings.Join(validator.GetSensitivePaths(), ","); got != "token" {
+			t.Fatalf("Expected cached token, got %q", got)
+		}
+
+		// And loading another fragment invalidates the cache so new markers are picked up
+		second := []byte(`
+$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+properties:
+  api_key:
+    type: string
+    sensitive: true
+`)
+		if err := validator.LoadSchemaFromBytes(second); err != nil {
+			t.Fatalf("Failed to load second schema: %v", err)
+		}
+		if validator.sensitivePathsOK {
+			t.Error("Expected cache to be invalidated after loading a new fragment")
+		}
+		if got := strings.Join(validator.GetSensitivePaths(), ","); got != "api_key,token" {
+			t.Errorf("Expected api_key,token after reload, got %q", got)
+		}
+	})
 }

--- a/pkg/runtime/config/schema_validator_test.go
+++ b/pkg/runtime/config/schema_validator_test.go
@@ -2999,4 +2999,100 @@ func TestSchemaValidator_GetSensitivePaths(t *testing.T) {
 			t.Errorf("Expected no paths, got: %v", paths)
 		}
 	})
+
+	t.Run("DescendsCompositionBranches", func(t *testing.T) {
+		// Given sensitive leaves nested under allOf and oneOf composition keywords
+		validator := NewSchemaValidator(shell.NewMockShell())
+		validator.Schema = map[string]any{
+			"$schema": "https://json-schema.org/draft/2020-12/schema",
+			"type":    "object",
+			"allOf": []any{
+				map[string]any{
+					"properties": map[string]any{
+						"token": map[string]any{"type": "string", "sensitive": true},
+					},
+				},
+			},
+			"properties": map[string]any{
+				"auth": map[string]any{
+					"oneOf": []any{
+						map[string]any{
+							"properties": map[string]any{
+								"password": map[string]any{"type": "string", "sensitive": true},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		// When collecting sensitive paths
+		got := strings.Join(validator.GetSensitivePaths(), ",")
+
+		// Then leaves under allOf (root prefix) and oneOf (auth prefix) are both found
+		want := "auth.password,token"
+		if got != want {
+			t.Errorf("Expected %q, got %q", want, got)
+		}
+	})
+
+	t.Run("PatternPropertiesUseWildcard", func(t *testing.T) {
+		// Given a sensitive leaf under a patternProperties (regex-keyed map) region
+		validator := NewSchemaValidator(shell.NewMockShell())
+		validator.Schema = map[string]any{
+			"$schema": "https://json-schema.org/draft/2020-12/schema",
+			"type":    "object",
+			"properties": map[string]any{
+				"vaults": map[string]any{
+					"type": "object",
+					"patternProperties": map[string]any{
+						"^[a-z]+$": map[string]any{
+							"type": "object",
+							"properties": map[string]any{
+								"token": map[string]any{"type": "string", "sensitive": true},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		// When collecting sensitive paths
+		got := strings.Join(validator.GetSensitivePaths(), ",")
+
+		// Then the dynamic key contributes a "*" segment
+		want := "vaults.*.token"
+		if got != want {
+			t.Errorf("Expected %q, got %q", want, got)
+		}
+	})
+
+	t.Run("DeduplicatesPathsFromMultipleBranches", func(t *testing.T) {
+		// Given the same sensitive path declared in two anyOf branches
+		validator := NewSchemaValidator(shell.NewMockShell())
+		validator.Schema = map[string]any{
+			"$schema": "https://json-schema.org/draft/2020-12/schema",
+			"type":    "object",
+			"anyOf": []any{
+				map[string]any{
+					"properties": map[string]any{
+						"token": map[string]any{"type": "string", "sensitive": true},
+					},
+				},
+				map[string]any{
+					"properties": map[string]any{
+						"token": map[string]any{"type": "string", "sensitive": true},
+					},
+				},
+			},
+		}
+
+		// When collecting sensitive paths
+		paths := validator.GetSensitivePaths()
+
+		// Then the duplicate is collapsed to a single entry
+		if len(paths) != 1 || paths[0] != "token" {
+			t.Errorf("Expected [token], got %v", paths)
+		}
+	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This PR modifies the shared `ConfigHandler` interface, which is a compile-breaking change for any external implementors, and introduces a security-adjacent API whose correctness depends on full schema coverage.
>
> **Overview**
>
> The PR adds `GetSensitivePaths()` and `IsSensitivePath()` to `ConfigHandler` and `SchemaValidator`, allowing consumers to identify config paths marked `sensitive: true` in the loaded JSON Schema. A `*` wildcard segment handles free-form map regions expressed via `additionalProperties`, and the public result is sorted for stable output. The mock is updated to match the expanded interface, and both new methods have solid test coverage.
>
> The recursive walker (`collectSensitivePaths`) only descends `properties` and `additionalProperties`. JSON Schema composition keywords (`allOf`, `anyOf`, `oneOf`) and `patternProperties` are not visited, so a schema that places sensitive properties under those constructs would silently under-report — a false-negative in a security-gating API. Additionally, `IsSensitivePath` re-walks the full schema on every call because it calls `GetSensitivePaths()` each time rather than caching the result.
>
> Reviewed by Claude for commit `aae750fb`.

<!-- /claude-code-review:summary -->
