### PR TITLE
fix(test): enhance exclusion matching logic for components in kustomizations and flux systems

### DIFF
--- a/pkg/test/runner.go
+++ b/pkg/test/runner.go
@@ -544,7 +544,7 @@ func (r *TestRunner) matchBlueprint(bp *blueprintv1alpha1.Blueprint, expect *blu
 // Uses partial matching: components are identified by name or path for Terraform components, and by
 // name for Kustomizations. A Kustomization exclusion that also sets components: doesn't assert the
 // whole entry is absent — the containing kustomization is expected to exist, so this asserts only
-// that those specific components are absent from it (see matchKustomizationComponentExclusion); a
+// that those specific components are absent from it (see matchComponentExclusion); a
 // bare name: with no components: keeps whole-entry-absence semantics. If any excluded component is
 // found in the blueprint, a descriptive error message is added to the differences list. Returns an
 // empty slice if all exclusions are satisfied.
@@ -857,8 +857,11 @@ func (r *TestRunner) matchFluxSystem(actual *blueprintv1alpha1.FluxSystem, expec
 // variant that also sets components: doesn't assert the tier/variant itself is absent — it's expected
 // to exist — so this asserts only that those specific components are absent from it, the same
 // name-plus-components treatment matchExclusions gives a Kustomization exclusion (see
-// matchComponentExclusion). A bare install: or resources variant with no components: keeps
-// whole-tier/whole-variant-absence semantics. Returns an empty slice if every excluded part is absent.
+// matchComponentExclusion). This narrowing applies whichever way findFluxVariant located the variant —
+// by exact name, or by its components-subset match for an unnamed variant — since either way the found
+// variant is expected to exist and only the listed components are asserted absent from it. A bare
+// install: or resources variant with no components: keeps whole-tier/whole-variant-absence semantics.
+// Returns an empty slice if every excluded part is absent.
 func (r *TestRunner) matchFluxSystemExclusions(actual *blueprintv1alpha1.FluxSystem, exclude blueprintv1alpha1.FluxSystem) []string {
 	var diffs []string
 	name := exclude.Name
@@ -876,8 +879,8 @@ func (r *TestRunner) matchFluxSystemExclusions(actual *blueprintv1alpha1.FluxSys
 		if found == nil {
 			continue
 		}
-		if excludeVariant.Name != "" && len(excludeVariant.Components) > 0 {
-			diffs = append(diffs, matchComponentExclusion(found.Components, excludeVariant.Components, fmt.Sprintf("flux[%s].resources[%s]", name, excludeVariant.Name))...)
+		if len(excludeVariant.Components) > 0 {
+			diffs = append(diffs, matchComponentExclusion(found.Components, excludeVariant.Components, fmt.Sprintf("flux[%s].resources[%s]", name, fluxVariantIdentifier(excludeVariant)))...)
 			continue
 		}
 		diffs = append(diffs, fmt.Sprintf("flux[%s].resources: variant should not exist: %s", name, fluxVariantIdentifier(excludeVariant)))

--- a/pkg/test/runner.go
+++ b/pkg/test/runner.go
@@ -542,8 +542,12 @@ func (r *TestRunner) matchBlueprint(bp *blueprintv1alpha1.Blueprint, expect *blu
 // actual composed blueprint. This allows tests to assert that certain components should be excluded
 // based on test conditions (e.g., a component should not exist when a feature flag is disabled).
 // Uses partial matching: components are identified by name or path for Terraform components, and by
-// name for Kustomizations. If any excluded component is found in the blueprint, a descriptive error
-// message is added to the differences list. Returns an empty slice if all exclusions are satisfied.
+// name for Kustomizations. A Kustomization exclusion that also sets components: doesn't assert the
+// whole entry is absent — the containing kustomization is expected to exist, so this asserts only
+// that those specific components are absent from it (see matchKustomizationComponentExclusion); a
+// bare name: with no components: keeps whole-entry-absence semantics. If any excluded component is
+// found in the blueprint, a descriptive error message is added to the differences list. Returns an
+// empty slice if all exclusions are satisfied.
 func (r *TestRunner) matchExclusions(bp *blueprintv1alpha1.Blueprint, exclude *blueprintv1alpha1.Blueprint) []string {
 	var diffs []string
 
@@ -564,9 +568,14 @@ func (r *TestRunner) matchExclusions(bp *blueprintv1alpha1.Blueprint, exclude *b
 
 	for _, excludeK := range exclude.Kustomizations {
 		found := r.findKustomization(bp, excludeK)
-		if found != nil {
-			diffs = append(diffs, fmt.Sprintf("kustomization should not exist: %s", excludeK.Name))
+		if found == nil {
+			continue
 		}
+		if len(excludeK.Components) == 0 {
+			diffs = append(diffs, fmt.Sprintf("kustomization should not exist: %s", excludeK.Name))
+			continue
+		}
+		diffs = append(diffs, matchComponentExclusion(found.Components, excludeK.Components, fmt.Sprintf("kustomize[%s]", excludeK.Name))...)
 	}
 
 	for _, excludeSys := range exclude.FluxSystems {
@@ -844,22 +853,52 @@ func (r *TestRunner) matchFluxSystem(actual *blueprintv1alpha1.FluxSystem, expec
 // absent: the install tier when exclude.Install is set, and each named/matched resources variant in
 // exclude.Resources. Used when a fixture wants to assert a system is still partially present (e.g. its
 // install tier remains while one resources variant is gated off) rather than absent entirely, which
-// matchExclusions handles by name lookup alone before calling this. Returns an empty slice if every
-// excluded part is absent.
+// matchExclusions handles by name lookup alone before calling this. An exclude.Install or resources
+// variant that also sets components: doesn't assert the tier/variant itself is absent — it's expected
+// to exist — so this asserts only that those specific components are absent from it, the same
+// name-plus-components treatment matchExclusions gives a Kustomization exclusion (see
+// matchComponentExclusion). A bare install: or resources variant with no components: keeps
+// whole-tier/whole-variant-absence semantics. Returns an empty slice if every excluded part is absent.
 func (r *TestRunner) matchFluxSystemExclusions(actual *blueprintv1alpha1.FluxSystem, exclude blueprintv1alpha1.FluxSystem) []string {
 	var diffs []string
 	name := exclude.Name
 
 	if exclude.Install != nil && actual.Install != nil {
-		diffs = append(diffs, fmt.Sprintf("flux[%s].install: should not exist", name))
-	}
-
-	for _, excludeVariant := range exclude.Resources {
-		if r.findFluxVariant(actual.Resources, excludeVariant) != nil {
-			diffs = append(diffs, fmt.Sprintf("flux[%s].resources: variant should not exist: %s", name, fluxVariantIdentifier(excludeVariant)))
+		if len(exclude.Install.Components) == 0 {
+			diffs = append(diffs, fmt.Sprintf("flux[%s].install: should not exist", name))
+		} else {
+			diffs = append(diffs, matchComponentExclusion(actual.Install.Components, exclude.Install.Components, fmt.Sprintf("flux[%s].install", name))...)
 		}
 	}
 
+	for _, excludeVariant := range exclude.Resources {
+		found := r.findFluxVariant(actual.Resources, excludeVariant)
+		if found == nil {
+			continue
+		}
+		if excludeVariant.Name != "" && len(excludeVariant.Components) > 0 {
+			diffs = append(diffs, matchComponentExclusion(found.Components, excludeVariant.Components, fmt.Sprintf("flux[%s].resources[%s]", name, excludeVariant.Name))...)
+			continue
+		}
+		diffs = append(diffs, fmt.Sprintf("flux[%s].resources: variant should not exist: %s", name, fluxVariantIdentifier(excludeVariant)))
+	}
+
+	return diffs
+}
+
+// matchComponentExclusion asserts that none of excludeComponents are present in actual, returning
+// one diff per component found in both. Used when an exclude entry (Kustomization, FluxSystem
+// Install, or a Resources variant) sets components: alongside identifying the entry by name — the
+// entry itself is expected to exist, so this checks the narrower "does it contain this component"
+// claim instead of the entry's presence. label prefixes each diff message (e.g. "kustomize[name]",
+// "flux[name].install", "flux[name].resources[variant]").
+func matchComponentExclusion(actual []string, excludeComponents []string, label string) []string {
+	var diffs []string
+	for _, comp := range excludeComponents {
+		if contains(actual, comp) {
+			diffs = append(diffs, fmt.Sprintf("%s.components: should not contain %q", label, comp))
+		}
+	}
 	return diffs
 }
 

--- a/pkg/test/runner_test.go
+++ b/pkg/test/runner_test.go
@@ -1410,9 +1410,11 @@ func TestTestRunner_matchExclusions(t *testing.T) {
 		// When matching exclusions
 		diffs := runner.matchExclusions(blueprint, exclude)
 
-		// Then a diff must be reported, not silently pass
-		if len(diffs) != 1 || !strings.Contains(diffs[0], "kustomization should not exist: pki-resources") {
-			t.Errorf("Expected excluded compiled kustomization diff, got: %v", diffs)
+		// Then a diff must be reported, not silently pass — and since the exclusion names both
+		// the kustomization and the component, the diff asserts the component's absence rather
+		// than the whole kustomization's absence (pki-resources is expected to exist)
+		if len(diffs) != 1 || !strings.Contains(diffs[0], `kustomize[pki-resources].components: should not contain "private-issuer/ca"`) {
+			t.Errorf("Expected excluded component diff, got: %v", diffs)
 		}
 	})
 
@@ -1499,6 +1501,201 @@ func TestTestRunner_matchExclusions(t *testing.T) {
 		// Then diffs should identify the variant, not the whole system
 		if len(diffs) != 1 || !strings.Contains(diffs[0], "flux[pki].resources: variant should not exist") {
 			t.Errorf("Expected variant-level exclusion diff, got: %v", diffs)
+		}
+	})
+
+	t.Run("AllowsComponentAbsentFromOtherwiseExistingKustomization", func(t *testing.T) {
+		// Given a kustomization that legitimately exists for an unrelated component, with the
+		// excluded component genuinely absent — the previous whole-entry-presence check would
+		// have always flagged this as a false positive merely because the kustomization exists,
+		// making name+components exclusions unusable against a shared entry
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "pki-resources", Components: []string{"other-issuer/ca"}},
+			},
+		}
+
+		exclude := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "pki-resources", Components: []string{"private-issuer/ca"}},
+			},
+		}
+
+		// When matching exclusions
+		diffs := runner.matchExclusions(blueprint, exclude)
+
+		// Then no diff is reported — the excluded component is genuinely absent
+		if len(diffs) != 0 {
+			t.Errorf("Expected no diffs, got: %v", diffs)
+		}
+	})
+
+	t.Run("ReportsOnlyTheExcludedComponentAmongOthers", func(t *testing.T) {
+		// Given a kustomization with several components, only one of which is excluded
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "pki-resources", Components: []string{"other-issuer/ca", "private-issuer/ca"}},
+			},
+		}
+
+		exclude := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "pki-resources", Components: []string{"private-issuer/ca"}},
+			},
+		}
+
+		// When matching exclusions
+		diffs := runner.matchExclusions(blueprint, exclude)
+
+		// Then only the excluded component is flagged, naming both the kustomization and component
+		if len(diffs) != 1 || !strings.Contains(diffs[0], `kustomize[pki-resources].components: should not contain "private-issuer/ca"`) {
+			t.Errorf("Expected a single component-level diff, got: %v", diffs)
+		}
+	})
+
+	t.Run("AllowsComponentAbsentFromOtherwiseExistingFluxInstallTier", func(t *testing.T) {
+		// Given a flux system's install tier that legitimately exists for an unrelated component,
+		// with the excluded component genuinely absent
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name:    "telemetry",
+					Install: &blueprintv1alpha1.Kustomization{Components: []string{"logs"}},
+				},
+			},
+		}
+
+		exclude := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name:    "telemetry",
+					Install: &blueprintv1alpha1.Kustomization{Components: []string{"prometheus"}},
+				},
+			},
+		}
+
+		// When matching exclusions
+		diffs := runner.matchExclusions(blueprint, exclude)
+
+		// Then no diff is reported — the excluded component is genuinely absent from the install
+		// tier, which is itself expected to exist
+		if len(diffs) != 0 {
+			t.Errorf("Expected no diffs, got: %v", diffs)
+		}
+	})
+
+	t.Run("ReportsExcludedComponentPresentInFluxInstallTier", func(t *testing.T) {
+		// Given a flux system's install tier that still carries the excluded component
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name:    "telemetry",
+					Install: &blueprintv1alpha1.Kustomization{Components: []string{"logs", "prometheus"}},
+				},
+			},
+		}
+
+		exclude := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name:    "telemetry",
+					Install: &blueprintv1alpha1.Kustomization{Components: []string{"prometheus"}},
+				},
+			},
+		}
+
+		// When matching exclusions
+		diffs := runner.matchExclusions(blueprint, exclude)
+
+		// Then the diff names the install tier and the specific component, not "should not exist"
+		if len(diffs) != 1 || !strings.Contains(diffs[0], `flux[telemetry].install.components: should not contain "prometheus"`) {
+			t.Errorf("Expected a component-level diff, got: %v", diffs)
+		}
+	})
+
+	t.Run("ReportsExcludedComponentPresentInNamedResourcesVariant", func(t *testing.T) {
+		// Given a named resources variant that still carries the excluded component alongside
+		// another one
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name: "pki",
+					Resources: []blueprintv1alpha1.FluxVariant{
+						{Kustomization: blueprintv1alpha1.Kustomization{Name: "extra", Components: []string{"other-issuer/ca", "private-issuer/ca"}}},
+					},
+				},
+			},
+		}
+
+		exclude := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name: "pki",
+					Resources: []blueprintv1alpha1.FluxVariant{
+						{Kustomization: blueprintv1alpha1.Kustomization{Name: "extra", Components: []string{"private-issuer/ca"}}},
+					},
+				},
+			},
+		}
+
+		// When matching exclusions
+		diffs := runner.matchExclusions(blueprint, exclude)
+
+		// Then the diff names the variant and the specific component, not the whole variant
+		if len(diffs) != 1 || !strings.Contains(diffs[0], `flux[pki].resources[extra].components: should not contain "private-issuer/ca"`) {
+			t.Errorf("Expected a component-level diff, got: %v", diffs)
+		}
+	})
+
+	t.Run("AllowsComponentAbsentFromNamedResourcesVariant", func(t *testing.T) {
+		// Given a named resources variant that legitimately exists for an unrelated component
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name: "pki",
+					Resources: []blueprintv1alpha1.FluxVariant{
+						{Kustomization: blueprintv1alpha1.Kustomization{Name: "extra", Components: []string{"other-issuer/ca"}}},
+					},
+				},
+			},
+		}
+
+		exclude := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name: "pki",
+					Resources: []blueprintv1alpha1.FluxVariant{
+						{Kustomization: blueprintv1alpha1.Kustomization{Name: "extra", Components: []string{"private-issuer/ca"}}},
+					},
+				},
+			},
+		}
+
+		// When matching exclusions
+		diffs := runner.matchExclusions(blueprint, exclude)
+
+		// Then no diff is reported — the excluded component is genuinely absent from the variant,
+		// which is itself expected to exist
+		if len(diffs) != 0 {
+			t.Errorf("Expected no diffs, got: %v", diffs)
 		}
 	})
 }

