### PR TITLE
fix(terraform): add support for NO_COLOR environment variable in Terraform commands

### DIFF
--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -1734,13 +1734,15 @@ func staleProviderLockHint(component *blueprintv1alpha1.TerraformComponent) stri
 	return fmt.Sprintf("the .terraform.lock.hcl in %s may be pinned to a provider version outside the current constraint; run `terraform init -upgrade` there (or remove the lock file if it isn't intentionally version-controlled) and retry", component.FullPath)
 }
 
-// noColorArgs returns []string{"-no-color"} when NO_COLOR is set, honoring the
-// convention windsor's own TUI output already follows (see tuiplan.Summary
-// callers). Terraform's own TTY auto-detection doesn't reliably disable color
-// under piped subprocess capture, so apply/destroy/init need this passed
-// explicitly to keep raw ANSI codes out of logs and CI artifacts.
+// noColorArgs returns []string{"-no-color"} when NO_COLOR is present (its mere
+// presence, any value including empty, opts out per the spec — see
+// awsprofile.shouldColorize for the same convention), honoring the convention
+// windsor's own TUI output already follows (see tuiplan.Summary callers).
+// Terraform's own TTY auto-detection doesn't reliably disable color under
+// piped subprocess capture, so apply/destroy/init need this passed explicitly
+// to keep raw ANSI codes out of logs and CI artifacts.
 func noColorArgs() []string {
-	if os.Getenv("NO_COLOR") != "" {
+	if _, present := os.LookupEnv("NO_COLOR"); present {
 		return []string{"-no-color"}
 	}
 	return nil

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -338,6 +338,7 @@ func (s *TerraformStack) Up(blueprint *blueprintv1alpha1.Blueprint, onApply ...f
 			}
 
 			applyArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "apply"}
+			applyArgs = append(applyArgs, noColorArgs()...)
 			applyArgs = append(applyArgs, terraformArgs.ApplyArgs...)
 			applyEnv := selectTerraformCommandEnv(terraformVars, false, scopedKeys)
 			if _, err = s.runtime.Shell.ExecProgressWithEnv(fmt.Sprintf("Applying Terraform changes in %s", component.Path), terraformCommand, applyEnv, applyArgs...); err != nil {
@@ -693,6 +694,7 @@ func (s *TerraformStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, cont
 				destroyRefreshFlag = "-refresh=true"
 			}
 			destroyArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "destroy", destroyRefreshFlag}
+			destroyArgs = append(destroyArgs, noColorArgs()...)
 			destroyArgs = append(destroyArgs, terraformArgs.DestroyArgs...)
 			destroyEnv := selectTerraformCommandEnv(terraformVars, true, scopedKeys)
 			output, err := s.runtime.Shell.ExecSilentWithEnvAndTimeout(terraformCommand, destroyEnv, destroyArgs, constants.DefaultTerraformDestroyTimeout)
@@ -848,6 +850,7 @@ func (s *TerraformStack) Apply(blueprint *blueprintv1alpha1.Blueprint, component
 		}
 
 		applyArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "apply"}
+		applyArgs = append(applyArgs, noColorArgs()...)
 		applyArgs = append(applyArgs, terraformArgs.ApplyArgs...)
 		applyEnv := selectTerraformCommandEnv(terraformVars, false, scopedKeys)
 		if _, err := s.runtime.Shell.ExecProgressWithEnv(fmt.Sprintf("Applying Terraform changes in %s", component.Path), terraformCommand, applyEnv, applyArgs...); err != nil {
@@ -926,6 +929,7 @@ func (s *TerraformStack) Destroy(blueprint *blueprintv1alpha1.Blueprint, compone
 			destroyRefreshFlag = "-refresh=true"
 		}
 		destroyArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "destroy", destroyRefreshFlag}
+		destroyArgs = append(destroyArgs, noColorArgs()...)
 		destroyArgs = append(destroyArgs, terraformArgs.DestroyArgs...)
 		destroyEnv := selectTerraformCommandEnv(terraformVars, true, scopedKeys)
 
