### PR TITLE
fix(provisioner): log omitted optional keys and dropped secrets in verbose mode

### DIFF
--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -1043,8 +1043,10 @@ type ResolvedSecret struct {
 // default, since a required key that resolves away is misconfiguration and silently dropping it strands a
 // downstream consumer with a missing key. Adding a ?? default marks the key optional and omits it. A
 // secret whose keys all resolve away is not created at all, so an optional secret leaves no empty Secret
-// behind. The result is keyed by owning kustomization
-// for PlaceSecrets to materialize post-Install; it is empty when no kustomization declares Secrets.
+// behind. Both omissions are logged in verbose mode, naming the secret, key, and reference, so a Secret
+// or key missing in-cluster is traceable to the reference that resolved away. The result is keyed by
+// owning kustomization for PlaceSecrets to materialize post-Install; it is empty when no kustomization
+// declares Secrets.
 func (i *Provisioner) ResolveSecrets(blueprint *blueprintv1alpha1.Blueprint) (ResolvedSecrets, error) {
 	if blueprint == nil {
 		return nil, fmt.Errorf("blueprint not provided")
@@ -1069,6 +1071,9 @@ func (i *Provisioner) ResolveSecrets(blueprint *blueprintv1alpha1.Blueprint) (Re
 				}
 				if s == "" {
 					if strings.Contains(ref, "??") {
+						if i.shell.IsVerbose() {
+							fmt.Fprintf(os.Stderr, "secret %q key %q: reference %q resolved to nothing; key omitted\n", secretName, key, ref)
+						}
 						continue
 					}
 					return nil, fmt.Errorf("resolving secret %q key %q: reference %q resolved to empty; add a ?? default (e.g. %q) to make the key optional", secretName, key, ref, "${... ?? ''}")
@@ -1079,14 +1084,18 @@ func (i *Provisioner) ResolveSecrets(blueprint *blueprintv1alpha1.Blueprint) (Re
 				i.shell.RegisterSecret(s)
 				stringData[key] = s
 			}
-			if len(stringData) > 0 {
-				if resolved[k.Name] == nil {
-					resolved[k.Name] = make(map[string]ResolvedSecret)
+			if len(stringData) == 0 {
+				if len(entry.Data) > 0 && i.shell.IsVerbose() {
+					fmt.Fprintf(os.Stderr, "secret %q: every key resolved to nothing; secret not created\n", secretName)
 				}
-				resolved[k.Name][secretName] = ResolvedSecret{
-					Namespaces: slices.Clone(entry.Namespaces),
-					Data:       stringData,
-				}
+				continue
+			}
+			if resolved[k.Name] == nil {
+				resolved[k.Name] = make(map[string]ResolvedSecret)
+			}
+			resolved[k.Name][secretName] = ResolvedSecret{
+				Namespaces: slices.Clone(entry.Namespaces),
+				Data:       stringData,
 			}
 		}
 	}

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -3,6 +3,7 @@ package provisioner
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -4581,6 +4582,21 @@ func TestProvisioner_ResolveSecrets(t *testing.T) {
 	entry := func(data map[string]string) blueprintv1alpha1.SecretEntry {
 		return blueprintv1alpha1.SecretEntry{Data: data}
 	}
+	captureStderr := func(t *testing.T, fn func()) string {
+		t.Helper()
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("Pipe failed: %v", err)
+		}
+		orig := os.Stderr
+		os.Stderr = w
+		fn()
+		os.Stderr = orig
+		w.Close()
+		out, _ := io.ReadAll(r)
+		r.Close()
+		return string(out)
+	}
 
 	t.Run("ResolvesValueKeyedByKustomization", func(t *testing.T) {
 		// Given a resolvable reference
@@ -4682,6 +4698,56 @@ func TestProvisioner_ResolveSecrets(t *testing.T) {
 		}
 		if len(resolved) != 0 {
 			t.Errorf("Expected no secret from nil-resolving optional reference, got %v", resolved)
+		}
+	})
+
+	t.Run("LogsOmittedOptionalKeyAndDroppedSecretInVerboseMode", func(t *testing.T) {
+		// Given an optional reference to a value absent from configuration, and verbose mode
+		mocks := setupProvisionerMocks(t)
+		withValues(mocks, map[string]any{})
+		mocks.Shell.IsVerboseFunc = func() bool { return true }
+
+		// When resolving
+		var resolved ResolvedSecrets
+		var err error
+		out := captureStderr(t, func() {
+			resolved, err = newProvisioner(mocks).ResolveSecrets(bp(map[string]blueprintv1alpha1.SecretEntry{"creds": entry(map[string]string{"token": "${hetzner.token ?? ''}"})}))
+		})
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if len(resolved) != 0 {
+			t.Errorf("Expected no secret from an optional reference resolving to nothing, got %v", resolved)
+		}
+
+		// Then both the omitted key and the dropped secret are named, so the missing Secret is
+		// traceable to the reference that resolved away
+		if !strings.Contains(out, `key "token"`) || !strings.Contains(out, `${hetzner.token ?? ''}`) {
+			t.Errorf("Expected the omitted key and its reference to be logged, got %q", out)
+		}
+		if !strings.Contains(out, "secret not created") {
+			t.Errorf("Expected the dropped secret to be logged, got %q", out)
+		}
+	})
+
+	t.Run("StaysSilentAboutOmissionsWhenNotVerbose", func(t *testing.T) {
+		// Given the same optional reference resolving to nothing, without verbose mode
+		mocks := setupProvisionerMocks(t)
+		withValues(mocks, map[string]any{})
+		mocks.Shell.IsVerboseFunc = func() bool { return false }
+
+		// When resolving
+		var err error
+		out := captureStderr(t, func() {
+			_, err = newProvisioner(mocks).ResolveSecrets(bp(map[string]blueprintv1alpha1.SecretEntry{"creds": entry(map[string]string{"token": "${hetzner.token ?? ''}"})}))
+		})
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then nothing is printed, keeping normal output free of routine optional-key omissions
+		if out != "" {
+			t.Errorf("Expected no output without verbose mode, got %q", out)
 		}
 	})
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Isolated diagnostic improvement to a single provisioner code path; only activates under `--verbose` and emits no secret values.
>
> **Overview**
>
> This fix adds a verbose-mode log line when a secret key reference resolves to `nil` during `ResolveSecrets`. Previously, nil-resolving references (where a config path is absent) were silently dropped; now the secret name, key, and reference path are printed to stderr so a typo'd path is diagnosable without enabling full debug tracing. A new unit test captures stderr via pipe to verify the message appears only when `IsVerbose()` returns true.
>
> The change is purely additive: non-verbose behavior is unchanged, no secret values are ever logged (the nil branch means no value exists), and the affected code path is confined to the provisioner package.
>
> Reviewed by Claude for commit `89a4cc1f`.

<!-- /claude-code-review:summary -->
