### PR TITLE
fix(flux): replace ExecCommand with Shell.ExecCaptureWithEnv for command execution

### DIFF
--- a/pkg/provisioner/flux/shims.go
+++ b/pkg/provisioner/flux/shims.go
@@ -6,7 +6,6 @@
 package flux
 
 import (
-	"bytes"
 	"os"
 	"os/exec"
 )
@@ -17,12 +16,11 @@ import (
 
 // Shims provides mockable wrappers around system and runtime functions
 type Shims struct {
-	LookPath    func(file string) (string, error)
-	MkdirAll    func(path string, perm os.FileMode) error
-	RemoveAll   func(path string) error
-	ReadFile    func(name string) ([]byte, error)
-	WriteFile   func(name string, data []byte, perm os.FileMode) error
-	ExecCommand func(command string, args ...string) (stdout string, stderr string, err error)
+	LookPath  func(file string) (string, error)
+	MkdirAll  func(path string, perm os.FileMode) error
+	RemoveAll func(path string) error
+	ReadFile  func(name string) ([]byte, error)
+	WriteFile func(name string, data []byte, perm os.FileMode) error
 }
 
 // =============================================================================
@@ -37,17 +35,5 @@ func NewShims() *Shims {
 		RemoveAll: os.RemoveAll,
 		ReadFile:  os.ReadFile,
 		WriteFile: os.WriteFile,
-		ExecCommand: func(command string, args ...string) (string, string, error) {
-			// command is always a compile-time literal "flux" or "kustomize"
-			// passed by pkg/provisioner/flux/stack.go; never user-controlled.
-			cmd := exec.Command(command, args...) // #nosec G204 G702
-
-			cmd.Env = append(os.Environ(), "NO_COLOR=1")
-			var stdoutBuf, stderrBuf bytes.Buffer
-			cmd.Stdout = &stdoutBuf
-			cmd.Stderr = &stderrBuf
-			err := cmd.Run()
-			return stdoutBuf.String(), stderrBuf.String(), err
-		},
 	}
 }

