### PR TITLE
feat(secrets): enhance secret management with owner tracking and pruning functionality

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -91,7 +91,7 @@ windsor apply kustomize dns`,
 				return fmt.Errorf("error applying kustomize: %w", err)
 			}
 
-			if err := proj.Provisioner.PlaceSecrets(cmd.Context(), resolvedSecrets); err != nil {
+			if err := proj.Provisioner.PlaceSecrets(cmd.Context(), resolvedSecrets, applyPruneFlag); err != nil {
 				return fmt.Errorf("error placing secrets: %w", err)
 			}
 

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -234,7 +234,7 @@ windsor bootstrap prod --yes`,
 				return fmt.Errorf("error installing blueprint: %w", err)
 			}
 
-			if err := proj.Provisioner.PlaceSecrets(cmd.Context(), resolvedSecrets); err != nil {
+			if err := proj.Provisioner.PlaceSecrets(cmd.Context(), resolvedSecrets, false); err != nil {
 				return fmt.Errorf("error placing secrets: %w", err)
 			}
 

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -46,7 +46,7 @@ windsor install --wait`,
 			return fmt.Errorf("error installing blueprint: %w", err)
 		}
 
-		if err := proj.Provisioner.PlaceSecrets(cmd.Context(), resolvedSecrets); err != nil {
+		if err := proj.Provisioner.PlaceSecrets(cmd.Context(), resolvedSecrets, false); err != nil {
 			return fmt.Errorf("error placing secrets: %w", err)
 		}
 

--- a/cmd/install_test.go
+++ b/cmd/install_test.go
@@ -114,7 +114,7 @@ func TestInstallCmd(t *testing.T) {
 		}
 		var placedNs string
 		var placedData map[string]string
-		mockKubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string) error {
+		mockKubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string, owner string) error {
 			placedNs = namespace
 			placedData = stringData
 			return nil

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -138,7 +138,7 @@ windsor up --blueprint=ghcr.io/myorg/blueprint:v1.0.0`,
 				return fmt.Errorf("error installing blueprint: %w", err)
 			}
 
-			if err := proj.Provisioner.PlaceSecrets(cmd.Context(), resolvedSecrets); err != nil {
+			if err := proj.Provisioner.PlaceSecrets(cmd.Context(), resolvedSecrets, false); err != nil {
 				return fmt.Errorf("error placing secrets: %w", err)
 			}
 

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -131,7 +131,7 @@ windsor upgrade cluster --nodes=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1
 				return fmt.Errorf("error installing blueprint: %w", err)
 			}
 
