### PR TITLE
fix(blueprint): scale same-block config convergence to chain depth

### DIFF
--- a/integration/composer_test.go
+++ b/integration/composer_test.go
@@ -64,6 +64,25 @@ func TestWindsorTest_DerivedConfigFixture(t *testing.T) {
 	}
 }
 
+// TestWindsorTest_ConfigSiblingChainsFixture reproduces #3206: two structurally identical
+// same-block sibling chains (ratio -> factor -> constrained flag -> reserve, several
+// references deep) must resolve independently. A same-block convergence budget too small for
+// the chain depth previously froze one chain's fields mid-resolution, so the second chain's
+// reserve value silently read the first chain's factor instead of its own.
+func TestWindsorTest_ConfigSiblingChainsFixture(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "config-sibling-chains")
+	env = append(env, "WINDSOR_CONTEXT=test")
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"test"}, env)
+	if err != nil {
+		t.Fatalf("windsor test: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
+	}
+	out := string(stdout) + string(stderr)
+	if !strings.Contains(out, "PASS") && !strings.Contains(out, "✓") {
+		t.Errorf("expected PASS or ✓ in output: %s", out)
+	}
+}
+
 // TestShowBlueprint_CrdsFacetSection verifies a facet's `crds:` declaration composes into the
 // blueprint's first-class `crds:` section (a flat scalar list, not kustomization objects), and that
 // the stack's root depends on the synthesized "crds" layer via the barrier.

--- a/integration/fixtures/config-sibling-chains/contexts/_template/blueprint.yaml
+++ b/integration/fixtures/config-sibling-chains/contexts/_template/blueprint.yaml
@@ -1,0 +1,5 @@
+kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: config-sibling-chains
+  description: Config sibling chains integration fixture

--- a/integration/fixtures/config-sibling-chains/contexts/_template/facets/config-tiers.yaml
+++ b/integration/fixtures/config-sibling-chains/contexts/_template/facets/config-tiers.yaml
@@ -1,0 +1,50 @@
+kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: config-tiers
+  description: >-
+    Two independent same-block sibling chains, each tapering a factor from a resource ratio
+    through several same-block references (ratio -> factor -> constrained flag -> reserve),
+    the shape that produced #3206: one chain's reserve value read the other chain's factor.
+
+when: (resources ?? null) != null
+
+config:
+- name: tiers
+  value:
+    a_threshold: { cpu: 2, memory: 4 }
+    b_threshold: { cpu: 4, memory: 4 }
+
+- name: tiers
+  value:
+    a_cpu_ratio: "${resources.a.cpu / tiers.a_threshold.cpu}"
+    a_memory_ratio: "${resources.a.memory / tiers.a_threshold.memory}"
+    a_ratio: "${tiers.a_cpu_ratio < tiers.a_memory_ratio ? tiers.a_cpu_ratio : tiers.a_memory_ratio}"
+    a_factor: "${tiers.a_ratio > 2 ? 0 : (tiers.a_ratio < 1 ? 1 : (2 - tiers.a_ratio))}"
+    a_constrained: "${tiers.a_factor > 0}"
+
+    b_cpu_ratio: "${resources.b.cpu / tiers.b_threshold.cpu}"
+    b_memory_ratio: "${resources.b.memory / tiers.b_threshold.memory}"
+    b_ratio: "${tiers.b_cpu_ratio < tiers.b_memory_ratio ? tiers.b_cpu_ratio : tiers.b_memory_ratio}"
+    b_factor: "${tiers.b_ratio > 2 ? 0 : (tiers.b_ratio < 1 ? 1 : (2 - tiers.b_ratio))}"
+    b_constrained: "${tiers.b_factor > 0}"
+    any_constrained: "${tiers.a_constrained || tiers.b_constrained}"
+
+- name: tiers
+  when: tiers.a_constrained
+  value:
+    a_reserve:
+      cpu: "${string(int(500 * tiers.a_factor + 0.5)) + 'm'}"
+
+- name: tiers
+  when: tiers.any_constrained
+  value:
+    b_reserve:
+      cpu: "${string(int(80 * tiers.b_factor + 0.5)) + 'm'}"
+
+terraform:
+- name: cluster
+  path: cluster/test
+  inputs:
+    a_reserve_cpu: "${tiers.a_reserve.cpu}"
+    b_reserve_cpu: "${tiers.b_reserve.cpu}"

--- a/integration/fixtures/config-sibling-chains/contexts/_template/metadata.yaml
+++ b/integration/fixtures/config-sibling-chains/contexts/_template/metadata.yaml
@@ -1,0 +1,2 @@
+name: config-sibling-chains
+description: Config sibling chains integration fixture

