### PR TITLE
fix(apply): refuse apply kustomize on unresolved terraform_output() substitutions

### DIFF
--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -186,6 +186,19 @@ windsor apply kustomize dns --wait`,
 		if blueprint == nil {
 			return fmt.Errorf("blueprint is not available")
 		}
+
+		scope := make(map[string]bool)
+		if len(args) == 0 {
+			for _, k := range blueprint.Kustomizations {
+				scope[k.Name] = true
+			}
+		} else {
+			scope[args[0]] = true
+		}
+		if deferred := proj.Composer.BlueprintHandler.GetDeferredPaths(); deferredSubstitutionsInScope(deferred, scope) {
+			return fmt.Errorf("unresolved terraform_output() substitutions in scope; run `windsor apply` (or `windsor upgrade`) first so this apply doesn't overwrite a resolved ConfigMap value with raw expression text")
+		}
+
 		waitBlueprint := blueprint
 
 		return stacklock.With(cmd.Context(), proj.Runtime, "apply", lockTimeout, func() error {
@@ -219,6 +232,32 @@ windsor apply kustomize dns --wait`,
 			return nil
 		})
 	},
+}
+
+// deferredSubstitutionsInScope reports whether any deferred substitution path is something
+// `apply kustomize` is about to write to the cluster. Blueprint-level ConfigMaps and global
+// substitutions are always in scope, since ApplyBlueprint writes them unconditionally regardless
+// of which single kustomization was requested; per-kustomization substitutions are in scope only
+// when their owning kustomization name appears in scope. `apply kustomize` calls Generate(), not
+// GenerateResolved(), so any still-deferred terraform_output() expression would otherwise be
+// serialized into a values-<kustomization> ConfigMap as raw, unevaluated text — silently
+// overwriting whatever a prior full apply had already resolved there.
+func deferredSubstitutionsInScope(deferred map[string]bool, scope map[string]bool) bool {
+	for path := range deferred {
+		if strings.HasPrefix(path, "configmaps.") || strings.HasPrefix(path, "substitutions.") {
+			return true
+		}
+		rest, ok := strings.CutPrefix(path, "kustomize.")
+		if !ok {
+			continue
+		}
+		for name := range scope {
+			if rest == name || strings.HasPrefix(rest, name+".") {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 func init() {

--- a/cmd/apply.go
+++ b/cmd/apply.go
@@ -190,6 +190,9 @@ windsor apply kustomize dns --wait`,
 		scope := make(map[string]bool)
 		if len(args) == 0 {
 			for _, k := range blueprint.Kustomizations {
+				if k.DestroyOnly != nil && *k.DestroyOnly {
+					continue
+				}
 				scope[k.Name] = true
 			}
 		} else {

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -836,6 +836,39 @@ func TestApplyKustomizeCmd(t *testing.T) {
 		}
 	})
 
+	t.Run("SuccessWhenDeferredSubstitutionBelongsOnlyToDestroyOnlyKustomization", func(t *testing.T) {
+		// Given a whole-blueprint apply (no name argument) where the only deferred
+		// substitution belongs to a destroyOnly kustomization — ApplyBlueprint skips
+		// destroyOnly entries when writing ConfigMaps/substitutions, so nothing would
+		// actually be overwritten
+		mocks := setupApplyTest(t)
+		destroyOnly := true
+		testBlueprint := &blueprintv1alpha1.Blueprint{
+			Metadata: blueprintv1alpha1.Metadata{Name: "test"},
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "my-app"},
+				{Name: "backup-hook", DestroyOnly: &destroyOnly},
+			},
+		}
+		mocks.BlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint { return testBlueprint }
+		mocks.BlueprintHandler.GetDeferredPathsFunc = func() map[string]bool {
+			return map[string]bool{"kustomize.backup-hook.substitutions.cert": true}
+		}
+		proj := newApplyKustomizeProject(mocks)
+
+		// When executing apply kustomize with no name argument
+		cmd := createTestApplyKustomizeCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then no error occurs, since the deferred substitution is scoped only to
+		// a destroyOnly kustomization that apply never touches
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
 	t.Run("SuccessWithWaitAll", func(t *testing.T) {
 		t.Cleanup(func() { applyWaitFlag = false })
 		// Given a blueprint with multiple kustomizations and --wait but no name argument

--- a/cmd/apply_test.go
+++ b/cmd/apply_test.go
@@ -736,6 +736,106 @@ func TestApplyKustomizeCmd(t *testing.T) {
 		}
 	})
 
+	t.Run("ErrorRefusesUnresolvedSubstitutionsInScope", func(t *testing.T) {
+		// Given a blueprint whose requested kustomization still has a deferred
+		// terraform_output() substitution
+		mocks := setupApplyTest(t)
+		testBlueprint := &blueprintv1alpha1.Blueprint{
+			Metadata:       blueprintv1alpha1.Metadata{Name: "test"},
+			Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "my-app"}},
+		}
+		mocks.BlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint { return testBlueprint }
+		mocks.BlueprintHandler.GetDeferredPathsFunc = func() map[string]bool {
+			return map[string]bool{"kustomize.my-app.substitutions.cert": true}
+		}
+		var applied bool
+		mocks.KubernetesManager.ApplyBlueprintFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) error {
+			applied = true
+			return nil
+		}
+		proj := newApplyKustomizeProject(mocks)
+
+		// When executing apply kustomize my-app
+		cmd := createTestApplyKustomizeCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"my-app"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then an error is returned and the cluster is never touched, so a
+		// resolved ConfigMap value is never overwritten with raw expression text
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "unresolved terraform_output() substitutions") {
+			t.Errorf("Expected unresolved-substitutions error, got: %v", err)
+		}
+		if applied {
+			t.Error("Expected ApplyBlueprint not to be called when substitutions are unresolved")
+		}
+	})
+
+	t.Run("ErrorRefusesUnresolvedGlobalConfigMapEvenForUnrelatedKustomization", func(t *testing.T) {
+		// Given a deferred substitution on a blueprint-level ConfigMap, which
+		// ApplyBlueprint writes unconditionally regardless of which single
+		// kustomization is requested
+		mocks := setupApplyTest(t)
+		testBlueprint := &blueprintv1alpha1.Blueprint{
+			Metadata:       blueprintv1alpha1.Metadata{Name: "test"},
+			Kustomizations: []blueprintv1alpha1.Kustomization{{Name: "my-app"}},
+		}
+		mocks.BlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint { return testBlueprint }
+		mocks.BlueprintHandler.GetDeferredPathsFunc = func() map[string]bool {
+			return map[string]bool{"configmaps.shared.cert": true}
+		}
+		proj := newApplyKustomizeProject(mocks)
+
+		// When executing apply kustomize my-app
+		cmd := createTestApplyKustomizeCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"my-app"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then an error is returned even though the deferred path names no kustomization
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "unresolved terraform_output() substitutions") {
+			t.Errorf("Expected unresolved-substitutions error, got: %v", err)
+		}
+	})
+
+	t.Run("SuccessWhenDeferredSubstitutionIsOutOfScope", func(t *testing.T) {
+		// Given a deferred substitution that belongs to a different kustomization
+		// than the one being applied
+		mocks := setupApplyTest(t)
+		testBlueprint := &blueprintv1alpha1.Blueprint{
+			Metadata: blueprintv1alpha1.Metadata{Name: "test"},
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "my-app"},
+				{Name: "other-app"},
+			},
+		}
+		mocks.BlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint { return testBlueprint }
+		mocks.BlueprintHandler.GetDeferredPathsFunc = func() map[string]bool {
+			return map[string]bool{"kustomize.other-app.substitutions.cert": true}
+		}
+		proj := newApplyKustomizeProject(mocks)
+
+		// When executing apply kustomize my-app
+		cmd := createTestApplyKustomizeCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"my-app"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then no error occurs, since the deferred substitution is out of scope
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
 	t.Run("SuccessWithWaitAll", func(t *testing.T) {
 		t.Cleanup(func() { applyWaitFlag = false })
 		// Given a blueprint with multiple kustomizations and --wait but no name argument
@@ -890,6 +990,58 @@ func TestApplyKustomizeCmd(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "blueprint is not available") {
 			t.Errorf("Expected blueprint error, got: %v", err)
+		}
+	})
+}
+
+func TestDeferredSubstitutionsInScope(t *testing.T) {
+	t.Run("NoDeferredPaths", func(t *testing.T) {
+		if deferredSubstitutionsInScope(nil, map[string]bool{"my-app": true}) {
+			t.Error("Expected false for no deferred paths")
+		}
+	})
+
+	t.Run("KustomizationInScope", func(t *testing.T) {
+		deferred := map[string]bool{"kustomize.my-app.substitutions.cert": true}
+		if !deferredSubstitutionsInScope(deferred, map[string]bool{"my-app": true}) {
+			t.Error("Expected true when the deferred kustomization is in scope")
+		}
+	})
+
+	t.Run("KustomizationOutOfScope", func(t *testing.T) {
+		deferred := map[string]bool{"kustomize.other-app.substitutions.cert": true}
+		if deferredSubstitutionsInScope(deferred, map[string]bool{"my-app": true}) {
+			t.Error("Expected false when the deferred kustomization is not in scope")
+		}
+	})
+
+	t.Run("NamePrefixCollisionDoesNotFalsePositive", func(t *testing.T) {
+		// A kustomization named "my-app-2" must not match scope {"my-app"} via a bare
+		// string-prefix check on the raw path.
+		deferred := map[string]bool{"kustomize.my-app-2.substitutions.cert": true}
+		if deferredSubstitutionsInScope(deferred, map[string]bool{"my-app": true}) {
+			t.Error("Expected false: 'my-app-2' is a different kustomization than 'my-app'")
+		}
+	})
+
+	t.Run("GlobalConfigMapAlwaysInScope", func(t *testing.T) {
+		deferred := map[string]bool{"configmaps.shared.cert": true}
+		if !deferredSubstitutionsInScope(deferred, map[string]bool{}) {
+			t.Error("Expected true: blueprint-level ConfigMaps are always in scope")
+		}
+	})
+
+	t.Run("GlobalSubstitutionAlwaysInScope", func(t *testing.T) {
+		deferred := map[string]bool{"substitutions.tenant_id": true}
+		if !deferredSubstitutionsInScope(deferred, map[string]bool{}) {
+			t.Error("Expected true: global substitutions are always in scope")
+		}
+	})
+
+	t.Run("UnrecognizedPrefixIgnored", func(t *testing.T) {
+		deferred := map[string]bool{"messages.0": true}
+		if deferredSubstitutionsInScope(deferred, map[string]bool{"my-app": true}) {
+			t.Error("Expected false for a path outside the recognized prefixes")
 		}
 	})
 }


### PR DESCRIPTION
Closes #3158

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change is isolated to `cmd/apply.go`'s `apply kustomize` command and its tests, adding a pre-flight guard rather than touching any write path itself.
>
> **Overview**
>
> `apply kustomize` now checks `BlueprintHandler.GetDeferredPaths()` before applying, and refuses with an error if an unresolved `terraform_output()` substitution falls within the scope of what's about to be written. This closes a real gap: `apply kustomize` calls `Generate()` rather than `GenerateResolved()`, so without this guard a still-deferred expression could be serialized as raw text into a ConfigMap, silently clobbering a value a prior full `apply` had already resolved.
>
> The scope computation for a whole-blueprint apply (no name argument) includes every kustomization in the blueprint, including ones marked `destroyOnly`. Since `ApplyBlueprint` skips `destroyOnly` kustomizations when writing ConfigMaps/substitutions, a deferred substitution scoped only to a `destroyOnly` kustomization can cause `apply kustomize` (no args) to refuse even though nothing unsafe would actually be written.

<!-- /claude-code-review:summary -->
