### PR TITLE
fix(blueprint): expose Flux healthCheckExprs on kustomizations

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -348,6 +348,26 @@ func (d *Decryption) DeepCopy() *Decryption {
 	return c
 }
 
+// HealthCheckExpr evaluates the health of a custom resource with CEL, mapping to an entry in Flux's
+// spec.healthCheckExprs. It gates a waiting Kustomization on resources kstatus reports Current
+// immediately — those exposing no status.observedGeneration and no Reconciling/Stalled condition.
+type HealthCheckExpr struct {
+	// APIVersion of the custom resource under evaluation.
+	APIVersion string `yaml:"apiVersion,omitempty"`
+
+	// Kind of the custom resource under evaluation.
+	Kind string `yaml:"kind,omitempty"`
+
+	// Current is the CEL expression matching the resource's desired state.
+	Current string `yaml:"current,omitempty"`
+
+	// InProgress is the CEL expression matching a resource still converging.
+	InProgress string `yaml:"inProgress,omitempty"`
+
+	// Failed is the CEL expression matching a resource that failed to converge.
+	Failed string `yaml:"failed,omitempty"`
+}
+
 // Blueprint is a configuration blueprint for initializing a project.
 type Blueprint struct {
 	// Kind is the blueprint type, following Kubernetes conventions.
@@ -631,6 +651,9 @@ type Kustomization struct {
 
 	// Prune enables garbage collection of resources that are no longer present in the source.
 	Prune *bool `yaml:"prune,omitempty"`
+
+	// HealthCheckExprs are CEL health checks for custom resources kstatus cannot evaluate.
+	HealthCheckExprs []HealthCheckExpr `yaml:"healthCheckExprs,omitempty"`
 
 	// Components to include in the kustomization.
 	Components []string `yaml:"components,omitempty"`
@@ -1344,27 +1367,28 @@ func (k *Kustomization) DeepCopy() *Kustomization {
 	}
 
 	return &Kustomization{
-		Name:            k.Name,
-		Path:            k.Path,
-		Source:          k.Source,
-		Namespace:       k.Namespace,
-		TargetNamespace: k.TargetNamespace,
-		DependsOn:       slices.Clone(k.DependsOn),
-		Interval:        k.Interval,
-		RetryInterval:   k.RetryInterval,
-		Timeout:         k.Timeout,
-		Patches:         slices.Clone(k.Patches),
-		Wait:            k.Wait,
-		Force:           k.Force,
-		Prune:           k.Prune,
-		Components:      slices.Clone(k.Components),
-		Destroy:         k.Destroy.DeepCopy(),
-		DestroyOnly:     k.DestroyOnly,
-		Enabled:         k.Enabled.DeepCopy(),
-		Substitutions:   maps.Clone(k.Substitutions),
-		Substitute:      maps.Clone(k.Substitute),
-		Secrets:         cloneSecretData(k.Secrets),
-		Decryption:      k.Decryption.DeepCopy(),
+		Name:             k.Name,
+		Path:             k.Path,
+		Source:           k.Source,
+		Namespace:        k.Namespace,
+		TargetNamespace:  k.TargetNamespace,
+		DependsOn:        slices.Clone(k.DependsOn),
+		Interval:         k.Interval,
+		RetryInterval:    k.RetryInterval,
+		Timeout:          k.Timeout,
+		Patches:          slices.Clone(k.Patches),
+		Wait:             k.Wait,
+		Force:            k.Force,
+		Prune:            k.Prune,
+		HealthCheckExprs: slices.Clone(k.HealthCheckExprs),
+		Components:       slices.Clone(k.Components),
+		Destroy:          k.Destroy.DeepCopy(),
+		DestroyOnly:      k.DestroyOnly,
+		Enabled:          k.Enabled.DeepCopy(),
+		Substitutions:    maps.Clone(k.Substitutions),
+		Substitute:       maps.Clone(k.Substitute),
+		Secrets:          cloneSecretData(k.Secrets),
+		Decryption:       k.Decryption.DeepCopy(),
 	}
 }
 
@@ -1526,6 +1550,8 @@ func (k *Kustomization) ToFluxKustomization(namespace string, defaultSourceName 
 		})
 	}
 
