### PR TITLE
fix(provisioner): flatten FluxSystem tiers in kustomize destroy-plan summaries

### DIFF
--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -690,7 +690,7 @@ func (i *Provisioner) PlanDestroyKustomizeComponentSummary(blueprint *blueprintv
 	if err := i.ensureFluxStack(); err != nil {
 		return fluxinfra.KustomizePlan{}, err
 	}
-	return i.FluxStack.PlanDestroyComponentSummary(blueprint, name), nil
+	return i.FluxStack.PlanDestroyComponentSummary(withCrdLayer(blueprint), name), nil
 }
 
 // PlanTerraformSummary runs a best-effort summary plan across every Terraform
@@ -784,7 +784,10 @@ func (i *Provisioner) PlanDestroyTerraformSummary(blueprint *blueprintv1alpha1.B
 // Flux kustomization by querying live cluster inventory. Returns an error if
 // the cluster is unreachable — destroy itself cannot proceed without it, so a
 // blueprint-derived fallback would mislead. DestroyOnly hooks and destroy=
-// false pinned kustomizations are filtered to match DeleteBlueprint.
+// false pinned kustomizations are filtered to match DeleteBlueprint. The
+// blueprint is passed through withCrdLayer so FluxSystem tiers and synthesized
+// CRD layers are flattened into Kustomizations — matching Uninstall's teardown
+// set exactly, so the plan lists the same kustomizations the destroy removes.
 func (i *Provisioner) PlanDestroyKustomizeSummary(blueprint *blueprintv1alpha1.Blueprint) (*DestroyPlanSummary, error) {
 	if blueprint == nil {
 		return nil, fmt.Errorf("blueprint not provided")
@@ -795,7 +798,7 @@ func (i *Provisioner) PlanDestroyKustomizeSummary(blueprint *blueprintv1alpha1.B
 	if err := i.ensureFluxStack(); err != nil {
 		return nil, err
 	}
-	results, err := i.FluxStack.PlanDestroySummary(blueprint)
+	results, err := i.FluxStack.PlanDestroySummary(withCrdLayer(blueprint))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -4205,6 +4205,58 @@ func TestProvisioner_PlanDestroyKustomizeComponentSummary(t *testing.T) {
 			t.Errorf("expected delegated result, got %#v", got)
 		}
 	})
+
+	t.Run("FlattensFluxSystemTiersBeforePlanning", func(t *testing.T) {
+		// Regression: a blueprint that declares its kustomizations via FluxSystems
+		// (not top-level kustomize:) must still preview the compiled install/
+		// resources tier. The plan iterates blueprint.Kustomizations, so the
+		// provisioner must pass the blueprint through withCrdLayer first — the
+		// same flattening Uninstall applies before DeleteBlueprint. Without it the
+		// component plan saw an empty Kustomizations slice while the teardown
+		// still destroyed the tier.
+		mocks := setupProvisionerMocks(t)
+		var seen *blueprintv1alpha1.Blueprint
+		mocks.FluxStack.PlanDestroyComponentSummaryFunc = func(bp *blueprintv1alpha1.Blueprint, name string) fluxinfra.KustomizePlan {
+			seen = bp
+			return fluxinfra.KustomizePlan{}
+		}
+		p := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{
+			TerraformStack:    mocks.TerraformStack,
+			FluxStack:         mocks.FluxStack,
+			KubernetesManager: mocks.KubernetesManager,
+			KubernetesClient:  mocks.KubernetesClient,
+		})
+
+		bp := &blueprintv1alpha1.Blueprint{
+			Metadata: blueprintv1alpha1.Metadata{Name: "test-blueprint"},
+			Crds:     []string{"cert-manager-crds"},
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name:   "pki",
+					Source: "source1",
+					Install: &blueprintv1alpha1.Kustomization{
+						Components: []string{"controller"},
+					},
+				},
+			},
+		}
+		if _, err := p.PlanDestroyKustomizeComponentSummary(bp, "pki-install"); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if seen == nil {
+			t.Fatal("FluxStack.PlanDestroyComponentSummary was not called")
+		}
+		if seen.FluxSystems != nil {
+			t.Errorf("expected FluxSystems flattened away, got %v", seen.FluxSystems)
+		}
+		names := make([]string, 0, len(seen.Kustomizations))
+		for _, k := range seen.Kustomizations {
+			names = append(names, k.Name)
+		}
+		if !slices.Contains(names, "pki-install") {
+			t.Errorf("expected pki-install tier flattened into Kustomizations, got %v", names)
+		}
+	})
 }
 
 func TestVersionFromImage(t *testing.T) {

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -4022,6 +4022,58 @@ func TestProvisioner_PlanDestroyKustomizeSummary(t *testing.T) {
 			t.Errorf("expected cluster error to propagate, got err=%v summary=%v", err, summary)
 		}
 	})
