### PR TITLE
fix(provisioner): enforce failure on required secrets resolving to nil and adjust test cases

### DIFF
--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -1038,12 +1038,12 @@ type ResolvedSecret struct {
 // ResolveSecrets resolves every flux system's declared Secrets to plaintext ahead of Install, so a
 // misconfigured secret fails the command before anything is applied to the cluster. For each compiled
 // kustomization carrying Secrets it evaluates each data reference (the evaluator registers resolved
-// values with the shell scrubber). A reference that resolves to nil — the value is absent from
-// configuration — is treated as unconfigured and its key is omitted, since a secret the user never set
-// is not misconfiguration. A reference that resolves to an empty string fails closed unless it carries a
-// "??" default, since a present-but-blank value is misconfiguration; adding a ?? default makes such a
-// key optional and omits it. A secret whose keys all resolve away is not created at all, so an
-// unconfigured optional secret leaves no empty Secret behind. The result is keyed by owning kustomization
+// values with the shell scrubber). A reference that resolves to nothing — nil (absent from configuration
+// or a secret() lookup that failed to resolve) or an empty string — fails closed unless it carries a "??"
+// default, since a required key that resolves away is misconfiguration and silently dropping it strands a
+// downstream consumer with a missing key. Adding a ?? default marks the key optional and omits it. A
+// secret whose keys all resolve away is not created at all, so an optional secret leaves no empty Secret
+// behind. The result is keyed by owning kustomization
 // for PlaceSecrets to materialize post-Install; it is empty when no kustomization declares Secrets.
 func (i *Provisioner) ResolveSecrets(blueprint *blueprintv1alpha1.Blueprint) (ResolvedSecrets, error) {
 	if blueprint == nil {
@@ -1063,10 +1063,10 @@ func (i *Provisioner) ResolveSecrets(blueprint *blueprintv1alpha1.Blueprint) (Re
 				if err != nil {
 					return nil, fmt.Errorf("resolving secret %q key %q: %w", secretName, key, err)
 				}
-				if value == nil {
-					continue
+				s := ""
+				if value != nil {
+					s = fmt.Sprint(value)
 				}
-				s := fmt.Sprint(value)
 				if s == "" {
 					if strings.Contains(ref, "??") {
 						continue

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -1943,8 +1943,9 @@ func TestProvisioner_Install(t *testing.T) {
 		}
 	})
 
-	t.Run("OmitsUnconfiguredNilSecretWithoutFailing", func(t *testing.T) {
-		// Given a secret reference to a value absent from configuration (resolves to nil)
+	t.Run("FailsWhenRequiredSecretResolvesToNil", func(t *testing.T) {
+		// Given a required secret reference to a value absent from configuration (resolves to nil), as
+		// when a secret() lookup fails to resolve non-interactively
 		mocks := setupProvisionerMocks(t)
 		mocks.ConfigHandler.(*config.MockConfigHandler).GetContextValuesFunc = func() (map[string]any, error) {
 			return map[string]any{}, nil
@@ -1962,12 +1963,40 @@ func TestProvisioner_Install(t *testing.T) {
 			}},
 		}}
 
-		// When installing, the unconfigured secret is skipped and install still succeeds
+		// When installing, it fails closed rather than placing an hcloud Secret missing its token key
+		if err := provisioner.Install(context.Background(), blueprint, false); err == nil {
+			t.Fatal("Expected error for a nil-resolving required secret, got nil")
+		}
+		if placed {
+			t.Error("Expected no secret placed for a nil-resolving reference")
+		}
+	})
+
+	t.Run("OmitsUnconfiguredOptionalSecretWithoutFailing", func(t *testing.T) {
+		// Given an optional secret reference (?? default) to a value absent from configuration
+		mocks := setupProvisionerMocks(t)
+		mocks.ConfigHandler.(*config.MockConfigHandler).GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{}, nil
+		}
+		mocks.KubernetesManager.ApplyBlueprintFunc = func(*blueprintv1alpha1.Blueprint, string) error { return nil }
+		placed := false
+		mocks.KubernetesManager.ApplySecretFunc = func(name, namespace string, stringData map[string]string, owner string) error {
+			placed = true
+			return nil
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager})
+		blueprint := &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{
+			{Name: "lb-install", Secrets: map[string]blueprintv1alpha1.SecretEntry{
+				"hcloud": {Data: map[string]string{"token": "${hetzner.token ?? ''}"}},
+			}},
+		}}
+
+		// When installing, the optional secret is skipped and install still succeeds
 		if err := provisioner.Install(context.Background(), blueprint, false); err != nil {
 			t.Fatalf("Expected no error, got: %v", err)
 		}
 		if placed {
-			t.Error("Expected no secret placed for a nil-resolving reference")
+			t.Error("Expected no secret placed for a nil-resolving optional reference")
 		}
 	})
 }
@@ -4570,18 +4599,31 @@ func TestProvisioner_ResolveSecrets(t *testing.T) {
 		}
 	})
 
