### PR TITLE
chore(docs): Docs v0.9.1 catchup prep

### DIFF
--- a/.claude/skills/architecture/SKILL.md
+++ b/.claude/skills/architecture/SKILL.md
@@ -54,6 +54,16 @@ If a change needs to run terraform or change how/when it runs, it belongs in `pk
 - Shims wrappers for external/system calls to keep logic testable (`pkg/runtime/*/shims.go`).
 - Explicit lifecycle sequencing in orchestration entrypoints (`cmd/env.go`, `pkg/runtime/runtime.go`).
 
+## Config/blueprint fields: three sources must agree
+
+A field on an `api/v1alpha1` struct (e.g. `AzureConfig`, `FluxSystem`) is not usable until three
+places agree: the Go struct, the JSON schema artifact under `pkg/runtime/config/schemas/artifacts/
+*.yaml` that the validator actually loads, and `docs/reference/*.md`. These artifacts declare
+`additionalProperties: false`, so a struct field missing from the artifact is silently rejected at
+validation time even though the Go type supports it — a real bug, not just a doc gap. When adding or
+renaming a field on a config/blueprint struct, update the schema artifact and the reference doc in
+the same PR; don't treat the struct change as done on its own.
+
 ## Do not introduce
 
 - Provider-specific syntax branching inside evaluator core.

--- a/docs/adrs/release-v0.9.1-docs.md
+++ b/docs/adrs/release-v0.9.1-docs.md
@@ -1,0 +1,71 @@
+# Release v0.9.1 — Docs Catch-Up Plan
+
+- Status: In progress
+- Date: 2026-08-04
+- Purpose: Scratch working plan, not an ADR. Tracks the docs punch list found while auditing
+  `docs/reference/**` against everything shipped between v0.8.1 and v0.9.0, and the order it's
+  getting done in. Deleted or folded into a proper changelog once v0.9.1 ships.
+
+## Why this exists
+
+v0.10.0 planning (see `release-v0.10.0.md`) allows breaking changes and touches architecture —
+the opposite of what we want live while we might need to cut an emergency patch. v0.9.1 is the
+safe place to land doc fixes: no architecture boundaries crossed, low risk, quick to release.
+
+## Sequence
+
+### 1. Verify Tier-1 schema-validation gaps — done
+
+Confirmed live via `SchemaValidator.Validate` against the real embedded artifacts: all three
+fields were real on their Go structs and rejected by the schema.
+
+- [x] `contexts{}.azure.region` (`AzureConfig.Region`) — was rejected
+      (`Additional property 'region' does not match the schema`). Fixed: added `region` to
+      `configuration.yaml`'s azure block.
+- [x] `flux[].globalDependency` (`FluxSystem.GlobalDependency`) — was rejected. Fixed: added to
+      `blueprint.yaml`'s flux-system object.
+- [x] `flux[].secrets` (`FluxSystem.Secrets`) — was rejected. Fixed: added `secrets` (with
+      `namespaces`/`data` sub-properties) to `blueprint.yaml`. `kustomize[].secrets` needed no fix
+      — that field is `yaml:"-"` (composer-internal only, never user-authored).
+
+Regression coverage added: `pkg/runtime/config/schema_artifacts_test.go` — loads the real
+artifacts and asserts each field validates, plus asserts unknown fields are still rejected (no
+regression toward over-permissiveness). `go build ./...`, `go vet ./pkg/runtime/config/...`, and
+`go test ./pkg/runtime/config/... ./pkg/composer/...` all pass.
+
+Staged, not committed — awaiting review before commit.
+
+### 2. Docs PR — global flags + secrets-file convention
+
+- [ ] Document `--lock-timeout`, `--no-cache`, `--verbose` (persistent flags on `cmd/root.go`,
+      currently absent from every command's flag table and from any global-flags page).
+- [ ] `docs/reference/contexts.md` — `secrets.yaml`/`.yml` (plaintext, gitignored) vs.
+      `secrets.enc.yaml`/`.yml` (SOPS-encrypted) convention, and the plaintext-refusal error.
+
+### 3. Docs PR — `blueprint.md` field-table completeness (depends on step 1's outcome)
+
+- [ ] Add `secrets` row + subsection to `flux[]`/`kustomize[]` tables (namespaces sub-key,
+      dockerconfigjson synthesis, owner-tracked pruning, auto-roll-on-change behavior).
+- [ ] Add `globalDependency` row.
+- [ ] Flesh out `contexts{}.terraform.lock.timeout` — currently only a source-code pointer, no
+      field/type/example.
+- [ ] Document the `sensitive: true` schema-authoring keyword (not used by any built-in schema
+      yet, but real and undiscoverable today).
+- [ ] Note near the `substitutions` field: `secret()` values are rejected there (must use
+      `secrets:` instead).
+
+### 4. Docs PR — small consistency fixes
+
+- [ ] `configuration.md` `vm.driver` enum — add a Hyper-V value or explain the gap.
+- [ ] Hetzner: kubernetes-backend-by-default behavior, and destroy-uses-local-state-for-
+      kubernetes-backend nuance.
+
+### 5. Downstream
+
+- [ ] Once v0.9.1 tags, bump `windsorcli.github.io`'s `docs/versions.yaml` CLI pin so the public
+      site picks up steps 2–4.
+
+## Reference
+
+Full punch list and repo-relationship notes captured in conversation on 2026-08-04; not
+duplicated here — this file is the sequencing checklist, not the research artifact.

--- a/docs/adrs/release-v0.9.1-docs.md
+++ b/docs/adrs/release-v0.9.1-docs.md
@@ -35,12 +35,21 @@ regression toward over-permissiveness). `go build ./...`, `go vet ./pkg/runtime/
 
 Staged, not committed — awaiting review before commit.
 
-### 2. Docs PR — global flags + secrets-file convention
+Swept every other top-level config block (`vsphere`, `aws`, `docker`, `git`, `cluster`, `network`,
+`dns`) struct-field-by-struct-field against its schema artifact as a sanity check — no further
+drift found. `cluster.controlplanes`/`.workers` are `additionalProperties: true` (permissive), so
+their under-documented field list is a pre-existing docs gap (already tracked in step 3), not a
+validation bug like azure/flux were.
 
-- [ ] Document `--lock-timeout`, `--no-cache`, `--verbose` (persistent flags on `cmd/root.go`,
-      currently absent from every command's flag table and from any global-flags page).
-- [ ] `docs/reference/contexts.md` — `secrets.yaml`/`.yml` (plaintext, gitignored) vs.
-      `secrets.enc.yaml`/`.yml` (SOPS-encrypted) convention, and the plaintext-refusal error.
+### 2. Docs PR — global flags + secrets-file convention — done
+
+- [x] New `docs/reference/commands/global-flags.md` documenting `--lock-timeout`, `--no-cache`,
+      `-v`/`--verbose`; cross-linked from `unlock.md`, `bootstrap.md`, `contexts.md`.
+- [x] `docs/reference/contexts.md` — new `## Secrets files` section covering `secrets.yaml`/`.yml`
+      (plaintext, gitignored) vs. `secrets.enc.yaml`/`.yml` (SOPS-encrypted), the content-not-
+      filename detection, and the plaintext-refusal error message. Verified flag defaults/behavior
+      and the dot-path key flattening directly against `cmd/root.go` and
+      `pkg/runtime/secrets/sops_provider.go` before writing.
 
 ### 3. Docs PR — `blueprint.md` field-table completeness (depends on step 1's outcome)
 

--- a/docs/reference/commands/bootstrap.md
+++ b/docs/reference/commands/bootstrap.md
@@ -42,4 +42,5 @@ windsor bootstrap prod --yes
 ## See also
 
 - [`init`](init.md), [`apply`](apply.md), [`destroy`](destroy.md)
+- [Global flags](global-flags.md) — `--no-cache`, `--lock-timeout`, `--verbose`
 - Source: [cmd/bootstrap.go](https://github.com/windsorcli/cli/blob/main/cmd/bootstrap.go)

--- a/docs/reference/commands/global-flags.md
+++ b/docs/reference/commands/global-flags.md
@@ -1,0 +1,32 @@
+---
+title: "Global flags"
+description: "Persistent flags accepted by every windsor command."
+---
+# Global flags
+
+These are persistent flags defined on the root command (`cmd/root.go`), not on any single
+subcommand — they're accepted by every `windsor` command but don't appear in an individual
+command's own `--help` flag list or in its reference page here.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `-v`, `--verbose` | `false` | Enable verbose output. |
+| `--no-cache` | `false` | Bypass the OCI artifact cache and force re-download of remote sources. Propagates to the `NO_CACHE` environment variable that `ArtifactBuilder.Pull` reads; an explicit `--no-cache` always wins over a pre-existing `NO_CACHE` in the environment. |
+| `--lock-timeout` | `0` (fail immediately) | Duration to wait for the stack lock before failing, e.g. `30s`, `5m`. Every command that acquires the per-context stack lock (`apply`, `up`, `bootstrap`, `destroy`, …) fails fast on contention by default; pass a duration to wait instead. See [`unlock`](unlock.md) for force-releasing a lock left behind by a killed holder. |
+
+## Examples
+
+```sh
+# Force a fresh pull of every OCI source instead of using the cache
+windsor apply --no-cache
+
+# Wait up to 5 minutes for the stack lock instead of failing immediately
+windsor apply --lock-timeout=5m
+```
+
+## See also
+
+- [Contexts directory](../contexts.md) — where the state these flags affect (locks, cached
+  artifacts) lives
+- [`unlock`](unlock.md)
+- Source: [cmd/root.go](https://github.com/windsorcli/cli/blob/main/cmd/root.go)

--- a/docs/reference/commands/unlock.md
+++ b/docs/reference/commands/unlock.md
@@ -32,4 +32,5 @@ windsor unlock --force
 ## See also
 
 - [`destroy`](destroy.md), [`up`](up.md)
+- [Global flags](global-flags.md) — `--lock-timeout` waits for a lock instead of failing immediately
 - Source: [cmd/unlock.go](https://github.com/windsorcli/cli/blob/main/cmd/unlock.go)

--- a/docs/reference/contexts.md
+++ b/docs/reference/contexts.md
@@ -24,6 +24,8 @@ contexts/
     ├── blueprint.yaml                      referential blueprint for this context
     ├── values.yaml                         user-set values that feed the schema
     ├── .env                                git-ignored operator env vars (e.g. provider credentials)
+    ├── secrets.enc.yaml                    SOPS-encrypted secrets, safe to commit
+    ├── secrets.yaml                        git-ignored plaintext secrets (pre-encryption / local-only)
     ├── terraform/<component-id>.tfvars     user-edited Terraform variable overrides
     ├── terraform/<component-id>.tfvars.json  JSON variant of the above
     ├── terraform/backend.tfvars            optional Terraform backend overrides
@@ -63,6 +65,8 @@ live under `contexts/<context-name>/`.
 | `terraform/backend.tfvars` | HCL | Optional overrides applied to the Terraform backend init. |
 | `terraform/.env` | dotenv | Terraform-only operator env vars, auto-git-ignored. See [Terraform-scoped `.env`](#terraform-scoped-env) below. |
 | `.env` | dotenv | Operator-supplied environment variables, auto-git-ignored. See [`.env` files](#env-files) below. |
+| `secrets.yaml`, `secrets.yml` | YAML | Secrets file, auto-git-ignored. See [Secrets files](#secrets-files) below. |
+| `secrets.enc.yaml`, `secrets.enc.yml` | YAML | SOPS-encrypted secrets file, safe to commit. See [Secrets files](#secrets-files) below. |
 | `.aws/config`, `.aws/credentials` | INI | AWS CLI files; the env hook sets `AWS_CONFIG_FILE` and `AWS_SHARED_CREDENTIALS_FILE` so `aws` commands inside the windsor shell write here instead of `~/.aws/`. |
 | `.azure/` | Directory | Azure CLI config; `AZURE_CONFIG_DIR` points `az` here. |
 | `.gcp/gcloud/` | Directory | gcloud CLI config; `CLOUDSDK_CONFIG` points `gcloud` here. |
@@ -114,6 +118,26 @@ line would just have it silently reappear. Appending `!.env` after it is
 stable: the line is still present, so Windsor leaves the file alone, and
 git's own last-match-wins rule un-ignores the file anyway.
 
+## Secrets files
+
+`contexts/<context-name>/secrets.yaml` (or `secrets.yml`) holds values resolved by `secret(...)`
+expressions elsewhere in config — the counterpart to `.env` for values that fit a nested YAML
+structure rather than a flat key/value dotenv file. Nested keys flatten to dot-path lookups (e.g.
+a `database: {password: ...}` entry resolves as `database.password`). Content, not the filename,
+decides whether a file is treated as SOPS-encrypted: an operator's own SOPS output can carry
+either the `secrets.yaml` or `secrets.enc.yaml` name. Windsor tries to decrypt every
+`secrets*.yaml`/`secrets*.yml` file it finds, in the order above.
+
+A `secrets.yaml`/`secrets.yml` that fails to decrypt is refused with a clear error — "refusing to
+load unencrypted secrets file ...: encrypt it with sops before use (see secrets.enc.yaml)" —
+rather than a raw SOPS failure, because the far more likely cause is a genuinely plaintext file
+that was never encrypted. Encrypt it with `sops -e` and rename it `secrets.enc.yaml` (or
+`secrets.enc.yml`) once it holds real values.
+
+- `secrets.yaml`/`secrets.yml` — conventionally plaintext (pre-encryption or local-only scratch
+  values); auto-git-ignored, same as `.env`.
+- `secrets.enc.yaml`/`secrets.enc.yml` — SOPS-encrypted; safe to commit and stays tracked.
+
 ## Terraform-scoped `.env`
 
 `contexts/<context-name>/terraform/.env` is a second, narrower dotenv file
@@ -138,3 +162,4 @@ latency.
 - [Blueprint reference](blueprint.md), [Configuration reference](configuration.md)
 - [Metadata reference](metadata.md), [Testing reference](testing.md)
 - [`init`](commands/init.md), [`set`](commands/set.md), [`get`](commands/get.md), [`bootstrap`](commands/bootstrap.md)
+- [Global flags](commands/global-flags.md)

--- a/pkg/runtime/config/schema_artifacts_test.go
+++ b/pkg/runtime/config/schema_artifacts_test.go
@@ -1,0 +1,162 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/windsorcli/cli/pkg/runtime/shell"
+)
+
+// loadArtifactValidator loads a production schema artifact from schemas/artifacts/ into a fresh
+// SchemaValidator, so tests exercise the exact JSON schema the CLI validates user config against.
+func loadArtifactValidator(t *testing.T, artifact string) *SchemaValidator {
+	t.Helper()
+	v := NewSchemaValidator(shell.NewMockShell())
+	content, err := os.ReadFile(filepath.Join("schemas", "artifacts", artifact))
+	if err != nil {
+		t.Fatalf("read %s: %v", artifact, err)
+	}
+	if err := v.LoadSchemaFromBytes(content); err != nil {
+		t.Fatalf("load %s: %v", artifact, err)
+	}
+	return v
+}
+
+// TestSchemaArtifacts_ConfigurationFieldsPresent guards against a Go struct field existing
+// without a corresponding property in the strict (additionalProperties: false) configuration
+// schema artifact, which silently rejects valid user config at validation time.
+func TestSchemaArtifacts_ConfigurationFieldsPresent(t *testing.T) {
+	t.Run("azure.region validates", func(t *testing.T) {
+		// Given the production configuration schema artifact
+		validator := loadArtifactValidator(t, "configuration.yaml")
+
+		// When validating a context that sets azure.region
+		result, err := validator.Validate(map[string]any{
+			"version": "v1alpha1",
+			"contexts": map[string]any{
+				"test": map[string]any{
+					"azure": map[string]any{"region": "eastus"},
+				},
+			},
+		})
+
+		// Then it validates without error
+		if err != nil {
+			t.Fatalf("Validate returned error: %v", err)
+		}
+		if !result.Valid {
+			t.Errorf("expected valid, got errors: %v", result.Errors)
+		}
+	})
+
+	t.Run("azure rejects unknown fields", func(t *testing.T) {
+		// Given the production configuration schema artifact
+		validator := loadArtifactValidator(t, "configuration.yaml")
+
+		// When validating an azure block with an unrecognized field
+		result, _ := validator.Validate(map[string]any{
+			"version": "v1alpha1",
+			"contexts": map[string]any{
+				"test": map[string]any{
+					"azure": map[string]any{"bogus": "nope"},
+				},
+			},
+		})
+
+		// Then it is rejected
+		if result.Valid {
+			t.Error("expected invalid for unknown azure field")
+		}
+	})
+}
+
+// TestSchemaArtifacts_BlueprintFieldsPresent guards against the same drift on the strict
+// blueprint schema artifact for fields on FluxSystem that are real on the Go struct.
+func TestSchemaArtifacts_BlueprintFieldsPresent(t *testing.T) {
+	baseBlueprint := func(fluxEntry map[string]any) map[string]any {
+		return map[string]any{
+			"apiVersion": "blueprints.windsorcli.dev/v1alpha1",
+			"kind":       "Blueprint",
+			"metadata":   map[string]any{"name": "test"},
+			"flux":       []any{fluxEntry},
+		}
+	}
+
+	t.Run("flux.globalDependency validates", func(t *testing.T) {
+		// Given the production blueprint schema artifact
+		validator := loadArtifactValidator(t, "blueprint.yaml")
+
+		// When validating a flux system with globalDependency set
+		result, err := validator.Validate(baseBlueprint(map[string]any{
+			"name":             "policy",
+			"globalDependency": true,
+		}))
+
+		// Then it validates without error
+		if err != nil {
+			t.Fatalf("Validate returned error: %v", err)
+		}
+		if !result.Valid {
+			t.Errorf("expected valid, got errors: %v", result.Errors)
+		}
+	})
+
+	t.Run("flux.secrets validates with namespaces and data", func(t *testing.T) {
+		// Given the production blueprint schema artifact
+		validator := loadArtifactValidator(t, "blueprint.yaml")
+
+		// When validating a flux system declaring a Secret with namespaces and data
+		result, err := validator.Validate(baseBlueprint(map[string]any{
+			"name": "policy",
+			"secrets": map[string]any{
+				"creds": map[string]any{
+					"namespaces": []any{"policy-system"},
+					"data":       map[string]any{"token": `${secret("foo")}`},
+				},
+			},
+		}))
+
+		// Then it validates without error
+		if err != nil {
+			t.Fatalf("Validate returned error: %v", err)
+		}
+		if !result.Valid {
+			t.Errorf("expected valid, got errors: %v", result.Errors)
+		}
+	})
+
+	t.Run("flux.secrets entry rejects unknown fields", func(t *testing.T) {
+		// Given the production blueprint schema artifact
+		validator := loadArtifactValidator(t, "blueprint.yaml")
+
+		// When validating a secrets entry with an unrecognized field
+		result, _ := validator.Validate(baseBlueprint(map[string]any{
+			"name": "policy",
+			"secrets": map[string]any{
+				"creds": map[string]any{"bogus": "nope"},
+			},
+		}))
+
+		// Then it is rejected
+		if result.Valid {
+			t.Error("expected invalid for unknown secrets entry field")
+		}
+	})
+
+	t.Run("flux rejects unknown fields", func(t *testing.T) {
+		// Given the production blueprint schema artifact
+		validator := loadArtifactValidator(t, "blueprint.yaml")
+
+		// When validating a flux system with an unrecognized field
+		result, _ := validator.Validate(baseBlueprint(map[string]any{
+			"name":  "policy",
+			"bogus": "nope",
+		}))
+
+		// Then it is rejected
+		if result.Valid {
+			t.Error("expected invalid for unknown flux field")
+		}
+	})
+}

--- a/pkg/runtime/config/schemas/artifacts/blueprint.yaml
+++ b/pkg/runtime/config/schemas/artifacts/blueprint.yaml
@@ -357,6 +357,13 @@ properties:
         ordinal:
           type: integer
           description: Overrides the facet ordinal for this system's merge precedence.
+        globalDependency:
+          type: boolean
+          description: |
+            When true, every kustomization and system outside this system's own
+            dependency closure is wired to depend on its terminal tier (resources
+            if present, else install). Declares a cluster-wide precondition once
+            instead of repeating it as dependsOn on every consumer.
         install:
           type: object
           additionalProperties: false
@@ -557,6 +564,36 @@ properties:
                       name:
                         type: string
                         description: The Secret's name, resolved in the variant's namespace.
+        secrets:
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties: false
+            properties:
+              namespaces:
+                type: array
+                items:
+                  type: string
+                description: |
+                  Namespaces to place this Secret into. Empty means auto-resolve the
+                  single namespace the owning kustomization creates; each named
+                  namespace must be one that kustomization provably created.
+              data:
+                type: object
+                additionalProperties:
+                  type: string
+                description: |
+                  Secret data: data key -> expression resolved at apply time (a
+                  '${...}' config reference, a secret() call, or an env("NAME")
+                  lookup), never a plaintext literal, and never rendered or written
+                  in plaintext. Materializes as an Opaque Secret by default; a
+                  '.dockerconfigjson' key, or 'docker-username' plus
+                  'docker-password' (optional 'docker-server', defaulting to
+                  'ghcr.io'), materializes as kubernetes.io/dockerconfigjson instead.
+          description: |
+            Kubernetes Secrets for this system, keyed by Secret name. Removing an
+            entry prunes the corresponding cluster Secret on next apply; changing
+            an entry's resolved data rolls workloads that reference it.
   substitutions:
     type: object
     additionalProperties:

--- a/pkg/runtime/config/schemas/artifacts/configuration.yaml
+++ b/pkg/runtime/config/schemas/artifacts/configuration.yaml
@@ -186,6 +186,9 @@ $defs:
       kubelogin_mode:
         type: string
         description: kubelogin auth mode (e.g. 'azurecli', 'workloadidentity').
+      region:
+        type: string
+        description: Azure region. Exported to downstream tools as TF_VAR_region.
   gcp:
     type: object
     additionalProperties: false


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This PR fixes a validation gap in two JSON schema artifacts and catches up several docs pages; it touches no runtime code paths and adds regression coverage, so blast radius is limited to config validation for previously-rejected-but-valid fields.
>
> **Overview**
>
> Three Go struct fields (`AzureConfig.Region`, `FluxSystem.GlobalDependency`, `FluxSystem.Secrets`) were real and settable in code but silently rejected by the strict (`additionalProperties: false`) schema artifacts used for validation. This PR adds the missing `region`, `globalDependency`, and `secrets` properties to `configuration.yaml` and `blueprint.yaml`, adds a new `schema_artifacts_test.go` that loads the real embedded artifacts and asserts both the fix and that unknown fields still get rejected, and documents a new "three sources must agree" convention in the `architecture` skill so this class of drift is caught earlier next time.
>
> The docs portion adds a new `global-flags.md` reference page for previously-undocumented persistent flags (`--no-cache`, `--lock-timeout`, `-v`/`--verbose`) and a "Secrets files" section in `contexts.md` describing the `secrets.yaml` vs `secrets.enc.yaml` convention, both cross-checked against the actual `cmd/root.go` and `sops_provider.go` behavior. All descriptions and field names were verified directly against the corresponding Go source in this review.

<!-- /claude-code-review:summary -->