+
+	t.Run("FlattensFluxSystemTiersBeforePlanning", func(t *testing.T) {
+		// Regression: a blueprint that declares its kustomizations via FluxSystems
+		// (not top-level kustomize:) must still preview every compiled install/
+		// resources tier. The plan iterates blueprint.Kustomizations, so the
+		// provisioner must pass the blueprint through withCrdLayer first — the
+		// same flattening Uninstall applies before DeleteBlueprint. Without it the
+		// plan saw an empty Kustomizations slice and rendered no Kustomize section
+		// while the teardown still destroyed every tier.
+		mocks := setupProvisionerMocks(t)
+		var seen *blueprintv1alpha1.Blueprint
+		mocks.FluxStack.PlanDestroySummaryFunc = func(bp *blueprintv1alpha1.Blueprint) ([]fluxinfra.KustomizePlan, error) {
+			seen = bp
+			return nil, nil
+		}
+		p := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{
+			TerraformStack:    mocks.TerraformStack,
+			FluxStack:         mocks.FluxStack,
+			KubernetesManager: mocks.KubernetesManager,
+			KubernetesClient:  mocks.KubernetesClient,
+		})
+
+		bp := &blueprintv1alpha1.Blueprint{
+			Metadata: blueprintv1alpha1.Metadata{Name: "test-blueprint"},
+			Crds:     []string{"cert-manager-crds"},
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name:   "pki",
+					Source: "source1",
+					Install: &blueprintv1alpha1.Kustomization{
+						Components: []string{"controller"},
+					},
+				},
+			},
+		}
+		if _, err := p.PlanDestroyKustomizeSummary(bp); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if seen == nil {
+			t.Fatal("FluxStack.PlanDestroySummary was not called")
+		}
+		if seen.FluxSystems != nil {
+			t.Errorf("expected FluxSystems flattened away, got %v", seen.FluxSystems)
+		}
+		names := make([]string, 0, len(seen.Kustomizations))
+		for _, k := range seen.Kustomizations {
+			names = append(names, k.Name)
+		}
+		if !slices.Contains(names, "pki-install") {
+			t.Errorf("expected pki-install tier flattened into Kustomizations, got %v", names)
+		}
+	})
 }
 
 func TestProvisioner_PlanDestroyAll(t *testing.T) {


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Isolated bug fix in the provisioner layer; the change is localized to two call sites and adds a regression test with no API or behavioral surface changes.
>
> **Overview**
>
> `PlanDestroyKustomizeSummary` and `PlanDestroyKustomizeComponentSummary` now wrap the incoming blueprint with `withCrdLayer` before passing it to `FluxStack`, mirroring what `Uninstall`/`DeleteBlueprint` already does during actual teardown. Previously, blueprints that declared kustomizations via `FluxSystems` (rather than top-level `kustomize:`) produced an empty destroy-plan preview because `FluxSystem` tiers were never flattened into the `Kustomizations` slice that the plan iterates. A targeted regression test is added for `PlanDestroyKustomizeSummary`; `PlanDestroyKustomizeComponentSummary` receives the same fix without its own new test case.
>
> Reviewed by Claude for commit `ed52fc69`.

<!-- /claude-code-review:summary -->
