### PR TITLE
feat(config): implement sensitive value redaction in output and add tests

### DIFF
--- a/cmd/show.go
+++ b/cmd/show.go
@@ -286,8 +286,9 @@ func listKustomizations(blueprint *blueprintv1alpha1.Blueprint, useJSON bool) er
 
 // getValues configures the project and returns the effective context values and loaded schema without
 // running full initialization. It merges schema defaults with values.yaml overrides, providing the
-// complete set of configuration values available for use in blueprint processing. No files are written
-// or terraform modules processed. Returns values, schema (may be nil), and any error.
+// complete set of configuration values available for use in blueprint processing. Values at
+// schema-declared sensitive paths are redacted so `windsor show values` never prints secret material.
+// No files are written or terraform modules processed. Returns values, schema (may be nil), and any error.
 func getValues(cmd *cobra.Command) (map[string]any, map[string]any, error) {
 	proj, err := configureProject(cmd)
 	if err != nil {
@@ -298,6 +299,7 @@ func getValues(cmd *cobra.Command) (map[string]any, map[string]any, error) {
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to get context values: %w", err)
 	}
+	config.RedactSensitiveValues(values, proj.Runtime.ConfigHandler.GetSensitivePaths())
 
 	schema := proj.Runtime.ConfigHandler.GetSchema()
 	return values, schema, nil

--- a/cmd/show_test.go
+++ b/cmd/show_test.go
@@ -106,8 +106,8 @@ func setupShowTest(t *testing.T, opts ...*SetupOptions) *ShowMocks {
 	mockBlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint { return testBlueprint }
 	mockBlueprintHandler.GetDeferredPathsFunc = func() map[string]bool {
 		return map[string]bool{
-			"terraform.test-component.inputs.deferred":       true,
-			"kustomize.test-kustomization.path":              true,
+			"terraform.test-component.inputs.deferred":                     true,
+			"kustomize.test-kustomization.path":                            true,
 			"kustomize.test-kustomization.substitutions.DEFERRED_ENDPOINT": true,
 		}
 	}
@@ -530,6 +530,49 @@ func TestShowValuesCmd(t *testing.T) {
 		}
 		if !strings.Contains(output, "provider: docker") {
 			t.Errorf("Expected provider value in output, got:\n%s", output)
+		}
+	})
+
+	t.Run("RedactsSensitiveValues", func(t *testing.T) {
+		mocks := setupShowTest(t)
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{
+				"cdn": map[string]any{
+					"cloudflare_api_key": "SUPERSECRET",
+					"zone":               "example.com",
+				},
+			}, nil
+		}
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetSensitivePathsFunc = func() []string {
+			return []string{"cdn.cloudflare_api_key"}
+		}
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetSchemaFunc = func() map[string]any {
+			return nil
+		}
+
+		proj := project.NewProject("", &project.Project{
+			Runtime: mocks.Runtime,
+		})
+
+		stdout, closePipes := setupOutput(t)
+
+		cmd := createTestCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		cmd.SetArgs([]string{})
+		_ = cmd.Execute()
+
+		closePipes()
+
+		output := stdout.String()
+		if strings.Contains(output, "SUPERSECRET") {
+			t.Errorf("Expected sensitive value to be redacted, but it leaked:\n%s", output)
+		}
+		if !strings.Contains(output, config.SensitiveRedactionMarker) {
+			t.Errorf("Expected redaction marker %q in output, got:\n%s", config.SensitiveRedactionMarker, output)
+		}
+		if !strings.Contains(output, "example.com") {
+			t.Errorf("Expected non-sensitive sibling preserved, got:\n%s", output)
 		}
 	})
 

--- a/pkg/runtime/config/values_renderer.go
+++ b/pkg/runtime/config/values_renderer.go
@@ -18,6 +18,10 @@ import (
 // Public Functions
 // =============================================================================
 
+// SensitiveRedactionMarker is the placeholder shown in place of a sensitive value in display
+// output, so operators see that a field exists and is sensitive without its value being printed.
+const SensitiveRedactionMarker = "<sensitive>"
+
 // RenderValuesWithDescriptions renders context values as YAML annotated with schema descriptions.
 // It walks the union of schema properties and effective values so that every configurable field
 // appears in the output. Set keys render as normal YAML with description comments; unset
@@ -27,9 +31,53 @@ func RenderValuesWithDescriptions(values map[string]any, schema map[string]any) 
 	return renderValuesBlock(values, schema, "")
 }
 
+// RedactSensitiveValues replaces, in place, every existing value at a sensitive path with
+// SensitiveRedactionMarker so display surfaces (e.g. windsor show values) never print secret
+// material while still revealing that the field is set. A "*" path segment matches any single
+// key. Absent paths are left untouched — redaction never fabricates keys. The same map is
+// returned for convenience.
+func RedactSensitiveValues(values map[string]any, sensitivePaths []string) map[string]any {
+	for _, path := range sensitivePaths {
+		redactValueAtPath(values, parsePath(path))
+	}
+	return values
+}
+
 // =============================================================================
 // Private Functions
 // =============================================================================
