### PR TITLE
chore(docs): update documentation for sensitive values and schema properties

### DIFF
--- a/docs/adrs/release-v0.9.1-docs.md
+++ b/docs/adrs/release-v0.9.1-docs.md
@@ -51,17 +51,29 @@ validation bug like azure/flux were.
       and the dot-path key flattening directly against `cmd/root.go` and
       `pkg/runtime/secrets/sops_provider.go` before writing.
 
-### 3. Docs PR — `blueprint.md` field-table completeness (depends on step 1's outcome)
+### 3. Docs PR — `blueprint.md` field-table completeness — done
 
-- [ ] Add `secrets` row + subsection to `flux[]`/`kustomize[]` tables (namespaces sub-key,
-      dockerconfigjson synthesis, owner-tracked pruning, auto-roll-on-change behavior).
-- [ ] Add `globalDependency` row.
-- [ ] Flesh out `contexts{}.terraform.lock.timeout` — currently only a source-code pointer, no
-      field/type/example.
-- [ ] Document the `sensitive: true` schema-authoring keyword (not used by any built-in schema
-      yet, but real and undiscoverable today).
-- [ ] Note near the `substitutions` field: `secret()` values are rejected there (must use
-      `secrets:` instead).
+- [x] Added `flux[].secrets` row + `### flux[].secrets` subsection (`namespaces`, `data`,
+      dockerconfigjson synthesis, owner-tracked pruning, auto-roll-on-change). Noted
+      `kustomize[].secrets` is composer-internal only (`yaml:"-"`), not user-authored — no row
+      needed there.
+- [x] Added `flux[].globalDependency` row.
+- [x] `contexts{}.terraform.lock.timeout` — new subsection in `configuration.md` with real
+      field/type/default/example, verified against `pkg/runtime/terraform/provider.go`. Corrected
+      the actual constraint along the way: it's not `secret()` calls specifically that get
+      rejected in substitutions, it's any reference to a property marked `sensitive: true` — a
+      broader and more accurate rule.
+- [x] Documented the `sensitive: true` schema-authoring keyword — new `### Marking values
+      sensitive` section in `contexts.md`, cross-linked from `show-values.md` (where the
+      `<sensitive>` redaction actually renders) and from the substitutions-rejection note in
+      `blueprint.md`.
+- [x] Disambiguated the two same-named "lock timeout" concepts two ways: Windsor's own stack lock
+      (`--lock-timeout` global flag, step 2) vs. terraform's native state lock
+      (`terraform.lock.timeout` config field, this step) — each page now links to the other.
+
+All claims verified directly against source before writing (`pkg/composer/blueprint/processor.go`
+`evaluateSubstitutions`/`sensitivePathsInValue`, `pkg/runtime/config/values_renderer.go`
+`RedactSensitiveValues`, `cmd/show.go`) rather than trusting the earlier recon-agent summaries.
 
 ### 4. Docs PR — small consistency fixes
 

--- a/docs/reference/blueprint.md
+++ b/docs/reference/blueprint.md
@@ -27,6 +27,12 @@ variable substitutions shared across them.
 | `substitutions` | `map<string>` | Blueprint-level substitutions injected into 'values-common' and made available to every kustomization via PostBuild substitution. Values may use expression syntax (e.g. '${dns.domain}') resolved against facet config blocks. |
 | `terraform` | `array<object>` | Terraform components included in the blueprint, in declaration order. Components are reordered topologically by dependsOn at apply time. |
 
