### PR TITLE
fix(cmd/destroy): halt destroy on plan generation errors and update documentation

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -35,6 +35,8 @@ Every form requires confirmation. Either type the context or component name at t
 
 If terraform reports resources protected by 'lifecycle { prevent_destroy = true }', destroy warns up front so the operator knows the destroy may halt partway through. Resources whose state is empty are skipped with a warning naming any potentially orphaned cloud resources.
 
+If any component fails destroy-plan generation, destroy halts before the confirmation prompt and names the failed components, rather than offering to destroy a plan it cannot fully execute. This is distinct from --continue, which governs failures during execution, after confirmation.
+
 The default behavior is to abort on the first per-component destroy failure. Pass --continue to keep going past individual failures, collect them, and print a one-line summary at the end (windsor destroy: N destroyed, N no-op (empty state), N failed (...), backend tier deferred). --continue is layer-wide only and is refused when combined with a component argument — on a single component there is nothing to continue past. When --continue leaves any non-tier component un-destroyed, the backend tier is NOT attempted — this prevents destroying the state store while other components still depend on it. Rerun 'windsor destroy --continue' after resolving the underlying failures; the second pass picks up where the first left off and converges on a clean slate.`,
 	Example: `# Destroy everything in the current context (interactive)
 windsor destroy
@@ -95,6 +97,10 @@ windsor destroy --confirm=local --continue`,
 			tuiplan.DestroySummary(os.Stdout, summary.Terraform, summary.Kustomize, os.Getenv("NO_COLOR") != "")
 
 			warnPreventDestroy(cmd.ErrOrStderr(), summary.Terraform)
+
+			if err := failOnDestroyPlanErrors(summary.Terraform); err != nil {
+				return err
+			}
 
 			contextName := proj.Runtime.ContextName
 			desc := fmt.Sprintf("This will permanently destroy all infrastructure in context %q.", contextName)
@@ -161,6 +167,10 @@ windsor destroy --confirm=local --continue`,
 		tuiplan.DestroySummary(os.Stdout, tfResults, k8sResults, os.Getenv("NO_COLOR") != "")
 
 		warnPreventDestroy(cmd.ErrOrStderr(), tfResults)
+
+		if err := failOnDestroyPlanErrors(tfResults); err != nil {
+			return err
+		}
 
 		desc := fmt.Sprintf("This will permanently destroy component %q across all layers.", componentID)
 		if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, componentID); err != nil {
@@ -239,6 +249,10 @@ windsor destroy terraform --confirm=local`,
 
 			warnPreventDestroy(cmd.ErrOrStderr(), summary.Terraform)
 
+			if err := failOnDestroyPlanErrors(summary.Terraform); err != nil {
+				return err
+			}
+
 			contextName := proj.Runtime.ContextName
 			desc := fmt.Sprintf("This will permanently destroy all Terraform components in context %q.", contextName)
 			if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, contextName); err != nil {
@@ -278,6 +292,10 @@ windsor destroy terraform --confirm=local`,
 		tuiplan.DestroySummary(os.Stdout, []terraforminfra.TerraformComponentPlan{tfResult}, nil, os.Getenv("NO_COLOR") != "")
 
 		warnPreventDestroy(cmd.ErrOrStderr(), []terraforminfra.TerraformComponentPlan{tfResult})
+
+		if err := failOnDestroyPlanErrors([]terraforminfra.TerraformComponentPlan{tfResult}); err != nil {
+			return err
+		}
 
 		desc := fmt.Sprintf("This will permanently destroy Terraform component %q.", componentID)
 		if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, componentID); err != nil {
@@ -437,6 +455,30 @@ func warnPreventDestroy(w io.Writer, plans []terraforminfra.TerraformComponentPl
 		fmt.Fprintf(w, "  %s\n", addr)
 	}
 	fmt.Fprintln(w, "   the destroy may halt partway; remove the lifecycle block in HCL to enable tear-down.")
+}
+
+// failOnDestroyPlanErrors halts the destroy before the confirmation prompt when
+// any component failed destroy-plan generation. Per-component plan errors are
+// carried on the plan's Err field and rendered inline in the summary, but the
+// summary methods return no error, so without this gate the flow proceeds to the
+// prompt and offers to "permanently destroy all infrastructure" while silently
+// skipping the components that could not be planned — often the ones owning the
+// underlying cloud infrastructure (servers, networks, zones), orphaning billed
+// resources and leaving state half-torn. The rendered plan already shows each
+// error; this refuses to let the operator confirm past them. No-op when every
+// component planned cleanly. This is distinct from --continue, which governs
+// failures during per-component destroy execution, after confirmation.
+func failOnDestroyPlanErrors(plans []terraforminfra.TerraformComponentPlan) error {
+	var failed []string
+	for _, p := range plans {
+		if p.Err != nil {
+			failed = append(failed, fmt.Sprintf("%s (%v)", p.ComponentID, p.Err))
+		}
+	}
+	if len(failed) == 0 {
+		return nil
+	}
+	return fmt.Errorf("destroy-plan generation failed for %d component(s): %s; resolve the errors above and rerun — refusing to confirm a destroy that cannot tear these down", len(failed), strings.Join(failed, ", "))
 }
 
 // resolveDestroyConfirmation gates a destructive operation. If --confirm was supplied it must

