### PR TITLE
feat(blueprint): add decryption field for Flux-native SOPS

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -13,6 +13,7 @@ import (
 
 	kustomizev1 "github.com/fluxcd/kustomize-controller/api/v1"
 	"github.com/fluxcd/pkg/apis/kustomize"
+	meta "github.com/fluxcd/pkg/apis/meta"
 	"github.com/windsorcli/cli/pkg/constants"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -312,6 +313,36 @@ func (s SecretEntry) DeepCopy() SecretEntry {
 		Namespaces: slices.Clone(s.Namespaces),
 		Data:       maps.Clone(s.Data),
 	}
+}
+
+// Decryption configures in-cluster decryption of a Kustomization's manifests, mapping to Flux's
+// spec.decryption. When set, kustomize-controller decrypts encrypted files in the source with the
+// referenced key Secret during reconciliation; leaving it nil keeps Flux's default of no decryption.
+type Decryption struct {
+	// Provider is the decryption backend, e.g. "sops".
+	Provider string `yaml:"provider,omitempty"`
+
+	// SecretRef names the in-cluster Secret holding the decryption key.
+	SecretRef *DecryptionSecretRef `yaml:"secretRef,omitempty"`
+}
+
+// DecryptionSecretRef names the Secret that holds the decryption key material, resolved in the
+// Kustomization's own namespace.
+type DecryptionSecretRef struct {
+	// Name is the Secret's name.
+	Name string `yaml:"name,omitempty"`
+}
+
+// DeepCopy returns a deep copy of the Decryption, sharing no pointer with the original.
+func (d *Decryption) DeepCopy() *Decryption {
+	if d == nil {
+		return nil
+	}
+	c := &Decryption{Provider: d.Provider}
+	if d.SecretRef != nil {
+		c.SecretRef = &DecryptionSecretRef{Name: d.SecretRef.Name}
+	}
+	return c
 }
 
 // Blueprint is a configuration blueprint for initializing a project.
@@ -633,6 +664,10 @@ type Kustomization struct {
 	// marshaled into show/apply output or the written blueprint, keeping secret material out of every
 	// serialized surface by construction.
 	Secrets map[string]SecretEntry `yaml:"-"`
+
+	// Decryption configures in-cluster decryption for this kustomization's manifests, mapping to Flux's
+	// spec.decryption. Nil leaves decryption unset (Flux default: no decryption).
+	Decryption *Decryption `yaml:"decryption,omitempty"`
 }
 
 // FluxSystem is a system entry under a blueprint or facet's `flux:` list — a functional layer that
@@ -1326,6 +1361,7 @@ func (k *Kustomization) DeepCopy() *Kustomization {
 		Substitutions:   maps.Clone(k.Substitutions),
 		Substitute:      maps.Clone(k.Substitute),
 		Secrets:         cloneSecretData(k.Secrets),
+		Decryption:      k.Decryption.DeepCopy(),
 	}
 }
 
@@ -1517,6 +1553,14 @@ func (k *Kustomization) ToFluxKustomization(namespace string, defaultSourceName 
 		}
 	}
 
+	var decryption *kustomizev1.Decryption
+	if k.Decryption != nil {
+		decryption = &kustomizev1.Decryption{Provider: k.Decryption.Provider}
+		if k.Decryption.SecretRef != nil {
+			decryption.SecretRef = &meta.LocalObjectReference{Name: k.Decryption.SecretRef.Name}
+		}
+	}
+
 	return kustomizev1.Kustomization{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Kustomization",
@@ -1545,6 +1589,7 @@ func (k *Kustomization) ToFluxKustomization(namespace string, defaultSourceName 
 			Components:      k.Components,
 			PostBuild:       postBuild,
 			TargetNamespace: k.TargetNamespace,
+			Decryption:      decryption,
 		},
 	}
 }
@@ -1770,6 +1815,9 @@ func MergeKustomizationFields(base, overlay Kustomization) Kustomization {
 			existing.Substitutions = make(map[string]string)
 		}
 		maps.Copy(existing.Substitutions, overlay.Substitutions)
