### PR TITLE
fix(composer): strip resolved when from composed flux systems

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -550,8 +550,9 @@ type BlueprintPatch struct {
 
 // Kustomization represents a kustomization configuration.
 type Kustomization struct {
-	// Name of the kustomization.
-	Name string `yaml:"name"`
+	// Name of the kustomization. Omitted when empty so an unnamed inline flux resources variant
+	// (a Kustomization embedded in FluxVariant) does not emit a blank name: into the composed output.
+	Name string `yaml:"name,omitempty"`
 
 	// Path of the kustomization. Defaults to Name.
 	Path string `yaml:"path,omitempty"`

--- a/api/v1alpha1/blueprint_types_test.go
+++ b/api/v1alpha1/blueprint_types_test.go
@@ -4014,6 +4014,32 @@ func TestBoolExpression_MarshalYAML(t *testing.T) {
 	})
 }
 
+func TestKustomization_MarshalYAML_OmitsEmptyName(t *testing.T) {
+	t.Run("UnnamedInlineFluxVariantEmitsNoName", func(t *testing.T) {
+		// Given a flux system whose install and resources variant have no explicit name
+		system := FluxSystem{
+			Name:      "cni",
+			Install:   &Kustomization{Components: []string{"helm"}},
+			Resources: []FluxVariant{{Kustomization: Kustomization{Components: []string{"cilium"}}}},
+		}
+
+		// When marshaled to YAML
+		out, err := yaml.Marshal(system)
+		if err != nil {
+			t.Fatalf("marshal: %v", err)
+		}
+
+		// Then the unnamed install and resources variant emit no blank name:, while the named
+		// system keeps its name
+		if strings.Contains(string(out), `name: ""`) {
+			t.Errorf("expected no empty name: in output, got:\n%s", out)
+		}
+		if !strings.Contains(string(out), "name: cni") {
+			t.Errorf("expected named system to keep its name, got:\n%s", out)
+		}
+	})
+}
+
 func TestIntExpression_MarshalYAML(t *testing.T) {
 	t.Run("PreservesExpressionInRoundTrip", func(t *testing.T) {
 		yamlData := []byte(`parallelism: "${cluster.parallelism ?? 10}"`)

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -1210,7 +1210,9 @@ func (p *BaseBlueprintProcessor) evalDropEmpty(raw []string, facetPath string, s
 // dependsOn reference to it stays valid whether or not the variant's own components ended up
 // empty. An install tier whose components prune to empty sets Install to nil, since install is
 // optional per system (a system may have none at all) and an empty install is equivalent to none
-// declared.
+// declared. The system's when is cleared once inclusion is decided (mirroring each variant's when):
+// it has already gated the system and its variants here, and often references composition-only derived
+// config that does not exist downstream, so emitting it would leak an unresolvable condition.
 func (p *BaseBlueprintProcessor) collectFluxSystems(facet blueprintv1alpha1.Facet, sourceName []string, fluxSystemByName map[string]*blueprintv1alpha1.FluxSystem, facetScope map[string]any) error {
 	for _, system := range facet.FluxSystems {
 		when := system.When
@@ -1305,6 +1307,7 @@ func (p *BaseBlueprintProcessor) collectFluxSystems(facet blueprintv1alpha1.Face
 		system.Resources = evaluatedResources
 		system.Ordinal = &effectiveOrdinal
 		system.Strategy = strategy
+		system.When = ""
 
 		if _, exists := fluxSystemByName[system.Name]; !exists {
 			stored := system

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -3004,6 +3004,52 @@ func TestProcessor_ProcessFacets_Tiers(t *testing.T) {
 		}
 	})
 }
+
+func TestProcessor_ProcessFacets_StripsFluxSystemWhen(t *testing.T) {
+	t.Run("EmittedSystemHasNoWhenAfterInclusion", func(t *testing.T) {
+		// Given a facet whose flux system is gated on composition-only derived config: talos_enabled
+		// comes from the facet's own config: block, so it exists during composition but not in the
+		// emitted values-* ConfigMaps downstream.
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"platform": "hetzner"}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		target := &blueprintv1alpha1.Blueprint{}
+		facets := []blueprintv1alpha1.Facet{{
+			Metadata: blueprintv1alpha1.Metadata{Name: "platform"},
+			Config: []blueprintv1alpha1.ConfigBlock{
+				{Name: "talos_enabled", Body: map[string]any{"value": true}},
+			},
+			FluxSystems: []blueprintv1alpha1.FluxSystem{{
+				Name:    "cni",
+				When:    "talos_enabled",
+				Install: &blueprintv1alpha1.Kustomization{Components: []string{"cilium"}},
+			}},
+		}}
+
+		// When the blueprint is composed
+		if _, err := processor.ProcessFacets(target, facets); err != nil {
+			t.Fatalf("ProcessFacets: %v", err)
+		}
+
+		// Then the system is included — its when evaluated true during composition — but the
+		// resolved when is stripped from the emitted system so it can't be re-evaluated (and misfire)
+		// against a downstream scope that lacks talos_enabled.
+		var cni *blueprintv1alpha1.FluxSystem
+		for i := range target.FluxSystems {
+			if target.FluxSystems[i].Name == "cni" {
+				cni = &target.FluxSystems[i]
+			}
+		}
+		if cni == nil {
+			t.Fatalf("expected cni flux system to be included, got %+v", target.FluxSystems)
+		}
+		if cni.When != "" {
+			t.Errorf("expected emitted FluxSystem.When to be stripped, got %q", cni.When)
+		}
+	})
+}
 func TestProcessor_mergeHelpers(t *testing.T) {
 	t.Run("deepMergeMapMergesNestedMaps", func(t *testing.T) {
 		base := map[string]any{"a": 1, "b": map[string]any{"x": 10}}


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Two isolated bug fixes in the composition layer with no shared-infrastructure blast radius and full unit-test coverage for both changes.
>
> **Overview**
>
> The PR addresses two output-correctness problems in the flux system composer. First, it adds `omitempty` to the `Kustomization.Name` yaml tag so that unnamed inline kustomizations embedded in a `FluxVariant` no longer emit a spurious `name: ""` line into the composed YAML. Second, it clears `FluxSystem.When` immediately after inclusion is decided, preventing the composition-time condition (which may reference derived config like `talos_enabled` that lives only in the composition scope) from being emitted and re-evaluated downstream against an incomplete value set.
>
> Both fixes are confined to marshal behavior and a single assignment in `collectFluxSystems`; deserialization and all other fields are unaffected.
>
> Reviewed by Claude for commit `3f97999b`.

<!-- /claude-code-review:summary -->

Closes #3070
