### PR TITLE
feat(cmd): add shared flag helpers for default configuration

### DIFF
--- a/cmd/flag_overrides.go
+++ b/cmd/flag_overrides.go
@@ -16,24 +16,10 @@ import (
 // applyWorkstationFlagOverrides maps --vm-driver and --platform flag values
 // onto a config override map. --vm-driver sets workstation.runtime (with the
 // colima-incus alias remapped to colima), and when no --platform is given the
-// platform is inferred from the driver. After platform resolution, the function
-// fills in a sensible default for terraform.backend.type when one isn't already
-// set in the override map:
-//
-//   - aws     → s3       (S3 is the canonical state store on AWS)
-//   - azure   → azurerm  (Azure Blob Storage via the azurerm backend)
-//   - metal, docker, incus, hetzner → kubernetes  (the cluster IS the state
-//     store; each component's state lives as a Secret in the cluster it
-//     manages. Hetzner joins this group because its Object Storage keys can't
-//     be provisioned via API, so in-cluster state avoids a manual key step)
-//
-// The default only kicks in when terraform.backend.type is absent from
-// overrides, so explicit --set values (which are merged into the same map by
-// callers after this helper runs) always win. gcp is intentionally not
-// defaulted today: GCS backend support requires a GCSBackend schema struct
-// and provider.go branches that don't yet exist. Shared by `windsor init`,
-// `windsor bootstrap`, and `windsor up` to guarantee consistent flag
-// semantics across commands.
+// platform is inferred from the driver. Once platform is resolved, it defaults
+// terraform.backend.type via defaultTerraformBackendType. Shared by
+// `windsor init`, `windsor bootstrap`, and `windsor up` to guarantee
+// consistent flag semantics across commands.
 func applyWorkstationFlagOverrides(overrides map[string]any, vmDriver, platform string) {
 	if platform != "" {
 		overrides["platform"] = platform
@@ -56,15 +42,33 @@ func applyWorkstationFlagOverrides(overrides map[string]any, vmDriver, platform 
 		}
 	}
 
-	if _, set := overrides["terraform.backend.type"]; !set {
-		switch overrides["platform"] {
-		case "aws":
-			overrides["terraform.backend.type"] = "s3"
-		case "azure":
-			overrides["terraform.backend.type"] = "azurerm"
-		case "metal", "docker", "incus", "hetzner":
-			overrides["terraform.backend.type"] = "kubernetes"
-		}
+	defaultTerraformBackendType(overrides)
+}
+
+// defaultTerraformBackendType fills in terraform.backend.type from
+// overrides["platform"] when the key is absent, so explicit --set values
+// (merged into the same map by callers after this runs) always win:
+//
+//   - aws     → s3       (S3 is the canonical state store on AWS)
+//   - azure   → azurerm  (Azure Blob Storage via the azurerm backend)
+//   - metal, docker, incus, hetzner, hyperv → kubernetes  (the cluster IS the
+//     state store; each component's state lives as a Secret in the cluster it
+//     manages. Hetzner joins this group because its Object Storage keys can't
+//     be provisioned via API, so in-cluster state avoids a manual key step)
+//
+// gcp is intentionally not defaulted today: GCS backend support requires a
+// GCSBackend schema struct and provider.go branches that don't yet exist.
+func defaultTerraformBackendType(overrides map[string]any) {
+	if _, set := overrides["terraform.backend.type"]; set {
+		return
+	}
+	switch overrides["platform"] {
+	case "aws":
+		overrides["terraform.backend.type"] = "s3"
+	case "azure":
+		overrides["terraform.backend.type"] = "azurerm"
+	case "metal", "docker", "incus", "hetzner", "hyperv":
+		overrides["terraform.backend.type"] = "kubernetes"
 	}
 }
 

--- a/cmd/flag_overrides.go
+++ b/cmd/flag_overrides.go
@@ -51,10 +51,11 @@ func applyWorkstationFlagOverrides(overrides map[string]any, vmDriver, platform 
 //
 //   - aws     → s3       (S3 is the canonical state store on AWS)
 //   - azure   → azurerm  (Azure Blob Storage via the azurerm backend)
-//   - metal, docker, incus, hetzner, hyperv → kubernetes  (the cluster IS the
-//     state store; each component's state lives as a Secret in the cluster it
-//     manages. Hetzner joins this group because its Object Storage keys can't
-//     be provisioned via API, so in-cluster state avoids a manual key step)
+//   - metal, docker, incus, hetzner, hyperv, vsphere → kubernetes  (the cluster
+//     IS the state store; each component's state lives as a Secret in the
+//     cluster it manages. Hetzner joins this group because its Object Storage
+//     keys can't be provisioned via API, so in-cluster state avoids a manual
+//     key step)
 //
 // gcp is intentionally not defaulted today: GCS backend support requires a
 // GCSBackend schema struct and provider.go branches that don't yet exist.
@@ -67,7 +68,7 @@ func defaultTerraformBackendType(overrides map[string]any) {
 		overrides["terraform.backend.type"] = "s3"
 	case "azure":
 		overrides["terraform.backend.type"] = "azurerm"
-	case "metal", "docker", "incus", "hetzner", "hyperv":
+	case "metal", "docker", "incus", "hetzner", "hyperv", "vsphere":
 		overrides["terraform.backend.type"] = "kubernetes"
 	}
 }

--- a/cmd/flag_overrides_test.go
+++ b/cmd/flag_overrides_test.go
@@ -237,6 +237,20 @@ func TestDefaultTerraformBackendType(t *testing.T) {
 		}
 	})
 
