### PR TITLE
feat(env): inject hetzner.token into the environment as HCLOUD_TOKEN

### DIFF
--- a/api/v1alpha1/config_types.go
+++ b/api/v1alpha1/config_types.go
@@ -8,6 +8,7 @@ import (
 	"github.com/windsorcli/cli/api/v1alpha1/docker"
 	"github.com/windsorcli/cli/api/v1alpha1/gcp"
 	"github.com/windsorcli/cli/api/v1alpha1/git"
+	"github.com/windsorcli/cli/api/v1alpha1/hetzner"
 	"github.com/windsorcli/cli/api/v1alpha1/network"
 	"github.com/windsorcli/cli/api/v1alpha1/secrets"
 	"github.com/windsorcli/cli/api/v1alpha1/terraform"
@@ -38,6 +39,7 @@ type Context struct {
 	AWS         *aws.AWSConfig             `yaml:"aws,omitempty"`
 	Azure       *azure.AzureConfig         `yaml:"azure,omitempty"`
 	GCP         *gcp.GCPConfig             `yaml:"gcp,omitempty"`
+	Hetzner     *hetzner.HetznerConfig     `yaml:"hetzner,omitempty"`
 	VSphere     *vsphere.VSphereConfig     `yaml:"vsphere,omitempty"`
 	Docker      *docker.DockerConfig       `yaml:"docker,omitempty"`
 	Git         *git.GitConfig             `yaml:"git,omitempty"`
@@ -93,6 +95,12 @@ func (base *Context) Merge(overlay *Context) {
 			base.GCP = &gcp.GCPConfig{}
 		}
 		base.GCP.Merge(overlay.GCP)
+	}
+	if overlay.Hetzner != nil {
+		if base.Hetzner == nil {
+			base.Hetzner = &hetzner.HetznerConfig{}
+		}
+		base.Hetzner.Merge(overlay.Hetzner)
 	}
 	if overlay.VSphere != nil {
 		if base.VSphere == nil {
@@ -165,6 +173,7 @@ func (c *Context) DeepCopy() *Context {
 		AWS:         c.AWS.Copy(),
 		Azure:       c.Azure.Copy(),
 		GCP:         c.GCP.Copy(),
+		Hetzner:     c.Hetzner.Copy(),
 		VSphere:     c.VSphere.Copy(),
 		Docker:      c.Docker.Copy(),
 		Git:         c.Git.Copy(),

--- a/api/v1alpha1/hetzner/hetzner_config.go
+++ b/api/v1alpha1/hetzner/hetzner_config.go
@@ -1,0 +1,29 @@
+package hetzner
+
+// HetznerConfig represents the Hetzner Cloud configuration. Hetzner integration activates
+// whenever this block is present in a context (or when platform is "hetzner"); there is no
+// separate `enabled` flag.
+type HetznerConfig struct {
+	// Token is the Hetzner Cloud API token, exported to downstream tools as HCLOUD_TOKEN.
+	Token *string `yaml:"token,omitempty"`
+}
+
+// Merge performs a deep merge of the current HetznerConfig with another HetznerConfig.
+func (base *HetznerConfig) Merge(overlay *HetznerConfig) {
+	if overlay == nil {
+		return
+	}
+	if overlay.Token != nil {
+		base.Token = overlay.Token
+	}
+}
+
+// Copy creates a deep copy of the HetznerConfig object
+func (c *HetznerConfig) Copy() *HetznerConfig {
+	if c == nil {
+		return nil
+	}
+	return &HetznerConfig{
+		Token: c.Token,
+	}
+}

--- a/api/v1alpha1/hetzner/hetzner_config_test.go
+++ b/api/v1alpha1/hetzner/hetzner_config_test.go
@@ -1,0 +1,71 @@
+package hetzner
+
+import (
+	"testing"
+)
+
+func TestHetznerConfig_Merge(t *testing.T) {
+	t.Run("OverlayTokenReplacesBase", func(t *testing.T) {
+		base := &HetznerConfig{Token: ptrString("base-token")}
+		overlay := &HetznerConfig{Token: ptrString("overlay-token")}
+
+		base.Merge(overlay)
+
+		if base.Token == nil || *base.Token != "overlay-token" {
+			t.Errorf("Token mismatch: expected 'overlay-token', got %v", base.Token)
+		}
+	})
+
+	t.Run("NilOverlayTokenLeavesBase", func(t *testing.T) {
+		base := &HetznerConfig{Token: ptrString("base-token")}
+		overlay := &HetznerConfig{Token: nil}
+
+		base.Merge(overlay)
+
+		if base.Token == nil || *base.Token != "base-token" {
+			t.Errorf("Token mismatch: expected 'base-token', got %v", base.Token)
+		}
+	})
+
+	t.Run("NilOverlayLeavesBaseUnchanged", func(t *testing.T) {
+		base := &HetznerConfig{Token: ptrString("base-token")}
+
+		base.Merge(nil)
+
+		if base.Token == nil || *base.Token != "base-token" {
+			t.Errorf("Token mismatch: expected 'base-token', got %v", base.Token)
+		}
+	})
+}
+
+func TestHetznerConfig_Copy(t *testing.T) {
+	t.Run("CopyWithToken", func(t *testing.T) {
+		original := &HetznerConfig{Token: ptrString("test-token")}
+
+		copied := original.Copy()
+
+		if copied == nil {
+			t.Fatal("Expected non-nil copy")
+		}
+		if copied.Token == nil || *copied.Token != "test-token" {
+			t.Errorf("Token mismatch: expected 'test-token', got %v", copied.Token)
+		}
+
+		copied.Token = ptrString("modified-token")
+		if *original.Token != "test-token" {
+			t.Errorf("Original Token was modified: got %v", *original.Token)
+		}
+	})
+
+	t.Run("CopyNil", func(t *testing.T) {
+		var original *HetznerConfig = nil
+
+		if copied := original.Copy(); copied != nil {
+			t.Errorf("Copy of nil should be nil, got %v", copied)
+		}
+	})
+}
+
+func ptrString(s string) *string {
+	return &s
+}

--- a/integration/env_test.go
+++ b/integration/env_test.go
@@ -160,6 +160,54 @@ contexts:
 	}
 }
 
+// TestHetznerEnv_InjectsHcloudTokenFromConfig verifies that a hetzner.token set in
+// windsor.yaml is exported by `windsor env` as HCLOUD_TOKEN, the credential the
+// hcloud Terraform provider and CLI read — the Hetzner analog of the aws/azure
+// provider env printers.
+func TestHetznerEnv_InjectsHcloudTokenFromConfig(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "default")
+
+	windsorYamlPath := filepath.Join(dir, "windsor.yaml")
+	windsorYaml := `version: v1alpha1
+contexts:
+  local:
+    hetzner:
+      token: test-hcloud-token
+`
+	if err := os.WriteFile(windsorYamlPath, []byte(windsorYaml), 0644); err != nil {
+		t.Fatalf("write windsor.yaml: %v", err)
+	}
+	helpers.MarkAsGitRepo(t, dir)
+	if _, stderr, err := helpers.RunCLI(dir, []string{"init"}, env); err != nil {
+		t.Fatalf("windsor init: %v\nstderr: %s", err, stderr)
+	}
+
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"env"}, env)
+	if err != nil {
+		t.Fatalf("env: %v\nstderr: %s", err, stderr)
+	}
+	if !strings.Contains(string(stdout), "HCLOUD_TOKEN=test-hcloud-token") {
+		t.Errorf("expected HCLOUD_TOKEN=test-hcloud-token in output, got:\n%s", stdout)
+	}
+}
+
+// TestHetznerEnv_OmitsHcloudTokenWhenUnset verifies that `windsor env` does not emit
+// HCLOUD_TOKEN when no hetzner.token is configured, so the operator's ambient
+// credential applies unchanged.
+func TestHetznerEnv_OmitsHcloudTokenWhenUnset(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "default")
+
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"env"}, env)
+	if err != nil {
+		t.Fatalf("env: %v\nstderr: %s", err, stderr)
+	}
+	if strings.Contains(string(stdout), "HCLOUD_TOKEN") {
+		t.Errorf("expected no HCLOUD_TOKEN in output when unset, got:\n%s", stdout)
+	}
+}
+
 // TestDotEnv_ContextGitignoreCoversDotEnvFile verifies that `windsor init` writes
 // contexts/<ctx>/.gitignore covering .env so the file can never be committed.
 func TestDotEnv_ContextGitignoreCoversDotEnvFile(t *testing.T) {

--- a/pkg/runtime/config/schemas/artifacts/configuration.yaml
+++ b/pkg/runtime/config/schemas/artifacts/configuration.yaml
@@ -91,6 +91,8 @@ $defs:
         $ref: '#/$defs/azure'
       gcp:
         $ref: '#/$defs/gcp'
+      hetzner:
+        $ref: '#/$defs/hetzner'
       vsphere:
         $ref: '#/$defs/vsphere'
       docker:
@@ -203,6 +205,18 @@ $defs:
       quota_project:
         type: string
         description: Project to bill quota usage against.
+  hetzner:
+    type: object
+    additionalProperties: false
+    description: |
+      Hetzner Cloud integration. Activates whenever this block is present (or
+      when platform is 'hetzner'); there is no separate 'enabled' flag.
+    properties:
+      token:
+        type: string
+        description: |
+          Hetzner Cloud API token. Exported as HCLOUD_TOKEN, the credential the
+          hcloud Terraform provider and CLI read for authentication.
   vsphere:
     type: object
     additionalProperties: false

--- a/pkg/runtime/env/hetzner_env.go
+++ b/pkg/runtime/env/hetzner_env.go
@@ -1,0 +1,89 @@
+// The HetznerEnvPrinter is a specialized component that manages Hetzner Cloud environment configuration.
+// It provides Hetzner-specific environment variable management and configuration.
+// The HetznerEnvPrinter emits the Hetzner Cloud API token as HCLOUD_TOKEN, the credential the
+// hcloud Terraform provider and CLI read, resolving secret(...) expressions and registering the
+// value for output scrubbing since the token is a credential.
+
+package env
+
+import (
+	"strings"
+
+	"github.com/windsorcli/cli/pkg/runtime/config"
+	"github.com/windsorcli/cli/pkg/runtime/evaluator"
+	"github.com/windsorcli/cli/pkg/runtime/secrets"
+	"github.com/windsorcli/cli/pkg/runtime/shell"
+)
+
+// =============================================================================
+// Types
+// =============================================================================
+
+// HetznerEnvPrinter is a struct that implements Hetzner Cloud environment configuration
+type HetznerEnvPrinter struct {
+	BaseEnvPrinter
+	evaluator evaluator.ExpressionEvaluator
+}
+
+// =============================================================================
+// Constructor
+// =============================================================================
+
+// NewHetznerEnvPrinter creates a new HetznerEnvPrinter instance
+func NewHetznerEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler, eval evaluator.ExpressionEvaluator) *HetznerEnvPrinter {
+	if shell == nil {
+		panic("shell is required")
+	}
+	if configHandler == nil {
+		panic("config handler is required")
+	}
+
+	return &HetznerEnvPrinter{
+		BaseEnvPrinter: *NewBaseEnvPrinter(shell, configHandler),
+		evaluator:      eval,
+	}
+}
+
+// =============================================================================
+// Public Methods
+// =============================================================================
+
+// GetEnvVars retrieves the environment variables for the Hetzner Cloud environment.
+// HCLOUD_TOKEN is emitted whenever hetzner.token is set, in both project and global modes,
+// since the token authenticates the hcloud Terraform provider and CLI which run from global
+// shells too. A secret(...) expression is resolved through the evaluator and the resolved
+// value registered for output scrubbing; an already-exported token is reused rather than
+// re-resolved so the secret provider is not hit on every shell prompt. When the token is unset
+// the var is omitted so the operator's ambient HCLOUD_TOKEN or credential chain applies.
+func (e *HetznerEnvPrinter) GetEnvVars() (map[string]string, error) {
+	envVars := make(map[string]string)
+
+	config := e.configHandler.GetConfig()
+	if config == nil || config.Hetzner == nil || config.Hetzner.Token == nil {
+		return envVars, nil
+	}
+
+	e.SetManagedEnv("HCLOUD_TOKEN")
+	normalizedValue := secrets.NormalizeLegacyBraces(*config.Hetzner.Token)
+
+	if e.evaluator != nil && evaluator.ContainsExpression(normalizedValue) {
+		if existingValue, exists := e.shims.LookupEnv("HCLOUD_TOKEN"); exists &&
+			e.shouldUseCache() && !strings.Contains(existingValue, "<ERROR") {
+			e.shell.RegisterSecret(existingValue)
+			return envVars, nil
+		}
+		envVars["HCLOUD_TOKEN"] = evaluateExpressionValue(e.evaluator, normalizedValue)
+	} else {
+		envVars["HCLOUD_TOKEN"] = normalizedValue
+	}
+	e.shell.RegisterSecret(envVars["HCLOUD_TOKEN"])
+
+	return envVars, nil
+}
+
+// =============================================================================
+// Interface Compliance
+// =============================================================================
+
+// Ensure HetznerEnvPrinter implements the EnvPrinter interface
+var _ EnvPrinter = (*HetznerEnvPrinter)(nil)

