### PR TITLE
fix(runtime): ensure NO_CACHE respects existing environment variable settings during session reset

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -230,8 +230,12 @@ func NewRuntime(opts ...*Runtime) *Runtime {
 
 // HandleSessionReset checks for reset flags and session tokens, then resets managed environment
 // variables if needed. It checks for WINDSOR_SESSION_TOKEN and uses the shell's CheckResetFlags
-// method to determine if a reset should occur. If reset is needed, it calls Shell.Reset() and
-// sets NO_CACHE=true. Returns an error if reset flag checking fails.
+// method to determine if a reset should occur. A command like `windsor exec` that never
+// establishes its own session token always has hasSessionToken false, so every invocation would
+// otherwise be treated as a fresh reset; NO_CACHE only defaults to "true" when the caller hasn't
+// already set it explicitly (to "true" or "false"), so an explicit `NO_CACHE=false windsor exec
+// -- ...` — or a value already present in the calling shell — is honored instead of being
+// force-overwritten on every reset. Returns an error if reset flag checking fails.
 func (rt *Runtime) HandleSessionReset() error {
 	hasSessionToken := os.Getenv("WINDSOR_SESSION_TOKEN") != ""
 	shouldReset, err := rt.Shell.CheckResetFlags()
@@ -243,8 +247,10 @@ func (rt *Runtime) HandleSessionReset() error {
 	}
 	if shouldReset {
 		rt.Shell.Reset()
-		if err := os.Setenv("NO_CACHE", "true"); err != nil {
-			return fmt.Errorf("failed to set NO_CACHE: %w", err)
+		if _, noCacheSet := os.LookupEnv("NO_CACHE"); !noCacheSet {
+			if err := os.Setenv("NO_CACHE", "true"); err != nil {
+				return fmt.Errorf("failed to set NO_CACHE: %w", err)
+			}
 		}
 		if rt.TerraformProvider != nil {
 			rt.TerraformProvider.ClearCache()

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -939,6 +939,70 @@ func TestRuntime_HandleSessionReset(t *testing.T) {
 		if !resetCalled {
 			t.Error("Expected Reset to be called when no session token")
 		}
+		if os.Getenv("NO_CACHE") != "true" {
+			t.Errorf("Expected NO_CACHE to default to true, got %q", os.Getenv("NO_CACHE"))
+		}
+	})
+
+	t.Run("PreservesExplicitNoCacheFalseOnReset", func(t *testing.T) {
+		// Given a caller that explicitly opted back into caching (e.g. `NO_CACHE=false windsor
+		// exec -- ...`), and no session token — so a reset is still triggered
+		t.Cleanup(func() {
+			os.Unsetenv("NO_CACHE")
+			os.Unsetenv("WINDSOR_SESSION_TOKEN")
+		})
+		os.Unsetenv("WINDSOR_SESSION_TOKEN")
+		t.Setenv("NO_CACHE", "false")
+
+		mocks := setupRuntimeMocks(t)
+		rt := mocks.Runtime
+
+		mockShell := mocks.Shell.(*shell.MockShell)
+		mockShell.CheckResetFlagsFunc = func() (bool, error) {
+			return false, nil
+		}
+
+		// When HandleSessionReset is called
+		err := rt.HandleSessionReset()
+
+		// Then the reset still runs, but the caller's explicit NO_CACHE=false is not
+		// force-overwritten to true
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+		if os.Getenv("NO_CACHE") != "false" {
+			t.Errorf("Expected explicit NO_CACHE=false to be preserved, got %q", os.Getenv("NO_CACHE"))
+		}
+	})
+
+	t.Run("PreservesExplicitNoCacheTrueOnReset", func(t *testing.T) {
+		// Given a caller that already set NO_CACHE=true itself, and no session token
+		t.Cleanup(func() {
+			os.Unsetenv("NO_CACHE")
+			os.Unsetenv("WINDSOR_SESSION_TOKEN")
+		})
+		os.Unsetenv("WINDSOR_SESSION_TOKEN")
+		t.Setenv("NO_CACHE", "true")
+
+		mocks := setupRuntimeMocks(t)
+		rt := mocks.Runtime
+
+		mockShell := mocks.Shell.(*shell.MockShell)
+		mockShell.CheckResetFlagsFunc = func() (bool, error) {
+			return false, nil
+		}
+
+		// When HandleSessionReset is called
+		err := rt.HandleSessionReset()
+
+		// Then the pre-existing value is left alone (not re-set, though the observable result
+		// is the same either way)
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+		if os.Getenv("NO_CACHE") != "true" {
+			t.Errorf("Expected NO_CACHE to remain true, got %q", os.Getenv("NO_CACHE"))
+		}
 	})
 
 	t.Run("ResetsWhenResetFlagSet", func(t *testing.T) {


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Touches only `Runtime.HandleSessionReset`'s `NO_CACHE` handling and its tests, with no change to when a reset is triggered or to any other caller.
>
> **Overview**
>
> Previously, every session reset (which fires on any invocation lacking a `WINDSOR_SESSION_TOKEN`, such as `windsor exec`) unconditionally set `NO_CACHE=true`, clobbering any value the caller had already set. The fix checks `os.LookupEnv("NO_CACHE")` first and only defaults it to `"true"` when the variable is unset, so an explicit `NO_CACHE=false` (or a pre-existing `NO_CACHE=true`) from the calling shell survives the reset.
>
> This brings `HandleSessionReset` in line with the "explicit wins, otherwise preserve" convention already used for `--no-cache` in `cmd/root.go`. Two new subtests cover both explicit values; the existing default-to-true behavior is preserved and asserted.

<!-- /claude-code-review:summary -->
