### PR TITLE
fix(composer): resolve same-block sibling references in config values

### DIFF
--- a/integration/fixtures/facet-composition/contexts/_template/facets/option-sibling-ref.yaml
+++ b/integration/fixtures/facet-composition/contexts/_template/facets/option-sibling-ref.yaml
@@ -1,0 +1,22 @@
+kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: option-sibling-ref
+  description: A config block whose value derives one key from a sibling key in the same block via a non-call operator; must resolve at compose time rather than erroring on nil.
+
+config:
+- name: identity_effective
+  value:
+    issuer: "https://id.local"
+    auth_url: "${identity_effective.issuer + '/protocol/openid-connect/auth'}"
+
+kustomize:
+
+# Gated on the sibling-derived value. Present only if auth_url resolved from issuer at compose
+# time rather than erroring on <nil> or being left unresolved.
+- name: sibling-ref-marker
+  path: sibling-ref/marker
+  when: identity_effective.auth_url == 'https://id.local/protocol/openid-connect/auth'
+  components: []
+  timeout: 5m
+  interval: 5m

--- a/integration/fixtures/facet-composition/contexts/_template/tests/composition.test.yaml
+++ b/integration/fixtures/facet-composition/contexts/_template/tests/composition.test.yaml
@@ -143,3 +143,17 @@ cases:
     kustomize:
     - name: schema-default-marker
       path: schema-default/marker
+
+# Same-block sibling references (#3086): option-sibling-ref derives auth_url from a sibling
+# issuer key in the same config block via string concatenation. Without the fix that value
+# errors on <nil> at compose; with it, auth_url resolves and its gated marker is included.
+- name: config_value_reads_sibling_key_in_same_block
+  values:
+    provider: docker
+    cluster:
+      driver: talos
+    network: *default-network
+  expect:
+    kustomize:
+    - name: sibling-ref-marker
+      path: sibling-ref/marker

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -762,6 +762,31 @@ func (p *BaseBlueprintProcessor) evaluateGlobalScopeConfig(globalScope map[strin
 			break
 		}
 	}
+
+	// After the block scopes have converged, surface a genuine (non-deferred) evaluation error that the
+	// tolerant per-key pass kept raw so transient same-block sibling references could resolve across
+	// passes. A value still failing here against the final scope is a real mistake (a typo or bad
+	// reference), not a sibling awaiting resolution — without this it would reach rendered config as an
+	// unexpanded ${...} rather than failing composition. EvaluateMap tolerates a DeferredError at every
+	// nesting level (a helper like terraform_output resolves later), so only genuine errors are returned;
+	// top-level derived keys (${string(block.key)}) are kept raw for JIT and so are excluded.
+	for name, val := range globalScope {
+		blockMap, ok := val.(map[string]any)
+		if !ok {
+			continue
+		}
+		validationBody := make(map[string]any, len(blockMap))
+		for k, v := range blockMap {
+			if s, isStr := v.(string); isStr && expressionIsDerivedFromBlock(s, name) {
+				continue
+			}
+			validationBody[k] = v
+		}
+		finalScope := p.scopeForConfigBlock(contextScope, globalScope, name, blockMap)
+		if _, err := p.evaluator.EvaluateMap(validationBody, "", finalScope, false); err != nil {
+			return fmt.Errorf("config block %q: %w", name, err)
+		}
+	}
 	return nil
 }
 

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -709,10 +709,7 @@ func (p *BaseBlueprintProcessor) evaluateGlobalScopeConfig(globalScope map[strin
 					}
 					nonDerivedBody[k] = v
 				}
-				evaluated, err := p.evaluator.EvaluateMap(nonDerivedBody, "", scopeWithBlock, false)
-				if err != nil {
-					return fmt.Errorf("config block %q: %w", name, err)
-				}
+				evaluated := p.evaluateBlockBodyTolerant(nonDerivedBody, scopeWithBlock)
 				if normalized, ok := normalizeDeferredValue(evaluated).(map[string]any); ok {
 					evaluated = normalized
 				}
@@ -766,6 +763,28 @@ func (p *BaseBlueprintProcessor) evaluateGlobalScopeConfig(globalScope map[strin
 		}
 	}
 	return nil
