### PR TITLE
fix(processor): ensure config block reads context under its own name without shadowing

### DIFF
--- a/integration/fixtures/facet-composition/contexts/_template/facets/provider-colima.yaml
+++ b/integration/fixtures/facet-composition/contexts/_template/facets/provider-colima.yaml
@@ -6,11 +6,27 @@ metadata:
 
 when: effective_runtime != ''
 
+config:
+# Derives a key from network.cidr_block inside the block that shares its name. The block
+# never sets cidr_block itself, so the context value has to stay readable from within the
+# block across every evaluation pass or cidrhost() is handed nil.
+- name: network
+  value:
+    lb_range:
+      start: "${cidrhost(network.cidr_block, 266)}"
+
 kustomize:
 
 - name: lb-colima
   path: lb/colima
   when: effective_runtime == 'colima'
+  components: []
+  timeout: 5m
+  interval: 5m
+
+- name: lb-colima-direct
+  path: lb/colima-direct
+  when: network.lb_range.start == '10.5.1.10'
   components: []
   timeout: 5m
   interval: 5m

--- a/integration/fixtures/facet-composition/contexts/_template/tests/composition.test.yaml
+++ b/integration/fixtures/facet-composition/contexts/_template/tests/composition.test.yaml
@@ -85,6 +85,23 @@ cases:
     - name: lb-colima
       path: lb/colima
 
