### PR TITLE
fix(kubernetes): enhance error reporting for stuck HelmReleases during Kustomization deletion

### DIFF
--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -180,6 +180,10 @@ func (k *BaseKubernetesManager) ApplyKustomization(kustomization kustomizev1.Kus
 // (LBs, EBS volumes, DNS records) leak. Returning an error here surfaces the stuck
 // state so the operator can re-deploy the controller, let it finish cleanup, and
 // re-run destroy — vs. silently masking the failure.
+//
+// The Kustomization's own conditions are often uninformative while stuck ("Progressing").
+// describeStuckHelmReleases checks its HelmReleases for a better reason (e.g. a CRD still
+// has live instances) and adds it to the error.
 func (k *BaseKubernetesManager) DeleteKustomization(name, namespace string) error {
 	gvr := schema.GroupVersionResource{
 		Group:    "kustomize.toolkit.fluxcd.io",
@@ -214,7 +218,7 @@ func (k *BaseKubernetesManager) DeleteKustomization(name, namespace string) erro
 		time.Sleep(k.kustomizationWaitPollInterval)
 	}
 
-	reason := describeStuckKustomization(lastObj)
+	reason := describeStuckKustomization(lastObj) + k.describeStuckHelmReleases(name, namespace)
 	return fmt.Errorf("timeout waiting for kustomization %s/%s to be deleted%s; an inventory item is likely stuck on a cloud-controller finalizer — inspect with `kubectl get kustomization %s -n %s -o yaml` (status.conditions, status.inventory) and `kubectl get pvc,svc,ingress,certificate -A | grep Terminating` to find the stuck object", namespace, name, reason, name, namespace)
 }
 
@@ -1677,6 +1681,52 @@ waitLoop:
 // =============================================================================
 // Private Methods
 // =============================================================================
+
+// describeStuckHelmReleases returns the most diagnostic non-Ready condition from a stuck
+// Kustomization's HelmReleases, for DeleteKustomization's timeout error. Lookup errors are
+// swallowed. Returns "" if there's nothing more specific to add.
+func (k *BaseKubernetesManager) describeStuckHelmReleases(name, namespace string) string {
+	helmReleases, err := k.GetHelmReleasesForKustomization(name, namespace)
+	if err != nil || len(helmReleases) == 0 {
+		return ""
+	}
+
+	var parts []string
+	for _, hr := range helmReleases {
+		var stalled, ready, other *metav1.Condition
+		for i := range hr.Status.Conditions {
+			cond := &hr.Status.Conditions[i]
+			switch {
+			case cond.Type == "Stalled" && cond.Status == "True":
+				stalled = cond
+			case cond.Type == "Ready" && cond.Status != "True":
+				ready = cond
+			case cond.Status != "True" && other == nil:
+				other = cond
+			}
+		}
+		pick := stalled
+		if pick == nil {
+			pick = ready
+		}
+		if pick == nil {
+			pick = other
+		}
+		if pick == nil || pick.Message == "" {
+			continue
+		}
+		message := strings.ReplaceAll(strings.TrimSpace(pick.Message), "\n", " ")
+		if pick.Reason != "" {
+			parts = append(parts, fmt.Sprintf("HelmRelease %s/%s (%s=%s %s: %s)", hr.Namespace, hr.Name, pick.Type, pick.Status, pick.Reason, message))
+		} else {
+			parts = append(parts, fmt.Sprintf("HelmRelease %s/%s (%s=%s: %s)", hr.Namespace, hr.Name, pick.Type, pick.Status, message))
+		}
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return "; " + strings.Join(parts, ", ")
+}
 
 // kustomizationCheckResult carries one kustomization's readiness outcome back from a
 // concurrent checkKustomizationReady call to WaitForKustomizations' tick loop.

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -392,6 +392,110 @@ func TestBaseKubernetesManager_DeleteKustomization(t *testing.T) {
 		}
 	})
 
