### PR TITLE
feat(test): add applySchemaDefaults opt-in for facet test cases

### DIFF
--- a/api/v1alpha1/test_types.go
+++ b/api/v1alpha1/test_types.go
@@ -44,4 +44,11 @@ type TestCase struct {
 	// If true, the test passes when composition fails and fails when composition succeeds.
 	// This is useful for testing invalid configurations that should be rejected by the framework.
 	ExpectError bool `yaml:"expectError,omitempty"`
+
+	// ApplySchemaDefaults composes this case with schema `default:` values materialized, as
+	// production does. The test path otherwise skips schema defaults so a facet is exercised on
+	// its own defaulting logic; set this to validate a facet that relies on a schema default
+	// (e.g. a read of network.cidr_block with no `?? <fallback>`). Off by default; other cases
+	// are unaffected.
+	ApplySchemaDefaults bool `yaml:"applySchemaDefaults,omitempty"`
 }

--- a/docs/reference/testing.md
+++ b/docs/reference/testing.md
@@ -20,6 +20,7 @@ specific terraform components and kustomizations are present (or absent).
 | Field | Type | Description |
 |------|------|-------------|
 | `name` | `string` | Unique identifier for the test case. **(required)** |
+| `applySchemaDefaults` | `boolean` | When true, this case composes with schema `default:` values materialized, as production does. The test path otherwise skips schema defaults so a facet is exercised on its own defaulting logic; set this to validate a facet that reads a schema-defaulted field with no `?? <fallback>` (e.g. network.cidr_block). Defaults to false; other cases are unaffected. |
 | `env` | `map<string>` | Environment variables visible to env() expressions during composition. Resolution is hermetic: env() sees only these entries, never the host environment. WINDSOR_CONTEXT defaults to "test" and can be overridden here. Example: env.ENABLE_DNS = "yes". |
 | `exclude` | `object` | Components and kustomizations that must NOT be present in the composed blueprint. Same partial-match semantics as 'expect'. |
 | `expect` | `object` | Components and kustomizations that must be present in the composed blueprint. Partial matching: only fields you specify are checked. |

--- a/integration/fixtures/facet-composition/contexts/_template/facets/option-schema-default.yaml
+++ b/integration/fixtures/facet-composition/contexts/_template/facets/option-schema-default.yaml
@@ -1,0 +1,16 @@
+kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: option-schema-default
+  description: Reads network.cidr_block with no ?? fallback; composes only when schema defaults are materialized, so it exercises a case's applySchemaDefaults opt-in.
+
+kustomize:
+
+# Gated on a fallback-free read of the schema-defaulted cidr_block. Present only when the case
+# opted into schema defaults so cidrhost() sees 10.5.0.0/16 rather than nil.
+- name: schema-default-marker
+  path: schema-default/marker
+  when: cidrhost(network.cidr_block, 10) == '10.5.0.10'
+  components: []
+  timeout: 5m
+  interval: 5m

--- a/integration/fixtures/facet-composition/contexts/_template/tests/composition.test.yaml
+++ b/integration/fixtures/facet-composition/contexts/_template/tests/composition.test.yaml
@@ -128,3 +128,18 @@ cases:
     - name: policy-resources
       components:
       - ordinal-merge-test
+
+# applySchemaDefaults opt-in (#3083): with no network set, the schema default for
+# network.cidr_block (10.5.0.0/16) is materialized as in production, so option-schema-default's
+# fallback-free cidrhost(network.cidr_block, 10) resolves to 10.5.0.10 and its marker is included.
+# Without the opt-in the test path skips schema defaults and this would compose against nil.
+- name: schema_default_applies_with_opt_in
+  applySchemaDefaults: true
+  values:
+    provider: docker
+    cluster:
+      driver: talos
+  expect:
+    kustomize:
+    - name: schema-default-marker
+      path: schema-default/marker

