### PR TITLE
fix(composer): name excluded facet in dangling-dependency errors

### DIFF
--- a/pkg/composer/blueprint/composer.go
+++ b/pkg/composer/blueprint/composer.go
@@ -31,6 +31,7 @@ type BaseBlueprintComposer struct {
 	runtime             *runtime.Runtime
 	commonSubstitutions map[string]string
 	shims               *Shims
+	excludedFacets      []ExcludedFacet
 }
 
 // CrdInstallLayer is a CRD kustomization the provisioner will synthesize: a source (empty for the
@@ -179,6 +180,13 @@ func (c *BaseBlueprintComposer) Compose(loaders []BlueprintLoader, initLoaderNam
 	c.applyGlobalDependencyBarrier(result)
 	validationErr := errors.Join(c.validateSources(result), c.validateReservedNames(result), c.validateDependencies(result))
 	return result, validationErr
+}
+
+// SetExcludedFacets provides the facets dropped by a false when: during facet processing, so
+// validateDependencies can attribute a dangling dependency to the excluded facet that would have
+// provided it and name the condition that excluded it.
+func (c *BaseBlueprintComposer) SetExcludedFacets(excluded []ExcludedFacet) {
+	c.excludedFacets = excluded
 }
 
 // SetCommonSubstitutions configures substitution values that will be added to all kustomizations
@@ -996,7 +1004,7 @@ func (c *BaseBlueprintComposer) validateDependencies(bp *blueprintv1alpha1.Bluep
 	for _, tf := range bp.TerraformComponents {
 		for _, dep := range tf.DependsOn {
 			if _, exists := tfIDs[dep]; !exists {
-				return fmt.Errorf("terraform component %q depends on non-existent component %q", tf.GetID(), dep)
+				return fmt.Errorf("terraform component %q depends on %s", tf.GetID(), c.describeMissingDependency(dep, "component"))
 			}
 		}
 	}
@@ -1004,12 +1012,29 @@ func (c *BaseBlueprintComposer) validateDependencies(bp *blueprintv1alpha1.Bluep
 	for _, k := range allK {
 		for _, dep := range k.DependsOn {
 			if _, exists := kNames[dep]; !exists {
-				return fmt.Errorf("kustomization %q depends on non-existent kustomization %q", k.Name, dep)
+				return fmt.Errorf("kustomization %q depends on %s", k.Name, c.describeMissingDependency(dep, "kustomization"))
 			}
 		}
 	}
 
 	return nil
+}
+
+// describeMissingDependency renders the tail of a dangling-dependency error. When an excluded facet
+// would have provided the missing name, it names that facet and the when: condition that excluded it,
+// turning a bare "non-existent X" into an actionable diagnostic. Otherwise it falls back to the plain
+// "non-existent X" message. kind is "component" or "kustomization".
+func (c *BaseBlueprintComposer) describeMissingDependency(dep, kind string) string {
+	for _, excluded := range c.excludedFacets {
+		if !slices.Contains(excluded.Provides, dep) {
+			continue
+		}
+		if excluded.When != "" {
+			return fmt.Sprintf("%q, which is not in the composition: it is contributed by facet %q, excluded because its when condition (%s) evaluated false", dep, excluded.Name, excluded.When)
+		}
+		return fmt.Sprintf("%q, which is not in the composition: it is contributed by facet %q, which was excluded", dep, excluded.Name)
+	}
+	return fmt.Sprintf("non-existent %s %q", kind, dep)
 }
 
 // =============================================================================

--- a/pkg/composer/blueprint/composer_test.go
+++ b/pkg/composer/blueprint/composer_test.go
@@ -3395,6 +3395,71 @@ func TestComposer_validateDependencies(t *testing.T) {
 		}
 	})
 
