### PR TITLE
feat(secrets): reject sensitive substitutions in evaluateSubstitutions

### DIFF
--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -1038,6 +1038,33 @@ func (p *BaseBlueprintProcessor) isSensitivePath(path string) bool {
 	return p.runtime != nil && p.runtime.ConfigHandler != nil && p.runtime.ConfigHandler.IsSensitivePath(path)
 }
 
+// sensitivePathsInValue returns the sensitive config paths referenced as bare "${path}" interpolation
+// segments anywhere in value — whole-string ("${cdn.key}") or embedded ("https://x/${cdn.key}",
+// "${cdn.key}-suffix"). A segment whose inner text is not a plain config path (it contains operators,
+// a function call, or quotes) can't be resolved to a single sensitive property and is skipped, so a
+// sensitive path used inside a larger expression remains the one uncaught form.
+func (p *BaseBlueprintProcessor) sensitivePathsInValue(value string) []string {
+	var found []string
+	rest := value
+	for {
+		start := strings.Index(rest, "${")
+		if start < 0 {
+			break
+		}
+		rest = rest[start+2:]
+		end := strings.Index(rest, "}")
+		if end < 0 {
+			break
+		}
+		inner := strings.TrimSpace(rest[:end])
+		if inner != "" && !strings.ContainsAny(inner, "(){}\"' \t\n\r") && p.isSensitivePath(inner) {
+			found = append(found, inner)
+		}
+		rest = rest[end+1:]
+	}
+	return found
+}
+
 // bareSecretReferencePath extracts the config path from a bare "${<path>}" reference, returning false
 // for literals, embedded interpolations, function calls, or secret() notation — anything that is not
 // a single sensitive-property reference.
