### PR TITLE
fix(provisioner): make up honor a declared backend tier like bootstrap

### DIFF
--- a/integration/bootstrap_test.go
+++ b/integration/bootstrap_test.go
@@ -156,6 +156,33 @@ func TestBootstrap_DanceIsScopedToTier(t *testing.T) {
 	}
 }
 
+// TestBootstrap_RefusesKubernetesBackendWithoutTierFromZero verifies the from-zero fail-fast
+// guard: a kubernetes backend with no declared backend tier and no kubeconfig for the
+// context (the cluster was never created) fails with an actionable error naming the missing
+// `backend:` declaration, instead of terraform surfacing a raw connection-refused once it
+// reaches the component that needs the not-yet-existent cluster.
+func TestBootstrap_RefusesKubernetesBackendWithoutTierFromZero(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "backend-first-no-tier")
+	helpers.MarkAsGitRepo(t, dir)
+	if _, stderr, err := helpers.RunCLI(dir, []string{"init", "local", "--set", "terraform.backend.type=kubernetes"}, env); err != nil {
+		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
+	}
+	env = append(env, "WINDSOR_CONTEXT=local")
+
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"bootstrap", "--yes"}, env)
+	if err == nil {
+		t.Fatalf("expected bootstrap to refuse a from-zero kubernetes backend with no declared tier, got success\nstdout: %s\nstderr: %s", stdout, stderr)
+	}
+	combined := string(stdout) + string(stderr)
+	if !strings.Contains(combined, "no kubeconfig") {
+		t.Errorf("expected error to explain the cluster does not exist yet, got:\n%s", combined)
+	}
+	if !strings.Contains(combined, "backend:") {
+		t.Errorf("expected error to name the missing `backend:` declaration, got:\n%s", combined)
+	}
+}
+
 // TestBootstrap_WritesContextFileOnFirstRun verifies the positional context arg
 // persists to .windsor/context even when bootstrap later fails at the install
 // step. Users on other machines need this file to resolve the same context,

--- a/integration/fixtures/backend-first-no-tier/contexts/_template/blueprint.yaml
+++ b/integration/fixtures/backend-first-no-tier/contexts/_template/blueprint.yaml
@@ -1,0 +1,7 @@
+kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: backend-first-no-tier
+  description: Fixture with a terraform component and no declared backend tier, used to exercise the kubernetes-backend-from-zero fail-fast guard.
+terraform:
+  - path: "cluster"

--- a/integration/fixtures/backend-first-no-tier/terraform/cluster/main.tf
+++ b/integration/fixtures/backend-first-no-tier/terraform/cluster/main.tf
@@ -1,0 +1,1 @@
+terraform {}

--- a/integration/fixtures/backend-first-no-tier/windsor.yaml
+++ b/integration/fixtures/backend-first-no-tier/windsor.yaml
@@ -1,0 +1,3 @@
+version: v1alpha1
+contexts:
+  local: {}

--- a/pkg/provisioner/bootstrap.go
+++ b/pkg/provisioner/bootstrap.go
@@ -32,70 +32,13 @@ type BootstrapConfirmFn func(*BootstrapSummary) bool
 // Public Methods
 // =============================================================================
 
