### PR TITLE
fix(secrets): close scrub registration coverage gaps

### DIFF
--- a/pkg/runtime/env/env.go
+++ b/pkg/runtime/env/env.go
@@ -18,7 +18,12 @@ import (
 // Types
 // =============================================================================
 
-// EnvPrinter defines the method for printing environment variables.
+// EnvPrinter defines the method for printing environment variables. Secret-scrubbing contract:
+// only values resolved through the evaluator's secret() expression are scrub-protected (the
+// resolver in pkg/runtime/secrets calls shell.RegisterSecret automatically at resolve time). A
+// printer setting literal credential material directly, not via secret(), must call
+// shell.RegisterSecret itself; none of the provider printers do today, since none currently emit
+// raw credentials — only identifiers, paths, and config, with the actual secret left to secrets.
 type EnvPrinter interface {
 	GetEnvVars() (map[string]string, error)
 	GetAlias() (map[string]string, error)

--- a/pkg/runtime/env/windsor_env.go
+++ b/pkg/runtime/env/windsor_env.go
@@ -117,6 +117,7 @@ func (e *WindsorEnvPrinter) GetEnvVars() (map[string]string, error) {
 					e.SetManagedEnv(k)
 				}
 				if e.shouldUseCache() && !strings.Contains(existingValue, "<ERROR") {
+					e.shell.RegisterSecret(existingValue)
 					continue
 				}
 			}

--- a/pkg/runtime/env/windsor_env_test.go
+++ b/pkg/runtime/env/windsor_env_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -184,6 +185,11 @@ func TestWindsorEnv_GetEnvVars(t *testing.T) {
 		printer := NewWindsorEnvPrinter(mocks.Shell, mocks.ConfigHandler, mockEval, []EnvPrinter{})
 		printer.shims = mocks.Shims
 
+		var registeredSecrets []string
+		mocks.Shell.RegisterSecretFunc = func(value string) {
+			registeredSecrets = append(registeredSecrets, value)
+		}
+
 		t.Setenv("NO_CACHE", "0")
 		t.Setenv("SECRET_VAR", "cached_value")
 		t.Setenv("WINDSOR_MANAGED_ENV", "")
@@ -213,6 +219,11 @@ contexts:
 		managedEnv := envVars["WINDSOR_MANAGED_ENV"]
 		if !strings.Contains(managedEnv, "SECRET_VAR") {
 			t.Error("Expected SECRET_VAR to be in managed env when caching is enabled")
+		}
+
+		// And the reused cached value should still be registered for scrubbing
+		if !slices.Contains(registeredSecrets, "cached_value") {
+			t.Errorf("Expected cached_value to be registered as a secret, got %v", registeredSecrets)
 		}
 	})
 

--- a/pkg/runtime/shell/shell_test.go
+++ b/pkg/runtime/shell/shell_test.go
@@ -937,6 +937,50 @@ func TestShell_ExecSudo(t *testing.T) {
 		}
 	})
 