+	t.Run("TimeoutSurfacesHelmReleaseCondition", func(t *testing.T) {
+		// Given a stuck kustomization with a bare "Progressing" status, but its
+		// inventory names a HelmRelease that is itself stalled
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			return nil
+		}
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			if gvr.Group == "helm.toolkit.fluxcd.io" && gvr.Resource == "helmreleases" {
+				return &unstructured.Unstructured{Object: map[string]any{
+					"apiVersion": "helm.toolkit.fluxcd.io/v2",
+					"kind":       "HelmRelease",
+					"metadata": map[string]any{
+						"name":      "cloudnativepg",
+						"namespace": "system-database",
+					},
+					"status": map[string]any{
+						"conditions": []any{
+							map[string]any{
+								"type":    "Stalled",
+								"status":  "True",
+								"reason":  "UninstallFailed",
+								"message": "CustomResourceDefinition/clusters.postgresql.cnpg.io: still has 1 instance(s)",
+							},
+						},
+					},
+				}}, nil
+			}
+			return &unstructured.Unstructured{Object: map[string]any{
+				"status": map[string]any{
+					"conditions": []any{
+						map[string]any{
+							"type":   "Ready",
+							"status": "Unknown",
+							"reason": "Progressing",
+						},
+					},
+					"inventory": map[string]any{
+						"entries": []any{
+							map[string]any{
+								"id": "system-database_cloudnativepg_helm.toolkit.fluxcd.io_HelmRelease",
+							},
+						},
+					},
+				},
+			}}, nil
+		}
+		manager.client = kubernetesClient
+		manager.kustomizationReconcileTimeout = 100 * time.Millisecond
+		manager.kustomizationWaitPollInterval = 50 * time.Millisecond
+
+		// When DeleteKustomization times out
+		err := manager.DeleteKustomization("database-install", "system-gitops")
+
+		// Then the error surfaces the HelmRelease's own stuck reason
+		if err == nil {
+			t.Fatal("Expected timeout error, got nil")
+		}
+		if !strings.Contains(err.Error(), "HelmRelease system-database/cloudnativepg") {
+			t.Errorf("Expected error to name the stuck HelmRelease, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "UninstallFailed") {
+			t.Errorf("Expected error to surface the HelmRelease's condition reason, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "still has 1 instance(s)") {
+			t.Errorf("Expected error to surface the HelmRelease's condition message, got: %v", err)
+		}
+	})
+
+	t.Run("TimeoutHelmReleaseLookupErrorIsSwallowed", func(t *testing.T) {
+		// Given a stuck kustomization whose HelmRelease lookup itself fails
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			return nil
+		}
+		calls := 0
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			calls++
+			if calls == 1 {
+				// deletion-status poll: one call, then timeout
+				return &unstructured.Unstructured{}, nil
+			}
+			// describeStuckHelmReleases' own re-fetch
+			return nil, fmt.Errorf("apiserver unreachable")
+		}
+		manager.client = kubernetesClient
+		// timeout < poll interval: deletion-status loop makes exactly one call
+		manager.kustomizationReconcileTimeout = 10 * time.Millisecond
+		manager.kustomizationWaitPollInterval = 50 * time.Millisecond
+
+		// When DeleteKustomization times out
+		err := manager.DeleteKustomization("test-kustomization", "test-namespace")
+
+		// Then the timeout error still surfaces; the lookup failure is swallowed
+		if err == nil {
+			t.Fatal("Expected timeout error, got nil")
+		}
+		if !strings.Contains(err.Error(), "timeout") {
+			t.Errorf("Expected error mentioning timeout, got: %v", err)
+		}
+	})
+
 	t.Run("ErrorCheckingDeletionStatus", func(t *testing.T) {
 		manager := setup(t)
 		kubernetesClient := client.NewMockKubernetesClient()


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> The change is isolated to one error-message helper in the Kubernetes provisioner's Kustomization-deletion path and adds only new test coverage; it does not alter deletion behavior, timing, or control flow.
>
> **Overview**
>
> When `DeleteKustomization` times out waiting for a stuck Kustomization to finish deleting, its error message previously reported only the Kustomization's own (often uninformative, "Progressing") condition. This PR adds `describeStuckHelmReleases`, which looks up the HelmReleases tracked in the Kustomization's inventory and appends the most diagnostic non-Ready condition (preferring `Stalled`) from each one, e.g. naming a CRD that still has live instances blocking Helm's uninstall.
>
> The lookup reuses the existing `GetHelmReleasesForKustomization`/`getHelmRelease` helpers and swallows any errors from that lookup, so a failed diagnostic fetch cannot mask or change the original timeout error — it only ever adds detail to it.

<!-- /claude-code-review:summary -->
