### PR TITLE
fix(kubernetes): ensure kustomizations are resumed on delete failure

### DIFF
--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -1298,6 +1298,13 @@ func (k *BaseKubernetesManager) ApplyBlueprint(blueprint *blueprintv1alpha1.Blue
 //     orphaned cloud resources. Re-running destroy after the operator restores the
 //     controller picks up where it left off — already-deleted Kustomizations
 //     short-circuit to NotFound on retry.
+//
+//     Every abort path (suspend failure, load balancer remediation failure, or a
+//     per-Kustomization resume/delete failure) runs abortDestroy first, which
+//     un-suspends the full eligible set before returning. Without this, Kustomizations
+//     suspended by the up-front suspend loop but not yet reached by the destroy walk
+//     would stay suspended forever — Install/ApplyBlueprint never resets spec.suspend
+//     on existing objects, so no subsequent bootstrap would self-heal them.
 func (k *BaseKubernetesManager) DeleteBlueprint(blueprint *blueprintv1alpha1.Blueprint, namespace string) error {
 	defaultSourceName := blueprint.Metadata.Name
 
@@ -1331,28 +1338,45 @@ func (k *BaseKubernetesManager) DeleteBlueprint(blueprint *blueprintv1alpha1.Blu
 	}
 	for _, kustomization := range eligible {
 		if err := k.setKustomizationSuspend(kustomization.Name, namespace, true); err != nil {
-			return fmt.Errorf("destroy aborted: failed to suspend kustomization %q: %w", kustomization.Name, err)
+			return k.abortDestroy(eligible, namespace, fmt.Errorf("destroy aborted: failed to suspend kustomization %q: %w", kustomization.Name, err))
 		}
 	}
 
 	if err := k.remediateLoadBalancerOwners(eligible, namespace); err != nil {
-		return fmt.Errorf("destroy aborted: %w", err)
+		return k.abortDestroy(eligible, namespace, fmt.Errorf("destroy aborted: %w", err))
 	}
 
 	for _, kustomization := range orderForDestroy(eligible, "destroy") {
 		tui.Start(fmt.Sprintf("Destroying kustomization %s", kustomization.Name))
 		if err := k.setKustomizationSuspend(kustomization.Name, namespace, false); err != nil {
 			tui.Fail()
-			return fmt.Errorf("destroy aborted: failed to resume kustomization %q before delete: %w", kustomization.Name, err)
+			return k.abortDestroy(eligible, namespace, fmt.Errorf("destroy aborted: failed to resume kustomization %q before delete: %w", kustomization.Name, err))
 		}
 		if err := k.DeleteKustomization(kustomization.Name, namespace); err != nil {
 			tui.Fail()
-			return fmt.Errorf("destroy aborted: failed to delete kustomization %q: %w (further deletions skipped to avoid cascading orphans)", kustomization.Name, err)
+			return k.abortDestroy(eligible, namespace, fmt.Errorf("destroy aborted: failed to delete kustomization %q: %w (further deletions skipped to avoid cascading orphans)", kustomization.Name, err))
 		}
 		tui.Done()
 	}
 
 	return nil
+}
+
+// abortDestroy un-suspends every eligible Kustomization before propagating cause, so a
+// DeleteBlueprint failure never leaves objects suspended by the up-front suspend loop with
+// nothing left to resume them — Install/ApplyBlueprint never resets spec.suspend on existing
+// objects, so a leftover suspend from an aborted destroy would otherwise persist indefinitely
+// across subsequent bootstrap runs. setKustomizationSuspend is a no-op against objects that are
+// already unsuspended or gone, so calling it on the full eligible set is safe regardless of how
+// far the destroy walk got. Un-suspend failures are joined with cause rather than swallowed.
+func (k *BaseKubernetesManager) abortDestroy(eligible []blueprintv1alpha1.Kustomization, namespace string, cause error) error {
+	errs := []error{cause}
+	for _, kustomization := range eligible {
+		if err := k.setKustomizationSuspend(kustomization.Name, namespace, false); err != nil {
+			errs = append(errs, fmt.Errorf("failed to un-suspend kustomization %q during abort cleanup: %w", kustomization.Name, err))
+		}
+	}
+	return errors.Join(errs...)
 }
 
 // PruneBlueprint deletes Kustomizations belonging to the current context that are no longer part of

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -3330,6 +3330,78 @@ func TestBaseKubernetesManager_DeleteBlueprint(t *testing.T) {
 		}
 	})
 
