### PR TITLE
fix(runtime): ensure dev mode defaults are applied correctly for non-local contexts

### DIFF
--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -665,3 +665,40 @@ func TestInit_AzureRegionPersistsAcrossInit(t *testing.T) {
 		t.Errorf("expected azure.region=eastus2 in values.yaml, got %v", region)
 	}
 }
+
+// TestInit_DevConfigOnNonLocalContextDefaultsWorkstation verifies that a persisted
+// dev: true on a context whose name does not match the local/local- naming
+// convention still triggers the same workstation.runtime/platform defaulting that
+// a local-named dev context gets for free. values.yaml is seeded with dev: true
+// before init ever runs, the way an operator hand-authoring a new context would,
+// so the very first config load (not a naming heuristic) is what discovers dev mode.
+func TestInit_DevConfigOnNonLocalContextDefaultsWorkstation(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "default")
+	helpers.MarkAsGitRepo(t, dir)
+
+	contextDir := filepath.Join(dir, "contexts", "remote")
+	if err := os.MkdirAll(contextDir, 0755); err != nil {
+		t.Fatalf("failed to create context dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(contextDir, "values.yaml"), []byte("dev: true\n"), 0644); err != nil {
+		t.Fatalf("failed to seed values.yaml with dev: true: %v", err)
+	}
+
+	_, stderr, err := helpers.RunCLI(dir, []string{"init", "remote"}, env)
+	if err != nil {
+		t.Fatalf("init remote with dev\\:true pre-seeded: %v\nstderr: %s", err, stderr)
+	}
+
+	statePath := filepath.Join(dir, ".windsor", "contexts", "remote", "workstation.yaml")
+	if !hasFile(statePath) {
+		t.Fatalf("expected workstation.yaml for remote context with dev:true persisted, found none")
+	}
+	state := readYAMLFile(t, statePath)
+	if platform, ok := getPathValue(state, "platform"); !ok || platform == "" {
+		t.Errorf("expected platform to be defaulted for dev:true non-local context, got %v", platform)
+	}
+	if wsRuntime, ok := getPathValue(state, "workstation", "runtime"); !ok || wsRuntime == "" {
+		t.Errorf("expected workstation.runtime to be defaulted for dev:true non-local context, got %v", wsRuntime)
+	}
+}

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -39,8 +39,9 @@ type Project struct {
 // =============================================================================
 
 // NewProject creates and initializes a new Project instance with all required managers.
-// It sets up the execution context, creates provisioner and composer, and creates the
-// workstation when in dev mode or when is true (config is loaded if needed for the latter).
+// It sets up the execution context and creates provisioner and composer. A name-driven dev
+// context (local/local-*) gets its Workstation eagerly; every other context is left nil and
+// picked up later by EnsureWorkstation, once Configure() has resolved config.
 // Panics if required dependencies are nil. After creation, call Configure() to apply flag overrides.
 // Optional overrides can be provided via opts to inject mocks for testing.
 // If opts contains a Project with Runtime set, that runtime will be reused.
@@ -92,13 +93,6 @@ func NewProject(contextName string, opts ...*Project) *Project {
 		ws = overrides.Workstation
 	} else if rt.ConfigHandler.IsDevMode(contextName) {
 		ws = workstation.NewWorkstation(rt)
-	} else {
-		if !rt.ConfigHandler.IsLoaded() {
-			_ = rt.ConfigHandler.LoadConfig()
-		}
-		if rt.ConfigHandler.GetString("workstation.runtime") != "" {
-			ws = workstation.NewWorkstation(rt)
-		}
 	}
 
 	var prov *provisioner.Provisioner

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -273,6 +273,12 @@ func TestNewProject(t *testing.T) {
 
 		proj := NewProject("test-context", &Project{Runtime: mocks.Runtime})
 
+		if proj.Workstation != nil {
+			t.Error("Expected Workstation to be nil until EnsureWorkstation resolves config")
+		}
+
+		proj.EnsureWorkstation()
+
 		if proj.Workstation == nil {
 			t.Error("Expected Workstation to be created when workstation.runtime is set")
 		}
@@ -292,6 +298,12 @@ func TestNewProject(t *testing.T) {
 
 		if proj.Workstation != nil {
 			t.Error("Expected Workstation to be nil when not in dev mode")
+		}
+
+		proj.EnsureWorkstation()
+
+		if proj.Workstation != nil {
+			t.Error("Expected Workstation to remain nil after EnsureWorkstation when workstation.runtime is unset")
 		}
 	})
 

--- a/pkg/runtime/config/handler.go
+++ b/pkg/runtime/config/handler.go
@@ -320,6 +320,8 @@ func (c *configHandler) SaveWorkstationState() error {
 
 // SetDefault sets the default context configuration in the config handler's internal data.
 // It marshals the given v1alpha1.Context struct to a map and merges it into the handler's data.
+// Values already present in data take precedence over the default, so this is safe to call
+// regardless of load order or how many times it runs.
 // This method is typically used during initialization when context files do not yet exist.
 // The original default config is stored so it can be used when saving a new config file to ensure
 // all default values are preserved even if they were empty/nil (which would be omitted by omitempty tags).
@@ -334,7 +336,7 @@ func (c *configHandler) SetDefault(context v1alpha1.Context) error {
 		return fmt.Errorf("error decoding context: %w", err)
 	}
 
-	c.data = c.deepMerge(c.data, contextMap)
+	c.data = c.deepMerge(contextMap, c.data)
 
 	contextCopy := context
 	c.defaultConfig = &contextCopy

--- a/pkg/runtime/config/handler_test.go
+++ b/pkg/runtime/config/handler_test.go
@@ -944,6 +944,27 @@ func TestConfigHandler_SetDefault(t *testing.T) {
 		}
 	})
 
