### PR TITLE
fix(composer): resolve context patches for FluxSystem tiers

### DIFF
--- a/pkg/composer/blueprint/composer.go
+++ b/pkg/composer/blueprint/composer.go
@@ -634,9 +634,15 @@ func (c *BaseBlueprintComposer) mergeLegacySpecialVariables(mergedCommonValues m
 }
 
 // discoverContextPatches discovers and adds patches from the context directory to kustomizations.
-// Patches are discovered from contexts/<context>/patches/<kustomization-name>/ and added to the
-// corresponding kustomization. Supports both strategic merge patches (standard Kubernetes YAML)
-// and JSON 6902 patches (with a patches field containing JSON 6902 operations).
+// Patches are discovered from contexts/<context>/patches/<name>/ and added to the corresponding
+// kustomize: entry or FluxSystem tier. <name> may be a plain kustomization name, a compiled tier
+// name ("<system>-install" or "<system>-resources[-<variant>]"), or a bare FluxSystem name — which
+// resolves to that system's install tier, or its lone resources variant when there is no install
+// tier and exactly one resources variant; a bare name is left unmatched when that would be
+// ambiguous, so the tier-qualified name must be used instead. A directory matching neither is
+// silently ignored (patches are opt-in overlays; an unrelated or stale directory is not an error).
+// Supports both strategic merge patches (standard Kubernetes YAML) and JSON 6902 patches (with a
+// patches field containing JSON 6902 operations).
 func (c *BaseBlueprintComposer) discoverContextPatches(blueprint *blueprintv1alpha1.Blueprint) error {
 	if c.runtime == nil || c.runtime.ConfigRoot == "" {
 		return nil
@@ -656,6 +662,7 @@ func (c *BaseBlueprintComposer) discoverContextPatches(blueprint *blueprintv1alp
 	for i := range blueprint.Kustomizations {
 		kustomizationMap[blueprint.Kustomizations[i].Name] = &blueprint.Kustomizations[i]
 	}
+	fluxTierMap := buildFluxTierMap(blueprint)
 
 	for _, entry := range entries {
 		if !entry.IsDir() {
@@ -664,6 +671,9 @@ func (c *BaseBlueprintComposer) discoverContextPatches(blueprint *blueprintv1alp
 
 		kustomizationName := entry.Name()
 		kustomization, exists := kustomizationMap[kustomizationName]
+		if !exists {
+			kustomization, exists = fluxTierMap[kustomizationName]
+		}
 		if !exists {
 			continue
 		}
@@ -702,6 +712,46 @@ func (c *BaseBlueprintComposer) discoverContextPatches(blueprint *blueprintv1alp
 	}
 
 	return nil
+}
+
+// buildFluxTierMap indexes a blueprint's FluxSystems by every name a context-patch directory may
+// use to target them: each compiled tier name ("<system>-install", "<system>-resources[-<variant>]")
+// always maps to that tier's Kustomization, and the bare system name additionally maps to the
+// install tier when present, or to the lone resources variant when there is no install tier and
+// exactly one resources variant. A bare name that could mean more than one tier (no install tier
+// with multiple resources variants) is left out of the map — the tier-qualified name must be used
+// instead. Returned pointers alias the blueprint's FluxSystems so callers can mutate tiers in place.
+func buildFluxTierMap(blueprint *blueprintv1alpha1.Blueprint) map[string]*blueprintv1alpha1.Kustomization {
+	tierMap := make(map[string]*blueprintv1alpha1.Kustomization)
+	for i := range blueprint.FluxSystems {
+		sys := &blueprint.FluxSystems[i]
+
+		var bareCandidate *blueprintv1alpha1.Kustomization
+		bareAmbiguous := false
+
+		if sys.Install != nil {
+			tierMap[sys.Name+"-install"] = sys.Install
+			bareCandidate = sys.Install
+		}
+
+		for j := range sys.Resources {
+			variantName := sys.Name + "-resources"
+			if sys.Resources[j].Name != "" {
+				variantName += "-" + sys.Resources[j].Name
+			}
+			tierMap[variantName] = &sys.Resources[j].Kustomization
+			if bareCandidate == nil {
+				bareCandidate = &sys.Resources[j].Kustomization
+			} else if sys.Install == nil {
+				bareAmbiguous = true
+			}
+		}
+
+		if bareCandidate != nil && !bareAmbiguous {
+			tierMap[sys.Name] = bareCandidate
+		}
+	}
+	return tierMap
 }
 
 // parsePatch parses a patch file and returns a BlueprintPatch. It detects whether the patch is

--- a/pkg/composer/blueprint/composer_test.go
+++ b/pkg/composer/blueprint/composer_test.go
@@ -2626,6 +2626,35 @@ spec:
 		}
 	})
 
+	t.Run("DiscoversPatchesForBareFluxSystemNameResolvingToLoneResourcesVariant", func(t *testing.T) {
+		// Given patches directly under the FluxSystem's bare name, with no install tier and
+		// exactly one resources variant, so the bare name resolves unambiguously
+		mocks := setupComposerMocks(t)
+		patchesDir := mocks.Runtime.ConfigRoot + "/patches/cni"
+		os.MkdirAll(patchesDir, 0755)
+		os.WriteFile(patchesDir+"/values.yaml", []byte("spec:\n  key: val\n"), 0644)
+		composer := NewBlueprintComposer(mocks.Runtime)
+		blueprint := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name:      "cni",
+					Resources: []blueprintv1alpha1.FluxVariant{{Kustomization: blueprintv1alpha1.Kustomization{}}},
+				},
+			},
+		}
+
+		// When discovering patches
+		err := composer.discoverContextPatches(blueprint)
+
+		// Then the bare name resolves to the lone resources variant
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if len(blueprint.FluxSystems[0].Resources[0].Patches) != 1 {
+			t.Fatalf("Expected 1 patch on lone resources variant via bare name, got %d", len(blueprint.FluxSystems[0].Resources[0].Patches))
+		}
+	})
+
 	t.Run("IgnoresBareFluxSystemNameWhenAmbiguousAcrossMultipleResourcesVariants", func(t *testing.T) {
 		// Given patches directly under a FluxSystem's bare name, but with no install tier and
 		// more than one resources variant, so the bare name cannot be resolved unambiguously

--- a/pkg/composer/blueprint/composer_test.go
+++ b/pkg/composer/blueprint/composer_test.go
@@ -2537,6 +2537,127 @@ spec:
 		}
 	})
 