-			if err := proj.Provisioner.PlaceSecrets(cmd.Context(), resolvedSecrets); err != nil {
+			if err := proj.Provisioner.PlaceSecrets(cmd.Context(), resolvedSecrets, true); err != nil {
 				return fmt.Errorf("error placing secrets: %w", err)
 			}
 

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -70,7 +70,7 @@ func TestUpgradeCmd(t *testing.T) {
 		}
 		var placedNs string
 		var placedData map[string]string
-		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string) error {
+		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string, owner string) error {
 			placedNs = namespace
 			placedData = stringData
 			return nil

--- a/pkg/provisioner/kubernetes/client/client.go
+++ b/pkg/provisioner/kubernetes/client/client.go
@@ -38,6 +38,7 @@ const applyTimeout = 5 * time.Minute
 type KubernetesClient interface {
 	GetResource(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error)
 	ListResources(gvr schema.GroupVersionResource, namespace string) (*unstructured.UnstructuredList, error)
+	ListResourcesByLabel(gvr schema.GroupVersionResource, namespace, labelSelector string) (*unstructured.UnstructuredList, error)
 	ApplyResource(gvr schema.GroupVersionResource, obj *unstructured.Unstructured, opts metav1.ApplyOptions) (*unstructured.Unstructured, error)
 	DeleteResource(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error
 	PatchResource(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*unstructured.Unstructured, error)
@@ -86,6 +87,18 @@ func (c *DynamicKubernetesClient) ListResources(gvr schema.GroupVersionResource,
 	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 	defer cancel()
 	return c.client.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{})
+}
+
+// ListResourcesByLabel lists resources of the given kind narrowed to a label selector; an empty
+// namespace lists across all namespaces. It lets callers ask the API server to return only the objects
+// they care about (e.g. this context's CLI-placed secrets) rather than listing everything and filtering.
+func (c *DynamicKubernetesClient) ListResourcesByLabel(gvr schema.GroupVersionResource, namespace, labelSelector string) (*unstructured.UnstructuredList, error) {
+	if err := c.ensureClient(); err != nil {
+		return nil, err
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
+	defer cancel()
+	return c.client.Resource(gvr).Namespace(namespace).List(ctx, metav1.ListOptions{LabelSelector: labelSelector})
 }
 
 // ApplyResource applies a resource using server-side apply

--- a/pkg/provisioner/kubernetes/client/mock_client.go
+++ b/pkg/provisioner/kubernetes/client/mock_client.go
@@ -19,13 +19,14 @@ import (
 
 // MockKubernetesClient is a mock implementation of KubernetesClient interface for testing
 type MockKubernetesClient struct {
-	GetResourceFunc        func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error)
-	ListResourcesFunc      func(gvr schema.GroupVersionResource, namespace string) (*unstructured.UnstructuredList, error)
-	ApplyResourceFunc      func(gvr schema.GroupVersionResource, obj *unstructured.Unstructured, opts metav1.ApplyOptions) (*unstructured.Unstructured, error)
-	DeleteResourceFunc     func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error
-	PatchResourceFunc      func(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*unstructured.Unstructured, error)
-	CheckHealthFunc        func(ctx context.Context, endpoint string) error
-	GetNodeReadyStatusFunc func(ctx context.Context, nodeNames []string) (map[string]bool, error)
+	GetResourceFunc          func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error)
+	ListResourcesFunc        func(gvr schema.GroupVersionResource, namespace string) (*unstructured.UnstructuredList, error)
+	ListResourcesByLabelFunc func(gvr schema.GroupVersionResource, namespace, labelSelector string) (*unstructured.UnstructuredList, error)
+	ApplyResourceFunc        func(gvr schema.GroupVersionResource, obj *unstructured.Unstructured, opts metav1.ApplyOptions) (*unstructured.Unstructured, error)
+	DeleteResourceFunc       func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error
+	PatchResourceFunc        func(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*unstructured.Unstructured, error)
+	CheckHealthFunc          func(ctx context.Context, endpoint string) error
+	GetNodeReadyStatusFunc   func(ctx context.Context, nodeNames []string) (map[string]bool, error)
 }
 
 // =============================================================================
@@ -53,6 +54,14 @@ func (m *MockKubernetesClient) GetResource(gvr schema.GroupVersionResource, name
 func (m *MockKubernetesClient) ListResources(gvr schema.GroupVersionResource, namespace string) (*unstructured.UnstructuredList, error) {
 	if m.ListResourcesFunc != nil {
 		return m.ListResourcesFunc(gvr, namespace)
+	}
+	return &unstructured.UnstructuredList{}, nil
+}
+
+// ListResourcesByLabel implements KubernetesClient interface
+func (m *MockKubernetesClient) ListResourcesByLabel(gvr schema.GroupVersionResource, namespace, labelSelector string) (*unstructured.UnstructuredList, error) {
+	if m.ListResourcesByLabelFunc != nil {
+		return m.ListResourcesByLabelFunc(gvr, namespace, labelSelector)
 	}
 	return &unstructured.UnstructuredList{}, nil
 }

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -45,7 +45,8 @@ type KubernetesManager interface {
 	CreateNamespace(name string) error
 	DeleteNamespace(name string) error
 	ApplyConfigMap(name, namespace string, data map[string]string) error
-	ApplySecret(name, namespace string, stringData map[string]string) error
+	ApplySecret(name, namespace string, stringData map[string]string, owner string) error
+	PruneSecrets(desired map[string]map[string]bool) error
 	RollWorkloadsForSecret(ctx context.Context, namespace, secretName, digest string) error
 	GetHelmReleasesForKustomization(name, namespace string) ([]helmv2.HelmRelease, error)
 	ApplyGitRepository(repo *sourcev1.GitRepository) error
@@ -523,8 +524,13 @@ func (k *BaseKubernetesManager) ApplyConfigMap(name, namespace string, data map[
 
 // ApplySecret creates or updates an Opaque Secret using SSA. Values are supplied as plaintext in
 // stringData (write-only; the API server folds them into data) and are never logged. Mirrors
-// ApplyConfigMap's server-side-apply handling.
-func (k *BaseKubernetesManager) ApplySecret(name, namespace string, stringData map[string]string) error {
+// ApplyConfigMap's server-side-apply handling. It stamps the context ownership labels plus a
+// secret-owner label naming the kustomization the secret belongs to; that label is set only by CLI
+// placement (never by Flux), so PruneSecrets can find and reclaim CLI-placed secrets without ever
+// touching a Flux-managed one.
+func (k *BaseKubernetesManager) ApplySecret(name, namespace string, stringData map[string]string, owner string) error {
+	labels := k.ownershipLabels()
+	labels[secretOwnerLabel] = owner
 	obj := &unstructured.Unstructured{
 		Object: map[string]any{
 			"apiVersion": "v1",
@@ -537,6 +543,7 @@ func (k *BaseKubernetesManager) ApplySecret(name, namespace string, stringData m
 			"stringData": stringData,
 		},
 	}
+	obj.SetLabels(labels)
 
 	if err := validateFields(obj); err != nil {
 		return fmt.Errorf("invalid secret fields: %w", err)
@@ -554,6 +561,45 @@ func (k *BaseKubernetesManager) ApplySecret(name, namespace string, stringData m
 	}
 
 	return k.applyWithRetry(gvr, obj, opts)
+}
+
+// PruneSecrets deletes the CLI-placed secrets for this context that the latest placement no longer
+// wants, reconciling the cluster to the desired set. desired maps a namespace to the set of secret
+// names just placed there; a secret whose (namespace, name) is absent is deleted. It lists only secrets
+// bearing this context's id and the secret-owner marker — a label set solely by ApplySecret, never by
+// Flux — so it reclaims exactly what the CLI placed (a secret dropped from a fan-out list, a secret
+// removed from a system, or every CLI secret when desired is empty) and never a Flux-managed secret
+// that merely inherited the context labels via CommonMetadata. It fails closed when the context id is
+// unset, since without it pruning cannot be scoped to this context.
+func (k *BaseKubernetesManager) PruneSecrets(desired map[string]map[string]bool) error {
+	contextID := k.configHandler.GetString("id")
+	if contextID == "" {
+		return fmt.Errorf("context id not set; cannot scope secret pruning to this context")
+	}
+
+	gvr := schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "secrets",
+	}
+
+	selector := fmt.Sprintf("windsorcli.dev/context-id=%s,%s", contextID, secretOwnerLabel)
+	list, err := k.client.ListResourcesByLabel(gvr, "", selector)
+	if err != nil {
+		return fmt.Errorf("failed to list CLI-placed secrets: %w", err)
+	}
+
+	for i := range list.Items {
+		item := list.Items[i]
+		namespace := item.GetNamespace()
+		if desired[namespace][item.GetName()] {
+			continue
+		}
+		if err := k.client.DeleteResource(gvr, namespace, item.GetName(), metav1.DeleteOptions{}); err != nil {
+			return fmt.Errorf("failed to delete orphaned secret %q in namespace %q: %w", item.GetName(), namespace, err)
+		}
+	}
+	return nil
 }
 
 // secretChecksumAnnotationPrefix prefixes the pod-template annotation whose value is a content digest
@@ -1465,6 +1511,12 @@ waitLoop:
 func (k *BaseKubernetesManager) gitopsNamespace() string {
 	return k.configHandler.GetString("gitops.namespace", constants.DefaultGitopsNamespace)
 }
+
+// secretOwnerLabel names the kustomization a CLI-placed Secret belongs to. It is set only by
+// ApplySecret, never by Flux, so it is the reliable marker for finding secrets the CLI itself placed —
+// PruneSecrets selects on it (scoped to the context) to reclaim orphans without touching Flux-managed
+// secrets that happen to carry the context labels via CommonMetadata.
+const secretOwnerLabel = "windsorcli.dev/secret-owner" // #nosec G101 -- label key, not a credential
 
 // ownershipLabels returns the Windsor context labels stamped on each Kustomization object (so the
 // objects are selectable by context) and propagated to its managed resources via CommonMetadata.

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -31,6 +31,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/validation"
 )
 
 // =============================================================================
@@ -570,11 +571,16 @@ func (k *BaseKubernetesManager) ApplySecret(name, namespace string, stringData m
 // Flux — so it reclaims exactly what the CLI placed (a secret dropped from a fan-out list, a secret
 // removed from a system, or every CLI secret when desired is empty) and never a Flux-managed secret
 // that merely inherited the context labels via CommonMetadata. It fails closed when the context id is
-// unset, since without it pruning cannot be scoped to this context.
+// unset or is not a valid label value, since without a well-formed id pruning cannot be scoped to this
+// context — a malformed id would otherwise build a selector the API server rejects, failing every
+// placement with an opaque error rather than a message that names the bad id.
 func (k *BaseKubernetesManager) PruneSecrets(desired map[string]map[string]bool) error {
 	contextID := k.configHandler.GetString("id")
 	if contextID == "" {
 		return fmt.Errorf("context id not set; cannot scope secret pruning to this context")
+	}
+	if errs := validation.IsValidLabelValue(contextID); len(errs) > 0 {
+		return fmt.Errorf("context id %q is not a valid label value, cannot scope secret pruning: %s", contextID, strings.Join(errs, "; "))
 	}
 
 	gvr := schema.GroupVersionResource{

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -5826,6 +5826,39 @@ func TestBaseKubernetesManager_PruneSecrets(t *testing.T) {
 		}
 	})
 
+	t.Run("InvalidContextIDFailsClosed", func(t *testing.T) {
+		// Given a context id that is not a valid label value (a comma would build a
+		// malformed selector the API server rejects)
+		mocks := setupKubernetesMocks(t, func(m *KubernetesTestMocks) {
+			m.ConfigHandler.(*config.MockConfigHandler).GetStringFunc = func(key string, defaultValue ...string) string {
+				if key == "id" {
+					return "bad,id"
+				}
+				if len(defaultValue) > 0 {
+					return defaultValue[0]
+				}
+				return ""
+			}
+		})
+		manager := NewKubernetesManager(mocks.KubernetesClient, mocks.ConfigHandler)
+		listed := false
+		c := client.NewMockKubernetesClient()
+		c.ListResourcesByLabelFunc = func(gvr schema.GroupVersionResource, ns, labelSelector string) (*unstructured.UnstructuredList, error) {
+			listed = true
+			return &unstructured.UnstructuredList{}, nil
+		}
+		manager.client = c
+
+		// When pruning, the guard rejects the id up front, names it, and never queries the cluster
+		err := manager.PruneSecrets(nil)
+		if err == nil || !strings.Contains(err.Error(), "bad,id") {
+			t.Errorf("Expected error naming the invalid context id, got %v", err)
+		}
+		if listed {
+			t.Error("Expected no list call when context id is invalid")
+		}
+	})
+
 	t.Run("DeleteErrorIsPropagated", func(t *testing.T) {
 		// Given the delete call fails
 		manager := setup(t)

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -5687,7 +5687,7 @@ func TestBaseKubernetesManager_ApplySecret(t *testing.T) {
 		manager.client = kubernetesClient
 
 		// When applying a secret
-		err := manager.ApplySecret("cloudflare-creds", "system-dns", map[string]string{"api_token": "PLAINTEXT"})
+		err := manager.ApplySecret("cloudflare-creds", "system-dns", map[string]string{"api_token": "PLAINTEXT"}, "dns-install")
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
@@ -5710,6 +5710,11 @@ func TestBaseKubernetesManager_ApplySecret(t *testing.T) {
 		if metadata["name"] != "cloudflare-creds" || metadata["namespace"] != "system-dns" {
 			t.Errorf("Unexpected metadata: %v", applied.Object["metadata"])
 		}
+
+		// And it carries the secret-owner marker so PruneSecrets can reclaim it later
+		if applied.GetLabels()[secretOwnerLabel] != "dns-install" {
+			t.Errorf("Expected secret-owner label dns-install, got %v", applied.GetLabels())
+		}
 	})
 
 	t.Run("EmptyNameFails", func(t *testing.T) {
@@ -5718,8 +5723,124 @@ func TestBaseKubernetesManager_ApplySecret(t *testing.T) {
 		manager.client = client.NewMockKubernetesClient()
 
 		// When applying a secret with no name, it fails validation
-		if err := manager.ApplySecret("", "system-dns", map[string]string{"k": "v"}); err == nil {
+		if err := manager.ApplySecret("", "system-dns", map[string]string{"k": "v"}, "dns-install"); err == nil {
 			t.Error("Expected error for empty name")
+		}
+	})
+}
+
+func TestBaseKubernetesManager_PruneSecrets(t *testing.T) {
+	setup := func(t *testing.T) *BaseKubernetesManager {
+		t.Helper()
+		mocks := setupKubernetesMocks(t)
+		return NewKubernetesManager(mocks.KubernetesClient, mocks.ConfigHandler)
+	}
+
+	// secretObj builds a CLI-placed Secret list item in a namespace, carrying this context's id and the
+	// secret-owner marker — what ListResourcesByLabel would return.
+	secretObj := func(name, namespace string) unstructured.Unstructured {
+		return unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Secret",
+			"metadata": map[string]any{
+				"name":      name,
+				"namespace": namespace,
+				"labels": map[string]any{
+					"windsorcli.dev/context-id": "test-context-id",
+					secretOwnerLabel:            "pki-install",
+				},
+			},
+		}}
+	}
+
+	// wire makes the manager return the given secrets from the label-scoped list and capture deletions.
+	wire := func(manager *BaseKubernetesManager, items ...unstructured.Unstructured) (*[]string, *string) {
+		deleted := []string{}
+		var selector string
+		c := client.NewMockKubernetesClient()
+		c.ListResourcesByLabelFunc = func(gvr schema.GroupVersionResource, ns, labelSelector string) (*unstructured.UnstructuredList, error) {
+			selector = labelSelector
+			return &unstructured.UnstructuredList{Items: items}, nil
+		}
+		c.DeleteResourceFunc = func(gvr schema.GroupVersionResource, ns, name string, opts metav1.DeleteOptions) error {
+			deleted = append(deleted, ns+"/"+name)
+			return nil
+		}
+		manager.client = c
+		return &deleted, &selector
+	}
+
+	t.Run("DeletesOrphansAndKeepsDesired", func(t *testing.T) {
+		// Given the same secret placed in two namespaces (a fan-out)
+		manager := setup(t)
+		deleted, selector := wire(manager,
+			secretObj("hetzner-dns", "system-pki"),
+			secretObj("hetzner-dns", "system-dns"),
+		)
+
+		// When reconciling to a desired set that keeps only the system-pki copy (fan-out shrank)
+		desired := map[string]map[string]bool{"system-pki": {"hetzner-dns": true}}
+		if err := manager.PruneSecrets(desired); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then only the dropped-namespace copy is deleted
+		if len(*deleted) != 1 || (*deleted)[0] != "system-dns/hetzner-dns" {
+			t.Errorf("Expected only system-dns/hetzner-dns deleted, got %v", *deleted)
+		}
+		// And the list is scoped to this context and the CLI secret-owner marker
+		if !strings.Contains(*selector, "windsorcli.dev/context-id=test-context-id") || !strings.Contains(*selector, secretOwnerLabel) {
+			t.Errorf("Expected context+owner-scoped selector, got %q", *selector)
+		}
+	})
+
+	t.Run("EmptyDesiredReclaimsEveryCLISecret", func(t *testing.T) {
+		// Given CLI-placed secrets but a blueprint that now declares none
+		manager := setup(t)
+		deleted, _ := wire(manager, secretObj("a", "ns1"), secretObj("b", "ns2"))
+
+		// When reconciling to an empty desired set, every CLI-placed secret is reclaimed
+		if err := manager.PruneSecrets(map[string]map[string]bool{}); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if len(*deleted) != 2 {
+			t.Errorf("Expected both CLI secrets reclaimed, got %v", *deleted)
+		}
+	})
+
+	t.Run("EmptyContextIDFailsClosed", func(t *testing.T) {
+		// Given a manager whose config handler reports no context id
+		mocks := setupKubernetesMocks(t, func(m *KubernetesTestMocks) {
+			m.ConfigHandler.(*config.MockConfigHandler).GetStringFunc = func(key string, defaultValue ...string) string {
+				if len(defaultValue) > 0 {
+					return defaultValue[0]
+				}
+				return ""
+			}
+		})
+		manager := NewKubernetesManager(mocks.KubernetesClient, mocks.ConfigHandler)
+
+		// When pruning without a context id, the guard rejects it before deleting anything
+		if err := manager.PruneSecrets(nil); err == nil {
+			t.Error("Expected error when context id is not set")
+		}
+	})
+
+	t.Run("DeleteErrorIsPropagated", func(t *testing.T) {
+		// Given the delete call fails
+		manager := setup(t)
+		c := client.NewMockKubernetesClient()
+		c.ListResourcesByLabelFunc = func(gvr schema.GroupVersionResource, ns, labelSelector string) (*unstructured.UnstructuredList, error) {
+			return &unstructured.UnstructuredList{Items: []unstructured.Unstructured{secretObj("x", "ns")}}, nil
+		}
+		c.DeleteResourceFunc = func(gvr schema.GroupVersionResource, ns, name string, opts metav1.DeleteOptions) error {
+			return fmt.Errorf("api down")
+		}
+		manager.client = c
+
+		// When reconciling, the delete failure surfaces
+		if err := manager.PruneSecrets(map[string]map[string]bool{}); err == nil || !strings.Contains(err.Error(), "api down") {
+			t.Errorf("Expected delete error propagated, got %v", err)
 		}
 	})
 }

--- a/pkg/provisioner/kubernetes/mock_kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/mock_kubernetes_manager.go
@@ -26,7 +26,8 @@ type MockKubernetesManager struct {
 	CreateNamespaceFunc                 func(name string) error
 	DeleteNamespaceFunc                 func(name string) error
 	ApplyConfigMapFunc                  func(name, namespace string, data map[string]string) error
-	ApplySecretFunc                     func(name, namespace string, stringData map[string]string) error
+	ApplySecretFunc                     func(name, namespace string, stringData map[string]string, owner string) error
+	PruneSecretsFunc                    func(desired map[string]map[string]bool) error
 	RollWorkloadsForSecretFunc          func(ctx context.Context, namespace, secretName, digest string) error
 	ApplyVersionMarkerFunc              func(namespace string, marker VersionMarker) error
 	GetVersionMarkerFunc                func(namespace string) (VersionMarker, bool, error)
@@ -114,9 +115,17 @@ func (m *MockKubernetesManager) ApplyConfigMap(name, namespace string, data map[
 }
 
 // ApplySecret implements KubernetesManager interface
-func (m *MockKubernetesManager) ApplySecret(name, namespace string, stringData map[string]string) error {
+func (m *MockKubernetesManager) ApplySecret(name, namespace string, stringData map[string]string, owner string) error {
 	if m.ApplySecretFunc != nil {
-		return m.ApplySecretFunc(name, namespace, stringData)
+		return m.ApplySecretFunc(name, namespace, stringData, owner)
+	}
+	return nil
+}
+
+// PruneSecrets implements KubernetesManager interface
+func (m *MockKubernetesManager) PruneSecrets(desired map[string]map[string]bool) error {
+	if m.PruneSecretsFunc != nil {
+		return m.PruneSecretsFunc(desired)
 	}
 	return nil
 }

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -1051,21 +1051,26 @@ func (i *Provisioner) ResolveSecrets(blueprint *blueprintv1alpha1.Blueprint) (Re
 }
 
 // PlaceSecrets materializes secrets that ResolveSecrets produced into the namespace(s) each owning
-// kustomization created. It runs after Install; for each secret it resolves the target namespace(s) —
-// either the ones the entry named or, when it named none, the single namespace the kustomization created
-// (failing closed on more than one so a secret is never placed by guessing) — and applies an Opaque
-// Secret into each. After placing each Secret it rolls the workloads in that namespace that consume it,
-// keyed by a content digest, so a changed value reaches running pods rather than sitting stale until the
-// next unrelated restart. It self-gates on the target namespace appearing rather than requiring a global
-// wait, and is a no-op when resolved is empty.
+// kustomization created, then reconciles: it deletes the CLI-placed secrets this context no longer
+// wants. It runs after Install; for each secret it resolves the target namespace(s) — either the ones
+// the entry named or, when it named none, the single namespace the kustomization created (failing closed
+// on more than one so a secret is never placed by guessing) — applies an Opaque Secret into each, and
+// rolls the workloads in that namespace that consume it, keyed by a content digest, so a changed value
+// reaches running pods rather than sitting stale until the next unrelated restart. It records every
+// (namespace, secret) it placed and hands that desired set to PruneSecrets, which reclaims any CLI-placed
+// secret not in it — a secret dropped from a fan-out list, a secret removed from a system, or every one
+// when the blueprint declares no secrets. It self-gates on the target namespace appearing rather than
+// requiring a global wait. When no kubernetes manager is configured it is a no-op only if there is also
+// nothing to place.
 func (i *Provisioner) PlaceSecrets(ctx context.Context, resolved ResolvedSecrets) error {
-	if len(resolved) == 0 {
-		return nil
-	}
 	if i.KubernetesManager == nil {
+		if len(resolved) == 0 {
+			return nil
+		}
 		return fmt.Errorf("kubernetes manager not configured")
 	}
 
+	placed := make(map[string]map[string]bool)
 	for kustomizationName, secrets := range resolved {
 		for secretName, secret := range secrets {
 			namespaces, err := i.resolveSecretNamespaces(ctx, kustomizationName, secret.Namespaces)
@@ -1073,14 +1078,22 @@ func (i *Provisioner) PlaceSecrets(ctx context.Context, resolved ResolvedSecrets
 				return err
 			}
 			for _, namespace := range namespaces {
-				if err := i.KubernetesManager.ApplySecret(secretName, namespace, secret.Data); err != nil {
+				if err := i.KubernetesManager.ApplySecret(secretName, namespace, secret.Data, kustomizationName); err != nil {
 					return fmt.Errorf("applying secret %q to namespace %q: %w", secretName, namespace, err)
 				}
 				if err := i.KubernetesManager.RollWorkloadsForSecret(ctx, namespace, secretName, secretDigest(secret.Data)); err != nil {
 					return fmt.Errorf("rolling workloads for secret %q in namespace %q: %w", secretName, namespace, err)
 				}
+				if placed[namespace] == nil {
+					placed[namespace] = make(map[string]bool)
+				}
+				placed[namespace][secretName] = true
 			}
 		}
+	}
+
+	if err := i.KubernetesManager.PruneSecrets(placed); err != nil {
+		return fmt.Errorf("pruning orphaned secrets: %w", err)
 	}
 	return nil
 }

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -1051,18 +1051,19 @@ func (i *Provisioner) ResolveSecrets(blueprint *blueprintv1alpha1.Blueprint) (Re
 }
 
 // PlaceSecrets materializes secrets that ResolveSecrets produced into the namespace(s) each owning
-// kustomization created, then reconciles: it deletes the CLI-placed secrets this context no longer
-// wants. It runs after Install; for each secret it resolves the target namespace(s) — either the ones
-// the entry named or, when it named none, the single namespace the kustomization created (failing closed
-// on more than one so a secret is never placed by guessing) — applies an Opaque Secret into each, and
-// rolls the workloads in that namespace that consume it, keyed by a content digest, so a changed value
-// reaches running pods rather than sitting stale until the next unrelated restart. It records every
-// (namespace, secret) it placed and hands that desired set to PruneSecrets, which reclaims any CLI-placed
-// secret not in it — a secret dropped from a fan-out list, a secret removed from a system, or every one
-// when the blueprint declares no secrets. It self-gates on the target namespace appearing rather than
-// requiring a global wait. When no kubernetes manager is configured it is a no-op only if there is also
-// nothing to place.
-func (i *Provisioner) PlaceSecrets(ctx context.Context, resolved ResolvedSecrets) error {
+// kustomization created, and — when prune is set — reconciles by deleting the CLI-placed secrets this
+// context no longer wants. It runs after Install; for each secret it resolves the target namespace(s) —
+// either the ones the entry named or, when it named none, the single namespace the kustomization created
+// (failing closed on more than one so a secret is never placed by guessing) — applies an Opaque Secret
+// into each, and rolls the workloads in that namespace that consume it, keyed by a content digest, so a
+// changed value reaches running pods rather than sitting stale until the next unrelated restart. It
+// self-gates on the target namespace appearing rather than requiring a global wait. When prune is set it
+// records every (namespace, secret) it placed and hands that desired set to PruneSecrets, which reclaims
+// any CLI-placed secret not in it — a secret dropped from a fan-out list, a secret removed from a system,
+// or every one when the blueprint declares no secrets. Pruning is gated so secret reclaim mirrors
+// Kustomization prune: on under apply's --prune and upgrade, off for the place-only flows. When no
+// kubernetes manager is configured it is a no-op only if there is also nothing to place.
+func (i *Provisioner) PlaceSecrets(ctx context.Context, resolved ResolvedSecrets, prune bool) error {
 	if i.KubernetesManager == nil {
 		if len(resolved) == 0 {
 			return nil
@@ -1092,6 +1093,9 @@ func (i *Provisioner) PlaceSecrets(ctx context.Context, resolved ResolvedSecrets
 		}
 	}
 
+	if !prune {
+		return nil
+	}
 	if err := i.KubernetesManager.PruneSecrets(placed); err != nil {
 		return fmt.Errorf("pruning orphaned secrets: %w", err)
 	}

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -4439,7 +4439,7 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		}
 
 		// When placing the resolved secrets
-		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved()); err != nil {
+		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved(), true); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
@@ -4462,7 +4462,7 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		}
 
 		// When placing the resolved secrets
-		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved()); err != nil {
+		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved(), true); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
@@ -4484,7 +4484,7 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		}
 
 		// When placing the resolved secrets, the roll failure surfaces
-		err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved())
+		err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved(), true)
 		if err == nil || !strings.Contains(err.Error(), "rolling workloads for secret") {
 			t.Errorf("Expected roll-failure error, got %v", err)
 		}
@@ -4495,7 +4495,7 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
 			return []kubernetes.InventoryEntry{{Kind: "Namespace", Name: "ns-a"}, {Kind: "Namespace", Name: "ns-b"}}, nil
 		}
-		err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved())
+		err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved(), true)
 		if err == nil || !strings.Contains(err.Error(), "multiple namespaces") {
 			t.Errorf("Expected multiple-namespaces error, got %v", err)
 		}
@@ -4508,7 +4508,7 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		}
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
-		err := newProvisioner(mocks).PlaceSecrets(ctx, resolved())
+		err := newProvisioner(mocks).PlaceSecrets(ctx, resolved(), true)
 		if err == nil || !strings.Contains(err.Error(), "to create its namespace") {
 			t.Errorf("Expected namespace-timeout error, got %v", err)
 		}
@@ -4528,7 +4528,7 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		explicit := ResolvedSecrets{"pki-install": {"hetzner-dns": {Namespaces: []string{"system-pki"}, Data: map[string]string{"token": "resolved"}}}}
 
 		// When placing, the named namespace disambiguates rather than failing closed
-		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), explicit); err != nil {
+		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), explicit, true); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 		if gotNs != "system-pki" {
@@ -4550,7 +4550,7 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		explicit := ResolvedSecrets{"pki-install": {"acme-dns": {Namespaces: []string{"system-pki", "system-dns"}, Data: map[string]string{"token": "resolved"}}}}
 
 		// When placing, the same secret lands in each named namespace
-		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), explicit); err != nil {
+		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), explicit, true); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 		if !placed["system-pki"] || !placed["system-dns"] || len(placed) != 2 {
@@ -4569,7 +4569,7 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		cancel()
 
 		// When placing, it fails naming the missing namespace rather than placing by guessing
-		err := newProvisioner(mocks).PlaceSecrets(ctx, explicit)
+		err := newProvisioner(mocks).PlaceSecrets(ctx, explicit, true)
 		if err == nil || !strings.Contains(err.Error(), "system-pki") || !strings.Contains(err.Error(), "before placing secrets") {
 			t.Errorf("Expected missing-namespace timeout error naming system-pki, got %v", err)
 		}
@@ -4592,7 +4592,7 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 
 		// When placing an empty set, nothing is placed (no inventory lookups) but reconcile still runs
 		// with an empty desired set, so any previously CLI-placed secret is reclaimed
-		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), ResolvedSecrets{}); err != nil {
+		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), ResolvedSecrets{}, true); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 		if queried {
@@ -4617,7 +4617,7 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		fanned := ResolvedSecrets{"pki-install": {"acme-dns": {Namespaces: []string{"system-pki", "system-dns"}, Data: map[string]string{"token": "resolved"}}}}
 
 		// When placing, the desired set handed to PruneSecrets names every (namespace, secret) placed
-		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), fanned); err != nil {
+		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), fanned, true); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 		if !gotDesired["system-pki"]["acme-dns"] || !gotDesired["system-dns"]["acme-dns"] {
@@ -4636,9 +4636,38 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		}
 
 		// When placing, the prune failure surfaces
