### PR TITLE
feat(check): detect missing x86-64-v2 microarchitecture support

### DIFF
--- a/pkg/runtime/tools/tools_manager.go
+++ b/pkg/runtime/tools/tools_manager.go
@@ -265,7 +265,12 @@ func (t *BaseToolsManager) checkColima() error {
 // golang.org/x/sys/cpu — no shelling out) fails fast during `windsor check` instead. A no-op on
 // non-amd64 hosts: Apple Silicon's Docker Desktop runs an ARM Linux VM, where this constraint
 // doesn't apply. See cli#1268.
-func checkCPUMicroarchitecture() error {
+//
+// Declared as a variable, not a func, so CheckRequirements' wiring to it — that it fires when
+// docker.enabled/workstation.runtime needs Docker AND cluster.driver is "talos" — is verifiable
+// in tests without depending on the test runner's actual CPU features; golang.org/x/sys/cpu.X86
+// has no injection point of its own.
+var checkCPUMicroarchitecture = func() error {
 	if runtime.GOARCH != "amd64" {
 		return nil
 	}

--- a/pkg/runtime/tools/tools_manager.go
+++ b/pkg/runtime/tools/tools_manager.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	"github.com/windsorcli/cli/pkg/runtime/internal/awsprofile"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
+	"golang.org/x/sys/cpu"
 )
 
 // The ToolsManager is a core component that manages development tools and dependencies
@@ -147,6 +149,11 @@ func (t *BaseToolsManager) CheckRequirements(reqs Requirements) error {
 		if err := t.checkDocker(); err != nil {
 			return err
 		}
+		if t.configHandler.GetString("cluster.driver", "") == "talos" {
+			if err := checkCPUMicroarchitecture(); err != nil {
+				return err
+			}
+		}
 	}
 
 	if reqs.Terraform && t.configHandler.GetBool("terraform.enabled") {
@@ -248,6 +255,63 @@ func (t *BaseToolsManager) checkColima() error {
 		return outdatedToolError("limactl", limactlVersion)
 	}
 
+	return nil
+}
+
+// checkCPUMicroarchitecture reports an error when the host CPU lacks the x86-64-v2 instruction
+// baseline that Talos requires. Talos's own container image already refuses to start with "This
+// program can only be run on AMD64 processors with v2 microarchitecture support," but that
+// failure surfaces deep inside the docker driver's startup path; catching it here (via
+// golang.org/x/sys/cpu — no shelling out) fails fast during `windsor check` instead. A no-op on
+// non-amd64 hosts: Apple Silicon's Docker Desktop runs an ARM Linux VM, where this constraint
+// doesn't apply. See cli#1268.
+func checkCPUMicroarchitecture() error {
+	if runtime.GOARCH != "amd64" {
+		return nil
+	}
+	return checkX86V2Baseline(x86V2Features{
+		HasCX16:   cpu.X86.HasCX16,
+		HasPOPCNT: cpu.X86.HasPOPCNT,
+		HasSSE3:   cpu.X86.HasSSE3,
+		HasSSSE3:  cpu.X86.HasSSSE3,
+		HasSSE41:  cpu.X86.HasSSE41,
+		HasSSE42:  cpu.X86.HasSSE42,
+	})
+}
+
+// x86V2Features is the subset of golang.org/x/sys/cpu.X86Info that defines the x86-64-v2
+// microarchitecture baseline (CMPXCHG16B, POPCNT, SSE3, SSSE3, SSE4.1, SSE4.2), taken as a
+// parameter so checkX86V2Baseline is testable without needing to run on hardware that actually
+// lacks these features.
+type x86V2Features struct {
+	HasCX16, HasPOPCNT, HasSSE3, HasSSSE3, HasSSE41, HasSSE42 bool
+}
+
+// checkX86V2Baseline returns an error naming every x86-64-v2 feature f is missing, or nil if f
+// satisfies the full baseline.
+func checkX86V2Baseline(f x86V2Features) error {
+	var missing []string
+	if !f.HasCX16 {
+		missing = append(missing, "CMPXCHG16B")
+	}
+	if !f.HasPOPCNT {
+		missing = append(missing, "POPCNT")
+	}
+	if !f.HasSSE3 {
+		missing = append(missing, "SSE3")
+	}
+	if !f.HasSSSE3 {
+		missing = append(missing, "SSSE3")
+	}
+	if !f.HasSSE41 {
+		missing = append(missing, "SSE4.1")
+	}
+	if !f.HasSSE42 {
+		missing = append(missing, "SSE4.2")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("CPU lacks x86-64-v2 microarchitecture support (missing: %s); Talos requires a v2-capable host CPU and will fail to start in Docker", strings.Join(missing, ", "))
+	}
 	return nil
 }
 

--- a/pkg/runtime/tools/tools_manager_test.go
+++ b/pkg/runtime/tools/tools_manager_test.go
@@ -636,6 +636,55 @@ contexts:
 		}
 	})
 
