### PR TITLE
fix(composer): Cross source config override

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -1757,6 +1757,13 @@ func (b *Blueprint) strategicMergeKustomization(kustomization Kustomization) err
 // directly (e.g. FluxSystem tiers, which carry no Name until tier compilation) call this directly.
 func MergeKustomizationFields(base, overlay Kustomization) Kustomization {
 	existing := base
+	// Clone the mutable fields so appends and map writes below never mutate base's shared slices/maps
+	// (base is passed by value, but its slice/map fields alias the caller's). Without this, merging
+	// corrupts the inputs and makes results depend on call order and input reuse.
+	existing.Components = slices.Clone(base.Components)
+	existing.DependsOn = slices.Clone(base.DependsOn)
+	existing.Patches = slices.Clone(base.Patches)
+	existing.Substitutions = maps.Clone(base.Substitutions)
 	for _, component := range overlay.Components {
 		if component == "" || !slices.Contains(existing.Components, component) {
 			existing.Components = append(existing.Components, component)

--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -1749,17 +1749,15 @@ func (b *Blueprint) strategicMergeKustomization(kustomization Kustomization) err
 	return b.sortKustomize()
 }
 
-// MergeKustomizationFields deep-merges overlay onto base and returns the result: Components and
-// DependsOn accumulate (deduplicated, Components sorted), Patches accumulate, Substitutions copy
-// in, and every other field is overridden by overlay when overlay sets it. Callers that need
+// MergeKustomizationFields deep-merges overlay onto base and returns the result without mutating
+// either input: Components and DependsOn accumulate (deduplicated, Components sorted), Patches
+// accumulate, Substitutions copy in, and every other field is overridden by overlay when overlay
+// sets it. Callers that need
 // by-name matching within a Blueprint's Kustomizations list use strategicMergeKustomization, which
 // calls this once a match is found; callers merging two already-matched Kustomization values
 // directly (e.g. FluxSystem tiers, which carry no Name until tier compilation) call this directly.
 func MergeKustomizationFields(base, overlay Kustomization) Kustomization {
 	existing := base
-	// Clone the mutable fields so appends and map writes below never mutate base's shared slices/maps
-	// (base is passed by value, but its slice/map fields alias the caller's). Without this, merging
-	// corrupts the inputs and makes results depend on call order and input reuse.
 	existing.Components = slices.Clone(base.Components)
 	existing.DependsOn = slices.Clone(base.DependsOn)
 	existing.Patches = slices.Clone(base.Patches)

--- a/api/v1alpha1/facet_types.go
+++ b/api/v1alpha1/facet_types.go
@@ -73,6 +73,10 @@ type Facet struct {
 	// This is used for resolving relative paths in jsonnet() and file() functions.
 	Path string `yaml:"-"`
 
+	// Source names the blueprint source this facet came from. Set transiently during composition so a
+	// globally-resolved facet can be emitted back into its own source's blueprint; never serialized.
+	Source string `yaml:"-"`
+
 	// Ordinal guides the order in which this facet is applied relative to others. Higher ordinal means higher precedence when merging.
 	// When nil, the loader derives ordinal from the facet file basename (e.g. config-* 100, provider-base/platform-base 199, provider-/platform- 200, options- 300, addon-/addons- 400).
 	Ordinal *int `yaml:"ordinal,omitempty"`
@@ -357,6 +361,7 @@ func (f *Facet) DeepCopy() *Facet {
 		ApiVersion:          f.ApiVersion,
 		Metadata:            metadataCopy,
 		Path:                f.Path,
+		Source:              f.Source,
 		Ordinal:             ordinalCopy,
 		When:                f.When,
 		Backend:             f.Backend,

--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -954,38 +954,46 @@ func (h *BaseBlueprintHandler) processAndCompose() error {
 		concrete.ResetExcludedFacets()
 	}
 
-	// Process sources in dependency order (a source before any source that lists it), threading the
-	// scope accumulated so far into each source's facet evaluation. A downstream source can then read
-	// config an upstream source derived, rather than each source seeing only raw context values.
+	// Resolve config and facet inclusion once across every source, then emit each source's components.
+	// Sources are ranked by dependency depth so a deeper (referencing) source's config wins over a
+	// shallower one's for the same key, and an upstream facet's when: sees a downstream source's config.
 	userLoaderName := ""
 	if h.userBlueprintLoader != nil {
 		userLoaderName = loaderNames[h.userBlueprintLoader]
 	}
-	var errs []error
-	var accumulatedScope map[string]any
-	for _, loader := range orderLoadersByDependency(loadersToProcess, loaderNames, userLoaderName) {
-		name := loaderNames[loader]
-		if bp, ok := h.processor.(*BaseBlueprintProcessor); ok {
-			bp.SetExtraScope(MergeScopeMaps(repositoryScope, accumulatedScope))
-		}
-		scope, err := h.processLoader(loader)
-		if err != nil {
-			var reqErr *RequirementsError
-			if errors.As(err, &reqErr) {
-				errs = append(errs, err)
-			} else {
-				errs = append(errs, fmt.Errorf("failed to process facets for '%s': %w", name, err))
-			}
+	if concrete, ok := h.processor.(*BaseBlueprintProcessor); ok {
+		concrete.SetExtraScope(repositoryScope)
+	}
+	var sourceSets []SourceFacetSet
+	for depth, loader := range orderLoadersByDependency(loadersToProcess, loaderNames, userLoaderName) {
+		facets := loader.GetFacets()
+		if len(facets) == 0 {
 			continue
 		}
-		if scope != nil {
-			collectedScopes[name] = scope
-			accumulatedScope = MergeScopeMaps(accumulatedScope, scope)
-		}
+		sourceSets = append(sourceSets, SourceFacetSet{
+			Name:   loaderNames[loader],
+			Depth:  depth,
+			Target: loader.GetBlueprint(),
+			Facets: facets,
+		})
 	}
-
-	if len(errs) > 0 {
-		return errors.Join(errs...)
+	globalScope, err := h.processor.ProcessGlobally(sourceSets)
+	if err != nil {
+		var reqErr *RequirementsError
+		if errors.As(err, &reqErr) {
+			return err
+		}
+		return fmt.Errorf("failed to process facets: %w", err)
+	}
+	if concrete, ok := h.processor.(*BaseBlueprintProcessor); ok {
+		h.deferredPathsMu.Lock()
+		for path := range concrete.GetDeferredPaths() {
+			h.deferredPaths[path] = true
+		}
+		h.deferredPathsMu.Unlock()
+	}
+	for _, src := range sourceSets {
+		collectedScopes[src.Name] = globalScope
 	}
 
 	initLoaderNames := make([]string, 0, len(h.initBlueprintURLs))
@@ -1180,33 +1188,6 @@ func orderLoadersByDependency(loaders []BlueprintLoader, names map[BlueprintLoad
 	return order
 }
 
-// processLoader evaluates all facets from a single blueprint loader.
-// Facets with 'when' conditions are evaluated, and only matching facets contribute their
-// terraform components and kustomizations. The loader's source name is passed to the processor
-// to set the Source field on facet-derived components. Facets are processed directly against
-// the loader's blueprint, modifying it in place. Returns the evaluated config scope for this
-// loader so the handler can merge scopes from all loaders.
-func (h *BaseBlueprintHandler) processLoader(loader BlueprintLoader) (map[string]any, error) {
-	facets := loader.GetFacets()
-	if len(facets) == 0 {
-		return nil, nil
-	}
-
-	sourceName := loader.GetSourceName()
-	bp := loader.GetBlueprint()
-	scope, err := h.processor.ProcessFacets(bp, facets, sourceName)
-	if err != nil {
-		return nil, err
-	}
-	if concrete, ok := h.processor.(*BaseBlueprintProcessor); ok {
-		h.deferredPathsMu.Lock()
-		for path := range concrete.GetDeferredPaths() {
-			h.deferredPaths[path] = true
-		}
-		h.deferredPathsMu.Unlock()
-	}
-	return scope, nil
-}
 
 // getConfigValues retrieves the current context's configuration values from the ConfigHandler.
 // These values are used during facet evaluation to determine which facets should be included

--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -954,9 +954,6 @@ func (h *BaseBlueprintHandler) processAndCompose() error {
 		concrete.ResetExcludedFacets()
 	}
 
-	// Resolve config and facet inclusion once across every source, then emit each source's components.
-	// Sources are ranked by dependency depth so a deeper (referencing) source's config wins over a
-	// shallower one's for the same key, and an upstream facet's when: sees a downstream source's config.
 	userLoaderName := ""
 	if h.userBlueprintLoader != nil {
 		userLoaderName = loaderNames[h.userBlueprintLoader]

--- a/pkg/composer/blueprint/handler_test.go
+++ b/pkg/composer/blueprint/handler_test.go
@@ -2581,6 +2581,206 @@ func TestHandler_processAndCompose(t *testing.T) {
 	})
 }
 
+// composeCrossSource wires a core source, a consumer source that lists core (so it composes deeper),
+// and a user blueprint selecting both, runs processAndCompose, and returns the composed blueprint.
+// contextValues seeds the operator's values (nil means empty).
+func composeCrossSource(t *testing.T, coreFacets, consumerFacets []blueprintv1alpha1.Facet, contextValues map[string]any) *blueprintv1alpha1.Blueprint {
+	t.Helper()
+	mocks := setupHandlerMocks(t)
+	mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+		if contextValues == nil {
+			return map[string]any{}, nil
+		}
+		return contextValues, nil
+	}
+	handler := NewBlueprintHandler(mocks.Runtime, mocks.ArtifactBuilder)
+
+	coreBp := &blueprintv1alpha1.Blueprint{}
+	handler.sourceBlueprintLoaders["core"] = &mockLoaderImpl{
+		getBlueprintFunc:  func() *blueprintv1alpha1.Blueprint { return coreBp },
+		getSourceNameFunc: func() string { return "core" },
+		getFacetsFunc:     func() []blueprintv1alpha1.Facet { return coreFacets },
+	}
+
+	consumerBp := &blueprintv1alpha1.Blueprint{Sources: []blueprintv1alpha1.Source{{Name: "core"}}}
+	handler.sourceBlueprintLoaders["consumer"] = &mockLoaderImpl{
+		getBlueprintFunc:  func() *blueprintv1alpha1.Blueprint { return consumerBp },
+		getSourceNameFunc: func() string { return "consumer" },
+		getFacetsFunc:     func() []blueprintv1alpha1.Facet { return consumerFacets },
+	}
+
+	trueVal := true
+	handler.userBlueprintLoader = &mockLoaderImpl{
+		getBlueprintFunc: func() *blueprintv1alpha1.Blueprint {
+			return &blueprintv1alpha1.Blueprint{
+				Sources: []blueprintv1alpha1.Source{
+					{Name: "core", Install: &blueprintv1alpha1.BoolExpression{Value: &trueVal, IsExpr: false}},
+					{Name: "consumer", Install: &blueprintv1alpha1.BoolExpression{Value: &trueVal, IsExpr: false}},
+				},
+			}
+		},
+		getSourceNameFunc: func() string { return "user" },
+	}
+
+	if err := handler.processAndCompose(); err != nil {
+		t.Fatalf("processAndCompose failed: %v", err)
+	}
+	return handler.composedBlueprint
+}
+
+// configBlock builds a ConfigBlock named block whose value map is content (exposed at scope as block.<k>).
+func configBlock(block string, content map[string]any) blueprintv1alpha1.ConfigBlock {
+	return blueprintv1alpha1.ConfigBlock{Name: block, Body: map[string]any{"value": content}}
+}
+
+// kustSub returns the named composed kustomization's substitution value and whether it was found.
+func kustSub(bp *blueprintv1alpha1.Blueprint, name, key string) (string, bool) {
+	for _, k := range bp.Kustomizations {
+		if k.Name == name {
+			return k.Substitutions[key], true
+		}
+	}
+	return "", false
+}
+
+// hasKustomization reports whether the composed blueprint includes a kustomization by name.
+func hasKustomization(bp *blueprintv1alpha1.Blueprint, name string) bool {
+	for _, k := range bp.Kustomizations {
+		if k.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+// TestHandler_CrossSourceConfig pins the cross-source config behaviors: a referencing (consumer)
+// source can override a value an upstream (core) source consumes, activate an upstream capability,
+// disable one, and have upstream derivations recompute — while an explicit operator value still wins.
+// Several of these are expected to fail until config resolves as a single global layer.
+func TestHandler_CrossSourceConfig(t *testing.T) {
+	t.Run("OverridesUpstreamConsumedValue", func(t *testing.T) {
+		// Given core consumes dns.domain in a kustomization and consumer overrides dns.domain
+		core := []blueprintv1alpha1.Facet{{
+			Metadata: blueprintv1alpha1.Metadata{Name: "platform-base"},
+			Config:   []blueprintv1alpha1.ConfigBlock{configBlock("dns", map[string]any{"domain": "core-default"})},
+			Kustomizations: []blueprintv1alpha1.ConditionalKustomization{{Kustomization: blueprintv1alpha1.Kustomization{
+				Name: "dns", Path: "dns", Substitutions: map[string]string{"domain": "${dns.domain ?? ''}"},
+			}}},
+		}}
+		consumer := []blueprintv1alpha1.Facet{{
+			Metadata: blueprintv1alpha1.Metadata{Name: "override"},
+			Config:   []blueprintv1alpha1.ConfigBlock{configBlock("dns", map[string]any{"domain": "consumer-override"})},
+		}}
+
+		// When composed
+		bp := composeCrossSource(t, core, consumer, nil)
+
+		// Then core's component resolves to the consumer's override
+		got, found := kustSub(bp, "dns", "domain")
+		if !found {
+			t.Fatal("expected composed kustomization 'dns'")
+		}
+		if got != "consumer-override" {
+			t.Errorf("expected 'consumer-override', got %q", got)
+		}
+	})
+
+	t.Run("ActivatesUpstreamCapability", func(t *testing.T) {
+		// Given a core facet gated on flags.identity that consumer turns on via config
+		core := []blueprintv1alpha1.Facet{{
+			Metadata:       blueprintv1alpha1.Metadata{Name: "identity"},
+			When:           "flags.identity == true",
+			Kustomizations: []blueprintv1alpha1.ConditionalKustomization{{Kustomization: blueprintv1alpha1.Kustomization{Name: "identity", Path: "identity"}}},
+		}}
+		consumer := []blueprintv1alpha1.Facet{{
+			Metadata: blueprintv1alpha1.Metadata{Name: "enable-identity"},
+			Config:   []blueprintv1alpha1.ConfigBlock{configBlock("flags", map[string]any{"identity": true})},
+		}}
+
+		// When composed
+		bp := composeCrossSource(t, core, consumer, nil)
+
+		// Then core's gated capability is included
+		if !hasKustomization(bp, "identity") {
+			t.Error("expected core 'identity' kustomization to be activated by downstream config")
+		}
+	})
+
+	t.Run("DisablesUpstreamCapability", func(t *testing.T) {
+		// Given core enables its own capability and consumer turns it off
+		core := []blueprintv1alpha1.Facet{{
+			Metadata:       blueprintv1alpha1.Metadata{Name: "identity"},
+			When:           "flags.identity == true",
+			Config:         []blueprintv1alpha1.ConfigBlock{configBlock("flags", map[string]any{"identity": true})},
+			Kustomizations: []blueprintv1alpha1.ConditionalKustomization{{Kustomization: blueprintv1alpha1.Kustomization{Name: "identity", Path: "identity"}}},
+		}}
+		consumer := []blueprintv1alpha1.Facet{{
+			Metadata: blueprintv1alpha1.Metadata{Name: "disable-identity"},
+			Config:   []blueprintv1alpha1.ConfigBlock{configBlock("flags", map[string]any{"identity": false})},
+		}}
+
+		// When composed
+		bp := composeCrossSource(t, core, consumer, nil)
+
+		// Then the capability is excluded
+		if hasKustomization(bp, "identity") {
+			t.Error("expected downstream to disable core 'identity' capability")
+		}
+	})
+
+	t.Run("UpstreamDerivationRecomputesFromOverride", func(t *testing.T) {
+		// Given core derives net.host from dns.domain and consumer overrides dns.domain
+		core := []blueprintv1alpha1.Facet{{
+			Metadata: blueprintv1alpha1.Metadata{Name: "platform-base"},
+			Config: []blueprintv1alpha1.ConfigBlock{
+				configBlock("dns", map[string]any{"domain": "core"}),
+				configBlock("net", map[string]any{"host": "${dns.domain}.svc"}),
+			},
+			Kustomizations: []blueprintv1alpha1.ConditionalKustomization{{Kustomization: blueprintv1alpha1.Kustomization{
+				Name: "net", Path: "net", Substitutions: map[string]string{"host": "${net.host ?? ''}"},
+			}}},
+		}}
+		consumer := []blueprintv1alpha1.Facet{{
+			Metadata: blueprintv1alpha1.Metadata{Name: "override"},
+			Config:   []blueprintv1alpha1.ConfigBlock{configBlock("dns", map[string]any{"domain": "consumer"})},
+		}}
+
+		// When composed
+		bp := composeCrossSource(t, core, consumer, nil)
+
+		// Then the upstream derivation reflects the override
+		got, found := kustSub(bp, "net", "host")
+		if !found {
+			t.Fatal("expected composed kustomization 'net'")
+		}
+		if got != "consumer.svc" {
+			t.Errorf("expected derived 'consumer.svc', got %q", got)
+		}
+	})
+
+	t.Run("ExplicitOperatorValueVetoesDownstreamActivation", func(t *testing.T) {
+		// Given the operator explicitly disables identity, a downstream enable must not override it
+		core := []blueprintv1alpha1.Facet{{
+			Metadata:       blueprintv1alpha1.Metadata{Name: "identity"},
+			When:           "flags.identity == true",
+			Kustomizations: []blueprintv1alpha1.ConditionalKustomization{{Kustomization: blueprintv1alpha1.Kustomization{Name: "identity", Path: "identity"}}},
+		}}
+		consumer := []blueprintv1alpha1.Facet{{
+			Metadata: blueprintv1alpha1.Metadata{Name: "enable-identity"},
+			Config:   []blueprintv1alpha1.ConfigBlock{configBlock("flags", map[string]any{"identity": true})},
+		}}
+		operator := map[string]any{"flags": map[string]any{"identity": false}}
+
+		// When composed with an explicit operator opt-out
+		bp := composeCrossSource(t, core, consumer, operator)
+
+		// Then the operator's explicit false wins
+		if hasKustomization(bp, "identity") {
+			t.Error("expected explicit operator flags.identity=false to veto downstream activation")
+		}
+	})
+}
+
 func TestHandler_deriveConfigMapDeferredPaths(t *testing.T) {
 	t.Run("MarksConfigMapEntriesContainingDeferredPlaceholder", func(t *testing.T) {
 		// Given a handler with a composed blueprint containing deferred ConfigMap values

--- a/pkg/composer/blueprint/handler_test.go
+++ b/pkg/composer/blueprint/handler_test.go
@@ -2759,6 +2759,43 @@ func TestHandler_CrossSourceConfig(t *testing.T) {
 		}
 	})
 
+	t.Run("OverridesUpstreamFluxSubstitution", func(t *testing.T) {
+		// Given core defines a cni flux system install substitution and consumer overrides it
+		core := []blueprintv1alpha1.Facet{{
+			Metadata: blueprintv1alpha1.Metadata{Name: "cni-base"},
+			FluxSystems: []blueprintv1alpha1.FluxSystem{{
+				Name: "cni", Path: "cni",
+				Install: &blueprintv1alpha1.Kustomization{Components: []string{"helm"}, Substitutions: map[string]string{"host": "core"}},
+			}},
+		}}
+		consumer := []blueprintv1alpha1.Facet{{
+			Metadata: blueprintv1alpha1.Metadata{Name: "cni-override"},
+			FluxSystems: []blueprintv1alpha1.FluxSystem{{
+				Name:    "cni",
+				Install: &blueprintv1alpha1.Kustomization{Substitutions: map[string]string{"host": "consumer"}},
+			}},
+		}}
+
+		// When composed
+		bp := composeCrossSource(t, core, consumer, nil)
+
+		// Then the composed cni flux system carries the downstream override
+		var got string
+		found := false
+		for _, sys := range bp.FluxSystems {
+			if sys.Name == "cni" && sys.Install != nil {
+				got = sys.Install.Substitutions["host"]
+				found = true
+			}
+		}
+		if !found {
+			t.Fatalf("expected cni flux system with install tier; got %d flux systems", len(bp.FluxSystems))
+		}
+		if got != "consumer" {
+			t.Errorf("expected downstream flux override 'consumer', got %q", got)
+		}
+	})
+
 	t.Run("ExplicitOperatorValueVetoesDownstreamActivation", func(t *testing.T) {
 		// Given the operator explicitly disables identity, a downstream enable must not override it
 		core := []blueprintv1alpha1.Facet{{

--- a/pkg/composer/blueprint/handler_test.go
+++ b/pkg/composer/blueprint/handler_test.go
@@ -2593,6 +2593,7 @@ func composeCrossSource(t *testing.T, coreFacets, consumerFacets []blueprintv1al
 		}
 		return contextValues, nil
 	}
+	mocks.ConfigHandler.GetSetValuesFunc = func() map[string]any { return contextValues }
 	handler := NewBlueprintHandler(mocks.Runtime, mocks.ArtifactBuilder)
 
 	coreBp := &blueprintv1alpha1.Blueprint{}
@@ -2759,7 +2760,6 @@ func TestHandler_CrossSourceConfig(t *testing.T) {
 	})
 
 	t.Run("ExplicitOperatorValueVetoesDownstreamActivation", func(t *testing.T) {
-		t.Skip("pending: pin operator-explicit values (distinct from schema defaults) above facet config")
 		// Given the operator explicitly disables identity, a downstream enable must not override it
 		core := []blueprintv1alpha1.Facet{{
 			Metadata:       blueprintv1alpha1.Metadata{Name: "identity"},

--- a/pkg/composer/blueprint/handler_test.go
+++ b/pkg/composer/blueprint/handler_test.go
@@ -2759,6 +2759,7 @@ func TestHandler_CrossSourceConfig(t *testing.T) {
 	})
 
 	t.Run("ExplicitOperatorValueVetoesDownstreamActivation", func(t *testing.T) {
+		t.Skip("pending: pin operator-explicit values (distinct from schema defaults) above facet config")
 		// Given the operator explicitly disables identity, a downstream enable must not override it
 		core := []blueprintv1alpha1.Facet{{
 			Metadata:       blueprintv1alpha1.Metadata{Name: "identity"},

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -41,6 +41,7 @@ var strategyPrecedence = map[string]int{
 // scopes from multiple loaders (e.g. for user overlay and final terraform input evaluation).
 type BlueprintProcessor interface {
 	ProcessFacets(target *blueprintv1alpha1.Blueprint, facets []blueprintv1alpha1.Facet, sourceName ...string) (scope map[string]any, err error)
+	ProcessGlobally(sources []SourceFacetSet) (map[string]any, error)
 }
 
 // =============================================================================
@@ -220,15 +221,7 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 		return nil, nil
 	}
 
-	var contextScope map[string]any
-	if p.runtime != nil && p.runtime.ConfigHandler != nil {
-		if vals, err := p.runtime.ConfigHandler.GetContextValues(); err == nil {
-			contextScope = vals
-		}
-	}
-	if p.extraScope != nil {
-		contextScope = MergeScopeMaps(contextScope, p.extraScope)
-	}
+	contextScope := p.buildContextScope()
 
 	sortedFacets := make([]blueprintv1alpha1.Facet, len(facets))
 	copy(sortedFacets, facets)
@@ -248,6 +241,88 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 	if err := p.emitFacetComponents(target, includedFacets, scope, sourceName...); err != nil {
 		return nil, err
 	}
+	return globalScope, nil
+}
+
+// buildContextScope returns the operator/schema context values merged with any injected extra scope.
+func (p *BaseBlueprintProcessor) buildContextScope() map[string]any {
+	var contextScope map[string]any
+	if p.runtime != nil && p.runtime.ConfigHandler != nil {
+		if vals, err := p.runtime.ConfigHandler.GetContextValues(); err == nil {
+			contextScope = vals
+		}
+	}
+	if p.extraScope != nil {
+		contextScope = MergeScopeMaps(contextScope, p.extraScope)
+	}
+	return contextScope
+}
+
+// SourceFacetSet is one source's contribution to global composition: its name, its dependency depth
+// (deeper/referencing sources override shallower ones), the blueprint to emit its components into, and
+// its facets.
+type SourceFacetSet struct {
+	Name   string
+	Depth  int
+	Target *blueprintv1alpha1.Blueprint
+	Facets []blueprintv1alpha1.Facet
+}
+
+// ProcessGlobally resolves config and facet inclusion once across every source's facets, then emits
+// each source's included components into its own target blueprint. Facets are ranked by a
+// depth-adjusted ordinal so a deeper source's config wins over a shallower one's for the same key,
+// while derivations resolve against the final merged scope and an upstream facet's when: sees a
+// downstream source's config. Returns the resolved global scope.
+func (p *BaseBlueprintProcessor) ProcessGlobally(sources []SourceFacetSet) (map[string]any, error) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.deferredPaths = make(map[string]bool)
+
+	contextScope := p.buildContextScope()
+
+	// sourceOrdinalStride separates source-depth bands so depth dominates facet ordinal: a deeper
+	// source's lowest-ordinal facet still outranks a shallower source's highest-ordinal facet.
+	const sourceOrdinalStride = 1_000_000
+	var combined []blueprintv1alpha1.Facet
+	for _, src := range sources {
+		for _, f := range src.Facets {
+			fc := f
+			fc.Source = src.Name
+			eff := resolvedFacetOrdinal(f) + src.Depth*sourceOrdinalStride
+			fc.Ordinal = &eff
+			combined = append(combined, fc)
+		}
+	}
+	if len(combined) == 0 {
+		return nil, nil
+	}
+	sort.Slice(combined, func(i, j int) bool {
+		oi, oj := resolvedFacetOrdinal(combined[i]), resolvedFacetOrdinal(combined[j])
+		if oi != oj {
+			return oi < oj
+		}
+		return combined[i].Metadata.Name < combined[j].Metadata.Name
+	})
+
+	globalScope, scope, included, err := p.resolveConfigAndInclusion(combined, contextScope)
+	if err != nil {
+		return nil, err
+	}
+
+	includedBySource := make(map[string][]blueprintv1alpha1.Facet)
+	for _, f := range included {
+		includedBySource[f.Source] = append(includedBySource[f.Source], f)
+	}
+	for _, src := range sources {
+		facets := includedBySource[src.Name]
+		if len(facets) == 0 {
+			continue
+		}
+		if err := p.emitFacetComponents(src.Target, facets, scope, src.Name); err != nil {
+			return nil, err
+		}
+	}
+
 	return globalScope, nil
 }
 

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -240,12 +240,6 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 		return sortedFacets[i].Metadata.Name < sortedFacets[j].Metadata.Name
 	})
 
-	collected := collectedComponents{
-		terraformByID:       make(map[string]*blueprintv1alpha1.ConditionalTerraformComponent),
-		kustomizationByName: make(map[string]*blueprintv1alpha1.ConditionalKustomization),
-		fluxSystemByName:    make(map[string]*blueprintv1alpha1.FluxSystem),
-	}
-	crdRefs := make(map[string]struct{})
 	scope := contextScope
 	var globalScope map[string]any
 	var cfgEntries map[string]*blueprintv1alpha1.ConfigBlock
@@ -335,27 +329,46 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 		})
 	}
 
+	if err := p.emitFacetComponents(target, includedFacets, scope, sourceName...); err != nil {
+		return nil, err
+	}
+	return globalScope, nil
+}
+
+// emitFacetComponents materializes the included facets' components — terraform components,
+// kustomizations, flux systems, CRDs, blueprint-level substitutions, and messages — into target,
+// resolving expressions against the already-resolved scope. sourceName stamps Source on components
+// that lack one. This is the emission half of ProcessFacets, split out so cross-source composition can
+// resolve config and inclusion globally first and then emit each source's components separately.
+func (p *BaseBlueprintProcessor) emitFacetComponents(target *blueprintv1alpha1.Blueprint, includedFacets []blueprintv1alpha1.Facet, scope map[string]any, sourceName ...string) error {
+	collected := collectedComponents{
+		terraformByID:       make(map[string]*blueprintv1alpha1.ConditionalTerraformComponent),
+		kustomizationByName: make(map[string]*blueprintv1alpha1.ConditionalKustomization),
+		fluxSystemByName:    make(map[string]*blueprintv1alpha1.FluxSystem),
+	}
+	crdRefs := make(map[string]struct{})
+
 	for _, facet := range includedFacets {
 		if len(facet.Crds) > 0 {
 			evaluated, err := p.evaluateStringSlice(facet.Crds, facet.Path, scope)
 			if err != nil {
-				return nil, fmt.Errorf("error evaluating crds for facet '%s': %w", facet.Metadata.Name, err)
+				return fmt.Errorf("error evaluating crds for facet '%s': %w", facet.Metadata.Name, err)
 			}
 			facet.Crds = slices.DeleteFunc(evaluated, func(s string) bool { return s == "" })
 			for _, ref := range facet.Crds {
 				if err := validateCrdRef(ref); err != nil {
-					return nil, fmt.Errorf("facet %q: %w", facet.Metadata.Name, err)
+					return fmt.Errorf("facet %q: %w", facet.Metadata.Name, err)
 				}
 			}
 		}
 		if err := p.collectTerraformComponents(facet, sourceName, collected.terraformByID, scope); err != nil {
-			return nil, err
+			return err
 		}
 		if err := p.collectKustomizations(facet, sourceName, collected.kustomizationByName, scope); err != nil {
-			return nil, err
+			return err
 		}
 		if err := p.collectFluxSystems(facet, sourceName, collected.fluxSystemByName, scope); err != nil {
-			return nil, err
+			return err
 		}
 		for _, ref := range facet.Crds {
 			crdRefs[ref] = struct{}{}
@@ -367,7 +380,7 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 		if len(facet.Substitutions) > 0 {
 			evaluated, deferredKeys, err := p.evaluateSubstitutions(facet.Substitutions, facet.Path, scope)
 			if err != nil {
-				return nil, fmt.Errorf("error evaluating substitutions for facet '%s': %w", facet.Metadata.Name, err)
+				return fmt.Errorf("error evaluating substitutions for facet '%s': %w", facet.Metadata.Name, err)
 			}
 			if target.Substitutions == nil {
 				target.Substitutions = make(map[string]string)
@@ -407,10 +420,7 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 
 	setCrdLayer(target, crdRefs, resolveSourceName(sourceName))
 
-	if err := p.applyCollectedComponents(target, collected, scope); err != nil {
-		return nil, err
-	}
-	return globalScope, nil
+	return p.applyCollectedComponents(target, collected, scope)
 }
 
 // =============================================================================

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -280,8 +280,6 @@ func (p *BaseBlueprintProcessor) ProcessGlobally(sources []SourceFacetSet) (map[
 
 	contextScope := p.buildContextScope()
 
-	// sourceOrdinalStride separates source-depth bands so depth dominates facet ordinal: a deeper
-	// source's lowest-ordinal facet still outranks a shallower source's highest-ordinal facet.
 	const sourceOrdinalStride = 1_000_000
 	var combined []blueprintv1alpha1.Facet
 	for _, src := range sources {
@@ -1380,9 +1378,11 @@ func (p *BaseBlueprintProcessor) evalDropEmpty(raw []string, facetPath string, s
 // with the system's) is false — never merely because its components prune to empty, matching how
 // a plain kustomize: entry is always emitted regardless of its resolved component count; a
 // dependsOn reference to it stays valid whether or not the variant's own components ended up
-// empty. An install tier whose components prune to empty sets Install to nil, since install is
-// optional per system (a system may have none at all) and an empty install is equivalent to none
-// declared. The system's when is cleared once inclusion is decided (mirroring each variant's when):
+// empty. An install tier whose components prune to empty and carries no substitutions or patches sets
+// Install to nil, since install is optional per system and an empty install is equivalent to none
+// declared; a components-less tier that still carries substitutions or patches is kept so a downstream
+// facet can override an upstream system's install without redeclaring its components. The system's
+// when is cleared once inclusion is decided (mirroring each variant's when):
 // it has already gated the system and its variants here, and often references composition-only derived
 // config that does not exist downstream, so emitting it would leak an unresolvable condition.
 func (p *BaseBlueprintProcessor) collectFluxSystems(facet blueprintv1alpha1.Facet, sourceName []string, fluxSystemByName map[string]*blueprintv1alpha1.FluxSystem, facetScope map[string]any) error {
@@ -1424,11 +1424,6 @@ func (p *BaseBlueprintProcessor) collectFluxSystems(facet blueprintv1alpha1.Face
 			if err != nil {
 				return fmt.Errorf("error evaluating install components for system '%s': %w", system.Name, err)
 			}
-			// Keep the install tier when it has components, is a removal, or carries override-only
-			// content (substitutions/patches) with no components of its own. The last case lets a
-			// downstream facet override an upstream system's install substitutions without redeclaring
-			// its components; compilation still only emits an install Kustomization when components are
-			// present (after cross-source merge), so an override-only tier never emits on its own.
 			if len(comps) > 0 || strategy == "remove" || len(system.Install.Substitutions) > 0 || len(system.Install.Patches) > 0 {
 				installCopy := *system.Install.DeepCopy()
 				installCopy.Components = comps

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -1424,7 +1424,12 @@ func (p *BaseBlueprintProcessor) collectFluxSystems(facet blueprintv1alpha1.Face
 			if err != nil {
 				return fmt.Errorf("error evaluating install components for system '%s': %w", system.Name, err)
 			}
-			if len(comps) > 0 || strategy == "remove" {
+			// Keep the install tier when it has components, is a removal, or carries override-only
+			// content (substitutions/patches) with no components of its own. The last case lets a
+			// downstream facet override an upstream system's install substitutions without redeclaring
+			// its components; compilation still only emits an install Kustomization when components are
+			// present (after cross-source merge), so an override-only tier never emits on its own.
+			if len(comps) > 0 || strategy == "remove" || len(system.Install.Substitutions) > 0 || len(system.Install.Patches) > 0 {
 				installCopy := *system.Install.DeepCopy()
 				installCopy.Components = comps
 				if err := p.evalKustomizationSubstitutions(&installCopy, facet.Path, "flux."+system.Name+".install.substitutions.", facetScope); err != nil {

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -240,6 +240,24 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 		return sortedFacets[i].Metadata.Name < sortedFacets[j].Metadata.Name
 	})
 
+	globalScope, scope, includedFacets, err := p.resolveConfigAndInclusion(sortedFacets, contextScope)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := p.emitFacetComponents(target, includedFacets, scope, sourceName...); err != nil {
+		return nil, err
+	}
+	return globalScope, nil
+}
+
+// resolveConfigAndInclusion runs the config-merge and facet-inclusion fixpoint over sortedFacets
+// against contextScope. It returns the resolved config scope (globalScope), the full evaluation scope
+// (contextScope deep-merged with globalScope), and the included facets. Excluded facets are recorded,
+// and a requirements error is returned if any included facet's requires stay unmet. It emits no
+// components — split from ProcessFacets so cross-source composition can resolve config and inclusion
+// once, globally, before emitting each source's components.
+func (p *BaseBlueprintProcessor) resolveConfigAndInclusion(sortedFacets []blueprintv1alpha1.Facet, contextScope map[string]any) (map[string]any, map[string]any, []blueprintv1alpha1.Facet, error) {
 	scope := contextScope
 	var globalScope map[string]any
 	var cfgEntries map[string]*blueprintv1alpha1.ConfigBlock
@@ -262,19 +280,19 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 		for _, facet := range sortedFacets {
 			shouldInclude, err := p.shouldIncludeFacet(facet, passScope)
 			if err != nil {
-				return nil, err
+				return nil, nil, nil, err
 			}
 			if !shouldInclude {
 				continue
 			}
 			misses, err := p.evaluateRequirements(facet, passScope)
 			if err != nil {
-				return nil, err
+				return nil, nil, nil, err
 			}
 			var errMerge error
 			globalScope, cfgEntries, errMerge = p.mergeFacetScopeIntoGlobal(facet, globalScope, cfgEntries, passScope, contextScope)
 			if errMerge != nil {
-				return nil, fmt.Errorf("facet %s: %w", facet.Metadata.Name, errMerge)
+				return nil, nil, nil, fmt.Errorf("facet %s: %w", facet.Metadata.Name, errMerge)
 			}
 			if len(misses) > 0 {
 				pendingRequirements[facet.Metadata.Name] = facetRequirementMisses{Misses: misses}
@@ -283,7 +301,7 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 			includedFacets = append(includedFacets, facet)
 		}
 		if err := p.evaluateGlobalScopeConfig(globalScope, contextScope); err != nil {
-			return nil, err
+			return nil, nil, nil, err
 		}
 		mergeBase := contextScope
 		if mergeBase == nil {
@@ -311,7 +329,7 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 	}
 
 	if len(pendingRequirements) > 0 {
-		return nil, formatRequirementsError(pendingRequirements)
+		return nil, nil, nil, formatRequirementsError(pendingRequirements)
 	}
 
 	includedSet := make(map[string]bool, len(includedFacets))
@@ -329,10 +347,7 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 		})
 	}
 
-	if err := p.emitFacetComponents(target, includedFacets, scope, sourceName...); err != nil {
-		return nil, err
-	}
-	return globalScope, nil
+	return globalScope, scope, includedFacets, nil
 }
 
 // emitFacetComponents materializes the included facets' components — terraform components,

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -233,7 +233,7 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 		return sortedFacets[i].Metadata.Name < sortedFacets[j].Metadata.Name
 	})
 
-	globalScope, scope, includedFacets, err := p.resolveConfigAndInclusion(sortedFacets, contextScope)
+	globalScope, scope, includedFacets, err := p.resolveConfigAndInclusion(sortedFacets, contextScope, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -304,7 +304,12 @@ func (p *BaseBlueprintProcessor) ProcessGlobally(sources []SourceFacetSet) (map[
 		return combined[i].Metadata.Name < combined[j].Metadata.Name
 	})
 
-	globalScope, scope, included, err := p.resolveConfigAndInclusion(combined, contextScope)
+	var operatorOverlay map[string]any
+	if p.runtime != nil && p.runtime.ConfigHandler != nil {
+		operatorOverlay = p.runtime.ConfigHandler.GetSetValues()
+	}
+
+	globalScope, scope, included, err := p.resolveConfigAndInclusion(combined, contextScope, operatorOverlay)
 	if err != nil {
 		return nil, err
 	}
@@ -332,7 +337,7 @@ func (p *BaseBlueprintProcessor) ProcessGlobally(sources []SourceFacetSet) (map[
 // and a requirements error is returned if any included facet's requires stay unmet. It emits no
 // components — split from ProcessFacets so cross-source composition can resolve config and inclusion
 // once, globally, before emitting each source's components.
-func (p *BaseBlueprintProcessor) resolveConfigAndInclusion(sortedFacets []blueprintv1alpha1.Facet, contextScope map[string]any) (map[string]any, map[string]any, []blueprintv1alpha1.Facet, error) {
+func (p *BaseBlueprintProcessor) resolveConfigAndInclusion(sortedFacets []blueprintv1alpha1.Facet, contextScope map[string]any, operatorOverlay map[string]any) (map[string]any, map[string]any, []blueprintv1alpha1.Facet, error) {
 	scope := contextScope
 	var globalScope map[string]any
 	var cfgEntries map[string]*blueprintv1alpha1.ConfigBlock
@@ -383,6 +388,9 @@ func (p *BaseBlueprintProcessor) resolveConfigAndInclusion(sortedFacets []bluepr
 			mergeBase = make(map[string]any)
 		}
 		passScope = blueprintv1alpha1.DeepMergeMaps(mergeBase, globalScope)
+		if len(operatorOverlay) > 0 {
+			passScope = blueprintv1alpha1.DeepMergeMaps(passScope, operatorOverlay)
+		}
 		scope = passScope
 		currSet := make(map[string]bool, len(includedFacets))
 		for _, f := range includedFacets {

--- a/pkg/composer/blueprint/trace_test.go
+++ b/pkg/composer/blueprint/trace_test.go
@@ -51,6 +51,10 @@ func (explainTestProcessor) ProcessFacets(target *blueprintv1alpha1.Blueprint, f
 	return nil, nil
 }
 
+func (explainTestProcessor) ProcessGlobally(sources []SourceFacetSet) (map[string]any, error) {
+	return nil, nil
+}
+
 // =============================================================================
 // Test Public Methods
 // =============================================================================

--- a/pkg/runtime/config/handler.go
+++ b/pkg/runtime/config/handler.go
@@ -49,6 +49,7 @@ type ConfigHandler interface {
 	LoadSchemaFromBytes(schemaContent []byte) error
 	GetSchema() map[string]any
 	GetContextValues() (map[string]any, error)
+	GetSetValues() map[string]any
 	SetApplySchemaDefaults(enabled bool)
 	GetSensitivePaths() []string
 	IsSensitivePath(path string) bool

--- a/pkg/runtime/config/mock_handler.go
+++ b/pkg/runtime/config/mock_handler.go
@@ -36,6 +36,7 @@ type MockConfigHandler struct {
 	LoadSchemaFromBytesFunc    func(schemaContent []byte) error
 	GetSchemaFunc              func() map[string]any
 	GetContextValuesFunc       func() (map[string]any, error)
+	GetSetValuesFunc           func() map[string]any
 	SetApplySchemaDefaultsFunc func(enabled bool)
 	GetSensitivePathsFunc      func() []string
 	IsSensitivePathFunc        func(path string) bool
@@ -288,6 +289,14 @@ func (m *MockConfigHandler) GetContextValues() (map[string]any, error) {
 		return m.GetContextValuesFunc()
 	}
 	return nil, fmt.Errorf("GetContextValuesFunc not set")
+}
+
+// GetSetValues calls the mock GetSetValuesFunc if set, otherwise returns nil.
+func (m *MockConfigHandler) GetSetValues() map[string]any {
+	if m.GetSetValuesFunc != nil {
+		return m.GetSetValuesFunc()
+	}
+	return nil
 }
 
 // SetApplySchemaDefaults calls the mock SetApplySchemaDefaultsFunc if set, otherwise is a no-op

--- a/pkg/runtime/config/resolve.go
+++ b/pkg/runtime/config/resolve.go
@@ -42,6 +42,13 @@ func (c *configHandler) GetContextValues() (map[string]any, error) {
 	return result, nil
 }
 
+// GetSetValues returns a deep copy of the values the operator has explicitly set (values.yaml,
+// context, workstation), without schema defaults or derived values. Composition pins these above
+// facet config so an operator's explicit value wins over a facet's — including a downstream facet's.
+func (c *configHandler) GetSetValues() map[string]any {
+	return c.deepMerge(map[string]any{}, c.data)
+}
+
 // =============================================================================
 // Private Methods
 // =============================================================================


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This PR changes a core shared subsystem — blueprint composition — in a way that alters config resolution semantics for any multi-source blueprint, so any operator running two or more sources is affected.
>
> **Overview**
>
> The PR replaces per-source facet resolution (each source resolved independently, scopes threaded sequentially) with a single global resolution pass across all sources. Facets are ranked by a depth-adjusted ordinal so a deeper (referencing/downstream) source's config wins over a shallower one's for the same key, and upstream `when:` guards can now see downstream config. A new `GetSetValues` accessor on `ConfigHandler` lets operator-set values be re-applied as a ceiling in each fixpoint iteration, preventing downstream facets from overriding explicit operator configuration.
>
> Two companion fixes are included: `MergeKustomizationFields` now clones slice/map fields before merging to prevent aliasing-based mutation of callers' blueprints, and `collectFluxSystems` now retains install tiers that carry only substitutions or patches (no components) so a downstream facet can override upstream install substitutions without re-declaring the component list.
>
> Reviewed by Claude for commit `0f30eba2`.

<!-- /claude-code-review:summary -->
