### PR TITLE
chore(docs/adrs): plan v0.10.0 roadmap

### DIFF
--- a/.claude/skills/go-style/SKILL.md
+++ b/.claude/skills/go-style/SKILL.md
@@ -62,6 +62,34 @@ Every implementation file begins with a 4-line class header:
 
 Every function and method has a header comment. No explanatory comments inside function bodies — context belongs in the header.
 
+### Function length
+
+Functions may be long when a single cohesive operation warrants it — this codebase does not chase
+artificially small functions. But length has a ceiling, checked against the codebase's own current
+distribution rather than picked arbitrarily: **under 100 lines is the norm** (the large majority of
+functions today), **100–150 lines is a look-twice zone** (worth a second read to confirm the body is
+genuinely one operation, not several stitched together), and **150+ lines should split** into private
+helper methods in the same file's Private Methods section — currently only a handful of functions in
+the whole codebase exceed that, and each is worth checking against this bar as its file comes up for
+cleanup. The one standing exception is mechanical, field-by-field methods (`DeepCopy`, marshal/
+unmarshal glue) where every line is a distinct field and splitting would fragment one operation into
+several without reducing its actual complexity.
+
+### No planning or process artifacts in comments
+
+A comment — header or, in the rare permitted case, in-body — documents current behavior only. It
+never contains:
+
+- **WIP or historical narrative** — "TODO: revisit after X ships," "previously did Y, now does Z,"
+  fix-history explanations. The codebase is always "now"; history lives in git and PR descriptions,
+  never in the source.
+- **ADR, ticket, or issue references** — `// per ADR 0002` or `// see #3104` describes why a decision
+  was made, which belongs in the ADR or the commit that implemented it, not in the code the decision
+  produced. A reader six months from now needs to know what the function does, not which planning
+  document justified it.
+- **Phase or wave labels** — "Phase 2:", "Wave 1 cleanup:" — these are release-planning vocabulary,
+  not descriptions of behavior, and go stale the moment the release ships.
+
 ## In-body comments are a smell, not a tool
 
 The non-negotiable: **do not write explanatory comments inside function bodies.** Not single lines, not multi-line "novels," not "// Note: ..." asides. If you feel the urge to explain *why* the code does what it does at the point of the code, that belongs in:
@@ -195,6 +223,10 @@ All tests for public methods belong under a single `// Test Public Methods` head
 - Section headers are valid, in required order, and use generic category names only.
 - All functions have header comments.
 - No inline comments inside function bodies.
+- No header comment cites an ADR, ticket/issue number, WIP marker, phase/wave label, or "previously
+  X now Y" narrative — it describes current behavior only.
+- No function exceeds ~150 lines without a specific reason (mechanical field-by-field methods are
+  the only standing exception); 100–150 is worth a second look.
 - Naming is consistent with existing package terminology.
 - No dump files introduced.
 - No `strings.Contains(err.Error(), ...)` (or equivalent) for error classification. Use `errors.As` / `errors.Is` against typed errors; if a library lacks one, define a typed wrapper at the boundary.

--- a/.claude/skills/test-engineer/SKILL.md
+++ b/.claude/skills/test-engineer/SKILL.md
@@ -12,29 +12,66 @@ description: Apply Windsor test workflow and design standards for unit tests. Us
 
 ## Test design principles
 
-- Test public contracts, state transitions, and externally visible outcomes.
-- Avoid testing private methods directly; allow it only for complex pure logic (parsers, edge-case math) where public coverage is impractical.
-- Keep tests resilient to refactors that preserve behavior.
+- **Black-box (`package xxx_test`) is the default for new and touched test files** — test through the
+  package's exported constructors and methods, not its unexported identifiers. This is enforced by
+  the package declaration itself, not just a preference: if a test needs an unexported identifier to
+  compile, that's the signal to check whether it belongs under the exemption below or whether the
+  package's public surface is missing something it should expose.
+- **White-box is a narrow, deliberate exemption, not a fallback.** Permitted only for complex
+  unexported logic where public coverage is genuinely impractical to reach — parsers, edge-case math,
+  dense algorithmic branches (see `pkg/composer/terraform/oci_module_resolver_private_test.go`'s
+  `HandlesEdgeCases`). "It's more convenient to call the private function directly" is not the bar;
+  "no reasonable sequence of public calls exercises this branch" is.
+- Keep tests resilient to refactors that preserve behavior — a black-box test by construction doesn't
+  care which file or private method the behavior lives in, only that the public contract holds.
 - Use Go standard `testing` package. No `testify`, no `ginkgo`, no external test frameworks.
-- Use BDD `t.Run` scenario naming with Given/When/Then flow inside each case.
+- Use BDD `t.Run` scenario naming with Given/When/Then flow inside each case (see below — this is a
+  structural requirement, not a loose suggestion).
+
+### When refactoring a package's internals (file splits, shims extraction, interface changes)
+
+Characterize before you move anything: if black-box coverage of the package's current public
+behavior doesn't already exist, write it first. Do the structural change under that net. The
+black-box tests should pass unchanged — that's the proof the refactor preserved behavior. Only after
+that does any new white-box test get added, and only for unexported logic that still meets the
+exemption bar above post-refactor. Never refactor first and patch tests afterward — a private-method
+test written before a refactor is exactly the thing that breaks during it for reasons that have
+nothing to do with correctness.
+
+### Mocks: only what's actually called
+
+A mock implements every method its interface declares (the compiler requires it), but that is not
+license for the interface to carry a method nothing calls. Before adding a new interface method (and
+its mock), confirm it has a real production call site planned, not just "the interface should
+probably support this." When touching an existing mock, check each method against real call sites —
+excluding its own package's tests and the mock file itself — not against whether tests customize its
+return value: a method can be production-critical and never need a custom mock return, and a method
+can look identically "unused" by customization frequency while actually being genuine dead code. Only
+the call-site check tells the two apart. A confirmed-dead method is removed from the interface, its
+real implementation, and its mock together, in the same change — never left on the mock "just in
+case."
 
 ## Test file pattern
 
+Package declaration is `foo_test`, not `foo` — the black-box default from above, made concrete:
+
 ```go
+package foo_test
+
 // =============================================================================
 // Test Setup
 // =============================================================================
 
 type mocks struct {
-    configHandler *MockConfigHandler
-    shell         *MockShell
+    configHandler *foo.MockConfigHandler
+    shell         *foo.MockShell
 }
 
 func setupMocks(t *testing.T) *mocks {
     t.Helper()
     return &mocks{
-        configHandler: NewMockConfigHandler(),
-        shell:         NewMockShell(),
+        configHandler: foo.NewMockConfigHandler(),
+        shell:         foo.NewMockShell(),
     }
 }
 
@@ -46,6 +83,7 @@ func TestFoo_Bar(t *testing.T) {
     t.Run("Success", func(t *testing.T) {
         // Given a valid configuration
         m := setupMocks(t)
+        subject := foo.NewFoo(m.configHandler, m.shell)
 
         // When Bar is called
         result, err := subject.Bar()
@@ -59,6 +97,42 @@ func TestFoo_Bar(t *testing.T) {
 }
 ```
 
+### BDD comment discipline — exactly three lines, nothing more
+
+Each `t.Run` case gets exactly one `// Given`, one `// When`, one `// Then` comment, immediately
+above the code they describe — no additional narrative, no restating what the next line does beyond
+those three labels. This mirrors the production-code rule against in-body novels: the comment names
+the phase, the code shows the mechanics.
+
+```go
+// ✅ Three labeled phases, nothing extra
+t.Run("ReturnsErrorWhenConfigMissing", func(t *testing.T) {
+    // Given no config file exists
+    m := setupMocks(t)
+    m.configHandler.LoadConfigFunc = func() error { return os.ErrNotExist }
+
+    // When LoadOrDefault is called
+    err := subject.LoadOrDefault()
+
+    // Then a not-found error is returned
+    if !errors.Is(err, os.ErrNotExist) {
+        t.Fatalf("expected not-exist error, got %v", err)
+    }
+})
+
+// ❌ Narrative padding beyond the three labels
+t.Run("ReturnsErrorWhenConfigMissing", func(t *testing.T) {
+    // Given no config file exists — this simulates a fresh checkout where
+    // windsor.yaml hasn't been created yet, which is the most common case
+    // new users hit on their first `windsor init`
+    ...
+})
+```
+
+Subtest names are `PascalCaseScenarioDescription` (`ReturnsErrorWhenConfigMissing`, not
+`"returns error when config missing"` or `"Success"` alone once a file has more than one scenario) —
+specific enough that a failing subtest name alone tells you what broke.
+
 ## Test-writing workflow
 
 - Default: write the full set of `t.Run` cases for the behavior in one pass, then run the whole file (or `-run` the new test function) and report pass/fail. Don't stop to confirm each case individually — that ceremony has outlived its usefulness for routine test-writing.
