### PR TITLE
chore(docs): v0.10.0 planning and adrs

### DIFF
--- a/docs/adrs/0008-airgap-media-and-hydration.md
+++ b/docs/adrs/0008-airgap-media-and-hydration.md
@@ -1,471 +1,231 @@
-# ADR 0008 — Airgap media and hydration
+# ADR 0008 — OCI registry mirror for images, charts, and Terraform providers
 
 - Status: Proposed
 - Date: 2026-08-09
 - Deciders: Ryan VanGundy
+- Rescoped: 2026-09-01 — narrowed from the original "Airgap media and hydration" design (write-once
+  physical media, a disconnected two-workstation `windsor bootstrap`) down to the piece actually
+  targeted for v0.10.0: extending the existing image/blueprint OCI mirror mode to also cover
+  Terraform providers, over a network-reachable registry. Full write-once airgap media — physical
+  distribution, BOM completeness via declared/observed reconciliation, offline Talos provisioning,
+  signing, the two-workstation model — is out of scope here. That design was fully drafted under
+  this same ADR number before the rescope and remains recoverable from this file's git history
+  (`git log -p -- docs/adrs/0008-airgap-media-and-hydration.md`) as the starting point for a future
+  ADR once airgap work is actually scoped, rather than something to re-derive from nothing.
 
-Goal: produce a single body of media — writable once, readable forever — that carries 100% of what
-a Windsor blueprint needs, and from which a disconnected workstation can run `windsor bootstrap`
-to completion with no egress at any point. This ADR fixes the media layout, the bill-of-materials
-(BOM) contract, the command surface, and the layer ownership; it names the eight feasibility
-questions that must be answered by spike before the sequence below is committed to.
+Goal: close the one gap in Windsor's existing OCI mirror story. Blueprint sources and container
+images already have a mirror path; Terraform providers don't, because HashiCorp's `terraform` has no
+OCI client and never fetches providers any way but straight from `registry.terraform.io`. This ADR
+gives providers the same mirror path the other two artifact types already have.
 
 ## Context
 
 ### What already exists, verified against the tree
 
-Windsor is closer to this than it looks. Five mechanisms already in place do most of the structural
-work, and each was checked directly rather than assumed.
+- **Blueprint OCI sources already pull through a local cache.** `ArtifactBuilder.Pull`
+  (`pkg/composer/artifact/artifact.go:481`) checks `.windsor/cache/oci/<key>` before reaching the
+  network, downloading only on a cache miss. Refs are used verbatim — pointing a blueprint source
+  `url` at a private mirror registry already works today, with no separate "mirror mode" flag.
+- **Container images have a separate pull-through mechanism**, `docker.registries`, which runs local
+  registry-proxy containers the container runtime pulls through. Unrelated to the blueprint OCI
+  path — a second, already-working mirror mechanism, not a gap.
+- **`terraform.driver` already selects `terraform` or `tofu`** (`BaseToolsManager.GetTerraformCommand`,
+  `pkg/runtime/tools/tools_manager.go:326`, `getTerraformDriver` at `:340`), both invoked as external
+  binaries — no Go SDK, no `terraform-exec` dependency. `runTerraformInit`
+  (`pkg/provisioner/terraform/stack.go:1566`) is the sole call into `terraform init` / `tofu init`,
+  and `selectTerraformCommandEnv` (`stack.go:1919`) is the one place that assembles the env passed
+  to it — the natural wiring point for anything provider-mirror-related.
+- **`.terraformrc` is already excluded from `windsor bundle` output**
+  (`shouldSkipTerraformFile`, `artifact.go:896-918`) — correctly, since it would encode local paths
+  that don't survive a bundle. Any generated CLI config needs to be produced at consumption time,
+  not shipped.
 
-**1. A BOM already ships inside every blueprint artifact.** `pkg/composer/artifact/manifest.go`
-defines `ArtifactManifest` / `ManifestEntry`, written as `artifact-manifest.yaml` into every bundle
-(`artifact.go:602`, regenerated at `artifact.go:801`). Its own header states the intent this ADR is
-picking up: *"bundled into the blueprint OCI artifact so downstream consumers can hydrate a local
-mirror without re-evaluating adaptive composition logic or rendering Helm charts."* It already
-models `ArtifactType` (docker / helm / github-release / git-tag) and `ArtifactTransport`
-(oci / tarball / git), and already records `helmRepo` provenance.
+### The actual gap
 
-It is populated by `pkg/composer/artifact/scanner.go`, which walks bundled files for Renovate
-annotations — deterministic and offline by construction. Against `windsorcli/core` today that scan
-finds annotations across 64 files: 94 `datasource=docker`, 33 `datasource=helm`, 27
-`datasource=github-releases`, 4 `git-refs`, 2 `github-tags`. Core's Renovate hygiene is good enough
-that this is a genuine inventory, not a token one.
+**No Terraform provider mirror mechanism exists at all.** A repo-wide grep for
+`TF_PLUGIN_CACHE_DIR`, `provider_installation`, `filesystem_mirror`, and `TF_CLI_CONFIG_FILE`
+returns nothing. Every `terraform init` / `tofu init` resolves providers straight from
+`registry.terraform.io` / `registry.opentofu.org`, with zero Windsor involvement.
 
