### PR TITLE
fix(evaluator): allow secrets derefs from computed config

### DIFF
--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -1082,6 +1082,10 @@ func (h *BaseBlueprintHandler) processAndCompose() error {
 		h.runtime.TerraformProvider.SetConfigScope(mergedScope)
 	}
 
+	if h.runtime.Evaluator != nil {
+		h.runtime.Evaluator.SetConfigScope(mergedScope)
+	}
+
 	return nil
 }
 

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -4599,6 +4599,29 @@ func TestProvisioner_ResolveSecrets(t *testing.T) {
 		}
 	})
 
+	t.Run("DereferencesComputedConfigBlockFromComposedScope", func(t *testing.T) {
+		// Given a computed config block value present only in the composed scope the composer publishes
+		// (not in context config), exactly as a substitutions: value would see it
+		mocks := setupProvisionerMocks(t)
+		withValues(mocks, map[string]any{})
+		mocks.Runtime.Evaluator.SetConfigScope(map[string]any{
+			"grafana_effective": map[string]any{"client_secret": "grafana-oidc-dev"},
+		})
+
+		// When resolving a secret whose value dereferences the computed block
+		resolved, err := newProvisioner(mocks).ResolveSecrets(bp(map[string]blueprintv1alpha1.SecretEntry{
+			"sso": entry(map[string]string{"clientSecret": "${grafana_effective.client_secret}"}),
+		}))
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the secret resolves against the composed scope, consistent with substitutions
+		if resolved["cdn-install"]["sso"].Data["clientSecret"] != "grafana-oidc-dev" {
+			t.Errorf("Expected secret to dereference the computed config block, got %v", resolved)
+		}
+	})
+
 	t.Run("RegistersResolvedValueWithScrubber", func(t *testing.T) {
 		// Given a resolvable secret reference and a shell that records scrubber registrations
 		mocks := setupProvisionerMocks(t)

--- a/pkg/runtime/evaluator/evaluator.go
+++ b/pkg/runtime/evaluator/evaluator.go
@@ -58,6 +58,7 @@ type expressionEvaluator struct {
 	Shims         *Shims
 	templateData  map[string][]byte
 	helpers       []func(allowDeferred bool) expr.Option
+	configScope   map[string]any
 }
 
 // =============================================================================
@@ -127,6 +128,7 @@ type ExpressionEvaluator interface {
 	HelperRegistrar
 	SetTemplateData(templateData map[string][]byte)
 	SetEnvLookup(lookup func(name string) (string, bool))
+	SetConfigScope(scope map[string]any)
 	Evaluate(expression string, facetPath string, scope map[string]any, evaluateDeferred bool) (any, error)
 	EvaluateMap(values map[string]any, facetPath string, scope map[string]any, evaluateDeferred bool) (map[string]any, error)
 }
@@ -176,6 +178,14 @@ func (e *expressionEvaluator) SetTemplateData(templateData map[string][]byte) {
 // The test runner uses this to supply a hermetic environment so composition never reads the host env.
 func (e *expressionEvaluator) SetEnvLookup(lookup func(name string) (string, bool)) {
 	e.Shims.LookupEnv = lookup
+}
+
+// SetConfigScope publishes the composed scope (facet config blocks merged over context config) that a
+// nil-scope evaluation should use as its base. The composer calls this after composition so apply-time
+// consumers — secret resolution in particular — dereference computed config values the same way
+// substitutions do. Passing nil clears it, reverting nil-scope evaluations to context config alone.
+func (e *expressionEvaluator) SetConfigScope(scope map[string]any) {
+	e.configScope = scope
 }
 
 // Register adds a custom helper function to the evaluator for expression evaluation.
@@ -304,19 +314,25 @@ func (e *expressionEvaluator) evaluate(s string, facetPath string, scope map[str
 	return result, nil
 }
 
-// evaluateExpression compiles and evaluates a single expression. When scope is nil, the environment
-// is enriched config (getConfig + context, project_root, etc.). When scope is non-nil, the environment
-// is that scope (with runtime keys injected so helpers like file() and jsonnet() have context and paths).
-// The expression should not include ${} bookends. Returns the evaluation result or an error.
+// evaluateExpression compiles and evaluates a single expression. The environment base is chosen by
+// precedence: an explicit non-nil scope wins; otherwise the composer-published configScope (which
+// includes facet config blocks, so nil-scope consumers like secret resolution see computed config);
+// otherwise enriched context config alone (pre-composition, or when no composed scope was published).
+// Runtime keys (context, project_root, etc.) are injected so helpers like file() and jsonnet() have
+// context and paths. The expression should not include ${} bookends. Returns the result or an error.
 func (e *expressionEvaluator) evaluateExpression(expression string, facetPath string, scope map[string]any, evaluateDeferred bool) (any, error) {
 	if rewritten, ok := secretsRuntime.NormalizeExpression(expression); ok {
 		expression = rewritten
 	}
 
+	base := scope
+	if base == nil {
+		base = e.configScope
+	}
 	var merged map[string]any
-	if scope != nil {
+	if base != nil {
 		merged = make(map[string]any)
-		maps.Copy(merged, scope)
+		maps.Copy(merged, base)
 		injectRuntimeKeys(merged, e)
 	} else {
 		merged = e.enrichConfig(e.getConfig())

--- a/pkg/runtime/evaluator/evaluator_public_test.go
+++ b/pkg/runtime/evaluator/evaluator_public_test.go
@@ -1986,3 +1986,61 @@ func TestExpressionBody(t *testing.T) {
 		}
 	})
 }
+
+func TestExpressionEvaluator_SetConfigScope(t *testing.T) {
+	t.Run("NilScopeEvaluationUsesPublishedConfigScope", func(t *testing.T) {
+		// Given an evaluator whose context config lacks a computed block, but the composer has
+		// published a config scope that contains it
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.GetContextValuesFunc = func() (map[string]any, error) { return map[string]any{}, nil }
+		evaluator := NewExpressionEvaluator(mockConfigHandler, "/project", "/template")
+		evaluator.SetConfigScope(map[string]any{
+			"grafana_effective": map[string]any{"client_secret": "grafana-oidc-dev"},
+		})
+
+		// When evaluating a reference to the computed block with a nil scope (as secret resolution does)
+		got, err := evaluator.Evaluate("${grafana_effective.client_secret}", "", nil, true)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then it resolves against the published config scope
+		if got != "grafana-oidc-dev" {
+			t.Errorf("Expected 'grafana-oidc-dev', got %v", got)
+		}
+	})
+
+	t.Run("ExplicitScopeStillWinsOverConfigScope", func(t *testing.T) {
+		// Given a published config scope
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.GetContextValuesFunc = func() (map[string]any, error) { return map[string]any{}, nil }
+		evaluator := NewExpressionEvaluator(mockConfigHandler, "/project", "/template")
+		evaluator.SetConfigScope(map[string]any{"x": map[string]any{"y": "from-config-scope"}})
+
+		// When an explicit scope is passed, it takes precedence
+		got, err := evaluator.Evaluate("${x.y}", "", map[string]any{"x": map[string]any{"y": "from-explicit"}}, true)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if got != "from-explicit" {
+			t.Errorf("Expected explicit scope to win, got %v", got)
+		}
+	})
+
+	t.Run("NilScopeFallsBackToContextConfigWhenNoConfigScope", func(t *testing.T) {
+		// Given no published config scope, nil-scope evaluation still uses context config
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"cluster": map[string]any{"name": "ctx"}}, nil
+		}
+		evaluator := NewExpressionEvaluator(mockConfigHandler, "/project", "/template")
+
+		got, err := evaluator.Evaluate("${cluster.name}", "", nil, true)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if got != "ctx" {
+			t.Errorf("Expected context config used when no config scope, got %v", got)
+		}
+	})
+}

--- a/pkg/runtime/evaluator/mock_evaluator.go
+++ b/pkg/runtime/evaluator/mock_evaluator.go
@@ -7,6 +7,7 @@ package evaluator
 type MockExpressionEvaluator struct {
 	SetTemplateDataFunc func(templateData map[string][]byte)
 	SetEnvLookupFunc    func(lookup func(name string) (string, bool))
+	SetConfigScopeFunc  func(scope map[string]any)
 	RegisterFunc        func(name string, helper func(params []any, deferred bool) (any, error), signature any)
 	EvaluateFunc        func(expression string, facetPath string, scope map[string]any, evaluateDeferred bool) (any, error)
 	EvaluateMapFunc     func(values map[string]any, facetPath string, scope map[string]any, evaluateDeferred bool) (map[string]any, error)
@@ -36,6 +37,13 @@ func (m *MockExpressionEvaluator) SetTemplateData(templateData map[string][]byte
 func (m *MockExpressionEvaluator) SetEnvLookup(lookup func(name string) (string, bool)) {
 	if m.SetEnvLookupFunc != nil {
 		m.SetEnvLookupFunc(lookup)
+	}
+}
+
+// SetConfigScope calls the mock SetConfigScopeFunc if set, otherwise does nothing.
+func (m *MockExpressionEvaluator) SetConfigScope(scope map[string]any) {
+	if m.SetConfigScopeFunc != nil {
+		m.SetConfigScopeFunc(scope)
 	}
 }
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This is a targeted evaluator bug fix with good test coverage and no cross-cutting side effects.
>
> **Overview**
>
> The PR adds a `configScope` field to `expressionEvaluator` that the composer populates after composition via `SetConfigScope`. This gives nil-scope callers (secret resolution in particular) access to computed facet config blocks, closing a gap where substitutions could dereference those blocks but secrets could not. The precedence is explicit scope > composer-published configScope > enriched context config, which is straightforward and well-documented in the updated `evaluateExpression` comment.
>
> Three unit tests covering all three precedence branches and one provisioner integration test are added; the interface and mock are updated in lockstep.
>
> Reviewed by Claude for commit `f4126d87`.

<!-- /claude-code-review:summary -->
