### PR TITLE
fix(composer): make config block guards blind to their own writes

### DIFF
--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -278,7 +278,7 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 				return nil, err
 			}
 			var errMerge error
-			globalScope, cfgEntries, errMerge = p.mergeFacetScopeIntoGlobal(facet, globalScope, cfgEntries, passScope)
+			globalScope, cfgEntries, errMerge = p.mergeFacetScopeIntoGlobal(facet, globalScope, cfgEntries, passScope, contextScope)
 			if errMerge != nil {
 				return nil, fmt.Errorf("facet %s: %w", facet.Metadata.Name, errMerge)
 			}
@@ -467,7 +467,11 @@ func (p *BaseBlueprintProcessor) scopeForConfigBlock(contextScope, globalScope m
 // For a given name, only blocks whose when condition is true contribute; if multiple blocks
 // with the same name have when true, their bodies are deep-merged in list order (later overlay).
 // Merge precedence: higher ordinal wins; when ordinals match, strategy precedence remove > replace > merge.
-func (p *BaseBlueprintProcessor) mergeFacetScopeIntoGlobal(facet blueprintv1alpha1.Facet, globalScope map[string]any, existing map[string]*blueprintv1alpha1.ConfigBlock, contextScope map[string]any) (map[string]any, map[string]*blueprintv1alpha1.ConfigBlock, error) {
+// A block's `when:` is evaluated against evalScope made blind to the keys that same block writes
+// (falling them back to contextScope, the round-0 operator/schema values), so a "default only when
+// unset" guard tests operator intent rather than the block's own prior-round contribution and does not
+// cancel itself across rounds.
+func (p *BaseBlueprintProcessor) mergeFacetScopeIntoGlobal(facet blueprintv1alpha1.Facet, globalScope map[string]any, existing map[string]*blueprintv1alpha1.ConfigBlock, evalScope, contextScope map[string]any) (map[string]any, map[string]*blueprintv1alpha1.ConfigBlock, error) {
 	facetOrdinal := resolvedFacetOrdinal(facet)
 	incoming := make(map[string]*blueprintv1alpha1.ConfigBlock)
 	byName := make(map[string][]any)
@@ -478,7 +482,8 @@ func (p *BaseBlueprintProcessor) mergeFacetScopeIntoGlobal(facet blueprintv1alph
 			continue
 		}
 		if block.When != "" {
-			shouldInclude, err := p.shouldIncludeComponent(block.When, facet.Path, contextScope)
+			guardScope := scopeBlindToBlockKeys(evalScope, contextScope, block.Name, block.Body)
+			shouldInclude, err := p.shouldIncludeComponent(block.When, facet.Path, guardScope)
 			if err != nil {
 				return nil, nil, fmt.Errorf("config block %q when: %w", block.Name, err)
 			}
@@ -2517,6 +2522,70 @@ func deepMergeMap(base, overlay map[string]any) map[string]any {
 		result[k] = v
 	}
 	return result
+}
+
+// scopeBlindToBlockKeys returns a scope in which the keys a config block writes under its own name
+// resolve to their round-0 context value rather than to what composition has accumulated, so the
+// block's `when:` guard cannot see the block's own contribution from a prior round. A guard like
+// `(network.cidr_block ?? '') == ''` therefore tests whether the operator or schema set cidr_block,
+// not whether this block already defaulted it, and no longer flips false after the block writes it.
+// Keys the block does not write — sibling keys other facets set, other blocks — are untouched; a block
+// whose value is not a map writes the whole name, so the whole name falls back to context. evalScope is
+// returned unchanged when the block writes nothing, so the common (unguarded) path allocates nothing.
+func scopeBlindToBlockKeys(evalScope, contextScope map[string]any, blockName string, body map[string]any) map[string]any {
+	keys, wholeName := blockWrittenKeys(body)
+	if !wholeName && len(keys) == 0 {
+		return evalScope
+	}
+	guard := maps.Clone(evalScope)
+	if guard == nil {
+		guard = make(map[string]any)
+	}
+	ctxVal, ctxHas := contextScope[blockName]
+	if wholeName {
+		if ctxHas {
+			guard[blockName] = ctxVal
+		} else {
+			delete(guard, blockName)
+		}
+		return guard
+	}
+	blockMap, _ := asMapStringAny(guard[blockName])
+	newBlock := maps.Clone(blockMap)
+	if newBlock == nil {
+		newBlock = make(map[string]any)
+	}
+	ctxBlock, _ := asMapStringAny(ctxVal)
+	for _, k := range keys {
+		if cv, ok := ctxBlock[k]; ok {
+			newBlock[k] = cv
+		} else {
+			delete(newBlock, k)
+		}
+	}
+	guard[blockName] = newBlock
+	return guard
+}
+
+// blockWrittenKeys reports the top-level keys a config block writes under its name. A map value writes
+// its own keys; a scalar or list value writes the whole name (wholeName true, no keys); a block with no
+// value writes nothing.
+func blockWrittenKeys(body map[string]any) (keys []string, wholeName bool) {
+	if body == nil {
+		return nil, false
+	}
+	value, ok := body["value"]
+	if !ok || value == nil {
+		return nil, false
+	}
+	valueMap, ok := asMapStringAny(value)
+	if !ok {
+		return nil, true
+	}
+	for k := range valueMap {
+		keys = append(keys, k)
+	}
+	return keys, false
 }
 
 // mergeBlockValueOverContext overlays a config block's in-progress value on the context value under

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -1977,6 +1977,135 @@ func TestProcessor_ProcessFacets_ConfigBlockReadsContextUnderOwnName(t *testing.
 	})
 }
 
+func TestProcessor_ProcessFacets_ConfigBlockGuardBlindToOwnWrite(t *testing.T) {
+	// A config block's `when:` guard must be blind to the keys that same block writes,
+	// so a "write this default only when the field is unset" guard does not cancel itself:
+	// the block's own write in one round must not flip its guard false in the next.
+
+	t.Run("WriteWhenUnsetDefaultAppliesInsteadOfSelfCancelling", func(t *testing.T) {
+		// Given an empty context and a network block that defaults cidr_block only when unset
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "platform-base"},
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "network", When: "(network.cidr_block ?? '') == ''", Body: map[string]any{"value": map[string]any{
+						"cidr_block": "10.5.0.0/16",
+					}}},
+				},
+			},
+		}
+
+		// When the facets are processed
+		scope, err := processor.ProcessFacets(&blueprintv1alpha1.Blueprint{}, facets)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the default applies and survives — the block's own write does not drop it
+		network, ok := scope["network"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected network map, got %#v", scope["network"])
+		}
+		if network["cidr_block"] != "10.5.0.0/16" {
+			t.Errorf("Expected network.cidr_block='10.5.0.0/16', got %v", network["cidr_block"])
+		}
+	})
+
+	t.Run("WriteWhenUnsetSkippedWhenOperatorAlreadySet", func(t *testing.T) {
+		// Given a context where the operator set cidr_block, and the same defaulting block
+		// carrying a sentinel that would appear only if the block wrongly fired
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{
+				"network": map[string]any{"cidr_block": "10.9.0.0/16"},
+			}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "platform-base"},
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "network", When: "(network.cidr_block ?? '') == ''", Body: map[string]any{"value": map[string]any{
+						"cidr_block": "10.5.0.0/16",
+						"defaulted":  "yes",
+					}}},
+				},
+			},
+		}
+
+		// When the facets are processed
+		scope, err := processor.ProcessFacets(&blueprintv1alpha1.Blueprint{}, facets)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the guard sees the operator value under its own name and the block does not fire,
+		// so it contributes neither the default cidr_block nor its sentinel
+		if network, ok := scope["network"].(map[string]any); ok {
+			if network["cidr_block"] == "10.5.0.0/16" {
+				t.Errorf("Expected operator value not overwritten by default, got %v", network["cidr_block"])
+			}
+			if network["defaulted"] != nil {
+				t.Errorf("Expected guarded block to be skipped, but its sentinel appeared: %v", network["defaulted"])
+			}
+		}
+	})
+
+	t.Run("GuardSeesSiblingKeyWrittenByAnotherFacet", func(t *testing.T) {
+		// Given one facet that unconditionally sets network.region and a second whose network
+		// block is guarded on that sibling key (not on the key it writes)
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		low, high := 100, 200
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "region-writer"},
+				Ordinal:  &low,
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "network", Body: map[string]any{"value": map[string]any{
+						"region": "us",
+					}}},
+				},
+			},
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "cidr-defaulter"},
+				Ordinal:  &high,
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "network", When: "network.region == 'us'", Body: map[string]any{"value": map[string]any{
+						"cidr_block": "10.5.0.0/16",
+					}}},
+				},
+			},
+		}
+
+		// When the facets are processed
+		scope, err := processor.ProcessFacets(&blueprintv1alpha1.Blueprint{}, facets)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the guard reads the sibling key from the other facet, so the block contributes
+		network, ok := scope["network"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected network map, got %#v", scope["network"])
+		}
+		if network["region"] != "us" {
+			t.Errorf("Expected network.region='us', got %v", network["region"])
+		}
+		if network["cidr_block"] != "10.5.0.0/16" {
+			t.Errorf("Expected guard on sibling key to include block, got cidr_block=%v", network["cidr_block"])
+		}
+	})
+}
+
 func TestProcessor_ProcessFacets_ConfigDeferredValues(t *testing.T) {
 	t.Run("DeferredConfigBlockValuePreservesExpressionInSubstitution", func(t *testing.T) {
 		// Given a config block with a deferred helper and a substitution that


### PR DESCRIPTION
Closes #3081

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Isolated fix to a single internal function in the blueprint processor with targeted tests; no public API or CLI surface is affected.
>
> **Overview**
>
> This PR fixes a self-cancellation bug in config block `when:` guard evaluation. Previously, guards were evaluated against the round-0 context scope only, meaning they could not see sibling keys written by earlier facets, and a "write this default only when unset" pattern (`(network.cidr_block ?? '') == ''`) would start failing after the block's own first write. The fix threads the accumulated eval scope into the guard evaluator but makes each block blind to the keys it itself writes, falling those back to the original context values.
>
> Two new helpers — `scopeBlindToBlockKeys` and `blockWrittenKeys` — implement the blinding logic. Three new tests cover the default-only-when-unset case, the operator-already-set case, and the sibling-key visibility case. The fix is correct and the tests are well-targeted.
>
> Reviewed by Claude for commit `bd46279f`.

<!-- /claude-code-review:summary -->