@@ -69,6 +143,9 @@ func TestFoo_Bar(t *testing.T) {
 
 - Modifying source code during test-engineering-only tasks.
 - Using `testify` or any non-standard test library.
+- Adding a white-box test as the first move on a package about to be structurally refactored —
+  characterize with black-box coverage first (see above).
+- Adding a mock method for an interface method with no real, currently-planned production call site.
 
 ## Table-driven tests
 

--- a/.gitignore
+++ b/.gitignore
@@ -56,9 +56,6 @@ age.public.key
 # Investigation/spike artifacts
 docs/spikes/
 
-# Architecture decision records (kept local for now)
-docs/adrs/
-
 # managed by windsor cli
 .windsor/
 .volumes/

--- a/docs/adrs/0001-apiv2-common-header-schema.md
+++ b/docs/adrs/0001-apiv2-common-header-schema.md
@@ -1,0 +1,204 @@
+# ADR 0001 — apiv2 common header schema and v1alpha1 retirement
+
+- Status: Proposed
+- Date: 2026-08-04
+- Deciders: Ryan VanGundy
+- Carried forward from the v0.9.0 planning round (previously numbered 0010) with no scope change —
+  none of this was started. It leads the v0.10.0 sequence because the codebase-sweep wave
+  (`release-v0.10.0.md`) touches every package that reads config, and each of those passes should
+  land against the finished header, not the two-schema straddle described below.
+
+## Context
+
+The config API has a half-finished v1alpha1→v1alpha2 migration. This ADR records the target model
+so the remaining moves land coherently rather than field-by-field.
+
+Verified from source:
+
+- **Two config type layouts coexist and disagree on structure.** v1alpha1 is a root `Config` holding
+  a `Contexts map[string]*Context`, and each `Context` carries thirteen typed sub-configs — `AWS`,
+  `Azure`, `GCP`, `VSphere`, `Docker`, `Git`, `Terraform`, `VM`, `Cluster`, `Network`, `DNS`,
+  `Secrets`, `Environment` ([`api/v1alpha1/config_types.go:32`](../../api/v1alpha1/config_types.go#L32)).
+  v1alpha2 is a flat per-context header — `Version`, `Workstation`, `Environment`, `Secrets`,
+  `Providers`, `Terraform`, with no `contexts` map and no top-level platform sub-configs
+  ([`api/v1alpha2/config/config.go:13`](../../api/v1alpha2/config/config.go#L13)). The
+  provider-specific blocks that were siblings of `Context` in v1alpha1 collapse into one `Providers`
+  block in v1alpha2.
+- **v1alpha1 is still the only parse path; v1alpha2 types are dead weight at read time.** For any
+  `version` other than `v1alpha1`, `LoadRoot` loads the v1alpha2 *schemas* for validation
+  ([`typed_source.go:68`](../../pkg/runtime/config/typed_source.go#L68)) but then still unmarshals
+  the file into a `v1alpha1.Config` ([`typed_source.go:76`](../../pkg/runtime/config/typed_source.go#L76)).
+  The v1alpha2 `Config`/`ProvidersConfig`/`TerraformConfig`/`WorkstationConfig` structs have full
+  `Merge`/`DeepCopy` + tests but nothing calls them to parse a file. Everything below the version key
+  flows as a dynamic `map[string]any` validated against the merged schema — the typed structs are
+  not the source of truth for reads.
+- **The schema itself lives in two overlapping places.** The CLI embeds its own baseline schema at
+  [`pkg/runtime/config/schemas/common.yaml`](../../pkg/runtime/config/schemas/common.yaml) (loaded
+  via `//go:embed schemas/*.yaml`, [`handler.go:14`](../../pkg/runtime/config/handler.go#L14)), and
+  v1alpha2 embeds a second set per subsystem — `providers`, `secrets`, `terraform`, `workstation` —
+  merged in by `LoadSchemas` walking `schemasFS`
+  ([`api/v1alpha2/config/schemas.go:18`](../../api/v1alpha2/config/schemas.go#L18)). Both define
+  `workstation`, `dns`, `vm`, and friends. They are hand-maintained in parallel with the Go structs,
+  so a field lives in up to three places.
+- **The schema is composed at runtime, not owned by any single file.** Every fragment — the CLI's
+  own embedded schemas and the `schema.yaml` a blueprint (i.e. `windsorcli/core`) ships — is fed to
+  the same `SchemaValidator.LoadSchemaFromBytes`, which deep-merges each over the accumulated
+  `sv.Schema` with overlay properties winning
+  ([`schema_validator.go:87`](../../pkg/runtime/config/schema_validator.go#L87),
+  [`schema_merge.go`](../../pkg/runtime/config/schema_merge.go)). Core's fragment enters via the
+  blueprint loader ([`loader.go:501`](../../pkg/composer/blueprint/loader.go#L501)), and the CLI's
+  enters via the embedded loaders — first fragment is the base, later fragments overlay. So the
+  effective schema for a context **is** the merge of the CLI header and whatever the blueprint
+  contributes; there is no single authoritative file, and no need for one fragment to restate
+  another's fields.
+- **The schema carries settings the CLI never consumes.** `workstation/schema.yaml` still defines
+  full cluster node-group detail — `cluster.controlplanes` / `cluster.workers` with per-node
+  `nodes`, `hostports`, `volumes`, `image`
+  ([`api/v1alpha2/config/workstation/schema.yaml:145`](../../api/v1alpha2/config/workstation/schema.yaml#L145)).
+  These describe control-plane and compute-layer provisioning owned by `windsorcli/core`, not
+  settings the CLI reads to do its own work.
+- **Rendering is alphabetical, not header-ordered.** `RenderValuesWithDescriptions` walks
+  `sortedUnionKeys`, which `sort.Strings` the union of schema and value keys
+  ([`values_renderer.go:211`](../../pkg/runtime/config/values_renderer.go#L211)). JSON-Schema
+  property order is lost the moment a fragment is unmarshalled into `map[string]any`, so there is
+  today no carrier for a defined order. The vendored `goccy/go-yaml` (v1.19.2) does provide
+  `yaml.MapSlice`/`MapItem` for an order-preserving decode, unused so far in `pkg/`.
+
+## Decision
+
+Finish the migration to a single **common header schema** (apiv2 / v1alpha2) that (a) is the CLI's
+one header fragment, defined once and merged with the blueprint's schema rather than mirroring it,
+(b) statically parses its typed header while leaving the remainder a schema-validated dynamic map,
+(c) contains only settings the CLI itself reads, and (d) renders first, in declaration order, when
+values are written out.
+
+### 1. The CLI header is a schema fragment that merges with core's — not a mirror of it
+
+The effective schema is composed at load time: the CLI contributes a header fragment, the blueprint
+(`windsorcli/core`) contributes its own `schema.yaml`, and `LoadSchemaFromBytes` deep-merges both
+into one `sv.Schema` ([`schema_validator.go:87`](../../pkg/runtime/config/schema_validator.go#L87)).
+This is the mechanism behind the observations above: the CLI header and the core schema become one
+"common" schema for any blueprint precisely because they merge, so neither has to restate the
+other. The CLI owns and defines only the header fragment — the fields it consumes — and lets core's
+fragment fill in everything a blueprint adds on top. Merge precedence is load order (base first,
+overlays win on conflict): the CLI header loads first as the base, the blueprint fragment overlays
+it, so core can extend or refine header fields without the CLI importing or code-generating from
+core. This keeps api-layer purity (types in `api/`, no consumer policy) intact.
+
+Concretely, `pkg/runtime/config/schemas/common.yaml` folds into the v1alpha2 embedded fragments
+([`api/v1alpha2/config/*/schema.yaml`](../../api/v1alpha2/config)) so the CLI defines each header
+field in exactly one place before the merge. Core defining the same fields is good practice and
+expected — the merge tolerates it (overlay wins) — but is not load-bearing: the CLI never depends
+on core to supply a header field it reads. Compatibility is a property of the merge, not a
+separately maintained mirror; an optional drift test can assert the CLI header stays assignable
+from a core-authored values file, but it is a safety net, not the contract.
+
+### 2. Typed header + dynamic remainder — the static-load seam
+
+The typed header is exactly the v1alpha2 `Config` struct: `Version`, `Workstation`, `Environment`,
+`Secrets`, `Providers`, `Terraform`. `LoadRoot`/`LoadContext` parse this header into the struct
+directly (retiring the v1alpha1-unmarshal fallback at
+[`typed_source.go:76`](../../pkg/runtime/config/typed_source.go#L76)), and everything the header
+does not claim stays a `map[string]any` validated against the merged schema — the path
+facet-authored `additionalProperties` regions already travel. The seam is the struct's field set —
+a field earns a typed home only when CLI code reads it as more than an opaque value.
+
+### 3. Scope the header to CLI-consumed settings only
+
+A setting stays in the header (and its schema) only if `pkg/`/`cmd/` reads it to make a decision.
+Provisioning detail consumed solely by core — cluster `controlplanes`/`workers` node groups and
+compute-layer node specs
+([`workstation/schema.yaml:145`](../../api/v1alpha2/config/workstation/schema.yaml#L145)) — is
+removed from the CLI schema and, where a v1alpha1 typed struct exists for it, that struct is
+retired. Such values do not vanish from a user's file: they still validate and pass through as
+dynamic `additionalProperties` and reach core unchanged; the CLI simply stops maintaining a type
+and schema for settings it never reads. Removal follows the established rule — silently drop the
+retired typed field, no `UnmarshalYAML` deprecation hook.
+
+### 4. Header renders first, in declaration order
+
+When effective values serialize to a real `values.yaml`, the header keys emit first, in the order
+the v1alpha2 `Config` declares them (`version`, `workstation`, `environment`, `secrets`,
+`providers`, `terraform`), followed by the dynamic remainder. This replaces the alphabetical
+`sortedUnionKeys` ([`values_renderer.go:199`](../../pkg/runtime/config/values_renderer.go#L199))
+with an ordered key source: an explicit declaration-order list for the header, then the remaining
+keys. Preserving nested schema order below the top level requires decoding fragments through
+`yaml.MapSlice` (or an explicit per-object order list) instead of `map[string]any`, since map
+iteration and re-marshal both discard order.
+
+### 5. Fold in sensitive-value enforcement while `GetContextValues` is already being reworked
+
+A separate, smaller gap in the same function: `GetContextValues`
+([`pkg/runtime/config/resolve.go`](../../pkg/runtime/config/resolve.go)) is the chokepoint an
+earlier ADR (the prior round's ADR 0009, "sensitive schema properties") specified for removing
+sensitive-marked values before they can reach a plaintext `values-<name>` ConfigMap or `windsor
+show` output. What shipped instead is two independent enforcement sites — `RedactSensitiveValues`
+([`values_renderer.go`](../../pkg/runtime/config/values_renderer.go)), used by `windsor show`, and
+`sensitivePathsInValue` ([`processor.go`](../../pkg/composer/blueprint/processor.go)), a fail-closed
+guard on `substitute:` — with `GetContextValues` itself never scrubbing. Both current consumers
+happen to be covered, but the guarantee depends on every future consumer independently remembering
+to call one of the two guards rather than on the source no longer carrying the value.
+
+Since this ADR already rewrites `GetContextValues`'s read path end to end, land the fix here rather
+than as a separate change touching the same function twice: `GetContextValues` removes
+sensitive-marked paths from the map it returns; `RedactSensitiveValues` and `sensitivePathsInValue`
+become simple consequences of consuming an already-scrubbed map instead of each re-implementing the
+check. `IsSensitivePath`/`GetSensitivePaths` stay as the enumeration primitive. `windsor show`'s
+display-placeholder behavior (showing a key *was* sensitive without exposing the value) still needs
+the sensitive-path set exposed alongside the scrubbed map, not the values themselves. The separate
+resolution path that legitimately reads a sensitive value to back a facet `secrets:` entry
+(`ResolveSecrets`/`PlaceSecrets`) is unaffected — it reads the raw config value directly, not
+through `GetContextValues`, exactly as it does today.
+
+### 6. v1alpha1 retires behind this release
+
+v1alpha1 stays only as long as a real config file names `version: v1alpha1`. The typed `Context`
+with its thirteen sub-configs is the legacy layout; new work targets the header. Consumers still
+importing `api/v1alpha1` (blueprint composer, provisioner, flux, terraform, and roughly three
+dozen other files across `cmd/`, `pkg/composer/blueprint`, `pkg/provisioner/*`,
+`pkg/runtime/config`, `pkg/runtime/terraform`, `pkg/workstation`) migrate to the header struct or
+to reading the dynamic map, one package at a time, so no single commit rewrites the whole read
+path.
+
+## Consequences
+
+- **The header struct becomes load-bearing.** Its `Merge`/`DeepCopy`/mock stay in lockstep with the
+  schema on every field change, now for reads too, not just validation.
+- **Two schema files become one**, ending the common.yaml↔v1alpha2 double maintenance; the merge
+  step in [`schema_merge.go`](../../pkg/runtime/config/schema_merge.go) still composes facet
+  fragments over the header, so facet extensibility is unchanged.
+- **Core-only settings degrade to opaque pass-through** — they validate loosely
+  (`additionalProperties`) and reach core intact, but the CLI no longer type-checks or documents
+  them. Accepted: they were never CLI policy.
+- **Ordered rendering costs a decode change** — the dynamic map path must carry order (`MapSlice`)
+  or the renderer must consult an explicit order list; alphabetical output is not order-preserving
+  and cannot be patched in place.
+- **No user-file breakage at the cut** — v1alpha1 files keep parsing on the legacy path; the header
+  path activates on `version` ≠ `v1alpha1`, exactly as `LoadRoot` already gates schema loading
+  today.
+- **This is the largest single item carried into v0.10.0's Wave 0/1.** Every per-package cleanup
+  pass in Wave 2 that touches config reads should land after this, not before, or it re-touches the
+  same call sites twice.
+- **Sensitive-value enforcement moves from two ad-hoc call sites to the chokepoint**, closing the
+  "a future `GetContextValues` consumer could forget to scrub" gap as a side effect of the header
+  rewrite, at no extra cost beyond what point 5 above already requires.
+
+## Deferred / rejected alternatives
+
+- **Generate the CLI schema from core** — a build-time dependency on the core repo's schema.
+  Rejected: the runtime merge already composes the two, so the CLI never needs a copy of core's
+  fields; coupling the build to core would restate a relationship the merge already expresses.
+- **Promote every v1alpha1 sub-config into a typed v1alpha2 block** — keeps `cluster`/`network`/
+  platform detail as first-class CLI types. Rejected by point 3: the CLI would maintain types for
+  settings it never reads. Those stay dynamic pass-through.
+- **Keep the dynamic-map-only model, no typed header** — simplest, but forfeits static typing for
+  the fields the CLI reads on every command and leaves point 4's ordering with no declaration to
+  anchor to. Rejected.
+- **`UnmarshalYAML` deprecation warnings on removed fields** — rejected per house rule; retired
+  fields are dropped silently and pass through as `additionalProperties`.
+
+## References
+
+- Source seams cited inline: `config_types.go`, `config.go`, `schemas.go`, `typed_source.go`,
+  `common.yaml`, `workstation/schema.yaml`, `values_renderer.go`, `schema_merge.go`, `handler.go`,
+  `resolve.go`, `processor.go`.

--- a/docs/adrs/0002-target-architecture-and-package-topology.md
+++ b/docs/adrs/0002-target-architecture-and-package-topology.md
@@ -1,0 +1,176 @@
+# ADR 0002 — Target architecture and package topology
+
+- Status: Proposed
+- Date: 2026-08-04
+- Deciders: Ryan VanGundy
+- This is the release doc's Wave 0 "north star" ADR — the layer-ownership map and nested folder
+  structure every later Wave 2 per-package cleanup pass conforms to. It resolves `release-v0.10.0.md`
+  open question #1 by deriving the topology from the current tree rather than a fresh vision,
+  because the current tree turns out to already be substantially right (see Decision).
+
+## Context
+
+`.claude/skills/architecture/SKILL.md` already documents a layer-ownership table — CLI / Runtime /
+Evaluator / Secrets / Runtime-Terraform / Composer / Provisioner / Workstation — and it holds today,
+verified directly rather than assumed: `pkg/runtime/evaluator` and `pkg/composer/*` import neither
+`pkg/provisioner/*` nor each other's layer inappropriately, and `pkg/provisioner/*` correctly depends
+downward on `pkg/composer` (it consumes composed blueprints), never the reverse. **There is no
+boundary-violation problem to fix.** What's missing is that this map has only ever lived in a skill
+file, informally, not as a decision record new packages and refactors can be checked against; and two
+concrete pain points the skill doesn't address at all:
+
+**1. Monolith files, surveyed directly (`find pkg api cmd -name '*.go' | xargs wc -l`):**
+
+| File | Lines | Package |
+|---|---|---|
+| `pkg/composer/blueprint/processor.go` | 2949 | composer |
+| `pkg/provisioner/kubernetes/kubernetes_manager.go` | 2397 | provisioner |
+| `api/v1alpha1/blueprint_types.go` | 2177 | api |
+| `pkg/provisioner/provisioner.go` | 2113 | provisioner |
+| `pkg/provisioner/terraform/stack.go` | 1889 | provisioner |
+| `pkg/runtime/evaluator/evaluator.go` | 1621 | runtime |
+| `pkg/composer/artifact/artifact.go` | 1563 | composer |
+| `pkg/composer/blueprint/handler.go` | 1420 | composer |
+| `pkg/test/runner.go` | 1292 | test |
+| `pkg/runtime/terraform/provider.go` | 1290 | runtime |
+| `pkg/composer/blueprint/composer.go` | 1196 | composer |
+| `pkg/runtime/runtime.go` | 1034 | runtime |
+| `pkg/workstation/virt/incus_virt.go` | 1018 | workstation |
+
+Thirteen files over 1000 lines, four of them (`processor.go`, `kubernetes_manager.go`,
+`blueprint_types.go`, `provisioner.go`) over 2000. None of these are unowned or misplaced — every one
+sits in exactly the package the architecture skill's table says it should. The problem is single-file
+size within a correctly-scoped package, not package boundaries.
+
+**2. Duplicated system-call shims, surveyed directly (`grep` across all 16 `shims.go` files, plus
+`cmd/shims.go`):** the same struct fields, independently declared with the same signature, recur
+across 3–4+ files each — `ReadFile`, `WriteFile`, `Stat`, `MkdirAll`, `RemoveAll`, `Rename`, `Glob`,
+`YamlMarshal`/`YamlUnmarshal`, `JsonMarshal`/`JsonUnmarshal`, `Getenv`/`Setenv`/`LookupEnv`,
+`UserHomeDir`. 16 packages under `pkg/` plus `cmd/` itself each hand-roll their own copy of the
+`Shims` struct pattern (the "proven pattern" the architecture skill names) with no shared
+declaration of the primitives every one of them needs.
+
+**3. Wide interfaces**, confirmed: `ConfigHandler` (33 methods) and `Shell` (25 methods, `pkg/runtime/
+shell/shell.go`) — both single interfaces covering what are, on inspection, several genuinely
+separable concerns (config: load/get/set/schema/values-render/sensitive-paths; shell: exec/verbosity/
+secret-registration/session-reset).
+
+**4. `cmd/` needs the shared primitives too** — `cmd/shims.go` already exists, duplicating the same
+pattern found in `pkg/`. A shared package must be reachable from both `cmd/` and every `pkg/`
+subpackage, which rules out nesting it under `pkg/` (Go's `internal/` visibility extends only to the
+tree rooted at the directory *containing* the `internal/` folder — `pkg/internal/x` is invisible to
+`cmd/`, a sibling of `pkg/`, not a descendant of it). The repo already has a working precedent for
+this exact placement: `internal/gendocs`, a top-level `internal/` sibling to both `cmd/` and `pkg/`.
+
+## Decision
+
+### 1. Ratify the existing layer map as this ADR's canonical table, not a fresh one
+
+The `architecture` skill's table — CLI (`cmd/*`) / Runtime (`pkg/runtime/runtime.go`) / Evaluator
+(`pkg/runtime/evaluator/*`) / Secrets (`pkg/runtime/secrets/*`) / Runtime-Terraform (`pkg/runtime/
+terraform/*`) / Composer (`pkg/composer/*`) / Provisioner (`pkg/provisioner/*`) / Workstation
+(`pkg/workstation/*`) — is correct and verified against the current import graph. This ADR makes it
+the recorded decision the skill file *implements*, rather than the skill being the only place it's
+written down. No package moves between layers. Every Wave 2 per-package cleanup pass checks itself
+against this table unchanged.
+
+### 2. No wholesale `internal/` migration
+
+Considered and rejected: moving all of `pkg/` under a top-level `internal/` to make the whole
+application non-importable by other Go modules. This module (`github.com/windsorcli/cli`) does have
+one genuinely external consumer surface — `api/v1alpha1`/`api/v1alpha2`, imported by tooling outside
+this repo — but `pkg/`, `cmd/`, and `internal/` are already correctly non-`api` and nothing indicates
+anything outside this repo imports them today. Moving ~150 files' import paths for an enforcement
+benefit with no evidence of an actual external-import problem is exactly the kind of one-time,
+high-blast-radius churn Wave 2's "touch each package once" principle warns against. Not adopted.
+
+### 3. Shared system-call primitives move to `internal/shims`, reachable from `cmd/` and `pkg/` alike
+
+New top-level `internal/shims` (sibling to the existing `internal/gendocs`) declares the ~12
+duplicated primitives found in the survey — file I/O (`ReadFile`, `WriteFile`, `Stat`, `MkdirAll`,
+`RemoveAll`, `Rename`, `Glob`, `UserHomeDir`), marshal (`YamlMarshal`/`YamlUnmarshal`,
+`JsonMarshal`/`JsonUnmarshal`), and env (`Getenv`/`Setenv`/`LookupEnv`) — once, as mockable function
+fields, matching the existing `Shims` struct pattern exactly (same field-of-func-type shape, not a
+new convention). Every package's own `shims.go` keeps its package-specific wrappers (terraform exec,
+Kubernetes client construction, `hcloud`/`aws` SDK calls, etc.) but **composes** `internal/shims` for
+the common primitives instead of re-declaring them — each package's own file shrinks to only what's
+genuinely specific to it. `cmd/shims.go` does the same. This is additive and mechanical per package
+(swap a locally-declared field for the shared one, update the constructor), not a redesign — it can
+land package-by-package in Wave 2 rather than as one cross-cutting commit.
+
+`internal/util` (same sibling location) holds pure, non-mockable helpers with no system-call surface
+— string/path manipulation, small generic collection helpers — kept separate from `shims` because
+mockability is the entire reason `shims` exists and a pure helper has no business behind a function
+field.
+
+### 4. Monolith files split in place by cohesive concern, not into new sub-packages
+
+The file-size cap is **1000 lines**, tests exempt where a single black-box test file genuinely
+covers one cohesive public surface (Wave 2's own test-strategy ADR governs that exemption). Every
+file on the table above splits into multiple files **within its existing package** — the
+"companion file" pattern the architecture skill already names as proven (e.g. `provider_sensitive_
+inputs.go` next to `provider.go`) — not into new nested sub-packages. A monolith file is a size
+problem, not a boundary problem; introducing a new package boundary to fix a size problem would
+undo the very ratification in point 1. Concretely, each split follows the seams the file already has:
+
+- `processor.go` (2949) → the file's own section-header comments already separate config-block
+  resolution, facet inclusion, tier compilation, and deferred-substitution handling — four
+  companion files along those lines.
+- `blueprint_types.go` (2177, `api/v1alpha1`) → types stay in the base file; `Merge`/`DeepCopy`,
+  `ToFluxKustomization`-style compilation, and tier-derivation logic (`compileFluxSystemTiers` and
+  neighbors) move to companion files in the same package — `api/` purity (types free of consumer
+  policy, [[feedback_api_layer_purity]]) is unaffected since nothing crosses into `pkg/`.
+- `kubernetes_manager.go` (2397) / `provisioner.go` (2113) / `terraform/stack.go` (1889) → each
+  already separates by operation family (apply/prune/secrets/inventory for the manager; apply/
+  destroy/lock for the provisioner and stack) — split along those families.
+- `evaluator.go` (1621) → separate the expression-parsing/scope core from the builtin-function
+  registrations (`env()`, `secret()`, `file()`, …), which are additive and independently testable.
+- The remaining files on the table (`artifact.go`, `handler.go`, `test/runner.go`, `runtime/
+  terraform/provider.go`, `composer.go`, `runtime.go`, `incus_virt.go`) get the same treatment —
+  the exact split lines are a per-package Wave 2 decision, not fixed here; this ADR fixes the
+  *rule* (in-place companion files, 1000-line cap, no new sub-package), not every line number.
+
+### 5. Wide interfaces split by concern where a per-package cleanup pass touches them
+
+`ConfigHandler` (33 methods) and `Shell` (25 methods) are flagged for the Wave 2 test-strategy /
+mock-rationalization pass to split along their already-visible seams (config:
+load/get-set/schema-validate/render/sensitive-paths; shell: exec/verbosity/secret-registration/
+session-lifecycle) rather than staying one interface each. Not designed in full here — this ADR
+names the two interfaces as in-scope for that pass, which is where the actual split shape gets
+decided against real call-site usage.
+
+### 6. `cmd/` stays pure Cobra glue
+
+No change from current practice — already the house rule
+([[feedback_cmd_is_cobra_glue]]) and already how the tree is organized: domain logic, ID generation,
+and orchestration wrappers live in `pkg/`, `cmd/` only parses flags, wires a runtime, and renders
+errors. Restated here because it's part of the topology decision, not because it's changing.
+
+## Consequences
+
+- **No package moves.** This ADR's cost is entirely file-splitting and shims-consolidation work,
+  not import-path churn — lower risk than a topology reshuffle, and directly enables Wave 2 to
+  proceed per-package without a separate "move things into place" phase first.
+- **`internal/shims`/`internal/util` become a new shared dependency of every package that adopts
+  them** — a bug in a shared primitive now has wider blast radius than a bug in one package's local
+  copy. Mitigated by the primitives being thin, well-tested wrappers with no business logic.
+- **The monolith split list is a floor, not a ceiling** — Wave 2 passes may find additional
+  companion-file splits worth making as they go; this ADR's role is only to fix the rule (in-place,
+  1000-line cap) so those decisions don't need their own ADR each time.
+- **This unblocks Wave 1 and Wave 2 immediately** — the open question this ADR resolves
+  ("derive from current tree") is answered, so ADR 0001 (apiv2 header) and the not-yet-written Wave 1
+  foundations ADRs can proceed without re-litigating package placement.
+
+## Alternatives considered
+
+- **Design a materially different nested topology** (e.g. re-grouping by feature rather than layer,
+  or introducing a new top-level `domain/` package). Rejected: the current layer map already holds
+  under verification, and the actual pain points (monolith files, shim duplication, wide interfaces)
+  are orthogonal to package grouping — a new topology would not fix any of them and would add
+  import-path churn for no measured benefit.
+- **Move shared shims under `pkg/internal/`.** Rejected per point 4 in Context — `cmd/` cannot import
+  it there; Go's `internal/` visibility is scoped to the directory tree rooted at the folder
+  containing `internal/`, and `cmd/` is a sibling of `pkg/`, not a descendant.
+- **New sub-packages for each monolith split** (e.g. `pkg/composer/blueprint/facets/`,
+  `pkg/composer/blueprint/tiers/`). Rejected: introduces new package boundaries and import cycles to
+  manage for a problem that's purely about file size within an already-correctly-scoped package.

--- a/docs/adrs/0003-test-strategy-black-box-default.md
+++ b/docs/adrs/0003-test-strategy-black-box-default.md
@@ -1,0 +1,180 @@
+# ADR 0003 — Test strategy: black-box default and characterize-then-refactor
+
+- Status: Proposed
+- Date: 2026-08-04
+- Deciders: Ryan VanGundy
+- Promoted from Wave 2 to Wave 1 — this is a contract every later per-package cleanup pass depends
+  on, not an independent cleanup item, and [ADR 0001](0001-apiv2-common-header-schema.md) needs a
+  scoped slice of it immediately, before its own implementation starts.
+
+## Context
+
+Surveyed directly (`grep -L "_test$" package declarations` across every `*_test.go` file in `pkg/`
+and `cmd/`): **zero** of the 158 existing unit/cmd test files (113 `pkg/` unit + 28 `cmd/` + 17
+`integration/`, matching the count already recorded in `release-v0.10.0.md`) declare `package
+xxx_test`. Every one declares the same package as the code it tests. The `_public_test.go` /
+`_private_test.go` filename split that exists in 6+6 files is a **naming convention**, not black-box
+testing — both still compile as `package xxx` with full access to unexported identifiers. 100%
+white-box, confirmed rather than assumed.
+
+Two wide interfaces, exact counts (`awk` over the interface block, not a loose grep): `ConfigHandler`
+(33 methods, `pkg/runtime/config/handler.go`) and `Shell` (25 methods, `pkg/runtime/shell/shell.go`).
+35 hand-written mock files exist across `pkg/`/`cmd/` (no `mockgen`); a mock implementing one of
+these interfaces must carry all 33/25 methods regardless of which ones a given test suite exercises.
+
+Checked directly whether any of that surface is genuinely dead, not just theoretically excessive:
+cross-referencing each `ConfigHandler` method against real call sites (not test-customization
+frequency — that undercounts, see below) turns up **`RegisterProvider`**
+(`pkg/runtime/config/handler.go:56`) as a confirmed case — declared on the interface, implemented on
+the mock, unit-tested against the concrete `configHandler` in isolation
+(`pkg/runtime/config/accessors_test.go`), but called by **nothing** outside its own package's tests:
+no `cmd/`, no other `pkg/`, no runtime wiring. That's real dead interface surface, not a hypothetical.
+Contrast with three other methods that also show zero test-customization
+(`LoadConfigForContextFunc`, `SaveWorkstationStateFunc`, `SetApplySchemaDefaultsFunc` never have
+their `Func` field assigned anywhere in the test suite) but that turned out, on the same call-site
+check, to be genuinely used in production (`cmd/get.go`, `pkg/workstation/workstation.go`,
+`pkg/runtime/runtime.go`, `pkg/test/runner.go`) — those are a mock-coverage gap, not dead code, and
+removing them would be wrong. **The distinguishing signal is real call sites, not mock-customization
+frequency** — a method can be production-critical and still never need a custom mock return value.
+
+This matters immediately, not just for Wave 2's codebase sweep: [ADR 0001](0001-apiv2-common-header-schema.md)
+rewrites `pkg/runtime/config`'s read path (v1alpha1-unmarshal-everything → typed v1alpha2 header +
+dynamic map), and [ADR 0002](0002-target-architecture-and-package-topology.md) splits thirteen
+monolith files in place and extracts `internal/shims`/`internal/util` out of 16 packages plus `cmd/`.
+Every one of those is an internal-representation change with no intended change in observable
+behavior — exactly the situation where a white-box test suite becomes a liability instead of a
+safety net: it's coupled to *how* the code is organized (which private method holds which logic,
+which file a function lives in, which struct field a shim uses), not to *what* the code does, so it
+breaks on the refactor whether or not the refactor was correct. Left unaddressed, the white-box
+suite would need patching once to survive ADR 0001/0002's structural moves, then patched again
+later when Wave 2's sweep converts it to black-box — the same code paying for two test rewrites.
+
+## Decision
+
+### 1. Black-box (`package xxx_test`) is the default for new and touched test files
+
+A test file asserts through the package's exported contract — its constructors, public methods,
+and observable state transitions — not through unexported identifiers. This is `test-engineer`'s
+existing "test public contracts... avoid testing private methods directly" principle, made the
+default rather than a preference, and given a concrete package-declaration marker
+(`package xxx_test`) so adherence is mechanically checkable, not just a style convention nobody
+enforces.
+
+### 2. White-box is a deliberate, narrow exemption — not a fallback
+
+A private-method test is permitted only for **complex unexported logic where public coverage is
+impractical** — parsers, edge-case math, the kind of pure-function case enumeration `test-engineer`
+already names (see `pkg/composer/terraform/oci_module_resolver_private_test.go`'s
+`HandlesEdgeCases` as the existing worked example). The bar is "public coverage genuinely can't
+reach this branch economically," not "it's more convenient to call the private function directly."
+Concretely: the deferred-substitution scope-blinding logic in `pkg/composer/blueprint/processor.go`,
+the semver/tag-walk logic in `pkg/composer/artifact/artifact.go`, and comparable dense-algorithm
+code are the kind of thing this exemption is *for*; a config handler's getter/setter pair is not.
+
+### 3. Characterize-then-refactor is binding on every structural change, starting with ADR 0001
+
+For a package about to be structurally touched (file split, shims extraction, interface split, or
+an internal-representation rewrite like ADR 0001's), the order is fixed:
+
+1. **Black-box-characterize current public behavior first.** If black-box coverage of the package's
+   public surface doesn't already exist, write it before touching internals — this is the safety
+   net, and it has to exist *before* the refactor to do its job.
+2. **Do the structural refactor** under that net.
+3. **The black-box tests pass unchanged.** That's the proof the refactor preserved behavior — the
+   same property a `terraform plan` gives you for infrastructure, applied to code structure.
+4. **Only then add white-box tests**, and only for whatever complex unexported logic survives the
+   refactor and still meets the point-2 bar. Never the reverse order — a private-method test written
+   before the refactor is exactly the thing that breaks during it for no behavioral reason.
+
+This is scoped per package, not a global up-front sweep: front-loading black-box conversion across
+the whole codebase before any refactor touches most of it would be speculative effort disconnected
+from when the actual restructuring happens. The rule fires exactly when a package is about to move
+under 0001 or a Wave 2 pass — not before, not as a separate disconnected pass after.
+
+**Immediate application:** ADR 0001's first implementation step is black-box characterization of
+`pkg/runtime/config`'s current behavior — asserting through `LoadConfig`/`LoadContext`/
+`GetContextValues`, never through `typedSource` internals — before the v1alpha1→v1alpha2 header
+rewrite begins. This is not deferred to whenever Wave 2 reaches `pkg/runtime/config` in its
+per-package order; it's pulled forward as part of 0001 itself.
+
+### 4. Coverage floor: >80%, measured on the package after conversion, not before
+
+The `>80%` figure from `release-v0.10.0.md`'s original scoping table is ratified as a floor per
+package once its black-box conversion lands — not a repo-wide average that lets one well-tested
+package subsidize a neglected one. `task test:all`'s existing coverage tooling
+(`go tool cover -func=coverage.out`) is the measurement, no new tooling needed.
+
+### 5. Mock rationalization: drop what nothing calls, keep what does — checked by real call sites
+
+No mock, and no mock method, exists for its own sake. Every package's cleanup pass audits its
+interface(s) and mock(s) against real call sites (`grep` the method name across the codebase
+excluding the interface's own package tests and mock file — the check that found `RegisterProvider`
+above) before touching them, and:
+
+- **A method with zero call sites outside its own package's tests is dead interface surface.**
+  Remove it from the interface, its concrete implementation, and its mock — not just "unused," a
+  method nobody calls is code with no reason to exist. `RegisterProvider` is the first confirmed
+  instance; each package's pass repeats this check for its own interfaces rather than assuming the
+  rest are clean.
+- **A method with real call sites but no test customization is a coverage gap, not dead code** — it
+  stays, and if the package's black-box conversion (point 3) doesn't already exercise it through a
+  scenario that needs a custom return value, that's a test to add, not a method to delete. Mock
+  customization frequency alone is the wrong signal (see Context) — it flags `RegisterProvider` and
+  three genuinely-needed methods identically; only the call-site check tells them apart.
+- **Wide interfaces split along their existing seams** once the dead methods are gone —
+  `ConfigHandler`: load/get-set/schema-validate/render/sensitive-paths; `Shell`: exec/verbosity/
+  secret-registration/session-lifecycle — when their owning package's cleanup pass reaches them. A
+  split interface's mock then only carries the methods its own seam actually needs.
+
+This rides the same per-package pass as everything else in this ADR — not a separate mock-only
+sweep across all 35 mock files up front, for the same reason point 3 scopes structurally: most
+mocks aren't being touched yet, and auditing them before their package's pass reaches them is
+speculative effort against code that may still change shape before it matters.
+
+### 6. Fixture cleanup is opportunistic, not a scheduled sweep
+
+Stale or duplicated test fixtures (YAML blueprints, context templates) get cleaned up as part of
+whichever package's black-box conversion touches the tests that reference them — not tracked as a
+separate backlog item, since fixture staleness is only ever visible in the context of the tests
+using it.
+
+## Consequences
+
+- **ADR 0001 and every Wave 2 per-package pass now carry a test-conversion step as part of their own
+  scope**, not as follow-on work from a separate ADR — this is intentional; it's what keeps the
+  double-rework this ADR exists to prevent from happening.
+- **Removing a dead interface method is a breaking change to that interface**, not just a test-file
+  edit — every mock and every real implementation of the interface must drop the method together in
+  the same commit, verified by the compiler (a mock left implementing a stale interface method is
+  harmless; a real implementation missing a still-declared method fails to build). `RegisterProvider`
+  removal touches `handler.go`, `accessors.go`, `mock_handler.go`, and `accessors_test.go` together.
+- **Coverage may dip temporarily mid-conversion** for a package where the black-box net doesn't yet
+  reach every branch the old white-box suite happened to cover — acceptable as a transient state
+  within one package's pass, not acceptable to leave unresolved once that pass is marked done.
+- **The white-box exemption is a judgment call each pass has to make explicitly** — "public coverage
+  is impractical" is not self-evident, so each pass's PR description should name which unexported
+  logic it kept white-box tests for and why, per the `large-pr` change-map convention.
+- **No mass mechanical rewrite of all 158 existing test files up front.** Files convert exactly when
+  their package is touched by 0001 or a Wave 2 pass — some packages may not convert until late in
+  the release, and that's fine; the rule only binds packages actually being restructured.
+
+## Alternatives considered
+
+- **Convert every existing test file to black-box before any structural work starts.** Rejected:
+  speculative effort against packages that may not be restructured for months, and delays Wave 0/1
+  for no immediate benefit — the value of black-box coverage is realized at the moment of refactor,
+  not before.
+- **Refactor first across 0001/0002, fix tests afterward.** Rejected: this is the exact double-rework
+  pattern this ADR exists to prevent — white-box tests break during the structural move for reasons
+  unrelated to correctness, then break again when later converted to black-box.
+- **Keep the `_public_test.go`/`_private_test.go` naming convention as sufficient.** Rejected: it
+  documents intent but doesn't enforce it — both file variants compile as the same white-box
+  package today, so the convention alone doesn't deliver the refactor-resilience this ADR needs.
+- **Repo-wide coverage average instead of a per-package floor.** Rejected: lets a strong package mask
+  a weak one; a per-package floor is the only version that actually gates each pass's completion.
+- **A dedicated, upfront mock-audit pass across all 35 mock files, ahead of Wave 2.** Rejected: same
+  reasoning as declining an upfront black-box conversion — most mocks aren't touched by 0001/0002
+  yet, so auditing them now is speculative. Also rejected: **using mock-customization frequency
+  (never-assigned `Func` fields) as the removal signal.** Checked directly and found it produces
+  false positives — three genuinely production-critical methods showed zero customization, the same
+  signal `RegisterProvider`'s real dead code showed. Only a real call-site check distinguishes them.

--- a/docs/adrs/0004-comment-and-doc-standard.md
+++ b/docs/adrs/0004-comment-and-doc-standard.md
@@ -1,0 +1,103 @@
+# ADR 0004 — Comment and documentation standard
+
+- Status: Proposed
+- Date: 2026-08-04
+- Deciders: Ryan VanGundy
+- Fills the "Comment & doc standard" placeholder from `release-v0.10.0.md`'s Wave 2. Ratifies
+  `.claude/skills/go-style/SKILL.md` as the canonical, already-largely-correct standard (it already
+  enforces no in-body comments and a 6-line header ceiling) and records the two gaps this round's
+  refactor waves exposed, both now added to that skill directly rather than left as a separate
+  unenforced document. Test-comment discipline (BDD `Given`/`When`/`Then`) is governed by
+  `.claude/skills/test-engineer/SKILL.md`, sharpened alongside [ADR 0003](0003-test-strategy-black-box-default.md)
+  rather than duplicated here.
+
+## Context
+
+`go-style` already does most of what a comment-standard ADR would otherwise need to establish from
+scratch: the 4-line file header, mandatory function headers, a hard "no explanatory comments inside
+function bodies" rule with named anti-patterns, a 6-line ceiling on header comments, and generic
+(not method-named) section headers. This held up under review — nothing in it needed reversing.
+
+Two gaps surfaced specifically because Wave 0–1's refactor work (ADR 0001's header migration, ADR
+0002's monolith splits, ADR 0003's characterize-then-refactor passes) is about to touch a large
+fraction of the codebase's comments at once, and neither gap was previously written down anywhere
+enforceable:
+
+1. **No function-length guideline existed.** Surveyed directly (`awk`-based function-length count
+   across every non-test, non-mock `.go` file): the codebase already mostly self-regulates — 1087 of
+   ~1158 functions are under 60 lines, 51 are 60–100, 15 are 100–150, and only **5** exceed 150. The
+   informal practice is sound; it was never codified, so a refactor pass (especially one splitting
+   monolith files per ADR 0002) had nothing written to check a newly-extracted function against.
+2. **No rule against planning artifacts leaking into comments.** Existing memory
+   ([[feedback_no_wip_labels_in_code]], [[feedback_no_phase_labels]]) already establishes "no WIP
+   markers, no phase labels, no fix-history narrative" as house practice, but this lived only in
+   Claude's session memory, not in the checked-in skill file every contributor (human or agent) reads.
+   Separately, nothing addressed **ADR/ticket references specifically** — a real risk during this
+   exact release, where dozens of comments could plausibly get written as `// per ADR 0002` while the
+   monolith splits are fresh in mind.
+
+## Decision
+
+### 1. Ratify `go-style` as-is for everything it already covers
+
+No changes to: the 4-file package structure, section-divider format and ordering, the 4-line file
+header, the "no in-body comments" rule and its anti-pattern list, the 6-line header ceiling, the
+1-line struct-field rule, or the `errors.As`/`errors.Is` classification rule. These are correct and
+stay exactly as written.
+
+### 2. Function-length guideline, added to `go-style` directly
+
+Under 100 lines is the norm; 100–150 is a look-twice zone (confirm the body is genuinely one
+operation); 150+ should split into private helper methods in the same file's Private Methods
+section, with mechanical field-by-field methods (`DeepCopy`, marshal/unmarshal glue) as the one
+standing exception, since splitting those fragments one operation without reducing its complexity.
+This is descriptive of current practice, not a new constraint invented for this ADR — the survey
+above shows the codebase already lands here in the overwhelming majority of cases; codifying it
+gives ADR 0002's monolith splits (and any future large function) a concrete bar to check new,
+extracted functions against.
+
+### 3. No planning or process artifacts in comments, added to `go-style` directly
+
+A comment documents current behavior only — never a WIP/historical marker, never an ADR/ticket/issue
+reference, never a phase or wave label. This closes both the previously-memory-only house rule and
+the new, release-specific risk of comments accumulating ADR citations while this cycle's refactors
+are underway. Rationale and decision history belong in the ADR or the commit that implemented it,
+never in the source the decision produced — a reader six months out needs the current contract, not
+the planning trail that produced it.
+
+### 4. Test-comment discipline stays owned by `test-engineer`, not duplicated here
+
+BDD `Given`/`When`/`Then` comment discipline (exactly three labeled lines per `t.Run` case, no
+narrative padding), the black-box-default package declaration, the white-box exemption bar, and the
+mock-rationalization rule ("only mock what's actually called," matching ADR 0003's confirmed
+`RegisterProvider` finding) all live in `test-engineer`, sharpened alongside ADR 0003 in the same
+change that produced this ADR. Splitting test-comment standards into a second document would create
+exactly the two-places-to-check problem this ADR's own point 1 avoids for production code.
+
+## Consequences
+
+- **Both new `go-style` rules are checkable by a reader without deep context** — line-count and
+  "does this cite an ADR" are mechanical checks, not judgment calls, which is what makes them
+  suitable for the editing checklist (`go-style` updated to include both).
+- **No existing code is grandfathered specially** — the function-length guideline applies as each
+  file is touched by ADR 0002's splits or any later edit, not as a separate retroactive sweep; the
+  five current 150+-line outliers get evaluated when their file's cleanup pass reaches them.
+- **This ADR adds no new document** beyond itself — both skill files it ratifies/extends were edited
+  directly rather than having their content restated here, so there is exactly one place (`go-style`,
+  `test-engineer`) a contributor checks for the live rule, and this ADR is the decision record
+  explaining why those two files say what they say.
+
+## Alternatives considered
+
+- **Write the full comment standard fresh in this ADR**, treating `go-style` as something to be
+  superseded. Rejected: `go-style` was reviewed against this ADR's own concerns and found correct on
+  every point except the two gaps — rewriting it wholesale would discard working, specific,
+  example-backed guidance for no reason.
+- **A separate test-comment-standard ADR**, splitting BDD discipline out from ADR 0003. Rejected:
+  ADR 0003 already owns the test-strategy decision space end to end (black-box default, white-box
+  exemption, characterize-then-refactor, mock rationalization); BDD comment discipline is one more
+  facet of the same decision, not an independent one.
+- **A numeric hard cap on function length instead of a three-tier guideline** (e.g., a lint-enforced
+  120-line maximum). Rejected: the survey shows a small number of legitimate exceptions (mechanical
+  DeepCopy methods); a hard cap would force those into an awkward split for no readability gain,
+  where a look-twice zone plus a named exception handles the real distribution better.

--- a/docs/adrs/0005-typed-error-model.md
+++ b/docs/adrs/0005-typed-error-model.md
@@ -1,0 +1,267 @@
+# ADR 0005 — Typed error model: `WindsorError`, doc-linkable codes, central rendering
+
+- Status: Proposed
+- Date: 2026-08-04
+- Deciders: Ryan VanGundy
+- Fills the "Typed error model" placeholder from `release-v0.10.0.md`'s Wave 1. Sequenced there
+  deliberately, not deferred past this release's refactor waves — see Context for why deferring it
+  would repeat the exact double-rework problem [ADR 0003](0003-test-strategy-black-box-default.md)
+  was written to prevent.
+
+## Context
+
+Surveyed directly (`grep -rlE 'fmt\.Errorf\(.*%w'`, excluding tests): **84 files, 882 wrap sites**
+across the codebase (close to the 877 the original release-planning doc estimated). Cross-referenced
+against Wave 2's per-package cleanup order:
+
+| Wave 2 directory | Files with typed wrap sites |
+|---|---|
+| `pkg/runtime` | 27 |
+| `cmd` | 24 |
+| `pkg/provisioner` | 9 |
+| `pkg/workstation` | 8 |
+| `pkg/composer/blueprint` | 5 |
+| `pkg/composer/terraform` | 4 |
+| `api` | 3 |
+| `pkg/provisioner/kubernetes` | 2 |
+| `pkg/composer/artifact`, `pkg/test` | 1 each |
+| `pkg/tui` | 0 wrap sites, but still handles `err` 33 times |
+
+**Every directory in Wave 2's sweep order touches error-handling code.** If the error model isn't
+decided before that sweep starts, each of these 84 files gets edited twice — once for its
+structural cleanup (file splits, shims extraction, black-box test conversion), again later when the
+error model lands and has to migrate the same sites. This is the identical problem ADR 0003 exists
+to prevent, just not yet visible when that ADR was written because the wrap-site count hadn't been
+checked against the sweep order. It belongs in Wave 1, alongside logging and test strategy, exactly
+where `release-v0.10.0.md` already placed it — this ADR fills that placeholder rather than moving it.
+
+Current state, verified: no central error formatter exists. Errors propagate as
+`fmt.Errorf("...: %w", err)` chains, surfaced through Cobra's default printer with ad-hoc
+`cmd.SilenceErrors = true` plus manual `err.Error()` prints scattered across `cmd/` files
+individually. A user sees whatever the deepest wrap produced, concatenated through however many
+layers wrapped it — the "nested-colon-string problem" the release doc's keystone section names.
+
+Checked against comparable typed-error models before finalizing this shape — Kubernetes
+`apimachinery`'s `StatusError{Code, Reason, Message, Details}` with `errors.IsNotFound(err)`-style
+predicates, Docker's `errdefs` typed-interface categories, AWS SDK v2's `APIError{ErrorCode(),
+ErrorMessage()}`, Stripe's `{type, code, message, param, doc_url}`, and gRPC's
+`google.rpc.Status{code, message, details[]}` — where `details` notably splits into an
+`ErrorInfo{domain, reason, metadata}` detail *and a separate* `DebugInfo{stack_entries[]}` detail.
+That split is the one this ADR's original draft was missing: this codebase's own wrap chains today
+are plain `fmt.Errorf("...: %w", err)` concatenation (confirmed — `github.com/pkg/errors` and
+`hashicorp/go-multierror` are present only as transitive, unused dependencies), which collapses into
+one opaque string exactly where gRPC and Terraform's `tfdiags` keep the "what happened" and "here's
+the trail that led here" separate. Point 1 below adopts that split.
+
+## Decision
+
+### 1. `WindsorError` type, plus a lightweight breadcrumb tier below it
+
+```go
+type WindsorError struct {
+    Code        string // e.g. "COMPOSER-014" — see taxonomy below
+    Category    string // domain the code's prefix names, redundant with Code but useful for dispatch
+    Message     string // one-line, user-facing, no Go error-chain colons
+    Remediation string // imperative sentence — what the user should do next
+    DocsURL     string // generated from Code, not authored per-error — see below
+    Cause       error  // wrapped original error; nil for a genuinely new condition
+}
+
+func (e *WindsorError) Error() string { return e.Message }
+func (e *WindsorError) Unwrap() error { return e.Cause }
+
+// New(code, message, remediation string, cause error) *WindsorError constructs one and derives
+// Category from the code's domain prefix and DocsURL from the code, so neither is hand-maintained.
+func New(code, message, remediation string, cause error) *WindsorError
+
+// IsCode/IsCategory are errors.As-based predicates, matching the errdefs/apimachinery pattern —
+// call sites check werror.IsCode(err, "CONFIG-002") instead of hand-rolling errors.As + a compare.
+func IsCode(err error, code string) bool
+func IsCategory(err error, category string) bool
+```
+
+`Unwrap()` is load-bearing, not incidental — `go-style`'s existing `errors.As`/`errors.Is` rule
+depends on the chain staying walkable through a `WindsorError`, so wrapping an error in one never
+breaks a downstream typed check. `DocsURL` is mechanical (`https://docs.windsor.sh/errors/<code>`),
+never authored per error — one less thing to keep in sync as codes are added.
+
+**A second, cheaper type sits below `WindsorError` for the common case that doesn't warrant a full
+code:**
+
+```go
+// Wrap adds one named breadcrumb frame — cheap, no code/category/remediation, safe to use at any
+// layer boundary worth naming. Implements Unwrap(), so errors.As/errors.Is see straight through it.
+func Wrap(err error, format string, args ...any) error
+
+// Breadcrumbs walks the full Unwrap() chain (through Wrap frames and a terminal WindsorError alike)
+// and returns each frame's own message, outermost first — for verbose rendering and JSON traces.
+// Never parses err.Error() strings; each frame's message is captured structurally at Wrap()/New()
+// time, which is the whole reason Wrap exists instead of relying on fmt.Errorf concatenation.
+func Breadcrumbs(err error) []string
+```
+
+Three tiers now exist, cheapest first: plain `fmt.Errorf("...: %w", err)` for genuinely low-value
+internal propagation (unchanged); `werror.Wrap(err, "applying component %s", id)` for a layer
+boundary worth naming in a trail, with no code required; `werror.New(...)` for the actual
+user-facing boundary with a stable code and remediation. Point 4 revises migration guidance around
+this third tier.
+
+Both types live in `internal/werror` (sibling to `internal/shims`/`internal/util` from
+[ADR 0002](0002-target-architecture-and-package-topology.md)), for the identical reason: both
+`cmd/` and every `pkg/` subpackage need to construct one, and `pkg/internal/` would be invisible to
+`cmd/`. Named `werror`, not `errors`, to avoid the unqualified-import collision with the stdlib
+package every file already imports.
+
+### 2. Code taxonomy: domain-prefixed, doc-linkable, purpose-built for support triage
+
+`<DOMAIN>-<NNN>` (e.g. `COMPOSER-014`, `CONFIG-002`), sequential per domain, assigned at
+first-use — not reserved numeric ranges, which the release doc's open question raised as an
+alternative and this ADR rejects (see Alternatives). Codes appear directly in user-facing output
+(the decision made in scoping this ADR): visible, greppable, and linkable from docs — `DocsURL` is
+derived mechanically from the code (point 1) at construction time, so `docs.windsor.sh/errors/`
+only needs one page per code to stay accurate, never a second hand-maintained mapping.
+
+The domain list is **deliberately not a 1:1 copy of ADR 0002's architecture layer table.** That
+table optimizes for internal ownership (which package owns this behavior); error domains optimize
+for what a user or support engineer actually searches for, which cuts across internal package
+boundaries differently:
+
+| Domain | Covers | ADR 0002 layer(s) it spans |
+|---|---|---|
+| `CONFIG` | Config load/validate/schema/resolve | Runtime (`pkg/runtime/config`), `api/v1alpha2/config` |
+| `SECRETS` | Secret provider/resolution failures | Runtime (`pkg/runtime/secrets`) |
+| `BLUEPRINT` | Composition/facet/template/tier errors | Composer (`pkg/composer/blueprint`) |
+| `ARTIFACT` | OCI pull/push/artifact errors | Composer (`pkg/composer/artifact`) |
+| `TERRAFORM` | Terraform exec/provider/module errors | Provisioner + Runtime-Terraform + Composer-Terraform |
+| `CLUSTER` | Kubernetes/Flux/cluster lifecycle errors | Provisioner (`kubernetes`, `cluster`, `flux`) |
+| `WORKSTATION` | Local VM/network errors | Workstation |
+| `SHELL` | Shell/env/tools/git errors | Runtime (`shell`, `env`, `tools`, `git`) |
+| `CLI` | Flag/argument/usage errors caught before reaching `pkg/` | CLI |
+
+A user hitting a Terraform failure shouldn't need to know whether it originated in
+`pkg/provisioner/terraform` (execution) or `pkg/runtime/terraform` (metadata) — both are
+`TERRAFORM-*`. This divergence from the architecture table is intentional, not an inconsistency to
+fix later.
+
+### 3. Central renderer at the `cmd/` boundary, incremental during migration
+
+One formatter, one call site — replacing the per-command `SilenceErrors` + manual `err.Error()`
+print pattern scattered across `cmd/` today:
+
+- If the returned error `errors.As`-unwraps to a `*WindsorError`, render:
+  ```
+  Error [COMPOSER-014]: <message>
+
+  <remediation>
+  Docs: <docs-url>
+  ```
+- If it doesn't (an untyped error — expected throughout the migration, and always possible for a
+  genuinely unanticipated failure), render `Error: <err.Error()>` — the existing wrap-chain string,
+  centralized to one formatting call instead of 84 scattered ones, but not fabricating a code or
+  remediation the code doesn't have. This is what makes the migration incremental and safe: the CLI
+  never regresses to a worse experience mid-migration, it just doesn't get the richer treatment
+  until a given site converts.
+- **`--verbose` appends the breadcrumb trail**, from `werror.Breadcrumbs(err)`, as an indented list
+  under the remediation — each `werror.Wrap` frame and the terminal cause on its own line, in the
+  order they were added:
+  ```
+  Trace:
+    applying component cluster
+    running terraform apply
+    exit status 1
+  ```
+  This is why `Wrap` captures each frame's message structurally instead of leaning on
+  `fmt.Errorf` string concatenation (Context) — the renderer never parses `err.Error()` to recover
+  the frames, it walks the chain.
+- `--output json` (the global surface question the release doc's open question #2 raises is not
+  resolved here, but this ADR's error shape is designed to satisfy it either way): a `WindsorError`
+  serializes to `{"code", "category", "message", "remediation", "docs_url"}`; `"trace": [...]` (from
+  `Breadcrumbs`) and `"cause"` are included only under `--verbose`, since the wrapped chain can carry
+  internal detail (file paths, raw provider errors) not meant for default-mode output.
+- This renderer is deliberately minimal — console text and JSON only, no TUI awareness. The
+  not-yet-written Presenter/event-stream ADR (Wave 1) is what later unifies this with logging and
+  progress rendering behind one contract; this ADR defines the *type* and a *interim* renderer the
+  presenter work subsumes, not a competing rendering system.
+
+### 4. Migration: three tiers, matched to what each wrap site is actually worth
+
+Not every wrap site becomes a `WindsorError`. Forcing all 882 into rich, coded errors would be the
+same mistake as mocking every interface method regardless of whether anything calls it
+([ADR 0003](0003-test-strategy-black-box-default.md)'s finding): effort spent on surface nobody
+distinctly needs. But leaving most of them as bare `fmt.Errorf` — this ADR's original position —
+under-uses the breadcrumb tier point 1 now adds, since a bare wrap contributes nothing to
+`Breadcrumbs()`. Revised guidance, per site:
+
+- **Stays bare `fmt.Errorf("...: %w", err)`** when the wrap is genuinely uninformative on its own —
+  re-raising the same error one call frame up with no new fact worth naming. Rare in practice once
+  the other two tiers exist; most wraps do name *something* ("resolving local state path for %s").
+- **Becomes `werror.Wrap(err, "...")`** for the common case: a layer boundary worth naming in a
+  trail, but with no independent remediation to write and no reason to assign it a code. This is
+  now the **default choice** for a site being touched anyway (not a mechanical sweep — only sites a
+  package's own Wave 2 pass already reaches), since it costs one function call more than
+  `fmt.Errorf` and makes `Breadcrumbs()` actually useful.
+- **Becomes `werror.New(...)`** only at the point in the call chain that has both (a) enough context
+  to write a specific, actionable remediation, and (b) a real chance of being the error a user
+  actually sees uncaught — a malformed context value, a missing terraform binary, an expired
+  credential. Not every intermediate layer, even ones already converted to `Wrap`.
+
+This still rides the same per-package cadence as ADR 0002/0003: a package's cleanup pass converts
+*its own* sites as part of that pass, not as a separate 882-site sweep. Sites untouched by any pass
+yet stay bare `fmt.Errorf` and still render correctly (point 3's fallback) — a fine steady state for
+a partially-converted codebase, not a broken one; they just don't contribute to the breadcrumb trail
+until their package's pass reaches them.
+
+## Consequences
+
+- **Positive:** closes the "nested-colon-string problem" and the ad-hoc `SilenceErrors` pattern the
+  release doc's keystone section names, with codes that are immediately useful for docs/support
+  without waiting for the full 882-site migration to complete.
+- **The domain taxonomy is a second classification scheme alongside ADR 0002's architecture
+  table** — accepted as a deliberate tradeoff (support legibility over internal-structure mirroring),
+  but means a contributor adding a new error needs to pick the right *error domain*, not just know
+  which package they're in.
+- **Codes are now part of the CLI's user-facing surface** — once documented and linked, changing a
+  code's meaning (not just adding new ones) is a compatibility break for anyone who bookmarked or
+  scripted against it. Sequential-per-domain numbering (not reserved ranges) means new codes append
+  cleanly; removing or repurposing an existing one should be rare and called out in release notes.
+- **Migration debt is visible, not hidden** — an unconverted site still renders acceptably (point 3),
+  so there's no pressure to rush all 882 sites at once, but also no forcing function beyond each
+  package's own Wave 2 pass to actually convert the ones worth converting.
+- **Three error-construction choices now exist at every call site** (`fmt.Errorf`, `werror.Wrap`,
+  `werror.New`) instead of one — a real increase in decision surface for whoever's writing the code,
+  offset by point 4's concrete criteria for each ("worth naming in a trail" vs. "worth a
+  remediation") being checkable rather than a matter of taste.
+- **`Breadcrumbs()` is only as complete as the `Wrap` calls that built the chain** — a site left as
+  bare `fmt.Errorf` contributes nothing to the trail, so early in the migration the breadcrumb list
+  will have gaps corresponding to not-yet-touched packages. Same accepted steady state as the code
+  migration itself.
+
+## Alternatives considered
+
+- **Reserved numeric ranges per subsystem** (e.g. `1000-1999` for config, `2000-2999` for
+  composer), the release doc's other named option. Rejected: ranges require reserving capacity
+  upfront per domain and renumbering risk if a domain outgrows its block; sequential-per-domain
+  string codes have no such ceiling and are more legible in output (`COMPOSER-014` vs `2014`).
+- **Internal-only categorization, no user-visible codes.** Rejected per the scoping decision — a CLI
+  with a real support surface benefits more from doc-linkable codes than it costs in taxonomy
+  upkeep.
+- **Codes matching ADR 0002's architecture layer table exactly.** Rejected: internal ownership and
+  user-facing failure categories are genuinely different groupings (see point 2); forcing them to
+  match would make either the architecture table or the error domains worse at their actual job.
+- **Mechanical mass-conversion of all 882 sites to `WindsorError` in one pass.** Rejected: most wrap
+  sites have no independent remediation to write, and the effort mirrors ADR 0003's
+  mock-rationalization finding — construct what's actually needed, not every technically possible
+  instance. This is why the breadcrumb tier exists as a *cheaper* middle option rather than the
+  choice being binary (full `WindsorError` or nothing).
+- **Rely on `fmt.Errorf` string concatenation for the breadcrumb trail instead of a structured
+  `Wrap`/`Breadcrumbs` type**, parsing `err.Error()` to recover frames for `--verbose`/JSON
+  rendering. Rejected: this is the same `strings.Contains`-on-error-text smell `go-style` already
+  forbids for classification, just applied to rendering instead of dispatch — fragile against
+  format changes and impossible to serialize cleanly as a JSON array.
+- **A single `WindsorError` type with no separate lightweight tier** (this ADR's original draft).
+  Rejected on review: it forced a false choice between "full code+remediation" and "opaque string,"
+  when gRPC's `DebugInfo`/`ErrorInfo` split and Terraform's `tfdiags.Detail` both show a named,
+  structured-but-code-free middle tier is standard practice for exactly this gap.
+- **Hand-maintained `DocsURL` per error, or no `DocsURL` field at all.** Rejected: hand-maintaining a
+  second mapping from code to URL drifts the moment one is added without the other; deriving it
+  mechanically from the code (Stripe's shape, adapted) costs nothing per error and can't drift.

--- a/docs/adrs/0006-structured-logging-contract.md
+++ b/docs/adrs/0006-structured-logging-contract.md
@@ -1,0 +1,151 @@
+# ADR 0006 — Structured logging contract: `slog`, context-injected, level-aware
+
+- Status: Proposed
+- Date: 2026-08-04
+- Deciders: Ryan VanGundy
+- Fills the "Structured logging contract" placeholder from `release-v0.10.0.md`'s Wave 1 — the last
+  content gap before the Presenter/event-stream ADR can be drafted, since Presenter unifies logging,
+  errors, and progress rendering rather than inventing what any of them contain.
+
+## Context
+
+Verified directly: **no `log/slog` usage anywhere in the codebase today**, and **no
+`charmbracelet`/`bubbletea`/`lipgloss` dependency** in `go.mod` — both named in the release doc's
+scoping table as the intended stack, neither started. **46 files** call `fmt.Print*`/`fmt.Fprint*`
+directly. The one existing output abstraction is `pkg/tui/tui.go`: a package-level `Active Spinner`
+global plus an `activeDepth` nesting counter and `WithProgress` wrapper — and it's reached directly
+from business layers, not just `cmd/`: `pkg/workstation/{network,virt}/*.go`,
+`pkg/composer/artifact/artifact.go`, `pkg/runtime/shell/shell.go`, `pkg/provisioner/terraform/
+stack.go`, `pkg/provisioner/provisioner.go`, and `pkg/provisioner/kubernetes/kubernetes_manager.go`
+all call `tui.Active`/`tui.WithProgress` directly — nine files confirming exactly the coupling the
+release doc's keystone section names as the root cause of the UX complaints.
+
+Verbosity plumbing already exists, but split across two disconnected mechanisms: `cmd/root.go`
+calls `proj.Runtime.Shell.SetVerbosity(verbose)` **and separately** does
+`ctx = context.WithValue(ctx, "verbose", true)` — a **string-keyed** `context.WithValue` call,
+which is a known Go anti-pattern (unexported typed keys avoid collision risk; a bare string key
+doesn't). Two calls, two mechanisms, one flag. `Shell.IsVerbose()` also does double duty today —
+it's read both for log-level-style decisions and for actual execution-mode branching (stream
+subprocess output live vs. capture silently), which are different concerns currently bundled into
+one bool.
+
+Some scaffolding already exists to build on: `cmd/root.go` does construct a real `context.Context`
+(`context.Background()`, then threaded through the command), so context-injected logging is an
+extension of an already-partially-plumbed mechanism, not new infrastructure from nothing.
+
+## Decision
+
+### 1. `log/slog` is the call-site API; business code never touches a handler directly
+
+`pkg/`/`cmd/` code logs via `slog.InfoContext(ctx, "message", "key", value, ...)` and friends,
+retrieving the active `*slog.Logger` from `context.Context` — never a package-level global, never a
+handler constructed inline. This is the direct fix for the `tui.Active`-from-business-layers problem
+in Context: a logger obtained from context is trivially fakeable in tests and has no reach-around
+path the way a package global does.
+
+### 2. Context injection: typed key, `internal/logging`, closes the string-key smell
+
+```go
+// internal/logging (sibling to internal/shims/util/werror from ADR 0002/0005 — reachable from
+// both cmd/ and pkg/, invisible to anything outside this module).
+
+type ctxKey struct{}
+
+func NewContext(ctx context.Context, logger *slog.Logger) context.Context
+func FromContext(ctx context.Context) *slog.Logger // never nil — falls back to a safe default
+```
+
+This retires `cmd/root.go`'s bare `context.WithValue(ctx, "verbose", true)` in favor of the typed
+key above, closing the collision-risk smell found in Context — one mechanism, not two, and it's the
+existing `ctx` variable already being threaded, not a new context to plumb in.
+
+### 3. Handlers: console (default), JSON (`--output json`), TUI-routing (reserved seam)
+
+Three backends behind the same `slog.Handler` interface, selected once at construction:
+
+- **Console** (default) — `charmbracelet/log`, human-readable, leveled, colored. New dependency,
+  added by this ADR (the release doc's scoping table already named it; this is where it lands).
+- **JSON** (`--output json` / CI, detected the same way other output-format decisions already are)
+  — `slog.JSONHandler`, stdlib, no new dependency.
+- **TUI-routing** (reserved now, implemented in Wave 3) — while a BubbleTea program owns the
+  screen, a log record must not hit stdout directly, or it corrupts the TUI's own rendering. This
+  ADR reserves the hook — a handler that checks an active-TUI signal (the same shape as `tui.go`'s
+  existing `activeDepth`, generalized) and routes to an event channel instead of `os.Stdout` when
+  set — without building the channel or the BubbleTea program itself. Call sites never change when
+  Wave 3 fills this in; only the handler's internal routing does.
+
+### 4. Level mapping: `--verbose` maps to `slog.LevelDebug`, unifies the two existing mechanisms
+
+`--verbose`/`-v` (already exists, `cmd/root.go`) sets the injected logger's level to
+`slog.LevelDebug`; unset, it's `slog.LevelInfo`. This becomes the **single** source of truth for
+verbosity — `cmd/root.go`'s current dual plumbing (`Shell.SetVerbosity` call plus the string-keyed
+context value) collapses to one: construct the logger with the right level, inject it via point 2,
+done. `Shell.IsVerbose()` stays, but as a **derived** read from the context logger's level via
+`logging.FromContext(ctx).Enabled(ctx, slog.LevelDebug)`, not a second independently-set bool — this
+is the one place this ADR reaches into Shell's existing surface, and it's a narrowing (one flag,
+one flow), not new API. Shell's separate execution-mode behavior (stream vs. capture subprocess
+output) is a distinct concern this ADR does not touch — it may still read the same derived signal,
+but that's a `pkg/runtime/shell` implementation choice, not a logging-contract decision.
+
+### 5. Logger construction lives in `Runtime`, injected at the `cmd/` boundary
+
+Per the already-ratified layer table (ADR 0002: "Runtime — Lifecycle orchestration and dependency
+wiring"), `NewRuntime` constructs the base `*slog.Logger` (handler chosen by `--output`, level by
+`--verbose`) as part of its existing dependency-wiring responsibility. `cmd/root.go`'s
+`PersistentPreRun`-equivalent injects it into the command's `context.Context` via
+`logging.NewContext` (point 2) once, at the top — every downstream `pkg/` call retrieves the same
+logger via `logging.FromContext(ctx)`, never constructs its own.
+
+### 6. `WindsorError` integration: structured fields, not string interpolation
+
+When a caller logs an error that `errors.As`-unwraps to a `*WindsorError`
+([ADR 0005](0005-typed-error-model.md)), the log call passes it as a structured attribute
+(`slog.Any("error", err)`) and a custom `LogValue()` method on `*WindsorError` expands it to
+`code`, `category`, and `message` fields — never string-interpolated into the log message itself.
+This is the same principle as `go-style`'s `errors.As` rule applied to logging: the code and
+category stay machine-readable fields in JSON output, not buried in free text.
+
+### 7. Migration: per-package, selective — not a mechanical 46-site sweep
+
+Consistent with ADR 0005's error-migration approach: a raw `fmt.Print*`/`fmt.Fprint*` call converts
+to a `slog` call when its package's Wave 2 cleanup pass reaches it, not as a separate upfront sweep.
+The nine files reaching `tui.Active` directly are **not** converted by this ADR — removing that
+direct reach is explicitly the Presenter ADR's job (per the release doc: Presenter "removes direct
+`os.Stdout` / `tui.Active` reach from business layers"), since it requires the domain-event
+vocabulary this ADR doesn't define. This ADR's job is narrower: the call-site API, the handlers, and
+context injection are ready for Presenter to build on, not a completed migration.
+
+## Consequences
+
+- **One flag, one flow** for verbosity — closes the dual-mechanism (`SetVerbosity` +
+  string-keyed context value) smell found in Context, and the string-key anti-pattern with it.
+- **New dependency** (`charmbracelet/log`) lands with this ADR rather than waiting for full
+  BubbleTea adoption in Wave 3 — reasonable since the console handler is needed immediately, not
+  just once the TUI exists.
+- **The TUI-routing handler is a reserved seam, not a working feature** until Wave 3 — a log call
+  made today behaves correctly (console or JSON) but doesn't yet coordinate with a TUI program,
+  because no TUI program exists yet. No regression; nothing to coordinate with.
+- **Business layers still reach `tui.Active` directly until Presenter's migration lands** — this ADR
+  does not fix the nine-file coupling found in Context, it only stops making it worse (new/touched
+  log call sites use the injected logger, not a new global) and prepares the handler seam Presenter
+  will route through.
+- **`--output json` for logging is decided; the release doc's global-JSON-surface open question
+  (errors + progress + logs uniformly, or per-concern) stays open**, same posture ADR 0005 took for
+  errors — this ADR's handler choice satisfies either resolution.
+
+## Alternatives considered
+
+- **A third-party structured-logging library** (`zap`, `zerolog`, `logrus` — the last already a
+  transitive dep per the release doc's current-state survey). Rejected: `log/slog` is stdlib as of
+  Go 1.21 (this repo targets 1.26), needs no new dependency for the core API, and the release doc's
+  own scoping table already locked in `slog` — this ADR implements that choice rather than
+  relitigating it.
+- **Keep `Shell.SetVerbosity`/`IsVerbose` as the sole verbosity mechanism, no context-injected
+  logger.** Rejected: doesn't give `pkg/` packages outside `pkg/runtime/shell` any way to read the
+  level, and doesn't solve the `tui.Active`-global-reach problem at all.
+- **Build the TUI-routing handler now, ahead of BubbleTea.** Rejected: there's nothing to route to
+  yet — the seam is reserved so call sites don't change later, but building the routing logic before
+  Wave 3's TUI program exists would mean guessing its shape.
+- **Convert all 46 raw print sites in one mechanical pass.** Rejected for the same reason ADR 0005
+  rejected a mechanical 882-site error conversion — most convert naturally as their package's Wave 2
+  pass reaches them; forcing it now is effort disconnected from when the code is actually touched.

--- a/docs/adrs/0007-presenter-event-stream.md
+++ b/docs/adrs/0007-presenter-event-stream.md
@@ -1,0 +1,258 @@
+# ADR 0007 — Presenter / event stream: the keystone seam
+
+- Status: Proposed
+- Date: 2026-08-04
+- Deciders: Ryan VanGundy
+- Fills the "Presenter / event stream" placeholder from `release-v0.10.0.md`'s Wave 1 — the last
+  Wave 1 gap. Builds directly on [ADR 0005](0005-typed-error-model.md) (errors) and
+  [ADR 0006](0006-structured-logging-contract.md) (logging), which both explicitly deferred their
+  own rendering-unification and business-layer-migration questions here rather than deciding them
+  twice.
+
+## Context
+
+ADR 0006 found nine files reaching `pkg/tui`'s global `Active`/`WithProgress` directly from business
+layers. This round's survey goes one level deeper — that coupling isn't the only ad-hoc mechanism in
+play; there are **three**, each solving a fragment of what a presenter should own:
+
+1. **`tui.WithProgress(message, fn func() error) error`** — wraps a synchronous closure, starts a
+   spinner, calls `Done()`/`Fail()` based on the closure's error. Used 10+ times across
+   `pkg/provisioner/terraform/stack.go` and `pkg/provisioner/provisioner.go` for "Applying %s" /
+   "Destroying %s" / "Migrating terraform state" style single-operation progress.
+2. **`tui.Start(message)` / `tui.Fail()` called directly, unpaired from `WithProgress`** —
+   `pkg/provisioner/kubernetes/kubernetes_manager.go` calls these asymmetrically for
+   longer-running waits that don't fit the closure-wrapping shape.
+3. **Ad-hoc `outputFunc func(string)` parameters** — `WaitForNodesHealthy`, `CheckNodeHealth`, and
+   similar wait-phase functions take a bespoke string-callback parameter, documented inline as
+   "receives status messages during the wait phases." Same job as (1)/(2), third independent shape.
+
+Three different shapes for the same underlying need — reporting "something is happening" to
+whatever's watching — is exactly the "four independent subsystems" problem the release doc's
+keystone section names, just discovered to be worse than "logging vs. errors vs. progress vs.
+prompts": progress reporting alone already has three competing internal shapes before a presenter
+unifies anything.
+
+**No global `--output json` flag exists today** (checked directly — the only `"output"` flag in
+`cmd/` is `bundle`'s unrelated archive-path flag). The release doc's open question #2 — "is JSON a
+global surface covering logs and errors and progress uniformly, or per-concern flags" — is still
+open, and both ADR 0005 and ADR 0006 explicitly punted it here rather than deciding it twice. This
+ADR is where it gets resolved, since the presenter is the one seam all three concerns pass through.
+
+Checked against real prior art before finalizing this shape, not just recalled from memory — this
+is an established idiom, not a novel design, verified across four independent, widely-used systems
+solving the identical problem (a heterogeneous progress/log/diagnostic stream from a multi-resource
+orchestration tool):
+
+- **Terraform's `-json` machine-readable output**
+  ([docs](https://developer.hashicorp.com/terraform/internals/machine-readable-ui)) — directly
+  relevant since the release doc's async wave targets concurrent Terraform. Every message shares a
+  common envelope — `@level`, `@message`, `@module` (always `"terraform.ui"`), `@timestamp`, and
+  `type` — where `type` (`"version"`, `"planned_change"`, `"apply_start"`, `"apply_progress"`,
+  `"diagnostic"`, `"log"`, …) drives which additional fields are present, streamed as **one JSON
+  object per line**, not one buffered document.
+- **`sigs.k8s.io/cli-utils/pkg/apply/event`** ([pkg.go.dev](https://pkg.go.dev/sigs.k8s.io/cli-utils/pkg/apply/event))
+  — the event package behind `kubectl apply`'s and `kpt live apply`'s apply/prune/wait pipeline.
+  `Event` has one `Type` enum (`ApplyType`, `PruneType`, `WaitType`, `ErrorType`, `StatusType`, …)
+  and — notably — **typed fields declared directly on the struct** (`ApplyEvent`, `PruneEvent`,
+  `WaitEvent`, `ErrorEvent`, …), not a generic `any` payload requiring a type assertion. Separate
+  `table` and `json` printer packages consume the same event channel.
+- **Pulumi's `engine.Event`** ([events.go](https://github.com/pulumi/pulumi/blob/master/pkg/engine/events.go),
+  [display/json.go](https://github.com/pulumi/pulumi/blob/master/pkg/backend/display/json.go)) —
+  rendered either as an interactive progress tree (`ShowProgressEvents`) or as JSON
+  (`ShowJSONEvents`/`ShowPreviewDigest`). A real fork worth naming: Pulumi's JSON renderer
+  deliberately does **not** stream incrementally — it buffers the whole event sequence to guarantee
+  one well-formed JSON document, trading incremental/tailable output for a validity guarantee.
+- **BuildKit's `util/progress/progressui`** ([display.go](https://github.com/moby/buildkit/blob/master/util/progress/progressui/display.go),
+  powering `docker build`) — a `Display` interface with `auto`/`tty`/`plain`/`rawjson` modes,
+  `AutoMode` picking `tty` vs. `plain` by terminal detection. The closest match to this ADR's
+  console/JSON/(eventually TUI) three-renderer split specifically.
+
+Every one of these converges on the same core shape — one discriminated envelope, pluggable
+renderers selected by output mode — which is the strongest signal this ADR is applying an
+established idiom, not inventing one. Where they diverge (Terraform/this ADR's per-line NDJSON
+streaming vs. Pulumi's buffered single document) is called out explicitly in Alternatives, since
+it's a real tradeoff, not an oversight.
+
+## Decision
+
+### 1. Domain event vocabulary: one envelope, a small closed set of kinds
+
+```go
+// internal/presenter (sibling to logging/werror/shims/util — reachable from cmd/ and pkg/ alike)
+
+type Kind string
+
+const (
+    KindApplying    Kind = "applying"     // an operation has started
+    KindApplied     Kind = "applied"      // an operation finished successfully
+    KindFailed      Kind = "failed"       // an operation finished with a *werror.WindsorError
+    KindProgress    Kind = "progress"     // a status update mid-operation (today's outputFunc case)
+    KindLog         Kind = "log"          // a structured log record (bridges ADR 0006's slog handler)
+    KindInputNeeded Kind = "input_needed" // reserved — Wave 3's interactive-input ADR fills this in
+)
+
+type Event struct {
+    Kind     Kind
+    Subject  string // "terraform:cluster", "kustomization:cert-manager" — what this is about
+    ParentID string // empty for top-level; set for a sub-resource event (Wave 3 hierarchy — reserved now)
+    Message  string
+    Err      *werror.WindsorError // set only when Kind == KindFailed
+    Record   *slog.Record         // set only when Kind == KindLog
+}
+```
+
+One envelope type with a discriminated `Kind`, not a Go interface with per-kind concrete types —
+deliberately matching Terraform's `-json` shape (Context) over the alternative sum-type-via-interface
+pattern, because every renderer (console, JSON, eventually TUI) needs to switch on kind anyway, and a
+single struct serializes to stable JSON without a custom `MarshalJSON` per event type. `ParentID` and
+`KindInputNeeded` are reserved now, unused until Wave 3, for the same reason ADR 0006 reserved its
+TUI-routing handler: the vocabulary shouldn't need to change shape once Wave 3 has something to put
+in those fields.
+
+`Err`/`Record` are declared as typed optional fields directly on `Event`, not behind a generic
+`any Data` field requiring a type assertion at every renderer — this specific choice is validated
+directly by `cli-utils`' `Event` (Context): it uses the identical pattern (`ApplyEvent`,
+`PruneEvent`, `WaitEvent`, … as typed fields on one struct, populated according to `Type`) at
+production scale behind `kubectl apply`. A generic payload field was not seriously considered as an
+alternative for this reason — real prior art already settled the question in favor of typed fields.
+
+### 2. The presenter port: one method, plus one convenience wrapper
+
+```go
+type Presenter interface {
+    Emit(ctx context.Context, event Event)
+}
+
+// Track is sugar over Emit, matching today's tui.WithProgress call shape exactly — emits
+// KindApplying, runs fn, emits KindApplied or KindFailed based on the result. This is what most of
+// the ~13 WithProgress call sites convert to, nearly mechanically.
+func Track(ctx context.Context, p Presenter, subject string, fn func() error) error
+```
+
+`Emit` alone is deliberately the entire port — "one seam" from the keystone section, not a growing
+interface. `Track` exists purely to keep the migration cheap for the majority-case call site
+(1 above): a call site that reads `tui.WithProgress(msg, fn)` today reads `presenter.Track(ctx,
+subject, fn)` after, same shape, same risk profile. The asymmetric `tui.Start`/`Fail` sites (2) and
+the `outputFunc` sites (3) convert to explicit `Emit` calls instead, since they don't fit the
+wrap-a-closure shape `Track` assumes.
+
+### 3. Presenter is injected, constructed by `Runtime`, same placement as the logger
+
+Per ADR 0002's layer table (Runtime owns lifecycle/dependency wiring) and ADR 0006's precedent
+(logger constructed once, injected via context): `NewRuntime` constructs the active `Presenter`
+(console, JSON, or — once Wave 3 lands — TUI, selected the same way the logger's handler is
+selected) and makes it available for constructor injection into `TerraformStack`,
+`KubernetesManager`, `Provisioner`, `WorkstationVirt`/`NetworkManager`, and `ArtifactBuilder` — the
+same five call sites currently reaching `tui.Active` directly. This is dependency injection, not
+context-carried, unlike the logger: a presenter is a structural collaborator business types already
+take constructor dependencies for (`ConfigHandler`, `Shell`), where the logger is inherently
+per-call-site ambient state. Matching each to the injection style already established for its kind
+of dependency, not introducing a third pattern.
+
+### 4. Three renderers behind the port
+
+- **Console** (default) — `KindApplying`/`KindApplied`/`KindProgress` drive spinner-style terminal
+  output (the rendering logic already in `pkg/tui/tui.go`'s `termSpinner` moves here, adapted to
+  read `Event` instead of raw `Start`/`Update`/`Done`/`Fail` calls); `KindFailed` renders through
+  the same format ADR 0005's central renderer already defined (`Error [CODE]: message` +
+  remediation); `KindLog` renders through the `charmbracelet/log` console handler ADR 0006 already
+  selected.
+- **JSON** (`--output json`, now a **global persistent flag** — this ADR's resolution of the release
+  doc's open question #2, decided as "yes, uniform," see Consequences) — every `Emit` call
+  marshals the `Event` as one newline-delimited JSON object to stdout, directly matching Terraform's
+  own `-json` shape (Context). Logs, errors, and progress are the same stream, distinguished only by
+  `"kind"` — exactly what the keystone section asks for ("renderings of the same event stream, not
+  four independent subsystems").
+- **TUI** (reserved, Wave 3) — routes `Event`s into a BubbleTea program's message channel instead of
+  stdout. Not built here; the port and the `KindInputNeeded`/`ParentID` reservations exist so Wave 3
+  implements a fourth renderer against an unchanged contract, not a contract redesign.
+
+### 5. How this reconciles with ADR 0006 (logging) and ADR 0005 (errors) — neither is superseded
+
+- **Logging call sites are unchanged.** Business code still calls `slog.InfoContext(ctx, ...)`
+  exactly as ADR 0006 decided. What changes is the **handler** `Runtime` wires into that logger:
+  `logging.NewPresenterHandler(presenter)` implements `slog.Handler` and, on `Handle()`, builds a
+  `KindLog` event and calls `presenter.Emit`. This is precisely the "TUI-routing handler" seam ADR
+  0006 reserved — the presenter *is* the routing target that handler was reserved for.
+- **`WindsorError` rendering is unchanged in shape, relocated in mechanism.** ADR 0005's central
+  `cmd/`-boundary renderer stops formatting directly and instead builds `Event{Kind: KindFailed, Err:
+  we}` and calls `presenter.Emit` — the format string, the `DocsURL` line, the `--verbose` breadcrumb
+  trail (`werror.Breadcrumbs`) all move into the console/JSON renderers' `KindFailed` handling
+  unchanged from how ADR 0005 specified them. ADR 0005 itself called this out as expected: "this ADR
+  defines the type and an interim renderer the presenter work subsumes."
+
+### 6. Migration: per-package, not mechanical — same discipline as 0005 and 0006
+
+This ADR does not migrate the nine `tui.Active`-reaching files, the `outputFunc` call sites, or the
+`kubernetes_manager.go` asymmetric `Start`/`Fail` calls. Every one of the affected packages
+(`pkg/provisioner`, `pkg/provisioner/kubernetes`, `pkg/workstation`, `pkg/composer/artifact`,
+`pkg/runtime/shell`) is already in Wave 2's per-package cleanup order — the migration happens as
+each package's pass reaches it, following ADR 0003's characterize-then-refactor rule: black-box
+characterize current progress-reporting behavior first (a fake `Presenter` capturing emitted events
+is the natural test double), then swap the mechanism, confirm the black-box tests still pass. `onApply
+func(id string) (bool, error)` hooks on `TerraformStack.Up`/`Provisioner.Up` are explicitly **out of
+scope** — they compose secret-placement and other post-apply logic, not user-facing output, and
+converting them would conflate two unrelated mechanisms that happen to nest today.
+
+## Consequences
+
+- **Resolves the release doc's open question #2**: `--output json` is a single global persistent
+  flag (same tier as `--verbose`), and it covers logs, errors, and progress uniformly through one
+  `Presenter` implementation — not per-concern flags. Decided here because the presenter is the only
+  place this question has a real answer; deferring it further (as both 0005 and 0006 did) would have
+  left it unresolved indefinitely.
+- **Three ad-hoc progress mechanisms collapse to one port** — `tui.WithProgress`, the asymmetric
+  `tui.Start`/`Fail` pattern, and bespoke `outputFunc` parameters all become `Emit`/`Track` calls,
+  closing a fragmentation problem this round's survey found was worse than the release doc's
+  original framing (three mechanisms, not one, needed replacing).
+- **`pkg/tui` doesn't disappear** — its spinner *rendering* logic (the actual terminal animation
+  code in `termSpinner`) is reused inside the console renderer, not thrown away; what's removed is
+  the global `Active` singleton and direct business-layer reach into it.
+- **Presenter is a fifth constructor dependency** on `TerraformStack`, `KubernetesManager`,
+  `Provisioner`, workstation types, and `ArtifactBuilder` — a real, if mechanical, signature change
+  to five widely-used types, landing during each one's already-scheduled Wave 2 pass rather than as
+  a separate cross-cutting commit.
+- **The event vocabulary is a new piece of public-ish surface** (even though `internal/presenter`
+  isn't externally importable, it's shared across every business package) — adding a `Kind` later is
+  cheap and backward-compatible for JSON consumers (an unrecognized kind just doesn't match a
+  switch case); removing or renegotiating one is not, once `--output json` has real consumers.
+
+## Alternatives considered
+
+- **A Go interface with one concrete type per event kind** (`Applying{}`, `Failed{Err error}`, …)
+  instead of one struct with a `Kind` tag. Rejected: every renderer has to type-switch across all
+  kinds anyway, and a single struct maps directly onto both Terraform's proven `-json` stream shape
+  and `cli-utils`' `Event` struct (Context) without per-type `MarshalJSON` implementations.
+- **Buffer the full event sequence and emit one JSON document**, Pulumi's approach (Context), instead
+  of streaming one JSON object per `Emit` call. Rejected for Windsor's case: a CI pipeline tailing
+  `windsor apply --output json` benefits more from incremental, tailable output (Terraform's choice,
+  and this ADR's) than from Pulumi's well-formedness guarantee — a killed process leaves a
+  truncated-but-still-line-valid NDJSON stream, which is an acceptable failure mode for a log,
+  whereas losing the whole document is not. Revisit only if a consumer needs the "always one valid
+  JSON blob" guarantee Pulumi optimized for, which no current Windsor use case does.
+- **Context-injected presenter, matching the logger's injection style.** Rejected: a presenter is a
+  structural collaborator the affected types already take similar dependencies for
+  (`ConfigHandler`, `Shell`) via constructor injection; forcing it through context would be a third
+  injection pattern for no benefit, where the logger's context injection exists specifically because
+  logging is called from many more places than the five presenter-consuming types.
+- **Keep JSON output as a per-command, per-concern flag** (e.g. `apply --json-errors`,
+  `plan --json-output`) rather than one global flag. Rejected: this is exactly the fragmentation
+  problem being solved for progress mechanisms; doing the same thing to output-format selection
+  would just relocate the inconsistency.
+- **Migrate all nine known call sites as part of this ADR.** Rejected for the same reason ADR 0005
+  and 0006 kept their own migrations selective and per-package: the affected packages are already
+  scheduled in Wave 2's order, and converting them here would mean touching them again during their
+  own cleanup pass for unrelated reasons (file splits, black-box tests).
+- **Build the Wave 3 TUI renderer now, alongside the port.** Rejected, consistent with ADR 0006:
+  nothing exists yet to route TUI events *to* — BubbleTea adoption is its own Wave 3 ADR, and
+  building the renderer first would mean guessing its shape before that ADR decides it.
+
+## References
+
+Prior art verified via live search, not recalled from memory — see Context for how each maps onto
+this ADR's decisions:
+
+- [Terraform machine-readable UI](https://developer.hashicorp.com/terraform/internals/machine-readable-ui) — envelope shape, NDJSON streaming
+- [`sigs.k8s.io/cli-utils/pkg/apply/event`](https://pkg.go.dev/sigs.k8s.io/cli-utils/pkg/apply/event) — typed-fields-on-one-struct pattern
+- [Pulumi `pkg/engine/events.go`](https://github.com/pulumi/pulumi/blob/master/pkg/engine/events.go) / [`pkg/backend/display/json.go`](https://github.com/pulumi/pulumi/blob/master/pkg/backend/display/json.go) — buffered-JSON alternative, considered and rejected
+- [BuildKit `util/progress/progressui/display.go`](https://github.com/moby/buildkit/blob/master/util/progress/progressui/display.go) — pluggable-renderer-by-output-mode precedent

--- a/docs/adrs/release-v0.10.0.md
+++ b/docs/adrs/release-v0.10.0.md
@@ -1,0 +1,380 @@
+# Release v0.10.0 — Planning & ADR Sequence
+
+- Status: Drafting
+- Date: 2026-08-04
+- Deciders: Ryan VanGundy
+- Purpose: Seed and sequence the ADRs that lead up to the v0.10.0 release. This is a living
+  planning document, not an ADR. Each numbered ADR below is authored separately in this directory.
+
+## Note on ADR numbering and pruning (2026-08-04)
+
+The prior release cycle's ADRs (0001–0012) were audited against the shipped codebase, twice:
+
+**First pass** — everything fully implemented, or explicitly rejected with nothing left to do, was
+deleted: per-context `.env` injection, tier-aware `windsor test` validation, and the rejected
+flat-entries-under-flux proposal. Work that's done from this repo's side with only cross-repo or
+merge-pending work remaining moved to the Stragglers list below instead of staying an ADR. Six ADRs
+were provisionally carried forward, rewritten to scope just their outstanding decision.
+
+**Second pass** — those six were re-checked against the release's own stated charter (smooth the
+UX via the presenter/logging/error/TUI keystone; smooth the codebase via architecture/DRY/tests),
+not just "is there a gap." Five turned out to be speculative future hardening with no dependency on
+this release, or pure documentation opinions that don't need an ADR in any release, or work that
+would just be superseded once a not-yet-written Wave 1 ADR lands. They were pruned to one-line
+Backlog notes rather than carried forward as full documents — see below. Only one ADR survived:
+apiv2 header schema retirement, which is a genuine, 0%-started blocker for the Wave 2 sweep.
+
+**Going forward, `docs/adrs/` is tracked in git, not gitignored — ADRs are deleted and the sequence
+restarts after every release, rather than accumulating indefinitely. A carried-forward ADR should
+justify itself against the release's actual charter, not just against "this isn't finished yet."
+
+## Why this release exists
+
+v0.9.0 was a rapid, scope-creep-heavy cycle — effectively a pre-GA reshaping. v0.10.0 is the
+deliberate counter-cycle. It has two goals:
+
+1. **Smooth the UX.** Consistent, leveled, optionally-JSON log output; a standard, genuinely
+   helpful error model; and a real TUI (BubbleTea) for interactive selection and live, async
+   progress rendering across Terraform and Kubernetes resources.
+2. **Smooth the codebase** for developer and agent ergonomics. Clarify the target architecture,
+   apply better Go composition, nest the package tree, centralize utilities, DRY, cap file size,
+   rework tests toward black-box coverage, rationalize mocks, and standardize comments/docs.
+
+## Decisions locked in scoping
+
+| Decision | Choice | Consequence |
+|---|---|---|
+| Sequencing | Cleanup first, then UX | Foundations (logging/error/output contracts) are pulled *into* the cleanup wave so packages are touched once, not twice. |
+| Scope stance | Broad but phased | Everything discussed is in scope, gated by wave with hard checkpoints. |
+| Breaking changes | Allowed | Last big pre-GA reshaping. Log format, error rendering, flags, and config fields may change. GA discipline starts at v1.0. |
+| Error model | Typed `WindsorError` | Structured type: code/category + user message + remediation + wrapped cause; rendered by one central formatter. |
+| UX ambition | Framework + async everywhere | BubbleTea + concurrent multi-project Terraform via graph + live Kubernetes sub-resource updates + interactive menus + chat-style prompting. |
+| Cleanup breadth | Every package gets a pass | Systematic sweep of all `pkg/` packages. Highest schedule risk; first cut line. |
+| Logging | `slog` API + swappable handlers | Call sites target `log/slog`. Backends: `slog.JSONHandler` (JSON), `charmbracelet/log` (console), a TUI-routing handler (while BubbleTea owns the screen). Logger injected via context, never global. |
+
+### Schedule risk
+
+"Every package gets a pass" and "async everywhere" are the two most expansive choices on the
+board, chosen against a release whose stated purpose is to escape scope creep. They are phased
+and gated so a slip in either does not hold the release hostage. Intermediate tags
+(`0.10.0-beta.N`) ship at wave boundaries. If the cycle runs long, per-package cleanup narrows to
+the monolith hit-list and async narrows to a single flagship flow.
+
+## Architectural keystone: emit events, don't print
+
+Today, business layers reach the terminal directly — `fmt.Fprintf(os.Stderr, ...)` and the global
+`tui.Active` singleton live deep inside [`pkg/runtime/shell`](../../pkg/runtime/shell/shell.go),
+[`pkg/provisioner`](../../pkg/provisioner/provisioner.go), and
+[`pkg/workstation`](../../pkg/workstation/). That coupling is the root cause behind all three UX
+complaints (inconsistent logs, nested errors, no live progress).
+
+The unifying fix is one seam. Business layers **emit domain events** — "module X applying",
+"resource Y ready", "needs input Z", "failed with WindsorError W" — to an injected **presenter**.
+The presenter renders those events three ways behind one contract:
+
+- **Console** — leveled, colored, human-readable (default).
+- **JSON** — one structured record per event (`--output json` / CI).
+- **TUI** — a live BubbleTea view: multi-line resource list, per-line spinner → green check,
+  async sub-resource trees.
+
+Logging, error rendering, progress display, and interactive prompting all become *renderings of the
+same event stream*, not four independent subsystems. This is the spine the cleanup wave builds and
+the UX wave consumes.
+
+## Current-state facts (verified from source)
+
+- **No logger, no logger interface, no structured logging.** All output is raw `fmt.Print*` /
+  `Fprint*` to `os.Stdout` / `os.Stderr`, plus a hardcoded-ANSI spinner layer
+  ([`pkg/tui/tui.go`](../../pkg/tui/tui.go)). `logrus`/`zap`/`slog` appear only as transitive deps.
+- **877 `fmt.Errorf("...: %w")` wrap sites**, surfaced via Cobra's default printer with ad-hoc
+  `SilenceErrors` + manual `err.Error()` prints in `cmd/`. No central formatter. This is the
+  nested-colon-string problem.
+- **Output reached via package globals** (`tui.Active`) and hardcoded OS streams inside the runtime
+  and provisioner layers — the coupling the keystone removes.
+- **The one existing abstraction** is the spinner: `Spinner` interface + global `Active` +
+  `WithProgress` nesting ([`pkg/tui/tui.go:39`](../../pkg/tui/tui.go#L39)). BubbleTea grows out of
+  or replaces this.
+- **Monoliths over the 1000-line cap:** [`blueprint/processor.go`](../../pkg/composer/blueprint/processor.go)
+  (2685), [`kubernetes_manager.go`](../../pkg/provisioner/kubernetes/kubernetes_manager.go) (2312),
+  [`provisioner.go`](../../pkg/provisioner/provisioner.go) (2110),
+  [`blueprint_types.go`](../../api/v1alpha1/blueprint_types.go) (2106),
+  [`terraform/stack.go`](../../pkg/provisioner/terraform/stack.go) (1889),
+  [`evaluator.go`](../../pkg/runtime/evaluator/evaluator.go) (1605),
+  [`artifact.go`](../../pkg/composer/artifact/artifact.go) (1553),
+  [`test/runner.go`](../../pkg/test/runner.go) (1247). Largest test: `processor_test.go` (7322).
+- **`shims.go` hand-rolled in ~14 packages; no shared `util`/`internal` package.** Clearest DRY win.
+- **Tests are 100% white-box** (`package xxx` everywhere; `*_public_test.go` is a naming convention,
+  not black-box testing). 113 unit / 28 cmd / 17 integration. Mocks hand-written (no mockgen), 19 of
+  them; widest interfaces are `config/handler` (31 methods) and `shell` (25 methods).
+
+## Carried forward from the prior round
+
+Only one ADR survived both audit passes:
+
+| ADR | Wave fit | Why |
+|---|---|---|
+| [0001 — apiv2 common header schema & v1alpha1 retirement](0001-apiv2-common-header-schema.md) | Wave 0/1 | 0% started; every config-touching cleanup pass in Wave 2 should land after this, not before. Now also folds in the sensitive-value-enforcement chokepoint fix (below), since both rework the same `GetContextValues` read path. |
+
+## Backlog (deferred past v0.10.0 — not carried forward as ADRs)
+
+Real gaps the prior round's audit found, kept as one-line pointers rather than full ADRs — none
+has a dependency on this release's charter (presenter/logging/errors/TUI; architecture/DRY/tests),
+so none blocks it. Revisit if a future release's scope actually touches this surface:
+
+- **Blueprint-lifecycle provenance and safety.** `windsorcli.dev/blueprint-version` and
+  `windsorcli.dev/origin` labels are missing from managed objects; no guard inspects
+  `prune: disabled`/`Retain`/`resource-policy: keep` before a destructive prune; `plan` doesn't
+  classify a transition as created/updated/migrated/reclaimed; no `--dry-run` alias exists.
+- **Kustomization tier namespace/label conventions.** Ratifying functional-layer namespaces and an
+  `app.kubernetes.io/name` vendor label is a documentation decision for `windsorcli/core`'s
+  `docs/reference/facets.md` — doesn't need a CLI ADR in any release.
+- **CLI self-update nudge.** No background check against `windsorcli/cli`'s latest release exists;
+  `upgrade` also doesn't say when it skipped a newer, incompatible core tag. Ambient UX, not tied
+  to the presenter keystone driving this release's actual UX wave.
+- **Hetzner ADR/code drift.** The deleted prior-round ADR's text (backend-type default, credential
+  delivery mechanism) no longer matches shipped code (`kubernetes` default, `.env`-only via
+  `env()`). Purely a stale-doc-text problem — already resolved by deleting the stale doc.
+- **`explain`/`trace` attribution rendering.** `ExplainContribution.SourceName`/`Ordinal` are
+  already tracked end-to-end but `cmd/explain.go`'s `printContribution` only ever prints them as a
+  fallback when no facet path exists — never alongside one, which is the common case. This is
+  presenter/rendering work; fold it into the Wave 1 "Presenter / event stream" ADR when that's
+  written rather than deciding it in isolation now.
+
+## Stragglers (tracked here, not as standalone ADRs)
+
+Work items surfaced by the same audit that don't need a CLI-repo ADR — either because the remaining
+work lives entirely in `windsorcli/core`, or because the CLI-side decision is already made and only
+execution (a merge) remains:
+
+- **Facet `install`/`resources` migration in `core`.** The CLI-side `flux:` mechanism (prior ADR
+  0004) is fully shipped; migrating `core`'s facets off flat `kustomize:` entries onto it is
+  `windsorcli/core` content, tracked there.
+- **Flux-native SOPS decryption wiring in `core`.** The CLI-side generic `decryption` field (prior
+  ADR 0010) is fully shipped; the `sops-age` secret entry and `decryption:` gating in `core`'s
+  gitops facet is `windsorcli/core` content, tracked there.
+- **Merge PR #3132** (`fix/talos-upgrade-empty-response`) — Talos node-reboot detection by boot ID
+  is fully coded and tested (prior ADR 0012) but sits on an unmerged branch. This needs a merge
+  decision, not a new ADR.
+
+## ADR sequence
+
+Numbers below continue from the carried-forward series above (next available is 0008). Waves are
+ordered; ADRs within a wave may proceed in parallel unless a dependency is noted.
+
+### Wave 0 — North star (must land first)
+
+- [x] **[0002 — Target architecture & package topology](0002-target-architecture-and-package-topology.md).**
+  Derived from the current tree, not a fresh vision (resolves open question #1 below): the existing
+  layer map already holds under verification, so this ADR ratifies it rather than redesigning it,
+  and fixes the two real pain points found instead — 13 files over the 1000-line cap (split in
+  place, no new sub-packages) and 16+1 duplicated `shims.go` files (consolidated into a new
+  top-level `internal/shims`/`internal/util`, reachable from both `cmd/` and `pkg/`). No package
+  moves. *Everything downstream references this.*
+
+### Wave 1 — Foundations (the cleanup wave's contracts) — ✅ complete, all decisions made
+
+- [x] **[0003 — Test strategy: black-box default and characterize-then-refactor](0003-test-strategy-black-box-default.md).**
+  Moved up from Wave 2 — it's a contract every later pass depends on, not an independent cleanup
+  item, and ADR 0001 needs it immediately (see below). Surveyed directly: 0 of 158 existing test
+  files are black-box today (100% `package xxx`, confirmed not assumed). Decides: black-box
+  (`package xxx_test`) is the default; a private-method test is permitted only for complex
+  unexported logic where public coverage is impractical (parsers, edge-case math — matching
+  `test-engineer`'s existing exemption); >80% coverage floor per package; mock rationalization by
+  real call sites, not customization frequency — confirmed one genuinely dead interface method
+  (`ConfigHandler.RegisterProvider`, zero production call sites) and confirmed the naive
+  never-customized-in-tests signal produces false positives (three real, actively-called methods
+  looked identical to it by that signal alone). Dead methods drop from the interface, its
+  implementation, and its mock together; live-but-uncustomized methods stay and get test coverage
+  added instead. `ConfigHandler` (33 methods) and `Shell` (25) then split along their existing
+  seams once the dead weight is gone. The **sequencing rule**, binding on ADR 0001 and every Wave 2
+  per-package pass:
+  for a package about to be structurally touched, black-box-characterize its current public
+  behavior *first*, refactor under that net, confirm the black-box tests pass unchanged (the proof
+  the refactor was behavior-preserving), and only then add narrow white-box tests for whatever
+  complex unexported logic survives and still needs them. Never refactor first and patch tests
+  after — that pays the test-rewrite cost twice for the same code.
+- [x] **[0006 — Structured logging contract](0006-structured-logging-contract.md).** Surveyed
+  directly: 0 `slog` usage, 0 `charmbracelet`/`bubbletea` deps, 46 raw print sites, and 9 files
+  reaching `tui.Active` directly from business layers (`pkg/workstation`, `pkg/composer/artifact`,
+  `pkg/runtime/shell`, `pkg/provisioner*`) — confirming the keystone section's coupling claim.
+  `log/slog` as the call-site API, retrieved from `context.Context` via a typed key in
+  `internal/logging` (closing an existing string-keyed `context.WithValue("verbose", ...)` smell in
+  `cmd/root.go`); console (`charmbracelet/log`, new dep)/JSON (stdlib)/TUI-routing (reserved seam,
+  Wave 3 fills it in) handlers; `--verbose` unifies the two currently-disconnected verbosity
+  mechanisms into one; `WindsorError` logs as structured fields via `LogValue()`, not string
+  interpolation. Does **not** migrate the nine `tui.Active` call sites — that's explicitly the
+  Presenter ADR's job below, which needs the domain-event vocabulary this ADR doesn't define.
+- [x] **[0005 — Typed error model](0005-typed-error-model.md).** Surveyed directly: 84 files, 882
+  wrap sites, spanning every Wave 2 directory — decided here rather than deferred, for the identical
+  reason ADR 0003 was promoted. Checked against prior art (Kubernetes `apimachinery`, Docker
+  `errdefs`, AWS SDK v2, Stripe, gRPC `google.rpc.Status`, Terraform `tfdiags`) before finalizing.
+  Three tiers in `internal/werror`: plain `fmt.Errorf` for uninformative wraps (rare); `werror.Wrap`
+  — a cheap, code-free breadcrumb frame, the default for a touched site, structurally capturing each
+  frame's message (never parsed from `err.Error()` strings) so `--verbose`/JSON can render a real
+  trace list; `werror.New` — a full `WindsorError` (doc-linkable domain-prefixed code, e.g.
+  `COMPOSER-014`, mechanically-derived `DocsURL`, remediation) reserved for boundaries with a real
+  actionable remediation. Domains are purpose-built for support triage, deliberately not a 1:1
+  mirror of ADR 0002's architecture layer table. Minimal central renderer at the `cmd/` boundary
+  (console + JSON, no TUI awareness yet — the Presenter ADR below subsumes it). Migration rides the
+  same per-package Wave 2 cadence, not a mechanical 882-site sweep.
+- [x] **[0007 — Presenter / event stream](0007-presenter-event-stream.md).** The keystone seam —
+  and Wave 1's last gap. Survey found the progress-reporting fragmentation was worse than the
+  original framing: **three** ad-hoc mechanisms today (`tui.WithProgress` closures, asymmetric
+  `tui.Start`/`Fail` calls in `kubernetes_manager.go`, bespoke `outputFunc func(string)`
+  parameters), not one. One `Event{Kind, Subject, ParentID, Message, Err, Record}` envelope,
+  verified against real prior art (not recalled from memory) across Terraform's `-json` output,
+  `sigs.k8s.io/cli-utils` (the `kubectl apply` event pipeline — validates typed fields directly on
+  the struct over a generic payload), Pulumi's `engine.Event`, and BuildKit's `progressui.Display`;
+  a one-method `Presenter{Emit}` port, injected via constructor (not context — matches how `ConfigHandler`/
+  `Shell` are already injected) into the five types that reach `tui.Active` today. Resolves the
+  release doc's open question #2: `--output json` becomes a single global flag covering logs,
+  errors, and progress uniformly, not per-concern flags. Reconciles cleanly with ADR 0006 (the
+  slog handler routes through `Emit`, call sites unchanged) and ADR 0005 (the error renderer builds
+  a `KindFailed` event instead of formatting directly, format unchanged). Migration is per-package,
+  riding Wave 2's existing order — not done here.
+- [x] **Shared foundations package(s).** Already fully decided by
+  [ADR 0002](0002-target-architecture-and-package-topology.md) point 3 (`internal/shims`/
+  `internal/util`) — no separate ADR needed; this line is kept only so Wave 1's list reads complete.
+
+### Immediate implication for ADR 0001 (apiv2 header)
+
+ADR 0001 rewrites `pkg/runtime/config`'s read path (v1alpha1-unmarshal-everything → typed v1alpha2
+header + dynamic map) — precisely the kind of internal-representation change the characterize-then-
+refactor rule exists for. Its implementation should not wait for the Wave 1 test-strategy ADR to be
+formally written and land everywhere; it pulls forward a **scoped** slice of that policy just for
+`pkg/runtime/config` and `api/v1alpha2/config`: black-box the current behavior (assert through
+`LoadConfig`/`LoadContext`/`GetContextValues`, not through `typedSource` internals) as 0001's actual
+first implementation step, then do the header rewrite under that net.
+
+### Wave 2 — Codebase sweep (every package)
+
+- [x] **[0004 — Comment and documentation standard](0004-comment-and-doc-standard.md).** Ratifies
+  `.claude/skills/go-style/SKILL.md` as-is (already correct: no in-body comments, 6-line header
+  ceiling, section-divider convention) and adds the two gaps this round's refactor waves exposed,
+  both now written directly into that skill: a function-length guideline (<100 lines the norm,
+  100–150 look-twice, 150+ splits — evidence-based against the codebase's own current distribution,
+  only 5 of ~1158 functions currently exceed it) and a hard rule against ADR/ticket/WIP/phase-label
+  references leaking into comments. Test-comment discipline (BDD `Given`/`When`/`Then`, black-box
+  package declaration, mock rationalization) is sharpened in `test-engineer` alongside ADR 0003
+  rather than duplicated here.
+- **Per-package cleanup passes** (each conforms to Wave 0–1, including the characterize-then-refactor
+  rule above; not each its own ADR unless a boundary moves). Suggested order by density/blast-radius:
+  1. `pkg/composer/blueprint/` (densest — processor/handler/composer/trace/loader)
+  2. `pkg/provisioner/` (root monolith) + `pkg/provisioner/kubernetes/`
+  3. `pkg/runtime/` (shell, evaluator, config, env, secrets, terraform, tools)
+  4. `pkg/composer/artifact/` + `pkg/composer/terraform/`
+  5. `pkg/workstation/` (network, virt)
+  6. `pkg/test/`, `pkg/tui/`, `cmd/`, `api/`
+
+### Wave 3 — UX (builds on the presenter)
+
+- **ADR — TUI framework adoption.** BubbleTea + charmbracelet; program lifecycle; how the logger
+  and presenter route through the running program; non-TTY / CI fallback.
+- **ADR — Async execution & progress model.** Concurrent multi-project Terraform via dependency
+  graph; live kustomize/Kubernetes sub-resource watching; hierarchical progress events;
+  cancellation and context propagation.
+- **ADR — Interactive input.** Selection menus and chat-style prompting for missing values and
+  secrets, sourced through the same presenter/event contract.
+
+## Implementation sequence
+
+The seven ADRs each decide *what* to build; this is the order to actually build it in, derived from
+the dependency graph between their own `internal/` packages — not restated per-ADR, since none of
+them fully spells out how it depends on the others' output.
+
+### Phase A — Foundational `internal/` packages (build once, no migration yet)
+
+Five small, low-risk packages, in this order because each depends on the previous:
+
+1. **`internal/shims` + `internal/util`** (ADR 0002) — no dependency on anything else in this list;
+   purely mechanical extraction from the 16+1 duplicated `shims.go` files. Do this first: it's the
+   lowest-risk, and every later step benefits from it existing.
+2. **`internal/werror`** (ADR 0005) — depends on nothing but stdlib.
+3. **`internal/logging`** (ADR 0006) — depends on `werror` for the `LogValue()` bridge
+   (`*WindsorError` → structured `code`/`category`/`message` log fields); otherwise independent.
+4. **`internal/presenter`** (ADR 0007) — depends on **both** `werror` (`Event.Err`) and `logging`
+   (the slog-handler-to-`Emit` bridge is defined in terms of the handler type `logging` provides).
+   Must come after both.
+5. **`Runtime`/`cmd/root.go` wiring** — ties the four together: `NewRuntime` constructs the logger
+   and presenter; `cmd/root.go` injects the logger via context (replacing the dual
+   `SetVerbosity`+string-keyed-`context.WithValue` mechanism ADR 0006 found) and wires the presenter
+   into the central error renderer (replacing the per-command `SilenceErrors`+manual-print pattern
+   ADR 0005 found). This step is what makes Phase A "done" — a command run today would already show
+   coded errors and leveled logs, before any business-layer migration happens.
+
+**Phase A gates both Phase B and Phase C below** — not just a nice-to-have ordering. `pkg/runtime/
+config` (Phase B) will want `CONFIG-*` `WindsorError`s for its own new validation-failure paths;
+building the header rewrite before `internal/werror` exists means coming back to add error codes
+later, which is the exact "touch the file twice" problem this whole planning exercise exists to
+avoid — just one level up, across ADRs instead of within one.
+
+### Phase B — ADR 0001 (apiv2 header schema)
+
+Runs after Phase A (or, if parallelizing, after Phase A steps 1–3 specifically — `pkg/runtime/
+config` needs `werror` and probably wants `logging`, not `presenter`). Internally sequenced per
+ADR 0001/0003's own text: black-box characterize `pkg/runtime/config`'s current behavior first,
+then the v1alpha1→v1alpha2 header rewrite, then the sensitive-value chokepoint fold-in (ADR 0001
+§5), then the package-by-package `api/v1alpha1` import retirement.
+
+### Phase C — Wave 2 per-package sweep, one pass per package, six contracts bundled into each
+
+This is the synthesis point: Wave 2 is not six separate sweeps (one per ADR). For each package, in
+ADR 0002's already-decided density/blast-radius order —
+
+1. `pkg/composer/blueprint/` 2. `pkg/provisioner/` + `pkg/provisioner/kubernetes/` 3. `pkg/runtime/`
+4. `pkg/composer/artifact/` + `pkg/composer/terraform/` 5. `pkg/workstation/`
+6. `pkg/test/`, `pkg/tui/`, `cmd/`, `api/`
+
+— a single pass applies, in order, within that package:
+
+1. **Black-box characterize** current public behavior (ADR 0003), if it doesn't already exist.
+2. **Structural refactor**: split files over the 1000/150-line caps into companion files, adopt
+   `internal/shims`/`internal/util` in place of the local `shims.go` (ADR 0002).
+3. **Selective error conversion** (ADR 0005): construct `werror.New`/`werror.Wrap` only where the
+   per-ADR criteria are met, not mechanically.
+4. **Selective logging conversion** (ADR 0006): raw `fmt.Print*` sites convert to `slog` calls
+   touched by this pass.
+5. **Presenter injection** (ADR 0007) — **only for the five types that need it**:
+   `TerraformStack` (`pkg/provisioner/terraform`), `KubernetesManager`
+   (`pkg/provisioner/kubernetes`), `Provisioner` (`pkg/provisioner`), the workstation virt/network
+   types (`pkg/workstation`), and `ArtifactBuilder` (`pkg/composer/artifact`). Every other package's
+   pass skips this step.
+6. **Comment/doc standard** (ADR 0004) applied to whatever this pass already touched.
+7. Confirm black-box tests pass unchanged — the proof steps 2–6 preserved behavior.
+
+Steps 3–6 don't all apply to every package (step 5 especially, per the list above) — this is a
+checklist to run per pass, not a mandate that every package changes in every dimension.
+
+### Phase D — Wave 3
+
+Starts once Phase C has reached the packages Wave 3 actually touches —
+`pkg/provisioner/terraform` and `pkg/provisioner/kubernetes` specifically, both early in Phase C's
+order (step 2) — not necessarily after all of Phase C. Each Wave 3 item (TUI framework, async
+execution, interactive input) still gets its own ADR when reached, per the existing wave list above;
+this phase just confirms none of them are blocked on Phase C finishing in full.
+
+## Open questions to resolve next
+
+1. ~~**Target-architecture vision**~~ — resolved: [ADR 0002](0002-target-architecture-and-package-topology.md)
+   derives the topology from the current tree.
+2. **JSON output surface** — is JSON a global `--output json` that covers logs *and* errors *and*
+   progress events uniformly, or per-concern flags?
+3. **`WindsorError` code taxonomy** — flat string codes, numeric ranges per subsystem, or
+   category enums? Do codes appear in user-facing output for support/docs linking?
+4. **Async blast radius** — is concurrent Terraform gated behind a flag initially (opt-in), or the
+   default once the graph executor lands?
+5. **Per-package cleanup as PRs** — one PR per package (many small), or grouped by wave? Interacts
+   with the `large-pr` phased-change convention.
+6. **Beta cadence** — tag `0.10.0-beta.N` at each wave boundary, or continuous pre-releases?
+7. **Feature requests to slot in** — you mentioned prioritizing a few. List them so they can be
+   mapped onto the waves above.
+
+## ADR lifecycle policy
+
+`docs/adrs/` is tracked in git (no longer gitignored). ADRs number sequentially within a release
+cycle, starting at 0001. At the close of a release, every ADR is either deleted (fully implemented,
+or rejected with nothing left to do) or reduced to just its outstanding decision and carried
+forward into the next release's sequence, renumbered from 0001 — as happened at the top of this
+document. The directory never accumulates indefinitely; it reflects the current release's open and
+recently-closed decisions only. Long-term architectural history, once genuinely settled, belongs in
+reference docs (`docs/reference/`), not in an ever-growing ADR backlog.


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This PR only touches documentation and Claude skill files (no source or CLI behavior changes), so the blast radius is limited to planning artifacts and doc-generation guidance.
>
> **Overview**
>
> The PR untracks `docs/adrs/` from `.gitignore` and adds a release-planning document plus seven ADRs that scope the v0.10.0 cycle (target architecture, test strategy, comment standards, typed errors, structured logging, presenter/event stream, and the carried-forward apiv2 header schema work). It also expands the `go-style` and `test-engineer` skill docs with function-length, comment-discipline, black-box-testing, and mock-rationalization guidance that mirrors the new ADRs.
>
> Several of the "verified from source" facts backing these ADRs were spot-checked against the current tree (test black-box ratio, a claimed-dead `RegisterProvider` method, ADR 0001's source line citations) and held up. However, the release doc's own monolith-file line-count table and wrap-site count disagree with the sibling ADRs added in this same PR — see inline comments.

<!-- /claude-code-review:summary -->
