### PR TITLE
fix(provisioner/kubernetes): Remediate orphaned loadbalancers

### DIFF
--- a/pkg/provisioner/kubernetes/client/client.go
+++ b/pkg/provisioner/kubernetes/client/client.go
@@ -10,12 +10,16 @@ import (
 	"os"
 	"time"
 
+	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/discovery/cached/memory"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/rest"
+	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -41,6 +45,7 @@ type KubernetesClient interface {
 	ListResourcesByLabel(gvr schema.GroupVersionResource, namespace, labelSelector string) (*unstructured.UnstructuredList, error)
 	ApplyResource(gvr schema.GroupVersionResource, obj *unstructured.Unstructured, opts metav1.ApplyOptions) (*unstructured.Unstructured, error)
 	DeleteResource(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error
+	ResourceFor(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error)
 	PatchResource(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*unstructured.Unstructured, error)
 	CheckHealth(ctx context.Context, endpoint string) error
 	GetNodeReadyStatus(ctx context.Context, nodeNames []string) (map[string]bool, error)
@@ -53,6 +58,7 @@ type KubernetesClient interface {
 // DynamicKubernetesClient implements KubernetesClient using dynamic client
 type DynamicKubernetesClient struct {
 	client   dynamic.Interface
+	mapper   meta.RESTMapper
 	endpoint string
 }
 
@@ -119,6 +125,20 @@ func (c *DynamicKubernetesClient) DeleteResource(gvr schema.GroupVersionResource
 	ctx, cancel := context.WithTimeout(context.Background(), requestTimeout)
 	defer cancel()
 	return c.client.Resource(gvr).Namespace(namespace).Delete(ctx, name, opts)
+}
+
+// ResourceFor resolves a GroupVersionKind to its GroupVersionResource using the API server's
+// discovery data, so callers holding only an ownerReference (apiVersion + kind) can address the
+// owning object with the dynamic client. Resolution is cached by the deferred discovery mapper.
+func (c *DynamicKubernetesClient) ResourceFor(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error) {
+	if err := c.ensureClient(); err != nil {
+		return schema.GroupVersionResource{}, err
+	}
+	mapping, err := c.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return schema.GroupVersionResource{}, err
+	}
+	return mapping.Resource, nil
 }
 
 // PatchResource patches a resource. The caller-supplied ctx is honoured so
@@ -209,44 +229,55 @@ func (c *DynamicKubernetesClient) GetNodeReadyStatus(ctx context.Context, nodeNa
 // Private Methods
 // =============================================================================
 
-// ensureClient initializes the dynamic Kubernetes client if unset. Uses endpoint, in-cluster, or kubeconfig as available.
-// Returns error if client setup fails at any stage.
+// ensureClient initializes the dynamic Kubernetes client and REST mapper if unset. Uses endpoint,
+// in-cluster, or kubeconfig as available. The mapper is a deferred discovery mapper, so it performs
+// no API calls until the first ResourceFor lookup. Returns error if client setup fails at any stage.
 func (c *DynamicKubernetesClient) ensureClient() error {
 	if c.client != nil {
 		return nil
 	}
 
-	var config *rest.Config
-	var err error
-
-	if c.endpoint != "" {
-		config = &rest.Config{
-			Host: c.endpoint,
-		}
-	} else {
-		config, err = rest.InClusterConfig()
-		if err != nil {
-			kubeconfig := os.Getenv("KUBECONFIG")
-			if kubeconfig == "" {
-				home, err := os.UserHomeDir()
-				if err != nil {
-					return err
-				}
-				kubeconfig = home + "/.kube/config"
-			}
-			config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
-			if err != nil {
-				return err
-			}
-		}
+	config, err := c.restConfig()
+	if err != nil {
+		return err
 	}
 
 	cli, err := dynamic.NewForConfig(config)
 	if err != nil {
 		return err
 	}
+
+	discoveryClient, err := discovery.NewDiscoveryClientForConfig(config)
+	if err != nil {
+		return err
+	}
+
+	c.mapper = restmapper.NewDeferredDiscoveryRESTMapper(memory.NewMemCacheClient(discoveryClient))
 	c.client = cli
 	return nil
+}
+
+// restConfig builds a Kubernetes REST config, preferring an explicit endpoint, then in-cluster
+// config, then the KUBECONFIG (or ~/.kube/config) kubeconfig file.
+func (c *DynamicKubernetesClient) restConfig() (*rest.Config, error) {
+	if c.endpoint != "" {
+		return &rest.Config{Host: c.endpoint}, nil
+	}
+
+	config, err := rest.InClusterConfig()
+	if err == nil {
+		return config, nil
+	}
+
+	kubeconfig := os.Getenv("KUBECONFIG")
+	if kubeconfig == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return nil, err
+		}
+		kubeconfig = home + "/.kube/config"
+	}
+	return clientcmd.BuildConfigFromFlags("", kubeconfig)
 }
 
 // isNodeReady checks if a node is in Ready state by examining its conditions.

--- a/pkg/provisioner/kubernetes/client/mock_client.go
+++ b/pkg/provisioner/kubernetes/client/mock_client.go
@@ -24,6 +24,7 @@ type MockKubernetesClient struct {
 	ListResourcesByLabelFunc func(gvr schema.GroupVersionResource, namespace, labelSelector string) (*unstructured.UnstructuredList, error)
 	ApplyResourceFunc        func(gvr schema.GroupVersionResource, obj *unstructured.Unstructured, opts metav1.ApplyOptions) (*unstructured.Unstructured, error)
 	DeleteResourceFunc       func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error
+	ResourceForFunc          func(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error)
 	PatchResourceFunc        func(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*unstructured.Unstructured, error)
 	CheckHealthFunc          func(ctx context.Context, endpoint string) error
 	GetNodeReadyStatusFunc   func(ctx context.Context, nodeNames []string) (map[string]bool, error)
@@ -80,6 +81,14 @@ func (m *MockKubernetesClient) DeleteResource(gvr schema.GroupVersionResource, n
 		return m.DeleteResourceFunc(gvr, namespace, name, opts)
 	}
 	return nil
+}
+
+// ResourceFor implements KubernetesClient interface
+func (m *MockKubernetesClient) ResourceFor(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error) {
+	if m.ResourceForFunc != nil {
+		return m.ResourceForFunc(gvk)
+	}
+	return schema.GroupVersionResource{}, nil
 }
 
 // PatchResource implements KubernetesClient interface

--- a/pkg/provisioner/kubernetes/client/mock_client_test.go
+++ b/pkg/provisioner/kubernetes/client/mock_client_test.go
@@ -154,6 +154,44 @@ func TestMockKubernetesClient_DeleteResource(t *testing.T) {
 	})
 }
 
+func TestMockKubernetesClient_ResourceFor(t *testing.T) {
+	setup := func(t *testing.T) *MockKubernetesClient {
+		t.Helper()
+		return NewMockKubernetesClient()
+	}
+	gvk := schema.GroupVersionKind{Group: "gateway.networking.k8s.io", Version: "v1", Kind: "Gateway"}
+
+	t.Run("FuncSet", func(t *testing.T) {
+		client := setup(t)
+		want := schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gateways"}
+		errVal := fmt.Errorf("err")
+		client.ResourceForFunc = func(g schema.GroupVersionKind) (schema.GroupVersionResource, error) {
+			if g != gvk {
+				t.Errorf("Expected gvk %v, got %v", gvk, g)
+			}
+			return want, errVal
+		}
+		got, err := client.ResourceFor(gvk)
+		if got != want {
+			t.Errorf("Expected gvr %v, got %v", want, got)
+		}
+		if err != errVal {
+			t.Errorf("Expected err, got %v", err)
+		}
+	})
+
+	t.Run("FuncNotSet", func(t *testing.T) {
+		client := setup(t)
+		got, err := client.ResourceFor(gvk)
+		if got != (schema.GroupVersionResource{}) {
+			t.Errorf("Expected zero gvr, got %v", got)
+		}
+		if err != nil {
+			t.Errorf("Expected nil, got %v", err)
+		}
+	})
+}
+
 func TestMockKubernetesClient_PatchResource(t *testing.T) {
 	setup := func(t *testing.T) *MockKubernetesClient {
 		t.Helper()
@@ -227,4 +265,3 @@ func TestMockKubernetesClient_CheckHealth(t *testing.T) {
 		}
 	})
 }
