### PR TITLE
fix(provisioner): operate on local terraform state when destroying a kubernetes backend

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -50,7 +50,7 @@ windsor destroy dns --confirm=dns
 windsor destroy --confirm=local --continue`,
 	Annotations: map[string]string{
 		"docs.seealso": "[`apply`](apply.md), [`down`](down.md), [`plan`](plan.md)",
-		"docs.source": "cmd/destroy.go",
+		"docs.source":  "cmd/destroy.go",
 	},
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
@@ -76,6 +76,16 @@ windsor destroy --confirm=local --continue`,
 			// should surface before the operator is asked to confirm.
 			if err := requireCloudAuth(cmd, proj); err != nil {
 				return err
+			}
+			// For a kubernetes backend, pull all terraform state to local and pivot the whole teardown to a
+			// local backend up front — before planning — so no step (plan or destroy) dials the kubernetes
+			// backend that this teardown is about to destroy.
+			pivoted, err := proj.Provisioner.PrepareLocalTeardown(blueprint)
+			if err != nil {
+				return err
+			}
+			if pivoted {
+				fmt.Fprintln(cmd.ErrOrStderr(), "Terraform state migrated to local; running teardown against local state.")
 			}
 			var summary *provisioner.DestroyPlanSummary
 			if err := tui.WithProgress("Generating destroy plan...", func() error {
@@ -116,6 +126,16 @@ windsor destroy --confirm=local --continue`,
 		// surface before the prompt rather than between plan and confirm.
 		if inTerraform {
 			if err := requireCloudAuth(cmd, proj); err != nil {
+				return err
+			}
+			// If the kubernetes backend's cluster is gone, operate on the local state a prior teardown
+			// migrated; otherwise refuse a backend-tier component up front, before the plan runs terraform
+			// init against the kubernetes backend — the operator gets the clean "run windsor destroy"
+			// guidance instead of a raw init connection error.
+			if _, err := proj.Provisioner.PivotToLocalIfClusterGone(blueprint); err != nil {
+				return err
+			}
+			if err := proj.Provisioner.CheckComponentDestroyable(blueprint, componentID); err != nil {
 				return err
 			}
 		}
@@ -174,7 +194,7 @@ var destroyTerraformCmd = &cobra.Command{
 	Use:     "terraform [component]",
 	Aliases: []string{"tf"},
 	Short:   "Destroy Terraform component(s).",
-	Long: `Destroy a specific Terraform component, or all components when no argument is given. Inherits --confirm from the parent 'destroy' command.`,
+	Long:    `Destroy a specific Terraform component, or all components when no argument is given. Inherits --confirm from the parent 'destroy' command.`,
 	Example: `# Destroy a single terraform component
 windsor destroy terraform cluster --confirm=cluster
 
@@ -182,7 +202,7 @@ windsor destroy terraform cluster --confirm=cluster
 windsor destroy terraform --confirm=local`,
 	Annotations: map[string]string{
 		"docs.seealso": "[`destroy`](destroy.md), [`apply terraform`](apply-terraform.md), [`plan terraform`](plan-terraform.md)",
-		"docs.source": "cmd/destroy.go",
+		"docs.source":  "cmd/destroy.go",
 	},
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
@@ -203,6 +223,15 @@ windsor destroy terraform --confirm=local`,
 		if len(args) == 0 {
 			if err := requireCloudAuth(cmd, proj); err != nil {
 				return err
+			}
+			// Destroying every terraform component: pull state to local and pivot up front, like the full
+			// teardown, so the plan and destroy never dial the kubernetes backend being torn down.
+			pivoted, err := proj.Provisioner.PrepareLocalTeardown(blueprint)
+			if err != nil {
+				return err
+			}
+			if pivoted {
+				fmt.Fprintln(cmd.ErrOrStderr(), "Terraform state migrated to local; running teardown against local state.")
 			}
 			var summary *provisioner.DestroyPlanSummary
 			if err := tui.WithProgress("Generating destroy plan...", func() error {
@@ -233,6 +262,15 @@ windsor destroy terraform --confirm=local`,
 
 		componentID := args[0]
 		if err := requireCloudAuth(cmd, proj); err != nil {
+			return err
+		}
+		// Targeted destroy: if the kubernetes backend's cluster is gone, operate on the local state a prior
+		// teardown migrated; otherwise refuse a backend-tier member (destroying it while its backend is live
+		// would orphan every other component's state) before the plan surfaces a raw init error.
+		if _, err := proj.Provisioner.PivotToLocalIfClusterGone(blueprint); err != nil {
+			return err
+		}
+		if err := proj.Provisioner.CheckComponentDestroyable(blueprint, componentID); err != nil {
 			return err
 		}
 		var tfResult terraforminfra.TerraformComponentPlan
@@ -268,7 +306,7 @@ var destroyKustomizeCmd = &cobra.Command{
 	Use:     "kustomize [name]",
 	Aliases: []string{"k8s"},
 	Short:   "Destroy Flux kustomization(s).",
-	Long: `Delete a specific Flux kustomization from the cluster, or all kustomizations when no argument is given. Inherits --confirm from the parent 'destroy' command.`,
+	Long:    `Delete a specific Flux kustomization from the cluster, or all kustomizations when no argument is given. Inherits --confirm from the parent 'destroy' command.`,
 	Example: `# Delete a single kustomization
 windsor destroy kustomize dns --confirm=dns
 
@@ -276,7 +314,7 @@ windsor destroy kustomize dns --confirm=dns
 windsor destroy kustomize --confirm=local`,
 	Annotations: map[string]string{
 		"docs.seealso": "[`destroy`](destroy.md), [`apply kustomize`](apply-kustomize.md), [`plan kustomize`](plan-kustomize.md)",
-		"docs.source": "cmd/destroy.go",
+		"docs.source":  "cmd/destroy.go",
 	},
 	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -132,7 +132,7 @@ windsor destroy --confirm=local --continue`,
 			// migrated; otherwise refuse a backend-tier component up front, before the plan runs terraform
 			// init against the kubernetes backend — the operator gets the clean "run windsor destroy"
 			// guidance instead of a raw init connection error.
-			if _, err := proj.Provisioner.PivotToLocalIfClusterGone(blueprint); err != nil {
+			if _, err := proj.Provisioner.PivotToLocalIfClusterGone(); err != nil {
 				return err
 			}
 			if err := proj.Provisioner.CheckComponentDestroyable(blueprint, componentID); err != nil {
@@ -267,7 +267,7 @@ windsor destroy terraform --confirm=local`,
 		// Targeted destroy: if the kubernetes backend's cluster is gone, operate on the local state a prior
 		// teardown migrated; otherwise refuse a backend-tier member (destroying it while its backend is live
 		// would orphan every other component's state) before the plan surfaces a raw init error.
-		if _, err := proj.Provisioner.PivotToLocalIfClusterGone(blueprint); err != nil {
+		if _, err := proj.Provisioner.PivotToLocalIfClusterGone(); err != nil {
 			return err
 		}
 		if err := proj.Provisioner.CheckComponentDestroyable(blueprint, componentID); err != nil {

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -79,13 +79,10 @@ windsor destroy --confirm=local --continue`,
 			}
 			// For a kubernetes backend, pull all terraform state to local and pivot the whole teardown to a
 			// local backend up front — before planning — so no step (plan or destroy) dials the kubernetes
-			// backend that this teardown is about to destroy.
-			pivoted, err := proj.Provisioner.PrepareLocalTeardown(blueprint)
-			if err != nil {
+			// backend that this teardown is about to destroy. The "Migrating terraform state" progress line
+			// already signals the migration, so no extra note is printed here.
+			if _, err := proj.Provisioner.PrepareLocalTeardown(blueprint); err != nil {
 				return err
-			}
-			if pivoted {
-				fmt.Fprintln(cmd.ErrOrStderr(), "Terraform state migrated to local; running teardown against local state.")
 			}
 			var summary *provisioner.DestroyPlanSummary
 			if err := tui.WithProgress("Generating destroy plan...", func() error {
@@ -225,13 +222,10 @@ windsor destroy terraform --confirm=local`,
 				return err
 			}
 			// Destroying every terraform component: pull state to local and pivot up front, like the full
-			// teardown, so the plan and destroy never dial the kubernetes backend being torn down.
-			pivoted, err := proj.Provisioner.PrepareLocalTeardown(blueprint)
-			if err != nil {
+			// teardown, so the plan and destroy never dial the kubernetes backend being torn down. The
+			// "Migrating terraform state" progress line already signals the migration.
+			if _, err := proj.Provisioner.PrepareLocalTeardown(blueprint); err != nil {
 				return err
-			}
-			if pivoted {
-				fmt.Fprintln(cmd.ErrOrStderr(), "Terraform state migrated to local; running teardown against local state.")
 			}
 			var summary *provisioner.DestroyPlanSummary
 			if err := tui.WithProgress("Generating destroy plan...", func() error {

--- a/pkg/provisioner/destroy.go
+++ b/pkg/provisioner/destroy.go
@@ -149,12 +149,17 @@ func (i *Provisioner) PrepareLocalTeardown(blueprint *blueprintv1alpha1.Blueprin
 		return false, nil
 	}
 
+	// The pivot must precede MigrateState — it migrates to the currently-configured backend, so the backend
+	// has to read local for state to move to local. On the abort path (a real migration failure while the
+	// cluster is reachable) the pivot is reverted, so a caller that continues does not read a local backend
+	// with no migrated state behind it and destroy against emptiness.
 	if err := i.configHandler.Set("terraform.backend.type", "local"); err != nil {
 		return false, fmt.Errorf("failed to pivot terraform backend to local for teardown: %w", err)
 	}
 
 	if _, err := i.MigrateState(blueprint); err != nil {
 		if i.clusterReachableForTeardown() {
+			_ = i.configHandler.Set("terraform.backend.type", backendType)
 			return false, fmt.Errorf("failed to migrate terraform state to local before teardown: %w", err)
 		}
 	}
@@ -169,7 +174,7 @@ func (i *Provisioner) PrepareLocalTeardown(blueprint *blueprintv1alpha1.Blueprin
 // destroyed locally while the rest still read kubernetes would drift), so it operates on kubernetes while
 // the cluster is up and on the already-migrated local state once the cluster is gone. A reachable cluster or
 // non-kubernetes backend is a no-op. Returns whether it pivoted.
-func (i *Provisioner) PivotToLocalIfClusterGone(blueprint *blueprintv1alpha1.Blueprint) (bool, error) {
+func (i *Provisioner) PivotToLocalIfClusterGone() (bool, error) {
 	backendType := i.configHandler.GetString("terraform.backend.type", "local")
 	if backendType == "" || backendType == "local" {
 		return false, nil

--- a/pkg/provisioner/destroy.go
+++ b/pkg/provisioner/destroy.go
@@ -114,11 +114,84 @@ func (i *Provisioner) Teardown(blueprint *blueprintv1alpha1.Blueprint, terraform
 // would orphan their state. Use `windsor destroy` (no arguments) for the
 // full-cycle teardown.
 func (i *Provisioner) TeardownComponent(blueprint *blueprintv1alpha1.Blueprint, componentID string) (bool, error) {
-	backendType := i.configHandler.GetString("terraform.backend.type", "local")
-	if backendType != "" && backendType != "local" && blueprint.IsBackendTierMember(componentID) {
-		return false, fmt.Errorf("cannot destroy backend-tier component %q in isolation: its state provides the %s backend that every other component uses, so destroying it directly would orphan their state. Run `windsor destroy` (no arguments) for the full-cycle teardown that migrates state to local first", componentID, backendType)
+	if err := i.CheckComponentDestroyable(blueprint, componentID); err != nil {
+		return false, err
 	}
 	return i.Destroy(blueprint, componentID)
+}
+
+// CheckComponentDestroyable reports whether a single terraform component may be destroyed in isolation.
+// On a non-local backend a backend-tier member is refused: its state provides the backend every other
+// component uses, so destroying it directly would orphan their state. Callers run this before generating a
+// destroy plan so the refusal is surfaced up front, rather than as a raw terraform init error when the
+// component tries to reach a kubernetes backend whose cluster may already be gone.
+func (i *Provisioner) CheckComponentDestroyable(blueprint *blueprintv1alpha1.Blueprint, componentID string) error {
+	backendType := i.configHandler.GetString("terraform.backend.type", "local")
+	if backendType != "" && backendType != "local" && blueprint.IsBackendTierMember(componentID) {
+		return fmt.Errorf("cannot destroy backend-tier component %q in isolation: its state provides the %s backend that every other component uses, so destroying it directly would orphan their state. Run `windsor destroy` (no arguments) for the full-cycle teardown that migrates state to local first", componentID, backendType)
+	}
+	return nil
+}
+
+// PrepareLocalTeardown makes a kubernetes-backend teardown operate entirely against local state. Because
+// the kubernetes backend stores state on the cluster the teardown is about to destroy, this pulls every
+// component's state to local up front — while the cluster still hosts the backend — and pivots
+// terraform.backend.type to local for the rest of the process. From that point the destroy plan and every
+// component destroy read local state, never dialing a backend that is going away, so "the cluster is gone"
+// can no longer strand the teardown. The pivot is unconditional for a kubernetes backend; reachability is
+// consulted only to classify a migration failure: while the cluster is still reachable a failure is real —
+// destroying now would run against empty local state and orphan resources, so it aborts — but once the
+// cluster is gone (a resumed teardown) the state was already migrated on the earlier pass and is the local
+// copy, so it proceeds against it. Returns whether it pivoted; a non-kubernetes backend is a no-op.
+func (i *Provisioner) PrepareLocalTeardown(blueprint *blueprintv1alpha1.Blueprint) (bool, error) {
+	backendType := i.configHandler.GetString("terraform.backend.type", "local")
+	if backendType == "" || backendType == "local" {
+		return false, nil
+	}
+
+	if err := i.configHandler.Set("terraform.backend.type", "local"); err != nil {
+		return false, fmt.Errorf("failed to pivot terraform backend to local for teardown: %w", err)
+	}
+
+	if _, err := i.MigrateState(blueprint); err != nil {
+		if i.clusterReachableForTeardown() {
+			return false, fmt.Errorf("failed to migrate terraform state to local before teardown: %w", err)
+		}
+	}
+	return true, nil
+}
+
+// PivotToLocalIfClusterGone pivots terraform.backend.type to local for the rest of the process when the
+// kubernetes backend's cluster is gone (no kubeconfig) or unreachable. Unlike PrepareLocalTeardown it does
+// not migrate — the state is already the local copy a prior full teardown pulled off the cluster before
+// destroying it — it only redirects reads to that copy. This is the targeted-destroy counterpart: a single
+// component destroy cannot migrate everything to local without stranding the cluster-up case (one component
+// destroyed locally while the rest still read kubernetes would drift), so it operates on kubernetes while
+// the cluster is up and on the already-migrated local state once the cluster is gone. A reachable cluster or
+// non-kubernetes backend is a no-op. Returns whether it pivoted.
+func (i *Provisioner) PivotToLocalIfClusterGone(blueprint *blueprintv1alpha1.Blueprint) (bool, error) {
+	backendType := i.configHandler.GetString("terraform.backend.type", "local")
+	if backendType == "" || backendType == "local" {
+		return false, nil
+	}
+	if i.clusterReachableForTeardown() {
+		return false, nil
+	}
+	if err := i.configHandler.Set("terraform.backend.type", "local"); err != nil {
+		return false, fmt.Errorf("failed to pivot terraform backend to local for teardown: %w", err)
+	}
+	return true, nil
+}
+
+// clusterReachableForTeardown reports whether the cluster hosting the kubernetes backend is present and
+// reachable. It is used to classify a state-migration failure during teardown preparation: a real error
+// while the cluster is up versus the expected resume case where the cluster is already gone and the state
+// is already the local copy.
+func (i *Provisioner) clusterReachableForTeardown() bool {
+	if !i.kubeconfigPresent() {
+		return false
+	}
+	return i.checkKubernetesReachableForDestroy() == nil
 }
 
 // =============================================================================

--- a/pkg/provisioner/destroy_test.go
+++ b/pkg/provisioner/destroy_test.go
@@ -64,7 +64,6 @@ func TestProvisioner_CheckComponentDestroyable(t *testing.T) {
 }
 
 func TestProvisioner_PivotToLocalIfClusterGone(t *testing.T) {
-	bp := &blueprintv1alpha1.Blueprint{Backend: "cluster", TerraformComponents: []blueprintv1alpha1.TerraformComponent{{Name: "cluster"}}}
 	kubernetesBackend := func(mocks *ProvisionerTestMocks, set *bool) {
 		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
 		mockCH.GetStringFunc = func(key string, dv ...string) string {
@@ -93,7 +92,7 @@ func TestProvisioner_PivotToLocalIfClusterGone(t *testing.T) {
 		prov.configRoot = t.TempDir()
 
 		// When checking, it pivots to local without migrating
-		pivoted, err := prov.PivotToLocalIfClusterGone(bp)
+		pivoted, err := prov.PivotToLocalIfClusterGone()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -116,7 +115,7 @@ func TestProvisioner_PivotToLocalIfClusterGone(t *testing.T) {
 		prov := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
 		prov.configRoot = dir
 
-		pivoted, err := prov.PivotToLocalIfClusterGone(bp)
+		pivoted, err := prov.PivotToLocalIfClusterGone()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -132,7 +131,7 @@ func TestProvisioner_PivotToLocalIfClusterGone(t *testing.T) {
 		prov := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{})
 		prov.configRoot = t.TempDir()
 
-		pivoted, err := prov.PivotToLocalIfClusterGone(bp)
+		pivoted, err := prov.PivotToLocalIfClusterGone()
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -204,11 +203,26 @@ func TestProvisioner_PrepareLocalTeardown(t *testing.T) {
 		}
 	})
 
-	t.Run("AbortsOnMigrationFailureWhileClusterReachable", func(t *testing.T) {
+	t.Run("AbortsAndRevertsPivotOnMigrationFailureWhileClusterReachable", func(t *testing.T) {
 		// Given a migration failure while the cluster is still up — destroying now would orphan resources
 		mocks := setupProvisionerMocks(t)
-		set := false
-		kubernetesBackend(mocks, &set)
+		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockCH.GetStringFunc = func(key string, dv ...string) string {
+			if key == "terraform.backend.type" {
+				return "kubernetes"
+			}
+			if len(dv) > 0 {
+				return dv[0]
+			}
+			return ""
+		}
+		var sets []string
+		mockCH.SetFunc = func(key string, value any) error {
+			if key == "terraform.backend.type" {
+				sets = append(sets, fmt.Sprintf("%v", value))
+			}
+			return nil
+		}
 		mockStack := terraforminfra.NewMockStack()
 		mockStack.MigrateStateFunc = func(_ *blueprintv1alpha1.Blueprint) ([]string, error) {
 			return nil, fmt.Errorf("boom")
@@ -222,10 +236,14 @@ func TestProvisioner_PrepareLocalTeardown(t *testing.T) {
 		prov := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack, KubernetesManager: mocks.KubernetesManager})
 		prov.configRoot = dir
 
-		// When preparing, the failure aborts rather than proceeding against empty local state
+		// When preparing, it aborts and reverts the pivot so nothing later reads a local backend with no
+		// migrated state behind it
 		_, err := prov.PrepareLocalTeardown(bp)
 		if err == nil || !strings.Contains(err.Error(), "migrate terraform state") {
 			t.Errorf("expected abort on migration failure with cluster up, got %v", err)
+		}
+		if len(sets) != 2 || sets[0] != "local" || sets[1] != "kubernetes" {
+			t.Errorf("expected pivot to local then revert to kubernetes, got %v", sets)
 		}
 	})
 

--- a/pkg/provisioner/destroy_test.go
+++ b/pkg/provisioner/destroy_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -12,6 +13,244 @@ import (
 	terraforminfra "github.com/windsorcli/cli/pkg/provisioner/terraform"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 )
+
+func TestProvisioner_CheckComponentDestroyable(t *testing.T) {
+	bp := &blueprintv1alpha1.Blueprint{
+		Backend: "cluster",
+		TerraformComponents: []blueprintv1alpha1.TerraformComponent{
+			{Name: "compute", Path: "compute/hcloud"},
+			{Name: "cluster", Path: "cluster/talos"},
+			{Name: "dns", Path: "dns/zone/hetzner"},
+		},
+	}
+	kubernetesBackend := func(mocks *ProvisionerTestMocks) {
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetStringFunc = func(key string, dv ...string) string {
+			if key == "terraform.backend.type" {
+				return "kubernetes"
+			}
+			if len(dv) > 0 {
+				return dv[0]
+			}
+			return ""
+		}
+	}
+
+	t.Run("RefusesBackendTierMemberOnKubernetesBackend", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		kubernetesBackend(mocks)
+		prov := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{})
+		err := prov.CheckComponentDestroyable(bp, "compute")
+		if err == nil || !strings.Contains(err.Error(), "backend-tier") {
+			t.Errorf("expected refusal naming backend-tier, got %v", err)
+		}
+	})
+
+	t.Run("AllowsNonTierMemberOnKubernetesBackend", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		kubernetesBackend(mocks)
+		prov := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{})
+		if err := prov.CheckComponentDestroyable(bp, "dns"); err != nil {
+			t.Errorf("expected non-tier member allowed, got %v", err)
+		}
+	})
+
+	t.Run("AllowsBackendTierMemberOnLocalBackend", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		prov := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{})
+		if err := prov.CheckComponentDestroyable(bp, "compute"); err != nil {
+			t.Errorf("expected local backend to allow any component, got %v", err)
+		}
+	})
+}
+
+func TestProvisioner_PivotToLocalIfClusterGone(t *testing.T) {
+	bp := &blueprintv1alpha1.Blueprint{Backend: "cluster", TerraformComponents: []blueprintv1alpha1.TerraformComponent{{Name: "cluster"}}}
+	kubernetesBackend := func(mocks *ProvisionerTestMocks, set *bool) {
+		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockCH.GetStringFunc = func(key string, dv ...string) string {
+			if key == "terraform.backend.type" {
+				return "kubernetes"
+			}
+			if len(dv) > 0 {
+				return dv[0]
+			}
+			return ""
+		}
+		mockCH.SetFunc = func(key string, _ any) error {
+			if key == "terraform.backend.type" {
+				*set = true
+			}
+			return nil
+		}
+	}
+
+	t.Run("PivotsWhenKubeconfigAbsent", func(t *testing.T) {
+		// Given a kubernetes backend and no kubeconfig — the cluster is gone, state is already local
+		mocks := setupProvisionerMocks(t)
+		set := false
+		kubernetesBackend(mocks, &set)
+		prov := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{})
+		prov.configRoot = t.TempDir()
+
+		// When checking, it pivots to local without migrating
+		pivoted, err := prov.PivotToLocalIfClusterGone(bp)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !pivoted || !set {
+			t.Errorf("expected pivot to local when kubeconfig absent, pivoted=%v set=%v", pivoted, set)
+		}
+	})
+
+	t.Run("DoesNotPivotWhenClusterReachable", func(t *testing.T) {
+		// Given a kubernetes backend, present kubeconfig, reachable cluster (first-run targeted destroy)
+		mocks := setupProvisionerMocks(t)
+		set := false
+		kubernetesBackend(mocks, &set)
+		dir := t.TempDir()
+		_ = os.MkdirAll(filepath.Join(dir, ".kube"), 0o755)
+		_ = os.WriteFile(filepath.Join(dir, ".kube", "config"), []byte("x"), 0o644)
+		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, out func(string), nodes ...string) error {
+			return nil
+		}
+		prov := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+		prov.configRoot = dir
+
+		pivoted, err := prov.PivotToLocalIfClusterGone(bp)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if pivoted || set {
+			t.Errorf("expected no pivot when cluster reachable, pivoted=%v set=%v", pivoted, set)
+		}
+	})
+
+	t.Run("NoOpOnLocalBackend", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		set := false
+		mocks.ConfigHandler.(*config.MockConfigHandler).SetFunc = func(_ string, _ any) error { set = true; return nil }
+		prov := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{})
+		prov.configRoot = t.TempDir()
+
+		pivoted, err := prov.PivotToLocalIfClusterGone(bp)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if pivoted || set {
+			t.Errorf("expected no pivot on local backend, pivoted=%v set=%v", pivoted, set)
+		}
+	})
+}
+
+func TestProvisioner_PrepareLocalTeardown(t *testing.T) {
+	bp := &blueprintv1alpha1.Blueprint{Backend: "cluster", TerraformComponents: []blueprintv1alpha1.TerraformComponent{{Name: "cluster", Path: "cluster/talos"}}}
+	kubernetesBackend := func(mocks *ProvisionerTestMocks, set *bool) {
+		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockCH.GetStringFunc = func(key string, dv ...string) string {
+			if key == "terraform.backend.type" {
+				return "kubernetes"
+			}
+			if len(dv) > 0 {
+				return dv[0]
+			}
+			return ""
+		}
+		mockCH.SetFunc = func(key string, _ any) error {
+			if key == "terraform.backend.type" {
+				*set = true
+			}
+			return nil
+		}
+	}
+
+	t.Run("PivotsToLocalAndMigratesUpFront", func(t *testing.T) {
+		// Given a kubernetes backend and a migration that succeeds (cluster up, first-run teardown)
+		mocks := setupProvisionerMocks(t)
+		set := false
+		kubernetesBackend(mocks, &set)
+		migrated := false
+		mockStack := terraforminfra.NewMockStack()
+		mockStack.MigrateStateFunc = func(_ *blueprintv1alpha1.Blueprint) ([]string, error) {
+			migrated = true
+			return nil, nil
+		}
+		prov := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+
+		// When preparing, it pivots the backend to local and migrates state up front
+		pivoted, err := prov.PrepareLocalTeardown(bp)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !pivoted || !set || !migrated {
+			t.Errorf("expected pivot + migration, pivoted=%v set=%v migrated=%v", pivoted, set, migrated)
+		}
+	})
+
+	t.Run("NoOpOnLocalBackend", func(t *testing.T) {
+		mocks := setupProvisionerMocks(t)
+		set := false
+		mocks.ConfigHandler.(*config.MockConfigHandler).SetFunc = func(_ string, _ any) error { set = true; return nil }
+		migrated := false
+		mockStack := terraforminfra.NewMockStack()
+		mockStack.MigrateStateFunc = func(_ *blueprintv1alpha1.Blueprint) ([]string, error) { migrated = true; return nil, nil }
+		prov := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+
+		pivoted, err := prov.PrepareLocalTeardown(bp)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if pivoted || set || migrated {
+			t.Errorf("expected no-op on local backend, pivoted=%v set=%v migrated=%v", pivoted, set, migrated)
+		}
+	})
+
+	t.Run("AbortsOnMigrationFailureWhileClusterReachable", func(t *testing.T) {
+		// Given a migration failure while the cluster is still up — destroying now would orphan resources
+		mocks := setupProvisionerMocks(t)
+		set := false
+		kubernetesBackend(mocks, &set)
+		mockStack := terraforminfra.NewMockStack()
+		mockStack.MigrateStateFunc = func(_ *blueprintv1alpha1.Blueprint) ([]string, error) {
+			return nil, fmt.Errorf("boom")
+		}
+		dir := t.TempDir()
+		_ = os.MkdirAll(filepath.Join(dir, ".kube"), 0o755)
+		_ = os.WriteFile(filepath.Join(dir, ".kube", "config"), []byte("x"), 0o644)
+		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, out func(string), nodes ...string) error {
+			return nil
+		}
+		prov := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack, KubernetesManager: mocks.KubernetesManager})
+		prov.configRoot = dir
+
+		// When preparing, the failure aborts rather than proceeding against empty local state
+		_, err := prov.PrepareLocalTeardown(bp)
+		if err == nil || !strings.Contains(err.Error(), "migrate terraform state") {
+			t.Errorf("expected abort on migration failure with cluster up, got %v", err)
+		}
+	})
+
+	t.Run("ProceedsOnMigrationFailureWhenClusterGone", func(t *testing.T) {
+		// Given a migration failure but the cluster is already gone (resume) — state is already local
+		mocks := setupProvisionerMocks(t)
+		set := false
+		kubernetesBackend(mocks, &set)
+		mockStack := terraforminfra.NewMockStack()
+		mockStack.MigrateStateFunc = func(_ *blueprintv1alpha1.Blueprint) ([]string, error) {
+			return nil, fmt.Errorf("dial tcp: connection refused")
+		}
+		prov := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+		prov.configRoot = t.TempDir() // no kubeconfig → cluster gone
+
+		// When preparing, it pivots and proceeds against the already-migrated local state
+		pivoted, err := prov.PrepareLocalTeardown(bp)
+		if err != nil {
+			t.Fatalf("expected resume to proceed, got %v", err)
+		}
+		if !pivoted || !set {
+			t.Errorf("expected pivot on resume, pivoted=%v set=%v", pivoted, set)
+		}
+	})
+}
 
 // =============================================================================
 // Test Public Methods
@@ -501,7 +740,9 @@ func TestProvisioner_Teardown(t *testing.T) {
 			return nil
 		}
 		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyOutcome, error) { return terraforminfra.DestroyOutcome{}, nil }
+		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyOutcome, error) {
+			return terraforminfra.DestroyOutcome{}, nil
+		}
 		mockStack.MigrateStateFunc = func(_ *blueprintv1alpha1.Blueprint) ([]string, error) { return nil, nil }
 
 		r, w, pipeErr := os.Pipe()


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This change touches terraform state migration during kubernetes backend teardown — an operation where mistakes can silently orphan cloud resources — but the logic is well-scoped to the kubernetes backend path and does not affect local or other backend types.
>
> **Overview**
>
> The PR fixes a class of teardown failures where `windsor destroy` would attempt to reach a kubernetes backend that the teardown itself is in the process of eliminating. It introduces `PrepareLocalTeardown`, which migrates all terraform state from the kubernetes backend to local storage before any plan or destroy step runs, and `PivotToLocalIfClusterGone`, which redirects targeted single-component destroys to the already-migrated local state when the cluster is no longer reachable. A third helper, `CheckComponentDestroyable`, is extracted from `TeardownComponent` and surfaced at the cmd layer so the backend-tier isolation check fires before a plan is generated rather than as a raw terraform init error.
>
> All three new paths are exercised by dedicated table-driven tests covering the cluster-up, cluster-gone, and migration-failure branches. The cmd layer wires the two entry points (full destroy and `destroy terraform`) symmetrically, and a user-visible message on stderr confirms when state has been migrated.
>
> Reviewed by Claude for commit `6bc57dce`.

<!-- /claude-code-review:summary -->
