### PR TITLE
fix(kubernetes): scale kustomization deletion timeout by inventory size

### DIFF
--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -221,7 +221,7 @@ func (k *BaseKubernetesManager) DeleteKustomization(name, namespace string) erro
 
 	reason := describeStuckKustomization(lastObj) + k.describeStuckHelmReleases(name, namespace)
 	if reason == "" {
-		return fmt.Errorf("timeout waiting for kustomization %s/%s to be deleted after %s; no status condition confirms a stuck finalizer, but that does not rule one out — check whether %s (status.inventory) is still shrinking before re-running `windsor destroy`; if it is not shrinking, find the stuck object with %s", namespace, name, waitFor, inspectCmd, terminatingCmd)
+		return fmt.Errorf("timeout waiting for kustomization %s/%s to be deleted after %s; no status condition confirms a stuck finalizer, but that does not rule one out — check whether %s (status.inventory) is still shrinking before retrying; if it is not shrinking, find the stuck object with %s", namespace, name, waitFor, inspectCmd, terminatingCmd)
 	}
 	return fmt.Errorf("timeout waiting for kustomization %s/%s to be deleted%s; an inventory item is likely stuck on a cloud-controller finalizer — inspect with %s (status.conditions, status.inventory) and %s to find the stuck object", namespace, name, reason, inspectCmd, terminatingCmd)
 }

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -94,10 +94,12 @@ type BaseKubernetesManager struct {
 	client        client.KubernetesClient
 	configHandler config.ConfigHandler
 
-	kustomizationWaitPollInterval     time.Duration
-	kustomizationWaitMinErrorDuration time.Duration
-	kustomizationReconcileTimeout     time.Duration
-	kustomizationReconcileSleep       time.Duration
+	kustomizationWaitPollInterval        time.Duration
+	kustomizationWaitMinErrorDuration    time.Duration
+	kustomizationReconcileTimeout        time.Duration
+	kustomizationReconcileSleep          time.Duration
+	kustomizationDeletionPerEntryTimeout time.Duration
+	kustomizationDeletionMaxExtraTimeout time.Duration
 
 	notReadyDescribeBudget time.Duration
 
@@ -117,17 +119,19 @@ func NewKubernetesManager(kubernetesClient client.KubernetesClient, configHandle
 	}
 
 	manager := &BaseKubernetesManager{
-		client:                            kubernetesClient,
-		configHandler:                     configHandler,
-		shims:                             NewShims(),
-		kustomizationWaitPollInterval:     2 * time.Second,
-		kustomizationWaitMinErrorDuration: 30 * time.Second,
-		kustomizationReconcileTimeout:     5 * time.Minute,
-		kustomizationReconcileSleep:       2 * time.Second,
-		notReadyDescribeBudget:            10 * time.Second,
-		healthCheckPollInterval:           10 * time.Second,
-		healthCheckSettleDuration:         30 * time.Second,
-		nodeReadyPollInterval:             5 * time.Second,
+		client:                               kubernetesClient,
+		configHandler:                        configHandler,
+		shims:                                NewShims(),
+		kustomizationWaitPollInterval:        2 * time.Second,
+		kustomizationWaitMinErrorDuration:    30 * time.Second,
+		kustomizationReconcileTimeout:        5 * time.Minute,
+		kustomizationReconcileSleep:          2 * time.Second,
+		kustomizationDeletionPerEntryTimeout: 3 * time.Second,
+		kustomizationDeletionMaxExtraTimeout: 20 * time.Minute,
+		notReadyDescribeBudget:               10 * time.Second,
+		healthCheckPollInterval:              10 * time.Second,
+		healthCheckSettleDuration:            30 * time.Second,
+		nodeReadyPollInterval:                5 * time.Second,
 	}
 
 	return manager
@@ -164,26 +168,12 @@ func (k *BaseKubernetesManager) ApplyKustomization(kustomization kustomizev1.Kus
 	return k.applyWithRetry(gvr, obj, opts)
 }
 
-// DeleteKustomization removes a Kustomization resource using background deletion.
-// Background deletion allows the kustomization to enter "Terminating" state while its
-// children are deleted in the background. The method waits for the deletion to complete.
-//
-// On timeout (Flux's WaitForTermination has not lifted its finalizer within
-// kustomizationReconcileTimeout), the method returns an error rather than stripping
-// finalizers. The timeout almost always means an inventory item is stuck on a
-// cloud-controller finalizer (CSI external-attacher, aws-load-balancer-controller's
-// service.k8s.aws/resources, cert-manager) — stripping the Kustomization's own
-// finalizer at that point reaps the Kustomization from etcd but leaves the inventory
-// items orphaned in their namespace, where the controller that should lift their
-// finalizers may already be torn down. The orphan then blocks namespace termination
-// and (worse) lets terraform proceed to destroy the cluster while cloud resources
-// (LBs, EBS volumes, DNS records) leak. Returning an error here surfaces the stuck
-// state so the operator can re-deploy the controller, let it finish cleanup, and
-// re-run destroy — vs. silently masking the failure.
-//
-// The Kustomization's own conditions are often uninformative while stuck ("Progressing").
-// describeStuckHelmReleases checks its HelmReleases for a better reason (e.g. a CRD still
-// has live instances) and adds it to the error.
+// DeleteKustomization removes a Kustomization using background deletion and waits for
+// it to disappear, scaling the wait by inventory size for CRD-heavy layers. On timeout
+// it returns an error instead of stripping finalizers, which would orphan inventory
+// items and let terraform destroy the cluster while their cloud resources leak. The
+// error asserts a stuck finalizer only when a status condition confirms one; otherwise
+// it reports the timeout as unconfirmed.
 func (k *BaseKubernetesManager) DeleteKustomization(name, namespace string) error {
 	gvr := schema.GroupVersionResource{
 		Group:    "kustomize.toolkit.fluxcd.io",
@@ -204,9 +194,10 @@ func (k *BaseKubernetesManager) DeleteKustomization(name, namespace string) erro
 		return err
 	}
 
-	timeout := time.Now().Add(k.kustomizationReconcileTimeout)
+	start := time.Now()
+	waitFor := k.kustomizationReconcileTimeout
 	var lastObj *unstructured.Unstructured
-	for time.Now().Before(timeout) {
+	for time.Now().Before(start.Add(waitFor)) {
 		obj, err := k.client.GetResource(gvr, namespace, name)
 		if err != nil && isNotFoundError(err) {
 			return nil
@@ -215,11 +206,52 @@ func (k *BaseKubernetesManager) DeleteKustomization(name, namespace string) erro
 			return fmt.Errorf("error checking kustomization deletion status: %w", err)
 		}
 		lastObj = obj
+
+		if size := inventorySize(obj); size > 0 {
+			if scaled := k.kustomizationDeletionTimeout(size); scaled > waitFor {
+				waitFor = scaled
+			}
+		}
+
 		time.Sleep(k.kustomizationWaitPollInterval)
 	}
 
+	inspectCmd := fmt.Sprintf("`kubectl get kustomization %s -n %s -o yaml`", name, namespace)
+	const terminatingCmd = "`kubectl get pvc,svc,ingress,certificate -A | grep Terminating`"
+
 	reason := describeStuckKustomization(lastObj) + k.describeStuckHelmReleases(name, namespace)
-	return fmt.Errorf("timeout waiting for kustomization %s/%s to be deleted%s; an inventory item is likely stuck on a cloud-controller finalizer — inspect with `kubectl get kustomization %s -n %s -o yaml` (status.conditions, status.inventory) and `kubectl get pvc,svc,ingress,certificate -A | grep Terminating` to find the stuck object", namespace, name, reason, name, namespace)
+	if reason == "" {
+		return fmt.Errorf("timeout waiting for kustomization %s/%s to be deleted after %s; no status condition confirms a stuck finalizer, but that does not rule one out — check whether %s (status.inventory) is still shrinking before re-running `windsor destroy`; if it is not shrinking, find the stuck object with %s", namespace, name, waitFor, inspectCmd, terminatingCmd)
+	}
+	return fmt.Errorf("timeout waiting for kustomization %s/%s to be deleted%s; an inventory item is likely stuck on a cloud-controller finalizer — inspect with %s (status.conditions, status.inventory) and %s to find the stuck object", namespace, name, reason, inspectCmd, terminatingCmd)
+}
+
+// inventorySize counts a Kustomization's status.inventory.entries. It returns 0 for a
+// nil object or a missing/malformed inventory.
+func inventorySize(obj *unstructured.Unstructured) int {
+	if obj == nil {
+		return 0
+	}
+	entries, found, err := unstructured.NestedSlice(obj.Object, "status", "inventory", "entries")
+	if err != nil || !found {
+		return 0
+	}
+	return len(entries)
+}
+
+// kustomizationDeletionTimeout scales DeleteKustomization's wait window by inventory
+// size, capped at kustomizationDeletionMaxExtraTimeout so a corrupted or unusually
+// large count cannot stall destroy indefinitely.
+func (k *BaseKubernetesManager) kustomizationDeletionTimeout(entryCount int) time.Duration {
+	const maxEntryCount = 100_000 // guards the Duration multiplication below against overflow
+	if entryCount > maxEntryCount {
+		entryCount = maxEntryCount
+	}
+	extra := time.Duration(entryCount) * k.kustomizationDeletionPerEntryTimeout
+	if extra > k.kustomizationDeletionMaxExtraTimeout {
+		extra = k.kustomizationDeletionMaxExtraTimeout
+	}
+	return k.kustomizationReconcileTimeout + extra
 }
 
 // describeStuckKustomization extracts the most diagnostic status condition from a

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -544,6 +544,173 @@ func TestBaseKubernetesManager_DeleteKustomization(t *testing.T) {
 			t.Errorf("Expected PropagationPolicy to be DeletePropagationBackground, got %s", *capturedOptions.PropagationPolicy)
 		}
 	})
