### PR TITLE
fix(artifact): update extraction logic to include kustomize directory

### DIFF
--- a/pkg/composer/artifact/artifact.go
+++ b/pkg/composer/artifact/artifact.go
@@ -1343,7 +1343,7 @@ func (a *ArtifactBuilder) validateAndSanitizePath(path string) (string, error) {
 }
 
 // extractTarEntries extracts specific entries from a tar archive into the given destination directory for caching and reuse.
-// Only entries within the "_template/" and "terraform/" directories, as well as the "metadata.yaml" file, are extracted.
+// Only entries within the "_template/", "kustomize/", and "terraform/" directories, as well as the "metadata.yaml" file, are extracted.
 // Directories and files are handled appropriately, and file permissions are set as specified in the tar headers.
 // The extraction process performs path validation to prevent directory traversal attacks, and the destination directory must preexist.
 // Returns an error if any part of the extraction or validation fails.
@@ -1363,6 +1363,7 @@ func (a *ArtifactBuilder) extractTarEntries(tarReader TarReader, destDir string)
 		}
 
 		if !strings.HasPrefix(sanitizedPath, "_template/") &&
+			!strings.HasPrefix(sanitizedPath, "kustomize/") &&
 			!strings.HasPrefix(sanitizedPath, "terraform/") &&
 			sanitizedPath != "metadata.yaml" {
 			if header.Typeflag != tar.TypeDir {

--- a/pkg/composer/artifact/artifact_private_test.go
+++ b/pkg/composer/artifact/artifact_private_test.go
@@ -2405,18 +2405,27 @@ func TestArtifactBuilder_extractTarEntries(t *testing.T) {
 		}
 	})
 
-	t.Run("SkipsKustomizeDirectory", func(t *testing.T) {
+	t.Run("ExtractsKustomizeDirectory", func(t *testing.T) {
 		builder, _ := setup(t)
 		tmpDir := t.TempDir()
 		callCount := 0
+		content := []byte("resources:\n")
 
 		mockReader := &mockTarReader{
 			nextFunc: func() (*tar.Header, error) {
 				callCount++
 				if callCount == 1 {
-					return &tar.Header{Name: "kustomize/file.yaml", Typeflag: tar.TypeReg}, nil
+					return &tar.Header{Name: "kustomize/file.yaml", Typeflag: tar.TypeReg, Size: int64(len(content)), Mode: 0644}, nil
 				}
 				return nil, io.EOF
+			},
+			readFunc: func(p []byte) (int, error) {
+				n := copy(p, content)
+				content = content[n:]
+				if len(content) == 0 {
+					return n, io.EOF
+				}
+				return n, nil
 			},
 		}
 
@@ -2425,13 +2434,9 @@ func TestArtifactBuilder_extractTarEntries(t *testing.T) {
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
 		}
-		kustomizePath := filepath.Join(tmpDir, "kustomize")
-		_, statErr := os.Stat(kustomizePath)
-		if statErr == nil {
-			t.Error("Expected kustomize directory to be skipped, but it exists")
-		}
-		if statErr != nil && !os.IsNotExist(statErr) {
-			t.Errorf("Expected kustomize directory to not exist, got stat error: %v", statErr)
+		kustomizeFile := filepath.Join(tmpDir, "kustomize", "file.yaml")
+		if _, statErr := os.Stat(kustomizeFile); statErr != nil {
+			t.Errorf("Expected kustomize/file.yaml to be extracted, got stat error: %v", statErr)
 		}
 	})
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change affects OCI artifact tar extraction in the composer package, is narrowly scoped, and easily reversible.
>
> **Overview**
>
> The PR adds `kustomize/` to the set of tar entry prefixes that `extractTarEntries` extracts from cached OCI artifacts, alongside the existing `_template/` and `terraform/` directories and `metadata.yaml`. Previously kustomize content was explicitly skipped during extraction; now it is preserved in the disk cache like the other recognized directories.
>
> The accompanying test is updated from `SkipsKustomizeDirectory` to `ExtractsKustomizeDirectory`, and now exercises the file's actual byte content via a mock `Read` implementation rather than just checking for the directory's absence. Path validation and traversal protections in `validateAndSanitizePath` are unchanged.

<!-- /claude-code-review:summary -->
