### PR TITLE
feat(test): add env support for hermetic expression resolution in test cases

### DIFF
--- a/api/v1alpha1/test_types.go
+++ b/api/v1alpha1/test_types.go
@@ -21,6 +21,10 @@ type TestCase struct {
 	// These override any existing configuration for the test.
 	Values map[string]any `yaml:"values,omitempty"`
 
+	// Env provides environment variables visible to env() expressions during composition.
+	// Resolution is hermetic: env() sees only these entries, never the host environment.
+	Env map[string]string `yaml:"env,omitempty"`
+
 	// TerraformOutputs provides mock terraform outputs for terraform_output() expressions.
 	// Keys are component IDs, values are maps of output key-value pairs.
 	// Example: {"network": {"vpc_id": "vpc-123", "subnet_ids": ["subnet-1", "subnet-2"]}}

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -20,6 +20,7 @@ specific terraform components and kustomizations are present (or absent).
 | Field | Type | Description |
 |------|------|-------------|
 | `name` | `string` | Unique identifier for the test case. **(required)** |
+| `env` | `map<string>` | Environment variables visible to env() expressions during composition. Resolution is hermetic: env() sees only these entries, never the host environment. WINDSOR_CONTEXT defaults to "test" and can be overridden here. Example: env.ENABLE_DNS = "yes". |
 | `exclude` | `object` | Components and kustomizations that must NOT be present in the composed blueprint. Same partial-match semantics as 'expect'. |
 | `expect` | `object` | Components and kustomizations that must be present in the composed blueprint. Partial matching: only fields you specify are checked. |
 | `expectError` | `boolean` | When true, the test passes only if blueprint composition fails. Use for testing invalid configurations that the framework should reject. Defaults to false. |
@@ -110,6 +111,12 @@ cases:
     terraformOutputs:
       network:
         external_dns_zone_id: Z123456
+  - env:
+      ENABLE_DNS: "yes"
+    expect:
+      kustomize:
+        - name: addon-dns
+    name: env-gates-addon
 ```
 
 ## See also

--- a/integration/fixtures/test-env/contexts/_template/blueprint.yaml
+++ b/integration/fixtures/test-env/contexts/_template/blueprint.yaml
@@ -1,0 +1,5 @@
+kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: test-env
+  description: Exercises hermetic env() resolution in the windsor test harness

--- a/integration/fixtures/test-env/contexts/_template/facets/platform.yaml
+++ b/integration/fixtures/test-env/contexts/_template/facets/platform.yaml
@@ -1,0 +1,14 @@
+kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: platform
+  description: dns addon is gated on the ENABLE_DNS environment variable via env()
+when: true
+kustomize:
+  - name: addon-dns
+    path: addons/dns
+    when: env('ENABLE_DNS') == 'yes'
+    components:
+      - coredns
+    timeout: 5m
+    interval: 5m

--- a/integration/fixtures/test-env/contexts/_template/tests/env.test.yaml
+++ b/integration/fixtures/test-env/contexts/_template/tests/env.test.yaml
@@ -1,0 +1,22 @@
+# Exercises the env: field of the windsor test harness. env() resolves hermetically
+# from each case's env map only — never from the host environment — so a case with
+# ENABLE_DNS=yes includes the gated addon and a case without it excludes the addon
+# even when the host has ENABLE_DNS set.
+
+cases:
+
+  # env map enables the gate: addon-dns is composed.
+  - name: env_enables_addon
+    env:
+      ENABLE_DNS: "yes"
+    expect:
+      kustomize:
+        - name: addon-dns
+          path: addons/dns
+
+  # No env map for the case: env() sees nothing, so the addon is excluded. The
+  # integration test sets ENABLE_DNS in the host env to prove resolution is hermetic.
+  - name: env_absent_excludes_addon
+    exclude:
+      kustomize:
+        - name: addon-dns

--- a/integration/fixtures/test-env/windsor.yaml
+++ b/integration/fixtures/test-env/windsor.yaml
@@ -1,0 +1,3 @@
+version: v1alpha1
+contexts:
+  default: {}

--- a/integration/test_test.go
+++ b/integration/test_test.go
@@ -64,6 +64,25 @@ func TestWindsorTest_TerraformOutputUnregisteredFixture(t *testing.T) {
 	}
 }
 
+// TestWindsorTest_EnvFixture exercises the env: field of a test case. The platform facet
+// gates addon-dns on env('ENABLE_DNS') == 'yes'. One case supplies that via env: and expects
+// the addon present; the other omits it and expects the addon absent. ENABLE_DNS is set in the
+// host environment for the whole run to prove env() resolves hermetically from the case env map
+// only — if the host leaked through, the exclude case would fail.
+func TestWindsorTest_EnvFixture(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "test-env")
+	env = append(env, "WINDSOR_CONTEXT=test", "ENABLE_DNS=yes")
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"test"}, env)
+	if err != nil {
+		t.Fatalf("windsor test: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
+	}
+	out := string(stdout) + string(stderr)
+	if !strings.Contains(out, "PASS") && !strings.Contains(out, "✓") {
+		t.Errorf("expected PASS or ✓ in output: %s", out)
+	}
+}
+
 // TestWindsorTest_FluxSystemTiersFixture exercises expect.flux/exclude.flux against the
 // facet-tiers fixture's tiers.test.yaml: a system merged across facets (install components
 // accumulate, same-ordinal resources variants merge), and a when:-gated system whose install

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -205,6 +205,9 @@ func facetProvides(facet blueprintv1alpha1.Facet) []string {
 // If sourceName is set, it updates Source on components lacking it. The target blueprint is modified in place.
 // Returns: evaluated config scope and block order for the loader. Runtime ConfigHandler context values are
 // merged over facet-derived scope so 'when' or component expressions use the actual config.
+// A facet whose requires are not yet satisfied still contributes its config blocks to the scope, so a value
+// it derives (e.g. a token sourced from env()) feeds its requires check on the next round; such a facet
+// contributes config only, never terraform, kustomizations, or flux systems.
 func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Blueprint, facets []blueprintv1alpha1.Facet, sourceName ...string) (map[string]any, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -274,16 +277,16 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 			if err != nil {
 				return nil, err
 			}
-			if len(misses) > 0 {
-				pendingRequirements[facet.Metadata.Name] = facetRequirementMisses{Misses: misses}
-				continue
-			}
-			includedFacets = append(includedFacets, facet)
 			var errMerge error
 			globalScope, cfgEntries, errMerge = p.mergeFacetScopeIntoGlobal(facet, globalScope, cfgEntries, passScope)
 			if errMerge != nil {
 				return nil, fmt.Errorf("facet %s: %w", facet.Metadata.Name, errMerge)
 			}
+			if len(misses) > 0 {
+				pendingRequirements[facet.Metadata.Name] = facetRequirementMisses{Misses: misses}
+				continue
+			}
+			includedFacets = append(includedFacets, facet)
 		}
 		if err := p.evaluateGlobalScopeConfig(globalScope, contextScope); err != nil {
 			return nil, err
@@ -646,10 +649,6 @@ func (p *BaseBlueprintProcessor) evaluateGlobalScopeConfig(globalScope map[strin
 			contextScope = vals
 		}
 	}
-	// Order blocks by their inter-block reference dependencies, not by the order facets
-	// happened to write them. A block that references another must evaluate after the
-	// block it references, regardless of authoring order. topoSortConfigBlocks returns
-	// blocks in dependency order with alphabetical tiebreak.
 	names, err := topoSortConfigBlocks(globalScope)
 	if err != nil {
 		return err

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -205,9 +205,6 @@ func facetProvides(facet blueprintv1alpha1.Facet) []string {
 // If sourceName is set, it updates Source on components lacking it. The target blueprint is modified in place.
 // Returns: evaluated config scope and block order for the loader. Runtime ConfigHandler context values are
 // merged over facet-derived scope so 'when' or component expressions use the actual config.
-// A facet whose requires are not yet satisfied still contributes its config blocks to the scope, so a value
-// it derives (e.g. a token sourced from env()) feeds its requires check on the next round; such a facet
-// contributes config only, never terraform, kustomizations, or flux systems.
 func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Blueprint, facets []blueprintv1alpha1.Facet, sourceName ...string) (map[string]any, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -277,16 +274,16 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 			if err != nil {
 				return nil, err
 			}
-			var errMerge error
-			globalScope, cfgEntries, errMerge = p.mergeFacetScopeIntoGlobal(facet, globalScope, cfgEntries, passScope)
-			if errMerge != nil {
-				return nil, fmt.Errorf("facet %s: %w", facet.Metadata.Name, errMerge)
-			}
 			if len(misses) > 0 {
 				pendingRequirements[facet.Metadata.Name] = facetRequirementMisses{Misses: misses}
 				continue
 			}
 			includedFacets = append(includedFacets, facet)
+			var errMerge error
+			globalScope, cfgEntries, errMerge = p.mergeFacetScopeIntoGlobal(facet, globalScope, cfgEntries, passScope)
+			if errMerge != nil {
+				return nil, fmt.Errorf("facet %s: %w", facet.Metadata.Name, errMerge)
+			}
 		}
 		if err := p.evaluateGlobalScopeConfig(globalScope, contextScope); err != nil {
 			return nil, err

--- a/pkg/runtime/config/schemas/artifacts/testing.yaml
+++ b/pkg/runtime/config/schemas/artifacts/testing.yaml
@@ -29,6 +29,15 @@ properties:
             Configuration values to apply before composing the blueprint.
             These override any existing configuration for the test. Dotted
             keys are allowed (e.g. 'cluster.driver: talos').
+        env:
+          type: object
+          additionalProperties:
+            type: string
+          description: |
+            Environment variables visible to env() expressions during
+            composition. Resolution is hermetic: env() sees only these
+            entries, never the host environment. WINDSOR_CONTEXT defaults to
+            "test" and can be overridden here. Example: env.ENABLE_DNS = "yes".
         terraformOutputs:
           type: object
           additionalProperties:
@@ -161,3 +170,9 @@ examples:
             - name: dns
               substitutions:
                 external_dns_zone_id: Z123456
+      - name: env-gates-addon
+        env:
+          ENABLE_DNS: "yes"
+        expect:
+          kustomize:
+            - name: addon-dns

--- a/pkg/runtime/evaluator/evaluator.go
+++ b/pkg/runtime/evaluator/evaluator.go
@@ -126,6 +126,7 @@ func ExpressionBody(value string) (string, bool) {
 type ExpressionEvaluator interface {
 	HelperRegistrar
 	SetTemplateData(templateData map[string][]byte)
+	SetEnvLookup(lookup func(name string) (string, bool))
 	Evaluate(expression string, facetPath string, scope map[string]any, evaluateDeferred bool) (any, error)
 	EvaluateMap(values map[string]any, facetPath string, scope map[string]any, evaluateDeferred bool) (map[string]any, error)
 }
@@ -169,6 +170,12 @@ func NewExpressionEvaluator(configHandler config.ConfigHandler, projectRoot, tem
 // relative to the template root, typically prefixed with "_template/".
 func (e *expressionEvaluator) SetTemplateData(templateData map[string][]byte) {
 	e.templateData = templateData
+}
+
+// SetEnvLookup replaces the source that env() expressions resolve against.
+// The test runner uses this to supply a hermetic environment so composition never reads the host env.
+func (e *expressionEvaluator) SetEnvLookup(lookup func(name string) (string, bool)) {
+	e.Shims.LookupEnv = lookup
 }
 
 // Register adds a custom helper function to the evaluator for expression evaluation.

--- a/pkg/runtime/evaluator/mock_evaluator.go
+++ b/pkg/runtime/evaluator/mock_evaluator.go
@@ -6,6 +6,7 @@ package evaluator
 // of all ExpressionEvaluator interface methods.
 type MockExpressionEvaluator struct {
 	SetTemplateDataFunc func(templateData map[string][]byte)
+	SetEnvLookupFunc    func(lookup func(name string) (string, bool))
 	RegisterFunc        func(name string, helper func(params []any, deferred bool) (any, error), signature any)
 	EvaluateFunc        func(expression string, facetPath string, scope map[string]any, evaluateDeferred bool) (any, error)
 	EvaluateMapFunc     func(values map[string]any, facetPath string, scope map[string]any, evaluateDeferred bool) (map[string]any, error)
@@ -28,6 +29,13 @@ func NewMockExpressionEvaluator() *MockExpressionEvaluator {
 func (m *MockExpressionEvaluator) SetTemplateData(templateData map[string][]byte) {
 	if m.SetTemplateDataFunc != nil {
 		m.SetTemplateDataFunc(templateData)
+	}
+}
+
+// SetEnvLookup calls the mock SetEnvLookupFunc if set, otherwise does nothing.
+func (m *MockExpressionEvaluator) SetEnvLookup(lookup func(name string) (string, bool)) {
+	if m.SetEnvLookupFunc != nil {
+		m.SetEnvLookupFunc(lookup)
 	}
 }
 

--- a/pkg/runtime/evaluator/mock_evaluator_test.go
+++ b/pkg/runtime/evaluator/mock_evaluator_test.go
@@ -98,6 +98,44 @@ func TestMockExpressionEvaluator_SetTemplateData(t *testing.T) {
 	})
 }
 
+// TestMockExpressionEvaluator_SetEnvLookup tests the SetEnvLookup method of MockExpressionEvaluator
+func TestMockExpressionEvaluator_SetEnvLookup(t *testing.T) {
+	t.Run("Success", func(t *testing.T) {
+		// Given a mock evaluator with SetEnvLookupFunc set
+		mockEvaluator := setupMockEvaluatorMocks(t)
+		called := false
+		mockEvaluator.SetEnvLookupFunc = func(lookup func(name string) (string, bool)) {
+			called = true
+			if value, present := lookup("FOO"); !present || value != "bar" {
+				t.Errorf("Expected lookup to return bar/true, got %q/%v", value, present)
+			}
+		}
+
+		// When SetEnvLookup is called
+		mockEvaluator.SetEnvLookup(func(name string) (string, bool) {
+			return "bar", name == "FOO"
+		})
+
+		// Then the function should be called
+		if !called {
+			t.Error("Expected SetEnvLookupFunc to be called")
+		}
+	})
+
+	t.Run("NotImplemented", func(t *testing.T) {
+		// Given a mock evaluator without SetEnvLookupFunc set
+		mockEvaluator := setupMockEvaluatorMocks(t)
+
+		// When SetEnvLookup is called
+		mockEvaluator.SetEnvLookup(func(name string) (string, bool) { return "", false })
+
+		// Then no error should occur (does nothing)
+		if mockEvaluator == nil {
+			t.Error("Expected mock evaluator to exist")
+		}
+	})
+}
+
 // TestMockExpressionEvaluator_Register tests the Register method of MockExpressionEvaluator
 func TestMockExpressionEvaluator_Register(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {

--- a/pkg/test/runner.go
+++ b/pkg/test/runner.go
@@ -89,9 +89,6 @@ func (r *TestRunner) RunAndPrint(filter string) error {
 // Run discovers and executes test cases, returning results for each test.
 // If filter is provided, only tests matching the filter name are executed.
 func (r *TestRunner) Run(filter string) ([]TestResult, error) {
-	restore := r.withTestContextEnv()
-	defer restore()
-
 	if r.RunFunc != nil {
 		return r.RunFunc(filter)
 	}
@@ -154,33 +151,18 @@ func (r *TestRunner) discoverTestCases(filter string) ([]testCaseWithFile, error
 	return out, nil
 }
 
-// withTestContextEnv sets WINDSOR_CONTEXT to "test" for the duration of a test run.
-// Test isolation is provided by createGenerator, which constructs each fresh ConfigHandler
-// with .WithContext("test") — the in-memory override takes highest priority in GetContext,
-// above both the .windsor/context file and the WINDSOR_CONTEXT env var.
-// The env var set here is a belt-and-suspenders signal for any code that reads it directly
-// via os.Getenv rather than through the ConfigHandler.
-// Returns a restore function that reverts the env var; call it via defer in Run().
-func (r *TestRunner) withTestContextEnv() (restore func()) {
-	originalContext := os.Getenv("WINDSOR_CONTEXT")
-	_ = os.Setenv("WINDSOR_CONTEXT", "test")
-	return func() {
-		if originalContext != "" {
-			_ = os.Setenv("WINDSOR_CONTEXT", originalContext)
-		} else {
-			_ = os.Unsetenv("WINDSOR_CONTEXT")
-		}
-	}
-}
-
 // createGenerator creates a function that generates blueprints from test values.
 // It sets up an isolated runtime environment for each test case, ensuring complete test isolation by creating
 // a fresh ConfigHandler instance and configuring the runtime to use only the _template directory. The generator
 // applies test values directly without loading any context files, ensuring tests only use explicitly provided inputs.
 // If terraformOutputs are provided, it registers a mock TerraformProvider to supply mock outputs for terraform_output()
 // expressions. This allows tests to validate blueprint composition that depends on Terraform outputs without requiring
-// actual Terraform state. Returns a function that takes test values and returns a composed blueprint or an error.
-func (r *TestRunner) createGenerator(terraformOutputs map[string]map[string]any) func(values map[string]any) (*blueprintv1alpha1.Blueprint, error) {
+// actual Terraform state. The env map supplies a hermetic environment for env() expressions, resolved only
+// from these entries so composition never reads the host env; WINDSOR_CONTEXT defaults to "test" and the
+// env map overrides it. Context isolation itself comes from the fresh ConfigHandler's .WithContext("test"),
+// which outranks the .windsor/context file and the WINDSOR_CONTEXT env var in GetContext.
+// Returns a function that takes test values and returns a composed blueprint or an error.
+func (r *TestRunner) createGenerator(terraformOutputs map[string]map[string]any, env map[string]string) func(values map[string]any) (*blueprintv1alpha1.Blueprint, error) {
 	return func(values map[string]any) (*blueprintv1alpha1.Blueprint, error) {
 		freshConfigHandler := config.NewConfigHandler(r.baseShell).WithContext("test")
 
@@ -218,6 +200,17 @@ func (r *TestRunner) createGenerator(terraformOutputs map[string]map[string]any)
 
 		if err := rt.InitializeComponents(); err != nil {
 			return nil, fmt.Errorf("failed to initialize components: %w", err)
+		}
+
+		if rt.Evaluator != nil {
+			effectiveEnv := map[string]string{"WINDSOR_CONTEXT": "test"}
+			for key, value := range env {
+				effectiveEnv[key] = value
+			}
+			rt.Evaluator.SetEnvLookup(func(name string) (string, bool) {
+				value, present := effectiveEnv[name]
+				return value, present
+			})
 		}
 
 		testBlueprintHandler := blueprint.NewBlueprintHandler(rt, r.artifactBuilder)
@@ -440,7 +433,7 @@ func (r *TestRunner) runTestCase(tc blueprintv1alpha1.TestCase) (TestResult, err
 	}
 	testValues["_testName"] = tc.Name
 
-	generator := r.createGenerator(tc.TerraformOutputs)
+	generator := r.createGenerator(tc.TerraformOutputs, tc.Env)
 	bp, err := generator(testValues)
 
 	if tc.ExpectError {

--- a/pkg/test/runner.go
+++ b/pkg/test/runner.go
@@ -202,16 +202,14 @@ func (r *TestRunner) createGenerator(terraformOutputs map[string]map[string]any,
 			return nil, fmt.Errorf("failed to initialize components: %w", err)
 		}
 
-		if rt.Evaluator != nil {
-			effectiveEnv := map[string]string{"WINDSOR_CONTEXT": "test"}
-			for key, value := range env {
-				effectiveEnv[key] = value
-			}
-			rt.Evaluator.SetEnvLookup(func(name string) (string, bool) {
-				value, present := effectiveEnv[name]
-				return value, present
-			})
+		effectiveEnv := map[string]string{"WINDSOR_CONTEXT": "test"}
+		for key, value := range env {
+			effectiveEnv[key] = value
 		}
+		rt.Evaluator.SetEnvLookup(func(name string) (string, bool) {
+			value, present := effectiveEnv[name]
+			return value, present
+		})
 
 		testBlueprintHandler := blueprint.NewBlueprintHandler(rt, r.artifactBuilder)
 

--- a/pkg/test/runner_test.go
+++ b/pkg/test/runner_test.go
@@ -2912,7 +2912,7 @@ func TestTestRunner_createGenerator(t *testing.T) {
 			},
 		}
 
-		generator := runner.createGenerator(terraformOutputs)
+		generator := runner.createGenerator(terraformOutputs, nil)
 		values := map[string]any{
 			"terraform.enabled": true,
 		}
@@ -2931,7 +2931,7 @@ func TestTestRunner_createGenerator(t *testing.T) {
 		mocks := setupTestRunnerMocks(t)
 		runner := createRunnerWithMockGenerator(mocks)
 
-		generator := runner.createGenerator(nil)
+		generator := runner.createGenerator(nil, nil)
 		values := map[string]any{
 			"terraform.enabled": true,
 		}
@@ -2950,7 +2950,7 @@ func TestTestRunner_createGenerator(t *testing.T) {
 		mocks := setupTestRunnerMocksForFailure(t)
 		runner := createRunnerForFailure(mocks)
 
-		generator := runner.createGenerator(nil)
+		generator := runner.createGenerator(nil, nil)
 		values := map[string]any{}
 
 		_, err := generator(values)
@@ -2975,7 +2975,7 @@ func TestTestRunner_createGenerator(t *testing.T) {
 			},
 		}
 
-		generator := runner.createGenerator(terraformOutputs)
+		generator := runner.createGenerator(terraformOutputs, nil)
 		values := map[string]any{}
 
 		blueprint, err := generator(values)
@@ -2998,7 +2998,7 @@ func TestTestRunner_createGenerator(t *testing.T) {
 			},
 		}
 
-		generator := runner.createGenerator(terraformOutputs)
+		generator := runner.createGenerator(terraformOutputs, nil)
 		values := map[string]any{
 			"terraform.enabled": false,
 		}
@@ -3040,7 +3040,7 @@ terraform:
 		terraformOutputs := map[string]map[string]any{
 			"cluster": {"endpoint": "https://cluster.local"},
 		}
-		generator := runner.createGenerator(terraformOutputs)
+		generator := runner.createGenerator(terraformOutputs, nil)
 
 		// When the generator composes a config where dns.public_domain is unset so dns-zone is filtered out
 		_, err := generator(map[string]any{
@@ -3081,7 +3081,7 @@ terraform:
 		terraformOutputs := map[string]map[string]any{
 			"dns-zone": {"zone_id": "Z123ABC"},
 		}
-		generator := runner.createGenerator(terraformOutputs)
+		generator := runner.createGenerator(terraformOutputs, nil)
 
 		// When the generator composes with dns.public_domain set so dns-zone is registered
 		_, err := generator(map[string]any{
@@ -3143,7 +3143,7 @@ allOf:
 			"dns":     map[string]any{"private_domain": "internal.example"},
 		}
 		for i := 0; i < 10; i++ {
-			generator := runner.createGenerator(nil)
+			generator := runner.createGenerator(nil, nil)
 			if _, err := generator(satisfied); err != nil {
 				t.Fatalf("iteration %d: expected satisfied cross-field rule to pass, got %v", i, err)
 			}
@@ -3153,11 +3153,118 @@ allOf:
 		violation := map[string]any{
 			"gateway": map[string]any{"access": "private"},
 		}
-		generator := runner.createGenerator(nil)
+		generator := runner.createGenerator(nil, nil)
 		if _, err := generator(violation); err == nil {
 			t.Fatal("expected cross-field rule violation to be surfaced from runner")
 		}
 	})
+
+	t.Run("ResolvesEnvExpressionsFromCaseEnvMap", func(t *testing.T) {
+		// Given a facet whose terraform component is gated on an env() expression
+		mocks := setupTestRunnerMocks(t)
+		templateDir := filepath.Join(mocks.TmpDir, "contexts", "_template")
+		facetsDir := filepath.Join(templateDir, "facets")
+		createTestFile(t, facetsDir, "platform.yaml", `kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: platform
+terraform:
+  - name: cluster
+    path: cluster
+  - name: dns-zone
+    path: dns/zone
+    when: env('ENABLE_DNS') == 'yes'
+`)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		// When the generator composes with an env map that enables the gate
+		generator := runner.createGenerator(nil, map[string]string{"ENABLE_DNS": "yes"})
+		bp, err := generator(map[string]any{"terraform.enabled": true})
+
+		// Then dns-zone is included because env() resolved from the case env map
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if !hasTerraformComponent(bp, "dns-zone") {
+			t.Error("Expected dns-zone component to be present when env map enables it")
+		}
+	})
+
+	t.Run("EnvResolutionIsHermeticAndIgnoresHostEnv", func(t *testing.T) {
+		// Given the same env-gated facet and ENABLE_DNS set in the host environment
+		mocks := setupTestRunnerMocks(t)
+		templateDir := filepath.Join(mocks.TmpDir, "contexts", "_template")
+		facetsDir := filepath.Join(templateDir, "facets")
+		createTestFile(t, facetsDir, "platform.yaml", `kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: platform
+terraform:
+  - name: cluster
+    path: cluster
+  - name: dns-zone
+    path: dns/zone
+    when: env('ENABLE_DNS') == 'yes'
+`)
+		t.Setenv("ENABLE_DNS", "yes")
+		runner := createRunnerWithMockGenerator(mocks)
+
+		// When the generator composes with no env map for the case
+		generator := runner.createGenerator(nil, nil)
+		bp, err := generator(map[string]any{"terraform.enabled": true})
+
+		// Then dns-zone is excluded: env() never reads the host environment
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if hasTerraformComponent(bp, "dns-zone") {
+			t.Error("Expected dns-zone component to be absent: env() must not read host environment")
+		}
+	})
+
+	t.Run("SeedsWindsorContextIntoEnvByDefault", func(t *testing.T) {
+		// Given a facet whose component is gated on env('WINDSOR_CONTEXT') == 'test'
+		mocks := setupTestRunnerMocks(t)
+		templateDir := filepath.Join(mocks.TmpDir, "contexts", "_template")
+		facetsDir := filepath.Join(templateDir, "facets")
+		createTestFile(t, facetsDir, "platform.yaml", `kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: platform
+terraform:
+  - name: cluster
+    path: cluster
+  - name: dns-zone
+    path: dns/zone
+    when: env('WINDSOR_CONTEXT') == 'test'
+`)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		// When the generator composes with no case env map
+		generator := runner.createGenerator(nil, nil)
+		bp, err := generator(map[string]any{"terraform.enabled": true})
+
+		// Then dns-zone is included: WINDSOR_CONTEXT defaults to "test" in the hermetic env
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if !hasTerraformComponent(bp, "dns-zone") {
+			t.Error("Expected dns-zone component: env('WINDSOR_CONTEXT') should default to test")
+		}
+	})
+}
+
+// hasTerraformComponent reports whether the composed blueprint contains a terraform component with the given name.
+func hasTerraformComponent(bp *blueprintv1alpha1.Blueprint, name string) bool {
+	if bp == nil {
+		return false
+	}
+	for _, c := range bp.TerraformComponents {
+		if c.Name == name {
+			return true
+		}
+	}
+	return false
 }
 
 // =============================================================================
@@ -3641,16 +3748,6 @@ cases:
 		originalContext := "original-context"
 		os.WriteFile(contextFile, []byte(originalContext), 0644)
 
-		// And an original environment variable
-		originalEnvContext := os.Getenv("WINDSOR_CONTEXT")
-		defer func() {
-			if originalEnvContext != "" {
-				os.Setenv("WINDSOR_CONTEXT", originalEnvContext)
-			} else {
-				os.Unsetenv("WINDSOR_CONTEXT")
-			}
-		}()
-
 		// When running tests (may fail due to composition, but that's okay)
 		_, _ = runner.Run("")
 
@@ -3664,7 +3761,7 @@ cases:
 		}
 	})
 
-	t.Run("RestoresOriginalEnvironmentVariable", func(t *testing.T) {
+	t.Run("LeavesHostContextEnvSetValueUntouched", func(t *testing.T) {
 		// Given a test runner with test files
 		mocks := setupTestRunnerMocks(t)
 		testsDir := filepath.Join(mocks.TmpDir, "contexts", "_template", "tests")
@@ -3675,24 +3772,19 @@ cases:
 `)
 		runner := createRunnerWithMockGenerator(mocks)
 