@@ -1579,6 +1583,7 @@ func (s *TerraformStack) runTerraformInit(component *blueprintv1alpha1.Terraform
 	terraformCommand := s.runtime.ToolsManager.GetTerraformCommand()
 	initArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "init"}
 	initArgs = append(initArgs, extraFlags...)
+	initArgs = append(initArgs, noColorArgs()...)
 	initArgs = append(initArgs, terraformArgs.InitArgs...)
 	initEnv := selectTerraformCommandEnv(terraformVars, false, scopedKeys)
 	_, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, initEnv, initArgs...)
@@ -1727,6 +1732,18 @@ func staleProviderLockHint(component *blueprintv1alpha1.TerraformComponent) stri
 		return fmt.Sprintf("the local terraform cache for this component is stale (its module source changed since the last local init); remove %s and re-run to pick up the new provider constraint", component.FullPath)
 	}
 	return fmt.Sprintf("the .terraform.lock.hcl in %s may be pinned to a provider version outside the current constraint; run `terraform init -upgrade` there (or remove the lock file if it isn't intentionally version-controlled) and retry", component.FullPath)
+}
+
+// noColorArgs returns []string{"-no-color"} when NO_COLOR is set, honoring the
+// convention windsor's own TUI output already follows (see tuiplan.Summary
+// callers). Terraform's own TTY auto-detection doesn't reliably disable color
+// under piped subprocess capture, so apply/destroy/init need this passed
+// explicitly to keep raw ANSI codes out of logs and CI artifacts.
+func noColorArgs() []string {
+	if os.Getenv("NO_COLOR") != "" {
+		return []string{"-no-color"}
+	}
+	return nil
 }
 
 // parseTerraformPlanJSON parses the line-delimited JSON event stream emitted by

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -415,6 +415,69 @@ func TestStack_Up(t *testing.T) {
 		}
 	})
 
+	t.Run("PassesNoColorToInitAndApplyWhenNoColorEnvSet", func(t *testing.T) {
+		stack, mocks := setup(t)
+		t.Setenv("NO_COLOR", "1")
+		var initArgs, applyArgs []string
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" && len(args) > 1 && args[1] == "init" {
+				initArgs = args
+			}
+			if command == "terraform" && len(args) >= 3 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[]}}}`, nil
+			}
+			return "", nil
+		}
+		mocks.Shell.ExecProgressWithEnvFunc = func(message string, command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" && len(args) > 1 && args[1] == "apply" {
+				applyArgs = args
+			}
+			return "", nil
+		}
+
+		blueprint := createTestBlueprint()
+		if _, err := stack.Up(blueprint); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !slices.Contains(initArgs, "-no-color") {
+			t.Errorf("Expected init args to contain -no-color, got %v", initArgs)
+		}
+		if !slices.Contains(applyArgs, "-no-color") {
+			t.Errorf("Expected apply args to contain -no-color, got %v", applyArgs)
+		}
+	})
+
+	t.Run("OmitsNoColorFromInitAndApplyByDefault", func(t *testing.T) {
+		stack, mocks := setup(t)
+		var initArgs, applyArgs []string
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" && len(args) > 1 && args[1] == "init" {
+				initArgs = args
+			}
+			if command == "terraform" && len(args) >= 3 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[]}}}`, nil
+			}
+			return "", nil
+		}
+		mocks.Shell.ExecProgressWithEnvFunc = func(message string, command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" && len(args) > 1 && args[1] == "apply" {
+				applyArgs = args
+			}
+			return "", nil
+		}
+
+		blueprint := createTestBlueprint()
+		if _, err := stack.Up(blueprint); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if slices.Contains(initArgs, "-no-color") {
+			t.Errorf("Expected init args to omit -no-color, got %v", initArgs)
+		}
+		if slices.Contains(applyArgs, "-no-color") {
+			t.Errorf("Expected apply args to omit -no-color, got %v", applyArgs)
+		}
+	})
+
 	t.Run("NilBlueprint", func(t *testing.T) {
 		stack, _ := setup(t)
 		_, err := stack.Up(nil)
@@ -3122,6 +3185,41 @@ func TestStack_Destroy(t *testing.T) {
 		}
 	})
 