+
+	t.Run("TimeoutWithoutConfirmedReasonIsHonestAboutUncertainty", func(t *testing.T) {
+		// Given a kustomization that never disappears and carries no diagnostic
+		// condition, so a still-deleting kustomization looks identical to a
+		// genuinely stuck one from status.conditions alone
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			return nil
+		}
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			return &unstructured.Unstructured{}, nil
+		}
+		manager.client = kubernetesClient
+		manager.kustomizationReconcileTimeout = 100 * time.Millisecond
+		manager.kustomizationWaitPollInterval = 50 * time.Millisecond
+
+		// When DeleteKustomization times out
+		err := manager.DeleteKustomization("test-kustomization", "test-namespace")
+
+		// Then the error does not assert a stuck finalizer it cannot confirm, and
+		// tells the operator to check whether deletion is still progressing
+		if err == nil {
+			t.Fatal("Expected timeout error, got nil")
+		}
+		if strings.Contains(err.Error(), "is likely stuck on a cloud-controller finalizer") {
+			t.Errorf("Expected no unconfirmed stuck-finalizer claim, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "does not rule one out") {
+			t.Errorf("Expected error to acknowledge the uncertainty, got: %v", err)
+		}
+	})
+
+	t.Run("TimeoutWithConfirmedReasonKeepsStuckFinalizerWording", func(t *testing.T) {
+		// Given a kustomization that never disappears and carries a diagnostic
+		// condition confirming it is genuinely stuck
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			return nil
+		}
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			return &unstructured.Unstructured{Object: map[string]any{
+				"status": map[string]any{
+					"conditions": []any{
+						map[string]any{
+							"type":    "Stalled",
+							"status":  "True",
+							"reason":  "PruneFailed",
+							"message": "ServiceAccount/telemetry/collector still has finalizer",
+						},
+					},
+				},
+			}}, nil
+		}
+		manager.client = kubernetesClient
+		manager.kustomizationReconcileTimeout = 100 * time.Millisecond
+		manager.kustomizationWaitPollInterval = 50 * time.Millisecond
+
+		// When DeleteKustomization times out
+		err := manager.DeleteKustomization("test-kustomization", "test-namespace")
+
+		// Then the error keeps asserting the stuck finalizer, since Flux's own
+		// condition confirms it, and does not use the unconfirmed wording
+		if err == nil {
+			t.Fatal("Expected timeout error, got nil")
+		}
+		if !strings.Contains(err.Error(), "is likely stuck on a cloud-controller finalizer") {
+			t.Errorf("Expected confirmed stuck-finalizer wording, got: %v", err)
+		}
+		if strings.Contains(err.Error(), "does not rule one out") {
+			t.Errorf("Expected no unconfirmed-deletion wording, got: %v", err)
+		}
+	})
+
+	t.Run("TimeoutWindowScalesWithInventorySize", func(t *testing.T) {
+		// Given a kustomization with a large inventory (a CRD-heavy layer)
+		// that never disappears within the base timeout
+		manager := setup(t)
+		manager.kustomizationReconcileTimeout = 20 * time.Millisecond
+		manager.kustomizationWaitPollInterval = 10 * time.Millisecond
+		manager.kustomizationDeletionPerEntryTimeout = 1 * time.Millisecond
+		manager.kustomizationDeletionMaxExtraTimeout = time.Second
+
+		inventoryEntries := make([]any, 100)
+		for i := range inventoryEntries {
+			inventoryEntries[i] = map[string]any{"id": fmt.Sprintf("ns_res%d_v1_ConfigMap", i)}
+		}
+
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			return nil
+		}
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			return &unstructured.Unstructured{Object: map[string]any{
+				"status": map[string]any{
+					"inventory": map[string]any{
+						"entries": inventoryEntries,
+					},
+				},
+			}}, nil
+		}
+		manager.client = kubernetesClient
+
+		// When DeleteKustomization times out
+		start := time.Now()
+		err := manager.DeleteKustomization("test-kustomization", "test-namespace")
+		elapsed := time.Since(start)
+
+		// Then it waits past the base timeout, scaled by the 100-entry inventory
+		// (100 * 1ms = 100ms extra), instead of aborting at the fixed 20ms window
+		if err == nil {
+			t.Fatal("Expected timeout error, got nil")
+		}
+		if elapsed < 100*time.Millisecond {
+			t.Errorf("Expected wait window scaled by inventory size (>=100ms), got %s", elapsed)
+		}
+	})
+
+	t.Run("TimeoutWindowScalesEvenWhenFirstReadHasNoInventory", func(t *testing.T) {
+		// Given a kustomization whose inventory is empty on the first poll (a status
+		// write racing the delete) but populated on every later poll
+		manager := setup(t)
+		manager.kustomizationReconcileTimeout = 20 * time.Millisecond
+		manager.kustomizationWaitPollInterval = 10 * time.Millisecond
+		manager.kustomizationDeletionPerEntryTimeout = 1 * time.Millisecond
+		manager.kustomizationDeletionMaxExtraTimeout = time.Second
+
+		inventoryEntries := make([]any, 100)
+		for i := range inventoryEntries {
+			inventoryEntries[i] = map[string]any{"id": fmt.Sprintf("ns_res%d_v1_ConfigMap", i)}
+		}
+
+		calls := 0
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			return nil
+		}
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			calls++
+			if calls == 1 {
+				return &unstructured.Unstructured{}, nil
+			}
+			return &unstructured.Unstructured{Object: map[string]any{
+				"status": map[string]any{
+					"inventory": map[string]any{
+						"entries": inventoryEntries,
+					},
+				},
+			}}, nil
+		}
+		manager.client = kubernetesClient
+
+		// When DeleteKustomization times out
+		start := time.Now()
+		err := manager.DeleteKustomization("test-kustomization", "test-namespace")
+		elapsed := time.Since(start)
+
+		// Then a later, populated read still scales the wait window — the empty
+		// first read does not permanently lock in the unscaled base timeout
+		if err == nil {
+			t.Fatal("Expected timeout error, got nil")
+		}
+		if elapsed < 100*time.Millisecond {
+			t.Errorf("Expected wait window scaled by a later inventory read (>=100ms), got %s", elapsed)
+		}
+	})
 }
 
 func TestBaseKubernetesManager_describeNotReadyKustomizations(t *testing.T) {


### PR DESCRIPTION
Closes #3241

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> Changes destroy-path timeout and error-messaging behavior in the shared Kubernetes provisioner, touching a code path used by both `windsor destroy` and blueprint apply/prune flows.
>
> **Overview**
>
> `DeleteKustomization` now scales its wait window by the kustomization's live inventory size, adding up to 20 extra minutes (3s per inventory entry, capped) so CRD-heavy layers with many objects get a fairer chance to finish deleting before timing out. It also refines the timeout error to only assert a "stuck cloud-controller finalizer" when a status condition actually confirms one, and otherwise reports the timeout as unconfirmed with guidance to check whether the inventory is still shrinking.
>
> The unconfirmed-timeout message tells the operator to check progress "before re-running `windsor destroy`," but `DeleteKustomization` is also called from blueprint prune and destroy-only-apply paths that aren't `windsor destroy` itself, so that instruction can be wrong in those contexts. The new logic is well covered by four added table-driven test cases.

<!-- /claude-code-review:summary -->