--- a/pkg/test/runner_test.go
+++ b/pkg/test/runner_test.go
@@ -1498,9 +1498,10 @@ func TestTestRunner_matchExclusions(t *testing.T) {
 		// When matching exclusions
 		diffs := runner.matchExclusions(blueprint, exclude)
 
-		// Then diffs should identify the variant, not the whole system
-		if len(diffs) != 1 || !strings.Contains(diffs[0], "flux[pki].resources: variant should not exist") {
-			t.Errorf("Expected variant-level exclusion diff, got: %v", diffs)
+		// Then diffs should identify the specific component within the variant found by
+		// its components-subset match, not the whole system or the whole variant
+		if len(diffs) != 1 || !strings.Contains(diffs[0], `.components: should not contain "private-issuer/ca"`) {
+			t.Errorf("Expected component-level exclusion diff, got: %v", diffs)
 		}
 	})
 
@@ -1696,6 +1697,48 @@ func TestTestRunner_matchExclusions(t *testing.T) {
 		// which is itself expected to exist
 		if len(diffs) != 0 {
 			t.Errorf("Expected no diffs, got: %v", diffs)
+		}
+	})
+
+	t.Run("ReportsExcludedComponentPresentInUnnamedResourcesVariant", func(t *testing.T) {
+		// Given an unnamed resources variant located by findFluxVariant's components-subset
+		// match, which carries an extra, unrelated component alongside the excluded one — the
+		// subset match already guarantees the excluded component is present, so this must not
+		// fall back to flagging the whole variant as unexpected
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name: "pki",
+					Resources: []blueprintv1alpha1.FluxVariant{
+						{Kustomization: blueprintv1alpha1.Kustomization{Components: []string{"other-issuer/ca", "private-issuer/ca"}}},
+					},
+				},
+			},
+		}
+
+		exclude := &blueprintv1alpha1.Blueprint{
+			FluxSystems: []blueprintv1alpha1.FluxSystem{
+				{
+					Name: "pki",
+					Resources: []blueprintv1alpha1.FluxVariant{
+						{Kustomization: blueprintv1alpha1.Kustomization{Components: []string{"private-issuer/ca"}}},
+					},
+				},
+			},
+		}
+
+		// When matching exclusions
+		diffs := runner.matchExclusions(blueprint, exclude)
+
+		// Then the diff names the specific component, not "variant should not exist"
+		if len(diffs) != 1 || !strings.Contains(diffs[0], `.components: should not contain "private-issuer/ca"`) {
+			t.Errorf("Expected a component-level diff, got: %v", diffs)
+		}
+		if len(diffs) == 1 && strings.Contains(diffs[0], "variant should not exist") {
+			t.Errorf("Expected a narrowed diff, not whole-variant-absence, got: %v", diffs)
 		}
 	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Changes are confined to `pkg/test`'s blueprint-exclusion matcher used by integration test fixtures, with matching test coverage added — no production runtime path is touched.
>
> **Overview**
>
> This PR refines `matchExclusions`/`matchFluxSystemExclusions` so that an exclusion entry naming both an entity (Kustomization, flux install tier, or a *named* resources variant) and a `components:` list no longer asserts the whole entity is absent. Instead it asserts only that the listed components are absent from an entity that's otherwise expected to exist, via a new shared helper `matchComponentExclusion`. Previously such exclusions always flagged the entity's mere existence as a violation, making name+components exclusions unusable against a shared entry.
>
> The narrower "components absent, entity present" treatment is applied only when the flux resources variant is matched by `Name`; a variant identified purely by a `components:` subset match (no `Name`) still falls back to whole-variant-absence semantics, which is inconsistent with the rest of this change and isn't covered by the new tests.

<!-- /claude-code-review:summary -->
