### PR TITLE
fix(env): warn on AWS profile name mismatch instead of silent omission

### DIFF
--- a/pkg/runtime/env/aws_env.go
+++ b/pkg/runtime/env/aws_env.go
@@ -57,10 +57,13 @@ func NewAwsEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler) *Aw
 // AWS_CONFIG_FILE override) in global mode. When the profile is absent the var
 // is omitted so the AWS SDK falls through to env keys, IMDS, ECS task creds,
 // or whatever else the credential chain finds rather than failing with
-// "profile not found" against a file the named profile was never in. When some
-// other profile is defined instead (e.g. a bare `aws configure sso` named it
-// after the SSO role rather than the context), WarnOnProfileMismatch writes a
-// non-fatal hint to warningWriter naming what was expected vs. what exists.
+// "profile not found" against a file the named profile was never in. In
+// project mode, when some other profile is defined instead (e.g. a bare
+// `aws configure sso` named it after the SSO role rather than the context),
+// WarnOnProfileMismatch writes a non-fatal hint to warningWriter naming what
+// was expected vs. what exists. Global mode never warns on this: the ambient
+// ~/.aws/config is shared across every project the operator touches, so an
+// unrelated profile there is normal, not evidence of misconfiguration.
 func (e *AwsEnvPrinter) GetEnvVars() (map[string]string, error) {
 	envVars := make(map[string]string)
 	global := e.shell.IsGlobal()
@@ -108,7 +111,7 @@ func (e *AwsEnvPrinter) GetEnvVars() (map[string]string, error) {
 		}
 		if resolver.HasProfile(profileName) {
 			envVars["AWS_PROFILE"] = profileName
-		} else {
+		} else if !global {
 			awsprofile.WarnOnProfileMismatch(e.warningWriter, resolver, profileName)
 		}
 	}

--- a/pkg/runtime/env/aws_env.go
+++ b/pkg/runtime/env/aws_env.go
@@ -7,6 +7,8 @@ package env
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"path/filepath"
 
 	"github.com/windsorcli/cli/pkg/runtime/config"
@@ -21,6 +23,7 @@ import (
 // AwsEnvPrinter is a struct that implements AWS environment configuration
 type AwsEnvPrinter struct {
 	BaseEnvPrinter
+	warningWriter io.Writer
 }
 
 // =============================================================================
@@ -38,6 +41,7 @@ func NewAwsEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler) *Aw
 
 	return &AwsEnvPrinter{
 		BaseEnvPrinter: *NewBaseEnvPrinter(shell, configHandler),
+		warningWriter:  os.Stderr,
 	}
 }
 
@@ -53,7 +57,10 @@ func NewAwsEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler) *Aw
 // AWS_CONFIG_FILE override) in global mode. When the profile is absent the var
 // is omitted so the AWS SDK falls through to env keys, IMDS, ECS task creds,
 // or whatever else the credential chain finds rather than failing with
-// "profile not found" against a file the named profile was never in.
+// "profile not found" against a file the named profile was never in. When some
+// other profile is defined instead (e.g. a bare `aws configure sso` named it
+// after the SSO role rather than the context), WarnOnProfileMismatch writes a
+// non-fatal hint to warningWriter naming what was expected vs. what exists.
 func (e *AwsEnvPrinter) GetEnvVars() (map[string]string, error) {
 	envVars := make(map[string]string)
 	global := e.shell.IsGlobal()
@@ -101,6 +108,8 @@ func (e *AwsEnvPrinter) GetEnvVars() (map[string]string, error) {
 		}
 		if resolver.HasProfile(profileName) {
 			envVars["AWS_PROFILE"] = profileName
+		} else {
+			awsprofile.WarnOnProfileMismatch(e.warningWriter, resolver, profileName)
 		}
 	}
 

