### PR TITLE
feat(upgrade): add --refresh to bypass cache for floating-tag sources

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -24,6 +24,7 @@ var (
 	upgradeSources        []string
 	upgradeYes            bool
 	upgradeAllowDowngrade bool
+	upgradeRefresh        bool
 	upgradeRebootMode     string
 
 	upgradeNodeAddr           string
@@ -36,7 +37,7 @@ var (
 var upgradeCmd = &cobra.Command{
 	Use:   "upgrade",
 	Short: "Move sources to their latest version and reconcile the blueprint.",
-	Long: `With no arguments, move every declared OCI source to its latest stable version, then reconcile: apply terraform and the Flux blueprint, wait, and prune kustomizations this context no longer declares. Use --source name=url to move named sources to specific versions instead. The whole reconcile — including the prune — is gated by --yes.
+	Long: `With no arguments, move every declared OCI source to its latest stable version, then reconcile: apply terraform and the Flux blueprint, wait, and prune kustomizations this context no longer declares. Use --source name=url to move named sources to specific versions instead. Sources already on a floating tag (e.g. :latest) are left untouched unless --refresh is set, since the on-disk cache never expires them on its own. The whole reconcile — including the prune — is gated by --yes.
 
 Use the 'cluster' or 'node' subcommand to upgrade Talos nodes instead.`,
 	Example: `# Move all sources to their latest stable version and reconcile
@@ -78,6 +79,10 @@ windsor upgrade cluster --nodes=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1
 		}
 
 		proj.SetToolRequirements(tools.AllRequirements())
+		proj.Composer.ArtifactBuilder.SetForceRefreshFloatingTags(upgradeRefresh)
+		if upgradeRefresh {
+			fmt.Fprintln(cmd.OutOrStdout(), "Refreshing floating-tag sources, bypassing cache.")
+		}
 		if err := proj.Initialize(false); err != nil {
 			return err
 		}
@@ -434,6 +439,7 @@ func init() {
 	upgradeCmd.Flags().StringArrayVar(&upgradeSources, "source", nil, "Retarget a declared source to a new tagged URL (name=url); repeatable. Persisted to blueprint.yaml.")
 	upgradeCmd.Flags().BoolVar(&upgradeYes, "yes", false, "Proceed without confirmation when the upgrade would prune kustomizations.")
 	upgradeCmd.Flags().BoolVar(&upgradeAllowDowngrade, "allow-downgrade", false, "Permit moving a source to an older version. Reverts infrastructure declaratively; does NOT reverse application data.")
+	upgradeCmd.Flags().BoolVar(&upgradeRefresh, "refresh", false, "Force sources on a floating tag (e.g. :latest) to bypass the artifact cache and pull fresh. Semver-pinned sources are unaffected.")
 
 	upgradeClusterCmd.Flags().StringSliceVar(&upgradeNodes, "nodes", []string{}, "Node addresses to upgrade. Required.")
 	upgradeClusterCmd.Flags().StringVar(&upgradeImage, "image", "", "Talos image to upgrade to. Required.")

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -10,11 +10,32 @@ import (
 
 	"github.com/spf13/cobra"
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+	"github.com/windsorcli/cli/pkg/composer"
+	"github.com/windsorcli/cli/pkg/composer/artifact"
 	"github.com/windsorcli/cli/pkg/composer/blueprint"
 	"github.com/windsorcli/cli/pkg/constants"
+	"github.com/windsorcli/cli/pkg/project"
+	"github.com/windsorcli/cli/pkg/provisioner"
 	"github.com/windsorcli/cli/pkg/provisioner/kubernetes"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 )
+
+// newApplyAllProjectWithArtifact wires the same mocks as newApplyAllProject, but with the given
+// ArtifactBuilder in place of the composer's default, so a test can spy on artifact-level calls
+// (e.g. SetForceRefreshFloatingTags) that newApplyAllProject's real ArtifactBuilder can't observe.
+func newApplyAllProjectWithArtifact(mocks *ApplyMocks, artifactBuilder artifact.Artifact) *project.Project {
+	comp := composer.NewComposer(mocks.Runtime)
+	comp.BlueprintHandler = mocks.BlueprintHandler
+	comp.ArtifactBuilder = artifactBuilder
+	return project.NewProject("", &project.Project{
+		Runtime:  mocks.Runtime,
+		Composer: comp,
+		Provisioner: provisioner.NewProvisioner(mocks.Runtime, comp.BlueprintHandler, &provisioner.Provisioner{
+			TerraformStack:    mocks.TerraformStack,
+			KubernetesManager: mocks.KubernetesManager,
+		}),
+	})
+}
 
 func TestUpgradeCmd(t *testing.T) {
 	createTestUpgradeCmd := func() *cobra.Command { return makeApplyTestCmd(upgradeCmd) }
@@ -439,6 +460,91 @@ func TestUpgradeCmd_Latest(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "resolving latest source versions") {
 			t.Errorf("Expected a resolution error, got: %v", err)
+		}
+	})
+}
+
+func TestUpgradeCmd_Refresh(t *testing.T) {
+	createTestUpgradeCmd := func() *cobra.Command { return makeApplyTestCmd(upgradeCmd) }
+
+	suppressProcessStdout(t)
+	suppressProcessStderr(t)
+
+	upgradeYes = true
+	t.Cleanup(func() { upgradeYes = false })
+
+	t.Run("SetsForceRefreshFloatingTagsAndNoticeWhenFlagPassed", func(t *testing.T) {
+		// Given --refresh is set
+		mocks := setupApplyTest(t)
+		mockArtifact := artifact.NewMockArtifact()
+		var received bool
+		var receivedCount int
+		mockArtifact.SetForceRefreshFloatingTagsFunc = func(force bool) {
+			received = force
+			receivedCount++
+		}
+		proj := newApplyAllProjectWithArtifact(mocks, mockArtifact)
+
+		upgradeRefresh = true
+		t.Cleanup(func() { upgradeRefresh = false })
+
+		// When running upgrade
+		var out bytes.Buffer
+		cmd := createTestUpgradeCmd()
+		cmd.SetOut(&out)
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the artifact builder is told to force-refresh floating tags
+		if receivedCount != 1 {
+			t.Fatalf("Expected SetForceRefreshFloatingTags to be called once, got %d calls", receivedCount)
+		}
+		if !received {
+			t.Error("Expected SetForceRefreshFloatingTags to be called with true")
+		}
+
+		// And a notice is printed
+		if !strings.Contains(out.String(), "Refreshing floating-tag sources") {
+			t.Errorf("Expected a refresh notice, got: %q", out.String())
+		}
+	})
+
+	t.Run("LeavesForceRefreshFloatingTagsFalseByDefault", func(t *testing.T) {
+		// Given --refresh is not set (the default)
+		mocks := setupApplyTest(t)
+		mockArtifact := artifact.NewMockArtifact()
+		var received bool
+		var receivedCount int
+		mockArtifact.SetForceRefreshFloatingTagsFunc = func(force bool) {
+			received = force
+			receivedCount++
+		}
+		proj := newApplyAllProjectWithArtifact(mocks, mockArtifact)
+
+		// When running bare upgrade
+		var out bytes.Buffer
+		cmd := createTestUpgradeCmd()
+		cmd.SetOut(&out)
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the artifact builder is told NOT to force-refresh floating tags
+		if receivedCount != 1 {
+			t.Fatalf("Expected SetForceRefreshFloatingTags to be called once, got %d calls", receivedCount)
+		}
+		if received {
+			t.Error("Expected SetForceRefreshFloatingTags to be called with false")
+		}
+
+		// And no refresh notice is printed
+		if strings.Contains(out.String(), "Refreshing floating-tag sources") {
+			t.Errorf("Expected no refresh notice, got: %q", out.String())
 		}
 	})
 }

--- a/integration/upgrade_test.go
+++ b/integration/upgrade_test.go
@@ -147,6 +147,27 @@ func TestUpgrade_AcceptsYesFlag(t *testing.T) {
 	_ = err // fails without a live cluster; the flag must be accepted
 }
 
+func TestUpgrade_AcceptsRefreshFlag(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
+	if _, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env); err != nil {
+		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
+	}
+	env = append(env, "WINDSOR_CONTEXT=local")
+
+	// --refresh must be a recognised flag that prints the bypass notice before reconciling
+	// (which then fails without a live cluster, same as --yes alone).
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"upgrade", "--yes", "--refresh"}, env)
+	if strings.Contains(string(stderr), "unknown flag") {
+		t.Errorf("--refresh should be a recognised flag on upgrade, got: %s", stderr)
+	}
+	if !strings.Contains(string(stdout), "Refreshing floating-tag sources") {
+		t.Errorf("expected the refresh notice on stdout, got: %s", stdout)
+	}
+	_ = err // fails without a live cluster; the flag must be accepted
+}
+
 // =============================================================================
 // Integration Tests — upgrade cluster
 // =============================================================================

