### PR TITLE
chore(claude): drop claude_args to mitigate Agent SDK crash

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -27,6 +27,13 @@ permissions:
 # tool sandbox, so it can never be permission-denied or silently skipped
 # mid-run, and the summary is guaranteed to post even if the review step
 # errors, hits its turn cap, or finishes early without posting anything.
+#
+# claude_args is intentionally omitted from every job below as a mitigation
+# attempt for a currently-open Agent SDK crash in claude-code-action
+# (is_error: true at $0 cost, before any API call — see
+# anthropics/claude-code-action#914, #965, #892). Upstream hasn't confirmed
+# a root cause; dropping claude_args is one of the few config-side levers
+# available. Re-add scoped tool/model args once upstream ships a fix.
 jobs:
   review:
     name: Full Review
@@ -111,11 +118,6 @@ jobs:
 
             Write the two files and stop. Do not run `gh`, do not post, do not
             edit the PR.
-          claude_args: |
-            --model claude-sonnet-5
-            --max-turns 40
-            --allowedTools Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Write
-            --disallowedTools WebSearch,WebFetch
       - name: Publish review
         if: always()
         env:
@@ -212,11 +214,6 @@ jobs:
 
             Write the two files and stop. Do not run `gh`, do not post, do not
             edit the PR.
-          claude_args: |
-            --model claude-sonnet-5
-            --max-turns 40
-            --allowedTools Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Write
-            --disallowedTools WebSearch,WebFetch
       - name: Publish review
         if: always()
         env:
@@ -321,8 +318,3 @@ jobs:
 
             That is all. Do not post new comments. Do not modify the PR
             description. Be fast.
-          claude_args: |
-            --model claude-sonnet-5
-            --max-turns 40
-            --allowedTools Read,Bash(gh:*),Bash(cat:*),Bash(jq:*)
-            --disallowedTools WebSearch,WebFetch


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!WARNING]
>
> **Review did not complete**
>
> The automated review produced no summary. See the [run](https://github.com/windsorcli/cli/actions/runs/30640828656).

<!-- /claude-code-review:summary -->