--- a/cmd/destroy_test.go
+++ b/cmd/destroy_test.go
@@ -253,6 +253,53 @@ func TestWarnPreventDestroy(t *testing.T) {
 	})
 }
 
+func TestFailOnDestroyPlanErrors(t *testing.T) {
+	t.Run("NilWhenEveryComponentPlannedCleanly", func(t *testing.T) {
+		// Given plans that all generated successfully
+		plans := []terraforminfra.TerraformComponentPlan{
+			{ComponentID: "compute/hcloud", Destroy: 10},
+			{ComponentID: "cluster/talos", Destroy: 5},
+		}
+
+		// When the gate runs
+		err := failOnDestroyPlanErrors(plans)
+
+		// Then it does not halt the destroy
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+	})
+
+	t.Run("HaltsAndNamesEveryComponentThatFailedToPlan", func(t *testing.T) {
+		// Given a mix of cleanly-planned and plan-failed components
+		plans := []terraforminfra.TerraformComponentPlan{
+			{ComponentID: "compute/hcloud", Err: fmt.Errorf("hcloud provider auth failed")},
+			{ComponentID: "cluster/talos", Destroy: 10},
+			{ComponentID: "dns/zone/hetzner", Err: fmt.Errorf("zone lookup failed")},
+		}
+
+		// When the gate runs
+		err := failOnDestroyPlanErrors(plans)
+
+		// Then it halts, reports the count, and names each failed component with its error
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+		out := err.Error()
+		if !strings.Contains(out, "2 component(s)") {
+			t.Errorf("expected count '2 component(s)' in error, got %q", out)
+		}
+		for _, want := range []string{"compute/hcloud", "hcloud provider auth failed", "dns/zone/hetzner", "zone lookup failed"} {
+			if !strings.Contains(out, want) {
+				t.Errorf("expected %q in error, got %q", want, out)
+			}
+		}
+		if strings.Contains(out, "cluster/talos") {
+			t.Errorf("did not expect cleanly-planned component named, got %q", out)
+		}
+	})
+}
+
 // =============================================================================
 // Test Cases
 // =============================================================================