+	}
+	if overlay.Decryption != nil {
+		existing.Decryption = overlay.Decryption.DeepCopy()
 	}
 	return existing
 }

--- a/api/v1alpha1/blueprint_types_test.go
+++ b/api/v1alpha1/blueprint_types_test.go
@@ -3220,6 +3220,129 @@ func TestKustomization_ToFluxKustomization(t *testing.T) {
 			t.Errorf("Expected explicit interval %v to override default, got %v", override.Duration, result.Spec.Interval.Duration)
 		}
 	})
+
+	t.Run("DecryptionUnsetByDefault", func(t *testing.T) {
+		// Given a kustomization with no Decryption
+		kustomization := &Kustomization{Name: "k", Path: "p"}
+
+		// When converted
+		result := kustomization.ToFluxKustomization("ns", "src", []Source{}, constants.GitopsModePull)
+
+		// Then spec.decryption is nil (Flux default: no decryption)
+		if result.Spec.Decryption != nil {
+			t.Errorf("Expected nil Decryption, got %+v", result.Spec.Decryption)
+		}
+	})
+
+	t.Run("DecryptionThreadedIntoSpec", func(t *testing.T) {
+		// Given a kustomization declaring sops decryption via a key Secret
+		kustomization := &Kustomization{
+			Name:       "k",
+			Path:       "p",
+			Decryption: &Decryption{Provider: "sops", SecretRef: &DecryptionSecretRef{Name: "sops-age"}},
+		}
+
+		// When converted
+		result := kustomization.ToFluxKustomization("ns", "src", []Source{}, constants.GitopsModePull)
+
+		// Then spec.decryption carries the provider and secretRef name
+		if result.Spec.Decryption == nil {
+			t.Fatal("Expected Decryption to be set")
+		}
+		if result.Spec.Decryption.Provider != "sops" {
+			t.Errorf("Expected provider 'sops', got '%s'", result.Spec.Decryption.Provider)
+		}
+		if result.Spec.Decryption.SecretRef == nil || result.Spec.Decryption.SecretRef.Name != "sops-age" {
+			t.Errorf("Expected secretRef name 'sops-age', got %+v", result.Spec.Decryption.SecretRef)
+		}
+	})
+
+	t.Run("DecryptionProviderOnlyOmitsSecretRef", func(t *testing.T) {
+		// Given a kustomization with a provider but no secretRef
+		kustomization := &Kustomization{
+			Name:       "k",
+			Path:       "p",
+			Decryption: &Decryption{Provider: "sops"},
+		}
+
+		// When converted
+		result := kustomization.ToFluxKustomization("ns", "src", []Source{}, constants.GitopsModePull)
+
+		// Then the provider is set and secretRef stays nil
+		if result.Spec.Decryption == nil || result.Spec.Decryption.Provider != "sops" {
+			t.Fatalf("Expected provider 'sops', got %+v", result.Spec.Decryption)
+		}
+		if result.Spec.Decryption.SecretRef != nil {
+			t.Errorf("Expected nil secretRef, got %+v", result.Spec.Decryption.SecretRef)
+		}
+	})
+}
+
+func TestKustomization_Decryption_DeepCopyAndMerge(t *testing.T) {
+	t.Run("DeepCopyIndependentOfOriginal", func(t *testing.T) {
+		// Given a kustomization with decryption set
+		original := &Kustomization{
+			Name:       "k",
+			Decryption: &Decryption{Provider: "sops", SecretRef: &DecryptionSecretRef{Name: "sops-age"}},
+		}
+
+		// When deep-copied and the copy mutated
+		clone := original.DeepCopy()
+		clone.Decryption.Provider = "vault"
+		clone.Decryption.SecretRef.Name = "other"
+
+		// Then the original is unchanged (no shared pointer)
+		if original.Decryption.Provider != "sops" || original.Decryption.SecretRef.Name != "sops-age" {
+			t.Errorf("Expected original unchanged, got %+v / %+v", original.Decryption, original.Decryption.SecretRef)
+		}
+	})
+
+	t.Run("NilDecryptionDeepCopiesToNil", func(t *testing.T) {
+		// Given a kustomization without decryption
+		original := &Kustomization{Name: "k"}
+
+		// When deep-copied
+		clone := original.DeepCopy()
+
+		// Then the clone's Decryption stays nil
+		if clone.Decryption != nil {
+			t.Errorf("Expected nil Decryption on clone, got %+v", clone.Decryption)
+		}
+	})
+
+	t.Run("OverlayDecryptionWinsAndIsCopied", func(t *testing.T) {
+		// Given a base with no decryption and an overlay that sets it
+		base := Kustomization{Name: "k"}
+		overlay := Kustomization{Name: "k", Decryption: &Decryption{Provider: "sops", SecretRef: &DecryptionSecretRef{Name: "sops-age"}}}
+
+		// When merged
+		merged := MergeKustomizationFields(base, overlay)
+
+		// Then the overlay's decryption is applied
+		if merged.Decryption == nil || merged.Decryption.Provider != "sops" || merged.Decryption.SecretRef.Name != "sops-age" {
+			t.Fatalf("Expected overlay decryption applied, got %+v", merged.Decryption)
+		}
+
+		// And it is a copy, not the overlay's pointer, so mutating the overlay does not bleed through
+		overlay.Decryption.SecretRef.Name = "mutated"
+		if merged.Decryption.SecretRef.Name != "sops-age" {
+			t.Errorf("Expected merged decryption independent of overlay, got '%s'", merged.Decryption.SecretRef.Name)
+		}
+	})
+
+	t.Run("NilOverlayDecryptionLeavesBaseIntact", func(t *testing.T) {
+		// Given a base that already has decryption and an overlay that does not set it
+		base := Kustomization{Name: "k", Decryption: &Decryption{Provider: "sops", SecretRef: &DecryptionSecretRef{Name: "sops-age"}}}
+		overlay := Kustomization{Name: "k"}
+
+		// When merged
+		merged := MergeKustomizationFields(base, overlay)
+
+		// Then the base decryption survives
+		if merged.Decryption == nil || merged.Decryption.Provider != "sops" {
+			t.Errorf("Expected base decryption preserved, got %+v", merged.Decryption)
+		}
+	})
 }
 
 func TestTerraformComponent_DeepCopy(t *testing.T) {

--- a/docs/reference/blueprint.md
+++ b/docs/reference/blueprint.md
@@ -55,6 +55,7 @@ variable substitutions shared across them.
 | Field | Type | Description |
 |------|------|-------------|
 | `components` | `array<string>` | Kustomize components to compose into the install tier. |
+| `decryption` | `object` | In-cluster decryption for this tier's manifests, mapping to Flux's spec.decryption. Set provider (e.g. 'sops') and a secretRef naming the in-cluster key Secret. |
 | `destroy` | `boolean / string` | Whether to delete this tier during 'windsor down'. Boolean or expression. Defaults to true. |
 | `destroyOnly` | `boolean` | When true, this tier only runs during destroy operations. |
 | `enabled` | `boolean / string` | Whether to include this tier in the final blueprint. Boolean or expression. Defaults to true. |
@@ -71,6 +72,19 @@ variable substitutions shared across them.
 | `timeout` | `string` | Maximum duration for a single reconciliation attempt. Defaults to 10m. |
 | `wait` | `boolean` | Wait for resources to settle before declaring reconciliation complete. |
 
+#### flux[].install.decryption
+
+| Field | Type | Description |
+|------|------|-------------|
+| `provider` | `string` | Decryption backend, e.g. 'sops'. |
+| `secretRef` | `object` | Names the in-cluster Secret holding the decryption key. |
+
+#### flux[].install.decryption.secretRef
+
+| Field | Type | Description |
+|------|------|-------------|
+| `name` | `string` | The Secret's name, resolved in the tier's namespace. |
+
 #### flux[].install.patches[]
 
 | Field | Type | Description |
@@ -84,6 +98,7 @@ variable substitutions shared across them.
 | Field | Type | Description |
 |------|------|-------------|
 | `components` | `array<string>` | Kustomize components to compose into this variant. |
+| `decryption` | `object` | In-cluster decryption for this variant's manifests, mapping to Flux's spec.decryption. Set provider (e.g. 'sops') and a secretRef naming the in-cluster key Secret. |
 | `dependsOn` | `array<string>` | Extra cross-layer edges, appended to the implicit install edge. |
 | `destroy` | `boolean / string` | Whether to delete this variant during 'windsor down'. Boolean or expression. Defaults to true. |
 | `destroyOnly` | `boolean` | When true, this variant only runs during destroy operations. |
@@ -103,6 +118,19 @@ variable substitutions shared across them.
 | `wait` | `boolean` | Wait for resources to settle before declaring reconciliation complete. |
 | `when` | `string` | Gates the variant; combined (AND) with the system's condition. |
 
+#### flux[].resources[].decryption
+
+| Field | Type | Description |
+|------|------|-------------|
+| `provider` | `string` | Decryption backend, e.g. 'sops'. |
+| `secretRef` | `object` | Names the in-cluster Secret holding the decryption key. |
+
+#### flux[].resources[].decryption.secretRef
+
+| Field | Type | Description |
+|------|------|-------------|
+| `name` | `string` | The Secret's name, resolved in the variant's namespace. |
+
 #### flux[].resources[].patches[]
 
 | Field | Type | Description |
@@ -117,6 +145,7 @@ variable substitutions shared across them.
 |------|------|-------------|
 | `name` | `string` | Identifier for the kustomization; referenced by dependsOn. **(required)** |
 | `components` | `array<string>` | Kustomize components to compose into this kustomization. |
+| `decryption` | `object` | In-cluster decryption for this kustomization's manifests, mapping to Flux's spec.decryption. Set provider (e.g. 'sops') and a secretRef naming the in-cluster key Secret; kustomize-controller then decrypts encrypted files in the source during reconciliation. |
 | `dependsOn` | `array<string>` | Names of kustomizations that must reconcile before this one. |
 | `destroy` | `boolean / string` | Whether to delete this kustomization during 'windsor down' / 'windsor destroy'. Boolean or expression. Defaults to true. |
 | `destroyOnly` | `boolean` | When true, the kustomization only runs during destroy. Useful for teardown-only resources (e.g. cleanup jobs). |
@@ -134,6 +163,19 @@ variable substitutions shared across them.
 | `targetNamespace` | `string` | Populates spec.targetNamespace, instructing Flux to override the namespace of every resource reconciled by this kustomization. |
 | `timeout` | `string` | Maximum duration for a single reconciliation attempt (e.g. '10m'). |
 | `wait` | `boolean` | Wait for resources to settle before declaring reconciliation complete. |
+
+### kustomize[].decryption
+
+| Field | Type | Description |
+|------|------|-------------|
+| `provider` | `string` | Decryption backend, e.g. 'sops'. |
+| `secretRef` | `object` | Names the in-cluster Secret holding the decryption key. |
+
+#### kustomize[].decryption.secretRef
+
+| Field | Type | Description |
+|------|------|-------------|
+| `name` | `string` | The Secret's name, resolved in the kustomization's namespace. |
 
 ### kustomize[].patches[]
 

--- a/docs/reference/blueprint.md
+++ b/docs/reference/blueprint.md
@@ -76,7 +76,7 @@ variable substitutions shared across them.
 
 | Field | Type | Description |
 |------|------|-------------|
-| `provider` | `string` | Decryption backend, e.g. 'sops'. |
+| `provider` | `string` | Decryption backend, e.g. 'sops'. **(required)** |
 | `secretRef` | `object` | Names the in-cluster Secret holding the decryption key. |
 
 #### flux[].install.decryption.secretRef
@@ -122,7 +122,7 @@ variable substitutions shared across them.
 
 | Field | Type | Description |
 |------|------|-------------|
-| `provider` | `string` | Decryption backend, e.g. 'sops'. |
+| `provider` | `string` | Decryption backend, e.g. 'sops'. **(required)** |
 | `secretRef` | `object` | Names the in-cluster Secret holding the decryption key. |
 
 #### flux[].resources[].decryption.secretRef
@@ -168,7 +168,7 @@ variable substitutions shared across them.
 
 | Field | Type | Description |
 |------|------|-------------|
-| `provider` | `string` | Decryption backend, e.g. 'sops'. |
+| `provider` | `string` | Decryption backend, e.g. 'sops'. **(required)** |
 | `secretRef` | `object` | Names the in-cluster Secret holding the decryption key. |
 
 #### kustomize[].decryption.secretRef

--- a/integration/fixtures/facet-tiers/contexts/_template/facets/pki.yaml
+++ b/integration/fixtures/facet-tiers/contexts/_template/facets/pki.yaml
@@ -13,6 +13,10 @@ flux:
     - helm-release
     timeout: 5m
     interval: 5m
+    decryption:
+      provider: sops
+      secretRef:
+        name: sops-age
   resources:
   - components:
     - private-issuer/ca

--- a/integration/show_test.go
+++ b/integration/show_test.go
@@ -153,6 +153,37 @@ func TestShowKustomization_TierNameRendersCompiledKustomization(t *testing.T) {
 	}
 }
 
