### PR TITLE
fix(terraform): hint at stale provider lock on init failure

### DIFF
--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -1556,7 +1556,9 @@ func (s *TerraformStack) prepareComponentOp(blueprint *blueprintv1alpha1.Bluepri
 // a single CLI run share one terraform invocation; failed inits aren't
 // cached. On cache miss without -migrate-state, clearStaleBackendPointer
 // drops a stale pointer file before init runs. Dedup assumes sequential
-// callers; parallel iteration would need per-key sync.Once.
+// callers; parallel iteration would need per-key sync.Once. A failure
+// matching isStaleProviderLockError gets staleProviderLockHint appended
+// rather than passing Terraform's raw error through unexplained.
 func (s *TerraformStack) runTerraformInit(component *blueprintv1alpha1.TerraformComponent, terraformVars map[string]string, scopedKeys []string, terraformArgs *envvars.TerraformArgs, extraFlags ...string) error {
 	migrateState := slices.Contains(extraFlags, "-migrate-state")
 	key := initCacheKey{
@@ -1581,6 +1583,9 @@ func (s *TerraformStack) runTerraformInit(component *blueprintv1alpha1.Terraform
 	initEnv := selectTerraformCommandEnv(terraformVars, false, scopedKeys)
 	_, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, initEnv, initArgs...)
 	if err != nil {
+		if isStaleProviderLockError(err) {
+			return fmt.Errorf("error running terraform init for %s: %s: %w", component.Path, staleProviderLockHint(component), err)
+		}
 		return fmt.Errorf("error running terraform init for %s: %w", component.Path, err)
 	}
 
@@ -1678,6 +1683,51 @@ func (s *TerraformStack) getTerraformEnv() *envvars.TerraformEnvPrinter {
 // =============================================================================
 // Helpers
 // =============================================================================
+
+// isScratchComponent reports whether a component's module content lives in windsor's own
+// OCI/git-sourced scratch cache (.windsor/contexts/<context>/terraform), rather than a plain local
+// directory the operator authors and version-controls directly. Mirrors the useScratchPath
+// condition in resolveComponentPaths, which is where this same distinction determines FullPath.
+func isScratchComponent(component *blueprintv1alpha1.TerraformComponent) bool {
+	return component.Name != "" || component.Source != ""
+}
+
+// staleProviderLockMarkers are substrings that together identify Terraform's "locked provider ...
+// does not match configured version constraint" failure — the signature of a leftover local
+// .terraform.lock.hcl from a previous windsor run whose module source has since changed. All
+// markers must be present since Terraform's wording could otherwise coincidentally partial-match
+// an unrelated error.
+var staleProviderLockMarkers = []string{
+	"does not match configured version constraint",
+	"terraform init -upgrade",
+}
+
+// isStaleProviderLockError reports whether err is Terraform's stale-provider-lock failure, the
+// one -upgrade actually resolves. See staleProviderLockMarkers.
+func isStaleProviderLockError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	for _, marker := range staleProviderLockMarkers {
+		if !strings.Contains(msg, marker) {
+			return false
+		}
+	}
+	return true
+}
+
+// staleProviderLockHint names the likely cause and remedy for isStaleProviderLockError; never
+// auto-retried with -upgrade since the MigrateState caller must not touch providers during a
+// state move. A windsor-managed scratch component's cache directory is safe to point at directly;
+// a plain local component's .terraform.lock.hcl may be an intentional, git-tracked pin, so the
+// hint asks the operator to re-init it themselves instead.
+func staleProviderLockHint(component *blueprintv1alpha1.TerraformComponent) string {
+	if isScratchComponent(component) {
+		return fmt.Sprintf("the local terraform cache for this component is stale (its module source changed since the last local init); remove %s and re-run to pick up the new provider constraint", component.FullPath)
+	}
+	return fmt.Sprintf("the .terraform.lock.hcl in %s may be pinned to a provider version outside the current constraint; run `terraform init -upgrade` there (or remove the lock file if it isn't intentionally version-controlled) and retry", component.FullPath)
+}
 
 // parseTerraformPlanJSON parses the line-delimited JSON event stream emitted by
 // `terraform plan -json` and extracts both the summary counts and the per-resource

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -904,6 +905,38 @@ func TestStack_MigrateState(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "backend not reachable") {
 			t.Errorf("Expected error to wrap the underlying cause, got: %v", err)
+		}
+	})
+
+	t.Run("HintsAtStaleProviderLockWithoutAddingUpgrade", func(t *testing.T) {
+		// Given a component whose migrate-state init fails with the stale-provider-lock
+		// signature — MigrateState must still never pass -upgrade (cli#3157: the hint is
+		// diagnostic only, not a retry, precisely because this contract must hold)
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+
+		var sawUpgrade bool
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == "init" {
+				if slices.Contains(args, "-upgrade") {
+					sawUpgrade = true
+				}
+				return "", fmt.Errorf("Error: Failed to query available provider packages\n\nCould not retrieve the list of available versions for provider hashicorp/aws: locked provider registry.terraform.io/hashicorp/aws 6.47.0 does not match configured version constraint 6.57.1; must use terraform init -upgrade to allow selection of new versions")
+			}
+			return "", nil
+		}
+
+		_, err := stack.MigrateState(blueprint)
+
+		// Then the error carries the hint but no init call ever added -upgrade
+		if err == nil {
+			t.Fatal("Expected MigrateState to return an error")
+		}
+		if !strings.Contains(err.Error(), "provider version outside the current constraint") && !strings.Contains(err.Error(), "local terraform cache for this component is stale") {
+			t.Errorf("Expected a stale-provider-lock hint, got: %v", err)
+		}
+		if sawUpgrade {
+			t.Error("Expected MigrateState never to pass -upgrade, even when hinting at a stale lock")
 		}
 	})
 
