### PR TITLE
fix(config): improve error reporting for schema validation failures

### DIFF
--- a/pkg/runtime/config/handler.go
+++ b/pkg/runtime/config/handler.go
@@ -574,7 +574,9 @@ func (c *configHandler) LoadSchemaFromBytes(schemaContent []byte) error {
 // rules spanning static (v1alpha1.Context) and dynamic fields are evaluated against the unified map,
 // matching the file-load validation path. Use before impactful operations (e.g. windsor up) and after
 // compositional Set sequences. Returns nil if no schema is loaded or if validation passes; returns an
-// error if validation fails.
+// error if validation fails. When the same invalid data was already warned about by valuesSource.Load
+// earlier in this invocation, the error refers back to that warning instead of re-printing the
+// identical error list a second time.
 func (c *configHandler) ValidateContextValues() error {
 	if c.schemaValidator == nil || c.schemaValidator.Schema == nil {
 		return nil
@@ -582,7 +584,10 @@ func (c *configHandler) ValidateContextValues() error {
 	if result, err := c.schemaValidator.Validate(c.data); err != nil {
 		return fmt.Errorf("error validating context values: %w", err)
 	} else if !result.Valid {
-		return fmt.Errorf("context value validation failed: %v", result.Errors)
+		if c.schemaValidator.ErrorsAlreadyReported(result.Errors) {
+			return fmt.Errorf("context value validation failed (see the values.yaml warning above)")
+		}
+		return fmt.Errorf("context value validation failed:%s", FormatValidationErrors(result.Errors))
 	}
 	return nil
 }

--- a/pkg/runtime/config/handler_test.go
+++ b/pkg/runtime/config/handler_test.go
@@ -1486,6 +1486,42 @@ additionalProperties: false
 		}
 	})
 
