### PR TITLE
fix(blueprint): load local facets when user blueprint lists sources

### DIFF
--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -704,14 +704,17 @@ func (h *BaseBlueprintHandler) loadUser() error {
 }
 
 // loadSources iterates through the user blueprint's sources array and loads each source.
-// When the user blueprint exists, its sources list is the source of truth and exclusive—only those
-// sources are loaded; no default template or other defaults are added. Sources with name "template"
-// are loaded from the local _template directory; sources with OCI URLs are loaded from the registry.
-// Sources are loaded in parallel. After loading direct sources, it recursively loads any sources
-// referenced by those blueprints. When the user blueprint is nil (e.g. no blueprint.yaml yet), the
-// local template is loaded if present so initial composition produces kustomizations to apply.
-// When there are no init blueprint URLs (e.g. test runner with local _template only) and the user
-// blueprint has no sources, the local template is also loaded so its facets are included in composition.
+// A blueprint's own facets under contexts/_template/ are the thing being authored, not a source, so the
+// local _template is loaded whenever it exists and the load is not an init-with-URLs flow — independent
+// of whether the sources list is empty. Listing sources (e.g. a downstream blueprint layering on core)
+// therefore no longer silently drops the blueprint's own facets. Sources with name "template" are loaded
+// from the local _template directory; sources with OCI URLs are loaded from the registry. The explicit
+// load is a no-op when the local template is already loaded, so listing "template" alongside other
+// sources still works. Sources are loaded in parallel. After loading direct sources, it recursively loads
+// any sources referenced by those blueprints. When the user blueprint is nil (e.g. no blueprint.yaml
+// yet), the local template is loaded if present so initial composition produces kustomizations to apply.
+// During an init-with-URLs flow the local template is left to loadInitBlueprints, which owns the template
+// name in that path.
 func (h *BaseBlueprintHandler) loadSources() error {
 	userBp := h.userBlueprintLoader.GetBlueprint()
 	if userBp == nil {
@@ -726,7 +729,7 @@ func (h *BaseBlueprintHandler) loadSources() error {
 		return nil
 	}
 
-	if len(userBp.Sources) == 0 && len(h.initBlueprintURLs) == 0 && h.runtime != nil && h.runtime.TemplateRoot != "" {
+	if len(h.initBlueprintURLs) == 0 && h.runtime != nil && h.runtime.TemplateRoot != "" {
 		if _, err := h.shims.Stat(h.runtime.TemplateRoot); err == nil {
 			if _, exists := h.sourceBlueprintLoaders["template"]; !exists {
 				loader := NewBlueprintLoader(h.runtime, h.artifactBuilder)

--- a/pkg/composer/blueprint/handler_test.go
+++ b/pkg/composer/blueprint/handler_test.go
@@ -306,6 +306,74 @@ sources:
 		}
 	})
 
+	t.Run("LoadsLocalFacetsWhenUserBlueprintListsSources", func(t *testing.T) {
+		// Given a user blueprint that lists a source (not "template") alongside a local _template
+		// carrying its own facet — the downstream-blueprint layout that previously dropped local facets.
+		mocks := setupHandlerMocks(t)
+		mocks.Runtime.TemplateRoot = filepath.Join(mocks.Runtime.ProjectRoot, "_template")
+
+		templateDir := mocks.Runtime.TemplateRoot
+		facetsDir := filepath.Join(templateDir, "facets")
+		os.MkdirAll(facetsDir, 0755)
+		os.WriteFile(filepath.Join(templateDir, "blueprint.yaml"), []byte(`kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: template
+`), 0644)
+		os.WriteFile(filepath.Join(facetsDir, "local-network.yaml"), []byte(`kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: local-network
+terraform:
+  - path: local-net
+`), 0644)
+
+		// And an OCI source that contributes nothing conflicting.
+		sourceCacheDir := filepath.Join(mocks.Runtime.ProjectRoot, "core-cache")
+		sourceTemplateDir := filepath.Join(sourceCacheDir, "_template")
+		os.MkdirAll(sourceTemplateDir, 0755)
+		os.WriteFile(filepath.Join(sourceTemplateDir, "blueprint.yaml"), []byte(`kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: core
+`), 0644)
+		mocks.ArtifactBuilder.PullFunc = func(refs []string) (map[string]string, error) {
+			return map[string]string{"example.com/core:v1.0.0": sourceCacheDir}, nil
+		}
+		mocks.ArtifactBuilder.ParseOCIRefFunc = func(ref string) (string, string, string, error) {
+			return "example.com", "core", "v1.0.0", nil
+		}
+
+		os.WriteFile(filepath.Join(mocks.Runtime.ConfigRoot, "blueprint.yaml"), []byte(`kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+sources:
+  - name: core
+    url: oci://example.com/core:v1.0.0
+    install: true
+`), 0644)
+
+		handler := NewBlueprintHandler(mocks.Runtime, mocks.ArtifactBuilder)
+
+		// When loading the blueprint
+		if err := handler.LoadBlueprint(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the local _template facet is loaded despite the sources list, and its component composes.
+		if _, exists := handler.sourceBlueprintLoaders["template"]; !exists {
+			t.Fatal("Expected local 'template' loaded even though the user blueprint lists sources")
+		}
+		found := false
+		for _, comp := range handler.composedBlueprint.TerraformComponents {
+			if comp.Path == "local-net" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("Expected local facet's 'local-net' component composed, got %v", handler.composedBlueprint.TerraformComponents)
+		}
+	})
+
 	t.Run("MergesUserBlueprintOverTemplate", func(t *testing.T) {
 		// Given template and user blueprints
 		mocks := setupHandlerMocks(t)


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change is isolated to the blueprint loading path and fixes a silent data-loss bug with no API surface changes.
>
> **Overview**
>
> The PR removes the `len(userBp.Sources) == 0` guard from the local-template loading block in `loadSources`. Previously, when a user blueprint listed any external sources (e.g., an OCI URL), the handler skipped loading the local `_template/` directory entirely, silently dropping the blueprint's own facets from composition. After the fix, the local template is always loaded when the init-with-URLs flow is not active, regardless of whether the sources list is non-empty.
>
> An `!exists` idempotency guard is already in place, so explicitly listing `"template"` as a named source alongside other sources remains safe and produces no double-load. The accompanying test exercises the exact downstream-blueprint layout that exposed the regression.
>
> Reviewed by Claude for commit `958732b9`.

<!-- /claude-code-review:summary -->
