### PR TITLE
fix(config): implement conservative merging for validation keywords in schema validator

### DIFF
--- a/pkg/runtime/config/schema_merge.go
+++ b/pkg/runtime/config/schema_merge.go
@@ -1,13 +1,17 @@
 package config
 
-import "maps"
+import (
+	"maps"
+	"reflect"
+)
 
 // Schema composition for the multi-file schema layout: SchemaValidator accumulates a merged
 // schema by deep-merging each loaded fragment over the previous one. The merge is pure
 // (no validator state), so it lives apart from validation to keep both surfaces obvious. The
 // invariants the merge preserves are operator-visible: properties union with overlay winning
 // on conflict, required arrays union and de-duplicate, items merge recursively when both sides
-// are object-typed.
+// are object-typed, and validation keywords merge conservatively (most restrictive wins) so
+// the result does not depend on the order fragments happen to load in.
 
 // =============================================================================
 // Private Methods
@@ -33,15 +37,17 @@ func (sv *SchemaValidator) mergeSchema(base, overlay map[string]any) map[string]
 		case "items":
 			merged[k] = sv.mergeItemsSchema(base["items"], v)
 		default:
-			merged[k] = v
+			merged[k] = sv.mergeKeyword(k, base, v)
 		}
 	}
 
 	return merged
 }
 
-// mergeProperties merges two property maps, with overlay properties overriding base properties.
-// Nested object properties are merged recursively.
+// mergeProperties merges two property maps. Each property is itself a schema, so a property
+// present in both fragments is merged with mergeSchema — unioning nested properties and
+// applying conservative validation-keyword merging to scalar leaves. A property is replaced
+// wholesale only when the two fragments give it conflicting types (a genuine redefinition).
 func (sv *SchemaValidator) mergeProperties(base, overlay any) map[string]any {
 	merged := make(map[string]any)
 
@@ -62,51 +68,26 @@ func (sv *SchemaValidator) mergeProperties(base, overlay any) map[string]any {
 			continue
 		}
 
-		baseProp, exists := merged[k]
-		if !exists {
-			merged[k] = overlayPropMap
-			continue
-		}
-
-		basePropMap, ok := baseProp.(map[string]any)
+		basePropMap, ok := merged[k].(map[string]any)
 		if !ok {
 			merged[k] = overlayPropMap
 			continue
 		}
 
-		if baseType, ok := basePropMap["type"].(string); ok && baseType == "object" {
-			if overlayType, ok := overlayPropMap["type"].(string); ok && overlayType == "object" {
-				mergedProp := make(map[string]any)
-				for bk, bv := range basePropMap {
-					mergedProp[bk] = bv
-				}
-				for ok, ov := range overlayPropMap {
-					switch ok {
-					case "properties":
-						mergedProp[ok] = sv.mergeProperties(basePropMap["properties"], ov)
-					case "required":
-						mergedProp[ok] = sv.mergeRequired(basePropMap["required"], ov)
-					case "items":
-						mergedProp[ok] = sv.mergeItemsSchema(basePropMap["items"], ov)
-					default:
-						mergedProp[ok] = ov
-					}
-				}
-				merged[k] = mergedProp
-			} else {
-				merged[k] = overlayPropMap
-			}
-		} else {
+		if typesConflict(basePropMap, overlayPropMap) {
 			merged[k] = overlayPropMap
+			continue
 		}
+
+		merged[k] = sv.mergeSchema(basePropMap, overlayPropMap)
 	}
 
 	return merged
 }
 