@@ -1941,8 +1968,8 @@ func (p *BaseBlueprintProcessor) evaluateSubstitutions(subs map[string]string, f
 	result := make(map[string]string)
 	deferredKeys := make(map[string]bool)
 	for key, value := range subs {
-		if path, ok := bareSecretReferencePath(value); ok && p.isSensitivePath(path) {
-			return nil, nil, fmt.Errorf("substitution %q references sensitive property %q; move it to the flux system's secrets: key instead of a plaintext substitution, which would be written to a ConfigMap", key, path)
+		if paths := p.sensitivePathsInValue(value); len(paths) > 0 {
+			return nil, nil, fmt.Errorf("substitution %q references sensitive property %q; move it to the flux system's secrets: key instead of a plaintext substitution, which would be written to a ConfigMap", key, paths[0])
 		}
 		evaluated, err := p.evaluator.Evaluate(value, facetPath, scope, false)
 		if err != nil {

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -1031,6 +1031,13 @@ func (p *BaseBlueprintProcessor) validateSystemSecrets(systemName string, secret
 	return nil
 }
 
+// isSensitivePath reports whether the config path is marked sensitive in the schema. It returns false
+// when no config handler is available (e.g. isolated composer tests), so callers that reject sensitive
+// references skip the check rather than failing spuriously.
+func (p *BaseBlueprintProcessor) isSensitivePath(path string) bool {
+	return p.runtime != nil && p.runtime.ConfigHandler != nil && p.runtime.ConfigHandler.IsSensitivePath(path)
+}
+
 // bareSecretReferencePath extracts the config path from a bare "${<path>}" reference, returning false
 // for literals, embedded interpolations, function calls, or secret() notation — anything that is not
 // a single sensitive-property reference.
@@ -1934,6 +1941,9 @@ func (p *BaseBlueprintProcessor) evaluateSubstitutions(subs map[string]string, f
 	result := make(map[string]string)
 	deferredKeys := make(map[string]bool)
 	for key, value := range subs {
+		if path, ok := bareSecretReferencePath(value); ok && p.isSensitivePath(path) {
+			return nil, nil, fmt.Errorf("substitution %q references sensitive property %q; move it to the flux system's secrets: key instead of a plaintext substitution, which would be written to a ConfigMap", key, path)
+		}
 		evaluated, err := p.evaluator.Evaluate(value, facetPath, scope, false)
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to evaluate '%s': %w", key, err)

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -7172,16 +7172,23 @@ func TestValidateSystemSecrets(t *testing.T) {
 }
 
 func TestEvaluateSubstitutions_RejectsSensitiveReference(t *testing.T) {
-	t.Run("RejectsBareSensitiveReference", func(t *testing.T) {
-		// Given a substitution whose value references a sensitive property
+	t.Run("RejectsSensitiveReferenceWholeAndEmbedded", func(t *testing.T) {
+		// Given substitutions that reference a sensitive property whole-string and embedded
 		mocks := setupProcessorMocks(t)
 		mocks.ConfigHandler.IsSensitivePathFunc = func(path string) bool { return path == "cdn.cloudflare_api_key" }
 		processor := NewBlueprintProcessor(mocks.Runtime)
 
-		// When evaluating substitutions, it fails closed before resolving the value
-		_, _, err := processor.evaluateSubstitutions(map[string]string{"FOO": "${cdn.cloudflare_api_key}"}, "", nil)
-		if err == nil || !strings.Contains(err.Error(), "references sensitive property") {
-			t.Errorf("Expected sensitive-substitution error, got %v", err)
+		// Then each form fails closed before the value is resolved
+		for name, value := range map[string]string{
+			"Whole":       "${cdn.cloudflare_api_key}",
+			"Prefixed":    "https://api.example.com/${cdn.cloudflare_api_key}",
+			"Suffixed":    "${cdn.cloudflare_api_key}-suffix",
+			"MidSentence": "token=${cdn.cloudflare_api_key};v=1",
+		} {
+			_, _, err := processor.evaluateSubstitutions(map[string]string{"FOO": value}, "", nil)
+			if err == nil || !strings.Contains(err.Error(), "references sensitive property") {
+				t.Errorf("%s: expected sensitive-substitution error for %q, got %v", name, value, err)
+			}
 		}
 	})
 

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -7170,3 +7170,53 @@ func TestValidateSystemSecrets(t *testing.T) {
 		}
 	})
 }
+
+func TestEvaluateSubstitutions_RejectsSensitiveReference(t *testing.T) {
+	t.Run("RejectsBareSensitiveReference", func(t *testing.T) {
+		// Given a substitution whose value references a sensitive property
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.IsSensitivePathFunc = func(path string) bool { return path == "cdn.cloudflare_api_key" }
+		processor := NewBlueprintProcessor(mocks.Runtime)
+
+		// When evaluating substitutions, it fails closed before resolving the value
+		_, _, err := processor.evaluateSubstitutions(map[string]string{"FOO": "${cdn.cloudflare_api_key}"}, "", nil)
+		if err == nil || !strings.Contains(err.Error(), "references sensitive property") {
+			t.Errorf("Expected sensitive-substitution error, got %v", err)
+		}
+	})
+
+	t.Run("AllowsNonSensitiveReference", func(t *testing.T) {
+		// Given a substitution referencing a non-sensitive property
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.IsSensitivePathFunc = func(path string) bool { return false }
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"cdn": map[string]any{"zone": "example.com"}}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+
+		// When evaluating, it resolves normally
+		result, _, err := processor.evaluateSubstitutions(map[string]string{"ZONE": "${cdn.zone}"}, "", nil)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if result["ZONE"] != "example.com" {
+			t.Errorf("Expected resolved value, got %v", result)
+		}
+	})
+
+	t.Run("AllowsPlainLiteral", func(t *testing.T) {
+		// Given a plaintext literal substitution (not a bare reference)
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.IsSensitivePathFunc = func(path string) bool { return true }
+		processor := NewBlueprintProcessor(mocks.Runtime)
+
+		// When evaluating, the literal is preserved and the guard does not fire
+		result, _, err := processor.evaluateSubstitutions(map[string]string{"REGION": "us-east-1"}, "", nil)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if result["REGION"] != "us-east-1" {
+			t.Errorf("Expected literal preserved, got %v", result)
+		}
+	})
+}


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This PR hardens a core composition path by rejecting bare sensitive-property references in flux system substitutions before they can be resolved and written to Kubernetes ConfigMaps as plaintext; a behavioral breaking change for any blueprint that currently does this.
>
> **Overview**
>
> The change adds a pre-evaluation guard in `evaluateSubstitutions` that calls the new `isSensitivePath` helper to detect whether a substitution value is a bare `${path}` reference to a schema-sensitive property. If so, composition fails immediately with an actionable error directing the author to use `secrets:` instead. The refactored `isSensitivePath` centralizes the nil-safety pattern already inlined in `validateSystemSecrets`, keeping the two callers consistent.
>
> Tests cover the three critical paths — bare sensitive reference rejected, non-sensitive reference resolved normally, and plain literals unaffected — but the guard intentionally does not cover embedded interpolations such as `prefix-${sensitive.path}`, which remain a latent leak surface.
>
> Reviewed by Claude for commit `4ee5ebf6`.

<!-- /claude-code-review:summary -->