-		err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved())
+		err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved(), true)
 		if err == nil || !strings.Contains(err.Error(), "pruning orphaned secrets") {
 			t.Errorf("Expected prune-failure error, got %v", err)
+		}
+	})
+
+	t.Run("PruneDisabledPlacesWithoutReconciling", func(t *testing.T) {
+		// Given a place-only flow (prune not requested)
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
+			return []kubernetes.InventoryEntry{{Kind: "Namespace", Name: "system-dns"}}, nil
+		}
+		placedName := ""
+		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string, owner string) error {
+			placedName = name
+			return nil
+		}
+		reconciled := false
+		mocks.KubernetesManager.PruneSecretsFunc = func(desired map[string]map[string]bool) error {
+			reconciled = true
+			return nil
+		}
+
+		// When placing with prune=false, the secret is placed but reclaim never runs
+		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved(), false); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if placedName != "cloudflare-creds" {
+			t.Errorf("Expected the secret to still be placed, got %q", placedName)
+		}
+		if reconciled {
+			t.Error("Expected no reconcile when prune is disabled")
 		}
 	})
 }

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -4431,10 +4431,10 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
 			return []kubernetes.InventoryEntry{{Kind: "Namespace", Name: "system-dns"}}, nil
 		}
-		var gotName, gotNs string
+		var gotName, gotNs, gotOwner string
 		var gotData map[string]string