--- a/pkg/runtime/env/aws_env_test.go
+++ b/pkg/runtime/env/aws_env_test.go
@@ -1,6 +1,7 @@
 package env
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -346,6 +347,65 @@ contexts:
 		// credentials, IMDS, or whatever else the credential chain finds
 		if _, ok := envVars["AWS_PROFILE"]; ok {
 			t.Errorf("AWS_PROFILE should be absent when ambient config lacks the profile, got %q", envVars["AWS_PROFILE"])
+		}
+	})
+
+	t.Run("WarnsWhenExpectedProfileMissingButOtherProfileExists", func(t *testing.T) {
+		// cli#3155: a bare `aws configure sso` (no --profile) names the profile
+		// after the SSO role/account rather than the windsor context, so the
+		// context's .aws/config has a profile, just not the expected one
+		mocks := setupAwsEnvMocks(t)
+		withProfile(t, mocks, "[profile AdministratorAccess-105746947080]\nregion = us-west-2\n", "")
+		env := NewAwsEnvPrinter(mocks.Shell, mocks.ConfigHandler)
+		env.shims = mocks.Shims
+		var stderr bytes.Buffer
+		env.warningWriter = &stderr
+
+		// When GetEnvVars is called
+		envVars, err := env.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars returned an error: %v", err)
+		}
+
+		// Then AWS_PROFILE is still omitted (unchanged safety behavior) but a
+		// warning names both the expected and the actual profile
+		if _, ok := envVars["AWS_PROFILE"]; ok {
+			t.Errorf("AWS_PROFILE should still be absent, got %q", envVars["AWS_PROFILE"])
+		}
+		msg := stderr.String()
+		if !strings.Contains(msg, `"default"`) {
+			t.Errorf("expected warning to name the expected profile, got %q", msg)
+		}
+		if !strings.Contains(msg, "AdministratorAccess-105746947080") {
+			t.Errorf("expected warning to name the actual profile found, got %q", msg)
+		}
+	})
+
+	t.Run("NoWarningWhenAWSDirEntirelyUnconfigured", func(t *testing.T) {
+		// Given a project-mode context whose .aws/ has no profile at all — not a
+		// mismatch, just not configured yet, so no warning should fire
+		mocks := setupAwsEnvMocks(t)
+		configStr := `
+version: v1alpha1
+contexts:
+  test-context: {}
+`
+		if err := mocks.ConfigHandler.LoadConfigString(configStr); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+		env := NewAwsEnvPrinter(mocks.Shell, mocks.ConfigHandler)
+		env.shims = mocks.Shims
+		var stderr bytes.Buffer
+		env.warningWriter = &stderr
+
+		// When GetEnvVars is called
+		if _, err := env.GetEnvVars(); err != nil {
+			t.Fatalf("GetEnvVars returned an error: %v", err)
+		}
+
+		// Then no warning is written
+		if stderr.Len() != 0 {
+			t.Errorf("expected no warning for an unconfigured AWS setup, got %q", stderr.String())
 		}
 	})
 

--- a/pkg/runtime/env/aws_env_test.go
+++ b/pkg/runtime/env/aws_env_test.go
@@ -350,6 +350,42 @@ contexts:
 		}
 	})
 