+}
+
+// evaluateBlockBodyTolerant evaluates each top-level key of a config block body independently against
+// scope, keeping a key that fails to evaluate at its raw value rather than aborting the whole body.
+// EvaluateMap fails the entire map atomically on the first key error and returns nothing, which would
+// discard siblings that did resolve; a key referencing a sibling not yet present in scope (e.g.
+// `${identity_effective.issuer + '/auth'}` before issuer has resolved) would then abort the block on
+// the first stabilization pass, before the multi-pass loop and resolve pass can feed the resolved
+// sibling back in. Keeping the raw value lets a later pass resolve it once its dependency is available;
+// a genuinely unresolvable key stays raw and is deferred, matching the resolve pass's own tolerance.
+// A DeferredError is already handled inside EvaluateMap (the value is kept raw), so it is not an error here.
+func (p *BaseBlueprintProcessor) evaluateBlockBodyTolerant(body map[string]any, scope map[string]any) map[string]any {
+	evaluated := make(map[string]any, len(body))
+	for k, v := range body {
+		one, err := p.evaluator.EvaluateMap(map[string]any{k: v}, "", scope, false)
+		if err != nil {
+			evaluated[k] = v
+			continue
+		}
+		evaluated[k] = one[k]
+	}
+	return evaluated
 }
 
 // evaluateConfigBlockValue recursively evaluates a config block value (scalar, list, or map) so that

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -796,9 +796,12 @@ func (p *BaseBlueprintProcessor) evaluateGlobalScopeConfig(globalScope map[strin
 // discard siblings that did resolve; a key referencing a sibling not yet present in scope (e.g.
 // `${identity_effective.issuer + '/auth'}` before issuer has resolved) would then abort the block on
 // the first stabilization pass, before the multi-pass loop and resolve pass can feed the resolved
-// sibling back in. Keeping the raw value lets a later pass resolve it once its dependency is available;
-// a genuinely unresolvable key stays raw and is deferred, matching the resolve pass's own tolerance.
-// A DeferredError is already handled inside EvaluateMap (the value is kept raw), so it is not an error here.
+// sibling back in. Keeping the raw value lets a later pass resolve it once its dependency is available.
+// This tolerance is deliberately scoped to the stabilization passes: a key that is still failing after
+// the scopes converge is NOT silently dropped — evaluateGlobalScopeConfig's post-convergence validation
+// re-evaluates it against the final scope and surfaces any genuine (non-deferred) error as a composition
+// failure. A DeferredError is already handled inside EvaluateMap (the value is kept raw), so it is not an
+// error here.
 func (p *BaseBlueprintProcessor) evaluateBlockBodyTolerant(body map[string]any, scope map[string]any) map[string]any {
 	evaluated := make(map[string]any, len(body))
 	for k, v := range body {

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -1769,6 +1769,38 @@ func TestProcessor_ProcessFacets_ConfigBlockSameBlockSiblingRefs(t *testing.T) {
 			t.Errorf("Expected later entry to read earlier entry's issuer, got %v", block["auth_url"])
 		}
 	})
+
+	t.Run("GenuineNonDeferredErrorStillSurfaces", func(t *testing.T) {
+		// Given a value with a genuine error — arithmetic on a reference that never resolves —
+		// the tolerant per-key pass keeps it raw, but composition must still fail rather than
+		// emit an unexpanded ${...} into rendered config
+		_, err := run(t, map[string]any{
+			"issuer":   "https://id.example",
+			"auth_url": "${identity_effective.nonexistent + '/auth'}",
+		})
+		if err == nil {
+			t.Fatal("Expected a genuine unresolved-reference error to surface, got nil")
+		}
+		if !strings.Contains(err.Error(), "identity_effective") {
+			t.Errorf("Expected error to name the config block, got %v", err)
+		}
+	})
+
+	t.Run("NestedGenuineErrorSurfaces", func(t *testing.T) {
+		// Given a genuine error nested inside a map value, it must surface too
+		_, err := run(t, map[string]any{
+			"issuer": "https://id.example",
+			"urls": map[string]any{
+				"auth": "${identity_effective.nonexistent + '/auth'}",
+			},
+		})
+		if err == nil {
+			t.Fatal("Expected a nested genuine error to surface, got nil")
+		}
+	})
+	// Note: a value referencing a deferred helper (e.g. terraform_output) is kept raw for JIT rather
+	// than surfaced as an error; that path is covered by TestProcessor_ProcessFacets_ConfigDeferredValues,
+	// which registers a real deferred helper and exercises this post-convergence validation.
 }
 
 func TestProcessor_ProcessFacets_ConfigBlockEvaluationOrder(t *testing.T) {

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -1667,6 +1667,110 @@ func TestProcessor_ProcessFacets_Config(t *testing.T) {
 	})
 }
 
