### PR TITLE
feat(secrets): implement PlaceSecrets functionality to manage Kubernetes Secrets placement

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -34,7 +34,7 @@ windsor apply terraform cluster
 windsor apply kustomize dns`,
 	Annotations: map[string]string{
 		"docs.seealso": "[`plan`](plan.md), [`destroy`](destroy.md), [`up`](up.md), [`bootstrap`](bootstrap.md)",
-		"docs.source": "cmd/apply.go",
+		"docs.source":  "cmd/apply.go",
 	},
 	Args:         cobra.NoArgs,
 	SilenceUsage: true,
@@ -86,6 +86,10 @@ windsor apply kustomize dns`,
 				return fmt.Errorf("error applying kustomize: %w", err)
 			}
 
+			if err := proj.Provisioner.PlaceSecrets(cmd.Context(), blueprint); err != nil {
+				return fmt.Errorf("error placing secrets: %w", err)
+			}
+
 			// --prune removes kustomizations the blueprint no longer declares; wait for the
 			// desired set to be Ready first so migrated resources are adopted before a deletion.
 			// Without --prune, orphans are left in place and only reported.
@@ -121,7 +125,7 @@ windsor apply terraform cluster
 windsor apply tf cluster`,
 	Annotations: map[string]string{
 		"docs.seealso": "[`apply`](apply.md), [`plan terraform`](plan-terraform.md), [`destroy terraform`](destroy-terraform.md)",
-		"docs.source": "cmd/apply.go",
+		"docs.source":  "cmd/apply.go",
 	},
 	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
@@ -166,7 +170,7 @@ windsor apply kustomize dns
 windsor apply kustomize dns --wait`,
 	Annotations: map[string]string{
 		"docs.seealso": "[`apply`](apply.md), [`plan kustomize`](plan-kustomize.md), [`destroy kustomize`](destroy-kustomize.md)",
-		"docs.source": "cmd/apply.go",
+		"docs.source":  "cmd/apply.go",
 	},
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -63,7 +63,7 @@ windsor bootstrap staging --platform=aws --blueprint=ghcr.io/myorg/blueprint:v1.
 windsor bootstrap prod --yes`,
 	Annotations: map[string]string{
 		"docs.seealso": "[`init`](init.md), [`apply`](apply.md), [`destroy`](destroy.md)",
-		"docs.source": "cmd/bootstrap.go",
+		"docs.source":  "cmd/bootstrap.go",
 	},
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
@@ -227,6 +227,10 @@ windsor bootstrap prod --yes`,
 
 			if err := proj.Provisioner.Install(cmd.Context(), blueprint); err != nil {
 				return fmt.Errorf("error installing blueprint: %w", err)
+			}
+
+			if err := proj.Provisioner.PlaceSecrets(cmd.Context(), blueprint); err != nil {
+				return fmt.Errorf("error placing secrets: %w", err)
 			}
 
 			if err := proj.Provisioner.Wait(cmd.Context(), blueprint); err != nil {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -40,7 +40,7 @@ windsor up --set cluster.workers.count=3
 windsor up --blueprint=ghcr.io/myorg/blueprint:v1.0.0`,
 	Annotations: map[string]string{
 		"docs.seealso": "[`down`](down.md), [`apply`](apply.md), [`destroy`](destroy.md)",
-		"docs.source": "cmd/up.go",
+		"docs.source":  "cmd/up.go",
 	},
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -131,6 +131,10 @@ windsor up --blueprint=ghcr.io/myorg/blueprint:v1.0.0`,
 
 			if err := proj.Provisioner.Install(cmd.Context(), blueprint); err != nil {
 				return fmt.Errorf("error installing blueprint: %w", err)
+			}
+
+			if err := proj.Provisioner.PlaceSecrets(cmd.Context(), blueprint); err != nil {
+				return fmt.Errorf("error placing secrets: %w", err)
 			}
 
 			if waitFlag {

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -42,6 +42,7 @@ type KubernetesManager interface {
 	CreateNamespace(name string) error
 	DeleteNamespace(name string) error
 	ApplyConfigMap(name, namespace string, data map[string]string) error
+	ApplySecret(name, namespace string, stringData map[string]string) error
 	GetHelmReleasesForKustomization(name, namespace string) ([]helmv2.HelmRelease, error)
 	ApplyGitRepository(repo *sourcev1.GitRepository) error
 	ApplyOCIRepository(repo *sourcev1.OCIRepository) error
@@ -506,6 +507,41 @@ func (k *BaseKubernetesManager) ApplyConfigMap(name, namespace string, data map[
 			return fmt.Errorf("failed to delete immutable configmap: %w", err)
 		}
 		time.Sleep(time.Second)
+	}
+
+	opts := metav1.ApplyOptions{
+		FieldManager: "windsor-cli",
+		Force:        false,
+	}
+
+	return k.applyWithRetry(gvr, obj, opts)
+}
+
+// ApplySecret creates or updates an Opaque Secret using SSA. Values are supplied as plaintext in
+// stringData (write-only; the API server folds them into data) and are never logged. Mirrors
+// ApplyConfigMap's server-side-apply handling.
+func (k *BaseKubernetesManager) ApplySecret(name, namespace string, stringData map[string]string) error {
+	obj := &unstructured.Unstructured{
+		Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"type":       "Opaque",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+			},
+			"stringData": stringData,
+		},
+	}
+
+	if err := validateFields(obj); err != nil {
+		return fmt.Errorf("invalid secret fields: %w", err)
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "secrets",
 	}
 
 	opts := metav1.ApplyOptions{
@@ -1646,6 +1682,10 @@ func validateFields(obj *unstructured.Unstructured) error {
 		if m, ok := data.(map[string]any); ok && len(m) == 0 {
 			return fmt.Errorf("data cannot be empty for ConfigMap")
 		}
+		return nil
+	}
+
+	if obj.GetKind() == "Secret" {
 		return nil
 	}
 

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -5658,3 +5658,68 @@ func TestBaseKubernetesManager_GetKustomizationInventory(t *testing.T) {
 		}
 	})
 }
