### PR TITLE
fix(kubernetes): enhance kustomization wait error tolerance and testing

### DIFF
--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -93,10 +93,10 @@ type BaseKubernetesManager struct {
 	client        client.KubernetesClient
 	configHandler config.ConfigHandler
 
-	kustomizationWaitPollInterval         time.Duration
-	kustomizationWaitMaxConsecutiveErrors int
-	kustomizationReconcileTimeout         time.Duration
-	kustomizationReconcileSleep           time.Duration
+	kustomizationWaitPollInterval     time.Duration
+	kustomizationWaitMinErrorDuration time.Duration
+	kustomizationReconcileTimeout     time.Duration
+	kustomizationReconcileSleep       time.Duration
 
 	notReadyDescribeBudget time.Duration
 
@@ -115,16 +115,16 @@ func NewKubernetesManager(kubernetesClient client.KubernetesClient, configHandle
 	}
 
 	manager := &BaseKubernetesManager{
-		client:                                kubernetesClient,
-		configHandler:                         configHandler,
-		shims:                                 NewShims(),
-		kustomizationWaitPollInterval:         2 * time.Second,
-		kustomizationWaitMaxConsecutiveErrors: 3,
-		kustomizationReconcileTimeout:         5 * time.Minute,
-		kustomizationReconcileSleep:           2 * time.Second,
-		notReadyDescribeBudget:                10 * time.Second,
-		healthCheckPollInterval:               10 * time.Second,
-		nodeReadyPollInterval:                 5 * time.Second,
+		client:                            kubernetesClient,
+		configHandler:                     configHandler,
+		shims:                             NewShims(),
+		kustomizationWaitPollInterval:     2 * time.Second,
+		kustomizationWaitMinErrorDuration: 30 * time.Second,
+		kustomizationReconcileTimeout:     5 * time.Minute,
+		kustomizationReconcileSleep:       2 * time.Second,
+		notReadyDescribeBudget:            10 * time.Second,
+		healthCheckPollInterval:           10 * time.Second,
+		nodeReadyPollInterval:             5 * time.Second,
 	}
 
 	return manager
@@ -336,17 +336,41 @@ func kustomizationReady(obj *unstructured.Unstructured) bool {
 	return false
 }
 
+// kustomizationWaitErrorBudgetFraction bounds how much of the total wait timeout a streak of
+// transient GetResource errors may consume before WaitForKustomizations gives up: a sustained
+// apiserver slowdown gets patience proportional to how patient the overall wait already is,
+// rather than a fixed tick count that's either too tight for a big blueprint or too loose for
+// a small one.
+const kustomizationWaitErrorBudgetFraction = 0.25
+
 // WaitForKustomizations waits for kustomizations to be ready, calculating the timeout
 // from the longest dependency chain in the blueprint. Outputs a debug message describing
 // the total wait timeout being used before beginning polling. The wait also honors ctx:
 // a cancelled or deadline-exceeded context ends the wait immediately and returns ctx.Err(),
 // so a parent SIGTERM/Ctrl+C or command deadline can interrupt it (rather than requiring a
 // SIGKILL that bypasses the caller's defer cleanup). A not-found GetResource error is treated
-// as not-ready-yet and keeps polling. Any other error (auth, connection, RBAC) counts toward
-// kustomizationWaitMaxConsecutiveErrors: a single transient blip (a brief apiserver restart, a
-// load-balancer failover) is tolerated and retried on the next tick, but a persistent failure
-// like broken cluster auth ends the wait immediately with the underlying error surfaced, rather
-// than silently retrying it for the full timeout budget.
+// as not-ready-yet and keeps polling.
+//
+// Every other GetResource error (auth, RBAC, TLS, connection, apiserver timeout) starts an
+// error streak timer and is tolerated as long as the streak stays within
+// kustomizationWaitErrorBudgetFraction of the total timeout (floored at
+// kustomizationWaitMinErrorDuration so a short wait still gets a few retries); the streak
+// resets the moment any tick completes with no error. Errors are deliberately not classified
+// into permanent-vs-transient buckets: kustomize-controller and helm-controller, reconciling
+// this exact kind of dependency-readiness check against the same apiserver, don't either —
+// their terminal (no-retry) path is reserved for static errors in the object's own spec (an
+// invalid CEL expression, their own cross-namespace ACL denial), never a raw API error, on the
+// grounds that auth/RBAC/certs can change out from under a long-running wait just as easily as
+// a load-balancer failover can. The budget is proportional to wall-clock time rather than tick
+// count for the same reason it applies uniformly: a CPU-starved apiserver can make a single
+// tick's sequential GetResource calls take far longer than the nominal poll interval, so
+// counting ticks either fails fast on a cluster that would have recovered, or (if loosened)
+// tolerates a wildly inconsistent amount of real time depending on how slow each tick happened
+// to be.
+//
+// A tick that hits an error on one kustomization keeps checking the rest of the pending list
+// rather than aborting the tick outright, so one flaky item doesn't mask readiness progress on
+// everything else scheduled to reconcile that tick.
 //
 // Readiness is tracked per kustomization: once observed Ready, a kustomization is dropped from
 // further polling, so a later periodic reconcile flipping it back to Reconciling doesn't reset
@@ -365,13 +389,18 @@ func (k *BaseKubernetesManager) WaitForKustomizations(ctx context.Context, messa
 		kustomizationNames = append(kustomizationNames, kustomization.Name)
 	}
 
+	maxErrorDuration := time.Duration(float64(timeout) * kustomizationWaitErrorBudgetFraction)
+	if maxErrorDuration < k.kustomizationWaitMinErrorDuration {
+		maxErrorDuration = k.kustomizationWaitMinErrorDuration
+	}
+
 	tui.Start(message)
 
 	timeoutChan := time.After(timeout)
 	ticker := time.NewTicker(k.kustomizationWaitPollInterval)
 	defer ticker.Stop()
 
-	consecutiveErrors := 0
+	var errorStreakStart time.Time
 	readyKustomizations := make(map[string]bool, len(kustomizationNames))
 
 	for {
@@ -398,8 +427,10 @@ func (k *BaseKubernetesManager) WaitForKustomizations(ctx context.Context, messa
 					continue
 				}
 				if err != nil {
-					tickErr = fmt.Errorf("error checking kustomization %s: %w", name, err)
-					break
+					if tickErr == nil {
+						tickErr = fmt.Errorf("error checking kustomization %s: %w", name, err)
+					}
+					continue
 				}
 				var kustomizationObj map[string]any
 				if err := k.shims.FromUnstructured(obj.UnstructuredContent(), &kustomizationObj); err != nil {
@@ -425,14 +456,16 @@ func (k *BaseKubernetesManager) WaitForKustomizations(ctx context.Context, messa
 				}
 			}
 			if tickErr != nil {
-				consecutiveErrors++
-				if consecutiveErrors >= k.kustomizationWaitMaxConsecutiveErrors {
+				if errorStreakStart.IsZero() {
+					errorStreakStart = time.Now()
+				}
+				if time.Since(errorStreakStart) >= maxErrorDuration {
 					tui.Fail()
-					return tickErr
+					return fmt.Errorf("kustomization readiness checks failing for over %s: %w", maxErrorDuration, tickErr)
 				}
 				continue
 			}
-			consecutiveErrors = 0
+			errorStreakStart = time.Time{}
 			if len(readyKustomizations) == len(kustomizationNames) {
 				tui.Done()
 				return nil

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/provisioner/kubernetes/client"
 	"github.com/windsorcli/cli/pkg/runtime/config"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -475,6 +476,7 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 		manager := NewKubernetesManager(mocks.KubernetesClient, mocks.ConfigHandler)
 		// Use shorter timeouts for tests
 		manager.kustomizationWaitPollInterval = 50 * time.Millisecond
+		manager.kustomizationWaitMinErrorDuration = 150 * time.Millisecond
 		manager.kustomizationReconcileTimeout = 100 * time.Millisecond
 		manager.kustomizationReconcileSleep = 50 * time.Millisecond
 		return manager
@@ -603,15 +605,19 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 		}
 	})
 
-	t.Run("PersistentErrorFailsFastInsteadOfBurningTimeout", func(t *testing.T) {
-		// Given GetResource returns a persistent, non-transient error (e.g. broken cluster auth)
-		// on every poll
+	t.Run("AuthErrorGetsTheSameBudgetAsAnyOtherError", func(t *testing.T) {
+		// Given GetResource returns a typed auth error (the way the real dynamic client
+		// surfaces it) on every poll, with no recovery in sight — mirroring
+		// kustomize-controller and helm-controller, which don't special-case auth/RBAC/TLS
+		// as terminal either: their own dependency-readiness checks retry-with-backoff on
+		// any apiserver error, reserving no-retry for static errors in the object's own spec
 		manager := setup(t)
+		manager.kustomizationWaitMinErrorDuration = 150 * time.Millisecond
 		kubernetesClient := client.NewMockKubernetesClient()
 		calls := 0
 		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
 			calls++
-			return nil, fmt.Errorf("Unauthorized")
+			return nil, apierrors.NewUnauthorized("cluster credentials rejected")
 		}
 		manager.client = kubernetesClient
 
@@ -619,7 +625,7 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 			Kustomizations: []blueprintv1alpha1.Kustomization{
 				{
 					Name:    "test-kustomization",
-					Timeout: &blueprintv1alpha1.DurationString{Duration: 10 * time.Minute},
+					Timeout: &blueprintv1alpha1.DurationString{Duration: 5 * time.Second},
 				},
 			},
 		}
@@ -627,31 +633,32 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 		// When waiting for kustomizations
 		err := manager.WaitForKustomizations(context.Background(), "Waiting for kustomizations", blueprint)
 
-		// Then the wait ends after a few consecutive failures with the underlying error, instead of
-		// retrying silently for the full timeout budget
+		// Then the wait retries across the same error budget as any other error — it doesn't
+		// fail on the very first occurrence — but still ends once the budget is exceeded,
+		// well before the much longer total timeout, with the underlying error surfaced
 		if err == nil {
 			t.Fatal("Expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), "Unauthorized") {
+		if !strings.Contains(err.Error(), "cluster credentials rejected") {
 			t.Errorf("Expected error to surface the underlying failure, got: %v", err)
 		}
 		if strings.Contains(err.Error(), "timeout waiting for kustomizations") {
-			t.Errorf("Expected a fail-fast error, not the generic timeout error, got: %v", err)
+			t.Errorf("Expected the error-budget path, not the generic timeout error, got: %v", err)
 		}
-		if calls != manager.kustomizationWaitMaxConsecutiveErrors {
-			t.Errorf("Expected GetResource to be called exactly %d times before failing fast, got %d calls", manager.kustomizationWaitMaxConsecutiveErrors, calls)
+		if calls < 2 {
+			t.Errorf("Expected multiple retries before giving up, got %d calls", calls)
 		}
 	})
 
 	t.Run("TransientErrorIsToleratedThenSucceeds", func(t *testing.T) {
-		// Given GetResource fails with a non-not-found error a couple of times (e.g. a brief
-		// apiserver restart) but recovers before hitting the consecutive-failure threshold
+		// Given GetResource fails with a non-not-found error a few times (e.g. a brief
+		// apiserver restart) but recovers well within the error-tolerance budget
 		manager := setup(t)
 		kubernetesClient := client.NewMockKubernetesClient()
 		calls := 0
 		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
 			calls++
-			if calls <= manager.kustomizationWaitMaxConsecutiveErrors-1 {
+			if calls <= 5 {
 				return nil, fmt.Errorf("connection refused")
 			}
 			return &unstructured.Unstructured{
@@ -678,9 +685,146 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 		// When waiting for kustomizations
 		err := manager.WaitForKustomizations(context.Background(), "Waiting for kustomizations", blueprint)
 
-		// Then the transient errors are tolerated and the wait succeeds once the resource recovers
+		// Then the transient errors are tolerated — well past the old fixed 3-strike limit —
+		// and the wait succeeds once the resource recovers
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("TransientErrorStreakExceedingBudgetEventuallyFails", func(t *testing.T) {
+		// Given GetResource fails transiently on every poll, with no recovery in sight, and an
+		// error-tolerance budget dominated by the small floor (well below the total timeout)
+		manager := setup(t)
+		manager.kustomizationWaitMinErrorDuration = 150 * time.Millisecond
+		kubernetesClient := client.NewMockKubernetesClient()
+		calls := 0
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			calls++
+			return nil, fmt.Errorf("connection refused")
+		}
+		manager.client = kubernetesClient
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{
+					Name:    "test-kustomization",
+					Timeout: &blueprintv1alpha1.DurationString{Duration: 5 * time.Second},
+				},
+			},
+		}
+
+		// When waiting for kustomizations
+		err := manager.WaitForKustomizations(context.Background(), "Waiting for kustomizations", blueprint)
+
+		// Then the wait ends once the error streak exceeds its time budget — well before the
+		// much longer total timeout — with a message distinct from the generic timeout error
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "connection refused") {
+			t.Errorf("Expected error to surface the underlying failure, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "checks failing") {
+			t.Errorf("Expected the error-budget message, got: %v", err)
+		}
+		if strings.Contains(err.Error(), "timeout waiting for kustomizations") {
+			t.Errorf("Expected the error-budget path, not the generic timeout error, got: %v", err)
+		}
+		if calls < 2 {
+			t.Errorf("Expected multiple retries before giving up, got %d calls", calls)
+		}
+	})
+
+	t.Run("ErrorStreakResetsAfterAnIntermediateSuccess", func(t *testing.T) {
+		// Given GetResource alternates between short transient-error streaks and single
+		// successful ticks, with no streak individually exceeding the error budget
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		calls := 0
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			calls++
+			// Two failures, then one clean (not-yet-ready) tick, repeated, then Ready for good
+			// from call 10 on. The clean tick has no error, so it resets the streak.
+			if calls >= 10 || calls%3 == 0 {
+				readyStatus := "False"
+				if calls >= 10 {
+					readyStatus = "True"
+				}
+				return &unstructured.Unstructured{
+					Object: map[string]any{
+						"status": map[string]any{
+							"conditions": []any{
+								map[string]any{"type": "Ready", "status": readyStatus},
+							},
+						},
+					},
+				}, nil
+			}
+			return nil, fmt.Errorf("connection refused")
+		}
+		manager.client = kubernetesClient
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{
+					Name:    "test-kustomization",
+					Timeout: &blueprintv1alpha1.DurationString{Duration: 10 * time.Second},
+				},
+			},
+		}
+
+		// When waiting for kustomizations
+		err := manager.WaitForKustomizations(context.Background(), "Waiting for kustomizations", blueprint)
+
+		// Then no individual streak ever exceeds the budget, so the wait succeeds
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if calls < 10 {
+			t.Errorf("Expected at least 10 calls, got %d", calls)
+		}
+	})
+
+	t.Run("TransientErrorOnOneKustomizationDoesNotBlockOthersInSameTick", func(t *testing.T) {
+		// Given "a" always fails transiently and "b" is Ready from the first poll
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		var callsForB int
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			if name == "a" {
+				return nil, fmt.Errorf("connection refused")
+			}
+			callsForB++
+			return &unstructured.Unstructured{
+				Object: map[string]any{
+					"status": map[string]any{
+						"conditions": []any{
+							map[string]any{"type": "Ready", "status": "True"},
+						},
+					},
+				},
+			}, nil
+		}
+		manager.client = kubernetesClient
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "a", Timeout: &blueprintv1alpha1.DurationString{Duration: 500 * time.Millisecond}},
+				{Name: "b", Timeout: &blueprintv1alpha1.DurationString{Duration: 500 * time.Millisecond}},
+			},
+		}
+
+		// When waiting for kustomizations
+		_ = manager.WaitForKustomizations(context.Background(), "Waiting for kustomizations", blueprint)
+
+		// Then "b" is observed Ready and dropped from polling well before "a"'s errors end the
+		// wait, instead of "a" masking the rest of the tick's progress
+		if callsForB == 0 {
+			t.Fatal("Expected \"b\" to be checked despite \"a\" erroring in the same tick")
+		}
+		if callsForB > 2 {
+			t.Errorf("Expected \"b\" to be dropped from polling once Ready, got %d calls", callsForB)
 		}
 	})
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This changes how `WaitForKustomizations` tolerates GetResource errors during cluster bootstrap/reconcile waits, replacing a fixed consecutive-error counter with a wall-clock error budget — a shared provisioner code path exercised by every `up`/apply flow, and a change to default retry patience.
>
> **Overview**
>
> `BaseKubernetesManager` no longer fails a kustomization wait after 3 consecutive GetResource errors; instead it starts a streak timer on the first error and only gives up once that streak exceeds 25% of the total wait timeout (floored at a configurable 30s minimum), resetting the streak the moment any tick succeeds cleanly. A single erroring kustomization within a tick no longer aborts checks for the rest of that tick's pending kustomizations, so one flaky item can't mask readiness progress elsewhere. Test coverage was expanded accordingly, including a new case confirming that one kustomization's errors don't block observing another's readiness in the same tick.
>
> The practical effect: a genuinely broken auth/RBAC error now takes noticeably longer to surface (up to the floor/fraction budget, e.g. ~30-75s by default) rather than failing fast after ~6s, trading faster failure detection for tolerance of transient apiserver blips — a deliberate tradeoff documented in the function's comment, worth confirming matches expectations for interactive `up` usage.

<!-- /claude-code-review:summary -->