+
+// redactValueAtPath overwrites the leaf addressed by segments with SensitiveRedactionMarker. A "*"
+// segment matches every key at that level: as the final segment it redacts each existing value,
+// otherwise it recurses into every child. Missing keys are ignored; no keys are created.
+func redactValueAtPath(node any, segments []string) {
+	current, ok := node.(map[string]any)
+	if !ok || len(segments) == 0 {
+		return
+	}
+	segment := segments[0]
+	if len(segments) == 1 {
+		if segment == "*" {
+			for key := range current {
+				current[key] = SensitiveRedactionMarker
+			}
+			return
+		}
+		if _, exists := current[segment]; exists {
+			current[segment] = SensitiveRedactionMarker
+		}
+		return
+	}
+	if segment == "*" {
+		for _, child := range current {
+			redactValueAtPath(child, segments[1:])
+		}
+		return
+	}
+	if child, exists := current[segment]; exists {
+		redactValueAtPath(child, segments[1:])
+	}
+}
 
 // renderValuesBlock is the recursive implementation for RenderValuesWithDescriptions.
 // It accumulates output into a strings.Builder, delegating scalar and array formatting

--- a/pkg/runtime/config/values_renderer_test.go
+++ b/pkg/runtime/config/values_renderer_test.go
@@ -197,3 +197,65 @@ func TestRenderValuesWithDescriptions(t *testing.T) {
 		}
 	})
 }
+
+func TestRedactSensitiveValues(t *testing.T) {
+	t.Run("RedactsExactPathPreservesSibling", func(t *testing.T) {
+		// Given values with a sensitive leaf and a sibling
+		values := map[string]any{
+			"cdn": map[string]any{
+				"cloudflare_api_key": "SUPERSECRET",
+				"zone":               "example.com",
+			},
+		}
+
+		// When redacting the sensitive path
+		RedactSensitiveValues(values, []string{"cdn.cloudflare_api_key"})
+
+		// Then the value is replaced with the marker and the sibling is untouched
+		cdn := values["cdn"].(map[string]any)
+		if cdn["cloudflare_api_key"] != SensitiveRedactionMarker {
+			t.Errorf("Expected redaction marker, got %v", cdn["cloudflare_api_key"])
+		}
+		if cdn["zone"] != "example.com" {
+			t.Errorf("Expected sibling preserved, got %v", cdn["zone"])
+		}
+	})
+
+	t.Run("RedactsWildcardLeavesAcrossKeys", func(t *testing.T) {
+		// Given a dynamic-key map with a sensitive leaf under each entry
+		values := map[string]any{
+			"stores": map[string]any{
+				"a": map[string]any{"token": "atok", "url": "https://a"},
+				"b": map[string]any{"token": "btok"},
+			},
+		}
+
+		// When redacting the wildcard path
+		RedactSensitiveValues(values, []string{"stores.*.token"})
+
+		// Then every store's token is redacted and non-sensitive siblings remain
+		stores := values["stores"].(map[string]any)
+		if stores["a"].(map[string]any)["token"] != SensitiveRedactionMarker {
+			t.Error("Expected stores.a.token redacted")
+		}
+		if stores["b"].(map[string]any)["token"] != SensitiveRedactionMarker {
+			t.Error("Expected stores.b.token redacted")
+		}
+		if stores["a"].(map[string]any)["url"] != "https://a" {
+			t.Error("Expected stores.a.url preserved")
+		}
+	})
+
+	t.Run("AbsentPathIsNotFabricated", func(t *testing.T) {
+		// Given values lacking the sensitive path
+		values := map[string]any{"cdn": map[string]any{"zone": "example.com"}}
+
+		// When redacting a path that is not present
+		RedactSensitiveValues(values, []string{"cdn.cloudflare_api_key"})
+
+		// Then no key is created
+		if _, exists := values["cdn"].(map[string]any)["cloudflare_api_key"]; exists {
+			t.Error("Expected absent sensitive key to not be fabricated")
+		}
+	})
+}


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change is isolated to the `windsor show values` display path and only affects output — no persistent state, no configuration writes, and no behavioral change to any other command.
>
> **Overview**
>
> The PR wires sensitive-value redaction into `getValues` in `cmd/show.go`, applying `RedactSensitiveValues` to the fresh map returned by `GetContextValues` before it reaches any display surface. The redaction function itself is new, living in `pkg/runtime/config/values_renderer.go`; it walks dotted path segments (with `*` wildcard support) and replaces matching leaf values with the exported `SensitiveRedactionMarker` constant. Both the YAML and JSON output branches of `showValuesCmd` consume the already-redacted map.
>
> Coverage is solid: the renderer package has three focused unit tests (exact path, wildcard, absent-path fabrication guard) and the cmd package adds an end-to-end test confirming the secret does not appear in output and the non-sensitive sibling is preserved.
>
> Reviewed by Claude for commit `bda2c0fc`.

<!-- /claude-code-review:summary -->