--- a/pkg/runtime/config/handler.go
+++ b/pkg/runtime/config/handler.go
@@ -49,6 +49,7 @@ type ConfigHandler interface {
 	LoadSchemaFromBytes(schemaContent []byte) error
 	GetSchema() map[string]any
 	GetContextValues() (map[string]any, error)
+	SetApplySchemaDefaults(enabled bool)
 	GetSensitivePaths() []string
 	IsSensitivePath(path string) bool
 	RegisterProvider(prefix string, provider ValueProvider)
@@ -82,6 +83,11 @@ type configHandler struct {
 	data            map[string]any
 	defaultConfig   *v1alpha1.Context
 	providers       map[string]ValueProvider
+
+	// applySchemaDefaults forces schema-default materialization in GetContextValues even for a
+	// test context, which otherwise skips it. Consumers that want the production composition path
+	// under a test context (the facet test runner, per case) set this; it is a no-op elsewhere.
+	applySchemaDefaults bool
 }
 
 // =============================================================================
@@ -434,6 +440,13 @@ func (c *configHandler) SetContext(context string) error {
 	}
 
 	return nil
+}
+
+// SetApplySchemaDefaults forces GetContextValues to materialize schema defaults even under a test
+// context, which otherwise skips them. It exists for the facet test runner to compose a case on the
+// production path; in any non-test context schema defaults already apply, so this is a no-op there.
+func (c *configHandler) SetApplySchemaDefaults(enabled bool) {
+	c.applySchemaDefaults = enabled
 }
 
 // GetConfigRoot retrieves the configuration root path based on the current context

--- a/pkg/runtime/config/mock_handler.go
+++ b/pkg/runtime/config/mock_handler.go
@@ -36,6 +36,7 @@ type MockConfigHandler struct {
 	LoadSchemaFromBytesFunc    func(schemaContent []byte) error
 	GetSchemaFunc              func() map[string]any
 	GetContextValuesFunc       func() (map[string]any, error)
+	SetApplySchemaDefaultsFunc func(enabled bool)
 	GetSensitivePathsFunc      func() []string
 	IsSensitivePathFunc        func(path string) bool
 	RegisterProviderFunc       func(prefix string, provider ValueProvider)
@@ -287,6 +288,13 @@ func (m *MockConfigHandler) GetContextValues() (map[string]any, error) {
 		return m.GetContextValuesFunc()
 	}
 	return nil, fmt.Errorf("GetContextValuesFunc not set")
+}
+
+// SetApplySchemaDefaults calls the mock SetApplySchemaDefaultsFunc if set, otherwise is a no-op
+func (m *MockConfigHandler) SetApplySchemaDefaults(enabled bool) {
+	if m.SetApplySchemaDefaultsFunc != nil {
+		m.SetApplySchemaDefaultsFunc(enabled)
+	}
 }
 
 // GetSensitivePaths calls the mock GetSensitivePathsFunc if set, otherwise returns nil

