### PR TITLE
fix(handler): ensure facet-derived values override raw context defaults

### DIFF
--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -922,6 +922,9 @@ func (h *BaseBlueprintHandler) loadNestedSources() error {
 // evaluated against the scope accumulated from the sources before it, so a downstream source can read
 // config an upstream source derived. After facet processing, sources are merged in the order:
 // initializer blueprints, other sources, then the user blueprint as a final override.
+// The final scope layers raw context values (config.yaml/schema defaults) as the base and the
+// ordinal-resolved facet scope as the overlay, so a facet's derived value always wins over an
+// unset or default context value instead of being silently clobbered by it.
 // The composed blueprint is updated on the handler. Terraform input expressions are fully evaluated
 // against the merged scope if possible. If a Terraform provider is configured, the composed components
 // are registered with the provider. Any errors during facet processing or composition are returned.
@@ -1020,6 +1023,9 @@ func (h *BaseBlueprintHandler) processAndCompose() error {
 	}
 
 	var mergedScope map[string]any
+	if contextValues := h.getConfigValues(); contextValues != nil {
+		mergedScope = MergeScopeMaps(mergedScope, contextValues)
+	}
 	for _, loader := range loaders {
 		name := loaderNames[loader]
 		if name == "" {
@@ -1028,9 +1034,6 @@ func (h *BaseBlueprintHandler) processAndCompose() error {
 		if scope, ok := collectedScopes[name]; ok && scope != nil {
 			mergedScope = MergeScopeMaps(mergedScope, scope)
 		}
-	}
-	if contextValues := h.getConfigValues(); contextValues != nil {
-		mergedScope = MergeScopeMaps(mergedScope, contextValues)
 	}
 
 	userPath := ""

--- a/pkg/composer/blueprint/handler_test.go
+++ b/pkg/composer/blueprint/handler_test.go
@@ -2536,6 +2536,62 @@ func TestHandler_processAndCompose(t *testing.T) {
 		}
 	})
 
+	t.Run("FacetDerivedConfigWinsOverRawContextValue", func(t *testing.T) {
+		// Given a raw context value (e.g. a schema default already reflected in config.yaml)
+		// for a key that a facet also derives
+		mocks := setupHandlerMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{
+				"talos_common": map[string]any{"k8s_service_host": "raw-default"},
+			}, nil
+		}
+		handler := NewBlueprintHandler(mocks.Runtime, mocks.ArtifactBuilder)
+
+		templateBp := &blueprintv1alpha1.Blueprint{}
+		handler.sourceBlueprintLoaders["template"] = &mockLoaderImpl{
+			getBlueprintFunc:  func() *blueprintv1alpha1.Blueprint { return templateBp },
+			getSourceNameFunc: func() string { return "template" },
+			getFacetsFunc: func() []blueprintv1alpha1.Facet {
+				return []blueprintv1alpha1.Facet{
+					{
+						Metadata: blueprintv1alpha1.Metadata{Name: "override-facet"},
+						Config: []blueprintv1alpha1.ConfigBlock{
+							{
+								Name: "talos_common",
+								Body: map[string]any{"value": map[string]any{"k8s_service_host": "override-value"}},
+							},
+						},
+					},
+				}
+			},
+		}
+		trueVal := true
+		handler.userBlueprintLoader = &mockLoaderImpl{
+			getBlueprintFunc: func() *blueprintv1alpha1.Blueprint {
+				return &blueprintv1alpha1.Blueprint{
+					Sources: []blueprintv1alpha1.Source{
+						{Name: "template", Install: &blueprintv1alpha1.BoolExpression{Value: &trueVal, IsExpr: false}},
+					},
+				}
+			},
+			getSourceNameFunc: func() string { return "user" },
+		}
+
+		// When processing and composing
+		if err := handler.processAndCompose(); err != nil {
+			t.Fatalf("processAndCompose failed: %v", err)
+		}
+
+		// Then the composed scope reflects the facet-derived value, not the raw context default
+		talosCommon, ok := handler.composedScope["talos_common"].(map[string]any)
+		if !ok {
+			t.Fatal("Expected composed scope to contain 'talos_common'")
+		}
+		if host := talosCommon["k8s_service_host"]; host != "override-value" {
+			t.Errorf("Expected facet-derived 'override-value' to win over raw context default, got %q", host)
+		}
+	})
+
 	t.Run("CallsSetConfigScopeWhenProviderExists", func(t *testing.T) {
 		// Given a handler with terraform provider and loaders
 		mocks := setupHandlerMocks(t)


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change fixes a merge-order bug in a single function inside the blueprint composer; it is isolated, well-tested, and fully reversible.
>
> **Overview**
>
> `processAndCompose` previously applied raw context values (config.yaml/schema defaults via `getConfigValues`) *after* iterating all source loaders, so any facet-derived value for the same key was silently overwritten by the raw default. The fix moves that merge to *before* the loader loop, establishing context values as the base layer while letting every loader — and therefore every facet — take precedence. The accompanying test exercises the exact regression scenario (facet derives `k8s_service_host: "override-value"` while context holds `k8s_service_host: "raw-default"`) and confirms the facet wins.
>
> No public API or CLI surface changes; the only observable difference is that facet-resolved values are no longer clobbered by schema/config defaults.

<!-- /claude-code-review:summary -->
