### PR TITLE
fix(secrets): harden secret scrub matcher

### DIFF
--- a/pkg/runtime/shell/scrubbing_writer.go
+++ b/pkg/runtime/shell/scrubbing_writer.go
@@ -13,14 +13,15 @@ import (
 // secret containing a literal newline, e.g. a PEM key, be split across separate emitted lines
 // and never matched whole), every Write re-scrubs the *entire* pending buffer up front — so a
 // complete secret occurrence is masked regardless of where it falls, not just at the tail — and
-// only then withholds the trailing holdBack() bytes of the (already-scrubbed) result, enough to
-// guarantee a secret still arriving across a future Write can't have a partial prefix released
-// early. Flush must be called once the source command completes to emit the final withheld bytes.
+// only then withholds the trailing bytes of the (already-scrubbed) result up to the longest
+// registered secret's length, enough to guarantee a secret still arriving across a future Write
+// can't have a partial prefix released early. scrubWithMaxLen returns both the scrubbed text and
+// that length from a single locked snapshot, so the two can never observe different secret sets.
+// Flush must be called once the source command completes to emit the final withheld bytes.
 type scrubbingWriter struct {
-	writer    io.Writer
-	scrubFunc func(string) string
-	holdBack  func() int
-	pending   []byte
+	writer          io.Writer
+	scrubWithMaxLen func(string) (string, int)
+	pending         []byte
 }
 
 // =============================================================================
@@ -28,22 +29,18 @@ type scrubbingWriter struct {
 // =============================================================================
 
 // Write appends incoming bytes to the pending buffer, scrubs the buffer as a whole, and emits
-// everything except the trailing holdBack() bytes of the scrubbed result — keeping those held-back
+// everything except the trailing hold-back bytes of the scrubbed result — keeping those held-back
 // bytes (mostly raw, since only already-complete matches were replaced) as the new pending, so a
 // secret split across Write calls still gets matched once fully arrived. The full length of p is
 // always reported consumed so the writer composes cleanly under io.MultiWriter.
 func (sw *scrubbingWriter) Write(p []byte) (n int, err error) {
 	sw.pending = append(sw.pending, p...)
 
-	hold := 0
-	if sw.holdBack != nil {
-		hold = sw.holdBack()
-	}
+	scrubbed, hold := sw.scrubWithMaxLen(string(sw.pending))
 	if hold < 0 {
 		hold = 0
 	}
 
-	scrubbed := sw.scrubFunc(string(sw.pending))
 	if emitLen := len(scrubbed) - hold; emitLen > 0 {
 		if _, err := sw.writer.Write([]byte(scrubbed[:emitLen])); err != nil {
 			return 0, err
@@ -63,7 +60,7 @@ func (sw *scrubbingWriter) Flush() error {
 	if len(sw.pending) == 0 {
 		return nil
 	}
-	out := sw.scrubFunc(string(sw.pending))
+	out, _ := sw.scrubWithMaxLen(string(sw.pending))
 	sw.pending = nil
 	_, err := sw.writer.Write([]byte(out))
 	return err

--- a/pkg/runtime/shell/scrubbing_writer.go
+++ b/pkg/runtime/shell/scrubbing_writer.go
@@ -1,7 +1,6 @@
 package shell
 
 import (
-	"bytes"
 	"io"
 )
 
@@ -10,13 +9,17 @@ import (
 // =============================================================================
 
 // scrubbingWriter wraps an io.Writer and masks values registered via RegisterSecret before
-// writing streamed output to the terminal. Output is buffered by line so a secret split
-// across multiple Write calls (e.g. at a buffer boundary) is still matched as a whole
-// value; Flush must be called once the source command completes to emit any trailing
-// partial line.
+// writing streamed output to the terminal. Rather than buffering by line (which would let a
+// secret containing a literal newline, e.g. a PEM key, be split across separate emitted lines
+// and never matched whole), every Write re-scrubs the *entire* pending buffer up front — so a
+// complete secret occurrence is masked regardless of where it falls, not just at the tail — and
+// only then withholds the trailing holdBack() bytes of the (already-scrubbed) result, enough to
+// guarantee a secret still arriving across a future Write can't have a partial prefix released
+// early. Flush must be called once the source command completes to emit the final withheld bytes.
 type scrubbingWriter struct {
 	writer    io.Writer
 	scrubFunc func(string) string
+	holdBack  func() int
 	pending   []byte
 }
 
@@ -24,38 +27,44 @@ type scrubbingWriter struct {
 // Methods
 // =============================================================================
 
-// Write buffers incoming bytes and emits complete lines once their newline arrives, holding
-// any trailing partial line until the next Write or Flush. The full length of p is always
-// reported consumed so the writer composes cleanly under io.MultiWriter.
+// Write appends incoming bytes to the pending buffer, scrubs the buffer as a whole, and emits
+// everything except the trailing holdBack() bytes of the scrubbed result — keeping those held-back
+// bytes (mostly raw, since only already-complete matches were replaced) as the new pending, so a
+// secret split across Write calls still gets matched once fully arrived. The full length of p is
+// always reported consumed so the writer composes cleanly under io.MultiWriter.
 func (sw *scrubbingWriter) Write(p []byte) (n int, err error) {
 	sw.pending = append(sw.pending, p...)
-	for {
-		i := bytes.IndexByte(sw.pending, '\n')
-		if i < 0 {
-			break
-		}
-		line := string(sw.pending[:i+1])
-		sw.pending = sw.pending[i+1:]
-		if err := sw.emit(line); err != nil {
+
+	hold := 0
+	if sw.holdBack != nil {
+		hold = sw.holdBack()
+	}
+	if hold < 0 {
+		hold = 0
+	}
+
+	scrubbed := sw.scrubFunc(string(sw.pending))
+	if emitLen := len(scrubbed) - hold; emitLen > 0 {
+		if _, err := sw.writer.Write([]byte(scrubbed[:emitLen])); err != nil {
 			return 0, err
 		}
+		sw.pending = []byte(scrubbed[emitLen:])
+	} else {
+		sw.pending = []byte(scrubbed)
 	}
+
 	return len(p), nil
 }
 
-// Flush emits any buffered partial line. It is called after the source command finishes so a
-// final line without a trailing newline is not dropped.
+// Flush emits any remaining withheld bytes, scrubbing them once more first since Write only
+// scrubs on arrival of new data. It is called after the source command finishes so trailing
+// output that never exceeded the hold-back window is not dropped.
 func (sw *scrubbingWriter) Flush() error {
 	if len(sw.pending) == 0 {
 		return nil
 	}
-	line := string(sw.pending)
+	out := sw.scrubFunc(string(sw.pending))
 	sw.pending = nil
-	return sw.emit(line)
-}
-
-// emit applies the registered-secret denylist to a line and writes the result.
-func (sw *scrubbingWriter) emit(line string) error {
-	_, err := sw.writer.Write([]byte(sw.scrubFunc(line)))
+	_, err := sw.writer.Write([]byte(out))
 	return err
 }

--- a/pkg/runtime/shell/scrubbing_writer_test.go
+++ b/pkg/runtime/shell/scrubbing_writer_test.go
@@ -7,7 +7,9 @@ import (
 )
 
 func TestScrubbingWriter_Write(t *testing.T) {
-	// setup builds a scrubbingWriter over a buffer with the given registered secrets.
+	// setup builds a scrubbingWriter over a buffer with the given registered secrets, holding
+	// back a window sized to the longest secret — mirroring how DefaultShell.newScrubbingWriter
+	// wires holdBack to maxSecretLen in production.
 	setup := func(secrets ...string) (*scrubbingWriter, *bytes.Buffer) {
 		var sink bytes.Buffer
 		scrub := func(in string) string {
@@ -17,81 +19,124 @@ func TestScrubbingWriter_Write(t *testing.T) {
 			}
 			return out
 		}
-		return &scrubbingWriter{writer: &sink, scrubFunc: scrub}, &sink
+		maxLen := 0
+		for _, sec := range secrets {
+			if len(sec) > maxLen {
+				maxLen = len(sec)
+			}
+		}
+		return &scrubbingWriter{writer: &sink, scrubFunc: scrub, holdBack: func() int { return maxLen }}, &sink
 	}
 
-	t.Run("BuffersPartialLineUntilFlush", func(t *testing.T) {
-		// Given a line delivered without a trailing newline
+	t.Run("StreamsImmediatelyWhenNoSecretsRegistered", func(t *testing.T) {
+		// Given no registered secrets, so there's nothing to hold back for
 		sw, sink := setup()
 
-		// When a partial line is written
+		// When a partial line (no trailing newline) is written
 		if _, err := sw.Write([]byte("no newline yet")); err != nil {
 			t.Fatalf("unexpected write error: %v", err)
 		}
 
-		// Then nothing is emitted until Flush
+		// Then it streams straight through without waiting for Flush
+		if sink.String() != "no newline yet" {
+			t.Errorf("Expected immediate passthrough, got %q", sink.String())
+		}
+	})
+
+	t.Run("HoldsBackTrailingWindowSizedToLongestSecret", func(t *testing.T) {
+		// Given a registered secret, so a hold-back window applies
+		sw, sink := setup("s3cr3t12")
+
+		// When a write arrives that doesn't yet exceed the hold-back window
+		if _, err := sw.Write([]byte("short")); err != nil {
+			t.Fatalf("unexpected write error: %v", err)
+		}
+
+		// Then nothing is released yet
 		if sink.Len() != 0 {
-			t.Errorf("Expected no output before flush, got %q", sink.String())
+			t.Errorf("Expected nothing emitted before exceeding hold-back window, got %q", sink.String())
 		}
 		if err := sw.Flush(); err != nil {
 			t.Fatalf("unexpected flush error: %v", err)
 		}
-		if sink.String() != "no newline yet" {
+		if sink.String() != "short" {
 			t.Errorf("Expected flushed content, got %q", sink.String())
 		}
 	})
 
 	t.Run("MasksSecretSplitAcrossWrites", func(t *testing.T) {
 		// Given a registered secret delivered across two separate Write calls
-		sw, sink := setup("s3cr3t")
+		sw, sink := setup("s3cr3t12")
 
 		// When the line is written in two chunks that split the secret
 		if _, err := sw.Write([]byte("value is s3")); err != nil {
 			t.Fatalf("unexpected write error: %v", err)
 		}
-		if _, err := sw.Write([]byte("cr3t here\n")); err != nil {
+		if _, err := sw.Write([]byte("cr3t12 here\n")); err != nil {
 			t.Fatalf("unexpected write error: %v", err)
+		}
+		if err := sw.Flush(); err != nil {
+			t.Fatalf("unexpected flush error: %v", err)
 		}
 
 		// Then the secret is still masked once the full line is assembled
-		if strings.Contains(sink.String(), "s3cr3t") {
+		if strings.Contains(sink.String(), "s3cr3t12") {
+			t.Errorf("Expected registered secret masked, got %q", sink.String())
+		}
+	})
+
+	t.Run("MasksSecretFollowedByMoreTrailingDataThanHoldBackWindow", func(t *testing.T) {
+		// Given a secret that appears mid-buffer, followed by more trailing bytes than the
+		// hold-back window alone would protect — regression case for a naive "hold back N
+		// trailing bytes without re-scrubbing the whole buffer first" implementation, which
+		// would slice straight through the secret instead of masking it whole.
+		sw, sink := setup("supersecretvalue")
+
+		if _, err := sw.Write([]byte("password for supersecretvalue accepted\n")); err != nil {
+			t.Fatalf("unexpected write error: %v", err)
+		}
+		if err := sw.Flush(); err != nil {
+			t.Fatalf("unexpected flush error: %v", err)
+		}
+
+		if strings.Contains(sink.String(), "supersecretvalue") {
 			t.Errorf("Expected registered secret masked, got %q", sink.String())
 		}
 	})
 
 	t.Run("AppliesRegisteredSecretDenylist", func(t *testing.T) {
 		// Given a writer with a registered secret
-		sw, sink := setup("s3cr3t")
+		sw, sink := setup("s3cr3t12")
 
 		// When a line containing the secret is written
-		if _, err := sw.Write([]byte("value is s3cr3t here\n")); err != nil {
+		if _, err := sw.Write([]byte("value is s3cr3t12 here\n")); err != nil {
 			t.Fatalf("unexpected write error: %v", err)
+		}
+		if err := sw.Flush(); err != nil {
+			t.Fatalf("unexpected flush error: %v", err)
 		}
 
 		// Then the registered secret is masked
-		if strings.Contains(sink.String(), "s3cr3t") {
+		if strings.Contains(sink.String(), "s3cr3t12") {
 			t.Errorf("Expected registered secret masked, got %q", sink.String())
 		}
 	})
 
 	t.Run("ReportsFullInputConsumedEvenWhenMaskingChangesLength", func(t *testing.T) {
 		// Given a writer with a registered secret shorter than its mask
-		sw, sink := setup("hi")
-		input := []byte("value is hi here\n")
+		sw, _ := setup("shorterthanmask")
+		input := []byte("value is shorterthanmask here\n")
 
 		// When the input is written
 		n, err := sw.Write(input)
 
 		// Then the writer reports the full input length consumed even though the masked
-		// output written to the sink is a different length
+		// output eventually written to the sink is a different length
 		if err != nil {
 			t.Fatalf("unexpected write error: %v", err)
 		}
 		if n != len(input) {
 			t.Errorf("Expected %d bytes consumed, got %d", len(input), n)
-		}
-		if sink.Len() == len(input) {
-			t.Errorf("expected masked output length to differ from input length, got equal %q", sink.String())
 		}
 	})
 }

--- a/pkg/runtime/shell/scrubbing_writer_test.go
+++ b/pkg/runtime/shell/scrubbing_writer_test.go
@@ -9,23 +9,21 @@ import (
 func TestScrubbingWriter_Write(t *testing.T) {
 	// setup builds a scrubbingWriter over a buffer with the given registered secrets, holding
 	// back a window sized to the longest secret — mirroring how DefaultShell.newScrubbingWriter
-	// wires holdBack to maxSecretLen in production.
+	// wires scrubWithMaxLen to scrubStringWithMaxLen in production.
 	setup := func(secrets ...string) (*scrubbingWriter, *bytes.Buffer) {
 		var sink bytes.Buffer
-		scrub := func(in string) string {
+		scrubWithMaxLen := func(in string) (string, int) {
 			out := in
+			maxLen := 0
 			for _, sec := range secrets {
 				out = strings.ReplaceAll(out, sec, "********")
+				if len(sec) > maxLen {
+					maxLen = len(sec)
+				}
 			}
-			return out
+			return out, maxLen
 		}
-		maxLen := 0
-		for _, sec := range secrets {
-			if len(sec) > maxLen {
-				maxLen = len(sec)
-			}
-		}
-		return &scrubbingWriter{writer: &sink, scrubFunc: scrub, holdBack: func() int { return maxLen }}, &sink
+		return &scrubbingWriter{writer: &sink, scrubWithMaxLen: scrubWithMaxLen}, &sink
 	}
 
 	t.Run("StreamsImmediatelyWhenNoSecretsRegistered", func(t *testing.T) {

--- a/pkg/runtime/shell/shell.go
+++ b/pkg/runtime/shell/shell.go
@@ -34,6 +34,11 @@ const MaxFolderSearchDepth = 10
 // SessionTokenPrefix is the prefix used for session token files
 const SessionTokenPrefix = ".session."
 
+// minRegisteredSecretLength is the shortest value RegisterSecret will add to the scrub denylist.
+// Short common words/values ("true", "1", "admin", "dev") carry no real confidentiality, and
+// scrubbing them would mangle unrelated output every time that substring happens to appear.
+const minRegisteredSecretLength = 8
+
 // =============================================================================
 // Types
 // =============================================================================
@@ -82,6 +87,7 @@ type DefaultShell struct {
 	sessionToken string
 	shims        *Shims
 	secrets      []string
+	secretsMu    sync.Mutex
 }
 
 // =============================================================================
@@ -182,8 +188,8 @@ func (s *DefaultShell) Exec(command string, args ...string) (string, error) {
 	cmd := s.shims.Command(command, args...)
 	var stdoutBuf, stderrBuf bytes.Buffer
 
-	scrubbingStdoutWriter := &scrubbingWriter{writer: os.Stdout, scrubFunc: s.scrubString}
-	scrubbingStderrWriter := &scrubbingWriter{writer: os.Stderr, scrubFunc: s.scrubString}
+	scrubbingStdoutWriter := s.newScrubbingWriter(os.Stdout)
+	scrubbingStderrWriter := s.newScrubbingWriter(os.Stderr)
 	defer func() { _ = scrubbingStdoutWriter.Flush() }()
 	defer func() { _ = scrubbingStderrWriter.Flush() }()
 
@@ -242,8 +248,8 @@ func (s *DefaultShell) ExecSilentWithEnv(command string, env map[string]string, 
 	}
 	cmd.Env = mergeEnvVars(s.shims.Environ(), env)
 	if s.verbose {
-		scrubbingStdoutWriter := &scrubbingWriter{writer: os.Stdout, scrubFunc: s.scrubString}
-		scrubbingStderrWriter := &scrubbingWriter{writer: os.Stderr, scrubFunc: s.scrubString}
+		scrubbingStdoutWriter := s.newScrubbingWriter(os.Stdout)
+		scrubbingStderrWriter := s.newScrubbingWriter(os.Stderr)
 		defer func() { _ = scrubbingStdoutWriter.Flush() }()
 		defer func() { _ = scrubbingStderrWriter.Flush() }()
 		cmd.Stdout = io.MultiWriter(scrubbingStdoutWriter, &stdoutBuf)
@@ -388,8 +394,8 @@ func (s *DefaultShell) ExecProgressWithEnv(message string, command string, env m
 			return "", fmt.Errorf("failed to create command")
 		}
 		var stdoutBuf, stderrBuf bytes.Buffer
-		scrubbingStdoutWriter := &scrubbingWriter{writer: os.Stdout, scrubFunc: s.scrubString}
-		scrubbingStderrWriter := &scrubbingWriter{writer: os.Stderr, scrubFunc: s.scrubString}
+		scrubbingStdoutWriter := s.newScrubbingWriter(os.Stdout)
+		scrubbingStderrWriter := s.newScrubbingWriter(os.Stderr)
 		defer func() { _ = scrubbingStdoutWriter.Flush() }()
 		defer func() { _ = scrubbingStderrWriter.Flush() }()
 		cmd.Stdout = io.MultiWriter(scrubbingStdoutWriter, &stdoutBuf)
@@ -717,13 +723,17 @@ func (s *DefaultShell) GetSessionToken() (string, error) {
 	return token, nil
 }
 
-// RegisterSecret adds a secret value to the internal list of secrets that will be scrubbed from all command output.
-// Empty strings are ignored to prevent unnecessary processing.
-// Duplicate values are automatically filtered out to maintain list efficiency.
+// RegisterSecret adds a secret value to the internal list of secrets that will be scrubbed from all
+// command output. Values shorter than minRegisteredSecretLength are ignored, since scrubbing a short
+// common substring mangles unrelated output while providing no real confidentiality. Duplicate values
+// are automatically filtered out to maintain list efficiency. Safe for concurrent use with scrubString.
 func (s *DefaultShell) RegisterSecret(value string) {
-	if value == "" {
+	if len(value) < minRegisteredSecretLength {
 		return
 	}
+
+	s.secretsMu.Lock()
+	defer s.secretsMu.Unlock()
 
 	if slices.Contains(s.secrets, value) {
 		return
@@ -841,16 +851,43 @@ func (s *DefaultShell) generateRandomString(length int) (string, error) {
 
 // scrubString replaces all registered secret values with fixed "********" strings for security.
 // It processes the input string and replaces any occurrence of registered secrets with asterisks.
-// This method is used internally by all command execution methods to prevent secret leakage in output.
+// This method is used internally by all command execution methods to prevent secret leakage in
+// output. Safe for concurrent use with RegisterSecret. Best-effort, exact-substring only: a
+// base64/URL-encoded/JSON-escaped transform of a registered value will not match.
 func (s *DefaultShell) scrubString(input string) string {
+	s.secretsMu.Lock()
+	secrets := slices.Clone(s.secrets)
+	s.secretsMu.Unlock()
+
 	result := input
-	for _, secret := range s.secrets {
+	for _, secret := range secrets {
 		if secret != "" {
 			result = strings.ReplaceAll(result, secret, "********")
 		}
 	}
 
 	return result
+}
+
+// maxSecretLen returns the length of the longest currently-registered secret, or 0 if none are
+// registered. Used by scrubbingWriter to size its hold-back window so a secret can never be split
+// across a streamed Write boundary.
+func (s *DefaultShell) maxSecretLen() int {
+	s.secretsMu.Lock()
+	defer s.secretsMu.Unlock()
+
+	maxLen := 0
+	for _, secret := range s.secrets {
+		if len(secret) > maxLen {
+			maxLen = len(secret)
+		}
+	}
+	return maxLen
+}
+
+// newScrubbingWriter builds a scrubbingWriter over w bound to this shell's registered secrets.
+func (s *DefaultShell) newScrubbingWriter(w io.Writer) *scrubbingWriter {
+	return &scrubbingWriter{writer: w, scrubFunc: s.scrubString, holdBack: s.maxSecretLen}
 }
 
 // PrintEnvVars is a platform-specific method that will be implemented by Unix/Windows-specific files

--- a/pkg/runtime/shell/shell.go
+++ b/pkg/runtime/shell/shell.go
@@ -869,25 +869,33 @@ func (s *DefaultShell) scrubString(input string) string {
 	return result
 }
 
-// maxSecretLen returns the length of the longest currently-registered secret, or 0 if none are
-// registered. Used by scrubbingWriter to size its hold-back window so a secret can never be split
-// across a streamed Write boundary.
-func (s *DefaultShell) maxSecretLen() int {
+// scrubStringWithMaxLen scrubs input identically to scrubString and, from that same locked
+// snapshot of registered secrets, also returns the longest secret's length. scrubbingWriter uses
+// this (rather than separate scrubString/maxSecretLen calls) so the hold-back window it sizes is
+// always computed from the exact secret set the scrub itself used — a RegisterSecret call landing
+// between two independently-locked calls could otherwise leave the window stale for one Write.
+func (s *DefaultShell) scrubStringWithMaxLen(input string) (string, int) {
 	s.secretsMu.Lock()
-	defer s.secretsMu.Unlock()
+	secrets := slices.Clone(s.secrets)
+	s.secretsMu.Unlock()
 
 	maxLen := 0
-	for _, secret := range s.secrets {
+	result := input
+	for _, secret := range secrets {
+		if secret != "" {
+			result = strings.ReplaceAll(result, secret, "********")
+		}
 		if len(secret) > maxLen {
 			maxLen = len(secret)
 		}
 	}
-	return maxLen
+
+	return result, maxLen
 }
 
 // newScrubbingWriter builds a scrubbingWriter over w bound to this shell's registered secrets.
 func (s *DefaultShell) newScrubbingWriter(w io.Writer) *scrubbingWriter {
-	return &scrubbingWriter{writer: w, scrubFunc: s.scrubString, holdBack: s.maxSecretLen}
+	return &scrubbingWriter{writer: w, scrubWithMaxLen: s.scrubStringWithMaxLen}
 }
 
 // PrintEnvVars is a platform-specific method that will be implemented by Unix/Windows-specific files

--- a/pkg/runtime/shell/shell_test.go
+++ b/pkg/runtime/shell/shell_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"text/template"
 	"time"
@@ -1317,12 +1318,12 @@ func TestShell_ExecSilentWithEnv(t *testing.T) {
 		// Given a shell with verbose mode and a registered secret
 		shell, mocks := setup(t)
 		shell.SetVerbosity(true)
-		shell.RegisterSecret("s3cr3t")
+		shell.RegisterSecret("s3cr3t123")
 
 		// Mock CmdRun to write a line containing the secret
 		mocks.Shims.CmdRun = func(cmd *exec.Cmd) error {
 			if cmd.Stdout != nil {
-				if _, err := cmd.Stdout.Write([]byte("output with s3cr3t inside\n")); err != nil {
+				if _, err := cmd.Stdout.Write([]byte("output with s3cr3t123 inside\n")); err != nil {
 					return fmt.Errorf("failed to write: %v", err)
 				}
 			}
@@ -1346,11 +1347,11 @@ func TestShell_ExecSilentWithEnv(t *testing.T) {
 			t.Errorf("Expected no error, got %v", err)
 		}
 		// And the secret is redacted in the return value
-		if strings.Contains(out, "s3cr3t") {
+		if strings.Contains(out, "s3cr3t123") {
 			t.Errorf("Expected secret to be redacted in return value, got %q", out)
 		}
 		// And the secret is redacted in terminal output
-		if strings.Contains(string(terminalOutput), "s3cr3t") {
+		if strings.Contains(string(terminalOutput), "s3cr3t123") {
 			t.Errorf("Expected secret to be redacted in terminal output, got %q", string(terminalOutput))
 		}
 	})
@@ -3826,15 +3827,15 @@ func TestShell_RegisterSecret(t *testing.T) {
 		shell, _ := setup(t)
 
 		// When registering multiple different secret values
-		shell.RegisterSecret("secret1")
-		shell.RegisterSecret("secret2")
-		shell.RegisterSecret("secret3")
+		shell.RegisterSecret("secret001")
+		shell.RegisterSecret("secret002")
+		shell.RegisterSecret("secret003")
 
 		// Then all secrets should be stored in the secrets list
 		if len(shell.secrets) != 3 {
 			t.Errorf("Expected 3 secrets, got %d", len(shell.secrets))
 		}
-		expectedSecrets := []string{"secret1", "secret2", "secret3"}
+		expectedSecrets := []string{"secret001", "secret002", "secret003"}
 		for i, expected := range expectedSecrets {
 			if shell.secrets[i] != expected {
 				t.Errorf("Expected secret[%d] to be '%s', got '%s'", i, expected, shell.secrets[i])
@@ -3855,6 +3856,21 @@ func TestShell_RegisterSecret(t *testing.T) {
 		}
 	})
 
+	t.Run("IgnoresValuesBelowMinimumLength", func(t *testing.T) {
+		// Given a shell instance with no registered secrets
+		shell, _ := setup(t)
+
+		// When registering common short values that carry no real confidentiality
+		for _, short := range []string{"true", "1", "admin", "dev"} {
+			shell.RegisterSecret(short)
+		}
+
+		// Then none are stored, since they're shorter than minRegisteredSecretLength
+		if len(shell.secrets) != 0 {
+			t.Errorf("Expected 0 secrets, got %d: %v", len(shell.secrets), shell.secrets)
+		}
+	})
+
 	t.Run("RegisterDuplicateSecrets", func(t *testing.T) {
 		// Given a shell instance with no registered secrets
 		shell, _ := setup(t)
@@ -3870,6 +3886,31 @@ func TestShell_RegisterSecret(t *testing.T) {
 		}
 		if shell.secrets[0] != "duplicate" {
 			t.Errorf("Expected secret to be 'duplicate', got '%s'", shell.secrets[0])
+		}
+	})
+
+	t.Run("ConcurrentRegisterAndScrubIsRaceFree", func(t *testing.T) {
+		// Given a shell instance, exercised the way ExecProgress's concurrent scanner
+		// goroutines and any in-flight RegisterSecret call would overlap in production
+		shell, _ := setup(t)
+
+		var wg sync.WaitGroup
+		for i := range 20 {
+			wg.Add(2)
+			go func(i int) {
+				defer wg.Done()
+				shell.RegisterSecret(fmt.Sprintf("concurrent-secret-%d", i))
+			}(i)
+			go func() {
+				defer wg.Done()
+				_ = shell.scrubString("some command output")
+			}()
+		}
+		wg.Wait()
+
+		// Then every registration landed without a torn read/write (run with -race to verify)
+		if len(shell.secrets) != 20 {
+			t.Errorf("Expected 20 secrets registered, got %d", len(shell.secrets))
 		}
 	})
 }
@@ -3902,12 +3943,12 @@ func TestShell_scrubString(t *testing.T) {
 	t.Run("ScrubMultipleSecrets", func(t *testing.T) {
 		// Given a shell with multiple registered secret values
 		shell, _ := setup(t)
-		shell.RegisterSecret("secret1")
-		shell.RegisterSecret("secret2")
-		shell.RegisterSecret("secret3")
+		shell.RegisterSecret("secret001")
+		shell.RegisterSecret("secret002")
+		shell.RegisterSecret("secret003")
 
 		// When scrubbing a string that contains multiple registered secrets
-		input := "First secret1, then secret2, finally secret3"
+		input := "First secret001, then secret002, finally secret003"
 		result := shell.scrubString(input)
 
 		// Then all secrets should be replaced with asterisks
@@ -3996,10 +4037,10 @@ func TestShell_scrubString(t *testing.T) {
 	t.Run("ScrubSecretMultipleOccurrences", func(t *testing.T) {
 		// Given a shell with a registered secret value
 		shell, _ := setup(t)
-		shell.RegisterSecret("secret")
+		shell.RegisterSecret("mysecret")
 
 		// When scrubbing a string where the same secret appears multiple times
-		input := "secret appears here and secret appears there, secret everywhere"
+		input := "mysecret appears here and mysecret appears there, mysecret everywhere"
 		result := shell.scrubString(input)
 
 		// Then all occurrences of the secret should be replaced with asterisks
@@ -4012,10 +4053,10 @@ func TestShell_scrubString(t *testing.T) {
 	t.Run("ScrubSecretPartialMatch", func(t *testing.T) {
 		// Given a shell with a registered secret value
 		shell, _ := setup(t)
-		shell.RegisterSecret("secret")
+		shell.RegisterSecret("mysecret")
 
 		// When scrubbing a string containing words that partially match the secret
-		input := "secretive and secrets contain secret"
+		input := "mysecretive and mysecrets contain mysecret"
 		result := shell.scrubString(input)
 
 		// Then all occurrences should be replaced using simple string replacement
@@ -4081,10 +4122,10 @@ func TestShell_scrubString(t *testing.T) {
 		// Given a shell with registered password and token secrets
 		shell, _ := setup(t)
 		shell.RegisterSecret("mypassword")
-		shell.RegisterSecret("mytoken")
+		shell.RegisterSecret("mytoken1")
 
 		// When scrubbing a JSON-formatted string containing secrets
-		input := `{"password": "mypassword", "token": "mytoken", "user": "admin"}`
+		input := `{"password": "mypassword", "token": "mytoken1", "user": "admin"}`
 		result := shell.scrubString(input)
 
 		// Then the secrets should be scrubbed while preserving JSON structure

--- a/pkg/runtime/shell/shell_test.go
+++ b/pkg/runtime/shell/shell_test.go
@@ -4168,6 +4168,50 @@ func TestShell_scrubString(t *testing.T) {
 	})
 }
 
+func TestShell_scrubStringWithMaxLen(t *testing.T) {
+	// setup creates a new shell with mocked dependencies for testing
+	setup := func(t *testing.T) *DefaultShell {
+		t.Helper()
+		setupShellMocks(t)
+		return NewDefaultShell()
+	}
+
+	t.Run("ReturnsScrubbedTextAndLongestSecretLengthFromOneSnapshot", func(t *testing.T) {
+		// Given a shell with secrets of different lengths registered
+		shell := setup(t)
+		shell.RegisterSecret("shortsecret")
+		shell.RegisterSecret("averylongregisteredsecretvalue")
+
+		// When scrubbing with the combined call
+		result, maxLen := shell.scrubStringWithMaxLen("value is shortsecret here")
+
+		// Then the text is scrubbed exactly as scrubString would, and maxLen reflects the
+		// longest secret from the same locked snapshot used for the scrub
+		if strings.Contains(result, "shortsecret") {
+			t.Errorf("Expected secret scrubbed, got %q", result)
+		}
+		if want := len("averylongregisteredsecretvalue"); maxLen != want {
+			t.Errorf("Expected maxLen %d, got %d", want, maxLen)
+		}
+	})
+
+	t.Run("ReturnsZeroMaxLenWhenNoSecretsRegistered", func(t *testing.T) {
+		// Given a shell with no registered secrets
+		shell := setup(t)
+
+		// When scrubbing with the combined call
+		result, maxLen := shell.scrubStringWithMaxLen("plain text")
+
+		// Then the text is unchanged and maxLen is zero
+		if result != "plain text" {
+			t.Errorf("Expected unchanged text, got %q", result)
+		}
+		if maxLen != 0 {
+			t.Errorf("Expected maxLen 0, got %d", maxLen)
+		}
+	})
+}
+
 func TestScrubbingWriter(t *testing.T) {
 	setup := func(t *testing.T) (*DefaultShell, *bytes.Buffer) {
 		t.Helper()
@@ -4186,7 +4230,7 @@ func TestScrubbingWriter(t *testing.T) {
 	t.Run("ScrubsSecretsFromOutput", func(t *testing.T) {
 		// Given a shell with registered secrets and a scrubbing writer configured
 		shell, buf := setup(t)
-		writer := &scrubbingWriter{writer: buf, scrubFunc: shell.scrubString}
+		writer := shell.newScrubbingWriter(buf)
 
 		// When writing a complete line that contains registered secrets to the scrubbing writer
 		testContent := "This contains secret123 and other text\n"
@@ -4214,7 +4258,7 @@ func TestScrubbingWriter(t *testing.T) {
 		// Given a shell with multiple registered secrets and a scrubbing writer
 		shell, buf := setup(t)
 		shell.RegisterSecret("password456")
-		writer := &scrubbingWriter{writer: buf, scrubFunc: shell.scrubString}
+		writer := shell.newScrubbingWriter(buf)
 
 		// When writing a complete line that contains multiple different secrets
 		testContent := "User secret123 has password456 for access\n"

--- a/pkg/runtime/shell/unix_shell.go
+++ b/pkg/runtime/shell/unix_shell.go
@@ -107,7 +107,7 @@ func (s *DefaultShell) ExecSudo(message string, command string, args ...string) 
 	defer tty.Close()
 
 	cmd.Stdin = tty
-	scrubbingTTYWriter := &scrubbingWriter{writer: tty, scrubFunc: s.scrubString}
+	scrubbingTTYWriter := s.newScrubbingWriter(tty)
 	defer func() { _ = scrubbingTTYWriter.Flush() }()
 	cmd.Stderr = scrubbingTTYWriter
 


### PR DESCRIPTION
Closes #3095

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Isolated security hardening of the command-output scrubbing subsystem; no user-visible behavior changes beyond output formatting, and all new paths are covered by tests.
>
> **Overview**
>
> The PR fixes three independent bugs in `pkg/runtime/shell/`: stream-split secret matching (previously line-buffered, so a secret buried mid-buffer or split across Write calls could slip through), concurrent access on the `secrets` slice (now guarded by a mutex shared between `RegisterSecret` and `scrubString`), and a minimum-length floor that prevents short, high-frequency substrings from being registered as secrets and mangling unrelated output. All `scrubbingWriter` construction sites are unified through a new `newScrubbingWriter` factory that wires a dynamic hold-back window sized to the longest registered secret.
>
> The behavioral change most likely to surprise existing callers is the `minRegisteredSecretLength = 8` floor: values shorter than 8 characters are now silently dropped by `RegisterSecret` rather than accepted. The commit documents this as intentional, but no callsite diagnostic is emitted.
>
> Reviewed by Claude for commit `fbc71946`.

<!-- /claude-code-review:summary -->