+	healthCheckExprs := toFluxHealthCheckExprs(k.HealthCheckExprs)
+
 	var postBuild *kustomizev1.PostBuild
 	if !IsCrdLayerName(k.Name) {
 		if len(k.Substitutions) > 0 {
@@ -1579,20 +1605,21 @@ func (k *Kustomization) ToFluxKustomization(namespace string, defaultSourceName 
 				Name:      sourceName,
 				Namespace: sourceRefNamespace,
 			},
-			Path:            path,
-			DependsOn:       dependsOn,
-			Interval:        interval,
-			RetryInterval:   &retryInterval,
-			Timeout:         &timeout,
-			Wait:            wait,
-			Force:           force,
-			Prune:           prune,
-			DeletionPolicy:  deletionPolicy,
-			Patches:         patches,
-			Components:      k.Components,
-			PostBuild:       postBuild,
-			TargetNamespace: k.TargetNamespace,
-			Decryption:      decryption,
+			Path:             path,
+			DependsOn:        dependsOn,
+			Interval:         interval,
+			RetryInterval:    &retryInterval,
+			Timeout:          &timeout,
+			Wait:             wait,
+			Force:            force,
+			Prune:            prune,
+			HealthCheckExprs: healthCheckExprs,
+			DeletionPolicy:   deletionPolicy,
+			Patches:          patches,
+			Components:       k.Components,
+			PostBuild:        postBuild,
+			TargetNamespace:  k.TargetNamespace,
+			Decryption:       decryption,
 		},
 	}
 }
@@ -1643,6 +1670,24 @@ func subtractKustomizationFields(existing, removal Kustomization) Kustomization 
 	}
 
 	return existing
+}
+
+// toFluxHealthCheckExprs converts blueprint health check expressions to their Flux equivalents,
+// returning nil for an empty input so spec.healthCheckExprs is omitted from the rendered resource.
+func toFluxHealthCheckExprs(exprs []HealthCheckExpr) []kustomize.CustomHealthCheck {
+	var converted []kustomize.CustomHealthCheck
+	for _, expr := range exprs {
+		converted = append(converted, kustomize.CustomHealthCheck{
+			APIVersion: expr.APIVersion,
+			Kind:       expr.Kind,
+			HealthCheckExpressions: kustomize.HealthCheckExpressions{
+				Current:    expr.Current,
+				InProgress: expr.InProgress,
+				Failed:     expr.Failed,
+			},
+		})
+	}
+	return converted
 }
 
 // validateTerraformComponents validates that all terraform component IDs are unique.
@@ -1754,8 +1799,9 @@ func (b *Blueprint) strategicMergeKustomization(kustomization Kustomization) err
 
 // MergeKustomizationFields deep-merges overlay onto base and returns the result without mutating
 // either input: Components and DependsOn accumulate (deduplicated, Components sorted), Patches
-// accumulate, Substitutions copy in, and every other field is overridden by overlay when overlay
-// sets it. Callers that need
+// accumulate, Substitutions copy in, HealthCheckExprs accumulate with overlay entries replacing
+// base entries of the same apiVersion and kind, and every other field is overridden by overlay when
+// overlay sets it. Callers that need
 // by-name matching within a Blueprint's Kustomizations list use strategicMergeKustomization, which
 // calls this once a match is found; callers merging two already-matched Kustomization values
 // directly (e.g. FluxSystem tiers, which carry no Name until tier compilation) call this directly.