+	t.Run("VspherePlatformDefaultsBackendToKubernetes", func(t *testing.T) {
+		// Given platform=vsphere, cluster.driver defaults to talos (resolve.go)
+		// alongside hyperv — same kubernetes-backend group, same rationale.
+		overrides := map[string]any{"platform": "vsphere"}
+
+		// When the default is applied
+		defaultTerraformBackendType(overrides)
+
+		// Then terraform.backend.type defaults to "kubernetes"
+		if overrides["terraform.backend.type"] != "kubernetes" {
+			t.Errorf("Expected terraform.backend.type=kubernetes, got %v", overrides["terraform.backend.type"])
+		}
+	})
+
 	t.Run("UnmappedPlatformDoesNotDefaultBackendType", func(t *testing.T) {
 		// Given platform=gcp (not yet wired up — GCSBackend schema is missing)
 		// the default switch must not invent a value. Operators on gcp are

--- a/cmd/flag_overrides_test.go
+++ b/cmd/flag_overrides_test.go
@@ -93,115 +93,6 @@ func TestApplyWorkstationFlagOverrides(t *testing.T) {
 		}
 	})
 
-	t.Run("AwsPlatformDefaultsBackendToS3", func(t *testing.T) {
-		// Given --platform aws and no explicit terraform.backend.type override
-		overrides := map[string]any{}
-
-		// When the helper is applied
-		applyWorkstationFlagOverrides(overrides, "", "aws")
-
-		// Then terraform.backend.type defaults to "s3" since AWS contexts overwhelmingly
-		// store terraform state in S3; the operator can still override via --set.
-		if overrides["terraform.backend.type"] != "s3" {
-			t.Errorf("Expected terraform.backend.type=s3, got %v", overrides["terraform.backend.type"])
-		}
-	})
-
-	t.Run("AzurePlatformDefaultsBackendToAzurerm", func(t *testing.T) {
-		// Given --platform azure and no explicit terraform.backend.type override
-		overrides := map[string]any{}
-
-		// When the helper is applied
-		applyWorkstationFlagOverrides(overrides, "", "azure")
-
-		// Then terraform.backend.type defaults to "azurerm"
-		if overrides["terraform.backend.type"] != "azurerm" {
-			t.Errorf("Expected terraform.backend.type=azurerm, got %v", overrides["terraform.backend.type"])
-		}
-	})
-
-	t.Run("ExplicitBackendTypePreservedOverDefault", func(t *testing.T) {
-		// Given --platform aws AND a pre-set terraform.backend.type (as if --set
-		// terraform.backend.type=local had already been merged into the map). Note:
-		// callers actually merge --set after this helper runs, so this test exercises
-		// the symmetric guard against a future change in merge ordering — the helper
-		// must never clobber a value already present.
-		overrides := map[string]any{
-			"terraform.backend.type": "local",
-		}
-
-		// When the helper is applied
-		applyWorkstationFlagOverrides(overrides, "", "aws")
-
-		// Then the explicit value wins; no platform-default takes effect
-		if overrides["terraform.backend.type"] != "local" {
-			t.Errorf("Expected explicit terraform.backend.type=local to be preserved, got %v", overrides["terraform.backend.type"])
-		}
-	})
-
-	t.Run("MetalPlatformDefaultsBackendToKubernetes", func(t *testing.T) {
-		// Given --platform metal (bare-metal Talos cluster). For platforms where
-		// the cluster is the natural state store (no canonical cloud bucket
-		// service), the kubernetes backend is the right default — each component's
-		// state lives as a Secret in the cluster it manages. The bootstrap dance
-		// runs the same shape as for s3: apply the cluster/backend component with
-		// local state, migrate to kubernetes once the cluster is up, then up rest.
-		overrides := map[string]any{}
-
-		// When the helper is applied
-		applyWorkstationFlagOverrides(overrides, "", "metal")
-
-		// Then terraform.backend.type defaults to "kubernetes"
-		if overrides["terraform.backend.type"] != "kubernetes" {
-			t.Errorf("Expected terraform.backend.type=kubernetes, got %v", overrides["terraform.backend.type"])
-		}
-	})
-
-	t.Run("DockerPlatformDefaultsBackendToKubernetes", func(t *testing.T) {
-		// Given --platform docker (local cluster on a docker workstation), the
-		// in-cluster kubernetes backend mirrors the metal case — the cluster
-		// Windsor brings up is also the state store for everything that follows.
-		overrides := map[string]any{}
-
-		// When the helper is applied
-		applyWorkstationFlagOverrides(overrides, "", "docker")
-
-		// Then terraform.backend.type defaults to "kubernetes"
-		if overrides["terraform.backend.type"] != "kubernetes" {
-			t.Errorf("Expected terraform.backend.type=kubernetes, got %v", overrides["terraform.backend.type"])
-		}
-	})
-
-	t.Run("IncusPlatformDefaultsBackendToKubernetes", func(t *testing.T) {
-		// Given --platform incus (the colima-incus inferred platform), same
-		// kubernetes-backend default applies — incus workstations run a cluster.
-		overrides := map[string]any{}
-
-		// When the helper is applied
-		applyWorkstationFlagOverrides(overrides, "", "incus")
-
-		// Then terraform.backend.type defaults to "kubernetes"
-		if overrides["terraform.backend.type"] != "kubernetes" {
-			t.Errorf("Expected terraform.backend.type=kubernetes, got %v", overrides["terraform.backend.type"])
-		}
-	})
-
-	t.Run("HetznerPlatformDefaultsBackendToKubernetes", func(t *testing.T) {
-		// Given --platform hetzner and no explicit terraform.backend.type override.
-		// Hetzner joins the in-cluster (kubernetes) backend group rather than s3
-		// because its Object Storage keys cannot be provisioned via any API, so the
-		// in-cluster backend avoids a mandatory manual key-generation step.
-		overrides := map[string]any{}
-
-		// When the helper is applied
-		applyWorkstationFlagOverrides(overrides, "", "hetzner")
-
-		// Then terraform.backend.type defaults to "kubernetes"
-		if overrides["terraform.backend.type"] != "kubernetes" {
-			t.Errorf("Expected terraform.backend.type=kubernetes, got %v", overrides["terraform.backend.type"])
-		}
-	})
-
 	t.Run("VmDriverInferenceFlowsThroughToBackendDefault", func(t *testing.T) {
 		// Given --vm-driver docker-desktop with no --platform, the helper infers
 		// platform=docker, and the backend default must then key off that inferred
@@ -223,15 +114,138 @@ func TestApplyWorkstationFlagOverrides(t *testing.T) {
 		}
 	})
 
