### PR TITLE
fix(tui): bind spinner terminal check to stderr to prevent silencing on stdout redirection

### DIFF
--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -157,6 +157,8 @@ func WithProgress(message string, fn func() error) error {
 }
 
 // Start stops any existing spinner and begins a new one with the given message.
+// WithWriterFile binds the animation's terminal check to stderr, the stream the frames go to;
+// WithWriter would leave that check on stdout, silencing the animation whenever stdout is redirected.
 func (s *termSpinner) Start(message string) {
 	if s.spin != nil && s.spin.Active() {
 		s.spin.Stop()
@@ -164,7 +166,7 @@ func (s *termSpinner) Start(message string) {
 	s.message = message
 	s.paused = 0
 	s.pauseCursorSaved = false
-	s.spin = spinner.New(spinner.CharSets[14], 100*time.Millisecond, spinner.WithColor("green"), spinner.WithWriter(os.Stderr))
+	s.spin = spinner.New(spinner.CharSets[14], 100*time.Millisecond, spinner.WithColor("green"), spinner.WithWriterFile(os.Stderr))
 	s.spin.Suffix = " " + message
 	s.spin.Start()
 }

--- a/pkg/tui/tui_test.go
+++ b/pkg/tui/tui_test.go
@@ -194,6 +194,29 @@ func TestTermSpinner_Start(t *testing.T) {
 		}
 	})
 
+	t.Run("BindsTerminalCheckToTheStreamItWrites", func(t *testing.T) {
+		// Given a termSpinner
+		s := &termSpinner{}
+		t.Cleanup(func() { captureStderr(t, s.Done) })
+
+		// When Start creates the underlying spinner
+		var writer io.Writer
+		var writerFile *os.File
+		captureStderr(t, func() {
+			s.Start("loading")
+			writer, writerFile = s.spin.Writer, s.spin.WriterFile
+		})
+
+		// Then the file the animation tests for a terminal is the file it writes frames to,
+		// so a redirected stdout cannot silence a spinner bound to stderr
+		if writerFile == nil {
+			t.Fatal("expected a writer file for the terminal check")
+		}
+		if writer != io.Writer(writerFile) {
+			t.Errorf("expected terminal check on the write target %v, got %v", writer, writerFile)
+		}
+	})
+
 	t.Run("StopsExistingSpinFirst", func(t *testing.T) {
 		// Given a termSpinner that has already been started
 		s := &termSpinner{}


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change touches only the TUI spinner construction in `pkg/tui/tui.go` — an isolated, easily reversible fix with no impact on callers or shared infrastructure.
>
> **Overview**
>
> The PR replaces `spinner.WithWriter(os.Stderr)` with `spinner.WithWriterFile(os.Stderr)` when constructing the `briandowns/spinner` in `termSpinner.Start`. The `briandowns/spinner` library performs its is-a-terminal check against whichever `*os.File` is set as the "writer file"; `WithWriter` sets only the `io.Writer` field, leaving the terminal check bound to stdout, so the animation was silenced whenever stdout was redirected. `WithWriterFile` sets both fields to the same `*os.File`, tying the TTY check to stderr where frames are actually written.
>
> A new unit test (`BindsTerminalCheckToTheStreamItWrites`) directly asserts the invariant by inspecting `spin.Writer` and `spin.WriterFile` after `Start` returns.
>
> Reviewed by Claude for commit `141480e`.

<!-- /claude-code-review:summary -->