--- a/pkg/runtime/config/resolve.go
+++ b/pkg/runtime/config/resolve.go
@@ -20,12 +20,13 @@ import (
 // If the schema validator or schema is unavailable, only the currently loaded data is returned.
 // It also ensures that cluster.controlplanes.nodes and cluster.workers.nodes are initialized as empty maps
 // even though they are not serialized to YAML, so template expressions can safely evaluate them.
-// For test contexts, schema defaults are skipped to ensure tests only use explicitly provided values.
+// For test contexts, schema defaults are skipped to ensure tests only use explicitly provided values,
+// unless SetApplySchemaDefaults(true) was called to opt a case onto the production composition path.
 func (c *configHandler) GetContextValues() (map[string]any, error) {
 	result := make(map[string]any)
 
 	contextName := c.GetContext()
-	skipSchemaDefaults := contextName == "test" || strings.HasPrefix(contextName, "test-")
+	skipSchemaDefaults := (contextName == "test" || strings.HasPrefix(contextName, "test-")) && !c.applySchemaDefaults
 	if !skipSchemaDefaults && c.schemaValidator != nil && c.schemaValidator.Schema != nil {
 		defaults, err := c.schemaValidator.GetSchemaDefaults()
 		if err == nil && defaults != nil {

--- a/pkg/runtime/config/resolve_test.go
+++ b/pkg/runtime/config/resolve_test.go
@@ -159,6 +159,73 @@ func TestConfigHandler_GetContextValues_Resolve(t *testing.T) {
 		}
 	})
 
+	t.Run("SkipsSchemaDefaultsInTestContext", func(t *testing.T) {
+		// Given a test context and a schema default for an unset field
+		handler, _ := setupPrivateTestHandler(t)
+		if err := handler.SetContext("test"); err != nil {
+			t.Fatalf("Expected no error setting context, got %v", err)
+		}
+		schema := []byte("$schema: https://json-schema.org/draft/2020-12/schema\n" +
+			"type: object\n" +
+			"properties:\n" +
+			"  network:\n" +
+			"    type: object\n" +
+			"    properties:\n" +
+			"      cidr_block:\n" +
+			"        type: string\n" +
+			"        default: \"10.5.0.0/16\"\n")
+		if err := handler.LoadSchemaFromBytes(schema); err != nil {
+			t.Fatalf("Expected no error loading schema, got %v", err)
+		}
+
+		values, err := handler.GetContextValues()
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the schema default is not materialized under a test context
+		if network, ok := values["network"].(map[string]any); ok {
+			if network["cidr_block"] != nil {
+				t.Errorf("Expected schema default skipped in test context, got %v", network["cidr_block"])
+			}
+		}
+	})
+
+	t.Run("AppliesSchemaDefaultsInTestContextWhenOptedIn", func(t *testing.T) {
+		// Given a test context that has opted into schema defaults
+		handler, _ := setupPrivateTestHandler(t)
+		if err := handler.SetContext("test"); err != nil {
+			t.Fatalf("Expected no error setting context, got %v", err)
+		}
+		handler.SetApplySchemaDefaults(true)
+		schema := []byte("$schema: https://json-schema.org/draft/2020-12/schema\n" +
+			"type: object\n" +
+			"properties:\n" +
+			"  network:\n" +
+			"    type: object\n" +
+			"    properties:\n" +
+			"      cidr_block:\n" +
+			"        type: string\n" +
+			"        default: \"10.5.0.0/16\"\n")
+		if err := handler.LoadSchemaFromBytes(schema); err != nil {
+			t.Fatalf("Expected no error loading schema, got %v", err)
+		}
+
+		values, err := handler.GetContextValues()
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the schema default is materialized, matching the production path
+		network, ok := values["network"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected network map, got %T", values["network"])
+		}
+		if network["cidr_block"] != "10.5.0.0/16" {
+			t.Errorf("Expected schema default applied on opt-in, got %v", network["cidr_block"])
+		}
+	})
+
 	t.Run("DoesNotDeriveSchedulable", func(t *testing.T) {
 		// schedulable is no longer synthesized by the generic resolver; the consuming facets derive
 		// it from count values via `?? ` fallbacks (#3062).

--- a/pkg/runtime/config/schemas/artifacts/testing.yaml
+++ b/pkg/runtime/config/schemas/artifacts/testing.yaml
@@ -63,6 +63,15 @@ properties:
             When true, the test passes only if blueprint composition fails.
             Use for testing invalid configurations that the framework should
             reject. Defaults to false.
+        applySchemaDefaults:
+          type: boolean
+          description: |
+            When true, this case composes with schema `default:` values
+            materialized, as production does. The test path otherwise skips
+            schema defaults so a facet is exercised on its own defaulting
+            logic; set this to validate a facet that reads a schema-defaulted
+            field with no `?? <fallback>` (e.g. network.cidr_block). Defaults
+            to false; other cases are unaffected.
 $defs:
   expectation:
     type: object

--- a/pkg/test/runner.go
+++ b/pkg/test/runner.go
@@ -161,10 +161,13 @@ func (r *TestRunner) discoverTestCases(filter string) ([]testCaseWithFile, error
 // from these entries so composition never reads the host env; WINDSOR_CONTEXT defaults to "test" and the
 // env map overrides it. Context isolation itself comes from the fresh ConfigHandler's .WithContext("test"),
 // which outranks the .windsor/context file and the WINDSOR_CONTEXT env var in GetContext.
+// When applySchemaDefaults is true the case composes with schema defaults materialized as production does,
+// rather than the test path's default skip, so a facet that reads a schema-defaulted field resolves it.
 // Returns a function that takes test values and returns a composed blueprint or an error.
-func (r *TestRunner) createGenerator(terraformOutputs map[string]map[string]any, env map[string]string) func(values map[string]any) (*blueprintv1alpha1.Blueprint, error) {
+func (r *TestRunner) createGenerator(terraformOutputs map[string]map[string]any, env map[string]string, applySchemaDefaults bool) func(values map[string]any) (*blueprintv1alpha1.Blueprint, error) {
 	return func(values map[string]any) (*blueprintv1alpha1.Blueprint, error) {
 		freshConfigHandler := config.NewConfigHandler(r.baseShell).WithContext("test")
+		freshConfigHandler.SetApplySchemaDefaults(applySchemaDefaults)
 
 		rt := runtime.NewRuntime(&runtime.Runtime{
 			Shell:         r.baseShell,
@@ -431,7 +434,7 @@ func (r *TestRunner) runTestCase(tc blueprintv1alpha1.TestCase) (TestResult, err
 	}
 	testValues["_testName"] = tc.Name
 
-	generator := r.createGenerator(tc.TerraformOutputs, tc.Env)
+	generator := r.createGenerator(tc.TerraformOutputs, tc.Env, tc.ApplySchemaDefaults)
 	bp, err := generator(testValues)
 
 	if tc.ExpectError {

--- a/pkg/test/runner_test.go
+++ b/pkg/test/runner_test.go
@@ -2912,7 +2912,7 @@ func TestTestRunner_createGenerator(t *testing.T) {
 			},
 		}
 
-		generator := runner.createGenerator(terraformOutputs, nil)
+		generator := runner.createGenerator(terraformOutputs, nil, false)
 		values := map[string]any{
 			"terraform.enabled": true,
 		}
@@ -2931,7 +2931,7 @@ func TestTestRunner_createGenerator(t *testing.T) {
 		mocks := setupTestRunnerMocks(t)
 		runner := createRunnerWithMockGenerator(mocks)
 
-		generator := runner.createGenerator(nil, nil)
+		generator := runner.createGenerator(nil, nil, false)
 		values := map[string]any{
 			"terraform.enabled": true,
 		}
@@ -2950,7 +2950,7 @@ func TestTestRunner_createGenerator(t *testing.T) {
 		mocks := setupTestRunnerMocksForFailure(t)
 		runner := createRunnerForFailure(mocks)
 
-		generator := runner.createGenerator(nil, nil)
+		generator := runner.createGenerator(nil, nil, false)
 		values := map[string]any{}
 
 		_, err := generator(values)
@@ -2975,7 +2975,7 @@ func TestTestRunner_createGenerator(t *testing.T) {
 			},
 		}
 
-		generator := runner.createGenerator(terraformOutputs, nil)
+		generator := runner.createGenerator(terraformOutputs, nil, false)
 		values := map[string]any{}
 
 		blueprint, err := generator(values)
@@ -2998,7 +2998,7 @@ func TestTestRunner_createGenerator(t *testing.T) {
 			},
 		}
 
-		generator := runner.createGenerator(terraformOutputs, nil)
+		generator := runner.createGenerator(terraformOutputs, nil, false)
 		values := map[string]any{
 			"terraform.enabled": false,
 		}
@@ -3040,7 +3040,7 @@ terraform:
 		terraformOutputs := map[string]map[string]any{
 			"cluster": {"endpoint": "https://cluster.local"},
 		}
-		generator := runner.createGenerator(terraformOutputs, nil)
+		generator := runner.createGenerator(terraformOutputs, nil, false)
 
 		// When the generator composes a config where dns.public_domain is unset so dns-zone is filtered out
 		_, err := generator(map[string]any{
@@ -3081,7 +3081,7 @@ terraform:
 		terraformOutputs := map[string]map[string]any{
 			"dns-zone": {"zone_id": "Z123ABC"},
 		}
-		generator := runner.createGenerator(terraformOutputs, nil)
+		generator := runner.createGenerator(terraformOutputs, nil, false)
 
 		// When the generator composes with dns.public_domain set so dns-zone is registered
 		_, err := generator(map[string]any{
@@ -3143,7 +3143,7 @@ allOf:
 			"dns":     map[string]any{"private_domain": "internal.example"},
 		}
 		for i := 0; i < 10; i++ {
-			generator := runner.createGenerator(nil, nil)
+			generator := runner.createGenerator(nil, nil, false)
 			if _, err := generator(satisfied); err != nil {
 				t.Fatalf("iteration %d: expected satisfied cross-field rule to pass, got %v", i, err)
 			}
@@ -3153,7 +3153,7 @@ allOf:
 		violation := map[string]any{
 			"gateway": map[string]any{"access": "private"},
 		}
-		generator := runner.createGenerator(nil, nil)
+		generator := runner.createGenerator(nil, nil, false)
 		if _, err := generator(violation); err == nil {
 			t.Fatal("expected cross-field rule violation to be surfaced from runner")
 		}
@@ -3178,7 +3178,7 @@ terraform:
 		runner := createRunnerWithMockGenerator(mocks)
 
 		// When the generator composes with an env map that enables the gate
-		generator := runner.createGenerator(nil, map[string]string{"ENABLE_DNS": "yes"})
+		generator := runner.createGenerator(nil, map[string]string{"ENABLE_DNS": "yes"}, false)
 		bp, err := generator(map[string]any{"terraform.enabled": true})
 
 		// Then dns-zone is included because env() resolved from the case env map
@@ -3210,7 +3210,7 @@ terraform:
 		runner := createRunnerWithMockGenerator(mocks)
 
 		// When the generator composes with no env map for the case
-		generator := runner.createGenerator(nil, nil)
+		generator := runner.createGenerator(nil, nil, false)
 		bp, err := generator(map[string]any{"terraform.enabled": true})
 
 		// Then dns-zone is excluded: env() never reads the host environment
@@ -3219,6 +3219,88 @@ terraform:
 		}
 		if hasTerraformComponent(bp, "dns-zone") {
 			t.Error("Expected dns-zone component to be absent: env() must not read host environment")
+		}
+	})
+
+	t.Run("SchemaDefaultResolvesForFallbackFreeReadWhenOptedIn", func(t *testing.T) {
+		// Given a schema default for network.cidr_block and a facet that reads it with no ?? fallback
+		mocks := setupTestRunnerMocks(t)
+		templateDir := filepath.Join(mocks.TmpDir, "contexts", "_template")
+		createTestFile(t, templateDir, "schema.yaml", `$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+properties:
+  network:
+    type: object
+    properties:
+      cidr_block:
+        type: string
+        default: "10.5.0.0/16"
+`)
+		facetsDir := filepath.Join(templateDir, "facets")
+		createTestFile(t, facetsDir, "platform.yaml", `kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: platform
+terraform:
+  - name: cluster
+    path: cluster
+  - name: dns-zone
+    path: dns/zone
+    when: network.cidr_block == '10.5.0.0/16'
+`)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		// When the case opts into schema defaults and sets no network.cidr_block
+		generator := runner.createGenerator(nil, nil, true)
+		bp, err := generator(map[string]any{"terraform.enabled": true})
+
+		// Then the fallback-free read resolves to the schema default and the gated component is included
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if !hasTerraformComponent(bp, "dns-zone") {
+			t.Error("Expected dns-zone: schema default should resolve network.cidr_block when opted in")
+		}
+	})
+
+	t.Run("SchemaDefaultSkippedForFallbackFreeReadByDefault", func(t *testing.T) {
+		// Given the same schema default and fallback-free facet read
+		mocks := setupTestRunnerMocks(t)
+		templateDir := filepath.Join(mocks.TmpDir, "contexts", "_template")
+		createTestFile(t, templateDir, "schema.yaml", `$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+properties:
+  network:
+    type: object
+    properties:
+      cidr_block:
+        type: string
+        default: "10.5.0.0/16"
+`)
+		facetsDir := filepath.Join(templateDir, "facets")
+		createTestFile(t, facetsDir, "platform.yaml", `kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: platform
+terraform:
+  - name: cluster
+    path: cluster
+  - name: dns-zone
+    path: dns/zone
+    when: network.cidr_block == '10.5.0.0/16'
+`)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		// When the case does not opt in
+		generator := runner.createGenerator(nil, nil, false)
+		bp, err := generator(map[string]any{"terraform.enabled": true})
+
+		// Then the schema default is skipped, the read is nil, and the gated component is excluded
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if hasTerraformComponent(bp, "dns-zone") {
+			t.Error("Expected dns-zone absent: schema default must be skipped by default in test context")
 		}
 	})
 
@@ -3241,7 +3323,7 @@ terraform:
 		runner := createRunnerWithMockGenerator(mocks)
 
 		// When the generator composes with no case env map
-		generator := runner.createGenerator(nil, nil)
+		generator := runner.createGenerator(nil, nil, false)
 		bp, err := generator(map[string]any{"terraform.enabled": true})
 
 		// Then dns-zone is included: WINDSOR_CONTEXT defaults to "test" in the hermetic env


### PR DESCRIPTION
Closes #3083

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Isolated, opt-in addition to the facet test runner with no change to production composition paths or existing test behavior.
>
> **Overview**
>
> This PR adds an `applySchemaDefaults` boolean field to `TestCase` that lets a single test case opt into the production composition path — materializing schema `default:` values — without affecting any other case. The default remains `false`, so all existing tests continue to skip schema defaults as before. The core logic change is a single-line guard in `resolve.go` that short-circuits the skip when the flag is set.
>
> The field is plumbed through the `ConfigHandler` interface via a new `SetApplySchemaDefaults` method, wired into the runner's per-case `createGenerator`, and documented in both the reference YAML schema and `docs/reference/testing.md`. An integration fixture and test case demonstrate the opt-in against a fallback-free `cidrhost(network.cidr_block, 10)` expression.
>
> Reviewed by Claude for commit `776852c8`.

<!-- /claude-code-review:summary -->