+	t.Run("NamesExcludedFacetAndConditionForDanglingTerraformDependency", func(t *testing.T) {
+		// Given the missing component is one an excluded facet would have contributed
+		mocks := setupComposerMocks(t)
+		composer := NewBlueprintComposer(mocks.Runtime)
+		composer.SetExcludedFacets([]ExcludedFacet{
+			{Name: "provider-hetzner", When: "cluster.driver == 'talos'", Provides: []string{"cluster"}},
+		})
+		bp := &blueprintv1alpha1.Blueprint{
+			TerraformComponents: []blueprintv1alpha1.TerraformComponent{{Path: "cni", DependsOn: []string{"cluster"}}},
+		}
+
+		// When validating, the error names the excluded facet and the condition that excluded it
+		err := composer.validateDependencies(bp)
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		for _, want := range []string{`facet "provider-hetzner"`, "cluster.driver == 'talos'", "evaluated false", `"cluster"`} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("Expected %q in error, got %v", want, err)
+			}
+		}
+	})
+
+	t.Run("NamesExcludedFacetForDanglingKustomizationDependency", func(t *testing.T) {
+		// Given a kustomization depending on a name an excluded facet would have contributed
+		mocks := setupComposerMocks(t)
+		composer := NewBlueprintComposer(mocks.Runtime)
+		composer.SetExcludedFacets([]ExcludedFacet{
+			{Name: "addon-private-dns", When: "addons.private_dns.enabled == true", Provides: []string{"dns-install"}},
+		})
+		bp := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "gateway-resources", DependsOn: []string{"dns-install"}}},
+		}
+
+		// When validating, the error attributes the missing kustomization to the excluded facet
+		err := composer.validateDependencies(bp)
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		for _, want := range []string{`facet "addon-private-dns"`, "addons.private_dns.enabled == true", `"dns-install"`} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("Expected %q in error, got %v", want, err)
+			}
+		}
+	})
+
+	t.Run("ReportsExclusionWithoutConditionWhenExcludedFacetHasNoWhen", func(t *testing.T) {
+		// Given the providing facet was excluded but carries no when: expression
+		mocks := setupComposerMocks(t)
+		composer := NewBlueprintComposer(mocks.Runtime)
+		composer.SetExcludedFacets([]ExcludedFacet{{Name: "options-extra", Provides: []string{"cluster"}}})
+		bp := &blueprintv1alpha1.Blueprint{
+			TerraformComponents: []blueprintv1alpha1.TerraformComponent{{Path: "cni", DependsOn: []string{"cluster"}}},
+		}
+
+		// When validating, it names the facet without a false-condition clause
+		err := composer.validateDependencies(bp)
+		if err == nil || !strings.Contains(err.Error(), `facet "options-extra"`) {
+			t.Fatalf("Expected excluded-facet attribution, got %v", err)
+		}
+		if strings.Contains(err.Error(), "evaluated false") {
+			t.Errorf("Did not expect a condition clause for a when-less facet, got %v", err)
+		}
+	})
+
 	t.Run("ReturnsNilForValidKustomizationDependencies", func(t *testing.T) {
 		mocks := setupComposerMocks(t)
 		composer := NewBlueprintComposer(mocks.Runtime)

--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -906,6 +906,10 @@ func (h *BaseBlueprintHandler) processAndCompose() error {
 	var scopeMu sync.Mutex
 	collectedScopes := make(map[string]map[string]any)
 
+	if concrete, ok := h.processor.(*BaseBlueprintProcessor); ok {
+		concrete.ResetExcludedFacets()
+	}
+
 	var wg sync.WaitGroup
 	var mu sync.Mutex
 	var errs []error
@@ -988,6 +992,12 @@ func (h *BaseBlueprintHandler) processAndCompose() error {
 			userPath = ul.GetBlueprintPath()
 		}
 	}
+	if concrete, ok := h.processor.(*BaseBlueprintProcessor); ok {
+		if comp, ok := h.composer.(*BaseBlueprintComposer); ok {
+			comp.SetExcludedFacets(concrete.GetExcludedFacets())
+		}
+	}
+
 	composedBp, composeErr := h.composer.Compose(loaders, initLoaderNames, userPath, mergedScope)
 	h.composedBlueprint = composedBp
 	h.composedScope = mergedScope

--- a/pkg/composer/blueprint/handler_test.go
+++ b/pkg/composer/blueprint/handler_test.go
@@ -374,6 +374,52 @@ sources:
 		}
 	})
 
