### PR TITLE
fix(blueprint): Flux system ordinal merge

### DIFF
--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -1508,6 +1508,14 @@ func (p *BaseBlueprintProcessor) collectFluxSystems(facet blueprintv1alpha1.Face
 // before RemoveFluxSystem ever runs — RemoveFluxSystem's field-level subtraction only has
 // something to act on when the target blueprint already has a matching entry (e.g. declared
 // directly in blueprint.yaml) independent of this collection pass.
+// A lower ordinal is not always discarded outright: "replace"/"remove" still require ordinal (or
+// strategy) precedence to take effect at all — a lower-precedence facet cannot forcibly overwrite
+// or delete a higher-precedence one — but a lower-ordinal "merge" still combines additively.
+// applyFluxSystemEntryByStrategy's merge case always treats its "new" argument as the
+// scalar-conflict-winning overlay, so that call passes the higher-ordinal existing entry as "new"
+// and the lower-ordinal contribution as "existing": the higher ordinal keeps winning scalar
+// conflicts and keeps the entry's recorded Ordinal, while list fields (Components, DependsOn,
+// Patches, Resources variants) still fold in from both sides.
 func (p *BaseBlueprintProcessor) updateFluxSystemEntry(name string, new *blueprintv1alpha1.FluxSystem, strategy string, entries map[string]*blueprintv1alpha1.FluxSystem) error {
 	existing := entries[name]
 	existingStrategy := existing.Strategy
@@ -1532,7 +1540,10 @@ func (p *BaseBlueprintProcessor) updateFluxSystemEntry(name string, new *bluepri
 		return p.applyFluxSystemEntryByStrategy(name, new, strategy, existing, entries)
 	}
 	if newOrdinal < existingOrdinal {
-		return nil
+		if strategy != "merge" || existingStrategy == "remove" {
+			return nil
+		}
+		return p.applyFluxSystemEntryByStrategy(name, existing, "merge", new, entries)
 	}
 
 	existingStrategyPrec := strategyPrecedence[existingStrategy]

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -1697,6 +1697,13 @@ func (p *BaseBlueprintProcessor) shouldIncludeComponent(when string, facetPath s
 // failures. This function is critical to the blueprint processor’s ability to aggregate, override, conditionally include
 // or exclude, and deconflict terraform components efficiently, making it safe to combine blueprint facets or overrides
 // without unintended duplication or omission. Returns an error if strategies are invalid or pre-merge fails.
+// A lower ordinal is not always discarded outright: "replace"/"remove" still require ordinal (or
+// strategy) precedence to take effect at all — a lower-precedence facet cannot forcibly overwrite
+// or delete a higher-precedence one — but a lower-ordinal "merge" still combines additively (see
+// updateFluxSystemEntry, which shares this shape: applyTerraformComponentEntryByStrategy's merge
+// case always treats its "new" argument as the scalar-conflict-winning overlay, so that call
+// passes the higher-ordinal existing entry as "new" and the lower-ordinal contribution as
+// "existing").
 func (p *BaseBlueprintProcessor) updateTerraformComponentEntry(
 	componentID string,
 	new *blueprintv1alpha1.ConditionalTerraformComponent,
@@ -1754,7 +1761,10 @@ func (p *BaseBlueprintProcessor) updateTerraformComponentEntry(
 	}
 
 	if newOrdinal < existingOrdinal {
-		return nil
+		if strategy != "merge" || existingStrategy == "remove" {
+			return nil
+		}
+		return p.applyTerraformComponentEntryByStrategy(componentID, existing, new, "merge", entries)
 	}
 	existingStrategyPrec := strategyPrecedence[existingStrategy]
 	if newStrategyPrec > existingStrategyPrec {

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -1831,6 +1831,12 @@ func (p *BaseBlueprintProcessor) applyTerraformComponentEntryByStrategy(
 // equal, strategy precedence is used (remove > replace > merge). If both ordinal and strategy are
 // equal, kustomizations are pre-merged (merge), removals are accumulated (remove), or new replaces
 // existing (replace). Returns an error if the merge operation fails.
+// A lower ordinal is not always discarded outright: "replace"/"remove" still require ordinal (or
+// strategy) precedence to take effect at all — a lower-precedence facet cannot forcibly overwrite
+// or delete a higher-precedence one — but a lower-ordinal "merge" still combines additively (see
+// updateFluxSystemEntry, which shares this shape: applyKustomizationEntryByStrategy's merge case
+// always treats its "new" argument as the scalar-conflict-winning overlay, so that call passes the
+// higher-ordinal existing entry as "new" and the lower-ordinal contribution as "existing").
 func (p *BaseBlueprintProcessor) updateKustomizationEntry(name string, new *blueprintv1alpha1.ConditionalKustomization, strategy string, entries map[string]*blueprintv1alpha1.ConditionalKustomization, scope map[string]any) error {
 	existing := entries[name]
 	existingStrategy := existing.Strategy
@@ -1877,7 +1883,10 @@ func (p *BaseBlueprintProcessor) updateKustomizationEntry(name string, new *blue
 	}
 
 	if newOrdinal < existingOrdinal {
-		return nil
+		if strategy != "merge" || existingStrategy == "remove" {
+			return nil
+		}
+		return p.applyKustomizationEntryByStrategy(name, existing, "merge", new, entries)
 	}
 	existingStrategyPrec := strategyPrecedence[existingStrategy]
 	if newStrategyPrec > existingStrategyPrec {

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -1508,14 +1508,9 @@ func (p *BaseBlueprintProcessor) collectFluxSystems(facet blueprintv1alpha1.Face
 // before RemoveFluxSystem ever runs — RemoveFluxSystem's field-level subtraction only has
 // something to act on when the target blueprint already has a matching entry (e.g. declared
 // directly in blueprint.yaml) independent of this collection pass.
-// A lower ordinal is not always discarded outright: "replace"/"remove" still require ordinal (or
-// strategy) precedence to take effect at all — a lower-precedence facet cannot forcibly overwrite
-// or delete a higher-precedence one — but a lower-ordinal "merge" still combines additively.
-// applyFluxSystemEntryByStrategy's merge case always treats its "new" argument as the
-// scalar-conflict-winning overlay, so that call passes the higher-ordinal existing entry as "new"
-// and the lower-ordinal contribution as "existing": the higher ordinal keeps winning scalar
-// conflicts and keeps the entry's recorded Ordinal, while list fields (Components, DependsOn,
-// Patches, Resources variants) still fold in from both sides.
+// A lower ordinal isn't always discarded outright: "merge" still combines additively via
+// applyFluxSystemEntryByStrategy, passing the higher-ordinal entry as that function's
+// scalar-conflict-winning "new" argument; "replace"/"remove" still require ordinal precedence.
 func (p *BaseBlueprintProcessor) updateFluxSystemEntry(name string, new *blueprintv1alpha1.FluxSystem, strategy string, entries map[string]*blueprintv1alpha1.FluxSystem) error {
 	existing := entries[name]
 	existingStrategy := existing.Strategy
@@ -1688,22 +1683,13 @@ func (p *BaseBlueprintProcessor) shouldIncludeComponent(when string, facetPath s
 	return matches, nil
 }
 
-// updateTerraformComponentEntry updates or merges a single ConditionalTerraformComponent entry in the component
-// collection based on ordinal, strategy, and conditional 'when' expressions. Higher ordinal wins; when ordinals are
-// equal, strategy precedence is used ('remove' > 'replace' > 'merge'), then merge behavior for equal ordinal and strategy. The function also rigorously re-evaluates 'when' conditions for
-// both the new and existing entries, removing entries from the collection if any relevant condition now resolves to false.
-// When the strategy is 'merge', it performs a strategic pre-merge and logically ANDs 'when' conditions. For 'remove',
-// component removals are accumulated; for 'replace', the new definition overwrites the existing one. Only valid strategies are allowed; otherwise, an error is returned, as is the case for merge
-// failures. This function is critical to the blueprint processor’s ability to aggregate, override, conditionally include
-// or exclude, and deconflict terraform components efficiently, making it safe to combine blueprint facets or overrides
-// without unintended duplication or omission. Returns an error if strategies are invalid or pre-merge fails.
-// A lower ordinal is not always discarded outright: "replace"/"remove" still require ordinal (or
-// strategy) precedence to take effect at all — a lower-precedence facet cannot forcibly overwrite
-// or delete a higher-precedence one — but a lower-ordinal "merge" still combines additively (see
-// updateFluxSystemEntry, which shares this shape: applyTerraformComponentEntryByStrategy's merge
-// case always treats its "new" argument as the scalar-conflict-winning overlay, so that call
-// passes the higher-ordinal existing entry as "new" and the lower-ordinal contribution as
-// "existing").
+// updateTerraformComponentEntry merges a new component into an existing entry based on ordinal,
+// strategy, and 'when' conditions: higher ordinal wins outright for 'replace'/'remove', equal
+// ordinal falls back to strategy precedence ('remove' > 'replace' > 'merge'), and 'when' conditions
+// that now resolve false drop the entry. A lower ordinal isn't always discarded outright: 'merge'
+// still combines additively via applyTerraformComponentEntryByStrategy, passing the higher-ordinal
+// entry as that function's scalar-conflict-winning "new" argument (see updateFluxSystemEntry,
+// which shares this shape); 'replace'/'remove' still require ordinal precedence to take effect.
 func (p *BaseBlueprintProcessor) updateTerraformComponentEntry(
 	componentID string,
 	new *blueprintv1alpha1.ConditionalTerraformComponent,
@@ -1841,12 +1827,10 @@ func (p *BaseBlueprintProcessor) applyTerraformComponentEntryByStrategy(
 // equal, strategy precedence is used (remove > replace > merge). If both ordinal and strategy are
 // equal, kustomizations are pre-merged (merge), removals are accumulated (remove), or new replaces
 // existing (replace). Returns an error if the merge operation fails.
-// A lower ordinal is not always discarded outright: "replace"/"remove" still require ordinal (or
-// strategy) precedence to take effect at all — a lower-precedence facet cannot forcibly overwrite
-// or delete a higher-precedence one — but a lower-ordinal "merge" still combines additively (see
-// updateFluxSystemEntry, which shares this shape: applyKustomizationEntryByStrategy's merge case
-// always treats its "new" argument as the scalar-conflict-winning overlay, so that call passes the
-// higher-ordinal existing entry as "new" and the lower-ordinal contribution as "existing").
+// A lower ordinal isn't always discarded outright: "merge" still combines additively via
+// applyKustomizationEntryByStrategy, passing the higher-ordinal entry as that function's
+// scalar-conflict-winning "new" argument (see updateFluxSystemEntry, which shares this shape);
+// "replace"/"remove" still require ordinal precedence.
 func (p *BaseBlueprintProcessor) updateKustomizationEntry(name string, new *blueprintv1alpha1.ConditionalKustomization, strategy string, entries map[string]*blueprintv1alpha1.ConditionalKustomization, scope map[string]any) error {
 	existing := entries[name]
 	existingStrategy := existing.Strategy

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -6,6 +6,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/runtime"
@@ -32,6 +33,13 @@ func ordinalOfK(c *blueprintv1alpha1.ConditionalKustomization) int {
 		return 0
 	}
 	return *c.Ordinal
+}
+
+func ordinalOfFS(s *blueprintv1alpha1.FluxSystem) int {
+	if s == nil || s.Ordinal == nil {
+		return 0
+	}
+	return *s.Ordinal
 }
 
 type ProcessorTestMocks struct {
@@ -4331,6 +4339,178 @@ func TestProcessor_updateKustomizationEntry(t *testing.T) {
 		}
 		if entries["app"].Substitutions["key1"] != "value1" {
 			t.Error("Expected original entry to remain unchanged when invalid strategy is rejected")
+		}
+	})
+}
+
+func TestProcessor_updateFluxSystemEntry(t *testing.T) {
+	mocks := setupProcessorMocks(t)
+	processor := NewBlueprintProcessor(mocks.Runtime)
+
+	t.Run("ReplacesWhenNewHasHigherOrdinal", func(t *testing.T) {
+		// Given existing entry at ordinal 100
+		entries := map[string]*blueprintv1alpha1.FluxSystem{
+			"cni": {
+				Name:    "cni",
+				Ordinal: intPtr(100),
+				Install: &blueprintv1alpha1.Kustomization{Components: []string{"a"}},
+			},
+		}
+
+		// When a higher-ordinal merge contribution arrives
+		new := &blueprintv1alpha1.FluxSystem{
+			Name:    "cni",
+			Ordinal: intPtr(200),
+			Install: &blueprintv1alpha1.Kustomization{Components: []string{"b"}},
+		}
+		err := processor.updateFluxSystemEntry("cni", new, "merge", entries)
+
+		// Then components accumulate and the higher ordinal is recorded
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ordinalOfFS(entries["cni"]) != 200 {
+			t.Errorf("Expected ordinal 200, got %d", ordinalOfFS(entries["cni"]))
+		}
+		if !slices.Contains(entries["cni"].Install.Components, "a") || !slices.Contains(entries["cni"].Install.Components, "b") {
+			t.Errorf("Expected both components to accumulate, got %v", entries["cni"].Install.Components)
+		}
+	})
+
+	t.Run("MergesAdditivelyWhenNewHasLowerOrdinal", func(t *testing.T) {
+		// Given existing entry at ordinal 200 with an install component and a scalar field set
+		existingTimeout := &blueprintv1alpha1.DurationString{Duration: 5 * time.Minute}
+		entries := map[string]*blueprintv1alpha1.FluxSystem{
+			"cni": {
+				Name:    "cni",
+				Ordinal: intPtr(200),
+				Install: &blueprintv1alpha1.Kustomization{
+					Components: []string{"cilium"},
+					Timeout:    existingTimeout,
+				},
+			},
+		}
+
+		// When a lower-ordinal facet contributes a merge with a patch and no conflicting timeout
+		new := &blueprintv1alpha1.FluxSystem{
+			Name:    "cni",
+			Ordinal: intPtr(100),
+			Install: &blueprintv1alpha1.Kustomization{
+				Patches: []blueprintv1alpha1.BlueprintPatch{{Patch: "lower-ordinal-patch"}},
+			},
+		}
+		err := processor.updateFluxSystemEntry("cni", new, "merge", entries)
+
+		// Then the higher ordinal is preserved, its scalar field is untouched, and the lower
+		// ordinal's patch is additively folded in rather than dropped
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ordinalOfFS(entries["cni"]) != 200 {
+			t.Errorf("Expected higher ordinal 200 to be preserved, got %d", ordinalOfFS(entries["cni"]))
+		}
+		if entries["cni"].Install.Timeout != existingTimeout {
+			t.Errorf("Expected higher-ordinal timeout to be preserved, got %v", entries["cni"].Install.Timeout)
+		}
+		if !slices.Contains(entries["cni"].Install.Components, "cilium") {
+			t.Errorf("Expected higher-ordinal component to be preserved, got %v", entries["cni"].Install.Components)
+		}
+		if len(entries["cni"].Install.Patches) != 1 || entries["cni"].Install.Patches[0].Patch != "lower-ordinal-patch" {
+			t.Errorf("Expected lower-ordinal patch to be folded in, got %v", entries["cni"].Install.Patches)
+		}
+	})
+
+	t.Run("IgnoresReplaceWhenNewHasLowerOrdinal", func(t *testing.T) {
+		// Given existing entry at ordinal 200
+		entries := map[string]*blueprintv1alpha1.FluxSystem{
+			"cni": {
+				Name:    "cni",
+				Ordinal: intPtr(200),
+				Install: &blueprintv1alpha1.Kustomization{Components: []string{"cilium"}},
+			},
+		}
+
+		// When a lower-ordinal facet attempts to replace
+		new := &blueprintv1alpha1.FluxSystem{
+			Name:    "cni",
+			Ordinal: intPtr(100),
+			Install: &blueprintv1alpha1.Kustomization{Components: []string{"other"}},
+		}
+		err := processor.updateFluxSystemEntry("cni", new, "replace", entries)
+
+		// Then the higher-ordinal entry is untouched — a lower-precedence facet cannot forcibly
+		// overwrite a higher-precedence one, unlike a "merge" contribution
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if len(entries["cni"].Install.Components) != 1 || entries["cni"].Install.Components[0] != "cilium" {
+			t.Errorf("Expected entry to remain unchanged, got %v", entries["cni"].Install.Components)
+		}
+	})
+
+	t.Run("IgnoresLowerOrdinalMergeWhenExistingIsRemoveTombstone", func(t *testing.T) {
+		// Given a higher-ordinal facet already removed this system
+		entries := map[string]*blueprintv1alpha1.FluxSystem{
+			"cni": {
+				Name:     "cni",
+				Ordinal:  intPtr(200),
+				Strategy: "remove",
+			},
+		}
+
+		// When a lower-ordinal facet attempts to merge
+		new := &blueprintv1alpha1.FluxSystem{
+			Name:    "cni",
+			Ordinal: intPtr(100),
+			Install: &blueprintv1alpha1.Kustomization{Components: []string{"cilium"}},
+		}
+		err := processor.updateFluxSystemEntry("cni", new, "merge", entries)
+
+		// Then the remove tombstone is not resurrected
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if entries["cni"].Strategy != "remove" {
+			t.Errorf("Expected remove tombstone to be preserved, got strategy %q", entries["cni"].Strategy)
+		}
+	})
+
+	t.Run("UsesStrategyPrecedenceWhenOrdinalsEqual", func(t *testing.T) {
+		// Given existing entry with merge strategy and ordinal 50
+		entries := map[string]*blueprintv1alpha1.FluxSystem{
+			"cni": {
+				Name:    "cni",
+				Ordinal: intPtr(50),
+				Install: &blueprintv1alpha1.Kustomization{Components: []string{"cilium"}},
+			},
+		}
+
+		// When updating with replace strategy at the same ordinal
+		new := &blueprintv1alpha1.FluxSystem{
+			Name:    "cni",
+			Ordinal: intPtr(50),
+			Install: &blueprintv1alpha1.Kustomization{Components: []string{"other"}},
+		}
+		err := processor.updateFluxSystemEntry("cni", new, "replace", entries)
+
+		// Then replace wins over merge at equal ordinal via strategy precedence
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if entries["cni"].Strategy != "replace" {
+			t.Errorf("Expected strategy 'replace', got %q", entries["cni"].Strategy)
+		}
+	})
+
+	t.Run("ReturnsErrorForInvalidStrategy", func(t *testing.T) {
+		entries := map[string]*blueprintv1alpha1.FluxSystem{
+			"cni": {Name: "cni", Ordinal: intPtr(100)},
+		}
+		new := &blueprintv1alpha1.FluxSystem{Name: "cni", Ordinal: intPtr(200)}
+		err := processor.updateFluxSystemEntry("cni", new, "typo", entries)
+
+		if err == nil || !strings.Contains(err.Error(), "invalid strategy") {
+			t.Errorf("Expected invalid strategy error, got: %v", err)
 		}
 	})
 }

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -3889,6 +3889,75 @@ func TestProcessor_updateTerraformComponentEntry(t *testing.T) {
 		}
 	})
 
+	t.Run("MergesAdditivelyWhenNewHasLowerOrdinal", func(t *testing.T) {
+		// Given existing entry with merge strategy, ordinal 100, a dependency, and a scalar
+		// field set
+		parallelism := 10
+		entries := map[string]*blueprintv1alpha1.ConditionalTerraformComponent{
+			"vpc": {
+				Strategy: "merge",
+				Ordinal:  intPtr(100),
+				TerraformComponent: blueprintv1alpha1.TerraformComponent{
+					Path:        "vpc",
+					DependsOn:   []string{"base"},
+					Parallelism: &blueprintv1alpha1.IntExpression{Value: &parallelism},
+				},
+			},
+		}
+
+		// When a lower-ordinal facet contributes a merge with an additional dependency and no
+		// conflicting parallelism
+		new := &blueprintv1alpha1.ConditionalTerraformComponent{
+			Ordinal: intPtr(50),
+			TerraformComponent: blueprintv1alpha1.TerraformComponent{
+				Path:      "vpc",
+				DependsOn: []string{"extra"},
+			},
+		}
+		err := processor.updateTerraformComponentEntry("vpc", new, "merge", entries, nil)
+
+		// Then the higher ordinal is preserved, its scalar field is untouched, and the lower
+		// ordinal's dependency is additively folded in rather than dropped
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ordinalOf(entries["vpc"]) != 100 {
+			t.Errorf("Expected higher ordinal 100 to be preserved, got %d", ordinalOf(entries["vpc"]))
+		}
+		if entries["vpc"].Parallelism == nil || *entries["vpc"].Parallelism.Value != 10 {
+			t.Errorf("Expected higher-ordinal parallelism to be preserved, got %v", entries["vpc"].Parallelism)
+		}
+		if !slices.Contains(entries["vpc"].DependsOn, "base") || !slices.Contains(entries["vpc"].DependsOn, "extra") {
+			t.Errorf("Expected both dependencies to accumulate, got %v", entries["vpc"].DependsOn)
+		}
+	})
+
+	t.Run("IgnoresLowerOrdinalMergeWhenExistingIsRemoveTombstone", func(t *testing.T) {
+		// Given a higher-ordinal facet already removed this entry
+		entries := map[string]*blueprintv1alpha1.ConditionalTerraformComponent{
+			"vpc": {
+				Strategy:           "remove",
+				Ordinal:            intPtr(100),
+				TerraformComponent: blueprintv1alpha1.TerraformComponent{Path: "vpc"},
+			},
+		}
+
+		// When a lower-ordinal facet attempts to merge
+		new := &blueprintv1alpha1.ConditionalTerraformComponent{
+			Ordinal:            intPtr(50),
+			TerraformComponent: blueprintv1alpha1.TerraformComponent{Path: "vpc", DependsOn: []string{"extra"}},
+		}
+		err := processor.updateTerraformComponentEntry("vpc", new, "merge", entries, nil)
+
+		// Then the remove tombstone is not resurrected
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if entries["vpc"].Strategy != "remove" {
+			t.Errorf("Expected remove tombstone to be preserved, got strategy %q", entries["vpc"].Strategy)
+		}
+	})
+
 	t.Run("UsesStrategyPrecedenceWhenOrdinalsEqual", func(t *testing.T) {
 		// Given existing entry with merge strategy and ordinal 50
 		entries := map[string]*blueprintv1alpha1.ConditionalTerraformComponent{

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -4234,6 +4234,74 @@ func TestProcessor_updateKustomizationEntry(t *testing.T) {
 		}
 	})
 
+	t.Run("MergesAdditivelyWhenNewHasLowerOrdinal", func(t *testing.T) {
+		// Given existing entry with merge strategy, ordinal 100, an existing component, and
+		// a scalar field set
+		entries := map[string]*blueprintv1alpha1.ConditionalKustomization{
+			"app": {
+				Strategy: "merge",
+				Ordinal:  intPtr(100),
+				Kustomization: blueprintv1alpha1.Kustomization{
+					Name:       "app",
+					Path:       "existing-path",
+					Components: []string{"base"},
+				},
+			},
+		}
+
+		// When a lower-ordinal facet contributes a merge with an additional component and no
+		// conflicting path
+		new := &blueprintv1alpha1.ConditionalKustomization{
+			Ordinal: intPtr(50),
+			Kustomization: blueprintv1alpha1.Kustomization{
+				Name:       "app",
+				Components: []string{"extra"},
+			},
+		}
+		err := processor.updateKustomizationEntry("app", new, "merge", entries, nil)
+
+		// Then the higher ordinal is preserved, its scalar field is untouched, and the lower
+		// ordinal's component is additively folded in rather than dropped
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if ordinalOfK(entries["app"]) != 100 {
+			t.Errorf("Expected higher ordinal 100 to be preserved, got %d", ordinalOfK(entries["app"]))
+		}
+		if entries["app"].Path != "existing-path" {
+			t.Errorf("Expected higher-ordinal path to be preserved, got %q", entries["app"].Path)
+		}
+		if !slices.Contains(entries["app"].Components, "base") || !slices.Contains(entries["app"].Components, "extra") {
+			t.Errorf("Expected both components to accumulate, got %v", entries["app"].Components)
+		}
+	})
+
+	t.Run("IgnoresLowerOrdinalMergeWhenExistingIsRemoveTombstone", func(t *testing.T) {
+		// Given a higher-ordinal facet already removed this entry
+		entries := map[string]*blueprintv1alpha1.ConditionalKustomization{
+			"app": {
+				Strategy:      "remove",
+				Ordinal:       intPtr(100),
+				Kustomization: blueprintv1alpha1.Kustomization{Name: "app"},
+			},
+		}
+
+		// When a lower-ordinal facet attempts to merge
+		new := &blueprintv1alpha1.ConditionalKustomization{
+			Ordinal:       intPtr(50),
+			Kustomization: blueprintv1alpha1.Kustomization{Name: "app", Components: []string{"extra"}},
+		}
+		err := processor.updateKustomizationEntry("app", new, "merge", entries, nil)
+
+		// Then the remove tombstone is not resurrected
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if entries["app"].Strategy != "remove" {
+			t.Errorf("Expected remove tombstone to be preserved, got strategy %q", entries["app"].Strategy)
+		}
+	})
+
 	t.Run("UsesStrategyPrecedenceWhenOrdinalsEqual", func(t *testing.T) {
 		// Given existing entry with merge strategy and ordinal 50
 		entries := map[string]*blueprintv1alpha1.ConditionalKustomization{


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This changes blueprint composition merge semantics in `pkg/composer/blueprint/processor.go`, affecting how FluxSystem, Terraform component, and Kustomization entries from multiple facets combine — a shared, cross-cutting path exercised by every multi-facet blueprint.
>
> **Overview**
>
> Previously, when a facet contributed an entry with a lower ordinal than one already collected, it was unconditionally discarded. This PR makes that discard conditional: if the lower-ordinal contribution's own strategy is `"merge"` and the existing (higher-ordinal) entry isn't a `"remove"` tombstone, the lower-ordinal entry is now additively folded into the higher-ordinal one instead of being dropped, with the higher-ordinal entry's ordinal and scalar fields winning any conflicts. `"replace"`/`"remove"` strategies on the losing side still require ordinal precedence and are discarded as before.
>
> The same fix is applied symmetrically to all three entry types (FluxSystem, Terraform component, Kustomization), reusing the existing `applyXEntryByStrategy` merge helpers with argument order flipped so the higher-ordinal entry is always passed as the scalar-conflict-winning argument. The accompanying tests cover the new additive-merge path, the tombstone-preservation case, and the still-discarded lower-ordinal `"replace"` case for each type.

<!-- /claude-code-review:summary -->
