### PR TITLE
fix(test): apply flux system name fallback in path assertions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,19 +6,27 @@ Skills are defined in `.claude/skills/` and are discovered automatically by Clau
 
 1. **Function comment placement** — behavior documentation belongs in function header comments, never inside function bodies.
 
-2. **Go testing** — use standard `go test` only. No `testify`. Follow `test-engineer` for test design and structure.
+2. **Writing style** — write all prose (comments, doc strings, CLI help text, error messages, commit and PR text) in Simplified Technical English (ASD-STE100):
+   - One instruction per sentence. Max 20 words for an instruction, 25 for a description.
+   - Active voice. Name the actor.
+   - Plain, consistent words. One word per meaning. No jargon, no idioms.
+   - Noun clusters of 3 words or fewer.
+   - One topic per paragraph, max 6 sentences.
+   - Use a vertical list for a sequence, a set of conditions, or an enumeration.
 
-3. **Style and organization** — follow STYLE.md and `go-style` for section headers, file layout, and naming.
+3. **Go testing** — use standard `go test` only. No `testify`. Follow `test-engineer` for test design and structure.
 
-4. **Architecture boundaries** — follow `architecture` for cmd/runtime/evaluator/secrets/provisioner/composer ownership. Do not cross layer boundaries.
+4. **Style and organization** — follow STYLE.md and `go-style` for section headers, file layout, and naming.
 
-5. **Large cross-cutting work** — follow `large-pr` for phased implementation and change-map reporting.
+5. **Architecture boundaries** — follow `architecture` for cmd/runtime/evaluator/secrets/provisioner/composer ownership. Do not cross layer boundaries.
 
-6. **Security and pre-commit review** — run `/review-pr` before every commit; it runs `task scan`, `go vet`, and six parallel bug passes automatically. For a PR-level or cross-repo review instead, use the generic `code-review` skill.
+6. **Large cross-cutting work** — follow `large-pr` for phased implementation and change-map reporting.
 
-7. **Integration tests** — every new CLI command or flag requires an integration test. Follow `integration-tests`.
+7. **Security and pre-commit review** — run `/review-pr` before every commit; it runs `task scan`, `go vet`, and six parallel bug passes automatically. For a PR-level or cross-repo review instead, use the generic `code-review` skill.
 
-8. **PRs** — use `create-pr` to push and open/update a PR, and `address-pr-feedback` to work through review comments and CI failures one finding at a time.
+8. **Integration tests** — every new CLI command or flag requires an integration test. Follow `integration-tests`.
+
+9. **PRs** — use `create-pr` to push and open/update a PR, and `address-pr-feedback` to work through review comments and CI failures one finding at a time.
 
 ## Key commands
 

--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -1249,6 +1249,17 @@ func (sys FluxSystem) TierNames() []string {
 	return names
 }
 
+// EffectivePath returns the system's Path. If Path is empty, it returns the Name.
+// This is the single source for the default that compileFluxSystemTiers applies to each tier.
+// Use this method, not the Path field, to read a system's path outside tier compilation.
+// A test assertion against a FluxSystem before tier compilation is one example.
+func (sys FluxSystem) EffectivePath() string {
+	if sys.Path == "" {
+		return sys.Name
+	}
+	return sys.Path
+}
+
 // compileFluxSystemTiers converts a pre-evaluated FluxSystem into its tier Kustomizations without
 // any expression evaluation. Install compiles to "<name>-install" at "<path>/install"; each
 // resources variant compiles to "<name>-resources[-<variant>]" at "<path>/resources". A timeout-less
@@ -1257,10 +1268,7 @@ func (sys FluxSystem) TierNames() []string {
 // first resources tier (out[0]) — so placement finds them after FluxSystems are flattened away.
 func compileFluxSystemTiers(sys FluxSystem) []Kustomization {
 	name := sys.Name
-	base := sys.Path
-	if base == "" {
-		base = name
-	}
+	base := sys.EffectivePath()
 	installName := name + "-install"
 
 	var out []Kustomization

--- a/api/v1alpha1/blueprint_types_test.go
+++ b/api/v1alpha1/blueprint_types_test.go
@@ -5408,6 +5408,24 @@ func TestFluxSystem_TierNames(t *testing.T) {
 	})
 }
 