+	t.Run("ScrubsSecretsFromInteractiveStderr", func(t *testing.T) {
+		// Given a shell with a registered secret and a real pipe standing in for /dev/tty
+		shell, mocks := setup(t)
+		shell.RegisterSecret("supersecretvalue")
+
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("failed to create pipe: %v", err)
+		}
+		defer r.Close()
+
+		mocks.Shims.Command = func(name string, args ...string) *exec.Cmd {
+			return &exec.Cmd{Path: name, Args: append([]string{name}, args...)}
+		}
+		mocks.Shims.CmdStart = func(cmd *exec.Cmd) error {
+			// Simulate the sudo'd child echoing a secret-bearing line to its interactive stderr.
+			_, writeErr := cmd.Stderr.Write([]byte("password for supersecretvalue accepted\n"))
+			return writeErr
+		}
+		mocks.Shims.CmdWait = func(cmd *exec.Cmd) error { return nil }
+		mocks.Shims.OpenFile = func(name string, flag int, perm os.FileMode) (*os.File, error) {
+			if name == "/dev/tty" {
+				return w, nil
+			}
+			return nil, fmt.Errorf("unexpected file: %s", name)
+		}
+
+		// When executing a sudo command
+		if _, err := shell.ExecSudo("Running test", "test", "arg"); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Then the registered secret never reaches what was written to the tty
+		buf := make([]byte, 4096)
+		n, _ := r.Read(buf)
+		got := string(buf[:n])
+		if strings.Contains(got, "supersecretvalue") {
+			t.Errorf("expected secret scrubbed from tty stderr, got %q", got)
+		}
+		if !strings.Contains(got, "********") {
+			t.Errorf("expected masked placeholder in tty stderr, got %q", got)
+		}
+	})
+
 	t.Run("CommandNil", func(t *testing.T) {
 		// Given a shell with Command returning nil
 		shell, mocks := setup(t)

--- a/pkg/runtime/shell/unix_shell.go
+++ b/pkg/runtime/shell/unix_shell.go
@@ -67,9 +67,9 @@ func (s *DefaultShell) RenderAliases(aliases map[string]string) string {
 // ExecSudo runs a command with 'sudo', ensuring elevated privileges. It handles password prompts by
 // connecting to the terminal and captures the command's output. If verbose mode is enabled or no TTY
 // is available (CI/CD environments), it uses direct execution. Otherwise, it connects to /dev/tty for
-// interactive password prompts; the child's stderr is routed through a scrubbingWriter (line-buffered,
-// flushed once the command completes) so registered secrets never reach the terminal raw. The function
-// returns the command's stdout or an error if execution fails.
+// interactive password prompts; the child's stderr is routed through a scrubbingWriter, buffered by
+// line and flushed once the command completes, so registered secrets never reach the terminal raw —
+// a child streaming \r-only progress on stderr won't appear live until it emits \n or exits.
 func (s *DefaultShell) ExecSudo(message string, command string, args ...string) (string, error) {
 	if command != "sudo" {
 		args = append([]string{command}, args...)

--- a/pkg/runtime/shell/unix_shell.go
+++ b/pkg/runtime/shell/unix_shell.go
@@ -67,7 +67,9 @@ func (s *DefaultShell) RenderAliases(aliases map[string]string) string {
 // ExecSudo runs a command with 'sudo', ensuring elevated privileges. It handles password prompts by
 // connecting to the terminal and captures the command's output. If verbose mode is enabled or no TTY
 // is available (CI/CD environments), it uses direct execution. Otherwise, it connects to /dev/tty for
-// interactive password prompts. The function returns the command's stdout or an error if execution fails.
+// interactive password prompts; the child's stderr is routed through a scrubbingWriter (line-buffered,
+// flushed once the command completes) so registered secrets never reach the terminal raw. The function
+// returns the command's stdout or an error if execution fails.
 func (s *DefaultShell) ExecSudo(message string, command string, args ...string) (string, error) {
 	if command != "sudo" {
 		args = append([]string{command}, args...)
@@ -105,7 +107,9 @@ func (s *DefaultShell) ExecSudo(message string, command string, args ...string) 
 	defer tty.Close()
 
 	cmd.Stdin = tty
-	cmd.Stderr = tty
+	scrubbingTTYWriter := &scrubbingWriter{writer: tty, scrubFunc: s.scrubString}
+	defer func() { _ = scrubbingTTYWriter.Flush() }()
+	cmd.Stderr = scrubbingTTYWriter
 
 	var stdoutBuf bytes.Buffer
 	cmd.Stdout = &stdoutBuf


### PR DESCRIPTION
Closes #3094

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This PR tightens secret scrubbing across two shared runtime paths — environment variable caching and interactive sudo execution — making the change Medium risk due to its effect on the shell's security-critical scrub pipeline.
>
> **Overview**
>
> The PR fixes two gaps where registered secrets could escape scrubbing: cached secret env-var values (skipped by the `continue` path in `WindsorEnvPrinter.GetEnvVars`) were not being passed to `shell.RegisterSecret`, so a warm-cache run would omit them from the scrub list; and `ExecSudo` wrote the child's stderr directly to `/dev/tty`, bypassing the `scrubbingWriter` that guards every other exec path. Both are now fixed: `RegisterSecret` is called on the cached value before `continue`, and `cmd.Stderr` is routed through a `scrubbingWriter` wrapping the TTY with a deferred `Flush` after `CmdWait`.
>
> The `scrubbingWriter` is line-buffered by design, which means stderr output from the sudo-wrapped command is now held until a newline arrives rather than streamed byte-by-byte to the terminal. Sudo's own password prompt goes to `/dev/tty` directly (not through `cmd.Stderr`) and is unaffected, but other partial-line stderr output from long-running subcommands will be delayed until line completion or command exit.
>
> Reviewed by Claude for commit `705520a5`.

<!-- /claude-code-review:summary -->
