### PR TITLE
fix(kubernetes): resolve cluster-scoped LB owners by empty namespace

### DIFF
--- a/pkg/provisioner/kubernetes/client/client.go
+++ b/pkg/provisioner/kubernetes/client/client.go
@@ -46,6 +46,7 @@ type KubernetesClient interface {
 	ApplyResource(gvr schema.GroupVersionResource, obj *unstructured.Unstructured, opts metav1.ApplyOptions) (*unstructured.Unstructured, error)
 	DeleteResource(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error
 	ResourceFor(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error)
+	IsNamespaced(gvk schema.GroupVersionKind) (bool, error)
 	PatchResource(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*unstructured.Unstructured, error)
 	CheckHealth(ctx context.Context, endpoint string) error
 	GetNodeReadyStatus(ctx context.Context, nodeNames []string) (map[string]bool, error)
@@ -139,6 +140,21 @@ func (c *DynamicKubernetesClient) ResourceFor(gvk schema.GroupVersionKind) (sche
 		return schema.GroupVersionResource{}, err
 	}
 	return mapping.Resource, nil
+}
+
+// IsNamespaced reports whether a GroupVersionKind is namespace-scoped, using the same discovery
+// data as ResourceFor. Callers walking an ownerReference chain need this alongside the resolved
+// GVR: a cluster-scoped owner (e.g. GatewayClass, ClusterRole) must be addressed with an empty
+// namespace, never the child object's namespace.
+func (c *DynamicKubernetesClient) IsNamespaced(gvk schema.GroupVersionKind) (bool, error) {
+	if err := c.ensureClient(); err != nil {
+		return false, err
+	}
+	mapping, err := c.mapper.RESTMapping(gvk.GroupKind(), gvk.Version)
+	if err != nil {
+		return false, err
+	}
+	return mapping.Scope.Name() == meta.RESTScopeNameNamespace, nil
 }
 
 // PatchResource patches a resource. The caller-supplied ctx is honoured so

--- a/pkg/provisioner/kubernetes/client/mock_client.go
+++ b/pkg/provisioner/kubernetes/client/mock_client.go
@@ -25,6 +25,7 @@ type MockKubernetesClient struct {
 	ApplyResourceFunc        func(gvr schema.GroupVersionResource, obj *unstructured.Unstructured, opts metav1.ApplyOptions) (*unstructured.Unstructured, error)
 	DeleteResourceFunc       func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error
 	ResourceForFunc          func(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error)
+	IsNamespacedFunc         func(gvk schema.GroupVersionKind) (bool, error)
 	PatchResourceFunc        func(ctx context.Context, gvr schema.GroupVersionResource, namespace, name string, pt types.PatchType, data []byte, opts metav1.PatchOptions) (*unstructured.Unstructured, error)
 	CheckHealthFunc          func(ctx context.Context, endpoint string) error
 	GetNodeReadyStatusFunc   func(ctx context.Context, nodeNames []string) (map[string]bool, error)
@@ -89,6 +90,15 @@ func (m *MockKubernetesClient) ResourceFor(gvk schema.GroupVersionKind) (schema.
 		return m.ResourceForFunc(gvk)
 	}
 	return schema.GroupVersionResource{}, nil
+}
+
+// IsNamespaced implements KubernetesClient interface. Defaults to true (namespaced) when
+// IsNamespacedFunc is unset, matching every existing owner-walk test's implicit assumption.
+func (m *MockKubernetesClient) IsNamespaced(gvk schema.GroupVersionKind) (bool, error) {
+	if m.IsNamespacedFunc != nil {
+		return m.IsNamespacedFunc(gvk)
+	}
+	return true, nil
 }
 
 // PatchResource implements KubernetesClient interface

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -1698,6 +1698,13 @@ func (k *BaseKubernetesManager) ownedInventorySet(eligible []blueprintv1alpha1.K
 // is its own target; otherwise the ascent follows the controller ownerReference upward, fetching
 // each owner to read its own references, until an owned ancestor is found or the chain ends.
 // Returns found=false when no ancestor is ours (a foreign LoadBalancer we must not touch).
+//
+// Each hop resolves its own scope via IsNamespaced rather than reusing the Service's namespace
+// unconditionally: a cluster-scoped owner (e.g. GatewayClass, ClusterRole) is addressed with an
+// empty namespace, both for the inventory lookup and the GetResource call. Flux's inventory
+// likewise encodes cluster-scoped entries with an empty namespace, so treating a cluster-scoped
+// owner as if it lived in the Service's namespace makes both the inventory lookup and the
+// GetResource call miss — the walk silently classifies an owned root as foreign and gives up.
 func (k *BaseKubernetesManager) ownedRootForService(svc *unstructured.Unstructured, owned map[string]bool) (ownedTarget, bool, error) {
 	namespace := svc.GetNamespace()
 	if owned[inventoryKey("", "Service", namespace, svc.GetName())] {
@@ -1714,17 +1721,29 @@ func (k *BaseKubernetesManager) ownedRootForService(svc *unstructured.Unstructur
 		if err != nil {
 			return ownedTarget{}, false, nil
 		}
-		gvr, err := k.client.ResourceFor(gv.WithKind(owner.Kind))
+		gvk := gv.WithKind(owner.Kind)
+		gvr, err := k.client.ResourceFor(gvk)
 		if err != nil {
 			if apimeta.IsNoMatchError(err) {
 				return ownedTarget{}, false, nil
 			}
 			return ownedTarget{}, false, fmt.Errorf("error resolving load balancer owner %s %q: %w", owner.Kind, owner.Name, err)
 		}
-		if owned[inventoryKey(gv.Group, owner.Kind, namespace, owner.Name)] {
-			return ownedTarget{gvr: gvr, namespace: namespace, name: owner.Name}, true, nil
+		namespaced, err := k.client.IsNamespaced(gvk)
+		if err != nil {
+			if apimeta.IsNoMatchError(err) {
+				return ownedTarget{}, false, nil
+			}
+			return ownedTarget{}, false, fmt.Errorf("error resolving scope of load balancer owner %s %q: %w", owner.Kind, owner.Name, err)
 		}
-		next, err := k.client.GetResource(gvr, namespace, owner.Name)
+		ownerNamespace := namespace
+		if !namespaced {
+			ownerNamespace = ""
+		}
+		if owned[inventoryKey(gv.Group, owner.Kind, ownerNamespace, owner.Name)] {
+			return ownedTarget{gvr: gvr, namespace: ownerNamespace, name: owner.Name}, true, nil
+		}
+		next, err := k.client.GetResource(gvr, ownerNamespace, owner.Name)
 		if err != nil {
 			if isNotFoundError(err) {
 				return ownedTarget{}, false, nil

--- a/pkg/provisioner/kubernetes/kubernetes_manager_private_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_private_test.go
@@ -134,6 +134,105 @@ func TestBaseKubernetesManager_remediateLoadBalancerOwners(t *testing.T) {
 		}
 	})
 
+	t.Run("ForegroundDeletesClusterScopedOwner", func(t *testing.T) {
+		// Given a LoadBalancer Service owned by a cluster-scoped GatewayClass (Envoy Gateway's
+		// actual ownerReference target, cli#3160) that IS in the eligible kustomization's
+		// inventory, encoded with an empty namespace segment as Flux does for cluster-scoped
+		// entries
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		gatewayClassOwner := metav1.OwnerReference{
+			APIVersion: "gateway.networking.k8s.io/v1",
+			Kind:       "GatewayClass",
+			Name:       "envoy",
+			Controller: &controller,
+		}
+		gatewayClassesGVR := schema.GroupVersionResource{Group: "gateway.networking.k8s.io", Version: "v1", Resource: "gatewayclasses"}
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			if gvr.Resource == "kustomizations" {
+				return kustomizationWithInventory("_envoy_gateway.networking.k8s.io_GatewayClass"), nil
+			}
+			return nil, fmt.Errorf("%s %q not found", gvr.Resource, name)
+		}
+		kubernetesClient.ListResourcesFunc = func(gvr schema.GroupVersionResource, namespace string) (*unstructured.UnstructuredList, error) {
+			return &unstructured.UnstructuredList{Items: []unstructured.Unstructured{
+				lbService("system-gateway", "envoy-system-gateway-external", &gatewayClassOwner),
+			}}, nil
+		}
+		kubernetesClient.ResourceForFunc = func(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error) {
+			return gatewayClassesGVR, nil
+		}
+		kubernetesClient.IsNamespacedFunc = func(gvk schema.GroupVersionKind) (bool, error) {
+			return gvk.Kind != "GatewayClass", nil
+		}
+		var deletedGVR schema.GroupVersionResource
+		var deletedNamespace, deletedName string
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			deletedGVR, deletedNamespace, deletedName = gvr, namespace, name
+			return nil
+		}
+		manager.client = kubernetesClient
+
+		// When remediation runs
+		if err := manager.remediateLoadBalancerOwners(eligible, "system-gitops"); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the cluster-scoped GatewayClass is recognized as owned and foreground-deleted
+		// with an empty namespace, rather than being silently treated as foreign
+		if deletedGVR != gatewayClassesGVR {
+			t.Errorf("Expected delete on %v, got %v", gatewayClassesGVR, deletedGVR)
+		}
+		if deletedName != "envoy" {
+			t.Errorf("Expected the owning GatewayClass 'envoy' deleted, got %q", deletedName)
+		}
+		if deletedNamespace != "" {
+			t.Errorf("Expected cluster-scoped delete with empty namespace, got %q", deletedNamespace)
+		}
+	})
+
+	t.Run("PropagatesTransientIsNamespacedError", func(t *testing.T) {
+		// Given a client whose scope resolution fails transiently after the owner's GVR
+		// resolves successfully
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			if gvr.Resource == "kustomizations" {
+				return kustomizationWithInventory(gatewayInventoryID), nil
+			}
+			return nil, fmt.Errorf("%s %q not found", gvr.Resource, name)
+		}
+		kubernetesClient.ListResourcesFunc = func(gvr schema.GroupVersionResource, namespace string) (*unstructured.UnstructuredList, error) {
+			return &unstructured.UnstructuredList{Items: []unstructured.Unstructured{
+				lbService("system-gateway", "cilium-gateway-external", &gatewayOwner),
+			}}, nil
+		}
+		kubernetesClient.ResourceForFunc = func(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error) {
+			return gatewaysGVR, nil
+		}
+		kubernetesClient.IsNamespacedFunc = func(gvk schema.GroupVersionKind) (bool, error) {
+			return false, fmt.Errorf("the server is currently unable to handle the request")
+		}
+		deleted := false
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			deleted = true
+			return nil
+		}
+		manager.client = kubernetesClient
+
+		// When remediation runs
+		err := manager.remediateLoadBalancerOwners(eligible, "system-gitops")
+
+		// Then the transient error aborts remediation rather than silently treating the
+		// owner as foreign
+		if err == nil {
+			t.Fatal("Expected a transient scope-resolution error to abort remediation, got nil")
+		}
+		if deleted {
+			t.Error("Expected no delete when scope resolution failed transiently")
+		}
+	})
+
 	t.Run("SkipsForeignLoadBalancer", func(t *testing.T) {
 		manager := setup(t)
 		kubernetesClient := client.NewMockKubernetesClient()


### PR DESCRIPTION
Closes #3160

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> The change is confined to the Kubernetes provisioner's load-balancer remediation path used during cluster teardown, and is additive to the client interface with a backward-compatible mock default.
>
> **Overview**
>
> This PR fixes `ownedRootForService`'s ownerReference walk so cluster-scoped owners (e.g. a Gateway API `GatewayClass`) are addressed and matched against Flux's inventory using an empty namespace instead of the child Service's namespace, which previously caused the walk to miss the match and misclassify an owned root as foreign. It adds an `IsNamespaced(gvk)` method to the `KubernetesClient` interface (and its mock), resolved via the same discovery mapper as `ResourceFor`, and uses it per hop to pick the correct namespace for both the inventory lookup and `GetResource` call.
>
> The mock's `IsNamespacedFunc` defaults to `true` (namespaced) when unset, preserving the previous behavior for all existing tests that don't set it explicitly. Two new tests cover the cluster-scoped-owner deletion path and correct propagation of a transient error from `IsNamespaced`.

<!-- /claude-code-review:summary -->