--- a/pkg/composer/artifact/artifact.go
+++ b/pkg/composer/artifact/artifact.go
@@ -60,6 +60,7 @@ type Artifact interface {
 	ListTags(ociRef string) ([]string, error)
 	GetCliVersionConstraint(ociRef string) (string, error)
 	VerifyCliVersionCompatibility(ociRef string) error
+	SetForceRefreshFloatingTags(force bool)
 }
 
 // =============================================================================
@@ -127,12 +128,13 @@ type PathProcessor struct {
 
 // ArtifactBuilder implements the Artifact interface
 type ArtifactBuilder struct {
-	files       map[string]FileInfo
-	shims       *Shims
-	shell       shell.Shell
-	runtime     *runtime.Runtime
-	tarballPath string
-	metadata    BlueprintMetadataInput
+	files                    map[string]FileInfo
+	shims                    *Shims
+	shell                    shell.Shell
+	runtime                  *runtime.Runtime
+	tarballPath              string
+	metadata                 BlueprintMetadataInput
+	forceRefreshFloatingTags bool
 }
 
 // =============================================================================
@@ -477,7 +479,9 @@ func (a *ArtifactBuilder) Push(registryBase string, repoName string, tag string)
 // of cache directory paths keyed by their registry/repository:tag identifier.
 // The method provides efficient caching to avoid duplicate downloads of the same artifact.
 // It checks disk cache first, then downloads if needed, and extracts artifacts to disk cache.
-// Returns cache directory paths instead of binary data.
+// Returns cache directory paths instead of binary data. NO_CACHE bypasses the disk cache for
+// every ref; SetForceRefreshFloatingTags(true) scopes that bypass to only the refs whose tag
+// is not a valid semver (e.g. "latest"), leaving semver-pinned refs in the same call cached.
 func (a *ArtifactBuilder) Pull(ociRefs []string) (map[string]string, error) {
 	ociArtifacts := make(map[string]string)
 
@@ -509,7 +513,7 @@ func (a *ArtifactBuilder) Pull(ociRefs []string) (map[string]string, error) {
 			return nil, fmt.Errorf("failed to get cache directory: %w", err)
 		}
 
-		if noCache {
+		if noCache || (a.forceRefreshFloatingTags && IsFloatingTag(tag)) {
 			artifactsToDownload = append(artifactsToDownload, ref)
 			continue
 		}
@@ -559,6 +563,13 @@ func (a *ArtifactBuilder) Pull(ociRefs []string) (map[string]string, error) {
 	}
 
 	return ociArtifacts, nil
+}
+
+// SetForceRefreshFloatingTags controls whether Pull bypasses the disk cache for refs on a
+// floating (non-semver) tag, so a caller can force a stale floating tag like "latest" to
+// re-pull without disturbing cache behavior for semver-pinned refs.
+func (a *ArtifactBuilder) SetForceRefreshFloatingTags(force bool) {
+	a.forceRefreshFloatingTags = force
 }
 
 // Bundle traverses the project directories and collects all relevant files to be
@@ -697,6 +708,13 @@ func ParseOCIReference(ociRef string) (*OCIArtifactInfo, error) {
 		URL:  fullURL,
 		Tag:  version,
 	}, nil
+}
+
+// IsFloatingTag reports whether tag is not a valid semver reference, meaning it moves as new
+// content is published under the same tag (e.g. "latest", "main", "stable").
+func IsFloatingTag(tag string) bool {
+	_, err := semver.NewVersion(tag)
+	return err != nil
 }
 
 // ParseRegistryURL parses a registry URL string into its components.

--- a/pkg/composer/artifact/artifact_helpers_test.go
+++ b/pkg/composer/artifact/artifact_helpers_test.go
@@ -597,3 +597,31 @@ func TestValidateCliVersion(t *testing.T) {
 		}
 	})
 }