+func TestProcessor_ProcessFacets_ConfigBlockSameBlockSiblingRefs(t *testing.T) {
+	// A config value expression must be able to read a sibling key computed in the same block,
+	// including through non-call operators (e.g. string concatenation), resolving at compose time
+	// in dependency order rather than erroring on <nil> or being left unresolved.
+
+	run := func(t *testing.T, body map[string]any) (map[string]any, error) {
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) { return map[string]any{}, nil }
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		facets := []blueprintv1alpha1.Facet{{
+			Metadata: blueprintv1alpha1.Metadata{Name: "identity"},
+			Config: []blueprintv1alpha1.ConfigBlock{
+				{Name: "identity_effective", Body: map[string]any{"value": body}},
+			},
+		}}
+		return processor.ProcessFacets(&blueprintv1alpha1.Blueprint{}, facets)
+	}
+
+	t.Run("SiblingReferenceViaConcatenationResolves", func(t *testing.T) {
+		// Given a literal sibling and a key deriving from it via + (a non-call operator)
+		scope, err := run(t, map[string]any{
+			"issuer":   "https://id.example",
+			"auth_url": "${identity_effective.issuer + '/protocol/openid-connect/auth'}",
+		})
+
+		// Then the derived key resolves against the sibling instead of erroring on <nil>
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		block, ok := scope["identity_effective"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected identity_effective map, got %#v", scope["identity_effective"])
+		}
+		if block["auth_url"] != "https://id.example/protocol/openid-connect/auth" {
+			t.Errorf("Expected auth_url derived from sibling issuer, got %v", block["auth_url"])
+		}
+	})
+
+	t.Run("SiblingReferenceWhereSiblingIsItselfComputed", func(t *testing.T) {
+		// Given a computed sibling and a key deriving from it, order must resolve issuer first
+		scope, err := run(t, map[string]any{
+			"issuer":   "${'https://' + 'id.example'}",
+			"auth_url": "${identity_effective.issuer + '/auth'}",
+		})
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		block, ok := scope["identity_effective"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected identity_effective map, got %#v", scope["identity_effective"])
+		}
+		if block["issuer"] != "https://id.example" {
+			t.Errorf("Expected issuer resolved, got %v", block["issuer"])
+		}
+		if block["auth_url"] != "https://id.example/auth" {
+			t.Errorf("Expected auth_url derived from computed issuer, got %v", block["auth_url"])
+		}
+	})
+
+	t.Run("MultipleSiblingsDeriveFromOneIntermediate", func(t *testing.T) {
+		// Given several keys deriving from one computed intermediate (the motivating OIDC case)
+		scope, err := run(t, map[string]any{
+			"issuer":       "${'https://id.example'}",
+			"auth_url":     "${identity_effective.issuer + '/protocol/openid-connect/auth'}",
+			"token_url":    "${identity_effective.issuer + '/protocol/openid-connect/token'}",
+			"userinfo_url": "${identity_effective.issuer + '/protocol/openid-connect/userinfo'}",
+		})
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		block := scope["identity_effective"].(map[string]any)
+		if block["token_url"] != "https://id.example/protocol/openid-connect/token" {
+			t.Errorf("Expected token_url derived, got %v", block["token_url"])
+		}
+		if block["userinfo_url"] != "https://id.example/protocol/openid-connect/userinfo" {
+			t.Errorf("Expected userinfo_url derived, got %v", block["userinfo_url"])
+		}
+	})
+
+	t.Run("LaterSameNameEntryReadsEarlierEntry", func(t *testing.T) {
+		// Given two config entries with the same block name, the later reading the earlier
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) { return map[string]any{}, nil }
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		facets := []blueprintv1alpha1.Facet{{
+			Metadata: blueprintv1alpha1.Metadata{Name: "identity"},
+			Config: []blueprintv1alpha1.ConfigBlock{
+				{Name: "identity_effective", Body: map[string]any{"value": map[string]any{"issuer": "https://id.example"}}},
+				{Name: "identity_effective", Body: map[string]any{"value": map[string]any{"auth_url": "${identity_effective.issuer + '/auth'}"}}},
+			},
+		}}
+		scope, err := processor.ProcessFacets(&blueprintv1alpha1.Blueprint{}, facets)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		block := scope["identity_effective"].(map[string]any)
+		if block["auth_url"] != "https://id.example/auth" {
+			t.Errorf("Expected later entry to read earlier entry's issuer, got %v", block["auth_url"])
+		}
+	})
+}
+
 func TestProcessor_ProcessFacets_ConfigBlockEvaluationOrder(t *testing.T) {
 	// These tests pin the dependency-driven evaluation order for config blocks. The
 	// processor must evaluate a block AFTER every block it references via ${...}, no


### PR DESCRIPTION
Closes #3086

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Isolated fix to blueprint config-block evaluation with solid test coverage; no shared interfaces changed, no data written to persistent state.
>
> **Overview**
>
> This PR fixes same-block sibling references in Facet config blocks (e.g. `auth_url` deriving from `issuer` in the same `identity_effective` block via string concatenation). The root cause was that `EvaluateMap` fails atomically on the first key error, discarding all already-resolved siblings; on the first stabilization pass a sibling not yet in scope caused the whole block to abort before the multi-pass loop could feed resolved values back in.
>
> The fix introduces `evaluateBlockBodyTolerant`, which evaluates each key independently and keeps the raw value for any key that errors rather than aborting the block. This aligns with the existing resolve-pass tolerance: a key that can never resolve stays raw in both old and new code, but now non-deferred errors (syntax errors, type errors) are also silently swallowed at this level rather than surfaced as `config block "X": <err>`. That tradeoff is intentional and documented in the function comment.
>
> Reviewed by Claude for commit `d299213d`.

<!-- /claude-code-review:summary -->
