### PR TITLE
fix(tui): add fallback message for spinner when stderr is not a terminal

### DIFF
--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/briandowns/spinner"
+	"golang.org/x/term"
 )
 
 // The tui package provides centralized terminal user interface primitives for the Windsor CLI.
@@ -159,6 +160,11 @@ func WithProgress(message string, fn func() error) error {
 // Start stops any existing spinner and begins a new one with the given message.
 // WithWriterFile binds the animation's terminal check to stderr, the stream the frames go to;
 // WithWriter would leave that check on stdout, silencing the animation whenever stdout is redirected.
+// The underlying spinner library silently no-ops its animation when stderr isn't a real
+// terminal (piped, redirected, captured by a log) — with nothing else printed until Done/Fail,
+// every step would otherwise appear to jump straight from nothing to its final result with no
+// visible waiting/in-progress phase. isInteractiveStderr falls back to printing the message as
+// a static line in that case, the same non-animated behavior verboseSpinner already uses.
 func (s *termSpinner) Start(message string) {
 	if s.spin != nil && s.spin.Active() {
 		s.spin.Stop()
@@ -169,12 +175,21 @@ func (s *termSpinner) Start(message string) {
 	s.spin = spinner.New(spinner.CharSets[14], 100*time.Millisecond, spinner.WithColor("green"), spinner.WithWriterFile(os.Stderr))
 	s.spin.Suffix = " " + message
 	s.spin.Start()
+	if !isInteractiveStderr() {
+		fmt.Fprintln(os.Stderr, message)
+	}
 }
 
 // Update changes the spinner suffix to the given message without altering the stored message.
+// Falls back to printing the message as a static line when stderr isn't a terminal, for the
+// same reason Start does — see Start's doc comment.
 func (s *termSpinner) Update(message string) {
-	if s.spin != nil {
-		s.spin.Suffix = " " + message
+	if s.spin == nil {
+		return
+	}
+	s.spin.Suffix = " " + message
+	if !isInteractiveStderr() {
+		fmt.Fprintln(os.Stderr, message)
 	}
 }
 
@@ -211,21 +226,6 @@ func (s *termSpinner) Pause() {
 	s.pause(false)
 }
 
-// pause stops the spinner animation and optionally prints a static progress line.
-func (s *termSpinner) pause(printMessage bool) {
-	if s.spin != nil {
-		if s.paused == 0 {
-			fmt.Fprint(os.Stderr, "\033[s")
-			s.pauseCursorSaved = true
-			s.spin.Stop()
-			if printMessage {
-				fmt.Fprintf(os.Stderr, "… %s\n", s.message)
-			}
-		}
-		s.paused++
-	}
-}
-
 // Resume restarts the spinner animation using the previously set message.
 func (s *termSpinner) Resume() {
 	if s.spin != nil && s.paused > 0 {
@@ -258,3 +258,26 @@ func (s *verboseSpinner) Pause() {}
 // Resume is a no-op in verbose mode since there is no animation to restart.
 func (s *verboseSpinner) Resume() {}
 
+// =============================================================================
+// Private Methods
+// =============================================================================
+
+// isInteractiveStderr reports whether stderr is attached to a real terminal.
+func isInteractiveStderr() bool {
+	return term.IsTerminal(int(os.Stderr.Fd())) // #nosec G115 -- file descriptors are small, safe to cast to int
+}
+
+// pause stops the spinner animation and optionally prints a static progress line.
+func (s *termSpinner) pause(printMessage bool) {
+	if s.spin != nil {
+		if s.paused == 0 {
+			fmt.Fprint(os.Stderr, "\033[s")
+			s.pauseCursorSaved = true
+			s.spin.Stop()
+			if printMessage {
+				fmt.Fprintf(os.Stderr, "… %s\n", s.message)
+			}
+		}
+		s.paused++
+	}
+}

--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -27,6 +27,7 @@ type termSpinner struct {
 	message           string
 	paused            int
 	pauseCursorSaved  bool
+	lastFallbackLine  string
 }
 
 // verboseSpinner is the Spinner implementation used in verbose mode.
@@ -164,7 +165,9 @@ func WithProgress(message string, fn func() error) error {
 // terminal (piped, redirected, captured by a log) — with nothing else printed until Done/Fail,
 // every step would otherwise appear to jump straight from nothing to its final result with no
 // visible waiting/in-progress phase. isInteractiveStderr falls back to printing the message as
-// a static line in that case, the same non-animated behavior verboseSpinner already uses.
+// a static line in that case, the same non-animated behavior verboseSpinner already uses. Start
+// always prints its message (announcing the new phase) and resets the dedup baseline Update
+// checks against, even if it happens to match the previous phase's last line.
 func (s *termSpinner) Start(message string) {
 	if s.spin != nil && s.spin.Active() {
 		s.spin.Stop()
@@ -178,19 +181,25 @@ func (s *termSpinner) Start(message string) {
 	if !isInteractiveStderr() {
 		fmt.Fprintln(os.Stderr, message)
 	}
+	s.lastFallbackLine = message
 }
 
 // Update changes the spinner suffix to the given message without altering the stored message.
 // Falls back to printing the message as a static line when stderr isn't a terminal, for the
-// same reason Start does — see Start's doc comment.
+// same reason Start does — see Start's doc comment. Skips the print when message is identical
+// to the last line printed (by Start or a prior Update), so a polling loop that calls Update
+// with an often-unchanged message (e.g. "waiting on X" across many ticks while nothing resolves)
+// doesn't spam duplicate lines while stderr is captured.
 func (s *termSpinner) Update(message string) {
 	if s.spin == nil {
 		return
 	}
 	s.spin.Suffix = " " + message
-	if !isInteractiveStderr() {
-		fmt.Fprintln(os.Stderr, message)
+	if isInteractiveStderr() || message == s.lastFallbackLine {
+		return
 	}
+	fmt.Fprintln(os.Stderr, message)
+	s.lastFallbackLine = message
 }
 
 // Done stops the spinner and prints a green success line to stderr.

--- a/pkg/tui/tui_test.go
+++ b/pkg/tui/tui_test.go
@@ -235,6 +235,22 @@ func TestTermSpinner_Start(t *testing.T) {
 			t.Errorf("expected message %q, got %q", "second", s.message)
 		}
 	})
+
+	t.Run("PrintsFallbackLineWhenStderrIsNotATerminal", func(t *testing.T) {
+		// Given a termSpinner, and stderr redirected to a pipe (never a terminal) — the
+		// underlying animated spinner silently no-ops in this case, so without a fallback,
+		// nothing would be printed until Done/Fail
+		s := &termSpinner{}
+		t.Cleanup(func() { captureStderr(t, s.Done) })
+
+		// When Start is called
+		output := captureStderr(t, func() { s.Start("waiting for reboot") })
+
+		// Then the message is still printed as a static line
+		if !strings.Contains(output, "waiting for reboot") {
+			t.Errorf("expected fallback line mentioning the message, got %q", output)
+		}
+	})
 }
 
 // Tests for termSpinner Update behavior
@@ -279,6 +295,35 @@ func TestTermSpinner_Update(t *testing.T) {
 		s.Update("msg")
 		if s.message != "" {
 			t.Errorf("expected message %q, got %q", "", s.message)
+		}
+	})
+
+	t.Run("PrintsFallbackLineWhenStderrIsNotATerminal", func(t *testing.T) {
+		// Given a termSpinner already started, with stderr redirected to a pipe (never a
+		// terminal)
+		s := &termSpinner{}
+		captureStderr(t, func() { s.Start("step 1") })
+		t.Cleanup(func() { captureStderr(t, s.Done) })
+
+		// When Update is called
+		output := captureStderr(t, func() { s.Update("step 2") })
+
+		// Then the updated message is printed as a static line
+		if !strings.Contains(output, "step 2") {
+			t.Errorf("expected fallback line mentioning the updated message, got %q", output)
+		}
+	})
+
+	t.Run("SkipsFallbackLineWhenNilSpin", func(t *testing.T) {
+		// Given a termSpinner with no active spin (Start was never called)
+		s := &termSpinner{}
+
+		// When Update is called
+		output := captureStderr(t, func() { s.Update("msg") })
+
+		// Then nothing is printed — Update on a never-started spinner is a no-op
+		if output != "" {
+			t.Errorf("expected no output, got %q", output)
 		}
 	})
 }

--- a/pkg/tui/tui_test.go
+++ b/pkg/tui/tui_test.go
@@ -326,6 +326,46 @@ func TestTermSpinner_Update(t *testing.T) {
 			t.Errorf("expected no output, got %q", output)
 		}
 	})
+
+	t.Run("DedupsRepeatedIdenticalMessageOnPollingLoops", func(t *testing.T) {
+		// Given a termSpinner started, with stderr redirected to a pipe (never a terminal) —
+		// mirrors a polling loop (e.g. provisioner.go's "waiting on %s" reconcile loop) calling
+		// Update every tick with a message that is often unchanged while nothing resolves
+		s := &termSpinner{}
+		captureStderr(t, func() { s.Start("waiting on a, b") })
+		t.Cleanup(func() { captureStderr(t, s.Done) })
+
+		// When Update is called repeatedly with the identical message
+		output := captureStderr(t, func() {
+			s.Update("waiting on a, b")
+			s.Update("waiting on a, b")
+			s.Update("waiting on a, b")
+		})
+
+		// Then nothing is printed — the message hasn't changed since Start's line
+		if output != "" {
+			t.Errorf("expected no duplicate lines for an unchanged message, got %q", output)
+		}
+	})
+
+	t.Run("PrintsAgainWhenMessageChangesAfterRepeats", func(t *testing.T) {
+		// Given a termSpinner started, with several identical Update calls already made
+		s := &termSpinner{}
+		captureStderr(t, func() { s.Start("waiting on a, b") })
+		t.Cleanup(func() { captureStderr(t, s.Done) })
+		captureStderr(t, func() {
+			s.Update("waiting on a, b")
+			s.Update("waiting on a, b")
+		})
+
+		// When Update is called with a genuinely different message (e.g. "a" resolved)
+		output := captureStderr(t, func() { s.Update("waiting on b") })
+
+		// Then the new message is printed
+		if !strings.Contains(output, "waiting on b") {
+			t.Errorf("expected the changed message to be printed, got %q", output)
+		}
+	})
 }
 
 // Tests for termSpinner Done output


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Changes are isolated to `pkg/tui`'s spinner implementation and are covered by new unit tests; no public API or CLI behavior outside progress-line rendering is affected.
>
> **Overview**
>
> This PR adds a fallback for `termSpinner` when stderr isn't attached to a real terminal (piped, redirected, or captured by a log): the underlying animated spinner library silently no-ops its animation in that case, so `Start` and `Update` now also print the message as a static line via a new `isInteractiveStderr()` check. The existing `pause` helper method was relocated below the newly added private `isInteractiveStderr` function to keep private methods grouped, with no behavior change to `pause` itself.
>
> Because `Update` now prints unconditionally whenever stderr is non-interactive, call sites that invoke it repeatedly on a polling loop with a slowly changing or identical message will emit a new line every tick rather than a single static line — see inline comment.

<!-- /claude-code-review:summary -->