+}
+
+func TestDefaultTerraformBackendType(t *testing.T) {
+	t.Run("AwsPlatformDefaultsBackendToS3", func(t *testing.T) {
+		// Given platform=aws and no explicit terraform.backend.type override
+		overrides := map[string]any{"platform": "aws"}
+
+		// When the default is applied
+		defaultTerraformBackendType(overrides)
+
+		// Then terraform.backend.type defaults to "s3" since AWS contexts overwhelmingly
+		// store terraform state in S3; the operator can still override via --set.
+		if overrides["terraform.backend.type"] != "s3" {
+			t.Errorf("Expected terraform.backend.type=s3, got %v", overrides["terraform.backend.type"])
+		}
+	})
+
+	t.Run("AzurePlatformDefaultsBackendToAzurerm", func(t *testing.T) {
+		// Given platform=azure and no explicit terraform.backend.type override
+		overrides := map[string]any{"platform": "azure"}
+
+		// When the default is applied
+		defaultTerraformBackendType(overrides)
+
+		// Then terraform.backend.type defaults to "azurerm"
+		if overrides["terraform.backend.type"] != "azurerm" {
+			t.Errorf("Expected terraform.backend.type=azurerm, got %v", overrides["terraform.backend.type"])
+		}
+	})
+
+	t.Run("ExplicitBackendTypePreservedOverDefault", func(t *testing.T) {
+		// Given platform=aws AND a pre-set terraform.backend.type (as if --set
+		// terraform.backend.type=local had already been merged into the map)
+		overrides := map[string]any{
+			"platform":               "aws",
+			"terraform.backend.type": "local",
+		}
+
+		// When the default is applied
+		defaultTerraformBackendType(overrides)
+
+		// Then the explicit value wins; no platform-default takes effect
+		if overrides["terraform.backend.type"] != "local" {
+			t.Errorf("Expected explicit terraform.backend.type=local to be preserved, got %v", overrides["terraform.backend.type"])
+		}
+	})
+
+	t.Run("MetalPlatformDefaultsBackendToKubernetes", func(t *testing.T) {
+		// Given platform=metal (bare-metal Talos cluster). For platforms where
+		// the cluster is the natural state store (no canonical cloud bucket
+		// service), the kubernetes backend is the right default — each component's
+		// state lives as a Secret in the cluster it manages.
+		overrides := map[string]any{"platform": "metal"}
+
+		// When the default is applied
+		defaultTerraformBackendType(overrides)
+
+		// Then terraform.backend.type defaults to "kubernetes"
+		if overrides["terraform.backend.type"] != "kubernetes" {
+			t.Errorf("Expected terraform.backend.type=kubernetes, got %v", overrides["terraform.backend.type"])
+		}
+	})
+
+	t.Run("DockerPlatformDefaultsBackendToKubernetes", func(t *testing.T) {
+		// Given platform=docker (local cluster on a docker workstation), the
+		// in-cluster kubernetes backend mirrors the metal case.
+		overrides := map[string]any{"platform": "docker"}
+
+		// When the default is applied
+		defaultTerraformBackendType(overrides)
+
+		// Then terraform.backend.type defaults to "kubernetes"
+		if overrides["terraform.backend.type"] != "kubernetes" {
+			t.Errorf("Expected terraform.backend.type=kubernetes, got %v", overrides["terraform.backend.type"])
+		}
+	})
+
+	t.Run("IncusPlatformDefaultsBackendToKubernetes", func(t *testing.T) {
+		// Given platform=incus (the colima-incus inferred platform), same
+		// kubernetes-backend default applies — incus workstations run a cluster.
+		overrides := map[string]any{"platform": "incus"}
+
+		// When the default is applied
+		defaultTerraformBackendType(overrides)
+
+		// Then terraform.backend.type defaults to "kubernetes"
+		if overrides["terraform.backend.type"] != "kubernetes" {
+			t.Errorf("Expected terraform.backend.type=kubernetes, got %v", overrides["terraform.backend.type"])
+		}
+	})
+
+	t.Run("HetznerPlatformDefaultsBackendToKubernetes", func(t *testing.T) {
+		// Given platform=hetzner and no explicit terraform.backend.type override.
+		// Hetzner joins the in-cluster (kubernetes) backend group rather than s3
+		// because its Object Storage keys cannot be provisioned via any API, so the
+		// in-cluster backend avoids a mandatory manual key-generation step.
+		overrides := map[string]any{"platform": "hetzner"}
+
+		// When the default is applied
+		defaultTerraformBackendType(overrides)
+
+		// Then terraform.backend.type defaults to "kubernetes"
+		if overrides["terraform.backend.type"] != "kubernetes" {
+			t.Errorf("Expected terraform.backend.type=kubernetes, got %v", overrides["terraform.backend.type"])
+		}
+	})
+
+	t.Run("HypervPlatformDefaultsBackendToKubernetes", func(t *testing.T) {
+		// Given platform=hyperv, cluster.driver defaults to talos (resolve.go),
+		// making the cluster the natural state store — same kubernetes-backend
+		// group as metal/docker/incus/hetzner, so state survives destroy+apply
+		// instead of living only on the workstation under the local backend.
+		overrides := map[string]any{"platform": "hyperv"}
+
+		// When the default is applied
+		defaultTerraformBackendType(overrides)
+
+		// Then terraform.backend.type defaults to "kubernetes"
+		if overrides["terraform.backend.type"] != "kubernetes" {
+			t.Errorf("Expected terraform.backend.type=kubernetes, got %v", overrides["terraform.backend.type"])
+		}
+	})
+
 	t.Run("UnmappedPlatformDoesNotDefaultBackendType", func(t *testing.T) {
-		// Given --platform gcp (not yet wired up — GCSBackend schema is missing)
+		// Given platform=gcp (not yet wired up — GCSBackend schema is missing)
 		// the default switch must not invent a value. Operators on gcp are
 		// expected to configure terraform.backend.type explicitly until the
 		// schema lands.
-		overrides := map[string]any{}
+		overrides := map[string]any{"platform": "gcp"}
 
-		// When the helper is applied
-		applyWorkstationFlagOverrides(overrides, "", "gcp")
+		// When the default is applied
+		defaultTerraformBackendType(overrides)
 
 		// Then no backend default is injected
 		if _, set := overrides["terraform.backend.type"]; set {


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> Refactors shared flag-override logic used by `windsor init`, `bootstrap`, and `up`, and changes a default (terraform backend selection) that affects real invocations of all three commands.
>
> **Overview**
>
> This PR renames `cmd/workstation_defaults.go` (and its test) to `cmd/flag_overrides.go`, and extracts the terraform-backend-type defaulting logic out of `applyWorkstationFlagOverrides` into a standalone `defaultTerraformBackendType` helper. Tests are reorganized to exercise the new helper directly rather than only through the combined entry point, and the removed inline documentation is relocated to a proper function header comment on the extracted helper.
>
> The behavioral change is that `hyperv` now joins the platform group that defaults `terraform.backend.type` to `kubernetes`, matching the existing `cluster.driver=talos` grouping in `resolve.go`. However, `vsphere` — which shares that same talos-driver grouping and is a documented `--platform` value — was not added alongside it, leaving an inconsistency between the two groupings.

<!-- /claude-code-review:summary -->