+
+func TestIsFloatingTag(t *testing.T) {
+	testCases := []struct {
+		name     string
+		tag      string
+		expected bool
+	}{
+		{name: "Latest", tag: "latest", expected: true},
+		{name: "Main", tag: "main", expected: true},
+		{name: "Stable", tag: "stable", expected: true},
+		{name: "Empty", tag: "", expected: true},
+		{name: "SemverWithVPrefix", tag: "v1.2.3", expected: false},
+		{name: "SemverWithoutVPrefix", tag: "1.2.3", expected: false},
+		{name: "SemverPrerelease", tag: "v1.2.3-rc.1", expected: false},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// When checking whether the tag is floating
+			result := IsFloatingTag(tc.tag)
+
+			// Then it should match the expected classification
+			if result != tc.expected {
+				t.Errorf("IsFloatingTag(%q) = %v, expected %v", tc.tag, result, tc.expected)
+			}
+		})
+	}
+}

--- a/pkg/composer/artifact/artifact_public_test.go
+++ b/pkg/composer/artifact/artifact_public_test.go
@@ -2057,6 +2057,109 @@ func TestArtifactBuilder_Pull(t *testing.T) {
 		}
 	})
 
+	t.Run("ForceRefreshFloatingTagsBypassesCacheForFloatingTagOnly", func(t *testing.T) {
+		// Given an ArtifactBuilder with a valid disk cache for a floating-tag ref and a
+		// semver-pinned ref, and SetForceRefreshFloatingTags enabled
+		builder, mocks := setup(t)
+
+		floatingCacheDir, err := builder.GetCacheDir("registry.example.com", "my-repo", "latest")
+		if err != nil {
+			t.Fatalf("Failed to get cache dir: %v", err)
+		}
+		semverCacheDir, err := builder.GetCacheDir("registry.example.com", "my-repo", "v1.0.0")
+		if err != nil {
+			t.Fatalf("Failed to get cache dir: %v", err)
+		}
+
+		testTarData := createTestTarGz(t, map[string][]byte{
+			"metadata.yaml":       []byte("name: test\nversion: v1.0.0\n"),
+			"_template/test.yaml": []byte("test content"),
+		})
+
+		for _, dir := range []string{floatingCacheDir, semverCacheDir} {
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				t.Fatalf("Failed to create cache dir: %v", err)
+			}
+			if err := os.WriteFile(filepath.Join(dir, artifactTarFilename), testTarData, 0644); err != nil {
+				t.Fatalf("Failed to write artifact.tar: %v", err)
+			}
+		}
+
+		mocks.Shims.Stat = os.Stat
+
+		downloadCount := 0
+		mocks.Shims.LayerUncompressed = func(layer v1.Layer) (io.ReadCloser, error) {
+			downloadCount++
+			return io.NopCloser(bytes.NewReader(testTarData)), nil
+		}
+
+		builder.SetForceRefreshFloatingTags(true)
+
+		// When Pull is called with both refs in the same batch
+		artifacts, err := builder.Pull([]string{
+			"oci://registry.example.com/my-repo:latest",
+			"oci://registry.example.com/my-repo:v1.0.0",
+		})
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if len(artifacts) != 2 {
+			t.Errorf("expected 2 artifacts, got %d", len(artifacts))
+		}
+
+		// And only the floating-tag ref should have been re-downloaded
+		if downloadCount != 1 {
+			t.Errorf("expected 1 download (floating tag only bypasses cache), got %d", downloadCount)
+		}
+	})
+
+	t.Run("ForceRefreshFloatingTagsDoesNothingWhenUnset", func(t *testing.T) {
+		// Given an ArtifactBuilder with a valid disk cache for a floating-tag ref and
+		// SetForceRefreshFloatingTags left at its default (false)
+		builder, mocks := setup(t)
+
+		cacheDir, err := builder.GetCacheDir("registry.example.com", "my-repo", "latest")
+		if err != nil {
+			t.Fatalf("Failed to get cache dir: %v", err)
+		}
+
+		testTarData := createTestTarGz(t, map[string][]byte{
+			"metadata.yaml":       []byte("name: test\nversion: v1.0.0\n"),
+			"_template/test.yaml": []byte("test content"),
+		})
+
+		if err := os.MkdirAll(cacheDir, 0755); err != nil {
+			t.Fatalf("Failed to create cache dir: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(cacheDir, artifactTarFilename), testTarData, 0644); err != nil {
+			t.Fatalf("Failed to write artifact.tar: %v", err)
+		}
+
+		mocks.Shims.Stat = os.Stat
+
+		downloadCount := 0
+		mocks.Shims.LayerUncompressed = func(layer v1.Layer) (io.ReadCloser, error) {
+			downloadCount++
+			return io.NopCloser(bytes.NewReader(testTarData)), nil
+		}
+
+		// When Pull is called for the floating-tag ref without enabling the force-refresh flag
+		artifacts, err := builder.Pull([]string{"oci://registry.example.com/my-repo:latest"})
+
+		// Then no error should occur and the cache should be used
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if len(artifacts) != 1 {
+			t.Errorf("expected 1 artifact, got %d", len(artifacts))
+		}
+		if downloadCount != 0 {
+			t.Errorf("expected 0 downloads (cache used by default), got %d", downloadCount)
+		}
+	})
+
 	t.Run("UsesDiskCacheWhenAvailable", func(t *testing.T) {
 		builder, mocks := setup(t)
 

--- a/pkg/composer/artifact/mock_artifact.go
+++ b/pkg/composer/artifact/mock_artifact.go
@@ -21,6 +21,7 @@ type MockArtifact struct {
 	ListTagsFunc                      func(ociRef string) ([]string, error)
 	GetCliVersionConstraintFunc       func(ociRef string) (string, error)
 	VerifyCliVersionCompatibilityFunc func(ociRef string) error
+	SetForceRefreshFloatingTagsFunc   func(force bool)
 }
 
 // =============================================================================
@@ -117,6 +118,13 @@ func (m *MockArtifact) GetCacheDir(registry, repository, tag string) (string, er
 		return m.GetCacheDirFunc(registry, repository, tag)
 	}
 	return "", nil
+}
+
+// SetForceRefreshFloatingTags calls the mock SetForceRefreshFloatingTagsFunc if set, otherwise does nothing
+func (m *MockArtifact) SetForceRefreshFloatingTags(force bool) {
+	if m.SetForceRefreshFloatingTagsFunc != nil {
+		m.SetForceRefreshFloatingTagsFunc(force)
+	}
 }
 
 // =============================================================================

--- a/pkg/composer/artifact/mock_artifact_test.go
+++ b/pkg/composer/artifact/mock_artifact_test.go
@@ -383,3 +383,31 @@ func TestMockArtifact_GetCacheDir(t *testing.T) {
 		}
 	})
 }