-		// And an original environment variable set
-		originalEnvContext := "my-original-context"
-		os.Setenv("WINDSOR_CONTEXT", originalEnvContext)
-		defer func() {
-			os.Setenv("WINDSOR_CONTEXT", originalEnvContext)
-		}()
+		// And a host WINDSOR_CONTEXT set
+		t.Setenv("WINDSOR_CONTEXT", "my-original-context")
 
 		// When running tests (may fail due to composition, but that's okay)
 		_, _ = runner.Run("")
 
-		// Then the environment variable should be restored
-		restoredContext := os.Getenv("WINDSOR_CONTEXT")
-		if restoredContext != originalEnvContext {
-			t.Errorf("Expected WINDSOR_CONTEXT to be restored to %q, got %q", originalEnvContext, restoredContext)
+		// Then the host env var is untouched: windsor test never mutates process env
+		if got := os.Getenv("WINDSOR_CONTEXT"); got != "my-original-context" {
+			t.Errorf("Expected WINDSOR_CONTEXT unchanged at %q, got %q", "my-original-context", got)
 		}
 	})
 
-	t.Run("RestoresUnsetEnvironmentVariable", func(t *testing.T) {
+	t.Run("LeavesHostContextEnvUnsetUntouched", func(t *testing.T) {
 		// Given a test runner with test files
 		mocks := setupTestRunnerMocks(t)
 		testsDir := filepath.Join(mocks.TmpDir, "contexts", "_template", "tests")
@@ -3703,16 +3795,16 @@ cases:
 `)
 		runner := createRunnerWithMockGenerator(mocks)
 
-		// And no original environment variable set
+		// And no host WINDSOR_CONTEXT set (t.Setenv restores prior state on cleanup)
+		t.Setenv("WINDSOR_CONTEXT", "")
 		os.Unsetenv("WINDSOR_CONTEXT")
 
 		// When running tests (may fail due to composition, but that's okay)
 		_, _ = runner.Run("")
 
-		// Then the environment variable should be unset after tests
-		restoredContext := os.Getenv("WINDSOR_CONTEXT")
-		if restoredContext != "" {
-			t.Errorf("Expected WINDSOR_CONTEXT to be unset after tests, got %q", restoredContext)
+		// Then the host env var stays unset: windsor test never sets process env
+		if got := os.Getenv("WINDSOR_CONTEXT"); got != "" {
+			t.Errorf("Expected WINDSOR_CONTEXT to stay unset, got %q", got)
 		}
 	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> The change touches all blueprint processing paths (processor.go), not just the test harness — the scope-merge reorder affects production composition for every facet with unsatisfied requires.
>
> **Overview**
>
> This PR wires per-case environment variables into the Windsor test harness by adding an `env` field to `TestCase` and a `SetEnvLookup` hook on `ExpressionEvaluator`. The test runner now injects a hermetic `map[string]string` (seeded with `WINDSOR_CONTEXT=test`, overridable per case) instead of mutating `os.Setenv`, which was a process-wide side-effect. An integration fixture and three new unit tests confirm that `env()` expressions resolve only from the case map and never from the host environment.
>
> The processor.go reorder — moving `mergeFacetScopeIntoGlobal` before the `misses` check — is necessary to break a bootstrap deadlock where env()-derived config values could not satisfy a facet's `requires` because scope was not yet built. As a side-effect, any facet whose `requires` are never satisfied now permanently contributes its config blocks to the global scope even though it is excluded from resource generation.
>
> Reviewed by Claude for commit `be83110b`.

<!-- /claude-code-review:summary -->