+	t.Run("GlobalModeNeverWarnsOnMismatch", func(t *testing.T) {
+		// Given global mode with an ambient ~/.aws/config that has unrelated
+		// profiles for other projects, but none matching this context — normal
+		// in global mode, not evidence of misconfiguration, since the ambient
+		// file is shared across every project the operator touches
+		mocks := setupAwsEnvMocks(t)
+		configStr := `
+version: v1alpha1
+contexts:
+  test-context: {}
+`
+		if err := mocks.ConfigHandler.LoadConfigString(configStr); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+		mocks.Shell.IsGlobalFunc = func() bool { return true }
+		withAmbientProfile(t, "[profile some-other-project]\nregion = us-east-1\n")
+		env := NewAwsEnvPrinter(mocks.Shell, mocks.ConfigHandler)
+		env.shims = mocks.Shims
+		var stderr bytes.Buffer
+		env.warningWriter = &stderr
+
+		// When GetEnvVars is called
+		envVars, err := env.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars returned an error: %v", err)
+		}
+
+		// Then AWS_PROFILE is absent (unchanged) and no warning is written
+		if _, ok := envVars["AWS_PROFILE"]; ok {
+			t.Errorf("AWS_PROFILE should be absent, got %q", envVars["AWS_PROFILE"])
+		}
+		if stderr.Len() != 0 {
+			t.Errorf("expected no warning in global mode against the shared ambient config, got %q", stderr.String())
+		}
+	})
+
 	t.Run("WarnsWhenExpectedProfileMissingButOtherProfileExists", func(t *testing.T) {
 		// cli#3155: a bare `aws configure sso` (no --profile) names the profile
 		// after the SSO role/account rather than the windsor context, so the

--- a/pkg/runtime/internal/awsprofile/awsprofile.go
+++ b/pkg/runtime/internal/awsprofile/awsprofile.go
@@ -12,6 +12,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"golang.org/x/term"
 )
 
 // Resolver carries the AWS config and credentials file paths a single profile
@@ -103,8 +105,28 @@ func WarnOnProfileMismatch(w io.Writer, r Resolver, expected string) {
 	if len(found) == 0 {
 		return
 	}
-	fmt.Fprintf(w, "\033[33mWarning: AWS profile %q not found; found %s instead. Set aws.awsProfile to match, or rename the profile to %q.\033[0m\n",
+	msg := fmt.Sprintf("Warning: AWS profile %q not found; found %s instead. Set aws.awsProfile to match, or rename the profile to %q.",
 		expected, strings.Join(found, ", "), expected)
+	if shouldColorize(w) {
+		msg = "\033[33m" + msg + "\033[0m"
+	}
+	fmt.Fprintln(w, msg)
+}
+
+// shouldColorize reports whether w is safe to color: NO_COLOR is unset (its mere presence, any
+// value, opts out per the spec) and w is a terminal file descriptor. A non-terminal writer —
+// a pipe, a redirected log file, or any io.Writer that isn't *os.File at all (e.g. a test's
+// bytes.Buffer) — never gets raw ANSI escapes, so captured/piped `windsor env` output stays
+// clean instead of showing literal \033[33m garbage.
+func shouldColorize(w io.Writer) bool {
+	if _, present := os.LookupEnv("NO_COLOR"); present {
+		return false
+	}
+	f, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	return term.IsTerminal(int(f.Fd())) // #nosec G115 -- file descriptors are small, safe to cast to int
 }
 
 // profileNamesInFile scans path for INI section headers and returns the profile name each one

--- a/pkg/runtime/internal/awsprofile/awsprofile.go
+++ b/pkg/runtime/internal/awsprofile/awsprofile.go
@@ -7,6 +7,8 @@ package awsprofile
 
 import (
 	"bufio"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -63,6 +65,88 @@ func (r Resolver) HasProfile(name string) bool {
 		return true
 	}
 	return iniContainsSection(r.credentialsPath, "["+name+"]")
+}
+
+// ListProfileNames returns every profile name defined across the resolver's config and
+// credentials files, deduplicated, in the order first encountered (config file scanned before
+// credentials). Used for diagnostics when an expected profile isn't found, so the caller can
+// name what's actually configured instead of just "not found" — e.g. a bare `aws configure sso`
+// (without --profile) names the profile after the SSO role/account rather than the windsor
+// context, which HasProfile alone can't distinguish from "nothing configured at all."
+func (r Resolver) ListProfileNames() []string {
+	seen := make(map[string]bool)
+	var names []string
+	for _, name := range profileNamesInFile(r.configPath, true) {
+		if !seen[name] {
+			seen[name] = true
+			names = append(names, name)
+		}
+	}
+	for _, name := range profileNamesInFile(r.credentialsPath, false) {
+		if !seen[name] {
+			seen[name] = true
+			names = append(names, name)
+		}
+	}
+	return names
+}
+
+// WarnOnProfileMismatch writes a non-fatal warning to w when expected is not defined in r's
+// files but at least one other profile is — the "configured under the wrong name" case HasProfile
+// alone can't distinguish from "nothing configured yet." Silent when expected is present (nothing
+// to warn about) or when no profile is defined at all (unconfigured, not mismatched).
+func WarnOnProfileMismatch(w io.Writer, r Resolver, expected string) {
+	if r.HasProfile(expected) {
+		return
+	}
+	found := r.ListProfileNames()
+	if len(found) == 0 {
+		return
+	}
+	fmt.Fprintf(w, "\033[33mWarning: AWS profile %q not found; found %s instead. Set aws.awsProfile to match, or rename the profile to %q.\033[0m\n",
+		expected, strings.Join(found, ", "), expected)
+}
+
+// profileNamesInFile scans path for INI section headers and returns the profile name each one
+// names. isConfigFile selects the config file's "[profile <name>]" / "[default]" header shape;
+// the credentials file uses a bare "[<name>]" for every profile including default. Returns nil
+// for a missing or unreadable file, matching iniContainsSection's tolerance.
+func profileNamesInFile(path string, isConfigFile bool) []string {
+	if path == "" {
+		return nil
+	}
+	// #nosec G304 - path is composed from the caller's trusted configRoot or AWS-SDK-equivalent env vars
+	f, err := os.Open(path)
+	if err != nil {
+		return nil
+	}
+	defer f.Close()
+
+	var names []string
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		line := scanner.Text()
+		if i := strings.IndexAny(line, "#;"); i >= 0 {
+			line = line[:i]
+		}
+		line = strings.TrimSpace(line)
+		if !strings.HasPrefix(line, "[") || !strings.HasSuffix(line, "]") {
+			continue
+		}
+		inner := line[1 : len(line)-1]
+		if isConfigFile {
+			if inner == "default" {
+				names = append(names, "default")
+			} else if name, ok := strings.CutPrefix(inner, "profile "); ok && name != "" {
+				names = append(names, name)
+			}
+			continue
+		}
+		if inner != "" {
+			names = append(names, inner)
+		}
+	}
+	return names
 }
 
 // iniContainsSection scans the file at path for a line whose trimmed contents

--- a/pkg/runtime/internal/awsprofile/awsprofile_test.go
+++ b/pkg/runtime/internal/awsprofile/awsprofile_test.go
@@ -1,8 +1,10 @@
 package awsprofile
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -197,6 +199,105 @@ func TestAmbient_HasProfile(t *testing.T) {
 		// Then the fallback path resolves to <home>/.aws/config and finds it
 		if !got {
 			t.Errorf("expected true when profile defined in $HOME/.aws/config, got false")
+		}
+	})
+}
+
+func TestForContext_ListProfileNames(t *testing.T) {
+	t.Run("ReturnsEmptyWhenAWSDirMissing", func(t *testing.T) {
+		root := t.TempDir()
+
+		got := ForContext(root).ListProfileNames()
+
+		if len(got) != 0 {
+			t.Errorf("expected no profile names for missing .aws/, got %v", got)
+		}
+	})
+
+	t.Run("ListsConfigAndCredentialsProfiles", func(t *testing.T) {
+		// Given a config file naming one profile via "[profile ...]" and a
+		// credentials file naming a different one via the bare "[...]" form
+		root := writeAWSDir(t,
+			"[profile AdministratorAccess-105746947080]\nregion = us-west-2\n",
+			"[legacy]\naws_access_key_id = AKIA...\n")
+
+		got := ForContext(root).ListProfileNames()
+
+		// Then both names are reported, config file first
+		want := []string{"AdministratorAccess-105746947080", "legacy"}
+		if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+			t.Errorf("expected %v, got %v", want, got)
+		}
+	})
+
+	t.Run("ReportsDefaultFromEitherFile", func(t *testing.T) {
+		root := writeAWSDir(t, "[default]\nregion = us-west-2\n", "")
+
+		got := ForContext(root).ListProfileNames()
+
+		if len(got) != 1 || got[0] != "default" {
+			t.Errorf("expected [default], got %v", got)
+		}
+	})
+
+	t.Run("DeduplicatesNameAppearingInBothFiles", func(t *testing.T) {
+		root := writeAWSDir(t, "[profile prod]\nregion = us-west-2\n", "[prod]\naws_access_key_id = AKIA...\n")
+
+		got := ForContext(root).ListProfileNames()
+
+		if len(got) != 1 || got[0] != "prod" {
+			t.Errorf("expected [prod] deduplicated, got %v", got)
+		}
+	})
+
+	t.Run("IgnoresLookAlikeHeadersInsideConfigFile", func(t *testing.T) {
+		root := writeAWSDir(t, "[profile staging]\n# comment about [profile prod]\nrole_arn = arn:aws:iam::1:role/prod\n", "")
+
+		got := ForContext(root).ListProfileNames()
+
+		if len(got) != 1 || got[0] != "staging" {
+			t.Errorf("expected only [staging], got %v", got)
+		}
+	})
+}
+
+func TestWarnOnProfileMismatch(t *testing.T) {
+	t.Run("SilentWhenExpectedProfilePresent", func(t *testing.T) {
+		root := writeAWSDir(t, "[profile prod]\nregion = us-west-2\n", "")
+		var buf bytes.Buffer
+
+		WarnOnProfileMismatch(&buf, ForContext(root), "prod")
+
+		if buf.Len() != 0 {
+			t.Errorf("expected no warning when the expected profile exists, got %q", buf.String())
+		}
+	})
+
+	t.Run("SilentWhenNoProfileConfiguredAtAll", func(t *testing.T) {
+		root := t.TempDir()
+		var buf bytes.Buffer
+
+		WarnOnProfileMismatch(&buf, ForContext(root), "prod")
+
+		if buf.Len() != 0 {
+			t.Errorf("expected no warning for an entirely unconfigured AWS setup, got %q", buf.String())
+		}
+	})
+
+	t.Run("WarnsNamingExpectedAndActualWhenMismatched", func(t *testing.T) {
+		// The cli#3155 scenario: a bare `aws configure sso` (no --profile) named
+		// the profile after the SSO role/account rather than the windsor context
+		root := writeAWSDir(t, "[profile AdministratorAccess-105746947080]\nregion = us-west-2\n", "")
+		var buf bytes.Buffer
+
+		WarnOnProfileMismatch(&buf, ForContext(root), "prod")
+
+		msg := buf.String()
+		if !strings.Contains(msg, `"prod"`) {
+			t.Errorf("expected warning to name the expected profile, got %q", msg)
+		}
+		if !strings.Contains(msg, "AdministratorAccess-105746947080") {
+			t.Errorf("expected warning to name the actual profile found, got %q", msg)
 		}
 	})
 }

