### PR TITLE
fix(terraform): tfvars header states actual regeneration behavior

### DIFF
--- a/pkg/composer/terraform/module_resolver.go
+++ b/pkg/composer/terraform/module_resolver.go
@@ -402,9 +402,12 @@ func (h *BaseModuleResolver) removeTfvarsFiles(dir string) error {
 
 // addTfvarsHeader adds a Windsor CLI management header to the tfvars file body.
 // It includes a module source comment if provided, ensuring users are aware of CLI management and module provenance.
+// The header states plainly that the file is fully regenerated (matching generateTfvarsFile's
+// actual behavior) and names the supported override path, rather than inviting hand edits that
+// the next run silently discards — see cli#3150.
 func addTfvarsHeader(body *hclwrite.Body, source string) {
 	windsorHeaderToken := "Managed by Windsor CLI:"
-	headerComment := fmt.Sprintf("# %s This file is partially managed by the windsor CLI. Your changes will not be overwritten.", windsorHeaderToken)
+	headerComment := fmt.Sprintf("# %s this file is regenerated on every run from the blueprint's component inputs. Edits here are discarded without warning — set values via this component's `inputs:` in blueprint.yaml instead.", windsorHeaderToken)
 	body.AppendUnstructuredTokens(hclwrite.Tokens{
 		{Type: hclsyntax.TokenComment, Bytes: []byte(headerComment + "\n")},
 	})

--- a/pkg/composer/terraform/module_resolver_test.go
+++ b/pkg/composer/terraform/module_resolver_test.go
@@ -1047,6 +1047,45 @@ func TestBaseModuleResolver_GenerateTfvars(t *testing.T) {
 		}
 	})
 
+	t.Run("HeaderStatesFullRegenerationAndOverridePath", func(t *testing.T) {
+		// cli#3150: the header used to claim "your changes will not be overwritten"
+		// while the implementation always fully regenerates the file — a direct
+		// contradiction that invited hand-edits the next run silently discarded.
+		resolver, mocks := setup(t)
+
+		projectRoot, _ := mocks.Shell.GetProjectRootFunc()
+		variablesDir := filepath.Join(projectRoot, ".windsor", "contexts", "local", "terraform", "test-module")
+		if err := os.MkdirAll(variablesDir, 0755); err != nil {
+			t.Fatalf("Failed to create dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(variablesDir, "variables.tf"), []byte(`variable "cluster_name" { type = string }`), 0644); err != nil {
+			t.Fatalf("Failed to write variables.tf: %v", err)
+		}
+
+		// When generating tfvars
+		if err := resolver.GenerateTfvars(false); err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// Then the written header states the file is regenerated and names the
+		// actual override path, and never claims edits are preserved
+		tfvarsPath := filepath.Join(variablesDir, "terraform.tfvars")
+		data, err := os.ReadFile(tfvarsPath)
+		if err != nil {
+			t.Fatalf("Failed to read generated tfvars: %v", err)
+		}
+		content := string(data)
+		if !strings.Contains(content, "regenerated on every run") {
+			t.Errorf("expected header to state the file is fully regenerated, got:\n%s", content)
+		}
+		if !strings.Contains(content, "`inputs:` in blueprint.yaml") {
+			t.Errorf("expected header to name the inputs: override path, got:\n%s", content)
+		}
+		if strings.Contains(content, "will not be overwritten") {
+			t.Errorf("expected the old, contradicted claim to be gone, got:\n%s", content)
+		}
+	})
+
 	t.Run("HandlesMultiLineStringValues", func(t *testing.T) {
 		// Given a resolver with a variable that has a multi-line string value
 		resolver, mocks := setup(t)


### PR DESCRIPTION
Closes #3150

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change only updates a comment string written into generated `terraform.tfvars` files and adds a corresponding unit test; it does not alter any control flow or generation logic.
>
> **Overview**
>
> The Windsor-managed header comment injected into generated `.tfvars` files previously claimed "your changes will not be overwritten," which directly contradicted the actual behavior: `removeTfvarsFiles` followed by `generateTfvarsFile` fully regenerates the file on every run. The new header states plainly that the file is regenerated on every run and points users to the supported override path (`inputs:` in `blueprint.yaml`) instead of inviting hand-edits that get silently discarded.
>
> A new test case (`HeaderStatesFullRegenerationAndOverridePath`) asserts the generated file contains the new wording and no longer contains the old, contradicted claim.

<!-- /claude-code-review:summary -->