+	t.Run("DiscoversPatchesForFluxSystemInstallTierName", func(t *testing.T) {
+		// Given patches under the compiled install-tier name for a FluxSystem
+		mocks := setupComposerMocks(t)
+		patchesDir := mocks.Runtime.ConfigRoot + "/patches/cni-install"
+		os.MkdirAll(patchesDir, 0755)
+		patchContent := "spec:\n  values:\n    key: val\n"
+		os.WriteFile(patchesDir+"/values.yaml", []byte(patchContent), 0644)
+		composer := NewBlueprintComposer(mocks.Runtime)
+		blueprint := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name:      "cni",
+					Install:   &blueprintv1alpha1.Kustomization{Components: []string{"cilium"}},
+					Resources: []blueprintv1alpha1.FluxVariant{{Kustomization: blueprintv1alpha1.Kustomization{}}},
+				},
+			},
+		}
+
+		// When discovering patches
+		err := composer.discoverContextPatches(blueprint)
+
+		// Then the patch is attached to the install tier
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if len(blueprint.FluxSystems[0].Install.Patches) != 1 {
+			t.Fatalf("Expected 1 patch on install tier, got %d", len(blueprint.FluxSystems[0].Install.Patches))
+		}
+	})
+
+	t.Run("DiscoversPatchesForFluxSystemResourcesVariantTierName", func(t *testing.T) {
+		// Given patches under a named resources variant's compiled tier name
+		mocks := setupComposerMocks(t)
+		patchesDir := mocks.Runtime.ConfigRoot + "/patches/cni-resources-l2"
+		os.MkdirAll(patchesDir, 0755)
+		os.WriteFile(patchesDir+"/values.yaml", []byte("spec:\n  key: val\n"), 0644)
+		composer := NewBlueprintComposer(mocks.Runtime)
+		blueprint := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name: "cni",
+					Resources: []blueprintv1alpha1.FluxVariant{
+						{Kustomization: blueprintv1alpha1.Kustomization{}},
+						{Kustomization: blueprintv1alpha1.Kustomization{Name: "l2"}},
+					},
+				},
+			},
+		}
+
+		// When discovering patches
+		err := composer.discoverContextPatches(blueprint)
+
+		// Then the patch is attached to the matching resources variant only
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if len(blueprint.FluxSystems[0].Resources[1].Patches) != 1 {
+			t.Fatalf("Expected 1 patch on 'l2' resources variant, got %d", len(blueprint.FluxSystems[0].Resources[1].Patches))
+		}
+		if len(blueprint.FluxSystems[0].Resources[0].Patches) != 0 {
+			t.Errorf("Expected unnamed resources variant to receive no patches, got %d", len(blueprint.FluxSystems[0].Resources[0].Patches))
+		}
+	})
+
+	t.Run("DiscoversPatchesForBareFluxSystemNameResolvingToInstallTier", func(t *testing.T) {
+		// Given patches directly under the FluxSystem's bare name, with only an install tier
+		mocks := setupComposerMocks(t)
+		patchesDir := mocks.Runtime.ConfigRoot + "/patches/cni"
+		os.MkdirAll(patchesDir, 0755)
+		os.WriteFile(patchesDir+"/values.yaml", []byte("spec:\n  key: val\n"), 0644)
+		composer := NewBlueprintComposer(mocks.Runtime)
+		blueprint := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{Name: "cni", Install: &blueprintv1alpha1.Kustomization{Components: []string{"cilium"}}},
+			},
+		}
+
+		// When discovering patches
+		err := composer.discoverContextPatches(blueprint)
+
+		// Then the bare name resolves to the install tier
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if len(blueprint.FluxSystems[0].Install.Patches) != 1 {
+			t.Fatalf("Expected 1 patch on install tier via bare name, got %d", len(blueprint.FluxSystems[0].Install.Patches))
+		}
+	})
+
+	t.Run("IgnoresBareFluxSystemNameWhenAmbiguousAcrossMultipleResourcesVariants", func(t *testing.T) {
+		// Given patches directly under a FluxSystem's bare name, but with no install tier and
+		// more than one resources variant, so the bare name cannot be resolved unambiguously
+		mocks := setupComposerMocks(t)
+		patchesDir := mocks.Runtime.ConfigRoot + "/patches/cni"
+		os.MkdirAll(patchesDir, 0755)
+		os.WriteFile(patchesDir+"/values.yaml", []byte("spec:\n  key: val\n"), 0644)
+		composer := NewBlueprintComposer(mocks.Runtime)
+		blueprint := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name: "cni",
+					Resources: []blueprintv1alpha1.FluxVariant{
+						{Kustomization: blueprintv1alpha1.Kustomization{Name: "a"}},
+						{Kustomization: blueprintv1alpha1.Kustomization{Name: "b"}},
+					},
+				},
+			},
+		}
+
+		// When discovering patches
+		err := composer.discoverContextPatches(blueprint)
+
+		// Then no variant receives the patch
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if len(blueprint.FluxSystems[0].Resources[0].Patches) != 0 || len(blueprint.FluxSystems[0].Resources[1].Patches) != 0 {
+			t.Error("Expected ambiguous bare name to be left unmatched")
+		}
+	})
+
 	t.Run("IgnoresPatchesForNonExistentKustomization", func(t *testing.T) {
 		// Given a composer with patches for kustomization that doesn't exist
 		mocks := setupComposerMocks(t)


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change extends an existing, additive discovery path inside the blueprint composer; unrecognized directory names are still silently skipped, so there is no regression surface for callers that do not use FluxSystem tiers.
>
> **Overview**
>
> The PR teaches `discoverContextPatches` to resolve patch directories against FluxSystem tiers in addition to plain kustomization names. A new `buildFluxTierMap` helper indexes each FluxSystem by its compiled tier names (`<system>-install`, `<system>-resources[-<variant>]`) and, where unambiguous, by the bare system name. The lookup is a pure fallback: the existing `kustomizationMap` check still runs first, and if neither map matches the directory is skipped as before.
>
> The bare-name disambiguation rule — install tier wins when present; lone resources variant wins when there is no install tier and exactly one variant; multiple variants with no install tier are left unmatched — is well-documented and covered by four new table-driven tests, though the "bare name → lone resources variant" path described in the comment is not exercised by any of those tests.

<!-- /claude-code-review:summary -->
