### PR TITLE
feat(secrets): enhance PlaceSecrets to omit empty keys and skip wholly empty secrets

### DIFF
--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -981,13 +981,16 @@ func (i *Provisioner) Wait(ctx context.Context, blueprint *blueprintv1alpha1.Blu
 }
 
 // PlaceSecrets materializes each flux system's declared Secrets into the namespace its owning
-// kustomization created. For every compiled kustomization carrying Secrets it waits for that
-// kustomization to reconcile (so the namespace exists), resolves the target namespace from the
-// kustomization's Flux inventory — failing closed unless exactly one Namespace was created so a
-// secret is never placed by guessing — resolves each data reference to plaintext via the evaluator
-// (which registers it with the shell scrubber), and applies an Opaque Secret. It is a no-op when no
-// kustomization declares Secrets. Placement is imperative and runs after Install; it self-gates on
-// the owning kustomization's readiness rather than requiring a global wait.
+// kustomization created. For every compiled kustomization carrying Secrets it resolves each data
+// reference to plaintext via the evaluator (which registers it with the shell scrubber). A reference
+// that resolves to nil fails closed — a required secret is misconfigured; an author opts a key into
+// optional by defaulting it (e.g. "${x ?? ”}"), which resolves to empty and omits that key. A secret
+// whose keys all resolve empty is not created at all, so an unconfigured optional secret leaves no
+// empty Secret behind. Only when a kustomization has something to place does it resolve the target
+// namespace from the kustomization's Flux inventory — failing closed unless exactly one Namespace was
+// created, so a secret is never placed by guessing — and apply an Opaque Secret. It is a no-op when no
+// kustomization declares Secrets. Placement is imperative and runs after Install; it self-gates on the
+// owning kustomization's namespace appearing rather than requiring a global wait.
 func (i *Provisioner) PlaceSecrets(ctx context.Context, blueprint *blueprintv1alpha1.Blueprint) error {
 	if blueprint == nil {
 		return fmt.Errorf("blueprint not provided")
@@ -1001,10 +1004,8 @@ func (i *Provisioner) PlaceSecrets(ctx context.Context, blueprint *blueprintv1al
 		if len(k.Secrets) == 0 {
 			continue
 		}
-		namespace, err := i.resolveSecretNamespace(ctx, k.Name)
-		if err != nil {
-			return err
-		}
+
+		resolved := make(map[string]map[string]string)
 		for secretName, data := range k.Secrets {
 			stringData := make(map[string]string, len(data))
 			for key, ref := range data {
@@ -1015,8 +1016,23 @@ func (i *Provisioner) PlaceSecrets(ctx context.Context, blueprint *blueprintv1al
 				if value == nil {
 					return fmt.Errorf("resolving secret %q key %q: reference %q resolved to nil", secretName, key, ref)
 				}
-				stringData[key] = fmt.Sprint(value)
+				if s := fmt.Sprint(value); s != "" {
+					stringData[key] = s
+				}
 			}
+			if len(stringData) > 0 {
+				resolved[secretName] = stringData
+			}
+		}
+		if len(resolved) == 0 {
+			continue
+		}
+
+		namespace, err := i.resolveSecretNamespace(ctx, k.Name)
+		if err != nil {
+			return err
+		}
+		for secretName, stringData := range resolved {
 			if err := i.KubernetesManager.ApplySecret(secretName, namespace, stringData); err != nil {
 				return fmt.Errorf("applying secret %q to namespace %q: %w", secretName, namespace, err)
 			}

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -983,10 +983,11 @@ func (i *Provisioner) Wait(ctx context.Context, blueprint *blueprintv1alpha1.Blu
 // PlaceSecrets materializes each flux system's declared Secrets into the namespace its owning
 // kustomization created. For every compiled kustomization carrying Secrets it resolves each data
 // reference to plaintext via the evaluator (which registers it with the shell scrubber). A reference
-// that resolves to nil fails closed — a required secret is misconfigured; an author opts a key into
-// optional by defaulting it (e.g. "${x ?? ”}"), which resolves to empty and omits that key. A secret
-// whose keys all resolve empty is not created at all, so an unconfigured optional secret leaves no
-// empty Secret behind. Only when a kustomization has something to place does it resolve the target
+// is required unless it carries a "??" default: a required reference (e.g. "${x}") that resolves to
+// nil or empty fails closed, since a missing required secret is misconfiguration. An author makes a
+// key optional by adding a ?? default to its reference; an optional key that resolves empty is omitted,
+// and a secret whose keys all resolve empty is not created at all, so an unconfigured optional secret
+// leaves no empty Secret behind. Only when a kustomization has something to place does it resolve the target
 // namespace from the kustomization's Flux inventory — failing closed unless exactly one Namespace was
 // created, so a secret is never placed by guessing — and apply an Opaque Secret. It is a no-op when no
 // kustomization declares Secrets. Placement is imperative and runs after Install; it self-gates on the
@@ -1013,12 +1014,18 @@ func (i *Provisioner) PlaceSecrets(ctx context.Context, blueprint *blueprintv1al
 				if err != nil {
 					return fmt.Errorf("resolving secret %q key %q: %w", secretName, key, err)
 				}
+				optional := strings.Contains(ref, "??")
 				if value == nil {
 					return fmt.Errorf("resolving secret %q key %q: reference %q resolved to nil", secretName, key, ref)
 				}
-				if s := fmt.Sprint(value); s != "" {
-					stringData[key] = s
+				s := fmt.Sprint(value)
+				if s == "" {
+					if optional {
+						continue
+					}
+					return fmt.Errorf("resolving secret %q key %q: reference %q resolved to empty; add a ?? default (e.g. %q) to make the key optional", secretName, key, ref, "${... ?? ''}")
 				}
+				stringData[key] = s
 			}
 			if len(stringData) > 0 {
 				resolved[secretName] = stringData

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -4443,8 +4443,8 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		}
 	})
 
-	t.Run("OmitsEmptyKeyAndPlacesRemaining", func(t *testing.T) {
-		// Given a secret with one key that resolves to a value and one that resolves empty
+	t.Run("OmitsEmptyOptionalKeyAndPlacesRemaining", func(t *testing.T) {
+		// Given a required key that resolves to a value and an optional (??-defaulted) key that resolves empty
 		mocks := setupProvisionerMocks(t)
 		mocks.ConfigHandler.(*config.MockConfigHandler).GetContextValuesFunc = func() (map[string]any, error) {
 			return map[string]any{"cdn": map[string]any{"token": "real-token", "extra": ""}}, nil
@@ -4459,10 +4459,10 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		}
 		bp := &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{{
 			Name:    "cdn-install",
-			Secrets: map[string]map[string]string{"creds": {"token": "${cdn.token}", "extra": "${cdn.extra}"}},
+			Secrets: map[string]map[string]string{"creds": {"token": "${cdn.token}", "extra": "${cdn.extra ?? ''}"}},
 		}}}
 
-		// When placing secrets, the empty key is omitted and the rest is placed
+		// When placing secrets, the empty optional key is omitted and the required one is placed
 		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), bp); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
@@ -4470,7 +4470,36 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 			t.Errorf("Expected token placed, got %v", gotData)
 		}
 		if _, exists := gotData["extra"]; exists {
-			t.Errorf("Expected empty key to be omitted, got %v", gotData)
+			t.Errorf("Expected empty optional key to be omitted, got %v", gotData)
+		}
+	})
+
+	t.Run("FailsWhenRequiredKeyResolvesEmpty", func(t *testing.T) {
+		// Given a required (no ?? default) key whose backing value is empty
+		mocks := setupProvisionerMocks(t)
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"cdn": map[string]any{"token": ""}}, nil
+		}
+		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
+			return []kubernetes.InventoryEntry{{Kind: "Namespace", Name: "system-dns"}}, nil
+		}
+		applied := false
+		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string) error {
+			applied = true
+			return nil
+		}
+		bp := &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{{
+			Name:    "cdn-install",
+			Secrets: map[string]map[string]string{"creds": {"token": "${cdn.token}"}},
+		}}}
+
+		// When placing secrets, the empty required key fails closed rather than being dropped
+		err := newProvisioner(mocks).PlaceSecrets(context.Background(), bp)
+		if err == nil || !strings.Contains(err.Error(), "resolved to empty") {
+			t.Errorf("Expected empty-required error, got %v", err)
+		}
+		if applied {
+			t.Error("Expected ApplySecret to not be called when a required key resolves empty")
 		}
 	})
 

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -4442,4 +4442,68 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 			t.Error("Expected no inventory query when no secrets are declared")
 		}
 	})