--- a/integration/fixtures/config-sibling-chains/contexts/_template/schema.yaml
+++ b/integration/fixtures/config-sibling-chains/contexts/_template/schema.yaml
@@ -1,0 +1,8 @@
+$schema: https://json-schema.org/draft/2020-12/schema
+title: Config Sibling Chains Fixture Schema
+type: object
+properties:
+  resources:
+    type: object
+    additionalProperties: true
+additionalProperties: true

--- a/integration/fixtures/config-sibling-chains/contexts/_template/tests/tiers.test.yaml
+++ b/integration/fixtures/config-sibling-chains/contexts/_template/tests/tiers.test.yaml
@@ -1,0 +1,17 @@
+cases:
+- name: two independent sibling chains resolve their own factor, not each other's (#3206)
+  values:
+    resources:
+      a:
+        cpu: 100
+        memory: 6
+      b:
+        cpu: 100
+        memory: 5
+  expect:
+    terraform:
+    - name: cluster
+      path: cluster/test
+      inputs:
+        a_reserve_cpu: 250m
+        b_reserve_cpu: 60m

--- a/integration/fixtures/config-sibling-chains/windsor.yaml
+++ b/integration/fixtures/config-sibling-chains/windsor.yaml
@@ -1,0 +1,4 @@
+version: v1alpha1
+contexts:
+  default: {}
+  test: {}

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -755,14 +755,12 @@ func (p *BaseBlueprintProcessor) mergeConfigBlocks(scope map[string]any, existin
 	return out, merged, nil
 }
 