-// mergeItemsSchema merges two array item schemas, with overlay properties overriding base
-// properties. If both items are object types, they are merged recursively similar to
-// properties.
+// mergeItemsSchema merges two array item schemas. An item schema is a schema, so matching
+// items are merged with mergeSchema; the overlay replaces the base wholesale only when the
+// item types conflict.
 func (sv *SchemaValidator) mergeItemsSchema(base, overlay any) map[string]any {
 	overlayItems, ok := overlay.(map[string]any)
 	if !ok {
@@ -121,30 +102,11 @@ func (sv *SchemaValidator) mergeItemsSchema(base, overlay any) map[string]any {
 		return overlayItems
 	}
 
-	baseType, baseIsObject := baseItems["type"].(string)
-	overlayType, overlayIsObject := overlayItems["type"].(string)
-
-	if baseIsObject && baseType == "object" && overlayIsObject && overlayType == "object" {
-		mergedItems := make(map[string]any)
-		for k, v := range baseItems {
-			mergedItems[k] = v
-		}
-		for k, v := range overlayItems {
-			switch k {
-			case "properties":
-				mergedItems[k] = sv.mergeProperties(baseItems["properties"], v)
-			case "required":
-				mergedItems[k] = sv.mergeRequired(baseItems["required"], v)
-			case "items":
-				mergedItems[k] = sv.mergeItemsSchema(baseItems["items"], v)
-			default:
-				mergedItems[k] = v
-			}
-		}
-		return mergedItems
+	if typesConflict(baseItems, overlayItems) {
+		return overlayItems
 	}
 
-	return overlayItems
+	return sv.mergeSchema(baseItems, overlayItems)
 }
 
 // mergeRequired merges two required field arrays, combining them and removing duplicates.
@@ -175,4 +137,114 @@ func (sv *SchemaValidator) mergeRequired(base, overlay any) []any {
 	}
 
 	return merged
+}
+
+// mergeKeyword combines a single validation keyword conservatively so the most restrictive
+// constraint across fragments wins, making the merged schema independent of the order
+// fragments load in: additionalProperties collapses to false once any fragment closes the
+// object, minimum-style bounds keep the larger value, maximum-style bounds keep the smaller,
+// and enum intersects. Any other keyword (including pattern and default) takes the overlay.
+func (sv *SchemaValidator) mergeKeyword(key string, base map[string]any, overlayVal any) any {
+	baseVal, ok := base[key]
+	if !ok {
+		return overlayVal
+	}
+
+	switch key {
+	case "additionalProperties":
+		if baseVal == false || overlayVal == false {
+			return false
+		}
+		return overlayVal
+	case "minimum", "exclusiveMinimum", "minLength", "minItems", "minProperties":
+		return tighterBound(baseVal, overlayVal, true)
+	case "maximum", "exclusiveMaximum", "maxLength", "maxItems", "maxProperties":
+		return tighterBound(baseVal, overlayVal, false)
+	case "enum":
+		return intersectEnum(baseVal, overlayVal)
+	default:
+		return overlayVal
+	}
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+// typesConflict reports whether two schema fragments assign the same node incompatible
+// declared types. A missing type on either side is not a conflict, so a fragment that adds
+// constraints without restating the type still merges.
+func typesConflict(base, overlay map[string]any) bool {
+	baseType, baseOk := base["type"].(string)
+	overlayType, overlayOk := overlay["type"].(string)
+	return baseOk && overlayOk && baseType != overlayType
+}
+
+// tighterBound returns the more restrictive of two numeric schema bounds: the larger when
+// keepLarger is set (minimum-style keywords), the smaller otherwise (maximum-style). The
+// original value is returned so its numeric type is preserved; a non-numeric operand falls
+// back to the overlay.
+func tighterBound(base, overlay any, keepLarger bool) any {
+	bv, bok := numericValue(base)
+	ov, ook := numericValue(overlay)
+	if !bok || !ook {
+		return overlay
+	}
+	if keepLarger {
+		if bv >= ov {
+			return base
+		}
+		return overlay
+	}
+	if bv <= ov {
+		return base
+	}
+	return overlay
+}
+
+// intersectEnum returns the enum members common to both fragments, preserving base order. A
+// non-array operand falls back to the overlay.
+func intersectEnum(base, overlay any) any {
+	baseSlice, bok := base.([]any)
+	overlaySlice, ook := overlay.([]any)
+	if !bok || !ook {
+		return overlay
+	}
+	var merged []any
+	for _, b := range baseSlice {
+		for _, o := range overlaySlice {
+			if enumEqual(b, o) {
+				merged = append(merged, b)
+				break
+			}
+		}
+	}
+	return merged
+}
+
+// enumEqual compares two enum members, treating numeric values equal across integer and
+// float encodings and falling back to a deep comparison otherwise.
+func enumEqual(a, b any) bool {
+	if av, aok := numericValue(a); aok {
+		if bv, bok := numericValue(b); bok {
+			return av == bv
+		}
+	}
+	return reflect.DeepEqual(a, b)
+}
+
+// numericValue reports the float64 value of any Go numeric type, so schema bounds compare
+// regardless of the integer or float kind the YAML decoder produced.
+func numericValue(v any) (float64, bool) {
+	rv := reflect.ValueOf(v)
+	switch rv.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return float64(rv.Int()), true
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return float64(rv.Uint()), true
+	case reflect.Float32, reflect.Float64:
+		return rv.Float(), true
+	default:
+		return 0, false
+	}
 }

--- a/pkg/runtime/config/schema_merge.go
+++ b/pkg/runtime/config/schema_merge.go
@@ -36,6 +36,8 @@ func (sv *SchemaValidator) mergeSchema(base, overlay map[string]any) map[string]
 			merged[k] = sv.mergeRequired(base["required"], v)
 		case "items":
 			merged[k] = sv.mergeItemsSchema(base["items"], v)
+		case "enum":
+			sv.mergeEnum(merged, base["enum"], v)
 		default:
 			merged[k] = sv.mergeKeyword(k, base, v)
 		}