+
+func TestBaseKubernetesManager_ApplySecret(t *testing.T) {
+	setup := func(t *testing.T) *BaseKubernetesManager {
+		t.Helper()
+		mocks := setupKubernetesMocks(t)
+		manager := NewKubernetesManager(mocks.KubernetesClient, mocks.ConfigHandler)
+		manager.kustomizationWaitPollInterval = 50 * time.Millisecond
+		manager.kustomizationReconcileTimeout = 100 * time.Millisecond
+		manager.kustomizationReconcileSleep = 50 * time.Millisecond
+		return manager
+	}
+
+	t.Run("AppliesOpaqueSecretWithStringData", func(t *testing.T) {
+		// Given a manager and a client that records the applied object
+		manager := setup(t)
+		var applied *unstructured.Unstructured
+		var appliedGVR schema.GroupVersionResource
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.ApplyResourceFunc = func(gvr schema.GroupVersionResource, obj *unstructured.Unstructured, opts metav1.ApplyOptions) (*unstructured.Unstructured, error) {
+			applied = obj
+			appliedGVR = gvr
+			return obj, nil
+		}
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			return nil, fmt.Errorf("not found")
+		}
+		manager.client = kubernetesClient
+
+		// When applying a secret
+		err := manager.ApplySecret("cloudflare-creds", "system-dns", map[string]string{"api_token": "PLAINTEXT"})
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then it applies an Opaque Secret via the secrets GVR with the plaintext under stringData
+		if appliedGVR.Resource != "secrets" {
+			t.Errorf("Expected secrets GVR, got %v", appliedGVR)
+		}
+		if applied.GetKind() != "Secret" {
+			t.Errorf("Expected kind Secret, got %q", applied.GetKind())
+		}
+		if applied.Object["type"] != "Opaque" {
+			t.Errorf("Expected type Opaque, got %v", applied.Object["type"])
+		}
+		stringData, _ := applied.Object["stringData"].(map[string]string)
+		if stringData["api_token"] != "PLAINTEXT" {
+			t.Errorf("Expected stringData api_token=PLAINTEXT, got %v", applied.Object["stringData"])
+		}
+		metadata, _ := applied.Object["metadata"].(map[string]any)
+		if metadata["name"] != "cloudflare-creds" || metadata["namespace"] != "system-dns" {
+			t.Errorf("Unexpected metadata: %v", applied.Object["metadata"])
+		}
+	})
+
+	t.Run("EmptyNameFails", func(t *testing.T) {
+		// Given a manager
+		manager := setup(t)
+		manager.client = client.NewMockKubernetesClient()
+
+		// When applying a secret with no name, it fails validation
+		if err := manager.ApplySecret("", "system-dns", map[string]string{"k": "v"}); err == nil {
+			t.Error("Expected error for empty name")
+		}
+	})
+}