--- a/pkg/provisioner/flux/stack.go
+++ b/pkg/provisioner/flux/stack.go
@@ -646,13 +646,12 @@ func (s *FluxStack) isKustomizeComponent(path string) bool {
 // runKustomizeBuild executes "kustomize build <path>" to render all kubernetes manifests
 // for a kustomization that does not yet exist in the cluster. Unlike flux diff/build,
 // kustomize build requires no cluster access and always emits rendered YAML to stdout.
+// Runs through the shell layer so rendered output (which may include Secret resources)
+// passes through the same scrubbing as every other executed command.
 func (s *FluxStack) runKustomizeBuild(name, path string) error {
 	fmt.Fprintf(os.Stderr, "\n%s\n", tui.SectionHeader("Kustomize: "+name))
-	stdout, stderr, err := s.shims.ExecCommand("kustomize", "build", path)
+	stdout, err := s.runtime.Shell.ExecCaptureWithEnv("kustomize", nil, "build", path)
 	if err != nil {
-		if stderr != "" {
-			return fmt.Errorf("%w\n%s", err, strings.TrimSpace(stderr))
-		}
 		return err
 	}
 	if stdout != "" {
@@ -663,15 +662,15 @@ func (s *FluxStack) runKustomizeBuild(name, path string) error {
 	return nil
 }
 
-// runFluxDiff executes "flux <args>" via the ExecCommand shim, which captures
-// stdout and stderr separately and sets NO_COLOR=1 to prevent flux from writing
-// progress indicators directly to the terminal TTY.
+// runFluxDiff executes "flux <args>" through the shell layer, which scrubs the
+// captured stdout/stderr and sets NO_COLOR=1 to prevent flux from writing progress
+// indicators directly to the terminal TTY.
 // flux diff exits 0 (no changes) or 1 (changes exist) — both are treated as success.
 // On exit 0 "No changes." is printed. On exit 1 the diff (stdout) is printed.
 // Any other exit code is returned as an error with stderr details.
 func (s *FluxStack) runFluxDiff(name string, args ...string) error {
 	fmt.Fprintf(os.Stderr, "\n%s\n", tui.SectionHeader("Kustomize: "+name))
-	stdout, stderr, err := s.shims.ExecCommand("flux", args...)
+	stdout, err := s.runtime.Shell.ExecCaptureWithEnv("flux", map[string]string{"NO_COLOR": "1"}, args...)
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
@@ -679,9 +678,6 @@ func (s *FluxStack) runFluxDiff(name string, args ...string) error {
 				fmt.Print(stdout)
 			}
 			return nil
-		}
-		if stderr != "" {
-			return fmt.Errorf("%w\n%s", err, strings.TrimSpace(stderr))
 		}
 		return err
 	}
@@ -727,14 +723,11 @@ func (s *FluxStack) checkFluxVersion() error {
 // Exit code 1 (changes detected) is treated as success, matching runFluxDiff semantics.
 // Any other non-zero exit code is returned as an error.
 func (s *FluxStack) captureFluxDiff(args ...string) (string, error) {
-	stdout, stderr, err := s.shims.ExecCommand("flux", args...)
+	stdout, err := s.runtime.Shell.ExecCaptureWithEnv("flux", map[string]string{"NO_COLOR": "1"}, args...)
 	if err != nil {
 		var exitErr *exec.ExitError
 		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
 			return stdout, nil
-		}
-		if stderr != "" {
-			return "", fmt.Errorf("%w\n%s", err, strings.TrimSpace(stderr))
 		}
 		return "", err
 	}
@@ -748,14 +741,7 @@ func (s *FluxStack) captureKustomizeBuild(k blueprintv1alpha1.Kustomization, com
 	baseIsComponent := s.isKustomizeComponent(localPath)
 
 	if !baseIsComponent && len(components) == 0 {
-		stdout, stderr, err := s.shims.ExecCommand("kustomize", "build", localPath)
-		if err != nil {
-			if stderr != "" {
-				return "", fmt.Errorf("%w\n%s", err, strings.TrimSpace(stderr))
-			}
-			return "", err
-		}
-		return stdout, nil
+		return s.runtime.Shell.ExecCaptureWithEnv("kustomize", nil, "build", localPath)
 	}
 
 	planDir := filepath.Join(sourceRoot, ".windsor", "plan", k.Name)
@@ -768,14 +754,7 @@ func (s *FluxStack) captureKustomizeBuild(k blueprintv1alpha1.Kustomization, com
 		return "", err
 	}
 
-	stdout, stderr, err := s.shims.ExecCommand("kustomize", "build", planDir)
-	if err != nil {
-		if stderr != "" {
-			return "", fmt.Errorf("%w\n%s", err, strings.TrimSpace(stderr))
-		}
-		return "", err
-	}
-	return stdout, nil
+	return s.runtime.Shell.ExecCaptureWithEnv("kustomize", nil, "build", planDir)
 }
 
 // countDiffLines counts added and removed lines in a unified diff.

--- a/pkg/provisioner/flux/stack_test.go
+++ b/pkg/provisioner/flux/stack_test.go
@@ -73,8 +73,8 @@ func setupFluxMocks(t *testing.T) *fluxMocks {
 	shims.RemoveAll = func(path string) error { return nil }
 	shims.ReadFile = func(name string) ([]byte, error) { return nil, os.ErrNotExist }
 	shims.WriteFile = func(name string, data []byte, perm os.FileMode) error { return nil }
-	shims.ExecCommand = func(command string, args ...string) (string, string, error) {
-		return "", "", nil
+	mockShell.ExecCaptureWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+		return "", nil
 	}
 
 	rt := &runtime.Runtime{
@@ -124,9 +124,9 @@ func TestFluxStack_Plan(t *testing.T) {
 		// Given a blueprint with a kustomization that already exists in the cluster
 		m := setupFluxMocks(t)
 		var capturedArgs []string
-		m.shims.ExecCommand = func(command string, args ...string) (string, string, error) {
+		m.shell.ExecCaptureWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
 			capturedArgs = args
-			return "", "", nil
+			return "", nil
 		}
 		s := newTestFluxStack(m)
 
@@ -253,9 +253,9 @@ func TestFluxStack_Plan(t *testing.T) {
 			return false, fmt.Errorf("stat /no/such/kubeconfig: no such file or directory")
 		}
 		var capturedCommand string
-		m.shims.ExecCommand = func(command string, args ...string) (string, string, error) {
+		m.shell.ExecCaptureWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
 			capturedCommand = command
-			return "", "", nil
+			return "", nil
 		}
 		s := newTestFluxStack(m)
 
@@ -274,8 +274,8 @@ func TestFluxStack_Plan(t *testing.T) {
 	t.Run("ErrorExecProgressFails", func(t *testing.T) {
 		// Given a stack where flux diff exits with a real error (exit status 2)
 		m := setupFluxMocks(t)
-		m.shims.ExecCommand = func(command string, args ...string) (string, string, error) {
-			return "", "server error", fmt.Errorf("exit status 2")
+		m.shell.ExecCaptureWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			return "", fmt.Errorf("exit status 2")
 		}
 		s := newTestFluxStack(m)
 
@@ -297,8 +297,8 @@ func TestFluxStack_Plan(t *testing.T) {
 		m.kubernetesManager.KustomizationExistsFunc = func(name, namespace string) (bool, error) {
 			return false, nil
 		}
-		m.shims.ExecCommand = func(command string, args ...string) (string, string, error) {
-			return "", "kustomize: no such file or directory", fmt.Errorf("exit status 1")
+		m.shell.ExecCaptureWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			return "", fmt.Errorf("exit status 1")
 		}
 		s := newTestFluxStack(m)
 
@@ -322,10 +322,10 @@ func TestFluxStack_Plan(t *testing.T) {
 		}
 		var capturedCommand string
 		var capturedArgs []string
-		m.shims.ExecCommand = func(command string, args ...string) (string, string, error) {
+		m.shell.ExecCaptureWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
 			capturedCommand = command
 			capturedArgs = args
-			return "rendered: yaml", "", nil
+			return "rendered: yaml", nil
 		}
 		s := newTestFluxStack(m)
 
@@ -361,8 +361,8 @@ func TestFluxStack_Plan(t *testing.T) {
 			capturedKustomizationYAML = string(data)
 			return nil
 		}
-		m.shims.ExecCommand = func(command string, args ...string) (string, string, error) {
-			return "rendered: yaml", "", nil
+		m.shell.ExecCaptureWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			return "rendered: yaml", nil
 		}
 		s := newTestFluxStack(m)
 
@@ -426,11 +426,11 @@ func TestFluxStack_Plan(t *testing.T) {
 			},
 		}
 		var capturedBuildPath string
-		m.shims.ExecCommand = func(command string, args ...string) (string, string, error) {
+		m.shell.ExecCaptureWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
 			if command == "kustomize" && len(args) >= 2 && args[0] == "build" {
 				capturedBuildPath = args[1]
 			}
-			return "rendered: yaml", "", nil
+			return "rendered: yaml", nil
 		}
 		s := newTestFluxStack(m)
 
@@ -454,13 +454,13 @@ func TestFluxStack_PlanAll(t *testing.T) {
 		// Given a blueprint with multiple kustomizations
 		m := setupFluxMocks(t)
 		var calledNames []string
-		m.shims.ExecCommand = func(command string, args ...string) (string, string, error) {
+		m.shell.ExecCaptureWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
 			for i, a := range args {
 				if a == "kustomization" && i+1 < len(args) {
 					calledNames = append(calledNames, args[i+1])
 				}
 			}
-			return "", "", nil
+			return "", nil
 		}
 		s := newTestFluxStack(m)
 
@@ -490,9 +490,9 @@ func TestFluxStack_PlanAll(t *testing.T) {
 			Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "cleanup", DestroyOnly: &destroyOnly}},
 		}
 		var callCount int
-		m.shims.ExecCommand = func(command string, args ...string) (string, string, error) {
+		m.shell.ExecCaptureWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
 			callCount++
-			return "", "", nil
+			return "", nil
 		}
 		s := newTestFluxStack(m)
 
@@ -613,13 +613,13 @@ func TestFluxStack_PlanSummary(t *testing.T) {
 	t.Run("ParsesDiffLinesForExistingKustomization", func(t *testing.T) {
 		// Given an existing kustomization that returns a unified diff with additions and removals
 		m := setupFluxMocks(t)
-		m.shims.ExecCommand = func(command string, args ...string) (string, string, error) {
+		m.shell.ExecCaptureWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
 			if command == "flux" {
 				// Exit code 1 means changes detected — real *exec.ExitError required for errors.As
 				diff := "--- a/deploy.yaml\n+++ b/deploy.yaml\n@@ -1,3 +1,4 @@\n+added line\n-removed line\n unchanged\n"
-				return diff, "", exitError(t, 1)
+				return diff, exitError(t, 1)
 			}
-			return "", "", nil
+			return "", nil
 		}
 		s := newTestFluxStack(m)
 
@@ -648,11 +648,11 @@ func TestFluxStack_PlanSummary(t *testing.T) {
 		m.kubernetesManager.KustomizationExistsFunc = func(name, namespace string) (bool, error) {
 			return false, fmt.Errorf("connection refused")
 		}
-		m.shims.ExecCommand = func(command string, args ...string) (string, string, error) {
+		m.shell.ExecCaptureWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
 			if command == "kustomize" {
-				return "apiVersion: v1\nkind: Namespace\n", "", nil
+				return "apiVersion: v1\nkind: Namespace\n", nil
 			}
-			return "", "", nil
+			return "", nil
 		}
 		s := newTestFluxStack(m)
 
@@ -678,11 +678,11 @@ func TestFluxStack_PlanSummary(t *testing.T) {
 		m.kubernetesManager.KustomizationExistsFunc = func(name, namespace string) (bool, error) {
 			return false, nil
 		}
-		m.shims.ExecCommand = func(command string, args ...string) (string, string, error) {
+		m.shell.ExecCaptureWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
 			if command == "kustomize" {
-				return "apiVersion: v1\nkind: Namespace\n---\napiVersion: apps/v1\nkind: Deployment\n", "", nil
+				return "apiVersion: v1\nkind: Namespace\n---\napiVersion: apps/v1\nkind: Deployment\n", nil
 			}
-			return "", "", nil
+			return "", nil
 		}
 		s := newTestFluxStack(m)
 
@@ -752,11 +752,11 @@ func TestFluxStack_PlanSummary(t *testing.T) {
 	t.Run("RecordsErrorWhenFluxDiffFails", func(t *testing.T) {
 		// Given an existing kustomization where flux diff fails with a non-1 exit code
 		m := setupFluxMocks(t)
-		m.shims.ExecCommand = func(command string, args ...string) (string, string, error) {
+		m.shell.ExecCaptureWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
 			if command == "flux" {
-				return "", "unexpected error", exitError(t, 2)
+				return "", exitError(t, 2)
 			}
-			return "", "", nil
+			return "", nil
 		}
 		s := newTestFluxStack(m)
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change touches only the Flux provisioner's internal command execution path and carries no API or user-facing contract changes.
>
> **Overview**
>
> The PR removes the bespoke `ExecCommand` shim from the Flux provisioner and routes all `flux` and `kustomize` subprocess calls through the shared `Shell.ExecCaptureWithEnv` abstraction already used by the Terraform provisioner. This consolidates subprocess execution into a single, tested layer and shrinks `shims.go` by ~20 lines. All tests are updated to mock `ExecCaptureWithEnvFunc` on `MockShell` rather than the removed shim field.
>
> The substantive behavioral improvement is that stderr from failing `flux`/`kustomize` invocations is now passed through the shell's secret-scrubbing pipeline before being embedded in error messages. Previously stderr was appended to errors verbatim, which meant any sensitive material in subprocess stderr could leak into logs or user-visible output.
>
> Reviewed by Claude for commit `13c9ed70`.

<!-- /claude-code-review:summary -->