+# A config block's own name must not shadow the context value it was built from:
+# provider-colima writes a `network` block deriving lb_range_start from network.cidr_block.
+# Without the fix the block's partial value replaces context after the first evaluation
+# pass, cidr_block resolves to nil and composition fails inside cidrhost().
+- name: block_reads_context_under_own_name
+  values:
+    provider: docker
+    cluster:
+      driver: talos
+    workstation:
+      runtime: colima
+    network: *default-network
+  expect:
+    kustomize:
+    - name: lb-colima-direct
+      path: lb/colima-direct
+
 # Ordinal: option-ordinal-override (300) runs after provider-base (199). Same-name kustomization
 # policy-base is replaced (strategy: replace), so path comes from higher ordinal.
 - name: higher_ordinal_replace_wins

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -437,7 +437,10 @@ func (p *BaseBlueprintProcessor) markDeferredPath(composedPath string) {
 // facet-derived config (globalScope) wins over context for all keys; the current block is set to
 // currentBlockValue when non-nil (e.g. in-place evaluation or resolve pass), otherwise to
 // contextScope[blockName] or omitted to avoid self-reference. This prevents context from
-// overwriting other blocks' facet values when one block has a scalar value.
+// overwriting other blocks' facet values when one block has a scalar value. currentBlockValue is
+// overlaid on the context value rather than replacing it, so keys the block does not define itself —
+// schema defaults and operator-set values under the same name — stay readable from inside the block
+// on every stabilization pass, not just the first.
 func (p *BaseBlueprintProcessor) scopeForConfigBlock(contextScope, globalScope map[string]any, blockName string, currentBlockValue any) map[string]any {
 	if globalScope == nil {
 		globalScope = make(map[string]any)
@@ -447,7 +450,7 @@ func (p *BaseBlueprintProcessor) scopeForConfigBlock(contextScope, globalScope m
 	}
 	scope := blueprintv1alpha1.DeepMergeMaps(contextScope, globalScope)
 	if currentBlockValue != nil {
-		scope[blockName] = currentBlockValue
+		scope[blockName] = mergeBlockValueOverContext(contextScope[blockName], currentBlockValue)
 	} else if contextScope != nil && contextScope[blockName] != nil {
 		scope[blockName] = contextScope[blockName]
 	} else {
@@ -2514,6 +2517,18 @@ func deepMergeMap(base, overlay map[string]any) map[string]any {
 		result[k] = v
 	}
 	return result
+}
+
+// mergeBlockValueOverContext overlays a config block's in-progress value on the context value under
+// the same name, so the block reads its own keys and inherits the rest. A non-map on either side has
+// nothing to merge and yields the block value unchanged.
+func mergeBlockValueOverContext(contextValue, blockValue any) any {
+	contextMap, contextIsMap := contextValue.(map[string]any)
+	blockMap, blockIsMap := blockValue.(map[string]any)
+	if !contextIsMap || !blockIsMap {
+		return blockValue
+	}
+	return blueprintv1alpha1.DeepMergeMaps(contextMap, blockMap)
 }
 
 // accumulateStringSlice merges two string slices into a deduplicated, sorted slice.

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -1811,6 +1811,172 @@ func TestProcessor_ProcessFacets_ConfigBlockEvaluationOrder(t *testing.T) {
 	})
 }
 
+func TestProcessor_ProcessFacets_ConfigBlockReadsContextUnderOwnName(t *testing.T) {
+	// A config block's own name must not be a blind spot: keys the block does not define
+	// itself — schema defaults and operator-set values — stay readable from inside it.
+
+	t.Run("ReadsSchemaDefaultUnderOwnName", func(t *testing.T) {
+		// Given a context carrying the network.cidr_block schema default and a network block
+		// that does not set cidr_block itself
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{
+				"network": map[string]any{"cidr_block": "10.5.0.0/16"},
+			}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "platform-base"},
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "network", Body: map[string]any{"value": map[string]any{
+						"loadbalancer_driver": "kube-vip",
+						"effective_cidr":      "${network.cidr_block}",
+					}}},
+				},
+			},
+		}
+
+		// When the facets are processed
+		scope, err := processor.ProcessFacets(&blueprintv1alpha1.Blueprint{}, facets)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the same-name read resolves against context rather than the block's partial value
+		network, ok := scope["network"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected network map, got %T", scope["network"])
+		}
+		if network["effective_cidr"] != "10.5.0.0/16" {
+			t.Errorf("Expected network.effective_cidr='10.5.0.0/16' from schema default, got %v", network["effective_cidr"])
+		}
+	})
+
+	t.Run("ReadsContextUnderOwnNameFromNestedValue", func(t *testing.T) {
+		// Given a network block whose nested loadbalancer_ips map reads network.cidr_block
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{
+				"network": map[string]any{"cidr_block": "10.5.0.0/16"},
+			}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "platform-base"},
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "network", Body: map[string]any{"value": map[string]any{
+						"loadbalancer_ips": map[string]any{
+							"start": "${cidrhost(network.cidr_block, 266)}",
+							"end":   "${cidrhost(network.cidr_block, 356)}",
+						},
+					}}},
+				},
+			},
+		}
+
+		// When the facets are processed
+		scope, err := processor.ProcessFacets(&blueprintv1alpha1.Blueprint{}, facets)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then both nested reads resolve
+		network, ok := scope["network"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected network map, got %T", scope["network"])
+		}
+		ips, ok := network["loadbalancer_ips"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected loadbalancer_ips map, got %T", network["loadbalancer_ips"])
+		}
+		if ips["start"] != "10.5.1.10" {
+			t.Errorf("Expected loadbalancer_ips.start='10.5.1.10', got %v", ips["start"])
+		}
+		if ips["end"] != "10.5.1.100" {
+			t.Errorf("Expected loadbalancer_ips.end='10.5.1.100', got %v", ips["end"])
+		}
+	})
+
+	t.Run("BlockValueWinsOverContextForSameKey", func(t *testing.T) {
+		// Given a block that sets the same key the context carries
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{
+				"network": map[string]any{"cidr_block": "10.5.0.0/16"},
+			}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "platform-base"},
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "network", Body: map[string]any{"value": map[string]any{
+						"cidr_block": "10.9.0.0/16",
+						"loadbalancer_ips": map[string]any{
+							"start": "${cidrhost(network.cidr_block, 266)}",
+						},
+					}}},
+				},
+			},
+		}
+
+		// When the facets are processed
+		scope, err := processor.ProcessFacets(&blueprintv1alpha1.Blueprint{}, facets)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the block's own value wins over context for that key
+		network, ok := scope["network"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected network map, got %T", scope["network"])
+		}
+		if network["cidr_block"] != "10.9.0.0/16" {
+			t.Errorf("Expected block value to win, got %v", network["cidr_block"])
+		}
+		ips, ok := network["loadbalancer_ips"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected loadbalancer_ips map, got %T", network["loadbalancer_ips"])
+		}
+		if ips["start"] != "10.9.1.10" {
+			t.Errorf("Expected loadbalancer_ips.start derived from block value, got %v", ips["start"])
+		}
+	})
+
+	t.Run("ScalarBlockValueReplacesContextValue", func(t *testing.T) {
+		// Given a block whose value is a scalar rather than a map, there is nothing to merge
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{
+				"network": map[string]any{"cidr_block": "10.5.0.0/16"},
+				"ha":      false,
+			}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "platform-base"},
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "network", Body: map[string]any{"value": "10.5.0.0/16"}},
+				},
+			},
+		}
+
+		// When the facets are processed
+		scope, err := processor.ProcessFacets(&blueprintv1alpha1.Blueprint{}, facets)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the scalar stands on its own
+		if scope["network"] != "10.5.0.0/16" {
+			t.Errorf("Expected scalar block value preserved, got %#v", scope["network"])
+		}
+	})
+}
+
 func TestProcessor_ProcessFacets_ConfigDeferredValues(t *testing.T) {
 	t.Run("DeferredConfigBlockValuePreservesExpressionInSubstitution", func(t *testing.T) {
 		// Given a config block with a deferred helper and a substitution that


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Narrow correctness fix in the blueprint processor's config-block scope builder, well-tested and confined to a single evaluation helper.
>
> **Overview**
>
> A config block that derives values by reading context under its own name (e.g. a `network` block calling `cidrhost(network.cidr_block, …)`) would silently lose access to those context keys on the second and later stabilization passes. The root cause was that `scopeForConfigBlock` replaced the full context entry with the block's partial in-progress value instead of overlaying it. This PR fixes that by introducing `mergeBlockValueOverContext`, which calls `DeepMergeMaps(contextValue, blockValue)` so the block's computed keys win while the rest of the context entry remains visible.
>
> The fix is exercised by four new unit tests covering schema defaults, nested reads, block-wins-over-context, and the scalar fallback, plus a new integration fixture (`lb-colima-direct`) whose `when` condition only passes when `cidrhost` resolves correctly across passes.
>
> Reviewed by Claude for commit `4718efb3`.

<!-- /claude-code-review:summary -->
