### PR TITLE
fix(tui): drop checkmarks on non-interactive stderr

### DIFF
--- a/pkg/tui/tui.go
+++ b/pkg/tui/tui.go
@@ -203,8 +203,9 @@ func (s *termSpinner) Update(message string) {
 }
 
 // Done stops the spinner and prints a green success line to stderr. When stderr isn't a
-// terminal and Start/Update already printed this exact message as a fallback line, the
-// message is omitted here to avoid printing it twice back to back.
+// terminal, Start/Update already printed the message as a plain fallback line, so no
+// checkmark or color decoration is added here — the same undecorated behavior verboseSpinner
+// already uses for non-interactive output.
 func (s *termSpinner) Done() {
 	if s.spin != nil && s.spin.Active() {
 		s.spin.Stop()
@@ -216,15 +217,14 @@ func (s *termSpinner) Done() {
 		s.pauseCursorSaved = false
 	}
 	if !isInteractiveStderr() && s.lastFallbackLine == s.message {
-		fmt.Fprint(os.Stderr, "\033[32m✔ Done\033[0m\n")
 		return
 	}
 	fmt.Fprintf(os.Stderr, "\033[32m✔\033[0m %s - \033[32mDone\033[0m\n", s.message)
 }
 
 // Fail stops the spinner and prints a red failure line to stderr. When stderr isn't a
-// terminal and Start/Update already printed this exact message as a fallback line, the
-// message is omitted here to avoid printing it twice back to back.
+// terminal, no failure line is printed — the same undecorated behavior verboseSpinner
+// already uses for non-interactive output, relying on the returned error to surface failure.
 func (s *termSpinner) Fail() {
 	if s.spin != nil && s.spin.Active() {
 		s.spin.Stop()
@@ -236,7 +236,6 @@ func (s *termSpinner) Fail() {
 		s.pauseCursorSaved = false
 	}
 	if !isInteractiveStderr() && s.lastFallbackLine == s.message {
-		fmt.Fprint(os.Stderr, "\033[31m✗ Failed\033[0m\n")
 		return
 	}
 	fmt.Fprintf(os.Stderr, "\033[31m✗ %s - Failed\033[0m\n", s.message)

--- a/pkg/tui/tui_test.go
+++ b/pkg/tui/tui_test.go
@@ -398,19 +398,18 @@ func TestTermSpinner_Done(t *testing.T) {
 		}
 	})
 
-	t.Run("OmitsMessageWhenFallbackAlreadyPrintedIt", func(t *testing.T) {
+	t.Run("PrintsNothingWhenStderrIsNotATerminal", func(t *testing.T) {
 		// Given a termSpinner started with stderr redirected to a pipe (never a terminal),
-		// so Start already printed "deploying" as a fallback line
+		// so Start already printed "deploying" as a plain fallback line
 		s := &termSpinner{}
 		captureStderr(t, func() { s.Start("deploying") })
 
 		// When Done is called
 		out := captureStderr(t, s.Done)
 
-		// Then the success line omits the message to avoid repeating it
-		want := "\033[32m✔ Done\033[0m\n"
-		if out != want {
-			t.Errorf("expected %q, got %q", want, out)
+		// Then no checkmark or color decoration is printed
+		if out != "" {
+			t.Errorf("expected no output, got %q", out)
 		}
 	})
 }
@@ -464,19 +463,18 @@ func TestTermSpinner_Fail(t *testing.T) {
 		}
 	})
 
-	t.Run("OmitsMessageWhenFallbackAlreadyPrintedIt", func(t *testing.T) {
+	t.Run("PrintsNothingWhenStderrIsNotATerminal", func(t *testing.T) {
 		// Given a termSpinner started with stderr redirected to a pipe (never a terminal),
-		// so Start already printed "deploying" as a fallback line
+		// so Start already printed "deploying" as a plain fallback line
 		s := &termSpinner{}
 		captureStderr(t, func() { s.Start("deploying") })
 
 		// When Fail is called
 		out := captureStderr(t, s.Fail)
 
-		// Then the failure line omits the message to avoid repeating it
-		want := "\033[31m✗ Failed\033[0m\n"
-		if out != want {
-			t.Errorf("expected %q, got %q", want, out)
+		// Then no checkmark or color decoration is printed
+		if out != "" {
+			t.Errorf("expected no output, got %q", out)
 		}
 	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Touches only `pkg/tui/tui.go` and its tests, changing stderr output formatting for non-interactive runs; the change is isolated, reversible, and covered by updated unit tests.
>
> **Overview**
>
> When stderr isn't a terminal and `Start`/`Update` already printed a plain fallback line matching the current message, `termSpinner.Done()` and `Fail()` previously still emitted a short colored line (`✔ Done` / `✗ Failed`). This PR removes that trailing decorated line entirely in that case, so non-interactive output shows only the plain message with no ANSI color/checkmark noise.
>
> For `Fail()`, this means non-interactive stderr no longer prints any failure marker in the fallback-matched case — failure is now surfaced only through the command's returned error/exit code, consistent with how `verboseSpinner` already behaves. Tests were updated to assert no output rather than the old decorated line.

<!-- /claude-code-review:summary -->
