### PR TITLE
fix(composer): merge active-facet config ahead of the requires check

### DIFF
--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -205,6 +205,9 @@ func facetProvides(facet blueprintv1alpha1.Facet) []string {
 // If sourceName is set, it updates Source on components lacking it. The target blueprint is modified in place.
 // Returns: evaluated config scope and block order for the loader. Runtime ConfigHandler context values are
 // merged over facet-derived scope so 'when' or component expressions use the actual config.
+// An active facet contributes its config blocks (not its components) even while its requires are unmet, so
+// facets with mutually dependent config and requires resolve across rounds; a facet still unsatisfied when the
+// loop settles fails composition, so a permanently-blocked facet never leaks config into a successful blueprint.
 func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Blueprint, facets []blueprintv1alpha1.Facet, sourceName ...string) (map[string]any, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -274,16 +277,16 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 			if err != nil {
 				return nil, err
 			}
-			if len(misses) > 0 {
-				pendingRequirements[facet.Metadata.Name] = facetRequirementMisses{Misses: misses}
-				continue
-			}
-			includedFacets = append(includedFacets, facet)
 			var errMerge error
 			globalScope, cfgEntries, errMerge = p.mergeFacetScopeIntoGlobal(facet, globalScope, cfgEntries, passScope)
 			if errMerge != nil {
 				return nil, fmt.Errorf("facet %s: %w", facet.Metadata.Name, errMerge)
 			}
+			if len(misses) > 0 {
+				pendingRequirements[facet.Metadata.Name] = facetRequirementMisses{Misses: misses}
+				continue
+			}
+			includedFacets = append(includedFacets, facet)
 		}
 		if err := p.evaluateGlobalScopeConfig(globalScope, contextScope); err != nil {
 			return nil, err

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -6486,6 +6486,46 @@ func TestProcessor_ProcessFacets_Requires(t *testing.T) {
 		}
 	})
 
+	t.Run("FacetOwnConfigSatisfiesItsRequiresAcrossRounds", func(t *testing.T) {
+		// Given an active facet whose requires (sconf.ready) is satisfied only by its own config
+		// block, alongside another active facet that keeps the multi-pass loop running. The
+		// self-referencing facet is pending in round one; its config must still merge so the value
+		// lands in scope and satisfies the requires in round two. If the merge were gated behind
+		// the requires check, the value never appears and composition fails. This mirrors ../core's
+		// hetzner facet, which derives hetzner.token from env("HCLOUD_TOKEN") in its own config and
+		// requires hetzner.token — the guardrail for keeping the config merge ahead of the check.
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"platform": "incus"}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "keeper"},
+				Ordinal:  intPtr(100),
+				When:     "platform == 'incus'",
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "kconf", Body: map[string]any{"value": map[string]any{"ok": "yes"}}},
+				},
+			},
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "selfref"},
+				Ordinal:  intPtr(200),
+				When:     "platform == 'incus'",
+				Requires: []blueprintv1alpha1.RequirementBlock{
+					{Paths: []string{"sconf.ready"}},
+				},
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "sconf", Body: map[string]any{"value": map[string]any{"ready": "yes"}}},
+				},
+			},
+		}
+		if _, err := processor.ProcessFacets(target, facets); err != nil {
+			t.Fatalf("Expected facet's own config to satisfy its requires across rounds, got: %v", err)
+		}
+	})
+
 	t.Run("MessageRendersInNotesSection", func(t *testing.T) {
 		mocks := setupProcessorMocks(t)
 		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change reorders two operations inside the facet-processing loop in a single file, with a focused regression test — the blast radius is limited to blueprint composition.
>
> **Overview**
>
> The PR fixes a multi-pass facet resolution bug where a facet's own config blocks were never merged into the global scope when that same facet had unmet `requires`. By moving `mergeFacetScopeIntoGlobal` ahead of the `misses > 0` guard, a self-referencing facet (one whose config provides the very value its `requires` checks) can now succeed across rounds. If the requires remain unsatisfied after all rounds settle, the facet correctly fails composition as before.
>
> A new test — `FacetOwnConfigSatisfiesItsRequiresAcrossRounds` — directly exercises this path, including a clear comment tracing the fix back to the `hetzner` facet pattern that motivated it.
>
> Reviewed by Claude for commit `cfabb373`.

<!-- /claude-code-review:summary -->
