### PR TITLE
chore(config): remove cluster topology defaulting logic in resolver

### DIFF
--- a/pkg/runtime/config/resolve.go
+++ b/pkg/runtime/config/resolve.go
@@ -2,7 +2,6 @@ package config
 
 import (
 	"runtime"
-	"strconv"
 	"strings"
 )
 
@@ -38,7 +37,6 @@ func (c *configHandler) GetContextValues() (map[string]any, error) {
 	c.applyPlatformDerivedDefaults(result)
 	c.applyWorkstationDefaults(result)
 	c.ensureClusterStructure(result)
-	c.applyClusterTopologyDefaults(result)
 
 	return result, nil
 }
@@ -135,96 +133,3 @@ func (c *configHandler) ensureClusterStructure(values map[string]any) {
 	}
 }
 
-// applyClusterTopologyDefaults computes count and schedulable defaults from explicit values and node shape.
-func (c *configHandler) applyClusterTopologyDefaults(values map[string]any) {
-	clusterMap, ok := values["cluster"].(map[string]any)
-	if !ok || clusterMap == nil {
-		return
-	}
-	controlplanesMap, controlplanesOK := clusterMap["controlplanes"].(map[string]any)
-	workersMap, workersOK := clusterMap["workers"].(map[string]any)
-	if !controlplanesOK || controlplanesMap == nil || !workersOK || workersMap == nil {
-		return
-	}
-
-	hasExplicitControlplaneCount := hasValueAtPath(c.data, []string{"cluster", "controlplanes", "count"})
-	controlplaneCount, hasControlplaneCount := getMapInt(values, "cluster.controlplanes.count")
-	if !hasExplicitControlplaneCount || !hasControlplaneCount {
-		if derivedCount, derived := getExplicitNodeCountFromData(c.data, []string{"cluster", "controlplanes", "nodes"}); derived {
-			controlplaneCount = derivedCount
-		} else {
-			controlplaneCount = 1
-		}
-		controlplanesMap["count"] = controlplaneCount
-	}
-
-	hasExplicitWorkersCount := hasValueAtPath(c.data, []string{"cluster", "workers", "count"})
-	workersCount, hasWorkersCount := getMapInt(values, "cluster.workers.count")
-	if !hasExplicitWorkersCount || !hasWorkersCount {
-		if derivedCount, derived := getExplicitNodeCountFromData(c.data, []string{"cluster", "workers", "nodes"}); derived {
-			workersCount = derivedCount
-			workersMap["count"] = workersCount
-		} else {
-			// Leave workers.count unset (nil) so a facet can default it via `?? N`; writing a
-			// zero-value here would be indistinguishable from an explicit 0 and would also clobber
-			// any schema default. workersCount stays 0 locally only for the schedulable derivation.
-			workersCount = 0
-		}
-	}
-
-	schedulable, hasSchedulable := controlplanesMap["schedulable"].(bool)
-	hasExplicitSchedulable := hasValueAtPath(c.data, []string{"cluster", "controlplanes", "schedulable"})
-	if !hasSchedulable || !hasExplicitSchedulable {
-		schedulable = workersCount == 0 && controlplaneCount == 1
-		controlplanesMap["schedulable"] = schedulable
-	}
-}
-
-// getExplicitNodeCountFromData returns node map length only when nodes were explicitly provided in loaded config data.
-func getExplicitNodeCountFromData(data map[string]any, pathKeys []string) (int, bool) {
-	if !hasValueAtPath(data, pathKeys) {
-		return 0, false
-	}
-	nodesAny := getValueByPathFromMap(data, pathKeys)
-	nodes, ok := nodesAny.(map[string]any)
-	if !ok {
-		return 0, true
-	}
-	return len(nodes), true
-}
-
-// getMapInt returns an int value from a map key path with permissive numeric conversion.
-func getMapInt(data map[string]any, path string) (int, bool) {
-	value := getValueByPathFromMap(data, parsePath(path))
-	if value == nil {
-		return 0, false
-	}
-	switch v := value.(type) {
-	case int:
-		return v, true
-	case int64:
-		maxInt := int64(^uint(0) >> 1)
-		minInt := -maxInt - 1
-		if v > maxInt || v < minInt {
-			return 0, false
-		}
-		return int(v), true
-	case uint64:
-		if v > uint64(^uint(0)>>1) {
-			return 0, false
-		}
-		return int(v), true
-	case uint:
-		if v > uint(^uint(0)>>1) {
-			return 0, false
-		}
-		return int(v), true
-	case float64:
-		return int(v), true
-	case string:
-		if parsed, err := strconv.Atoi(v); err == nil {
-			return parsed, true
-		}
-	}
-	return 0, false
-}

--- a/pkg/runtime/config/resolve_test.go
+++ b/pkg/runtime/config/resolve_test.go
@@ -60,20 +60,16 @@ func TestConfigHandler_GetContextValues_Resolve(t *testing.T) {
 		}
 	})
 
