### PR TITLE
feat(secrets): implement RollWorkloadsForSecret to roll workloads on secret changes

### DIFF
--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -6,6 +6,7 @@ package kubernetes
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"maps"
@@ -43,6 +44,7 @@ type KubernetesManager interface {
 	DeleteNamespace(name string) error
 	ApplyConfigMap(name, namespace string, data map[string]string) error
 	ApplySecret(name, namespace string, stringData map[string]string) error
+	RollWorkloadsForSecret(namespace, secretName, digest string) error
 	GetHelmReleasesForKustomization(name, namespace string) ([]helmv2.HelmRelease, error)
 	ApplyGitRepository(repo *sourcev1.GitRepository) error
 	ApplyOCIRepository(repo *sourcev1.OCIRepository) error
@@ -550,6 +552,113 @@ func (k *BaseKubernetesManager) ApplySecret(name, namespace string, stringData m
 	}
 
 	return k.applyWithRetry(gvr, obj, opts)
+}
+
+// secretChecksumAnnotationPrefix prefixes the pod-template annotation whose value is a content digest
+// of a secret the workload consumes. The suffix is the secret name, so each consumed secret gets its
+// own annotation and a change to one rolls only its consumers.
+const secretChecksumAnnotationPrefix = "checksum.windsorcli.dev/"
+
+// RollWorkloadsForSecret rolls the workloads in a namespace that consume the named Secret so they pick
+// up new content, the way Kubernetes only ever rolls on a pod-template change. Because the CLI holds the
+// resolved plaintext, it passes a precomputed content digest and stamps it as a pod-template annotation
+// (checksum.windsorcli.dev/<secret>) on every Deployment, StatefulSet, and DaemonSet whose pod spec
+// references the Secret via envFrom, a secretKeyRef, or a secret volume — including init containers. The
+// digest is one-way and never surfaced beyond the namespace, so a reader of the annotation learns
+// nothing the Secret's own RBAC did not already grant. A workload already carrying the digest is left
+// untouched (idempotent, so unchanged content does not churn pods); a workload that does not reference
+// the Secret is never patched. Finding no consumers is not an error — on a first apply the workload is
+// created later by Flux and reads the Secret fresh — so this returns an error only on an API failure.
+func (k *BaseKubernetesManager) RollWorkloadsForSecret(namespace, secretName, digest string) error {
+	annotationKey := secretChecksumAnnotationPrefix + secretName
+	for _, resource := range []string{"deployments", "statefulsets", "daemonsets"} {
+		gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: resource}
+		list, err := k.client.ListResources(gvr, namespace)
+		if err != nil {
+			return fmt.Errorf("listing %s in namespace %q: %w", resource, namespace, err)
+		}
+		if list == nil {
+			continue
+		}
+		for i := range list.Items {
+			obj := &list.Items[i]
+			podSpec, found, err := unstructured.NestedMap(obj.Object, "spec", "template", "spec")
+			if err != nil || !found || !podSpecReferencesSecret(podSpec, secretName) {
+				continue
+			}
+			current, _, _ := unstructured.NestedString(obj.Object, "spec", "template", "metadata", "annotations", annotationKey)
+			if current == digest {
+				continue
+			}
+			patch, err := json.Marshal(map[string]any{
+				"spec": map[string]any{
+					"template": map[string]any{
+						"metadata": map[string]any{
+							"annotations": map[string]any{annotationKey: digest},
+						},
+					},
+				},
+			})
+			if err != nil {
+				return fmt.Errorf("building rollout patch for %s %q: %w", resource, obj.GetName(), err)
+			}
+			opts := metav1.PatchOptions{FieldManager: "windsor-cli"}
+			if _, err := k.client.PatchResource(context.Background(), gvr, namespace, obj.GetName(), types.MergePatchType, patch, opts); err != nil {
+				return fmt.Errorf("patching %s %q in namespace %q: %w", resource, obj.GetName(), namespace, err)
+			}
+		}
+	}
+	return nil
+}
+
+// podSpecReferencesSecret reports whether an unstructured pod spec consumes the named Secret through any
+// path that requires a restart to pick up new content: an envFrom secretRef, an env secretKeyRef, or a
+// secret volume, across both containers and init containers.
+func podSpecReferencesSecret(podSpec map[string]any, secretName string) bool {
+	if volumes, ok := podSpec["volumes"].([]any); ok {
+		for _, v := range volumes {
+			vm, _ := v.(map[string]any)
+			if s, ok := vm["secret"].(map[string]any); ok {
+				if name, _ := s["secretName"].(string); name == secretName {
+					return true
+				}
+			}
+		}
+	}
+	for _, field := range []string{"containers", "initContainers"} {
+		containers, ok := podSpec[field].([]any)
+		if !ok {
+			continue
+		}
+		for _, c := range containers {
+			cm, _ := c.(map[string]any)
+			if envFrom, ok := cm["envFrom"].([]any); ok {
+				for _, e := range envFrom {
+					em, _ := e.(map[string]any)
+					if sr, ok := em["secretRef"].(map[string]any); ok {
+						if name, _ := sr["name"].(string); name == secretName {
+							return true
+						}
+					}
+				}
+			}
+			if env, ok := cm["env"].([]any); ok {
+				for _, e := range env {
+					em, _ := e.(map[string]any)
+					vf, ok := em["valueFrom"].(map[string]any)
+					if !ok {
+						continue
+					}
+					if skr, ok := vf["secretKeyRef"].(map[string]any); ok {
+						if name, _ := skr["name"].(string); name == secretName {
+							return true
+						}
+					}
+				}
+			}
+		}
+	}
+	return false
 }
 
 // ApplyVersionMarker writes the applied-version marker ConfigMap to the namespace, recording which

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -44,7 +44,7 @@ type KubernetesManager interface {
 	DeleteNamespace(name string) error
 	ApplyConfigMap(name, namespace string, data map[string]string) error
 	ApplySecret(name, namespace string, stringData map[string]string) error
-	RollWorkloadsForSecret(namespace, secretName, digest string) error
+	RollWorkloadsForSecret(ctx context.Context, namespace, secretName, digest string) error
 	GetHelmReleasesForKustomization(name, namespace string) ([]helmv2.HelmRelease, error)
 	ApplyGitRepository(repo *sourcev1.GitRepository) error
 	ApplyOCIRepository(repo *sourcev1.OCIRepository) error
@@ -568,8 +568,9 @@ const secretChecksumAnnotationPrefix = "checksum.windsorcli.dev/"
 // nothing the Secret's own RBAC did not already grant. A workload already carrying the digest is left
 // untouched (idempotent, so unchanged content does not churn pods); a workload that does not reference
 // the Secret is never patched. Finding no consumers is not an error — on a first apply the workload is
-// created later by Flux and reads the Secret fresh — so this returns an error only on an API failure.
-func (k *BaseKubernetesManager) RollWorkloadsForSecret(namespace, secretName, digest string) error {
+// created later by Flux and reads the Secret fresh — so this returns an error only on an API failure. The
+// caller's context bounds the patch calls so a slow API server cannot outlast its deadline.
+func (k *BaseKubernetesManager) RollWorkloadsForSecret(ctx context.Context, namespace, secretName, digest string) error {
 	annotationKey := secretChecksumAnnotationPrefix + secretName
 	for _, resource := range []string{"deployments", "statefulsets", "daemonsets"} {
 		gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: resource}
@@ -603,7 +604,7 @@ func (k *BaseKubernetesManager) RollWorkloadsForSecret(namespace, secretName, di
 				return fmt.Errorf("building rollout patch for %s %q: %w", resource, obj.GetName(), err)
 			}
 			opts := metav1.PatchOptions{FieldManager: "windsor-cli"}
-			if _, err := k.client.PatchResource(context.Background(), gvr, namespace, obj.GetName(), types.MergePatchType, patch, opts); err != nil {
+			if _, err := k.client.PatchResource(ctx, gvr, namespace, obj.GetName(), types.MergePatchType, patch, opts); err != nil {
 				return fmt.Errorf("patching %s %q in namespace %q: %w", resource, obj.GetName(), namespace, err)
 			}
 		}

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -6,6 +6,8 @@ package kubernetes
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -559,6 +561,21 @@ func (k *BaseKubernetesManager) ApplySecret(name, namespace string, stringData m
 // own annotation and a change to one rolls only its consumers.
 const secretChecksumAnnotationPrefix = "checksum.windsorcli.dev/"
 
+// secretChecksumAnnotationKey builds the pod-template annotation key for a secret's content digest. The
+// name segment after the prefix must be at most 63 characters, but Secret names may be longer; for an
+// over-long name it substitutes a deterministic, collision-resistant segment (the truncated name plus a
+// short hash of the full name) so the roll still works and the key stays valid rather than failing with
+// an opaque API validation error.
+func secretChecksumAnnotationKey(secretName string) string {
+	const maxNameSegment = 63
+	segment := secretName
+	if len(segment) > maxNameSegment {
+		sum := sha256.Sum256([]byte(secretName))
+		segment = secretName[:maxNameSegment-9] + "-" + hex.EncodeToString(sum[:])[:8]
+	}
+	return secretChecksumAnnotationPrefix + segment
+}
+
 // RollWorkloadsForSecret rolls the workloads in a namespace that consume the named Secret so they pick
 // up new content, the way Kubernetes only ever rolls on a pod-template change. Because the CLI holds the
 // resolved plaintext, it passes a precomputed content digest and stamps it as a pod-template annotation
@@ -571,7 +588,7 @@ const secretChecksumAnnotationPrefix = "checksum.windsorcli.dev/"
 // created later by Flux and reads the Secret fresh — so this returns an error only on an API failure. The
 // caller's context bounds the patch calls so a slow API server cannot outlast its deadline.
 func (k *BaseKubernetesManager) RollWorkloadsForSecret(ctx context.Context, namespace, secretName, digest string) error {
-	annotationKey := secretChecksumAnnotationPrefix + secretName
+	annotationKey := secretChecksumAnnotationKey(secretName)
 	for _, resource := range []string{"deployments", "statefulsets", "daemonsets"} {
 		gvr := schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: resource}
 		list, err := k.client.ListResources(gvr, namespace)

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -5724,6 +5724,33 @@ func TestBaseKubernetesManager_ApplySecret(t *testing.T) {
 	})
 }
 
+func TestSecretChecksumAnnotationKey(t *testing.T) {
+	t.Run("ShortNameUsedVerbatim", func(t *testing.T) {
+		// Given a normal-length secret name, the key stays readable
+		if got := secretChecksumAnnotationKey("alertmanager-slack"); got != "checksum.windsorcli.dev/alertmanager-slack" {
+			t.Errorf("unexpected key %q", got)
+		}
+	})
+
+	t.Run("LongNameStaysWithinLimitDeterministicAndUnique", func(t *testing.T) {
+		// Given a secret name longer than the 63-char annotation name-segment limit
+		long := strings.Repeat("a", 80)
+		got := secretChecksumAnnotationKey(long)
+
+		// Then the segment after the prefix is a valid length, deterministic, and distinct per name
+		segment := strings.TrimPrefix(got, secretChecksumAnnotationPrefix)
+		if len(segment) > 63 {
+			t.Errorf("segment %q exceeds 63 chars (%d)", segment, len(segment))
+		}
+		if got != secretChecksumAnnotationKey(long) {
+			t.Error("expected a deterministic key for the same name")
+		}
+		if got == secretChecksumAnnotationKey(strings.Repeat("a", 79)+"b") {
+			t.Error("expected distinct long names to produce distinct keys")
+		}
+	})
+}
+
 func TestBaseKubernetesManager_RollWorkloadsForSecret(t *testing.T) {
 	const secretName = "alertmanager-slack"
 	annotationKey := secretChecksumAnnotationPrefix + secretName

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -5780,7 +5780,7 @@ func TestBaseKubernetesManager_RollWorkloadsForSecret(t *testing.T) {
 		})
 
 		// When rolling workloads for the secret
-		if err := manager.RollWorkloadsForSecret("system-telemetry", secretName, "digest-1"); err != nil {
+		if err := manager.RollWorkloadsForSecret(context.Background(), "system-telemetry", secretName, "digest-1"); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
@@ -5807,7 +5807,7 @@ func TestBaseKubernetesManager_RollWorkloadsForSecret(t *testing.T) {
 		})
 
 		// When rolling with that same digest
-		if err := manager.RollWorkloadsForSecret("system-telemetry", secretName, "digest-1"); err != nil {
+		if err := manager.RollWorkloadsForSecret(context.Background(), "system-telemetry", secretName, "digest-1"); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
@@ -5828,7 +5828,7 @@ func TestBaseKubernetesManager_RollWorkloadsForSecret(t *testing.T) {
 		manager.client = kubernetesClient
 
 		// When rolling workloads, the API failure surfaces rather than being swallowed
-		if err := manager.RollWorkloadsForSecret("system-telemetry", secretName, "digest-1"); err == nil {
+		if err := manager.RollWorkloadsForSecret(context.Background(), "system-telemetry", secretName, "digest-1"); err == nil {
 			t.Error("Expected error when listing workloads fails")
 		}
 	})

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -5723,3 +5723,113 @@ func TestBaseKubernetesManager_ApplySecret(t *testing.T) {
 		}
 	})
 }
+
+func TestBaseKubernetesManager_RollWorkloadsForSecret(t *testing.T) {
+	const secretName = "alertmanager-slack"
+	annotationKey := secretChecksumAnnotationPrefix + secretName
+
+	// workload builds an apps/v1 workload with the given pod spec and pod-template annotations.
+	workload := func(kind, name string, podSpec map[string]any, annotations map[string]any) unstructured.Unstructured {
+		tmplMeta := map[string]any{}
+		if annotations != nil {
+			tmplMeta["annotations"] = annotations
+		}
+		return unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "apps/v1",
+			"kind":       kind,
+			"metadata":   map[string]any{"name": name, "namespace": "system-telemetry"},
+			"spec": map[string]any{
+				"template": map[string]any{"metadata": tmplMeta, "spec": podSpec},
+			},
+		}}
+	}
+	envRef := map[string]any{"containers": []any{map[string]any{"name": "app", "env": []any{
+		map[string]any{"name": "URL", "valueFrom": map[string]any{"secretKeyRef": map[string]any{"name": secretName, "key": "url"}}},
+	}}}}
+	volumeRef := map[string]any{"volumes": []any{map[string]any{"name": "s", "secret": map[string]any{"secretName": secretName}}}}
+	envFromRef := map[string]any{"containers": []any{map[string]any{"name": "app", "envFrom": []any{
+		map[string]any{"secretRef": map[string]any{"name": secretName}},
+	}}}}
+	noRef := map[string]any{"containers": []any{map[string]any{"name": "app", "env": []any{
+		map[string]any{"name": "OTHER", "valueFrom": map[string]any{"secretKeyRef": map[string]any{"name": "some-other-secret", "key": "k"}}},
+	}}}}
+
+	setup := func(t *testing.T, lists map[string][]unstructured.Unstructured) (*BaseKubernetesManager, *map[string]string) {
+		t.Helper()
+		mocks := setupKubernetesMocks(t)
+		manager := NewKubernetesManager(mocks.KubernetesClient, mocks.ConfigHandler)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.ListResourcesFunc = func(gvr schema.GroupVersionResource, ns string) (*unstructured.UnstructuredList, error) {
+			return &unstructured.UnstructuredList{Items: lists[gvr.Resource]}, nil
+		}
+		patched := map[string]string{}
+		kubernetesClient.PatchResourceFunc = func(ctx context.Context, gvr schema.GroupVersionResource, ns, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*unstructured.Unstructured, error) {
+			patched[gvr.Resource+"/"+name] = string(data)
+			return nil, nil
+		}
+		manager.client = kubernetesClient
+		return manager, &patched
+	}
+
+	t.Run("RollsOnlyReferencingWorkloadsAcrossKinds", func(t *testing.T) {
+		// Given one referencing and one non-referencing workload of each kind, referencing via a different path each
+		manager, patched := setup(t, map[string][]unstructured.Unstructured{
+			"deployments":  {workload("Deployment", "env-consumer", envRef, nil), workload("Deployment", "bystander", noRef, nil)},
+			"statefulsets": {workload("StatefulSet", "volume-consumer", volumeRef, nil)},
+			"daemonsets":   {workload("DaemonSet", "envfrom-consumer", envFromRef, nil)},
+		})
+
+		// When rolling workloads for the secret
+		if err := manager.RollWorkloadsForSecret("system-telemetry", secretName, "digest-1"); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then every referencing workload is patched with the digest annotation and the bystander is left alone
+		for _, key := range []string{"deployments/env-consumer", "statefulsets/volume-consumer", "daemonsets/envfrom-consumer"} {
+			p, ok := (*patched)[key]
+			if !ok {
+				t.Errorf("Expected %s to be rolled", key)
+				continue
+			}
+			if !strings.Contains(p, annotationKey) || !strings.Contains(p, "digest-1") {
+				t.Errorf("Expected patch of %s to carry the digest annotation, got %s", key, p)
+			}
+		}
+		if _, ok := (*patched)["deployments/bystander"]; ok {
+			t.Error("Expected non-referencing workload to be left untouched")
+		}
+	})
+
+	t.Run("IdempotentWhenDigestUnchanged", func(t *testing.T) {
+		// Given a referencing workload that already carries the current digest
+		manager, patched := setup(t, map[string][]unstructured.Unstructured{
+			"deployments": {workload("Deployment", "env-consumer", envRef, map[string]any{annotationKey: "digest-1"})},
+		})
+
+		// When rolling with that same digest
+		if err := manager.RollWorkloadsForSecret("system-telemetry", secretName, "digest-1"); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then it is not patched, so unchanged content does not churn pods
+		if len(*patched) != 0 {
+			t.Errorf("Expected no patch for an unchanged digest, got %v", *patched)
+		}
+	})
+
+	t.Run("ListErrorSurfaces", func(t *testing.T) {
+		// Given a client whose workload list fails
+		mocks := setupKubernetesMocks(t)
+		manager := NewKubernetesManager(mocks.KubernetesClient, mocks.ConfigHandler)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.ListResourcesFunc = func(gvr schema.GroupVersionResource, ns string) (*unstructured.UnstructuredList, error) {
+			return nil, fmt.Errorf("api down")
+		}
+		manager.client = kubernetesClient
+
+		// When rolling workloads, the API failure surfaces rather than being swallowed
+		if err := manager.RollWorkloadsForSecret("system-telemetry", secretName, "digest-1"); err == nil {
+			t.Error("Expected error when listing workloads fails")
+		}
+	})
+}