--- a/pkg/provisioner/kubernetes/mock_kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/mock_kubernetes_manager.go
@@ -26,6 +26,7 @@ type MockKubernetesManager struct {
 	CreateNamespaceFunc                 func(name string) error
 	DeleteNamespaceFunc                 func(name string) error
 	ApplyConfigMapFunc                  func(name, namespace string, data map[string]string) error
+	ApplySecretFunc                     func(name, namespace string, stringData map[string]string) error
 	ApplyVersionMarkerFunc              func(namespace string, marker VersionMarker) error
 	GetVersionMarkerFunc                func(namespace string) (VersionMarker, bool, error)
 	GetHelmReleasesForKustomizationFunc func(name, namespace string) ([]helmv2.HelmRelease, error)
@@ -107,6 +108,14 @@ func (m *MockKubernetesManager) DeleteNamespace(name string) error {
 func (m *MockKubernetesManager) ApplyConfigMap(name, namespace string, data map[string]string) error {
 	if m.ApplyConfigMapFunc != nil {
 		return m.ApplyConfigMapFunc(name, namespace, data)
+	}
+	return nil
+}
+
+// ApplySecret implements KubernetesManager interface
+func (m *MockKubernetesManager) ApplySecret(name, namespace string, stringData map[string]string) error {
+	if m.ApplySecretFunc != nil {
+		return m.ApplySecretFunc(name, namespace, stringData)
 	}
 	return nil
 }

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -21,9 +21,9 @@ import (
 	terraforminfra "github.com/windsorcli/cli/pkg/provisioner/terraform"
 	"github.com/windsorcli/cli/pkg/runtime"
 	"github.com/windsorcli/cli/pkg/runtime/config"
-	"github.com/windsorcli/cli/pkg/tui"
 	"github.com/windsorcli/cli/pkg/runtime/evaluator"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
+	"github.com/windsorcli/cli/pkg/tui"
 )
 
 // The Provisioner package provides high-level infrastructure provisioning functionality
@@ -48,15 +48,15 @@ type Provisioner struct {
 	configRoot    string
 	runtime       *runtime.Runtime
 
-	TerraformStack         terraforminfra.Stack
-	FluxStack              fluxinfra.Stack
-	Notifier               fluxinfra.Notifier
-	onTerraformApply       []func(id string) (bool, error)
-	onTerraformPostApply   []func(id string) error
-	KubernetesManager kubernetes.KubernetesManager
-	KubernetesClient  k8sclient.KubernetesClient
-	ClusterClient     cluster.ClusterClient
-	blueprintHandler  blueprint.BlueprintHandler
+	TerraformStack       terraforminfra.Stack
+	FluxStack            fluxinfra.Stack
+	Notifier             fluxinfra.Notifier
+	onTerraformApply     []func(id string) (bool, error)
+	onTerraformPostApply []func(id string) error
+	KubernetesManager    kubernetes.KubernetesManager
+	KubernetesClient     k8sclient.KubernetesClient
+	ClusterClient        cluster.ClusterClient
+	blueprintHandler     blueprint.BlueprintHandler
 }
 
 // PlanSummary holds aggregated plan results across all infrastructure layers.
@@ -978,6 +978,85 @@ func (i *Provisioner) Wait(ctx context.Context, blueprint *blueprintv1alpha1.Blu
 	}
 
 	return nil
+}
+
+// PlaceSecrets materializes each flux system's declared Secrets into the namespace its owning
+// kustomization created. For every compiled kustomization carrying Secrets it waits for that
+// kustomization to reconcile (so the namespace exists), resolves the target namespace from the
+// kustomization's Flux inventory — failing closed unless exactly one Namespace was created so a
+// secret is never placed by guessing — resolves each data reference to plaintext via the evaluator
+// (which registers it with the shell scrubber), and applies an Opaque Secret. It is a no-op when no
+// kustomization declares Secrets. Placement is imperative and runs after Install; it self-gates on
+// the owning kustomization's readiness rather than requiring a global wait.
+func (i *Provisioner) PlaceSecrets(ctx context.Context, blueprint *blueprintv1alpha1.Blueprint) error {
+	if blueprint == nil {
+		return fmt.Errorf("blueprint not provided")
+	}
+	if i.KubernetesManager == nil {
+		return fmt.Errorf("kubernetes manager not configured")
+	}
+
+	bp := withCrdLayer(blueprint)
+	for _, k := range bp.Kustomizations {
+		if len(k.Secrets) == 0 {
+			continue
+		}
+		namespace, err := i.resolveSecretNamespace(ctx, k.Name)
+		if err != nil {
+			return err
+		}
+		for secretName, data := range k.Secrets {
+			stringData := make(map[string]string, len(data))
+			for key, ref := range data {
+				value, err := i.evaluator.Evaluate(ref, "", nil, true)
+				if err != nil {
+					return fmt.Errorf("resolving secret %q key %q: %w", secretName, key, err)
+				}
+				if value != nil {
+					stringData[key] = fmt.Sprint(value)
+				}
+			}
+			if err := i.KubernetesManager.ApplySecret(secretName, namespace, stringData); err != nil {
+				return fmt.Errorf("applying secret %q to namespace %q: %w", secretName, namespace, err)
+			}
+		}
+	}
+	return nil
+}
+
+// resolveSecretNamespace polls the owning kustomization's Flux inventory until Flux has applied the
+// namespace it creates, then returns it. Gating on the namespace being applied — not on the whole
+// kustomization being Ready — places the secret the moment the namespace exists, so a workload that
+// consumes it recovers promptly and a kustomization whose readiness depends on that secret can never
+// deadlock placement. It fails closed: an error on more than one namespace (ambiguous target), and a
+// bounded timeout if none ever appears (a re-run places it once the namespace is created). Flux
+// records inventory only after a successful apply, so a namespace present there is really applied.
+func (i *Provisioner) resolveSecretNamespace(ctx context.Context, kustomizationName string) (string, error) {
+	waitCtx, cancel := context.WithTimeout(ctx, constants.DefaultFluxKustomizationInstallTimeout)
+	defer cancel()
+	for {
+		entries, err := i.KubernetesManager.GetKustomizationInventory(kustomizationName, i.fluxNamespace())
+		if err != nil {
+			return "", fmt.Errorf("reading inventory for kustomization %q: %w", kustomizationName, err)
+		}
+		var namespaces []string
+		for _, entry := range entries {
+			if entry.Kind == "Namespace" {
+				namespaces = append(namespaces, entry.Name)
+			}
+		}
+		switch {
+		case len(namespaces) == 1:
+			return namespaces[0], nil
+		case len(namespaces) > 1:
+			return "", fmt.Errorf("kustomization %q created multiple namespaces (%s); cannot determine where to place its secrets", kustomizationName, strings.Join(namespaces, ", "))
+		}
+		select {
+		case <-waitCtx.Done():
+			return "", fmt.Errorf("timed out waiting for kustomization %q to create its namespace before placing secrets", kustomizationName)
+		case <-time.After(constants.DefaultKustomizationWaitPollInterval):
+		}
+	}
 }
 
 // WriteVersionMarker records the blueprint version applied to this context as a marker ConfigMap

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -1012,9 +1012,10 @@ func (i *Provisioner) PlaceSecrets(ctx context.Context, blueprint *blueprintv1al
 				if err != nil {
 					return fmt.Errorf("resolving secret %q key %q: %w", secretName, key, err)
 				}
-				if value != nil {
-					stringData[key] = fmt.Sprint(value)
+				if value == nil {
+					return fmt.Errorf("resolving secret %q key %q: reference %q resolved to nil", secretName, key, ref)
 				}
+				stringData[key] = fmt.Sprint(value)
 			}
 			if err := i.KubernetesManager.ApplySecret(secretName, namespace, stringData); err != nil {
 				return fmt.Errorf("applying secret %q to namespace %q: %w", secretName, namespace, err)

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -4384,6 +4384,31 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		}
 	})
 