@@ -330,6 +377,41 @@ func TestDestroyCmd(t *testing.T) {
 
 		if err != nil {
 			t.Errorf("Expected no error with correct confirmation, got %v", err)
+		}
+	})
+
+	t.Run("HaltsBeforeConfirmationWhenPlanGenerationFails", func(t *testing.T) {
+		// Given a destroy plan where a component failed terraform plan -destroy (its error
+		// carried on the plan, not returned), and confirmation would otherwise be satisfied.
+		mocks := setupDestroyTest(t)
+		mocks.TerraformStack.PlanDestroySummaryFunc = func(*blueprintv1alpha1.Blueprint) []terraforminfra.TerraformComponentPlan {
+			return []terraforminfra.TerraformComponentPlan{
+				{ComponentID: "compute/hcloud", Err: fmt.Errorf("hcloud provider auth failed")},
+				{ComponentID: "cluster/talos", Destroy: 10},
+			}
+		}
+		destroyed := false
+		mocks.TerraformStack.DestroyAllFunc = func(*blueprintv1alpha1.Blueprint, bool, ...string) (terraforminfra.DestroyOutcome, error) {
+			destroyed = true
+			return terraforminfra.DestroyOutcome{}, nil
+		}
+		proj := newDestroyProject(mocks)
+
+		cmd := createTestDestroyCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--confirm=test-context"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then it refuses before the confirmation gate and destroys nothing.
+		if err == nil {
+			t.Fatal("Expected plan-generation error, got nil")
+		}
+		if !strings.Contains(err.Error(), "destroy-plan generation failed") {
+			t.Errorf("Expected plan-generation error, got: %v", err)
+		}
+		if destroyed {
+			t.Error("Expected no destroy to run when plan generation failed")
 		}
 	})
 
@@ -797,6 +879,36 @@ func TestDestroyTerraformCmd(t *testing.T) {
 
 		if err != nil {
 			t.Errorf("Expected no error with correct confirmation, got %v", err)
+		}
+	})
+
+	t.Run("HaltsBeforeConfirmationWhenPlanGenerationFails", func(t *testing.T) {
+		// Given a terraform destroy plan where a component failed plan -destroy
+		mocks := setupDestroyTest(t)
+		mocks.TerraformStack.PlanDestroySummaryFunc = func(*blueprintv1alpha1.Blueprint) []terraforminfra.TerraformComponentPlan {
+			return []terraforminfra.TerraformComponentPlan{
+				{ComponentID: "compute/hcloud", Err: fmt.Errorf("hcloud provider auth failed")},
+			}
+		}
+		destroyed := false
+		mocks.TerraformStack.DestroyAllFunc = func(*blueprintv1alpha1.Blueprint, bool, ...string) (terraforminfra.DestroyOutcome, error) {
+			destroyed = true
+			return terraforminfra.DestroyOutcome{}, nil
+		}
+		proj := newDestroyProject(mocks)
+
+		cmd := createTestDestroyTerraformCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--confirm=test-context"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then it refuses before confirmation and destroys nothing
+		if err == nil || !strings.Contains(err.Error(), "destroy-plan generation failed") {
+			t.Fatalf("Expected plan-generation error, got: %v", err)
+		}
+		if destroyed {
+			t.Error("Expected no destroy to run when plan generation failed")
 		}
 	})
 

--- a/cmd/destroy_test.go
+++ b/cmd/destroy_test.go
@@ -450,6 +450,35 @@ func TestDestroyCmd(t *testing.T) {
 		}
 	})
 