-	t.Run("OmitsKeyWhenReferenceResolvesToNil", func(t *testing.T) {
-		// Given a reference to a value absent from configuration (resolves to nil)
+	t.Run("FailsWhenRequiredReferenceResolvesToNil", func(t *testing.T) {
+		// Given a required reference to a value absent from configuration (resolves to nil), as when a
+		// secret() lookup fails to resolve and coalesces to nil
 		mocks := setupProvisionerMocks(t)
 		withValues(mocks, map[string]any{})
 
-		// When resolving, the unconfigured key is omitted and the wholly-empty secret is dropped
-		resolved, err := newProvisioner(mocks).ResolveSecrets(bp(map[string]blueprintv1alpha1.SecretEntry{"creds": entry(map[string]string{"token": "${hetzner.token}"})}))
+		// When resolving, it fails closed rather than silently dropping the key
+		_, err := newProvisioner(mocks).ResolveSecrets(bp(map[string]blueprintv1alpha1.SecretEntry{"creds": entry(map[string]string{"token": "${hetzner.token}"})}))
+		if err == nil || !strings.Contains(err.Error(), "resolved to empty") {
+			t.Errorf("Expected nil-required error, got %v", err)
+		}
+	})
+
+	t.Run("OmitsNilOptionalKeyAndDropsWhollyEmptySecret", func(t *testing.T) {
+		// Given an optional reference (?? default) to a value absent from configuration
+		mocks := setupProvisionerMocks(t)
+		withValues(mocks, map[string]any{})
+
+		// When resolving, the optional key is omitted and the wholly-empty secret is dropped
+		resolved, err := newProvisioner(mocks).ResolveSecrets(bp(map[string]blueprintv1alpha1.SecretEntry{"creds": entry(map[string]string{"token": "${hetzner.token ?? ''}"})}))
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 		if len(resolved) != 0 {
-			t.Errorf("Expected no secret from nil-resolving reference, got %v", resolved)
+			t.Errorf("Expected no secret from nil-resolving optional reference, got %v", resolved)
 		}
 	})
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This PR changes secret-resolution behavior in the provisioner, so any existing blueprint that has a required (non-`??`) secret key that currently resolves to `nil` will now fail at `ResolveSecrets` time instead of silently passing — a visible behavioral break for affected users.
>
> **Overview**
>
> The PR tightens `ResolveSecrets` so that a required secret key resolving to `nil` (absent configuration or a failed `secret()` lookup) is now treated identically to a key resolving to an empty string: both fail closed with an actionable error pointing users toward the `??` default syntax. Previously, `nil` was silently skipped, which could leave downstream consumers with a Kubernetes Secret missing an expected key. The updated logic is a two-line restructure — initialize `s` to `""`, then only call `fmt.Sprint(value)` when `value != nil` — so the code is tight and correct.
>
> Tests are fully updated: the old `OmitsUnconfiguredNilSecretWithoutFailing` case is replaced by `FailsWhenRequiredSecretResolvesToNil`, and a new sibling test confirms that `??`-optional references still resolve without error and produce no empty Secret.
>
> Reviewed by Claude for commit `5cfe6b8c`.

<!-- /claude-code-review:summary -->
