### PR TITLE
fix(provisioner): add healthCheckSettleDuration to improve API health check reliability

### DIFF
--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -101,8 +101,9 @@ type BaseKubernetesManager struct {
 
 	notReadyDescribeBudget time.Duration
 
-	healthCheckPollInterval time.Duration
-	nodeReadyPollInterval   time.Duration
+	healthCheckPollInterval   time.Duration
+	healthCheckSettleDuration time.Duration
+	nodeReadyPollInterval     time.Duration
 }
 
 // NewKubernetesManager creates a new instance of BaseKubernetesManager.
@@ -125,6 +126,7 @@ func NewKubernetesManager(kubernetesClient client.KubernetesClient, configHandle
 		kustomizationReconcileSleep:       2 * time.Second,
 		notReadyDescribeBudget:            10 * time.Second,
 		healthCheckPollInterval:           10 * time.Second,
+		healthCheckSettleDuration:         30 * time.Second,
 		nodeReadyPollInterval:             5 * time.Second,
 	}
 
@@ -1152,7 +1154,13 @@ func decodeInventoryID(id string) (InventoryEntry, bool) {
 
 // WaitForKubernetesHealthy waits for the Kubernetes API to become healthy within the context deadline.
 // If nodeNames are provided, verifies all specified nodes reach Ready state before returning.
-// Returns an error if the API is unreachable or any specified nodes are not Ready within the deadline.
+// A machine config apply (e.g. Talos resource reservations touching the apiServer/controllerManager/
+// scheduler static pods) is accepted synchronously but reconciled asynchronously, so the very next
+// health check can still observe the pre-change apiserver and return healthy moments before it's
+// recreated. To catch that race, a success only counts once the API (and, if requested, node
+// readiness) has held continuously for healthCheckSettleDuration; any failure during that window
+// resets the clock. Returns an error if the API is unreachable or any specified nodes are not Ready
+// within the deadline.
 func (k *BaseKubernetesManager) WaitForKubernetesHealthy(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
 	if k.client == nil {
 		return fmt.Errorf("kubernetes client not initialized")
@@ -1168,7 +1176,13 @@ func (k *BaseKubernetesManager) WaitForKubernetesHealthy(ctx context.Context, en
 		pollInterval = 10 * time.Second
 	}
 
+	settleDuration := k.healthCheckSettleDuration
+	if settleDuration == 0 {
+		settleDuration = 30 * time.Second
+	}
+
 	var lastErr error
+	var settleSince time.Time
 	for time.Now().Before(deadline) {
 		select {
 		case <-ctx.Done():
@@ -1176,6 +1190,7 @@ func (k *BaseKubernetesManager) WaitForKubernetesHealthy(ctx context.Context, en
 		default:
 			if err := k.client.CheckHealth(ctx, endpoint); err != nil {
 				lastErr = fmt.Errorf("health check for API endpoint %s failed: %w", endpoint, err)
+				settleSince = time.Time{}
 				select {
 				case <-ctx.Done():
 					return healthyTimeoutError(lastErr)
@@ -1187,12 +1202,25 @@ func (k *BaseKubernetesManager) WaitForKubernetesHealthy(ctx context.Context, en
 			if len(nodeNames) > 0 {
 				if err := k.waitForNodesReady(ctx, nodeNames, outputFunc); err != nil {
 					lastErr = err
+					settleSince = time.Time{}
 					select {
 					case <-ctx.Done():
 						return healthyTimeoutError(lastErr)
 					case <-time.After(pollInterval):
 						continue
 					}
+				}
+			}
+
+			if settleSince.IsZero() {
+				settleSince = time.Now()
+			}
+			if time.Since(settleSince) < settleDuration {
+				select {
+				case <-ctx.Done():
+					return healthyTimeoutError(lastErr)
+				case <-time.After(pollInterval):
+					continue
 				}
 			}
 

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -1159,7 +1159,11 @@ func decodeInventoryID(id string) (InventoryEntry, bool) {
 // health check can still observe the pre-change apiserver and return healthy moments before it's
 // recreated. To catch that race, a success only counts once the API (and, if requested, node
 // readiness) has held continuously for healthCheckSettleDuration; any failure during that window
-// resets the clock. Returns an error if the API is unreachable or any specified nodes are not Ready
+// resets the clock. healthCheckSettleDuration is bounded by the context's own remaining deadline
+// (minus one poll interval of margin) so a caller with a short overall timeout — e.g. the 30s
+// reachability check windsor destroy runs before invoking terraform — still has a reachable window
+// in which to succeed, rather than the settle requirement alone guaranteeing a timeout regardless of
+// cluster health. Returns an error if the API is unreachable or any specified nodes are not Ready
 // within the deadline.
 func (k *BaseKubernetesManager) WaitForKubernetesHealthy(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
 	if k.client == nil {
@@ -1179,6 +1183,12 @@ func (k *BaseKubernetesManager) WaitForKubernetesHealthy(ctx context.Context, en
 	settleDuration := k.healthCheckSettleDuration
 	if settleDuration == 0 {
 		settleDuration = 30 * time.Second
+	}
+	if remaining := time.Until(deadline) - pollInterval; settleDuration > remaining {
+		if remaining < 0 {
+			remaining = 0
+		}
+		settleDuration = remaining
 	}
 
 	var lastErr error

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -2880,6 +2880,7 @@ func TestBaseKubernetesManager_WaitForKubernetesHealthy(t *testing.T) {
 		mocks := setupKubernetesMocks(t)
 		manager := NewKubernetesManager(mocks.KubernetesClient, mocks.ConfigHandler)
 		manager.healthCheckPollInterval = 50 * time.Millisecond
+		manager.healthCheckSettleDuration = 120 * time.Millisecond
 		manager.nodeReadyPollInterval = 50 * time.Millisecond
 		return manager
 	}
@@ -2966,6 +2967,88 @@ func TestBaseKubernetesManager_WaitForKubernetesHealthy(t *testing.T) {
 		}
 		if callCount < 2 {
 			t.Error("Expected CheckHealth to be called multiple times")
+		}
+	})
+
+	t.Run("SettlesBeforeReturningHealthy", func(t *testing.T) {
+		// Given an API that reports healthy on the very first check
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		var mu sync.Mutex
+		var checkTimes []time.Time
+		kubernetesClient.CheckHealthFunc = func(ctx context.Context, endpoint string) error {
+			mu.Lock()
+			checkTimes = append(checkTimes, time.Now())
+			mu.Unlock()
+			return nil
+		}
+		manager.client = kubernetesClient
+
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+
+		start := time.Now()
+		err := manager.WaitForKubernetesHealthy(ctx, "https://test-endpoint:6443", nil)
+		elapsed := time.Since(start)
+
+		// Then it does not return on the first success: it keeps polling until
+		// healthCheckSettleDuration has elapsed with no observed failure, so a
+		// static-pod recreation that lands moments after the first success is
+		// still caught.
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if elapsed < manager.healthCheckSettleDuration {
+			t.Errorf("Expected wait to span at least the settle duration (%v), took %v", manager.healthCheckSettleDuration, elapsed)
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		if len(checkTimes) < 2 {
+			t.Errorf("Expected CheckHealth to be called more than once to confirm the settle window, got %d calls", len(checkTimes))
+		}
+	})
+
+	t.Run("FailureDuringSettleWindowResetsTheClock", func(t *testing.T) {
+		// Given a health check that succeeds, then fails once (simulating an
+		// async static-pod restart), then succeeds continuously afterward
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		var mu sync.Mutex
+		callCount := 0
+		failedOnce := false
+		kubernetesClient.CheckHealthFunc = func(ctx context.Context, endpoint string) error {
+			mu.Lock()
+			defer mu.Unlock()
+			callCount++
+			if callCount == 2 {
+				failedOnce = true
+				return fmt.Errorf("apiserver restarting")
+			}
+			return nil
+		}
+		manager.client = kubernetesClient
+
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+
+		err := manager.WaitForKubernetesHealthy(ctx, "https://test-endpoint:6443", nil)
+
+		// Then the mid-window failure is not masked by the earlier success: the
+		// wait only returns once a fresh, uninterrupted settle window completes
+		// after the failure, so at least a settle-duration's worth of ticks must
+		// follow it before the wait is allowed to return.
+		if err != nil {
+			t.Errorf("Expected no error once the restart resolves, got %v", err)
+		}
+		if !failedOnce {
+			t.Fatal("Expected the mid-window failure to have occurred")
+		}
+		mu.Lock()
+		successesAfterFailure := callCount - 2
+		mu.Unlock()
+		minTicksAfterFailure := int(manager.healthCheckSettleDuration / manager.healthCheckPollInterval)
+		if successesAfterFailure < minTicksAfterFailure {
+			t.Errorf("Expected at least %d successful checks after the failure to satisfy the settle window, got %d", minTicksAfterFailure, successesAfterFailure)
 		}
 	})
 

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -3052,6 +3052,35 @@ func TestBaseKubernetesManager_WaitForKubernetesHealthy(t *testing.T) {
 		}
 	})
 
+	t.Run("SettleDurationBoundedByCallerDeadline", func(t *testing.T) {
+		// Given a caller whose total context budget is no larger than the
+		// configured settle duration itself (e.g. windsor destroy's fail-fast
+		// reachability check, which hands WaitForKubernetesHealthy a 30s context
+		// against the same 30s default settle duration), and a health check that
+		// always succeeds
+		manager := setup(t)
+		manager.healthCheckSettleDuration = 300 * time.Millisecond
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.CheckHealthFunc = func(ctx context.Context, endpoint string) error {
+			return nil
+		}
+		manager.client = kubernetesClient
+
+		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+		defer cancel()
+
+		// When it waits for health
+		err := manager.WaitForKubernetesHealthy(ctx, "https://test-endpoint:6443", nil)
+
+		// Then it still succeeds: the settle window is bounded by the remaining
+		// context deadline rather than being layered on top of it, so a healthy
+		// cluster isn't guaranteed to time out just because the caller's overall
+		// budget isn't comfortably larger than the settle duration.
+		if err != nil {
+			t.Errorf("Expected settle duration to be bounded by the caller's deadline so a healthy cluster still succeeds, got %v", err)
+		}
+	})
+
 	t.Run("TimeoutWaitingForHealth", func(t *testing.T) {
 		manager := setup(t)
 		kubernetesClient := client.NewMockKubernetesClient()


### PR DESCRIPTION
Closes #3204

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **High Risk**
>
> This changes the core wait loop used by every Kubernetes health check in the provisioner, and introduces a mandatory 30-second "settle" window whose default collides with an existing fixed 30-second caller timeout, likely breaking that caller outright.
>
> **Overview**
>
> The PR adds a `healthCheckSettleDuration` to `BaseKubernetesManager.WaitForKubernetesHealthy` so a health check only counts as successful once the API (and any requested node readiness) has held continuously for that duration, guarding against a Talos machine-config apply that reconciles asynchronously right after a health check passes. Any failure during the settle window resets the clock, and new tests cover both the settle-before-success and reset-on-mid-window-failure cases.
>
> The new default (30s) is added on top of whatever deadline the caller's context provides, rather than being carved out of it. `checkKubernetesReachableForDestroy` in `pkg/provisioner/provisioner.go` calls this function with a context whose entire timeout is `constants.DefaultKubernetesReachabilityCheckTimeout` (also 30s) — see the inline finding for why this makes that call effectively always time out, even against a healthy, reachable cluster.

<!-- /claude-code-review:summary -->