+	t.Run("TalosClusterDriverWithoutDockerNeverChecksCPU", func(t *testing.T) {
+		// Given cluster.driver is talos but no docker-family workstation runtime is
+		// configured (e.g. Talos on bare metal/cloud) — the CPU microarchitecture
+		// check only applies to Talos-in-Docker, so it must never fire here
+		_, toolsManager := setup(t, `
+contexts:
+  test:
+    cluster:
+      driver: talos
+`)
+
+		// When CheckRequirements runs with Docker requested
+		err := toolsManager.CheckRequirements(Requirements{Docker: true})
+
+		// Then it succeeds trivially — the docker check itself is skipped since
+		// needsDocker is false, so the CPU check nested inside it never runs
+		// regardless of this host's actual CPU
+		if err != nil {
+			t.Errorf("Expected no error when docker isn't needed, got: %v", err)
+		}
+	})
+
+	t.Run("NonTalosClusterDriverNeverChecksCPU", func(t *testing.T) {
+		// Given a docker-family workstation runtime with a non-talos cluster driver
+		// (e.g. an EKS/AKS/GKE cluster where docker is only used for local tooling)
+		_, toolsManager := setup(t, `
+contexts:
+  test:
+    docker:
+      enabled: true
+    cluster:
+      driver: eks
+`)
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			return "/usr/bin/" + name, nil
+		}
+		t.Cleanup(func() { execLookPath = originalExecLookPath })
+
+		// When CheckRequirements runs with Docker requested
+		err := toolsManager.CheckRequirements(Requirements{Docker: true})
+
+		// Then it succeeds regardless of this host's actual CPU — the
+		// microarchitecture check is scoped to cluster.driver == "talos" only
+		if err != nil {
+			t.Errorf("Expected no error for a non-talos cluster driver, got: %v", err)
+		}
+	})
+
 	t.Run("SecretsRequestedChecksBothSopsAndOnePassword", func(t *testing.T) {
 		// Given both sops and 1password are enabled in config and Secrets is requested
 		_, toolsManager := setup(t, configWithEverythingEnabled)
@@ -1035,6 +1084,67 @@ func TestToolsManager_checkColima(t *testing.T) {
 		// Then an error indicating version is too low should be returned
 		if err == nil || !strings.Contains(err.Error(), "Lima 0.5.0 is below the minimum required version") {
 			t.Errorf("Expected limactl version too low error, got %v", err)
+		}
+	})
+}
+
+// Tests for the x86-64-v2 microarchitecture baseline check (cli#1268)
+func TestCheckX86V2Baseline(t *testing.T) {
+	fullBaseline := x86V2Features{
+		HasCX16: true, HasPOPCNT: true, HasSSE3: true, HasSSSE3: true, HasSSE41: true, HasSSE42: true,
+	}
+
+	t.Run("SucceedsWhenEveryFeaturePresent", func(t *testing.T) {
+		if err := checkX86V2Baseline(fullBaseline); err != nil {
+			t.Errorf("Expected no error for a full v2 baseline, got: %v", err)
+		}
+	})
+
+	t.Run("NamesEachMissingFeature", func(t *testing.T) {
+		f := fullBaseline
+		f.HasPOPCNT = false
+		f.HasSSE42 = false
+
+		err := checkX86V2Baseline(f)
+
+		if err == nil {
+			t.Fatal("Expected an error when features are missing, got nil")
+		}
+		if !strings.Contains(err.Error(), "POPCNT") {
+			t.Errorf("Expected error to name POPCNT, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "SSE4.2") {
+			t.Errorf("Expected error to name SSE4.2, got: %v", err)
+		}
+		if strings.Contains(err.Error(), "CMPXCHG16B") {
+			t.Errorf("Expected error not to name a feature that IS present, got: %v", err)
+		}
+	})
+
+	t.Run("FailsWhenEveryFeatureMissing", func(t *testing.T) {
+		err := checkX86V2Baseline(x86V2Features{})
+
+		if err == nil {
+			t.Fatal("Expected an error for a CPU with none of the baseline features, got nil")
+		}
+		for _, feature := range []string{"CMPXCHG16B", "POPCNT", "SSE3", "SSSE3", "SSE4.1", "SSE4.2"} {
+			if !strings.Contains(err.Error(), feature) {
+				t.Errorf("Expected error to name %s, got: %v", feature, err)
+			}
+		}
+	})
+}
+
+func TestCheckCPUMicroarchitecture(t *testing.T) {
+	t.Run("NoOpOnNonAMD64Architectures", func(t *testing.T) {
+		// runtime.GOARCH is fixed for this test binary, so this only exercises the
+		// gate directly when the test runner itself is non-amd64 (e.g. macOS/Linux
+		// arm64 in CI); the feature-level logic is covered by TestCheckX86V2Baseline.
+		if runtime.GOARCH == "amd64" {
+			t.Skip("test binary is amd64; the non-amd64 no-op path isn't exercised here")
+		}
+		if err := checkCPUMicroarchitecture(); err != nil {
+			t.Errorf("Expected no error on a non-amd64 host, got: %v", err)
 		}
 	})
 }

--- a/pkg/runtime/tools/tools_manager_test.go
+++ b/pkg/runtime/tools/tools_manager_test.go
@@ -636,25 +636,78 @@ contexts:
 		}
 	})
 
