### PR TITLE
feat(blueprint): add Secrets handling to Kustomization

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -594,6 +594,13 @@ type Kustomization struct {
 	// during composition. It exists so `flux:` system tiers and `kustomize:` entries can spell
 	// postBuild substitutions the same short way (matching Flux's `postBuild.substitute`).
 	Substitute map[string]string `yaml:"substitute,omitempty"`
+
+	// Secrets carries a flux system's secrets onto its compiled namespace-owning tier so the
+	// imperative placement step can find them after flattening. Each value is a reference to a
+	// sensitive schema property, resolved JIT at placement — never during composition. It is
+	// yaml:"-" so it is never marshaled into show/apply output or the written blueprint, keeping
+	// secret material out of every serialized surface by construction.
+	Secrets map[string]string `yaml:"-"`
 }
 
 // FluxSystem is a system entry under a blueprint or facet's `flux:` list — a functional layer that
@@ -1142,6 +1149,8 @@ func (sys FluxSystem) TierNames() []string {
 // any expression evaluation. Install compiles to "<name>-install" at "<path>/install"; each
 // resources variant compiles to "<name>-resources[-<variant>]" at "<path>/resources". A timeout-less
 // install tier falls back to DefaultFluxKustomizationInstallTimeout instead of the generic default.
+// The system's Secrets attach to its namespace-owning tier — the install tier when emitted, else the
+// first resources tier (out[0]) — so placement finds them after FluxSystems are flattened away.
 func compileFluxSystemTiers(sys FluxSystem) []Kustomization {
 	name := sys.Name
 	base := sys.Path
@@ -1181,6 +1190,10 @@ func compileFluxSystemTiers(sys FluxSystem) []Kustomization {
 		}
 		applySystemTierDefaults(&k, sys)
 		out = append(out, k)
+	}
+
+	if len(sys.Secrets) > 0 && len(out) > 0 {
+		out[0].Secrets = maps.Clone(sys.Secrets)
 	}
 	return out
 }
@@ -1227,6 +1240,7 @@ func (k *Kustomization) DeepCopy() *Kustomization {
 		Enabled:         k.Enabled.DeepCopy(),
 		Substitutions:   maps.Clone(k.Substitutions),
 		Substitute:      maps.Clone(k.Substitute),
+		Secrets:         maps.Clone(k.Secrets),
 	}
 }
 

--- a/api/v1alpha1/blueprint_types_test.go
+++ b/api/v1alpha1/blueprint_types_test.go
@@ -5127,3 +5127,116 @@ install:
 		}
 	})
 }