@@ -1764,6 +1810,7 @@ func MergeKustomizationFields(base, overlay Kustomization) Kustomization {
 	existing.Components = slices.Clone(base.Components)
 	existing.DependsOn = slices.Clone(base.DependsOn)
 	existing.Patches = slices.Clone(base.Patches)
+	existing.HealthCheckExprs = slices.Clone(base.HealthCheckExprs)
 	existing.Substitutions = maps.Clone(base.Substitutions)
 	for _, component := range overlay.Components {
 		if component == "" || !slices.Contains(existing.Components, component) {
@@ -1817,6 +1864,16 @@ func MergeKustomizationFields(base, overlay Kustomization) Kustomization {
 	}
 	if len(overlay.Patches) > 0 {
 		existing.Patches = append(existing.Patches, overlay.Patches...)
+	}
+	for _, expr := range overlay.HealthCheckExprs {
+		index := slices.IndexFunc(existing.HealthCheckExprs, func(candidate HealthCheckExpr) bool {
+			return candidate.APIVersion == expr.APIVersion && candidate.Kind == expr.Kind
+		})
+		if index >= 0 {
+			existing.HealthCheckExprs[index] = expr
+			continue
+		}
+		existing.HealthCheckExprs = append(existing.HealthCheckExprs, expr)
 	}
 	if len(overlay.Substitutions) > 0 {
 		if existing.Substitutions == nil {

--- a/api/v1alpha1/blueprint_types_test.go
+++ b/api/v1alpha1/blueprint_types_test.go
@@ -3345,6 +3345,164 @@ func TestKustomization_Decryption_DeepCopyAndMerge(t *testing.T) {
 	})
 }
 
+func TestKustomization_HealthCheckExprs(t *testing.T) {
+	cnpgReady := HealthCheckExpr{
+		APIVersion: "postgresql.cnpg.io/v1",
+		Kind:       "Cluster",
+		Current:    "status.conditions.exists(e, e.type == 'Ready' && e.status == 'True')",
+	}
+
+	t.Run("UnmarshalsCamelCaseKeys", func(t *testing.T) {
+		// Given a kustomization authored with healthCheckExprs
+		yamlData := []byte(`name: identity-resources-database
+healthCheckExprs:
+  - apiVersion: postgresql.cnpg.io/v1
+    kind: Cluster
+    current: status.conditions.exists(e, e.type == 'Ready' && e.status == 'True')
+    inProgress: status.conditions.exists(e, e.type == 'Initialized')
+    failed: status.conditions.exists(e, e.type == 'Failed')
+`)
+
+		// When unmarshaled
+		var k Kustomization
+		if err := yaml.Unmarshal(yamlData, &k); err != nil {
+			t.Fatalf("Failed to unmarshal Kustomization with healthCheckExprs: %v", err)
+		}
+
+		// Then every camelCase key lands on its field
+		if len(k.HealthCheckExprs) != 1 {
+			t.Fatalf("Expected 1 health check expression, got %d", len(k.HealthCheckExprs))
+		}
+		expr := k.HealthCheckExprs[0]
+		if expr.APIVersion != "postgresql.cnpg.io/v1" {
+			t.Errorf("Expected APIVersion 'postgresql.cnpg.io/v1', got %q", expr.APIVersion)
+		}
+		if expr.Kind != "Cluster" {
+			t.Errorf("Expected Kind 'Cluster', got %q", expr.Kind)
+		}
+		if expr.Current != "status.conditions.exists(e, e.type == 'Ready' && e.status == 'True')" {
+			t.Errorf("Expected Current CEL expression, got %q", expr.Current)
+		}
+		if expr.InProgress != "status.conditions.exists(e, e.type == 'Initialized')" {
+			t.Errorf("Expected InProgress CEL expression, got %q", expr.InProgress)
+		}
+		if expr.Failed != "status.conditions.exists(e, e.type == 'Failed')" {
+			t.Errorf("Expected Failed CEL expression, got %q", expr.Failed)
+		}
+	})
+
+	t.Run("ConvertsToFluxHealthCheckExprs", func(t *testing.T) {
+		// Given a waiting kustomization with a CNPG health check
+		wait := true
+		kustomization := &Kustomization{
+			Name:             "identity-resources-database",
+			Wait:             &wait,
+			HealthCheckExprs: []HealthCheckExpr{cnpgReady},
+		}
+
+		// When converted to a Flux Kustomization
+		result := kustomization.ToFluxKustomization("system-gitops", "core", []Source{}, constants.GitopsModePull)
+
+		// Then the expression is carried onto spec.healthCheckExprs
+		if len(result.Spec.HealthCheckExprs) != 1 {
+			t.Fatalf("Expected 1 health check expression on the Flux spec, got %d", len(result.Spec.HealthCheckExprs))
+		}
+		got := result.Spec.HealthCheckExprs[0]
+		if got.APIVersion != cnpgReady.APIVersion || got.Kind != cnpgReady.Kind {
+			t.Errorf("Expected %s/%s under evaluation, got %s/%s", cnpgReady.APIVersion, cnpgReady.Kind, got.APIVersion, got.Kind)
+		}
+		if got.Current != cnpgReady.Current {
+			t.Errorf("Expected Current %q, got %q", cnpgReady.Current, got.Current)
+		}
+	})
+
+	t.Run("OmitsFluxHealthCheckExprsWhenUnset", func(t *testing.T) {
+		// Given a kustomization with no health check expressions
+		kustomization := &Kustomization{Name: "policy"}
+
+		// When converted to a Flux Kustomization
+		result := kustomization.ToFluxKustomization("system-gitops", "core", []Source{}, constants.GitopsModePull)
+
+		// Then spec.healthCheckExprs stays nil so it is omitted from the rendered output
+		if result.Spec.HealthCheckExprs != nil {
+			t.Errorf("Expected nil HealthCheckExprs, got %+v", result.Spec.HealthCheckExprs)
+		}
+	})
+
+	t.Run("DeepCopyIndependentOfOriginal", func(t *testing.T) {
+		// Given a kustomization with a health check expression
+		original := &Kustomization{Name: "k", HealthCheckExprs: []HealthCheckExpr{cnpgReady}}
+
+		// When deep-copied and the copy mutated
+		clone := original.DeepCopy()
+		clone.HealthCheckExprs[0].Current = "false"
+
+		// Then the original is unchanged
+		if original.HealthCheckExprs[0].Current != cnpgReady.Current {
+			t.Errorf("Expected original unchanged, got %q", original.HealthCheckExprs[0].Current)
+		}
+	})
+
+	t.Run("OverlayReplacesMatchingApiVersionAndKind", func(t *testing.T) {
+		// Given a base and an overlay gating the same resource kind
+		base := Kustomization{Name: "k", HealthCheckExprs: []HealthCheckExpr{cnpgReady}}
+		overlay := Kustomization{Name: "k", HealthCheckExprs: []HealthCheckExpr{{
+			APIVersion: "postgresql.cnpg.io/v1",
+			Kind:       "Cluster",
+			Current:    "status.conditions.exists(e, e.type == 'ConsistentSystemID')",
+		}}}
+
+		// When merged
+		merged := MergeKustomizationFields(base, overlay)
+
+		// Then the overlay expression replaces the base one rather than duplicating it
+		if len(merged.HealthCheckExprs) != 1 {
+			t.Fatalf("Expected 1 health check expression, got %d", len(merged.HealthCheckExprs))
+		}
+		if merged.HealthCheckExprs[0].Current != "status.conditions.exists(e, e.type == 'ConsistentSystemID')" {
+			t.Errorf("Expected overlay expression to win, got %q", merged.HealthCheckExprs[0].Current)
+		}
+	})
+
+	t.Run("OverlayAppendsUnmatchedKindAndLeavesBaseIntact", func(t *testing.T) {
+		// Given a base gating one kind and an overlay gating another
+		base := Kustomization{Name: "k", HealthCheckExprs: []HealthCheckExpr{cnpgReady}}
+		overlay := Kustomization{Name: "k", HealthCheckExprs: []HealthCheckExpr{{
+			APIVersion: "helm.toolkit.fluxcd.io/v2",
+			Kind:       "HelmRelease",
+			Current:    "status.conditions.exists(e, e.type == 'Ready' && e.status == 'True')",
+		}}}
+
+		// When merged
+		merged := MergeKustomizationFields(base, overlay)
+
+		// Then both gates survive and the base slice is not mutated
+		if len(merged.HealthCheckExprs) != 2 {
+			t.Fatalf("Expected 2 health check expressions, got %d", len(merged.HealthCheckExprs))
+		}
+		if merged.HealthCheckExprs[0].Kind != "Cluster" || merged.HealthCheckExprs[1].Kind != "HelmRelease" {
+			t.Errorf("Expected Cluster then HelmRelease, got %s then %s", merged.HealthCheckExprs[0].Kind, merged.HealthCheckExprs[1].Kind)
+		}
+		if len(base.HealthCheckExprs) != 1 {
+			t.Errorf("Expected base left intact, got %d expressions", len(base.HealthCheckExprs))
+		}
+	})
+
+	t.Run("EmptyOverlayLeavesBaseExpressions", func(t *testing.T) {
+		// Given a base with a health check and an overlay without one
+		base := Kustomization{Name: "k", HealthCheckExprs: []HealthCheckExpr{cnpgReady}}
+		overlay := Kustomization{Name: "k"}
+
+		// When merged
+		merged := MergeKustomizationFields(base, overlay)
+
+		// Then the base expression survives
+		if len(merged.HealthCheckExprs) != 1 || merged.HealthCheckExprs[0].Current != cnpgReady.Current {
+			t.Errorf("Expected base expression preserved, got %+v", merged.HealthCheckExprs)
+		}
+	})
+}
+
 func TestTerraformComponent_DeepCopy(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		component := &TerraformComponent{

--- a/docs/reference/blueprint.md
+++ b/docs/reference/blueprint.md
@@ -62,6 +62,7 @@ variable substitutions shared across them.
 | `destroyOnly` | `boolean` | When true, this tier only runs during destroy operations. |
 | `enabled` | `boolean / string` | Whether to include this tier in the final blueprint. Boolean or expression. Defaults to true. |
 | `force` | `boolean` | Force-apply resources Flux would otherwise refuse to update. |
+| `healthCheckExprs` | `array<object>` | CEL health checks for custom resources kstatus cannot evaluate — those exposing no status.observedGeneration and no Reconciling/Stalled condition, which kstatus reports healthy the moment they are applied. Each entry gates 'wait' on the named resource kind, and with it any dependsOn edge pointing at this kustomization. |
 | `interval` | `string` | Reconciliation interval as a Go duration string (e.g. '5m', '1h'). |
 | `namespace` | `string` | Namespace where the Flux Kustomization object lives. Defaults to the gitops namespace. |
 | `patches` | `array<object>` | Strategic-merge or Flux-style patches applied to this tier. |
@@ -87,6 +88,16 @@ variable substitutions shared across them.
 |------|------|-------------|
 | `name` | `string` | The Secret's name, resolved in the tier's namespace. |
 
+#### flux[].install.healthCheckExprs[]
+
+| Field | Type | Description |
+|------|------|-------------|
+| `apiVersion` | `string` | APIVersion of the custom resource under evaluation. |
+| `current` | `string` | CEL expression matching the resource's desired state. |
+| `failed` | `string` | CEL expression matching a resource that failed to converge. |
+| `inProgress` | `string` | CEL expression matching a resource still converging. |
+| `kind` | `string` | Kind of the custom resource under evaluation. |
+
 #### flux[].install.patches[]
 
 | Field | Type | Description |
@@ -106,6 +117,7 @@ variable substitutions shared across them.
 | `destroyOnly` | `boolean` | When true, this variant only runs during destroy operations. |
 | `enabled` | `boolean / string` | Whether to include this variant in the final blueprint. Boolean or expression. Defaults to true. |
 | `force` | `boolean` | Force-apply resources Flux would otherwise refuse to update. |
+| `healthCheckExprs` | `array<object>` | CEL health checks for custom resources kstatus cannot evaluate — those exposing no status.observedGeneration and no Reconciling/Stalled condition, which kstatus reports healthy the moment they are applied. Each entry gates 'wait' on the named resource kind, and with it any dependsOn edge pointing at this kustomization. |
 | `interval` | `string` | Reconciliation interval as a Go duration string (e.g. '5m', '1h'). |
 | `name` | `string` | Variant suffix ('<system>-resources-<name>'); omit for a single unnamed variant. |
 | `namespace` | `string` | Namespace where the Flux Kustomization object lives. Defaults to the gitops namespace. |
@@ -132,6 +144,16 @@ variable substitutions shared across them.
 | Field | Type | Description |
 |------|------|-------------|
 | `name` | `string` | The Secret's name, resolved in the variant's namespace. |
+
+#### flux[].resources[].healthCheckExprs[]
+
+| Field | Type | Description |
+|------|------|-------------|
+| `apiVersion` | `string` | APIVersion of the custom resource under evaluation. |
+| `current` | `string` | CEL expression matching the resource's desired state. |
+| `failed` | `string` | CEL expression matching a resource that failed to converge. |
+| `inProgress` | `string` | CEL expression matching a resource still converging. |
+| `kind` | `string` | Kind of the custom resource under evaluation. |
 
 #### flux[].resources[].patches[]
 
@@ -160,6 +182,7 @@ variable substitutions shared across them.
 | `destroyOnly` | `boolean` | When true, the kustomization only runs during destroy. Useful for teardown-only resources (e.g. cleanup jobs). |
 | `enabled` | `boolean / string` | Whether to include this kustomization in the final blueprint. Boolean or expression. Defaults to true. |
 | `force` | `boolean` | Force-apply resources Flux would otherwise refuse to update. |
+| `healthCheckExprs` | `array<object>` | CEL health checks for custom resources kstatus cannot evaluate — those exposing no status.observedGeneration and no Reconciling/Stalled condition, which kstatus reports healthy the moment they are applied. Each entry gates 'wait' on the named resource kind, and with it any dependsOn edge pointing at this kustomization. |
 | `interval` | `string` | Reconciliation interval, expressed as a Go duration string (e.g. '5m', '1h'). Defaults to 1m when source is unset (falls back to the blueprint's own repository, presumed live and actively pushed); defaults to 1h when source names a vendor entry (presumed pinned and explicitly re-triggered rather than continuously tracked). |
 | `namespace` | `string` | Namespace where the Flux Kustomization object itself lives. Defaults to the gitops namespace. DependsOn references always resolve in the gitops namespace; cross-namespace dependencies are not supported. |
 | `patches` | `array<object>` | Strategic-merge or Flux-style patches applied to the kustomization. Each entry is either a 'path:' to a patch file relative to the kustomization, or a 'patch:' inline YAML body with an optional 'target:' selector (kind / name / namespace). |
@@ -185,6 +208,16 @@ variable substitutions shared across them.
 | Field | Type | Description |
 |------|------|-------------|
 | `name` | `string` | The Secret's name, resolved in the kustomization's namespace. |
+
+### kustomize[].healthCheckExprs[]
+
+| Field | Type | Description |
+|------|------|-------------|
+| `apiVersion` | `string` | APIVersion of the custom resource under evaluation. |
+| `current` | `string` | CEL expression matching the resource's desired state. |
+| `failed` | `string` | CEL expression matching a resource that failed to converge. |
+| `inProgress` | `string` | CEL expression matching a resource still converging. |
+| `kind` | `string` | Kind of the custom resource under evaluation. |
 
 ### kustomize[].patches[]
 

--- a/integration/fixtures/facet-tiers/contexts/_template/facets/addon-cert-manager-extra.yaml
+++ b/integration/fixtures/facet-tiers/contexts/_template/facets/addon-cert-manager-extra.yaml
@@ -10,6 +10,10 @@ flux:
   install:
     components:
     - helm-release-extra-metrics
+    healthCheckExprs:
+    - apiVersion: cert-manager.io/v1
+      kind: ClusterIssuer
+      current: status.conditions.exists(e, e.type == 'Ready' && e.status == 'True')
   resources:
   - name: extra
     components:

--- a/integration/fixtures/facet-tiers/contexts/_template/facets/pki.yaml
+++ b/integration/fixtures/facet-tiers/contexts/_template/facets/pki.yaml
@@ -17,6 +17,10 @@ flux:
       provider: sops
       secretRef:
         name: sops-age
+    healthCheckExprs:
+    - apiVersion: cert-manager.io/v1
+      kind: Issuer
+      current: status.conditions.exists(e, e.type == 'Ready' && e.status == 'True')
   resources:
   - components:
     - private-issuer/ca

--- a/integration/show_test.go
+++ b/integration/show_test.go
@@ -184,6 +184,59 @@ func TestShowKustomization_RendersDecryptionThroughFacetMerge(t *testing.T) {
 	}
 }
 
+func TestShowKustomization_RendersHealthCheckExprsAccumulatedAcrossFacets(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "facet-tiers")
+	env = append(env, "WINDSOR_CONTEXT=default")
+	// pki.yaml gates cert-manager's install tier on Issuer and addon-cert-manager-extra.yaml adds a
+	// ClusterIssuer gate to the same tier, so both rendering on spec.healthCheckExprs proves the
+	// field survives cross-facet merge and reaches the Flux CR.
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"show", "kustomization", "cert-manager-install"}, env)
+	if err != nil {
+		t.Fatalf("show kustomization cert-manager-install: %v\nstderr: %s", err, stderr)
+	}
+	var k struct {
+		Spec struct {
+			HealthCheckExprs []struct {
+				APIVersion string `yaml:"apiVersion"`
+				Kind       string `yaml:"kind"`
+				Current    string `yaml:"current"`
+			} `yaml:"healthCheckExprs"`
+		} `yaml:"spec"`
+	}
+	if err := yaml.Unmarshal(stdout, &k); err != nil {
+		t.Fatalf("parse kustomization YAML: %v\nstdout: %s", err, stdout)
+	}
+	if len(k.Spec.HealthCheckExprs) != 2 {
+		t.Fatalf("expected 2 health check expressions, got %d\nstdout: %s", len(k.Spec.HealthCheckExprs), stdout)
+	}
+	kinds := []string{k.Spec.HealthCheckExprs[0].Kind, k.Spec.HealthCheckExprs[1].Kind}
+	if !slices.Contains(kinds, "Issuer") || !slices.Contains(kinds, "ClusterIssuer") {
+		t.Errorf("expected Issuer and ClusterIssuer gates, got %v", kinds)
+	}
+	for _, expr := range k.Spec.HealthCheckExprs {
+		if expr.APIVersion != "cert-manager.io/v1" {
+			t.Errorf("expected apiVersion cert-manager.io/v1, got %q", expr.APIVersion)
+		}
+		if expr.Current != "status.conditions.exists(e, e.type == 'Ready' && e.status == 'True')" {
+			t.Errorf("expected Ready CEL expression for %s, got %q", expr.Kind, expr.Current)
+		}
+	}
+}
+
+func TestShowKustomization_OmitsHealthCheckExprsWhenUnset(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "facet-tiers")
+	env = append(env, "WINDSOR_CONTEXT=default")
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"show", "kustomization", "dns"}, env)
+	if err != nil {
+		t.Fatalf("show kustomization dns: %v\nstderr: %s", err, stderr)
+	}
+	if strings.Contains(string(stdout), "healthCheckExprs") {
+		t.Errorf("expected no healthCheckExprs on a kustomization that declares none, got:\n%s", stdout)
+	}
+}
+
 func TestShowKustomization_PathDefaultsToNameWhenUnset(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.PrepareFixture(t, "facet-tiers")

--- a/pkg/runtime/config/schemas/artifacts/blueprint.yaml
+++ b/pkg/runtime/config/schemas/artifacts/blueprint.yaml
@@ -253,6 +253,33 @@ properties:
         prune:
           type: boolean
           description: Garbage-collect resources removed from the source. Defaults to true.
+        healthCheckExprs:
+          type: array
+          description: |
+            CEL health checks for custom resources kstatus cannot evaluate — those
+            exposing no status.observedGeneration and no Reconciling/Stalled
+            condition, which kstatus reports healthy the moment they are applied.
+            Each entry gates 'wait' on the named resource kind, and with it any
+            dependsOn edge pointing at this kustomization.
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              apiVersion:
+                type: string
+                description: APIVersion of the custom resource under evaluation.
+              kind:
+                type: string
+                description: Kind of the custom resource under evaluation.
+              current:
+                type: string
+                description: CEL expression matching the resource's desired state.
+              inProgress:
+                type: string
+                description: CEL expression matching a resource still converging.
+              failed:
+                type: string
+                description: CEL expression matching a resource that failed to converge.
         components:
           type: array
           items:
@@ -416,6 +443,33 @@ properties:
             prune:
               type: boolean
               description: Garbage-collect resources removed from the source. Defaults to true.
+            healthCheckExprs:
+              type: array
+              description: |
+                CEL health checks for custom resources kstatus cannot evaluate — those
+                exposing no status.observedGeneration and no Reconciling/Stalled
+                condition, which kstatus reports healthy the moment they are applied.
+                Each entry gates 'wait' on the named resource kind, and with it any
+                dependsOn edge pointing at this kustomization.
+              items:
+                type: object
+                additionalProperties: false
+                properties:
+                  apiVersion:
+                    type: string
+                    description: APIVersion of the custom resource under evaluation.
+                  kind:
+                    type: string
+                    description: Kind of the custom resource under evaluation.
+                  current:
+                    type: string
+                    description: CEL expression matching the resource's desired state.
+                  inProgress:
+                    type: string
+                    description: CEL expression matching a resource still converging.
+                  failed:
+                    type: string
+                    description: CEL expression matching a resource that failed to converge.
             components:
               type: array
               items:
@@ -520,6 +574,33 @@ properties:
               prune:
                 type: boolean
                 description: Garbage-collect resources removed from the source. Defaults to true.
+              healthCheckExprs:
+                type: array
+                description: |
+                  CEL health checks for custom resources kstatus cannot evaluate — those
+                  exposing no status.observedGeneration and no Reconciling/Stalled
+                  condition, which kstatus reports healthy the moment they are applied.
+                  Each entry gates 'wait' on the named resource kind, and with it any
+                  dependsOn edge pointing at this kustomization.
+                items:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    apiVersion:
+                      type: string
+                      description: APIVersion of the custom resource under evaluation.
+                    kind:
+                      type: string
+                      description: Kind of the custom resource under evaluation.
+                    current:
+                      type: string
+                      description: CEL expression matching the resource's desired state.
+                    inProgress:
+                      type: string
+                      description: CEL expression matching a resource still converging.
+                    failed:
+                      type: string
+                      description: CEL expression matching a resource that failed to converge.
               components:
                 type: array
                 items:

--- a/pkg/runtime/config/schemas/artifacts/facets.yaml
+++ b/pkg/runtime/config/schemas/artifacts/facets.yaml
@@ -302,8 +302,9 @@ $defs:
     description: |
       Inherits every field from the blueprint's Kustomization shape (name,
       path, source, namespace, targetNamespace, dependsOn, interval,
-      retryInterval, timeout, patches, wait, force, prune, components, destroy,
-      destroyOnly, enabled, substitutions, substitute) and adds the conditional
+      retryInterval, timeout, patches, wait, force, prune, healthCheckExprs,
+      components, destroy, destroyOnly, enabled, substitutions, substitute)
+      and adds the conditional
       fields below. See the [Blueprint reference](blueprint.md) for the inherited
       fields.
     properties:


