### PR TITLE
fix(terraform): always pass -no-color to init/plan/apply/destroy

### DIFF
--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -1734,18 +1734,13 @@ func staleProviderLockHint(component *blueprintv1alpha1.TerraformComponent) stri
 	return fmt.Sprintf("the .terraform.lock.hcl in %s may be pinned to a provider version outside the current constraint; run `terraform init -upgrade` there (or remove the lock file if it isn't intentionally version-controlled) and retry", component.FullPath)
 }
 
-// noColorArgs returns []string{"-no-color"} when NO_COLOR is present (its mere
-// presence, any value including empty, opts out per the spec — see
-// awsprofile.shouldColorize for the same convention), honoring the convention
-// windsor's own TUI output already follows (see tuiplan.Summary callers).
-// Terraform's own TTY auto-detection doesn't reliably disable color under
-// piped subprocess capture, so apply/destroy/init need this passed explicitly
-// to keep raw ANSI codes out of logs and CI artifacts.
+// noColorArgs returns []string{"-no-color"} unconditionally. Windsor's own TUI
+// already owns presentation of apply/destroy/init progress, and terraform's TTY
+// auto-detection doesn't reliably disable color under piped subprocess capture,
+// so raw ANSI codes leak into logs and CI artifacts unless the flag is passed
+// explicitly regardless of the caller's environment.
 func noColorArgs() []string {
-	if _, present := os.LookupEnv("NO_COLOR"); present {
-		return []string{"-no-color"}
-	}
-	return nil
+	return []string{"-no-color"}
 }
 
 // parseTerraformPlanJSON parses the line-delimited JSON event stream emitted by

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -415,9 +415,8 @@ func TestStack_Up(t *testing.T) {
 		}
 	})
 
-	t.Run("PassesNoColorToInitAndApplyWhenNoColorEnvSet", func(t *testing.T) {
+	t.Run("PassesNoColorToInitAndApply", func(t *testing.T) {
 		stack, mocks := setup(t)
-		t.Setenv("NO_COLOR", "1")
 		var initArgs, applyArgs []string
 		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
 			if command == "terraform" && len(args) > 1 && args[1] == "init" {
@@ -444,37 +443,6 @@ func TestStack_Up(t *testing.T) {
 		}
 		if !slices.Contains(applyArgs, "-no-color") {
 			t.Errorf("Expected apply args to contain -no-color, got %v", applyArgs)
-		}
-	})
-
-	t.Run("OmitsNoColorFromInitAndApplyByDefault", func(t *testing.T) {
-		stack, mocks := setup(t)
-		var initArgs, applyArgs []string
-		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
-			if command == "terraform" && len(args) > 1 && args[1] == "init" {
-				initArgs = args
-			}
-			if command == "terraform" && len(args) >= 3 && args[1] == "show" && args[2] == "-json" {
-				return `{"values":{"root_module":{"resources":[]}}}`, nil
-			}
-			return "", nil
-		}
-		mocks.Shell.ExecProgressWithEnvFunc = func(message string, command string, env map[string]string, args ...string) (string, error) {
-			if command == "terraform" && len(args) > 1 && args[1] == "apply" {
-				applyArgs = args
-			}
-			return "", nil
-		}
-
-		blueprint := createTestBlueprint()
-		if _, err := stack.Up(blueprint); err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if slices.Contains(initArgs, "-no-color") {
-			t.Errorf("Expected init args to omit -no-color, got %v", initArgs)
-		}
-		if slices.Contains(applyArgs, "-no-color") {
-			t.Errorf("Expected apply args to omit -no-color, got %v", applyArgs)
 		}
 	})
 
@@ -3185,9 +3153,8 @@ func TestStack_Destroy(t *testing.T) {
 		}
 	})
 
-	t.Run("PassesNoColorWhenNoColorEnvSet", func(t *testing.T) {
+	t.Run("PassesNoColor", func(t *testing.T) {
 		stack, mocks := setup(t)
-		t.Setenv("NO_COLOR", "1")
 		var destroyArgs []string
 		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
 			destroyArgs = args
@@ -3200,23 +3167,6 @@ func TestStack_Destroy(t *testing.T) {
 		}
 		if !slices.Contains(destroyArgs, "-no-color") {
 			t.Errorf("Expected destroy args to contain -no-color, got %v", destroyArgs)
-		}
-	})
-
-	t.Run("OmitsNoColorByDefault", func(t *testing.T) {
-		stack, mocks := setup(t)
-		var destroyArgs []string
-		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
-			destroyArgs = args
-			return "", nil
-		}
-
-		blueprint := createTestBlueprint()
-		if _, err := stack.Destroy(blueprint, "local/path"); err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if slices.Contains(destroyArgs, "-no-color") {
-			t.Errorf("Expected destroy args to omit -no-color, got %v", destroyArgs)
 		}
 	})
 
@@ -4121,23 +4071,9 @@ func TestIsStaleProviderLockError(t *testing.T) {
 }
 
 func TestNoColorArgs(t *testing.T) {
-	t.Run("ReturnsNoColorFlagWhenNoColorEnvSet", func(t *testing.T) {
-		t.Setenv("NO_COLOR", "1")
+	t.Run("ReturnsNoColorFlagUnconditionally", func(t *testing.T) {
 		if got := noColorArgs(); !slices.Equal(got, []string{"-no-color"}) {
 			t.Errorf("Expected [-no-color], got %v", got)
-		}
-	})
-
-	t.Run("ReturnsNoColorFlagWhenNoColorEnvSetToEmptyString", func(t *testing.T) {
-		t.Setenv("NO_COLOR", "")
-		if got := noColorArgs(); !slices.Equal(got, []string{"-no-color"}) {
-			t.Errorf("Expected [-no-color], got %v", got)
-		}
-	})
-
-	t.Run("ReturnsNilByDefault", func(t *testing.T) {
-		if got := noColorArgs(); got != nil {
-			t.Errorf("Expected nil, got %v", got)
 		}
 	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This change alters a CLI output default in the Terraform provisioner, so it's contained but user-visible.
>
> **Overview**
>
> `noColorArgs()` in `pkg/provisioner/terraform/stack.go` now unconditionally returns `-no-color` instead of only doing so when the `NO_COLOR` environment variable is set. The corresponding tests in `stack_test.go` were updated to match — the "respects `NO_COLOR`" cases were removed and replaced with a single unconditional check, and the now-dead `t.Setenv("NO_COLOR", ...)` setup was dropped along with it.
>
> This reverses the conditional behavior added in the immediately preceding commit, so Terraform's `init`, `apply`, and `destroy` invocations will no longer emit ANSI color codes even for users who didn't opt out via `NO_COLOR`, on the rationale that Windsor's own TUI already owns presentation of that output. The change is small and fully covered by updated unit tests; no unused imports or other loose ends remain (`os` and `slices` are still used elsewhere in both files).

<!-- /claude-code-review:summary -->
