### PR TITLE
fix(evaluator): improve error handling for deferred values and unclosed expressions

### DIFF
--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -2198,6 +2198,12 @@ func (p *BaseBlueprintProcessor) evaluateCondition(expr string, path string, sco
 	if err != nil {
 		return false, err
 	}
+	if evaluator.IsDeferredValue(evaluated) {
+		if deferredExpr, ok := evaluator.DeferredExpression(evaluated); ok {
+			return false, fmt.Errorf("condition references a value that is not yet resolved (still evaluating config, or awaiting a terraform apply): %s", deferredExpr)
+		}
+		return false, fmt.Errorf("condition references a value that is not yet resolved (still evaluating config, or awaiting a terraform apply)")
+	}
 	var result bool
 	switch v := evaluated.(type) {
 	case nil:

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -7211,6 +7211,55 @@ func TestEvaluateCondition_EvaluatesAgainstScope(t *testing.T) {
 			t.Error("Expected condition to be false when platform is 'docker'")
 		}
 	})
+
+	t.Run("ReturnsNamedErrorWhenExpressionEvaluatesToDeferredValue", func(t *testing.T) {
+		// Given a when: expression that resolves to a deferred value
+		mocks := setupProcessorMocks(t)
+		mocks.Evaluator.EvaluateFunc = func(expression string, featurePath string, scope map[string]any, evaluateDeferred bool) (any, error) {
+			return evaluator.DeferredValue{Expression: "terraform_output('compute', 'host_cpu')"}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+
+		// When evaluating the condition
+		got, err := processor.evaluateCondition("terraform_output('compute', 'host_cpu') > 4", "", nil)
+
+		// Then it returns a named error identifying the unresolved expression, not a type-name leak
+		if got {
+			t.Error("Expected false result on error")
+		}
+		if err == nil {
+			t.Fatal("Expected an error")
+		}
+		if !strings.Contains(err.Error(), "not yet resolved") {
+			t.Errorf("Expected error to name the unresolved-value cause, got: %v", err)
+		}
+		if strings.Contains(err.Error(), "evaluator.DeferredValue") {
+			t.Errorf("Expected error not to leak the internal Go type name, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "terraform_output('compute', 'host_cpu')") {
+			t.Errorf("Expected error to include the deferred expression text, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsNamedErrorWhenExpressionEvaluatesToDeferredValuePointer", func(t *testing.T) {
+		// Given a when: expression that resolves to a deferred value in its pointer form
+		mocks := setupProcessorMocks(t)
+		mocks.Evaluator.EvaluateFunc = func(expression string, featurePath string, scope map[string]any, evaluateDeferred bool) (any, error) {
+			return &evaluator.DeferredValue{Expression: "terraform_output('pki', 'cert')"}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+
+		// When evaluating the condition
+		got, err := processor.evaluateCondition("terraform_output('pki', 'cert') != ''", "", nil)
+
+		// Then it returns the same named not-yet-resolved error as the value form
+		if got {
+			t.Error("Expected false result on error")
+		}
+		if err == nil || !strings.Contains(err.Error(), "not yet resolved") {
+			t.Errorf("Expected a named not-yet-resolved error, got: %v", err)
+		}
+	})
 }
 
 // =============================================================================

--- a/pkg/runtime/evaluator/evaluator.go
+++ b/pkg/runtime/evaluator/evaluator.go
@@ -252,6 +252,7 @@ func (e *expressionEvaluator) evaluate(s string, facetPath string, scope map[str
 	}
 	result := s
 	deferredEncountered := false
+	nestedResultRescan := false
 	searchStart := 0
 	for iter := 0; iter < 20; iter++ {
 		idx := strings.Index(result[searchStart:], "${")
@@ -261,6 +262,9 @@ func (e *expressionEvaluator) evaluate(s string, facetPath string, scope map[str
 		start := searchStart + idx
 		end := findExpressionEnd(result, start)
 		if end == -1 {
+			if nestedResultRescan {
+				return "", fmt.Errorf("a nested expression's result still contains an unresolved expression that could not be re-parsed for further evaluation (likely an embedded reference that is not yet resolved): %.300s", result)
+			}
 			return "", fmt.Errorf("unclosed expression in string: %s", s)
 		}
 		expr := result[start+2 : end]
@@ -288,6 +292,7 @@ func (e *expressionEvaluator) evaluate(s string, facetPath string, scope map[str
 					return value, nil
 				}
 				result = str
+				nestedResultRescan = true
 				searchStart = 0
 				continue
 			}

--- a/pkg/runtime/evaluator/evaluator_public_test.go
+++ b/pkg/runtime/evaluator/evaluator_public_test.go
@@ -800,6 +800,59 @@ func TestExpressionEvaluator_Evaluate(t *testing.T) {
 		}
 	})
 
+	t.Run("ReturnsOriginalUnclosedErrorForAPlainLaterTypoNotProducedByNesting", func(t *testing.T) {
+		// Given a string with one expression that resolves fine and a second, independent
+		// expression that was already unclosed in the original literal input
+		evaluator, mockConfigHandler, _, _ := setupEvaluatorTest(t)
+		mockHandler := mockConfigHandler.(*config.MockConfigHandler)
+		mockHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"b": "X"}, nil
+		}
+
+		// When evaluating the string
+		_, err := evaluator.Evaluate("${b} rest ${bad", "", nil, false)
+
+		// Then the original-input message is returned, not the nested-rescan message — the first
+		// expression resolving successfully must not misattribute the second's plain typo
+		if err == nil {
+			t.Fatal("Expected an error")
+		}
+		if !strings.Contains(err.Error(), "unclosed expression in string: ${b} rest ${bad") {
+			t.Errorf("Expected the original-input message, got: %v", err)
+		}
+		if strings.Contains(err.Error(), "nested expression") {
+			t.Errorf("Expected no nested-expression misattribution, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsNamedErrorWhenANestedFunctionResultStillContainsAnUnresolvedExpression", func(t *testing.T) {
+		// Given a single expression whose own result (from string()) is itself a string that
+		// still contains an unresolved, unclosed expression — the pattern a preserved/deferred
+		// value produces once embedded in a larger value and stringified
+		evaluator, mockConfigHandler, _, _ := setupEvaluatorTest(t)
+		mockHandler := mockConfigHandler.(*config.MockConfigHandler)
+		mockHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{"b": "X", "raw": "${b} tail ${nope"}, nil
+		}
+
+		// When evaluating the string
+		_, err := evaluator.Evaluate("${string(raw)}", "", nil, false)
+
+		// Then the nested-rescan message names the cause instead of dumping the original input
+		if err == nil {
+			t.Fatal("Expected an error")
+		}
+		if strings.Contains(err.Error(), "unclosed expression in string: ${string(raw)}") {
+			t.Errorf("Expected the nested-rescan message, not the original-input message, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "still contains an unresolved expression") {
+			t.Errorf("Expected the nested-rescan error, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "X tail") {
+			t.Errorf("Expected the error to reference the re-scanned result, got: %v", err)
+		}
+	})
+
 	t.Run("SingleExprStringWithNestedExpressionContinuesUntilResolved", func(t *testing.T) {
 		evaluator, mockConfigHandler, _, _ := setupEvaluatorTest(t)
 		mockHandler := mockConfigHandler.(*config.MockConfigHandler)


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Touches error-message construction in the expression evaluator and blueprint condition evaluation; no control-flow or evaluation semantics change, so the blast radius is limited to clearer diagnostics.
>
> **Overview**
>
> This PR improves two error paths that previously leaked internal Go type names or pointed users at the wrong string. `evaluateCondition` in the blueprint processor now detects when a `when:` expression resolves to a `DeferredValue` (value or pointer form) and returns a named "not yet resolved" error naming the deferred expression, instead of falling through to the generic `%T` type-leak error. In the evaluator's `evaluate` loop, a new `nestedResultRescan` flag distinguishes an unclosed `${` found in a re-scanned nested result (from a resolved value that itself contains an unresolved expression) from one present in the original literal input, so the error message names the actual unresolved content rather than dumping the original string.
>
> Both changes are additive and narrowly scoped; new unit tests cover the deferred-value and pointer-form cases in the processor, and both the new nested-rescan message and a negative case (ensuring a plain later typo in the original input is not misattributed) in the evaluator.

<!-- /claude-code-review:summary -->