### PR DESCRIPTION
Closes #3186

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change is additive to the blueprint Kustomization schema and Flux CR generation; every new field is `omitempty` and no existing default or code path changes.
>
> **Overview**
>
> Adds `healthCheckExprs` to the blueprint `Kustomization` type, letting a tier gate Flux's `wait` on CEL expressions for custom resources that kstatus cannot evaluate on its own (e.g. cert-manager `Issuer`/`ClusterIssuer`, CNPG `Cluster`). The field is threaded through `DeepCopy`, `ToFluxKustomization` (converted to `kustomize.CustomHealthCheck`), and `MergeKustomizationFields`, and mirrored across the three schema locations (`install`, `resources`, top-level `kustomize`) plus `docs/reference/blueprint.md`.
>
> On merge, overlay entries replace a base entry with the same `apiVersion`/`kind` rather than duplicating it, while non-conflicting entries from both sides accumulate — consistent with how `Patches` and `Components` already merge. The one asymmetry: `subtractKustomizationFields` (used by `RemoveKustomization`/`RemoveFluxSystem`) does not support removing individual `HealthCheckExprs` entries, but this matches several other non-subtractable fields already on `Kustomization` (e.g. `Secrets`, `Decryption`), so it's not a regression.

<!-- /claude-code-review:summary -->