+	t.Run("UnsuspendsRemainingKustomizationsWhenDeleteFails", func(t *testing.T) {
+		// Given a blueprint with two eligible kustomizations, ordered so that
+		// deleting the first fails
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+
+		var events []string
+		kubernetesClient.PatchResourceFunc = func(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*unstructured.Unstructured, error) {
+			switch string(data) {
+			case `{"spec":{"suspend":true}}`:
+				events = append(events, "suspend:"+name)
+			case `{"spec":{"suspend":false}}`:
+				events = append(events, "resume:"+name)
+			}
+			return nil, nil
+		}
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			events = append(events, "delete:"+name)
+			if name == "test-kustomization-2" {
+				return fmt.Errorf("finalizer stuck")
+			}
+			return nil
+		}
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			return nil, fmt.Errorf("the server could not find the requested resource")
+		}
+		manager.client = kubernetesClient
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Metadata: blueprintv1alpha1.Metadata{Name: "test-blueprint"},
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "test-kustomization-1"},
+				{Name: "test-kustomization-2"},
+			},
+		}
+
+		// When the blueprint delete aborts on the first-processed kustomization's
+		// failed delete (no DependsOn, so the destroy walk visits the input in
+		// reverse: test-kustomization-2 then test-kustomization-1)
+		err := manager.DeleteBlueprint(blueprint, "test-namespace")
+
+		// Then the error is surfaced and test-kustomization-1 — suspended up
+		// front but never reached by the destroy walk before the abort — is
+		// resumed by the abort cleanup instead of being left permanently suspended
+		if err == nil {
+			t.Fatal("Expected error when delete fails, got nil")
+		}
+		if !strings.Contains(err.Error(), "failed to delete kustomization") {
+			t.Errorf("Expected delete-failure error, got %v", err)
+		}
+
+		resumed := map[string]bool{}
+		for _, e := range events {
+			if strings.HasPrefix(e, "resume:") {
+				resumed[strings.TrimPrefix(e, "resume:")] = true
+			}
+		}
+		if !resumed["test-kustomization-1"] {
+			t.Errorf("Expected test-kustomization-1 to be resumed by abort cleanup, got events %v", events)
+		}
+
+		deleted := map[string]bool{}
+		for _, e := range events {
+			if strings.HasPrefix(e, "delete:") {
+				deleted[strings.TrimPrefix(e, "delete:")] = true
+			}
+		}
+		if deleted["test-kustomization-1"] {
+			t.Errorf("Expected test-kustomization-1 not to be deleted after abort, got events %v", events)
+		}
+	})
+
 	t.Run("SuccessWithDestroyOnlyKustomizations", func(t *testing.T) {
 		manager := setup(t)
 		kubernetesClient := client.NewMockKubernetesClient()


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This change touches the Kustomization destroy/abort path in the Kubernetes provisioner — production teardown logic — but the change itself is narrow and additive to error handling rather than the happy path.
>
> **Overview**
>
> `DeleteBlueprint` previously left any Kustomization that had been suspended by the up-front freeze-all loop but not yet reached by the destroy walk permanently suspended if a later step (suspend, load-balancer remediation, resume-before-delete, or delete) failed and the function returned early. This PR adds an `abortDestroy` helper that un-suspends the full eligible set on every abort path before returning, so an interrupted destroy no longer leaves orphaned suspended Kustomizations that nothing would later self-heal (`Install`/`ApplyBlueprint` never resets `spec.suspend` on existing objects).
>
> Un-suspend failures encountered during cleanup are joined (via `errors.Join`) with the original abort cause rather than swallowed, so the original error remains visible even if cleanup itself has trouble. A new unit test verifies that a mid-walk delete failure still resumes the untouched-but-suspended Kustomization instead of leaving it suspended.

<!-- /claude-code-review:summary -->