--- a/pkg/runtime/internal/awsprofile/awsprofile_test.go
+++ b/pkg/runtime/internal/awsprofile/awsprofile_test.go
@@ -300,4 +300,39 @@ func TestWarnOnProfileMismatch(t *testing.T) {
 			t.Errorf("expected warning to name the actual profile found, got %q", msg)
 		}
 	})
+
+	t.Run("NeverColorizesWhenWriterIsNotAFile", func(t *testing.T) {
+		// A bytes.Buffer (or any non-*os.File io.Writer, e.g. a captured-output
+		// test double) is never a terminal, so the warning must stay plain text.
+		root := writeAWSDir(t, "[profile actual]\nregion = us-west-2\n", "")
+		var buf bytes.Buffer
+
+		WarnOnProfileMismatch(&buf, ForContext(root), "prod")
+
+		if strings.Contains(buf.String(), "\033[") {
+			t.Errorf("expected no ANSI escape codes for a non-terminal writer, got %q", buf.String())
+		}
+	})
+
+	t.Run("NeverColorizesPlainFileEvenWhenNOCOLORUnset", func(t *testing.T) {
+		// A redirected/piped destination (`windsor env > out.log`) is a real
+		// *os.File but never a terminal — confirms the terminal check itself,
+		// not just the non-*os.File short-circuit above, keeps output clean.
+		root := writeAWSDir(t, "[profile actual]\nregion = us-west-2\n", "")
+		f, err := os.CreateTemp(t.TempDir(), "warn-output")
+		if err != nil {
+			t.Fatalf("create temp file: %v", err)
+		}
+		defer f.Close()
+
+		WarnOnProfileMismatch(f, ForContext(root), "prod")
+
+		data, err := os.ReadFile(f.Name())
+		if err != nil {
+			t.Fatalf("read temp file: %v", err)
+		}
+		if strings.Contains(string(data), "\033[") {
+			t.Errorf("expected no ANSI escape codes when writing to a non-terminal file, got %q", data)
+		}
+	})
 }


### PR DESCRIPTION
Closes #3155

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> Adds a stderr diagnostic to the AWS env printer, a shared code path exercised by every `windsor env`/`hook` invocation, though the existing `AWS_PROFILE` emission logic itself is unchanged.
>
> **Overview**
>
> When the configured/context AWS profile isn't found in the resolved config, but some other profile is, `AwsEnvPrinter.GetEnvVars` now calls a new `awsprofile.WarnOnProfileMismatch` to print a non-fatal, colored warning naming the expected and actual profile — addressing the case where a bare `aws configure sso` names the profile after the SSO role instead of the windsor context. `Resolver` gained `ListProfileNames`, which scans both the config (`[profile x]`/`[default]`) and credentials (`[x]`) files for section headers.
>
> The heuristic is scoped correctly for project mode, where `.aws/` is dedicated to the context, but in global mode the resolver falls back to the operator's real `~/.aws/config` — a file that legitimately holds unrelated profiles for other clients/projects — which can make the "mismatch" warning fire on unrelated ambient profiles. The `windsor env --hook` path is unaffected since it redirects `os.Stderr` to `/dev/null` before the printer is constructed.

<!-- /claude-code-review:summary -->