-**2. Local registries already run, and Talos already pulls through them.** `windsorcli/core`'s
-`terraform/workstation/docker` runs one `ghcr.io/distribution/distribution:3.0.0` container per
-upstream registry, on fixed IPs in the reserved block `[4, node_start_offset)`, with storage
-bind-mounted from `.windsor/cache/docker/registries/<host>/` (`main.tf:260`; the Incus module does
-the same at `main.tf:217`). `contexts/_template/facets/option-workstation.yaml` then maps the
-module's `registries` output straight into `machine.registries.mirrors` on the Talos machine patch.
-The default map covers `gcr.io`, `ghcr.io`, `quay.io`, `reg.kyverno.io`, `registry-1.docker.io`,
-`registry.k8s.io`.
+**HashiCorp's `terraform` has no OCI client for providers, and there's no signal that's changing.**
+Providers are distributed over the Terraform Registry Protocol (HTTPS + JSON, zip packages,
+SHA256SUMS + GPG signature) — there is no OCI presence to mirror from the way there is for images
+and OCI-native Helm charts. The feature request
+([hashicorp/terraform#31463](https://github.com/hashicorp/terraform/issues/31463)) has been open
+since July 2022 with no roadmap commitment. OpenTofu 1.10 added native, still-experimental OCI
+provider mirroring (`provider_installation { oci_mirror { ... } }`), but this organization is
+terraform-primary and needs both drivers supported, so the design can't center on tofu's feature.
 
-Today those containers run in pull-through mode (`REGISTRY_PROXY_REMOTEURL`, `main.tf:243`). The
-airgap change is to run the same containers, at the same IPs and hostnames, in plain storage mode
-against pre-seeded content. Nothing in the Talos mirror wiring has to change.
+**Provider packages are OS/arch-specific, and a naive mirror breaks every platform but the
+publisher's own.** `terraform providers mirror` — the only existing tool that actually fetches
+provider packages, verifying SHA256SUMS and signature — only downloads the platforms passed via
+repeated `-platform=os_arch` flags, defaulting to the invoking machine's platform if none are given.
 
-**3. Blueprint sources and Terraform modules already resolve from a local cache.** `Pull` checks
-`.windsor/cache/oci/<key>` before reaching the network (`artifact.go:517`) and only downloads on a
-cache miss or `NO_CACHE`. `FluxStack.resolveSourceRoot` (`pkg/provisioner/flux/stack.go:546`)
-derives the same path. A pre-populated cache directory is therefore already a working offline path
-for the blueprint artifact and every Terraform module it carries.
+**OpenTofu's own OCI provider-mirror layout already solves the multi-platform representation
+problem**, using the same primitive as Docker multi-arch images (checked live against
+[opentofu.org/docs/cli/oci_registries/provider-mirror](https://opentofu.org/docs/cli/oci_registries/provider-mirror/),
+not recalled from memory). One version tag resolves to an OCI Image Index
+(`artifactType: application/vnd.opentofu.provider`) whose `manifests[]` holds one descriptor per
+platform (`artifactType: application/vnd.opentofu.provider-target`, a `platform: {os, architecture}`
+field), each pointing at an image manifest wrapping a single `archive/zip` layer. A client resolves
+by fetching the index and matching its own OS/arch against the descriptors.
 
-**4. A local git server already runs.** The workstation stack runs a `git-livereload` container at
-`git.<domain>`, which is the in-enclave Git origin Flux `GitRepository` sources need when the
-blueprint is not consumed over OCI.
-
-**5. Windsor checks tools; it does not install them.** `pkg/runtime/tools/tools_manager.go` has
-`Install()` and `WriteManifest()` as explicit placeholders returning nil; the real surface is
-`CheckRequirements`, which does `execLookPath` plus a minimum-version comparison against
-`registry.go`'s `toolRegistry`. This is load-bearing for airgap: Windsor never has to acquire a
-tool, only to find an acceptable one on `PATH`. Supplying tools becomes a `PATH` question, not an
-installer question.
-
-### What does not exist, and what actually breaks
-
-**No Terraform provider mirror.** `grep` for `TF_PLUGIN_CACHE_DIR`, `provider_installation`,
-`filesystem_mirror`, `TF_CLI_CONFIG_FILE` across both repos returns nothing. Core's modules require
-15 distinct providers — `hashicorp/{aws,azurerm,helm,kubernetes,local,null,random,tls}`,
-`kreuzwerker/docker`, `lxc/incus`, `siderolabs/talos`, `vmware/vsphere`, `hetznercloud/hcloud`,
-`hcloud-talos/imager`, `windsorcli/hyperv`. Every `terraform init` in the enclave hits
-`registry.terraform.io` today and fails.
-
-**Helm charts are pulled by Flux over HTTPS, and containerd mirrors do not cover that.** Core
-declares 24 distinct HTTP `HelmRepository` URLs (`charts.jetstack.io`, `helm.cilium.io`,
-`prometheus-community.github.io`, and so on) plus `oci://docker.io/envoyproxy`. Those fetches come
-from source-controller inside the cluster over HTTPS to the public internet. `machine.registries.
-mirrors` redirects containerd image pulls only; it does nothing for a chart download. Every HTTP
-`HelmRepository` must be republished as OCI and its URL rewritten, or the enclave install stalls at
-the first `HelmRelease`.
-
-**The declared BOM is incomplete by construction.** A Renovate annotation covers what the blueprint
-author pinned. It does not cover images a chart's own defaults introduce — sidecars,
-`kube-rbac-proxy`, init containers, an operator's operand image chosen at runtime. `kustomize/database/
-install/cloudnativepg/helm-release.yaml` is representative: the annotation pins the operator image,
-while the Postgres image the operator later pulls appears nowhere in the blueprint source. A media
-set built from the declared BOM alone will fail somewhere in the middle of a bootstrap, which is the
-worst possible failure mode for write-once media.
-
-**Two Terraform paths call the internet at apply time.** `terraform/cluster/talos/extensions/main.tf:34`
-resolves a schematic through `talos_image_factory_schematic` against `factory.talos.dev`, and
-`terraform/compute/incus/main.tf:33` registers an image remote at `https://images.windsorcli.dev`.
-Both need an offline substitute.
-
-**Flux installs itself from OCI charts.** `terraform/gitops/flux/main.tf:150,163` installs
-`flux-operator` and `flux-instance` from `oci://ghcr.io/controlplaneio-fluxcd/charts` via the Helm
-provider, and pins controller images with `registry = "ghcr.io/fluxcd"` (`main.tf:175`). The
-registry field is already parameterized, which is the hook airgap needs; the chart repository is not.
-
-**The container runtime itself is not a binary problem.** Docker Desktop, Colima, and Incus are
-daemons and VMs. On macOS, `colima start` provisions a Lima guest that is downloaded from the
-internet on first run. A media set that carries every CLI but assumes a working local container
-runtime is only honest if that assumption is written down as a prerequisite.
-
-### The two-workstation model
-
-Everything below assumes two roles, because conflating them is where airgap designs usually go
-wrong.
-
-- **Staging workstation** — connected. Runs `windsor pack`. Has egress, a container runtime, and the
-  same tool versions the enclave will get.
-- **Enclave workstation** — disconnected. Has the media mounted read-only and nothing else. Runs
-  `windsor verify`, `windsor hydrate`, then `windsor bootstrap`.
-
-The enclave workstation may already have Docker or Terraform installed, at versions Windsor did not
-choose. That is a supported and expected condition, not an error, and decision 7 handles it.
+**"Platform" is already an overloaded word in this CLI** — it names the aws/incus/docker/metal/azure
+deployment-target dimension elsewhere. Any OS/arch selector this feature introduces needs a visibly
+distinct name.
 
 ## Decision
 
-### 1. Media is a content-addressed directory tree with a signed root index, not an archive
+### 1. One registry-population mechanism serves both drivers
 
-The unit of distribution is a directory that can be burned to optical media, written to a
-write-protected volume, or served from a read-only mount. It is usable in place — `windsor hydrate
---media /Volumes/WINDSOR_AIRGAP` — with no unpack step required.
+`filesystem_mirror` (in `provider_installation`) is wire-compatible across both `terraform` and
+`tofu`; `oci_mirror` is tofu-only and experimental. Windsor owns the full pipeline for both drivers
+rather than branching on `terraform.driver`:
 
-```
-windsor-airgap-<blueprint>-<version>/
-  index.yaml              # root: schema version, blueprint refs, platforms, arches, digests
-  index.sig               # detached signature over index.yaml
-  checksums.txt           # sha256 of every file, for readers without the CLI
-  oci/                    # ONE OCI image layout (spec v1.1) for all OCI content
-    index.json
-    oci-layout
-    blobs/sha256/...
-  providers/              # terraform filesystem-mirror layout, per platform
-  bin/<os>_<arch>/        # pinned CLI binaries + per-file checksums
-  images/                 # machine images: talos iso/raw/ova, incus image files
-  talos/                  # image-cache.oci, schematic pins, boot assets
-  runbook.md              # generated, blueprint-specific, human-readable
-```
+- **Publish** (from any environment with egress): fetch each requested platform's package via
+  `terraform providers mirror -platform=<os_arch>` — still the real, only origin-side fetch and
+  verification mechanism — then wrap the results into an OCI Image Index per (2) and push to the
+  mirror registry.
+- **Consume** (any environment, either driver): for each required provider, pull only its Image
+  Index (small — JSON only), pick the one descriptor whose `platform` matches the consuming
+  machine's own `runtime.GOOS`/`runtime.GOARCH` (no flag needed here — unlike publish, the consuming
+  machine already knows its own platform), and pull only that descriptor's `archive/zip` layer.
+  Write it to `<mirror-dir>/<HOSTNAME>/<NAMESPACE>/<TYPE>/terraform-provider-<TYPE>_<VERSION>_
+  <TARGET>.zip` — Terraform's documented **packed filesystem mirror** layout, verified directly
+  against [developer.hashicorp.com/terraform/cli/config/config-file](https://developer.hashicorp.com/terraform/cli/config/config-file):
+  no `index.json`, no version manifest required, Terraform infers everything from the nesting and
+  filename alone. Generate a CLI config with `provider_installation { filesystem_mirror { path =
+  <mirror-dir> } }`, and export `TF_CLI_CONFIG_FILE` alongside the `TF_DATA_DIR` and `TF_VAR_*`
+  variables `selectTerraformCommandEnv` already assembles, ahead of `runTerraformInit`. Terraform
+  itself never resolves multi-arch — it only ever sees a directory already narrowed to its own
+  platform, so `init` runs against the identical filesystem-mirror code path it already has, unmodified.
 
-Rationale, in order of weight:
+This works unmodified for `terraform` and `tofu` alike.
 
-- **A single tarball is unusable on WORM optical media.** ISO 9660 caps a single file at 4 GiB
-  without multi-extent support that many readers do not implement. A content-addressed blob tree
-  keeps every file at layer size, well under the cap, and stays readable from an ISO 9660 filesystem
-  without requiring UDF. (Spike S7 confirms this against the target readers.)
-- **One `oci/` layout for everything OCI.** Container images, Helm charts republished as OCI, the
-  Windsor blueprint artifact, and Talos installer images all share one blob store, so shared base
-  layers are stored once. Against core's image set this is not a marginal saving.
-- **Partial verification and resumable copy.** A blob tree can be verified, diffed, and
-  incrementally re-copied. A 20 GB tarball cannot.
-- **The user can point at folders.** Serving the registry directly off the mounted media, with no
-  copy, becomes possible (decision 3).
+### 2. Providers are stored as OCI Image Indexes — OpenTofu's layout, not a bespoke one
 
-`index.yaml` is the manifest of record: schema version, the blueprint reference and digest it was
-built from, the platform/arch matrix, the full resolved BOM with digests, and the provenance of each
-entry (declared, observed, or manually added).
+Adopting OpenTofu's exact media types and structure (Context) means the registry content stays
+legible to standard OCI tooling and, once `oci_mirror` graduates past experimental, is directly
+consumable by `tofu` with zero Windsor involvement — interoperability that a Windsor-specific format
+would forfeit for no benefit. `go-containerregistry` — already a dependency via `ArtifactBuilder` —
+builds and pushes the index directly (`v1.IndexManifest`, `remote.WriteIndex`); no new library.
 
-### 2. The BOM is declared ∪ observed, and pack fails closed on the delta
+### 3. Platform/arch selection is explicit, never inferred from the publishing machine
 
-Two independent passes produce the BOM, and `windsor pack` refuses to write media when they
-disagree in the dangerous direction.
+The publish path takes a repeatable OS/arch selector, deliberately not named `--platform` (Context —
+collides with the existing deployment-platform dimension). Defaults to a configured set rather than
+the invoking machine's own platform; publishing from one developer's laptop must never silently
+produce a mirror that only works on that laptop's architecture. The exact flag name and where its
+default set is configured (a new `windsor.yaml` key, most likely) is an open follow-up, not decided
+here.
 
-- **Declared** — the existing Renovate scan (`scanner.go`), extended to resolve every entry to a
-  digest and to expand chart references into their `helm template` render so chart-default images
-  are captured. This runs offline against blueprint source.
-- **Observed** — captured from a reference deployment of the same blueprint at the same version on
-  the staging workstation. The capture sources are the registry cache trees at
-  `.windsor/cache/docker/registries/<host>/`, which by construction contain exactly what was pulled,
-  plus the node-side image list read through the existing cluster client.
+### 4. Command structure: `windsor push` gains objects; `windsor pull providers` is new
 
-`windsor pack` computes `observed \ declared`. A non-empty delta is an error naming each missing
-reference, its digest, and the node or repository that pulled it. `--allow-undeclared` records them
-in `index.yaml` with `provenance: observed` and proceeds. The default is to fail, because a missing
-image discovered after the media is burned is unrecoverable in the enclave.
+`windsor push <registry/repo[:tag]>` already exists (`cmd/push.go`), pushing only the blueprint with
+no object argument — the "object optional when singular" case, since there was only one pushable
+thing. Adding two more artifact types makes the object necessary going forward; the bare form is
+preserved unchanged:
 
-This is the single most important decision in the ADR. A static scan is not sufficient for a
-promise of 100% completeness, and no amount of scanner improvement makes it sufficient, because
-chart defaults and operator-chosen operand images are not statically present in the blueprint at
-all.
+- `windsor push <registry>` — **unchanged.** Still blueprint-only.
+- `windsor push images <registry>` — new object. OCI-to-OCI copy of the image refs the existing
+  scanner already extracts (`pkg/composer/artifact/scanner.go`) for the manifest.
+- `windsor push providers <registry> [--arch=<os_arch>]...` — new object. Runs the publish pipeline
+  in (1)/(2)/(3).
+- `windsor push mirror <registry>` — convenience object equivalent to running all three together
+  (blueprint + images + providers), with `--include`/`--exclude` to scope down. Same three calls,
+  not a fourth mechanism.
+- `windsor pull providers` — new command family (no `windsor pull` exists today). Resolves the
+  current blueprint's provider requirements and runs the consume path in (1). No bare `windsor pull`
+  form yet: blueprint sources and image references stay purely config-driven and need no explicit
+  pull step, so `providers` is the only object today.
 
-### 3. The airgap registry is the existing workstation registry with proxying off, seeded by push
+Cobra dispatches to a child command only when the first positional token exactly matches a
+registered subcommand name (`images`, `providers`, `mirror`) — none of which collide with a valid
+`registry/repo[:tag]` token — so `pushCmd`'s existing `RunE` keeps handling the bare form unchanged.
 
-`windsor hydrate` starts the same per-upstream `distribution` containers core already runs, at the
-same IPs and hostnames, with `REGISTRY_PROXY_REMOTEURL` unset, and pushes the media's `oci/` layout
-into them. `docker.registries` and the generated `machine.registries.mirrors` are unchanged, so
-neither core's Terraform nor the Talos machine patch needs an airgap branch.
+Split objects plus a `mirror` convenience wrapper were chosen over a single umbrella command because
+providers and images have different natural re-push cadences — a provider version bump shouldn't
+require re-pushing images, and forcing every re-push through `--include`/`--exclude` flags on one
+command is worse ergonomics than a dedicated object for the common surgical case.
+`windsor mirror push` / `windsor mirror pull` (mirror as a shared noun root) was considered and
+rejected against this codebase's verb-first command convention (`windsor unlock`, not
+`windsor stack lock`).
 
-Two things are deliberately rejected here:
+### 5. `.terraformrc` stays out of `windsor bundle`, unchanged
 
-- **Copying the proxy cache directory and re-serving it as a proxy.** Distribution's
-  `proxyTagService.Get` tries the remote first and falls back to the local association only on
-  error, so every tag resolution in the enclave pays a DNS or connect timeout before succeeding, and
-  the fallback path is not a supported offline mode. Issue distribution/distribution#4046 documents
-  the cache failing to serve content it demonstrably holds. Depending on that behavior for a
-  disconnected install is not defensible.
-- **A single hub registry with `overridePath`.** Talos supports pointing many upstreams at one
-  endpoint with distinct paths, which is how Harbor is used (and how Manager's
-  [ADR-0008](../../../manager/docs/adr/0008-harbor.md) intends to use it). It is the better shape at
-  fleet scale, and it is not the shape core's mirror map generates today. Adopting it here would mean
-  changing the mirror derivation in `option-workstation.yaml` as part of an airgap change. Deferred
-  to the point where Harbor is the enclave registry; see Deferred.
-
-Where the registry storage lives is a hydrate-time choice: copied into the enclave work directory
-(default, needs disk equal to the image set), or served read-only directly from the mounted media
-via `REGISTRY_STORAGE_MAINTENANCE_READONLY_ENABLED` (no copy, gated on spike S2).
-
-### 4. Every Helm chart is republished as OCI, and core parameterizes the repository base
-
-`windsor pack` converts all 24 HTTP `HelmRepository` sources into OCI artifacts inside the media's
-`oci/` layout, keyed by chart name and version. In the enclave they are served from the local
-registry, and Flux consumes them through `HelmRepository` with `type: oci`.
-
-Ownership of the URL rewrite goes to **core, not the CLI**. Core's chart repository URLs become
-config-derived — a facet value with the public URL as its default and the enclave registry as the
-airgap override — the same pattern `flux/main.tf:175`'s `registry` field already uses for controller
-images. This keeps the rewrite declarative and visible in `windsor explain`, and it keeps the CLI
-out of the business of mutating third-party YAML.
-
-For blueprints Windsor does not own, `windsor hydrate` will apply a transitional source rewrite
-driven by `index.yaml`. That mechanism is explicitly transitional and is not the path core takes.
-
-### 5. Terraform providers ship as a filesystem mirror, and `pkg/runtime/terraform` owns pointing at it
-
-`windsor pack` synthesizes an aggregate `required_providers` block from every Terraform component
-the composed blueprint references, runs `terraform providers mirror -platform=<os>_<arch>` per
-target platform into `providers/`, and runs `terraform providers lock -platform=...` so that
-`.terraform.lock.hcl` carries hashes valid for the enclave's platform rather than the staging
-workstation's.
-
-`windsor hydrate` writes a CLI configuration file with a `provider_installation` /
-`filesystem_mirror` block, and `pkg/runtime/terraform` exports `TF_CLI_CONFIG_FILE` alongside the
-`TF_DATA_DIR` and `TF_VAR_*` variables it already assembles. The architecture skill assigns
-"provider policy" to that package, so this needs no new ownership.
-
-OpenTofu is a separate mirror namespace (`registry.opentofu.org`), and
-`BaseToolsManager.detectTerraformDriver` already chooses between the two at runtime. `windsor pack`
-mirrors for the driver the context is configured for, and `index.yaml` records which. Packing both
-is a flag, not a default, because it roughly doubles the largest single component of the media.
-
-### 6. Talos gets two independent offline paths, and schematics are pinned, never resolved
-
-- **Registry mirrors** are the primary path, and already work once decision 3 lands. Nodes pull
-  system images from the workstation registries.
-- **Talos Image Cache** covers the case where no registry can precede the node — bare metal, and the
-  bootstrap window before the workstation stack is up. `windsor pack` runs `talosctl images
-  cache-create` over the Talos default image list plus the blueprint's own images into
-  `talos/image-cache.oci`, and builds boot media with `imager --image-cache`. The enclave machine
-  config sets `machine.features.imageCache.localEnabled: true` with an `IMAGECACHE` volume. The 1 GiB
-  default volume size is far too small for core's image set and must be sized from the actual cache
-  (spike S5).
-
-Schematic IDs are **pinned in blueprint config, never resolved at apply time**. `platform-vsphere`
-and `platform-hetzner` already do this with a literal schematic ID; `cluster/talos/extensions`
-resolving one through `talos_image_factory_schematic` does not. That module gains an input that
-accepts a pre-computed ID and skips the resource — a core change this ADR depends on. `windsor pack`
-downloads the boot assets for the pinned ID and Talos version into `images/`.
-
-Two platform-specific notes. On `platform: docker`, Talos runs as a container image
-(`ghcr.io/siderolabs/talos:v<version>`) pulled by the local Docker daemon, which does not consult
-`machine.registries.mirrors` — hydrate must load or retag that image into the daemon directly. On
-`platform: incus`, `terraform/compute/incus/main.tf:340` already resolves an image that is a local
-file path through `incus_image.local`, so shipping the Incus image as a file in `images/` needs no
-module change; only the remote registration at `main.tf:33` needs to become conditional.
-
-### 7. Tools are supplied by PATH prepend, and an existing tool is respected if it qualifies
-
-`bin/<os>_<arch>/` carries pinned binaries for the tools `toolRegistry` knows about, plus `windsor`
-itself. `windsor hydrate` does not install anything and does not modify the system. It records the
-media's `bin` directory in the context, and the existing env printer prepends it to `PATH` through
-the shell hook that already manages Windsor's environment.
-
-If the enclave workstation already has a qualifying tool, `--prefer-system-tools` skips the prepend
-for that tool. The `CheckRequirements` minimum-version gate applies either way, so a stale system
-Terraform fails the same check it fails today, with the same actionable error — except that in the
-enclave the error can now name the bundled binary as the remedy instead of a vendor download page
-that is unreachable.
-
-**Explicit non-goal: Windsor does not supply the container runtime.** Docker Desktop, Colima, Incus,
-and their guest images are prerequisites of the enclave workstation, documented in the generated
-runbook and asserted by `windsor verify`. The Colima case on macOS is the sharpest instance —
-`colima start` fetches a Lima guest image — and is spike S4.
-
-### 8. The media is signed, verification is mandatory, and it does not depend on a transparency log
-
-`index.yaml` is covered by a detached signature in `index.sig`, over a key whose public half travels
-out of band. Keyless signing is not usable here: Fulcio and Rekor both require egress at verify
-time, which is precisely what the enclave does not have.
-
-`windsor verify --media <path>` checks the signature, then every file against `checksums.txt`, then
-that every BOM entry in `index.yaml` is present in `oci/`, `providers/`, `bin/`, or `images/`.
-`windsor hydrate` runs verification first and refuses to proceed on failure unless
-`--insecure-skip-verify` is passed. `verify` is also the read-only pre-flight an operator can run
-against media before committing an enclave to it.
-
-In-cluster image signature policy (a Kyverno `verifyImages` rule, for instance) has the same
-transparency-log problem and must either be configured against a local key or disabled for the
-enclave. That is a core policy decision, flagged here rather than made here.
-
-### 9. Airgap is scoped to the workstation and metal platforms, not to cloud
-
-`platform: docker`, `platform: incus`, and `platform: metal` are in scope. `aws`, `azure`, `gcp`,
-`hetzner`, and `vsphere` are not, because provisioning against a cloud control plane requires egress
-to that control plane by definition. The media set is still useful there — provider mirror, tool
-binaries, image mirror all apply to a restricted-egress environment — but "runs `windsor bootstrap`
-with no egress at any point" is only claimed for the first three.
-
-### 10. No new architectural layer
-
-Work lands in existing packages, per the ownership table in
-`docs/adrs/0002-target-architecture-and-package-topology.md`:
-
-| Concern | Package |
-|---|---|
-| BOM model, resolution, media index, pack/verify | `pkg/composer/artifact` (already owns the manifest, `Bundle`, `Push`, `Pull`) |
-| Registry seeding, enclave registry lifecycle | `pkg/workstation/registry` (new companion package under the workstation layer) |
-| Provider mirror config and `TF_CLI_CONFIG_FILE` | `pkg/runtime/terraform` |
-| Tool PATH resolution against media | `pkg/runtime/tools` |
-| Hydrate orchestration | `Composer` for media-side work, `Provisioner` for cluster-side |
-| Command surface | `cmd/pack.go`, `cmd/verify.go`, `cmd/hydrate.go` — Cobra glue only |
-
-### 11. Command surface
-
-Verb-first, consistent with the house convention.
-
-```
-# Staging workstation (connected)
-windsor pack --output ./media --platform docker --arch amd64
-windsor pack --output ./media --observe            # capture from a live reference deployment
-windsor pack --output ./media --dry-run            # print the resolved BOM, write nothing
-
-# Enclave workstation (disconnected)
-windsor verify --media /Volumes/WINDSOR_AIRGAP
-windsor hydrate --media /Volumes/WINDSOR_AIRGAP
-windsor bootstrap local
-```
-
-`windsor bootstrap --media <path>` is sugar for hydrate-then-bootstrap, since that is the sequence
-an operator runs once and then never thinks about again.
-
-`pack` flags: `--output`, `--platform`, `--arch` (repeatable), `--include` / `--exclude` by BOM
-entry, `--observe`, `--allow-undeclared`, `--sign-key`, `--tofu` / `--terraform`, `--dry-run`.
-`hydrate` flags: `--media`, `--work-dir`, `--registry-mode=copy|readonly`, `--prefer-system-tools`,
-`--insecure-skip-verify`.
-
-## Feasibility spikes — gates on the sequence below
-
-Each spike has one question and one pass criterion. None of the implementation phases start before
-its listed spikes pass.
-
-| # | Question | Pass criterion |
-|---|---|---|
-| S1 | Can a plain (non-proxy) `distribution:3.0.0` serve a storage tree written by the same image in proxy mode? | A cache tree produced by a real core bootstrap serves `docker pull` by tag and by digest with `REGISTRY_PROXY_REMOTEURL` unset. Determines whether cache harvesting is a viable seeding path at all, or whether push-only is mandatory. |
-| S2 | Can `distribution` serve read-only directly from a mounted ISO 9660 volume, bind-mounted into the Docker Desktop / Colima VM? | Full core image set pulls from a registry whose storage is the mounted media, with zero copies. Determines whether `--registry-mode=readonly` ships. |
-| S3 | `terraform providers mirror` across all 15 providers, per platform. | Mirror builds; `terraform init` succeeds offline for every core component; lockfile hashes validate. Records total size — `hashicorp/aws` alone is the single largest artifact in the media. Repeat for OpenTofu. |
-| S4 | Colima on macOS with no egress. | `colima start` completes against a Lima guest image supplied from the media. If it cannot, macOS enclave support is Docker Desktop only and the runbook says so. |
-| S5 | Talos Image Cache at core's actual image volume. | `talosctl images cache-create` over the full BOM, `imager --image-cache` builds bootable media, node provisions with a correctly sized `IMAGECACHE` volume. Records the required size against the 1 GiB default. |
-| S6 | How large is `observed \ declared` for a full core bootstrap? | Measured, enumerated, and categorized by cause. If it is small and confined to chart defaults, `helm template` expansion in the declared pass may close it and `--observe` becomes optional rather than required. If it is large, `--observe` is mandatory and decision 2 is load-bearing. |
-| S7 | Total media size for core at one platform and one arch, and does the layout survive an ISO 9660 round trip? | Size measured against BD-R capacities (25 / 50 / 100 GB). Every file under the 4 GiB single-file cap. Filenames survive the filesystem's constraints. |
-| S8 | Chart republish and rewrite end to end. | All 24 HTTP `HelmRepository` sources convert to OCI, and a `HelmRelease` reconciles from the enclave registry through `type: oci`. `fluxcd/flux-mirror` is evaluated here as an existing implementation before writing one. |
-
-S6 is the one that can change the design rather than just the parameters, and should run first.
-
-## Implementation sequence
-
-**Phase 1 — BOM and pack, no enclave yet.** Extend `scanner.go` to resolve digests and expand chart
-renders. Add the media index model and `windsor pack` / `windsor verify` against
-`platform: docker`. Gate: S3, S7. Deliverable is media that verifies, with no hydration path yet.
-
-**Phase 2 — Observed capture and the completeness gate.** Cache-tree and node-side harvest,
-`observed \ declared` computation, fail-closed default. Gate: S6.
-
-**Phase 3 — Hydrate and the closed loop.** Enclave registry lifecycle, provider mirror wiring, tool
-PATH, `windsor hydrate`, and `bootstrap --media`. Gate: S1, S2, S4, S8. Deliverable is a full
-`windsor bootstrap` on a disconnected workstation at `platform: docker`, running in CI on a
-network-namespaced runner. This is the point at which the ADR's central claim is proven or not.
-
-**Phase 4 — Metal and Incus.** Talos Image Cache media, pinned schematics, Incus image files,
-conditional image remote. Gate: S5. Requires the core changes named in decisions 4 and 6.
-
-Phases 1 and 2 land in the CLI alone. Phase 3 depends on core parameterizing chart repository URLs.
-Phase 4 depends on core accepting a pre-computed schematic ID and making the Incus remote
-conditional. Those core changes are tracked as blockers, not assumed.
+The generated CLI config encodes local materialized paths and is regenerated by
+`windsor pull providers` at consumption time — `shouldSkipTerraformFile`'s existing exclusion
+(`artifact.go:896-918`) needs no change.
 
 ## Consequences
 
-- **Media is version-locked to a blueprint version, and correctly so.** A media set is built from
-  one blueprint at one version for one platform/arch matrix. Upgrading the enclave means new media.
-  This matches the direction in [[project_windsor_lifecycle]] — bootstrap once, then upgrade per
-  blueprint version — and makes `windsor upgrade` in an enclave a media-swap operation, which is a
-  separate design that this ADR does not attempt.
-- **`windsor pack` becomes a first-class CI artifact producer.** It is slow, large, and needs a
-  container runtime, egress, and (for `--observe`) a real cluster. That is a heavier build job than
-  anything in the repo today.
-- **The fail-closed default will be annoying before it is valuable.** Every new chart-default image
-  in an upstream bump surfaces as a pack failure. That is the intended trade: an annoying failure on
-  the staging workstation instead of an unrecoverable one in the enclave.
-- **Registry storage is duplicated at rest by default.** `--registry-mode=copy` needs enclave disk
-  equal to the image set. S2 decides whether the read-only path removes that.
-- **Two Terraform paths in core stop being able to call the internet at apply time**, which is a
-  strict improvement in determinism for connected installs too — pinned schematics do not drift.
-- **Cloud platforms are explicitly excluded from the completeness claim.** The media remains useful
-  in restricted-egress cloud environments, and the ADR does not promise more than that.
-- **Signing introduces key management this repo does not have.** A signing key for pack, and a
-  distribution path for its public half, are new operational surface.
+- `windsor push` gains three subcommands; the existing single-argument invocation is preserved
+  exactly.
+- A new `windsor pull` command family exists with exactly one object today (`providers`); a bare
+  `windsor pull` form isn't built until something else needs it.
+- The provider OCI layout matches OpenTofu's `oci_mirror` convention exactly, so no format migration
+  is needed if tofu users later want to bypass Windsor's own pull path.
+- The publish-side conversion (`terraform providers mirror` → OCI index) is genuinely new code with
+  no existing tool to lean on — unlike the blueprint/image push paths, which are pure OCI-to-OCI
+  copies. This is the real scope of the build.
+- The platform-set default (what feeds the OS/arch selector when unset) is an open follow-up.
+- Full airgap media is explicitly not delivered by this ADR. Anyone reaching for "run
+  `windsor bootstrap` with zero egress" from this design will not find it here — see Deferred.
 
 ## Alternatives considered
 
-- **Extend `windsor bundle` rather than adding `windsor pack`.** Rejected: `bundle` produces a
-  blueprint tarball consumable by Flux `OCIRepository` and is a stable published contract. Airgap
-  media is a different artifact with a different lifecycle, different size class, and a different
-  consumer. Overloading the verb would make both harder to reason about.
-- **Ship a single signed tarball.** Rejected on the 4 GiB ISO 9660 single-file limit, on the loss of
-  blob-level dedupe across images and charts, and on the user requirement that the media be usable
-  by pointing at folders.
-- **Harvest the pull-through cache directories and re-serve them as proxies.** Rejected per decision
-  3 — the remote-first tag resolution and the documented cache-serving failures make it unsuitable
-  as the primary mechanism. S1 keeps it alive as a possible *seeding* optimization for the push
-  path, not as the serving mode.
-- **A single hub registry with `overridePath`.** Deferred rather than rejected. It is the right
-  answer once Harbor is the enclave registry (Manager ADR-0008), and adopting it now would mean
-  rewriting core's mirror derivation as part of an airgap change.
-- **Rely on `helm template` alone to close the image gap, with no observed pass.** Rejected as the
-  sole mechanism: it does not cover images an operator selects at runtime from its own logic rather
-  than from chart values, which is exactly the CloudNativePG case. S6 may show it closes enough of
-  the gap to make `--observe` optional; it cannot make it unnecessary.
-- **Have Windsor install missing tools in the enclave.** Rejected: `Install()` has been a deliberate
-  placeholder since the tools manager was written, and modifying a locked-down enclave workstation's
-  system state is exactly the wrong default for that environment. PATH prepend achieves the same
-  outcome without mutating the host.
-- **Vendor charts into the blueprint at build time instead of republishing them as OCI.** Rejected:
-  it discards chart provenance and version metadata, and it diverges the enclave install path from
-  the connected one. Republishing as OCI keeps both paths on the same Flux mechanism.
-- **A self-hosted Talos Image Factory in the enclave.** Rejected for this ADR. Sidero's own guidance
-  is that an air-gapped factory needs its images and Talos versions pre-seeded and signed, so it adds
-  a service to operate without removing the pre-seeding work. Pinned schematics plus pre-downloaded
-  boot assets achieve the same result with no running service. Revisit if the enclave needs to
-  generate new schematics rather than consume pinned ones.
+- **tofu-native `oci_mirror` as the sole mechanism, `terraform` left unsupported.** Rejected — this
+  org is terraform-primary, and HashiCorp shows no movement after four years (#31463 still open).
+- **A Windsor-specific OCI packaging format for providers.** Rejected in favor of OpenTofu's
+  `oci_mirror` layout — an existing, documented spec, consumable by standard OCI tooling and
+  directly by `tofu` itself.
+- **Per-platform tags instead of an OCI Image Index.** Rejected — loses at-pull-time platform
+  resolution and doesn't match the standard OpenTofu already established.
+- **A single `windsor push mirror` as the only push object.** Rejected for ergonomics — forces
+  `--include`/`--exclude` flags for the common "just re-push providers" case.
+- **Keep the full write-once airgap media scope in this ADR.** Rejected for v0.10.0: that design
+  (content-addressed media tree, declared/observed BOM reconciliation, Talos Image Cache, signing,
+  the two-workstation model) is real and was fully drafted, but isn't being built this cycle. Kept
+  out rather than left half-decided alongside a decision that is shipping, per Deferred below.
 
 ## Deferred
 
-- `windsor upgrade` inside an enclave — media-to-media transition, what is diffed, and whether
-  incremental media (deltas against a previously hydrated set) is worth the complexity.
-- Harbor as the enclave registry, and the `overridePath` mirror layout that follows from it.
-- Multi-blueprint media carrying core plus manager plus a tenant blueprint in one set.
-- Enclave-side secrets. SOPS with a local age key works offline; 1Password and cloud KMS backends do
-  not. The blueprint's secrets configuration constrains which contexts can be airgapped at all, and
-  that constraint deserves its own record.
-- In-cluster image signature verification policy against a local key.
+Everything below was decided in this ADR's original 2026-08-09 draft and is recoverable in full from
+git history (`git log -p -- docs/adrs/0008-airgap-media-and-hydration.md`) rather than needing to be
+re-derived when it's actually scoped:
+
+- Write-once physical media (content-addressed directory tree, ISO 9660 constraints, BD-R capacity
+  planning) as the distribution mechanism for a fully disconnected enclave.
+- BOM completeness via declared-vs-observed reconciliation, fail-closed on the delta.
+- Talos Image Cache, pinned schematic IDs, and the two independent offline paths for node
+  provisioning.
+- Media signing and mandatory verification (`windsor verify`), without dependence on a transparency
+  log.
+- The two-workstation (staging/enclave) operational model and a `windsor bootstrap --media` entry
+  point.
+- Comprehensive Helm chart republishing as OCI with core-side config-derived repository URLs.
+- Container runtime provisioning in a disconnected environment (Colima's Lima guest fetch on macOS,
+  specifically).
+- Enclave-side secrets handling (SOPS with a local age key works offline; 1Password/cloud KMS don't).
 
 ## References
 
-- `pkg/composer/artifact/manifest.go` — the existing BOM model and its stated hydration intent
-- `pkg/composer/artifact/scanner.go` — Renovate-annotation scan
-- `pkg/composer/artifact/artifact.go:481` — `Pull` and the OCI disk cache
-- `pkg/provisioner/flux/stack.go:546` — `resolveSourceRoot` and the same cache path
-- `pkg/runtime/tools/tools_manager.go`, `pkg/runtime/tools/registry.go` — check-don't-install
-- `windsorcli/core` `terraform/workstation/docker/main.tf:213-266` — registry containers and cache volumes
-- `windsorcli/core` `contexts/_template/facets/option-workstation.yaml` — mirror map to Talos machine patch
-- `windsorcli/core` `terraform/gitops/flux/main.tf:150-176` — Flux install and the parameterized image registry
-- `windsorcli/core` `terraform/cluster/talos/extensions/main.tf:34` — online schematic resolution
-- `docs/adrs/0002-target-architecture-and-package-topology.md` — layer ownership table
-- Sidero Labs, [Air-Gapped Kubernetes With Talos Linux](https://www.siderolabs.com/blog/air-gapped-kubernetes-with-talos-linux) — Image Cache workflow
-- Sidero Labs, [Pull-through cache](https://docs.siderolabs.com/talos/v1.11/configure-your-talos-cluster/images-container-runtime/pull-through-cache) — `mirrors`, `overridePath`, `skipFallback`
-- Sidero Labs, [Run Image Factory On-Prem](https://docs.siderolabs.com/omni/self-hosted/run-image-factory-on-prem)
-- Flux, [Air-gapped installation](https://fluxcd.io/flux/installation/configuration/air-gapped/)
-- [`fluxcd/flux-mirror`](https://github.com/fluxcd/flux-mirror) — chart and artifact mirroring, evaluated in S8
-- CNCF Distribution, [Registry as a pull through cache](https://distribution.github.io/distribution/recipes/mirror/)
-- [distribution/distribution#4046](https://github.com/distribution/distribution/issues/4046) — proxy cache failing to serve held content
-- HashiCorp, [`terraform providers mirror`](https://developer.hashicorp.com/terraform/cli/commands/providers/mirror)
-- `windsorcli/manager` [ADR-0008 — Harbor](../../../manager/docs/adr/0008-harbor.md)
+- `pkg/composer/artifact/artifact.go:382,481` — `ArtifactBuilder.Push`/`.Pull`, the existing OCI
+  push/pull mechanism this design extends
+- `pkg/composer/artifact/artifact.go:896-918` — `shouldSkipTerraformFile`, existing `.terraformrc`
+  bundle exclusion
+- `pkg/composer/artifact/scanner.go` — existing image-reference extraction, reused for `push images`
+- `pkg/runtime/tools/tools_manager.go:326,340` — `GetTerraformCommand`/`getTerraformDriver`
+- `pkg/provisioner/terraform/stack.go:1566,1919` — `runTerraformInit`, `selectTerraformCommandEnv`
+- `cmd/push.go` — existing `windsor push` command this ADR extends
+- [hashicorp/terraform#31463](https://github.com/hashicorp/terraform/issues/31463) — OCI registry
+  support requested 2022, still open, no roadmap commitment
+- OpenTofu, [Provider Mirrors in OCI Registries](https://opentofu.org/docs/cli/oci_registries/provider-mirror/) —
+  Image Index / per-platform manifest layout adopted verbatim in decision 2
+- HashiCorp, [`terraform providers mirror`](https://developer.hashicorp.com/terraform/cli/commands/providers/mirror) —
+  origin-side fetch mechanism and `-platform` flag behavior
+- HashiCorp, [Provider network mirror protocol](https://developer.hashicorp.com/terraform/internals/provider-network-mirror-protocol) —
+  the non-OCI mirror protocol HashiCorp does support, referenced for contrast
+- HashiCorp, [CLI Configuration File — `filesystem_mirror`](https://developer.hashicorp.com/terraform/cli/config/config-file) —
+  the packed-layout naming convention (`HOSTNAME/NAMESPACE/TYPE/terraform-provider-TYPE_VERSION_TARGET.zip`)
+  decision 1's consume path writes

--- a/docs/adrs/0008-airgap-media-and-hydration.md
+++ b/docs/adrs/0008-airgap-media-and-hydration.md
@@ -1,0 +1,471 @@
+# ADR 0008 — Airgap media and hydration
+
+- Status: Proposed
+- Date: 2026-08-09
+- Deciders: Ryan VanGundy
+
+Goal: produce a single body of media — writable once, readable forever — that carries 100% of what
+a Windsor blueprint needs, and from which a disconnected workstation can run `windsor bootstrap`
+to completion with no egress at any point. This ADR fixes the media layout, the bill-of-materials
+(BOM) contract, the command surface, and the layer ownership; it names the eight feasibility
+questions that must be answered by spike before the sequence below is committed to.
+
+## Context
+
+### What already exists, verified against the tree
+
+Windsor is closer to this than it looks. Five mechanisms already in place do most of the structural
+work, and each was checked directly rather than assumed.
+
+**1. A BOM already ships inside every blueprint artifact.** `pkg/composer/artifact/manifest.go`
+defines `ArtifactManifest` / `ManifestEntry`, written as `artifact-manifest.yaml` into every bundle
+(`artifact.go:602`, regenerated at `artifact.go:801`). Its own header states the intent this ADR is
+picking up: *"bundled into the blueprint OCI artifact so downstream consumers can hydrate a local
+mirror without re-evaluating adaptive composition logic or rendering Helm charts."* It already
+models `ArtifactType` (docker / helm / github-release / git-tag) and `ArtifactTransport`
+(oci / tarball / git), and already records `helmRepo` provenance.
+
+It is populated by `pkg/composer/artifact/scanner.go`, which walks bundled files for Renovate
+annotations — deterministic and offline by construction. Against `windsorcli/core` today that scan
+finds annotations across 64 files: 94 `datasource=docker`, 33 `datasource=helm`, 27
+`datasource=github-releases`, 4 `git-refs`, 2 `github-tags`. Core's Renovate hygiene is good enough
+that this is a genuine inventory, not a token one.
+
+**2. Local registries already run, and Talos already pulls through them.** `windsorcli/core`'s
+`terraform/workstation/docker` runs one `ghcr.io/distribution/distribution:3.0.0` container per
+upstream registry, on fixed IPs in the reserved block `[4, node_start_offset)`, with storage
+bind-mounted from `.windsor/cache/docker/registries/<host>/` (`main.tf:260`; the Incus module does
+the same at `main.tf:217`). `contexts/_template/facets/option-workstation.yaml` then maps the
+module's `registries` output straight into `machine.registries.mirrors` on the Talos machine patch.
+The default map covers `gcr.io`, `ghcr.io`, `quay.io`, `reg.kyverno.io`, `registry-1.docker.io`,
+`registry.k8s.io`.
+
+Today those containers run in pull-through mode (`REGISTRY_PROXY_REMOTEURL`, `main.tf:243`). The
+airgap change is to run the same containers, at the same IPs and hostnames, in plain storage mode
+against pre-seeded content. Nothing in the Talos mirror wiring has to change.
+
+**3. Blueprint sources and Terraform modules already resolve from a local cache.** `Pull` checks
+`.windsor/cache/oci/<key>` before reaching the network (`artifact.go:517`) and only downloads on a
+cache miss or `NO_CACHE`. `FluxStack.resolveSourceRoot` (`pkg/provisioner/flux/stack.go:546`)
+derives the same path. A pre-populated cache directory is therefore already a working offline path
+for the blueprint artifact and every Terraform module it carries.
+
+**4. A local git server already runs.** The workstation stack runs a `git-livereload` container at
+`git.<domain>`, which is the in-enclave Git origin Flux `GitRepository` sources need when the
+blueprint is not consumed over OCI.
+
+**5. Windsor checks tools; it does not install them.** `pkg/runtime/tools/tools_manager.go` has
+`Install()` and `WriteManifest()` as explicit placeholders returning nil; the real surface is
+`CheckRequirements`, which does `execLookPath` plus a minimum-version comparison against
+`registry.go`'s `toolRegistry`. This is load-bearing for airgap: Windsor never has to acquire a
+tool, only to find an acceptable one on `PATH`. Supplying tools becomes a `PATH` question, not an
+installer question.
+
+### What does not exist, and what actually breaks
+
+**No Terraform provider mirror.** `grep` for `TF_PLUGIN_CACHE_DIR`, `provider_installation`,
+`filesystem_mirror`, `TF_CLI_CONFIG_FILE` across both repos returns nothing. Core's modules require
+15 distinct providers — `hashicorp/{aws,azurerm,helm,kubernetes,local,null,random,tls}`,
+`kreuzwerker/docker`, `lxc/incus`, `siderolabs/talos`, `vmware/vsphere`, `hetznercloud/hcloud`,
+`hcloud-talos/imager`, `windsorcli/hyperv`. Every `terraform init` in the enclave hits
+`registry.terraform.io` today and fails.
+
+**Helm charts are pulled by Flux over HTTPS, and containerd mirrors do not cover that.** Core
+declares 24 distinct HTTP `HelmRepository` URLs (`charts.jetstack.io`, `helm.cilium.io`,
+`prometheus-community.github.io`, and so on) plus `oci://docker.io/envoyproxy`. Those fetches come
+from source-controller inside the cluster over HTTPS to the public internet. `machine.registries.
+mirrors` redirects containerd image pulls only; it does nothing for a chart download. Every HTTP
+`HelmRepository` must be republished as OCI and its URL rewritten, or the enclave install stalls at
+the first `HelmRelease`.
+
+**The declared BOM is incomplete by construction.** A Renovate annotation covers what the blueprint
+author pinned. It does not cover images a chart's own defaults introduce — sidecars,
+`kube-rbac-proxy`, init containers, an operator's operand image chosen at runtime. `kustomize/database/
+install/cloudnativepg/helm-release.yaml` is representative: the annotation pins the operator image,
+while the Postgres image the operator later pulls appears nowhere in the blueprint source. A media
+set built from the declared BOM alone will fail somewhere in the middle of a bootstrap, which is the
+worst possible failure mode for write-once media.
+
+**Two Terraform paths call the internet at apply time.** `terraform/cluster/talos/extensions/main.tf:34`
+resolves a schematic through `talos_image_factory_schematic` against `factory.talos.dev`, and
+`terraform/compute/incus/main.tf:33` registers an image remote at `https://images.windsorcli.dev`.
+Both need an offline substitute.
+
+**Flux installs itself from OCI charts.** `terraform/gitops/flux/main.tf:150,163` installs
+`flux-operator` and `flux-instance` from `oci://ghcr.io/controlplaneio-fluxcd/charts` via the Helm
+provider, and pins controller images with `registry = "ghcr.io/fluxcd"` (`main.tf:175`). The
+registry field is already parameterized, which is the hook airgap needs; the chart repository is not.
+
+**The container runtime itself is not a binary problem.** Docker Desktop, Colima, and Incus are
+daemons and VMs. On macOS, `colima start` provisions a Lima guest that is downloaded from the
+internet on first run. A media set that carries every CLI but assumes a working local container
+runtime is only honest if that assumption is written down as a prerequisite.
+
+### The two-workstation model
+
+Everything below assumes two roles, because conflating them is where airgap designs usually go
+wrong.
+
+- **Staging workstation** — connected. Runs `windsor pack`. Has egress, a container runtime, and the
+  same tool versions the enclave will get.
+- **Enclave workstation** — disconnected. Has the media mounted read-only and nothing else. Runs
+  `windsor verify`, `windsor hydrate`, then `windsor bootstrap`.
+
+The enclave workstation may already have Docker or Terraform installed, at versions Windsor did not
+choose. That is a supported and expected condition, not an error, and decision 7 handles it.
+
+## Decision
+
+### 1. Media is a content-addressed directory tree with a signed root index, not an archive
+
+The unit of distribution is a directory that can be burned to optical media, written to a
+write-protected volume, or served from a read-only mount. It is usable in place — `windsor hydrate
+--media /Volumes/WINDSOR_AIRGAP` — with no unpack step required.
+
+```
+windsor-airgap-<blueprint>-<version>/
+  index.yaml              # root: schema version, blueprint refs, platforms, arches, digests
+  index.sig               # detached signature over index.yaml
+  checksums.txt           # sha256 of every file, for readers without the CLI
+  oci/                    # ONE OCI image layout (spec v1.1) for all OCI content
+    index.json
+    oci-layout
+    blobs/sha256/...
+  providers/              # terraform filesystem-mirror layout, per platform
+  bin/<os>_<arch>/        # pinned CLI binaries + per-file checksums
+  images/                 # machine images: talos iso/raw/ova, incus image files
+  talos/                  # image-cache.oci, schematic pins, boot assets
+  runbook.md              # generated, blueprint-specific, human-readable
+```
+
+Rationale, in order of weight:
+
+- **A single tarball is unusable on WORM optical media.** ISO 9660 caps a single file at 4 GiB
+  without multi-extent support that many readers do not implement. A content-addressed blob tree
+  keeps every file at layer size, well under the cap, and stays readable from an ISO 9660 filesystem
+  without requiring UDF. (Spike S7 confirms this against the target readers.)
+- **One `oci/` layout for everything OCI.** Container images, Helm charts republished as OCI, the
+  Windsor blueprint artifact, and Talos installer images all share one blob store, so shared base
+  layers are stored once. Against core's image set this is not a marginal saving.
+- **Partial verification and resumable copy.** A blob tree can be verified, diffed, and
+  incrementally re-copied. A 20 GB tarball cannot.
+- **The user can point at folders.** Serving the registry directly off the mounted media, with no
+  copy, becomes possible (decision 3).
+
+`index.yaml` is the manifest of record: schema version, the blueprint reference and digest it was
+built from, the platform/arch matrix, the full resolved BOM with digests, and the provenance of each
+entry (declared, observed, or manually added).
+
+### 2. The BOM is declared ∪ observed, and pack fails closed on the delta
+
+Two independent passes produce the BOM, and `windsor pack` refuses to write media when they
+disagree in the dangerous direction.
+
+- **Declared** — the existing Renovate scan (`scanner.go`), extended to resolve every entry to a
+  digest and to expand chart references into their `helm template` render so chart-default images
+  are captured. This runs offline against blueprint source.
+- **Observed** — captured from a reference deployment of the same blueprint at the same version on
+  the staging workstation. The capture sources are the registry cache trees at
+  `.windsor/cache/docker/registries/<host>/`, which by construction contain exactly what was pulled,
+  plus the node-side image list read through the existing cluster client.
+
+`windsor pack` computes `observed \ declared`. A non-empty delta is an error naming each missing
+reference, its digest, and the node or repository that pulled it. `--allow-undeclared` records them
+in `index.yaml` with `provenance: observed` and proceeds. The default is to fail, because a missing
+image discovered after the media is burned is unrecoverable in the enclave.
+
+This is the single most important decision in the ADR. A static scan is not sufficient for a
+promise of 100% completeness, and no amount of scanner improvement makes it sufficient, because
+chart defaults and operator-chosen operand images are not statically present in the blueprint at
+all.
+
+### 3. The airgap registry is the existing workstation registry with proxying off, seeded by push
+
+`windsor hydrate` starts the same per-upstream `distribution` containers core already runs, at the
+same IPs and hostnames, with `REGISTRY_PROXY_REMOTEURL` unset, and pushes the media's `oci/` layout
+into them. `docker.registries` and the generated `machine.registries.mirrors` are unchanged, so
+neither core's Terraform nor the Talos machine patch needs an airgap branch.
+
+Two things are deliberately rejected here:
+
+- **Copying the proxy cache directory and re-serving it as a proxy.** Distribution's
+  `proxyTagService.Get` tries the remote first and falls back to the local association only on
+  error, so every tag resolution in the enclave pays a DNS or connect timeout before succeeding, and
+  the fallback path is not a supported offline mode. Issue distribution/distribution#4046 documents
+  the cache failing to serve content it demonstrably holds. Depending on that behavior for a
+  disconnected install is not defensible.
+- **A single hub registry with `overridePath`.** Talos supports pointing many upstreams at one
+  endpoint with distinct paths, which is how Harbor is used (and how Manager's
+  [ADR-0008](../../../manager/docs/adr/0008-harbor.md) intends to use it). It is the better shape at
+  fleet scale, and it is not the shape core's mirror map generates today. Adopting it here would mean
+  changing the mirror derivation in `option-workstation.yaml` as part of an airgap change. Deferred
+  to the point where Harbor is the enclave registry; see Deferred.
+
+Where the registry storage lives is a hydrate-time choice: copied into the enclave work directory
+(default, needs disk equal to the image set), or served read-only directly from the mounted media
+via `REGISTRY_STORAGE_MAINTENANCE_READONLY_ENABLED` (no copy, gated on spike S2).
+
+### 4. Every Helm chart is republished as OCI, and core parameterizes the repository base
+
+`windsor pack` converts all 24 HTTP `HelmRepository` sources into OCI artifacts inside the media's
+`oci/` layout, keyed by chart name and version. In the enclave they are served from the local
+registry, and Flux consumes them through `HelmRepository` with `type: oci`.
+
+Ownership of the URL rewrite goes to **core, not the CLI**. Core's chart repository URLs become
+config-derived — a facet value with the public URL as its default and the enclave registry as the
+airgap override — the same pattern `flux/main.tf:175`'s `registry` field already uses for controller
+images. This keeps the rewrite declarative and visible in `windsor explain`, and it keeps the CLI
+out of the business of mutating third-party YAML.
+
+For blueprints Windsor does not own, `windsor hydrate` will apply a transitional source rewrite
+driven by `index.yaml`. That mechanism is explicitly transitional and is not the path core takes.
+
+### 5. Terraform providers ship as a filesystem mirror, and `pkg/runtime/terraform` owns pointing at it
+
+`windsor pack` synthesizes an aggregate `required_providers` block from every Terraform component
+the composed blueprint references, runs `terraform providers mirror -platform=<os>_<arch>` per
+target platform into `providers/`, and runs `terraform providers lock -platform=...` so that
+`.terraform.lock.hcl` carries hashes valid for the enclave's platform rather than the staging
+workstation's.
+
+`windsor hydrate` writes a CLI configuration file with a `provider_installation` /
+`filesystem_mirror` block, and `pkg/runtime/terraform` exports `TF_CLI_CONFIG_FILE` alongside the
+`TF_DATA_DIR` and `TF_VAR_*` variables it already assembles. The architecture skill assigns
+"provider policy" to that package, so this needs no new ownership.
+
+OpenTofu is a separate mirror namespace (`registry.opentofu.org`), and
+`BaseToolsManager.detectTerraformDriver` already chooses between the two at runtime. `windsor pack`
+mirrors for the driver the context is configured for, and `index.yaml` records which. Packing both
+is a flag, not a default, because it roughly doubles the largest single component of the media.
+
+### 6. Talos gets two independent offline paths, and schematics are pinned, never resolved
+
+- **Registry mirrors** are the primary path, and already work once decision 3 lands. Nodes pull
+  system images from the workstation registries.
+- **Talos Image Cache** covers the case where no registry can precede the node — bare metal, and the
+  bootstrap window before the workstation stack is up. `windsor pack` runs `talosctl images
+  cache-create` over the Talos default image list plus the blueprint's own images into
+  `talos/image-cache.oci`, and builds boot media with `imager --image-cache`. The enclave machine
+  config sets `machine.features.imageCache.localEnabled: true` with an `IMAGECACHE` volume. The 1 GiB
+  default volume size is far too small for core's image set and must be sized from the actual cache
+  (spike S5).
+
+Schematic IDs are **pinned in blueprint config, never resolved at apply time**. `platform-vsphere`
+and `platform-hetzner` already do this with a literal schematic ID; `cluster/talos/extensions`
+resolving one through `talos_image_factory_schematic` does not. That module gains an input that
+accepts a pre-computed ID and skips the resource — a core change this ADR depends on. `windsor pack`
+downloads the boot assets for the pinned ID and Talos version into `images/`.
+
+Two platform-specific notes. On `platform: docker`, Talos runs as a container image
+(`ghcr.io/siderolabs/talos:v<version>`) pulled by the local Docker daemon, which does not consult
+`machine.registries.mirrors` — hydrate must load or retag that image into the daemon directly. On
+`platform: incus`, `terraform/compute/incus/main.tf:340` already resolves an image that is a local
+file path through `incus_image.local`, so shipping the Incus image as a file in `images/` needs no
+module change; only the remote registration at `main.tf:33` needs to become conditional.
+
+### 7. Tools are supplied by PATH prepend, and an existing tool is respected if it qualifies
+
+`bin/<os>_<arch>/` carries pinned binaries for the tools `toolRegistry` knows about, plus `windsor`
+itself. `windsor hydrate` does not install anything and does not modify the system. It records the
+media's `bin` directory in the context, and the existing env printer prepends it to `PATH` through
+the shell hook that already manages Windsor's environment.
+
+If the enclave workstation already has a qualifying tool, `--prefer-system-tools` skips the prepend
+for that tool. The `CheckRequirements` minimum-version gate applies either way, so a stale system
+Terraform fails the same check it fails today, with the same actionable error — except that in the
+enclave the error can now name the bundled binary as the remedy instead of a vendor download page
+that is unreachable.
+
+**Explicit non-goal: Windsor does not supply the container runtime.** Docker Desktop, Colima, Incus,
+and their guest images are prerequisites of the enclave workstation, documented in the generated
+runbook and asserted by `windsor verify`. The Colima case on macOS is the sharpest instance —
+`colima start` fetches a Lima guest image — and is spike S4.
+
+### 8. The media is signed, verification is mandatory, and it does not depend on a transparency log
+
+`index.yaml` is covered by a detached signature in `index.sig`, over a key whose public half travels
+out of band. Keyless signing is not usable here: Fulcio and Rekor both require egress at verify
+time, which is precisely what the enclave does not have.
+
+`windsor verify --media <path>` checks the signature, then every file against `checksums.txt`, then
+that every BOM entry in `index.yaml` is present in `oci/`, `providers/`, `bin/`, or `images/`.
+`windsor hydrate` runs verification first and refuses to proceed on failure unless
+`--insecure-skip-verify` is passed. `verify` is also the read-only pre-flight an operator can run
+against media before committing an enclave to it.
+
+In-cluster image signature policy (a Kyverno `verifyImages` rule, for instance) has the same
+transparency-log problem and must either be configured against a local key or disabled for the
+enclave. That is a core policy decision, flagged here rather than made here.
+
+### 9. Airgap is scoped to the workstation and metal platforms, not to cloud
+
+`platform: docker`, `platform: incus`, and `platform: metal` are in scope. `aws`, `azure`, `gcp`,
+`hetzner`, and `vsphere` are not, because provisioning against a cloud control plane requires egress
+to that control plane by definition. The media set is still useful there — provider mirror, tool
+binaries, image mirror all apply to a restricted-egress environment — but "runs `windsor bootstrap`
+with no egress at any point" is only claimed for the first three.
+
+### 10. No new architectural layer
+
+Work lands in existing packages, per the ownership table in
+`docs/adrs/0002-target-architecture-and-package-topology.md`:
+
+| Concern | Package |
+|---|---|
+| BOM model, resolution, media index, pack/verify | `pkg/composer/artifact` (already owns the manifest, `Bundle`, `Push`, `Pull`) |
+| Registry seeding, enclave registry lifecycle | `pkg/workstation/registry` (new companion package under the workstation layer) |
+| Provider mirror config and `TF_CLI_CONFIG_FILE` | `pkg/runtime/terraform` |
+| Tool PATH resolution against media | `pkg/runtime/tools` |
+| Hydrate orchestration | `Composer` for media-side work, `Provisioner` for cluster-side |
+| Command surface | `cmd/pack.go`, `cmd/verify.go`, `cmd/hydrate.go` — Cobra glue only |
+
+### 11. Command surface
+
+Verb-first, consistent with the house convention.
+
+```
+# Staging workstation (connected)
+windsor pack --output ./media --platform docker --arch amd64
+windsor pack --output ./media --observe            # capture from a live reference deployment
+windsor pack --output ./media --dry-run            # print the resolved BOM, write nothing
+
+# Enclave workstation (disconnected)
+windsor verify --media /Volumes/WINDSOR_AIRGAP
+windsor hydrate --media /Volumes/WINDSOR_AIRGAP
+windsor bootstrap local
+```
+
+`windsor bootstrap --media <path>` is sugar for hydrate-then-bootstrap, since that is the sequence
+an operator runs once and then never thinks about again.
+
+`pack` flags: `--output`, `--platform`, `--arch` (repeatable), `--include` / `--exclude` by BOM
+entry, `--observe`, `--allow-undeclared`, `--sign-key`, `--tofu` / `--terraform`, `--dry-run`.
+`hydrate` flags: `--media`, `--work-dir`, `--registry-mode=copy|readonly`, `--prefer-system-tools`,
+`--insecure-skip-verify`.
+
+## Feasibility spikes — gates on the sequence below
+
+Each spike has one question and one pass criterion. None of the implementation phases start before
+its listed spikes pass.
+
+| # | Question | Pass criterion |
+|---|---|---|
+| S1 | Can a plain (non-proxy) `distribution:3.0.0` serve a storage tree written by the same image in proxy mode? | A cache tree produced by a real core bootstrap serves `docker pull` by tag and by digest with `REGISTRY_PROXY_REMOTEURL` unset. Determines whether cache harvesting is a viable seeding path at all, or whether push-only is mandatory. |
+| S2 | Can `distribution` serve read-only directly from a mounted ISO 9660 volume, bind-mounted into the Docker Desktop / Colima VM? | Full core image set pulls from a registry whose storage is the mounted media, with zero copies. Determines whether `--registry-mode=readonly` ships. |
+| S3 | `terraform providers mirror` across all 15 providers, per platform. | Mirror builds; `terraform init` succeeds offline for every core component; lockfile hashes validate. Records total size — `hashicorp/aws` alone is the single largest artifact in the media. Repeat for OpenTofu. |
+| S4 | Colima on macOS with no egress. | `colima start` completes against a Lima guest image supplied from the media. If it cannot, macOS enclave support is Docker Desktop only and the runbook says so. |
+| S5 | Talos Image Cache at core's actual image volume. | `talosctl images cache-create` over the full BOM, `imager --image-cache` builds bootable media, node provisions with a correctly sized `IMAGECACHE` volume. Records the required size against the 1 GiB default. |
+| S6 | How large is `observed \ declared` for a full core bootstrap? | Measured, enumerated, and categorized by cause. If it is small and confined to chart defaults, `helm template` expansion in the declared pass may close it and `--observe` becomes optional rather than required. If it is large, `--observe` is mandatory and decision 2 is load-bearing. |
+| S7 | Total media size for core at one platform and one arch, and does the layout survive an ISO 9660 round trip? | Size measured against BD-R capacities (25 / 50 / 100 GB). Every file under the 4 GiB single-file cap. Filenames survive the filesystem's constraints. |
+| S8 | Chart republish and rewrite end to end. | All 24 HTTP `HelmRepository` sources convert to OCI, and a `HelmRelease` reconciles from the enclave registry through `type: oci`. `fluxcd/flux-mirror` is evaluated here as an existing implementation before writing one. |
+
+S6 is the one that can change the design rather than just the parameters, and should run first.
+
+## Implementation sequence
+
+**Phase 1 — BOM and pack, no enclave yet.** Extend `scanner.go` to resolve digests and expand chart
+renders. Add the media index model and `windsor pack` / `windsor verify` against
+`platform: docker`. Gate: S3, S7. Deliverable is media that verifies, with no hydration path yet.
+
+**Phase 2 — Observed capture and the completeness gate.** Cache-tree and node-side harvest,
+`observed \ declared` computation, fail-closed default. Gate: S6.
+
+**Phase 3 — Hydrate and the closed loop.** Enclave registry lifecycle, provider mirror wiring, tool
+PATH, `windsor hydrate`, and `bootstrap --media`. Gate: S1, S2, S4, S8. Deliverable is a full
+`windsor bootstrap` on a disconnected workstation at `platform: docker`, running in CI on a
+network-namespaced runner. This is the point at which the ADR's central claim is proven or not.
+
+**Phase 4 — Metal and Incus.** Talos Image Cache media, pinned schematics, Incus image files,
+conditional image remote. Gate: S5. Requires the core changes named in decisions 4 and 6.
+
+Phases 1 and 2 land in the CLI alone. Phase 3 depends on core parameterizing chart repository URLs.
+Phase 4 depends on core accepting a pre-computed schematic ID and making the Incus remote
+conditional. Those core changes are tracked as blockers, not assumed.
+
+## Consequences
+
+- **Media is version-locked to a blueprint version, and correctly so.** A media set is built from
+  one blueprint at one version for one platform/arch matrix. Upgrading the enclave means new media.
+  This matches the direction in [[project_windsor_lifecycle]] — bootstrap once, then upgrade per
+  blueprint version — and makes `windsor upgrade` in an enclave a media-swap operation, which is a
+  separate design that this ADR does not attempt.
+- **`windsor pack` becomes a first-class CI artifact producer.** It is slow, large, and needs a
+  container runtime, egress, and (for `--observe`) a real cluster. That is a heavier build job than
+  anything in the repo today.
+- **The fail-closed default will be annoying before it is valuable.** Every new chart-default image
+  in an upstream bump surfaces as a pack failure. That is the intended trade: an annoying failure on
+  the staging workstation instead of an unrecoverable one in the enclave.
+- **Registry storage is duplicated at rest by default.** `--registry-mode=copy` needs enclave disk
+  equal to the image set. S2 decides whether the read-only path removes that.
+- **Two Terraform paths in core stop being able to call the internet at apply time**, which is a
+  strict improvement in determinism for connected installs too — pinned schematics do not drift.
+- **Cloud platforms are explicitly excluded from the completeness claim.** The media remains useful
+  in restricted-egress cloud environments, and the ADR does not promise more than that.
+- **Signing introduces key management this repo does not have.** A signing key for pack, and a
+  distribution path for its public half, are new operational surface.
+
+## Alternatives considered
+
+- **Extend `windsor bundle` rather than adding `windsor pack`.** Rejected: `bundle` produces a
+  blueprint tarball consumable by Flux `OCIRepository` and is a stable published contract. Airgap
+  media is a different artifact with a different lifecycle, different size class, and a different
+  consumer. Overloading the verb would make both harder to reason about.
+- **Ship a single signed tarball.** Rejected on the 4 GiB ISO 9660 single-file limit, on the loss of
+  blob-level dedupe across images and charts, and on the user requirement that the media be usable
+  by pointing at folders.
+- **Harvest the pull-through cache directories and re-serve them as proxies.** Rejected per decision
+  3 — the remote-first tag resolution and the documented cache-serving failures make it unsuitable
+  as the primary mechanism. S1 keeps it alive as a possible *seeding* optimization for the push
+  path, not as the serving mode.
+- **A single hub registry with `overridePath`.** Deferred rather than rejected. It is the right
+  answer once Harbor is the enclave registry (Manager ADR-0008), and adopting it now would mean
+  rewriting core's mirror derivation as part of an airgap change.
+- **Rely on `helm template` alone to close the image gap, with no observed pass.** Rejected as the
+  sole mechanism: it does not cover images an operator selects at runtime from its own logic rather
+  than from chart values, which is exactly the CloudNativePG case. S6 may show it closes enough of
+  the gap to make `--observe` optional; it cannot make it unnecessary.
+- **Have Windsor install missing tools in the enclave.** Rejected: `Install()` has been a deliberate
+  placeholder since the tools manager was written, and modifying a locked-down enclave workstation's
+  system state is exactly the wrong default for that environment. PATH prepend achieves the same
+  outcome without mutating the host.
+- **Vendor charts into the blueprint at build time instead of republishing them as OCI.** Rejected:
+  it discards chart provenance and version metadata, and it diverges the enclave install path from
+  the connected one. Republishing as OCI keeps both paths on the same Flux mechanism.
+- **A self-hosted Talos Image Factory in the enclave.** Rejected for this ADR. Sidero's own guidance
+  is that an air-gapped factory needs its images and Talos versions pre-seeded and signed, so it adds
+  a service to operate without removing the pre-seeding work. Pinned schematics plus pre-downloaded
+  boot assets achieve the same result with no running service. Revisit if the enclave needs to
+  generate new schematics rather than consume pinned ones.
+
+## Deferred
+
+- `windsor upgrade` inside an enclave — media-to-media transition, what is diffed, and whether
+  incremental media (deltas against a previously hydrated set) is worth the complexity.
+- Harbor as the enclave registry, and the `overridePath` mirror layout that follows from it.
+- Multi-blueprint media carrying core plus manager plus a tenant blueprint in one set.
+- Enclave-side secrets. SOPS with a local age key works offline; 1Password and cloud KMS backends do
+  not. The blueprint's secrets configuration constrains which contexts can be airgapped at all, and
+  that constraint deserves its own record.
+- In-cluster image signature verification policy against a local key.
+
+## References
+
+- `pkg/composer/artifact/manifest.go` — the existing BOM model and its stated hydration intent
+- `pkg/composer/artifact/scanner.go` — Renovate-annotation scan
+- `pkg/composer/artifact/artifact.go:481` — `Pull` and the OCI disk cache
+- `pkg/provisioner/flux/stack.go:546` — `resolveSourceRoot` and the same cache path
+- `pkg/runtime/tools/tools_manager.go`, `pkg/runtime/tools/registry.go` — check-don't-install
+- `windsorcli/core` `terraform/workstation/docker/main.tf:213-266` — registry containers and cache volumes
+- `windsorcli/core` `contexts/_template/facets/option-workstation.yaml` — mirror map to Talos machine patch
+- `windsorcli/core` `terraform/gitops/flux/main.tf:150-176` — Flux install and the parameterized image registry
+- `windsorcli/core` `terraform/cluster/talos/extensions/main.tf:34` — online schematic resolution
+- `docs/adrs/0002-target-architecture-and-package-topology.md` — layer ownership table
+- Sidero Labs, [Air-Gapped Kubernetes With Talos Linux](https://www.siderolabs.com/blog/air-gapped-kubernetes-with-talos-linux) — Image Cache workflow
+- Sidero Labs, [Pull-through cache](https://docs.siderolabs.com/talos/v1.11/configure-your-talos-cluster/images-container-runtime/pull-through-cache) — `mirrors`, `overridePath`, `skipFallback`
+- Sidero Labs, [Run Image Factory On-Prem](https://docs.siderolabs.com/omni/self-hosted/run-image-factory-on-prem)
+- Flux, [Air-gapped installation](https://fluxcd.io/flux/installation/configuration/air-gapped/)
+- [`fluxcd/flux-mirror`](https://github.com/fluxcd/flux-mirror) — chart and artifact mirroring, evaluated in S8
+- CNCF Distribution, [Registry as a pull through cache](https://distribution.github.io/distribution/recipes/mirror/)
+- [distribution/distribution#4046](https://github.com/distribution/distribution/issues/4046) — proxy cache failing to serve held content
+- HashiCorp, [`terraform providers mirror`](https://developer.hashicorp.com/terraform/cli/commands/providers/mirror)
+- `windsorcli/manager` [ADR-0008 — Harbor](../../../manager/docs/adr/0008-harbor.md)

--- a/docs/adrs/release-v0.10.0.md
+++ b/docs/adrs/release-v0.10.0.md
@@ -326,15 +326,16 @@ These are not part of the refactor charter and do not gate any wave. They share 
 numbering because the lifecycle policy below numbers sequentially per release cycle, not per
 program of work.
 
-- **[0008 — Airgap media and hydration](0008-airgap-media-and-hydration.md).** Write-once media
-  carrying the full dependency set of a blueprint, and a disconnected `windsor bootstrap` that
-  consumes it. Scoped to `platform: docker`/`incus`/`metal`; cloud platforms are explicitly
-  excluded from the no-egress claim. Builds on mechanisms already in the tree (the Renovate-derived
-  `artifact-manifest.yaml`, the workstation pull-through registries and their cache volumes, the
-  OCI disk cache) rather than new plumbing. Gated on eight named feasibility spikes, of which the
-  observed-vs-declared image delta (S6) is the one that can change the design rather than its
-  parameters. Depends on cross-repo work in `windsorcli/core` (config-derived Helm repository URLs,
-  pre-computed Talos schematic IDs) from phase 3 onward.
+- **[0008 — OCI registry mirror for images, charts, and Terraform providers](0008-airgap-media-and-hydration.md).**
+  Extends the existing image/blueprint OCI mirror mode to close the one gap it doesn't reach:
+  Terraform providers, which HashiCorp's `terraform` has no OCI client for
+  (`hashicorp/terraform#31463`, open since 2022, no roadmap movement). `windsor push` gains
+  `images`/`providers`/`mirror` objects; `windsor pull providers` materializes a local
+  `filesystem_mirror` for `terraform init`/`tofu init`. Providers are stored as OCI Image Indexes
+  using OpenTofu's own provider-mirror layout, so the same registry content works for both drivers.
+  Rescoped 2026-09-01 from a full write-once airgap media design (physical distribution, BOM
+  completeness, offline Talos provisioning, signing) down to this network-mirror piece for
+  v0.10.0 — the original broader design remains in this file's git history for a future ADR.
 
 ## Implementation sequence
 

--- a/docs/adrs/release-v0.10.0.md
+++ b/docs/adrs/release-v0.10.0.md
@@ -139,6 +139,50 @@ so none blocks it. Revisit if a future release's scope actually touches this sur
   fallback when no facet path exists — never alongside one, which is the common case. This is
   presenter/rendering work; fold it into the Wave 1 "Presenter / event stream" ADR when that's
   written rather than deciding it in isolation now.
+- **Omni support: two distinct problems, not one layer.** Sidero's Terraform provider for Omni is
+  an early skeleton (`omni_user` only, no etcd-backup/cluster-template coverage) — not a viable
+  parity path either way. Both problems below compose the same way `flux:` already does — CLI
+  resolves/renders the Omni resource manifests through kustomize, same pipeline `kustomize:`/
+  `flux:` entries go through today, not a bespoke templating path. (1) *Configuring Omni's own
+  objects* (etcd backups, machine classes) is a reconciled-resource-YAML problem, the Flux shape
+  not the terraform plan/apply/state shape; canonical answer if/when it's needed is a generic
+  COSI-envelope CRD (`OmniResource`: `type`/`metadata`/`spec` passthrough, no per-kind schema to
+  track) reconciled by a thin controller-runtime operator, with the CRs themselves delivered via
+  Flux like everything else — check with Sidero first, they may already be building this. (2) *Omni
+  as a cluster-formation backend* — an alternative or complement to terraform for standing up the
+  Talos cluster itself — is the one with no getting around it; its manifests (machine classes,
+  cluster templates, schematics) go through the same kustomize composition as any other blueprint
+  content before being applied via the Omni SDK. See the cross-domain dependency item below, which
+  this depends on. Omni's own cloud bring-up story (infra providers) only reaches bare-metal/
+  Proxmox/vSphere/libvirt/KubeVirt today, no AWS/GCP/Azure — so formation is composable with
+  terraform, not a replacement for it, on cloud platforms specifically. No dependency on this
+  release's charter (presenter/logging/errors/TUI; architecture/DRY/tests) — revisit when a
+  release actually scopes Omni work.
+- **Cross-domain dependency graph (`dependsOn`/`GlobalDependency` generalized across terraform,
+  omni, and flux).** Decided direction, not yet an ADR. Cluster provisioning has real structural
+  ordering that today has no vocabulary: substrate (terraform) → formation (terraform or Omni,
+  composable) → bootstrap (CNI/cilium, must precede Flux itself) → Flux-managed resources. Forcing
+  this through today's whole-phase-then-whole-phase provisioner execution ("all terraform, then
+  all flux") produces ad hoc alternating terraform/omni/terraform layers. Rejected: a `postInstall`
+  boolean (doesn't scale past two phases, breaks the moment a third domain — Omni — exists);
+  a nested `cluster:` container owning its own private `terraform:`/`omni:` (terraform is
+  legitimately dual-purpose — arbitrary infra and cluster-forming both — a container duplicates
+  the primitive). Decided instead: reuse the mechanism `flux:` systems already prove out, not their
+  container type — `install`/`resources` compile down into ordinary `Kustomization` objects in the
+  same flat list the plain `kustomize:` entries use; the new part is just two barrier mechanisms
+  (implicit tier edges, `GlobalDependency`'s "declare the precondition once, it wires into every
+  downstream consumer automatically"). Generalize both across domains: `dependsOn` gains
+  kind-qualified cross-domain references (`terraform:vpc`, `omni:cluster`, `flux:cilium`);
+  `GlobalDependency` widens from "within this flux system" to "across everything the provisioner
+  runs." `terraform:`/`omni:`/`flux:` stay flat, peer, general-purpose lists — no new blueprint
+  container. Provisioner execution moves from two fixed phases to resolving one cross-domain DAG
+  and walking it, though each domain still owns its own actual execution semantics (terraform
+  apply, Omni SDK, Flux controller) — the DAG only decides entry order. Explicitly out of scope for
+  this mechanism: live-endpoint/health-gated "day 2" service configuration (e.g. configuring
+  openbao once it's up and authenticated) — that's dynamic/runtime discovery, not static plan-time
+  topology, and stays a phase-gated concern (run after the graph reaches Ready), never a graph
+  edge. No dependency on this release's charter — revisit alongside the Omni work above, since
+  Omni-as-formation-backend is the concrete case that needs it.
 
 ## Stragglers (tracked here, not as standalone ADRs)
 
@@ -367,7 +411,8 @@ this phase just confirms none of them are blocked on Phase C finishing in full.
    with the `large-pr` phased-change convention.
 6. **Beta cadence** — tag `0.10.0-beta.N` at each wave boundary, or continuous pre-releases?
 7. **Feature requests to slot in** — you mentioned prioritizing a few. List them so they can be
-   mapped onto the waves above.
+   mapped onto the waves above. First one recorded: Omni layer direction, see Backlog above —
+   doesn't map onto a v0.10.0 wave, tracked for a future release's scope.
 
 ## ADR lifecycle policy
 

--- a/docs/adrs/release-v0.10.0.md
+++ b/docs/adrs/release-v0.10.0.md
@@ -202,7 +202,7 @@ execution (a merge) remains:
 
 ## ADR sequence
 
-Numbers below continue from the carried-forward series above (next available is 0008). Waves are
+Numbers below continue from the carried-forward series above (next available is 0009). Waves are
 ordered; ADRs within a wave may proceed in parallel unless a dependency is noted.
 
 ### Wave 0 — North star (must land first)
@@ -319,6 +319,22 @@ first implementation step, then do the header rewrite under that net.
   cancellation and context propagation.
 - **ADR — Interactive input.** Selection menus and chat-style prompting for missing values and
   secrets, sourced through the same presenter/event contract.
+
+### Outside the waves — feature ADRs sharing the numbering sequence
+
+These are not part of the refactor charter and do not gate any wave. They share `docs/adrs/`
+numbering because the lifecycle policy below numbers sequentially per release cycle, not per
+program of work.
+
+- **[0008 — Airgap media and hydration](0008-airgap-media-and-hydration.md).** Write-once media
+  carrying the full dependency set of a blueprint, and a disconnected `windsor bootstrap` that
+  consumes it. Scoped to `platform: docker`/`incus`/`metal`; cloud platforms are explicitly
+  excluded from the no-egress claim. Builds on mechanisms already in the tree (the Renovate-derived
+  `artifact-manifest.yaml`, the workstation pull-through registries and their cache volumes, the
+  OCI disk cache) rather than new plumbing. Gated on eight named feasibility spikes, of which the
+  observed-vs-declared image delta (S6) is the one that can change the design rather than its
+  parameters. Depends on cross-repo work in `windsorcli/core` (config-derived Helm repository URLs,
+  pre-computed Talos schematic IDs) from phase 3 onward.
 
 ## Implementation sequence
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This is a docs-only change to a living planning document (`docs/adrs/release-v0.10.0.md`); it carries no code or behavioral impact.
>
> **Overview**
>
> The PR appends two new Backlog entries to the v0.10.0 planning ADR: one scoping Omni support into two distinct problems (configuring Omni's own resources vs. Omni as a cluster-formation backend), and one recording the decided direction for a cross-domain dependency graph (`dependsOn`/`GlobalDependency`) spanning terraform, Omni, and flux. It also updates the "feature requests to slot in" open question to point at the new Omni backlog entry.
>
> Both entries are explicitly marked as out of scope for the current v0.10.0 charter and are recorded for a future release, so the document's own scoping conclusions are unchanged.

<!-- /claude-code-review:summary -->
