### PR TITLE
fix(provisioner): parallelize kustomization readiness checks per tick

### DIFF
--- a/pkg/provisioner/kubernetes/client/client.go
+++ b/pkg/provisioner/kubernetes/client/client.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"sync"
 	"time"
 
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -58,6 +59,7 @@ type KubernetesClient interface {
 
 // DynamicKubernetesClient implements KubernetesClient using dynamic client
 type DynamicKubernetesClient struct {
+	mu       sync.Mutex
 	client   dynamic.Interface
 	mapper   meta.RESTMapper
 	endpoint string
@@ -175,7 +177,9 @@ func (c *DynamicKubernetesClient) PatchResource(ctx context.Context, gvr schema.
 // If an endpoint is specified, it overrides the default kubeconfig for this check.
 // Returns an error if the client cannot be initialized or the API is unreachable.
 func (c *DynamicKubernetesClient) CheckHealth(ctx context.Context, endpoint string) error {
+	c.mu.Lock()
 	c.endpoint = endpoint
+	c.mu.Unlock()
 
 	if err := c.ensureClient(); err != nil {
 		return fmt.Errorf("failed to initialize Kubernetes client: %w", err)
@@ -248,7 +252,12 @@ func (c *DynamicKubernetesClient) GetNodeReadyStatus(ctx context.Context, nodeNa
 // ensureClient initializes the dynamic Kubernetes client and REST mapper if unset. Uses endpoint,
 // in-cluster, or kubeconfig as available. The mapper is a deferred discovery mapper, so it performs
 // no API calls until the first ResourceFor lookup. Returns error if client setup fails at any stage.
+// Safe for concurrent use: initialization is guarded by a mutex so callers issuing overlapping
+// requests (e.g. a wait loop polling several resources at once) don't race the first setup.
 func (c *DynamicKubernetesClient) ensureClient() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
 	if c.client != nil {
 		return nil
 	}

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -15,6 +15,7 @@ import (
 	"maps"
 	"os"
 	"strings"
+	"sync"
 	"time"
 
 	helmv2 "github.com/fluxcd/helm-controller/api/v2"
@@ -343,6 +344,11 @@ func kustomizationReady(obj *unstructured.Unstructured) bool {
 // a small one.
 const kustomizationWaitErrorBudgetFraction = 0.25
 
+// kustomizationCheckConcurrencyLimit caps how many GetResource calls WaitForKustomizations
+// issues at once within a single tick, so a blueprint with a large number of kustomizations
+// doesn't burst the apiserver with one request per kustomization on every poll interval.
+const kustomizationCheckConcurrencyLimit = 10
+
 // WaitForKustomizations waits for kustomizations to be ready, calculating the timeout
 // from the longest dependency chain in the blueprint. Outputs a debug message describing
 // the total wait timeout being used before beginning polling. The wait also honors ctx:
@@ -362,15 +368,15 @@ const kustomizationWaitErrorBudgetFraction = 0.25
 // invalid CEL expression, their own cross-namespace ACL denial), never a raw API error, on the
 // grounds that auth/RBAC/certs can change out from under a long-running wait just as easily as
 // a load-balancer failover can. The budget is proportional to wall-clock time rather than tick
-// count for the same reason it applies uniformly: a CPU-starved apiserver can make a single
-// tick's sequential GetResource calls take far longer than the nominal poll interval, so
-// counting ticks either fails fast on a cluster that would have recovered, or (if loosened)
-// tolerates a wildly inconsistent amount of real time depending on how slow each tick happened
-// to be.
+// count for the same reason it applies uniformly: even with per-kustomization checks run
+// concurrently, a CPU-starved apiserver can still make a tick take far longer than the nominal
+// poll interval, so counting ticks either fails fast on a cluster that would have recovered, or
+// (if loosened) tolerates a wildly inconsistent amount of real time depending on how slow each
+// tick happened to be.
 //
-// A tick that hits an error on one kustomization keeps checking the rest of the pending list
-// rather than aborting the tick outright, so one flaky item doesn't mask readiness progress on
-// everything else scheduled to reconcile that tick.
+// Each pending kustomization is checked concurrently within a tick, up to
+// kustomizationCheckConcurrencyLimit at once, so one slow or erroring GetResource call
+// doesn't hold up observing the rest of that tick's readiness progress.
 //
 // Readiness is tracked per kustomization: once observed Ready, a kustomization is dropped from
 // further polling, so a later periodic reconcile flipping it back to Reconciling doesn't reset
@@ -412,47 +418,42 @@ func (k *BaseKubernetesManager) WaitForKustomizations(ctx context.Context, messa
 			tui.Fail()
 			return fmt.Errorf("timeout waiting for kustomizations%s", k.describeNotReadyKustomizations(kustomizationNames, k.gitopsNamespace()))
 		case <-ticker.C:
-			var tickErr error
+			pending := make([]string, 0, len(kustomizationNames))
+			seen := make(map[string]bool, len(kustomizationNames))
 			for _, name := range kustomizationNames {
-				if readyKustomizations[name] {
+				if readyKustomizations[name] || seen[name] {
 					continue
 				}
-				gvr := schema.GroupVersionResource{
-					Group:    "kustomize.toolkit.fluxcd.io",
-					Version:  "v1",
-					Resource: "kustomizations",
-				}
-				obj, err := k.client.GetResource(gvr, k.gitopsNamespace(), name)
-				if err != nil && isNotFoundError(err) {
-					continue
-				}
-				if err != nil {
+				seen[name] = true
+				pending = append(pending, name)
+			}
+
+			results := make([]kustomizationCheckResult, len(pending))
+			var wg sync.WaitGroup
+			sem := make(chan struct{}, kustomizationCheckConcurrencyLimit)
+			for i, name := range pending {
+				wg.Add(1)
+				sem <- struct{}{}
+				go func(i int, name string) {
+					defer wg.Done()
+					defer func() { <-sem }()
+					ready, err := k.checkKustomizationReady(name)
+					results[i] = kustomizationCheckResult{ready: ready, err: err}
+				}(i, name)
+			}
+			wg.Wait()
+
+			var tickErr error
+			for i, name := range pending {
+				result := results[i]
+				if result.err != nil {
 					if tickErr == nil {
-						tickErr = fmt.Errorf("error checking kustomization %s: %w", name, err)
+						tickErr = fmt.Errorf("error checking kustomization %s: %w", name, result.err)
 					}
 					continue
 				}
-				var kustomizationObj map[string]any
-				if err := k.shims.FromUnstructured(obj.UnstructuredContent(), &kustomizationObj); err != nil {
-					continue
-				}
-				status, ok := kustomizationObj["status"].(map[string]any)
-				if !ok {
-					continue
-				}
-				conditions, ok := status["conditions"].([]any)
-				if !ok {
-					continue
-				}
-				for _, cond := range conditions {
-					condMap, ok := cond.(map[string]any)
-					if !ok {
-						continue
-					}
-					if condMap["type"] == "Ready" && condMap["status"] == "True" {
-						readyKustomizations[name] = true
-						break
-					}
+				if result.ready {
+					readyKustomizations[name] = true
 				}
 			}
 			if tickErr != nil {
@@ -1636,6 +1637,54 @@ waitLoop:
 // =============================================================================
 // Private Methods
 // =============================================================================
+
+// kustomizationCheckResult carries one kustomization's readiness outcome back from a
+// concurrent checkKustomizationReady call to WaitForKustomizations' tick loop.
+type kustomizationCheckResult struct {
+	ready bool
+	err   error
+}
+
+// checkKustomizationReady fetches a single Kustomization and reports whether its status
+// carries a Ready=True condition. A not-found resource is reported not-ready with no error,
+// since it hasn't reconciled into existence yet; any other GetResource or decode failure is
+// reported not-ready with the error, for the caller's error-budget accounting.
+func (k *BaseKubernetesManager) checkKustomizationReady(name string) (bool, error) {
+	gvr := schema.GroupVersionResource{
+		Group:    "kustomize.toolkit.fluxcd.io",
+		Version:  "v1",
+		Resource: "kustomizations",
+	}
+	obj, err := k.client.GetResource(gvr, k.gitopsNamespace(), name)
+	if err != nil {
+		if isNotFoundError(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	var kustomizationObj map[string]any
+	if err := k.shims.FromUnstructured(obj.UnstructuredContent(), &kustomizationObj); err != nil {
+		return false, nil
+	}
+	status, ok := kustomizationObj["status"].(map[string]any)
+	if !ok {
+		return false, nil
+	}
+	conditions, ok := status["conditions"].([]any)
+	if !ok {
+		return false, nil
+	}
+	for _, cond := range conditions {
+		condMap, ok := cond.(map[string]any)
+		if !ok {
+			continue
+		}
+		if condMap["type"] == "Ready" && condMap["status"] == "True" {
+			return true, nil
+		}
+	}
+	return false, nil
+}
 
 // servicesGVR is the core v1 Services resource, scanned during destroy to find cloud
 // LoadBalancers that must be released before their controller is torn down.

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -825,6 +826,115 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 		}
 		if callsForB > 2 {
 			t.Errorf("Expected \"b\" to be dropped from polling once Ready, got %d calls", callsForB)
+		}
+	})
+
+	t.Run("ChecksRunConcurrentlyWithinATick", func(t *testing.T) {
+		// Given two kustomizations whose GetResource calls each block until both have
+		// started, so a sequential implementation would deadlock waiting on itself
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		var mu sync.Mutex
+		started := map[string]bool{}
+		bothStarted := make(chan struct{})
+		var closeOnce sync.Once
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			mu.Lock()
+			started[name] = true
+			both := started["a"] && started["b"]
+			mu.Unlock()
+			if both {
+				closeOnce.Do(func() { close(bothStarted) })
+			}
+			select {
+			case <-bothStarted:
+			case <-time.After(2 * time.Second):
+				t.Errorf("expected \"a\" and \"b\" to be checked concurrently within the same tick")
+			}
+			return &unstructured.Unstructured{
+				Object: map[string]any{
+					"status": map[string]any{
+						"conditions": []any{
+							map[string]any{"type": "Ready", "status": "True"},
+						},
+					},
+				},
+			}, nil
+		}
+		manager.client = kubernetesClient
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "a", Timeout: &blueprintv1alpha1.DurationString{Duration: 2 * time.Second}},
+				{Name: "b", Timeout: &blueprintv1alpha1.DurationString{Duration: 2 * time.Second}},
+			},
+		}
+
+		// When waiting for kustomizations
+		err := manager.WaitForKustomizations(context.Background(), "Waiting for kustomizations", blueprint)
+
+		// Then the wait succeeds without either check having to wait for the other to finish first
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("LimitsConcurrentChecksPerTick", func(t *testing.T) {
+		// Given more kustomizations than the concurrency limit, each check briefly stalls
+		// so overlapping in-flight calls can be observed
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		var mu sync.Mutex
+		inFlight := 0
+		peak := 0
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			mu.Lock()
+			inFlight++
+			if inFlight > peak {
+				peak = inFlight
+			}
+			mu.Unlock()
+			time.Sleep(20 * time.Millisecond)
+			mu.Lock()
+			inFlight--
+			mu.Unlock()
+			return &unstructured.Unstructured{
+				Object: map[string]any{
+					"status": map[string]any{
+						"conditions": []any{
+							map[string]any{"type": "Ready", "status": "True"},
+						},
+					},
+				},
+			}, nil
+		}
+		manager.client = kubernetesClient
+
+		kustomizations := make([]blueprintv1alpha1.Kustomization, 0, kustomizationCheckConcurrencyLimit+5)
+		for i := 0; i < kustomizationCheckConcurrencyLimit+5; i++ {
+			kustomizations = append(kustomizations, blueprintv1alpha1.Kustomization{
+				Name:    fmt.Sprintf("k%d", i),
+				Timeout: &blueprintv1alpha1.DurationString{Duration: 2 * time.Second},
+			})
+		}
+		blueprint := &blueprintv1alpha1.Blueprint{Kustomizations: kustomizations}
+
+		// When waiting for kustomizations
+		err := manager.WaitForKustomizations(context.Background(), "Waiting for kustomizations", blueprint)
+
+		// Then the wait succeeds, but the observed in-flight peak never exceeds the cap
+		// while still showing checks genuinely ran concurrently, not one at a time
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		mu.Lock()
+		finalPeak := peak
+		mu.Unlock()
+		if finalPeak > kustomizationCheckConcurrencyLimit {
+			t.Errorf("Expected concurrency capped at %d, observed peak of %d", kustomizationCheckConcurrencyLimit, finalPeak)
+		}
+		if finalPeak < 2 {
+			t.Errorf("Expected checks to run concurrently, observed peak of %d", finalPeak)
 		}
 	})
 


### PR DESCRIPTION
Closes #3198

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change is isolated to the kustomization-readiness polling path in the Kubernetes provisioner, and is reversible with a single constant/behavioral revert if it ever misbehaves.
>
> **Overview**
>
> `WaitForKustomizations` now checks all pending kustomizations within a tick concurrently instead of sequentially, bounded by a new `kustomizationCheckConcurrencyLimit` (10) worker semaphore. The per-kustomization GetResource-and-decode logic was extracted into a new `checkKustomizationReady` helper that returns a `(ready, err)` result consumed by the tick loop, preserving the existing not-found-is-not-ready and error-budget semantics.
>
> To make this safe, `DynamicKubernetesClient` gained a mutex guarding its lazy `ensureClient` initialization and the `endpoint` field, since multiple goroutines can now call into the client concurrently during a single tick. Two new tests assert checks genuinely run concurrently and that concurrency is capped at the configured limit.

<!-- /claude-code-review:summary -->