--- a/pkg/runtime/env/hetzner_env_test.go
+++ b/pkg/runtime/env/hetzner_env_test.go
@@ -1,0 +1,307 @@
+package env
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/goccy/go-yaml"
+	"github.com/windsorcli/cli/api/v1alpha1"
+	"github.com/windsorcli/cli/pkg/runtime/config"
+	"github.com/windsorcli/cli/pkg/runtime/evaluator"
+)
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+func setupHetznerEnvMocks(t *testing.T, overrides ...*EnvTestMocks) *EnvTestMocks {
+	t.Helper()
+
+	mocks := setupEnvMocks(t, overrides...)
+
+	if _, ok := mocks.ConfigHandler.(*config.MockConfigHandler); !ok {
+		mocks.ConfigHandler = config.NewMockConfigHandler()
+	}
+
+	mockConfigHandler := mocks.ConfigHandler.(*config.MockConfigHandler)
+
+	loadedConfigs := make(map[string]*v1alpha1.Context)
+	currentContext := "test-context"
+
+	mockConfigHandler.GetContextFunc = func() string {
+		return currentContext
+	}
+
+	mockConfigHandler.SetContextFunc = func(context string) error {
+		currentContext = context
+		return nil
+	}
+
+	mockConfigHandler.LoadConfigStringFunc = func(content string) error {
+		var cfg v1alpha1.Config
+		if err := yaml.Unmarshal([]byte(content), &cfg); err != nil {
+			return err
+		}
+		for name, ctx := range cfg.Contexts {
+			if ctx != nil {
+				ctxCopy := *ctx
+				loadedConfigs[name] = &ctxCopy
+			} else {
+				loadedConfigs[name] = &v1alpha1.Context{}
+			}
+		}
+		return nil
+	}
+
+	mockConfigHandler.GetConfigFunc = func() *v1alpha1.Context {
+		if ctx, ok := loadedConfigs[currentContext]; ok {
+			return ctx
+		}
+		return &v1alpha1.Context{}
+	}
+
+	if len(overrides) == 0 || overrides[0] == nil || overrides[0].ConfigHandler == nil {
+		defaultConfigStr := `
+version: v1alpha1
+contexts:
+  test-context:
+    hetzner:
+      token: "test-token"
+`
+		if err := mocks.ConfigHandler.LoadConfigString(defaultConfigStr); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+	}
+
+	if err := mocks.ConfigHandler.SetContext("test-context"); err != nil {
+		t.Fatalf("Failed to set context: %v", err)
+	}
+
+	return mocks
+}
+
+// =============================================================================
+// Test Public Methods
+// =============================================================================
+
+func TestHetznerEnv_GetEnvVars(t *testing.T) {
+	setup := func(t *testing.T, eval evaluator.ExpressionEvaluator, overrides ...*EnvTestMocks) (*HetznerEnvPrinter, *EnvTestMocks) {
+		t.Helper()
+		mocks := setupHetznerEnvMocks(t, overrides...)
+		printer := NewHetznerEnvPrinter(mocks.Shell, mocks.ConfigHandler, eval)
+		printer.shims = mocks.Shims
+		return printer, mocks
+	}
+
+	t.Run("EmitsHcloudTokenWhenTokenSet", func(t *testing.T) {
+		// Given a printer with a literal Hetzner token configured
+		printer, _ := setup(t, nil)
+
+		// When GetEnvVars is called
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		// Then HCLOUD_TOKEN reflects the configured token verbatim
+		if envVars["HCLOUD_TOKEN"] != "test-token" {
+			t.Errorf("GetEnvVars returned HCLOUD_TOKEN=%v, want test-token", envVars["HCLOUD_TOKEN"])
+		}
+		if len(envVars) != 1 {
+			t.Errorf("Expected 1 environment variable, got %d: %v", len(envVars), envVars)
+		}
+	})
+
+	t.Run("ResolvesSecretExpression", func(t *testing.T) {
+		// Given a token expressed as a secret(...) reference and a mock evaluator
+		mockEval := evaluator.NewMockExpressionEvaluator()
+		mockEval.EvaluateFunc = func(expression string, facetPath string, scope map[string]any, evaluateDeferred bool) (any, error) {
+			if strings.Contains(expression, "secret(") {
+				return "resolved-token", nil
+			}
+			return expression, nil
+		}
+		mocks := setupHetznerEnvMocks(t)
+		configStr := `
+version: v1alpha1
+contexts:
+  test-context:
+    hetzner:
+      token: ${secret("Developer", "hetzner_windsortest", "hetzner_key")}
+`
+		if err := mocks.ConfigHandler.LoadConfigString(configStr); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+		printer := NewHetznerEnvPrinter(mocks.Shell, mocks.ConfigHandler, mockEval)
+		printer.shims = mocks.Shims
+
+		// When GetEnvVars is called
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		// Then HCLOUD_TOKEN holds the decrypted value, not the literal expression
+		if envVars["HCLOUD_TOKEN"] != "resolved-token" {
+			t.Errorf("GetEnvVars returned HCLOUD_TOKEN=%q, want resolved-token", envVars["HCLOUD_TOKEN"])
+		}
+	})
+
+	t.Run("RegistersResolvedTokenForScrubbing", func(t *testing.T) {
+		// Given a resolved secret token
+		mockEval := evaluator.NewMockExpressionEvaluator()
+		mockEval.EvaluateFunc = func(expression string, facetPath string, scope map[string]any, evaluateDeferred bool) (any, error) {
+			return "resolved-token", nil
+		}
+		var registered []string
+		mocks := setupHetznerEnvMocks(t)
+		mocks.Shell.RegisterSecretFunc = func(value string) { registered = append(registered, value) }
+		configStr := `
+version: v1alpha1
+contexts:
+  test-context:
+    hetzner:
+      token: ${secret("Developer", "item", "field")}
+`
+		if err := mocks.ConfigHandler.LoadConfigString(configStr); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+		printer := NewHetznerEnvPrinter(mocks.Shell, mocks.ConfigHandler, mockEval)
+		printer.shims = mocks.Shims
+
+		// When GetEnvVars is called
+		if _, err := printer.GetEnvVars(); err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		// Then the resolved token is registered for output scrubbing
+		found := false
+		for _, v := range registered {
+			if v == "resolved-token" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("Expected resolved token to be registered for scrubbing, got %v", registered)
+		}
+	})
+
+	t.Run("ReusesExportedTokenWithoutReResolving", func(t *testing.T) {
+		// Given an already-exported HCLOUD_TOKEN and caching enabled
+		mockEval := evaluator.NewMockExpressionEvaluator()
+		evaluateCalled := false
+		mockEval.EvaluateFunc = func(expression string, facetPath string, scope map[string]any, evaluateDeferred bool) (any, error) {
+			evaluateCalled = true
+			return "freshly-resolved", nil
+		}
+		mocks := setupHetznerEnvMocks(t)
+		configStr := `
+version: v1alpha1
+contexts:
+  test-context:
+    hetzner:
+      token: ${secret("Developer", "item", "field")}
+`
+		if err := mocks.ConfigHandler.LoadConfigString(configStr); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+		t.Setenv("NO_CACHE", "0")
+		t.Setenv("HCLOUD_TOKEN", "cached-token")
+		mocks.Shims.LookupEnv = func(key string) (string, bool) {
+			if key == "HCLOUD_TOKEN" {
+				return "cached-token", true
+			}
+			return "", false
+		}
+		printer := NewHetznerEnvPrinter(mocks.Shell, mocks.ConfigHandler, mockEval)
+		printer.shims = mocks.Shims
+
+		// When GetEnvVars is called
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		// Then the secret provider is not hit and the key is omitted (already exported)
+		if evaluateCalled {
+			t.Error("Expected evaluator not to be called when a cached token exists")
+		}
+		if _, exists := envVars["HCLOUD_TOKEN"]; exists {
+			t.Errorf("Expected HCLOUD_TOKEN to be omitted when already exported, got %v", envVars)
+		}
+	})
+
+	t.Run("EmitsHcloudTokenInGlobalMode", func(t *testing.T) {
+		// Given a Hetzner context running in global mode
+		printer, mocks := setup(t, nil)
+		mocks.Shell.IsGlobalFunc = func() bool { return true }
+
+		// When GetEnvVars is called
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		// Then HCLOUD_TOKEN is still emitted since the token feeds terraform,
+		// which runs from global shells too
+		if envVars["HCLOUD_TOKEN"] != "test-token" {
+			t.Errorf("GetEnvVars returned HCLOUD_TOKEN=%v, want test-token", envVars["HCLOUD_TOKEN"])
+		}
+	})
+
+	t.Run("OmitsHcloudTokenWhenTokenUnset", func(t *testing.T) {
+		// Given a Hetzner block present but no token set
+		mocks := setupHetznerEnvMocks(t)
+		configStr := `
+version: v1alpha1
+contexts:
+  test-context:
+    hetzner: {}
+`
+		if err := mocks.ConfigHandler.LoadConfigString(configStr); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+		printer := NewHetznerEnvPrinter(mocks.Shell, mocks.ConfigHandler, nil)
+		printer.shims = mocks.Shims
+
+		// When GetEnvVars is called
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		// Then HCLOUD_TOKEN is omitted so the ambient credential applies
+		if _, ok := envVars["HCLOUD_TOKEN"]; ok {
+			t.Errorf("HCLOUD_TOKEN should not be set when token is unset, got %q", envVars["HCLOUD_TOKEN"])
+		}
+		if len(envVars) != 0 {
+			t.Errorf("Expected empty environment variables, got %v", envVars)
+		}
+	})
+
+	t.Run("OmitsHcloudTokenWhenNoHetznerConfig", func(t *testing.T) {
+		// Given a context with no hetzner block at all
+		mocks := setupHetznerEnvMocks(t)
+		configStr := `
+version: v1alpha1
+contexts:
+  test-context: {}
+`
+		if err := mocks.ConfigHandler.LoadConfigString(configStr); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+		printer := NewHetznerEnvPrinter(mocks.Shell, mocks.ConfigHandler, nil)
+		printer.shims = mocks.Shims
+
+		// When GetEnvVars is called
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		// Then no environment variables are emitted
+		if len(envVars) != 0 {
+			t.Errorf("Expected empty environment variables, got %v", envVars)
+		}
+	})
+}

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -60,6 +60,7 @@ type Runtime struct {
 		AwsEnv       env.EnvPrinter
 		AzureEnv     env.EnvPrinter
 		GcpEnv       env.EnvPrinter
+		HetznerEnv   env.EnvPrinter
 		VsphereEnv   env.EnvPrinter
 		DockerEnv    env.EnvPrinter
 		KubeEnv      env.EnvPrinter
@@ -145,6 +146,9 @@ func NewRuntime(opts ...*Runtime) *Runtime {
 		}
 		if overrides.EnvPrinters.GcpEnv != nil {
 			rt.EnvPrinters.GcpEnv = overrides.EnvPrinters.GcpEnv
+		}
+		if overrides.EnvPrinters.HetznerEnv != nil {
+			rt.EnvPrinters.HetznerEnv = overrides.EnvPrinters.HetznerEnv
 		}
 		if overrides.EnvPrinters.VsphereEnv != nil {
 			rt.EnvPrinters.VsphereEnv = overrides.EnvPrinters.VsphereEnv
@@ -735,6 +739,7 @@ func (rt *Runtime) initializeEnvPrinters() {
 	hasAWSConfig := configData != nil && configData.AWS != nil
 	hasAzureConfig := configData != nil && configData.Azure != nil
 	hasGCPConfig := configData != nil && configData.GCP != nil
+	hasHetznerConfig := configData != nil && configData.Hetzner != nil
 	hasVSphereConfig := configData != nil && configData.VSphere != nil
 
 	if rt.EnvPrinters.DotEnvEnv == nil {
@@ -748,6 +753,9 @@ func (rt *Runtime) initializeEnvPrinters() {
 	}
 	if rt.EnvPrinters.GcpEnv == nil && gcpEnabled && hasGCPConfig {
 		rt.EnvPrinters.GcpEnv = env.NewGcpEnvPrinter(rt.Shell, rt.ConfigHandler)
+	}
+	if rt.EnvPrinters.HetznerEnv == nil && (hasHetznerConfig || platform == "hetzner") {
+		rt.EnvPrinters.HetznerEnv = env.NewHetznerEnvPrinter(rt.Shell, rt.ConfigHandler, rt.Evaluator)
 	}
 	if rt.EnvPrinters.VsphereEnv == nil && (hasVSphereConfig || platform == "vsphere") {
 		rt.EnvPrinters.VsphereEnv = env.NewVsphereEnvPrinter(rt.Shell, rt.ConfigHandler)
@@ -898,6 +906,7 @@ func (rt *Runtime) getAllEnvPrinters() []env.EnvPrinter {
 		rt.EnvPrinters.AwsEnv,
 		rt.EnvPrinters.AzureEnv,
 		rt.EnvPrinters.GcpEnv,
+		rt.EnvPrinters.HetznerEnv,
 		rt.EnvPrinters.VsphereEnv,
 		rt.EnvPrinters.DockerEnv,
 		rt.EnvPrinters.KubeEnv,


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This PR adds a new, isolated cloud-provider integration that has no effect on existing providers or any shared runtime path.
>
> **Overview**
>
> The change introduces Hetzner Cloud as a supported provider in the Windsor CLI. A new `hetzner.token` field in `windsor.yaml` is picked up by a `HetznerEnvPrinter` and exported as `HCLOUD_TOKEN` — the credential the hcloud Terraform provider and CLI expect. The implementation follows the same pattern already used for AWS, Azure, and GCP env printers, including secret-expression resolution, output scrubbing via `RegisterSecret`, and an ambient-credential passthrough when the token is unset.
>
> The config type, JSON Schema, runtime wiring, unit tests, and an integration test are all included. Activation requires an explicit `hetzner:` block in the context config or `platform: hetzner`; no existing context is affected.
>
> Reviewed by Claude for commit `22a81ce9`.

<!-- /claude-code-review:summary -->