+	t.Run("HaltsBeforeConfirmationWhenComponentPlanGenerationFails", func(t *testing.T) {
+		// Given a single-component destroy whose plan -destroy failed (error carried on the plan,
+		// not returned), with confirmation that would otherwise be satisfied.
+		mocks := setupDestroyTest(t)
+		mocks.TerraformStack.PlanDestroyComponentSummaryFunc = func(_ *blueprintv1alpha1.Blueprint, componentID string) terraforminfra.TerraformComponentPlan {
+			return terraforminfra.TerraformComponentPlan{ComponentID: componentID, Err: fmt.Errorf("hcloud provider auth failed")}
+		}
+		destroyed := false
+		mocks.TerraformStack.DestroyFunc = func(*blueprintv1alpha1.Blueprint, string) (bool, error) {
+			destroyed = true
+			return false, nil
+		}
+		proj := newDestroyProject(mocks)
+
+		cmd := createTestDestroyCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--confirm=cluster", "cluster"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then it refuses before the confirmation gate and destroys nothing.
+		if err == nil || !strings.Contains(err.Error(), "destroy-plan generation failed") {
+			t.Fatalf("Expected plan-generation error, got: %v", err)
+		}
+		if destroyed {
+			t.Error("Expected no destroy to run when plan generation failed")
+		}
+	})
+
 	t.Run("ErrorDestroyComponentWithMismatchedConfirmFlag", func(t *testing.T) {
 		// Given --confirm does not match the component name.
 		mocks := setupDestroyTest(t)
@@ -940,6 +969,34 @@ func TestDestroyTerraformCmd(t *testing.T) {
 
 		if err != nil {
 			t.Errorf("Expected no error with correct confirmation, got %v", err)
+		}
+	})
+
+	t.Run("HaltsBeforeConfirmationWhenComponentPlanGenerationFails", func(t *testing.T) {
+		// Given a single terraform component whose plan -destroy failed (error carried on the plan)
+		mocks := setupDestroyTest(t)
+		mocks.TerraformStack.PlanDestroyComponentSummaryFunc = func(_ *blueprintv1alpha1.Blueprint, componentID string) terraforminfra.TerraformComponentPlan {
+			return terraforminfra.TerraformComponentPlan{ComponentID: componentID, Err: fmt.Errorf("hcloud provider auth failed")}
+		}
+		destroyed := false
+		mocks.TerraformStack.DestroyFunc = func(*blueprintv1alpha1.Blueprint, string) (bool, error) {
+			destroyed = true
+			return false, nil
+		}
+		proj := newDestroyProject(mocks)
+
+		cmd := createTestDestroyTerraformCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--confirm=cluster", "cluster"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then it refuses before confirmation and destroys nothing
+		if err == nil || !strings.Contains(err.Error(), "destroy-plan generation failed") {
+			t.Fatalf("Expected plan-generation error, got: %v", err)
+		}
+		if destroyed {
+			t.Error("Expected no destroy to run when plan generation failed")
 		}
 	})
 

--- a/docs/reference/commands/destroy.md
+++ b/docs/reference/commands/destroy.md
@@ -14,6 +14,8 @@ Every form requires confirmation. Either type the context or component name at t
 
 If terraform reports resources protected by 'lifecycle { prevent_destroy = true }', destroy warns up front so the operator knows the destroy may halt partway through. Resources whose state is empty are skipped with a warning naming any potentially orphaned cloud resources.
 
+If any component fails destroy-plan generation, destroy halts before the confirmation prompt and names the failed components, rather than offering to destroy a plan it cannot fully execute. This is distinct from --continue, which governs failures during execution, after confirmation.
+
 The default behavior is to abort on the first per-component destroy failure. Pass --continue to keep going past individual failures, collect them, and print a one-line summary at the end (windsor destroy: N destroyed, N no-op (empty state), N failed (...), backend tier deferred). --continue is layer-wide only and is refused when combined with a component argument — on a single component there is nothing to continue past. When --continue leaves any non-tier component un-destroyed, the backend tier is NOT attempted — this prevents destroying the state store while other components still depend on it. Rerun 'windsor destroy --continue' after resolving the underlying failures; the second pass picks up where the first left off and converges on a clean slate.
 
 ## Flags


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change adds a pre-confirmation safety gate to `windsor destroy` that catches per-component plan-generation failures before the operator is asked to confirm a destructive action, preventing a scenario where infrastructure owners would be silently orphaned.
>
> **Overview**
>
> The PR introduces `failOnDestroyPlanErrors`, a small helper that iterates the already-assembled `[]TerraformComponentPlan` slice, collects any entries where `Err != nil`, and returns a descriptive error naming each failed component. This gate is inserted in all four destroy entry-points (all-components and single-component for both `destroy` and `destroy terraform`) between `warnPreventDestroy` and `resolveDestroyConfirmation`. The change is purely additive: no existing code is modified, only called after.
>
> Documentation in the command's long description and the reference docs is updated to describe the new behavior and clarify its distinction from `--continue`. Unit tests cover the clean and failure paths of the helper; integration tests for the two all-components variants verify `DestroyAll` is never reached when the gate fires.
>
> Reviewed by Claude for commit `0638aeae`.

<!-- /claude-code-review:summary -->