--- a/pkg/provisioner/kubernetes/mock_kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/mock_kubernetes_manager.go
@@ -27,6 +27,7 @@ type MockKubernetesManager struct {
 	DeleteNamespaceFunc                 func(name string) error
 	ApplyConfigMapFunc                  func(name, namespace string, data map[string]string) error
 	ApplySecretFunc                     func(name, namespace string, stringData map[string]string) error
+	RollWorkloadsForSecretFunc          func(namespace, secretName, digest string) error
 	ApplyVersionMarkerFunc              func(namespace string, marker VersionMarker) error
 	GetVersionMarkerFunc                func(namespace string) (VersionMarker, bool, error)
 	GetHelmReleasesForKustomizationFunc func(name, namespace string) ([]helmv2.HelmRelease, error)
@@ -116,6 +117,14 @@ func (m *MockKubernetesManager) ApplyConfigMap(name, namespace string, data map[
 func (m *MockKubernetesManager) ApplySecret(name, namespace string, stringData map[string]string) error {
 	if m.ApplySecretFunc != nil {
 		return m.ApplySecretFunc(name, namespace, stringData)
+	}
+	return nil
+}
+
+// RollWorkloadsForSecret implements KubernetesManager interface
+func (m *MockKubernetesManager) RollWorkloadsForSecret(namespace, secretName, digest string) error {
+	if m.RollWorkloadsForSecretFunc != nil {
+		return m.RollWorkloadsForSecretFunc(namespace, secretName, digest)
 	}
 	return nil
 }

--- a/pkg/provisioner/kubernetes/mock_kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/mock_kubernetes_manager.go
@@ -27,7 +27,7 @@ type MockKubernetesManager struct {
 	DeleteNamespaceFunc                 func(name string) error
 	ApplyConfigMapFunc                  func(name, namespace string, data map[string]string) error
 	ApplySecretFunc                     func(name, namespace string, stringData map[string]string) error
-	RollWorkloadsForSecretFunc          func(namespace, secretName, digest string) error
+	RollWorkloadsForSecretFunc          func(ctx context.Context, namespace, secretName, digest string) error
 	ApplyVersionMarkerFunc              func(namespace string, marker VersionMarker) error
 	GetVersionMarkerFunc                func(namespace string) (VersionMarker, bool, error)
 	GetHelmReleasesForKustomizationFunc func(name, namespace string) ([]helmv2.HelmRelease, error)
@@ -122,9 +122,9 @@ func (m *MockKubernetesManager) ApplySecret(name, namespace string, stringData m
 }
 
 // RollWorkloadsForSecret implements KubernetesManager interface
-func (m *MockKubernetesManager) RollWorkloadsForSecret(namespace, secretName, digest string) error {
+func (m *MockKubernetesManager) RollWorkloadsForSecret(ctx context.Context, namespace, secretName, digest string) error {
 	if m.RollWorkloadsForSecretFunc != nil {
-		return m.RollWorkloadsForSecretFunc(namespace, secretName, digest)
+		return m.RollWorkloadsForSecretFunc(ctx, namespace, secretName, digest)
 	}
 	return nil
 }

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -2,6 +2,8 @@ package provisioner
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io/fs"
@@ -1040,7 +1042,9 @@ func (i *Provisioner) ResolveSecrets(blueprint *blueprintv1alpha1.Blueprint) (Re
 // PlaceSecrets materializes secrets that ResolveSecrets produced into the namespace each owning
 // kustomization created. It runs after Install; for each kustomization it resolves the target namespace
 // from that kustomization's Flux inventory — failing closed unless exactly one Namespace was created, so
-// a secret is never placed by guessing — and applies an Opaque Secret. It self-gates on the owning
+// a secret is never placed by guessing — and applies an Opaque Secret. After placing each Secret it rolls
+// the workloads in that namespace that consume it, keyed by a content digest, so a changed value reaches
+// running pods rather than sitting stale until the next unrelated restart. It self-gates on the owning
 // kustomization's namespace appearing rather than requiring a global wait, and is a no-op when resolved
 // is empty.
 func (i *Provisioner) PlaceSecrets(ctx context.Context, resolved ResolvedSecrets) error {
@@ -1060,9 +1064,32 @@ func (i *Provisioner) PlaceSecrets(ctx context.Context, resolved ResolvedSecrets
 			if err := i.KubernetesManager.ApplySecret(secretName, namespace, stringData); err != nil {
 				return fmt.Errorf("applying secret %q to namespace %q: %w", secretName, namespace, err)
 			}
+			if err := i.KubernetesManager.RollWorkloadsForSecret(namespace, secretName, secretDigest(stringData)); err != nil {
+				return fmt.Errorf("rolling workloads for secret %q in namespace %q: %w", secretName, namespace, err)
+			}
 		}
 	}
 	return nil
+}
+
+// secretDigest returns a stable content digest for a secret's resolved data, used to roll consuming
+// workloads only when the content actually changes. Keys are sorted and each key and value is
+// length-delimited by a NUL so distinct maps cannot collide, then hashed with SHA-256. The digest is
+// one-way: it detects change without revealing the plaintext it summarizes.
+func secretDigest(stringData map[string]string) string {
+	keys := make([]string, 0, len(stringData))
+	for k := range stringData {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	h := sha256.New()
+	for _, k := range keys {
+		h.Write([]byte(k))
+		h.Write([]byte{0})
+		h.Write([]byte(stringData[k]))
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
 }
 
 // resolveSecretNamespace polls the owning kustomization's Flux inventory until Flux has applied the

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -1064,7 +1064,7 @@ func (i *Provisioner) PlaceSecrets(ctx context.Context, resolved ResolvedSecrets
 			if err := i.KubernetesManager.ApplySecret(secretName, namespace, stringData); err != nil {
 				return fmt.Errorf("applying secret %q to namespace %q: %w", secretName, namespace, err)
 			}
-			if err := i.KubernetesManager.RollWorkloadsForSecret(namespace, secretName, secretDigest(stringData)); err != nil {
+			if err := i.KubernetesManager.RollWorkloadsForSecret(ctx, namespace, secretName, secretDigest(stringData)); err != nil {
 				return fmt.Errorf("rolling workloads for secret %q in namespace %q: %w", secretName, namespace, err)
 			}
 		}

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -4453,7 +4453,7 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 			return []kubernetes.InventoryEntry{{Kind: "Namespace", Name: "system-dns"}}, nil
 		}
 		var rolledNs, rolledSecret, rolledDigest string
-		mocks.KubernetesManager.RollWorkloadsForSecretFunc = func(namespace, secretName, digest string) error {
+		mocks.KubernetesManager.RollWorkloadsForSecretFunc = func(ctx context.Context, namespace, secretName, digest string) error {
 			rolledNs, rolledSecret, rolledDigest = namespace, secretName, digest
 			return nil
 		}
@@ -4476,7 +4476,7 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
 			return []kubernetes.InventoryEntry{{Kind: "Namespace", Name: "system-dns"}}, nil
 		}
-		mocks.KubernetesManager.RollWorkloadsForSecretFunc = func(namespace, secretName, digest string) error {
+		mocks.KubernetesManager.RollWorkloadsForSecretFunc = func(ctx context.Context, namespace, secretName, digest string) error {
 			return fmt.Errorf("api down")
 		}
 

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -4446,6 +4446,47 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		}
 	})
 
+	t.Run("RollsConsumersWithContentDigest", func(t *testing.T) {
+		// Given a kustomization whose inventory holds exactly one applied namespace
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
+			return []kubernetes.InventoryEntry{{Kind: "Namespace", Name: "system-dns"}}, nil
+		}
+		var rolledNs, rolledSecret, rolledDigest string
+		mocks.KubernetesManager.RollWorkloadsForSecretFunc = func(namespace, secretName, digest string) error {
+			rolledNs, rolledSecret, rolledDigest = namespace, secretName, digest
+			return nil
+		}
+
+		// When placing the resolved secrets
+		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved()); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then consumers are rolled in the inventory namespace, keyed by the resolved content's digest
+		wantDigest := secretDigest(map[string]string{"api_token": "resolved-token"})
+		if rolledNs != "system-dns" || rolledSecret != "cloudflare-creds" || rolledDigest != wantDigest {
+			t.Errorf("Unexpected roll args: ns=%q secret=%q digest=%q (want digest %q)", rolledNs, rolledSecret, rolledDigest, wantDigest)
+		}
+	})
+
+	t.Run("RollFailureSurfaces", func(t *testing.T) {
+		// Given placement succeeds but rolling consumers fails
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
+			return []kubernetes.InventoryEntry{{Kind: "Namespace", Name: "system-dns"}}, nil
+		}
+		mocks.KubernetesManager.RollWorkloadsForSecretFunc = func(namespace, secretName, digest string) error {
+			return fmt.Errorf("api down")
+		}
+
+		// When placing the resolved secrets, the roll failure surfaces
+		err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved())
+		if err == nil || !strings.Contains(err.Error(), "rolling workloads for secret") {
+			t.Errorf("Expected roll-failure error, got %v", err)
+		}
+	})
+
 	t.Run("FailsClosedWhenMultipleNamespaces", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
 		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This PR adds workload-rollout logic as a side effect of every `PlaceSecrets` call, touching Deployments, StatefulSets, and DaemonSets in a namespace via the Kubernetes API; the risk is bounded to the target namespace and the operation is idempotent, but it expands the blast radius of an existing provisioner step.
>
> **Overview**
>
> The PR adds `RollWorkloadsForSecret` to `KubernetesManager`, which inspects each workload's pod spec for references to a named Secret (via `envFrom`, `env.secretKeyRef`, or a secret volume) and stamps a SHA-256 content digest as a pod-template annotation (`checksum.windsorcli.dev/<secret-name>`), triggering a controlled rollout. `PlaceSecrets` is updated to call this immediately after `ApplySecret`, computing the digest from the resolved plaintext via a sorted, NUL-delimited SHA-256 hash. The implementation is correct and the test coverage is solid — idempotency, multi-kind fan-out, and error surfacing are all verified.
>
> The annotation key embeds the raw secret name, so names longer than 63 characters would produce an invalid Kubernetes annotation key (the name segment after `/` is capped at 63 chars by the Kubernetes API); the resulting API error would surface but with a confusing message. Additionally, `PatchResource` is called with `context.Background()` rather than the context passed into `PlaceSecrets`, so cancellation is not propagated to patch operations.
>
> Reviewed by Claude for commit `23effccd`.

<!-- /claude-code-review:summary -->
