### PR TITLE
fix(upgrade): recompose blueprint after source retarget

### DIFF
--- a/cmd/upgrade.go
+++ b/cmd/upgrade.go
@@ -100,6 +100,9 @@ windsor upgrade cluster --nodes=10.0.0.5 --image=ghcr.io/siderolabs/installer:v1
 				return err
 			}
 		}
+		if err := recomposeBlueprint(proj); err != nil {
+			return err
+		}
 		blueprint = proj.Composer.BlueprintHandler.Generate()
 		if blueprint == nil {
 			return fmt.Errorf("blueprint is not available")
@@ -327,6 +330,17 @@ func upgradeToLatest(cmd *cobra.Command, proj *project.Project) error {
 	}
 	for _, u := range upgrades {
 		fmt.Fprintf(cmd.OutOrStdout(), "Upgraded %s from %s to %s\n", u.Name, u.From, u.To)
+	}
+	return nil
+}
+
+// recomposeBlueprint reloads the blueprint from disk and recomposes it against the sources'
+// current content. RetargetSource and UpgradeSourcesToLatest only change source URLs in memory.
+// Write persists those URLs to blueprint.yaml but does not recompose. Without this call, Up,
+// Install, and Wait would build manifests from the blueprint composed before the source change.
+func recomposeBlueprint(proj *project.Project) error {
+	if err := proj.Composer.BlueprintHandler.LoadBlueprint(); err != nil {
+		return fmt.Errorf("error recomposing blueprint against updated sources: %w", err)
 	}
 	return nil
 }

--- a/cmd/upgrade_test.go
+++ b/cmd/upgrade_test.go
@@ -419,6 +419,51 @@ func TestUpgradeCmd_Latest(t *testing.T) {
 		}
 	})
 