+
+func TestKustomization_Secrets(t *testing.T) {
+	t.Run("DeepCopyClonesSecretsIndependently", func(t *testing.T) {
+		// Given a kustomization carrying secrets
+		original := &Kustomization{
+			Name:    "cdn-install",
+			Secrets: map[string]string{"cloudflare-api-token": "${cdn.cloudflare_api_key}"},
+		}
+
+		// When deep-copying and mutating the copy
+		clone := original.DeepCopy()
+		clone.Secrets["cloudflare-api-token"] = "changed"
+		clone.Secrets["extra"] = "value"
+
+		// Then the original is untouched
+		if original.Secrets["cloudflare-api-token"] != "${cdn.cloudflare_api_key}" {
+			t.Errorf("Expected original unchanged, got %q", original.Secrets["cloudflare-api-token"])
+		}
+		if _, exists := original.Secrets["extra"]; exists {
+			t.Error("Expected original to not gain the clone's key")
+		}
+	})
+
+	t.Run("SecretsNeverMarshalToYAML", func(t *testing.T) {
+		// Given a kustomization with a literal secret in its compiled carrier
+		k := Kustomization{
+			Name:    "cdn-install",
+			Secrets: map[string]string{"token": "PLAINTEXT-SECRET"},
+		}
+
+		// When marshaling to YAML
+		out, err := yaml.Marshal(k)
+		if err != nil {
+			t.Fatalf("Marshal: %v", err)
+		}
+
+		// Then neither the key, the value, nor a "secrets" field appears
+		s := string(out)
+		if strings.Contains(s, "PLAINTEXT-SECRET") || strings.Contains(s, "token") || strings.Contains(s, "secrets") {
+			t.Errorf("Expected Secrets to be omitted from marshaled output, got:\n%s", s)
+		}
+	})
+}
+
+func TestCompileFluxSystemTiers_Secrets(t *testing.T) {
+	secretsMap := func() map[string]string {
+		return map[string]string{"cloudflare-api-token": "${cdn.cloudflare_api_key}"}
+	}
+
+	t.Run("AttachesSecretsToInstallTier", func(t *testing.T) {
+		// Given a system with an install tier, a resources tier, and secrets
+		bp := &Blueprint{FluxSystems: []FluxSystem{{
+			Name:      "cdn",
+			Install:   &Kustomization{Components: []string{"cloudflared"}},
+			Resources: []FluxVariant{{Kustomization: Kustomization{Components: []string{"tunnel"}}}},
+			Secrets:   secretsMap(),
+		}}}
+
+		// When compiling all kustomizations
+		all := bp.AllKustomizations()
+
+		// Then the install tier carries the secrets and the resources tier does not
+		install := findKustomizationByName(all, "cdn-install")
+		resources := findKustomizationByName(all, "cdn-resources")
+		if install == nil || resources == nil {
+			t.Fatalf("Expected both tiers, got %v", kustomizationNames(all))
+		}
+		if install.Secrets["cloudflare-api-token"] != "${cdn.cloudflare_api_key}" {
+			t.Errorf("Expected install tier to carry secrets, got %v", install.Secrets)
+		}
+		if len(resources.Secrets) != 0 {
+			t.Errorf("Expected resources tier to carry no secrets, got %v", resources.Secrets)
+		}
+	})
+
+	t.Run("FallsBackToResourcesTierWhenNoInstall", func(t *testing.T) {
+		// Given a system with only a resources tier
+		bp := &Blueprint{FluxSystems: []FluxSystem{{
+			Name:      "cdn",
+			Resources: []FluxVariant{{Kustomization: Kustomization{Components: []string{"tunnel"}}}},
+			Secrets:   secretsMap(),
+		}}}
+
+		// When compiling all kustomizations
+		all := bp.AllKustomizations()
+
+		// Then the first (resources) tier carries the secrets
+		resources := findKustomizationByName(all, "cdn-resources")
+		if resources == nil {
+			t.Fatalf("Expected resources tier, got %v", kustomizationNames(all))
+		}
+		if resources.Secrets["cloudflare-api-token"] != "${cdn.cloudflare_api_key}" {
+			t.Errorf("Expected resources tier to carry secrets, got %v", resources.Secrets)
+		}
+	})
+}
+
+func findKustomizationByName(all []Kustomization, name string) *Kustomization {
+	for i := range all {
+		if all[i].Name == name {
+			return &all[i]
+		}
+	}
+	return nil
+}
+
+func kustomizationNames(all []Kustomization) []string {
+	names := make([]string, len(all))
+	for i, k := range all {
+		names[i] = k.Name
+	}
+	return names
+}


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This PR extends the `Kustomization` struct with a `Secrets` field and wires it through the FluxSystem compilation pipeline; the change is additive and backward-compatible with no behavior change for systems that carry no secrets.
>
> **Overview**
>
> The PR adds a `Secrets map[string]string` field to `Kustomization` that is explicitly tagged `yaml:"-"`, ensuring it is never written into any serialized surface (show output, apply output, or the stored blueprint). `compileFluxSystemTiers` attaches the parent `FluxSystem`'s secrets to the namespace-owning tier — the install tier when one is emitted, otherwise `out[0]` — so that a downstream placement step can locate them after flattening. `DeepCopy` is updated to clone the new map.
>
> The test suite covers map isolation under `DeepCopy`, YAML exclusion (including with a plaintext value to prove the tag holds), secrets attachment to the install tier, and fallback attachment to the first resources tier when no install tier exists. The implementation is guarded by `if len(sys.Secrets) > 0`, so all existing systems are entirely unaffected.
>
> Reviewed by Claude for commit `3ec6c17a`.

<!-- /claude-code-review:summary -->