-		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string) error {
-			gotName, gotNs, gotData = name, namespace, stringData
+		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string, owner string) error {
+			gotName, gotNs, gotData, gotOwner = name, namespace, stringData, owner
 			return nil
 		}
 
@@ -4443,9 +4443,9 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
-		// Then the secret lands in the inventory namespace with the resolved value
-		if gotName != "cloudflare-creds" || gotNs != "system-dns" || gotData["api_token"] != "resolved-token" {
-			t.Errorf("Unexpected ApplySecret args: name=%q ns=%q data=%v", gotName, gotNs, gotData)
+		// Then the secret lands in the inventory namespace with the resolved value, owned by its kustomization
+		if gotName != "cloudflare-creds" || gotNs != "system-dns" || gotData["api_token"] != "resolved-token" || gotOwner != "cdn-install" {
+			t.Errorf("Unexpected ApplySecret args: name=%q ns=%q data=%v owner=%q", gotName, gotNs, gotData, gotOwner)
 		}
 	})
 
@@ -4521,7 +4521,7 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 			return []kubernetes.InventoryEntry{{Kind: "Namespace", Name: "system-pki"}, {Kind: "Namespace", Name: "system-pki-trust"}}, nil
 		}
 		var gotNs string
-		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string) error {
+		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string, owner string) error {
 			gotNs = namespace
 			return nil
 		}