+	t.Run("RecomposesAfterUpgradeBeforeGeneratingManifests", func(t *testing.T) {
+		// Given a bare upgrade that moves a source to its latest tag
+		mocks := setupApplyTest(t)
+		mocks.BlueprintHandler.UpgradeSourcesToLatestFunc = func() ([]blueprint.SourceUpgrade, error) {
+			return []blueprint.SourceUpgrade{{
+				Name: "core",
+				From: "oci://ghcr.io/windsorcli/core:v0.5.0",
+				To:   "oci://ghcr.io/windsorcli/core:v0.6.0",
+			}}, nil
+		}
+		var order []string
+		mocks.BlueprintHandler.WriteFunc = func(overwrite ...bool) error {
+			order = append(order, "write")
+			return nil
+		}
+		mocks.BlueprintHandler.LoadBlueprintFunc = func(...string) error {
+			order = append(order, "recompose")
+			return nil
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When running bare upgrade
+		cmd := createTestUpgradeCmd()
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the blueprint is reloaded and recomposed against the persisted bump, matching the
+		// --source retarget path's recompose behavior
+		writeIdx, recomposeIdx := -1, -1
+		for i, ev := range order {
+			if ev == "write" {
+				writeIdx = i
+			}
+			if ev == "recompose" {
+				recomposeIdx = i
+			}
+		}
+		if writeIdx == -1 || recomposeIdx == -1 || recomposeIdx < writeIdx {
+			t.Errorf("Expected recompose to follow the persisted write, got order: %v", order)
+		}
+	})
+
 	t.Run("ResolutionErrorAborts", func(t *testing.T) {
 		// Given resolving latest fails
 		mocks := setupApplyTest(t)
@@ -490,6 +535,102 @@ func TestUpgradeCmd_Source(t *testing.T) {
 		}
 		if !strings.Contains(out.String(), "Retargeted core") {
 			t.Errorf("Expected a retarget report, got: %q", out.String())
+		}
+	})
+
+	t.Run("RecomposesAfterRetargetBeforeGeneratingManifests", func(t *testing.T) {
+		t.Cleanup(func() { upgradeSources = nil })
+		// Given a retarget that persists a new source URL to blueprint.yaml
+		mocks := setupApplyTest(t)
+		var order []string
+		mocks.BlueprintHandler.RetargetSourceFunc = func(name, url string) (string, error) {
+			order = append(order, "retarget")
+			return "oci://ghcr.io/windsorcli/core:v0.3.0", nil
+		}
+		mocks.BlueprintHandler.WriteFunc = func(overwrite ...bool) error {
+			order = append(order, "write")
+			return nil
+		}
+		mocks.BlueprintHandler.LoadBlueprintFunc = func(...string) error {
+			order = append(order, "recompose")
+			return nil
+		}
+		generated := 0
+		mocks.BlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint {
+			generated++
+			order = append(order, fmt.Sprintf("generate-%d", generated))
+			return &blueprintv1alpha1.Blueprint{Metadata: blueprintv1alpha1.Metadata{Name: "test"}}
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When upgrading with --source
+		cmd := createTestUpgradeCmd()
+		cmd.SetArgs([]string{"--source", "core=oci://ghcr.io/windsorcli/core:v0.6.0"})
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the blueprint is reloaded and recomposed against the persisted source before the
+		// Generate() call whose result Up/Install/Wait actually build manifests from
+		recomposeIdx, writeIdx, lastGenerateIdx := -1, -1, -1
+		for i, ev := range order {
+			switch {
+			case ev == "write":
+				writeIdx = i
+			case ev == "recompose":
+				recomposeIdx = i
+			case strings.HasPrefix(ev, "generate-"):
+				lastGenerateIdx = i
+			}
+		}
+		if writeIdx == -1 || recomposeIdx == -1 || recomposeIdx < writeIdx {
+			t.Errorf("Expected recompose to follow the persisted write, got order: %v", order)
+		}
+		if lastGenerateIdx == -1 || lastGenerateIdx < recomposeIdx {
+			t.Errorf("Expected the final Generate() to follow recompose, got order: %v", order)
+		}
+	})
+
+	t.Run("RecomposeFailureAbortsBeforeApplying", func(t *testing.T) {
+		t.Cleanup(func() { upgradeSources = nil })
+		// Given a retarget whose recompose fails to pull the newly targeted source
+		mocks := setupApplyTest(t)
+		mocks.BlueprintHandler.RetargetSourceFunc = func(name, url string) (string, error) {
+			return "oci://ghcr.io/windsorcli/core:v0.3.0", nil
+		}
+		loadCalls := 0
+		mocks.BlueprintHandler.LoadBlueprintFunc = func(...string) error {
+			loadCalls++
+			if loadCalls == 1 {
+				return nil // Initialize's own load, before the retarget
+			}
+			return fmt.Errorf("failed to load source 'core': registry unreachable")
+		}
+		applied := false
+		mocks.KubernetesManager.ApplyBlueprintFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) error {
+			applied = true
+			return nil
+		}
+		proj := newApplyAllProject(mocks)
+
+		// When upgrading with --source
+		cmd := createTestUpgradeCmd()
+		cmd.SetArgs([]string{"--source", "core=oci://ghcr.io/windsorcli/core:v0.6.0"})
+		ctx := stdcontext.WithValue(stdcontext.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then it aborts with the recompose error before applying anything to the cluster
+		if err == nil {
+			t.Fatal("Expected an error when recompose fails, got nil")
+		}
+		if !strings.Contains(err.Error(), "recomposing blueprint") {
+			t.Errorf("Expected a recompose error, got: %v", err)
+		}
+		if applied {
+			t.Error("Expected no blueprint apply when recompose fails")
 		}
 	})
 

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -351,38 +351,30 @@ const kustomizationWaitErrorBudgetFraction = 0.25
 // doesn't burst the apiserver with one request per kustomization on every poll interval.
 const kustomizationCheckConcurrencyLimit = 10
 
-// WaitForKustomizations waits for kustomizations to be ready, calculating the timeout
-// from the longest dependency chain in the blueprint. Outputs a debug message describing
-// the total wait timeout being used before beginning polling. The wait also honors ctx:
-// a cancelled or deadline-exceeded context ends the wait immediately and returns ctx.Err(),
-// so a parent SIGTERM/Ctrl+C or command deadline can interrupt it (rather than requiring a
-// SIGKILL that bypasses the caller's defer cleanup). A not-found GetResource error is treated
-// as not-ready-yet and keeps polling.
+// WaitForKustomizations waits for kustomizations to be ready, calculating the timeout from the
+// longest dependency chain in the blueprint. It honors ctx: a cancelled or deadline-exceeded
+// context ends the wait immediately and returns ctx.Err(), so a parent SIGTERM/Ctrl+C or command
+// deadline can interrupt it cleanly.
 //
-// Every other GetResource error (auth, RBAC, TLS, connection, apiserver timeout) starts an
-// error streak timer and is tolerated as long as the streak stays within
+// A not-found GetResource error is treated as not-ready-yet. Any other GetResource error (auth,
+// RBAC, TLS, connection, apiserver timeout) is tolerated for up to
 // kustomizationWaitErrorBudgetFraction of the total timeout (floored at
-// kustomizationWaitMinErrorDuration so a short wait still gets a few retries); the streak
-// resets the moment any tick completes with no error. Errors are deliberately not classified
-// into permanent-vs-transient buckets: kustomize-controller and helm-controller, reconciling
-// this exact kind of dependency-readiness check against the same apiserver, don't either —
-// their terminal (no-retry) path is reserved for static errors in the object's own spec (an
-// invalid CEL expression, their own cross-namespace ACL denial), never a raw API error, on the
-// grounds that auth/RBAC/certs can change out from under a long-running wait just as easily as
-// a load-balancer failover can. The budget is proportional to wall-clock time rather than tick
-// count for the same reason it applies uniformly: even with per-kustomization checks run
-// concurrently, a CPU-starved apiserver can still make a tick take far longer than the nominal
-// poll interval, so counting ticks either fails fast on a cluster that would have recovered, or
-// (if loosened) tolerates a wildly inconsistent amount of real time depending on how slow each
-// tick happened to be.
+// kustomizationWaitMinErrorDuration), and the streak resets on any clean tick. These errors are
+// deliberately not classified as permanent vs. transient — matching kustomize-controller and
+// helm-controller, which reserve their no-retry path for a static error in the object's own
+// spec, never a raw API error.
+//
+// A Kustomization's own Ready=False condition is different: a Reason in
+// kustomizationTerminalReasons (BuildFailed, ArtifactFailed, ReconciliationFailed) ends the wait
+// immediately, since kustomize-controller repeats the same reason on every retry. Any other
+// Reason (Progressing, DependencyNotReady, or none yet) still counts as not-ready and keeps
+// polling.
 //
 // Each pending kustomization is checked concurrently within a tick, up to
-// kustomizationCheckConcurrencyLimit at once, so one slow or erroring GetResource call
-// doesn't hold up observing the rest of that tick's readiness progress.
-//
-// Readiness is tracked per kustomization: once observed Ready, a kustomization is dropped from
-// further polling, so a later periodic reconcile flipping it back to Reconciling doesn't reset
-// the wait.
+// kustomizationCheckConcurrencyLimit, so one slow or erroring check doesn't block the rest. Once
+// observed Ready, a kustomization is dropped from polling, so a later reconcile flipping it back
+// doesn't reset the wait. The tracked name set is deduplicated, since withCrdLayer can prepend a
+// CRD kustomization whose name collides with one declared elsewhere.
 func (k *BaseKubernetesManager) WaitForKustomizations(ctx context.Context, message string, blueprint *blueprintv1alpha1.Blueprint) error {
 	if blueprint == nil {
 		return fmt.Errorf("blueprint not provided")
@@ -390,10 +382,15 @@ func (k *BaseKubernetesManager) WaitForKustomizations(ctx context.Context, messa
 
 	timeout := k.calculateTotalWaitTime(blueprint)
 	kustomizationNames := make([]string, 0, len(blueprint.Kustomizations))
+	seenNames := make(map[string]bool, len(blueprint.Kustomizations))
 	for _, kustomization := range blueprint.Kustomizations {
 		if kustomization.DestroyOnly != nil && *kustomization.DestroyOnly {
 			continue
 		}
+		if seenNames[kustomization.Name] {
+			continue
+		}
+		seenNames[kustomization.Name] = true
 		kustomizationNames = append(kustomizationNames, kustomization.Name)
 	}
 
@@ -449,6 +446,11 @@ func (k *BaseKubernetesManager) WaitForKustomizations(ctx context.Context, messa
 			for i, name := range pending {
 				result := results[i]
 				if result.err != nil {
+					var failed *kustomizationFailedError
+					if errors.As(result.err, &failed) {
+						tui.Fail()
+						return fmt.Errorf("kustomization will not become ready: %w", failed)
+					}
 					if tickErr == nil {
 						tickErr = fmt.Errorf("error checking kustomization %s: %w", name, result.err)
 					}
@@ -973,8 +975,8 @@ func (k *BaseKubernetesManager) CheckGitRepositoryStatus() error {
 
 // GetKustomizationStatus returns a map indicating readiness for each specified kustomization in the default
 // Flux system namespace. If a kustomization is not found, its status is set to false. If any kustomization
-// has a Ready condition with Status False and Reason "ReconciliationFailed", an error is returned with the
-// failure message.
+// has a Ready condition with Status False and a Reason in kustomizationTerminalReasons, an error is
+// returned with the failure message.
 func (k *BaseKubernetesManager) GetKustomizationStatus(names []string) (map[string]bool, error) {
 	gvr := schema.GroupVersionResource{
 		Group:    "kustomize.toolkit.fluxcd.io",
@@ -1002,7 +1004,7 @@ func (k *BaseKubernetesManager) GetKustomizationStatus(names []string) (map[stri
 			if condition.Type == "Ready" {
 				if condition.Status == "True" {
 					ready = true
-				} else if condition.Status == "False" && (condition.Reason == "ReconciliationFailed" || condition.Reason == "ArtifactFailed") {
+				} else if condition.Status == "False" && kustomizationTerminalReasons[condition.Reason] {
 					return nil, fmt.Errorf("kustomization %s failed: %s", kustomizeObj.Name, condition.Message)
 				}
 				break
@@ -1683,10 +1685,38 @@ type kustomizationCheckResult struct {
 	err   error
 }
 
+// kustomizationTerminalReasons are Ready=False Reasons that describe a permanent problem: a
+// build error, an artifact fetch failure, or a failed apply. kustomize-controller repeats the
+// same reason on every retry, so waiting longer never helps. This differs from a reason like
+// "Progressing" or "DependencyNotReady", which does resolve with time. GetKustomizationStatus
+// and checkKustomizationReady both treat these reasons as fatal instead of polling to the
+// timeout.
+var kustomizationTerminalReasons = map[string]bool{
+	meta.BuildFailedReason:          true,
+	meta.ArtifactFailedReason:       true,
+	meta.ReconciliationFailedReason: true,
+}
+
+// kustomizationFailedError signals a Ready condition with a Reason in kustomizationTerminalReasons:
+// a failure polling will never resolve. WaitForKustomizations fails immediately on this error.
+// A raw GetResource API error still gets the error-streak tolerance instead (see WaitForKustomizations).
+type kustomizationFailedError struct {
+	name    string
+	reason  string
+	message string
+}
+
+func (e *kustomizationFailedError) Error() string {
+	return fmt.Sprintf("kustomization %s failed (%s): %s", e.name, e.reason, e.message)
+}
+
 // checkKustomizationReady fetches a single Kustomization and reports whether its status
 // carries a Ready=True condition. A not-found resource is reported not-ready with no error,
 // since it hasn't reconciled into existence yet; any other GetResource or decode failure is
-// reported not-ready with the error, for the caller's error-budget accounting.
+// reported not-ready with the error, for the caller's error-budget accounting. A Ready=False
+// condition with a Reason in kustomizationTerminalReasons returns a *kustomizationFailedError
+// instead, so WaitForKustomizations can fail immediately rather than poll a Kustomization
+// that will never become Ready.
 func (k *BaseKubernetesManager) checkKustomizationReady(name string) (bool, error) {
 	gvr := schema.GroupVersionResource{
 		Group:    "kustomize.toolkit.fluxcd.io",
@@ -1717,9 +1747,20 @@ func (k *BaseKubernetesManager) checkKustomizationReady(name string) (bool, erro
 		if !ok {
 			continue
 		}
-		if condMap["type"] == "Ready" && condMap["status"] == "True" {
+		if condMap["type"] != "Ready" {
+			continue
+		}
+		if condMap["status"] == "True" {
 			return true, nil
 		}
+		if condMap["status"] == "False" {
+			reason, _ := condMap["reason"].(string)
+			if kustomizationTerminalReasons[reason] {
+				message, _ := condMap["message"].(string)
+				return false, &kustomizationFailedError{name: name, reason: reason, message: message}
+			}
+		}
+		break
 	}
 	return false, nil
 }

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -651,6 +651,138 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 		}
 	})
 
+	t.Run("BuildFailedConditionFailsImmediately", func(t *testing.T) {
+		// Given a Kustomization stuck reporting a Ready=False/BuildFailed condition on every
+		// poll (e.g. a spec.components path composed against a source that no longer has it) —
+		// a state re-polling can never resolve, unlike a raw GetResource error
+		manager := setup(t)
+		manager.kustomizationWaitMinErrorDuration = 150 * time.Millisecond
+		kubernetesClient := client.NewMockKubernetesClient()
+		calls := 0
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			calls++
+			return &unstructured.Unstructured{
+				Object: map[string]any{
+					"status": map[string]any{
+						"conditions": []any{
+							map[string]any{
+								"type":    "Ready",
+								"status":  "False",
+								"reason":  meta.BuildFailedReason,
+								"message": "kustomize build failed: accumulating components: no such file or directory",
+							},
+						},
+					},
+				},
+			}, nil
+		}
+		manager.client = kubernetesClient
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{
+					Name:    "crds-core",
+					Timeout: &blueprintv1alpha1.DurationString{Duration: 10 * time.Minute},
+				},
+			},
+		}
+
+		start := time.Now()
+		err := manager.WaitForKustomizations(context.Background(), "Waiting for kustomizations", blueprint)
+		elapsed := time.Since(start)
+
+		// Then it fails immediately — well inside the error-streak budget, let alone the
+		// 10-minute timeout — naming the kustomization, reason, and underlying message
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "crds-core") || !strings.Contains(err.Error(), "no such file or directory") {
+			t.Errorf("Expected the failure to name the kustomization and its message, got: %v", err)
+		}
+		if elapsed >= manager.kustomizationWaitMinErrorDuration {
+			t.Errorf("Expected an immediate failure bypassing the error-streak budget, took %s", elapsed)
+		}
+		if calls > 2 {
+			t.Errorf("Expected the wait to stop after the first tick observes the failure, got %d calls", calls)
+		}
+	})
+
+	t.Run("ArtifactFailedAndReconciliationFailedAlsoFailImmediately", func(t *testing.T) {
+		// Given the other two terminal reasons kustomize-controller reports on Ready=False
+		for _, reason := range []string{meta.ArtifactFailedReason, meta.ReconciliationFailedReason} {
+			t.Run(reason, func(t *testing.T) {
+				manager := setup(t)
+				kubernetesClient := client.NewMockKubernetesClient()
+				kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+					return &unstructured.Unstructured{
+						Object: map[string]any{
+							"status": map[string]any{
+								"conditions": []any{
+									map[string]any{"type": "Ready", "status": "False", "reason": reason, "message": "boom"},
+								},
+							},
+						},
+					}, nil
+				}
+				manager.client = kubernetesClient
+
+				blueprint := &blueprintv1alpha1.Blueprint{
+					Kustomizations: []blueprintv1alpha1.Kustomization{
+						{Name: "test-kustomization", Timeout: &blueprintv1alpha1.DurationString{Duration: 10 * time.Minute}},
+					},
+				}
+
+				err := manager.WaitForKustomizations(context.Background(), "Waiting for kustomizations", blueprint)
+				if err == nil {
+					t.Fatalf("Expected an immediate failure for reason %s, got nil", reason)
+				}
+				if !strings.Contains(err.Error(), "boom") {
+					t.Errorf("Expected the underlying message surfaced, got: %v", err)
+				}
+			})
+		}
+	})
+
+	t.Run("ProgressingConditionKeepsPollingUntilReady", func(t *testing.T) {
+		// Given a Kustomization that reports Ready=False/Progressing — a normal in-flight
+		// state, not a terminal failure — before becoming Ready
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		calls := 0
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			calls++
+			status := "False"
+			reason := meta.ProgressingReason
+			if calls >= 3 {
+				status, reason = "True", ""
+			}
+			return &unstructured.Unstructured{
+				Object: map[string]any{
+					"status": map[string]any{
+						"conditions": []any{
+							map[string]any{"type": "Ready", "status": status, "reason": reason},
+						},
+					},
+				},
+			}, nil
+		}
+		manager.client = kubernetesClient
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "test-kustomization", Timeout: &blueprintv1alpha1.DurationString{Duration: 500 * time.Millisecond}},
+			},
+		}
+
+		err := manager.WaitForKustomizations(context.Background(), "Waiting for kustomizations", blueprint)
+		if err != nil {
+			t.Errorf("Expected Progressing to keep polling rather than fail, got %v", err)
+		}
+		if calls < 3 {
+			t.Errorf("Expected multiple polls before Ready, got %d calls", calls)
+		}
+	})
+
 	t.Run("TransientErrorIsToleratedThenSucceeds", func(t *testing.T) {
 		// Given GetResource fails with a non-not-found error a few times (e.g. a brief
 		// apiserver restart) but recovers well within the error-tolerance budget
@@ -1353,6 +1485,41 @@ func TestBaseKubernetesManager_WaitForKustomizations(t *testing.T) {
 		}
 		if !foundRegular {
 			t.Error("Expected regular kustomization to be queried")
+		}
+	})
+
+	t.Run("DuplicateNameCompletesOnceBothTicksObserveReady", func(t *testing.T) {
+		// Given a blueprint whose "crds-core" name is declared twice — e.g. withCrdLayer's
+		// synthesized CRD kustomization colliding with a name declared elsewhere — with both
+		// entries immediately reporting Ready. A non-deduplicated name list would compare a
+		// readyKustomizations map (naturally deduplicated, so it can only ever reach 1 entry
+		// for this name) against a target count of 2, which is never satisfiable and would
+		// hang until the timeout even though nothing is actually unready.
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, ns, name string) (*unstructured.Unstructured, error) {
+			return &unstructured.Unstructured{
+				Object: map[string]any{
+					"status": map[string]any{
+						"conditions": []any{
+							map[string]any{"type": "Ready", "status": "True"},
+						},
+					},
+				},
+			}, nil
+		}
+		manager.client = kubernetesClient
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Kustomizations: []blueprintv1alpha1.Kustomization{
+				{Name: "crds-core", Timeout: &blueprintv1alpha1.DurationString{Duration: 500 * time.Millisecond}},
+				{Name: "crds-core", Timeout: &blueprintv1alpha1.DurationString{Duration: 500 * time.Millisecond}},
+			},
+		}
+
+		err := manager.WaitForKustomizations(context.Background(), "Waiting for kustomizations", blueprint)
+		if err != nil {
+			t.Errorf("Expected the duplicate name to be collapsed and the wait to succeed, got %v", err)
 		}
 	})
 }
@@ -2823,6 +2990,55 @@ func TestBaseKubernetesManager_GetKustomizationStatus(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "kustomization k1 failed: kustomization path not found") {
 			t.Errorf("Expected error containing 'kustomization k1 failed: kustomization path not found', got %v", err)
+		}
+		if status != nil {
+			t.Errorf("Expected nil status, got %v", status)
+		}
+	})
+
+	t.Run("KustomizationBuildFailed", func(t *testing.T) {
+		// A BuildFailed Ready=False condition (a bad spec.components/spec.path in the composed
+		// Kustomization itself, distinct from ArtifactFailed's missing-fetched-content case) must
+		// also fail fast rather than reading back as merely not-ready.
+		manager := func(t *testing.T) *BaseKubernetesManager {
+			mocks := setupKubernetesMocks(t)
+			manager := NewKubernetesManager(mocks.KubernetesClient, mocks.ConfigHandler)
+			return manager
+		}(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.ListResourcesFunc = func(gvr schema.GroupVersionResource, namespace string) (*unstructured.UnstructuredList, error) {
+			return &unstructured.UnstructuredList{
+				Items: []unstructured.Unstructured{
+					{
+						Object: map[string]any{
+							"apiVersion": "kustomize.toolkit.fluxcd.io/v1",
+							"kind":       "Kustomization",
+							"metadata": map[string]any{
+								"name": "k1",
+							},
+							"status": map[string]any{
+								"conditions": []any{
+									map[string]any{
+										"type":    "Ready",
+										"status":  "False",
+										"reason":  "BuildFailed",
+										"message": "accumulating components: no such file or directory",
+									},
+								},
+							},
+						},
+					},
+				},
+			}, nil
+		}
+		manager.client = kubernetesClient
+
+		status, err := manager.GetKustomizationStatus([]string{"k1"})
+		if err == nil {
+			t.Error("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "kustomization k1 failed: accumulating components") {
+			t.Errorf("Expected error containing 'kustomization k1 failed: accumulating components', got %v", err)
 		}
 		if status != nil {
 			t.Errorf("Expected nil status, got %v", status)

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -389,37 +389,6 @@ func (i *Provisioner) DestroyAllTerraform(blueprint *blueprintv1alpha1.Blueprint
 	return i.destroyAllTerraform(blueprint, continueOnError, true, excludeIDs...)
 }
 
-// destroyAllTerraform is the shared implementation behind DestroyAllTerraform. checkReachability
-// is false only for Teardown's Stage 2 tier destroy: by the time Stage 2 runs, Stage 1 has
-// already destroyed the cluster by design, so an unreachable Kubernetes API is the expected state
-// rather than a signal of broken auth, and the backend tier never has a kubernetes/helm provider
-// dependency for the check to protect.
-func (i *Provisioner) destroyAllTerraform(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, checkReachability bool, excludeIDs ...string) (DestroyResult, error) {
-	var result DestroyResult
-	if blueprint == nil {
-		return result, fmt.Errorf("blueprint not provided")
-	}
-	if err := i.ensureTerraformStack(); err != nil {
-		return result, err
-	}
-	if i.TerraformStack == nil {
-		return result, fmt.Errorf("terraform is disabled")
-	}
-	if checkReachability {
-		if err := i.checkKubernetesReachableForDestroy(); err != nil {
-			return result, err
-		}
-	}
-	outcome, err := i.TerraformStack.DestroyAll(blueprint, continueOnError, excludeIDs...)
-	result.Destroyed = outcome.Destroyed
-	result.Skipped = outcome.Skipped
-	result.Failed = outcome.Failed
-	if err != nil {
-		return result, fmt.Errorf("failed to run terraform destroy: %w", err)
-	}
-	return result, nil
-}
-
 // Apply runs terraform init, plan, and apply for a single component identified by componentID.
 // Returns an error if terraform is disabled, the stack cannot be initialized, the component is
 // not found, or any terraform operation fails.
@@ -1202,193 +1171,12 @@ func (i *Provisioner) PlaceSecrets(ctx context.Context, resolved ResolvedSecrets
 	})
 }
 
-// secretDigest returns a stable content digest for a secret's resolved data, used to roll consuming
-// workloads only when the content actually changes. Keys are sorted and each key and value is
-// length-delimited by a NUL so distinct maps cannot collide, then hashed with SHA-256. The digest is
-// one-way: it detects change without revealing the plaintext it summarizes.
-func secretDigest(stringData map[string]string) string {
-	keys := make([]string, 0, len(stringData))
-	for k := range stringData {
-		keys = append(keys, k)
-	}
-	slices.Sort(keys)
-	h := sha256.New()
-	for _, k := range keys {
-		h.Write([]byte(k))
-		h.Write([]byte{0})
-		h.Write([]byte(stringData[k]))
-		h.Write([]byte{0})
-	}
-	return hex.EncodeToString(h.Sum(nil))
-}
-
-// trySecretNamespaces reports where a secret should be placed and whether every target namespace exists
-// yet, without blocking, so PlaceSecrets can place the ready ones and poll for the rest. When the entry
-// names namespaces explicitly they are the targets, gated on each existing in the cluster regardless of
-// which kustomization created it — the author named the target, so a secret whose namespace is created by a
-// different kustomization is not blocked on the owning kustomization's inventory. When it names none the
-// target is auto-resolved from the owning kustomization's Flux inventory: the namespace it creates, or —
-// when it creates none — the single namespace its resources are deployed into. Auto-resolution fails closed
-// when that spans more than one namespace (ambiguous — the author must name the target via `namespaces:`),
-// and once the kustomization has reconciled but offers nothing to infer from (its inventory is populated
-// yet names no namespace), rather than waiting forever. A (nil, false, nil) return means "not resolvable
-// yet, keep polling" — the named namespaces don't exist, or the owning kustomization has not reconciled.
-// Gating on the namespace existing — not on the owning kustomization being Ready — lets a secret be placed
-// the moment its namespace appears, so a consumer whose readiness depends on it can never deadlock.
-func (i *Provisioner) trySecretNamespaces(kustomizationName string, explicit []string) ([]string, bool, error) {
-	if len(explicit) > 0 {
-		missing, err := i.missingClusterNamespaces(explicit)
-		if err != nil {
-			return nil, false, err
-		}
-		if len(missing) == 0 {
-			return slices.Clone(explicit), true, nil
-		}
-		return nil, false, nil
-	}
-	entries, err := i.KubernetesManager.GetKustomizationInventory(kustomizationName, i.fluxNamespace())
-	if err != nil {
-		return nil, false, fmt.Errorf("reading inventory for kustomization %q: %w", kustomizationName, err)
-	}
-	candidates := autoResolveNamespaces(entries)
-	switch {
-	case len(candidates) == 1:
-		return candidates, true, nil
-	case len(candidates) > 1:
-		return nil, false, fmt.Errorf("kustomization %q spans multiple namespaces (%s); set `namespaces:` on the secret to choose where to place it", kustomizationName, strings.Join(candidates, ", "))
-	case len(entries) > 0:
-		return nil, false, fmt.Errorf("kustomization %q creates no namespace and deploys no namespaced resources to infer one from; set `namespaces:` on the secret to choose where to place it", kustomizationName)
-	}
-	return nil, false, nil
-}
-
-// pendingSummary renders the secrets still awaiting a namespace as sorted "secret (kustomization)" entries —
-// naming the explicit target namespaces when the entry declared them — for the progress and timeout lines.
-func pendingSummary(pending []pendingPlacement) string {
-	parts := make([]string, 0, len(pending))
-	for _, p := range pending {
-		if len(p.secret.Namespaces) > 0 {
-			parts = append(parts, fmt.Sprintf("%s (%s)→%s", p.secretName, p.kustomization, strings.Join(p.secret.Namespaces, ",")))
-		} else {
-			parts = append(parts, fmt.Sprintf("%s (%s)", p.secretName, p.kustomization))
-		}
-	}
-	slices.Sort(parts)
-	return strings.Join(parts, ", ")
-}
-
-// autoResolveNamespaces infers where a secret should land when its entry names no namespace, from the
-// owning kustomization's Flux inventory. It prefers the Namespace object(s) the kustomization creates; when
-// it creates none, it falls back to the distinct namespaces its namespaced resources are deployed into, so
-// a kustomization that deploys into a namespace another kustomization created is still resolvable. The
-// result is sorted so a multi-namespace outcome reads deterministically.
-func autoResolveNamespaces(entries []kubernetes.InventoryEntry) []string {
-	created := make(map[string]struct{})
-	deployed := make(map[string]struct{})
-	for _, entry := range entries {
-		if entry.Kind == "Namespace" {
-			created[entry.Name] = struct{}{}
-		}
-		if entry.Namespace != "" {
-			deployed[entry.Namespace] = struct{}{}
-		}
-	}
-	chosen := created
-	if len(chosen) == 0 {
-		chosen = deployed
-	}
-	out := make([]string, 0, len(chosen))
-	for ns := range chosen {
-		out = append(out, ns)
-	}
-	slices.Sort(out)
-	return out
-}
-
-// missingClusterNamespaces returns the members of want that do not yet exist in the cluster, preserving
-// want's order. It is how placement gates a secret that names its target namespace(s) explicitly: on those
-// namespaces existing, regardless of which kustomization created them.
-func (i *Provisioner) missingClusterNamespaces(want []string) ([]string, error) {
-	var missing []string
-	for _, ns := range want {
-		exists, err := i.KubernetesManager.NamespaceExists(ns)
-		if err != nil {
-			return nil, fmt.Errorf("checking namespace %q: %w", ns, err)
-		}
-		if !exists {
-			missing = append(missing, ns)
-		}
-	}
-	return missing, nil
-}
-
-// reconcileKustomizations requests an immediate flux reconcile of the named Kustomizations, best-effort: it
-// initializes the notifier if needed and swallows any error, so a placement round is never failed by a
-// reconcile nudge. A nil or empty names slice is a no-op.
-func (i *Provisioner) reconcileKustomizations(ctx context.Context, names []string) {
-	if len(names) == 0 {
-		return
-	}
-	if err := i.ensureNotifier(); err != nil {
-		return
-	}
-	_ = i.Notifier.ReconcileKustomizations(ctx, names)
-}
-
-// helmReleaseReady reports whether a HelmRelease currently carries a Ready=True condition.
-func helmReleaseReady(hr helmv2.HelmRelease) bool {
-	for _, c := range hr.Status.Conditions {
-		if c.Type == "Ready" {
-			return c.Status == "True"
-		}
-	}
-	return false
-}
-
-// forceStalledHelmReleases force-reconciles any HelmRelease owned by the given kustomizations that is not
-// Ready. A release that failed to install or upgrade — e.g. because a secret it needs was not yet present —
-// stalls and will not retry on a plain reconcile of its owning Kustomization, since the release spec is
-// unchanged; forcing it (requestedAt + forceAt) makes helm-controller retry now that its inputs may be in
-// place. Best-effort: read failures and the reconcile request are swallowed, and healthy releases are left
-// untouched so no needless upgrade fires.
-func (i *Provisioner) forceStalledHelmReleases(ctx context.Context, kustomizations []string) {
-	var refs []fluxinfra.HelmReleaseRef
-	seen := make(map[string]struct{})
-	for _, name := range kustomizations {
-		hrs, err := i.KubernetesManager.GetHelmReleasesForKustomization(name, i.fluxNamespace())
-		if err != nil {
-			continue
-		}
-		for _, hr := range hrs {
-			if helmReleaseReady(hr) {
-				continue
-			}
-			key := hr.Namespace + "/" + hr.Name
-			if _, dup := seen[key]; dup {
-				continue
-			}
-			seen[key] = struct{}{}
-			refs = append(refs, fluxinfra.HelmReleaseRef{Namespace: hr.Namespace, Name: hr.Name})
-		}
-	}
-	if len(refs) == 0 {
-		return
-	}
-	if err := i.ensureNotifier(); err != nil {
-		return
-	}
-	_ = i.Notifier.ReconcileHelmReleases(ctx, refs, true)
-}
-
-// Converge actively drives the blueprint's kustomizations toward Ready within timeout, best-effort. Each
-// round it reads readiness (without failing on a failed kustomization) and, for every kustomization not yet
-// Ready, requests an immediate reconcile and forces any stalled HelmRelease it owns — so a chain that
-// stalled after apply (a dependent waiting on a now-ready dependency, or a HelmRelease that failed and
-// exhausted its remediation) recovers in seconds rather than at the next flux interval. Nudges are
-// throttled to keep reconcile traffic modest. It returns as soon as every kustomization is Ready, or when
-// timeout elapses; it is a driver, not a gate, so a still-unready cluster is not an error here — callers
-// that must fail on un-readiness use Wait afterward. A nil blueprint or missing kubernetes manager is a
-// no-op.
+// Converge drives the blueprint's kustomizations toward Ready within timeout, best-effort. Each
+// round it reads readiness, then reconciles and force-nudges any stalled HelmRelease for every
+// kustomization not yet Ready, so a stalled chain recovers in seconds instead of waiting for the
+// next Flux interval. It returns once everything is Ready or the timeout elapses; a still-unready
+// cluster is not an error here (use Wait for that). A nil blueprint or missing kubernetes manager
+// is a no-op.
 func (i *Provisioner) Converge(ctx context.Context, blueprint *blueprintv1alpha1.Blueprint, timeout time.Duration) error {
 	if blueprint == nil || i.KubernetesManager == nil {
 		return nil
@@ -1421,88 +1209,6 @@ func (i *Provisioner) Converge(ctx context.Context, blueprint *blueprintv1alpha1
 			}
 		}
 	})
-}
-
-// convergeNames returns the names of the blueprint's non-destroyOnly kustomizations, the set Converge
-// drives toward Ready.
-func convergeNames(bp *blueprintv1alpha1.Blueprint) []string {
-	names := make([]string, 0, len(bp.Kustomizations))
-	for _, k := range bp.Kustomizations {
-		if k.DestroyOnly != nil && *k.DestroyOnly {
-			continue
-		}
-		names = append(names, k.Name)
-	}
-	return names
-}
-
-// nudgeFrontier requests an immediate reconcile of the blueprint's "frontier" kustomizations — those not
-// yet Ready whose every dependency is already Ready — and force-reconciles any stalled HelmRelease they own.
-// The frontier is the only set a nudge can actually advance: an already-Ready kustomization would just churn
-// (needless reconciles that flap otherwise-healthy resources), and one still blocked on a not-ready
-// dependency will not progress no matter how often it is poked. Each frontier member is nudged at most once
-// while it stays not-Ready — recorded in nudged and cleared when it goes Ready — so successive calls do not
-// re-poke the same resource; instead, as a layer goes Ready the next layer becomes the frontier and gets its
-// single nudge, walking the DAG upward by state transition rather than a blanket timer. Best-effort: a
-// readiness read error is a no-op, and nudged carries the one-shot state across calls within one operation.
-func (i *Provisioner) nudgeFrontier(ctx context.Context, blueprint *blueprintv1alpha1.Blueprint, nudged map[string]struct{}) []string {
-	if blueprint == nil {
-		return nil
-	}
-	names := convergeNames(blueprint)
-	if len(names) == 0 {
-		return nil
-	}
-	readiness, err := i.KubernetesManager.GetKustomizationReadiness(names)
-	if err != nil {
-		return names // unknown readiness: report all not-Ready so a caller keeps waiting, but nudge nothing
-	}
-	deps := make(map[string][]string, len(blueprint.Kustomizations))
-	for _, k := range blueprint.Kustomizations {
-		deps[k.Name] = k.DependsOn
-	}
-
-	var notReady, frontier []string
-	for _, name := range names {
-		if readiness[name] {
-			delete(nudged, name) // Ready now — permit a fresh nudge if it later regresses
-			continue
-		}
-		notReady = append(notReady, name)
-		if _, done := nudged[name]; done {
-			continue // already nudged while not-Ready; wait for it to progress rather than re-poking
-		}
-		depsReady := true
-		for _, d := range deps[name] {
-			if r, known := readiness[d]; known && !r {
-				depsReady = false
-				break
-			}
-		}
-		if depsReady {
-			frontier = append(frontier, name)
-		}
-	}
-	if len(frontier) > 0 {
-		slices.Sort(frontier)
-		for _, n := range frontier {
-			nudged[n] = struct{}{}
-		}
-		i.reconcileKustomizations(ctx, frontier)
-		i.forceStalledHelmReleases(ctx, frontier)
-	}
-	slices.Sort(notReady)
-	return notReady
-}
-
-// sortedStringKeys returns the keys of a set as a sorted slice.
-func sortedStringKeys(m map[string]struct{}) []string {
-	out := make([]string, 0, len(m))
-	for k := range m {
-		out = append(out, k)
-	}
-	slices.Sort(out)
-	return out
 }
 
 // WriteVersionMarker records the blueprint version applied to this context as a marker ConfigMap
@@ -1884,6 +1590,287 @@ func (i *Provisioner) Close() {
 // =============================================================================
 // Private Methods
 // =============================================================================
+
+// convergeNames returns the deduplicated names of the blueprint's non-destroyOnly kustomizations.
+// This is the set Converge drives toward Ready. withCrdLayer prepends CRD kustomizations
+// without checking for name collisions. Dedup keeps a collision from double-printing in
+// progress output.
+func convergeNames(bp *blueprintv1alpha1.Blueprint) []string {
+	names := make([]string, 0, len(bp.Kustomizations))
+	seen := make(map[string]bool, len(bp.Kustomizations))
+	for _, k := range bp.Kustomizations {
+		if k.DestroyOnly != nil && *k.DestroyOnly {
+			continue
+		}
+		if seen[k.Name] {
+			continue
+		}
+		seen[k.Name] = true
+		names = append(names, k.Name)
+	}
+	return names
+}
+
+// nudgeFrontier reconciles the blueprint's "frontier" kustomizations: those not yet Ready whose
+// dependencies are all Ready. It also force-reconciles any stalled HelmRelease they own. Each
+// frontier member is nudged once per not-Ready streak, tracked in nudged, so repeat calls do not
+// re-poke it. On a readiness read error, every kustomization is reported not-ready and nothing is
+// nudged.
+func (i *Provisioner) nudgeFrontier(ctx context.Context, blueprint *blueprintv1alpha1.Blueprint, nudged map[string]struct{}) []string {
+	if blueprint == nil {
+		return nil
+	}
+	names := convergeNames(blueprint)
+	if len(names) == 0 {
+		return nil
+	}
+	readiness, err := i.KubernetesManager.GetKustomizationReadiness(names)
+	if err != nil {
+		return names
+	}
+	deps := make(map[string][]string, len(blueprint.Kustomizations))
+	for _, k := range blueprint.Kustomizations {
+		deps[k.Name] = k.DependsOn
+	}
+
+	var notReady, frontier []string
+	for _, name := range names {
+		if readiness[name] {
+			delete(nudged, name)
+			continue
+		}
+		notReady = append(notReady, name)
+		if _, done := nudged[name]; done {
+			continue
+		}
+		depsReady := true
+		for _, d := range deps[name] {
+			if r, known := readiness[d]; known && !r {
+				depsReady = false
+				break
+			}
+		}
+		if depsReady {
+			frontier = append(frontier, name)
+		}
+	}
+	if len(frontier) > 0 {
+		slices.Sort(frontier)
+		for _, n := range frontier {
+			nudged[n] = struct{}{}
+		}
+		i.reconcileKustomizations(ctx, frontier)
+		i.forceStalledHelmReleases(ctx, frontier)
+	}
+	slices.Sort(notReady)
+	return notReady
+}
+
+// sortedStringKeys returns the keys of a set as a sorted slice.
+func sortedStringKeys(m map[string]struct{}) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// destroyAllTerraform is the shared implementation behind DestroyAllTerraform. checkReachability
+// is false only for Teardown's Stage 2 tier destroy. By that stage, Stage 1 has already destroyed
+// the cluster, so an unreachable Kubernetes API is expected, not a sign of broken auth. The
+// backend tier also has no kubernetes/helm provider dependency for the check to protect.
+func (i *Provisioner) destroyAllTerraform(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, checkReachability bool, excludeIDs ...string) (DestroyResult, error) {
+	var result DestroyResult
+	if blueprint == nil {
+		return result, fmt.Errorf("blueprint not provided")
+	}
+	if err := i.ensureTerraformStack(); err != nil {
+		return result, err
+	}
+	if i.TerraformStack == nil {
+		return result, fmt.Errorf("terraform is disabled")
+	}
+	if checkReachability {
+		if err := i.checkKubernetesReachableForDestroy(); err != nil {
+			return result, err
+		}
+	}
+	outcome, err := i.TerraformStack.DestroyAll(blueprint, continueOnError, excludeIDs...)
+	result.Destroyed = outcome.Destroyed
+	result.Skipped = outcome.Skipped
+	result.Failed = outcome.Failed
+	if err != nil {
+		return result, fmt.Errorf("failed to run terraform destroy: %w", err)
+	}
+	return result, nil
+}
+
+// secretDigest returns a stable content digest for a secret's resolved data. Consumers use it to
+// roll workloads only when the content changes. Keys are sorted, and each key and value is
+// NUL-delimited so distinct maps cannot collide, then hashed with SHA-256. The digest is one-way:
+// it detects change without revealing the plaintext.
+func secretDigest(stringData map[string]string) string {
+	keys := make([]string, 0, len(stringData))
+	for k := range stringData {
+		keys = append(keys, k)
+	}
+	slices.Sort(keys)
+	h := sha256.New()
+	for _, k := range keys {
+		h.Write([]byte(k))
+		h.Write([]byte{0})
+		h.Write([]byte(stringData[k]))
+		h.Write([]byte{0})
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// trySecretNamespaces resolves where to place a secret and reports whether every target namespace
+// exists yet. Explicit namespaces are gated on existing in the cluster. With no explicit
+// namespaces, the target is auto-resolved from the owning kustomization's Flux inventory, and
+// fails if that resolves to more than one namespace. A (nil, false, nil) return means not
+// resolvable yet: keep polling.
+func (i *Provisioner) trySecretNamespaces(kustomizationName string, explicit []string) ([]string, bool, error) {
+	if len(explicit) > 0 {
+		missing, err := i.missingClusterNamespaces(explicit)
+		if err != nil {
+			return nil, false, err
+		}
+		if len(missing) == 0 {
+			return slices.Clone(explicit), true, nil
+		}
+		return nil, false, nil
+	}
+	entries, err := i.KubernetesManager.GetKustomizationInventory(kustomizationName, i.fluxNamespace())
+	if err != nil {
+		return nil, false, fmt.Errorf("reading inventory for kustomization %q: %w", kustomizationName, err)
+	}
+	candidates := autoResolveNamespaces(entries)
+	switch {
+	case len(candidates) == 1:
+		return candidates, true, nil
+	case len(candidates) > 1:
+		return nil, false, fmt.Errorf("kustomization %q spans multiple namespaces (%s); set `namespaces:` on the secret to choose where to place it", kustomizationName, strings.Join(candidates, ", "))
+	case len(entries) > 0:
+		return nil, false, fmt.Errorf("kustomization %q creates no namespace and deploys no namespaced resources to infer one from; set `namespaces:` on the secret to choose where to place it", kustomizationName)
+	}
+	return nil, false, nil
+}
+
+// pendingSummary renders secrets still awaiting a namespace as sorted "secret (kustomization)"
+// entries, naming explicit target namespaces when the entry declared them.
+func pendingSummary(pending []pendingPlacement) string {
+	parts := make([]string, 0, len(pending))
+	for _, p := range pending {
+		if len(p.secret.Namespaces) > 0 {
+			parts = append(parts, fmt.Sprintf("%s (%s)→%s", p.secretName, p.kustomization, strings.Join(p.secret.Namespaces, ",")))
+		} else {
+			parts = append(parts, fmt.Sprintf("%s (%s)", p.secretName, p.kustomization))
+		}
+	}
+	slices.Sort(parts)
+	return strings.Join(parts, ", ")
+}
+
+// autoResolveNamespaces infers where a secret should land when its entry names no namespace, using
+// the owning kustomization's Flux inventory. It prefers namespaces the kustomization creates, and
+// falls back to the namespaces its resources deploy into. The result is sorted.
+func autoResolveNamespaces(entries []kubernetes.InventoryEntry) []string {
+	created := make(map[string]struct{})
+	deployed := make(map[string]struct{})
+	for _, entry := range entries {
+		if entry.Kind == "Namespace" {
+			created[entry.Name] = struct{}{}
+		}
+		if entry.Namespace != "" {
+			deployed[entry.Namespace] = struct{}{}
+		}
+	}
+	chosen := created
+	if len(chosen) == 0 {
+		chosen = deployed
+	}
+	out := make([]string, 0, len(chosen))
+	for ns := range chosen {
+		out = append(out, ns)
+	}
+	slices.Sort(out)
+	return out
+}
+
+// missingClusterNamespaces returns the members of want that do not yet exist in the cluster,
+// preserving want's order.
+func (i *Provisioner) missingClusterNamespaces(want []string) ([]string, error) {
+	var missing []string
+	for _, ns := range want {
+		exists, err := i.KubernetesManager.NamespaceExists(ns)
+		if err != nil {
+			return nil, fmt.Errorf("checking namespace %q: %w", ns, err)
+		}
+		if !exists {
+			missing = append(missing, ns)
+		}
+	}
+	return missing, nil
+}
+
+// reconcileKustomizations requests an immediate Flux reconcile of the named Kustomizations. It is
+// best-effort: errors are swallowed, so a placement round never fails on a reconcile nudge. A nil
+// or empty names slice is a no-op.
+func (i *Provisioner) reconcileKustomizations(ctx context.Context, names []string) {
+	if len(names) == 0 {
+		return
+	}
+	if err := i.ensureNotifier(); err != nil {
+		return
+	}
+	_ = i.Notifier.ReconcileKustomizations(ctx, names)
+}
+
+// helmReleaseReady reports whether a HelmRelease currently carries a Ready=True condition.
+func helmReleaseReady(hr helmv2.HelmRelease) bool {
+	for _, c := range hr.Status.Conditions {
+		if c.Type == "Ready" {
+			return c.Status == "True"
+		}
+	}
+	return false
+}
+
+// forceStalledHelmReleases force-reconciles any HelmRelease owned by the given kustomizations that
+// is not Ready. A release that failed to install or upgrade (for example, a missing secret) stalls
+// and does not retry on a plain Kustomization reconcile, since its spec is unchanged. Forcing it
+// makes helm-controller retry. Best-effort: failures are swallowed, and healthy releases are left
+// untouched.
+func (i *Provisioner) forceStalledHelmReleases(ctx context.Context, kustomizations []string) {
+	var refs []fluxinfra.HelmReleaseRef
+	seen := make(map[string]struct{})
+	for _, name := range kustomizations {
+		hrs, err := i.KubernetesManager.GetHelmReleasesForKustomization(name, i.fluxNamespace())
+		if err != nil {
+			continue
+		}
+		for _, hr := range hrs {
+			if helmReleaseReady(hr) {
+				continue
+			}
+			key := hr.Namespace + "/" + hr.Name
+			if _, dup := seen[key]; dup {
+				continue
+			}
+			seen[key] = struct{}{}
+			refs = append(refs, fluxinfra.HelmReleaseRef{Namespace: hr.Namespace, Name: hr.Name})
+		}
+	}
+	if len(refs) == 0 {
+		return
+	}
+	if err := i.ensureNotifier(); err != nil {
+		return
+	}
+	_ = i.Notifier.ReconcileHelmReleases(ctx, refs, true)
+}
 
 // applyDirect runs terraform apply directly against the configured backend, with no tier
 // detection or pivot. Used by Up when no tier applies, and by applyWithBackendPivot's Stage

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -4762,6 +4762,41 @@ func TestProvisioner_ResolveSecrets(t *testing.T) {
 	})
 }
 
+func TestConvergeNames(t *testing.T) {
+	t.Run("DeduplicatesACollidingName", func(t *testing.T) {
+		// Given a blueprint where a kustomization name appears twice — e.g. withCrdLayer's
+		// synthesized CRD kustomization colliding with a name already declared elsewhere
+		bp := &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{
+			{Name: "crds-core"},
+			{Name: "crds-core"},
+			{Name: "lb-install"},
+		}}
+
+		// When collecting the names Converge drives toward Ready
+		names := convergeNames(bp)
+
+		// Then the duplicate collapses to one entry, so a nudgeFrontier readiness comparison
+		// against this set can't be inflated past what is actually reachable
+		if !slices.Equal(names, []string{"crds-core", "lb-install"}) {
+			t.Errorf("expected deduplicated [crds-core lb-install], got %v", names)
+		}
+	})
+
+	t.Run("SkipsDestroyOnlyRegardlessOfADuplicateNonDestroyOnlyEntry", func(t *testing.T) {
+		destroyOnly := true
+		bp := &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{
+			{Name: "a"},
+			{Name: "a", DestroyOnly: &destroyOnly},
+		}}
+
+		names := convergeNames(bp)
+
+		if !slices.Equal(names, []string{"a"}) {
+			t.Errorf("expected [a], got %v", names)
+		}
+	})
+}
+
 func TestProvisioner_nudgeFrontier(t *testing.T) {
 	// crds Ready; lb depends on crds (frontier); gateway depends on the not-ready lb (blocked, not frontier).
 	bp := &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{
@@ -4790,6 +4825,29 @@ func TestProvisioner_nudgeFrontier(t *testing.T) {
 		newProv(mocks, notifier).nudgeFrontier(context.Background(), bp, map[string]struct{}{})
 		if len(nudgedNames) != 1 || !slices.Equal(nudgedNames[0], []string{"lb-install"}) {
 			t.Errorf("expected only lb-install nudged, got %v", nudgedNames)
+		}
+	})
+
+	t.Run("DuplicateNameIsQueriedOnce", func(t *testing.T) {
+		// Given a blueprint whose crds kustomization name is declared twice (e.g. a collision
+		// with withCrdLayer's synthesized entry), all Ready
+		dup := &blueprintv1alpha1.Blueprint{Kustomizations: []blueprintv1alpha1.Kustomization{
+			{Name: "crds"},
+			{Name: "crds"},
+			{Name: "lb-install", DependsOn: []string{"crds"}},
+		}}
+		mocks := setupProvisionerMocks(t)
+		var queried []string
+		mocks.KubernetesManager.GetKustomizationReadinessFunc = func(names []string) (map[string]bool, error) {
+			queried = names
+			return map[string]bool{"crds": true, "lb-install": false}, nil
+		}
+		notifier := fluxinfra.NewMockNotifier()
+
+		// When nudging, the duplicate is queried once rather than twice
+		newProv(mocks, notifier).nudgeFrontier(context.Background(), dup, map[string]struct{}{})
+		if len(queried) != 2 || !slices.Contains(queried, "crds") || !slices.Contains(queried, "lb-install") {
+			t.Errorf("expected [crds lb-install] queried once each, got %v", queried)
 		}
 	})
 


### PR DESCRIPTION
Closes #3218

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This touches the shared `upgrade` command flow and the Flux kustomization wait/status logic used by `apply`, `upgrade`, and `bootstrap`, so a regression here would surface broadly, though both changes are narrowly scoped and well covered by new tests.
>
> **Overview**
>
> The PR fixes two related staleness/hang bugs. First, `windsor upgrade` now recomposes the blueprint from disk after retargeting or bumping sources, since `Write` only persists new source URLs without recomposing — without this fix, `Up`/`Install`/`Wait` would build manifests from the pre-upgrade blueprint. Second, kustomization readiness checks now fail fast when a Kustomization's `Ready=False` condition carries a terminal reason (`BuildFailed`, `ArtifactFailed`, `ReconciliationFailed`) instead of polling it to timeout, and both the wait loop and status check now deduplicate kustomization names so a name collision (e.g. from `withCrdLayer`'s synthesized CRD kustomization) can't make the wait's target count unreachable.
>
> The bulk of the diff in `provisioner.go` is a pure reorganization moving several private helper functions into the file's "Private Methods" section (per repo style), with no behavioral change beyond the same name-deduplication fix applied to `convergeNames`.

<!-- /claude-code-review:summary -->