+	t.Run("RefersBackToWarningWhenSameErrorsAlreadyReported", func(t *testing.T) {
+		handler, tmpDir := setupPrivateTestHandler(t)
+		schemaPath := filepath.Join(tmpDir, "schema.yaml")
+		schemaContent := `$schema: https://json-schema.org/draft/2020-12/schema
+type: object
+properties:
+  allowed:
+    type: string
+additionalProperties: false
+`
+		os.WriteFile(schemaPath, []byte(schemaContent), 0644)
+		if err := handler.LoadSchema(schemaPath); err != nil {
+			t.Fatalf("Expected no error loading schema, got %v", err)
+		}
+		handler.data = map[string]any{"dynamic_key": "value"}
+
+		// Given the same invalid data was already validated and warned about earlier (e.g. by
+		// valuesSource.Load) in this invocation
+		result, err := handler.schemaValidator.Validate(handler.data)
+		if err != nil {
+			t.Fatalf("Expected no error validating, got %v", err)
+		}
+		handler.schemaValidator.MarkErrorsReported(result.Errors)
+
+		// When ValidateContextValues revalidates the identical data
+		err = handler.ValidateContextValues()
+
+		// Then it refers back to the earlier warning instead of re-dumping the same error list
+		if err == nil {
+			t.Fatal("Expected validation error")
+		}
+		if err.Error() != "context value validation failed (see the values.yaml warning above)" {
+			t.Errorf("Expected a reference to the earlier warning, got %v", err)
+		}
+	})
+
 	t.Run("ValidatesStaticFieldsAgainstSchema", func(t *testing.T) {
 		handler, tmpDir := setupPrivateTestHandler(t)
 		schemaPath := filepath.Join(tmpDir, "schema.yaml")

--- a/pkg/runtime/config/schema_validator.go
+++ b/pkg/runtime/config/schema_validator.go
@@ -37,6 +37,13 @@ type SchemaValidator struct {
 	// distinguishes a computed-empty result from an uncomputed cache.
 	sensitivePaths   []string
 	sensitivePathsOK bool
+
+	// lastReportedErrors caches the error list last surfaced to the operator (e.g. by
+	// valuesSource.Load's warning), joined into one comparable string. A later caller validating
+	// the same invalid data (e.g. ValidateContextValues, run after Load in the same invocation)
+	// checks ErrorsAlreadyReported before printing, so the identical wall of text isn't dumped
+	// twice for one root cause.
+	lastReportedErrors string
 }
 
 // SchemaValidationResult carries the outcome of a Validate call. Defaults is populated by
@@ -107,7 +114,9 @@ func (sv *SchemaValidator) LoadSchemaFromBytes(schemaContent []byte) error {
 
 // Validate checks values against the loaded schema and returns the outcome plus extracted
 // defaults. Errors are flattened from kaptinlin's hierarchical EvaluationResult into one
-// "<instance-path>: <message>" line per leaf, suitable for direct %v formatting by callers.
+// deduplicated, prioritized "<instance-path>: <keyword>: <message>" line per leaf — see
+// collectErrors — pass them to FormatValidationErrors for display, or ErrorsAlreadyReported to
+// check whether a caller earlier in this invocation already surfaced the identical set.
 func (sv *SchemaValidator) Validate(values map[string]any) (*SchemaValidationResult, error) {
 	schema, err := sv.ensureCompiled()
 	if err != nil {
@@ -121,6 +130,46 @@ func (sv *SchemaValidator) Validate(values map[string]any) (*SchemaValidationRes
 		Defaults: extractDefaults(sv.Schema),
 	}
 	return result, nil
+}
+
+// MarkErrorsReported records errs (a Validate result's Errors) as already surfaced to the
+// operator, so a later ErrorsAlreadyReported call for the identical error set — e.g.
+// ValidateContextValues revalidating the same invalid data already warned about by
+// valuesSource.Load earlier in the same invocation — can recognize the duplicate and skip
+// re-printing it.
+func (sv *SchemaValidator) MarkErrorsReported(errs []string) {
+	sv.lastReportedErrors = errorSetFingerprint(errs)
+}
+
+// ErrorsAlreadyReported reports whether errs is the same set of errors last recorded by
+// MarkErrorsReported, regardless of order.
+func (sv *SchemaValidator) ErrorsAlreadyReported(errs []string) bool {
+	return sv.lastReportedErrors != "" && sv.lastReportedErrors == errorSetFingerprint(errs)
+}
+
+// errorSetFingerprint builds an order-independent fingerprint for an error slice. Two separate
+// Validate calls against the identical invalid data can each produce their Errors in a different
+// order — kaptinlin's per-node Errors map (multiple keywords failing at the same instance
+// location) iterates in Go's randomized map order, and collectErrors' stable sort only
+// reorders by structural/specific priority, not by content — so comparing raw join order would
+// spuriously treat the same error set as different across calls.
+func errorSetFingerprint(errs []string) string {
+	sorted := make([]string, len(errs))
+	copy(sorted, errs)
+	sort.Strings(sorted)
+	return strings.Join(sorted, "\x00")
+}
+
+// FormatValidationErrors renders a Validate result's Errors as an indented list, one violation
+// per line, instead of Go's flat space-joined %v slice format, so a multi-error result reads as
+// a scannable list rather than a run-on string.
+func FormatValidationErrors(errs []string) string {
+	var b strings.Builder
+	for _, e := range errs {
+		b.WriteString("\n  - ")
+		b.WriteString(e)
+	}
+	return b.String()
 }
 
 // GetSchemaDefaults returns the default values declared in the loaded schema as a single
@@ -324,36 +373,91 @@ func collectSensitivePaths(schema map[string]any, prefix string, out *[]string) 
 	}
 }
 
-// collectErrors flattens a kaptinlin EvaluationResult into one error string per leaf,
-// formatted as "<instance-path>: <keyword>: <message>" so callers that %v-format the
-// []string surface readable paths to operators.
+// structuralValidationKeywords are keywords whose failure is a symptom of a nested, more
+// specific failure elsewhere rather than the actionable violation itself — "properties" only
+// ever says "property X doesn't match its schema", never why; "allOf"/"anyOf"/"oneOf"/"if"
+// are the same shape one level up. collectErrors sorts these after every other keyword so an
+// operator sees the specific cause (additionalProperties, const, required, type, ...) first,
+// instead of every ancestor schema that failed as a consequence of it.
+var structuralValidationKeywords = map[string]bool{
+	"properties": true,
+	"allOf":      true,
+	"anyOf":      true,
+	"oneOf":      true,
+	"if":         true,
+}
+
+// validationError pairs a fully formatted error line with the keyword that produced it, so
+// collectErrors can dedup and prioritize without re-parsing the formatted string.
+type validationError struct {
+	keyword string
+	line    string
+}
+
+// collectErrors flattens a kaptinlin EvaluationResult into a deduplicated, prioritized list of
+// error strings, one per distinct leaf, formatted as "<instance-path>: <keyword>: <message>".
+// A schema with several allOf/if branches referencing the same property routinely reports the
+// identical (path, keyword, message) triple from each branch — e.g. a cluster-driver coherence
+// check and an identity-driver coherence check both restating "/: properties: Property
+// 'cluster' does not match the schema" — so exact-duplicate lines are dropped, and the survivors
+// are stably reordered per structuralValidationKeywords.
 func collectErrors(result *jsonschema.EvaluationResult) []string {
 	if result.IsValid() {
 		return nil
 	}
-	list := result.ToList(true)
-	var errs []string
-	walkList(list, "", &errs)
-	if len(errs) == 0 {
-		errs = []string{"validation failed"}
+	return flattenErrorList(result.ToList(true))
+}
+
+// flattenErrorList walks list via walkList, then dedups and prioritizes the result — split out
+// from collectErrors so the dedup/prioritization logic is testable directly against a
+// hand-constructed *jsonschema.List, without needing a real schema evaluation to reproduce a
+// specific duplicate/cascading shape.
+func flattenErrorList(list *jsonschema.List) []string {
+	var raw []validationError
+	walkList(list, "", &raw)
+	if len(raw) == 0 {
+		return []string{"validation failed"}
+	}
+
+	seen := make(map[string]bool, len(raw))
+	deduped := make([]validationError, 0, len(raw))
+	for _, e := range raw {
+		if seen[e.line] {
+			continue
+		}
+		seen[e.line] = true
+		deduped = append(deduped, e)
+	}
+
+	sort.SliceStable(deduped, func(i, j int) bool {
+		return !structuralValidationKeywords[deduped[i].keyword] && structuralValidationKeywords[deduped[j].keyword]
+	})
+
+	errs := make([]string, len(deduped))
+	for i, e := range deduped {
+		errs[i] = e.line
 	}
 	return errs
 }
 
-// walkList descends a flattened List, emitting one string per (instance-location, keyword)
-// pair. Instance locations use JSON Pointer notation rooted at "/" (e.g. "/network/cidr_block").
-// kaptinlin scopes each evaluator's leaf to a path local to that evaluator — a nested enum
-// failure on storage.driver surfaces as "/driver" rather than "/storage/driver" — so this
-// walker carries the parent location down the recursion and joins it onto each child to
-// reconstruct the fully-qualified pointer operators expect when reading the message.
-func walkList(list *jsonschema.List, parent string, errs *[]string) {
+// walkList descends a flattened List, emitting one validationError per (instance-location,
+// keyword) pair. Instance locations use JSON Pointer notation rooted at "/" (e.g.
+// "/network/cidr_block"). kaptinlin scopes each evaluator's leaf to a path local to that
+// evaluator — a nested enum failure on storage.driver surfaces as "/driver" rather than
+// "/storage/driver" — so this walker carries the parent location down the recursion and joins
+// it onto each child to reconstruct the fully-qualified pointer operators expect when reading
+// the message.
+func walkList(list *jsonschema.List, parent string, errs *[]validationError) {
 	loc := joinInstanceLocation(parent, list.InstanceLocation)
 	display := loc
 	if display == "" {
 		display = "/"
 	}
 	for keyword, msg := range list.Errors {
-		*errs = append(*errs, fmt.Sprintf("%s: %s: %s", display, keyword, msg))
+		*errs = append(*errs, validationError{
+			keyword: keyword,
+			line:    fmt.Sprintf("%s: %s: %s", display, keyword, msg),
+		})
 	}
 	for i := range list.Details {
 		walkList(&list.Details[i], loc, errs)

--- a/pkg/runtime/config/schema_validator_test.go
+++ b/pkg/runtime/config/schema_validator_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/kaptinlin/jsonschema"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
 )
 
@@ -915,6 +916,165 @@ func TestSchemaValidator_Validate(t *testing.T) {
 		expectedError := "config schema has not been loaded"
 		if err.Error() != expectedError {
 			t.Errorf("Expected error '%s', got: %v", expectedError, err)
+		}
+	})
+}
+
+func TestFlattenErrorList(t *testing.T) {
+	t.Run("DropsExactDuplicateLines", func(t *testing.T) {
+		// Given two branches that both fail with the identical (path, keyword, message) triple
+		// at the root — the shape a schema with several allOf branches referencing the same
+		// property produces — plus one leaf-specific failure
+		list := &jsonschema.List{
+			Details: []jsonschema.List{
+				{
+					InstanceLocation: "/",
+					Errors:           map[string]string{"properties": "Property 'cluster' does not match the schema"},
+					Details: []jsonschema.List{
+						{InstanceLocation: "/cluster", Errors: map[string]string{"additionalProperties": "Additional property 'oidc' does not match the schema"}},
+					},
+				},
+				{
+					InstanceLocation: "/",
+					Errors:           map[string]string{"properties": "Property 'cluster' does not match the schema"},
+				},
+			},
+		}
+
+		// When flattening
+		errs := flattenErrorList(list)
+
+		// Then the duplicate "/: properties: ..." line appears exactly once
+		count := 0
+		for _, e := range errs {
+			if e == "/: properties: Property 'cluster' does not match the schema" {
+				count++
+			}
+		}
+		if count != 1 {
+			t.Errorf("Expected the duplicate line to appear once, got %d occurrences in %v", count, errs)
+		}
+		if len(errs) != 2 {
+			t.Errorf("Expected 2 distinct errors, got %d: %v", len(errs), errs)
+		}
+	})
+
+	t.Run("SortsStructuralKeywordsAfterSpecificOnes", func(t *testing.T) {
+		// Given a "properties" (structural) failure at the root and an "additionalProperties"
+		// (specific/actionable) failure nested under it
+		list := &jsonschema.List{
+			InstanceLocation: "/",
+			Errors:           map[string]string{"properties": "Property 'cluster' does not match the schema"},
+			Details: []jsonschema.List{
+				{InstanceLocation: "/cluster", Errors: map[string]string{"additionalProperties": "Additional property 'oidc' does not match the schema"}},
+			},
+		}
+
+		// When flattening
+		errs := flattenErrorList(list)
+
+		// Then the specific error sorts before the structural one, even though it was nested
+		// (and so walked) after it
+		if len(errs) != 2 {
+			t.Fatalf("Expected 2 errors, got %d: %v", len(errs), errs)
+		}
+		if !strings.Contains(errs[0], "additionalProperties") {
+			t.Errorf("Expected the additionalProperties error first, got %v", errs)
+		}
+		if !strings.Contains(errs[1], "properties") {
+			t.Errorf("Expected the properties error last, got %v", errs)
+		}
+	})
+
+	t.Run("PreservesRelativeOrderWithinEachPriorityGroup", func(t *testing.T) {
+		// Given two specific (non-structural) failures and two structural failures, interleaved
+		list := &jsonschema.List{
+			Details: []jsonschema.List{
+				{InstanceLocation: "/a", Errors: map[string]string{"required": "Required property 'a' is missing"}},
+				{InstanceLocation: "/", Errors: map[string]string{"properties": "Property 'x' does not match the schema"}},
+				{InstanceLocation: "/b", Errors: map[string]string{"const": "Value does not match the constant value"}},
+				{InstanceLocation: "/", Errors: map[string]string{"allOf": "Value does not match the allOf schema at index 0"}},
+			},
+		}
+
+		// When flattening
+		errs := flattenErrorList(list)
+
+		// Then the two specific errors keep their original relative order, ahead of the two
+		// structural errors, which also keep their original relative order
+		if len(errs) != 4 {
+			t.Fatalf("Expected 4 errors, got %d: %v", len(errs), errs)
+		}
+		if !strings.Contains(errs[0], "required") || !strings.Contains(errs[1], "const") {
+			t.Errorf("Expected required then const first, got %v", errs)
+		}
+		if !strings.Contains(errs[2], "properties") || !strings.Contains(errs[3], "allOf") {
+			t.Errorf("Expected properties then allOf last, got %v", errs)
+		}
+	})
+
+	t.Run("ReturnsPlaceholderWhenListHasNoErrors", func(t *testing.T) {
+		// Given a list with no error entries anywhere
+		list := &jsonschema.List{}
+
+		// When flattening
+		errs := flattenErrorList(list)
+
+		// Then a placeholder is returned rather than an empty slice
+		if len(errs) != 1 || errs[0] != "validation failed" {
+			t.Errorf("Expected placeholder 'validation failed', got %v", errs)
+		}
+	})
+}
+
+func TestSchemaValidator_ErrorReportingDedup(t *testing.T) {
+	t.Run("NotReportedInitially", func(t *testing.T) {
+		// Given a fresh validator
+		validator := NewSchemaValidator(shell.NewMockShell())
+
+		// Then an arbitrary error set is not considered already reported
+		if validator.ErrorsAlreadyReported([]string{"/: required: x is missing"}) {
+			t.Error("Expected ErrorsAlreadyReported to be false before any MarkErrorsReported call")
+		}
+	})
+
+	t.Run("ReportsTrueForIdenticalErrorSet", func(t *testing.T) {
+		// Given a validator that already reported a specific error set
+		validator := NewSchemaValidator(shell.NewMockShell())
+		errs := []string{"/: required: x is missing", "/cluster: const: bad value"}
+		validator.MarkErrorsReported(errs)
+
+		// Then the identical set (even a distinct slice with the same contents) is recognized
+		same := []string{"/: required: x is missing", "/cluster: const: bad value"}
+		if !validator.ErrorsAlreadyReported(same) {
+			t.Error("Expected the identical error set to be recognized as already reported")
+		}
+	})
+
+	t.Run("ReportsFalseForDifferentErrorSet", func(t *testing.T) {
+		// Given a validator that already reported one error set
+		validator := NewSchemaValidator(shell.NewMockShell())
+		validator.MarkErrorsReported([]string{"/: required: x is missing"})
+
+		// Then a different error set is not recognized as already reported
+		if validator.ErrorsAlreadyReported([]string{"/: required: y is missing"}) {
+			t.Error("Expected a different error set not to be recognized as already reported")
+		}
+	})
+}
+
+func TestFormatValidationErrors(t *testing.T) {
+	t.Run("FormatsEachErrorOnItsOwnIndentedLine", func(t *testing.T) {
+		got := FormatValidationErrors([]string{"/a: required: a is missing", "/b: const: bad value"})
+		want := "\n  - /a: required: a is missing\n  - /b: const: bad value"
+		if got != want {
+			t.Errorf("Expected %q, got %q", want, got)
+		}
+	})
+
+	t.Run("ReturnsEmptyStringForNoErrors", func(t *testing.T) {
+		if got := FormatValidationErrors(nil); got != "" {
+			t.Errorf("Expected empty string, got %q", got)
 		}
 	})
 }

--- a/pkg/runtime/config/values_source.go
+++ b/pkg/runtime/config/values_source.go
@@ -65,7 +65,8 @@ func (s *valuesSource) Load(projectRoot, contextName string) (map[string]any, bo
 
 	if s.schemaValidator != nil && s.schemaValidator.Schema != nil {
 		if result, err := s.schemaValidator.Validate(values); err == nil && !result.Valid {
-			fmt.Fprintf(os.Stderr, "Warning: values.yaml validation failed (config still loaded): %v\n", result.Errors)
+			fmt.Fprintf(os.Stderr, "Warning: values.yaml validation failed (config still loaded):%s\n", FormatValidationErrors(result.Errors))
+			s.schemaValidator.MarkErrorsReported(result.Errors)
 		}
 	}
 

--- a/pkg/runtime/config/values_source_test.go
+++ b/pkg/runtime/config/values_source_test.go
@@ -1,9 +1,13 @@
 package config
 
 import (
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	"github.com/windsorcli/cli/pkg/runtime/shell"
 )
 
 // =============================================================================
@@ -48,6 +52,65 @@ func TestValuesSource_Load(t *testing.T) {
 		}
 		if values["provider"] != "docker" {
 			t.Errorf("Expected provider=docker, got %v", values["provider"])
+		}
+	})
+
+	t.Run("WarnsWithFormattedErrorsAndMarksReportedWhenSchemaInvalid", func(t *testing.T) {
+		validator := NewSchemaValidator(shell.NewMockShell())
+		validator.Schema = map[string]any{
+			"$schema":              "https://json-schema.org/draft/2020-12/schema",
+			"type":                 "object",
+			"properties":           map[string]any{"provider": map[string]any{"type": "string"}},
+			"required":             []any{"provider"},
+			"additionalProperties": false,
+		}
+		source := newValuesSource(NewShims(), validator, newPersistencePolicy())
+		projectRoot := t.TempDir()
+		contextName := "local"
+		contextDir := filepath.Join(projectRoot, "contexts", contextName)
+		if err := os.MkdirAll(contextDir, 0755); err != nil {
+			t.Fatalf("Expected no error creating context dir, got %v", err)
+		}
+		// Missing required "provider" and carrying an undeclared "oidc" property.
+		if err := os.WriteFile(filepath.Join(contextDir, "values.yaml"), []byte("oidc: not-allowed\n"), 0644); err != nil {
+			t.Fatalf("Expected no error writing values.yaml, got %v", err)
+		}
+
+		oldStderr := os.Stderr
+		r, w, _ := os.Pipe()
+		os.Stderr = w
+		values, found, err := source.Load(projectRoot, contextName)
+		w.Close()
+		var buf strings.Builder
+		_, _ = io.Copy(&buf, r)
+		os.Stderr = oldStderr
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !found {
+			t.Fatal("Expected values.yaml to be found")
+		}
+		if values["oidc"] != "not-allowed" {
+			t.Errorf("Expected values to still be returned despite validation failure, got %v", values)
+		}
+
+		output := buf.String()
+		if !strings.HasPrefix(output, "Warning: values.yaml validation failed (config still loaded):\n  - ") {
+			t.Errorf("Expected an indented multi-line warning, got %q", output)
+		}
+		if !strings.Contains(output, "required") || !strings.Contains(output, "additionalProperties") {
+			t.Errorf("Expected the warning to mention both violations, got %q", output)
+		}
+
+		// And the reported error set is now recognized by ErrorsAlreadyReported, so a later
+		// ValidateContextValues call against the same invalid data won't re-print it.
+		result, err := validator.Validate(values)
+		if err != nil {
+			t.Fatalf("Expected no error re-validating, got %v", err)
+		}
+		if !validator.ErrorsAlreadyReported(result.Errors) {
+			t.Error("Expected the warned error set to be marked as already reported")
 		}
 	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Touches only schema-validation error formatting and message plumbing in `pkg/runtime/config`; it changes how validation errors are rendered and deduplicated, not whether a given configuration passes or fails validation.
>
> **Overview**
>
> This PR reworks how JSON-schema validation errors are collected and displayed. `collectErrors` now deduplicates exact-duplicate error lines (common when multiple `allOf`/`if` branches restate the same failure) and sorts structural keywords (`properties`, `allOf`, `anyOf`, `oneOf`, `if`) after the specific keyword that actually explains the failure, so operators see the actionable cause first. A new `FormatValidationErrors` helper renders errors as an indented list instead of Go's flat `%v` slice format.
>
> It also adds a same-invocation dedup mechanism: `valuesSource.Load` now marks the error set it warns about via `MarkErrorsReported`, and `ValidateContextValues` checks `ErrorsAlreadyReported` before re-validating, replacing a duplicate wall of text with a short pointer back to the earlier warning when the two calls hit the identical error set. All new logic is covered by unit tests in `schema_validator_test.go`, `handler_test.go`, and `values_source_test.go`.

<!-- /claude-code-review:summary -->