@@ -142,8 +144,10 @@ func (sv *SchemaValidator) mergeRequired(base, overlay any) []any {
 // mergeKeyword combines a single validation keyword conservatively so the most restrictive
 // constraint across fragments wins, making the merged schema independent of the order
 // fragments load in: additionalProperties collapses to false once any fragment closes the
-// object, minimum-style bounds keep the larger value, maximum-style bounds keep the smaller,
-// and enum intersects. Any other keyword (including pattern and default) takes the overlay.
+// object and otherwise keeps the stricter of a schema-object constraint over a bare true,
+// minimum-style bounds keep the larger value, and maximum-style bounds keep the smaller. Any
+// other keyword (including pattern and default) takes the overlay. enum is handled separately
+// by mergeEnum, which needs the containing schema to mark a disjoint intersection.
 func (sv *SchemaValidator) mergeKeyword(key string, base map[string]any, overlayVal any) any {
 	baseVal, ok := base[key]
 	if !ok {
@@ -155,16 +159,39 @@ func (sv *SchemaValidator) mergeKeyword(key string, base map[string]any, overlay
 		if baseVal == false || overlayVal == false {
 			return false
 		}
-		return overlayVal
+		baseMap, baseIsMap := baseVal.(map[string]any)
+		overlayMap, overlayIsMap := overlayVal.(map[string]any)
+		switch {
+		case baseIsMap && overlayIsMap:
+			return sv.mergeSchema(baseMap, overlayMap)
+		case baseIsMap:
+			return baseMap
+		case overlayIsMap:
+			return overlayMap
+		default:
+			return overlayVal
+		}
 	case "minimum", "exclusiveMinimum", "minLength", "minItems", "minProperties":
 		return tighterBound(baseVal, overlayVal, true)
 	case "maximum", "exclusiveMaximum", "maxLength", "maxItems", "maxProperties":
 		return tighterBound(baseVal, overlayVal, false)
-	case "enum":
-		return intersectEnum(baseVal, overlayVal)
 	default:
 		return overlayVal
 	}
+}
+
+// mergeEnum writes the intersection of two enum constraints into merged. When the fragments
+// share no members the node cannot be satisfied, so the enum key is dropped and merged is
+// marked with "not: {}" (which matches nothing): the validator ignores an empty enum but
+// honors "not", so without this a disjoint intersection would silently permit any value.
+func (sv *SchemaValidator) mergeEnum(merged map[string]any, base, overlay any) {
+	intersection := intersectEnum(base, overlay)
+	if slice, ok := intersection.([]any); ok && len(slice) == 0 {
+		delete(merged, "enum")
+		merged["not"] = map[string]any{}
+		return
+	}
+	merged["enum"] = intersection
 }
 
 // =============================================================================
@@ -202,15 +229,17 @@ func tighterBound(base, overlay any, keepLarger bool) any {
 	return overlay
 }
 
-// intersectEnum returns the enum members common to both fragments, preserving base order. A
-// non-array operand falls back to the overlay.
+// intersectEnum returns the enum members common to both fragments, preserving base order, as
+// a non-nil slice. A non-array operand falls back to the overlay. Disjoint enums yield an
+// empty slice; mergeEnum turns that into an unsatisfiable node, since the validator ignores
+// an empty enum on its own.
 func intersectEnum(base, overlay any) any {
 	baseSlice, bok := base.([]any)
 	overlaySlice, ook := overlay.([]any)
 	if !bok || !ook {
 		return overlay
 	}
-	var merged []any
+	merged := []any{}
 	for _, b := range baseSlice {
 		for _, o := range overlaySlice {
 			if enumEqual(b, o) {

--- a/pkg/runtime/config/schema_validator_test.go
+++ b/pkg/runtime/config/schema_validator_test.go
@@ -414,6 +414,164 @@ additionalProperties: false
 	})
 }
 
+func TestSchemaValidator_ConservativeKeywordMerge(t *testing.T) {
+	// loadMerged loads each fragment in turn and returns the resulting validator, so a test
+	// can assert the merged constraints without pinning to fragment load order.
+	loadMerged := func(t *testing.T, fragments ...string) *SchemaValidator {
+		t.Helper()
+		validator := NewSchemaValidator(shell.NewMockShell())
+		for i, fragment := range fragments {
+			if err := validator.LoadSchemaFromBytes([]byte(fragment)); err != nil {
+				t.Fatalf("Failed to load fragment %d: %v", i, err)
+			}
+		}
+		return validator
+	}
+
+	closed := `$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+properties:
+  a:
+    type: string
+additionalProperties: false
+`
+	open := `$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+properties:
+  b:
+    type: string
+additionalProperties: true
+`
+
+	t.Run("AdditionalPropertiesFalseSurvivesRegardlessOfLoadOrder", func(t *testing.T) {
+		// Given fragments that disagree on additionalProperties, loaded in each order
+		for _, order := range [][]string{{closed, open}, {open, closed}} {
+			validator := loadMerged(t, order...)
+
+			// And a value carrying a key neither fragment declares
+			values := map[string]any{"a": "x", "b": "y", "c": "z"}
+
+			// When validating
+			result, err := validator.Validate(values)
+			if err != nil {
+				t.Fatalf("Validation failed: %v", err)
+			}
+
+			// Then the closed constraint wins and the undeclared key is rejected
+			if result.Valid {
+				t.Errorf("Expected 'c' to be rejected once any fragment closes the object, order %v", order)
+			}
+			if !hasErrorMatching(result.Errors, "additionalProperties") {
+				t.Errorf("Expected an additionalProperties error, got %v", result.Errors)
+			}
+		}
+	})
+
+	t.Run("NumericBoundsKeepTighterValue", func(t *testing.T) {
+		// Given fragments that widen and narrow the same numeric bounds
+		loose := `$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+properties:
+  count:
+    type: integer
+    minimum: 1
+    maximum: 100
+additionalProperties: true
+`
+		strict := `$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+properties:
+  count:
+    type: integer
+    minimum: 5
+    maximum: 10
+additionalProperties: true
+`
+		// When loaded in either order, the tighter bounds hold both ways
+		for _, order := range [][]string{{loose, strict}, {strict, loose}} {
+			validator := loadMerged(t, order...)
+
+			// Then a value below the tighter minimum (5) is rejected
+			result, err := validator.Validate(map[string]any{"count": 3})
+			if err != nil {
+				t.Fatalf("Validation failed: %v", err)
+			}
+			if result.Valid {
+				t.Errorf("Expected count=3 to fail the tighter minimum of 5, order %v", order)
+			}
+
+			// And a value above the tighter maximum (10) is rejected
+			result, err = validator.Validate(map[string]any{"count": 50})
+			if err != nil {
+				t.Fatalf("Validation failed: %v", err)
+			}
+			if result.Valid {
+				t.Errorf("Expected count=50 to fail the tighter maximum of 10, order %v", order)
+			}
+
+			// And a value inside the intersection passes
+			result, err = validator.Validate(map[string]any{"count": 7})
+			if err != nil {
+				t.Fatalf("Validation failed: %v", err)
+			}
+			if !result.Valid {
+				t.Errorf("Expected count=7 to pass, order %v, got errors: %v", order, result.Errors)
+			}
+		}
+	})
+
+	t.Run("EnumIntersectsAcrossFragments", func(t *testing.T) {
+		// Given fragments whose enums overlap but are not identical
+		first := `$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+properties:
+  platform:
+    type: string
+    enum: [aws, azure, gcp]
+additionalProperties: true
+`
+		second := `$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+properties:
+  platform:
+    type: string
+    enum: [azure, gcp, metal]
+additionalProperties: true
+`
+		// When loaded in either order, only the intersection {azure, gcp} stays valid
+		for _, order := range [][]string{{first, second}, {second, first}} {
+			validator := loadMerged(t, order...)
+
+			// Then a value in only the first fragment's enum is rejected
+			result, err := validator.Validate(map[string]any{"platform": "aws"})
+			if err != nil {
+				t.Fatalf("Validation failed: %v", err)
+			}
+			if result.Valid {
+				t.Errorf("Expected platform=aws to fail (outside intersection), order %v", order)
+			}
+
+			// And a value in only the second fragment's enum is rejected
+			result, err = validator.Validate(map[string]any{"platform": "metal"})
+			if err != nil {
+				t.Fatalf("Validation failed: %v", err)
+			}
+			if result.Valid {
+				t.Errorf("Expected platform=metal to fail (outside intersection), order %v", order)
+			}
+
+			// And a value in both fragments' enums passes
+			result, err = validator.Validate(map[string]any{"platform": "azure"})
+			if err != nil {
+				t.Fatalf("Validation failed: %v", err)
+			}
+			if !result.Valid {
+				t.Errorf("Expected platform=azure to pass, order %v, got errors: %v", order, result.Errors)
+			}
+		}
+	})
+}
+
 func TestSchemaValidator_ExtractDefaults(t *testing.T) {
 	t.Run("SuccessSimpleDefaults", func(t *testing.T) {
 		// Given a schema validator with loaded schema

--- a/pkg/runtime/config/schema_validator_test.go
+++ b/pkg/runtime/config/schema_validator_test.go
@@ -570,6 +570,77 @@ additionalProperties: true
 			}
 		}
 	})
+
+	t.Run("SchemaObjectAdditionalPropertiesMergeConservatively", func(t *testing.T) {
+		// Given fragments whose additionalProperties are schema objects, not booleans:
+		// one constrains extra keys to strings, the other requires a minimum length
+		strings := `$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+additionalProperties:
+  type: string
+`
+		minLen := `$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+additionalProperties:
+  minLength: 3
+`
+		for _, order := range [][]string{{strings, minLen}, {minLen, strings}} {
+			validator := loadMerged(t, order...)
+
+			// Then an extra key satisfying both constraints passes
+			result, err := validator.Validate(map[string]any{"extra": "abcd"})
+			if err != nil {
+				t.Fatalf("Validation failed: %v", err)
+			}
+			if !result.Valid {
+				t.Errorf("Expected extra='abcd' to pass, order %v, got errors: %v", order, result.Errors)
+			}
+
+			// And one violating the base fragment's constraint (too short) is still rejected,
+			// proving the base constraint was not dropped when the overlay was also a schema
+			result, err = validator.Validate(map[string]any{"extra": "ab"})
+			if err != nil {
+				t.Fatalf("Validation failed: %v", err)
+			}
+			if result.Valid {
+				t.Errorf("Expected extra='ab' to fail the merged minLength constraint, order %v", order)
+			}
+		}
+	})
+
+	t.Run("DisjointEnumsRejectEveryValue", func(t *testing.T) {
+		// Given fragments whose enums share no members
+		first := `$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+properties:
+  mode:
+    type: string
+    enum: [a, b]
+additionalProperties: true
+`
+		second := `$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+properties:
+  mode:
+    type: string
+    enum: [c, d]
+additionalProperties: true
+`
+		validator := loadMerged(t, first, second)
+
+		// When validating a value from either fragment's enum
+		for _, val := range []string{"a", "c"} {
+			result, err := validator.Validate(map[string]any{"mode": val})
+			if err != nil {
+				t.Fatalf("Validation failed: %v", err)
+			}
+
+			// Then it is rejected: an empty intersection permits no value
+			if result.Valid {
+				t.Errorf("Expected mode=%q to fail against an empty enum intersection", val)
+			}
+		}
+	})
 }
 
 func TestSchemaValidator_ExtractDefaults(t *testing.T) {


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change is confined to the schema-merging layer of the config package, introducing conservative keyword semantics where the most restrictive constraint wins across loaded fragments.
>
> **Overview**
>
> The PR makes multi-fragment schema merging order-independent by routing all non-structural keywords through a new `mergeKeyword` dispatcher: `additionalProperties` collapses to `false` if any fragment closes the object, numeric bounds keep the tighter value, and enum intersects across fragments. It simultaneously simplifies `mergeProperties` and `mergeItemsSchema` by generalising the previously object-only recursion into a type-conflict guard plus a single `mergeSchema` call, removing roughly 40 lines of duplicated branching.
>
> Three new table-driven tests cover each conservative strategy under both load orders. One edge case is worth watching: `intersectEnum` returns a nil slice when no common members exist, which downstream JSON Schema validators may interpret as "no enum constraint" rather than "nothing is valid" — a permissive failure when two fragments declare incompatible enum sets.
>
> Reviewed by Claude for commit `c58432bf`.

<!-- /claude-code-review:summary -->