+func TestShowKustomization_RendersDecryptionThroughFacetMerge(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "facet-tiers")
+	env = append(env, "WINDSOR_CONTEXT=default")
+	// cert-manager's install tier declares decryption in pki.yaml and merges across three facets,
+	// so a rendered spec.decryption proves the field survives composition and reaches the Flux CR.
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"show", "kustomization", "cert-manager-install"}, env)
+	if err != nil {
+		t.Fatalf("show kustomization cert-manager-install: %v\nstderr: %s", err, stderr)
+	}
+	var k struct {
+		Spec struct {
+			Decryption struct {
+				Provider  string `yaml:"provider"`
+				SecretRef struct {
+					Name string `yaml:"name"`
+				} `yaml:"secretRef"`
+			} `yaml:"decryption"`
+		} `yaml:"spec"`
+	}
+	if err := yaml.Unmarshal(stdout, &k); err != nil {
+		t.Fatalf("parse kustomization YAML: %v\nstdout: %s", err, stdout)
+	}
+	if k.Spec.Decryption.Provider != "sops" {
+		t.Errorf("expected spec.decryption.provider sops, got %q\nstdout: %s", k.Spec.Decryption.Provider, stdout)
+	}
+	if k.Spec.Decryption.SecretRef.Name != "sops-age" {
+		t.Errorf("expected spec.decryption.secretRef.name sops-age, got %q", k.Spec.Decryption.SecretRef.Name)
+	}
+}
+
 func TestShowKustomization_PathDefaultsToNameWhenUnset(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.PrepareFixture(t, "facet-tiers")

--- a/pkg/runtime/config/schemas/artifacts/blueprint.yaml
+++ b/pkg/runtime/config/schemas/artifacts/blueprint.yaml
@@ -287,6 +287,26 @@ properties:
           description: |
             PostBuild variable substitutions for this kustomization. Collected
             into a 'values-<name>' ConfigMap that Flux substitutes from.
+        decryption:
+          type: object
+          additionalProperties: false
+          description: |
+            In-cluster decryption for this kustomization's manifests, mapping to
+            Flux's spec.decryption. Set provider (e.g. 'sops') and a secretRef
+            naming the in-cluster key Secret; kustomize-controller then decrypts
+            encrypted files in the source during reconciliation.
+          properties:
+            provider:
+              type: string
+              description: Decryption backend, e.g. 'sops'.
+            secretRef:
+              type: object
+              additionalProperties: false
+              description: Names the in-cluster Secret holding the decryption key.
+              properties:
+                name:
+                  type: string
+                  description: The Secret's name, resolved in the kustomization's namespace.
   flux:
     type: array
     description: |
@@ -410,6 +430,25 @@ properties:
             enabled:
               type: [boolean, string]
               description: Whether to include this tier in the final blueprint. Boolean or expression. Defaults to true.
+            decryption:
+              type: object
+              additionalProperties: false
+              description: |
+                In-cluster decryption for this tier's manifests, mapping to Flux's
+                spec.decryption. Set provider (e.g. 'sops') and a secretRef naming
+                the in-cluster key Secret.
+              properties:
+                provider:
+                  type: string
+                  description: Decryption backend, e.g. 'sops'.
+                secretRef:
+                  type: object
+                  additionalProperties: false
+                  description: Names the in-cluster Secret holding the decryption key.
+                  properties:
+                    name:
+                      type: string
+                      description: The Secret's name, resolved in the tier's namespace.
         resources:
           type: array
           description: Custom-resource tier variants, all sharing '<path>/resources'.
@@ -493,6 +532,25 @@ properties:
               enabled:
                 type: [boolean, string]
                 description: Whether to include this variant in the final blueprint. Boolean or expression. Defaults to true.
+              decryption:
+                type: object
+                additionalProperties: false
+                description: |
+                  In-cluster decryption for this variant's manifests, mapping to
+                  Flux's spec.decryption. Set provider (e.g. 'sops') and a secretRef
+                  naming the in-cluster key Secret.
+                properties:
+                  provider:
+                    type: string
+                    description: Decryption backend, e.g. 'sops'.
+                  secretRef:
+                    type: object
+                    additionalProperties: false
+                    description: Names the in-cluster Secret holding the decryption key.
+                    properties:
+                      name:
+                        type: string
+                        description: The Secret's name, resolved in the variant's namespace.
   substitutions:
     type: object
     additionalProperties:

--- a/pkg/runtime/config/schemas/artifacts/blueprint.yaml
+++ b/pkg/runtime/config/schemas/artifacts/blueprint.yaml
@@ -290,6 +290,8 @@ properties:
         decryption:
           type: object
           additionalProperties: false
+          required:
+            - provider
           description: |
             In-cluster decryption for this kustomization's manifests, mapping to
             Flux's spec.decryption. Set provider (e.g. 'sops') and a secretRef
@@ -433,6 +435,8 @@ properties:
             decryption:
               type: object
               additionalProperties: false
+              required:
+                - provider
               description: |
                 In-cluster decryption for this tier's manifests, mapping to Flux's
                 spec.decryption. Set provider (e.g. 'sops') and a secretRef naming
@@ -535,6 +539,8 @@ properties:
               decryption:
                 type: object
                 additionalProperties: false
+                required:
+                  - provider
                 description: |
                   In-cluster decryption for this variant's manifests, mapping to
                   Flux's spec.decryption. Set provider (e.g. 'sops') and a secretRef


### PR DESCRIPTION
Closes #3005

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Additive, opt-in field on an internal type; no existing behavior changes and rollback requires only removing the new field from a blueprint.
>
> **Overview**
>
> This PR adds an optional `decryption` block to the Windsor `Kustomization` type (and its flux install/resources counterparts), wiring it through `MergeKustomizationFields`, `DeepCopy`, and `ToFluxKustomization` to produce a native Flux `spec.decryption` stanza. The schema artifact, reference docs, and an integration fixture are all updated in the same commit set, so the surface is complete.
>
> Nil-safety is handled uniformly: `Decryption.DeepCopy()` guards on a nil receiver, merge only applies the overlay when it is non-nil (preserving base otherwise), and the Flux conversion skips the block entirely when unset. Unit coverage spans the nil, provider-only, and full-field cases; an integration test confirms the field survives facet composition end-to-end.
>
> Reviewed by Claude for commit `df955e22`.

<!-- /claude-code-review:summary -->
