### PR TITLE
refactor(config): remove applyClusterResourceDefaults function and related tests

### DIFF
--- a/pkg/runtime/config/resolve.go
+++ b/pkg/runtime/config/resolve.go
@@ -4,8 +4,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-
-	"github.com/windsorcli/cli/pkg/constants"
 )
 
 // The ConfigResolver is an effective-values materialization component for runtime config.
@@ -41,7 +39,6 @@ func (c *configHandler) GetContextValues() (map[string]any, error) {
 	c.applyWorkstationDefaults(result)
 	c.ensureClusterStructure(result)
 	c.applyClusterTopologyDefaults(result)
-	c.applyClusterResourceDefaults(result)
 
 	return result, nil
 }
@@ -180,39 +177,6 @@ func (c *configHandler) applyClusterTopologyDefaults(values map[string]any) {
 	if !hasSchedulable || !hasExplicitSchedulable {
 		schedulable = workersCount == 0 && controlplaneCount == 1
 		controlplanesMap["schedulable"] = schedulable
-	}
-}
-
-// applyClusterResourceDefaults injects CPU and memory defaults into cluster values when absent.
-func (c *configHandler) applyClusterResourceDefaults(values map[string]any) {
-	clusterMap, ok := values["cluster"].(map[string]any)
-	if !ok || clusterMap == nil {
-		return
-	}
-	controlplanesMap, controlplanesOK := clusterMap["controlplanes"].(map[string]any)
-	workersMap, workersOK := clusterMap["workers"].(map[string]any)
-	if !controlplanesOK || controlplanesMap == nil || !workersOK || workersMap == nil {
-		return
-	}
-
-	schedulable, _ := controlplanesMap["schedulable"].(bool)
-	defaultControlplaneCPU := constants.DefaultControlPlaneCPUDedicated
-	defaultControlplaneMemory := constants.DefaultControlPlaneMemoryDedicated
-	if schedulable {
-		defaultControlplaneCPU = constants.DefaultControlPlaneCPUSchedulable
-		defaultControlplaneMemory = constants.DefaultControlPlaneMemorySchedulable
-	}
-	if _, exists := controlplanesMap["cpu"]; !exists {
-		controlplanesMap["cpu"] = defaultControlplaneCPU
-	}
-	if _, exists := controlplanesMap["memory"]; !exists {
-		controlplanesMap["memory"] = defaultControlplaneMemory
-	}
-	if _, exists := workersMap["cpu"]; !exists {
-		workersMap["cpu"] = constants.DefaultWorkerCPU
-	}
-	if _, exists := workersMap["memory"]; !exists {
-		workersMap["memory"] = constants.DefaultWorkerMemory
 	}
 }
 

--- a/pkg/runtime/config/resolve_test.go
+++ b/pkg/runtime/config/resolve_test.go
@@ -3,8 +3,6 @@ package config
 import (
 	"runtime"
 	"testing"
-
-	"github.com/windsorcli/cli/pkg/constants"
 )
 
 // =============================================================================
@@ -192,17 +190,17 @@ func TestConfigHandler_GetContextValues_Resolve(t *testing.T) {
 		}
 	})
 