+
+func TestMockArtifact_SetForceRefreshFloatingTags(t *testing.T) {
+	t.Run("CallsSetForceRefreshFloatingTagsFuncWhenSet", func(t *testing.T) {
+		// Given
+		mockArtifact := setupMockArtifactMocks(t)
+		var received bool
+		mockArtifact.SetForceRefreshFloatingTagsFunc = func(force bool) {
+			received = force
+		}
+
+		// When setting force refresh
+		mockArtifact.SetForceRefreshFloatingTags(true)
+
+		// Then the mock func should have been called with the given value
+		if !received {
+			t.Error("Expected SetForceRefreshFloatingTagsFunc to be called with true")
+		}
+	})
+
+	t.Run("DoesNothingWhenSetForceRefreshFloatingTagsFuncNotSet", func(t *testing.T) {
+		// Given
+		mockArtifact := setupMockArtifactMocks(t)
+
+		// When setting force refresh without func set
+		// Then it should not panic
+		mockArtifact.SetForceRefreshFloatingTags(true)
+	})
+}


### PR DESCRIPTION
Closes #3177

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Adds an opt-in `--refresh` flag to `windsor upgrade`; the change is additive, gated behind the flag, and leaves default cache behavior untouched.
>
> **Overview**
>
> This PR adds `--refresh` to `windsor upgrade`, letting operators force sources pinned to a floating tag (e.g. `:latest`) to bypass the on-disk artifact cache and pull fresh content, since such tags never expire the cache on their own. The new `ArtifactBuilder.SetForceRefreshFloatingTags` method scopes the cache bypass to only refs whose tag fails semver parsing (via the new `IsFloatingTag` helper), leaving semver-pinned refs in the same `Pull` call served from cache exactly as before.
>
> The flag is set on the `Artifact` interface and threaded through before `proj.Initialize`, so it's in effect for the whole compose. It composes cleanly with existing behavior: `UpgradeSourcesToLatest` already skips non-semver tags when bumping sources, so `--refresh` only affects the separate `Pull` cache check used during blueprint composition. Unit, mock, and integration tests cover both the flag-set and default-off paths.

<!-- /claude-code-review:summary -->