+	t.Run("DanglingDependencyOnExcludedFacetNamesTheFacetAndCondition", func(t *testing.T) {
+		// Given a local template where one facet (excluded by a false when:) would contribute the
+		// "cluster" component, and an always-on facet's "cni" depends on it.
+		mocks := setupHandlerMocks(t)
+		mocks.Runtime.TemplateRoot = filepath.Join(mocks.Runtime.ProjectRoot, "_template")
+		facetsDir := filepath.Join(mocks.Runtime.TemplateRoot, "facets")
+		os.MkdirAll(facetsDir, 0755)
+		os.WriteFile(filepath.Join(mocks.Runtime.TemplateRoot, "blueprint.yaml"), []byte(`kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: template
+`), 0644)
+		os.WriteFile(filepath.Join(facetsDir, "provider-hetzner.yaml"), []byte(`kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: provider-hetzner
+when: cluster.driver == 'talos'
+terraform:
+  - path: cluster
+`), 0644)
+		os.WriteFile(filepath.Join(facetsDir, "cni.yaml"), []byte(`kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: cni
+terraform:
+  - path: cni
+    dependsOn:
+      - cluster
+`), 0644)
+
+		handler := NewBlueprintHandler(mocks.Runtime, mocks.ArtifactBuilder)
+
+		// When loading, composition fails because "cluster" was excluded.
+		err := handler.LoadBlueprint()
+
+		// Then the error names the excluded facet and the condition that excluded it, not just the edge.
+		if err == nil {
+			t.Fatal("Expected a dangling-dependency error, got nil")
+		}
+		for _, want := range []string{`facet "provider-hetzner"`, "cluster.driver == 'talos'", "evaluated false"} {
+			if !strings.Contains(err.Error(), want) {
+				t.Errorf("Expected %q in error, got %v", want, err)
+			}
+		}
+	})
+
 	t.Run("MergesUserBlueprintOverTemplate", func(t *testing.T) {
 		// Given template and user blueprints
 		mocks := setupHandlerMocks(t)

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -55,6 +55,17 @@ type BaseBlueprintProcessor struct {
 	mu             sync.Mutex
 	deferredPaths  map[string]bool
 	extraScope     map[string]any
+	excludedFacets []ExcludedFacet
+}
+
+// ExcludedFacet records a facet dropped from composition by a false when: condition, along with the
+// component and kustomization names it would have contributed. Dependency validation joins a dangling
+// dependency name against these so it can name the excluded facet and the condition that excluded it,
+// rather than only reporting the unresolvable edge.
+type ExcludedFacet struct {
+	Name     string   // facet metadata name
+	When     string   // the when: expression that evaluated false
+	Provides []string // terraform component IDs and kustomization names (including flux tiers) it declares
 }
 
 // requirementBlockMiss records the unsatisfied paths and the effective condition under which a
@@ -142,6 +153,46 @@ func (p *BaseBlueprintProcessor) GetDeferredPaths() map[string]bool {
 		out[k] = v
 	}
 	return out
+}
+
+// ResetExcludedFacets clears the accumulated excluded-facet record. Callers invoke it once before a
+// composition's per-source ProcessFacets pass, so the set reflects only that composition. ProcessFacets
+// appends across sources rather than resetting, letting a multi-source compose accumulate one set.
+func (p *BaseBlueprintProcessor) ResetExcludedFacets() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.excludedFacets = nil
+}
+
+// GetExcludedFacets returns a copy of the facets excluded by a false when: across every ProcessFacets
+// call since the last reset. Read after the per-source passes complete so the set is stable.
+func (p *BaseBlueprintProcessor) GetExcludedFacets() []ExcludedFacet {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if len(p.excludedFacets) == 0 {
+		return nil
+	}
+	out := make([]ExcludedFacet, len(p.excludedFacets))
+	copy(out, p.excludedFacets)
+	return out
+}
+
+// facetProvides returns the names a facet would contribute to composition: each terraform component's
+// ID, each kustomization's name, and each flux system's compiled tier names ("<name>-install" /
+// "<name>-resources"). Dependency validation matches a dangling dependency against these to attribute it
+// to the excluded facet that would have provided it.
+func facetProvides(facet blueprintv1alpha1.Facet) []string {
+	var provides []string
+	for i := range facet.TerraformComponents {
+		provides = append(provides, facet.TerraformComponents[i].GetID())
+	}
+	for _, k := range facet.Kustomizations {
+		provides = append(provides, k.Name)
+	}
+	for _, sys := range facet.FluxSystems {
+		provides = append(provides, sys.TierNames()...)
+	}
+	return provides
 }
 
 // ProcessFacets iterates facets, evaluating each facet's 'when' against config data. Facets with
