### PR TITLE
fix(composer/artifact): allow release-candidate CLI versions to satisfy cliVersion constraints

### DIFF
--- a/pkg/composer/artifact/artifact.go
+++ b/pkg/composer/artifact/artifact.go
@@ -748,6 +748,10 @@ func IsAuthenticationError(err error) bool {
 // specified in the template metadata. If constraint is empty, validation is skipped.
 // If cliVersion is empty, validation is skipped (caller cannot determine version).
 // If the CLI version is "dev" or "main" or "latest", validation is skipped as these are development builds.
+// A pre-release CLI version (e.g. "0.9.0-rc.1") is checked against its release version
+// (Masterminds/semver excludes pre-releases from a range unless the constraint itself
+// declares one, which would otherwise fail every release-candidate build against an
+// ordinary ">=" constraint).
 // Returns an error if the constraint is specified and the version does not satisfy it.
 func ValidateCliVersion(cliVersion, constraint string) error {
 	if constraint == "" {
@@ -773,7 +777,12 @@ func ValidateCliVersion(cliVersion, constraint string) error {
 		return fmt.Errorf("invalid cliVersion constraint '%s': %w", constraint, err)
 	}
 
-	if !c.Check(version) {
+	releaseVersion, err := version.SetPrerelease("")
+	if err != nil {
+		return fmt.Errorf("invalid CLI version format '%s': %w", cliVersion, err)
+	}
+
+	if !c.Check(&releaseVersion) {
 		return fmt.Errorf("CLI version %s does not satisfy required constraint '%s'", cliVersion, constraint)
 	}
 

--- a/pkg/composer/artifact/artifact_helpers_test.go
+++ b/pkg/composer/artifact/artifact_helpers_test.go
@@ -560,4 +560,40 @@ func TestValidateCliVersion(t *testing.T) {
 			t.Errorf("Expected error to contain 'does not satisfy required constraint', got: %v", err)
 		}
 	})
+
+	t.Run("ReturnsNilWhenReleaseCandidateSatisfiesGreaterThanEqualConstraint", func(t *testing.T) {
+		// Given a release-candidate CLI version whose release satisfies a >= constraint
+		// When validating
+		err := ValidateCliVersion("0.9.0-rc.1", ">=0.9.0")
+
+		// Then should return nil — the RC is treated as its release version
+		if err != nil {
+			t.Errorf("Expected nil for RC version satisfying constraint, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsNilWhenReleaseCandidateWithVPrefixSatisfiesConstraint", func(t *testing.T) {
+		// Given a v-prefixed release-candidate CLI version
+		// When validating
+		err := ValidateCliVersion("v0.9.0-rc.1", ">=0.9.0")
+
+		// Then should return nil
+		if err != nil {
+			t.Errorf("Expected nil for v-prefixed RC version satisfying constraint, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenReleaseCandidateDoesNotSatisfyConstraint", func(t *testing.T) {
+		// Given a release-candidate CLI version whose release does not satisfy the constraint
+		// When validating
+		err := ValidateCliVersion("0.8.0-rc.1", ">=0.9.0")
+
+		// Then should return error
+		if err == nil {
+			t.Error("Expected error when RC's release version doesn't satisfy constraint")
+		}
+		if !strings.Contains(err.Error(), "does not satisfy required constraint") {
+			t.Errorf("Expected error to contain 'does not satisfy required constraint', got: %v", err)
+		}
+	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change touches a single validation function in the composer/artifact package with matching unit tests, so the blast radius is small and easily reversible.
>
> **Overview**
>
> `ValidateCliVersion` now strips the pre-release suffix (e.g. `-rc.1`) from the running CLI's version before checking it against a template's `cliVersion` constraint. Previously, Masterminds/semver excludes pre-release versions from a range unless the constraint itself declares a pre-release, so any release-candidate build would fail an ordinary `>=` constraint even though its underlying release version satisfied it.
>
> The fix computes a release-only copy of the parsed version via `SetPrerelease("")` and checks that against the constraint instead of the original version. Three new test cases cover an RC satisfying, an RC with a `v` prefix satisfying, and an RC correctly failing a constraint its release version doesn't meet.

<!-- /claude-code-review:summary -->
