### PR TITLE
fix(kubernetes): drop simultaneous-ready requirement in wait

### DIFF
--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -347,6 +347,10 @@ func kustomizationReady(obj *unstructured.Unstructured) bool {
 // load-balancer failover) is tolerated and retried on the next tick, but a persistent failure
 // like broken cluster auth ends the wait immediately with the underlying error surfaced, rather
 // than silently retrying it for the full timeout budget.
+//
+// Readiness is tracked per kustomization: once observed Ready, a kustomization is dropped from
+// further polling, so a later periodic reconcile flipping it back to Reconciling doesn't reset
+// the wait.
 func (k *BaseKubernetesManager) WaitForKustomizations(ctx context.Context, message string, blueprint *blueprintv1alpha1.Blueprint) error {
 	if blueprint == nil {
 		return fmt.Errorf("blueprint not provided")
@@ -368,6 +372,7 @@ func (k *BaseKubernetesManager) WaitForKustomizations(ctx context.Context, messa
 	defer ticker.Stop()
 
 	consecutiveErrors := 0
+	readyKustomizations := make(map[string]bool, len(kustomizationNames))
 
 	for {
 		select {
@@ -378,9 +383,11 @@ func (k *BaseKubernetesManager) WaitForKustomizations(ctx context.Context, messa
 			tui.Fail()
 			return fmt.Errorf("timeout waiting for kustomizations%s", k.describeNotReadyKustomizations(kustomizationNames, k.gitopsNamespace()))
 		case <-ticker.C:
-			allReady := true
 			var tickErr error
 			for _, name := range kustomizationNames {
+				if readyKustomizations[name] {
+					continue
+				}
 				gvr := schema.GroupVersionResource{
 					Group:    "kustomize.toolkit.fluxcd.io",
 					Version:  "v1",
@@ -388,43 +395,33 @@ func (k *BaseKubernetesManager) WaitForKustomizations(ctx context.Context, messa
 				}
 				obj, err := k.client.GetResource(gvr, k.gitopsNamespace(), name)
 				if err != nil && isNotFoundError(err) {
-					allReady = false
-					break
+					continue
 				}
 				if err != nil {
-					allReady = false
 					tickErr = fmt.Errorf("error checking kustomization %s: %w", name, err)
 					break
 				}
 				var kustomizationObj map[string]any
 				if err := k.shims.FromUnstructured(obj.UnstructuredContent(), &kustomizationObj); err != nil {
-					allReady = false
-					break
+					continue
 				}
 				status, ok := kustomizationObj["status"].(map[string]any)
 				if !ok {
-					allReady = false
-					break
+					continue
 				}
 				conditions, ok := status["conditions"].([]any)
 				if !ok {
-					allReady = false
-					break
+					continue
 				}
-				ready := false
 				for _, cond := range conditions {
 					condMap, ok := cond.(map[string]any)
 					if !ok {
 						continue
 					}
 					if condMap["type"] == "Ready" && condMap["status"] == "True" {
-						ready = true
+						readyKustomizations[name] = true
 						break
 					}
-				}
-				if !ready {
-					allReady = false
-					break
 				}
 			}
 			if tickErr != nil {
@@ -436,7 +433,7 @@ func (k *BaseKubernetesManager) WaitForKustomizations(ctx context.Context, messa
 				continue
 			}
 			consecutiveErrors = 0
-			if allReady {
+			if len(readyKustomizations) == len(kustomizationNames) {
 				tui.Done()
 				return nil
 			}

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -516,6 +516,50 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 		}
 	})
 
+	t.Run("SurvivesPeriodicReconcileFlipOnceObservedReady", func(t *testing.T) {
+		// "a" goes Ready on its first poll, then flips back on every later poll; "b" stays Ready throughout.
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		callsForA := 0
+		readyCondition := func(status string) *unstructured.Unstructured {
+			return &unstructured.Unstructured{
+				Object: map[string]any{
+					"status": map[string]any{
+						"conditions": []any{
+							map[string]any{"type": "Ready", "status": status},
+						},
+					},
+				},
+			}
+		}
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			if name == "a" {
+				callsForA++
+				if callsForA == 1 {
+					return readyCondition("True"), nil
+				}
+				return readyCondition("False"), nil
+			}
+			return readyCondition("True"), nil
+		}
+		manager.client = kubernetesClient
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "a", Timeout: &blueprintv1alpha1.DurationString{Duration: 500 * time.Millisecond}},
+				{Name: "b", Timeout: &blueprintv1alpha1.DurationString{Duration: 500 * time.Millisecond}},
+			},
+		}
+
+		err := manager.WaitForKustomizations(context.Background(), "Waiting for kustomizations", blueprint)
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if callsForA != 1 {
+			t.Errorf("Expected \"a\" to be checked exactly once after becoming Ready, got %d calls", callsForA)
+		}
+	})
+
 	t.Run("NotFoundKeepsPollingUntilReady", func(t *testing.T) {
 		// Given a kustomization that isn't created yet, then becomes Ready
 		manager := setup(t)


### PR DESCRIPTION
Closes #3184

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> The change is isolated to a single function in the Kubernetes provisioner's kustomization-wait loop and is covered by a new unit test; no public API or default behavior changes.
>
> **Overview**
>
> `WaitForKustomizations` now tracks readiness per kustomization in a map instead of recomputing an `allReady` flag on every tick. Once a kustomization is observed `Ready`, it's dropped from further polling for the rest of the wait, so a later Flux periodic reconcile that transiently flips its status back to `Reconciling` no longer resets progress or extends the effective wait.
>
> As a side effect of switching several early `break` statements to `continue`, each tick now checks every not-yet-ready kustomization instead of stopping at the first not-ready one encountered — a minor, favorable behavior change since it surfaces errors and readiness for all kustomizations rather than just the first in the list. The added test confirms a kustomization observed once as `Ready` is never re-queried even if its status later flips.

<!-- /claude-code-review:summary -->
