### PR TITLE
feat(composer): implement component ordering by source depth in blueprint composition

### DIFF
--- a/docs/reference/composition-order.md
+++ b/docs/reference/composition-order.md
@@ -1,0 +1,116 @@
+---
+title: "Composition order"
+description: "How facets and components are ordered when blueprints compose, within a blueprint and across its sources."
+---
+# Composition order
+
+Two independent levels decide what composes before what. Keeping them
+apart is the whole trick: `ordinal` orders facets **within a single
+blueprint**, and source depth orders **across blueprints**.
+
+| Level | Question it answers | Mechanism |
+|------|------|------|
+| Within one blueprint | Which of my own facets goes first? | `ordinal`, derived from the file basename, tie-broken by `metadata.name` |
+| Across blueprints | Does my source's work land before mine? | Source depth — a source composes before the blueprint that references it |
+
+An `ordinal` never crosses a source boundary. A downstream facet cannot
+give itself a low ordinal to compose ahead of the source it extends.
+
+## How composition runs
+
+```
+1. Load      Each source becomes its own loader. Sources that themselves
+             declare sources: are resolved recursively.
+
+2. Process   Facets are evaluated once per source. Within that source
+             they sort by ordinal, then by name. Every component it
+             contributes is stamped with its source name ("" for the
+             blueprint you are composing).
+
+3. Merge     The per-source blueprints merge in the order the sources:
+             list declares, and your own blueprint merges last.
+             Same-named components merge rather than duplicate.
+
+4. Order     Components sort topologically on dependsOn, then cluster by
+             name prefix (every addon-* together, alphabetically inside
+             the cluster). This step does not consider source.
+
+5. Depth     Components stably sort by source depth. This runs last.
+```
+
+Step 2 is the one that surprises people. Facets from different sources
+are never in the same sort, so the ordinal table cannot rank a source's
+facets against yours — they are evaluated in separate passes and only
+meet at the merge in step 3.
+
+## Source depth
+
+Depth is distance in the reference graph:
+
+- A source that references nothing else is depth 0.
+- A source is one deeper than the deepest source it references.
+- The blueprint you are composing is deepest of all.
+
+A component inherits the depth of the source that contributed it. A
+component whose source is not in the graph is treated as depth 0,
+because nothing establishes it as layered on top of anything.
+
+The depth sort is stable, so within one depth nothing moves and each
+source keeps its own tier order. Dependencies flow from a referencing
+blueprint down into its sources, so ordering by ascending depth already
+places every dependency ahead of the components that depend on it.
+
+Sources are walked in sorted order, and a source caught in a reference
+cycle is pinned to depth 0, so a cyclic graph resolves to the same
+depths on every run.
+
+## Worked example
+
+A `manager` blueprint references `core`. Core ships `addon-object-store`
+and `addon-private-ca`; manager adds `addon-omni`. All three are
+`addon-` facets, so all three carry ordinal 400.
+
+Without the depth step, step 4 clusters the three under the `addon`
+prefix and alphabetizes them:
+
+```
+addon-object-store   (core)
+addon-omni           (manager)   <- stranded mid-list
+addon-private-ca     (core)
+```
+
+Core is depth 0 and manager is depth 1, so the depth step lifts
+manager's contribution to the end without disturbing core's own order:
+
+```
+addon-object-store   (core)
+addon-private-ca     (core)
+addon-omni           (manager)
+```
+
+Extending a blueprint now means composing after it, with no reserved
+ordinal band to memorize and nothing for a new upstream layer to break.
+
+## Common confusions
+
+**"I set a lower ordinal so my facet runs first."** Ordinal only orders
+facets inside one blueprint. Against a source, depth decides, and depth
+wins.
+
+**"My facet ties with the source's facets."** They never tie, because
+they are never compared. Each source is processed on its own, and the
+ordering between them comes from depth.
+
+**"I need to feed a value into a source's facets."** Set it in context
+configuration rather than reaching backwards with an ordinal. Context
+values are in scope for every facet regardless of depth.
+
+**"Single-source projects behave differently now."** They do not. With
+no referencing blueprint every component sits at depth 0, so the depth
+step changes nothing.
+
+## See also
+
+- [Facets reference](facets.md) — facet fields, including `ordinal`
+- [Blueprint reference](blueprint.md) — the composed blueprint
+- [Contexts directory](contexts.md) — where facets live on disk

