### PR TITLE
fix(apply): add k8s alias to apply kustomize

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -151,8 +151,9 @@ windsor apply tf cluster`,
 }
 
 var applyKustomizeCmd = &cobra.Command{
-	Use:   "kustomize [name]",
-	Short: "Apply Flux kustomization(s) to the cluster.",
+	Use:     "kustomize [name]",
+	Aliases: []string{"k8s"},
+	Short:   "Apply Flux kustomization(s) to the cluster.",
 	Long: `Apply a single Flux kustomization to the cluster by name, or all kustomizations when no argument is given.
 
 When a name is supplied with --wait, the wait scope is narrowed to only that kustomization.`,
@@ -161,6 +162,9 @@ windsor apply kustomize
 
 # Apply just the dns kustomization
 windsor apply kustomize dns
+
+# Same, using the 'k8s' alias
+windsor apply k8s dns
 
 # Apply and wait for one kustomization to be ready
 windsor apply kustomize dns --wait`,

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -632,6 +633,13 @@ func TestApplyKustomizeCmd(t *testing.T) {
 
 	suppressProcessStdout(t)
 	suppressProcessStderr(t)
+
+	t.Run("HasK8sAlias", func(t *testing.T) {
+		// Matches the 'k8s' alias already on plan kustomize and destroy kustomize.
+		if !slices.Contains(applyKustomizeCmd.Aliases, "k8s") {
+			t.Errorf("expected 'k8s' alias on apply kustomize, got %v", applyKustomizeCmd.Aliases)
+		}
+	})
 
 	t.Run("SuccessAll", func(t *testing.T) {
 		// Given a properly configured apply kustomize command with no argument

--- a/docs/reference/commands/apply-kustomize.md
+++ b/docs/reference/commands/apply-kustomize.md
@@ -27,6 +27,9 @@ windsor apply kustomize
 # Apply just the dns kustomization
 windsor apply kustomize dns
 
+# Same, using the 'k8s' alias
+windsor apply k8s dns
+
 # Apply and wait for one kustomization to be ready
 windsor apply kustomize dns --wait
 ```


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Additive alias registration on a single command; existing behavior is unchanged and the change is trivially reversible.
>
> **Overview**
>
> This PR adds `k8s` as a Cobra alias for `apply kustomize`, closing a symmetry gap with `plan kustomize` and `destroy kustomize`, which already carry that alias. The command struct is extended with one field, the help text gains an example, and the reference docs are updated to match.
>
> A focused unit test verifies the alias is registered by inspecting `applyKustomizeCmd.Aliases` directly. No routing logic or flags are touched.
>
> Reviewed by Claude for commit `7c991ff2`.

<!-- /claude-code-review:summary -->