-// Bootstrap brings up a context's infrastructure end-to-end. For local or external backends
-// it forwards to Up. For an in-blueprint backend tier (Blueprint.Backend set) it always
-// pivots the tier: Stage 1 pins local, pulls any existing tier state from the configured
-// backend to local, applies the tier against local; Stage 2 pushes tier state to the
-// configured backend; Stage 3 applies non-tier components. The algorithm is idempotent —
-// every bootstrap runs the same flow regardless of whether the backend already exists.
-//
-// Returns (halted, err). halted=true means one of the inner Up calls signaled a clean
-// halt-after-component (e.g. cluster reachability needs operator action). On halt the
-// caller surfaces the deferred-work summary; bootstrap is partially complete and the
-// operator re-runs after addressing it. Operator confirmation is the project layer's
-// responsibility — callers gate Bootstrap on the operator's decision so declining the
-// plan never reaches privileged work (workstation startup, DNS, etc.).
+// Bootstrap brings up a context's infrastructure end-to-end; it is a thin alias for Up — see
+// Up's doc for the backend-tier pivot. Kept as a distinct, self-documenting entry point for
+// `windsor bootstrap`'s explicit-confirmation flow. Returns (halted, err); halted=true means
+// an inner apply call stopped cleanly after a component (e.g. cluster reachability needs
+// operator action), leaving bootstrap partially complete until the operator re-runs it.
 func (i *Provisioner) Bootstrap(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(id string) (bool, error)) (bool, error) {
-	if blueprint == nil {
-		return false, fmt.Errorf("blueprint not provided")
-	}
-
-	backendType := i.configHandler.GetString("terraform.backend.type", "local")
-	tier := blueprint.BackendTier()
-	if backendType == "" || backendType == "local" || len(tier) == 0 {
-		return i.Up(blueprint, onApply...)
-	}
-
-	tierBP := blueprintWithComponents(blueprint, tier)
-	nonTierBP := blueprintWithoutComponents(blueprint, tier)
-
-	var tierHalted bool
-	if err := i.withBackendOverride("bootstrap", func() error {
-		if _, err := i.MigrateState(tierBP); err != nil {
-			return err
-		}
-		halted, err := i.Up(tierBP, onApply...)
-		if err != nil {
-			return err
-		}
-		tierHalted = halted
-		return nil
-	}); err != nil {
-		return false, err
-	}
-	if tierHalted {
-		// Halt during tier apply — don't migrate state or run non-tier components yet.
-		return true, nil
-	}
-
-	skipped, err := i.MigrateState(tierBP)
-	if err != nil {
-		return false, err
-	}
-	if len(skipped) > 0 {
-		return false, fmt.Errorf("bootstrap migration skipped tier components after a successful local apply: %v — their directories should have been materialised by Up", skipped)
-	}
-
-	for _, c := range tier {
-		if err := i.RemoveLocalState(c.GetID()); err != nil {
-			fmt.Fprintf(os.Stderr, "warning: failed to remove local state file for %q after migration: %v\n", c.GetID(), err)
-		}
-	}
-
-	if len(nonTierBP.TerraformComponents) == 0 {
-		return false, nil
-	}
-	return i.Up(nonTierBP, onApply...)
+	return i.Up(blueprint, onApply...)
 }
 
 // BuildBootstrapSummary constructs the operator-visible intent description for a bootstrap,