+Any `substitutions`/`substitute` value (blueprint-level, or on a `kustomize[]`, `flux[].install`,
+or `flux[].resources[]` entry) that references a schema property marked `sensitive: true` is
+rejected at composition time — substitutions render into a plaintext ConfigMap, so a sensitive
+value would leak. Use [`flux[].secrets`](#fluxsecrets) instead; it resolves and places the value
+as a real Kubernetes Secret, never rendered in plaintext.
+
 ## metadata
 
 | Field | Type | Description |
@@ -42,10 +48,12 @@ variable substitutions shared across them.
 | `dependsOn` | `array<string>` | Cross-layer edges to other systems (a bare '<other>' resolves to '<other>-install'). Attached to the install tier when present (resources reach them transitively), otherwise to each variant. |
 | `destroy` | `boolean / string` | Whether the system's kustomizations are removed on teardown. Defaults to true. |
 | `enabled` | `boolean / string` | Include or exclude the whole system. Defaults to true. |
+| `globalDependency` | `boolean` | When true, every kustomization and system outside this system's own dependency closure is wired to depend on its terminal tier (resources if present, else install). Declares a cluster-wide precondition (e.g. admission policies that must be enforcing before any workload lands) once, instead of repeating it as a dependsOn on every consumer. |
 | `install` | `object` | Controller/operator tier. Reuses the Kustomization shape — its components/substitute and operational properties (interval, timeout, wait, prune, patches, namespace, …) flow to '<name>-install'; its name/path/dependsOn are derived. When every component prunes to empty, no install Kustomization is emitted. |
 | `ordinal` | `integer` | Overrides the facet ordinal for this system's merge precedence. |
 | `path` | `string` | Base path; tiers reconcile from '<path>/install' and '<path>/resources'. Defaults to name. |
 | `resources` | `array<object>` | Custom-resource tier variants, all sharing '<path>/resources'. |
+| `secrets` | `map<object>` | Kubernetes Secrets for this system, keyed by Secret name. See [flux[].secrets](#fluxsecrets) below. |
 | `source` | `string` | Name of the source that provides the tier bases. |
 | `strategy` | `string` | How a system with this name merges across facets. Defaults to merge. One of: `merge`, `replace`, `remove`. |
 | `when` | `string` | Gates the system; combined (AND) with each resources variant's condition. |
@@ -138,6 +146,20 @@ variable substitutions shared across them.
 | `patch` | `string` |  |
 | `path` | `string` |  |
 | `target` | `object` |  |
+
+### flux[].secrets
+
+| Field | Type | Description |
+|------|------|-------------|
+| `namespaces` | `array<string>` | Namespaces to place this Secret into. Empty means auto-resolve the single namespace the owning kustomization creates; each named namespace must be one that kustomization provably created. |
+| `data` | `map<string>` | Secret data: data key -> expression resolved at apply time (a '${...}' config reference, a secret() call, or an env("NAME") lookup) — never a plaintext literal, and never rendered or written in plaintext. Materializes as an Opaque Secret by default; a '.dockerconfigjson' key, or 'docker-username' plus 'docker-password' (optional 'docker-server', defaulting to 'ghcr.io'), materializes as kubernetes.io/dockerconfigjson instead, for use as an imagePullSecret. |
+
+Removing an entry prunes the corresponding cluster Secret on the next apply. Changing an entry's
+resolved data rolls the workloads that reference it, so consumers pick up the new value without a
+manual restart.
+
+`kustomize[]` entries carry an internal `Secrets` field of the same shape, populated by composition
+from the owning `flux[]` system — it isn't user-authored and doesn't appear in `kustomize.yaml`.
 
 ## kustomize[]
 
@@ -286,7 +308,9 @@ substitutions:
 
 ## See also
 
-- [Facets reference](facets.md), [Metadata reference](metadata.md), [Schema reference](schema.md)
+- [Facets reference](facets.md), [Metadata reference](metadata.md)
+- [Contexts directory](contexts.md) — `schema.yaml`, the JSON Schema that validates context input
+  values
 - [`apply`](commands/apply.md), [`up`](commands/up.md), [`bootstrap`](commands/bootstrap.md), [`destroy`](commands/destroy.md)
 - [`show blueprint`](commands/show-blueprint.md), [`explain`](commands/explain.md)
 - [Lifecycle guide](https://www.windsorcli.dev/docs/cli/lifecycle), [Sharing blueprints](https://www.windsorcli.dev/docs/blueprints/sharing)

--- a/docs/reference/commands/global-flags.md
+++ b/docs/reference/commands/global-flags.md
@@ -12,7 +12,7 @@ command's own `--help` flag list or in its reference page here.
 |------|---------|-------------|
 | `-v`, `--verbose` | `false` | Enable verbose output. |
 | `--no-cache` | `false` | Bypass the OCI artifact cache and force re-download of remote sources. Propagates to the `NO_CACHE` environment variable that `ArtifactBuilder.Pull` reads; an explicit `--no-cache` always wins over a pre-existing `NO_CACHE` in the environment. |
-| `--lock-timeout` | `0` (fail immediately) | Duration to wait for the stack lock before failing, e.g. `30s`, `5m`. Every command that acquires the per-context stack lock (`apply`, `up`, `bootstrap`, `destroy`, …) fails fast on contention by default; pass a duration to wait instead. See [`unlock`](unlock.md) for force-releasing a lock left behind by a killed holder. |
+| `--lock-timeout` | `0` (fail immediately) | Duration to wait for **Windsor's own stack lock** before failing, e.g. `30s`, `5m`. Every command that acquires the per-context stack lock (`apply`, `up`, `bootstrap`, `destroy`, …) fails fast on contention by default; pass a duration to wait instead. See [`unlock`](unlock.md) for force-releasing a lock left behind by a killed holder. Distinct from `terraform.lock.timeout` in the [Configuration reference](../configuration.md), which governs terraform's own native state lock. |
 
 ## Examples
 

--- a/docs/reference/commands/show-values.md
+++ b/docs/reference/commands/show-values.md
@@ -10,6 +10,8 @@ windsor show values [flags]
 
 Print the effective context values, merging schema defaults with values.yaml overrides. YAML output includes schema descriptions as comments. Use --json for plain JSON.
 
+A property marked `sensitive: true` in its schema renders as `<sensitive>` instead of its actual value. See [Marking values sensitive](../contexts.md#marking-values-sensitive).
+
 ## Flags
 
 | Flag | Default | Description |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -173,7 +173,13 @@ system-managed and not covered here.
 |------|------|-------------|
 | `backend` | `object` | State backend configuration (type plus per-type fields). See api/v1alpha1/terraform/terraform_config.go for the full BackendConfig field set (s3, azurerm, kubernetes, local, oss). |
 | `enabled` | `boolean` | Whether terraform components are applied for this context. |
-| `lock` | `object` | State-lock policy (timeout). See api/v1alpha1/terraform/terraform_config.go for LockConfig fields. |
+| `lock` | `object` | State-lock policy. See below. |
+
+#### contexts{}.terraform.lock
+
+| Field | Type | Description |
+|------|------|-------------|
+| `timeout` | `string` | How long terraform waits to acquire its own state lock before failing, as a Go duration string (e.g. '30s', '5m'). Passed as `-lock-timeout` to every state-touching terraform subcommand (init, plan, apply, refresh, destroy, import). Defaults to '5m'. An invalid duration is rejected before terraform runs. This is terraform's native state lock, distinct from Windsor's own stack lock — see the global [`--lock-timeout`](commands/global-flags.md) flag and [`unlock`](commands/unlock.md) for that one. |
 
 ### contexts{}.vm
 

--- a/docs/reference/contexts.md
+++ b/docs/reference/contexts.md
@@ -54,6 +54,27 @@ contexts/
 The same template is reused across every context. Per-context inputs
 live under `contexts/<context-name>/`.
 
+### Marking values sensitive
+
+Add `sensitive: true` alongside any property in `schema.yaml` (or `windsor.yaml`'s own schema) to
+have that value's path redacted as `<sensitive>` wherever config is displayed — currently
+[`windsor show values`](commands/show-values.md). It doesn't change how the value is stored or
+resolved, only how it's rendered back to the operator.
+
+```yaml
+properties:
+  hetzner:
+    properties:
+      token:
+        type: string
+        sensitive: true
+```
+
+A `substitutions`/`substitute` value that references a `sensitive: true` property is rejected at
+composition time rather than rendered into a plaintext ConfigMap — see the note in the
+[Blueprint reference](blueprint.md). No built-in Windsor schema marks a property sensitive today;
+this is for custom facet/context schemas that need it.
+
 ## `<context-name>/`
 
 | Path | Type | Description |


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Documentation-only change across five reference pages and one ADR; no code, schema, or behavior is touched.
>
> **Overview**
>
> This PR closes out the pending "docs PR" checklist item in `release-v0.9.1-docs.md` by documenting three previously-undocumented blueprint concepts: `flux[].secrets` (and the related `flux[].globalDependency` field), the `contexts{}.terraform.lock.timeout` config field, and the `sensitive: true` schema-authoring keyword. Cross-links are added between the two same-named "lock timeout" concepts (Windsor's stack lock vs. terraform's native state lock) and between the sensitive-value redaction behavior in `show-values.md` and its source in `contexts.md`.
>
> One claim is stated more absolutely than the code backs up: `blueprint.md` and `contexts.md` both say a substitution referencing a `sensitive: true` property "is rejected at composition time," but the underlying check (`sensitivePathsInValue` in `pkg/composer/blueprint/processor.go`) only catches bare `${path}` interpolation — a sensitive path embedded in a larger expression is explicitly left uncaught per the function's own doc comment. See the inline comment for details.

<!-- /claude-code-review:summary -->
