### PR TITLE
fix(upgrade): add --reboot-mode flag for powercycle Talos upgrades

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -167,6 +167,11 @@ windsor upgrade cluster \
 	},
 	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
+		powercycle, err := parseRebootMode(upgradeRebootMode)
+		if err != nil {
+			return err
+		}
+
 		var rtOpts []*runtime.Runtime
 		if overridesVal := cmd.Context().Value(runtimeOverridesKey); overridesVal != nil {
 			rtOpts = []*runtime.Runtime{overridesVal.(*runtime.Runtime)}
@@ -184,11 +189,6 @@ windsor upgrade cluster \
 
 		if !rt.ConfigHandler.IsLoaded() {
 			return fmt.Errorf("Nothing to upgrade. Have you run \033[1mwindsor init\033[0m?")
-		}
-
-		powercycle, err := parseRebootMode(upgradeRebootMode)
-		if err != nil {
-			return err
 		}
 
 		comp := composer.NewComposer(rt)

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -24,11 +24,13 @@ var (
 	upgradeSources        []string
 	upgradeYes            bool
 	upgradeAllowDowngrade bool
+	upgradeRebootMode     string
 
 	upgradeNodeAddr           string
 	upgradeNodeImage          string
 	upgradeNodeTimeout        time.Duration
 	upgradeNodeOfflineTimeout time.Duration
+	upgradeNodeRebootMode     string
 )
 
 var upgradeCmd = &cobra.Command{
@@ -184,10 +186,15 @@ windsor upgrade cluster \
 			return fmt.Errorf("Nothing to upgrade. Have you run \033[1mwindsor init\033[0m?")
 		}
 
+		powercycle, err := parseRebootMode(upgradeRebootMode)
+		if err != nil {
+			return err
+		}
+
 		comp := composer.NewComposer(rt)
 		prov := provisioner.NewProvisioner(rt, comp.BlueprintHandler)
 
-		if err := prov.UpgradeNodes(cmd.Context(), upgradeNodes, upgradeImage); err != nil {
+		if err := prov.UpgradeNodes(cmd.Context(), upgradeNodes, upgradeImage, powercycle); err != nil {
 			return fmt.Errorf("node upgrade failed: %w", err)
 		}
 
@@ -208,7 +215,10 @@ windsor upgrade node --node=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.
 windsor upgrade node --node=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.0 --timeout=20m
 
 # Nested-virtualized platforms can take longer than 3m to go offline after the upgrade request
-windsor upgrade node --node=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.0 --offline-timeout=8m`,
+windsor upgrade node --node=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.0 --offline-timeout=8m
+
+# Some platforms don't reliably register kexec as an offline transition; powercycle is slower but more reliable
+windsor upgrade node --node=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.0 --reboot-mode=powercycle`,
 	Annotations: map[string]string{
 		"docs.seealso": "[`upgrade cluster`](upgrade-cluster.md)\n" +
 			"[`check node-health`](check-node-health.md)",
@@ -224,6 +234,11 @@ windsor upgrade node --node=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.
 		}
 		if upgradeNodeTimeout > 0 && upgradeNodeOfflineTimeout > upgradeNodeTimeout {
 			return fmt.Errorf("--offline-timeout (%s) cannot exceed --timeout (%s)", upgradeNodeOfflineTimeout, upgradeNodeTimeout)
+		}
+
+		powercycle, err := parseRebootMode(upgradeNodeRebootMode)
+		if err != nil {
+			return err
 		}
 
 		var rtOpts []*runtime.Runtime
@@ -259,12 +274,25 @@ windsor upgrade node --node=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.
 			fmt.Fprintln(cmd.OutOrStdout(), output)
 		}
 
-		if err := prov.UpgradeNode(ctx, upgradeNodeAddr, upgradeNodeImage, upgradeNodeOfflineTimeout, outputFunc); err != nil {
+		if err := prov.UpgradeNode(ctx, upgradeNodeAddr, upgradeNodeImage, upgradeNodeOfflineTimeout, powercycle, outputFunc); err != nil {
 			return fmt.Errorf("node upgrade failed: %w", err)
 		}
 
 		return nil
 	},
+}
+
+// parseRebootMode validates a --reboot-mode value and reports whether it requests powercycle.
+// "default" (kexec, fast) and "powercycle" (full ACPI reset) are the only accepted values.
+func parseRebootMode(mode string) (bool, error) {
+	switch mode {
+	case "", "default":
+		return false, nil
+	case "powercycle":
+		return true, nil
+	default:
+		return false, fmt.Errorf("invalid --reboot-mode %q: must be \"default\" or \"powercycle\"", mode)
+	}
 }
 
 // pruneOrphaned deletes the kustomizations the blueprint no longer declares, after printing them.