+	t.Run("FailsWhenReferenceResolvesToNil", func(t *testing.T) {
+		// Given a sensitive property that exists but holds a nil value
+		mocks := setupProvisionerMocks(t)
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"cdn": map[string]any{"cloudflare_api_key": nil}}, nil
+		}
+		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
+			return []kubernetes.InventoryEntry{{Kind: "Namespace", Name: "system-dns"}}, nil
+		}
+		applied := false
+		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string) error {
+			applied = true
+			return nil
+		}
+
+		// When placing secrets, the nil resolution fails closed rather than dropping the key
+		err := newProvisioner(mocks).PlaceSecrets(context.Background(), secretBlueprint())
+		if err == nil || !strings.Contains(err.Error(), "resolved to nil") {
+			t.Errorf("Expected nil-resolution error, got %v", err)
+		}
+		if applied {
+			t.Error("Expected ApplySecret to not be called when a key resolves to nil")
+		}
+	})
+
 	t.Run("FailsClosedWhenMultipleNamespaces", func(t *testing.T) {
 		// Given a kustomization whose inventory created more than one namespace
 		mocks := setupProvisionerMocks(t)

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -135,8 +135,12 @@ func setupProvisionerMocks(t *testing.T, opts ...func(*ProvisionerTestMocks)) *P
 	}
 
 	terraformStack := terraforminfra.NewMockStack()
-	terraformStack.UpFunc = func(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(id string) (bool, error)) (bool, error) { return false, nil }
-	terraformStack.DestroyAllFunc = func(blueprint *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) { return terraforminfra.DestroyOutcome{}, nil }
+	terraformStack.UpFunc = func(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(id string) (bool, error)) (bool, error) {
+		return false, nil
+	}
+	terraformStack.DestroyAllFunc = func(blueprint *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) {
+		return terraforminfra.DestroyOutcome{}, nil
+	}
 
 	fluxStack := fluxinfra.NewMockStack()
 
@@ -727,7 +731,9 @@ func TestProvisioner_DestroyAllTerraform(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) { return terraforminfra.DestroyOutcome{}, nil }
+		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) {
+			return terraforminfra.DestroyOutcome{}, nil
+		}
 		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
