### PR TITLE
fix(tools): add error handling for missing Terraform in module resolver

### DIFF
--- a/pkg/composer/terraform/standard_module_resolver.go
+++ b/pkg/composer/terraform/standard_module_resolver.go
@@ -66,6 +66,8 @@ func NewStandardModuleResolver(rt *runtime.Runtime, blueprintHandler blueprint.B
 func (h *StandardModuleResolver) ProcessModules() error {
 	components := h.blueprintHandler.GetTerraformComponents()
 
+	terraformChecked := false
+
 	for _, component := range components {
 		if component.Source == "" {
 			if component.Name != "" {
@@ -147,8 +149,11 @@ func (h *StandardModuleResolver) ProcessModules() error {
 			return fmt.Errorf("failed to set TF_DATA_DIR for %s: %w", componentID, err)
 		}
 
-		if err := h.runtime.ToolsManager.CheckTerraform(); err != nil {
-			return fmt.Errorf("failed to initialize terraform for %s: %w", componentID, err)
+		if !terraformChecked {
+			if err := h.runtime.ToolsManager.CheckTerraform(); err != nil {
+				return fmt.Errorf("failed to initialize terraform for %s: %w", componentID, err)
+			}
+			terraformChecked = true
 		}
 
 		terraformCommand := h.runtime.ToolsManager.GetTerraformCommand()

--- a/pkg/composer/terraform/standard_module_resolver.go
+++ b/pkg/composer/terraform/standard_module_resolver.go
@@ -147,6 +147,10 @@ func (h *StandardModuleResolver) ProcessModules() error {
 			return fmt.Errorf("failed to set TF_DATA_DIR for %s: %w", componentID, err)
 		}
 
+		if err := h.runtime.ToolsManager.CheckTerraform(); err != nil {
+			return fmt.Errorf("failed to initialize terraform for %s: %w", componentID, err)
+		}
+
 		terraformCommand := h.runtime.ToolsManager.GetTerraformCommand()
 		output, err := h.runtime.Shell.ExecSilent(
 			terraformCommand,

--- a/pkg/composer/terraform/standard_module_resolver_test.go
+++ b/pkg/composer/terraform/standard_module_resolver_test.go
@@ -231,6 +231,43 @@ func TestStandardModuleResolver_ProcessModules(t *testing.T) {
 		}
 	})
 
+	t.Run("ChecksTerraformOnceAcrossMultipleComponents", func(t *testing.T) {
+		// Given a resolver processing two standard-source components
+		resolver, mocks := setup(t)
+		resolver.BaseModuleResolver.runtime.ConfigRoot = "/test/config"
+		mocks.BlueprintHandler.GetTerraformComponentsFunc = func() []blueprintv1alpha1.TerraformComponent {
+			return []blueprintv1alpha1.TerraformComponent{
+				{
+					Path:     "module-one",
+					Source:   "git::https://github.com/test/module-one.git",
+					FullPath: filepath.Join("/test", "terraform", "module-one"),
+				},
+				{
+					Path:     "module-two",
+					Source:   "git::https://github.com/test/module-two.git",
+					FullPath: filepath.Join("/test", "terraform", "module-two"),
+				},
+			}
+		}
+		checkTerraformCalls := 0
+		mockToolsManager := mocks.Runtime.ToolsManager.(*tools.MockToolsManager)
+		mockToolsManager.CheckTerraformFunc = func() error {
+			checkTerraformCalls++
+			return nil
+		}
+
+		// When ProcessModules is called
+		err := resolver.ProcessModules()
+
+		// Then CheckTerraform runs exactly once despite two matching components
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if checkTerraformCalls != 1 {
+			t.Errorf("Expected CheckTerraform to be called once, got %d calls", checkTerraformCalls)
+		}
+	})
+
 	t.Run("HandlesWriteShimMainTfError", func(t *testing.T) {
 		// Given a resolver with WriteFile shim returning error for main.tf
 		resolver, _ := setup(t)

--- a/pkg/composer/terraform/standard_module_resolver_test.go
+++ b/pkg/composer/terraform/standard_module_resolver_test.go
@@ -10,6 +10,7 @@ import (
 
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/runtime/config"
+	"github.com/windsorcli/cli/pkg/runtime/tools"
 )
 
 // The StandardModuleResolverTest is a test suite for the StandardModuleResolver implementation
@@ -199,6 +200,34 @@ func TestStandardModuleResolver_ProcessModules(t *testing.T) {
 		// Then an error is returned indicating failure to initialize terraform
 		if err == nil || !strings.Contains(err.Error(), "failed to initialize terraform") {
 			t.Errorf("Expected terraform init error, got: %v", err)
+		}
+	})
+
+	t.Run("HandlesTerraformNotAvailable", func(t *testing.T) {
+		// Given a resolver whose ToolsManager reports terraform as missing
+		resolver, mocks := setup(t)
+		resolver.BaseModuleResolver.runtime.ConfigRoot = "/test/config"
+		mockToolsManager := mocks.Runtime.ToolsManager.(*tools.MockToolsManager)
+		mockToolsManager.CheckTerraformFunc = func() error {
+			return errors.New("Terraform >= 1.0.0 is required but was not found on PATH.\n  Install: https://developer.hashicorp.com/terraform/install")
+		}
+		execCalled := false
+		mocks.Shell.ExecSilentFunc = func(cmd string, args ...string) (string, error) {
+			if cmd == "terraform" && len(args) > 0 && args[0] == "init" {
+				execCalled = true
+			}
+			return "", nil
+		}
+
+		// When ProcessModules is called
+		err := resolver.ProcessModules()
+
+		// Then the friendly missing-tool error is returned without ever shelling out to terraform
+		if err == nil || !strings.Contains(err.Error(), "was not found on PATH") {
+			t.Errorf("Expected missing-tool error, got: %v", err)
+		}
+		if execCalled {
+			t.Error("Expected terraform init to be skipped when the tool check fails")
 		}
 	})
 

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -114,6 +114,7 @@ type MockToolsManager struct {
 	CheckFunc               func() error
 	CheckRequirementsFunc   func(reqs tools.Requirements) error
 	CheckAuthFunc           func() error
+	CheckTerraformFunc      func() error
 	GetTerraformCommandFunc func() string
 }
 
@@ -151,6 +152,13 @@ func (m *MockToolsManager) CheckRequirements(reqs tools.Requirements) error {
 func (m *MockToolsManager) CheckAuth() error {
 	if m.CheckAuthFunc != nil {
 		return m.CheckAuthFunc()
+	}
+	return nil
+}
+
+func (m *MockToolsManager) CheckTerraform() error {
+	if m.CheckTerraformFunc != nil {
+		return m.CheckTerraformFunc()
 	}
 	return nil
 }

--- a/pkg/runtime/tools/mock_tools_manager.go
+++ b/pkg/runtime/tools/mock_tools_manager.go
@@ -7,6 +7,7 @@ type MockToolsManager struct {
 	CheckFunc               func() error
 	CheckRequirementsFunc   func(reqs Requirements) error
 	CheckAuthFunc           func() error
+	CheckTerraformFunc      func() error
 	GetTerraformCommandFunc func() string
 }
 
@@ -65,6 +66,14 @@ func (m *MockToolsManager) CheckRequirements(reqs Requirements) error {
 func (m *MockToolsManager) CheckAuth() error {
 	if m.CheckAuthFunc != nil {
 		return m.CheckAuthFunc()
+	}
+	return nil
+}
+
+// CheckTerraform calls the mock CheckTerraformFunc if set, otherwise returns nil.
+func (m *MockToolsManager) CheckTerraform() error {
+	if m.CheckTerraformFunc != nil {
+		return m.CheckTerraformFunc()
 	}
 	return nil
 }

--- a/pkg/runtime/tools/tools_manager.go
+++ b/pkg/runtime/tools/tools_manager.go
@@ -31,6 +31,7 @@ type ToolsManager interface {
 	Check() error
 	CheckRequirements(reqs Requirements) error
 	CheckAuth() error
+	CheckTerraform() error
 	GetTerraformCommand() string
 }
 
@@ -149,7 +150,7 @@ func (t *BaseToolsManager) CheckRequirements(reqs Requirements) error {
 	}
 
 	if reqs.Terraform && t.configHandler.GetBool("terraform.enabled") {
-		if err := t.checkTerraform(); err != nil {
+		if err := t.CheckTerraform(); err != nil {
 			return err
 		}
 	}
@@ -313,10 +314,15 @@ func (t *BaseToolsManager) detectTerraformDriver() string {
 	return "terraform"
 }
 
-// checkTerraform ensures Terraform or OpenTofu is available in the system's PATH using execLookPath.
+// CheckTerraform ensures Terraform or OpenTofu is available in the system's PATH using execLookPath.
 // It checks for the configured driver command in the system's PATH and verifies its version.
 // Returns nil if found and meets the minimum version requirement, else an error indicating it is not available or outdated.
-func (t *BaseToolsManager) checkTerraform() error {
+// Exported (unlike the other check* methods) so callers that need Terraform unconditionally —
+// e.g. the composer's standard module resolver, which shells out to `terraform init` to resolve
+// git/registry-sourced modules regardless of terraform.enabled — can get the same
+// missingToolError/outdatedToolError messages as CheckRequirements without going through its
+// config-gated Terraform field.
+func (t *BaseToolsManager) CheckTerraform() error {
 	command := t.GetTerraformCommand()
 	if _, err := execLookPath(command); err != nil {
 		return missingToolError(command)

--- a/pkg/runtime/tools/tools_manager_test.go
+++ b/pkg/runtime/tools/tools_manager_test.go
@@ -722,6 +722,82 @@ contexts:
 	})
 }
 
+// Tests for Terraform version validation
+func TestToolsManager_CheckTerraform(t *testing.T) {
+	setup := func(t *testing.T) (*Mocks, *BaseToolsManager) {
+		t.Helper()
+		mocks := setupMocks(t)
+		toolsManager := NewToolsManager(mocks.ConfigHandler, mocks.Shell)
+		return mocks, toolsManager
+	}
+
+	t.Run("Success", func(t *testing.T) {
+		// Given terraform is available with correct version
+		_, toolsManager := setup(t)
+		// When checking terraform version
+		err := toolsManager.CheckTerraform()
+		// Then no error should be returned
+		if err != nil {
+			t.Errorf("Expected CheckTerraform to succeed, but got error: %v", err)
+		}
+	})
+
+	t.Run("TerraformNotAvailable", func(t *testing.T) {
+		// Given neither terraform nor tofu is found in PATH
+		_, toolsManager := setup(t)
+		originalExecLookPath := execLookPath
+		defer func() {
+			execLookPath = originalExecLookPath
+		}()
+		execLookPath = func(name string) (string, error) {
+			if name == "terraform" || name == "tofu" {
+				return "", fmt.Errorf("%s is not available in the PATH", name)
+			}
+			return "/usr/bin/" + name, nil
+		}
+		// When checking terraform version
+		err := toolsManager.CheckTerraform()
+		// Then an error indicating terraform or tofu is not available should be returned
+		if err == nil || ((!strings.Contains(err.Error(), "Terraform") && !strings.Contains(err.Error(), "OpenTofu")) || !strings.Contains(err.Error(), "not found on PATH")) {
+			t.Errorf("Expected terraform or tofu not available error, got %v", err)
+		}
+	})
+
+	t.Run("TerraformVersionInvalidResponse", func(t *testing.T) {
+		// Given terraform version response is invalid
+		mocks, toolsManager := setup(t)
+		mocks.Shell.ExecSilentFunc = func(name string, args ...string) (string, error) {
+			if name == "terraform" && args[0] == "version" {
+				return "Invalid version response", nil
+			}
+			return "", fmt.Errorf("command not found")
+		}
+		// When checking terraform version
+		err := toolsManager.CheckTerraform()
+		// Then an error indicating version extraction failed should be returned
+		if err == nil || !strings.Contains(err.Error(), "failed to extract terraform version") {
+			t.Errorf("Expected failed to extract terraform version error, got %v", err)
+		}
+	})
+
+	t.Run("TerraformVersionTooLow", func(t *testing.T) {
+		// Given terraform version is below minimum required version
+		mocks, toolsManager := setup(t)
+		mocks.Shell.ExecSilentFunc = func(name string, args ...string) (string, error) {
+			if name == "terraform" && args[0] == "version" {
+				return "Terraform v0.1.0", nil
+			}
+			return "", fmt.Errorf("command not found")
+		}
+		// When checking terraform version
+		err := toolsManager.CheckTerraform()
+		// Then an error indicating version is too low should be returned
+		if err == nil || !strings.Contains(err.Error(), "Terraform 0.1.0 is below the minimum required version") {
+			t.Errorf("Expected terraform version too low error, got %v", err)
+		}
+	})
+}
+
 // =============================================================================
 // Test Private Methods
 // =============================================================================
@@ -959,82 +1035,6 @@ func TestToolsManager_checkColima(t *testing.T) {
 		// Then an error indicating version is too low should be returned
 		if err == nil || !strings.Contains(err.Error(), "Lima 0.5.0 is below the minimum required version") {
 			t.Errorf("Expected limactl version too low error, got %v", err)
-		}
-	})
-}
-
-// Tests for Terraform version validation
-func TestToolsManager_checkTerraform(t *testing.T) {
-	setup := func(t *testing.T) (*Mocks, *BaseToolsManager) {
-		t.Helper()
-		mocks := setupMocks(t)
-		toolsManager := NewToolsManager(mocks.ConfigHandler, mocks.Shell)
-		return mocks, toolsManager
-	}
-
-	t.Run("Success", func(t *testing.T) {
-		// Given terraform is available with correct version
-		_, toolsManager := setup(t)
-		// When checking terraform version
-		err := toolsManager.checkTerraform()
-		// Then no error should be returned
-		if err != nil {
-			t.Errorf("Expected checkTerraform to succeed, but got error: %v", err)
-		}
-	})
-
-	t.Run("TerraformNotAvailable", func(t *testing.T) {
-		// Given neither terraform nor tofu is found in PATH
-		_, toolsManager := setup(t)
-		originalExecLookPath := execLookPath
-		defer func() {
-			execLookPath = originalExecLookPath
-		}()
-		execLookPath = func(name string) (string, error) {
-			if name == "terraform" || name == "tofu" {
-				return "", fmt.Errorf("%s is not available in the PATH", name)
-			}
-			return "/usr/bin/" + name, nil
-		}
-		// When checking terraform version
-		err := toolsManager.checkTerraform()
-		// Then an error indicating terraform or tofu is not available should be returned
-		if err == nil || ((!strings.Contains(err.Error(), "Terraform") && !strings.Contains(err.Error(), "OpenTofu")) || !strings.Contains(err.Error(), "not found on PATH")) {
-			t.Errorf("Expected terraform or tofu not available error, got %v", err)
-		}
-	})
-
-	t.Run("TerraformVersionInvalidResponse", func(t *testing.T) {
-		// Given terraform version response is invalid
-		mocks, toolsManager := setup(t)
-		mocks.Shell.ExecSilentFunc = func(name string, args ...string) (string, error) {
-			if name == "terraform" && args[0] == "version" {
-				return "Invalid version response", nil
-			}
-			return "", fmt.Errorf("command not found")
-		}
-		// When checking terraform version
-		err := toolsManager.checkTerraform()
-		// Then an error indicating version extraction failed should be returned
-		if err == nil || !strings.Contains(err.Error(), "failed to extract terraform version") {
-			t.Errorf("Expected failed to extract terraform version error, got %v", err)
-		}
-	})
-
-	t.Run("TerraformVersionTooLow", func(t *testing.T) {
-		// Given terraform version is below minimum required version
-		mocks, toolsManager := setup(t)
-		mocks.Shell.ExecSilentFunc = func(name string, args ...string) (string, error) {
-			if name == "terraform" && args[0] == "version" {
-				return "Terraform v0.1.0", nil
-			}
-			return "", fmt.Errorf("command not found")
-		}
-		// When checking terraform version
-		err := toolsManager.checkTerraform()
-		// Then an error indicating version is too low should be returned
-		if err == nil || !strings.Contains(err.Error(), "Terraform 0.1.0 is below the minimum required version") {
-			t.Errorf("Expected terraform version too low error, got %v", err)
 		}
 	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Adds a Terraform-availability check to the standard module resolver before it shells out to `terraform init`; the change is additive, isolated to two files' behavior, and easily reversible.
>
> **Overview**
>
> This PR exports `BaseToolsManager.checkTerraform` as `CheckTerraform` on the `ToolsManager` interface and calls it from `StandardModuleResolver.ProcessModules` before running `terraform init` for git/registry-sourced modules. This surfaces the existing friendly "not found on PATH" / "below minimum version" errors instead of a raw exec failure when Terraform or OpenTofu is missing or outdated.
>
> The check now runs unconditionally in the resolver, independent of the `terraform.enabled` config gate that guards the same check inside `CheckRequirements`. Tests and mocks (`MockToolsManager` in both `pkg/runtime/tools` and `pkg/runtime/runtime_test.go`) were updated in lockstep with the rename, and a new resolver test confirms `terraform init` is skipped when the check fails.

<!-- /claude-code-review:summary -->
