### PR TITLE
fix(down): update cleanup process to remove stale cluster credentials

### DIFF
--- a/cmd/down.go
+++ b/cmd/down.go
@@ -12,7 +12,7 @@ import (
 var downCmd = &cobra.Command{
 	Use:   "down",
 	Short: "Stop the local workstation environment.",
-	Long: `Tear down the workstation VM, stop container runtimes, and clear the runtime caches (.terraform, .tfstate) under .windsor/contexts/<name>/. Operator-managed state (credentials, kubeconfig, hand-edited tfvars) is preserved so a follow-up 'windsor up' does not force re-authentication. Live infrastructure is NOT destroyed by down — run 'windsor destroy' first if you need to remove cloud resources. Workstation contexts only.
+	Long: `Tear down the workstation VM, stop container runtimes, and clear the runtime caches (.terraform, .tfstate) and stale cluster credentials (.kube, .talos). Hand-edited tfvars and cloud credentials are preserved. Live infrastructure is NOT destroyed by down — run 'windsor destroy' first if you need to remove cloud resources. Workstation contexts only.
 
 If any host-side network or DNS configuration was previously installed by 'windsor configure network', down prints a follow-up command at the end so the operator can clean up leftover host state.`,
 	Example: `# Standard teardown

--- a/docs/reference/commands/down.md
+++ b/docs/reference/commands/down.md
@@ -8,7 +8,7 @@ description: "Stop the local workstation environment."
 windsor down
 ```
 
-Tear down the workstation VM, stop container runtimes, and clear the runtime caches (.terraform, .tfstate) under .windsor/contexts/<name>/. Operator-managed state (credentials, kubeconfig, hand-edited tfvars) is preserved so a follow-up 'windsor up' does not force re-authentication. Live infrastructure is NOT destroyed by down — run 'windsor destroy' first if you need to remove cloud resources. Workstation contexts only.
+Tear down the workstation VM, stop container runtimes, and clear the runtime caches (.terraform, .tfstate) and stale cluster credentials (.kube, .talos). Hand-edited tfvars and cloud credentials are preserved. Live infrastructure is NOT destroyed by down — run 'windsor destroy' first if you need to remove cloud resources. Workstation contexts only.
 
 If any host-side network or DNS configuration was previously installed by 'windsor configure network', down prints a follow-up command at the end so the operator can clean up leftover host state.
 

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -270,12 +270,22 @@ func (p *Project) Bootstrap(confirm provisioner.BootstrapConfirmFn) (*blueprintv
 	return blueprint, true, halted, nil
 }
 
-// PerformCleanup removes context-specific artifacts: config state and
-// contents of .windsor/contexts/<context> (preserving workstation.yaml).
-// Returns an error if any step fails.
+// PerformCleanup removes context-specific artifacts: config state, the local-cluster credentials
+// (.kube, .talos) under contexts/<context>, and the contents of .windsor/contexts/<context>
+// (preserving workstation.yaml). Returns an error if any step fails.
 func (p *Project) PerformCleanup() error {
 	if err := p.configHandler.Clean(); err != nil {
 		return fmt.Errorf("error cleaning up context specific artifacts: %w", err)
+	}
+
+	configRoot, err := p.configHandler.GetConfigRoot()
+	if err != nil {
+		return fmt.Errorf("error getting config root: %w", err)
+	}
+	for _, dir := range []string{".kube", ".talos"} {
+		if err := os.RemoveAll(filepath.Join(configRoot, dir)); err != nil {
+			return fmt.Errorf("error deleting %s: %w", dir, err)
+		}
 	}
 
 	contextDir := filepath.Join(p.projectRoot, ".windsor", "contexts", p.contextName)

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -1236,6 +1236,57 @@ func TestProject_PerformCleanup(t *testing.T) {
 			t.Error("Expected ephemeral.txt to be deleted, but it still exists")
 		}
 	})
+
+	t.Run("RemovesLocalClusterCredentials", func(t *testing.T) {
+		// Given a config root holding .kube and .talos credentials alongside operator state to keep
+		mocks := setupProjectMocks(t)
+		proj := NewProject("test-context", &Project{Runtime: mocks.Runtime})
+
+		configRoot := filepath.Join(mocks.Runtime.ProjectRoot, "contexts", "test-context")
+		kubeCfg := filepath.Join(configRoot, ".kube", "config")
+		talosCfg := filepath.Join(configRoot, ".talos", "config")
+		awsCfg := filepath.Join(configRoot, ".aws", "config")
+		tfvars := filepath.Join(configRoot, "terraform", "cluster.tfvars")
+		for _, f := range []string{kubeCfg, talosCfg, awsCfg, tfvars} {
+			if err := os.MkdirAll(filepath.Dir(f), 0755); err != nil {
+				t.Fatalf("Failed to create dir for %s: %v", f, err)
+			}
+			if err := os.WriteFile(f, []byte("x"), 0644); err != nil {
+				t.Fatalf("Failed to write %s: %v", f, err)
+			}
+		}
+
+		// When
+		if err := proj.PerformCleanup(); err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// Then the stale local-cluster credentials are removed
+		if _, err := os.Stat(filepath.Join(configRoot, ".kube")); !os.IsNotExist(err) {
+			t.Error("Expected .kube to be removed")
+		}
+		if _, err := os.Stat(filepath.Join(configRoot, ".talos")); !os.IsNotExist(err) {
+			t.Error("Expected .talos to be removed")
+		}
+		// And unrelated operator state is preserved
+		if _, err := os.Stat(awsCfg); os.IsNotExist(err) {
+			t.Error("Expected .aws credentials to be preserved")
+		}
+		if _, err := os.Stat(tfvars); os.IsNotExist(err) {
+			t.Error("Expected hand-edited tfvars to be preserved")
+		}
+	})
+
+	t.Run("SucceedsWhenCredentialsAbsent", func(t *testing.T) {
+		// Given a config root with no .kube or .talos directories
+		mocks := setupProjectMocks(t)
+		proj := NewProject("test-context", &Project{Runtime: mocks.Runtime})
+
+		// When cleanup runs, the missing credential dirs are a no-op rather than an error
+		if err := proj.PerformCleanup(); err != nil {
+			t.Errorf("Expected no error when credentials are absent, got: %v", err)
+		}
+	})
 }
 
 func TestProject_Up(t *testing.T) {

--- a/pkg/runtime/config/handler.go
+++ b/pkg/runtime/config/handler.go
@@ -473,10 +473,8 @@ func (c *configHandler) GetWindsorScratchPath() (string, error) {
 	return windsorScratchPath, nil
 }
 
-// Clean removes runtime caches from .windsor/contexts/<name>/. Operator-managed
-// state in contexts/<name>/ — credentials, kubeconfig, hand-edited tfvars — is
-// preserved so that `windsor down` followed by `windsor up` does not force the
-// operator to re-authenticate or restore config.
+// Clean removes runtime caches (.terraform, .tfstate) from .windsor/contexts/<name>/. Cluster
+// credentials (.kube, .talos) are removed separately during 'down' (see Project.PerformCleanup).
 func (c *configHandler) Clean() error {
 	windsorScratchPath, err := c.GetWindsorScratchPath()
 	if err != nil {


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This change alters the behavior of `windsor down` to now delete cluster credential directories (`.kube`, `.talos`) that were previously preserved, which is a breaking change for users who relied on kubeconfig persistence across down/up cycles.
>
> **Overview**
>
> The PR extends `Project.PerformCleanup` to remove `.kube` and `.talos` directories from the config root on `windsor down`, treating them as stale cluster credentials rather than operator-managed state worth preserving. The `configHandler.Clean` comment is updated to reflect that credential removal now lives in `PerformCleanup`, and both the CLI `--help` text and the reference docs are updated to match the new behavior.
>
> Two new test cases cover the happy path (`.kube`/`.talos` deleted, `.aws` and `tfvars` preserved) and the absence case (no error when credential dirs don't exist). The change is intentional and well-documented, but operators who previously reused kubeconfig across down/up cycles will need to re-authenticate after upgrading.
>
> Reviewed by Claude for commit `927c019`.

<!-- /claude-code-review:summary -->