-// evaluateGlobalScopeConfig evaluates all config block body expressions in globalScope in
-// blueprint context. The evaluation scope is contextScope (values from ConfigHandler) merged
-// with globalScope (facet config blocks) so expressions can reference both (e.g.
-// cluster.controlplanes.schedulable from values and talos.controlplanes from config blocks).
-// Same-block references are supported by re-evaluating each block until stable. Mutates
-// globalScope in place. Block evaluation order is determined by topoSortConfigBlocks —
-// each block evaluates after every block it references, regardless of which facet wrote
-// which first; alphabetical tiebreak for independent blocks.
+// evaluateGlobalScopeConfig evaluates every config block body in globalScope against contextScope
+// (ConfigHandler values) merged with globalScope (facet config blocks), so expressions can
+// reference both. Same-block sibling references converge by re-evaluating a block repeatedly, up
+// to its own key count — a chain of N dependent keys can take up to N passes, since each pass only
+// propagates values one dependency level further. Cross-block order comes from
+// topoSortConfigBlocks (alphabetical tiebreak for independents). Mutates globalScope in place.
 func (p *BaseBlueprintProcessor) evaluateGlobalScopeConfig(globalScope map[string]any, contextScope map[string]any) error {
 	if globalScope == nil {
 		return nil
@@ -776,7 +774,7 @@ func (p *BaseBlueprintProcessor) evaluateGlobalScopeConfig(globalScope map[strin
 	if err != nil {
 		return err
 	}
-	const maxSameBlockPasses = 5
+	const minSameBlockPasses = 5
 	const maxCrossBlockRounds = 5
 	for round := 0; round < maxCrossBlockRounds; round++ {
 		anyBlockChanged := false
@@ -810,6 +808,10 @@ func (p *BaseBlueprintProcessor) evaluateGlobalScopeConfig(globalScope map[strin
 					derivedKeys[k] = s
 				}
 			}
+			maxSameBlockPasses := len(bodyMap)
+			if maxSameBlockPasses < minSameBlockPasses {
+				maxSameBlockPasses = minSameBlockPasses
+			}
 			var previousEvaluatedOnly map[string]any
 			for pass := 0; pass < maxSameBlockPasses; pass++ {
 				var blockVal any
@@ -828,7 +830,7 @@ func (p *BaseBlueprintProcessor) evaluateGlobalScopeConfig(globalScope map[strin
 				if normalized, ok := normalizeDeferredValue(evaluated).(map[string]any); ok {
 					evaluated = normalized
 				}
-				if previousEvaluatedOnly != nil && reflect.DeepEqual(evaluated, previousEvaluatedOnly) && !containsExpressionInValue(evaluated) {
+				if previousEvaluatedOnly != nil && reflect.DeepEqual(evaluated, previousEvaluatedOnly) {
 					for k, orig := range derivedKeys {
 						evaluated[k] = orig
 					}

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -1811,6 +1811,97 @@ func TestProcessor_ProcessFacets_ConfigBlockSameBlockSiblingRefs(t *testing.T) {
 	// which registers a real deferred helper and exercises this post-convergence validation.
 }
 
+// TestProcessor_ProcessFacets_ConfigBlockDeepSameBlockChain reconstructs the shape of the
+// resource-tapering config in windsorcli/core's config-talos.yaml (#3206): sibling fields chained
+// five-plus levels deep within one config block (ratio -> factor -> a boolean derived from the
+// factor -> a boolean OR'd from two such booleans -> a when:-gated block reading the factor again).
+// A same-block convergence budget too small for the chain's depth causes a field partway through
+// the chain to freeze at a stale value instead of erroring, so a structurally-identical sibling
+// chain (the worker axis) silently resolves using a value read from a different chain (the
+// control-plane axis) instead of its own.
+func TestProcessor_ProcessFacets_ConfigBlockDeepSameBlockChain(t *testing.T) {
+	t.Run("StructurallyIdenticalSiblingChainsResolveIndependently", func(t *testing.T) {
+		// Given two independent tiers computing a taper factor via a chained ratio -> factor ->
+		// constrained-flag -> reserve pipeline, five-plus same-block references deep, gated
+		// behind when: clauses that themselves depend on earlier links in the same chain
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{
+				"cluster_resources_effective": map[string]any{
+					"controlplanes": map[string]any{"cpu": 100, "memory": 6},
+					"workers":       map[string]any{"cpu": 100, "memory": 5},
+				},
+			}, nil
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "talos"},
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "talos_common", Body: map[string]any{"value": map[string]any{
+						"cp_tier":          map[string]any{"threshold": map[string]any{"cpu": 2, "memory": 4}, "max": map[string]any{"kubelet_cpu": 500}},
+						"worker_threshold": map[string]any{"cpu": 4, "memory": 4},
+						"worker_max":       map[string]any{"kubelet_cpu": 80},
+					}}},
+					{Name: "talos_common", Body: map[string]any{"value": map[string]any{
+						"cp_cpu_ratio":          "${cluster_resources_effective.controlplanes.cpu / talos_common.cp_tier.threshold.cpu}",
+						"cp_memory_ratio":       "${cluster_resources_effective.controlplanes.memory / talos_common.cp_tier.threshold.memory}",
+						"cp_ratio":              "${talos_common.cp_cpu_ratio < talos_common.cp_memory_ratio ? talos_common.cp_cpu_ratio : talos_common.cp_memory_ratio}",
+						"cp_factor":             "${talos_common.cp_ratio > 2 ? 0 : (talos_common.cp_ratio < 1 ? 1 : (2 - talos_common.cp_ratio))}",
+						"resource_constrained":  "${talos_common.cp_factor > 0}",
+						"worker_cpu_ratio":      "${cluster_resources_effective.workers.cpu / talos_common.worker_threshold.cpu}",
+						"worker_memory_ratio":   "${cluster_resources_effective.workers.memory / talos_common.worker_threshold.memory}",
+						"worker_ratio":          "${talos_common.worker_cpu_ratio < talos_common.worker_memory_ratio ? talos_common.worker_cpu_ratio : talos_common.worker_memory_ratio}",
+						"worker_factor":         "${talos_common.worker_ratio > 2 ? 0 : (talos_common.worker_ratio < 1 ? 1 : (2 - talos_common.worker_ratio))}",
+						"worker_constrained":    "${talos_common.worker_factor > 0}",
+						"worker_reserve_needed": "${talos_common.resource_constrained || talos_common.worker_constrained}",
+					}}},
+					{Name: "talos_common", When: "talos_common.resource_constrained", Body: map[string]any{"value": map[string]any{
+						"cp_reserve": map[string]any{
+							"kubelet_cpu": "${string(int(talos_common.cp_tier.max.kubelet_cpu * talos_common.cp_factor + 0.5)) + 'm'}",
+						},
+					}}},
+					{Name: "talos_common", When: "talos_common.worker_reserve_needed", Body: map[string]any{"value": map[string]any{
+						"worker_reserve": map[string]any{
+							"kubelet_cpu": "${string(int(talos_common.worker_max.kubelet_cpu * talos_common.worker_factor + 0.5)) + 'm'}",
+						},
+					}}},
+				},
+			},
+		}
+
+		// When processing
+		scope, err := processor.ProcessFacets(&blueprintv1alpha1.Blueprint{}, facets)
+
+		// Then both chains converge, and the worker chain resolves using its own factor
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		block := scope["talos_common"].(map[string]any)
+		if block["cp_factor"] != 0.5 {
+			t.Errorf("Expected cp_factor 0.5, got %v", block["cp_factor"])
+		}
+		if block["worker_factor"] != 0.75 {
+			t.Errorf("Expected worker_factor 0.75, got %v", block["worker_factor"])
+		}
+		cpReserve, ok := block["cp_reserve"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected cp_reserve to resolve, got %#v", block["cp_reserve"])
+		}
+		if cpReserve["kubelet_cpu"] != "250m" {
+			t.Errorf("Expected cp_reserve.kubelet_cpu 250m, got %v", cpReserve["kubelet_cpu"])
+		}
+		workerReserve, ok := block["worker_reserve"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected worker_reserve to resolve, got %#v", block["worker_reserve"])
+		}
+		if workerReserve["kubelet_cpu"] != "60m" {
+			t.Errorf("Expected worker_reserve.kubelet_cpu 60m (worker_factor 0.75), not a value collided from cp_factor, got %v", workerReserve["kubelet_cpu"])
+		}
+	})
+}
+
 func TestProcessor_ProcessFacets_ConfigBlockEvaluationOrder(t *testing.T) {
 	// These tests pin the dependency-driven evaluation order for config blocks. The
 	// processor must evaluate a block AFTER every block it references via ${...}, no
@@ -2306,6 +2397,52 @@ func TestProcessor_ProcessFacets_ConfigDeferredValues(t *testing.T) {
 		deferred := processor.GetDeferredPaths()
 		if !deferred["substitutions.helm_registry"] {
 			t.Errorf("Expected helm_registry to be marked as deferred, got deferred paths: %v (value: %q)", deferred, helmReg)
+		}
+	})
+
+	t.Run("PermanentlyUnresolvableKeyStopsPassesEarlyRegardlessOfBlockSize", func(t *testing.T) {
+		// Given a large config block (so the same-block pass cap, sized to the block's own key
+		// count, would be large too) where one key can never resolve at composition time
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{}, nil
+		}
+
+		realEval := evaluator.NewExpressionEvaluator(mocks.ConfigHandler, mocks.Runtime.ProjectRoot, mocks.Runtime.ConfigRoot)
+		calls := 0
+		realEval.Register("deferred_helper", func(params []any, deferred bool) (any, error) {
+			calls++
+			if !deferred {
+				return nil, &evaluator.DeferredError{Expression: "deferred_helper()", Message: "deferred"}
+			}
+			return "resolved", nil
+		}, new(func() any))
+
+		mocks.Evaluator.EvaluateFunc = realEval.Evaluate
+		mocks.Evaluator.EvaluateMapFunc = realEval.EvaluateMap
+
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		body := map[string]any{"deferred_field": "${deferred_helper()}"}
+		for i := 0; i < 30; i++ {
+			body[fmt.Sprintf("padding_%d", i)] = fmt.Sprintf("literal_%d", i)
+		}
+		facets := []blueprintv1alpha1.Facet{{
+			Metadata: blueprintv1alpha1.Metadata{Name: "test-facet"},
+			Config: []blueprintv1alpha1.ConfigBlock{
+				{Name: "wide_block", Body: map[string]any{"value": body}},
+			},
+		}}
+
+		// When processing
+		_, err := processor.ProcessFacets(&blueprintv1alpha1.Blueprint{}, facets)
+
+		// Then the pass loop stops as soon as re-evaluation stops changing, not after burning
+		// through all 30+ keys' worth of passes on a value that can never resolve here
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if calls > 20 {
+			t.Errorf("Expected the pass loop to stop quickly once stable rather than scaling with the block's 31 keys, got %d calls to the never-resolving helper", calls)
 		}
 	})
 }


### PR DESCRIPTION
Closes #3206

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This changes the convergence loop in the composer's blueprint config-block evaluator, a shared code path exercised by every facet's `config:` blocks, though the change is narrowly scoped and well covered by new tests.
>
> **Overview**
>
> Fixes #3206: same-block sibling references (e.g. `ratio -> factor -> constrained flag -> reserve`) were capped at a fixed 5 re-evaluation passes regardless of chain depth, so a chain deeper than 5 links could freeze mid-resolution and let one sibling chain silently read a stale value computed for a different, structurally identical chain. The pass budget now scales with the block's own key count (floor of 5), and the same-block loop also drops an early-exit guard that previously kept iterating even after two passes produced identical output, so blocks that stabilize on an unresolved (e.g. permanently-deferred) expression stop promptly instead of burning through the full pass budget.
>
> The fix ships with a new processor unit test reconstructing the reported bug's chain depth, a "no error, but stops early" test bounding calls on a wide, never-resolving block, and a new integration fixture (`config-sibling-chains`) that reproduces the scenario end-to-end via `windsor test`.

<!-- /claude-code-review:summary -->