+	t.Run("DoesNotOverwriteValueAlreadySetBeforeIt", func(t *testing.T) {
+		mocks := setupConfigMocks(t)
+		handler := NewConfigHandler(mocks.Shell)
+
+		handler.Set("provider", "already_set_provider")
+
+		defaultContext := v1alpha1.Context{
+			Provider: ptrString("default_provider"),
+		}
+		err := handler.SetDefault(defaultContext)
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		provider := handler.GetString("provider")
+		if provider != "already_set_provider" {
+			t.Errorf("Expected SetDefault called after Set to not clobber the existing value, got '%s'", provider)
+		}
+	})
+
 	t.Run("HandlesMarshalError", func(t *testing.T) {
 		// Given a config handler with failing marshal
 		handler, _ := setupPrivateTestHandler(t)

--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -426,114 +426,19 @@ func (rt *Runtime) InitializeComponents() error {
 	return nil
 }
 
-// ApplyConfigDefaults applies base configuration defaults if no config is currently loaded.
-// It sets "dev" mode in config if the context is a dev context, chooses a default workstation runtime
-// (optionally honoring flagOverrides["workstation.runtime"]), and sets
-// platform to "docker" in dev mode if not already set, or "incus" when overrides or config specify incus.
-// After those, it loads a default configuration set, choosing among standard, full, localhost, or none
-// defaults depending on platform, dev mode, and workstation runtime.
-// This must be called before loading from disk to ensure proper defaulting. Returns error on config operation failure.
+// ApplyConfigDefaults sets pre-load defaults: dev mode, workstation runtime, platform, and a
+// baseline config set. Defers entirely when dev mode isn't knowable yet (no explicit platform,
+// no confirmed dev mode, nothing loaded), so it doesn't commit platform: "none" before
+// ResolveConfig's post-load call (setConfigDefaults) sees the real value.
 func (rt *Runtime) ApplyConfigDefaults(flagOverrides ...map[string]any) error {
-	if !rt.ConfigHandler.IsLoaded() {
-		existingPlatform := rt.ConfigHandler.GetString("platform")
-		if existingPlatform == "" {
-			existingPlatform = rt.ConfigHandler.GetString("provider")
-		}
-		isDevMode := rt.ConfigHandler.IsDevMode(rt.ContextName)
-
-		if isDevMode {
-			if err := rt.ConfigHandler.Set("dev", true); err != nil {
-				return fmt.Errorf("failed to set dev mode: %w", err)
-			}
-		}
-
-		workstationRuntime := rt.ConfigHandler.GetString("workstation.runtime")
-		hadRuntime := workstationRuntime != ""
-		if workstationRuntime == "" && len(flagOverrides) > 0 && flagOverrides[0] != nil {
-			if driver, ok := flagOverrides[0]["workstation.runtime"].(string); ok && driver != "" {
-				workstationRuntime = driver
-			}
-		}
-		overridePlatform := ""
-		if len(flagOverrides) > 0 && flagOverrides[0] != nil {
-			if p, ok := flagOverrides[0]["platform"].(string); ok && p != "" {
-				overridePlatform = p
-			}
-		}
-		effectivePlatform := overridePlatform
-		if effectivePlatform == "" {
-			effectivePlatform = existingPlatform
-		}
-		needsWorkstationRuntime := effectivePlatform == "" || effectivePlatform == "docker" || effectivePlatform == "incus"
-		if isDevMode && workstationRuntime == "" && needsWorkstationRuntime {
-			switch runtime.GOOS {
-			case "darwin", "windows":
-				workstationRuntime = "docker-desktop"
-			default:
-				workstationRuntime = "docker"
-			}
-		}
-
-		if isDevMode && !hadRuntime && workstationRuntime != "" {
-			if err := rt.ConfigHandler.Set("workstation.runtime", workstationRuntime); err != nil {
-				return fmt.Errorf("failed to set workstation.runtime: %w", err)
-			}
-		}
-		vmRuntime := ""
-		if len(flagOverrides) > 0 && flagOverrides[0] != nil {
-			if r, ok := flagOverrides[0]["vm.runtime"].(string); ok && r != "" {
-				vmRuntime = r
-			}
-		}
-		if vmRuntime == "" {
-			vmRuntime = rt.ConfigHandler.GetString("vm.runtime", "docker")
-		}
-
-		if existingPlatform == "" && isDevMode {
-			if overridePlatform != "" {
-				if err := rt.ConfigHandler.Set("platform", overridePlatform); err != nil {
-					return fmt.Errorf("failed to set platform from overrides: %w", err)
-				}
-			} else if workstationRuntime == "colima" && vmRuntime == "incus" {
-				fmt.Fprintln(os.Stderr, "\033[33mWarning: vm.runtime is deprecated; use platform: incus in your context configuration instead. Support for vm.runtime will be removed in a future version.\033[0m")
-				if err := rt.ConfigHandler.Set("platform", "incus"); err != nil {
-					return fmt.Errorf("failed to set platform to incus: %w", err)
-				}
-			} else {
-				if err := rt.ConfigHandler.Set("platform", "docker"); err != nil {
-					return fmt.Errorf("failed to set platform: %w", err)
-				}
-			}
-		}
-
-		platform := rt.ConfigHandler.GetString("platform")
-		if platform == "" {
-			platform = rt.ConfigHandler.GetString("provider")
-		}
-		if platform == "none" {
-			defaultConfig := config.DefaultConfig
-			nonePlatform := "none"
-			defaultConfig.Platform = &nonePlatform
-			if err := rt.ConfigHandler.SetDefault(defaultConfig); err != nil {
-				return fmt.Errorf("failed to set default config: %w", err)
-			}
-		} else if isDevMode {
-			if err := rt.ConfigHandler.SetDefault(config.DefaultConfig_Dev); err != nil {
-				return fmt.Errorf("failed to set default config: %w", err)
-			}
-		} else {
-			if err := rt.ConfigHandler.SetDefault(config.DefaultConfig); err != nil {
-				return fmt.Errorf("failed to set default config: %w", err)
-			}
-		}
+	if rt.canonicalPlatform() == "" && !rt.ConfigHandler.IsDevMode(rt.ContextName) && !rt.ConfigHandler.IsLoaded() {
+		return nil
 	}
-
-	return nil
+	return rt.setConfigDefaults(flagOverrides...)
 }
 
-// ResolveConfig runs the full config pipeline: infer platform for dev when missing, apply pre-load
-// defaults, load from disk, apply flag overrides, then
-// apply dev-mode platform normalization (colima+incus). Call this once to produce final config.
+// ResolveConfig runs the full config pipeline: pre-load defaults, load from disk, post-load
+// defaults, flag overrides, then dev-mode platform normalization. Call once per command.
 // Mutates flagOverrides when inferring platform. Returns error on config load or set failure.
 func (rt *Runtime) ResolveConfig(flagOverrides map[string]any) error {
 	if flagOverrides == nil {
@@ -559,6 +464,9 @@ func (rt *Runtime) ResolveConfig(flagOverrides map[string]any) error {
 	}
 	if err := rt.ConfigHandler.LoadConfig(); err != nil {
 		return fmt.Errorf("failed to load config: %w", err)
+	}
+	if err := rt.setConfigDefaults(preLoadOverrides); err != nil {
+		return fmt.Errorf("failed to apply post-load config defaults: %w", err)
 	}
 	for key, value := range flagOverrides {
 		if key == "provider" {
@@ -651,6 +559,99 @@ func (rt *Runtime) PrepareToolsFor(reqs tools.Requirements) error {
 // =============================================================================
 // Private Methods
 // =============================================================================
+
+// setConfigDefaults holds the defaulting work for ApplyConfigDefaults, and is also what
+// ResolveConfig calls directly for its post-load pass, once LoadConfig has already run and
+// dev mode is fully resolved (unlike ApplyConfigDefaults, this never defers).
+func (rt *Runtime) setConfigDefaults(flagOverrides ...map[string]any) error {
+	existingPlatform := rt.canonicalPlatform()
+	isDevMode := rt.ConfigHandler.IsDevMode(rt.ContextName)
+
+	if isDevMode {
+		if err := rt.ConfigHandler.Set("dev", true); err != nil {
+			return fmt.Errorf("failed to set dev mode: %w", err)
+		}
+	}
+
+	workstationRuntime := rt.ConfigHandler.GetString("workstation.runtime")
+	hadRuntime := workstationRuntime != ""
+	if workstationRuntime == "" && len(flagOverrides) > 0 && flagOverrides[0] != nil {
+		if driver, ok := flagOverrides[0]["workstation.runtime"].(string); ok && driver != "" {
+			workstationRuntime = driver
+		}
+	}
+	overridePlatform := ""
+	if len(flagOverrides) > 0 && flagOverrides[0] != nil {
+		if p, ok := flagOverrides[0]["platform"].(string); ok && p != "" {
+			overridePlatform = p
+		}
+	}
+	effectivePlatform := overridePlatform
+	if effectivePlatform == "" {
+		effectivePlatform = existingPlatform
+	}
+	needsWorkstationRuntime := effectivePlatform == "" || effectivePlatform == "docker" || effectivePlatform == "incus"
+	if isDevMode && workstationRuntime == "" && needsWorkstationRuntime {
+		switch runtime.GOOS {
+		case "darwin", "windows":
+			workstationRuntime = "docker-desktop"
+		default:
+			workstationRuntime = "docker"
+		}
+	}
+
+	if isDevMode && !hadRuntime && workstationRuntime != "" {
+		if err := rt.ConfigHandler.Set("workstation.runtime", workstationRuntime); err != nil {
+			return fmt.Errorf("failed to set workstation.runtime: %w", err)
+		}
+	}
+	vmRuntime := ""
+	if len(flagOverrides) > 0 && flagOverrides[0] != nil {
+		if r, ok := flagOverrides[0]["vm.runtime"].(string); ok && r != "" {
+			vmRuntime = r
+		}
+	}
+	if vmRuntime == "" {
+		vmRuntime = rt.ConfigHandler.GetString("vm.runtime", "docker")
+	}
+
+	if existingPlatform == "" && isDevMode {
+		if overridePlatform != "" {
+			if err := rt.ConfigHandler.Set("platform", overridePlatform); err != nil {
+				return fmt.Errorf("failed to set platform from overrides: %w", err)
+			}
+		} else if workstationRuntime == "colima" && vmRuntime == "incus" {
+			fmt.Fprintln(os.Stderr, "\033[33mWarning: vm.runtime is deprecated; use platform: incus in your context configuration instead. Support for vm.runtime will be removed in a future version.\033[0m")
+			if err := rt.ConfigHandler.Set("platform", "incus"); err != nil {
+				return fmt.Errorf("failed to set platform to incus: %w", err)
+			}
+		} else {
+			if err := rt.ConfigHandler.Set("platform", "docker"); err != nil {
+				return fmt.Errorf("failed to set platform: %w", err)
+			}
+		}
+	}
+
+	platform := rt.canonicalPlatform()
+	if platform == "none" {
+		defaultConfig := config.DefaultConfig
+		nonePlatform := "none"
+		defaultConfig.Platform = &nonePlatform
+		if err := rt.ConfigHandler.SetDefault(defaultConfig); err != nil {
+			return fmt.Errorf("failed to set default config: %w", err)
+		}
+	} else if isDevMode {
+		if err := rt.ConfigHandler.SetDefault(config.DefaultConfig_Dev); err != nil {
+			return fmt.Errorf("failed to set default config: %w", err)
+		}
+	} else {
+		if err := rt.ConfigHandler.SetDefault(config.DefaultConfig); err != nil {
+			return fmt.Errorf("failed to set default config: %w", err)
+		}
+	}
+
+	return nil
+}
 
 // explicitPlatformFromOverrides extracts an explicitly provided platform selection from CLI overrides.
 // It treats both "platform" and legacy "provider" override keys as explicit platform intent.

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1116,23 +1116,116 @@ func TestRuntime_HandleSessionReset(t *testing.T) {
 }
 
 func TestRuntime_ApplyConfigDefaults(t *testing.T) {
-	t.Run("SkipsWhenConfigAlreadyLoaded", func(t *testing.T) {
-		// Given a runtime with config already loaded
+	t.Run("AppliesDevDefaultsAfterConfigIsLoaded", func(t *testing.T) {
+		// Given a runtime whose config is already loaded and dev mode is now known
+		// (e.g. "dev: true" was only discoverable once values.yaml was read)
 		mocks := setupRuntimeMocks(t)
 		rt := mocks.Runtime
+		rt.ContextName = "remote"
 
 		mockConfigHandler := mocks.ConfigHandler.(*config.MockConfigHandler)
 		mockConfigHandler.IsLoadedFunc = func() bool {
 			return true
 		}
+		mockConfigHandler.IsDevModeFunc = func(contextName string) bool {
+			return true
+		}
+		mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+			return ""
+		}
+
+		setDefaultCalled := false
+		mockConfigHandler.SetDefaultFunc = func(cfg v1alpha1.Context) error {
+			setDefaultCalled = true
+			return nil
+		}
 
 		// When ApplyConfigDefaults is called
 		err := rt.ApplyConfigDefaults()
 
-		// Then no error should be returned
-
+		// Then it should still apply dev-mode defaults rather than skip them
 		if err != nil {
 			t.Errorf("Expected no error, got: %v", err)
+		}
+		if !setDefaultCalled {
+			t.Error("Expected SetDefault to be called even though config was already loaded")
+		}
+	})
+
+	t.Run("SkipsBaselineSelectionWhenNotLoadedAndDevModeUnknown", func(t *testing.T) {
+		// Given a runtime that has not yet loaded config and whose dev mode cannot be
+		// determined by name (only a persisted "dev: true" would answer it, and nothing
+		// has been loaded yet)
+		mocks := setupRuntimeMocks(t)
+		rt := mocks.Runtime
+		rt.ContextName = "remote"
+
+		mockConfigHandler := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockConfigHandler.IsLoadedFunc = func() bool {
+			return false
+		}
+		mockConfigHandler.IsDevModeFunc = func(contextName string) bool {
+			return false
+		}
+		mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+			return ""
+		}
+
+		setDefaultCalled := false
+		mockConfigHandler.SetDefaultFunc = func(cfg v1alpha1.Context) error {
+			setDefaultCalled = true
+			return nil
+		}
+
+		// When ApplyConfigDefaults is called
+		err := rt.ApplyConfigDefaults()
+
+		// Then it must not commit a baseline (e.g. platform: "none") before dev mode can
+		// be confirmed one way or the other, since that baseline would look like an
+		// explicit choice to a later call made once config is actually loaded
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+		if setDefaultCalled {
+			t.Error("Expected SetDefault not to be called before load with dev mode still unknown")
+		}
+	})
+
+	t.Run("BackfillNeverSkipsEvenWhenLoadFoundNothing", func(t *testing.T) {
+		// Given a from-zero context (e.g. global mode with no windsor.yaml/values.yaml
+		// anywhere), where LoadConfig has already run but found no files to merge, so
+		// IsLoaded() stays false even though the load was genuinely attempted
+		mocks := setupRuntimeMocks(t)
+		rt := mocks.Runtime
+		rt.ContextName = "prod"
+
+		mockConfigHandler := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockConfigHandler.IsLoadedFunc = func() bool {
+			return false
+		}
+		mockConfigHandler.IsDevModeFunc = func(contextName string) bool {
+			return false
+		}
+		mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+			return ""
+		}
+
+		setDefaultCalled := false
+		mockConfigHandler.SetDefaultFunc = func(cfg v1alpha1.Context) error {
+			setDefaultCalled = true
+			return nil
+		}
+
+		// When the post-load backfill runs (as ResolveConfig does right after LoadConfig)
+		err := rt.setConfigDefaults()
+
+		// Then it must still commit the baseline: by this point a load was attempted and
+		// dev mode is as resolved as it will ever be, regardless of whether any file existed
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+		if !setDefaultCalled {
+			t.Error("Expected SetDefault to be called on backfill even when nothing was found to load")
 		}
 	})
 
@@ -1246,14 +1339,14 @@ func TestRuntime_ApplyConfigDefaults(t *testing.T) {
 	})
 
 	t.Run("SetsDefaultsForNonDevMode", func(t *testing.T) {
-		// Given a runtime not in dev mode
+		// Given a runtime not in dev mode, confirmed by a completed config load
 		mocks := setupRuntimeMocks(t)
 		rt := mocks.Runtime
 		rt.ContextName = "prod"
 
 		mockConfigHandler := mocks.ConfigHandler.(*config.MockConfigHandler)
 		mockConfigHandler.IsLoadedFunc = func() bool {
-			return false
+			return true
 		}
 		mockConfigHandler.IsDevModeFunc = func(contextName string) bool {
 			return false
@@ -1371,14 +1464,14 @@ func TestRuntime_ApplyConfigDefaults(t *testing.T) {
 	})
 
 	t.Run("UsesStandardConfigForNonDevMode", func(t *testing.T) {
-		// Given a runtime not in dev mode
+		// Given a runtime not in dev mode, confirmed by a completed config load
 		mocks := setupRuntimeMocks(t)
 		rt := mocks.Runtime
 		rt.ContextName = "prod"
 
 		mockConfigHandler := mocks.ConfigHandler.(*config.MockConfigHandler)
 		mockConfigHandler.IsLoadedFunc = func() bool {
-			return false
+			return true
 		}
 		mockConfigHandler.IsDevModeFunc = func(contextName string) bool {
 			return false


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This changes the shared config-defaulting pipeline used by every command (`ApplyConfigDefaults`/`ResolveConfig`), so it's medium risk despite being a targeted fix: a regression here would affect dev-mode and platform detection CLI-wide.
>
> **Overview**
>
> The PR fixes two related bugs in dev-mode/platform defaulting. First, `ApplyConfigDefaults` used to skip entirely once config was loaded, which meant a context named anything other than `local`/`local-*` that persisted `dev: true` in `values.yaml` never got its workstation runtime and platform defaults applied. The logic is now split into `ApplyConfigDefaults` (pre-load, defers only when dev mode truly can't be known yet) and a new private `setConfigDefaults` helper that also runs unconditionally right after `LoadConfig()`, so a `dev: true` discovered only from disk is still honored.
>
> Second, `configHandler.SetDefault` previously merged with the default config as the overlay, so `SetDefault` could silently clobber values already set earlier in the same run; the merge order is now flipped so existing data always wins. `NewProject` also no longer eagerly loads config and probes `workstation.runtime` for non-dev contexts — that's deferred to the existing `EnsureWorkstation`, which is already called from `Initialize` and `configure` before `Workstation` is used.

<!-- /claude-code-review:summary -->