@@ -4543,7 +4543,7 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 			return []kubernetes.InventoryEntry{{Kind: "Namespace", Name: "system-pki"}, {Kind: "Namespace", Name: "system-dns"}}, nil
 		}
 		placed := map[string]bool{}
-		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string) error {
+		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string, owner string) error {
 			placed[namespace] = true
 			return nil
 		}
@@ -4575,18 +4575,70 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		}
 	})
 
-	t.Run("EmptyResolvedIsNoOp", func(t *testing.T) {
+	t.Run("EmptyResolvedPlacesNothingButStillReconciles", func(t *testing.T) {
+		// Given a blueprint that declares no secrets
 		mocks := setupProvisionerMocks(t)
 		queried := false
 		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
 			queried = true
 			return nil, nil
 		}
+		var pruned bool
+		var prunedDesired map[string]map[string]bool
+		mocks.KubernetesManager.PruneSecretsFunc = func(desired map[string]map[string]bool) error {
+			pruned, prunedDesired = true, desired
+			return nil
+		}
+
+		// When placing an empty set, nothing is placed (no inventory lookups) but reconcile still runs
+		// with an empty desired set, so any previously CLI-placed secret is reclaimed
 		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), ResolvedSecrets{}); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 		if queried {
-			t.Error("Expected no inventory query for empty resolved secrets")
+			t.Error("Expected no inventory query when nothing is placed")
+		}
+		if !pruned || len(prunedDesired) != 0 {
+			t.Errorf("Expected reconcile with empty desired set, pruned=%v desired=%v", pruned, prunedDesired)
+		}
+	})
+
+	t.Run("ReconcilesFanOutPlacementIntoDesiredSet", func(t *testing.T) {
+		// Given a secret that fans out into two namespaces its kustomization created
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
+			return []kubernetes.InventoryEntry{{Kind: "Namespace", Name: "system-pki"}, {Kind: "Namespace", Name: "system-dns"}}, nil
+		}
+		var gotDesired map[string]map[string]bool
+		mocks.KubernetesManager.PruneSecretsFunc = func(desired map[string]map[string]bool) error {
+			gotDesired = desired
+			return nil
+		}
+		fanned := ResolvedSecrets{"pki-install": {"acme-dns": {Namespaces: []string{"system-pki", "system-dns"}, Data: map[string]string{"token": "resolved"}}}}
+
+		// When placing, the desired set handed to PruneSecrets names every (namespace, secret) placed
+		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), fanned); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !gotDesired["system-pki"]["acme-dns"] || !gotDesired["system-dns"]["acme-dns"] {
+			t.Errorf("Expected desired set to include both placements, got %v", gotDesired)
+		}
+	})
+
+	t.Run("PruneFailureSurfaces", func(t *testing.T) {
+		// Given placement succeeds but the reconcile delete fails
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
+			return []kubernetes.InventoryEntry{{Kind: "Namespace", Name: "system-dns"}}, nil
+		}
+		mocks.KubernetesManager.PruneSecretsFunc = func(desired map[string]map[string]bool) error {
+			return fmt.Errorf("api down")
+		}
+
+		// When placing, the prune failure surfaces
+		err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved())
+		if err == nil || !strings.Contains(err.Error(), "pruning orphaned secrets") {
+			t.Errorf("Expected prune-failure error, got %v", err)
 		}
 	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This PR changes a shared Kubernetes infrastructure interface and introduces new deletion behavior, making it Medium risk despite careful scoping.
>
> **Overview**
>
> The PR adds owner-tracking to CLI-placed Kubernetes Secrets and a reconciliation sweep to reclaim them. `ApplySecret` gains an `owner string` parameter (the kustomization name), which is stamped as a `windsorcli.dev/secret-owner` label on every Secret the CLI writes. A new `PruneSecrets` method lists all Secrets matching this context's ID and the owner marker, then deletes any not present in the desired set passed from `PlaceSecrets`.
>
> The notable behavioral change is in `PlaceSecrets`: it now calls `PruneSecrets` unconditionally, including when the resolved set is empty — so a blueprint that declares no secrets will delete every previously CLI-placed Secret for this context. The `KubernetesManager` nil-check was also reordered so an unconfigured manager errors only when there is actually work to do, rather than on any call.
>
> Reviewed by Claude for commit `791b54ee`.

<!-- /claude-code-review:summary -->