@@ -2712,6 +2745,84 @@ func TestStack_Apply(t *testing.T) {
 		}
 	})
 
+	t.Run("HintsAtStaleCacheOnStaleProviderLockForScratchComponent", func(t *testing.T) {
+		// Given a scratch (Source-set) component whose init fails with Terraform's
+		// stale-provider-lock signature
+		stack, mocks := setup(t)
+		staleLockErr := "Error: Failed to query available provider packages\n\nCould not retrieve the list of available versions for provider hashicorp/aws: locked provider registry.terraform.io/hashicorp/aws 6.47.0 does not match configured version constraint 6.57.1; must use terraform init -upgrade to allow selection of new versions"
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" && len(args) > 1 && args[1] == "init" {
+				return "", fmt.Errorf("%s", staleLockErr)
+			}
+			return "", nil
+		}
+		blueprint := createTestBlueprint()
+
+		// When applying the scratch component
+		err := stack.Apply(blueprint, "remote/path")
+
+		// Then the error is a windsor-native hint naming the scratch cache directory to
+		// clear, wrapping (not replacing) Terraform's own error text
+		if err == nil {
+			t.Fatal("Expected an error, got nil")
+		}
+		if !strings.Contains(err.Error(), "local terraform cache for this component is stale") {
+			t.Errorf("Expected a scratch-cache hint, got %v", err)
+		}
+		if !strings.Contains(err.Error(), staleLockErr) {
+			t.Errorf("Expected the underlying terraform error preserved, got %v", err)
+		}
+	})
+
+	t.Run("HintsAtLockFileOnStaleProviderLockForNonScratchComponent", func(t *testing.T) {
+		// Given a plain local (no Name, no Source) component whose init fails with the same
+		// stale-provider-lock signature — its .terraform.lock.hcl may be an intentional,
+		// git-tracked pin, so the hint must not presume to say "delete this directory"
+		stack, mocks := setup(t)
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" && len(args) > 1 && args[1] == "init" {
+				return "", fmt.Errorf("Error: Failed to query available provider packages\n\nCould not retrieve the list of available versions for provider hashicorp/aws: locked provider registry.terraform.io/hashicorp/aws 6.47.0 does not match configured version constraint 6.57.1; must use terraform init -upgrade to allow selection of new versions")
+			}
+			return "", nil
+		}
+		blueprint := createTestBlueprint()
+
+		// When applying the non-scratch component
+		err := stack.Apply(blueprint, "local/path")
+
+		// Then the hint points at re-running init with -upgrade in that directory, not at
+		// deleting anything
+		if err == nil {
+			t.Fatal("Expected an error, got nil")
+		}
+		if !strings.Contains(err.Error(), "terraform init -upgrade") {
+			t.Errorf("Expected a lock-file hint pointing at terraform init -upgrade, got %v", err)
+		}
+	})
+
+	t.Run("UnrelatedInitFailureGetsNoHint", func(t *testing.T) {
+		// Given an init failure that is not the stale-provider-lock signature
+		stack, mocks := setup(t)
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" && len(args) > 1 && args[1] == "init" {
+				return "", fmt.Errorf("mock error running terraform init")
+			}
+			return "", nil
+		}
+		blueprint := createTestBlueprint()
+
+		// When applying
+		err := stack.Apply(blueprint, "local/path")
+
+		// Then no stale-lock hint is added
+		if err == nil {
+			t.Fatal("Expected an error, got nil")
+		}
+		if strings.Contains(err.Error(), "provider lock") || strings.Contains(err.Error(), "terraform init -upgrade") {
+			t.Errorf("Expected no stale-lock hint on an unrelated failure, got %v", err)
+		}
+	})
+
 	t.Run("ErrorRunningTerraformPlan", func(t *testing.T) {
 		// Given a stack whose shell fails on terraform plan
 		stack, mocks := setup(t)
@@ -3854,6 +3965,59 @@ func TestStack_Destroy(t *testing.T) {
 			if strings.HasSuffix(p, "/terraform.tfstate") {
 				t.Errorf("Backend pointer must not be cleared on destroy failure, got removals: %v", removed)
 			}
+		}
+	})
+}
+
+func TestIsScratchComponent(t *testing.T) {
+	t.Run("TrueWhenNameSet", func(t *testing.T) {
+		c := &blueprintv1alpha1.TerraformComponent{Name: "cluster"}
+		if !isScratchComponent(c) {
+			t.Error("Expected true when Name is set")
+		}
+	})
+
+	t.Run("TrueWhenSourceSet", func(t *testing.T) {
+		c := &blueprintv1alpha1.TerraformComponent{Source: "core"}
+		if !isScratchComponent(c) {
+			t.Error("Expected true when Source is set")
+		}
+	})
+
+	t.Run("FalseWhenNeitherSet", func(t *testing.T) {
+		c := &blueprintv1alpha1.TerraformComponent{Path: "local/path"}
+		if isScratchComponent(c) {
+			t.Error("Expected false when neither Name nor Source is set")
+		}
+	})
+}
+
+func TestIsStaleProviderLockError(t *testing.T) {
+	t.Run("NilError", func(t *testing.T) {
+		if isStaleProviderLockError(nil) {
+			t.Error("Expected false for nil error")
+		}
+	})
+
+	t.Run("MatchesTerraformsStaleLockSignature", func(t *testing.T) {
+		err := fmt.Errorf("Error: Failed to query available provider packages\n\nCould not retrieve the list of available versions for provider hashicorp/aws: locked provider registry.terraform.io/hashicorp/aws 6.47.0 does not match configured version constraint 6.57.1; must use terraform init -upgrade to allow selection of new versions")
+		if !isStaleProviderLockError(err) {
+			t.Error("Expected true for terraform's stale-provider-lock error text")
+		}
+	})
+
+	t.Run("UnrelatedErrorDoesNotMatch", func(t *testing.T) {
+		err := fmt.Errorf("mock error running terraform init")
+		if isStaleProviderLockError(err) {
+			t.Error("Expected false for an unrelated init failure")
+		}
+	})
+
+	t.Run("PartialMarkerMatchDoesNotMatch", func(t *testing.T) {
+		// Only one of the two markers present — must not false-positive.
+		err := fmt.Errorf("does not match configured version constraint, but no upgrade hint here")
+		if isStaleProviderLockError(err) {
+			t.Error("Expected false when only one marker is present")
 		}
 	})
 }


### PR DESCRIPTION
Closes #3157

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> The change is confined to error-message construction in one Terraform provisioner file, with no changes to control flow, retry behavior, or command arguments.
>
> **Overview**
>
> When `terraform init` fails with the specific "locked provider ... does not match configured version constraint" signature, the CLI now appends a diagnostic hint to the wrapped error instead of surfacing Terraform's raw message alone. The hint is worded differently depending on whether the component is a windsor-managed scratch component (suggests removing the local cache directory) or a plain local component (suggests `terraform init -upgrade` or removing an intentionally-versioned lock file).
>
> The detection (`isStaleProviderLockError`) requires both a "does not match configured version constraint" and a "terraform init -upgrade" substring to match, avoiding false positives on unrelated init failures. Critically, the hint is diagnostic only — `-upgrade` is never automatically added to the init invocation, which matters most for `MigrateState`, where mutating provider selection during a state move would be unsafe. This invariant is explicitly covered by a new test.

<!-- /claude-code-review:summary -->