+	t.Run("PassesNoColorWhenNoColorEnvSet", func(t *testing.T) {
+		stack, mocks := setup(t)
+		t.Setenv("NO_COLOR", "1")
+		var destroyArgs []string
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			destroyArgs = args
+			return "", nil
+		}
+
+		blueprint := createTestBlueprint()
+		if _, err := stack.Destroy(blueprint, "local/path"); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !slices.Contains(destroyArgs, "-no-color") {
+			t.Errorf("Expected destroy args to contain -no-color, got %v", destroyArgs)
+		}
+	})
+
+	t.Run("OmitsNoColorByDefault", func(t *testing.T) {
+		stack, mocks := setup(t)
+		var destroyArgs []string
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			destroyArgs = args
+			return "", nil
+		}
+
+		blueprint := createTestBlueprint()
+		if _, err := stack.Destroy(blueprint, "local/path"); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if slices.Contains(destroyArgs, "-no-color") {
+			t.Errorf("Expected destroy args to omit -no-color, got %v", destroyArgs)
+		}
+	})
+
 	t.Run("NilBlueprint", func(t *testing.T) {
 		// Given a stack with a nil blueprint
 		stack, _ := setup(t)
@@ -4018,6 +4116,21 @@ func TestIsStaleProviderLockError(t *testing.T) {
 		err := fmt.Errorf("does not match configured version constraint, but no upgrade hint here")
 		if isStaleProviderLockError(err) {
 			t.Error("Expected false when only one marker is present")
+		}
+	})
+}
+
+func TestNoColorArgs(t *testing.T) {
+	t.Run("ReturnsNoColorFlagWhenNoColorEnvSet", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "1")
+		if got := noColorArgs(); !slices.Equal(got, []string{"-no-color"}) {
+			t.Errorf("Expected [-no-color], got %v", got)
+		}
+	})
+
+	t.Run("ReturnsNilByDefault", func(t *testing.T) {
+		if got := noColorArgs(); got != nil {
+			t.Errorf("Expected nil, got %v", got)
 		}
 	})
 }

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -4128,6 +4128,13 @@ func TestNoColorArgs(t *testing.T) {
 		}
 	})
 
+	t.Run("ReturnsNoColorFlagWhenNoColorEnvSetToEmptyString", func(t *testing.T) {
+		t.Setenv("NO_COLOR", "")
+		if got := noColorArgs(); !slices.Equal(got, []string{"-no-color"}) {
+			t.Errorf("Expected [-no-color], got %v", got)
+		}
+	})
+
 	t.Run("ReturnsNilByDefault", func(t *testing.T) {
 		if got := noColorArgs(); got != nil {
 			t.Errorf("Expected nil, got %v", got)


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> The change is confined to argument construction for `terraform apply`, `destroy`, and `init` invocations in one provisioner file, and is purely additive.
>
> **Overview**
>
> This PR adds a `noColorArgs()` helper to `pkg/provisioner/terraform/stack.go` that appends `-no-color` to Terraform `apply`, `destroy`, and `init` invocations whenever the `NO_COLOR` environment variable is set, keeping raw ANSI escape codes out of logs and CI artifacts. New unit tests cover both the flag-present and flag-absent paths for `Up`, `Destroy`, and the helper itself.
>
> Two things worth a second look: the helper treats `NO_COLOR=""` (set but empty) as "not set," whereas the NO_COLOR spec and this codebase's own `awsprofile.shouldColorize` treat mere presence as opt-out regardless of value. Separately, the fix only touches `apply`/`destroy`/`init`; the plain-text `terraform plan` and `terraform refresh` calls elsewhere in the same file go through the same verbose-mode streaming path but weren't updated, so colored output can still leak from those subcommands under `NO_COLOR`.

<!-- /claude-code-review:summary -->