@@ -2369,7 +2375,9 @@ func TestProvisioner_DestroyAll(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
 		mocks.KubernetesManager.DeleteBlueprintFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) error { return nil }
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) { return terraforminfra.DestroyOutcome{}, nil }
+		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) {
+			return terraforminfra.DestroyOutcome{}, nil
+		}
 		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
@@ -2383,7 +2391,9 @@ func TestProvisioner_DestroyAll(t *testing.T) {
 	t.Run("SuccessNoKubernetesManager", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) { return terraforminfra.DestroyOutcome{}, nil }
+		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) {
+			return terraforminfra.DestroyOutcome{}, nil
+		}
 		opts := &Provisioner{TerraformStack: mockStack}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 		provisioner.KubernetesManager = nil
@@ -2493,7 +2503,9 @@ func TestProvisioner_DestroyAll(t *testing.T) {
 			return nil
 		}
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) { return terraforminfra.DestroyOutcome{}, nil }
+		mockStack.DestroyAllFunc = func(bp *blueprintv1alpha1.Blueprint, _ bool, excludeIDs ...string) (terraforminfra.DestroyOutcome, error) {
+			return terraforminfra.DestroyOutcome{}, nil
+		}
 		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
@@ -4292,6 +4304,117 @@ func TestProvisioner_UpgradeNode(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "no cluster client found") {
 			t.Errorf("Expected no cluster client error, got: %v", err)
+		}
+	})
+}
+
+func TestProvisioner_PlaceSecrets(t *testing.T) {
+	newProvisioner := func(mocks *ProvisionerTestMocks) *Provisioner {
+		return NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{
+			TerraformStack:    mocks.TerraformStack,
+			KubernetesManager: mocks.KubernetesManager,
+			KubernetesClient:  mocks.KubernetesClient,
+			ClusterClient:     mocks.ClusterClient,
+			FluxStack:         mocks.FluxStack,
+		})
+	}
+
+	secretBlueprint := func() *blueprintv1alpha1.Blueprint {
+		return &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{{
+				Name:    "cdn-install",
+				Secrets: map[string]map[string]string{"cloudflare-creds": {"api_token": "${cdn.cloudflare_api_key}"}},
+			}},
+		}
+	}
+
+	withResolvedValue := func(mocks *ProvisionerTestMocks) {
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"cdn": map[string]any{"cloudflare_api_key": "resolved-token"}}, nil
+		}
+	}
+
+	t.Run("ResolvesValueAndPlacesIntoInventoryNamespace", func(t *testing.T) {
+		// Given a kustomization whose inventory holds exactly one applied namespace
+		mocks := setupProvisionerMocks(t)
+		withResolvedValue(mocks)
+		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
+			return []kubernetes.InventoryEntry{{Kind: "Namespace", Name: "system-dns"}}, nil
+		}
+		var gotName, gotNs string
+		var gotData map[string]string
+		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string) error {
+			gotName, gotNs, gotData = name, namespace, stringData
+			return nil
+		}
+
+		// When placing secrets
+		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), secretBlueprint()); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the resolved value lands in the inventory namespace under the right data key
+		if gotName != "cloudflare-creds" || gotNs != "system-dns" || gotData["api_token"] != "resolved-token" {
+			t.Errorf("Unexpected ApplySecret args: name=%q ns=%q data=%v", gotName, gotNs, gotData)
+		}
+	})
+
+	t.Run("TimesOutAndAppliesNothingWhenNoNamespaceAppears", func(t *testing.T) {
+		// Given a kustomization whose inventory never includes a namespace, and a cancelled context
+		mocks := setupProvisionerMocks(t)
+		withResolvedValue(mocks)
+		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
+			return []kubernetes.InventoryEntry{{Kind: "ConfigMap", Name: "values-cdn"}}, nil
+		}
+		applied := false
+		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string) error {
+			applied = true
+			return nil
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		// When placing secrets, it times out waiting for the namespace and applies nothing
+		err := newProvisioner(mocks).PlaceSecrets(ctx, secretBlueprint())
+		if err == nil || !strings.Contains(err.Error(), "to create its namespace") {
+			t.Errorf("Expected namespace-timeout error, got %v", err)
+		}
+		if applied {
+			t.Error("Expected ApplySecret to not be called when the namespace never appears")
+		}
+	})
+
+	t.Run("FailsClosedWhenMultipleNamespaces", func(t *testing.T) {
+		// Given a kustomization whose inventory created more than one namespace
+		mocks := setupProvisionerMocks(t)
+		withResolvedValue(mocks)
+		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
+			return []kubernetes.InventoryEntry{{Kind: "Namespace", Name: "ns-a"}, {Kind: "Namespace", Name: "ns-b"}}, nil
+		}
+
+		// When placing secrets, it fails closed immediately
+		err := newProvisioner(mocks).PlaceSecrets(context.Background(), secretBlueprint())
+		if err == nil || !strings.Contains(err.Error(), "multiple namespaces") {
+			t.Errorf("Expected multiple-namespaces error, got %v", err)
+		}
+	})
+
+	t.Run("NoSecretsIsNoOp", func(t *testing.T) {
+		// Given a blueprint whose kustomizations declare no secrets
+		mocks := setupProvisionerMocks(t)
+		checked := false
+		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
+			checked = true
+			return nil, nil
+		}
+
+		// When placing secrets, no inventory is queried and nothing is applied
+		bp := &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "plain"}}}
+		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), bp); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if checked {
+			t.Error("Expected no inventory query when no secrets are declared")
 		}
 	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This PR adds secret-placement logic wired into three high-traffic CLI commands (`apply`, `bootstrap`, `up`), writing sensitive credentials to live Kubernetes clusters on every invocation where secrets are declared.
>
> **Overview**
>
> The change introduces `PlaceSecrets` on the `Provisioner`, a new `ApplySecret` SSA method on `KubernetesManager`, and the corresponding interface/mock additions. For each kustomization that declares Secrets in the blueprint, `PlaceSecrets` polls the Flux inventory until the kustomization's namespace appears, then resolves each data reference through the evaluator (which registers the value with the shell scrubber) and calls `ApplySecret` to upsert an Opaque Secret via server-side apply. The operation is a no-op when no kustomization declares Secrets, so existing workflows are unaffected.
>
> The implementation fails closed on ambiguous namespace inventory (more than one Namespace in a kustomization's inventory aborts placement) and gates on a bounded timeout, which is the right conservative default. One correctness gap exists: if the evaluator returns `nil` for a key reference the key is silently dropped from `stringData`, so a misconfigured or missing config value produces a Secret that is missing the expected key rather than a placement-time error.
>
> Reviewed by Claude for commit `48be2e94`.

<!-- /claude-code-review:summary -->
