### PR TITLE
fix(blueprint): reset source loader cache on reload

### DIFF
--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -118,11 +118,15 @@ func (h *BaseBlueprintHandler) SetTraceCollector(tc TraceCollector) {
 // for all source blueprints and composes them into a single unified blueprint, applying the user
 // blueprint as the final override layer. The blueprintURL parameter stores URLs that should be added
 // to sources during initialization. These URLs are loaded first so their metadata names can be used.
+// Each call starts a fresh pipeline: sourceBlueprintLoaders is reset first, so a second call on the
+// same handler (e.g. after RetargetSource changes a source's URL) re-pulls every source instead of
+// reusing loaders cached from the previous call.
 func (h *BaseBlueprintHandler) LoadBlueprint(blueprintURL ...string) error {
 	h.initBlueprintURLs = blueprintURL
 	h.deferredPathsMu.Lock()
 	h.deferredPaths = make(map[string]bool)
 	h.deferredPathsMu.Unlock()
+	h.sourceBlueprintLoaders = make(map[string]BlueprintLoader)
 
 	if err := h.loadInitBlueprints(); err != nil {
 		return fmt.Errorf("failed to load init blueprints: %w", err)

--- a/pkg/composer/blueprint/handler_test.go
+++ b/pkg/composer/blueprint/handler_test.go
@@ -374,6 +374,90 @@ sources:
 		}
 	})
 
+	t.Run("ReloadPullsSourceContentChangedSinceThePreviousLoad", func(t *testing.T) {
+		// Given a source pinned to one tag, loaded once
+		mocks := setupHandlerMocks(t)
+
+		oldDir := filepath.Join(mocks.Runtime.ProjectRoot, "core-old")
+		os.MkdirAll(oldDir, 0755)
+		os.WriteFile(filepath.Join(oldDir, "blueprint.yaml"), []byte(`kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: core
+terraform:
+  - path: old-path
+`), 0644)
+
+		newDir := filepath.Join(mocks.Runtime.ProjectRoot, "core-new")
+		os.MkdirAll(newDir, 0755)
+		os.WriteFile(filepath.Join(newDir, "blueprint.yaml"), []byte(`kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: core
+terraform:
+  - path: new-path
+`), 0644)
+
+		currentTag := "v1.0.0"
+		mocks.ArtifactBuilder.ParseOCIRefFunc = func(ref string) (string, string, string, error) {
+			return "example.com", "core", currentTag, nil
+		}
+		mocks.ArtifactBuilder.PullFunc = func(refs []string) (map[string]string, error) {
+			dir := oldDir
+			if currentTag == "v2.0.0" {
+				dir = newDir
+			}
+			return map[string]string{"example.com/core:" + currentTag: dir}, nil
+		}
+
+		os.WriteFile(filepath.Join(mocks.Runtime.ConfigRoot, "blueprint.yaml"), []byte(`kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: test
+sources:
+  - name: core
+    url: oci://example.com/core:v1.0.0
+`), 0644)
+
+		handler := NewBlueprintHandler(mocks.Runtime, mocks.ArtifactBuilder)
+		if err := handler.LoadBlueprint(); err != nil {
+			t.Fatalf("Expected no error on first load, got %v", err)
+		}
+		hasPath := func(path string) bool {
+			for _, comp := range handler.composedBlueprint.TerraformComponents {
+				if comp.Path == path {
+					return true
+				}
+			}
+			return false
+		}
+		if !hasPath("old-path") {
+			t.Fatalf("Expected first load to include old-path, got %v", handler.composedBlueprint.TerraformComponents)
+		}
+
+		// When the source is retargeted to a tag with different content, persisted, and reloaded
+		// on the same handler — mirroring windsor upgrade's RetargetSource -> Write -> LoadBlueprint
+		if _, err := handler.RetargetSource("core", "oci://example.com/core:v2.0.0"); err != nil {
+			t.Fatalf("RetargetSource: %v", err)
+		}
+		if err := handler.Write(true); err != nil {
+			t.Fatalf("Write: %v", err)
+		}
+		currentTag = "v2.0.0"
+		if err := handler.LoadBlueprint(); err != nil {
+			t.Fatalf("Expected no error on reload, got %v", err)
+		}
+
+		// Then the reload pulls the new source content instead of reusing the loader cached from
+		// the first LoadBlueprint call
+		if hasPath("old-path") {
+			t.Errorf("Expected reload to drop stale content from the old source, got %v", handler.composedBlueprint.TerraformComponents)
+		}
+		if !hasPath("new-path") {
+			t.Errorf("Expected reload to pull the new source content, got %v", handler.composedBlueprint.TerraformComponents)
+		}
+	})
+
 	t.Run("DanglingDependencyOnExcludedFacetNamesTheFacetAndCondition", func(t *testing.T) {
 		// Given a local template where one facet (excluded by a false when:) would contribute the
 		// "cluster" component, and an always-on facet's "cni" depends on it.


### PR DESCRIPTION
Closes #3218

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change is isolated to the blueprint composer's source-loader cache and only affects behavior when `LoadBlueprint` is called more than once on the same handler instance.
>
> **Overview**
>
> `BaseBlueprintHandler.LoadBlueprint` now resets `sourceBlueprintLoaders` to a fresh map at the start of every call, alongside the existing `deferredPaths` reset. Previously, loaders from a prior `LoadBlueprint` call stayed cached on the handler, so a second call (e.g. `windsor upgrade`'s `RetargetSource` → `Write` → `LoadBlueprint` sequence) could keep serving stale source content instead of re-pulling the newly targeted source.
>
> The fix is a two-line addition plus a new regression test (`ReloadPullsSourceContentChangedSinceThePreviousLoad`) that reproduces the retarget-then-reload scenario end-to-end and asserts the stale terraform component is dropped and the new one appears. Other call sites of `LoadBlueprint` (`ComposeBlueprint`, `Initialize`, `cmd/upgrade.go`, `cmd/env.go`) each invoke it once per handler per process, so this reset does not introduce extra re-pulls in normal command flows.

<!-- /claude-code-review:summary -->