@@ -264,6 +315,21 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 
 	if len(pendingRequirements) > 0 {
 		return nil, formatRequirementsError(pendingRequirements)
+	}
+
+	includedSet := make(map[string]bool, len(includedFacets))
+	for _, f := range includedFacets {
+		includedSet[f.Metadata.Name] = true
+	}
+	for _, facet := range sortedFacets {
+		if includedSet[facet.Metadata.Name] {
+			continue
+		}
+		p.excludedFacets = append(p.excludedFacets, ExcludedFacet{
+			Name:     facet.Metadata.Name,
+			When:     facet.When,
+			Provides: facetProvides(facet),
+		})
 	}
 
 	for _, facet := range includedFacets {

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -317,6 +317,54 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 		}
 	})
 
+	t.Run("RecordsExcludedFacetWithWhenAndProvidedNames", func(t *testing.T) {
+		// Given one included and one when-excluded facet, the excluded one contributing a terraform
+		// component, a kustomization, and a flux system.
+		mocks := setupProcessorMocks(t)
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"enabled": false}, nil
+		}
+		facets := []blueprintv1alpha1.Facet{
+			{Metadata: blueprintv1alpha1.Metadata{Name: "always"}, TerraformComponents: []blueprintv1alpha1.ConditionalTerraformComponent{
+				{TerraformComponent: blueprintv1alpha1.TerraformComponent{Path: "vpc"}},
+			}},
+			{
+				Metadata:            blueprintv1alpha1.Metadata{Name: "addon-private-dns"},
+				When:                "enabled == true",
+				TerraformComponents: []blueprintv1alpha1.ConditionalTerraformComponent{{TerraformComponent: blueprintv1alpha1.TerraformComponent{Path: "cluster"}}},
+				Kustomizations:      []blueprintv1alpha1.ConditionalKustomization{{Kustomization: blueprintv1alpha1.Kustomization{Name: "dns-config"}}},
+				FluxSystems:         []blueprintv1alpha1.FluxSystem{{Name: "dns", Install: &blueprintv1alpha1.Kustomization{Components: []string{"external-dns"}}}},
+			},
+		}
+
+		// When processing
+		processor.ResetExcludedFacets()
+		if _, err := processor.ProcessFacets(&blueprintv1alpha1.Blueprint{}, facets); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then only the excluded facet is recorded, with its when: and every name it would contribute.
+		excluded := processor.GetExcludedFacets()
+		if len(excluded) != 1 {
+			t.Fatalf("Expected 1 excluded facet, got %d (%v)", len(excluded), excluded)
+		}
+		if excluded[0].Name != "addon-private-dns" || excluded[0].When != "enabled == true" {
+			t.Errorf("Expected addon-private-dns/when recorded, got %+v", excluded[0])
+		}
+		for _, want := range []string{"cluster", "dns-config", "dns-install"} {
+			if !slices.Contains(excluded[0].Provides, want) {
+				t.Errorf("Expected Provides to contain %q, got %v", want, excluded[0].Provides)
+			}
+		}
+
+		// And ResetExcludedFacets clears the record.
+		processor.ResetExcludedFacets()
+		if got := processor.GetExcludedFacets(); got != nil {
+			t.Errorf("Expected nil after reset, got %v", got)
+		}
+	})
+
 	t.Run("ExcludesFacetWhenConditionReferencesUndefinedVariable", func(t *testing.T) {
 		mocks := setupProcessorMocks(t)
 		processor := NewBlueprintProcessor(mocks.Runtime)


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change is confined to diagnostic error messages in the blueprint composition pipeline; no happy-path behavior is altered and the change is reversible without data loss.
>
> **Overview**
>
> The PR improves dangling-dependency error messages during blueprint composition. When a `dependsOn` reference cannot be resolved, the validator now checks whether the missing name would have been contributed by a facet that was excluded via a false `when:` condition. If so, the error names the excluded facet and the condition expression, giving operators an actionable diagnostic instead of a bare "non-existent X" message.
>
> The implementation threads state from `BaseBlueprintProcessor` (which knows which facets were excluded) to `BaseBlueprintComposer` (which validates dependencies) via `processAndCompose` in the handler, using concrete type assertions. All three layers receive unit tests and an integration-level handler test that exercises the full flow with real YAML fixtures.
>
> Reviewed by Claude for commit `43bba453`.

<!-- /claude-code-review:summary -->