-	t.Run("AppliesDedicatedVsSchedulableClusterResourceDefaults", func(t *testing.T) {
-		schedulableHandler, _ := setupPrivateTestHandler(t)
+	t.Run("DoesNotFabricateClusterResourceDefaults", func(t *testing.T) {
+		handler, _ := setupPrivateTestHandler(t)
 
-		if err := schedulableHandler.Set("cluster.controlplanes.count", 1); err != nil {
+		if err := handler.Set("cluster.controlplanes.count", 1); err != nil {
 			t.Fatalf("Expected no error setting controlplanes.count, got %v", err)
 		}
-		if err := schedulableHandler.Set("cluster.workers.count", 0); err != nil {
+		if err := handler.Set("cluster.workers.count", 0); err != nil {
 			t.Fatalf("Expected no error setting workers.count, got %v", err)
 		}
 
-		values, err := schedulableHandler.GetContextValues()
+		values, err := handler.GetContextValues()
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
@@ -210,38 +208,17 @@ func TestConfigHandler_GetContextValues_Resolve(t *testing.T) {
 		clusterValues := values["cluster"].(map[string]any)
 		controlplanesValues := clusterValues["controlplanes"].(map[string]any)
 		workersValues := clusterValues["workers"].(map[string]any)
-		if controlplanesValues["cpu"] != constants.DefaultControlPlaneCPUSchedulable {
-			t.Errorf("Expected schedulable controlplane cpu=%d, got %v", constants.DefaultControlPlaneCPUSchedulable, controlplanesValues["cpu"])
+		if _, exists := controlplanesValues["cpu"]; exists {
+			t.Errorf("Expected controlplanes.cpu to be absent, got %v", controlplanesValues["cpu"])
 		}
-		if controlplanesValues["memory"] != constants.DefaultControlPlaneMemorySchedulable {
-			t.Errorf("Expected schedulable controlplane memory=%d, got %v", constants.DefaultControlPlaneMemorySchedulable, controlplanesValues["memory"])
+		if _, exists := controlplanesValues["memory"]; exists {
+			t.Errorf("Expected controlplanes.memory to be absent, got %v", controlplanesValues["memory"])
 		}
-		if workersValues["cpu"] != constants.DefaultWorkerCPU {
-			t.Errorf("Expected worker cpu=%d, got %v", constants.DefaultWorkerCPU, workersValues["cpu"])
+		if _, exists := workersValues["cpu"]; exists {
+			t.Errorf("Expected workers.cpu to be absent, got %v", workersValues["cpu"])
 		}
-		if workersValues["memory"] != constants.DefaultWorkerMemory {
-			t.Errorf("Expected worker memory=%d, got %v", constants.DefaultWorkerMemory, workersValues["memory"])
-		}
-
-		dedicatedHandler, _ := setupPrivateTestHandler(t)
-		if err := dedicatedHandler.Set("cluster.controlplanes.count", 1); err != nil {
-			t.Fatalf("Expected no error setting controlplanes.count, got %v", err)
-		}
-		if err := dedicatedHandler.Set("cluster.workers.count", 1); err != nil {
-			t.Fatalf("Expected no error setting workers.count, got %v", err)
-		}
-		values, err = dedicatedHandler.GetContextValues()
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-
-		clusterValues = values["cluster"].(map[string]any)
-		controlplanesValues = clusterValues["controlplanes"].(map[string]any)
-		if controlplanesValues["cpu"] != constants.DefaultControlPlaneCPUDedicated {
-			t.Errorf("Expected dedicated controlplane cpu=%d, got %v", constants.DefaultControlPlaneCPUDedicated, controlplanesValues["cpu"])
-		}
-		if controlplanesValues["memory"] != constants.DefaultControlPlaneMemoryDedicated {
-			t.Errorf("Expected dedicated controlplane memory=%d, got %v", constants.DefaultControlPlaneMemoryDedicated, controlplanesValues["memory"])
+		if _, exists := workersValues["memory"]; exists {
+			t.Errorf("Expected workers.memory to be absent, got %v", workersValues["memory"])
 		}
 	})
 
@@ -422,7 +399,7 @@ func TestGetMapInt(t *testing.T) {
 		data := map[string]any{
 			"cluster": map[string]any{
 				"workers": map[string]any{
-					"count_int64": int64(7),
+					"count_int64":  int64(7),
 					"count_uint64": uint64(8),
 				},
 			},


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This PR removes a single, self-contained defaults-injection step from `GetContextValues()`, with fully matching test updates; the blast radius is limited to callers that previously relied on cpu/memory being silently populated.
>
> **Overview**
>
> The change deletes `applyClusterResourceDefaults` from `resolve.go`, which previously injected CPU and memory defaults for cluster controlplanes (varying between dedicated and schedulable modes) and workers when those keys were absent. The `constants` import is cleaned up as a consequence. The companion test is rewritten to verify the inverse: that cpu/memory keys are now absent from `GetContextValues()` output when not explicitly set.
>
> Callers downstream of `GetContextValues()` that read `cluster.controlplanes.cpu`, `cluster.controlplanes.memory`, `cluster.workers.cpu`, or `cluster.workers.memory` without nil/existence guards will now receive absent values instead of the former constants-derived defaults. Whether those defaults have been relocated elsewhere is not visible in this diff.
>
> Reviewed by Claude for commit `c6633d40`.

<!-- /claude-code-review:summary -->
