### PR TITLE
feat(provisioner): implement lock timeout for commands to fail fast on contention

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -64,7 +64,7 @@ windsor apply kustomize dns`,
 			fmt.Fprintln(cmd.ErrOrStderr(), "Warning: an upgrade is in progress or was interrupted for this context. apply will reconcile to the declared blueprint; run `windsor upgrade` to complete the version transition.")
 		}
 
-		return stacklock.With(cmd.Context(), proj.Runtime, "apply", func() error {
+		return stacklock.With(cmd.Context(), proj.Runtime, "apply", lockTimeout, func() error {
 			// 'apply' doesn't run the workstation prep that registers MakeApplyHook, so no
 			// onApply hooks fire and the halted return is always false. Ignore it.
 			if _, err := proj.Provisioner.Up(blueprint); err != nil {
@@ -141,7 +141,7 @@ windsor apply tf cluster`,
 		}
 
 		blueprint := proj.Composer.BlueprintHandler.Generate()
-		return stacklock.With(cmd.Context(), proj.Runtime, "apply", func() error {
+		return stacklock.With(cmd.Context(), proj.Runtime, "apply", lockTimeout, func() error {
 			if err := proj.Provisioner.Apply(blueprint, componentID); err != nil {
 				return fmt.Errorf("error applying terraform for %s: %w", componentID, err)
 			}
@@ -188,7 +188,7 @@ windsor apply kustomize dns --wait`,
 		}
 		waitBlueprint := blueprint
 
-		return stacklock.With(cmd.Context(), proj.Runtime, "apply", func() error {
+		return stacklock.With(cmd.Context(), proj.Runtime, "apply", lockTimeout, func() error {
 			if len(args) == 0 {
 				if err := proj.Provisioner.ApplyKustomizeAll(cmd.Context(), blueprint); err != nil {
 					return fmt.Errorf("error applying kustomize: %w", err)

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -212,7 +212,7 @@ windsor bootstrap prod --yes`,
 		// is rare; revisit if the prompt grows into a longer flow.
 		var applied, halted bool
 		var postRunMessages []blueprintv1alpha1.Message
-		if err := stacklock.With(cmd.Context(), proj.Runtime, "bootstrap", func() error {
+		if err := stacklock.With(cmd.Context(), proj.Runtime, "bootstrap", lockTimeout, func() error {
 			_, ok, h, err := proj.Bootstrap(confirmFn)
 			finishPlan(err)
 			if err != nil {
@@ -315,7 +315,7 @@ func makeBootstrapConfirmFn(in io.Reader, out io.Writer) (provisioner.BootstrapC
 	confirmFn := func(summary *provisioner.BootstrapSummary) bool {
 		resolved = true
 		printBootstrapSummary(out, summary)
-		fmt.Fprintf(out, "Note: bootstrap holds the windsor stack lock during this prompt; concurrent windsor commands in this context will wait up to %s before failing.\n", stacklock.DefaultTimeout)
+		fmt.Fprintf(out, "Note: bootstrap holds the windsor stack lock during this prompt; concurrent windsor commands in this context will fail immediately unless run with --lock-timeout (e.g. --lock-timeout=%s) to wait instead.\n", stacklock.DefaultTimeout)
 		fmt.Fprint(out, "Continue? [y/N]: ")
 		reader := bufio.NewReader(in)
 		answer, _ := reader.ReadString('\n')

--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -107,7 +107,7 @@ windsor destroy --confirm=local --continue`,
 			if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, contextName); err != nil {
 				return err
 			}
-			return stacklock.With(cmd.Context(), proj.Runtime, "destroy", func() error {
+			return stacklock.With(cmd.Context(), proj.Runtime, "destroy", lockTimeout, func() error {
 				result, err := proj.Provisioner.Teardown(blueprint, false, destroyContinue)
 				reportSkippedDestroyComponents(cmd.ErrOrStderr(), result.Skipped)
 				if err != nil {
@@ -177,7 +177,7 @@ windsor destroy --confirm=local --continue`,
 			return err
 		}
 
-		return stacklock.With(cmd.Context(), proj.Runtime, "destroy", func() error {
+		return stacklock.With(cmd.Context(), proj.Runtime, "destroy", lockTimeout, func() error {
 			if inKustomize {
 				if err := proj.Provisioner.DestroyKustomize(blueprint, componentID); err != nil {
 					return fmt.Errorf("error destroying kustomization %s: %w", componentID, err)
@@ -258,7 +258,7 @@ windsor destroy terraform --confirm=local`,
 			if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, contextName); err != nil {
 				return err
 			}
-			return stacklock.With(cmd.Context(), proj.Runtime, "destroy", func() error {
+			return stacklock.With(cmd.Context(), proj.Runtime, "destroy", lockTimeout, func() error {
 				result, err := proj.Provisioner.Teardown(blueprint, true, destroyContinue)
 				reportSkippedDestroyComponents(cmd.ErrOrStderr(), result.Skipped)
 				if err != nil {
@@ -301,7 +301,7 @@ windsor destroy terraform --confirm=local`,
 		if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, componentID); err != nil {
 			return err
 		}
-		return stacklock.With(cmd.Context(), proj.Runtime, "destroy", func() error {
+		return stacklock.With(cmd.Context(), proj.Runtime, "destroy", lockTimeout, func() error {
 			skipped, err := proj.Provisioner.TeardownComponent(blueprint, componentID)
 			if err != nil {
 				return fmt.Errorf("error destroying terraform for %s: %w", componentID, err)
@@ -359,7 +359,7 @@ windsor destroy kustomize --confirm=local`,
 			if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, contextName); err != nil {
 				return err
 			}
-			return stacklock.With(cmd.Context(), proj.Runtime, "destroy", func() error {
+			return stacklock.With(cmd.Context(), proj.Runtime, "destroy", lockTimeout, func() error {
 				if err := proj.Provisioner.Uninstall(blueprint); err != nil {
 					return fmt.Errorf("error destroying all kustomizations: %w", err)
 				}
@@ -382,7 +382,7 @@ windsor destroy kustomize --confirm=local`,
 		if err := resolveDestroyConfirmation(cmd.InOrStdin(), cmd.ErrOrStderr(), desc, componentID); err != nil {
 			return err
 		}
-		return stacklock.With(cmd.Context(), proj.Runtime, "destroy", func() error {
+		return stacklock.With(cmd.Context(), proj.Runtime, "destroy", lockTimeout, func() error {
 			if err := proj.Provisioner.DestroyKustomize(blueprint, componentID); err != nil {
 				return fmt.Errorf("error destroying kustomization %s: %w", componentID, err)
 			}

--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -64,7 +64,7 @@ windsor plan terraform cluster`,
 			if err := requireCloudAuth(cmd, proj); err != nil {
 				return err
 			}
-			return stacklock.With(cmd.Context(), proj.Runtime, "plan", func() error {
+			return stacklock.With(cmd.Context(), proj.Runtime, "plan", lockTimeout, func() error {
 				var summary *provisioner.PlanSummary
 				if err := tui.WithProgress("Generating plan...", func() error {
 					var planErr error
@@ -101,7 +101,7 @@ windsor plan terraform cluster`,
 		// against the cluster and must not block infra-mutating windsor operations.
 		runPlan := func(fn func() error) error {
 			if inTerraform {
-				return stacklock.With(cmd.Context(), proj.Runtime, "plan", fn)
+				return stacklock.With(cmd.Context(), proj.Runtime, "plan", lockTimeout, fn)
 			}
 			return fn()
 		}
@@ -181,7 +181,7 @@ windsor plan terraform --json`,
 
 		blueprint := proj.Composer.BlueprintHandler.Generate()
 
-		return stacklock.With(cmd.Context(), proj.Runtime, "plan", func() error {
+		return stacklock.With(cmd.Context(), proj.Runtime, "plan", lockTimeout, func() error {
 			if len(args) == 0 {
 				if planJSON && !planSummary {
 					return proj.Provisioner.PlanTerraformAllJSON(blueprint)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/windsorcli/cli/pkg/project"
@@ -18,6 +19,11 @@ var verbose bool
 // command's preflight sets NO_CACHE=true so ArtifactBuilder.Pull skips the
 // disk cache and re-downloads (and atomically overwrites) the cached entry.
 var noCache bool
+
+// lockTimeout is a flag for how long a command waits to acquire the stack lock before
+// failing. Defaults to 0 (fail immediately on contention, matching terraform's own
+// -lock-timeout default) rather than silently blocking; pass a duration to wait instead.
+var lockTimeout time.Duration
 
 // Define a custom type for context keys
 type contextKey string
@@ -66,6 +72,9 @@ func init() {
 	// bootstrap, bundle, ...) inherits it; the effect is plumbed via the NO_CACHE env
 	// var that ArtifactBuilder.Pull already honors.
 	rootCmd.PersistentFlags().BoolVar(&noCache, "no-cache", false, "Bypass the OCI artifact cache and force re-download of remote sources")
+	// Define the --lock-timeout flag. Persistent so every command that acquires the stack
+	// lock (apply, up, destroy, plan, bootstrap, upgrade) inherits it.
+	rootCmd.PersistentFlags().DurationVar(&lockTimeout, "lock-timeout", 0, "Duration to wait for the stack lock before failing (e.g. 30s, 5m). Defaults to 0 (fail immediately).")
 }
 
 // commandPreflight orchestrates global CLI preflight checks and context initialization for all commands.

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -110,7 +110,7 @@ windsor up --blueprint=ghcr.io/myorg/blueprint:v1.0.0`,
 
 		var halted bool
 		var postRunMessages []blueprintv1alpha1.Message
-		if err := stacklock.With(cmd.Context(), proj.Runtime, "up", func() error {
+		if err := stacklock.With(cmd.Context(), proj.Runtime, "up", lockTimeout, func() error {
 			_, h, err := proj.Up()
 			if err != nil {
 				return err

--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -105,7 +105,7 @@ windsor upgrade cluster --nodes=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1
 			return fmt.Errorf("blueprint is not available")
 		}
 
-		return stacklock.With(cmd.Context(), proj.Runtime, "upgrade", func() error {
+		return stacklock.With(cmd.Context(), proj.Runtime, "upgrade", lockTimeout, func() error {
 			if _, err := proj.Provisioner.Up(blueprint); err != nil {
 				return fmt.Errorf("error applying terraform: %w", err)
 			}

--- a/integration/apply_test.go
+++ b/integration/apply_test.go
@@ -4,8 +4,13 @@
 package integration
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/gofrs/flock"
 
 	"github.com/windsorcli/cli/integration/helpers"
 )
@@ -153,5 +158,84 @@ func TestApplyTerraform_MissingBinary_ShowsActionableError(t *testing.T) {
 	}
 	if strings.Contains(out, "aqua g -i") {
 		t.Errorf("expected stderr to OMIT third-party 'aqua g -i' hint, got: %s", out)
+	}
+}
+
+// TestApplyTerraform_FailsFastOnLockContentionByDefault verifies that with no
+// --lock-timeout flag, a command contending for an already-held stack lock fails
+// immediately with a busy error rather than silently blocking for minutes.
+func TestApplyTerraform_FailsFastOnLockContentionByDefault(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
+	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
+	if err != nil {
+		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
+	}
+	env = append(env, "WINDSOR_CONTEXT=local")
+
+	scratch := filepath.Join(dir, ".windsor", "contexts", "local")
+	if err := os.MkdirAll(scratch, 0o755); err != nil {
+		t.Fatalf("mkdir scratch: %v", err)
+	}
+	held := flock.New(filepath.Join(scratch, ".stacklock"))
+	locked, err := held.TryLock()
+	if err != nil || !locked {
+		t.Fatalf("hold lock: locked=%v err=%v", locked, err)
+	}
+	t.Cleanup(func() { _ = held.Unlock() })
+
+	start := time.Now()
+	_, stderr, err = helpers.RunCLI(dir, []string{"apply", "terraform", "null"}, env)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected failure while the stack lock is held, command succeeded")
+	}
+	if !strings.Contains(string(stderr), "stack lock") || !strings.Contains(string(stderr), "is held by") {
+		t.Errorf("expected a stack-lock busy error, got: %s", stderr)
+	}
+	if elapsed > 4*time.Second {
+		t.Errorf("expected the default (no --lock-timeout) to fail immediately, took %v", elapsed)
+	}
+}
+
+// TestApplyTerraform_LockTimeoutFlagWaitsBeforeFailing verifies that --lock-timeout
+// causes a command to retry against a contended stack lock for roughly the given
+// duration before surfacing the same busy error, confirming the flag is wired
+// through to the underlying Acquire call.
+func TestApplyTerraform_LockTimeoutFlagWaitsBeforeFailing(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
+	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
+	if err != nil {
+		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
+	}
+	env = append(env, "WINDSOR_CONTEXT=local")
+
+	scratch := filepath.Join(dir, ".windsor", "contexts", "local")
+	if err := os.MkdirAll(scratch, 0o755); err != nil {
+		t.Fatalf("mkdir scratch: %v", err)
+	}
+	held := flock.New(filepath.Join(scratch, ".stacklock"))
+	locked, err := held.TryLock()
+	if err != nil || !locked {
+		t.Fatalf("hold lock: locked=%v err=%v", locked, err)
+	}
+	t.Cleanup(func() { _ = held.Unlock() })
+
+	start := time.Now()
+	_, stderr, err = helpers.RunCLI(dir, []string{"apply", "terraform", "null", "--lock-timeout=300ms"}, env)
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected failure while the stack lock is held, command succeeded")
+	}
+	if !strings.Contains(string(stderr), "stack lock") || !strings.Contains(string(stderr), "is held by") {
+		t.Errorf("expected a stack-lock busy error, got: %s", stderr)
+	}
+	if elapsed < 250*time.Millisecond {
+		t.Errorf("expected --lock-timeout=300ms to retry for ~300ms before failing, took %v", elapsed)
 	}
 }

--- a/pkg/provisioner/stacklock/stacklock.go
+++ b/pkg/provisioner/stacklock/stacklock.go
@@ -199,12 +199,16 @@ type localFlockLock struct {
 	path string
 }
 
-// Acquire takes the lock, retrying every acquireRetryInterval until it is held,
-// the timeout elapses, or ctx is cancelled. A timeout of 0 makes a single attempt
-// and fails immediately on contention, matching terraform's own -lock-timeout=0
-// default, rather than blocking silently. Cancellation returns ctx.Err(); timeout
-// returns *LockBusyError, populating Holder from the sidecar info file when one is
-// present. The first retry (timeout > 0 only) prints a one-line notice to stderr
+// Acquire makes one immediate attempt and, on contention, either fails right away
+// (timeout <= 0) or retries every acquireRetryInterval until it is held, the
+// timeout elapses, or ctx is cancelled. The zero-timeout case is a structural
+// single attempt — no deadline arithmetic — rather than a zero-width time window,
+// because wall-clock comparisons taken close together can read as equal (not
+// strictly after) on platforms with coarse clock resolution, which would let one
+// extra retry cycle slip in. This matches terraform's own -lock-timeout=0 default:
+// fail immediately rather than block silently. Cancellation returns ctx.Err();
+// timeout returns *LockBusyError, populating Holder from the sidecar info file
+// when one is present. Entering the retry loop prints a one-line notice to stderr
 // naming the holder when known, so an operator who opted into waiting sees why the
 // command appears to hang instead of staring at a silent terminal. After flock
 // succeeds, info is persisted to a sidecar (<path>.info) via atomic temp+rename so
@@ -217,29 +221,36 @@ func (s *localFlockLock) Acquire(ctx context.Context, info LockInfo, timeout tim
 	}
 	flk := flock.New(s.path)
 	infoPath := s.path + stackLockInfoSuffix
-	deadline := time.Now().Add(timeout)
-	waitAnnounced := false
-	for {
-		locked, err := flk.TryLock()
-		if err != nil {
-			return nil, fmt.Errorf("flock acquire: %w", err)
-		}
-		if locked {
-			break
-		}
-		if time.Now().After(deadline) {
+
+	locked, err := flk.TryLock()
+	if err != nil {
+		return nil, fmt.Errorf("flock acquire: %w", err)
+	}
+	if !locked {
+		if timeout <= 0 {
 			return nil, &LockBusyError{Path: s.path, Holder: readHolderInfo(infoPath)}
 		}
-		if !waitAnnounced {
-			announceWaiting(s.path, readHolderInfo(infoPath))
-			waitAnnounced = true
-		}
-		select {
-		case <-ctx.Done():
-			return nil, ctx.Err()
-		case <-time.After(acquireRetryInterval):
+		deadline := time.Now().Add(timeout)
+		announceWaiting(s.path, readHolderInfo(infoPath))
+		for {
+			select {
+			case <-ctx.Done():
+				return nil, ctx.Err()
+			case <-time.After(acquireRetryInterval):
+			}
+			locked, err = flk.TryLock()
+			if err != nil {
+				return nil, fmt.Errorf("flock acquire: %w", err)
+			}
+			if locked {
+				break
+			}
+			if time.Now().After(deadline) {
+				return nil, &LockBusyError{Path: s.path, Holder: readHolderInfo(infoPath)}
+			}
 		}
 	}
+
 	if info.PID == 0 {
 		info.PID = os.Getpid()
 	}

--- a/pkg/provisioner/stacklock/stacklock.go
+++ b/pkg/provisioner/stacklock/stacklock.go
@@ -30,10 +30,11 @@ import (
 // Constants
 // =============================================================================
 
-// DefaultTimeout is the lock-wait timeout used by With and by Acquire when the
-// caller passes 0. Matches §7.4 of the terraform-lifecycle-hardening spike.
-// Declared as a var so tests can shorten it; production callers must not
-// reassign at runtime.
+// DefaultTimeout is a suggested wait duration for callers that want to opt into
+// waiting on a contended lock (e.g. via --lock-timeout) rather than the
+// fail-immediately default. It is no longer applied automatically: a caller-supplied
+// timeout of 0 means "fail immediately," matching terraform's own -lock-timeout=0
+// default, rather than silently blocking for minutes with no output.
 var DefaultTimeout = 5 * time.Minute
 
 // acquireRetryInterval is the wait between TryLock attempts under contention.
@@ -137,13 +138,15 @@ func NewLocalFlockLock(lockPath string) StackLock {
 // fn while holding it. The lock is released on return — including on panic —
 // via deferred Release. operation labels what the caller is doing ("up",
 // "apply", "destroy", "bootstrap", "plan") so concurrent operators see the
-// holder's intent in busy-error messages.
-func With(ctx context.Context, rt *runtime.Runtime, operation string, fn func() error) error {
+// holder's intent in busy-error messages. timeout is how long to wait on
+// contention before failing; 0 fails immediately (matching terraform's own
+// -lock-timeout=0 default) rather than blocking silently.
+func With(ctx context.Context, rt *runtime.Runtime, operation string, timeout time.Duration, fn func() error) error {
 	lock, err := ForRuntime(rt)
 	if err != nil {
 		return err
 	}
-	release, err := lock.Acquire(ctx, NewInfo(rt, operation), DefaultTimeout)
+	release, err := lock.Acquire(ctx, NewInfo(rt, operation), timeout)
 	if err != nil {
 		return err
 	}
@@ -197,22 +200,25 @@ type localFlockLock struct {
 }
 
 // Acquire takes the lock, retrying every acquireRetryInterval until it is held,
-// the timeout elapses, or ctx is cancelled. Cancellation returns ctx.Err();
-// timeout returns *LockBusyError, populating Holder from the sidecar info file
-// when one is present. After flock succeeds, info is persisted to a sidecar
-// (<path>.info) via atomic temp+rename so a future contender's busy error can
-// name the holder and PID. The sidecar is removed by Release; it is diagnostic
-// only and a missing or partial file is not load-bearing for correctness.
+// the timeout elapses, or ctx is cancelled. A timeout of 0 makes a single attempt
+// and fails immediately on contention, matching terraform's own -lock-timeout=0
+// default, rather than blocking silently. Cancellation returns ctx.Err(); timeout
+// returns *LockBusyError, populating Holder from the sidecar info file when one is
+// present. The first retry (timeout > 0 only) prints a one-line notice to stderr
+// naming the holder when known, so an operator who opted into waiting sees why the
+// command appears to hang instead of staring at a silent terminal. After flock
+// succeeds, info is persisted to a sidecar (<path>.info) via atomic temp+rename so
+// a future contender's busy error can name the holder and PID. The sidecar is
+// removed by Release; it is diagnostic only and a missing or partial file is not
+// load-bearing for correctness.
 func (s *localFlockLock) Acquire(ctx context.Context, info LockInfo, timeout time.Duration) (Release, error) {
-	if timeout <= 0 {
-		timeout = DefaultTimeout
-	}
 	if err := os.MkdirAll(filepath.Dir(s.path), lockDirPerm); err != nil {
 		return nil, fmt.Errorf("create lock directory: %w", err)
 	}
 	flk := flock.New(s.path)
 	infoPath := s.path + stackLockInfoSuffix
 	deadline := time.Now().Add(timeout)
+	waitAnnounced := false
 	for {
 		locked, err := flk.TryLock()
 		if err != nil {
@@ -223,6 +229,10 @@ func (s *localFlockLock) Acquire(ctx context.Context, info LockInfo, timeout tim
 		}
 		if time.Now().After(deadline) {
 			return nil, &LockBusyError{Path: s.path, Holder: readHolderInfo(infoPath)}
+		}
+		if !waitAnnounced {
+			announceWaiting(s.path, readHolderInfo(infoPath))
+			waitAnnounced = true
 		}
 		select {
 		case <-ctx.Done():
@@ -310,6 +320,19 @@ func makeRelease(flk *flock.Flock, infoPath string) Release {
 // =============================================================================
 // Helpers
 // =============================================================================
+
+// announceWaiting prints a one-line notice to stderr the first time Acquire is
+// about to retry against a contended lock, naming the holder when known. Only
+// called when timeout > 0 (the caller opted into waiting), so a fail-fast
+// (timeout == 0) Acquire never prints anything.
+func announceWaiting(path string, holder *LockInfo) {
+	if holder == nil {
+		fmt.Fprintf(os.Stderr, "Waiting for the stack lock at %s...\n", path)
+		return
+	}
+	fmt.Fprintf(os.Stderr, "Waiting for the stack lock at %s, held by %s (PID=%d, operation=%s)...\n",
+		path, holder.Who, holder.PID, holder.Operation)
+}
 
 // writeHolderInfo persists the holder LockInfo to the sidecar path via an
 // atomic temp+rename so a concurrent reader never observes a partial file.

--- a/pkg/provisioner/stacklock/stacklock_test.go
+++ b/pkg/provisioner/stacklock/stacklock_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -46,16 +47,6 @@ func newTestRuntime(t *testing.T) *runtime.Runtime {
 		ProjectRoot:        "/tmp/windsor-test-proj",
 		ContextName:        "test-ctx",
 	}
-}
-
-// withDefaultTimeout swaps DefaultTimeout for the duration of the test. Tests
-// that override must not run in parallel — the var is package-global. Restored
-// on cleanup.
-func withDefaultTimeout(t *testing.T, d time.Duration) {
-	t.Helper()
-	prev := DefaultTimeout
-	DefaultTimeout = d
-	t.Cleanup(func() { DefaultTimeout = prev })
 }
 
 // =============================================================================
@@ -144,6 +135,70 @@ func TestLocalFlockLock_Acquire(t *testing.T) {
 		}
 		if elapsed < 150*time.Millisecond {
 			t.Fatalf("expected ~200ms wait, got %v", elapsed)
+		}
+	})
+
+	t.Run("fails immediately on contention when timeout is zero", func(t *testing.T) {
+		// Given a lock already held by one instance against a shared path
+		path := filepath.Join(t.TempDir(), ".stacklock")
+		first := NewLocalFlockLock(path)
+		release1, err := first.Acquire(context.Background(), newTestLockInfo(), time.Second)
+		if err != nil {
+			t.Fatalf("first acquire: %v", err)
+		}
+		t.Cleanup(func() { _ = release1() })
+
+		// When a second instance attempts to acquire with a zero timeout
+		second := NewLocalFlockLock(path)
+		start := time.Now()
+		_, err = second.Acquire(context.Background(), newTestLockInfo(), 0)
+		elapsed := time.Since(start)
+
+		// Then a LockBusyError is returned without retrying — no acquireRetryInterval wait
+		var busy *LockBusyError
+		if !errors.As(err, &busy) {
+			t.Fatalf("expected *LockBusyError, got %T: %v", err, err)
+		}
+		if elapsed >= acquireRetryInterval {
+			t.Fatalf("expected an immediate failure with no retry wait, took %v", elapsed)
+		}
+	})
+
+	t.Run("prints a waiting notice to stderr when timeout is non-zero and the lock is contended", func(t *testing.T) {
+		// Given a lock held by another holder with a populated sidecar
+		path := filepath.Join(t.TempDir(), ".stacklock")
+		first := NewLocalFlockLock(path)
+		holderInfo := newTestLockInfo()
+		holderInfo.Who = "ci@runner-9"
+		holderInfo.Operation = "bootstrap"
+		holderInfo.PID = 4242
+		release1, err := first.Acquire(context.Background(), holderInfo, time.Second)
+		if err != nil {
+			t.Fatalf("first acquire: %v", err)
+		}
+		t.Cleanup(func() { _ = release1() })
+
+		// When a second instance waits with a non-zero timeout, capturing stderr
+		origStderr := os.Stderr
+		r, w, err := os.Pipe()
+		if err != nil {
+			t.Fatalf("pipe: %v", err)
+		}
+		os.Stderr = w
+		second := NewLocalFlockLock(path)
+		_, acquireErr := second.Acquire(context.Background(), newTestLockInfo(), 150*time.Millisecond)
+		os.Stderr = origStderr
+		_ = w.Close()
+		var buf strings.Builder
+		_, _ = io.Copy(&buf, r)
+
+		// Then a waiting notice naming the holder was printed, and the call still times out
+		var busy *LockBusyError
+		if !errors.As(acquireErr, &busy) {
+			t.Fatalf("expected *LockBusyError, got %T: %v", acquireErr, acquireErr)
+		}
+		if !strings.Contains(buf.String(), "Waiting for the stack lock") || !strings.Contains(buf.String(), "ci@runner-9") {
+			t.Fatalf("expected a waiting notice naming the holder, got %q", buf.String())
 		}
 	})
 
@@ -420,7 +475,7 @@ func TestWith(t *testing.T) {
 	t.Run("returns an error when runtime is nil", func(t *testing.T) {
 		// Given a nil runtime
 		// When invoking With
-		err := With(context.Background(), nil, "up", func() error { return nil })
+		err := With(context.Background(), nil, "up", time.Second, func() error { return nil })
 		// Then an error is returned (fn would panic on nil access if it ran)
 		if err == nil {
 			t.Fatal("expected error, got nil")
@@ -432,7 +487,7 @@ func TestWith(t *testing.T) {
 		rt := &runtime.Runtime{}
 
 		// When invoking With
-		err := With(context.Background(), rt, "up", func() error { return nil })
+		err := With(context.Background(), rt, "up", time.Second, func() error { return nil })
 
 		// Then an error is returned identifying the missing path
 		if err == nil {
@@ -446,7 +501,7 @@ func TestWith(t *testing.T) {
 		called := false
 
 		// When invoking With
-		err := With(context.Background(), rt, "up", func() error {
+		err := With(context.Background(), rt, "up", time.Second, func() error {
 			called = true
 			return nil
 		})
@@ -466,7 +521,7 @@ func TestWith(t *testing.T) {
 		sentinel := errors.New("from fn")
 
 		// When invoking With
-		err := With(context.Background(), rt, "up", func() error { return sentinel })
+		err := With(context.Background(), rt, "up", time.Second, func() error { return sentinel })
 
 		// Then the sentinel surfaces unchanged
 		if !errors.Is(err, sentinel) {
@@ -479,12 +534,12 @@ func TestWith(t *testing.T) {
 		rt := newTestRuntime(t)
 
 		// When the first call completes
-		if err := With(context.Background(), rt, "up", func() error { return nil }); err != nil {
+		if err := With(context.Background(), rt, "up", time.Second, func() error { return nil }); err != nil {
 			t.Fatalf("first: %v", err)
 		}
 
 		// Then a second call against the same path acquires successfully
-		if err := With(context.Background(), rt, "apply", func() error { return nil }); err != nil {
+		if err := With(context.Background(), rt, "apply", time.Second, func() error { return nil }); err != nil {
 			t.Fatalf("second: %v", err)
 		}
 	})
@@ -492,10 +547,10 @@ func TestWith(t *testing.T) {
 	t.Run("releases the lock when fn returns an error", func(t *testing.T) {
 		// Given fn that errors out
 		rt := newTestRuntime(t)
-		_ = With(context.Background(), rt, "up", func() error { return errors.New("boom") })
+		_ = With(context.Background(), rt, "up", time.Second, func() error { return errors.New("boom") })
 
 		// When a second invocation runs against the same path
-		err := With(context.Background(), rt, "apply", func() error { return nil })
+		err := With(context.Background(), rt, "apply", time.Second, func() error { return nil })
 
 		// Then the second invocation succeeds, proving the first released
 		if err != nil {
@@ -521,8 +576,7 @@ func TestWith(t *testing.T) {
 		t.Cleanup(func() { _ = peerRelease() })
 
 		// When With runs against the same path with a short timeout
-		withDefaultTimeout(t, 100*time.Millisecond)
-		err = With(context.Background(), rt, "up", func() error {
+		err = With(context.Background(), rt, "up", 100*time.Millisecond, func() error {
 			t.Fatal("fn must not run when acquire fails")
 			return nil
 		})


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This changes the default locking behavior for every stack-mutating command (`apply`, `up`, `destroy`, `plan`, `bootstrap`, `upgrade`), so it's a shared-CLI default change even though the code touched is small and well-tested.
>
> **Overview**
>
> The PR adds a persistent `--lock-timeout` flag (default `0`) and threads it through `stacklock.With` into every command that acquires the stack lock, replacing the old behavior of silently waiting up to `DefaultTimeout` (5 minutes) on contention.
>
> Previously, any command that hit a held lock would block for up to 5 minutes with no output before failing. Now the default is to fail immediately (matching Terraform's own `-lock-timeout=0` convention), and only passing `--lock-timeout` opts into waiting — in which case a one-line stderr notice announces the wait and names the current holder. The bootstrap confirmation prompt's message was updated to match. Test coverage for both the fail-fast and wait-with-notice paths looks solid.

<!-- /claude-code-review:summary -->
