### PR TITLE
fix(config): enhance persistence for network CIDR block in workstation state

### DIFF
--- a/pkg/runtime/config/handler.go
+++ b/pkg/runtime/config/handler.go
@@ -301,7 +301,7 @@ func (c *configHandler) SaveConfig(overwrite ...bool) error {
 
 // SaveWorkstationState extracts workstation-managed keys from config data and writes them
 // to .windsor/contexts/<context>/workstation.yaml. This is the canonical persistence point for system-derived
-// workstation configuration (runtime, address, platform, DNS settings).
+// workstation configuration (runtime, address, platform, DNS settings, network CIDR block).
 func (c *configHandler) SaveWorkstationState() error {
 	if c.shell == nil {
 		return fmt.Errorf("shell not initialized")

--- a/pkg/runtime/config/persistence_policy.go
+++ b/pkg/runtime/config/persistence_policy.go
@@ -44,6 +44,7 @@ func (p *persistencePolicy) Partition(data map[string]any, input persistencePoli
 	workstation := make(map[string]any)
 
 	persistPlatform := p.shouldPersistPlatform(input)
+	persistNetwork := p.shouldPersistNetwork(input)
 	for key, value := range data {
 		if key == "provider" {
 			continue
@@ -56,7 +57,7 @@ func (p *persistencePolicy) Partition(data map[string]any, input persistencePoli
 			workstation[key] = value
 			continue
 		}
-		if key == "network" && persistPlatform {
+		if key == "network" && persistNetwork {
 			if cidrBlock, ok := networkCIDRBlock(value); ok {
 				workstation["network"] = map[string]any{"cidr_block": cidrBlock}
 			}
@@ -76,6 +77,17 @@ func (p *persistencePolicy) Partition(data map[string]any, input persistencePoli
 
 // shouldPersistPlatform reports whether platform should be owned by workstation state.
 func (p *persistencePolicy) shouldPersistPlatform(input persistencePolicyInput) bool {
+	if input.IsDevMode {
+		return true
+	}
+
+	return input.WorkstationRuntime != ""
+}
+
+// shouldPersistNetwork reports whether the computed network.cidr_block should be duplicated into
+// workstation state. Same condition as shouldPersistPlatform today, kept as its own predicate so a
+// future change to platform-persistence rules doesn't silently change network CIDR persistence too.
+func (p *persistencePolicy) shouldPersistNetwork(input persistencePolicyInput) bool {
 	if input.IsDevMode {
 		return true
 	}

--- a/pkg/runtime/config/persistence_policy.go
+++ b/pkg/runtime/config/persistence_policy.go
@@ -2,8 +2,9 @@ package config
 
 // The PersistencePolicy is a partitioning component for config persistence targets.
 // It provides deterministic routing of merged config data into values and workstation maps,
-// The PersistencePolicy centralizes conditional ownership rules for special keys like platform,
-// and removes policy-specific booleans from file source save method signatures.
+// The PersistencePolicy centralizes conditional ownership rules for special keys like platform
+// and the computed network.cidr_block, and removes policy-specific booleans from file source
+// save method signatures.
 
 // =============================================================================
 // Types
@@ -55,6 +56,11 @@ func (p *persistencePolicy) Partition(data map[string]any, input persistencePoli
 			workstation[key] = value
 			continue
 		}
+		if key == "network" && persistPlatform {
+			if cidrBlock, ok := networkCIDRBlock(value); ok {
+				workstation["network"] = map[string]any{"cidr_block": cidrBlock}
+			}
+		}
 		values[key] = value
 	}
 
@@ -86,4 +92,17 @@ func (p *persistencePolicy) isWorkstationManagedKey(key string) bool {
 	}
 
 	return false
+}
+
+// networkCIDRBlock extracts the cidr_block field from a network config map, if present.
+func networkCIDRBlock(value any) (any, bool) {
+	network, ok := value.(map[string]any)
+	if !ok {
+		return nil, false
+	}
+	cidrBlock, ok := network["cidr_block"]
+	if !ok {
+		return nil, false
+	}
+	return cidrBlock, true
 }

--- a/pkg/runtime/config/persistence_policy_test.go
+++ b/pkg/runtime/config/persistence_policy_test.go
@@ -79,6 +79,74 @@ func TestPersistencePolicy_Partition(t *testing.T) {
 		}
 	})
 
+	t.Run("RoutesNetworkCIDRBlockToWorkstationWhenRuntimeConfigured", func(t *testing.T) {
+		policy := newPersistencePolicy()
+		data := map[string]any{
+			"network": map[string]any{
+				"cidr_block":       "10.5.0.0/16",
+				"loadbalancer_ips": map[string]any{"start": "10.5.0.10"},
+			},
+		}
+
+		partition := policy.Partition(data, persistencePolicyInput{
+			WorkstationRuntime: "colima",
+		})
+
+		workstationNetwork, ok := partition.Workstation["network"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected network map in workstation partition, got %v", partition.Workstation["network"])
+		}
+		if workstationNetwork["cidr_block"] != "10.5.0.0/16" {
+			t.Errorf("Expected cidr_block in workstation partition, got %v", workstationNetwork["cidr_block"])
+		}
+		if _, ok := workstationNetwork["loadbalancer_ips"]; ok {
+			t.Errorf("Did not expect loadbalancer_ips in workstation partition, got %v", workstationNetwork)
+		}
+
+		valuesNetwork, ok := partition.Values["network"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected network map in values partition, got %v", partition.Values["network"])
+		}
+		if valuesNetwork["cidr_block"] != "10.5.0.0/16" {
+			t.Errorf("Expected cidr_block still present in values partition, got %v", valuesNetwork["cidr_block"])
+		}
+		if _, ok := valuesNetwork["loadbalancer_ips"]; !ok {
+			t.Errorf("Expected loadbalancer_ips still present in values partition, got %v", valuesNetwork)
+		}
+	})
+
+	t.Run("RoutesNetworkToValuesOnlyWhenRuntimeNotConfigured", func(t *testing.T) {
+		policy := newPersistencePolicy()
+		data := map[string]any{
+			"network": map[string]any{"cidr_block": "10.5.0.0/16"},
+		}
+
+		partition := policy.Partition(data, persistencePolicyInput{})
+
+		if _, ok := partition.Workstation["network"]; ok {
+			t.Errorf("Did not expect network in workstation partition, got %v", partition.Workstation["network"])
+		}
+		valuesNetwork, ok := partition.Values["network"].(map[string]any)
+		if !ok || valuesNetwork["cidr_block"] != "10.5.0.0/16" {
+			t.Errorf("Expected cidr_block in values partition, got %v", partition.Values["network"])
+		}
+	})
+
+	t.Run("SkipsWorkstationNetworkWhenCIDRBlockAbsent", func(t *testing.T) {
+		policy := newPersistencePolicy()
+		data := map[string]any{
+			"network": map[string]any{"loadbalancer_ips": map[string]any{"start": "10.5.0.10"}},
+		}
+
+		partition := policy.Partition(data, persistencePolicyInput{
+			WorkstationRuntime: "colima",
+		})
+
+		if _, ok := partition.Workstation["network"]; ok {
+			t.Errorf("Did not expect network in workstation partition, got %v", partition.Workstation["network"])
+		}
+	})
+
 	t.Run("RoutesNonManagedKeysToValuesPartition", func(t *testing.T) {
 		policy := newPersistencePolicy()
 		data := map[string]any{

--- a/pkg/runtime/config/workstation_source.go
+++ b/pkg/runtime/config/workstation_source.go
@@ -8,7 +8,8 @@ import (
 // The WorkstationSource is a configuration source for system-managed workstation state.
 // It provides load, save, and delete operations for context-scoped workstation.yaml files,
 // The WorkstationSource isolates ephemeral workstation persistence from user-authored values,
-// and centralizes filtering/policy logic for workstation-managed keys and platform persistence.
+// and centralizes filtering/policy logic for workstation-managed keys, platform persistence,
+// and the computed network.cidr_block a standalone 'configure network' needs to read back.
 
 // =============================================================================
 // Types

--- a/pkg/runtime/config/workstation_source_test.go
+++ b/pkg/runtime/config/workstation_source_test.go
@@ -91,6 +91,35 @@ func TestWorkstationSource_Save(t *testing.T) {
 		}
 	})
 
+	t.Run("RoundTripsNetworkCIDRBlockForStandaloneConfigureNetwork", func(t *testing.T) {
+		source := newWorkstationSource(NewShims(), newPersistencePolicy())
+		projectRoot := t.TempDir()
+		contextName := "local"
+		data := map[string]any{
+			"workstation": map[string]any{"runtime": "colima"},
+			"network":     map[string]any{"cidr_block": "10.5.0.0/16"},
+		}
+
+		if err := source.Save(projectRoot, contextName, data, persistencePolicyInput{WorkstationRuntime: "colima"}); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		values, found, err := source.Load(projectRoot, contextName)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !found {
+			t.Fatal("Expected workstation.yaml to be found")
+		}
+		network, ok := values["network"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected network map, got %T", values["network"])
+		}
+		if network["cidr_block"] != "10.5.0.0/16" {
+			t.Errorf("Expected network.cidr_block to round-trip, got %v", network["cidr_block"])
+		}
+	})
+
 	t.Run("DeletesStateFileWhenNoWorkstationPartition", func(t *testing.T) {
 		source := newWorkstationSource(NewShims(), newPersistencePolicy())
 		projectRoot := t.TempDir()

--- a/pkg/workstation/network/darwin_network.go
+++ b/pkg/workstation/network/darwin_network.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/tui"
 )
 
@@ -28,10 +29,7 @@ import (
 // if no primary network service can be detected, the live route is left in place and a warning is
 // printed.
 func (n *BaseNetworkManager) ConfigureHostRoute() error {
-	networkCIDR := n.configHandler.GetString("network.cidr_block")
-	if networkCIDR == "" {
-		return fmt.Errorf("network CIDR is not configured")
-	}
+	networkCIDR := n.configHandler.GetString("network.cidr_block", constants.DefaultNetworkCIDR)
 	guestIP := n.configHandler.GetString("workstation.address")
 	if guestIP == "" {
 		return fmt.Errorf("guest address is required")

--- a/pkg/workstation/network/darwin_network.go
+++ b/pkg/workstation/network/darwin_network.go
@@ -29,7 +29,10 @@ import (
 // if no primary network service can be detected, the live route is left in place and a warning is
 // printed.
 func (n *BaseNetworkManager) ConfigureHostRoute() error {
-	networkCIDR := n.configHandler.GetString("network.cidr_block", constants.DefaultNetworkCIDR)
+	networkCIDR := n.configHandler.GetString("network.cidr_block")
+	if networkCIDR == "" {
+		networkCIDR = constants.DefaultNetworkCIDR
+	}
 	guestIP := n.configHandler.GetString("workstation.address")
 	if guestIP == "" {
 		return fmt.Errorf("guest address is required")

--- a/pkg/workstation/network/darwin_network_test.go
+++ b/pkg/workstation/network/darwin_network_test.go
@@ -38,8 +38,9 @@ func TestDarwinNetworkManager_ConfigureHostRoute(t *testing.T) {
 		}
 	})
 
-	t.Run("NoNetworkCIDRConfigured", func(t *testing.T) {
-		// Given a network manager with no CIDR configured
+	t.Run("FallsBackToDefaultCIDRWhenNotConfigured", func(t *testing.T) {
+		// Given a network manager with no CIDR configured (e.g. a facet-computed default that
+		// never reached configHandler, or a standalone 'configure network' invocation)
 		manager, mocks := setup(t)
 		mocks.ConfigHandler.Set("network.cidr_block", "")
 		mocks.ConfigHandler.Set("workstation.address", "192.168.1.10")
@@ -47,13 +48,9 @@ func TestDarwinNetworkManager_ConfigureHostRoute(t *testing.T) {
 		// And configuring the host route
 		err := manager.ConfigureHostRoute()
 
-		// Then an error should occur
-		if err == nil {
-			t.Fatalf("expected error, got nil")
-		}
-		expectedError := "network CIDR is not configured"
-		if err.Error() != expectedError {
-			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
+		// Then it succeeds using constants.DefaultNetworkCIDR instead of erroring
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
 		}
 	})
 

--- a/pkg/workstation/network/linux_network.go
+++ b/pkg/workstation/network/linux_network.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/tui"
 )
 
@@ -42,10 +43,7 @@ const systemdResolvedSymlinkHint = "systemd-resolved is active but /etc/resolv.c
 // route survives reboot. When neither persistence mechanism is available the live route is left in
 // place and an actionable warning is printed.
 func (n *BaseNetworkManager) ConfigureHostRoute() error {
-	networkCIDR := n.configHandler.GetString("network.cidr_block")
-	if networkCIDR == "" {
-		return fmt.Errorf("network CIDR is not configured")
-	}
+	networkCIDR := n.configHandler.GetString("network.cidr_block", constants.DefaultNetworkCIDR)
 	guestIP := n.configHandler.GetString("workstation.address")
 	if guestIP == "" {
 		return fmt.Errorf("guest address is required")

--- a/pkg/workstation/network/linux_network.go
+++ b/pkg/workstation/network/linux_network.go
@@ -43,7 +43,10 @@ const systemdResolvedSymlinkHint = "systemd-resolved is active but /etc/resolv.c
 // route survives reboot. When neither persistence mechanism is available the live route is left in
 // place and an actionable warning is printed.
 func (n *BaseNetworkManager) ConfigureHostRoute() error {
-	networkCIDR := n.configHandler.GetString("network.cidr_block", constants.DefaultNetworkCIDR)
+	networkCIDR := n.configHandler.GetString("network.cidr_block")
+	if networkCIDR == "" {
+		networkCIDR = constants.DefaultNetworkCIDR
+	}
 	guestIP := n.configHandler.GetString("workstation.address")
 	if guestIP == "" {
 		return fmt.Errorf("guest address is required")

--- a/pkg/workstation/network/linux_network_test.go
+++ b/pkg/workstation/network/linux_network_test.go
@@ -38,8 +38,9 @@ func TestLinuxNetworkManager_ConfigureHostRoute(t *testing.T) {
 		}
 	})
 
-	t.Run("NoNetworkCIDRConfigured", func(t *testing.T) {
-		// Given a network manager with no CIDR configured
+	t.Run("FallsBackToDefaultCIDRWhenNotConfigured", func(t *testing.T) {
+		// Given a network manager with no CIDR configured (e.g. a facet-computed default that
+		// never reached configHandler, or a standalone 'configure network' invocation)
 		manager, mocks := setup(t)
 		mocks.ConfigHandler.Set("network.cidr_block", "")
 		mocks.ConfigHandler.Set("workstation.address", "192.168.1.10")
@@ -47,13 +48,9 @@ func TestLinuxNetworkManager_ConfigureHostRoute(t *testing.T) {
 		// And configuring the host route
 		err := manager.ConfigureHostRoute()
 
-		// Then an error should occur
-		if err == nil {
-			t.Fatalf("expected error, got nil")
-		}
-		expectedError := "network CIDR is not configured"
-		if !strings.Contains(err.Error(), expectedError) {
-			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
+		// Then it succeeds using constants.DefaultNetworkCIDR instead of erroring
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
 		}
 	})
 

--- a/pkg/workstation/network/windows_network.go
+++ b/pkg/workstation/network/windows_network.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/tui"
 )
 
@@ -73,10 +74,7 @@ if ($rule) {
 // Guest address is read from config (workstation.address). It checks if the route exists via
 // PowerShell; if not, adds a route to the VM guest.
 func (n *BaseNetworkManager) ConfigureHostRoute() error {
-	networkCIDR := n.configHandler.GetString("network.cidr_block")
-	if networkCIDR == "" {
-		return fmt.Errorf("network CIDR is not configured")
-	}
+	networkCIDR := n.configHandler.GetString("network.cidr_block", constants.DefaultNetworkCIDR)
 	cidr, err := validateCIDR(networkCIDR)
 	if err != nil {
 		return err

--- a/pkg/workstation/network/windows_network.go
+++ b/pkg/workstation/network/windows_network.go
@@ -74,7 +74,10 @@ if ($rule) {
 // Guest address is read from config (workstation.address). It checks if the route exists via
 // PowerShell; if not, adds a route to the VM guest.
 func (n *BaseNetworkManager) ConfigureHostRoute() error {
-	networkCIDR := n.configHandler.GetString("network.cidr_block", constants.DefaultNetworkCIDR)
+	networkCIDR := n.configHandler.GetString("network.cidr_block")
+	if networkCIDR == "" {
+		networkCIDR = constants.DefaultNetworkCIDR
+	}
 	cidr, err := validateCIDR(networkCIDR)
 	if err != nil {
 		return err

--- a/pkg/workstation/network/windows_network_test.go
+++ b/pkg/workstation/network/windows_network_test.go
@@ -36,8 +36,9 @@ func TestWindowsNetworkManager_ConfigureHostRoute(t *testing.T) {
 		}
 	})
 
-	t.Run("NoNetworkCIDR", func(t *testing.T) {
-		// Given a network manager with no CIDR configured
+	t.Run("FallsBackToDefaultCIDRWhenNotConfigured", func(t *testing.T) {
+		// Given a network manager with no CIDR configured (e.g. a facet-computed default that
+		// never reached configHandler, or a standalone 'configure network' invocation)
 		manager, mocks := setup(t)
 		mocks.ConfigHandler.Set("network.cidr_block", "")
 		mocks.ConfigHandler.Set("workstation.address", "192.168.1.10")
@@ -45,13 +46,9 @@ func TestWindowsNetworkManager_ConfigureHostRoute(t *testing.T) {
 		// And configuring the host route
 		err := manager.ConfigureHostRoute()
 
-		// Then an error should occur
-		if err == nil {
-			t.Fatalf("expected error, got nil")
-		}
-		expectedError := "network CIDR is not configured"
-		if !strings.Contains(err.Error(), expectedError) {
-			t.Fatalf("expected error %q, got %q", expectedError, err.Error())
+		// Then it succeeds using constants.DefaultNetworkCIDR instead of erroring
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
 		}
 	})
 

--- a/pkg/workstation/workstation.go
+++ b/pkg/workstation/workstation.go
@@ -479,7 +479,10 @@ func (w *Workstation) PendingNetworkChanges() []NetworkChange {
 	}
 	var changes []NetworkChange
 	if w.NetworkManager.NeedsPrivilegeForCluster() {
-		cidr := w.configHandler.GetString("network.cidr_block", constants.DefaultNetworkCIDR)
+		cidr := w.configHandler.GetString("network.cidr_block")
+		if cidr == "" {
+			cidr = constants.DefaultNetworkCIDR
+		}
 		gateway := w.configHandler.GetString("workstation.address")
 		changes = append(changes,
 			NetworkChange{Kind: "host-route", Detail: fmt.Sprintf("%s via %s", cidr, gateway)},

--- a/pkg/workstation/workstation.go
+++ b/pkg/workstation/workstation.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/runtime"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	"github.com/windsorcli/cli/pkg/runtime/evaluator"
@@ -478,7 +479,7 @@ func (w *Workstation) PendingNetworkChanges() []NetworkChange {
 	}
 	var changes []NetworkChange
 	if w.NetworkManager.NeedsPrivilegeForCluster() {
-		cidr := w.configHandler.GetString("network.cidr_block")
+		cidr := w.configHandler.GetString("network.cidr_block", constants.DefaultNetworkCIDR)
 		gateway := w.configHandler.GetString("workstation.address")
 		changes = append(changes,
 			NetworkChange{Kind: "host-route", Detail: fmt.Sprintf("%s via %s", cidr, gateway)},


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This touches the shared config persistence policy that routes data into `config.yaml` versus `workstation.yaml`, and changes what gets written to disk by default whenever a workstation runtime is configured.
>
> **Overview**
>
> The PR extends `persistencePolicy.Partition` so that, when platform/workstation persistence is active, the `network.cidr_block` value is additionally duplicated into the workstation-managed partition alongside the rest of the `network` map, which continues to flow into `config.yaml` as before. `WorkstationSource` and its doc comments are updated to describe this new responsibility, and unit tests cover the three relevant paths: CIDR present with a runtime configured, no runtime configured, and CIDR absent.
>
> The gating condition reuses the existing `shouldPersistPlatform`/`persistPlatform` check (dev mode or a non-empty `workstation.runtime`), so network CIDR persistence is now tied to platform-persistence logic rather than having its own independent rule — worth keeping in mind if platform and network persistence requirements diverge later.

<!-- /claude-code-review:summary -->
