### PR TITLE
fix(tui): stop double-printing spinner messages

### DIFF
--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -202,7 +202,9 @@ func (s *termSpinner) Update(message string) {
 	s.lastFallbackLine = message
 }
 
-// Done stops the spinner and prints a green success line to stderr.
+// Done stops the spinner and prints a green success line to stderr. When stderr isn't a
+// terminal and Start/Update already printed this exact message as a fallback line, the
+// message is omitted here to avoid printing it twice back to back.
 func (s *termSpinner) Done() {
 	if s.spin != nil && s.spin.Active() {
 		s.spin.Stop()
@@ -213,10 +215,16 @@ func (s *termSpinner) Done() {
 		fmt.Fprint(os.Stderr, "\033[u\033[2K\r")
 		s.pauseCursorSaved = false
 	}
+	if !isInteractiveStderr() && s.lastFallbackLine == s.message {
+		fmt.Fprint(os.Stderr, "\033[32m✔ Done\033[0m\n")
+		return
+	}
 	fmt.Fprintf(os.Stderr, "\033[32m✔\033[0m %s - \033[32mDone\033[0m\n", s.message)
 }
 
-// Fail stops the spinner and prints a red failure line to stderr.
+// Fail stops the spinner and prints a red failure line to stderr. When stderr isn't a
+// terminal and Start/Update already printed this exact message as a fallback line, the
+// message is omitted here to avoid printing it twice back to back.
 func (s *termSpinner) Fail() {
 	if s.spin != nil && s.spin.Active() {
 		s.spin.Stop()
@@ -226,6 +234,10 @@ func (s *termSpinner) Fail() {
 	if s.pauseCursorSaved {
 		fmt.Fprint(os.Stderr, "\033[u\033[2K\r")
 		s.pauseCursorSaved = false
+	}
+	if !isInteractiveStderr() && s.lastFallbackLine == s.message {
+		fmt.Fprint(os.Stderr, "\033[31m✗ Failed\033[0m\n")
+		return
 	}
 	fmt.Fprintf(os.Stderr, "\033[31m✗ %s - Failed\033[0m\n", s.message)
 }

--- a/pkg/tui/tui_test.go
+++ b/pkg/tui/tui_test.go
@@ -397,6 +397,22 @@ func TestTermSpinner_Done(t *testing.T) {
 			t.Errorf("expected %q, got %q", want, out)
 		}
 	})
+
+	t.Run("OmitsMessageWhenFallbackAlreadyPrintedIt", func(t *testing.T) {
+		// Given a termSpinner started with stderr redirected to a pipe (never a terminal),
+		// so Start already printed "deploying" as a fallback line
+		s := &termSpinner{}
+		captureStderr(t, func() { s.Start("deploying") })
+
+		// When Done is called
+		out := captureStderr(t, s.Done)
+
+		// Then the success line omits the message to avoid repeating it
+		want := "\033[32m✔ Done\033[0m\n"
+		if out != want {
+			t.Errorf("expected %q, got %q", want, out)
+		}
+	})
 }
 
 // Tests for termSpinner Fail output
@@ -445,6 +461,22 @@ func TestTermSpinner_Fail(t *testing.T) {
 		// And pauseCursorSaved is reset
 		if s.pauseCursorSaved {
 			t.Error("expected pauseCursorSaved to be false after Fail")
+		}
+	})
+
+	t.Run("OmitsMessageWhenFallbackAlreadyPrintedIt", func(t *testing.T) {
+		// Given a termSpinner started with stderr redirected to a pipe (never a terminal),
+		// so Start already printed "deploying" as a fallback line
+		s := &termSpinner{}
+		captureStderr(t, func() { s.Start("deploying") })
+
+		// When Fail is called
+		out := captureStderr(t, s.Fail)
+
+		// Then the failure line omits the message to avoid repeating it
+		want := "\033[31m✗ Failed\033[0m\n"
+		if out != want {
+			t.Errorf("expected %q, got %q", want, out)
 		}
 	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> The change is confined to `pkg/tui/tui.go`'s spinner fallback-printing path and only alters what gets written to stderr when it isn't a terminal, so the blast radius is small and easily reversible.
>
> **Overview**
>
> This PR fixes `termSpinner.Done()` and `termSpinner.Fail()` printing the operation's message a second time when stderr is non-interactive (piped, redirected, or captured by a log) and `Start`/`Update` already printed that exact message as a static fallback line. Both methods now compare the last fallback line against the stored message and, when they match, print a bare `✔ Done` / `✗ Failed` instead of repeating the full `"{message} - Done/Failed"` line.
>
> The dedup condition is only reachable when `lastFallbackLine` was populated by an actual `Start`/`Update` call in non-interactive mode, so existing interactive-terminal behavior is unchanged. No test was added for the new dedup branch itself — existing `Done`/`Fail` tests construct `termSpinner` literals with `lastFallbackLine` left at its zero value, so they exercise the pre-existing code path but not the new one.

<!-- /claude-code-review:summary -->
