### PR TITLE
fix(terraform): don't stream 'output -json' to avoid leaking sensitive outputs

### DIFF
--- a/pkg/runtime/terraform/provider.go
+++ b/pkg/runtime/terraform/provider.go
@@ -601,7 +601,8 @@ func (p *terraformProvider) FormatArgsForEnv(args []string) string {
 // If output fails initially, it attempts to initialize the module and retry, allowing outputs to be retrieved
 // even if the module hasn't been initialized yet. Returns empty map without error if outputs cannot be retrieved
 // (component not ready), enabling graceful fallback via ?? operator. Only returns error for JSON parse failures
-// indicating state corruption. Only output 'value' fields are returned.
+// indicating state corruption. Only output 'value' fields are returned. The 'output -json' command runs via the
+// non-streaming capture path so sensitive outputs are never echoed under --verbose.
 func (p *terraformProvider) GetTerraformOutputs(componentID string) (map[string]any, error) {
 	return p.withTerraformContext(componentID, func(ctx *terraformContext) (map[string]any, error) {
 		terraformCommand := ctx.provider.toolsManager.GetTerraformCommand()
@@ -610,7 +611,7 @@ func (p *terraformProvider) GetTerraformOutputs(componentID string) (map[string]
 		}
 
 		outputArgs := []string{fmt.Sprintf("-chdir=%s", ctx.AbsModulePath), "output", "-json"}
-		output, err := ctx.provider.shell.ExecSilent(terraformCommand, outputArgs...)
+		output, err := ctx.provider.shell.ExecCaptureWithEnv(terraformCommand, nil, outputArgs...)
 		if err != nil {
 			chdirInitArgs := []string{fmt.Sprintf("-chdir=%s", ctx.AbsModulePath), "init", "-reconfigure"}
 			chdirInitArgs = append(chdirInitArgs, ctx.TerraformArgs.InitArgs...)
@@ -618,7 +619,7 @@ func (p *terraformProvider) GetTerraformOutputs(componentID string) (map[string]
 			if initErr != nil {
 				return make(map[string]any), nil
 			}
-			output, err = ctx.provider.shell.ExecSilent(terraformCommand, outputArgs...)
+			output, err = ctx.provider.shell.ExecCaptureWithEnv(terraformCommand, nil, outputArgs...)
 			if err != nil {
 				return make(map[string]any), nil
 			}

--- a/pkg/runtime/terraform/provider_public_test.go
+++ b/pkg/runtime/terraform/provider_public_test.go
@@ -2866,6 +2866,53 @@ terraform:
 		}
 	})
 
+	t.Run("UsesNonStreamingCaptureForOutputJSON", func(t *testing.T) {
+		// Given a provider whose terraform output carries sensitive values
+		blueprintYAML := `apiVersion: blueprints.windsorcli.dev/v1alpha1
+kind: Blueprint
+metadata:
+  name: test
+terraform:
+  - path: cluster
+    name: cluster`
+
+		mocks := setupMocks(t, &SetupOptions{BlueprintYAML: blueprintYAML, BackendType: "local"})
+
+		outputViaSilent := false
+		outputViaCapture := false
+		mocks.Shell.ExecSilentFunc = func(command string, args ...string) (string, error) {
+			if command == "terraform" && len(args) >= 2 && args[1] == "output" {
+				outputViaSilent = true
+				return `{"private_key_pem": {"value": "SENSITIVE", "sensitive": true}}`, nil
+			}
+			return "", nil
+		}
+		mocks.Shell.ExecCaptureWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" && len(args) >= 2 && args[1] == "output" {
+				outputViaCapture = true
+				return `{"private_key_pem": {"value": "SENSITIVE", "sensitive": true}}`, nil
+			}
+			return "", nil
+		}
+
+		// When getting terraform outputs
+		outputs, err := mocks.Provider.GetTerraformOutputs("cluster")
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// Then 'output -json' must run via the non-streaming capture path, never the verbose-echoing ExecSilent
+		if outputViaSilent {
+			t.Error("Expected 'terraform output -json' to run via ExecCaptureWithEnv, but it ran via ExecSilent (streams under --verbose)")
+		}
+		if !outputViaCapture {
+			t.Error("Expected 'terraform output -json' to run via ExecCaptureWithEnv, but it did not")
+		}
+		if outputs["private_key_pem"] != "SENSITIVE" {
+			t.Errorf("Expected private_key_pem to be parsed, got: %v", outputs["private_key_pem"])
+		}
+	})
+
 }
 
 func TestTerraformProvider_GetEnvVars(t *testing.T) {


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Targeted two-line fix in a single function path with a focused test; no shared infrastructure or defaults are affected.
>
> **Overview**
>
> This PR replaces `ExecSilent` with `ExecCaptureWithEnv` (env `nil`) for the `terraform output -json` call inside `GetTerraformOutputs`, preventing sensitive output values from being streamed to the terminal when `--verbose` is active. Both the initial attempt and the post-`init` retry path are updated. A new test (`UsesNonStreamingCaptureForOutputJSON`) verifies the routing by asserting that `ExecSilent` is never invoked for the output command and that `ExecCaptureWithEnv` is.
>
> The functional contract of `GetTerraformOutputs` is unchanged — only `value` fields are returned, and errors still fall through identically — so callers see no behavioral difference outside of verbose logging.
>
> Reviewed by Claude for commit `84152788`.

<!-- /claude-code-review:summary -->