--- a/docs/reference/facets.md
+++ b/docs/reference/facets.md
@@ -9,7 +9,9 @@ declares terraform components, kustomizations, configuration blocks, and
 substitutions that are merged into the blueprint only when the facet's
 'when' expression evaluates to true against the operator's configuration.
 Facets live under contexts/_template/facets/ as one .yaml file per facet
-and are composed in ordinal order (lower-priority first).
+and are composed in ordinal order (lower-priority first) within a single
+blueprint. Across blueprints, a source composes before the blueprint that
+references it; see the Composition order reference.
 
 ## Fields
 
@@ -23,7 +25,7 @@ and are composed in ordinal order (lower-priority first).
 | `crds` | `array<string>` | References into the vendored CRD catalog, version-pinned (e.g. 'cert-manager-1.16.2'). The composer collects these across all enabled facets and dedups them; a facet's CRDs install from the source that carries it — the blueprint's own (default/project) crds: list, or that source's crds when it comes from an install:true OCI source. The provisioner installs each ahead of the kustomize layer, so every kustomization sees its CRDs Established without a facet author naming a CRD in dependsOn. Entries may use '${...}' expressions that resolve against the facet scope and prune to empty — e.g. "${gateway.driver == 'envoy' ? 'envoy-gateway-1.7.1' : ''}" — so one facet can select different CRDs per driver. Each resolved reference must be a single path segment; values containing '/', '\', or '..' are rejected at composition time because they would escape the crds/ catalog directory. |
 | `flux` | `array<object>` | System entries contributed by this facet — functional layers that each compile to an install Kustomization plus resources-variant Kustomizations. Distinct from 'kustomize:' (1:1 passthrough). See the flux: shape in the [Blueprint reference](blueprint.md): name (required), path, source, enabled, destroy, when, dependsOn, strategy, ordinal, install, resources, secrets. 'secrets' maps <secret-name> to a data map of <key>: <value>, where each value is an expression resolved at apply time — a ${...} reference to any config property, a secret() call, or an env("NAME") lookup (nil when unset, so it composes with ??, e.g. `${hetzner.token ?? env("HETZNER_TOKEN")}`) — not a plaintext literal. Each entry is materialized as a Kubernetes Secret with those data keys in the system's namespace. |
 | `kustomize` | `array<object>` | Kustomizations contributed by this facet. Each entry extends the blueprint's Kustomization shape with conditional fields (when, strategy, ordinal, requires). Deprecated alias of 'flux:'; both keys are accepted and merge into the same list. |
-| `ordinal` | `integer` | Merge precedence relative to other facets. Higher ordinal wins on conflict (processed later). When unset, the loader derives an ordinal from the file basename: 'config-*' = 100; 'provider-*' or 'platform-*' with '-base' in the name = 199; other 'provider-*' / 'platform-*' = 200; 'option-*' / 'options-*' = 300; 'addon-*' / 'addons-*' = 400; no match = 0. |
+| `ordinal` | `integer` | Merge precedence relative to other facets in the same blueprint. Higher ordinal wins on conflict (processed later). When unset, the loader derives an ordinal from the file basename: 'config-*' = 100; 'provider-*' or 'platform-*' with '-base' in the name = 199; other 'provider-*' / 'platform-*' = 200; 'option-*' / 'options-*' = 300; 'addon-*' / 'addons-*' = 400; no match = 0. Ordinal does not cross a source boundary: a blueprint's facets always compose after the facets of the sources it references, whatever ordinal either side sets. |
 | `requires` | `array<object>` | Input-requirement blocks for the facet as a whole. When the facet is active and a block's optional 'when' holds, every path in that block must resolve to a present, non-empty value in the merged scope. Unsatisfied paths across every active facet are aggregated into a single user-facing error. |
 | `substitutions` | `map<string>` | Top-level key/value pairs evaluated with facet scope and injected into 'values-common', making them available to every kustomization via PostBuild substitution. Values may use expression syntax (e.g. '${dns.domain}') resolved against active facet config blocks. |
 | `terraform` | `array<object>` | Terraform components contributed by this facet. Each entry extends the blueprint's TerraformComponent shape with conditional fields (when, strategy, ordinal, requires). |
