### PR TITLE
fix(cmd): Default to kubernetes backend for hetzner platform

### DIFF
--- a/cmd/workstation_defaults.go
+++ b/cmd/workstation_defaults.go
@@ -21,15 +21,11 @@ import (
 // set in the override map:
 //
 //   - aws     → s3       (S3 is the canonical state store on AWS)
-//   - hetzner → s3       (Hetzner Object Storage is S3-API-compatible;
-//     avoids the kubernetes backend's bootstrap-ordering complexity, since
-//     state lives in a bucket rather than the cluster being provisioned.
-//     The endpoint override, S3Backend compatibility flags, and Object
-//     Storage credentials still require operator/facet configuration —
-//     this default only selects the backend type)
 //   - azure   → azurerm  (Azure Blob Storage via the azurerm backend)
-//   - metal, docker, incus → kubernetes  (the cluster IS the state store;
-//     each component's state lives as a Secret in the cluster it manages)
+//   - metal, docker, incus, hetzner → kubernetes  (the cluster IS the state
+//     store; each component's state lives as a Secret in the cluster it
+//     manages. Hetzner joins this group because its Object Storage keys can't
+//     be provisioned via API, so in-cluster state avoids a manual key step)
 //
 // The default only kicks in when terraform.backend.type is absent from
 // overrides, so explicit --set values (which are merged into the same map by
@@ -62,11 +58,11 @@ func applyWorkstationFlagOverrides(overrides map[string]any, vmDriver, platform 
 
 	if _, set := overrides["terraform.backend.type"]; !set {
 		switch overrides["platform"] {
-		case "aws", "hetzner":
+		case "aws":
 			overrides["terraform.backend.type"] = "s3"
 		case "azure":
 			overrides["terraform.backend.type"] = "azurerm"
-		case "metal", "docker", "incus":
+		case "metal", "docker", "incus", "hetzner":
 			overrides["terraform.backend.type"] = "kubernetes"
 		}
 	}

--- a/cmd/workstation_defaults_test.go
+++ b/cmd/workstation_defaults_test.go
@@ -186,21 +186,19 @@ func TestApplyWorkstationFlagOverrides(t *testing.T) {
 		}
 	})
 
-	t.Run("HetznerPlatformDefaultsBackendToS3", func(t *testing.T) {
+	t.Run("HetznerPlatformDefaultsBackendToKubernetes", func(t *testing.T) {
 		// Given --platform hetzner and no explicit terraform.backend.type override.
-		// Hetzner Object Storage is S3-API-compatible, so "s3" is the default rather
-		// than "kubernetes" — this avoids the in-cluster backend's bootstrap-ordering
-		// complexity. The endpoint override, S3Backend compatibility flags, and
-		// Object Storage credentials still require operator/facet configuration;
-		// this default only selects the backend type.
+		// Hetzner joins the in-cluster (kubernetes) backend group rather than s3
+		// because its Object Storage keys cannot be provisioned via any API, so the
+		// in-cluster backend avoids a mandatory manual key-generation step.
 		overrides := map[string]any{}
 
 		// When the helper is applied
 		applyWorkstationFlagOverrides(overrides, "", "hetzner")
 
-		// Then terraform.backend.type defaults to "s3"
-		if overrides["terraform.backend.type"] != "s3" {
-			t.Errorf("Expected terraform.backend.type=s3, got %v", overrides["terraform.backend.type"])
+		// Then terraform.backend.type defaults to "kubernetes"
+		if overrides["terraform.backend.type"] != "kubernetes" {
+			t.Errorf("Expected terraform.backend.type=kubernetes, got %v", overrides["terraform.backend.type"])
 		}
 	})
 

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -509,12 +509,11 @@ func TestInit_PlatformMetalDefaultsBackendTypeToKubernetes(t *testing.T) {
 	}
 }
 
-// TestInit_PlatformHetznerDefaultsBackendTypeToS3 confirms --platform hetzner defaults
-// terraform.backend.type to "s3" rather than "kubernetes". Hetzner Object Storage is
-// S3-API-compatible, and using it avoids the in-cluster backend's bootstrap-ordering
-// complexity; the endpoint override, S3Backend compatibility flags, and Object Storage
-// credentials still require operator/facet configuration beyond this default.
-func TestInit_PlatformHetznerDefaultsBackendTypeToS3(t *testing.T) {
+// TestInit_PlatformHetznerDefaultsBackendTypeToKubernetes confirms --platform hetzner
+// defaults terraform.backend.type to "kubernetes" rather than "s3". Hetzner Object
+// Storage keys cannot be provisioned via any API, so the in-cluster backend avoids a
+// mandatory manual key-generation step; hetzner joins the metal/docker/incus group.
+func TestInit_PlatformHetznerDefaultsBackendTypeToKubernetes(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")
 	helpers.MarkAsGitRepo(t, dir)
@@ -529,8 +528,8 @@ func TestInit_PlatformHetznerDefaultsBackendTypeToS3(t *testing.T) {
 		t.Fatalf("expected values.yaml at %s, got %v\nstdout: %s\nstderr: %s", valuesPath, readErr, stdout, stderr)
 	}
 	body := string(data)
-	if !strings.Contains(body, "terraform:") || !strings.Contains(body, "type: s3") {
-		t.Errorf("expected terraform.backend.type=s3 persisted for --platform hetzner, got values.yaml:\n%s", body)
+	if !strings.Contains(body, "terraform:") || !strings.Contains(body, "type: kubernetes") {
+		t.Errorf("expected terraform.backend.type=kubernetes persisted for --platform hetzner, got values.yaml:\n%s", body)
 	}
 }
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change affects only the Hetzner platform's default Terraform backend selection, a single-platform default with no shared-infrastructure impact.
>
> **Overview**
>
> The PR moves Hetzner from the `s3` backend group to the `kubernetes` backend group when `terraform.backend.type` is unset. The stated reason is that Hetzner Object Storage keys cannot be provisioned via API, so defaulting to the in-cluster `kubernetes` backend avoids a mandatory manual key-generation step. The switch covers the default logic, its unit test, and the integration test in lockstep.
>
> All three files change in concert — the comment, the switch case, and both test assertions are consistent with each other and with the new behaviour. This is a reversible default that only fires when no explicit `--set terraform.backend.type` override is supplied.
>
> Reviewed by Claude for commit `d71eb8f1`.

<!-- /claude-code-review:summary -->