-	t.Run("DerivesControlplaneAndWorkerCountFromExplicitNodes", func(t *testing.T) {
+	t.Run("DoesNotDeriveCountFromNodes", func(t *testing.T) {
+		// The generic resolver no longer synthesizes cluster topology; count is left to explicit
+		// config or facet `?? N` defaulting (#3062).
 		handler, _ := setupPrivateTestHandler(t)
 
 		if err := handler.Set("cluster.controlplanes.nodes.cp1.endpoint", "127.0.0.1:50001"); err != nil {
 			t.Fatalf("Expected no error setting cp1, got %v", err)
 		}
-		if err := handler.Set("cluster.controlplanes.nodes.cp2.endpoint", "127.0.0.1:50002"); err != nil {
-			t.Fatalf("Expected no error setting cp2, got %v", err)
-		}
 		if err := handler.Set("cluster.workers.nodes.w1.endpoint", "127.0.0.1:50101"); err != nil {
 			t.Fatalf("Expected no error setting w1, got %v", err)
-		}
-		if err := handler.Set("cluster.workers.nodes.w2.endpoint", "127.0.0.1:50102"); err != nil {
-			t.Fatalf("Expected no error setting w2, got %v", err)
 		}
 
 		values, err := handler.GetContextValues()
@@ -84,12 +80,11 @@ func TestConfigHandler_GetContextValues_Resolve(t *testing.T) {
 		clusterValues := values["cluster"].(map[string]any)
 		controlplanesValues := clusterValues["controlplanes"].(map[string]any)
 		workersValues := clusterValues["workers"].(map[string]any)
-
-		if controlplanesValues["count"] != 2 {
-			t.Errorf("Expected controlplanes count=2, got %v", controlplanesValues["count"])
+		if v, exists := controlplanesValues["count"]; exists {
+			t.Errorf("Expected controlplanes.count not fabricated from nodes, got %v", v)
 		}
-		if workersValues["count"] != 2 {
-			t.Errorf("Expected workers count=2, got %v", workersValues["count"])
+		if v, exists := workersValues["count"]; exists {
+			t.Errorf("Expected workers.count not fabricated from nodes, got %v", v)
 		}
 	})
 
@@ -164,7 +159,9 @@ func TestConfigHandler_GetContextValues_Resolve(t *testing.T) {
 		}
 	})
 
-	t.Run("DerivesSchedulableWhenNotExplicit", func(t *testing.T) {
+	t.Run("DoesNotDeriveSchedulable", func(t *testing.T) {
+		// schedulable is no longer synthesized by the generic resolver; the consuming facets derive
+		// it from count values via `?? ` fallbacks (#3062).
 		handler, _ := setupPrivateTestHandler(t)
 
 		if err := handler.Set("cluster.controlplanes.count", 1); err != nil {
@@ -179,14 +176,9 @@ func TestConfigHandler_GetContextValues_Resolve(t *testing.T) {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
-		clusterValues := values["cluster"].(map[string]any)
-		controlplanesValues := clusterValues["controlplanes"].(map[string]any)
-		schedulable, ok := controlplanesValues["schedulable"].(bool)
-		if !ok {
-			t.Fatalf("Expected bool schedulable, got %T", controlplanesValues["schedulable"])
-		}
-		if !schedulable {
-			t.Errorf("Expected schedulable=true, got %v", schedulable)
+		controlplanesValues := values["cluster"].(map[string]any)["controlplanes"].(map[string]any)
+		if v, exists := controlplanesValues["schedulable"]; exists {
+			t.Errorf("Expected schedulable not fabricated by the resolver, got %v", v)
 		}
 	})
 
@@ -390,44 +382,6 @@ func TestConfigHandler_GetContextValues_Resolve(t *testing.T) {
 		clusterValues := values["cluster"].(map[string]any)
 		if clusterValues["driver"] != "talos" {
 			t.Errorf("Expected explicit cluster.driver to remain talos, got %v", clusterValues["driver"])
-		}
-	})
-}
-
-func TestGetMapInt(t *testing.T) {
-	t.Run("ConvertsInt64AndUint64WithinBounds", func(t *testing.T) {
-		data := map[string]any{
-			"cluster": map[string]any{
-				"workers": map[string]any{
-					"count_int64":  int64(7),
-					"count_uint64": uint64(8),
-				},
-			},
-		}
-
-		if got, ok := getMapInt(data, "cluster.workers.count_int64"); !ok || got != 7 {
-			t.Errorf("Expected int64 conversion to 7, got (%d, %v)", got, ok)
-		}
-		if got, ok := getMapInt(data, "cluster.workers.count_uint64"); !ok || got != 8 {
-			t.Errorf("Expected uint64 conversion to 8, got (%d, %v)", got, ok)
-		}
-	})
-
-	t.Run("ReturnsFalseForUint64OverflowAndInvalidString", func(t *testing.T) {
-		data := map[string]any{
-			"cluster": map[string]any{
-				"workers": map[string]any{
-					"overflow": uint64(^uint(0)>>1) + 1,
-					"bad":      "not-an-int",
-				},
-			},
-		}
-
-		if _, ok := getMapInt(data, "cluster.workers.overflow"); ok {
-			t.Error("Expected overflow uint64 conversion to fail")
-		}
-		if _, ok := getMapInt(data, "cluster.workers.bad"); ok {
-			t.Error("Expected invalid string conversion to fail")
 		}
 	})
 }

--- a/pkg/workstation/virt/colima_virt.go
+++ b/pkg/workstation/virt/colima_virt.go
@@ -323,10 +323,10 @@ func (v *ColimaVirt) getDefaultValues(context string) (int, int, int, string, st
 
 // calculateVMResources calculates the required CPU and memory for the Colima VM
 // based on cluster node topology and overhead. Explicit values from config take precedence;
-// when unset, topology-aware defaults are applied: control-plane count defaults to 1 only when the
-// key is absent (the generic config resolver no longer synthesizes it) so an explicit count is
-// honored, a single controlplane with no workers gets larger resources since it handles everything,
-// while a CP/worker split uses smaller CP resources. Fixed overhead covers the VM base and services.
+// when unset, topology-aware defaults are applied: control-plane count defaults to 1 when the key is
+// absent (the generic config resolver no longer synthesizes it) while an explicit count is honored, a
+// single controlplane with no workers gets larger resources since it handles everything, and a
+// CP/worker split uses smaller CP resources. Fixed overhead covers the VM base and services.
 // Warns if calculated resources exceed available host resources.
 // Returns calculated CPU count and memory in GB.
 func (v *ColimaVirt) calculateVMResources() (int, int) {
@@ -338,10 +338,7 @@ func (v *ColimaVirt) calculateVMResources() (int, int) {
 		hostMemoryReserveGB        = 4
 	)
 
-	controlPlaneCount := v.configHandler.GetInt("cluster.controlplanes.count", 0)
-	if v.configHandler.Get("cluster.controlplanes.count") == nil {
-		controlPlaneCount = 1
-	}
+	controlPlaneCount := v.configHandler.GetInt("cluster.controlplanes.count", 1)
 	controlPlaneCPU := v.configHandler.GetInt("cluster.controlplanes.cpu", 0)
 	controlPlaneMemory := v.configHandler.GetInt("cluster.controlplanes.memory", 0)
 

--- a/pkg/workstation/virt/colima_virt.go
+++ b/pkg/workstation/virt/colima_virt.go
@@ -323,9 +323,10 @@ func (v *ColimaVirt) getDefaultValues(context string) (int, int, int, string, st
 
 // calculateVMResources calculates the required CPU and memory for the Colima VM
 // based on cluster node topology and overhead. Explicit values from config take precedence;
-// when unset (0), topology-aware defaults are applied: a single controlplane with no workers
-// gets larger resources since it handles everything, while a CP/worker split uses smaller CP
-// resources. Fixed overhead covers the Ubuntu VM base system and Docker services.
+// when unset, topology-aware defaults are applied: control-plane count defaults to 1 only when the
+// key is absent (the generic config resolver no longer synthesizes it) so an explicit count is
+// honored, a single controlplane with no workers gets larger resources since it handles everything,
+// while a CP/worker split uses smaller CP resources. Fixed overhead covers the VM base and services.
 // Warns if calculated resources exceed available host resources.
 // Returns calculated CPU count and memory in GB.
 func (v *ColimaVirt) calculateVMResources() (int, int) {
@@ -338,6 +339,9 @@ func (v *ColimaVirt) calculateVMResources() (int, int) {
 	)
 
 	controlPlaneCount := v.configHandler.GetInt("cluster.controlplanes.count", 0)
+	if v.configHandler.Get("cluster.controlplanes.count") == nil {
+		controlPlaneCount = 1
+	}
 	controlPlaneCPU := v.configHandler.GetInt("cluster.controlplanes.cpu", 0)
 	controlPlaneMemory := v.configHandler.GetInt("cluster.controlplanes.memory", 0)
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This PR removes shared resolver logic for cluster topology defaults (`count`, `schedulable`), shifting that responsibility to downstream facets; any consumer that has not yet adopted `?? N` fallbacks will silently receive `nil` instead of a derived value.
>
> **Overview**
>
> The change deletes `applyClusterTopologyDefaults` and its helpers (`getExplicitNodeCountFromData`, `getMapInt`) from the generic config resolver, so `controlplanes.count`, `workers.count`, and `controlplanes.schedulable` are no longer synthesized during `GetContextValues`. The `colima_virt.go` caller compensates by adding a local nil-guard that defaults `controlPlaneCount` to 1 when the key is absent. Tests are updated to assert the absence of synthesized keys rather than their presence.
>
> The behavioral assumption — that all consumers of `schedulable` and `workers.count` already derive those values via facet-level `?? N` fallbacks — is not verifiable from within the diff and is the primary residual risk of this change.
>
> Reviewed by Claude for commit `8f658961`.

<!-- /claude-code-review:summary -->
