### PR TITLE
fix(composer): warn on unmatched context patch directories

### DIFF
--- a/pkg/composer/blueprint/composer.go
+++ b/pkg/composer/blueprint/composer.go
@@ -639,10 +639,11 @@ func (c *BaseBlueprintComposer) mergeLegacySpecialVariables(mergedCommonValues m
 // name ("<system>-install" or "<system>-resources[-<variant>]"), or a bare FluxSystem name — which
 // resolves to that system's install tier, or its lone resources variant when there is no install
 // tier and exactly one resources variant; a bare name is left unmatched when that would be
-// ambiguous, so the tier-qualified name must be used instead. A directory matching neither is
-// silently ignored (patches are opt-in overlays; an unrelated or stale directory is not an error).
-// Supports both strategic merge patches (standard Kubernetes YAML) and JSON 6902 patches (with a
-// patches field containing JSON 6902 operations).
+// ambiguous, so the tier-qualified name must be used instead. A directory matching neither is not
+// an error (patches are opt-in overlays; composition still succeeds), but is reported to stderr —
+// a typo'd or stale directory would otherwise apply nothing with no indication why. Supports both
+// strategic merge patches (standard Kubernetes YAML) and JSON 6902 patches (with a patches field
+// containing JSON 6902 operations).
 func (c *BaseBlueprintComposer) discoverContextPatches(blueprint *blueprintv1alpha1.Blueprint) error {
 	if c.runtime == nil || c.runtime.ConfigRoot == "" {
 		return nil
@@ -675,6 +676,7 @@ func (c *BaseBlueprintComposer) discoverContextPatches(blueprint *blueprintv1alp
 			kustomization, exists = fluxTierMap[kustomizationName]
 		}
 		if !exists {
+			fmt.Fprintf(os.Stderr, "Warning: %s does not match any kustomization or FluxSystem tier; patches ignored\n", filepath.Join(patchesDir, kustomizationName))
 			continue
 		}
 

--- a/pkg/composer/blueprint/composer_test.go
+++ b/pkg/composer/blueprint/composer_test.go
@@ -2,6 +2,7 @@ package blueprint
 
 import (
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"slices"
@@ -2687,7 +2688,7 @@ spec:
 		}
 	})
 
-	t.Run("IgnoresPatchesForNonExistentKustomization", func(t *testing.T) {
+	t.Run("IgnoresPatchesForNonExistentKustomizationAndWarns", func(t *testing.T) {
 		// Given a composer with patches for kustomization that doesn't exist
 		mocks := setupComposerMocks(t)
 		patchesDir := mocks.Runtime.ConfigRoot + "/patches/non-existent"
@@ -2701,14 +2702,24 @@ spec:
 		}
 
 		// When discovering patches
+		oldStderr := os.Stderr
+		r, w, _ := os.Pipe()
+		os.Stderr = w
 		err := composer.discoverContextPatches(blueprint)
+		w.Close()
+		var buf strings.Builder
+		_, _ = io.Copy(&buf, r)
+		os.Stderr = oldStderr
 
-		// Then patches should be ignored
+		// Then patches should be ignored, but a warning is printed naming the unmatched directory
 		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 		if len(blueprint.Kustomizations[0].Patches) != 0 {
 			t.Errorf("Expected 0 patches, got %d", len(blueprint.Kustomizations[0].Patches))
+		}
+		if !strings.Contains(buf.String(), "non-existent") || !strings.Contains(buf.String(), "does not match") {
+			t.Errorf("Expected warning naming the unmatched 'non-existent' directory, got: %q", buf.String())
 		}
 	})
 


### PR DESCRIPTION
Closes #3098

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> The change is isolated to the blueprint composer's context-patch discovery, adding a diagnostic message with no change to control flow or error semantics.
>
> **Overview**
>
> When a `patches/<name>/` directory doesn't match any kustomization or FluxSystem tier, `discoverContextPatches` now emits a warning to stderr naming the unmatched directory before continuing, instead of silently ignoring it. The function still returns no error and composition still succeeds — this is purely an added diagnostic for what was previously a silent no-op, useful for catching typo'd or stale patch directories.
>
> The accompanying test renames `IgnoresPatchesForNonExistentKustomization` to `IgnoresPatchesForNonExistentKustomizationAndWarns` and captures stderr via an `os.Pipe` swap to assert the warning text, matching the pattern used by similar stderr warnings elsewhere in the codebase.

<!-- /claude-code-review:summary -->