@@ -143,6 +145,7 @@ kustomize:
 ## See also
 
 - [Blueprint reference](blueprint.md) — for the inherited TerraformComponent and Kustomization fields
+- [Composition order](composition-order.md) — how ordinal and source depth decide what composes first
 - [`apply`](commands/apply.md), [`up`](commands/up.md), [`explain`](commands/explain.md)
 - [Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)
 - Source schema: [pkg/runtime/config/schemas/artifacts/facets.yaml](https://github.com/windsorcli/cli/blob/main/pkg/runtime/config/schemas/artifacts/facets.yaml)

--- a/pkg/composer/blueprint/composer.go
+++ b/pkg/composer/blueprint/composer.go
@@ -178,6 +178,7 @@ func (c *BaseBlueprintComposer) Compose(loaders []BlueprintLoader, initLoaderNam
 	c.finalizeCrdLayers(result)
 	c.applyCrdLayerBarrier(result)
 	c.applyGlobalDependencyBarrier(result)
+	c.orderComponentsBySourceDepth(result, userBlueprint, sourceLoaders)
 	validationErr := errors.Join(c.validateSources(result), c.validateReservedNames(result), c.validateDependencies(result))
 	return result, validationErr
 }
@@ -430,6 +431,85 @@ func (c *BaseBlueprintComposer) orderSources(userBlueprint *blueprintv1alpha1.Bl
 // OCI sources with Install omitted (nil) are treated as merge for backward compatibility; otherwise Install must be true.
 func (c *BaseBlueprintComposer) sourceShouldBeMerged(source blueprintv1alpha1.Source) bool {
 	return sourceInstalls(source)
+}
+
+// orderComponentsBySourceDepth stably reorders the composed blueprint's components so a component from a
+// source composes before a component from the blueprint that references it, recursively. Depth comes from
+// the source-reference graph; the primary/user blueprint (component Source "") is deepest. The sort is
+// stable, so each source keeps its own prefix/ordinal order, and because dependencies flow from a
+// referencing blueprint down into its sources (higher depth to lower), ascending-depth order keeps every
+// dependency ahead of its dependents. Explicit ordinals stay within a source and never cross a boundary.
+func (c *BaseBlueprintComposer) orderComponentsBySourceDepth(result *blueprintv1alpha1.Blueprint, userBlueprint *blueprintv1alpha1.Blueprint, sourceLoaders []BlueprintLoader) {
+	depth := c.sourceDepths(userBlueprint, sourceLoaders)
+	if len(depth) == 0 {
+		return
+	}
+	sort.SliceStable(result.TerraformComponents, func(i, j int) bool {
+		return depth[result.TerraformComponents[i].Source] < depth[result.TerraformComponents[j].Source]
+	})
+	sort.SliceStable(result.Kustomizations, func(i, j int) bool {
+		return depth[result.Kustomizations[i].Source] < depth[result.Kustomizations[j].Source]
+	})
+	sort.SliceStable(result.FluxSystems, func(i, j int) bool {
+		return depth[result.FluxSystems[i].Source] < depth[result.FluxSystems[j].Source]
+	})
+}
+
+// sourceDepths computes each source's depth in the reference graph: a source that references no other
+// in-set source is depth 0, and any source is one deeper than the deepest source it references. The
+// primary/user blueprint is keyed by "" (the Source stamped on its own components) and references the
+// sources it lists. Returns an empty map when there is no referencing blueprint, so single-source
+// compositions skip reordering entirely.
+func (c *BaseBlueprintComposer) sourceDepths(userBlueprint *blueprintv1alpha1.Blueprint, sourceLoaders []BlueprintLoader) map[string]int {
+	refs := make(map[string][]string)
+	inSet := make(map[string]bool)
+	for _, loader := range sourceLoaders {
+		name := loader.GetSourceName()
+		inSet[name] = true
+		if bp := loader.GetBlueprint(); bp != nil {
+			for _, s := range bp.Sources {
+				if s.Name != "" {
+					refs[name] = append(refs[name], s.Name)
+				}
+			}
+		}
+	}
+	if userBlueprint == nil {
+		return map[string]int{}
+	}
+	inSet[""] = true
+	for _, s := range userBlueprint.Sources {
+		if s.Name != "" {
+			refs[""] = append(refs[""], s.Name)
+		}
+	}
+
+	depth := make(map[string]int)
+	var compute func(name string, stack map[string]bool) int
+	compute = func(name string, stack map[string]bool) int {
+		if d, ok := depth[name]; ok {
+			return d
+		}
+		if stack[name] {
+			return 0
+		}
+		stack[name] = true
+		max := 0
+		for _, dep := range refs[name] {
+			if inSet[dep] {
+				if d := compute(dep, stack) + 1; d > max {
+					max = d
+				}
+			}
+		}
+		stack[name] = false
+		depth[name] = max
+		return max
+	}
+	for name := range inSet {
+		compute(name, make(map[string]bool))
+	}
+	return depth
 }
 
 // applyCommonSubstitutions extracts common substitutions from values.yaml, merges legacy special

--- a/pkg/composer/blueprint/composer.go
+++ b/pkg/composer/blueprint/composer.go
@@ -439,19 +439,27 @@ func (c *BaseBlueprintComposer) sourceShouldBeMerged(source blueprintv1alpha1.So
 // stable, so each source keeps its own prefix/ordinal order, and because dependencies flow from a
 // referencing blueprint down into its sources (higher depth to lower), ascending-depth order keeps every
 // dependency ahead of its dependents. Explicit ordinals stay within a source and never cross a boundary.
+// A component whose Source is absent from the graph is treated as base level, since nothing establishes
+// it as layered on top of another source; this is decided here rather than left to a map's zero value.
 func (c *BaseBlueprintComposer) orderComponentsBySourceDepth(result *blueprintv1alpha1.Blueprint, userBlueprint *blueprintv1alpha1.Blueprint, sourceLoaders []BlueprintLoader) {
 	depth := c.sourceDepths(userBlueprint, sourceLoaders)
 	if len(depth) == 0 {
 		return
 	}
+	depthOf := func(source string) int {
+		if d, ok := depth[source]; ok {
+			return d
+		}
+		return 0
+	}
 	sort.SliceStable(result.TerraformComponents, func(i, j int) bool {
-		return depth[result.TerraformComponents[i].Source] < depth[result.TerraformComponents[j].Source]
+		return depthOf(result.TerraformComponents[i].Source) < depthOf(result.TerraformComponents[j].Source)
 	})
 	sort.SliceStable(result.Kustomizations, func(i, j int) bool {
-		return depth[result.Kustomizations[i].Source] < depth[result.Kustomizations[j].Source]
+		return depthOf(result.Kustomizations[i].Source) < depthOf(result.Kustomizations[j].Source)
 	})
 	sort.SliceStable(result.FluxSystems, func(i, j int) bool {
-		return depth[result.FluxSystems[i].Source] < depth[result.FluxSystems[j].Source]
+		return depthOf(result.FluxSystems[i].Source) < depthOf(result.FluxSystems[j].Source)
 	})
 }
 
@@ -459,7 +467,9 @@ func (c *BaseBlueprintComposer) orderComponentsBySourceDepth(result *blueprintv1
 // in-set source is depth 0, and any source is one deeper than the deepest source it references. The
 // primary/user blueprint is keyed by "" (the Source stamped on its own components) and references the
 // sources it lists. Returns an empty map when there is no referencing blueprint, so single-source
-// compositions skip reordering entirely.
+// compositions skip reordering entirely. Sources are walked in sorted order and a source caught in a
+// reference cycle is pinned to base depth, so a cyclic graph still resolves to the same depths on every
+// run rather than varying with map iteration order.
 func (c *BaseBlueprintComposer) sourceDepths(userBlueprint *blueprintv1alpha1.Blueprint, sourceLoaders []BlueprintLoader) map[string]int {
 	refs := make(map[string][]string)
 	inSet := make(map[string]bool)
@@ -485,12 +495,14 @@ func (c *BaseBlueprintComposer) sourceDepths(userBlueprint *blueprintv1alpha1.Bl
 	}
 
 	depth := make(map[string]int)
+	cyclic := make(map[string]bool)
 	var compute func(name string, stack map[string]bool) int
 	compute = func(name string, stack map[string]bool) int {
 		if d, ok := depth[name]; ok {
 			return d
 		}
 		if stack[name] {
+			cyclic[name] = true
 			return 0
 		}
 		stack[name] = true
@@ -503,10 +515,18 @@ func (c *BaseBlueprintComposer) sourceDepths(userBlueprint *blueprintv1alpha1.Bl
 			}
 		}
 		stack[name] = false
+		if cyclic[name] {
+			max = 0
+		}
 		depth[name] = max
 		return max
 	}
+	names := make([]string, 0, len(inSet))
 	for name := range inSet {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
 		compute(name, make(map[string]bool))
 	}
 	return depth

--- a/pkg/composer/blueprint/composer_test.go
+++ b/pkg/composer/blueprint/composer_test.go
@@ -404,6 +404,61 @@ func TestComposer_Compose(t *testing.T) {
 		}
 	})
 
+	t.Run("SourceDepthReorderIsDeterministicWithCyclicSources", func(t *testing.T) {
+		// Given two sources that reference each other, depth resolution must terminate and settle on
+		// the same answer regardless of which node the walk reaches first. Cycles are rejected upstream
+		// by loader ordering; this guards the depth walk itself against an order-dependent result.
+		mocks := setupComposerMocks(t)
+		trueVal := true
+		install := func(name string) blueprintv1alpha1.Source {
+			return blueprintv1alpha1.Source{Name: name, Install: &blueprintv1alpha1.BoolExpression{Value: &trueVal, IsExpr: false}}
+		}
+
+		compose := func() []string {
+			composer := NewBlueprintComposer(mocks.Runtime)
+			aBp := &blueprintv1alpha1.Blueprint{
+				Metadata:       blueprintv1alpha1.Metadata{Name: "a"},
+				Sources:        []blueprintv1alpha1.Source{install("b")},
+				Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "addon-a", Path: "addons/a", Source: "a"}},
+			}
+			bBp := &blueprintv1alpha1.Blueprint{
+				Metadata:       blueprintv1alpha1.Metadata{Name: "b"},
+				Sources:        []blueprintv1alpha1.Source{install("a")},
+				Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "addon-b", Path: "addons/b", Source: "b"}},
+			}
+			userBp := &blueprintv1alpha1.Blueprint{
+				Metadata:       blueprintv1alpha1.Metadata{Name: "user"},
+				Sources:        []blueprintv1alpha1.Source{install("a"), install("b")},
+				Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "addon-user", Path: "addons/user"}},
+			}
+			loaders := []BlueprintLoader{
+				createMockBlueprintLoader("a", aBp),
+				createMockBlueprintLoader("b", bBp),
+				createMockBlueprintLoader("user", userBp),
+			}
+			result, err := composer.Compose(loaders, nil, "", nil)
+			if err != nil {
+				t.Fatalf("Expected no error, got %v", err)
+			}
+			names := make([]string, 0, len(result.Kustomizations))
+			for _, k := range result.Kustomizations {
+				names = append(names, k.Name)
+			}
+			return names
+		}
+
+		// When composing the same cyclic graph twice
+		first, second := compose(), compose()
+
+		// Then the ordering settles identically, and the referencing blueprint still composes last
+		if !slices.Equal(first, second) {
+			t.Errorf("expected deterministic order across runs, got %v then %v", first, second)
+		}
+		if len(first) == 0 || first[len(first)-1] != "addon-user" {
+			t.Errorf("expected addon-user (referencing blueprint) last, got %v", first)
+		}
+	})
+
 	t.Run("DoesNotMergeSourcesWithInstallFalse", func(t *testing.T) {
 		// Given a user blueprint with a source that has install:false
 		mocks := setupComposerMocks(t)

--- a/pkg/composer/blueprint/composer_test.go
+++ b/pkg/composer/blueprint/composer_test.go
@@ -298,6 +298,112 @@ func TestComposer_Compose(t *testing.T) {
 		}
 	})
 