-	t.Run("TalosClusterDriverWithoutDockerNeverChecksCPU", func(t *testing.T) {
-		// Given cluster.driver is talos but no docker-family workstation runtime is
-		// configured (e.g. Talos on bare metal/cloud) — the CPU microarchitecture
-		// check only applies to Talos-in-Docker, so it must never fire here
+	t.Run("TalosClusterDriverWithDockerChecksCPU", func(t *testing.T) {
+		// Given docker.enabled AND cluster.driver: talos together — the one
+		// combination that must actually wire through to the CPU check. Stubs
+		// checkCPUMicroarchitecture itself so the assertion doesn't depend on
+		// this test runner's real CPU features.
 		_, toolsManager := setup(t, `
 contexts:
   test:
+    docker:
+      enabled: true
     cluster:
       driver: talos
 `)
+		originalExecLookPath := execLookPath
+		execLookPath = func(name string) (string, error) {
+			return "/usr/bin/" + name, nil
+		}
+		t.Cleanup(func() { execLookPath = originalExecLookPath })
+
+		originalCheckCPUMicroarchitecture := checkCPUMicroarchitecture
+		var called bool
+		checkCPUMicroarchitecture = func() error {
+			called = true
+			return nil
+		}
+		t.Cleanup(func() { checkCPUMicroarchitecture = originalCheckCPUMicroarchitecture })
+
+		// When CheckRequirements runs with Docker requested
+		if err := toolsManager.CheckRequirements(Requirements{Docker: true}); err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+
+		// Then the CPU check actually fired — this is the wiring a regression
+		// (dropped call, or a broken "talos" string match) would silently break
+		if !called {
+			t.Error("Expected checkCPUMicroarchitecture to be called for docker+talos, got not called")
+		}
+	})
+
+	t.Run("TalosClusterDriverWithoutDockerNeverChecksCPU", func(t *testing.T) {
+		// Given cluster.driver is talos but no docker-family workstation runtime is
+		// configured (e.g. Talos on bare metal/cloud) — the CPU microarchitecture
+		// check only applies to Talos-in-Docker, so it must never fire here.
+		// docker.enabled is explicitly false: setupMocks' own defaultConfig sets
+		// it true for context "test", and LoadConfigString merges rather than
+		// replaces, so omitting it here would silently leave docker enabled.
+		_, toolsManager := setup(t, `
+contexts:
+  test:
+    docker:
+      enabled: false
+    cluster:
+      driver: talos
+`)
+		originalCheckCPUMicroarchitecture := checkCPUMicroarchitecture
+		var called bool
+		checkCPUMicroarchitecture = func() error {
+			called = true
+			return nil
+		}
+		t.Cleanup(func() { checkCPUMicroarchitecture = originalCheckCPUMicroarchitecture })
 
 		// When CheckRequirements runs with Docker requested
 		err := toolsManager.CheckRequirements(Requirements{Docker: true})
 
 		// Then it succeeds trivially — the docker check itself is skipped since
 		// needsDocker is false, so the CPU check nested inside it never runs
-		// regardless of this host's actual CPU
 		if err != nil {
 			t.Errorf("Expected no error when docker isn't needed, got: %v", err)
+		}
+		if called {
+			t.Error("Expected checkCPUMicroarchitecture NOT to be called when docker isn't needed")
 		}
 	})
 
@@ -675,13 +728,24 @@ contexts:
 		}
 		t.Cleanup(func() { execLookPath = originalExecLookPath })
 
+		originalCheckCPUMicroarchitecture := checkCPUMicroarchitecture
+		var called bool
+		checkCPUMicroarchitecture = func() error {
+			called = true
+			return nil
+		}
+		t.Cleanup(func() { checkCPUMicroarchitecture = originalCheckCPUMicroarchitecture })
+
 		// When CheckRequirements runs with Docker requested
 		err := toolsManager.CheckRequirements(Requirements{Docker: true})
 
-		// Then it succeeds regardless of this host's actual CPU — the
-		// microarchitecture check is scoped to cluster.driver == "talos" only
+		// Then it succeeds and the microarchitecture check never fired — it's
+		// scoped to cluster.driver == "talos" only
 		if err != nil {
 			t.Errorf("Expected no error for a non-talos cluster driver, got: %v", err)
+		}
+		if called {
+			t.Error("Expected checkCPUMicroarchitecture NOT to be called for a non-talos cluster driver")
 		}
 	})
 


### PR DESCRIPTION
Closes #1268

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> The change adds a single new gated check to `BaseToolsManager.CheckRequirements`; it only fires for the narrow combination of a docker-family workstation with `cluster.driver: talos`, so existing behavior for every other configuration is unchanged.
>
> **Overview**
>
> This PR adds a fail-fast check for the x86-64-v2 microarchitecture baseline (CMPXCHG16B, POPCNT, SSE3, SSSE3, SSE4.1, SSE4.2) that Talos's container image requires. It runs via `golang.org/x/sys/cpu` (no shelling out) immediately after the existing Docker check succeeds, and only when `cluster.driver` is `talos`; it is a no-op on non-amd64 hosts since the constraint doesn't apply there (e.g. Apple Silicon's ARM Linux VM).
>
> The feature-level logic (`checkX86V2Baseline`) is well covered with a fake CPU-features struct, and both "doesn't fire" branches (no docker, non-talos driver) are tested. There is no test exercising the actual wiring point inside `CheckRequirements` for the true/true case, since `checkCPUMicroarchitecture` isn't injectable the way `execLookPath` is elsewhere in this package — see inline comment.

<!-- /claude-code-review:summary -->