@@ -409,6 +437,7 @@ func init() {
 
 	upgradeClusterCmd.Flags().StringSliceVar(&upgradeNodes, "nodes", []string{}, "Node addresses to upgrade. Required.")
 	upgradeClusterCmd.Flags().StringVar(&upgradeImage, "image", "", "Talos image to upgrade to. Required.")
+	upgradeClusterCmd.Flags().StringVar(&upgradeRebootMode, "reboot-mode", "default", "Reboot mode: \"default\" (kexec, fast) or \"powercycle\" (full ACPI reset). Use powercycle on platforms where kexec doesn't reliably register as offline (e.g. nested virtualization).")
 	_ = upgradeClusterCmd.MarkFlagRequired("nodes")
 	_ = upgradeClusterCmd.MarkFlagRequired("image")
 
@@ -416,6 +445,7 @@ func init() {
 	upgradeNodeCmd.Flags().StringVar(&upgradeNodeImage, "image", "", "Talos image to upgrade to. Required.")
 	upgradeNodeCmd.Flags().DurationVar(&upgradeNodeTimeout, "timeout", 0, "Overall timeout for the whole upgrade, including the offline wait (see --offline-timeout). Default 10m.")
 	upgradeNodeCmd.Flags().DurationVar(&upgradeNodeOfflineTimeout, "offline-timeout", 0, "Timeout for the node to go offline after the upgrade request, before it's assumed rebooting. Raise this on slow-rebooting or nested-virtualized platforms. Default 3m.")
+	upgradeNodeCmd.Flags().StringVar(&upgradeNodeRebootMode, "reboot-mode", "default", "Reboot mode: \"default\" (kexec, fast) or \"powercycle\" (full ACPI reset). Use powercycle on platforms where kexec doesn't reliably register as offline (e.g. nested virtualization).")
 	_ = upgradeNodeCmd.MarkFlagRequired("node")
 	_ = upgradeNodeCmd.MarkFlagRequired("image")
 }

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -1049,3 +1049,36 @@ func TestUpgradeNodeCmd(t *testing.T) {
 	})
 
 }