@@ -129,6 +72,53 @@ func BuildBootstrapSummary(blueprint *blueprintv1alpha1.Blueprint, contextName, 
 // =============================================================================
 // Private Helpers
 // =============================================================================
+
+// applyWithBackendPivot pins local, migrates any existing tier state to local, applies the
+// tier locally, migrates it to the configured backend, then applies non-tier components
+// directly against it. Idempotent regardless of whether the backend already exists.
+// Sub-applies use applyDirect, not Up, to avoid re-deriving a tier and recursing.
+func (i *Provisioner) applyWithBackendPivot(blueprint *blueprintv1alpha1.Blueprint, tier []*blueprintv1alpha1.TerraformComponent, onApply ...func(id string) (bool, error)) (bool, error) {
+	tierBP := blueprintWithComponents(blueprint, tier)
+	nonTierBP := blueprintWithoutComponents(blueprint, tier)
+
+	var tierHalted bool
+	if err := i.withBackendOverride("backend-pivot", func() error {
+		if _, err := i.MigrateState(tierBP); err != nil {
+			return err
+		}
+		halted, err := i.applyDirect(tierBP, onApply...)
+		if err != nil {
+			return err
+		}
+		tierHalted = halted
+		return nil
+	}); err != nil {
+		return false, err
+	}
+	if tierHalted {
+		// Halt during tier apply — don't migrate state or run non-tier components yet.
+		return true, nil
+	}
+
+	skipped, err := i.MigrateState(tierBP)
+	if err != nil {
+		return false, err
+	}
+	if len(skipped) > 0 {
+		return false, fmt.Errorf("backend-tier migration skipped components after a successful local apply: %v — their directories should have been materialised by the local apply", skipped)
+	}
+
+	for _, c := range tier {
+		if err := i.RemoveLocalState(c.GetID()); err != nil {
+			fmt.Fprintf(os.Stderr, "warning: failed to remove local state file for %q after migration: %v\n", c.GetID(), err)
+		}
+	}
+
+	if len(nonTierBP.TerraformComponents) == 0 {
+		return false, nil
+	}
+	return i.applyDirect(nonTierBP, onApply...)
+}
 
 // blueprintWithComponents returns a shallow copy of bp containing only the given
 // terraform components, in their order in the slice. Non-terraform fields are shared.

--- a/pkg/provisioner/bootstrap_test.go
+++ b/pkg/provisioner/bootstrap_test.go
@@ -28,9 +28,10 @@ func TestProvisioner_Bootstrap(t *testing.T) {
 	})
 
 	t.Run("KubernetesBackendWithoutBlueprintBackendCollapsesToUp", func(t *testing.T) {
-		// terraform.backend.type=kubernetes with no Blueprint.Backend is the
-		// "external cluster already provisioned" case. Bootstrap forwards to Up
-		// without the local-pin/migrate dance — len(tier) == 0 short-circuits.
+		// terraform.backend.type=kubernetes with no Blueprint.Backend and a present
+		// kubeconfig (setupProvisionerMocks seeds one by default) is the "cluster
+		// already provisioned" case — len(tier) == 0 short-circuits straight to a
+		// plain apply, no local-pin/migrate dance and no fail-fast guard.
 		mocks := setupProvisionerMocks(t)
 		bp := &blueprintv1alpha1.Blueprint{
 			TerraformComponents: []blueprintv1alpha1.TerraformComponent{
@@ -67,6 +68,72 @@ func TestProvisioner_Bootstrap(t *testing.T) {
 		// Must be a plain Up — no backend pinning, no migrate dance.
 		if len(ops) != 1 || ops[0] != "up" {
 			t.Errorf("Expected ops=[up], got %v", ops)
+		}
+	})
+
+	t.Run("RefusesKubernetesBackendWithoutTierWhenClusterNotYetCreated", func(t *testing.T) {
+		// terraform.backend.type=kubernetes, no Blueprint.Backend, and no kubeconfig for
+		// this context is the from-zero case: the blueprint gives no tier
+		// boundary to pivot on, so applying anything would dial a cluster that cannot
+		// exist yet. Refuse up front with an actionable error instead of letting
+		// terraform's raw connection-refused surface.
+		mocks := setupProvisionerMocks(t)
+		bp := &blueprintv1alpha1.Blueprint{
+			TerraformComponents: []blueprintv1alpha1.TerraformComponent{
+				{Path: "cluster/talos"},
+			},
+		}
+		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockCH.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "terraform.backend.type" {
+				return "kubernetes"
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
+		mockStack := terraforminfra.NewMockStack()
+		upCalled := false
+		mockStack.UpFunc = func(_ *blueprintv1alpha1.Blueprint, _ ...func(id string) (bool, error)) (bool, error) {
+			upCalled = true
+			return false, nil
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+		provisioner.configRoot = t.TempDir() // no .kube/config — cluster not yet created
+
+		if _, err := provisioner.Bootstrap(bp); err == nil {
+			t.Fatal("Expected error, got nil")
+		} else if !strings.Contains(err.Error(), "no kubeconfig") || !strings.Contains(err.Error(), "backend:") {
+			t.Errorf("Expected error to explain the missing tier declaration, got: %v", err)
+		}
+		if upCalled {
+			t.Error("TerraformStack.Up must not run when the guard refuses")
+		}
+	})
+
+	t.Run("EmptyBlueprintOnKubernetesBackendDoesNotTripTheGuard", func(t *testing.T) {
+		// No terraform components at all means there is nothing to apply against the
+		// cluster in the first place — the from-zero guard must not refuse a legitimate
+		// no-op just because the backend happens to be kubernetes.
+		mocks := setupProvisionerMocks(t)
+		bp := &blueprintv1alpha1.Blueprint{}
+		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockCH.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "terraform.backend.type" {
+				return "kubernetes"
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
+		mockStack := terraforminfra.NewMockStack()
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+		provisioner.configRoot = t.TempDir() // no kubeconfig
+
+		if _, err := provisioner.Bootstrap(bp); err != nil {
+			t.Fatalf("Expected no error for an empty blueprint, got %v", err)
 		}
 	})
 
@@ -617,6 +684,102 @@ func TestProvisioner_Bootstrap(t *testing.T) {
 		}
 		if !sawSecondUp {
 			t.Errorf("Expected Stage 3 Up after cleanup warning, got %v", ops)
+		}
+	})
+}
+
+func TestProvisioner_Up_BackendPivot(t *testing.T) {
+	t.Run("PivotsDeclaredBackendTierWithoutBootstrap", func(t *testing.T) {
+		// windsor up, called directly on a from-zero context whose blueprint declares
+		// a backend tier, must run the same local-pin/migrate/apply sequence Bootstrap
+		// runs — up no longer needs bootstrap called first.
+		mocks := setupProvisionerMocks(t)
+		bp := &blueprintv1alpha1.Blueprint{
+			Backend: "cluster",
+			TerraformComponents: []blueprintv1alpha1.TerraformComponent{
+				{Name: "cluster", Path: "cluster/talos"},
+				{Path: "gitops/flux"},
+			},
+		}
+
+		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockCH.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "terraform.backend.type" {
+				return "kubernetes"
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
+
+		var ops []string
+		mockCH.SetFunc = func(key string, value any) error {
+			if key == "terraform.backend.type" {
+				ops = append(ops, fmt.Sprintf("set:%v", value))
+			}
+			return nil
+		}
+		mockStack := terraforminfra.NewMockStack()
+		mockStack.UpFunc = func(_ *blueprintv1alpha1.Blueprint, _ ...func(id string) (bool, error)) (bool, error) {
+			ops = append(ops, "up")
+			return false, nil
+		}
+		mockStack.MigrateStateFunc = func(_ *blueprintv1alpha1.Blueprint) ([]string, error) {
+			ops = append(ops, "migrate")
+			return nil, nil
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+		provisioner.configRoot = t.TempDir() // no kubeconfig — genuinely from zero
+
+		if _, err := provisioner.Up(bp); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		expected := []string{"set:local", "migrate", "up", "set:kubernetes", "migrate", "up"}
+		if len(ops) != len(expected) {
+			t.Fatalf("Expected %v, got %v", expected, ops)
+		}
+		for i, want := range expected {
+			if ops[i] != want {
+				t.Errorf("op %d: got %q, want %q (full: %v)", i, ops[i], want, ops)
+			}
+		}
+	})
+
+	t.Run("NoTierDeclaredStillAppliesDirectlyOnceClusterExists", func(t *testing.T) {
+		// Steady state: kubeconfig present (already bootstrapped), no declared tier —
+		// Up applies directly against the configured backend, same as before this fix.
+		mocks := setupProvisionerMocks(t)
+		bp := &blueprintv1alpha1.Blueprint{
+			TerraformComponents: []blueprintv1alpha1.TerraformComponent{
+				{Path: "gitops/flux"},
+			},
+		}
+		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockCH.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "terraform.backend.type" {
+				return "kubernetes"
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
+		mockStack := terraforminfra.NewMockStack()
+		upCalled := false
+		mockStack.UpFunc = func(_ *blueprintv1alpha1.Blueprint, _ ...func(id string) (bool, error)) (bool, error) {
+			upCalled = true
+			return false, nil
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+		// setupProvisionerMocks seeds a kubeconfig by default — cluster already exists.
+
+		if _, err := provisioner.Up(bp); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !upCalled {
+			t.Error("Expected TerraformStack.Up to run directly")
 		}
 	})
 }

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -207,10 +207,11 @@ func (i *Provisioner) OnTerraformPostApply(fn func(id string) error) {
 
 // Up orchestrates the high-level infrastructure deployment process. When the blueprint
 // declares a backend tier it pivots through local state first, then the configured backend
-// (applyWithBackendPivot); otherwise it applies directly. A kubernetes backend with no
-// declared tier and no kubeconfig yet is refused with an actionable error rather than a raw
-// terraform connection failure. Returns (halted, err); halted=true means a hook stopped the
-// run cleanly after a component. The blueprint parameter is required.
+// (applyWithBackendPivot) — unconfirmed, same as any other apply through this method,
+// including from cmd/apply.go and cmd/up.go; confirmation is a cmd/bootstrap.go concern, not
+// this method's. Without a declared tier it applies directly. A kubernetes backend with no
+// tier and no kubeconfig yet is refused with an actionable error instead of a raw terraform
+// connection failure. Returns (halted, err); halted=true means a hook stopped after a component.
 func (i *Provisioner) Up(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(id string) (bool, error)) (bool, error) {
 	if blueprint == nil {
 		return false, fmt.Errorf("blueprint not provided")

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -205,37 +205,26 @@ func (i *Provisioner) OnTerraformPostApply(fn func(id string) error) {
 	}
 }
 
-// Up orchestrates the high-level infrastructure deployment process. It runs Terraform apply
-// when terraform.enabled and the stack exists, invoking the given onApply hooks after each
-// component apply (after any hooks registered via OnTerraformApply). The blueprint parameter
-// is required.
-//
-// Returns (halted bool, err error). halted=true means a hook signaled a clean stop after a
-// component apply — the apply succeeded, but subsequent components were intentionally
-// skipped. err remains the path for real failures.
+// Up orchestrates the high-level infrastructure deployment process. When the blueprint
+// declares a backend tier it pivots through local state first, then the configured backend
+// (applyWithBackendPivot); otherwise it applies directly. A kubernetes backend with no
+// declared tier and no kubeconfig yet is refused with an actionable error rather than a raw
+// terraform connection failure. Returns (halted, err); halted=true means a hook stopped the
+// run cleanly after a component. The blueprint parameter is required.
 func (i *Provisioner) Up(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(id string) (bool, error)) (bool, error) {
 	if blueprint == nil {
 		return false, fmt.Errorf("blueprint not provided")
 	}
-	if err := i.ensureTerraformStack(); err != nil {
-		return false, err
+
+	backendType := i.configHandler.GetString("terraform.backend.type", "local")
+	tier := blueprint.BackendTier()
+	if backendType == "" || backendType == "local" || len(tier) == 0 {
+		if backendType == "kubernetes" && len(tier) == 0 && hasEnabledTerraformComponent(blueprint) && !i.kubeconfigPresent() {
+			return false, fmt.Errorf("context has no kubeconfig (cluster not yet created) and the blueprint declares no backend tier for the kubernetes backend; add `backend: <component-id>` to the blueprint naming the component that creates the cluster, or set terraform.backend.type to \"local\" until it exists")
+		}
+		return i.applyDirect(blueprint, onApply...)
 	}
-	if i.TerraformStack == nil {
-		return false, nil
-	}
-	if err := i.recoverHalfMigratedComponents(blueprint); err != nil {
-		return false, err
-	}
-	hooks := append([]func(id string) (bool, error){}, i.onTerraformApply...)
-	hooks = append(hooks, onApply...)
-	if len(i.onTerraformPostApply) > 0 {
-		i.TerraformStack.PostApply(i.onTerraformPostApply...)
-	}
-	halted, err := i.TerraformStack.Up(blueprint, hooks...)
-	if err != nil {
-		return false, fmt.Errorf("failed to run terraform up: %w", err)
-	}
-	return halted, nil
+	return i.applyWithBackendPivot(blueprint, tier, onApply...)
 }
 
 // MigrateState reinitializes every Terraform component's backend against the currently configured
@@ -1894,6 +1883,43 @@ func (i *Provisioner) Close() {
 // =============================================================================
 // Private Methods
 // =============================================================================
+
+// applyDirect runs terraform apply directly against the configured backend, with no tier
+// detection or pivot. Used by Up when no tier applies, and by applyWithBackendPivot's Stage
+// 1/3 sub-applies, which must not re-derive a tier from an already-sliced blueprint.
+func (i *Provisioner) applyDirect(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(id string) (bool, error)) (bool, error) {
+	if err := i.ensureTerraformStack(); err != nil {
+		return false, err
+	}
+	if i.TerraformStack == nil {
+		return false, nil
+	}
+	if err := i.recoverHalfMigratedComponents(blueprint); err != nil {
+		return false, err
+	}
+	hooks := append([]func(id string) (bool, error){}, i.onTerraformApply...)
+	hooks = append(hooks, onApply...)
+	if len(i.onTerraformPostApply) > 0 {
+		i.TerraformStack.PostApply(i.onTerraformPostApply...)
+	}
+	halted, err := i.TerraformStack.Up(blueprint, hooks...)
+	if err != nil {
+		return false, fmt.Errorf("failed to run terraform up: %w", err)
+	}
+	return halted, nil
+}
+
+// hasEnabledTerraformComponent reports whether the blueprint has at least one terraform
+// component that isn't explicitly disabled. Guards against refusing an apply for a
+// kubernetes backend when there is nothing to apply in the first place.
+func hasEnabledTerraformComponent(blueprint *blueprintv1alpha1.Blueprint) bool {
+	for _, c := range blueprint.TerraformComponents {
+		if c.Enabled == nil || c.Enabled.IsEnabled() {
+			return true
+		}
+	}
+	return false
+}
 
 // recoverHalfMigratedComponents migrates leftover local state to the
 // configured remote backend for components with local state but no remote


### PR DESCRIPTION
Closes #3192

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This changes core provisioning control flow in `pkg/provisioner` (`Up`/`Bootstrap`) — a shared path used by `apply`, `up`, `upgrade`, and `bootstrap` — so a logic error here has wide blast radius even though the change is well-tested.
>
> **Overview**
>
> `Bootstrap` is now a thin alias for `Up`: the backend-tier pivot logic (pin local, migrate, apply tier, migrate to remote backend, apply the rest) moves into `Up` itself via a new private `applyWithBackendPivot`, with the old direct-apply path extracted into `applyDirect`. A new fail-fast guard refuses a kubernetes backend with no declared tier and no existing kubeconfig, with an actionable error instead of a raw terraform connection failure.
>
> The most notable behavioral shift: `windsor up`/`windsor apply` (via `Project.Up` → `Provisioner.Up`) can now trigger the full local-pin/migrate/apply/migrate pivot on a from-zero context — previously that sequence only ran from `windsor bootstrap`, which shows an operator confirmation summary first. `up`/`apply` have no equivalent confirmation step.

<!-- /claude-code-review:summary -->
