### PR TITLE
fix(upgrade): add offline timeout flag for node upgrades

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -222,6 +222,9 @@ windsor upgrade node --node=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.
 		if !cmd.Flags().Changed("offline-timeout") {
 			upgradeNodeOfflineTimeout = constants.DefaultNodeOfflineTimeout
 		}
+		if upgradeNodeTimeout > 0 && upgradeNodeOfflineTimeout > upgradeNodeTimeout {
+			return fmt.Errorf("--offline-timeout (%s) cannot exceed --timeout (%s)", upgradeNodeOfflineTimeout, upgradeNodeTimeout)
+		}
 
 		var rtOpts []*runtime.Runtime
 		if overridesVal := cmd.Context().Value(runtimeOverridesKey); overridesVal != nil {

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -25,9 +25,10 @@ var (
 	upgradeYes            bool
 	upgradeAllowDowngrade bool
 
-	upgradeNodeAddr    string
-	upgradeNodeImage   string
-	upgradeNodeTimeout time.Duration
+	upgradeNodeAddr           string
+	upgradeNodeImage          string
+	upgradeNodeTimeout        time.Duration
+	upgradeNodeOfflineTimeout time.Duration
 )
 
 var upgradeCmd = &cobra.Command{
@@ -203,8 +204,11 @@ var upgradeNodeCmd = &cobra.Command{
 	Example: `# Roll one node, blocking until it is healthy
 windsor upgrade node --node=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.0
 
-# Same with a longer timeout for slow rebooters
-windsor upgrade node --node=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.0 --timeout=20m`,
+# Same with a longer overall timeout for slow rebooters
+windsor upgrade node --node=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.0 --timeout=20m
+
+# Nested-virtualized platforms can take longer than 3m to go offline after the upgrade request
+windsor upgrade node --node=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.0 --offline-timeout=8m`,
 	Annotations: map[string]string{
 		"docs.seealso": "[`upgrade cluster`](upgrade-cluster.md)\n" +
 			"[`check node-health`](check-node-health.md)",
@@ -214,6 +218,9 @@ windsor upgrade node --node=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if !cmd.Flags().Changed("timeout") {
 			upgradeNodeTimeout = constants.DefaultNodeUpgradeTimeout
+		}
+		if !cmd.Flags().Changed("offline-timeout") {
+			upgradeNodeOfflineTimeout = constants.DefaultNodeOfflineTimeout
 		}
 
 		var rtOpts []*runtime.Runtime
@@ -249,7 +256,7 @@ windsor upgrade node --node=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.
 			fmt.Fprintln(cmd.OutOrStdout(), output)
 		}
 
-		if err := prov.UpgradeNode(ctx, upgradeNodeAddr, upgradeNodeImage, constants.DefaultNodeOfflineTimeout, outputFunc); err != nil {
+		if err := prov.UpgradeNode(ctx, upgradeNodeAddr, upgradeNodeImage, upgradeNodeOfflineTimeout, outputFunc); err != nil {
 			return fmt.Errorf("node upgrade failed: %w", err)
 		}
 
@@ -404,7 +411,8 @@ func init() {
 
 	upgradeNodeCmd.Flags().StringVar(&upgradeNodeAddr, "node", "", "Node IP address to upgrade. Required.")
 	upgradeNodeCmd.Flags().StringVar(&upgradeNodeImage, "image", "", "Talos image to upgrade to. Required.")
-	upgradeNodeCmd.Flags().DurationVar(&upgradeNodeTimeout, "timeout", 0, "Overall timeout. Default 10m.")
+	upgradeNodeCmd.Flags().DurationVar(&upgradeNodeTimeout, "timeout", 0, "Overall timeout for the whole upgrade, including the offline wait (see --offline-timeout). Default 10m.")
+	upgradeNodeCmd.Flags().DurationVar(&upgradeNodeOfflineTimeout, "offline-timeout", 0, "Timeout for the node to go offline after the upgrade request, before it's assumed rebooting. Raise this on slow-rebooting or nested-virtualized platforms. Default 3m.")
 	_ = upgradeNodeCmd.MarkFlagRequired("node")
 	_ = upgradeNodeCmd.MarkFlagRequired("image")
 }

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -917,4 +917,69 @@ func TestUpgradeNodeCmd(t *testing.T) {
 		}
 	})
 
+	t.Run("RejectsOfflineTimeoutExceedingOverallTimeout", func(t *testing.T) {
+		setup(t)
+		mockConfigHandler := config.NewMockConfigHandler()
+		loadConfigCalled := false
+		mockConfigHandler.LoadConfigFunc = func() error {
+			loadConfigCalled = true
+			return nil
+		}
+		mocks := setupMocks(t, &SetupOptions{ConfigHandler: mockConfigHandler})
+
+		ctx := stdcontext.WithValue(stdcontext.Background(), runtimeOverridesKey, mocks.Runtime)
+		rootCmd.SetContext(ctx)
+		rootCmd.SetArgs([]string{"upgrade", "node", "--node", "10.0.0.1", "--image", "img", "--timeout", "10m", "--offline-timeout", "15m"})
+
+		err := Execute()
+
+		if err == nil {
+			t.Fatal("Expected error for offline-timeout exceeding overall timeout, got nil")
+		}
+		if !strings.Contains(err.Error(), "--offline-timeout") || !strings.Contains(err.Error(), "cannot exceed") {
+			t.Errorf("Expected guard error naming both flags, got: %v", err)
+		}
+		if loadConfigCalled {
+			t.Error("Expected guard to fail before LoadConfig is reachable")
+		}
+	})
+
+	t.Run("AllowsOfflineTimeoutEqualToOverallTimeout", func(t *testing.T) {
+		setup(t)
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.LoadConfigFunc = func() error { return nil }
+		mockConfigHandler.IsLoadedFunc = func() bool { return true }
+		mocks := setupMocks(t, &SetupOptions{ConfigHandler: mockConfigHandler})
+
+		ctx := stdcontext.WithValue(stdcontext.Background(), runtimeOverridesKey, mocks.Runtime)
+		rootCmd.SetContext(ctx)
+		rootCmd.SetArgs([]string{"upgrade", "node", "--node", "10.0.0.1", "--image", "img", "--timeout", "10m", "--offline-timeout", "10m"})
+
+		err := Execute()
+
+		// Guard should not fire; the command proceeds to the next failure (no TALOSCONFIG).
+		if err == nil || strings.Contains(err.Error(), "cannot exceed") {
+			t.Errorf("Expected guard to allow equal timeouts, got: %v", err)
+		}
+	})
+
+	t.Run("AllowsOfflineTimeoutExceedingUnboundedOverallTimeout", func(t *testing.T) {
+		setup(t)
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.LoadConfigFunc = func() error { return nil }
+		mockConfigHandler.IsLoadedFunc = func() bool { return true }
+		mocks := setupMocks(t, &SetupOptions{ConfigHandler: mockConfigHandler})
+
+		ctx := stdcontext.WithValue(stdcontext.Background(), runtimeOverridesKey, mocks.Runtime)
+		rootCmd.SetContext(ctx)
+		rootCmd.SetArgs([]string{"upgrade", "node", "--node", "10.0.0.1", "--image", "img", "--timeout", "0", "--offline-timeout", "15m"})
+
+		err := Execute()
+
+		// An explicit --timeout=0 means unbounded; the guard must not fire against it.
+		if err == nil || strings.Contains(err.Error(), "cannot exceed") {
+			t.Errorf("Expected guard to allow unbounded overall timeout, got: %v", err)
+		}
+	})
+
 }

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -6,10 +6,12 @@ import (
 	"fmt"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/spf13/cobra"
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/composer/blueprint"
+	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/provisioner/kubernetes"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 )
@@ -771,6 +773,7 @@ func TestUpgradeNodeCmd(t *testing.T) {
 		upgradeNodeAddr = ""
 		upgradeNodeImage = ""
 		upgradeNodeTimeout = 0
+		upgradeNodeOfflineTimeout = 0
 	})
 
 	setup := func(t *testing.T) (*bytes.Buffer, *bytes.Buffer) {
@@ -778,6 +781,7 @@ func TestUpgradeNodeCmd(t *testing.T) {
 		upgradeNodeAddr = ""
 		upgradeNodeImage = ""
 		upgradeNodeTimeout = 0
+		upgradeNodeOfflineTimeout = 0
 
 		stdout, stderr := captureOutput(t)
 		rootCmd.SetOut(stdout)
@@ -874,6 +878,42 @@ func TestUpgradeNodeCmd(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "node upgrade failed") {
 			t.Errorf("Expected node upgrade error, got: %v", err)
+		}
+	})
+
+	t.Run("DefaultsOfflineTimeoutWhenFlagNotSet", func(t *testing.T) {
+		setup(t)
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.LoadConfigFunc = func() error { return nil }
+		mockConfigHandler.IsLoadedFunc = func() bool { return true }
+		mocks := setupMocks(t, &SetupOptions{ConfigHandler: mockConfigHandler})
+
+		ctx := stdcontext.WithValue(stdcontext.Background(), runtimeOverridesKey, mocks.Runtime)
+		rootCmd.SetContext(ctx)
+		rootCmd.SetArgs([]string{"upgrade", "node", "--node", "10.0.0.1", "--image", "img"})
+
+		_ = Execute()
+
+		if upgradeNodeOfflineTimeout != constants.DefaultNodeOfflineTimeout {
+			t.Errorf("Expected default offline timeout %v, got %v", constants.DefaultNodeOfflineTimeout, upgradeNodeOfflineTimeout)
+		}
+	})
+
+	t.Run("UsesProvidedOfflineTimeout", func(t *testing.T) {
+		setup(t)
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.LoadConfigFunc = func() error { return nil }
+		mockConfigHandler.IsLoadedFunc = func() bool { return true }
+		mocks := setupMocks(t, &SetupOptions{ConfigHandler: mockConfigHandler})
+
+		ctx := stdcontext.WithValue(stdcontext.Background(), runtimeOverridesKey, mocks.Runtime)
+		rootCmd.SetContext(ctx)
+		rootCmd.SetArgs([]string{"upgrade", "node", "--node", "10.0.0.1", "--image", "img", "--offline-timeout", "8m"})
+
+		_ = Execute()
+
+		if upgradeNodeOfflineTimeout != 8*time.Minute {
+			t.Errorf("Expected offline timeout 8m, got %v", upgradeNodeOfflineTimeout)
 		}
 	})
 

--- a/docs/reference/commands/upgrade-node.md
+++ b/docs/reference/commands/upgrade-node.md
@@ -16,7 +16,8 @@ Send an upgrade request to a single Talos node, wait for it to reboot, then veri
 |------|---------|-------------|
 | `--image` | `""` | Talos image to upgrade to. Required. |
 | `--node` | `""` | Node IP address to upgrade. Required. |
-| `--timeout` | `0s` | Overall timeout. Default 10m. |
+| `--offline-timeout` | `0s` | Timeout for the node to go offline after the upgrade request, before it's assumed rebooting. Raise this on slow-rebooting or nested-virtualized platforms. Default 3m. |
+| `--timeout` | `0s` | Overall timeout for the whole upgrade, including the offline wait (see --offline-timeout). Default 10m. |
 
 ## Examples
 
@@ -24,8 +25,11 @@ Send an upgrade request to a single Talos node, wait for it to reboot, then veri
 # Roll one node, blocking until it is healthy
 windsor upgrade node --node=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.0
 
-# Same with a longer timeout for slow rebooters
+# Same with a longer overall timeout for slow rebooters
 windsor upgrade node --node=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.0 --timeout=20m
+
+# Nested-virtualized platforms can take longer than 3m to go offline after the upgrade request
+windsor upgrade node --node=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.0 --offline-timeout=8m
 ```
 
 ## See also

--- a/integration/upgrade_test.go
+++ b/integration/upgrade_test.go
@@ -240,3 +240,19 @@ func TestUpgradeNode_FailsWhenConfigNotLoaded(t *testing.T) {
 		t.Errorf("expected stderr to mention 'upgrade', got: %s", stderr)
 	}
 }
+
+func TestUpgradeNode_AcceptsOfflineTimeoutFlag(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "plan")
+	env = append(env, "WINDSOR_CONTEXT=nonexistent")
+	_, stderr, err := helpers.RunCLI(dir, []string{"upgrade", "node", "--node", "10.0.0.1", "--image", "ghcr.io/siderolabs/talos:v1.9.0", "--offline-timeout", "8m"}, env)
+	if err == nil {
+		t.Fatal("expected failure but command succeeded")
+	}
+	if strings.Contains(string(stderr), "unknown flag") {
+		t.Errorf("expected --offline-timeout to be a recognized flag, got: %s", stderr)
+	}
+	if !strings.Contains(string(stderr), "upgrade") {
+		t.Errorf("expected stderr to mention 'upgrade', got: %s", stderr)
+	}
+}


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This is a purely additive CLI change: the offline-timeout that was previously hardcoded to `constants.DefaultNodeOfflineTimeout` is now user-configurable, so all existing invocations behave identically to before.
>
> **Overview**
>
> The PR adds `--offline-timeout` to `windsor upgrade node`, letting operators raise the time the CLI waits for a node to drop off the network after an upgrade request is issued. The flag mirrors the existing `--timeout` pattern: it defaults to `0` at flag-parse time and is resolved to `constants.DefaultNodeOfflineTimeout` in `PreRunE` when not explicitly set. Unit and integration tests cover both the default path and an explicit override, and the reference docs are updated to match.
>
> One behavioral nuance worth noting: there is no guard preventing `--offline-timeout` from being set larger than `--timeout`. If a user passes `--offline-timeout=15m --timeout=10m`, the overall timeout will fire first and the error message will not be specific about which deadline was hit.

<!-- /claude-code-review:summary -->
