### PR TITLE
fix(secrets): prevent loading unencrypted secrets files and update .gitignore entries

### DIFF
--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -622,7 +622,7 @@ func TestInit_WritesLocalGitignoresAndLeavesProjectRootAlone(t *testing.T) {
 	if readErr != nil {
 		t.Fatalf("expected contexts/local/.gitignore at %s, got %v", contextIgnore, readErr)
 	}
-	expected := ".kube/\n.talos/\n.omni/\n.aws/\n.azure/\n.gcp/\n.env\n"
+	expected := ".kube/\n.talos/\n.omni/\n.aws/\n.azure/\n.gcp/\n.env\nsecrets.yaml\nsecrets.yml\n"
 	if string(content) != expected {
 		t.Errorf("expected contexts/local/.gitignore to contain credential dirs, got: %q", string(content))
 	}

--- a/pkg/composer/composer.go
+++ b/pkg/composer/composer.go
@@ -186,8 +186,10 @@ func (r *Composer) Generate(overwrite ...bool) error {
 const windsorMarkerContent = "*\n"
 
 // contextIgnoreContent is written to contexts/<ctx>/.gitignore to keep
-// per-context credential and state directories out of version control.
-const contextIgnoreContent = ".kube/\n.talos/\n.omni/\n.aws/\n.azure/\n.gcp/\n.env\n"
+// per-context credential and state directories out of version control. The
+// unencrypted secrets.yaml/secrets.yml variants are excluded; the encrypted
+// secrets.enc.yaml/secrets.enc.yml variants are safe to commit and stay tracked.
+const contextIgnoreContent = ".kube/\n.talos/\n.omni/\n.aws/\n.azure/\n.gcp/\n.env\nsecrets.yaml\nsecrets.yml\n"
 
 // writeLocalGitignores writes self-contained .gitignore files into Windsor-owned
 // folders so re-running Windsor never touches the project-root .gitignore.

--- a/pkg/composer/composer_test.go
+++ b/pkg/composer/composer_test.go
@@ -1014,7 +1014,7 @@ func TestComposer_writeLocalGitignores(t *testing.T) {
 		}
 
 		// And each non-template context should have a .gitignore with cred dirs
-		expected := ".kube/\n.talos/\n.omni/\n.aws/\n.azure/\n.gcp/\n.env\n"
+		expected := ".kube/\n.talos/\n.omni/\n.aws/\n.azure/\n.gcp/\n.env\nsecrets.yaml\nsecrets.yml\n"
 		for _, name := range []string{"local", "prod"} {
 			path := filepath.Join(root, "contexts", name, ".gitignore")
 			content, readErr := os.ReadFile(path)
@@ -1056,13 +1056,13 @@ func TestComposer_writeLocalGitignores(t *testing.T) {
 			t.Fatalf("Expected no error, got: %v", err)
 		}
 
-		// And the missing ".env" line should be appended
+		// And the missing lines should be appended
 		content, readErr := os.ReadFile(path)
 		if readErr != nil {
 			t.Fatalf("Failed to read .gitignore: %v", readErr)
 		}
-		if string(content) != staleContent+".env\n" {
-			t.Errorf("Expected .env to be backfilled, got: %q", string(content))
+		if string(content) != staleContent+".env\nsecrets.yaml\nsecrets.yml\n" {
+			t.Errorf("Expected missing lines to be backfilled, got: %q", string(content))
 		}
 	})
 
@@ -1086,13 +1086,13 @@ func TestComposer_writeLocalGitignores(t *testing.T) {
 			t.Fatalf("Expected no error, got: %v", err)
 		}
 
-		// Then the user's line should be preserved and ".env" appended
+		// Then the user's line should be preserved and the missing lines appended
 		content, readErr := os.ReadFile(path)
 		if readErr != nil {
 			t.Fatalf("Failed to read .gitignore: %v", readErr)
 		}
-		if string(content) != staleContent+".env\n" {
-			t.Errorf("Expected user line preserved and .env appended, got: %q", string(content))
+		if string(content) != staleContent+".env\nsecrets.yaml\nsecrets.yml\n" {
+			t.Errorf("Expected user line preserved and missing lines appended, got: %q", string(content))
 		}
 	})
 

--- a/pkg/runtime/secrets/sops_provider.go
+++ b/pkg/runtime/secrets/sops_provider.go
@@ -49,10 +49,17 @@ func NewSopsProvider(configPath string) *SopsProvider {
 // Provider Interface
 // =============================================================================
 
-// LoadSecrets loads and decrypts secrets from all existing SOPS-encrypted files.
+// LoadSecrets loads and decrypts secrets from all existing SOPS-encrypted files. Refuses to load,
+// with an error naming the offending path, if an unencrypted secrets.yaml/secrets.yml is present:
+// sops --decrypt on a plaintext file is a nonsensical path, and silently succeeding would let a raw
+// secrets file sit unencrypted (and, without a matching .gitignore entry, at risk of being committed).
 func (s *SopsProvider) LoadSecrets() error {
 	if s.unlocked {
 		return nil
+	}
+
+	if plaintextPath, found := s.findPlaintextSecretsFile(); found {
+		return fmt.Errorf("refusing to load unencrypted secrets file %s: encrypt it with sops before use (see secrets.enc.yaml)", plaintextPath)
 	}
 
 	secretsFilePaths := s.findSecretsFilePaths()
@@ -166,10 +173,10 @@ func (s *SopsProvider) Resolve(ref SecretRef) (string, bool, error) {
 // Private Methods
 // =============================================================================
 
+// findSecretsFilePaths returns existing SOPS-encrypted secrets files. Unencrypted variants are
+// checked separately by findPlaintextSecretsFile and never decrypted.
 func (s *SopsProvider) findSecretsFilePaths() []string {
 	candidates := []string{
-		filepath.Join(s.configPath, secretsFileNameYaml),
-		filepath.Join(s.configPath, secretsFileNameYml),
 		filepath.Join(s.configPath, secretsFileNameEncYaml),
 		filepath.Join(s.configPath, secretsFileNameEncYml),
 	}
@@ -181,6 +188,17 @@ func (s *SopsProvider) findSecretsFilePaths() []string {
 		}
 	}
 	return existingPaths
+}
+
+// findPlaintextSecretsFile returns the first unencrypted secrets file found, if any.
+func (s *SopsProvider) findPlaintextSecretsFile() (string, bool) {
+	for _, name := range []string{secretsFileNameYaml, secretsFileNameYml} {
+		path := filepath.Join(s.configPath, name)
+		if _, err := s.shims.Stat(path); err == nil {
+			return path, true
+		}
+	}
+	return "", false
 }
 
 // =============================================================================

--- a/pkg/runtime/secrets/sops_provider.go
+++ b/pkg/runtime/secrets/sops_provider.go
@@ -49,17 +49,15 @@ func NewSopsProvider(configPath string) *SopsProvider {
 // Provider Interface
 // =============================================================================
 
-// LoadSecrets loads and decrypts secrets from all existing SOPS-encrypted files. Refuses to load,
-// with an error naming the offending path, if an unencrypted secrets.yaml/secrets.yml is present:
-// sops --decrypt on a plaintext file is a nonsensical path, and silently succeeding would let a raw
-// secrets file sit unencrypted (and, without a matching .gitignore entry, at risk of being committed).
+// LoadSecrets loads and decrypts secrets from all existing secrets files, including the
+// conventionally-unencrypted secrets.yaml/secrets.yml names: content decides whether a file is
+// SOPS-encrypted, not its name, since an operator's own SOPS file can be named either way. A
+// secrets.yaml/secrets.yml that fails to decrypt is refused with a clear error naming the path
+// rather than the raw sops failure, since the far more likely cause is a genuinely plaintext file
+// that was never encrypted (and, without a matching .gitignore entry, at risk of being committed).
 func (s *SopsProvider) LoadSecrets() error {
 	if s.unlocked {
 		return nil
-	}
-
-	if plaintextPath, found := s.findPlaintextSecretsFile(); found {
-		return fmt.Errorf("refusing to load unencrypted secrets file %s: encrypt it with sops before use (see secrets.enc.yaml)", plaintextPath)
 	}
 
 	secretsFilePaths := s.findSecretsFilePaths()
@@ -99,10 +97,12 @@ func (s *SopsProvider) LoadSecrets() error {
 
 			plaintextBytes, err := s.shims.DecryptFile(filePath, "yaml")
 			if err != nil {
-				results[idx] = fileResult{
-					index: idx,
-					err:   fmt.Errorf("failed to decrypt file %s: %w", filePath, err),
+				if isConventionallyPlaintextName(filePath) {
+					err = fmt.Errorf("refusing to load unencrypted secrets file %s: encrypt it with sops before use (see secrets.enc.yaml): %w", filePath, err)
+				} else {
+					err = fmt.Errorf("failed to decrypt file %s: %w", filePath, err)
 				}
+				results[idx] = fileResult{index: idx, err: err}
 				return
 			}
 
@@ -173,10 +173,12 @@ func (s *SopsProvider) Resolve(ref SecretRef) (string, bool, error) {
 // Private Methods
 // =============================================================================
 
-// findSecretsFilePaths returns existing SOPS-encrypted secrets files. Unencrypted variants are
-// checked separately by findPlaintextSecretsFile and never decrypted.
+// findSecretsFilePaths returns existing secrets files of any name; LoadSecrets decides encrypted
+// vs. plaintext by attempting decryption, not by which of these candidate names matched.
 func (s *SopsProvider) findSecretsFilePaths() []string {
 	candidates := []string{
+		filepath.Join(s.configPath, secretsFileNameYaml),
+		filepath.Join(s.configPath, secretsFileNameYml),
 		filepath.Join(s.configPath, secretsFileNameEncYaml),
 		filepath.Join(s.configPath, secretsFileNameEncYml),
 	}
@@ -190,15 +192,11 @@ func (s *SopsProvider) findSecretsFilePaths() []string {
 	return existingPaths
 }
 
-// findPlaintextSecretsFile returns the first unencrypted secrets file found, if any.
-func (s *SopsProvider) findPlaintextSecretsFile() (string, bool) {
-	for _, name := range []string{secretsFileNameYaml, secretsFileNameYml} {
-		path := filepath.Join(s.configPath, name)
-		if _, err := s.shims.Stat(path); err == nil {
-			return path, true
-		}
-	}
-	return "", false
+// isConventionallyPlaintextName reports whether path uses Windsor's unencrypted naming convention
+// (secrets.yaml/secrets.yml), used only to pick a decrypt-failure message, never to skip decryption.
+func isConventionallyPlaintextName(path string) bool {
+	base := filepath.Base(path)
+	return base == secretsFileNameYaml || base == secretsFileNameYml
 }
 
 // =============================================================================

--- a/pkg/runtime/secrets/sops_provider_test.go
+++ b/pkg/runtime/secrets/sops_provider_test.go
@@ -16,7 +16,11 @@ func setupSopsMocks(t *testing.T) *SopsProvider {
 	t.Helper()
 	p := NewSopsProvider("/valid/config/path")
 	p.shims.Stat = func(name string) (os.FileInfo, error) {
-		return nil, nil // all files exist
+		base := filepath.Base(name)
+		if base == secretsFileNameEncYaml || base == secretsFileNameEncYml {
+			return nil, nil // encrypted files exist
+		}
+		return nil, os.ErrNotExist // plaintext variants absent
 	}
 	p.shims.DecryptFile = func(filePath string, format string) ([]byte, error) {
 		return []byte("nested:\n  key: value\n  another:\n    deep: secret\n"), nil
@@ -98,7 +102,7 @@ func TestSopsProvider_LoadSecrets(t *testing.T) {
 		var mu sync.Mutex
 		calls := 0
 		p.shims.Stat = func(name string) (os.FileInfo, error) {
-			if filepath.Base(name) == "secrets.yaml" || filepath.Base(name) == "secrets.enc.yaml" {
+			if filepath.Base(name) == "secrets.enc.yaml" || filepath.Base(name) == "secrets.enc.yml" {
 				return nil, nil
 			}
 			return nil, os.ErrNotExist
@@ -107,7 +111,7 @@ func TestSopsProvider_LoadSecrets(t *testing.T) {
 			mu.Lock()
 			calls++
 			mu.Unlock()
-			if filepath.Base(filePath) == "secrets.yaml" {
+			if filepath.Base(filePath) == "secrets.enc.yaml" {
 				return []byte("key1: value1\nkey2: first\n"), nil
 			}
 			return []byte("key2: second\nkey3: value3\n"), nil
@@ -136,6 +140,50 @@ func TestSopsProvider_LoadSecrets(t *testing.T) {
 		err := p.LoadSecrets()
 		if err == nil || !containsStr(err.Error(), "decryption failed") {
 			t.Errorf("expected decryption error, got %v", err)
+		}
+	})
+
+	t.Run("RefusesPlaintextSecretsYaml", func(t *testing.T) {
+		p := NewSopsProvider("/valid/config/path")
+		p.shims.Stat = func(name string) (os.FileInfo, error) {
+			if filepath.Base(name) == secretsFileNameYaml {
+				return nil, nil
+			}
+			return nil, os.ErrNotExist
+		}
+		p.shims.DecryptFile = func(_ string, _ string) ([]byte, error) {
+			t.Fatal("DecryptFile should not be called for a plaintext secrets file")
+			return nil, nil
+		}
+
+		err := p.LoadSecrets()
+		if err == nil || !containsStr(err.Error(), "secrets.yaml") {
+			t.Errorf("expected refusal naming secrets.yaml, got %v", err)
+		}
+		if p.unlocked {
+			t.Error("expected locked after refusing plaintext secrets file")
+		}
+	})
+
+	t.Run("RefusesPlaintextSecretsYml", func(t *testing.T) {
+		p := NewSopsProvider("/valid/config/path")
+		p.shims.Stat = func(name string) (os.FileInfo, error) {
+			if filepath.Base(name) == secretsFileNameYml {
+				return nil, nil
+			}
+			return nil, os.ErrNotExist
+		}
+		p.shims.DecryptFile = func(_ string, _ string) ([]byte, error) {
+			t.Fatal("DecryptFile should not be called for a plaintext secrets file")
+			return nil, nil
+		}
+
+		err := p.LoadSecrets()
+		if err == nil || !containsStr(err.Error(), "secrets.yml") {
+			t.Errorf("expected refusal naming secrets.yml, got %v", err)
+		}
+		if p.unlocked {
+			t.Error("expected locked after refusing plaintext secrets file")
 		}
 	})
 

--- a/pkg/runtime/secrets/sops_provider_test.go
+++ b/pkg/runtime/secrets/sops_provider_test.go
@@ -143,7 +143,7 @@ func TestSopsProvider_LoadSecrets(t *testing.T) {
 		}
 	})
 
-	t.Run("RefusesPlaintextSecretsYaml", func(t *testing.T) {
+	t.Run("RefusesSecretsYamlThatFailsToDecrypt", func(t *testing.T) {
 		p := NewSopsProvider("/valid/config/path")
 		p.shims.Stat = func(name string) (os.FileInfo, error) {
 			if filepath.Base(name) == secretsFileNameYaml {
@@ -152,12 +152,11 @@ func TestSopsProvider_LoadSecrets(t *testing.T) {
 			return nil, os.ErrNotExist
 		}
 		p.shims.DecryptFile = func(_ string, _ string) ([]byte, error) {
-			t.Fatal("DecryptFile should not be called for a plaintext secrets file")
-			return nil, nil
+			return nil, fmt.Errorf("sops metadata not found")
 		}
 
 		err := p.LoadSecrets()
-		if err == nil || !containsStr(err.Error(), "secrets.yaml") {
+		if err == nil || !containsStr(err.Error(), "refusing to load unencrypted secrets file") || !containsStr(err.Error(), "secrets.yaml") {
 			t.Errorf("expected refusal naming secrets.yaml, got %v", err)
 		}
 		if p.unlocked {
@@ -165,7 +164,7 @@ func TestSopsProvider_LoadSecrets(t *testing.T) {
 		}
 	})
 
-	t.Run("RefusesPlaintextSecretsYml", func(t *testing.T) {
+	t.Run("RefusesSecretsYmlThatFailsToDecrypt", func(t *testing.T) {
 		p := NewSopsProvider("/valid/config/path")
 		p.shims.Stat = func(name string) (os.FileInfo, error) {
 			if filepath.Base(name) == secretsFileNameYml {
@@ -174,16 +173,40 @@ func TestSopsProvider_LoadSecrets(t *testing.T) {
 			return nil, os.ErrNotExist
 		}
 		p.shims.DecryptFile = func(_ string, _ string) ([]byte, error) {
-			t.Fatal("DecryptFile should not be called for a plaintext secrets file")
-			return nil, nil
+			return nil, fmt.Errorf("sops metadata not found")
 		}
 
 		err := p.LoadSecrets()
-		if err == nil || !containsStr(err.Error(), "secrets.yml") {
+		if err == nil || !containsStr(err.Error(), "refusing to load unencrypted secrets file") || !containsStr(err.Error(), "secrets.yml") {
 			t.Errorf("expected refusal naming secrets.yml, got %v", err)
 		}
 		if p.unlocked {
 			t.Error("expected locked after refusing plaintext secrets file")
+		}
+	})
+
+	t.Run("LoadsSecretsYamlThatDecryptsSuccessfully", func(t *testing.T) {
+		// A secrets.yaml that IS genuinely SOPS-encrypted (misnamed relative to the
+		// secrets.enc.yaml convention) should still load, since content decides, not the name.
+		p := NewSopsProvider("/valid/config/path")
+		p.shims.Stat = func(name string) (os.FileInfo, error) {
+			if filepath.Base(name) == secretsFileNameYaml {
+				return nil, nil
+			}
+			return nil, os.ErrNotExist
+		}
+		p.shims.DecryptFile = func(_ string, _ string) ([]byte, error) {
+			return []byte("key: value\n"), nil
+		}
+
+		if err := p.LoadSecrets(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !p.unlocked {
+			t.Error("expected unlocked after successful decrypt")
+		}
+		if p.secrets["key"] != "value" {
+			t.Errorf("key = %q, want %q", p.secrets["key"], "value")
 		}
 	})
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change hardens secrets handling in an isolated subsystem; existing encrypted workflows are unaffected and the new guard surfaces a clear error rather than silent misbehavior.
>
> **Overview**
>
> The PR adds a safety check to `SopsProvider.LoadSecrets` that refuses to proceed if a plaintext `secrets.yaml` or `secrets.yml` is present, returning a named error instead of attempting (and likely failing) a `sops --decrypt` call on an unencrypted file. In parallel, those two filenames are removed from the encrypted-file candidate list so the decryption path never touches them. The context-level `.gitignore` template is updated to include both plaintext variants, and existing `.gitignore` files will have the lines backfilled on next `windsor generate`.
>
> The plaintext guard is stat-based (file existence only), so a SOPS-encrypted file that happens to be named `secrets.yaml` — Windsor convention uses `.enc.yaml` but the check doesn't verify content — would be rejected. Within Windsor's naming convention this is the correct behavior; the error message directing users to `secrets.enc.yaml` makes the expected layout explicit.
>
> Reviewed by Claude for commit `04f90125`.

<!-- /claude-code-review:summary -->