+	t.Run("ReferencingBlueprintComponentsComposeAfterSourceComponents", func(t *testing.T) {
+		// Given a core source contributing two addon kustomizations and a referencing (user)
+		// blueprint contributing its own addon, with components stamped by source as the real
+		// composition flow stamps them (named source -> its name; primary/user -> "").
+		mocks := setupComposerMocks(t)
+		composer := NewBlueprintComposer(mocks.Runtime)
+		trueVal := true
+
+		coreBp := &blueprintv1alpha1.Blueprint{
+			Metadata: blueprintv1alpha1.Metadata{Name: "core"},
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "addon-object-store", Path: "addons/object-store", Source: "core"},
+				{Name: "addon-private-ca", Path: "addons/private-ca", Source: "core"},
+			},
+		}
+		userBp := &blueprintv1alpha1.Blueprint{
+			Metadata: blueprintv1alpha1.Metadata{Name: "user"},
+			Sources: []blueprintv1alpha1.Source{
+				{Name: "core", Install: &blueprintv1alpha1.BoolExpression{Value: &trueVal, IsExpr: false}},
+			},
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "addon-omni", Path: "addons/omni"},
+			},
+		}
+		loaders := []BlueprintLoader{
+			createMockBlueprintLoader("core", coreBp),
+			createMockBlueprintLoader("user", userBp),
+		}
+
+		// When composing
+		result, err := composer.Compose(loaders, nil, "", nil)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the referencing blueprint's addon-omni composes after both of core's addons,
+		// rather than sorting alphabetically into the middle of them.
+		order := make([]string, 0, len(result.Kustomizations))
+		for _, k := range result.Kustomizations {
+			order = append(order, k.Name)
+		}
+		idx := func(name string) int {
+			for i, n := range order {
+				if n == name {
+					return i
+				}
+			}
+			return -1
+		}
+		if idx("addon-omni") < idx("addon-object-store") || idx("addon-omni") < idx("addon-private-ca") {
+			t.Errorf("expected addon-omni (referencing blueprint) after core's addons, got order %v", order)
+		}
+	})
+
+	t.Run("SourceDepthReorderPreservesCrossSourceDependency", func(t *testing.T) {
+		// Given a referencing blueprint whose kustomization depends on a source kustomization, the
+		// depth reorder must keep the dependency (source, shallower) ahead of its dependent.
+		mocks := setupComposerMocks(t)
+		composer := NewBlueprintComposer(mocks.Runtime)
+		trueVal := true
+
+		coreBp := &blueprintv1alpha1.Blueprint{
+			Metadata: blueprintv1alpha1.Metadata{Name: "core"},
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "addon-base", Path: "addons/base", Source: "core"},
+			},
+		}
+		userBp := &blueprintv1alpha1.Blueprint{
+			Metadata: blueprintv1alpha1.Metadata{Name: "user"},
+			Sources: []blueprintv1alpha1.Source{
+				{Name: "core", Install: &blueprintv1alpha1.BoolExpression{Value: &trueVal, IsExpr: false}},
+			},
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "addon-extension", Path: "addons/extension", DependsOn: []string{"addon-base"}},
+			},
+		}
+		loaders := []BlueprintLoader{
+			createMockBlueprintLoader("core", coreBp),
+			createMockBlueprintLoader("user", userBp),
+		}
+
+		// When composing
+		result, err := composer.Compose(loaders, nil, "", nil)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the dependency (addon-base) still precedes its dependent (addon-extension)
+		order := make([]string, 0, len(result.Kustomizations))
+		for _, k := range result.Kustomizations {
+			order = append(order, k.Name)
+		}
+		baseIdx, extIdx := -1, -1
+		for i, n := range order {
+			if n == "addon-base" {
+				baseIdx = i
+			}
+			if n == "addon-extension" {
+				extIdx = i
+			}
+		}
+		if baseIdx < 0 || extIdx < 0 || baseIdx > extIdx {
+			t.Errorf("expected addon-base before addon-extension, got order %v", order)
+		}
+	})
+
 	t.Run("DoesNotMergeSourcesWithInstallFalse", func(t *testing.T) {
 		// Given a user blueprint with a source that has install:false
 		mocks := setupComposerMocks(t)

--- a/pkg/runtime/config/schemas/artifacts/facets.seealso.md
+++ b/pkg/runtime/config/schemas/artifacts/facets.seealso.md
@@ -1,3 +1,4 @@
 - [Blueprint reference](blueprint.md) — for the inherited TerraformComponent and Kustomization fields
+- [Composition order](composition-order.md) — how ordinal and source depth decide what composes first
 - [`apply`](commands/apply.md), [`up`](commands/up.md), [`explain`](commands/explain.md)
 - [Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle)

--- a/pkg/runtime/config/schemas/artifacts/facets.yaml
+++ b/pkg/runtime/config/schemas/artifacts/facets.yaml
@@ -6,7 +6,9 @@ description: |
   substitutions that are merged into the blueprint only when the facet's
   'when' expression evaluates to true against the operator's configuration.
   Facets live under contexts/_template/facets/ as one .yaml file per facet
-  and are composed in ordinal order (lower-priority first).
+  and are composed in ordinal order (lower-priority first) within a single
+  blueprint. Across blueprints, a source composes before the blueprint that
+  references it; see the Composition order reference.
 type: object
 required:
   - kind
@@ -40,12 +42,14 @@ properties:
   ordinal:
     type: integer
     description: |
-      Merge precedence relative to other facets. Higher ordinal wins on
-      conflict (processed later). When unset, the loader derives an ordinal
-      from the file basename: 'config-*' = 100; 'provider-*' or
-      'platform-*' with '-base' in the name = 199; other 'provider-*' /
-      'platform-*' = 200; 'option-*' / 'options-*' = 300; 'addon-*' /
-      'addons-*' = 400; no match = 0.
+      Merge precedence relative to other facets in the same blueprint. Higher
+      ordinal wins on conflict (processed later). When unset, the loader
+      derives an ordinal from the file basename: 'config-*' = 100;
+      'provider-*' or 'platform-*' with '-base' in the name = 199; other
+      'provider-*' / 'platform-*' = 200; 'option-*' / 'options-*' = 300;
+      'addon-*' / 'addons-*' = 400; no match = 0. Ordinal does not cross a
+      source boundary: a blueprint's facets always compose after the facets
+      of the sources it references, whatever ordinal either side sets.
   when:
     type: string
     description: |


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This change modifies the core blueprint composition pipeline, inserting a new component-ordering step between the global dependency barrier and validation; incorrect ordering could silently produce misconfigured deployments.
>
> **Overview**
>
> The PR adds `orderComponentsBySourceDepth`, which stably re-sorts TerraformComponents, Kustomizations, and FluxSystems so that components from referenced (shallower) sources appear before components from the blueprint that references them. Depth is computed by `sourceDepths` via a memoized DFS over the source-reference graph. The sort is stable, preserving intra-source ordinal order.
>
> One structural detail worth noting: `depth[component.Source]` is an ordinary map lookup, so any component whose `Source` field names a key absent from the computed depth map (for example, a synthetic source stamped by the CRD or dependency barrier layers that run just before this step) silently receives depth 0 and is sorted to the front. This may be fine in practice but is not guarded against.
>
> Reviewed by Claude for commit `f34fe38b`.

<!-- /claude-code-review:summary -->