+
+	t.Run("OmitsEmptyKeyAndPlacesRemaining", func(t *testing.T) {
+		// Given a secret with one key that resolves to a value and one that resolves empty
+		mocks := setupProvisionerMocks(t)
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"cdn": map[string]any{"token": "real-token", "extra": ""}}, nil
+		}
+		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
+			return []kubernetes.InventoryEntry{{Kind: "Namespace", Name: "system-dns"}}, nil
+		}
+		var gotData map[string]string
+		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string) error {
+			gotData = stringData
+			return nil
+		}
+		bp := &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{{
+			Name:    "cdn-install",
+			Secrets: map[string]map[string]string{"creds": {"token": "${cdn.token}", "extra": "${cdn.extra}"}},
+		}}}
+
+		// When placing secrets, the empty key is omitted and the rest is placed
+		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), bp); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if gotData["token"] != "real-token" {
+			t.Errorf("Expected token placed, got %v", gotData)
+		}
+		if _, exists := gotData["extra"]; exists {
+			t.Errorf("Expected empty key to be omitted, got %v", gotData)
+		}
+	})
+
+	t.Run("SkipsWhollyEmptySecretWithoutQueryingNamespace", func(t *testing.T) {
+		// Given an optional secret defaulted with ?? '' whose source is unset
+		mocks := setupProvisionerMocks(t)
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"telemetry": map[string]any{"alerts": map[string]any{"slack": map[string]any{"webhook_url": nil}}}}, nil
+		}
+		queried := false
+		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
+			queried = true
+			return []kubernetes.InventoryEntry{{Kind: "Namespace", Name: "system-telemetry"}}, nil
+		}
+		applied := false
+		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string) error {
+			applied = true
+			return nil
+		}
+		bp := &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{{
+			Name:    "telemetry-install",
+			Secrets: map[string]map[string]string{"alertmanager-notification-slack": {"url": "${telemetry.alerts.slack.webhook_url ?? ''}"}},
+		}}}
+
+		// When placing secrets, no Secret is created and the namespace is never queried
+		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), bp); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if applied {
+			t.Error("Expected no Secret to be created when all keys resolve empty")
+		}
+		if queried {
+			t.Error("Expected no namespace query when there is nothing to place")
+		}
+	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This PR changes how `PlaceSecrets` materializes Kubernetes Secrets, silently dropping any key whose resolved value is an empty string — a behavioral shift that affects all existing callers of this path.
>
> **Overview**
>
> The PR restructures `PlaceSecrets` in two ways: keys that resolve to an empty string are now omitted from the Secret's `stringData` rather than included, and a kustomization whose every key resolves empty is skipped entirely — including the namespace inventory query — rather than creating an empty Secret. This avoids leaving vestigial Secrets for unconfigured optional values.
>
> The most notable behavioral detail is that the empty-string guard applies to all resolved values, not only those that explicitly opted in via the `?? ''` default operator. A required key whose backing config value is accidentally set to `""` will now be silently omitted rather than triggering a configuration error, which could surface later as a runtime failure in the consuming workload rather than at provisioning time. The two new tests cover the intended cases cleanly.
>
> Reviewed by Claude for commit `1ef7cbcd`.

<!-- /claude-code-review:summary -->
