### PR TITLE
feat(secrets): place facet secrets into explicitly named namespaces

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -288,6 +288,32 @@ func (i *IntExpression) DeepCopy() *IntExpression {
 	return copy
 }
 
+// SecretEntry is one `secrets:` entry on a flux system tier: the data that backs a Kubernetes Secret
+// plus the namespaces it is placed into. Namespaces is optional — when omitted the target auto-resolves
+// to the single namespace the owning kustomization creates (unchanged from the original behavior); when
+// set it names the target(s) explicitly, so a system that owns more than one namespace (e.g. pki, which
+// owns system-pki and system-pki-trust) can place a secret and a single entry can fan out to several
+// namespaces. It is a plain struct decoded directly by the YAML decoder — data lives under `data:` so a
+// data key can never collide with the `namespaces:` selector.
+type SecretEntry struct {
+	// Namespaces are the namespaces to place this Secret into. Empty means auto-resolve the single
+	// namespace the owning kustomization creates; each named namespace must be one that kustomization
+	// provably created.
+	Namespaces []string `yaml:"namespaces,omitempty"`
+
+	// Data is the Secret's contents: data key -> reference to a schema property, resolved JIT at
+	// placement and never rendered in plaintext.
+	Data map[string]string `yaml:"data,omitempty"`
+}
+
+// DeepCopy returns a deep copy of the SecretEntry, sharing no slice or map with the original.
+func (s SecretEntry) DeepCopy() SecretEntry {
+	return SecretEntry{
+		Namespaces: slices.Clone(s.Namespaces),
+		Data:       maps.Clone(s.Data),
+	}
+}
+
 // Blueprint is a configuration blueprint for initializing a project.
 type Blueprint struct {
 	// Kind is the blueprint type, following Kubernetes conventions.
@@ -596,11 +622,11 @@ type Kustomization struct {
 	Substitute map[string]string `yaml:"substitute,omitempty"`
 
 	// Secrets carries a flux system's Secrets onto its compiled namespace-owning tier so the imperative
-	// placement step can find them after flattening: Secret name -> data key -> reference to a sensitive
-	// schema property, resolved JIT at placement, never during composition. It is yaml:"-" so it is
-	// never marshaled into show/apply output or the written blueprint, keeping secret material out of
-	// every serialized surface by construction.
-	Secrets map[string]map[string]string `yaml:"-"`
+	// placement step can find them after flattening: Secret name -> SecretEntry (target namespaces plus
+	// data), resolved JIT at placement, never during composition. It is yaml:"-" so it is never
+	// marshaled into show/apply output or the written blueprint, keeping secret material out of every
+	// serialized surface by construction.
+	Secrets map[string]SecretEntry `yaml:"-"`
 }
 
 // FluxSystem is a system entry under a blueprint or facet's `flux:` list — a functional layer that
@@ -653,12 +679,12 @@ type FluxSystem struct {
 	// Resources are the custom-resource tier variants, all sharing "<path>/resources".
 	Resources []FluxVariant `yaml:"resources,omitempty"`
 
-	// Secrets declares Kubernetes Secrets for this system, keyed by Secret name; each inner map is that
-	// Secret's data (data key -> reference to a schema property marked `sensitive: true`). Unlike
-	// Substitute (plaintext ConfigMap material), Secrets back real Secrets placed into the system's
-	// namespace and are resolved and materialized separately — their values are never rendered or
-	// written in plaintext.
-	Secrets map[string]map[string]string `yaml:"secrets,omitempty"`
+	// Secrets declares Kubernetes Secrets for this system, keyed by Secret name; each entry carries the
+	// Secret's data (data key -> reference to a schema property marked `sensitive: true`) and, optionally,
+	// the namespaces to place it into. Unlike Substitute (plaintext ConfigMap material), Secrets back real
+	// Secrets placed into the system's namespace(s) and are resolved and materialized separately — their
+	// values are never rendered or written in plaintext.
+	Secrets map[string]SecretEntry `yaml:"secrets,omitempty"`
 }
 
 // FluxVariant is one resources-tier Kustomization of a system. It reuses Kustomization for its
@@ -1200,35 +1226,44 @@ func compileFluxSystemTiers(sys FluxSystem) []Kustomization {
 	return out
 }
 
-// cloneSecretData deep-copies a nested secret map (Secret name -> data key -> value reference) so a
-// clone shares no inner maps with the original.
-func cloneSecretData(in map[string]map[string]string) map[string]map[string]string {
+// cloneSecretData deep-copies a secret map (Secret name -> SecretEntry) so a clone shares no slice or
+// map with the original.
+func cloneSecretData(in map[string]SecretEntry) map[string]SecretEntry {
 	if in == nil {
 		return nil
 	}
-	out := make(map[string]map[string]string, len(in))
-	for name, data := range in {
-		out[name] = maps.Clone(data)
+	out := make(map[string]SecretEntry, len(in))
+	for name, entry := range in {
+		out[name] = entry.DeepCopy()
 	}
 	return out
 }
 
-// mergeSecretData unions two nested secret maps (Secret name -> data key -> reference) with overlay
-// winning per data key, and nil when both are empty. Neither input is mutated. Used to combine a flux
-// system's Secrets when the same-named system is upserted across sources.
-func mergeSecretData(base, overlay map[string]map[string]string) map[string]map[string]string {
+// mergeSecretData unions two secret maps (Secret name -> SecretEntry) with overlay winning per data key
+// and the two entries' namespaces unioned, and nil when both are empty. Neither input is mutated. Used
+// to combine a flux system's Secrets when the same-named system is upserted across sources.
+func mergeSecretData(base, overlay map[string]SecretEntry) map[string]SecretEntry {
 	if len(base) == 0 && len(overlay) == 0 {
 		return nil
 	}
 	out := cloneSecretData(base)
 	if out == nil {
-		out = make(map[string]map[string]string, len(overlay))
+		out = make(map[string]SecretEntry, len(overlay))
 	}
-	for name, data := range overlay {
-		if out[name] == nil {
-			out[name] = make(map[string]string, len(data))
+	for name, entry := range overlay {
+		merged := out[name]
+		for _, ns := range entry.Namespaces {
+			if !slices.Contains(merged.Namespaces, ns) {
+				merged.Namespaces = append(merged.Namespaces, ns)
+			}
 		}
-		maps.Copy(out[name], data)
+		if len(entry.Data) > 0 {
+			if merged.Data == nil {
+				merged.Data = make(map[string]string, len(entry.Data))
+			}
+			maps.Copy(merged.Data, entry.Data)
+		}
+		out[name] = merged
 	}
 	return out
 }

--- a/api/v1alpha1/blueprint_types_test.go
+++ b/api/v1alpha1/blueprint_types_test.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -4988,7 +4989,7 @@ func TestBlueprint_UpsertFluxSystem(t *testing.T) {
 		// When another source's same-named system contributes a secret
 		if err := b.UpsertFluxSystem(FluxSystem{
 			Name:    "telemetry",
-			Secrets: map[string]map[string]string{"alertmanager-slack": {"webhook_url": `${secret("Developer", "slack_webhooks", "url")}`}},
+			Secrets: map[string]SecretEntry{"alertmanager-slack": {Data: map[string]string{"webhook_url": `${secret("Developer", "slack_webhooks", "url")}`}}},
 		}); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -4997,7 +4998,7 @@ func TestBlueprint_UpsertFluxSystem(t *testing.T) {
 		if len(b.FluxSystems) != 1 {
 			t.Fatalf("expected one merged telemetry entry, got %+v", b.FluxSystems)
 		}
-		got := b.FluxSystems[0].Secrets["alertmanager-slack"]["webhook_url"]
+		got := b.FluxSystems[0].Secrets["alertmanager-slack"].Data["webhook_url"]
 		if got != `${secret("Developer", "slack_webhooks", "url")}` {
 			t.Errorf("expected the contributed secret to survive the merge, got %q (all: %+v)", got, b.FluxSystems[0].Secrets)
 		}
@@ -5008,22 +5009,46 @@ func TestBlueprint_UpsertFluxSystem(t *testing.T) {
 		b := &Blueprint{
 			FluxSystems: []FluxSystem{{
 				Name:    "telemetry",
-				Secrets: map[string]map[string]string{"creds": {"a": "${x.a}"}},
+				Secrets: map[string]SecretEntry{"creds": {Data: map[string]string{"a": "${x.a}"}}},
 			}},
 		}
 
 		// When a same-named system contributes another secret data key
 		if err := b.UpsertFluxSystem(FluxSystem{
 			Name:    "telemetry",
-			Secrets: map[string]map[string]string{"creds": {"b": "${x.b}"}},
+			Secrets: map[string]SecretEntry{"creds": {Data: map[string]string{"b": "${x.b}"}}},
 		}); err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 
 		// Then both data keys survive under the same secret name
-		creds := b.FluxSystems[0].Secrets["creds"]
+		creds := b.FluxSystems[0].Secrets["creds"].Data
 		if creds["a"] != "${x.a}" || creds["b"] != "${x.b}" {
 			t.Errorf("expected secret data keys to union, got %+v", creds)
+		}
+	})
+
+	t.Run("UnionsSecretNamespacesAcrossBothSidesOnNameCollision", func(t *testing.T) {
+		// Given a system whose secret already targets one namespace
+		b := &Blueprint{
+			FluxSystems: []FluxSystem{{
+				Name:    "pki",
+				Secrets: map[string]SecretEntry{"acme-dns": {Namespaces: []string{"system-pki"}, Data: map[string]string{"token": "${pki.token}"}}},
+			}},
+		}
+
+		// When a same-named system contributes the same secret targeting another namespace
+		if err := b.UpsertFluxSystem(FluxSystem{
+			Name:    "pki",
+			Secrets: map[string]SecretEntry{"acme-dns": {Namespaces: []string{"system-dns"}, Data: map[string]string{"token": "${pki.token}"}}},
+		}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Then the secret fans out to both namespaces without duplication
+		got := b.FluxSystems[0].Secrets["acme-dns"].Namespaces
+		if len(got) != 2 || !slices.Contains(got, "system-pki") || !slices.Contains(got, "system-dns") {
+			t.Errorf("expected namespaces to union to [system-pki system-dns], got %+v", got)
 		}
 	})
 }
@@ -5136,34 +5161,41 @@ func findKustomization(all []Kustomization, name string) *Kustomization {
 
 func TestFluxSystem_Secrets(t *testing.T) {
 	t.Run("DeepCopyClonesSecretsIndependently", func(t *testing.T) {
-		// Given a flux system with a named secret carrying a data key
+		// Given a flux system with a named secret carrying namespaces and a data key
 		original := &FluxSystem{
 			Name:    "cdn",
-			Secrets: map[string]map[string]string{"cloudflare-creds": {"api_token": "${cdn.cloudflare_api_key}"}},
+			Secrets: map[string]SecretEntry{"cloudflare-creds": {Namespaces: []string{"system-dns"}, Data: map[string]string{"api_token": "${cdn.cloudflare_api_key}"}}},
 		}
 
-		// When deep-copying and mutating the copy's inner data map
+		// When deep-copying and mutating the copy's inner data map and namespaces
 		clone := original.DeepCopy()
-		clone.Secrets["cloudflare-creds"]["api_token"] = "changed"
-		clone.Secrets["cloudflare-creds"]["extra"] = "value"
+		entry := clone.Secrets["cloudflare-creds"]
+		entry.Data["api_token"] = "changed"
+		entry.Data["extra"] = "value"
+		entry.Namespaces[0] = "system-other"
+		clone.Secrets["cloudflare-creds"] = entry
 
-		// Then the original inner map is untouched
-		if original.Secrets["cloudflare-creds"]["api_token"] != "${cdn.cloudflare_api_key}" {
-			t.Errorf("Expected original secret unchanged, got %q", original.Secrets["cloudflare-creds"]["api_token"])
+		// Then the original inner map and namespaces are untouched
+		if original.Secrets["cloudflare-creds"].Data["api_token"] != "${cdn.cloudflare_api_key}" {
+			t.Errorf("Expected original secret unchanged, got %q", original.Secrets["cloudflare-creds"].Data["api_token"])
 		}
-		if _, exists := original.Secrets["cloudflare-creds"]["extra"]; exists {
+		if _, exists := original.Secrets["cloudflare-creds"].Data["extra"]; exists {
 			t.Error("Expected original to not gain the clone's key")
+		}
+		if original.Secrets["cloudflare-creds"].Namespaces[0] != "system-dns" {
+			t.Errorf("Expected original namespaces unchanged, got %v", original.Secrets["cloudflare-creds"].Namespaces)
 		}
 	})
 
 	t.Run("UnmarshalsNestedSecretsFromYAML", func(t *testing.T) {
-		// Given a flux system authored with a nested secrets: map
+		// Given a flux system authored with a nested secrets: map using the data: form
 		data := []byte(`
 name: cdn
 secrets:
   cloudflare-creds:
-    api_token: ${cdn.cloudflare_api_key}
-    zone_id: ${cdn.cloudflare_zone_id}
+    data:
+      api_token: ${cdn.cloudflare_api_key}
+      zone_id: ${cdn.cloudflare_zone_id}
 install:
   components: [cloudflared]
 `)
@@ -5175,11 +5207,40 @@ install:
 		}
 
 		// Then each data key is populated under the secret name
-		if got := system.Secrets["cloudflare-creds"]["api_token"]; got != "${cdn.cloudflare_api_key}" {
+		if got := system.Secrets["cloudflare-creds"].Data["api_token"]; got != "${cdn.cloudflare_api_key}" {
 			t.Errorf("Expected api_token reference, got %q", got)
 		}
-		if got := system.Secrets["cloudflare-creds"]["zone_id"]; got != "${cdn.cloudflare_zone_id}" {
+		if got := system.Secrets["cloudflare-creds"].Data["zone_id"]; got != "${cdn.cloudflare_zone_id}" {
 			t.Errorf("Expected zone_id reference, got %q", got)
+		}
+	})
+
+	t.Run("UnmarshalsExplicitNamespacesFromYAML", func(t *testing.T) {
+		// Given a flux system whose secret names the namespaces to place it into
+		data := []byte(`
+name: pki
+secrets:
+  hetzner-dns:
+    namespaces: [system-pki, system-dns]
+    data:
+      token: ${hetzner.dns_token}
+install:
+  components: [cert-manager]
+`)
+
+		// When unmarshaling
+		var system FluxSystem
+		if err := yaml.Unmarshal(data, &system); err != nil {
+			t.Fatalf("Unmarshal: %v", err)
+		}
+
+		// Then the target namespaces and data both decode without a custom parser
+		entry := system.Secrets["hetzner-dns"]
+		if len(entry.Namespaces) != 2 || entry.Namespaces[0] != "system-pki" || entry.Namespaces[1] != "system-dns" {
+			t.Errorf("Expected namespaces [system-pki system-dns], got %v", entry.Namespaces)
+		}
+		if entry.Data["token"] != "${hetzner.dns_token}" {
+			t.Errorf("Expected token reference, got %q", entry.Data["token"])
 		}
 	})
 }
@@ -5189,19 +5250,21 @@ func TestKustomization_Secrets(t *testing.T) {
 		// Given a kustomization carrying a named secret with a data key
 		original := &Kustomization{
 			Name:    "cdn-install",
-			Secrets: map[string]map[string]string{"cloudflare-creds": {"api_token": "${cdn.cloudflare_api_key}"}},
+			Secrets: map[string]SecretEntry{"cloudflare-creds": {Data: map[string]string{"api_token": "${cdn.cloudflare_api_key}"}}},
 		}
 
 		// When deep-copying and mutating the copy's inner data map
 		clone := original.DeepCopy()
-		clone.Secrets["cloudflare-creds"]["api_token"] = "changed"
-		clone.Secrets["cloudflare-creds"]["extra"] = "value"
+		entry := clone.Secrets["cloudflare-creds"]
+		entry.Data["api_token"] = "changed"
+		entry.Data["extra"] = "value"
+		clone.Secrets["cloudflare-creds"] = entry
 
 		// Then the original inner map is untouched
-		if original.Secrets["cloudflare-creds"]["api_token"] != "${cdn.cloudflare_api_key}" {
-			t.Errorf("Expected original unchanged, got %q", original.Secrets["cloudflare-creds"]["api_token"])
+		if original.Secrets["cloudflare-creds"].Data["api_token"] != "${cdn.cloudflare_api_key}" {
+			t.Errorf("Expected original unchanged, got %q", original.Secrets["cloudflare-creds"].Data["api_token"])
 		}
-		if _, exists := original.Secrets["cloudflare-creds"]["extra"]; exists {
+		if _, exists := original.Secrets["cloudflare-creds"].Data["extra"]; exists {
 			t.Error("Expected original to not gain the clone's key")
 		}
 	})
@@ -5210,7 +5273,7 @@ func TestKustomization_Secrets(t *testing.T) {
 		// Given a kustomization with a literal secret in its compiled carrier
 		k := Kustomization{
 			Name:    "cdn-install",
-			Secrets: map[string]map[string]string{"cloudflare-creds": {"api_token": "PLAINTEXT-SECRET"}},
+			Secrets: map[string]SecretEntry{"cloudflare-creds": {Data: map[string]string{"api_token": "PLAINTEXT-SECRET"}}},
 		}
 
 		// When marshaling to YAML
@@ -5228,8 +5291,8 @@ func TestKustomization_Secrets(t *testing.T) {
 }
 
 func TestCompileFluxSystemTiers_Secrets(t *testing.T) {
-	secretsMap := func() map[string]map[string]string {
-		return map[string]map[string]string{"cloudflare-creds": {"api_token": "${cdn.cloudflare_api_key}"}}
+	secretsMap := func() map[string]SecretEntry {
+		return map[string]SecretEntry{"cloudflare-creds": {Data: map[string]string{"api_token": "${cdn.cloudflare_api_key}"}}}
 	}
 
 	t.Run("AttachesSecretsToInstallTier", func(t *testing.T) {
@@ -5250,7 +5313,7 @@ func TestCompileFluxSystemTiers_Secrets(t *testing.T) {
 		if install == nil || resources == nil {
 			t.Fatalf("Expected both tiers, got %v", kustomizationNames(all))
 		}
-		if install.Secrets["cloudflare-creds"]["api_token"] != "${cdn.cloudflare_api_key}" {
+		if install.Secrets["cloudflare-creds"].Data["api_token"] != "${cdn.cloudflare_api_key}" {
 			t.Errorf("Expected install tier to carry secrets, got %v", install.Secrets)
 		}
 		if len(resources.Secrets) != 0 {
@@ -5274,7 +5337,7 @@ func TestCompileFluxSystemTiers_Secrets(t *testing.T) {
 		if resources == nil {
 			t.Fatalf("Expected resources tier, got %v", kustomizationNames(all))
 		}
-		if resources.Secrets["cloudflare-creds"]["api_token"] != "${cdn.cloudflare_api_key}" {
+		if resources.Secrets["cloudflare-creds"].Data["api_token"] != "${cdn.cloudflare_api_key}" {
 			t.Errorf("Expected resources tier to carry secrets, got %v", resources.Secrets)
 		}
 	})

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -102,7 +102,7 @@ func TestInstallCmd(t *testing.T) {
 			return &blueprintv1alpha1.Blueprint{
 				Kustomizations: []blueprintv1alpha1.Kustomization{{
 					Name:    "telemetry-install",
-					Secrets: map[string]map[string]string{"alertmanager-slack": {"url": "${'placed-value'}"}},
+					Secrets: map[string]blueprintv1alpha1.SecretEntry{"alertmanager-slack": {Data: map[string]string{"url": "${'placed-value'}"}}},
 				}},
 			}, nil
 		}

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -61,7 +61,7 @@ func TestUpgradeCmd(t *testing.T) {
 				Metadata: blueprintv1alpha1.Metadata{Name: "test"},
 				Kustomizations: []blueprintv1alpha1.Kustomization{{
 					Name:    "telemetry-install",
-					Secrets: map[string]map[string]string{"alertmanager-slack": {"url": "${'placed-value'}"}},
+					Secrets: map[string]blueprintv1alpha1.SecretEntry{"alertmanager-slack": {Data: map[string]string{"url": "${'placed-value'}"}}},
 				}},
 			}, nil
 		}

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -1018,9 +1018,9 @@ func mergeSubstitute(k blueprintv1alpha1.Kustomization) map[string]string {
 // is rejected because the authored value is serialized with the blueprint, so a hardcoded secret would
 // be committed to git. Keeping sensitive values out of ConfigMaps and output is enforced separately —
 // see the substitution guard (sensitivePathsInValue) and display redaction.
-func (p *BaseBlueprintProcessor) validateSystemSecrets(systemName string, secrets map[string]map[string]string) error {
-	for secretName, data := range secrets {
-		for key, ref := range data {
+func (p *BaseBlueprintProcessor) validateSystemSecrets(systemName string, secrets map[string]blueprintv1alpha1.SecretEntry) error {
+	for secretName, entry := range secrets {
+		for key, ref := range entry.Data {
 			open := strings.Index(ref, "${")
 			if open < 0 || !strings.Contains(ref[open+2:], "}") {
 				return fmt.Errorf("secret %q key %q in flux system %q must contain a complete ${...} expression (a reference or a secret() call), not a plaintext literal or unterminated expression, got %q", secretName, key, systemName, ref)
@@ -1064,22 +1064,31 @@ func (p *BaseBlueprintProcessor) sensitivePathsInValue(value string) []string {
 	return found
 }
 
-// mergeSecretData unions two nested secret maps (Secret name -> data key -> reference), overlay
-// winning per data key, and nil when both are empty. Neither input is mutated. Used to union a flux
-// system's Secrets across facets.
-func mergeSecretData(base, overlay map[string]map[string]string) map[string]map[string]string {
+// mergeSecretData unions two secret maps (Secret name -> SecretEntry), overlay winning per data key and
+// the two entries' namespaces unioned, and nil when both are empty. Neither input is mutated. Used to
+// union a flux system's Secrets across facets.
+func mergeSecretData(base, overlay map[string]blueprintv1alpha1.SecretEntry) map[string]blueprintv1alpha1.SecretEntry {
 	if len(base) == 0 && len(overlay) == 0 {
 		return nil
 	}
-	out := make(map[string]map[string]string, len(base)+len(overlay))
-	for name, data := range base {
-		out[name] = maps.Clone(data)
+	out := make(map[string]blueprintv1alpha1.SecretEntry, len(base)+len(overlay))
+	for name, entry := range base {
+		out[name] = entry.DeepCopy()
 	}
-	for name, data := range overlay {
-		if out[name] == nil {
-			out[name] = make(map[string]string, len(data))
+	for name, entry := range overlay {
+		merged := out[name]
+		for _, ns := range entry.Namespaces {
+			if !slices.Contains(merged.Namespaces, ns) {
+				merged.Namespaces = append(merged.Namespaces, ns)
+			}
 		}
-		maps.Copy(out[name], data)
+		if len(entry.Data) > 0 {
+			if merged.Data == nil {
+				merged.Data = make(map[string]string, len(entry.Data))
+			}
+			maps.Copy(merged.Data, entry.Data)
+		}
+		out[name] = merged
 	}
 	return out
 }

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -1011,15 +1011,22 @@ func mergeSubstitute(k blueprintv1alpha1.Kustomization) map[string]string {
 	return out
 }
 
-// validateSystemSecrets fails composition when a flux system's secrets: value is a plaintext literal
-// rather than an expression. Any ${...} reference or secret() call is allowed — the value is resolved
-// at placement and materialized into a Kubernetes Secret (the protected sink), so it need not point at
-// a sensitive schema property; wiring a non-sensitive value into a Secret is safe. A plaintext literal
-// is rejected because the authored value is serialized with the blueprint, so a hardcoded secret would
-// be committed to git. Keeping sensitive values out of ConfigMaps and output is enforced separately —
-// see the substitution guard (sensitivePathsInValue) and display redaction.
+// validateSystemSecrets fails composition when a flux system's secrets: entry is malformed. An entry
+// with no data keys is rejected: a secret entry is `data: {<key>: <ref>}` plus an optional
+// `namespaces:` selector, so an empty Data means either a genuinely empty entry or the retired flat
+// form (`<name>: {<key>: <ref>}`), whose keys the decoder silently discards — failing here turns that
+// into a loud composition error instead of a secret that silently never places. Each data value must be
+// a complete ${...} expression: any reference or secret() call is allowed — the value is resolved at
+// placement and materialized into a Kubernetes Secret (the protected sink), so it need not point at a
+// sensitive schema property; wiring a non-sensitive value into a Secret is safe. A plaintext literal is
+// rejected because the authored value is serialized with the blueprint, so a hardcoded secret would be
+// committed to git. Keeping sensitive values out of ConfigMaps and output is enforced separately — see
+// the substitution guard (sensitivePathsInValue) and display redaction.
 func (p *BaseBlueprintProcessor) validateSystemSecrets(systemName string, secrets map[string]blueprintv1alpha1.SecretEntry) error {
 	for secretName, entry := range secrets {
+		if len(entry.Data) == 0 {
+			return fmt.Errorf("secret %q in flux system %q declares no data keys; nest them under `data:` (an entry is `data: {<key>: <ref>}` plus an optional `namespaces:` selector)", secretName, systemName)
+		}
 		for key, ref := range entry.Data {
 			open := strings.Index(ref, "${")
 			if open < 0 || !strings.Contains(ref[open+2:], "}") {

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -7165,6 +7165,15 @@ func TestValidateSystemSecrets(t *testing.T) {
 			t.Errorf("Expected unterminated-expression error, got %v", err)
 		}
 	})
+
+	t.Run("RejectsEntryWithNoDataKeys", func(t *testing.T) {
+		// An entry with no data keys — a genuinely empty entry, or the retired flat form whose keys the
+		// decoder silently discarded — fails loudly rather than silently placing nothing
+		err := processor(t).validateSystemSecrets("cdn", map[string]blueprintv1alpha1.SecretEntry{"creds": {Namespaces: []string{"system-dns"}}})
+		if err == nil || !strings.Contains(err.Error(), "no data keys") {
+			t.Errorf("Expected no-data-keys error, got %v", err)
+		}
+	})
 }
 
 func TestEvaluateSubstitutions_RejectsSensitiveReference(t *testing.T) {

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -7051,24 +7051,39 @@ func TestMergeSecretData(t *testing.T) {
 	t.Run("UnionsSecretsAndDataKeysWithOverlayWinning", func(t *testing.T) {
 		// Given two facets contributing secrets: a shared secret with an overlapping data key,
 		// and a secret unique to each side
-		base := map[string]map[string]string{
-			"shared":    {"a": "1", "b": "2"},
-			"base-only": {"x": "9"},
+		base := map[string]blueprintv1alpha1.SecretEntry{
+			"shared":    {Data: map[string]string{"a": "1", "b": "2"}},
+			"base-only": {Data: map[string]string{"x": "9"}},
 		}
-		overlay := map[string]map[string]string{
-			"shared":       {"b": "override", "c": "3"},
-			"overlay-only": {"y": "8"},
+		overlay := map[string]blueprintv1alpha1.SecretEntry{
+			"shared":       {Data: map[string]string{"b": "override", "c": "3"}},
+			"overlay-only": {Data: map[string]string{"y": "8"}},
 		}
 
 		// When merging
 		got := mergeSecretData(base, overlay)
 
 		// Then secrets union, data keys union, and overlay wins the data-key conflict
-		if got["shared"]["a"] != "1" || got["shared"]["b"] != "override" || got["shared"]["c"] != "3" {
+		if got["shared"].Data["a"] != "1" || got["shared"].Data["b"] != "override" || got["shared"].Data["c"] != "3" {
 			t.Errorf("Unexpected shared secret merge: %v", got["shared"])
 		}
-		if got["base-only"]["x"] != "9" || got["overlay-only"]["y"] != "8" {
+		if got["base-only"].Data["x"] != "9" || got["overlay-only"].Data["y"] != "8" {
 			t.Errorf("Expected unique secrets preserved, got %v", got)
+		}
+	})
+
+	t.Run("UnionsNamespacesForASharedSecret", func(t *testing.T) {
+		// Given two facets targeting the same secret at different namespaces
+		base := map[string]blueprintv1alpha1.SecretEntry{"acme-dns": {Namespaces: []string{"system-pki"}, Data: map[string]string{"token": "${x.t}"}}}
+		overlay := map[string]blueprintv1alpha1.SecretEntry{"acme-dns": {Namespaces: []string{"system-dns", "system-pki"}, Data: map[string]string{"token": "${x.t}"}}}
+
+		// When merging
+		got := mergeSecretData(base, overlay)
+
+		// Then the namespaces union without duplicating the shared one
+		ns := got["acme-dns"].Namespaces
+		if len(ns) != 2 || ns[0] != "system-pki" || ns[1] != "system-dns" {
+			t.Errorf("Expected namespaces to union to [system-pki system-dns], got %v", ns)
 		}
 	})
 
@@ -7080,17 +7095,17 @@ func TestMergeSecretData(t *testing.T) {
 
 	t.Run("DoesNotMutateInputs", func(t *testing.T) {
 		// Given a base with a shared secret
-		base := map[string]map[string]string{"shared": {"a": "1"}}
-		overlay := map[string]map[string]string{"shared": {"b": "2"}}
+		base := map[string]blueprintv1alpha1.SecretEntry{"shared": {Data: map[string]string{"a": "1"}}}
+		overlay := map[string]blueprintv1alpha1.SecretEntry{"shared": {Data: map[string]string{"b": "2"}}}
 
 		// When merging
 		_ = mergeSecretData(base, overlay)
 
 		// Then the base's inner map is unchanged
-		if len(base["shared"]) != 1 || base["shared"]["a"] != "1" {
+		if len(base["shared"].Data) != 1 || base["shared"].Data["a"] != "1" {
 			t.Errorf("Expected base unmutated, got %v", base)
 		}
-		if _, exists := base["shared"]["b"]; exists {
+		if _, exists := base["shared"].Data["b"]; exists {
 			t.Error("Expected base inner map to not gain overlay key")
 		}
 	})
@@ -7102,7 +7117,7 @@ func TestValidateSystemSecrets(t *testing.T) {
 	}
 
 	t.Run("AcceptsSensitivePropertyReference", func(t *testing.T) {
-		err := processor(t).validateSystemSecrets("cdn", map[string]map[string]string{"cloudflare-creds": {"api_token": "${cdn.cloudflare_api_key}"}})
+		err := processor(t).validateSystemSecrets("cdn", map[string]blueprintv1alpha1.SecretEntry{"cloudflare-creds": {Data: map[string]string{"api_token": "${cdn.cloudflare_api_key}"}}})
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -7110,8 +7125,8 @@ func TestValidateSystemSecrets(t *testing.T) {
 
 	t.Run("AcceptsNonSensitiveReferenceWithOptionalDefault", func(t *testing.T) {
 		// A reference to a non-sensitive property (with a ?? default) is fine — it goes into a Secret
-		err := processor(t).validateSystemSecrets("telemetry", map[string]map[string]string{
-			"alertmanager-notification-slack": {"url": "${telemetry.alerts.slack.webhook_url ?? ''}"},
+		err := processor(t).validateSystemSecrets("telemetry", map[string]blueprintv1alpha1.SecretEntry{
+			"alertmanager-notification-slack": {Data: map[string]string{"url": "${telemetry.alerts.slack.webhook_url ?? ''}"}},
 		})
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
@@ -7119,8 +7134,8 @@ func TestValidateSystemSecrets(t *testing.T) {
 	})
 
 	t.Run("AcceptsDirectSecretExpression", func(t *testing.T) {
-		err := processor(t).validateSystemSecrets("telemetry", map[string]map[string]string{
-			"alertmanager-slack": {"webhook_url": `${secret("Developer", "slack_webhooks", "url")}`},
+		err := processor(t).validateSystemSecrets("telemetry", map[string]blueprintv1alpha1.SecretEntry{
+			"alertmanager-slack": {Data: map[string]string{"webhook_url": `${secret("Developer", "slack_webhooks", "url")}`}},
 		})
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
@@ -7129,7 +7144,7 @@ func TestValidateSystemSecrets(t *testing.T) {
 
 	t.Run("AcceptsHybridExpression", func(t *testing.T) {
 		// An expression embedded in surrounding text resolves to a valid secret value and is allowed
-		err := processor(t).validateSystemSecrets("cdn", map[string]map[string]string{"creds": {"url": "https://api.example.com/${cdn.token}"}})
+		err := processor(t).validateSystemSecrets("cdn", map[string]blueprintv1alpha1.SecretEntry{"creds": {Data: map[string]string{"url": "https://api.example.com/${cdn.token}"}}})
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
@@ -7137,7 +7152,7 @@ func TestValidateSystemSecrets(t *testing.T) {
 
 	t.Run("RejectsPlaintextLiteral", func(t *testing.T) {
 		// A hardcoded literal would be serialized with the blueprint (git-committed), so it fails closed
-		err := processor(t).validateSystemSecrets("cdn", map[string]map[string]string{"creds": {"token": "actual-secret-value"}})
+		err := processor(t).validateSystemSecrets("cdn", map[string]blueprintv1alpha1.SecretEntry{"creds": {Data: map[string]string{"token": "actual-secret-value"}}})
 		if err == nil || !strings.Contains(err.Error(), "not a plaintext literal") {
 			t.Errorf("Expected plaintext-literal error, got %v", err)
 		}
@@ -7145,7 +7160,7 @@ func TestValidateSystemSecrets(t *testing.T) {
 
 	t.Run("RejectsUnterminatedExpression", func(t *testing.T) {
 		// A malformed, unterminated interpolation is caught at composition rather than at apply time
-		err := processor(t).validateSystemSecrets("cdn", map[string]map[string]string{"creds": {"token": "${cdn.token"}})
+		err := processor(t).validateSystemSecrets("cdn", map[string]blueprintv1alpha1.SecretEntry{"creds": {Data: map[string]string{"token": "${cdn.token"}}})
 		if err == nil || !strings.Contains(err.Error(), "unterminated expression") {
 			t.Errorf("Expected unterminated-expression error, got %v", err)
 		}

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -7082,7 +7082,7 @@ func TestMergeSecretData(t *testing.T) {
 
 		// Then the namespaces union without duplicating the shared one
 		ns := got["acme-dns"].Namespaces
-		if len(ns) != 2 || ns[0] != "system-pki" || ns[1] != "system-dns" {
+		if len(ns) != 2 || !slices.Contains(ns, "system-pki") || !slices.Contains(ns, "system-dns") {
 			t.Errorf("Expected namespaces to union to [system-pki system-dns], got %v", ns)
 		}
 	})

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -982,11 +982,19 @@ func (i *Provisioner) Wait(ctx context.Context, blueprint *blueprintv1alpha1.Blu
 	return nil
 }
 
-// ResolvedSecrets maps an owning kustomization name to the Secrets ready to place in the namespace it
-// creates: Secret name -> data key -> resolved plaintext value. It holds resolved secret material in
-// memory only (never serialized), produced by ResolveSecrets before Install and consumed by
-// PlaceSecrets after.
-type ResolvedSecrets map[string]map[string]map[string]string
+// ResolvedSecrets maps an owning kustomization name to the Secrets ready to place in the namespace(s)
+// it creates: Secret name -> ResolvedSecret (target namespaces plus resolved plaintext data). It holds
+// resolved secret material in memory only (never serialized), produced by ResolveSecrets before Install
+// and consumed by PlaceSecrets after.
+type ResolvedSecrets map[string]map[string]ResolvedSecret
+
+// ResolvedSecret is one Secret ready to place: its resolved plaintext data and the namespaces it targets.
+// Namespaces is empty when the authored entry named none, in which case placement auto-resolves the single
+// namespace the owning kustomization creates.
+type ResolvedSecret struct {
+	Namespaces []string
+	Data       map[string]string
+}
 
 // ResolveSecrets resolves every flux system's declared Secrets to plaintext ahead of Install, so a
 // misconfigured secret fails the command before anything is applied to the cluster. For each compiled
@@ -1009,9 +1017,9 @@ func (i *Provisioner) ResolveSecrets(blueprint *blueprintv1alpha1.Blueprint) (Re
 		if len(k.Secrets) == 0 {
 			continue
 		}
-		for secretName, data := range k.Secrets {
-			stringData := make(map[string]string, len(data))
-			for key, ref := range data {
+		for secretName, entry := range k.Secrets {
+			stringData := make(map[string]string, len(entry.Data))
+			for key, ref := range entry.Data {
 				value, err := i.evaluator.Evaluate(ref, "", nil, true)
 				if err != nil {
 					return nil, fmt.Errorf("resolving secret %q key %q: %w", secretName, key, err)
@@ -1030,23 +1038,26 @@ func (i *Provisioner) ResolveSecrets(blueprint *blueprintv1alpha1.Blueprint) (Re
 			}
 			if len(stringData) > 0 {
 				if resolved[k.Name] == nil {
-					resolved[k.Name] = make(map[string]map[string]string)
+					resolved[k.Name] = make(map[string]ResolvedSecret)
 				}
-				resolved[k.Name][secretName] = stringData
+				resolved[k.Name][secretName] = ResolvedSecret{
+					Namespaces: slices.Clone(entry.Namespaces),
+					Data:       stringData,
+				}
 			}
 		}
 	}
 	return resolved, nil
 }
 
-// PlaceSecrets materializes secrets that ResolveSecrets produced into the namespace each owning
-// kustomization created. It runs after Install; for each kustomization it resolves the target namespace
-// from that kustomization's Flux inventory — failing closed unless exactly one Namespace was created, so
-// a secret is never placed by guessing — and applies an Opaque Secret. After placing each Secret it rolls
-// the workloads in that namespace that consume it, keyed by a content digest, so a changed value reaches
-// running pods rather than sitting stale until the next unrelated restart. It self-gates on the owning
-// kustomization's namespace appearing rather than requiring a global wait, and is a no-op when resolved
-// is empty.
+// PlaceSecrets materializes secrets that ResolveSecrets produced into the namespace(s) each owning
+// kustomization created. It runs after Install; for each secret it resolves the target namespace(s) —
+// either the ones the entry named or, when it named none, the single namespace the kustomization created
+// (failing closed on more than one so a secret is never placed by guessing) — and applies an Opaque
+// Secret into each. After placing each Secret it rolls the workloads in that namespace that consume it,
+// keyed by a content digest, so a changed value reaches running pods rather than sitting stale until the
+// next unrelated restart. It self-gates on the target namespace appearing rather than requiring a global
+// wait, and is a no-op when resolved is empty.
 func (i *Provisioner) PlaceSecrets(ctx context.Context, resolved ResolvedSecrets) error {
 	if len(resolved) == 0 {
 		return nil
@@ -1056,16 +1067,18 @@ func (i *Provisioner) PlaceSecrets(ctx context.Context, resolved ResolvedSecrets
 	}
 
 	for kustomizationName, secrets := range resolved {
-		namespace, err := i.resolveSecretNamespace(ctx, kustomizationName)
-		if err != nil {
-			return err
-		}
-		for secretName, stringData := range secrets {
-			if err := i.KubernetesManager.ApplySecret(secretName, namespace, stringData); err != nil {
-				return fmt.Errorf("applying secret %q to namespace %q: %w", secretName, namespace, err)
+		for secretName, secret := range secrets {
+			namespaces, err := i.resolveSecretNamespaces(ctx, kustomizationName, secret.Namespaces)
+			if err != nil {
+				return err
 			}
-			if err := i.KubernetesManager.RollWorkloadsForSecret(ctx, namespace, secretName, secretDigest(stringData)); err != nil {
-				return fmt.Errorf("rolling workloads for secret %q in namespace %q: %w", secretName, namespace, err)
+			for _, namespace := range namespaces {
+				if err := i.KubernetesManager.ApplySecret(secretName, namespace, secret.Data); err != nil {
+					return fmt.Errorf("applying secret %q to namespace %q: %w", secretName, namespace, err)
+				}
+				if err := i.KubernetesManager.RollWorkloadsForSecret(ctx, namespace, secretName, secretDigest(secret.Data)); err != nil {
+					return fmt.Errorf("rolling workloads for secret %q in namespace %q: %w", secretName, namespace, err)
+				}
 			}
 		}
 	}
@@ -1092,39 +1105,63 @@ func secretDigest(stringData map[string]string) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-// resolveSecretNamespace polls the owning kustomization's Flux inventory until Flux has applied the
-// namespace it creates, then returns it. Gating on the namespace being applied — not on the whole
-// kustomization being Ready — places the secret the moment the namespace exists, so a workload that
-// consumes it recovers promptly and a kustomization whose readiness depends on that secret can never
-// deadlock placement. It fails closed: an error on more than one namespace (ambiguous target), and a
-// bounded timeout if none ever appears (a re-run places it once the namespace is created). Flux
-// records inventory only after a successful apply, so a namespace present there is really applied.
-func (i *Provisioner) resolveSecretNamespace(ctx context.Context, kustomizationName string) (string, error) {
+// resolveSecretNamespaces determines which namespace(s) a secret is placed into, gating on each target
+// being provably created by the owning kustomization before returning. When explicit names the target(s)
+// it polls the kustomization's Flux inventory until every named namespace has been applied, so a secret
+// is never placed into a namespace the owning kustomization did not create — a typo or a namespace owned
+// by another kustomization surfaces as the bounded timeout naming what is missing. When explicit is empty
+// it auto-resolves the single namespace the kustomization creates, failing closed on more than one
+// (ambiguous — the author must name the target via `namespaces:`). Gating on the namespace being applied
+// — not on the whole kustomization being Ready — places the secret the moment its namespace exists, so a
+// consumer recovers promptly and a kustomization whose readiness depends on the secret can never deadlock
+// placement. Flux records inventory only after a successful apply, so a namespace present there is really
+// applied.
+func (i *Provisioner) resolveSecretNamespaces(ctx context.Context, kustomizationName string, explicit []string) ([]string, error) {
 	waitCtx, cancel := context.WithTimeout(ctx, constants.DefaultFluxKustomizationInstallTimeout)
 	defer cancel()
 	for {
 		entries, err := i.KubernetesManager.GetKustomizationInventory(kustomizationName, i.fluxNamespace())
 		if err != nil {
-			return "", fmt.Errorf("reading inventory for kustomization %q: %w", kustomizationName, err)
+			return nil, fmt.Errorf("reading inventory for kustomization %q: %w", kustomizationName, err)
 		}
-		var namespaces []string
+		var created []string
 		for _, entry := range entries {
 			if entry.Kind == "Namespace" {
-				namespaces = append(namespaces, entry.Name)
+				created = append(created, entry.Name)
 			}
 		}
-		switch {
-		case len(namespaces) == 1:
-			return namespaces[0], nil
-		case len(namespaces) > 1:
-			return "", fmt.Errorf("kustomization %q created multiple namespaces (%s); cannot determine where to place its secrets", kustomizationName, strings.Join(namespaces, ", "))
+		if len(explicit) > 0 {
+			if len(missingNamespaces(explicit, created)) == 0 {
+				return slices.Clone(explicit), nil
+			}
+		} else {
+			switch {
+			case len(created) == 1:
+				return created, nil
+			case len(created) > 1:
+				return nil, fmt.Errorf("kustomization %q created multiple namespaces (%s); set `namespaces:` on the secret to choose where to place it", kustomizationName, strings.Join(created, ", "))
+			}
 		}
 		select {
 		case <-waitCtx.Done():
-			return "", fmt.Errorf("timed out waiting for kustomization %q to create its namespace before placing secrets", kustomizationName)
+			if len(explicit) > 0 {
+				return nil, fmt.Errorf("timed out waiting for kustomization %q to create namespace(s) %s before placing secrets", kustomizationName, strings.Join(missingNamespaces(explicit, created), ", "))
+			}
+			return nil, fmt.Errorf("timed out waiting for kustomization %q to create its namespace before placing secrets", kustomizationName)
 		case <-time.After(constants.DefaultKustomizationWaitPollInterval):
 		}
 	}
+}
+
+// missingNamespaces returns the members of want not present in have, preserving want's order.
+func missingNamespaces(want, have []string) []string {
+	var missing []string
+	for _, ns := range want {
+		if !slices.Contains(have, ns) {
+			missing = append(missing, ns)
+		}
+	}
+	return missing
 }
 
 // WriteVersionMarker records the blueprint version applied to this context as a marker ConfigMap

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -4321,8 +4321,11 @@ func TestProvisioner_ResolveSecrets(t *testing.T) {
 	withValues := func(mocks *ProvisionerTestMocks, values map[string]any) {
 		mocks.ConfigHandler.(*config.MockConfigHandler).GetContextValuesFunc = func() (map[string]any, error) { return values, nil }
 	}
-	bp := func(secrets map[string]map[string]string) *blueprintv1alpha1.Blueprint {
+	bp := func(secrets map[string]blueprintv1alpha1.SecretEntry) *blueprintv1alpha1.Blueprint {
 		return &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "cdn-install", Secrets: secrets}}}
+	}
+	entry := func(data map[string]string) blueprintv1alpha1.SecretEntry {
+		return blueprintv1alpha1.SecretEntry{Data: data}
 	}
 
 	t.Run("ResolvesValueKeyedByKustomization", func(t *testing.T) {
@@ -4331,13 +4334,13 @@ func TestProvisioner_ResolveSecrets(t *testing.T) {
 		withValues(mocks, map[string]any{"cdn": map[string]any{"cloudflare_api_key": "resolved-token"}})
 
 		// When resolving secrets
-		resolved, err := newProvisioner(mocks).ResolveSecrets(bp(map[string]map[string]string{"cloudflare-creds": {"api_token": "${cdn.cloudflare_api_key}"}}))
+		resolved, err := newProvisioner(mocks).ResolveSecrets(bp(map[string]blueprintv1alpha1.SecretEntry{"cloudflare-creds": entry(map[string]string{"api_token": "${cdn.cloudflare_api_key}"})}))
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
 		// Then the value is keyed by owning kustomization -> secret -> data key
-		if resolved["cdn-install"]["cloudflare-creds"]["api_token"] != "resolved-token" {
+		if resolved["cdn-install"]["cloudflare-creds"].Data["api_token"] != "resolved-token" {
 			t.Errorf("Expected resolved token keyed by kustomization, got %v", resolved)
 		}
 	})
@@ -4348,7 +4351,7 @@ func TestProvisioner_ResolveSecrets(t *testing.T) {
 		withValues(mocks, map[string]any{"cdn": map[string]any{"cloudflare_api_key": nil}})
 
 		// When resolving, it fails closed before any apply
-		_, err := newProvisioner(mocks).ResolveSecrets(bp(map[string]map[string]string{"creds": {"token": "${cdn.cloudflare_api_key}"}}))
+		_, err := newProvisioner(mocks).ResolveSecrets(bp(map[string]blueprintv1alpha1.SecretEntry{"creds": entry(map[string]string{"token": "${cdn.cloudflare_api_key}"})}))
 		if err == nil || !strings.Contains(err.Error(), "resolved to nil") {
 			t.Errorf("Expected nil-resolution error, got %v", err)
 		}
@@ -4360,7 +4363,7 @@ func TestProvisioner_ResolveSecrets(t *testing.T) {
 		withValues(mocks, map[string]any{"cdn": map[string]any{"token": ""}})
 
 		// When resolving, it fails closed
-		_, err := newProvisioner(mocks).ResolveSecrets(bp(map[string]map[string]string{"creds": {"token": "${cdn.token}"}}))
+		_, err := newProvisioner(mocks).ResolveSecrets(bp(map[string]blueprintv1alpha1.SecretEntry{"creds": entry(map[string]string{"token": "${cdn.token}"})}))
 		if err == nil || !strings.Contains(err.Error(), "resolved to empty") {
 			t.Errorf("Expected empty-required error, got %v", err)
 		}
@@ -4375,16 +4378,16 @@ func TestProvisioner_ResolveSecrets(t *testing.T) {
 		})
 
 		// When resolving
-		resolved, err := newProvisioner(mocks).ResolveSecrets(bp(map[string]map[string]string{
-			"creds":            {"token": "${cdn.token}", "extra": "${cdn.extra ?? ''}"},
-			"optional-webhook": {"url": "${telemetry.alerts.slack.webhook_url ?? ''}"},
+		resolved, err := newProvisioner(mocks).ResolveSecrets(bp(map[string]blueprintv1alpha1.SecretEntry{
+			"creds":            entry(map[string]string{"token": "${cdn.token}", "extra": "${cdn.extra ?? ''}"}),
+			"optional-webhook": entry(map[string]string{"url": "${telemetry.alerts.slack.webhook_url ?? ''}"}),
 		}))
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
 		// Then the optional empty key is omitted and the wholly-empty optional secret is dropped
-		creds := resolved["cdn-install"]["creds"]
+		creds := resolved["cdn-install"]["creds"].Data
 		if creds["token"] != "real" {
 			t.Errorf("Expected token resolved, got %v", creds)
 		}
@@ -4419,7 +4422,7 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		})
 	}
 	resolved := func() ResolvedSecrets {
-		return ResolvedSecrets{"cdn-install": {"cloudflare-creds": {"api_token": "resolved-token"}}}
+		return ResolvedSecrets{"cdn-install": {"cloudflare-creds": {Data: map[string]string{"api_token": "resolved-token"}}}}
 	}
 
 	t.Run("PlacesIntoInventoryNamespace", func(t *testing.T) {
@@ -4508,6 +4511,67 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		err := newProvisioner(mocks).PlaceSecrets(ctx, resolved())
 		if err == nil || !strings.Contains(err.Error(), "to create its namespace") {
 			t.Errorf("Expected namespace-timeout error, got %v", err)
+		}
+	})
+
+	t.Run("PlacesIntoExplicitNamespaceOnMultiNamespaceSystem", func(t *testing.T) {
+		// Given a system that owns two namespaces and a secret naming one of them
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
+			return []kubernetes.InventoryEntry{{Kind: "Namespace", Name: "system-pki"}, {Kind: "Namespace", Name: "system-pki-trust"}}, nil
+		}
+		var gotNs string
+		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string) error {
+			gotNs = namespace
+			return nil
+		}
+		explicit := ResolvedSecrets{"pki-install": {"hetzner-dns": {Namespaces: []string{"system-pki"}, Data: map[string]string{"token": "resolved"}}}}
+
+		// When placing, the named namespace disambiguates rather than failing closed
+		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), explicit); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if gotNs != "system-pki" {
+			t.Errorf("Expected placement into system-pki, got %q", gotNs)
+		}
+	})
+
+	t.Run("FansOutToEveryNamedNamespace", func(t *testing.T) {
+		// Given a secret naming two namespaces both created by the owning kustomization
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
+			return []kubernetes.InventoryEntry{{Kind: "Namespace", Name: "system-pki"}, {Kind: "Namespace", Name: "system-dns"}}, nil
+		}
+		placed := map[string]bool{}
+		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string) error {
+			placed[namespace] = true
+			return nil
+		}
+		explicit := ResolvedSecrets{"pki-install": {"acme-dns": {Namespaces: []string{"system-pki", "system-dns"}, Data: map[string]string{"token": "resolved"}}}}
+
+		// When placing, the same secret lands in each named namespace
+		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), explicit); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !placed["system-pki"] || !placed["system-dns"] || len(placed) != 2 {
+			t.Errorf("Expected fan-out into system-pki and system-dns, got %v", placed)
+		}
+	})
+
+	t.Run("TimesOutNamingAnUncreatedExplicitNamespace", func(t *testing.T) {
+		// Given a named namespace the owning kustomization never creates
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
+			return []kubernetes.InventoryEntry{{Kind: "Namespace", Name: "system-pki-trust"}}, nil
+		}
+		explicit := ResolvedSecrets{"pki-install": {"hetzner-dns": {Namespaces: []string{"system-pki"}, Data: map[string]string{"token": "resolved"}}}}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		// When placing, it fails naming the missing namespace rather than placing by guessing
+		err := newProvisioner(mocks).PlaceSecrets(ctx, explicit)
+		if err == nil || !strings.Contains(err.Error(), "system-pki") || !strings.Contains(err.Error(), "before placing secrets") {
+			t.Errorf("Expected missing-namespace timeout error naming system-pki, got %v", err)
 		}
 	})
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This PR touches the secrets placement pipeline across `api/`, `pkg/composer/blueprint/`, and `pkg/provisioner/`, and ships a user-facing YAML format change that silently breaks existing blueprints.
>
> **Overview**
>
> The PR introduces a `SecretEntry` struct (replacing the raw `map[string]map[string]string` shape for `FluxSystem.Secrets` and `Kustomization.Secrets`) and a `ResolvedSecret` struct in the provisioner, giving the secrets data model a proper named type. The new `namespaces:` field on each entry enables a single secret to fan out to multiple namespaces — for systems like `pki` that own more than one namespace — with `PlaceSecrets` and `resolveSecretNamespaces` updated to iterate over and gate on each target namespace independently.
>
> The authored YAML format has changed in a backward-incompatible way: where a `secrets:` block previously placed data keys directly under the secret name (`cloudflare-creds: {api_token: ...}`), data keys must now be nested under `data:` (`cloudflare-creds: {data: {api_token: ...}}`). YAML decoders silently discard unknown fields, so an existing blueprint using the old format parses without error but produces an empty `SecretEntry.Data`, meaning no secret is placed and no warning is emitted.
>
> Reviewed by Claude for commit `521ddc9d`.

<!-- /claude-code-review:summary -->
