### PR TITLE
feat(provisioner): enhance secret management and kustomization handling

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -82,17 +82,8 @@ windsor apply kustomize dns`,
 				return fmt.Errorf("resolved blueprint is not available")
 			}
 
-			resolvedSecrets, secretsErr := proj.Provisioner.ResolveSecrets(blueprint)
-			if secretsErr != nil {
-				return fmt.Errorf("error resolving secrets: %w", secretsErr)
-			}
-
-			if err := proj.Provisioner.Install(cmd.Context(), blueprint); err != nil {
+			if err := proj.Provisioner.Install(cmd.Context(), blueprint, applyPruneFlag); err != nil {
 				return fmt.Errorf("error applying kustomize: %w", err)
-			}
-
-			if err := proj.Provisioner.PlaceSecrets(cmd.Context(), resolvedSecrets, applyPruneFlag); err != nil {
-				return fmt.Errorf("error placing secrets: %w", err)
 			}
 
 			// --prune removes kustomizations the blueprint no longer declares; wait for the

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -225,17 +225,8 @@ windsor bootstrap prod --yes`,
 				return fmt.Errorf("error resolving blueprint substitutions: %w", err)
 			}
 
-			resolvedSecrets, secretsErr := proj.Provisioner.ResolveSecrets(blueprint)
-			if secretsErr != nil {
-				return fmt.Errorf("error resolving secrets: %w", secretsErr)
-			}
-
-			if err := proj.Provisioner.Install(cmd.Context(), blueprint); err != nil {
+			if err := proj.Provisioner.Install(cmd.Context(), blueprint, false); err != nil {
 				return fmt.Errorf("error installing blueprint: %w", err)
-			}
-
-			if err := proj.Provisioner.PlaceSecrets(cmd.Context(), resolvedSecrets, false); err != nil {
-				return fmt.Errorf("error placing secrets: %w", err)
 			}
 
 			if err := proj.Provisioner.Wait(cmd.Context(), blueprint); err != nil {

--- a/cmd/install.go
+++ b/cmd/install.go
@@ -37,17 +37,8 @@ windsor install --wait`,
 			return fmt.Errorf("error resolving blueprint substitutions: %w", err)
 		}
 
-		resolvedSecrets, err := proj.Provisioner.ResolveSecrets(blueprint)
-		if err != nil {
-			return fmt.Errorf("error resolving secrets: %w", err)
-		}
-
-		if err := proj.Provisioner.Install(cmd.Context(), blueprint); err != nil {
+		if err := proj.Provisioner.Install(cmd.Context(), blueprint, false); err != nil {
 			return fmt.Errorf("error installing blueprint: %w", err)
-		}
-
-		if err := proj.Provisioner.PlaceSecrets(cmd.Context(), resolvedSecrets, false); err != nil {
-			return fmt.Errorf("error placing secrets: %w", err)
 		}
 
 		if installWaitFlag {

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -129,17 +129,8 @@ windsor up --blueprint=ghcr.io/myorg/blueprint:v1.0.0`,
 				return fmt.Errorf("error resolving blueprint substitutions: %w", err)
 			}
 
-			resolvedSecrets, secretsErr := proj.Provisioner.ResolveSecrets(blueprint)
-			if secretsErr != nil {
-				return fmt.Errorf("error resolving secrets: %w", secretsErr)
-			}
-
-			if err := proj.Provisioner.Install(cmd.Context(), blueprint); err != nil {
+			if err := proj.Provisioner.Install(cmd.Context(), blueprint, false); err != nil {
 				return fmt.Errorf("error installing blueprint: %w", err)
-			}
-
-			if err := proj.Provisioner.PlaceSecrets(cmd.Context(), resolvedSecrets, false); err != nil {
-				return fmt.Errorf("error placing secrets: %w", err)
 			}
 
 			if waitFlag {

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -122,17 +122,8 @@ windsor upgrade cluster --nodes=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1
 				return fmt.Errorf("error recording version transition: %w", err)
 			}
 
-			resolvedSecrets, secretsErr := proj.Provisioner.ResolveSecrets(blueprint)
-			if secretsErr != nil {
-				return fmt.Errorf("error resolving secrets: %w", secretsErr)
-			}
-
-			if err := proj.Provisioner.Install(cmd.Context(), blueprint); err != nil {
+			if err := proj.Provisioner.Install(cmd.Context(), blueprint, true); err != nil {
 				return fmt.Errorf("error installing blueprint: %w", err)
-			}
-
-			if err := proj.Provisioner.PlaceSecrets(cmd.Context(), resolvedSecrets, true); err != nil {
-				return fmt.Errorf("error placing secrets: %w", err)
 			}
 
 			if err := proj.Provisioner.Wait(cmd.Context(), blueprint); err != nil {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -86,6 +86,12 @@ const DefaultFluxKustomizationTimeout = 5 * time.Minute
 // than plain resources.
 const DefaultFluxKustomizationInstallTimeout = 10 * time.Minute
 
+// DefaultConvergeTimeout bounds the best-effort convergence pass an apply/up/bootstrap runs after placing
+// secrets: it actively nudges not-ready kustomizations and forces stalled HelmReleases, returning early
+// once everything is Ready. It is bounded (not the full install timeout) so an unwaited apply pushes the
+// cluster along without blocking indefinitely; --wait paths still gate on the full Wait afterward.
+const DefaultConvergeTimeout = 5 * time.Minute
+
 // DefaultFluxSourceInterval is the reconciliation interval for flux Sources. Same rationale
 // as DefaultFluxKustomizationInterval: sources are pinned and explicitly re-fetched by the
 // notifier, so this is a backstop rather than the propagation path.

--- a/pkg/provisioner/flux/mock_notifier.go
+++ b/pkg/provisioner/flux/mock_notifier.go
@@ -18,7 +18,9 @@ import (
 // Tests set NotifyFunc to control behavior; the default implementation returns
 // nil to keep callers' "best-effort" semantics unchanged when no override is set.
 type MockNotifier struct {
-	NotifyFunc func(ctx context.Context, blueprint *blueprintv1alpha1.Blueprint) error
+	NotifyFunc                  func(ctx context.Context, blueprint *blueprintv1alpha1.Blueprint) error
+	ReconcileKustomizationsFunc func(ctx context.Context, names []string) error
+	ReconcileHelmReleasesFunc   func(ctx context.Context, refs []HelmReleaseRef, force bool) error
 }
 
 // =============================================================================
@@ -39,6 +41,24 @@ func NewMockNotifier() *MockNotifier {
 func (m *MockNotifier) Notify(ctx context.Context, blueprint *blueprintv1alpha1.Blueprint) error {
 	if m.NotifyFunc != nil {
 		return m.NotifyFunc(ctx, blueprint)
+	}
+	return nil
+}
+
+// ReconcileKustomizations implements the Notifier interface. Delegates to ReconcileKustomizationsFunc when
+// set and otherwise returns nil to match the Notifier's best-effort contract.
+func (m *MockNotifier) ReconcileKustomizations(ctx context.Context, names []string) error {
+	if m.ReconcileKustomizationsFunc != nil {
+		return m.ReconcileKustomizationsFunc(ctx, names)
+	}
+	return nil
+}
+
+// ReconcileHelmReleases implements the Notifier interface. Delegates to ReconcileHelmReleasesFunc when set
+// and otherwise returns nil to match the Notifier's best-effort contract.
+func (m *MockNotifier) ReconcileHelmReleases(ctx context.Context, refs []HelmReleaseRef, force bool) error {
+	if m.ReconcileHelmReleasesFunc != nil {
+		return m.ReconcileHelmReleasesFunc(ctx, refs, force)
 	}
 	return nil
 }

--- a/pkg/provisioner/flux/notifier.go
+++ b/pkg/provisioner/flux/notifier.go
@@ -5,9 +5,12 @@
 // source-controller re-fetches them immediately instead of waiting for the
 // next scheduled interval. When the artifact revision changes, kustomize-
 // controller reconciles the dependent Kustomizations automatically via its
-// watch on source status, so only sources need annotating — not Kustomizations.
-// This approach is receiver-type-agnostic, requires no cluster-side secret or
-// webhook receiver, and works uniformly against any flux installation.
+// watch on source status, so a revision change needs only sources annotated.
+// ReconcileKustomizations covers the other case: advancing already-applied
+// Kustomizations whose dependencies are satisfied mid-flight (e.g. by a secret
+// the CLI just placed) without a source revision change, by annotating those
+// Kustomizations directly. Both approaches are receiver-type-agnostic, require
+// no cluster-side secret or webhook receiver, and work against any flux install.
 
 package flux
 
@@ -39,6 +42,11 @@ const (
 	// controller convention when it handles webhook POSTs.
 	reconcileAnnotation = "reconcile.fluxcd.io/requestedAt"
 
+	// forceAnnotation, set alongside reconcileAnnotation, tells helm-controller to force a HelmRelease
+	// release even when the desired state is unchanged — resetting an exhausted-remediation/stalled release
+	// so it retries. It is what `flux reconcile helmrelease --force` sets; use it only for stuck releases.
+	forceAnnotation = "reconcile.fluxcd.io/forceAt"
+
 	// fieldManager identifies windsor-cli as the writer of the annotation under
 	// server-side apply accounting. Keeps kustomize-controller from considering
 	// its own field ownership conflicted when it later rewrites other fields.
@@ -63,6 +71,14 @@ const (
 // never for cluster state.
 type Notifier interface {
 	Notify(ctx context.Context, blueprint *blueprintv1alpha1.Blueprint) error
+	ReconcileKustomizations(ctx context.Context, names []string) error
+	ReconcileHelmReleases(ctx context.Context, refs []HelmReleaseRef, force bool) error
+}
+
+// HelmReleaseRef identifies a HelmRelease to reconcile by its namespace and name.
+type HelmReleaseRef struct {
+	Namespace string
+	Name      string
 }
 
 // =============================================================================
@@ -177,6 +193,87 @@ func (n *BaseNotifier) Notify(ctx context.Context, blueprint *blueprintv1alpha1.
 	}
 	if len(notified) > 0 {
 		n.logf("flux reconcile requested in namespace %s: %s", namespace, strings.Join(notified, ", "))
+	}
+	return nil
+}
+
+// ReconcileKustomizations annotates each named Kustomization in the gitops namespace with the current
+// timestamp under reconcile.fluxcd.io/requestedAt, causing kustomize-controller to re-reconcile it
+// immediately — re-evaluating its dependency readiness and re-applying — instead of waiting for its
+// scheduled interval. Unlike Notify, which pokes sources to re-fetch git (and only progresses dependents
+// when the artifact revision changes), this advances already-applied Kustomizations, so a dependency chain
+// unblocked mid-flight (e.g. by a just-placed secret) progresses in seconds rather than one interval per
+// hop. Best-effort like Notify: per-name PATCH errors are logged and swallowed, a nil is returned for
+// every cluster-state condition, and an empty names list is a no-op.
+func (n *BaseNotifier) ReconcileKustomizations(ctx context.Context, names []string) error {
+	if len(names) == 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, notifyTimeout)
+	defer cancel()
+
+	namespace := n.runtime.ConfigHandler.GetString("gitops.namespace", constants.DefaultGitopsNamespace)
+	ts := n.shims.Now().UTC().Format(time.RFC3339Nano)
+	patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{%q:%q}}}`, reconcileAnnotation, ts))
+	opts := metav1.PatchOptions{FieldManager: fieldManager}
+	gvr := schema.GroupVersionResource{Group: "kustomize.toolkit.fluxcd.io", Version: "v1", Resource: "kustomizations"}
+
+	var reconciled []string
+	for _, name := range names {
+		if err := ctx.Err(); err != nil {
+			n.logf("flux kustomization reconcile aborted: %v", err)
+			return nil
+		}
+		if _, err := n.kubeClient.PatchResource(ctx, gvr, namespace, name, types.MergePatchType, patch, opts); err != nil {
+			n.logf("flux reconcile request for Kustomization/%s skipped: %v", name, err)
+			continue
+		}
+		reconciled = append(reconciled, name)
+	}
+	if len(reconciled) > 0 {
+		n.logf("flux reconcile requested in namespace %s for kustomizations: %s", namespace, strings.Join(reconciled, ", "))
+	}
+	return nil
+}
+
+// ReconcileHelmReleases annotates each referenced HelmRelease with reconcile.fluxcd.io/requestedAt (and,
+// when force is set, reconcile.fluxcd.io/forceAt) so helm-controller reconciles it immediately. force is
+// how a HelmRelease that failed to install/upgrade and stalled — e.g. because a secret it needs was not yet
+// present — is made to retry now that the secret exists; a plain reconcile of the owning Kustomization does
+// not, since the release spec is unchanged. Best-effort like Notify: per-ref PATCH errors are logged and
+// swallowed, nil is returned for every cluster-state condition, and an empty refs list is a no-op.
+func (n *BaseNotifier) ReconcileHelmReleases(ctx context.Context, refs []HelmReleaseRef, force bool) error {
+	if len(refs) == 0 {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, notifyTimeout)
+	defer cancel()
+
+	ts := n.shims.Now().UTC().Format(time.RFC3339Nano)
+	annotations := fmt.Sprintf("%q:%q", reconcileAnnotation, ts)
+	if force {
+		annotations += fmt.Sprintf(",%q:%q", forceAnnotation, ts)
+	}
+	patch := []byte(fmt.Sprintf(`{"metadata":{"annotations":{%s}}}`, annotations))
+	opts := metav1.PatchOptions{FieldManager: fieldManager}
+	gvr := schema.GroupVersionResource{Group: "helm.toolkit.fluxcd.io", Version: "v2", Resource: "helmreleases"}
+
+	var reconciled []string
+	for _, ref := range refs {
+		if err := ctx.Err(); err != nil {
+			n.logf("flux helmrelease reconcile aborted: %v", err)
+			return nil
+		}
+		if _, err := n.kubeClient.PatchResource(ctx, gvr, ref.Namespace, ref.Name, types.MergePatchType, patch, opts); err != nil {
+			n.logf("flux reconcile request for HelmRelease/%s/%s skipped: %v", ref.Namespace, ref.Name, err)
+			continue
+		}
+		reconciled = append(reconciled, ref.Namespace+"/"+ref.Name)
+	}
+	if len(reconciled) > 0 {
+		n.logf("flux reconcile requested (force=%t) for helmreleases: %s", force, strings.Join(reconciled, ", "))
 	}
 	return nil
 }

--- a/pkg/provisioner/flux/notifier_test.go
+++ b/pkg/provisioner/flux/notifier_test.go
@@ -332,6 +332,109 @@ func TestNotifier_Notify(t *testing.T) {
 	})
 }
 
+func TestNotifier_ReconcileKustomizations(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("AnnotatesEachNamedKustomization", func(t *testing.T) {
+		// Given a set of kustomization names
+		m := setupNotifierMocks(t)
+		n := newTestNotifier(m)
+
+		// When ReconcileKustomizations is called
+		if err := n.ReconcileKustomizations(ctx, []string{"lb-install", "gateway-install"}); err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+
+		// Then one PATCH per name targets the kustomizations GVR carrying the reconcile annotation
+		if len(*m.patches) != 2 {
+			t.Fatalf("expected 2 patches, got %d", len(*m.patches))
+		}
+		for _, p := range *m.patches {
+			if p.gvr.Resource != "kustomizations" || p.gvr.Group != "kustomize.toolkit.fluxcd.io" {
+				t.Errorf("expected kustomizations GVR, got %s/%s", p.gvr.Group, p.gvr.Resource)
+			}
+			if !strings.Contains(string(p.data), "reconcile.fluxcd.io/requestedAt") || !strings.Contains(string(p.data), "2026-04-19T20:00:00Z") {
+				t.Errorf("expected reconcile annotation with injected timestamp, got %s", p.data)
+			}
+		}
+		if (*m.patches)[0].name != "lb-install" || (*m.patches)[1].name != "gateway-install" {
+			t.Errorf("expected the named kustomizations patched, got %s, %s", (*m.patches)[0].name, (*m.patches)[1].name)
+		}
+	})
+
+	t.Run("EmptyNamesIsNoOp", func(t *testing.T) {
+		// Given no names
+		m := setupNotifierMocks(t)
+		n := newTestNotifier(m)
+
+		// When ReconcileKustomizations is called with an empty slice, nothing is patched
+		if err := n.ReconcileKustomizations(ctx, nil); err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+		if len(*m.patches) != 0 {
+			t.Errorf("expected no patches, got %d", len(*m.patches))
+		}
+	})
+}
+
+func TestNotifier_ReconcileHelmReleases(t *testing.T) {
+	ctx := context.Background()
+
+	t.Run("ForceAddsForceAtAnnotation", func(t *testing.T) {
+		// Given a stalled HelmRelease reference
+		m := setupNotifierMocks(t)
+		n := newTestNotifier(m)
+
+		// When ReconcileHelmReleases is called with force
+		if err := n.ReconcileHelmReleases(ctx, []HelmReleaseRef{{Namespace: "system-lb", Name: "hcloud-cloud-controller-manager"}}, true); err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+
+		// Then the HelmRelease GVR is patched in its own namespace with both requestedAt and forceAt
+		if len(*m.patches) != 1 {
+			t.Fatalf("expected 1 patch, got %d", len(*m.patches))
+		}
+		p := (*m.patches)[0]
+		if p.gvr.Resource != "helmreleases" || p.gvr.Group != "helm.toolkit.fluxcd.io" {
+			t.Errorf("expected helmreleases GVR, got %s/%s", p.gvr.Group, p.gvr.Resource)
+		}
+		if p.namespace != "system-lb" || p.name != "hcloud-cloud-controller-manager" {
+			t.Errorf("expected the HR patched in system-lb, got %s/%s", p.namespace, p.name)
+		}
+		if !strings.Contains(string(p.data), "reconcile.fluxcd.io/requestedAt") || !strings.Contains(string(p.data), "reconcile.fluxcd.io/forceAt") {
+			t.Errorf("expected both requestedAt and forceAt, got %s", p.data)
+		}
+	})
+
+	t.Run("WithoutForceOmitsForceAt", func(t *testing.T) {
+		// Given a HelmRelease reference reconciled without force
+		m := setupNotifierMocks(t)
+		n := newTestNotifier(m)
+
+		// When ReconcileHelmReleases is called without force
+		if err := n.ReconcileHelmReleases(ctx, []HelmReleaseRef{{Namespace: "system-lb", Name: "hr"}}, false); err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+
+		// Then only requestedAt is set, not forceAt
+		p := (*m.patches)[0]
+		if !strings.Contains(string(p.data), "reconcile.fluxcd.io/requestedAt") || strings.Contains(string(p.data), "forceAt") {
+			t.Errorf("expected requestedAt without forceAt, got %s", p.data)
+		}
+	})
+
+	t.Run("EmptyRefsIsNoOp", func(t *testing.T) {
+		m := setupNotifierMocks(t)
+		n := newTestNotifier(m)
+		if err := n.ReconcileHelmReleases(ctx, nil, true); err != nil {
+			t.Fatalf("expected nil, got %v", err)
+		}
+		if len(*m.patches) != 0 {
+			t.Errorf("expected no patches, got %d", len(*m.patches))
+		}
+	})
+}
+
 func TestNewNotifier(t *testing.T) {
 	t.Run("PanicsOnNilRuntime", func(t *testing.T) {
 		defer func() {

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -54,7 +54,9 @@ type KubernetesManager interface {
 	ApplyOCIRepository(repo *sourcev1.OCIRepository) error
 	CheckGitRepositoryStatus() error
 	GetKustomizationStatus(names []string) (map[string]bool, error)
+	GetKustomizationReadiness(names []string) (map[string]bool, error)
 	KustomizationExists(name, namespace string) (bool, error)
+	NamespaceExists(name string) (bool, error)
 	GetKustomizationInventory(name, namespace string) ([]InventoryEntry, error)
 	WaitForKubernetesHealthy(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error
 	GetNodeReadyStatus(ctx context.Context, nodeNames []string) (map[string]bool, error)
@@ -966,6 +968,35 @@ func (k *BaseKubernetesManager) GetKustomizationStatus(names []string) (map[stri
 	return status, nil
 }
 
+// GetKustomizationReadiness returns whether each named Kustomization currently reports Ready=True, in the
+// gitops namespace. Unlike GetKustomizationStatus it never fails on a Kustomization in a failed state — a
+// failed one is simply reported not-ready — so a convergence driver can keep nudging it toward Ready rather
+// than aborting. Names absent from the cluster report false; only an API list error propagates.
+func (k *BaseKubernetesManager) GetKustomizationReadiness(names []string) (map[string]bool, error) {
+	gvr := schema.GroupVersionResource{
+		Group:    "kustomize.toolkit.fluxcd.io",
+		Version:  "v1",
+		Resource: "kustomizations",
+	}
+
+	objList, err := k.client.ListResources(gvr, k.gitopsNamespace())
+	if err != nil {
+		return nil, fmt.Errorf("failed to list kustomizations: %w", err)
+	}
+
+	ready := make(map[string]bool, len(names))
+	for _, name := range names {
+		ready[name] = false
+	}
+	for i := range objList.Items {
+		obj := &objList.Items[i]
+		if _, wanted := ready[obj.GetName()]; wanted {
+			ready[obj.GetName()] = kustomizationReady(obj)
+		}
+	}
+	return ready, nil
+}
+
 // KustomizationExists returns true if a Kustomization resource with the given name exists in the given namespace.
 // Returns false (not an error) when the resource is simply absent; propagates other API errors.
 func (k *BaseKubernetesManager) KustomizationExists(name, namespace string) (bool, error) {
@@ -975,6 +1006,21 @@ func (k *BaseKubernetesManager) KustomizationExists(name, namespace string) (boo
 		Resource: "kustomizations",
 	}
 	_, err := k.client.GetResource(gvr, namespace, name)
+	if err != nil {
+		if isNotFoundError(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
+// NamespaceExists reports whether the named namespace exists in the cluster. Namespaces are cluster-scoped,
+// so the lookup passes an empty namespace to GetResource. A NotFound is reported as (false, nil); any other
+// API error propagates.
+func (k *BaseKubernetesManager) NamespaceExists(name string) (bool, error) {
+	gvr := schema.GroupVersionResource{Group: "", Version: "v1", Resource: "namespaces"}
+	_, err := k.client.GetResource(gvr, "", name)
 	if err != nil {
 		if isNotFoundError(err) {
 			return false, nil

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -5541,6 +5541,72 @@ func TestBaseKubernetesManager_KustomizationExists(t *testing.T) {
 }
 
 // =============================================================================
+// Test NamespaceExists
+// =============================================================================
+
+func TestBaseKubernetesManager_NamespaceExists(t *testing.T) {
+	t.Run("ReturnsTrueWhenExists", func(t *testing.T) {
+		// Given a kubernetes manager whose client returns the namespace successfully
+		m := setupKubernetesMocks(t)
+		m.KubernetesClient.(*client.MockKubernetesClient).GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			return &unstructured.Unstructured{}, nil
+		}
+		manager := NewKubernetesManager(m.KubernetesClient, m.ConfigHandler)
+
+		// When NamespaceExists is called
+		exists, err := manager.NamespaceExists("system-lb")
+
+		// Then it returns true with no error
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if !exists {
+			t.Error("expected exists=true, got false")
+		}
+	})
+
+	t.Run("ReturnsFalseWhenNotFound", func(t *testing.T) {
+		// Given a kubernetes manager whose client returns a not-found error
+		m := setupKubernetesMocks(t)
+		m.KubernetesClient.(*client.MockKubernetesClient).GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			return nil, fmt.Errorf("%q not found", name)
+		}
+		manager := NewKubernetesManager(m.KubernetesClient, m.ConfigHandler)
+
+		// When NamespaceExists is called
+		exists, err := manager.NamespaceExists("system-lb")
+
+		// Then it returns false with no error
+		if err != nil {
+			t.Fatalf("expected no error for not-found, got %v", err)
+		}
+		if exists {
+			t.Error("expected exists=false, got true")
+		}
+	})
+
+	t.Run("ReturnsErrorOnOtherAPIError", func(t *testing.T) {
+		// Given a kubernetes manager whose client returns an unexpected API error
+		m := setupKubernetesMocks(t)
+		m.KubernetesClient.(*client.MockKubernetesClient).GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			return nil, fmt.Errorf("connection refused")
+		}
+		manager := NewKubernetesManager(m.KubernetesClient, m.ConfigHandler)
+
+		// When NamespaceExists is called
+		exists, err := manager.NamespaceExists("system-lb")
+
+		// Then it returns the error and false
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		if exists {
+			t.Error("expected exists=false on error, got true")
+		}
+	})
+}
+
+// =============================================================================
 // Test GetKustomizationInventory
 // =============================================================================
 

--- a/pkg/provisioner/kubernetes/mock_kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/mock_kubernetes_manager.go
@@ -23,6 +23,7 @@ type MockKubernetesManager struct {
 	DeleteKustomizationFunc             func(name, namespace string) error
 	WaitForKustomizationsFunc           func(ctx context.Context, message string, blueprint *blueprintv1alpha1.Blueprint) error
 	GetKustomizationStatusFunc          func(names []string) (map[string]bool, error)
+	GetKustomizationReadinessFunc       func(names []string) (map[string]bool, error)
 	CreateNamespaceFunc                 func(name string) error
 	DeleteNamespaceFunc                 func(name string) error
 	ApplyConfigMapFunc                  func(name, namespace string, data map[string]string) error
@@ -36,6 +37,7 @@ type MockKubernetesManager struct {
 	ApplyOCIRepositoryFunc              func(repo *sourcev1.OCIRepository) error
 	CheckGitRepositoryStatusFunc        func() error
 	KustomizationExistsFunc             func(name, namespace string) (bool, error)
+	NamespaceExistsFunc                 func(name string) (bool, error)
 	GetKustomizationInventoryFunc       func(name, namespace string) ([]InventoryEntry, error)
 	WaitForKubernetesHealthyFunc        func(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error
 	GetNodeReadyStatusFunc              func(ctx context.Context, nodeNames []string) (map[string]bool, error)
@@ -88,6 +90,20 @@ func (m *MockKubernetesManager) GetKustomizationStatus(names []string) (map[stri
 		return m.GetKustomizationStatusFunc(names)
 	}
 	return make(map[string]bool), nil
+}
+
+// GetKustomizationReadiness implements KubernetesManager interface. The default reports every requested
+// kustomization Ready so a convergence pass returns immediately in tests that do not exercise it; tests
+// that drive convergence set GetKustomizationReadinessFunc.
+func (m *MockKubernetesManager) GetKustomizationReadiness(names []string) (map[string]bool, error) {
+	if m.GetKustomizationReadinessFunc != nil {
+		return m.GetKustomizationReadinessFunc(names)
+	}
+	ready := make(map[string]bool, len(names))
+	for _, n := range names {
+		ready[n] = true
+	}
+	return ready, nil
 }
 
 // CreateNamespace implements KubernetesManager interface
@@ -192,6 +208,14 @@ func (m *MockKubernetesManager) CheckGitRepositoryStatus() error {
 func (m *MockKubernetesManager) KustomizationExists(name, namespace string) (bool, error) {
 	if m.KustomizationExistsFunc != nil {
 		return m.KustomizationExistsFunc(name, namespace)
+	}
+	return false, nil
+}
+
+// NamespaceExists implements KubernetesManager interface
+func (m *MockKubernetesManager) NamespaceExists(name string) (bool, error) {
+	if m.NamespaceExistsFunc != nil {
+		return m.NamespaceExistsFunc(name)
 	}
 	return false, nil
 }

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -1144,7 +1144,7 @@ func (i *Provisioner) PlaceSecrets(ctx context.Context, resolved ResolvedSecrets
 		waitCtx, cancel := context.WithTimeout(ctx, constants.DefaultFluxKustomizationInstallTimeout)
 		defer cancel()
 
-		stuckRounds := 0
+		nudged := make(map[string]struct{})
 		for len(pending) > 0 {
 			var stillPending []pendingPlacement
 			placedOwners := make(map[string]struct{})
@@ -1181,24 +1181,15 @@ func (i *Provisioner) PlaceSecrets(ctx context.Context, resolved ResolvedSecrets
 				owners := sortedStringKeys(placedOwners)
 				i.reconcileKustomizations(ctx, owners)
 				i.forceStalledHelmReleases(ctx, owners)
-				stuckRounds = 0
 			}
 			if len(pending) == 0 {
 				break
 			}
-			// No placement this round: what's left is gated behind kustomizations that have not created
-			// their namespace yet. Nudge the dependency closure of those owners — only the chains that gate
-			// what remains, and throttled — so the DAG advances in seconds rather than one flux interval per
-			// hop. Reconciling a not-yet-Ready dependency is a harmless no-op, so the closure walks Ready
-			// bottom-up across successive nudges.
-			if len(placedOwners) == 0 {
-				if stuckRounds%reconcileEveryStuckRounds == 0 {
-					closure := dependencyClosure(blueprint, pendingOwners(pending))
-					i.reconcileKustomizations(ctx, closure)
-					i.forceStalledHelmReleases(ctx, closure)
-				}
-				stuckRounds++
-			}
+			// Drive the DAG toward creating the still-pending namespaces by nudging only the frontier —
+			// not-Ready kustomizations whose dependencies are all Ready — once each. Already-Ready
+			// kustomizations (e.g. crds) are never touched, and a member blocked upstream is left alone
+			// until its dependency clears, so this advances the chain without churning healthy resources.
+			i.nudgeFrontier(ctx, blueprint, nudged)
 			tui.Update(fmt.Sprintf("Placing secrets: waiting on %s", pendingSummary(pending)))
 			select {
 			case <-waitCtx.Done():
@@ -1337,11 +1328,6 @@ func (i *Provisioner) missingClusterNamespaces(want []string) ([]string, error) 
 	return missing, nil
 }
 
-// reconcileEveryStuckRounds throttles the dependency-closure reconcile nudge: while placement is blocked
-// waiting for namespaces, PlaceSecrets nudges the closure once every this many poll rounds (and on the
-// first stuck round), rather than every round, to keep reconcile-request traffic modest.
-const reconcileEveryStuckRounds = 6
-
 // reconcileKustomizations requests an immediate flux reconcile of the named Kustomizations, best-effort: it
 // initializes the notifier if needed and swallows any error, so a placement round is never failed by a
 // reconcile nudge. A nil or empty names slice is a no-op.
@@ -1413,7 +1399,8 @@ func (i *Provisioner) Converge(ctx context.Context, blueprint *blueprintv1alpha1
 	if blueprint == nil || i.KubernetesManager == nil {
 		return nil
 	}
-	names := convergeNames(withCrdLayer(blueprint))
+	bp := withCrdLayer(blueprint)
+	names := convergeNames(bp)
 	if len(names) == 0 {
 		return nil
 	}
@@ -1426,27 +1413,13 @@ func (i *Provisioner) Converge(ctx context.Context, blueprint *blueprintv1alpha1
 	defer cancel()
 
 	return tui.WithProgress("Reconciling resources", func() error {
-		round := 0
+		nudged := make(map[string]struct{})
 		for {
-			readiness, err := i.KubernetesManager.GetKustomizationReadiness(names)
-			if err == nil {
-				var notReady []string
-				for _, n := range names {
-					if !readiness[n] {
-						notReady = append(notReady, n)
-					}
-				}
-				if len(notReady) == 0 {
-					return nil
-				}
-				slices.Sort(notReady)
-				tui.Update(fmt.Sprintf("Reconciling resources: waiting on %s", strings.Join(notReady, ", ")))
-				if round%reconcileEveryStuckRounds == 0 {
-					i.reconcileKustomizations(ctx, notReady)
-					i.forceStalledHelmReleases(ctx, notReady)
-				}
+			notReady := i.nudgeFrontier(ctx, bp, nudged)
+			if len(notReady) == 0 {
+				return nil
 			}
-			round++
+			tui.Update(fmt.Sprintf("Reconciling resources: waiting on %s", strings.Join(notReady, ", ")))
 			select {
 			case <-waitCtx.Done():
 				return nil
@@ -1469,47 +1442,63 @@ func convergeNames(bp *blueprintv1alpha1.Blueprint) []string {
 	return names
 }
 
-// dependencyClosure returns the transitive dependsOn closure of the given owner kustomizations within the
-// blueprint — the owners plus every kustomization they transitively depend on — deduplicated and sorted.
-// It is the minimal set worth force-reconciling to advance a stuck owner: reconciling a dependency that is
-// not yet Ready is a harmless no-op, so nudging the whole closure walks it Ready bottom-up. Names not
-// present in the blueprint (e.g. an external dependency) are dropped. Returns nil for a nil blueprint.
-func dependencyClosure(blueprint *blueprintv1alpha1.Blueprint, owners []string) []string {
+// nudgeFrontier requests an immediate reconcile of the blueprint's "frontier" kustomizations — those not
+// yet Ready whose every dependency is already Ready — and force-reconciles any stalled HelmRelease they own.
+// The frontier is the only set a nudge can actually advance: an already-Ready kustomization would just churn
+// (needless reconciles that flap otherwise-healthy resources), and one still blocked on a not-ready
+// dependency will not progress no matter how often it is poked. Each frontier member is nudged at most once
+// while it stays not-Ready — recorded in nudged and cleared when it goes Ready — so successive calls do not
+// re-poke the same resource; instead, as a layer goes Ready the next layer becomes the frontier and gets its
+// single nudge, walking the DAG upward by state transition rather than a blanket timer. Best-effort: a
+// readiness read error is a no-op, and nudged carries the one-shot state across calls within one operation.
+func (i *Provisioner) nudgeFrontier(ctx context.Context, blueprint *blueprintv1alpha1.Blueprint, nudged map[string]struct{}) []string {
 	if blueprint == nil {
 		return nil
+	}
+	names := convergeNames(blueprint)
+	if len(names) == 0 {
+		return nil
+	}
+	readiness, err := i.KubernetesManager.GetKustomizationReadiness(names)
+	if err != nil {
+		return names // unknown readiness: report all not-Ready so a caller keeps waiting, but nudge nothing
 	}
 	deps := make(map[string][]string, len(blueprint.Kustomizations))
 	for _, k := range blueprint.Kustomizations {
 		deps[k.Name] = k.DependsOn
 	}
-	seen := make(map[string]struct{})
-	var walk func(name string)
-	walk = func(name string) {
-		if _, done := seen[name]; done {
-			return
-		}
-		if _, known := deps[name]; !known {
-			return
-		}
-		seen[name] = struct{}{}
-		for _, d := range deps[name] {
-			walk(d)
-		}
-	}
-	for _, o := range owners {
-		walk(o)
-	}
-	return sortedStringKeys(seen)
-}
 
-// pendingOwners returns the owning kustomization of each still-pending secret (duplicates allowed;
-// dependencyClosure deduplicates as it walks).
-func pendingOwners(pending []pendingPlacement) []string {
-	owners := make([]string, 0, len(pending))
-	for _, p := range pending {
-		owners = append(owners, p.kustomization)
+	var notReady, frontier []string
+	for _, name := range names {
+		if readiness[name] {
+			delete(nudged, name) // Ready now — permit a fresh nudge if it later regresses
+			continue
+		}
+		notReady = append(notReady, name)
+		if _, done := nudged[name]; done {
+			continue // already nudged while not-Ready; wait for it to progress rather than re-poking
+		}
+		depsReady := true
+		for _, d := range deps[name] {
+			if r, known := readiness[d]; known && !r {
+				depsReady = false
+				break
+			}
+		}
+		if depsReady {
+			frontier = append(frontier, name)
+		}
 	}
-	return owners
+	if len(frontier) > 0 {
+		slices.Sort(frontier)
+		for _, n := range frontier {
+			nudged[n] = struct{}{}
+		}
+		i.reconcileKustomizations(ctx, frontier)
+		i.forceStalledHelmReleases(ctx, frontier)
+	}
+	slices.Sort(notReady)
+	return notReady
 }
 
 // sortedStringKeys returns the keys of a set as a sorted slice.

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -993,9 +993,7 @@ func (i *Provisioner) Install(ctx context.Context, blueprint *blueprintv1alpha1.
 	// Actively drive the just-applied kustomizations toward Ready — nudging any that are stuck and forcing
 	// HelmReleases that stalled (e.g. one that failed to install before its secret was placed) — for a
 	// bounded window, returning early once all are Ready. Best-effort: --wait paths still gate via Wait.
-	if err := i.Converge(ctx, applied, constants.DefaultConvergeTimeout); err != nil {
-		return fmt.Errorf("error reconciling resources: %w", err)
-	}
+	_ = i.Converge(ctx, applied, constants.DefaultConvergeTimeout)
 
 	return nil
 }

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/composer/blueprint"
 	"github.com/windsorcli/cli/pkg/constants"
@@ -49,6 +50,10 @@ type Provisioner struct {
 	projectRoot   string
 	configRoot    string
 	runtime       *runtime.Runtime
+
+	// secretPollInterval overrides how often PlaceSecrets re-checks for a pending secret's namespace;
+	// zero uses constants.DefaultKustomizationWaitPollInterval. Set small in tests to avoid real waits.
+	secretPollInterval time.Duration
 
 	TerraformStack       terraforminfra.Stack
 	FluxStack            fluxinfra.Stack
@@ -875,12 +880,15 @@ func (i *Provisioner) PlanKustomization(blueprint *blueprintv1alpha1.Blueprint, 
 	return nil
 }
 
-// ApplyKustomize applies a single kustomization identified by componentID to the cluster.
-// It finds the named kustomization in the blueprint, filters the blueprint to that one
-// kustomization (preserving sources and repository for correct source creation), then
-// delegates to the kubernetes manager. Returns an error if the blueprint is nil, the
-// kubernetes manager is not configured, the kustomization is not found, the kustomization
-// is marked destroyOnly, or the apply fails.
+// ApplyKustomize applies a single kustomization identified by componentID to the cluster and places its
+// declared secrets. It finds the named kustomization in the blueprint, filters the blueprint to that one
+// kustomization (preserving sources and repository for correct source creation), resolves that
+// kustomization's secrets, applies it via the kubernetes manager, then places the resolved secrets into
+// the namespace it creates — scoped to the one kustomization so placement never blocks on a namespace
+// another kustomization would create. Secret pruning is off, since a single-kustomization apply is
+// additive. Returns an error if the blueprint is nil, the kubernetes manager is not configured, the
+// kustomization is not found, the kustomization is marked destroyOnly, or resolution, apply, or placement
+// fails.
 func (i *Provisioner) ApplyKustomize(ctx context.Context, blueprint *blueprintv1alpha1.Blueprint, componentID string) error {
 	if blueprint == nil {
 		return fmt.Errorf("blueprint not provided")
@@ -909,6 +917,11 @@ func (i *Provisioner) ApplyKustomize(ctx context.Context, blueprint *blueprintv1
 	filtered := *blueprint
 	filtered.Kustomizations = []blueprintv1alpha1.Kustomization{*found}
 
+	resolvedSecrets, err := i.ResolveSecrets(&filtered)
+	if err != nil {
+		return fmt.Errorf("error resolving secrets: %w", err)
+	}
+
 	if err := tui.WithProgress(fmt.Sprintf("Applying kustomization %s", componentID), func() error {
 		if err := i.KubernetesManager.ApplyBlueprint(&filtered, i.fluxNamespace()); err != nil {
 			return err
@@ -919,26 +932,35 @@ func (i *Provisioner) ApplyKustomize(ctx context.Context, blueprint *blueprintv1
 		return fmt.Errorf("failed to apply kustomization %s: %w", componentID, err)
 	}
 
+	if err := i.PlaceSecrets(ctx, resolvedSecrets, &filtered, false); err != nil {
+		return fmt.Errorf("error placing secrets: %w", err)
+	}
+
 	return nil
 }
 
-// ApplyKustomizeAll applies all non-destroyOnly kustomizations in the blueprint to the cluster.
-// Delegates to Install, which creates the namespace, applies sources, and applies each
-// kustomization in order. Returns an error if the blueprint is nil, the kubernetes manager
-// is not configured, or the apply fails.
+// ApplyKustomizeAll applies all non-destroyOnly kustomizations in the blueprint to the cluster and places
+// their declared secrets. Delegates to Install with pruning off, since applying the full set is additive
+// here — kustomization and secret pruning are separate, explicitly-flagged steps. Returns an error if the
+// blueprint is nil, the kubernetes manager is not configured, or the apply or placement fails.
 func (i *Provisioner) ApplyKustomizeAll(ctx context.Context, blueprint *blueprintv1alpha1.Blueprint) error {
-	return i.Install(ctx, blueprint)
+	return i.Install(ctx, blueprint, false)
 }
 
-// Install orchestrates the high-level kustomization installation process from the blueprint.
-// It initializes the kubernetes manager and applies all blueprint resources in order: creates namespace,
-// applies source repositories, and applies all kustomizations. After the apply completes it fires a
-// best-effort flux webhook notification inside the same progress scope so flux reconciles sources
-// immediately instead of waiting for the next scheduled interval; notification failures never abort
-// Install. The ctx parameter is threaded into Notify so a cancelled parent context (e.g. Ctrl+C)
-// tears down the port-forward and HTTP POST immediately instead of waiting for notifyTimeout.
-// The blueprint must be provided. Returns an error if the apply step fails.
-func (i *Provisioner) Install(ctx context.Context, blueprint *blueprintv1alpha1.Blueprint) error {
+// Install applies the blueprint's kustomization layer and places its declared secrets as one unit, so
+// every command that installs kustomizations also materializes their secrets rather than re-wiring that
+// sequence itself. It first resolves the blueprint's declared Secrets to plaintext, failing before any
+// cluster mutation on a misconfigured secret; then applies all blueprint resources in order — namespace,
+// source repositories, and each kustomization — firing a best-effort flux webhook notification inside the
+// same progress scope so flux reconciles immediately instead of at the next interval (notification
+// failures never abort the install); then places the resolved secrets into the namespaces their owning
+// kustomizations create, gating each on namespace creation rather than kustomization readiness so a
+// consumer whose readiness depends on its secret cannot deadlock placement. prune reclaims CLI-placed
+// secrets this context no longer declares, mirroring kustomization prune (on for upgrade and apply
+// --prune, off otherwise). ctx is threaded into Notify and placement so a cancelled parent context
+// (e.g. Ctrl+C) tears down promptly. The blueprint must be provided. Returns an error if resolution,
+// apply, or placement fails.
+func (i *Provisioner) Install(ctx context.Context, blueprint *blueprintv1alpha1.Blueprint, prune bool) error {
 	if blueprint == nil {
 		return fmt.Errorf("blueprint not provided")
 	}
@@ -947,16 +969,32 @@ func (i *Provisioner) Install(ctx context.Context, blueprint *blueprintv1alpha1.
 		return fmt.Errorf("kubernetes manager not configured")
 	}
 
-	blueprint = withCrdLayer(blueprint)
+	resolvedSecrets, err := i.ResolveSecrets(blueprint)
+	if err != nil {
+		return fmt.Errorf("error resolving secrets: %w", err)
+	}
+
+	applied := withCrdLayer(blueprint)
 
 	if err := tui.WithProgress("Installing blueprint resources", func() error {
-		if err := i.KubernetesManager.ApplyBlueprint(blueprint, i.fluxNamespace()); err != nil {
+		if err := i.KubernetesManager.ApplyBlueprint(applied, i.fluxNamespace()); err != nil {
 			return err
 		}
-		_ = i.Notify(ctx, blueprint)
+		_ = i.Notify(ctx, applied)
 		return nil
 	}); err != nil {
 		return fmt.Errorf("failed to apply blueprint: %w", err)
+	}
+
+	if err := i.PlaceSecrets(ctx, resolvedSecrets, applied, prune); err != nil {
+		return fmt.Errorf("error placing secrets: %w", err)
+	}
+
+	// Actively drive the just-applied kustomizations toward Ready — nudging any that are stuck and forcing
+	// HelmReleases that stalled (e.g. one that failed to install before its secret was placed) — for a
+	// bounded window, returning early once all are Ready. Best-effort: --wait paths still gate via Wait.
+	if err := i.Converge(ctx, applied, constants.DefaultConvergeTimeout); err != nil {
+		return fmt.Errorf("error reconciling resources: %w", err)
 	}
 
 	return nil
@@ -1002,13 +1040,13 @@ type ResolvedSecret struct {
 // ResolveSecrets resolves every flux system's declared Secrets to plaintext ahead of Install, so a
 // misconfigured secret fails the command before anything is applied to the cluster. For each compiled
 // kustomization carrying Secrets it evaluates each data reference (the evaluator registers resolved
-// values with the shell scrubber). A reference is required unless it carries a "??" default: a required
-// reference (e.g. "${x}") that resolves to nil or empty fails closed, since a populated-but-unresolvable
-// or missing required secret is misconfiguration. An author makes a key optional by adding a ?? default;
-// an optional key that resolves empty is omitted, and a secret whose keys all resolve empty is not
-// created at all, so an unconfigured optional secret leaves no empty Secret behind. The result is keyed
-// by owning kustomization for PlaceSecrets to materialize post-Install; it is empty when no kustomization
-// declares Secrets.
+// values with the shell scrubber). A reference that resolves to nil — the value is absent from
+// configuration — is treated as unconfigured and its key is omitted, since a secret the user never set
+// is not misconfiguration. A reference that resolves to an empty string fails closed unless it carries a
+// "??" default, since a present-but-blank value is misconfiguration; adding a ?? default makes such a
+// key optional and omits it. A secret whose keys all resolve away is not created at all, so an
+// unconfigured optional secret leaves no empty Secret behind. The result is keyed by owning kustomization
+// for PlaceSecrets to materialize post-Install; it is empty when no kustomization declares Secrets.
 func (i *Provisioner) ResolveSecrets(blueprint *blueprintv1alpha1.Blueprint) (ResolvedSecrets, error) {
 	if blueprint == nil {
 		return nil, fmt.Errorf("blueprint not provided")
@@ -1028,7 +1066,7 @@ func (i *Provisioner) ResolveSecrets(blueprint *blueprintv1alpha1.Blueprint) (Re
 					return nil, fmt.Errorf("resolving secret %q key %q: %w", secretName, key, err)
 				}
 				if value == nil {
-					return nil, fmt.Errorf("resolving secret %q key %q: reference %q resolved to nil", secretName, key, ref)
+					continue
 				}
 				s := fmt.Sprint(value)
 				if s == "" {
@@ -1053,56 +1091,132 @@ func (i *Provisioner) ResolveSecrets(blueprint *blueprintv1alpha1.Blueprint) (Re
 	return resolved, nil
 }
 
-// PlaceSecrets materializes secrets that ResolveSecrets produced into the namespace(s) each owning
-// kustomization created, and — when prune is set — reconciles by deleting the CLI-placed secrets this
-// context no longer wants. It runs after Install; for each secret it resolves the target namespace(s) —
-// either the ones the entry named or, when it named none, the single namespace the kustomization created
-// (failing closed on more than one so a secret is never placed by guessing) — applies an Opaque Secret
-// into each, and rolls the workloads in that namespace that consume it, keyed by a content digest, so a
-// changed value reaches running pods rather than sitting stale until the next unrelated restart. It
-// self-gates on the target namespace appearing rather than requiring a global wait. When prune is set it
-// records every (namespace, secret) it placed and hands that desired set to PruneSecrets, which reclaims
-// any CLI-placed secret not in it — a secret dropped from a fan-out list, a secret removed from a system,
-// or every one when the blueprint declares no secrets. Pruning is gated so secret reclaim mirrors
-// Kustomization prune: on under apply's --prune and upgrade, off for the place-only flows. When no
-// kubernetes manager is configured it is a no-op only if there is also nothing to place.
-func (i *Provisioner) PlaceSecrets(ctx context.Context, resolved ResolvedSecrets, prune bool) error {
+// pendingPlacement is one secret awaiting its target namespace during PlaceSecrets.
+type pendingPlacement struct {
+	kustomization string
+	secretName    string
+	secret        ResolvedSecret
+}
+
+// PlaceSecrets materializes secrets that ResolveSecrets produced into their target namespace(s), and —
+// when prune is set — reconciles by deleting the CLI-placed secrets this context no longer wants. It runs
+// after Install. Placement is not serialized: on each round it places every secret whose target namespace
+// already exists and defers the rest, then polls, so a secret whose namespace is ready is never blocked
+// behind one whose namespace is not. This matters because kustomizations commonly depend on a secret the
+// CLI places (e.g. a cloud-controller-manager needs its token before nodes initialize and downstream
+// namespaces appear); placing the ready ones first breaks that cycle rather than deadlocking on a namespace
+// that only appears once an earlier secret is placed. For each secret it resolves the target namespace(s) —
+// the ones the entry named (gated on those existing in the cluster) or, when it named none, the namespace
+// its owning kustomization creates or deploys into (failing closed on more than one so a secret is never
+// placed by guessing) — applies an Opaque Secret into each, and rolls the workloads there that consume it,
+// keyed by a content digest, so a changed value reaches running pods rather than sitting stale. It surfaces
+// a single progress line naming what it is placing or waiting on, and times out naming the secrets whose
+// namespaces never appeared. As it places a secret it requests an immediate flux reconcile of the owning
+// kustomization (the secret is what that kustomization was waiting on), and while waiting it nudges the
+// dependency closure of the still-pending owners on a throttle, so a chain unblocked by a placement
+// advances in seconds rather than one flux interval per hop. When prune is set it records every
+// (namespace, secret) it placed and hands
+// that desired set to PruneSecrets, which reclaims any CLI-placed secret not in it. Pruning is gated so
+// secret reclaim mirrors Kustomization prune: on under apply's --prune and upgrade, off for the place-only
+// flows. When no kubernetes manager is configured it is a no-op only if there is also nothing to place.
+func (i *Provisioner) PlaceSecrets(ctx context.Context, resolved ResolvedSecrets, blueprint *blueprintv1alpha1.Blueprint, prune bool) error {
 	if i.KubernetesManager == nil {
 		if len(resolved) == 0 {
 			return nil
 		}
 		return fmt.Errorf("kubernetes manager not configured")
 	}
-
-	placed := make(map[string]map[string]bool)
-	for kustomizationName, secrets := range resolved {
-		for secretName, secret := range secrets {
-			namespaces, err := i.resolveSecretNamespaces(ctx, kustomizationName, secret.Namespaces)
-			if err != nil {
-				return err
-			}
-			for _, namespace := range namespaces {
-				if err := i.KubernetesManager.ApplySecret(secretName, namespace, secret.Data, kustomizationName); err != nil {
-					return fmt.Errorf("applying secret %q to namespace %q: %w", secretName, namespace, err)
-				}
-				if err := i.KubernetesManager.RollWorkloadsForSecret(ctx, namespace, secretName, secretDigest(secret.Data)); err != nil {
-					return fmt.Errorf("rolling workloads for secret %q in namespace %q: %w", secretName, namespace, err)
-				}
-				if placed[namespace] == nil {
-					placed[namespace] = make(map[string]bool)
-				}
-				placed[namespace][secretName] = true
-			}
-		}
-	}
-
-	if !prune {
+	if len(resolved) == 0 && !prune {
 		return nil
 	}
-	if err := i.KubernetesManager.PruneSecrets(placed); err != nil {
-		return fmt.Errorf("pruning orphaned secrets: %w", err)
-	}
-	return nil
+
+	return tui.WithProgress("Placing secrets", func() error {
+		pending := make([]pendingPlacement, 0)
+		for kustomizationName, secrets := range resolved {
+			for secretName, secret := range secrets {
+				pending = append(pending, pendingPlacement{kustomizationName, secretName, secret})
+			}
+		}
+
+		placed := make(map[string]map[string]bool)
+		pollInterval := i.secretPollInterval
+		if pollInterval == 0 {
+			pollInterval = constants.DefaultKustomizationWaitPollInterval
+		}
+		waitCtx, cancel := context.WithTimeout(ctx, constants.DefaultFluxKustomizationInstallTimeout)
+		defer cancel()
+
+		stuckRounds := 0
+		for len(pending) > 0 {
+			var stillPending []pendingPlacement
+			placedOwners := make(map[string]struct{})
+			for _, p := range pending {
+				namespaces, ready, err := i.trySecretNamespaces(p.kustomization, p.secret.Namespaces)
+				if err != nil {
+					return err
+				}
+				if !ready {
+					stillPending = append(stillPending, p)
+					continue
+				}
+				tui.Update(fmt.Sprintf("Placing secrets: %s (%s)", p.secretName, p.kustomization))
+				for _, namespace := range namespaces {
+					if err := i.KubernetesManager.ApplySecret(p.secretName, namespace, p.secret.Data, p.kustomization); err != nil {
+						return fmt.Errorf("applying secret %q to namespace %q: %w", p.secretName, namespace, err)
+					}
+					if err := i.KubernetesManager.RollWorkloadsForSecret(ctx, namespace, p.secretName, secretDigest(p.secret.Data)); err != nil {
+						return fmt.Errorf("rolling workloads for secret %q in namespace %q: %w", p.secretName, namespace, err)
+					}
+					if placed[namespace] == nil {
+						placed[namespace] = make(map[string]bool)
+					}
+					placed[namespace][p.secretName] = true
+				}
+				placedOwners[p.kustomization] = struct{}{}
+			}
+			pending = stillPending
+
+			// A secret we just placed is what its owner was waiting on — reconcile that owner now so it
+			// applies and re-checks readiness immediately, and force any HelmRelease it owns that had
+			// stalled for lack of the secret, rather than waiting on its scheduled interval.
+			if len(placedOwners) > 0 {
+				owners := sortedStringKeys(placedOwners)
+				i.reconcileKustomizations(ctx, owners)
+				i.forceStalledHelmReleases(ctx, owners)
+				stuckRounds = 0
+			}
+			if len(pending) == 0 {
+				break
+			}
+			// No placement this round: what's left is gated behind kustomizations that have not created
+			// their namespace yet. Nudge the dependency closure of those owners — only the chains that gate
+			// what remains, and throttled — so the DAG advances in seconds rather than one flux interval per
+			// hop. Reconciling a not-yet-Ready dependency is a harmless no-op, so the closure walks Ready
+			// bottom-up across successive nudges.
+			if len(placedOwners) == 0 {
+				if stuckRounds%reconcileEveryStuckRounds == 0 {
+					closure := dependencyClosure(blueprint, pendingOwners(pending))
+					i.reconcileKustomizations(ctx, closure)
+					i.forceStalledHelmReleases(ctx, closure)
+				}
+				stuckRounds++
+			}
+			tui.Update(fmt.Sprintf("Placing secrets: waiting on %s", pendingSummary(pending)))
+			select {
+			case <-waitCtx.Done():
+				return fmt.Errorf("timed out waiting on namespaces before placing secrets: %s", pendingSummary(pending))
+			case <-time.After(pollInterval):
+			}
+		}
+
+		if !prune {
+			return nil
+		}
+		if err := i.KubernetesManager.PruneSecrets(placed); err != nil {
+			return fmt.Errorf("pruning orphaned secrets: %w", err)
+		}
+		return nil
+	})
 }
 
 // secretDigest returns a stable content digest for a secret's resolved data, used to roll consuming
@@ -1125,63 +1239,289 @@ func secretDigest(stringData map[string]string) string {
 	return hex.EncodeToString(h.Sum(nil))
 }
 
-// resolveSecretNamespaces determines which namespace(s) a secret is placed into, gating on each target
-// being provably created by the owning kustomization before returning. When explicit names the target(s)
-// it polls the kustomization's Flux inventory until every named namespace has been applied, so a secret
-// is never placed into a namespace the owning kustomization did not create — a typo or a namespace owned
-// by another kustomization surfaces as the bounded timeout naming what is missing. When explicit is empty
-// it auto-resolves the single namespace the kustomization creates, failing closed on more than one
-// (ambiguous — the author must name the target via `namespaces:`). Gating on the namespace being applied
-// — not on the whole kustomization being Ready — places the secret the moment its namespace exists, so a
-// consumer recovers promptly and a kustomization whose readiness depends on the secret can never deadlock
-// placement. Flux records inventory only after a successful apply, so a namespace present there is really
-// applied.
-func (i *Provisioner) resolveSecretNamespaces(ctx context.Context, kustomizationName string, explicit []string) ([]string, error) {
-	waitCtx, cancel := context.WithTimeout(ctx, constants.DefaultFluxKustomizationInstallTimeout)
-	defer cancel()
-	for {
-		entries, err := i.KubernetesManager.GetKustomizationInventory(kustomizationName, i.fluxNamespace())
+// trySecretNamespaces reports where a secret should be placed and whether every target namespace exists
+// yet, without blocking, so PlaceSecrets can place the ready ones and poll for the rest. When the entry
+// names namespaces explicitly they are the targets, gated on each existing in the cluster regardless of
+// which kustomization created it — the author named the target, so a secret whose namespace is created by a
+// different kustomization is not blocked on the owning kustomization's inventory. When it names none the
+// target is auto-resolved from the owning kustomization's Flux inventory: the namespace it creates, or —
+// when it creates none — the single namespace its resources are deployed into. Auto-resolution fails closed
+// when that spans more than one namespace (ambiguous — the author must name the target via `namespaces:`),
+// and once the kustomization has reconciled but offers nothing to infer from (its inventory is populated
+// yet names no namespace), rather than waiting forever. A (nil, false, nil) return means "not resolvable
+// yet, keep polling" — the named namespaces don't exist, or the owning kustomization has not reconciled.
+// Gating on the namespace existing — not on the owning kustomization being Ready — lets a secret be placed
+// the moment its namespace appears, so a consumer whose readiness depends on it can never deadlock.
+func (i *Provisioner) trySecretNamespaces(kustomizationName string, explicit []string) ([]string, bool, error) {
+	if len(explicit) > 0 {
+		missing, err := i.missingClusterNamespaces(explicit)
 		if err != nil {
-			return nil, fmt.Errorf("reading inventory for kustomization %q: %w", kustomizationName, err)
+			return nil, false, err
 		}
-		var created []string
-		for _, entry := range entries {
-			if entry.Kind == "Namespace" {
-				created = append(created, entry.Name)
-			}
+		if len(missing) == 0 {
+			return slices.Clone(explicit), true, nil
 		}
-		if len(explicit) > 0 {
-			if len(missingNamespaces(explicit, created)) == 0 {
-				return slices.Clone(explicit), nil
-			}
-		} else {
-			switch {
-			case len(created) == 1:
-				return created, nil
-			case len(created) > 1:
-				return nil, fmt.Errorf("kustomization %q created multiple namespaces (%s); set `namespaces:` on the secret to choose where to place it", kustomizationName, strings.Join(created, ", "))
-			}
-		}
-		select {
-		case <-waitCtx.Done():
-			if len(explicit) > 0 {
-				return nil, fmt.Errorf("timed out waiting for kustomization %q to create namespace(s) %s before placing secrets", kustomizationName, strings.Join(missingNamespaces(explicit, created), ", "))
-			}
-			return nil, fmt.Errorf("timed out waiting for kustomization %q to create its namespace before placing secrets", kustomizationName)
-		case <-time.After(constants.DefaultKustomizationWaitPollInterval):
-		}
+		return nil, false, nil
 	}
+	entries, err := i.KubernetesManager.GetKustomizationInventory(kustomizationName, i.fluxNamespace())
+	if err != nil {
+		return nil, false, fmt.Errorf("reading inventory for kustomization %q: %w", kustomizationName, err)
+	}
+	candidates := autoResolveNamespaces(entries)
+	switch {
+	case len(candidates) == 1:
+		return candidates, true, nil
+	case len(candidates) > 1:
+		return nil, false, fmt.Errorf("kustomization %q spans multiple namespaces (%s); set `namespaces:` on the secret to choose where to place it", kustomizationName, strings.Join(candidates, ", "))
+	case len(entries) > 0:
+		return nil, false, fmt.Errorf("kustomization %q creates no namespace and deploys no namespaced resources to infer one from; set `namespaces:` on the secret to choose where to place it", kustomizationName)
+	}
+	return nil, false, nil
 }
 
-// missingNamespaces returns the members of want not present in have, preserving want's order.
-func missingNamespaces(want, have []string) []string {
+// pendingSummary renders the secrets still awaiting a namespace as sorted "secret (kustomization)" entries —
+// naming the explicit target namespaces when the entry declared them — for the progress and timeout lines.
+func pendingSummary(pending []pendingPlacement) string {
+	parts := make([]string, 0, len(pending))
+	for _, p := range pending {
+		if len(p.secret.Namespaces) > 0 {
+			parts = append(parts, fmt.Sprintf("%s (%s)→%s", p.secretName, p.kustomization, strings.Join(p.secret.Namespaces, ",")))
+		} else {
+			parts = append(parts, fmt.Sprintf("%s (%s)", p.secretName, p.kustomization))
+		}
+	}
+	slices.Sort(parts)
+	return strings.Join(parts, ", ")
+}
+
+// autoResolveNamespaces infers where a secret should land when its entry names no namespace, from the
+// owning kustomization's Flux inventory. It prefers the Namespace object(s) the kustomization creates; when
+// it creates none, it falls back to the distinct namespaces its namespaced resources are deployed into, so
+// a kustomization that deploys into a namespace another kustomization created is still resolvable. The
+// result is sorted so a multi-namespace outcome reads deterministically.
+func autoResolveNamespaces(entries []kubernetes.InventoryEntry) []string {
+	created := make(map[string]struct{})
+	deployed := make(map[string]struct{})
+	for _, entry := range entries {
+		if entry.Kind == "Namespace" {
+			created[entry.Name] = struct{}{}
+		}
+		if entry.Namespace != "" {
+			deployed[entry.Namespace] = struct{}{}
+		}
+	}
+	chosen := created
+	if len(chosen) == 0 {
+		chosen = deployed
+	}
+	out := make([]string, 0, len(chosen))
+	for ns := range chosen {
+		out = append(out, ns)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// missingClusterNamespaces returns the members of want that do not yet exist in the cluster, preserving
+// want's order. It is how placement gates a secret that names its target namespace(s) explicitly: on those
+// namespaces existing, regardless of which kustomization created them.
+func (i *Provisioner) missingClusterNamespaces(want []string) ([]string, error) {
 	var missing []string
 	for _, ns := range want {
-		if !slices.Contains(have, ns) {
+		exists, err := i.KubernetesManager.NamespaceExists(ns)
+		if err != nil {
+			return nil, fmt.Errorf("checking namespace %q: %w", ns, err)
+		}
+		if !exists {
 			missing = append(missing, ns)
 		}
 	}
-	return missing
+	return missing, nil
+}
+
+// reconcileEveryStuckRounds throttles the dependency-closure reconcile nudge: while placement is blocked
+// waiting for namespaces, PlaceSecrets nudges the closure once every this many poll rounds (and on the
+// first stuck round), rather than every round, to keep reconcile-request traffic modest.
+const reconcileEveryStuckRounds = 6
+
+// reconcileKustomizations requests an immediate flux reconcile of the named Kustomizations, best-effort: it
+// initializes the notifier if needed and swallows any error, so a placement round is never failed by a
+// reconcile nudge. A nil or empty names slice is a no-op.
+func (i *Provisioner) reconcileKustomizations(ctx context.Context, names []string) {
+	if len(names) == 0 {
+		return
+	}
+	if err := i.ensureNotifier(); err != nil {
+		return
+	}
+	_ = i.Notifier.ReconcileKustomizations(ctx, names)
+}
+
+// helmReleaseReady reports whether a HelmRelease currently carries a Ready=True condition.
+func helmReleaseReady(hr helmv2.HelmRelease) bool {
+	for _, c := range hr.Status.Conditions {
+		if c.Type == "Ready" {
+			return c.Status == "True"
+		}
+	}
+	return false
+}
+
+// forceStalledHelmReleases force-reconciles any HelmRelease owned by the given kustomizations that is not
+// Ready. A release that failed to install or upgrade — e.g. because a secret it needs was not yet present —
+// stalls and will not retry on a plain reconcile of its owning Kustomization, since the release spec is
+// unchanged; forcing it (requestedAt + forceAt) makes helm-controller retry now that its inputs may be in
+// place. Best-effort: read failures and the reconcile request are swallowed, and healthy releases are left
+// untouched so no needless upgrade fires.
+func (i *Provisioner) forceStalledHelmReleases(ctx context.Context, kustomizations []string) {
+	var refs []fluxinfra.HelmReleaseRef
+	seen := make(map[string]struct{})
+	for _, name := range kustomizations {
+		hrs, err := i.KubernetesManager.GetHelmReleasesForKustomization(name, i.fluxNamespace())
+		if err != nil {
+			continue
+		}
+		for _, hr := range hrs {
+			if helmReleaseReady(hr) {
+				continue
+			}
+			key := hr.Namespace + "/" + hr.Name
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+			refs = append(refs, fluxinfra.HelmReleaseRef{Namespace: hr.Namespace, Name: hr.Name})
+		}
+	}
+	if len(refs) == 0 {
+		return
+	}
+	if err := i.ensureNotifier(); err != nil {
+		return
+	}
+	_ = i.Notifier.ReconcileHelmReleases(ctx, refs, true)
+}
+
+// Converge actively drives the blueprint's kustomizations toward Ready within timeout, best-effort. Each
+// round it reads readiness (without failing on a failed kustomization) and, for every kustomization not yet
+// Ready, requests an immediate reconcile and forces any stalled HelmRelease it owns — so a chain that
+// stalled after apply (a dependent waiting on a now-ready dependency, or a HelmRelease that failed and
+// exhausted its remediation) recovers in seconds rather than at the next flux interval. Nudges are
+// throttled to keep reconcile traffic modest. It returns as soon as every kustomization is Ready, or when
+// timeout elapses; it is a driver, not a gate, so a still-unready cluster is not an error here — callers
+// that must fail on un-readiness use Wait afterward. A nil blueprint or missing kubernetes manager is a
+// no-op.
+func (i *Provisioner) Converge(ctx context.Context, blueprint *blueprintv1alpha1.Blueprint, timeout time.Duration) error {
+	if blueprint == nil || i.KubernetesManager == nil {
+		return nil
+	}
+	names := convergeNames(withCrdLayer(blueprint))
+	if len(names) == 0 {
+		return nil
+	}
+
+	pollInterval := i.secretPollInterval
+	if pollInterval == 0 {
+		pollInterval = constants.DefaultKustomizationWaitPollInterval
+	}
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	return tui.WithProgress("Reconciling resources", func() error {
+		round := 0
+		for {
+			readiness, err := i.KubernetesManager.GetKustomizationReadiness(names)
+			if err == nil {
+				var notReady []string
+				for _, n := range names {
+					if !readiness[n] {
+						notReady = append(notReady, n)
+					}
+				}
+				if len(notReady) == 0 {
+					return nil
+				}
+				slices.Sort(notReady)
+				tui.Update(fmt.Sprintf("Reconciling resources: waiting on %s", strings.Join(notReady, ", ")))
+				if round%reconcileEveryStuckRounds == 0 {
+					i.reconcileKustomizations(ctx, notReady)
+					i.forceStalledHelmReleases(ctx, notReady)
+				}
+			}
+			round++
+			select {
+			case <-waitCtx.Done():
+				return nil
+			case <-time.After(pollInterval):
+			}
+		}
+	})
+}
+
+// convergeNames returns the names of the blueprint's non-destroyOnly kustomizations, the set Converge
+// drives toward Ready.
+func convergeNames(bp *blueprintv1alpha1.Blueprint) []string {
+	names := make([]string, 0, len(bp.Kustomizations))
+	for _, k := range bp.Kustomizations {
+		if k.DestroyOnly != nil && *k.DestroyOnly {
+			continue
+		}
+		names = append(names, k.Name)
+	}
+	return names
+}
+
+// dependencyClosure returns the transitive dependsOn closure of the given owner kustomizations within the
+// blueprint — the owners plus every kustomization they transitively depend on — deduplicated and sorted.
+// It is the minimal set worth force-reconciling to advance a stuck owner: reconciling a dependency that is
+// not yet Ready is a harmless no-op, so nudging the whole closure walks it Ready bottom-up. Names not
+// present in the blueprint (e.g. an external dependency) are dropped. Returns nil for a nil blueprint.
+func dependencyClosure(blueprint *blueprintv1alpha1.Blueprint, owners []string) []string {
+	if blueprint == nil {
+		return nil
+	}
+	deps := make(map[string][]string, len(blueprint.Kustomizations))
+	for _, k := range blueprint.Kustomizations {
+		deps[k.Name] = k.DependsOn
+	}
+	seen := make(map[string]struct{})
+	var walk func(name string)
+	walk = func(name string) {
+		if _, done := seen[name]; done {
+			return
+		}
+		if _, known := deps[name]; !known {
+			return
+		}
+		seen[name] = struct{}{}
+		for _, d := range deps[name] {
+			walk(d)
+		}
+	}
+	for _, o := range owners {
+		walk(o)
+	}
+	return sortedStringKeys(seen)
+}
+
+// pendingOwners returns the owning kustomization of each still-pending secret (duplicates allowed;
+// dependencyClosure deduplicates as it walks).
+func pendingOwners(pending []pendingPlacement) []string {
+	owners := make([]string, 0, len(pending))
+	for _, p := range pending {
+		owners = append(owners, p.kustomization)
+	}
+	return owners
+}
+
+// sortedStringKeys returns the keys of a set as a sorted slice.
+func sortedStringKeys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	slices.Sort(out)
+	return out
 }
 
 // WriteVersionMarker records the blueprint version applied to this context as a marker ConfigMap

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -4639,30 +4639,56 @@ func TestProvisioner_ResolveSecrets(t *testing.T) {
 	})
 }
 
-func TestProvisioner_dependencyClosure(t *testing.T) {
+func TestProvisioner_nudgeFrontier(t *testing.T) {
+	// crds Ready; lb depends on crds (frontier); gateway depends on the not-ready lb (blocked, not frontier).
 	bp := &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{
-		{Name: "dns-install", DependsOn: []string{"gateway-install"}},
-		{Name: "gateway-install", DependsOn: []string{"lb-install", "pki-install"}},
-		{Name: "lb-install", DependsOn: []string{"crds"}},
-		{Name: "pki-install"},
 		{Name: "crds"},
-		{Name: "observability-install"}, // unrelated — must not appear
+		{Name: "lb-install", DependsOn: []string{"crds"}},
+		{Name: "gateway-install", DependsOn: []string{"lb-install"}},
 	}}
+	newProv := func(mocks *ProvisionerTestMocks, notifier *fluxinfra.MockNotifier) *Provisioner {
+		return NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager, Notifier: notifier})
+	}
 
-	t.Run("WalksTransitiveDependsOnAndExcludesUnrelated", func(t *testing.T) {
-		got := dependencyClosure(bp, []string{"dns-install"})
-		want := []string{"crds", "dns-install", "gateway-install", "lb-install", "pki-install"}
-		if !slices.Equal(got, want) {
-			t.Errorf("Expected closure %v, got %v", want, got)
+	t.Run("NudgesOnlyNotReadyFrontierAndNeverReadyOrBlocked", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.GetKustomizationReadinessFunc = func(names []string) (map[string]bool, error) {
+			return map[string]bool{"crds": true, "lb-install": false, "gateway-install": false}, nil
+		}
+		notifier := fluxinfra.NewMockNotifier()
+		var nudgedNames [][]string
+		notifier.ReconcileKustomizationsFunc = func(ctx context.Context, names []string) error {
+			nudgedNames = append(nudgedNames, names)
+			return nil
+		}
+
+		// When nudging, only lb-install (not-ready, deps ready) is reconciled — not crds (Ready) nor
+		// gateway-install (blocked on not-ready lb-install)
+		newProv(mocks, notifier).nudgeFrontier(context.Background(), bp, map[string]struct{}{})
+		if len(nudgedNames) != 1 || !slices.Equal(nudgedNames[0], []string{"lb-install"}) {
+			t.Errorf("expected only lb-install nudged, got %v", nudgedNames)
 		}
 	})
 
-	t.Run("DropsNamesNotInBlueprintAndHandlesNil", func(t *testing.T) {
-		if got := dependencyClosure(bp, []string{"external-thing"}); len(got) != 0 {
-			t.Errorf("Expected unknown owner to yield empty closure, got %v", got)
+	t.Run("NudgesEachFrontierMemberOnlyOnce", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.GetKustomizationReadinessFunc = func(names []string) (map[string]bool, error) {
+			return map[string]bool{"crds": true, "lb-install": false, "gateway-install": false}, nil
 		}
-		if got := dependencyClosure(nil, []string{"dns-install"}); got != nil {
-			t.Errorf("Expected nil blueprint to yield nil closure, got %v", got)
+		notifier := fluxinfra.NewMockNotifier()
+		calls := 0
+		notifier.ReconcileKustomizationsFunc = func(ctx context.Context, names []string) error {
+			calls++
+			return nil
+		}
+		prov := newProv(mocks, notifier)
+		nudged := map[string]struct{}{}
+
+		// When nudging twice with lb-install still not-Ready, it is reconciled only on the first pass
+		prov.nudgeFrontier(context.Background(), bp, nudged)
+		prov.nudgeFrontier(context.Background(), bp, nudged)
+		if calls != 1 {
+			t.Errorf("expected the frontier member nudged once, got %d nudges", calls)
 		}
 	})
 }
@@ -5055,10 +5081,14 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		}
 	})
 
-	t.Run("ReconcilesDependencyClosureWhilePending", func(t *testing.T) {
-		// Given a pending secret whose namespace never appears, and a dependency chain gating it
+	t.Run("NudgesOnlyTheFrontierWhilePending", func(t *testing.T) {
+		// Given a pending secret whose namespace never appears, and a dependency chain that is entirely
+		// not-Ready — only the base (lb-install, no unmet deps) is on the frontier
 		mocks := setupProvisionerMocks(t)
 		mocks.KubernetesManager.NamespaceExistsFunc = func(name string) (bool, error) { return false, nil }
+		mocks.KubernetesManager.GetKustomizationReadinessFunc = func(names []string) (map[string]bool, error) {
+			return map[string]bool{"dns-install": false, "gateway-install": false, "lb-install": false}, nil
+		}
 		notifier := fluxinfra.NewMockNotifier()
 		var reconciled [][]string
 		notifier.ReconcileKustomizationsFunc = func(ctx context.Context, names []string) error {
@@ -5075,16 +5105,13 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
-		// When placing, the whole dependency chain gating the pending secret is nudged to reconcile
+		// When placing, only the frontier (lb-install) is nudged — not the blocked gateway/dns upstream
 		_ = prov.PlaceSecrets(ctx, secrets, bp, false)
 		if len(reconciled) == 0 {
-			t.Fatalf("Expected a dependency-closure reconcile, got none")
+			t.Fatalf("expected a frontier reconcile, got none")
 		}
-		got := reconciled[0]
-		for _, want := range []string{"dns-install", "gateway-install", "lb-install"} {
-			if !slices.Contains(got, want) {
-				t.Errorf("Expected closure to include %q, got %v", want, got)
-			}
+		if got := reconciled[0]; !slices.Equal(got, []string{"lb-install"}) {
+			t.Errorf("expected only frontier lb-install nudged, got %v", got)
 		}
 	})
 

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	helmv2 "github.com/fluxcd/helm-controller/api/v2"
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/composer/blueprint"
 	"github.com/windsorcli/cli/pkg/provisioner/cluster"
@@ -22,6 +23,7 @@ import (
 	"github.com/windsorcli/cli/pkg/runtime/evaluator"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
 	terraformruntime "github.com/windsorcli/cli/pkg/runtime/terraform"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // =============================================================================
@@ -1177,6 +1179,37 @@ func TestProvisioner_ApplyKustomize(t *testing.T) {
 			t.Errorf("Expected kustomization name 'test-kustomization', got %q", appliedBlueprint.Kustomizations[0].Name)
 		}
 	})
+
+	t.Run("PlacesNamedKustomizationSecret", func(t *testing.T) {
+		// Given a blueprint whose named kustomization declares a secret referencing a configured value
+		mocks := setupProvisionerMocks(t)
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"hetzner": map[string]any{"token": "resolved-token"}}, nil
+		}
+		mocks.KubernetesManager.ApplyBlueprintFunc = func(*blueprintv1alpha1.Blueprint, string) error { return nil }
+		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
+			return []kubernetes.InventoryEntry{{Kind: "Namespace", Name: "system-lb"}}, nil
+		}
+		var placedName, placedNs string
+		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string, owner string) error {
+			placedName, placedNs = name, namespace
+			return nil
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+		blueprint := &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{
+			{Name: "lb-install", Secrets: map[string]blueprintv1alpha1.SecretEntry{
+				"hcloud": {Data: map[string]string{"token": "${hetzner.token}"}},
+			}},
+		}}
+
+		// When applying just that kustomization, its secret is placed into the namespace it created
+		if err := provisioner.ApplyKustomize(context.Background(), blueprint, "lb-install"); err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if placedName != "hcloud" || placedNs != "system-lb" {
+			t.Errorf("Expected hcloud placed into system-lb, got name=%q ns=%q", placedName, placedNs)
+		}
+	})
 }
 
 func TestProvisioner_ApplyKustomizeAll(t *testing.T) {
@@ -1710,7 +1743,7 @@ func TestProvisioner_Install(t *testing.T) {
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
 		blueprint := createTestBlueprint()
-		err := provisioner.Install(context.Background(), blueprint)
+		err := provisioner.Install(context.Background(), blueprint, false)
 
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)
@@ -1733,7 +1766,7 @@ func TestProvisioner_Install(t *testing.T) {
 		}
 
 		// When installing
-		if err := provisioner.Install(context.Background(), blueprint); err != nil {
+		if err := provisioner.Install(context.Background(), blueprint, false); err != nil {
 			t.Fatalf("Expected no error, got: %v", err)
 		}
 
@@ -1779,7 +1812,7 @@ func TestProvisioner_Install(t *testing.T) {
 		}
 
 		// When installing
-		if err := provisioner.Install(context.Background(), blueprint); err != nil {
+		if err := provisioner.Install(context.Background(), blueprint, false); err != nil {
 			t.Fatalf("Expected no error, got: %v", err)
 		}
 
@@ -1800,7 +1833,7 @@ func TestProvisioner_Install(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler)
 
-		err := provisioner.Install(context.Background(), nil)
+		err := provisioner.Install(context.Background(), nil, false)
 
 		if err == nil {
 			t.Error("Expected error for nil blueprint")
@@ -1817,7 +1850,7 @@ func TestProvisioner_Install(t *testing.T) {
 		provisioner.KubernetesManager = nil
 
 		blueprint := createTestBlueprint()
-		err := provisioner.Install(context.Background(), blueprint)
+		err := provisioner.Install(context.Background(), blueprint, false)
 
 		if err == nil {
 			t.Error("Expected error for nil kubernetes manager")
@@ -1839,7 +1872,7 @@ func TestProvisioner_Install(t *testing.T) {
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
 		blueprint := createTestBlueprint()
-		err := provisioner.Install(context.Background(), blueprint)
+		err := provisioner.Install(context.Background(), blueprint, false)
 
 		if err == nil {
 			t.Error("Expected error for apply blueprint failure")
@@ -1847,6 +1880,94 @@ func TestProvisioner_Install(t *testing.T) {
 
 		if !strings.Contains(err.Error(), "failed to apply blueprint") {
 			t.Errorf("Expected specific error message, got: %v", err)
+		}
+	})
+
+	t.Run("ResolvesAndPlacesDeclaredSecrets", func(t *testing.T) {
+		// Given a blueprint whose kustomization declares a secret referencing a configured value
+		mocks := setupProvisionerMocks(t)
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"hetzner": map[string]any{"token": "resolved-token"}}, nil
+		}
+		mocks.KubernetesManager.ApplyBlueprintFunc = func(*blueprintv1alpha1.Blueprint, string) error { return nil }
+		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
+			return []kubernetes.InventoryEntry{{Kind: "Namespace", Name: "system-lb"}}, nil
+		}
+		var placedName, placedNs string
+		var placedData map[string]string
+		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string, owner string) error {
+			placedName, placedNs, placedData = name, namespace, stringData
+			return nil
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+		blueprint := &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{
+			{Name: "lb-install", Secrets: map[string]blueprintv1alpha1.SecretEntry{
+				"hcloud": {Data: map[string]string{"token": "${hetzner.token}"}},
+			}},
+		}}
+
+		// When installing, the declared secret is placed into the namespace its kustomization created
+		if err := provisioner.Install(context.Background(), blueprint, false); err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if placedName != "hcloud" || placedNs != "system-lb" || placedData["token"] != "resolved-token" {
+			t.Errorf("Expected hcloud/token placed into system-lb, got name=%q ns=%q data=%v", placedName, placedNs, placedData)
+		}
+	})
+
+	t.Run("FailsBeforeApplyWhenSecretResolvesEmpty", func(t *testing.T) {
+		// Given a required secret reference whose configured value is empty
+		mocks := setupProvisionerMocks(t)
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"hetzner": map[string]any{"token": ""}}, nil
+		}
+		applied := false
+		mocks.KubernetesManager.ApplyBlueprintFunc = func(*blueprintv1alpha1.Blueprint, string) error {
+			applied = true
+			return nil
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+		blueprint := &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{
+			{Name: "lb-install", Secrets: map[string]blueprintv1alpha1.SecretEntry{
+				"hcloud": {Data: map[string]string{"token": "${hetzner.token}"}},
+			}},
+		}}
+
+		// When installing, resolution fails closed before anything is applied to the cluster
+		err := provisioner.Install(context.Background(), blueprint, false)
+		if err == nil || !strings.Contains(err.Error(), "error resolving secrets") {
+			t.Errorf("Expected resolve error, got: %v", err)
+		}
+		if applied {
+			t.Error("Expected no apply when secret resolution fails")
+		}
+	})
+
+	t.Run("OmitsUnconfiguredNilSecretWithoutFailing", func(t *testing.T) {
+		// Given a secret reference to a value absent from configuration (resolves to nil)
+		mocks := setupProvisionerMocks(t)
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{}, nil
+		}
+		mocks.KubernetesManager.ApplyBlueprintFunc = func(*blueprintv1alpha1.Blueprint, string) error { return nil }
+		placed := false
+		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string, owner string) error {
+			placed = true
+			return nil
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+		blueprint := &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{
+			{Name: "lb-install", Secrets: map[string]blueprintv1alpha1.SecretEntry{
+				"hcloud": {Data: map[string]string{"token": "${hetzner.token}"}},
+			}},
+		}}
+
+		// When installing, the unconfigured secret is skipped and install still succeeds
+		if err := provisioner.Install(context.Background(), blueprint, false); err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if placed {
+			t.Error("Expected no secret placed for a nil-resolving reference")
 		}
 	})
 }
@@ -4449,15 +4570,18 @@ func TestProvisioner_ResolveSecrets(t *testing.T) {
 		}
 	})
 
-	t.Run("FailsWhenRequiredReferenceResolvesToNil", func(t *testing.T) {
-		// Given a required reference whose value is nil (populated but unresolvable)
+	t.Run("OmitsKeyWhenReferenceResolvesToNil", func(t *testing.T) {
+		// Given a reference to a value absent from configuration (resolves to nil)
 		mocks := setupProvisionerMocks(t)
-		withValues(mocks, map[string]any{"cdn": map[string]any{"cloudflare_api_key": nil}})
+		withValues(mocks, map[string]any{})
 
-		// When resolving, it fails closed before any apply
-		_, err := newProvisioner(mocks).ResolveSecrets(bp(map[string]blueprintv1alpha1.SecretEntry{"creds": entry(map[string]string{"token": "${cdn.cloudflare_api_key}"})}))
-		if err == nil || !strings.Contains(err.Error(), "resolved to nil") {
-			t.Errorf("Expected nil-resolution error, got %v", err)
+		// When resolving, the unconfigured key is omitted and the wholly-empty secret is dropped
+		resolved, err := newProvisioner(mocks).ResolveSecrets(bp(map[string]blueprintv1alpha1.SecretEntry{"creds": entry(map[string]string{"token": "${hetzner.token}"})}))
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if len(resolved) != 0 {
+			t.Errorf("Expected no secret from nil-resolving reference, got %v", resolved)
 		}
 	})
 
@@ -4515,6 +4639,150 @@ func TestProvisioner_ResolveSecrets(t *testing.T) {
 	})
 }
 
+func TestProvisioner_dependencyClosure(t *testing.T) {
+	bp := &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{
+		{Name: "dns-install", DependsOn: []string{"gateway-install"}},
+		{Name: "gateway-install", DependsOn: []string{"lb-install", "pki-install"}},
+		{Name: "lb-install", DependsOn: []string{"crds"}},
+		{Name: "pki-install"},
+		{Name: "crds"},
+		{Name: "observability-install"}, // unrelated — must not appear
+	}}
+
+	t.Run("WalksTransitiveDependsOnAndExcludesUnrelated", func(t *testing.T) {
+		got := dependencyClosure(bp, []string{"dns-install"})
+		want := []string{"crds", "dns-install", "gateway-install", "lb-install", "pki-install"}
+		if !slices.Equal(got, want) {
+			t.Errorf("Expected closure %v, got %v", want, got)
+		}
+	})
+
+	t.Run("DropsNamesNotInBlueprintAndHandlesNil", func(t *testing.T) {
+		if got := dependencyClosure(bp, []string{"external-thing"}); len(got) != 0 {
+			t.Errorf("Expected unknown owner to yield empty closure, got %v", got)
+		}
+		if got := dependencyClosure(nil, []string{"dns-install"}); got != nil {
+			t.Errorf("Expected nil blueprint to yield nil closure, got %v", got)
+		}
+	})
+}
+
+func TestProvisioner_Converge(t *testing.T) {
+	newProv := func(mocks *ProvisionerTestMocks, notifier *fluxinfra.MockNotifier) *Provisioner {
+		p := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager, Notifier: notifier})
+		p.secretPollInterval = time.Millisecond
+		return p
+	}
+
+	t.Run("DrivesNotReadyKustomizationsAndForcesStalledHelmReleases", func(t *testing.T) {
+		// Given a kustomization not Ready on the first read then Ready, owning a stalled HelmRelease
+		mocks := setupProvisionerMocks(t)
+		var reads int
+		mocks.KubernetesManager.GetKustomizationReadinessFunc = func(names []string) (map[string]bool, error) {
+			reads++
+			out := make(map[string]bool)
+			for _, n := range names {
+				out[n] = reads >= 2
+			}
+			return out, nil
+		}
+		mocks.KubernetesManager.GetHelmReleasesForKustomizationFunc = func(name, namespace string) ([]helmv2.HelmRelease, error) {
+			return []helmv2.HelmRelease{{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "system-lb", Name: "hcloud-ccm"},
+				Status:     helmv2.HelmReleaseStatus{Conditions: []metav1.Condition{{Type: "Ready", Status: metav1.ConditionFalse}}},
+			}}, nil
+		}
+		notifier := fluxinfra.NewMockNotifier()
+		var reconciledK [][]string
+		var forcedRefs [][]fluxinfra.HelmReleaseRef
+		var forcedFlags []bool
+		notifier.ReconcileKustomizationsFunc = func(ctx context.Context, names []string) error {
+			reconciledK = append(reconciledK, names)
+			return nil
+		}
+		notifier.ReconcileHelmReleasesFunc = func(ctx context.Context, refs []fluxinfra.HelmReleaseRef, force bool) error {
+			forcedRefs = append(forcedRefs, refs)
+			forcedFlags = append(forcedFlags, force)
+			return nil
+		}
+		bp := &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "lb-install"}}}
+
+		// When converging, it nudges the not-ready kustomization and force-reconciles its stalled HR, then
+		// returns once everything reports Ready
+		if err := newProv(mocks, notifier).Converge(context.Background(), bp, time.Second); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if len(reconciledK) == 0 || !slices.Contains(reconciledK[0], "lb-install") {
+			t.Errorf("expected lb-install reconciled, got %v", reconciledK)
+		}
+		if len(forcedRefs) == 0 || forcedRefs[0][0].Name != "hcloud-ccm" || !forcedFlags[0] {
+			t.Errorf("expected stalled HR force-reconciled, got refs=%v force=%v", forcedRefs, forcedFlags)
+		}
+	})
+
+	t.Run("ReturnsImmediatelyWhenAllReady", func(t *testing.T) {
+		// Given everything already Ready
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.GetKustomizationReadinessFunc = func(names []string) (map[string]bool, error) {
+			out := make(map[string]bool)
+			for _, n := range names {
+				out[n] = true
+			}
+			return out, nil
+		}
+		notifier := fluxinfra.NewMockNotifier()
+		nudged := false
+		notifier.ReconcileKustomizationsFunc = func(ctx context.Context, names []string) error {
+			nudged = true
+			return nil
+		}
+		bp := &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "lb-install"}}}
+
+		// When converging, it returns without nudging anything
+		if err := newProv(mocks, notifier).Converge(context.Background(), bp, time.Second); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if nudged {
+			t.Error("expected no reconcile when everything is already Ready")
+		}
+	})
+
+	t.Run("LeavesHealthyHelmReleasesUntouched", func(t *testing.T) {
+		// Given a not-ready kustomization whose HelmRelease is nonetheless Ready
+		mocks := setupProvisionerMocks(t)
+		var reads int
+		mocks.KubernetesManager.GetKustomizationReadinessFunc = func(names []string) (map[string]bool, error) {
+			reads++
+			out := make(map[string]bool)
+			for _, n := range names {
+				out[n] = reads >= 2
+			}
+			return out, nil
+		}
+		mocks.KubernetesManager.GetHelmReleasesForKustomizationFunc = func(name, namespace string) ([]helmv2.HelmRelease, error) {
+			return []helmv2.HelmRelease{{
+				ObjectMeta: metav1.ObjectMeta{Namespace: "system-lb", Name: "healthy"},
+				Status:     helmv2.HelmReleaseStatus{Conditions: []metav1.Condition{{Type: "Ready", Status: metav1.ConditionTrue}}},
+			}}, nil
+		}
+		notifier := fluxinfra.NewMockNotifier()
+		forcedAny := false
+		notifier.ReconcileHelmReleasesFunc = func(ctx context.Context, refs []fluxinfra.HelmReleaseRef, force bool) error {
+			forcedAny = true
+			return nil
+		}
+		bp := &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "lb-install"}}}
+
+		// When converging, a healthy HelmRelease is not force-reconciled
+		if err := newProv(mocks, notifier).Converge(context.Background(), bp, time.Second); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		if forcedAny {
+			t.Error("expected healthy HelmRelease left untouched")
+		}
+	})
+}
+
 func TestProvisioner_PlaceSecrets(t *testing.T) {
 	newProvisioner := func(mocks *ProvisionerTestMocks) *Provisioner {
 		return NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{
@@ -4543,7 +4811,7 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		}
 
 		// When placing the resolved secrets
-		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved(), true); err != nil {
+		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved(), nil, true); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
@@ -4566,7 +4834,7 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		}
 
 		// When placing the resolved secrets
-		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved(), true); err != nil {
+		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved(), nil, true); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
@@ -4588,7 +4856,7 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		}
 
 		// When placing the resolved secrets, the roll failure surfaces
-		err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved(), true)
+		err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved(), nil, true)
 		if err == nil || !strings.Contains(err.Error(), "rolling workloads for secret") {
 			t.Errorf("Expected roll-failure error, got %v", err)
 		}
@@ -4599,30 +4867,70 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
 			return []kubernetes.InventoryEntry{{Kind: "Namespace", Name: "ns-a"}, {Kind: "Namespace", Name: "ns-b"}}, nil
 		}
-		err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved(), true)
+		err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved(), nil, true)
 		if err == nil || !strings.Contains(err.Error(), "multiple namespaces") {
 			t.Errorf("Expected multiple-namespaces error, got %v", err)
 		}
 	})
 
-	t.Run("TimesOutWhenNamespaceNeverAppears", func(t *testing.T) {
+	t.Run("AutoResolvesFromResourceNamespaceWhenNoNamespaceCreated", func(t *testing.T) {
+		// Given a kustomization that deploys into a namespace it does not itself create (no Namespace entry
+		// in its inventory, only a namespaced resource living in system-csi)
 		mocks := setupProvisionerMocks(t)
 		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
-			return []kubernetes.InventoryEntry{{Kind: "ConfigMap", Name: "values-cdn"}}, nil
+			return []kubernetes.InventoryEntry{{Kind: "DaemonSet", Name: "hcloud-csi-node", Namespace: "system-csi"}}, nil
 		}
-		ctx, cancel := context.WithCancel(context.Background())
-		cancel()
-		err := newProvisioner(mocks).PlaceSecrets(ctx, resolved(), true)
-		if err == nil || !strings.Contains(err.Error(), "to create its namespace") {
-			t.Errorf("Expected namespace-timeout error, got %v", err)
+		var gotNs string
+		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string, owner string) error {
+			gotNs = namespace
+			return nil
+		}
+
+		// When placing, the target is inferred from where its resources live
+		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved(), nil, true); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if gotNs != "system-csi" {
+			t.Errorf("Expected placement into system-csi, got %q", gotNs)
 		}
 	})
 
-	t.Run("PlacesIntoExplicitNamespaceOnMultiNamespaceSystem", func(t *testing.T) {
-		// Given a system that owns two namespaces and a secret naming one of them
+	t.Run("FailsFastWhenNothingToInferNamespaceFrom", func(t *testing.T) {
+		// Given a reconciled kustomization whose inventory holds only a cluster-scoped resource, so there is
+		// neither a created namespace nor a namespaced resource to infer a target from
 		mocks := setupProvisionerMocks(t)
 		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
-			return []kubernetes.InventoryEntry{{Kind: "Namespace", Name: "system-pki"}, {Kind: "Namespace", Name: "system-pki-trust"}}, nil
+			return []kubernetes.InventoryEntry{{Kind: "ClusterRole", Name: "csi-role"}}, nil
+		}
+
+		// When placing, it fails immediately (not at the timeout) with the fix, even under a live context
+		err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved(), nil, true)
+		if err == nil || !strings.Contains(err.Error(), "creates no namespace and deploys no namespaced resources") {
+			t.Errorf("Expected fail-fast no-namespace error, got %v", err)
+		}
+	})
+
+	t.Run("TimesOutWhileInventoryStillEmpty", func(t *testing.T) {
+		// Given a kustomization that has not reconciled yet (empty inventory)
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
+			return nil, nil
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		// When placing, it keeps waiting for the namespace and surfaces the timeout when the context ends
+		err := newProvisioner(mocks).PlaceSecrets(ctx, resolved(), nil, true)
+		if err == nil || !strings.Contains(err.Error(), "before placing secrets") || !strings.Contains(err.Error(), "cdn-install") {
+			t.Errorf("Expected namespace-timeout error naming the pending secret, got %v", err)
+		}
+	})
+
+	t.Run("PlacesIntoExplicitNamespaceThatExists", func(t *testing.T) {
+		// Given a secret naming its namespace explicitly, and that namespace exists in the cluster
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.NamespaceExistsFunc = func(name string) (bool, error) {
+			return name == "system-pki", nil
 		}
 		var gotNs string
 		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string, owner string) error {
@@ -4631,8 +4939,8 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		}
 		explicit := ResolvedSecrets{"pki-install": {"hetzner-dns": {Namespaces: []string{"system-pki"}, Data: map[string]string{"token": "resolved"}}}}
 
-		// When placing, the named namespace disambiguates rather than failing closed
-		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), explicit, true); err != nil {
+		// When placing, the named namespace is used as soon as it exists, without consulting inventory
+		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), explicit, nil, true); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 		if gotNs != "system-pki" {
@@ -4640,11 +4948,151 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		}
 	})
 
-	t.Run("FansOutToEveryNamedNamespace", func(t *testing.T) {
-		// Given a secret naming two namespaces both created by the owning kustomization
+	t.Run("PlacesIntoExplicitNamespaceCreatedByAnotherKustomization", func(t *testing.T) {
+		// Given a secret owned by lb-install but naming system-lb, which a different kustomization created
+		// (lb-install's own inventory holds no namespace)
 		mocks := setupProvisionerMocks(t)
 		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
-			return []kubernetes.InventoryEntry{{Kind: "Namespace", Name: "system-pki"}, {Kind: "Namespace", Name: "system-dns"}}, nil
+			return []kubernetes.InventoryEntry{}, nil
+		}
+		mocks.KubernetesManager.NamespaceExistsFunc = func(name string) (bool, error) {
+			return name == "system-lb", nil
+		}
+		var gotNs string
+		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string, owner string) error {
+			gotNs = namespace
+			return nil
+		}
+		explicit := ResolvedSecrets{"lb-install": {"hcloud": {Namespaces: []string{"system-lb"}, Data: map[string]string{"token": "resolved"}}}}
+
+		// When placing, existence — not the owning kustomization's inventory — gates it, so it is not blocked
+		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), explicit, nil, false); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if gotNs != "system-lb" {
+			t.Errorf("Expected placement into system-lb, got %q", gotNs)
+		}
+	})
+
+	t.Run("PlacesReadySecretWithoutBlockingOnAPendingOne", func(t *testing.T) {
+		// Given two secrets: one whose namespace exists, one whose namespace does not — the deadlock case
+		// where a serial placer would block on the pending one and never place the ready one.
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.NamespaceExistsFunc = func(name string) (bool, error) {
+			return name == "system-lb", nil // system-dns never appears
+		}
+		placed := map[string]bool{}
+		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string, owner string) error {
+			placed[namespace] = true
+			return nil
+		}
+		secrets := ResolvedSecrets{
+			"lb-install":  {"hcloud": {Namespaces: []string{"system-lb"}, Data: map[string]string{"token": "t"}}},
+			"dns-install": {"hetzner-dns": {Namespaces: []string{"system-dns"}, Data: map[string]string{"token": "t"}}},
+		}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		// When placing, the ready secret lands even though the other never resolves, and the timeout names
+		// only the one still pending
+		err := newProvisioner(mocks).PlaceSecrets(ctx, secrets, nil, false)
+		if !placed["system-lb"] {
+			t.Error("Expected the ready secret to be placed into system-lb despite a pending peer")
+		}
+		if err == nil || !strings.Contains(err.Error(), "system-dns") || strings.Contains(err.Error(), "system-lb") {
+			t.Errorf("Expected timeout naming only the pending system-dns, got %v", err)
+		}
+	})
+
+	t.Run("PlacesSecretOnceItsNamespaceAppears", func(t *testing.T) {
+		// Given a secret whose namespace does not exist on the first poll but appears on a later one
+		mocks := setupProvisionerMocks(t)
+		var checks int
+		mocks.KubernetesManager.NamespaceExistsFunc = func(name string) (bool, error) {
+			checks++
+			return checks >= 3, nil // absent, absent, then created
+		}
+		var gotNs string
+		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string, owner string) error {
+			gotNs = namespace
+			return nil
+		}
+		secrets := ResolvedSecrets{"dns-install": {"hetzner-dns": {Namespaces: []string{"system-dns"}, Data: map[string]string{"token": "t"}}}}
+
+		prov := newProvisioner(mocks)
+		prov.secretPollInterval = time.Millisecond
+
+		// When placing, it keeps polling and places the secret the moment its namespace appears
+		if err := prov.PlaceSecrets(context.Background(), secrets, nil, false); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if gotNs != "system-dns" {
+			t.Errorf("Expected placement into system-dns once it appeared, got %q", gotNs)
+		}
+	})
+
+	t.Run("ReconcilesOwnerAfterPlacingItsSecret", func(t *testing.T) {
+		// Given a secret whose namespace exists, so it is placed on the first round
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.NamespaceExistsFunc = func(name string) (bool, error) { return name == "system-lb", nil }
+		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string, owner string) error { return nil }
+		notifier := fluxinfra.NewMockNotifier()
+		var reconciled [][]string
+		notifier.ReconcileKustomizationsFunc = func(ctx context.Context, names []string) error {
+			reconciled = append(reconciled, names)
+			return nil
+		}
+		prov := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager, Notifier: notifier})
+		secrets := ResolvedSecrets{"lb-install": {"hcloud": {Namespaces: []string{"system-lb"}, Data: map[string]string{"token": "t"}}}}
+		bp := &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "lb-install"}}}
+
+		// When placing, the owning kustomization is reconciled immediately so it picks up its secret
+		if err := prov.PlaceSecrets(context.Background(), secrets, bp, false); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if len(reconciled) == 0 || !slices.Contains(reconciled[0], "lb-install") {
+			t.Errorf("Expected lb-install to be reconciled after placement, got %v", reconciled)
+		}
+	})
+
+	t.Run("ReconcilesDependencyClosureWhilePending", func(t *testing.T) {
+		// Given a pending secret whose namespace never appears, and a dependency chain gating it
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.NamespaceExistsFunc = func(name string) (bool, error) { return false, nil }
+		notifier := fluxinfra.NewMockNotifier()
+		var reconciled [][]string
+		notifier.ReconcileKustomizationsFunc = func(ctx context.Context, names []string) error {
+			reconciled = append(reconciled, names)
+			return nil
+		}
+		prov := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager, Notifier: notifier})
+		secrets := ResolvedSecrets{"dns-install": {"hetzner-dns": {Namespaces: []string{"system-dns"}, Data: map[string]string{"token": "t"}}}}
+		bp := &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{
+			{Name: "dns-install", DependsOn: []string{"gateway-install"}},
+			{Name: "gateway-install", DependsOn: []string{"lb-install"}},
+			{Name: "lb-install"},
+		}}
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel()
+
+		// When placing, the whole dependency chain gating the pending secret is nudged to reconcile
+		_ = prov.PlaceSecrets(ctx, secrets, bp, false)
+		if len(reconciled) == 0 {
+			t.Fatalf("Expected a dependency-closure reconcile, got none")
+		}
+		got := reconciled[0]
+		for _, want := range []string{"dns-install", "gateway-install", "lb-install"} {
+			if !slices.Contains(got, want) {
+				t.Errorf("Expected closure to include %q, got %v", want, got)
+			}
+		}
+	})
+
+	t.Run("FansOutToEveryNamedNamespace", func(t *testing.T) {
+		// Given a secret naming two namespaces that both exist in the cluster
+		mocks := setupProvisionerMocks(t)
+		mocks.KubernetesManager.NamespaceExistsFunc = func(name string) (bool, error) {
+			return name == "system-pki" || name == "system-dns", nil
 		}
 		placed := map[string]bool{}
 		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string, owner string) error {
@@ -4654,7 +5102,7 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		explicit := ResolvedSecrets{"pki-install": {"acme-dns": {Namespaces: []string{"system-pki", "system-dns"}, Data: map[string]string{"token": "resolved"}}}}
 
 		// When placing, the same secret lands in each named namespace
-		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), explicit, true); err != nil {
+		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), explicit, nil, true); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 		if !placed["system-pki"] || !placed["system-dns"] || len(placed) != 2 {
@@ -4662,18 +5110,18 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		}
 	})
 
-	t.Run("TimesOutNamingAnUncreatedExplicitNamespace", func(t *testing.T) {
-		// Given a named namespace the owning kustomization never creates
+	t.Run("TimesOutNamingANonexistentExplicitNamespace", func(t *testing.T) {
+		// Given a named namespace that does not exist in the cluster
 		mocks := setupProvisionerMocks(t)
-		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
-			return []kubernetes.InventoryEntry{{Kind: "Namespace", Name: "system-pki-trust"}}, nil
+		mocks.KubernetesManager.NamespaceExistsFunc = func(name string) (bool, error) {
+			return false, nil
 		}
 		explicit := ResolvedSecrets{"pki-install": {"hetzner-dns": {Namespaces: []string{"system-pki"}, Data: map[string]string{"token": "resolved"}}}}
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
 
 		// When placing, it fails naming the missing namespace rather than placing by guessing
-		err := newProvisioner(mocks).PlaceSecrets(ctx, explicit, true)
+		err := newProvisioner(mocks).PlaceSecrets(ctx, explicit, nil, true)
 		if err == nil || !strings.Contains(err.Error(), "system-pki") || !strings.Contains(err.Error(), "before placing secrets") {
 			t.Errorf("Expected missing-namespace timeout error naming system-pki, got %v", err)
 		}
@@ -4696,7 +5144,7 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 
 		// When placing an empty set, nothing is placed (no inventory lookups) but reconcile still runs
 		// with an empty desired set, so any previously CLI-placed secret is reclaimed
-		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), ResolvedSecrets{}, true); err != nil {
+		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), ResolvedSecrets{}, nil, true); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 		if queried {
@@ -4708,10 +5156,10 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 	})
 
 	t.Run("ReconcilesFanOutPlacementIntoDesiredSet", func(t *testing.T) {
-		// Given a secret that fans out into two namespaces its kustomization created
+		// Given a secret that fans out into two namespaces that exist in the cluster
 		mocks := setupProvisionerMocks(t)
-		mocks.KubernetesManager.GetKustomizationInventoryFunc = func(name, namespace string) ([]kubernetes.InventoryEntry, error) {
-			return []kubernetes.InventoryEntry{{Kind: "Namespace", Name: "system-pki"}, {Kind: "Namespace", Name: "system-dns"}}, nil
+		mocks.KubernetesManager.NamespaceExistsFunc = func(name string) (bool, error) {
+			return name == "system-pki" || name == "system-dns", nil
 		}
 		var gotDesired map[string]map[string]bool
 		mocks.KubernetesManager.PruneSecretsFunc = func(desired map[string]map[string]bool) error {
@@ -4721,7 +5169,7 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		fanned := ResolvedSecrets{"pki-install": {"acme-dns": {Namespaces: []string{"system-pki", "system-dns"}, Data: map[string]string{"token": "resolved"}}}}
 
 		// When placing, the desired set handed to PruneSecrets names every (namespace, secret) placed
-		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), fanned, true); err != nil {
+		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), fanned, nil, true); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 		if !gotDesired["system-pki"]["acme-dns"] || !gotDesired["system-dns"]["acme-dns"] {
@@ -4740,7 +5188,7 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		}
 
 		// When placing, the prune failure surfaces
-		err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved(), true)
+		err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved(), nil, true)
 		if err == nil || !strings.Contains(err.Error(), "pruning orphaned secrets") {
 			t.Errorf("Expected prune-failure error, got %v", err)
 		}
@@ -4764,7 +5212,7 @@ func TestProvisioner_PlaceSecrets(t *testing.T) {
 		}
 
 		// When placing with prune=false, the secret is placed but reclaim never runs
-		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved(), false); err != nil {
+		if err := newProvisioner(mocks).PlaceSecrets(context.Background(), resolved(), nil, false); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 		if placedName != "cloudflare-creds" {


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This PR restructures the shared provisioner layer that every install path uses, making `Install` the single owner of secret resolution, placement, and a new convergence step — a coordination-heavy change across five cmd entrypoints and the core provisioner.
>
> **Overview**
>
> `ResolveSecrets` and `PlaceSecrets` are folded into `Install`, so every command that installs kustomizations automatically materializes their secrets without each caller wiring the three-step sequence. The `PlaceSecrets` implementation is rewritten from a blocking serial loop to a non-blocking polling model: secrets whose target namespaces already exist are placed immediately while others wait, breaking a potential deadlock where a kustomization depends on a secret the CLI places but whose namespace that kustomization creates. A new `Converge` step follows placement to actively force-reconcile stalled Flux HelmReleases and kustomizations rather than waiting for the next scheduled interval.
>
> One notable semantic change: `ResolveSecrets` previously failed on a reference that resolved to `nil` (absent config key); it now silently omits that key. A typo in a `${path.to.key}` reference that points to an absent config value will no longer surface as an error — the key is quietly dropped and the secret may not be placed.
>
> Reviewed by Claude for commit `d481d545`.

<!-- /claude-code-review:summary -->