+func TestFluxSystem_EffectivePath(t *testing.T) {
+	t.Run("ReturnsPathWhenSet", func(t *testing.T) {
+		sys := FluxSystem{Name: "cert-manager", Path: "custom-path"}
+
+		if got := sys.EffectivePath(); got != "custom-path" {
+			t.Errorf("expected %q, got %q", "custom-path", got)
+		}
+	})
+
+	t.Run("FallsBackToNameWhenPathUnset", func(t *testing.T) {
+		sys := FluxSystem{Name: "cert-manager"}
+
+		if got := sys.EffectivePath(); got != "cert-manager" {
+			t.Errorf("expected %q, got %q", "cert-manager", got)
+		}
+	})
+}
+
 func TestBlueprint_AllKustomizations_InstallTierTimeoutDefault(t *testing.T) {
 	t.Run("InstallTierFallsBackToInstallTimeoutDefaultWhenUnset", func(t *testing.T) {
 		// Given a flux system whose install tier sets no timeout of its own

--- a/pkg/test/runner.go
+++ b/pkg/test/runner.go
@@ -773,22 +773,31 @@ func (r *TestRunner) matchKustomization(actual *blueprintv1alpha1.Kustomization,
 	return diffs
 }
 
-// matchFluxSystem compares an actual FluxSystem (from bp.FluxSystems, post facet-merge and
-// when-expression evaluation) against expected properties and returns a list of differences. It uses
-// partial matching: only properties set in the expect system are validated. Path, source, when, strategy,
-// and dependsOn are compared as the author wrote them (dependsOn is the system's own cross-layer edges,
-// not a composer-computed one). Ordinal and globalDependency compare when the expectation sets them;
-// globalDependency only asserts the true direction, since false is indistinguishable from unset. Install
-// and each Resources variant delegate to matchKustomization for their Kustomization fields. Enabled and
-// Destroy are not compared: neither is evaluated during composition, so they carry only the raw authored
-// expression at this stage, not a rendering outcome. Returns an empty slice if all specified properties
-// match.
+// matchFluxSystem compares an actual FluxSystem against expected properties. The actual system comes
+// from bp.FluxSystems, after facet merge and when-expression evaluation. The function returns a list
+// of differences.
+//
+// The function uses partial matching. It checks only the properties set on the expect system.
+//
+// The function compares fields this way:
+//   - Path: compares against actual.EffectivePath(), the same name fallback compileFluxSystemTiers
+//     uses. A fixture that omits path: still matches.
+//   - Source, When, Strategy, DependsOn: compares the raw values the author wrote. DependsOn is the
+//     system's own cross-layer edges, not a value the composer computes.
+//   - Ordinal, GlobalDependency: compares only when the expectation sets them. GlobalDependency
+//     checks only the true direction, because false is indistinguishable from unset.
+//   - Install, Resources: delegates to matchKustomization for each Kustomization field.
+//   - Enabled, Destroy: not compared. Composition does not evaluate these fields, so they hold the
+//     raw authored expression, not a rendering outcome.
+//
+// The function returns an empty slice when all specified properties match.
 func (r *TestRunner) matchFluxSystem(actual *blueprintv1alpha1.FluxSystem, expect blueprintv1alpha1.FluxSystem) []string {
 	var diffs []string
 	name := expect.Name
 
-	if expect.Path != "" && actual.Path != expect.Path {
-		diffs = append(diffs, fmt.Sprintf("flux[%s].path: expected %q, got %q", name, expect.Path, actual.Path))
+	actualPath := actual.EffectivePath()
+	if expect.Path != "" && actualPath != expect.Path {
+		diffs = append(diffs, fmt.Sprintf("flux[%s].path: expected %q, got %q", name, expect.Path, actualPath))
 	}
 
 	if expect.Source != "" && actual.Source != expect.Source {

--- a/pkg/test/runner_test.go
+++ b/pkg/test/runner_test.go
@@ -2480,6 +2480,40 @@ func TestTestRunner_matchFluxSystem(t *testing.T) {
 		}
 	})
 
+	t.Run("PathFallsBackToNameWhenActualPathOmitted", func(t *testing.T) {
+		// Given an actual system with no Path, and an expected Path equal to the system's Name
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		actual := &blueprintv1alpha1.FluxSystem{Name: "demo"}
+		expect := blueprintv1alpha1.FluxSystem{Name: "demo", Path: "demo"}
+
+		// When matching the systems
+		diffs := runner.matchFluxSystem(actual, expect)
+
+		// Then the match returns no diffs
+		if len(diffs) != 0 {
+			t.Errorf("Expected no diffs, got: %v", diffs)
+		}
+	})
+
+	t.Run("ReturnsDiffWhenActualPathOmittedAndNameDoesNotMatchExpectedPath", func(t *testing.T) {
+		// Given an actual system with no Path, and an expected Path different from the system's Name
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		actual := &blueprintv1alpha1.FluxSystem{Name: "demo"}
+		expect := blueprintv1alpha1.FluxSystem{Name: "demo", Path: "other"}
+
+		// When matching the systems
+		diffs := runner.matchFluxSystem(actual, expect)
+
+		// Then the match returns one diff
+		if len(diffs) != 1 {
+			t.Errorf("Expected 1 diff, got: %d", len(diffs))
+		}
+	})
+
 	t.Run("ReturnsDiffWhenSourceMismatches", func(t *testing.T) {
 		mocks := setupTestRunnerMocks(t)
 		runner := createRunnerWithMockGenerator(mocks)


### PR DESCRIPTION
Closes #3235

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> Changes are limited to a docs update and a test-tooling fix, with no production behavior change beyond a pure refactor.
>
> **Overview**
>
> This PR adds a Simplified Technical English writing-style rule to CLAUDE.md and renumbers the subsequent rules. It also extracts the existing `Path`-or-`Name` fallback in `compileFluxSystemTiers` into a new `FluxSystem.EffectivePath()` method, which `compileFluxSystemTiers` now calls instead of inlining the check.
>
> `pkg/test/runner.go`'s `matchFluxSystem` is updated to compare expected paths against `actual.EffectivePath()` rather than the raw `Path` field, so a test fixture that omits `path:` now matches correctly against the name-derived default the composer actually produces. Both changes are covered by new unit tests.

<!-- /claude-code-review:summary -->