-

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -1315,6 +1315,10 @@ func (k *BaseKubernetesManager) DeleteBlueprint(blueprint *blueprintv1alpha1.Blu
 		}
 	}
 
+	if err := k.remediateLoadBalancerOwners(eligible, namespace); err != nil {
+		return fmt.Errorf("destroy aborted: %w", err)
+	}
+
 	for _, kustomization := range orderForDestroy(eligible, "destroy") {
 		tui.Start(fmt.Sprintf("Destroying kustomization %s", kustomization.Name))
 		if err := k.setKustomizationSuspend(kustomization.Name, namespace, false); err != nil {
@@ -1558,6 +1562,160 @@ waitLoop:
 // =============================================================================
 // Private Methods
 // =============================================================================
+
+// servicesGVR is the core v1 Services resource, scanned during destroy to find cloud
+// LoadBalancers that must be released before their controller is torn down.
+var servicesGVR = schema.GroupVersionResource{Group: "", Version: "v1", Resource: "services"}
+
+// maxOwnerWalkDepth bounds the ownerReference ascent when resolving the inventory-owned root of a
+// LoadBalancer Service, guarding against cyclic or pathologically deep owner chains.
+const maxOwnerWalkDepth = 8
+
+// ownedTarget identifies an inventory-owned resource to foreground-delete during load balancer
+// remediation, addressed by its resolved GVR, namespace, and name.
+type ownedTarget struct {
+	gvr       schema.GroupVersionResource
+	namespace string
+	name      string
+}
+
+// remediateLoadBalancerOwners releases cloud LoadBalancers that would otherwise be orphaned when
+// their controller (a cloud-controller-manager) is torn down before the LoadBalancer Service's
+// cloud finalizer runs. Flux prunes with background propagation and waits only on its own
+// inventory, so a controller-generated type=LoadBalancer Service — a child of an inventory object
+// such as a Gateway, never itself in the inventory — is garbage-collected asynchronously and its
+// cloud-LB finalizer can outlive the controller, leaking the LB and wedging the terraform network
+// delete. Called while every controller is still alive (after suspend, before the teardown walk),
+// it lists live type=LoadBalancer Services, walks each one's ownerReferences to the first ancestor
+// present in the eligible kustomizations' inventory, and foreground-deletes that owned root so the
+// ownerReference cascade blocks on the child Service's cloud finalizer while the CCM can still
+// release the LB. Services with no inventory-owned ancestor are foreign and left untouched.
+func (k *BaseKubernetesManager) remediateLoadBalancerOwners(eligible []blueprintv1alpha1.Kustomization, namespace string) error {
+	owned, err := k.ownedInventorySet(eligible, namespace)
+	if err != nil {
+		return err
+	}
+	if len(owned) == 0 {
+		return nil
+	}
+
+	services, err := k.client.ListResources(servicesGVR, "")
+	if err != nil {
+		return fmt.Errorf("error listing services for load balancer remediation: %w", err)
+	}
+	if services == nil {
+		return nil
+	}
+
+	handled := make(map[string]bool)
+	for i := range services.Items {
+		svc := &services.Items[i]
+		if !isLoadBalancerService(svc) {
+			continue
+		}
+		target, found, err := k.ownedRootForService(svc, owned)
+		if err != nil {
+			return err
+		}
+		if !found {
+			continue
+		}
+		key := target.gvr.String() + "|" + target.namespace + "|" + target.name
+		if handled[key] {
+			continue
+		}
+		handled[key] = true
+		if err := k.foregroundDeleteAndWaitService(target, svc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// ownedInventorySet returns the set of resources managed by the eligible kustomizations, keyed by
+// group/kind/namespace/name, from each kustomization's Flux inventory. This is the ground truth of
+// "resources we own" that scopes load balancer remediation to our own LoadBalancers.
+func (k *BaseKubernetesManager) ownedInventorySet(eligible []blueprintv1alpha1.Kustomization, namespace string) (map[string]bool, error) {
+	owned := make(map[string]bool)
+	for _, kustomization := range eligible {
+		entries, err := k.GetKustomizationInventory(kustomization.Name, namespace)
+		if err != nil {
+			return nil, err
+		}
+		for _, entry := range entries {
+			owned[inventoryKey(entry.Group, entry.Kind, entry.Namespace, entry.Name)] = true
+		}
+	}
+	return owned, nil
+}
+
+// ownedRootForService walks a LoadBalancer Service's ownerReferences to the first ancestor present
+// in the owned inventory set and returns it as the deletion target. A Service we applied directly
+// is its own target; otherwise the ascent follows the controller ownerReference upward, fetching
+// each owner to read its own references, until an owned ancestor is found or the chain ends.
+// Returns found=false when no ancestor is ours (a foreign LoadBalancer we must not touch).
+func (k *BaseKubernetesManager) ownedRootForService(svc *unstructured.Unstructured, owned map[string]bool) (ownedTarget, bool, error) {
+	namespace := svc.GetNamespace()
+	if owned[inventoryKey("", "Service", namespace, svc.GetName())] {
+		return ownedTarget{gvr: servicesGVR, namespace: namespace, name: svc.GetName()}, true, nil
+	}
+
+	current := svc
+	for range maxOwnerWalkDepth {
+		owner := controllerOwnerRef(current)
+		if owner == nil {
+			return ownedTarget{}, false, nil
+		}
+		gv, err := schema.ParseGroupVersion(owner.APIVersion)
+		if err != nil {
+			return ownedTarget{}, false, nil
+		}
+		gvr, err := k.client.ResourceFor(gv.WithKind(owner.Kind))
+		if err != nil {
+			return ownedTarget{}, false, nil
+		}
+		if owned[inventoryKey(gv.Group, owner.Kind, namespace, owner.Name)] {
+			return ownedTarget{gvr: gvr, namespace: namespace, name: owner.Name}, true, nil
+		}
+		next, err := k.client.GetResource(gvr, namespace, owner.Name)
+		if err != nil {
+			if isNotFoundError(err) {
+				return ownedTarget{}, false, nil
+			}
+			return ownedTarget{}, false, err
+		}
+		current = next
+	}
+	return ownedTarget{}, false, nil
+}
+
+// foregroundDeleteAndWaitService foreground-deletes an owned load balancer root and waits for the
+// backing LoadBalancer Service to disappear, confirming the cloud-controller-manager released the
+// LB. Foreground propagation holds the owner until its garbage-collected children clear, so the
+// child Service's cloud finalizer runs while the CCM is still alive. A NotFound on delete is
+// treated as already-gone. On timeout the LoadBalancer is likely orphaned, so it returns an error
+// rather than letting destroy proceed into the terraform teardown that the orphan would wedge.
+func (k *BaseKubernetesManager) foregroundDeleteAndWaitService(target ownedTarget, svc *unstructured.Unstructured) error {
+	policy := metav1.DeletePropagationForeground
+	err := k.client.DeleteResource(target.gvr, target.namespace, target.name, metav1.DeleteOptions{PropagationPolicy: &policy})
+	if err != nil && !isNotFoundError(err) {
+		return fmt.Errorf("error foreground-deleting load balancer owner %s/%s: %w", target.namespace, target.name, err)
+	}
+
+	namespace, name := svc.GetNamespace(), svc.GetName()
+	timeout := time.Now().Add(k.kustomizationReconcileTimeout)
+	for time.Now().Before(timeout) {
+		_, err := k.client.GetResource(servicesGVR, namespace, name)
+		if err != nil && isNotFoundError(err) {
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("error waiting for load balancer service %s/%s deletion: %w", namespace, name, err)
+		}
+		time.Sleep(k.kustomizationWaitPollInterval)
+	}
+	return fmt.Errorf("timeout waiting for load balancer service %s/%s to be released; its cloud finalizer has not lifted and the cloud load balancer may be orphaned — inspect with `kubectl get svc %s -n %s -o yaml` and confirm the cloud-controller-manager is still running", namespace, name, name, namespace)
+}
 
 // gitopsNamespace returns the configured gitops namespace, defaulting to DefaultGitopsNamespace.
 func (k *BaseKubernetesManager) gitopsNamespace() string {
@@ -1880,6 +2038,34 @@ func (k *BaseKubernetesManager) applyBlueprintOCIRepository(source blueprintv1al
 // =============================================================================
 // Helpers
 // =============================================================================
+
+// inventoryKey builds the group/kind/namespace/name key used to match live objects against a
+// kustomization's Flux inventory. Group is empty for core API objects; namespace is empty for
+// cluster-scoped resources.
+func inventoryKey(group, kind, namespace, name string) string {
+	return strings.Join([]string{group, kind, namespace, name}, "|")
+}
+
+// isLoadBalancerService reports whether an object is a Service of spec.type LoadBalancer.
+func isLoadBalancerService(svc *unstructured.Unstructured) bool {
+	svcType, found, err := unstructured.NestedString(svc.Object, "spec", "type")
+	return err == nil && found && svcType == "LoadBalancer"
+}
+
+// controllerOwnerRef returns the controller ownerReference of an object, falling back to the first
+// ownerReference when none is marked controller. Returns nil when the object has no owners.
+func controllerOwnerRef(obj *unstructured.Unstructured) *metav1.OwnerReference {
+	refs := obj.GetOwnerReferences()
+	for i := range refs {
+		if refs[i].Controller != nil && *refs[i].Controller {
+			return &refs[i]
+		}
+	}
+	if len(refs) > 0 {
+		return &refs[0]
+	}
+	return nil
+}
 
 // validateFields validates required fields and types
 func validateFields(obj *unstructured.Unstructured) error {

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -26,6 +26,7 @@ import (
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	runtimegit "github.com/windsorcli/cli/pkg/runtime/git"
 	"github.com/windsorcli/cli/pkg/tui"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -1672,7 +1673,10 @@ func (k *BaseKubernetesManager) ownedRootForService(svc *unstructured.Unstructur
 		}
 		gvr, err := k.client.ResourceFor(gv.WithKind(owner.Kind))
 		if err != nil {
-			return ownedTarget{}, false, nil
+			if apimeta.IsNoMatchError(err) {
+				return ownedTarget{}, false, nil
+			}
+			return ownedTarget{}, false, fmt.Errorf("error resolving load balancer owner %s %q: %w", owner.Kind, owner.Name, err)
 		}
 		if owned[inventoryKey(gv.Group, owner.Kind, namespace, owner.Name)] {
 			return ownedTarget{gvr: gvr, namespace: namespace, name: owner.Name}, true, nil

--- a/pkg/provisioner/kubernetes/kubernetes_manager_private_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_private_test.go
@@ -10,6 +10,7 @@ import (
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/provisioner/kubernetes/client"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -162,6 +163,71 @@ func TestBaseKubernetesManager_remediateLoadBalancerOwners(t *testing.T) {
 		}
 		if deleted {
 			t.Error("Expected no delete for a LoadBalancer whose owner is not in our inventory")
+		}
+	})
+
+	t.Run("PropagatesTransientResourceForError", func(t *testing.T) {
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			if gvr.Resource == "kustomizations" {
+				return kustomizationWithInventory(gatewayInventoryID), nil
+			}
+			return nil, fmt.Errorf("%s %q not found", gvr.Resource, name)
+		}
+		kubernetesClient.ListResourcesFunc = func(gvr schema.GroupVersionResource, namespace string) (*unstructured.UnstructuredList, error) {
+			return &unstructured.UnstructuredList{Items: []unstructured.Unstructured{
+				lbService("system-gateway", "cilium-gateway-external", &gatewayOwner),
+			}}, nil
+		}
+		kubernetesClient.ResourceForFunc = func(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error) {
+			return schema.GroupVersionResource{}, fmt.Errorf("the server is currently unable to handle the request")
+		}
+		deleted := false
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			deleted = true
+			return nil
+		}
+		manager.client = kubernetesClient
+
+		err := manager.remediateLoadBalancerOwners(eligible, "system-gitops")
+		if err == nil {
+			t.Fatal("Expected a transient discovery error to abort remediation, got nil")
+		}
+		if deleted {
+			t.Error("Expected no delete when owner resolution failed transiently")
+		}
+	})
+
+	t.Run("SkipsWhenOwnerKindHasNoMatch", func(t *testing.T) {
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			if gvr.Resource == "kustomizations" {
+				return kustomizationWithInventory(gatewayInventoryID), nil
+			}
+			return nil, fmt.Errorf("%s %q not found", gvr.Resource, name)
+		}
+		kubernetesClient.ListResourcesFunc = func(gvr schema.GroupVersionResource, namespace string) (*unstructured.UnstructuredList, error) {
+			return &unstructured.UnstructuredList{Items: []unstructured.Unstructured{
+				lbService("system-gateway", "cilium-gateway-external", &gatewayOwner),
+			}}, nil
+		}
+		kubernetesClient.ResourceForFunc = func(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error) {
+			return schema.GroupVersionResource{}, &apimeta.NoKindMatchError{GroupKind: gvk.GroupKind()}
+		}
+		deleted := false
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			deleted = true
+			return nil
+		}
+		manager.client = kubernetesClient
+
+		if err := manager.remediateLoadBalancerOwners(eligible, "system-gitops"); err != nil {
+			t.Fatalf("Expected no error when the owner kind has no match, got %v", err)
+		}
+		if deleted {
+			t.Error("Expected no delete when the owner kind is unresolvable")
 		}
 	})
 

--- a/pkg/provisioner/kubernetes/kubernetes_manager_private_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_private_test.go
@@ -10,9 +10,250 @@ import (
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/provisioner/kubernetes/client"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
+
+func TestBaseKubernetesManager_remediateLoadBalancerOwners(t *testing.T) {
+	setup := func(t *testing.T) *BaseKubernetesManager {
+		t.Helper()
+		mocks := setupKubernetesMocks(t)
+		manager := NewKubernetesManager(mocks.KubernetesClient, mocks.ConfigHandler)
+		manager.kustomizationWaitPollInterval = 20 * time.Millisecond
+		manager.kustomizationReconcileTimeout = 100 * time.Millisecond
+		return manager
+	}
+
+	controller := true
+	gatewayOwner := metav1.OwnerReference{
+		APIVersion: "gateway.networking.k8s.io/v1",
+		Kind:       "Gateway",
+		Name:       "external",
+		Controller: &controller,
+	}
+	gatewaysGVR := schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gateways"}
+
+	// lbService builds a type=LoadBalancer Service, optionally owned by the given ownerReference.
+	lbService := func(namespace, name string, owner *metav1.OwnerReference) unstructured.Unstructured {
+		u := unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "v1",
+			"kind":       "Service",
+			"metadata":   map[string]any{"namespace": namespace, "name": name},
+			"spec":       map[string]any{"type": "LoadBalancer"},
+		}}
+		if owner != nil {
+			u.SetOwnerReferences([]metav1.OwnerReference{*owner})
+		}
+		return u
+	}
+
+	// kustomizationWithInventory builds a Kustomization object carrying the given inventory IDs
+	// (each of the form "<namespace>_<name>_<group>_<kind>").
+	kustomizationWithInventory := func(ids ...string) *unstructured.Unstructured {
+		entries := make([]any, 0, len(ids))
+		for _, id := range ids {
+			entries = append(entries, map[string]any{"id": id})
+		}
+		return &unstructured.Unstructured{Object: map[string]any{
+			"status": map[string]any{"inventory": map[string]any{"entries": entries}},
+		}}
+	}
+
+	gatewayInventoryID := "system-gateway_external_gateway.networking.k8s.io_Gateway"
+	eligible := []blueprintv1alpha1.Kustomization{{Name: "gateway-resources"}}
+
+	t.Run("ForegroundDeletesGatewayOwningLoadBalancer", func(t *testing.T) {
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			if gvr.Resource == "kustomizations" {
+				return kustomizationWithInventory(gatewayInventoryID), nil
+			}
+			return nil, fmt.Errorf("%s %q not found", gvr.Resource, name)
+		}
+		kubernetesClient.ListResourcesFunc = func(gvr schema.GroupVersionResource, namespace string) (*unstructured.UnstructuredList, error) {
+			return &unstructured.UnstructuredList{Items: []unstructured.Unstructured{
+				lbService("system-gateway", "cilium-gateway-external", &gatewayOwner),
+			}}, nil
+		}
+		kubernetesClient.ResourceForFunc = func(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error) {
+			return gatewaysGVR, nil
+		}
+		var deletedGVR schema.GroupVersionResource
+		var deletedName string
+		var deletedPolicy *metav1.DeletionPropagation
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			deletedGVR, deletedName, deletedPolicy = gvr, name, opts.PropagationPolicy
+			return nil
+		}
+		manager.client = kubernetesClient
+
+		if err := manager.remediateLoadBalancerOwners(eligible, "system-gitops"); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if deletedGVR != gatewaysGVR {
+			t.Errorf("Expected delete on %v, got %v", gatewaysGVR, deletedGVR)
+		}
+		if deletedName != "external" {
+			t.Errorf("Expected the owning Gateway 'external' deleted, got %q", deletedName)
+		}
+		if deletedPolicy == nil || *deletedPolicy != metav1.DeletePropagationForeground {
+			t.Errorf("Expected foreground propagation, got %v", deletedPolicy)
+		}
+	})
+
+	t.Run("ForegroundDeletesDirectlyOwnedLoadBalancerService", func(t *testing.T) {
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			if gvr.Resource == "kustomizations" {
+				return kustomizationWithInventory("system-lb_my-lb__Service"), nil
+			}
+			return nil, fmt.Errorf("%s %q not found", gvr.Resource, name)
+		}
+		kubernetesClient.ListResourcesFunc = func(gvr schema.GroupVersionResource, namespace string) (*unstructured.UnstructuredList, error) {
+			return &unstructured.UnstructuredList{Items: []unstructured.Unstructured{
+				lbService("system-lb", "my-lb", nil),
+			}}, nil
+		}
+		var deletedGVR schema.GroupVersionResource
+		var deletedName string
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			deletedGVR, deletedName = gvr, name
+			return nil
+		}
+		manager.client = kubernetesClient
+
+		if err := manager.remediateLoadBalancerOwners(eligible, "system-gitops"); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if deletedGVR != servicesGVR || deletedName != "my-lb" {
+			t.Errorf("Expected delete on service my-lb, got %v %q", deletedGVR, deletedName)
+		}
+	})
+
+	t.Run("SkipsForeignLoadBalancer", func(t *testing.T) {
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			if gvr.Resource == "kustomizations" {
+				return kustomizationWithInventory("system-gateway_other_gateway.networking.k8s.io_Gateway"), nil
+			}
+			return nil, fmt.Errorf("%s %q not found", gvr.Resource, name)
+		}
+		kubernetesClient.ListResourcesFunc = func(gvr schema.GroupVersionResource, namespace string) (*unstructured.UnstructuredList, error) {
+			return &unstructured.UnstructuredList{Items: []unstructured.Unstructured{
+				lbService("system-gateway", "cilium-gateway-external", &gatewayOwner),
+			}}, nil
+		}
+		kubernetesClient.ResourceForFunc = func(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error) {
+			return gatewaysGVR, nil
+		}
+		deleted := false
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			deleted = true
+			return nil
+		}
+		manager.client = kubernetesClient
+
+		if err := manager.remediateLoadBalancerOwners(eligible, "system-gitops"); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if deleted {
+			t.Error("Expected no delete for a LoadBalancer whose owner is not in our inventory")
+		}
+	})
+
+	t.Run("NoOpWhenNoLoadBalancerServices", func(t *testing.T) {
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			if gvr.Resource == "kustomizations" {
+				return kustomizationWithInventory(gatewayInventoryID), nil
+			}
+			return nil, fmt.Errorf("%s %q not found", gvr.Resource, name)
+		}
+		clusterIPService := unstructured.Unstructured{Object: map[string]any{
+			"apiVersion": "v1", "kind": "Service",
+			"metadata": map[string]any{"namespace": "system-gateway", "name": "internal"},
+			"spec":     map[string]any{"type": "ClusterIP"},
+		}}
+		kubernetesClient.ListResourcesFunc = func(gvr schema.GroupVersionResource, namespace string) (*unstructured.UnstructuredList, error) {
+			return &unstructured.UnstructuredList{Items: []unstructured.Unstructured{clusterIPService}}, nil
+		}
+		deleted := false
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			deleted = true
+			return nil
+		}
+		manager.client = kubernetesClient
+
+		if err := manager.remediateLoadBalancerOwners(eligible, "system-gitops"); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if deleted {
+			t.Error("Expected no delete when there are no type=LoadBalancer services")
+		}
+	})
+
+	t.Run("NoOpWhenInventoryEmpty", func(t *testing.T) {
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			return nil, fmt.Errorf("%s %q not found", gvr.Resource, name)
+		}
+		listed := false
+		kubernetesClient.ListResourcesFunc = func(gvr schema.GroupVersionResource, namespace string) (*unstructured.UnstructuredList, error) {
+			listed = true
+			return &unstructured.UnstructuredList{}, nil
+		}
+		manager.client = kubernetesClient
+
+		if err := manager.remediateLoadBalancerOwners(eligible, "system-gitops"); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if listed {
+			t.Error("Expected no service scan when the eligible inventory is empty")
+		}
+	})
+
+	t.Run("ErrorsWhenLoadBalancerServiceNeverReleases", func(t *testing.T) {
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			if gvr.Resource == "kustomizations" {
+				return kustomizationWithInventory(gatewayInventoryID), nil
+			}
+			if gvr.Resource == "services" {
+				return &unstructured.Unstructured{Object: map[string]any{
+					"metadata": map[string]any{"namespace": namespace, "name": name},
+				}}, nil
+			}
+			return nil, fmt.Errorf("%s %q not found", gvr.Resource, name)
+		}
+		kubernetesClient.ListResourcesFunc = func(gvr schema.GroupVersionResource, namespace string) (*unstructured.UnstructuredList, error) {
+			return &unstructured.UnstructuredList{Items: []unstructured.Unstructured{
+				lbService("system-gateway", "cilium-gateway-external", &gatewayOwner),
+			}}, nil
+		}
+		kubernetesClient.ResourceForFunc = func(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error) {
+			return gatewaysGVR, nil
+		}
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			return nil
+		}
+		manager.client = kubernetesClient
+
+		err := manager.remediateLoadBalancerOwners(eligible, "system-gitops")
+		if err == nil {
+			t.Fatal("Expected a timeout error when the load balancer service never releases")
+		}
+		if !strings.Contains(err.Error(), "cilium-gateway-external") {
+			t.Errorf("Expected error to name the stuck service, got %v", err)
+		}
+	})
+}
 
 func TestBaseKubernetesManager_waitForNodesReady(t *testing.T) {
 	setup := func(t *testing.T) *BaseKubernetesManager {


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This change runs in the `DeleteBlueprint` destroy path — a one-way operation — and introduces a new foreground-delete + wait step that can abort the entire teardown if the cloud LB finalizer never lifts.
>
> **Overview**
>
> The PR adds a `remediateLoadBalancerOwners` step to the Kubernetes destroy flow, inserted after kustomizations are suspended but before teardown begins. It lists all type=LoadBalancer Services cluster-wide, walks each one's ownerReference chain to find the first ancestor tracked in the eligible Flux inventory, and foreground-deletes that ancestor so the cascading garbage-collection holds the owner open until the cloud-controller-manager can release the LB. Services with no inventory-owned ancestor are left untouched.
>
> To resolve GVK→GVR for ownerReferences, a deferred REST discovery mapper is added to `DynamicKubernetesClient` and exposed via a new `ResourceFor` interface method. The mapper is initialized alongside the dynamic client in `ensureClient` and uses an in-memory cache to avoid redundant API-server calls.
>
> Reviewed by Claude for commit `cb7d0031`.

<!-- /claude-code-review:summary -->