+
+func TestUpgradeClusterCmd_RejectsInvalidRebootModeBeforeConfig(t *testing.T) {
+	t.Cleanup(func() {
+		rootCmd.SetContext(stdcontext.Background())
+		upgradeNodes = []string{}
+		upgradeImage = ""
+		upgradeRebootMode = ""
+	})
+
+	mockConfigHandler := config.NewMockConfigHandler()
+	loadConfigCalled := false
+	mockConfigHandler.LoadConfigFunc = func() error {
+		loadConfigCalled = true
+		return nil
+	}
+	mocks := setupMocks(t, &SetupOptions{ConfigHandler: mockConfigHandler})
+
+	ctx := stdcontext.WithValue(stdcontext.Background(), runtimeOverridesKey, mocks.Runtime)
+	rootCmd.SetContext(ctx)
+	rootCmd.SetArgs([]string{"upgrade", "cluster", "--nodes", "10.0.0.1", "--image", "img", "--reboot-mode", "reboot-now-please"})
+
+	err := Execute()
+
+	if err == nil {
+		t.Fatal("Expected error for invalid --reboot-mode, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid --reboot-mode") {
+		t.Errorf("Expected invalid reboot-mode error, got: %v", err)
+	}
+	if loadConfigCalled {
+		t.Error("Expected guard to fail before LoadConfig is reachable, matching upgrade node's ordering")
+	}
+}

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -774,6 +774,7 @@ func TestUpgradeNodeCmd(t *testing.T) {
 		upgradeNodeImage = ""
 		upgradeNodeTimeout = 0
 		upgradeNodeOfflineTimeout = 0
+		upgradeNodeRebootMode = ""
 	})
 
 	setup := func(t *testing.T) (*bytes.Buffer, *bytes.Buffer) {
@@ -782,6 +783,7 @@ func TestUpgradeNodeCmd(t *testing.T) {
 		upgradeNodeImage = ""
 		upgradeNodeTimeout = 0
 		upgradeNodeOfflineTimeout = 0
+		upgradeNodeRebootMode = ""
 
 		stdout, stderr := captureOutput(t)
 		rootCmd.SetOut(stdout)
@@ -979,6 +981,70 @@ func TestUpgradeNodeCmd(t *testing.T) {
 		// An explicit --timeout=0 means unbounded; the guard must not fire against it.
 		if err == nil || strings.Contains(err.Error(), "cannot exceed") {
 			t.Errorf("Expected guard to allow unbounded overall timeout, got: %v", err)
+		}
+	})
+
+	t.Run("DefaultsToKexecRebootMode", func(t *testing.T) {
+		setup(t)
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.LoadConfigFunc = func() error { return nil }
+		mockConfigHandler.IsLoadedFunc = func() bool { return true }
+		mocks := setupMocks(t, &SetupOptions{ConfigHandler: mockConfigHandler})
+
+		ctx := stdcontext.WithValue(stdcontext.Background(), runtimeOverridesKey, mocks.Runtime)
+		rootCmd.SetContext(ctx)
+		rootCmd.SetArgs([]string{"upgrade", "node", "--node", "10.0.0.1", "--image", "img"})
+
+		err := Execute()
+
+		// No TALOSCONFIG set — confirms the reboot-mode guard passed and the code reached UpgradeNode.
+		if err == nil || !strings.Contains(err.Error(), "node upgrade failed") {
+			t.Errorf("Expected node upgrade error (guard passed), got: %v", err)
+		}
+	})
+
+	t.Run("AcceptsPowercycleRebootMode", func(t *testing.T) {
+		setup(t)
+		mockConfigHandler := config.NewMockConfigHandler()
+		mockConfigHandler.LoadConfigFunc = func() error { return nil }
+		mockConfigHandler.IsLoadedFunc = func() bool { return true }
+		mocks := setupMocks(t, &SetupOptions{ConfigHandler: mockConfigHandler})
+
+		ctx := stdcontext.WithValue(stdcontext.Background(), runtimeOverridesKey, mocks.Runtime)
+		rootCmd.SetContext(ctx)
+		rootCmd.SetArgs([]string{"upgrade", "node", "--node", "10.0.0.1", "--image", "img", "--reboot-mode", "powercycle"})
+
+		err := Execute()
+
+		if err == nil || !strings.Contains(err.Error(), "node upgrade failed") {
+			t.Errorf("Expected node upgrade error (guard passed), got: %v", err)
+		}
+	})
+
+	t.Run("RejectsInvalidRebootMode", func(t *testing.T) {
+		setup(t)
+		mockConfigHandler := config.NewMockConfigHandler()
+		loadConfigCalled := false
+		mockConfigHandler.LoadConfigFunc = func() error {
+			loadConfigCalled = true
+			return nil
+		}
+		mocks := setupMocks(t, &SetupOptions{ConfigHandler: mockConfigHandler})
+
+		ctx := stdcontext.WithValue(stdcontext.Background(), runtimeOverridesKey, mocks.Runtime)
+		rootCmd.SetContext(ctx)
+		rootCmd.SetArgs([]string{"upgrade", "node", "--node", "10.0.0.1", "--image", "img", "--reboot-mode", "reboot-now-please"})
+
+		err := Execute()
+
+		if err == nil {
+			t.Fatal("Expected error for invalid --reboot-mode, got nil")
+		}
+		if !strings.Contains(err.Error(), "invalid --reboot-mode") {
+			t.Errorf("Expected invalid reboot-mode error, got: %v", err)
+		}
+		if loadConfigCalled {
+			t.Error("Expected guard to fail before LoadConfig is reachable")
 		}
 	})
 

--- a/docs/reference/commands/upgrade-cluster.md
+++ b/docs/reference/commands/upgrade-cluster.md
@@ -18,6 +18,7 @@ Use 'windsor check node-health --wait-for-reboot' afterward to verify each node 
 |------|---------|-------------|
 | `--image` | `""` | Talos image to upgrade to. Required. |
 | `--nodes` | `[]` | Node addresses to upgrade. Required. |
+| `--reboot-mode` | `default` | Reboot mode: "default" (kexec, fast) or "powercycle" (full ACPI reset). Use powercycle on platforms where kexec doesn't reliably register as offline (e.g. nested virtualization). |
 
 ## Examples
 

--- a/docs/reference/commands/upgrade-node.md
+++ b/docs/reference/commands/upgrade-node.md
@@ -17,6 +17,7 @@ Send an upgrade request to a single Talos node, wait for it to reboot, then veri
 | `--image` | `""` | Talos image to upgrade to. Required. |
 | `--node` | `""` | Node IP address to upgrade. Required. |
 | `--offline-timeout` | `0s` | Timeout for the node to go offline after the upgrade request, before it's assumed rebooting. Raise this on slow-rebooting or nested-virtualized platforms. Default 3m. |
+| `--reboot-mode` | `default` | Reboot mode: "default" (kexec, fast) or "powercycle" (full ACPI reset). Use powercycle on platforms where kexec doesn't reliably register as offline (e.g. nested virtualization). |
 | `--timeout` | `0s` | Overall timeout for the whole upgrade, including the offline wait (see --offline-timeout). Default 10m. |
 
 ## Examples
@@ -30,6 +31,9 @@ windsor upgrade node --node=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.
 
 # Nested-virtualized platforms can take longer than 3m to go offline after the upgrade request
 windsor upgrade node --node=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.0 --offline-timeout=8m
+
+# Some platforms don't reliably register kexec as an offline transition; powercycle is slower but more reliable
+windsor upgrade node --node=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1.13.0 --reboot-mode=powercycle
 ```
 
 ## See also

--- a/integration/upgrade_test.go
+++ b/integration/upgrade_test.go
@@ -194,6 +194,34 @@ func TestUpgradeCluster_FailsWhenConfigNotLoaded(t *testing.T) {
 	}
 }
 
+func TestUpgradeCluster_AcceptsRebootModeFlag(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "plan")
+	env = append(env, "WINDSOR_CONTEXT=nonexistent")
+	_, stderr, err := helpers.RunCLI(dir, []string{"upgrade", "cluster", "--nodes", "10.0.0.1", "--image", "ghcr.io/siderolabs/talos:v1.9.0", "--reboot-mode", "powercycle"}, env)
+	if err == nil {
+		t.Fatal("expected failure but command succeeded")
+	}
+	if strings.Contains(string(stderr), "unknown flag") {
+		t.Errorf("expected --reboot-mode to be a recognized flag, got: %s", stderr)
+	}
+	if !strings.Contains(string(stderr), "upgrade") {
+		t.Errorf("expected stderr to mention 'upgrade', got: %s", stderr)
+	}
+}
+
+func TestUpgradeCluster_RejectsInvalidRebootMode(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "plan")
+	_, stderr, err := helpers.RunCLI(dir, []string{"upgrade", "cluster", "--nodes", "10.0.0.1", "--image", "ghcr.io/siderolabs/talos:v1.9.0", "--reboot-mode", "reboot-now-please"}, env)
+	if err == nil {
+		t.Fatal("expected failure for invalid --reboot-mode, got success")
+	}
+	if !strings.Contains(string(stderr), "invalid --reboot-mode") {
+		t.Errorf("expected stderr to mention 'invalid --reboot-mode', got: %s", stderr)
+	}
+}
+
 // =============================================================================
 // Integration Tests — upgrade node
 // =============================================================================
@@ -254,5 +282,33 @@ func TestUpgradeNode_AcceptsOfflineTimeoutFlag(t *testing.T) {
 	}
 	if !strings.Contains(string(stderr), "upgrade") {
 		t.Errorf("expected stderr to mention 'upgrade', got: %s", stderr)
+	}
+}
+
+func TestUpgradeNode_AcceptsRebootModeFlag(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "plan")
+	env = append(env, "WINDSOR_CONTEXT=nonexistent")
+	_, stderr, err := helpers.RunCLI(dir, []string{"upgrade", "node", "--node", "10.0.0.1", "--image", "ghcr.io/siderolabs/talos:v1.9.0", "--reboot-mode", "powercycle"}, env)
+	if err == nil {
+		t.Fatal("expected failure but command succeeded")
+	}
+	if strings.Contains(string(stderr), "unknown flag") {
+		t.Errorf("expected --reboot-mode to be a recognized flag, got: %s", stderr)
+	}
+	if !strings.Contains(string(stderr), "upgrade") {
+		t.Errorf("expected stderr to mention 'upgrade', got: %s", stderr)
+	}
+}
+
+func TestUpgradeNode_RejectsInvalidRebootMode(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "plan")
+	_, stderr, err := helpers.RunCLI(dir, []string{"upgrade", "node", "--node", "10.0.0.1", "--image", "ghcr.io/siderolabs/talos:v1.9.0", "--reboot-mode", "reboot-now-please"}, env)
+	if err == nil {
+		t.Fatal("expected failure for invalid --reboot-mode, got success")
+	}
+	if !strings.Contains(string(stderr), "invalid --reboot-mode") {
+		t.Errorf("expected stderr to mention 'invalid --reboot-mode', got: %s", stderr)
 	}
 }

--- a/pkg/provisioner/cluster/cluster_client.go
+++ b/pkg/provisioner/cluster/cluster_client.go
@@ -25,8 +25,9 @@ type ClusterClient interface {
 	// Phase 2 polls until all nodes are healthy again within the remaining context deadline.
 	WaitForNodesReboot(ctx context.Context, nodeAddresses []string, expectedVersion string, skipServices []string, offlineTimeout time.Duration) error
 
-	// UpgradeNodes upgrades the specified nodes to the specified image
-	UpgradeNodes(ctx context.Context, nodeAddresses []string, image string) error
+	// UpgradeNodes upgrades the specified nodes to the specified image. powercycle requests
+	// a full ACPI reboot instead of the default kexec.
+	UpgradeNodes(ctx context.Context, nodeAddresses []string, image string, powercycle bool) error
 
 	// WaitForControlPlaneAPIReady waits for the kube-apiserver on a control-plane node
 	// to accept TCP connections on port 6443. Returns nil immediately when the node is
@@ -81,7 +82,7 @@ func (c *BaseClusterClient) WaitForNodesReboot(ctx context.Context, nodeAddresse
 
 // UpgradeNodes is a stub that returns an error indicating the method is not implemented.
 // Provider-specific implementations should override this to perform node upgrades.
-func (c *BaseClusterClient) UpgradeNodes(ctx context.Context, nodeAddresses []string, image string) error {
+func (c *BaseClusterClient) UpgradeNodes(ctx context.Context, nodeAddresses []string, image string, powercycle bool) error {
 	return fmt.Errorf("UpgradeNodes not implemented")
 }
 

--- a/pkg/provisioner/cluster/mock_cluster_client.go
+++ b/pkg/provisioner/cluster/mock_cluster_client.go
@@ -17,11 +17,11 @@ import (
 // MockClusterClient is a mock implementation of the ClusterClient interface
 type MockClusterClient struct {
 	BaseClusterClient
-	WaitForNodesHealthyFunc func(ctx context.Context, nodeAddresses []string, expectedVersion string, skipServices []string) error
-	WaitForNodesRebootFunc  func(ctx context.Context, nodeAddresses []string, expectedVersion string, skipServices []string, offlineTimeout time.Duration) error
-	UpgradeNodesFunc        func(ctx context.Context, nodeAddresses []string, image string) error
+	WaitForNodesHealthyFunc         func(ctx context.Context, nodeAddresses []string, expectedVersion string, skipServices []string) error
+	WaitForNodesRebootFunc          func(ctx context.Context, nodeAddresses []string, expectedVersion string, skipServices []string, offlineTimeout time.Duration) error
+	UpgradeNodesFunc                func(ctx context.Context, nodeAddresses []string, image string, powercycle bool) error
 	WaitForControlPlaneAPIReadyFunc func(ctx context.Context, nodeAddress string, outputFunc func(string)) error
-	CloseFunc               func()
+	CloseFunc                       func()
 }
 
 // =============================================================================
@@ -54,9 +54,9 @@ func (m *MockClusterClient) WaitForNodesReboot(ctx context.Context, nodeAddresse
 }
 
 // UpgradeNodes calls the mock UpgradeNodesFunc if set, otherwise returns nil
-func (m *MockClusterClient) UpgradeNodes(ctx context.Context, nodeAddresses []string, image string) error {
+func (m *MockClusterClient) UpgradeNodes(ctx context.Context, nodeAddresses []string, image string, powercycle bool) error {
 	if m.UpgradeNodesFunc != nil {
-		return m.UpgradeNodesFunc(ctx, nodeAddresses, image)
+		return m.UpgradeNodesFunc(ctx, nodeAddresses, image, powercycle)
 	}
 	return nil
 }

--- a/pkg/provisioner/cluster/shims.go
+++ b/pkg/provisioner/cluster/shims.go
@@ -27,7 +27,7 @@ type Shims struct {
 	TalosVersion     func(ctx context.Context, client *client.Client) (*machine.VersionResponse, error)
 	TalosWithNodes   func(ctx context.Context, nodes ...string) context.Context
 	TalosServiceList func(ctx context.Context, client *client.Client) (*machine.ServiceListResponse, error)
-	TalosUpgrade     func(ctx context.Context, client *client.Client, image string) error
+	TalosUpgrade     func(ctx context.Context, client *client.Client, image string, powercycle bool) error
 	TalosClose       func(client *client.Client)
 
 	// Network operations
@@ -53,9 +53,12 @@ func NewShims() *Shims {
 		TalosServiceList: func(ctx context.Context, c *client.Client) (*machine.ServiceListResponse, error) {
 			return c.ServiceList(ctx)
 		},
-		TalosUpgrade: func(ctx context.Context, c *client.Client, image string) error {
-			// Use the provided image
-			_, err := c.Upgrade(ctx, image, false, false)
+		TalosUpgrade: func(ctx context.Context, c *client.Client, image string, powercycle bool) error {
+			opts := []client.UpgradeOption{client.WithUpgradeImage(image)}
+			if powercycle {
+				opts = append(opts, client.WithUpgradeRebootMode(machine.UpgradeRequest_POWERCYCLE))
+			}
+			_, err := c.UpgradeWithOptions(ctx, opts...)
 			return err
 		},
 		TalosClose: func(c *client.Client) {

--- a/pkg/provisioner/cluster/talos_cluster_client.go
+++ b/pkg/provisioner/cluster/talos_cluster_client.go
@@ -156,8 +156,10 @@ func (c *TalosClusterClient) WaitForNodesHealthy(ctx context.Context, nodeAddres
 
 // UpgradeNodes upgrades the specified nodes to the specified image.
 // It iterates through each node address and initiates an upgrade using the Talos Upgrade API.
+// powercycle requests a full ACPI reboot instead of the default kexec, needed on platforms
+// (e.g. nested virtualization) where kexec doesn't reliably register as an offline transition.
 // Returns an error if any node upgrade fails or if the Talos client cannot be initialized.
-func (c *TalosClusterClient) UpgradeNodes(ctx context.Context, nodeAddresses []string, image string) error {
+func (c *TalosClusterClient) UpgradeNodes(ctx context.Context, nodeAddresses []string, image string, powercycle bool) error {
 	if err := c.ensureClient(); err != nil {
 		return fmt.Errorf("failed to initialize Talos client: %w", err)
 	}
@@ -166,7 +168,7 @@ func (c *TalosClusterClient) UpgradeNodes(ctx context.Context, nodeAddresses []s
 		fmt.Printf("upgrading node %s\n", nodeAddress)
 
 		nodeCtx := c.shims.TalosWithNodes(ctx, nodeAddress)
-		err := c.shims.TalosUpgrade(nodeCtx, c.client, image)
+		err := c.shims.TalosUpgrade(nodeCtx, c.client, image, powercycle)
 
 		if err != nil {
 			return fmt.Errorf("failed to upgrade node %s: %w", nodeAddress, err)

--- a/pkg/provisioner/cluster/talos_cluster_client_test.go
+++ b/pkg/provisioner/cluster/talos_cluster_client_test.go
@@ -664,6 +664,93 @@ func TestTalosClusterClient_Close(t *testing.T) {
 	})
 }
 
+func TestTalosClusterClient_UpgradeNodes(t *testing.T) {
+	setup := func(t *testing.T) *TalosClusterClient {
+		t.Helper()
+		client := NewTalosClusterClient()
+		client.shims = setupDefaultShims()
+		os.Setenv("TALOSCONFIG", "/tmp/talosconfig")
+		t.Cleanup(func() { os.Unsetenv("TALOSCONFIG") })
+		return client
+	}
+
+	t.Run("PassesPowercycleTrue", func(t *testing.T) {
+		client := setup(t)
+		var capturedPowercycle bool
+		client.shims.TalosUpgrade = func(ctx context.Context, c *talosclient.Client, image string, powercycle bool) error {
+			capturedPowercycle = powercycle
+			return nil
+		}
+
+		err := client.UpgradeNodes(context.Background(), []string{"10.0.0.1"}, "ghcr.io/siderolabs/installer:v1.13.0", true)
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if !capturedPowercycle {
+			t.Error("Expected powercycle=true to reach TalosUpgrade")
+		}
+	})
+
+	t.Run("PassesPowercycleFalse", func(t *testing.T) {
+		client := setup(t)
+		capturedPowercycle := true
+		client.shims.TalosUpgrade = func(ctx context.Context, c *talosclient.Client, image string, powercycle bool) error {
+			capturedPowercycle = powercycle
+			return nil
+		}
+
+		err := client.UpgradeNodes(context.Background(), []string{"10.0.0.1"}, "ghcr.io/siderolabs/installer:v1.13.0", false)
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if capturedPowercycle {
+			t.Error("Expected powercycle=false to reach TalosUpgrade")
+		}
+	})
+
+	t.Run("UpgradesEachNode", func(t *testing.T) {
+		client := setup(t)
+		var upgraded []string
+		client.shims.TalosUpgrade = func(ctx context.Context, c *talosclient.Client, image string, powercycle bool) error {
+			upgraded = append(upgraded, image)
+			return nil
+		}
+
+		err := client.UpgradeNodes(context.Background(), []string{"10.0.0.1", "10.0.0.2"}, "img", false)
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if len(upgraded) != 2 {
+			t.Errorf("Expected 2 upgrade calls, got %d", len(upgraded))
+		}
+	})
+
+	t.Run("UpgradeFails", func(t *testing.T) {
+		client := setup(t)
+		client.shims.TalosUpgrade = func(ctx context.Context, c *talosclient.Client, image string, powercycle bool) error {
+			return fmt.Errorf("upgrade rejected")
+		}
+
+		err := client.UpgradeNodes(context.Background(), []string{"10.0.0.1"}, "img", false)
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "upgrade rejected") {
+			t.Errorf("Expected upgrade error, got: %v", err)
+		}
+	})
+
+	t.Run("NoClient", func(t *testing.T) {
+		client := NewTalosClusterClient()
+		os.Unsetenv("TALOSCONFIG")
+
+		err := client.UpgradeNodes(context.Background(), []string{"10.0.0.1"}, "img", false)
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+	})
+}
+
 // =============================================================================
 // Test Private Methods
 // =============================================================================

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -1690,9 +1690,11 @@ func (i *Provisioner) Uninstall(blueprint *blueprintv1alpha1.Blueprint) error {
 // UpgradeNode performs a complete per-node upgrade: sends the upgrade gRPC request (wait=false),
 // waits for the node to go offline via version polling (offlineTimeout caps this phase),
 // waits for the node to come back healthy, then performs a final service health check.
+// powercycle requests a full ACPI reboot instead of the default kexec, needed on platforms
+// (e.g. nested virtualization) where kexec doesn't reliably register as an offline transition.
 // outputFunc receives status messages during the wait phases. Returns an error if any
 // step fails or times out.
-func (i *Provisioner) UpgradeNode(ctx context.Context, node string, image string, offlineTimeout time.Duration, outputFunc func(string)) error {
+func (i *Provisioner) UpgradeNode(ctx context.Context, node string, image string, offlineTimeout time.Duration, powercycle bool, outputFunc func(string)) error {
 	if err := i.ensureClusterClient(); err != nil {
 		return err
 	}
@@ -1703,7 +1705,7 @@ func (i *Provisioner) UpgradeNode(ctx context.Context, node string, image string
 	if outputFunc != nil {
 		outputFunc(fmt.Sprintf("Sending upgrade request to node %s...", node))
 	}
-	if err := i.ClusterClient.UpgradeNodes(ctx, nodes, image); err != nil {
+	if err := i.ClusterClient.UpgradeNodes(ctx, nodes, image, powercycle); err != nil {
 		return fmt.Errorf("upgrade request failed: %w", err)
 	}
 
@@ -1727,17 +1729,18 @@ func (i *Provisioner) UpgradeNode(ctx context.Context, node string, image string
 	return nil
 }
 
-// UpgradeNodes sends an upgrade request to specified cluster nodes.
+// UpgradeNodes sends an upgrade request to specified cluster nodes. powercycle requests
+// a full ACPI reboot instead of the default kexec.
 // It initializes the cluster client based on config, then calls UpgradeNodes on it.
 // The caller is responsible for subsequently monitoring reboot status. Returns an error
 // if the cluster client cannot be initialized or if any node upgrade request fails.
-func (i *Provisioner) UpgradeNodes(ctx context.Context, nodes []string, image string) error {
+func (i *Provisioner) UpgradeNodes(ctx context.Context, nodes []string, image string, powercycle bool) error {
 	if err := i.ensureClusterClient(); err != nil {
 		return err
 	}
 	defer i.ClusterClient.Close()
 
-	return i.ClusterClient.UpgradeNodes(ctx, nodes, image)
+	return i.ClusterClient.UpgradeNodes(ctx, nodes, image, powercycle)
 }
 
 // CheckNodeHealth performs health checks for cluster nodes and Kubernetes endpoints.

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -4435,7 +4435,7 @@ func TestProvisioner_UpgradeNode(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
 
 		upgradeCalled := false
-		mocks.ClusterClient.UpgradeNodesFunc = func(ctx context.Context, nodeAddresses []string, image string) error {
+		mocks.ClusterClient.UpgradeNodesFunc = func(ctx context.Context, nodeAddresses []string, image string, powercycle bool) error {
 			upgradeCalled = true
 			if len(nodeAddresses) != 1 || nodeAddresses[0] != "10.0.0.1" {
 				t.Errorf("Expected node 10.0.0.1, got %v", nodeAddresses)
@@ -4460,7 +4460,7 @@ func TestProvisioner_UpgradeNode(t *testing.T) {
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
 		var output []string
-		err := provisioner.UpgradeNode(context.Background(), "10.0.0.1", "ghcr.io/siderolabs/installer:v1.7.0", 0, func(msg string) {
+		err := provisioner.UpgradeNode(context.Background(), "10.0.0.1", "ghcr.io/siderolabs/installer:v1.7.0", 0, false, func(msg string) {
 			output = append(output, msg)
 		})
 
@@ -4496,7 +4496,7 @@ func TestProvisioner_UpgradeNode(t *testing.T) {
 		opts := &Provisioner{ClusterClient: mocks.ClusterClient}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
-		err := provisioner.UpgradeNode(context.Background(), "10.0.0.1", "img", 0, nil)
+		err := provisioner.UpgradeNode(context.Background(), "10.0.0.1", "img", 0, false, nil)
 
 		if err == nil {
 			t.Fatal("Expected error, got nil")
@@ -4508,14 +4508,14 @@ func TestProvisioner_UpgradeNode(t *testing.T) {
 
 	t.Run("UpgradeRequestFails", func(t *testing.T) {
 		mocks := setupProvisionerMocks(t)
-		mocks.ClusterClient.UpgradeNodesFunc = func(ctx context.Context, nodeAddresses []string, image string) error {
+		mocks.ClusterClient.UpgradeNodesFunc = func(ctx context.Context, nodeAddresses []string, image string, powercycle bool) error {
 			return fmt.Errorf("upgrade request rejected")
 		}
 
 		opts := &Provisioner{ClusterClient: mocks.ClusterClient}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
-		err := provisioner.UpgradeNode(context.Background(), "10.0.0.1", "img", 0, nil)
+		err := provisioner.UpgradeNode(context.Background(), "10.0.0.1", "img", 0, false, nil)
 
 		if err == nil {
 			t.Error("Expected error, got nil")
@@ -4534,7 +4534,7 @@ func TestProvisioner_UpgradeNode(t *testing.T) {
 		opts := &Provisioner{ClusterClient: mocks.ClusterClient}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
-		err := provisioner.UpgradeNode(context.Background(), "10.0.0.1", "img", 0, nil)
+		err := provisioner.UpgradeNode(context.Background(), "10.0.0.1", "img", 0, false, nil)
 
 		if err == nil {
 			t.Error("Expected error, got nil")
@@ -4551,7 +4551,7 @@ func TestProvisioner_UpgradeNode(t *testing.T) {
 		mockCfg.GetContextValuesFunc = func() (map[string]any, error) { return nil, nil }
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{})
 
-		err := provisioner.UpgradeNode(context.Background(), "10.0.0.1", "img", 0, nil)
+		err := provisioner.UpgradeNode(context.Background(), "10.0.0.1", "img", 0, false, nil)
 
 		if err == nil {
 			t.Error("Expected error, got nil")


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> The change is confined to the Talos node/cluster upgrade path (new opt-in `--reboot-mode` flag), is backward compatible by default, and is well covered by unit tests.
>
> **Overview**
>
> This PR adds a `--reboot-mode` flag to both `windsor upgrade node` and `windsor upgrade cluster`, letting operators request a full ACPI powercycle instead of the default kexec reboot when a node's platform doesn't reliably signal kexec as an offline transition (e.g. nested virtualization). The new `powercycle bool` threads through `Provisioner.UpgradeNode(s)` down to `ClusterClient.UpgradeNodes` and the Talos shim, which now calls `client.UpgradeWithOptions` with `WithUpgradeRebootMode` instead of the old two-bool `Upgrade` call.
>
> The flag defaults to `"default"` (kexec) everywhere, so existing invocations are unaffected. Validation of the flag value is duplicated per-command via a shared `parseRebootMode` helper, and the two commands validate it at different points in their `RunE` (see inline comment).

<!-- /claude-code-review:summary -->
