### PR TITLE
fix(env): unset cloud platform env vars on context switch away

### DIFF
--- a/integration/env_test.go
+++ b/integration/env_test.go
@@ -226,3 +226,93 @@ func TestTerraformDotEnv_AbsentFromHookOutsideTerraformDirectory(t *testing.T) {
 		t.Errorf("expected HYPERV_HOST to be absent outside a Terraform directory, got:\n%s", stdout)
 	}
 }
+
+// exportedEnvFrom parses "export KEY=VALUE" and "export KEY='VALUE'" lines from
+// `windsor env --hook` output into an env slice, simulating what the shell hook's
+// `eval` would have applied to the live shell before the next invocation.
+func exportedEnvFrom(stdout []byte) []string {
+	var result []string
+	for _, line := range strings.Split(string(stdout), "\n") {
+		rest, ok := strings.CutPrefix(line, "export ")
+		if !ok {
+			continue
+		}
+		key, value, ok := strings.Cut(rest, "=")
+		if !ok {
+			continue
+		}
+		value = strings.Trim(value, "'\"")
+		result = append(result, key+"="+value)
+	}
+	return result
+}
+
+// TestAzureEnv_UnsetOnContextSwitchAway reproduces cli#3245: switching from an
+// azure-platform context to one with no azure config must unset the ARM_* and
+// TF_VAR_* vars the prior context exported, not leave them live in the shell.
+func TestAzureEnv_UnsetOnContextSwitchAway(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "default")
+
+	windsorYamlPath := filepath.Join(dir, "windsor.yaml")
+	windsorYaml := `version: v1alpha1
+contexts:
+  local: {}
+  azure-test:
+    platform: azure
+    azure:
+      subscription_id: "11111111-1111-1111-1111-111111111111"
+      tenant_id: "22222222-2222-2222-2222-222222222222"
+      region: eastus2
+`
+	if err := os.WriteFile(windsorYamlPath, []byte(windsorYaml), 0644); err != nil {
+		t.Fatalf("write windsor.yaml: %v", err)
+	}
+	helpers.MarkAsGitRepo(t, dir)
+	if _, stderr, err := helpers.RunCLI(dir, []string{"init"}, env); err != nil {
+		t.Fatalf("windsor init: %v\nstderr: %s", err, stderr)
+	}
+	if _, stderr, err := helpers.RunCLI(dir, []string{"init", "azure-test"}, env); err != nil {
+		t.Fatalf("windsor init azure-test: %v\nstderr: %s", err, stderr)
+	}
+
+	if _, stderr, err := helpers.RunCLI(dir, []string{"set", "context", "azure-test"}, env); err != nil {
+		t.Fatalf("set context azure-test: %v\nstderr: %s", err, stderr)
+	}
+
+	azureStdout, stderr, err := helpers.RunCLI(dir, []string{"env", "--hook"}, env)
+	if err != nil {
+		t.Fatalf("env --hook (azure-test): %v\nstderr: %s", err, stderr)
+	}
+	if !strings.Contains(string(azureStdout), "ARM_SUBSCRIPTION_ID") {
+		t.Fatalf("expected ARM_SUBSCRIPTION_ID while on azure-test, got:\n%s", azureStdout)
+	}
+
+	envAfterAzure := append(append([]string{}, env...), exportedEnvFrom(azureStdout)...)
+	if _, stderr, err := helpers.RunCLI(dir, []string{"set", "context", "local"}, envAfterAzure); err != nil {
+		t.Fatalf("set context local: %v\nstderr: %s", err, stderr)
+	}
+
+	localStdout, stderr, err := helpers.RunCLI(dir, []string{"env", "--hook"}, envAfterAzure)
+	if err != nil {
+		t.Fatalf("env --hook (local): %v\nstderr: %s", err, stderr)
+	}
+
+	unset := map[string]bool{}
+	for _, line := range strings.Split(string(localStdout), "\n") {
+		rest, ok := strings.CutPrefix(line, "unset ")
+		if !ok {
+			continue
+		}
+		for _, key := range strings.Fields(rest) {
+			unset[key] = true
+		}
+	}
+	for _, key := range []string{
+		"ARM_SUBSCRIPTION_ID", "ARM_TENANT_ID", "TF_VAR_region", "TF_VAR_kubelogin_mode",
+	} {
+		if !unset[key] {
+			t.Errorf("expected %q to be unset after switching away from azure-test, got:\n%s", key, localStdout)
+		}
+	}
+}

--- a/pkg/runtime/env/aws_env.go
+++ b/pkg/runtime/env/aws_env.go
@@ -63,7 +63,9 @@ func NewAwsEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler) *Aw
 // WarnOnProfileMismatch writes a non-fatal hint to warningWriter naming what
 // was expected vs. what exists. Global mode never warns on this: the ambient
 // ~/.aws/config is shared across every project the operator touches, so an
-// unrelated profile there is normal, not evidence of misconfiguration.
+// unrelated profile there is normal, not evidence of misconfiguration. Every
+// emitted key is registered as managed, so WindsorEnvPrinter unsets it once a
+// context switch stops this printer from emitting it.
 func (e *AwsEnvPrinter) GetEnvVars() (map[string]string, error) {
 	envVars := make(map[string]string)
 	global := e.shell.IsGlobal()
@@ -114,6 +116,10 @@ func (e *AwsEnvPrinter) GetEnvVars() (map[string]string, error) {
 		} else if !global {
 			awsprofile.WarnOnProfileMismatch(e.warningWriter, resolver, profileName)
 		}
+	}
+
+	for key := range envVars {
+		e.SetManagedEnv(key)
 	}
 
 	return envVars, nil

--- a/pkg/runtime/env/azure_env.go
+++ b/pkg/runtime/env/azure_env.go
@@ -55,7 +55,9 @@ func NewAzureEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler) *
 // modes — the ARM_* vars describe the target account/tenant and the TF_VAR_*
 // vars feed terraform, which runs from global shells too. TF_VAR_region is
 // omitted when azure.region is unset so consuming modules fall back to their
-// own variable defaults rather than receiving an empty string.
+// own variable defaults rather than receiving an empty string. Every emitted
+// key is registered as managed, so WindsorEnvPrinter unsets it once a context
+// switch stops this printer from emitting it.
 func (e *AzureEnvPrinter) GetEnvVars() (map[string]string, error) {
 	envVars := make(map[string]string)
 	global := e.shell.IsGlobal()
@@ -87,6 +89,10 @@ func (e *AzureEnvPrinter) GetEnvVars() (map[string]string, error) {
 	}
 
 	envVars["TF_VAR_kubelogin_mode"] = e.resolveKubeloginMode(config)
+
+	for key := range envVars {
+		e.SetManagedEnv(key)
+	}
 
 	return envVars, nil
 }

--- a/pkg/runtime/env/gcp_env.go
+++ b/pkg/runtime/env/gcp_env.go
@@ -51,7 +51,13 @@ func NewGcpEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler) *Gc
 // is only emitted when gcp.credentials_path is set explicitly. The project
 // identifiers (GOOGLE_CLOUD_PROJECT, GCLOUD_PROJECT, GOOGLE_CLOUD_QUOTA_PROJECT)
 // are still emitted because they describe which GCP project the context
-// targets, not whose credentials are used.
+// targets, not whose credentials are used. Every emitted key except
+// GOOGLE_APPLICATION_CREDENTIALS is registered as managed, so WindsorEnvPrinter
+// unsets it once a context switch stops this printer from emitting it.
+// GOOGLE_APPLICATION_CREDENTIALS is excluded because it is left untouched
+// whenever it's already present in the shell, so Windsor cannot tell its own
+// prior export apart from a value the operator set intentionally and must not
+// risk clearing the latter.
 func (e *GcpEnvPrinter) GetEnvVars() (map[string]string, error) {
 	envVars := make(map[string]string)
 	global := e.shell.IsGlobal()
@@ -92,6 +98,13 @@ func (e *GcpEnvPrinter) GetEnvVars() (map[string]string, error) {
 		if config.GCP.QuotaProject != nil {
 			envVars["GOOGLE_CLOUD_QUOTA_PROJECT"] = *config.GCP.QuotaProject
 		}
+	}
+
+	for key := range envVars {
+		if key == "GOOGLE_APPLICATION_CREDENTIALS" {
+			continue
+		}
+		e.SetManagedEnv(key)
 	}
 
 	return envVars, nil

--- a/pkg/runtime/env/vsphere_env.go
+++ b/pkg/runtime/env/vsphere_env.go
@@ -57,7 +57,9 @@ func NewVsphereEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler)
 // datastore, network, etc.) are Terraform variable inputs wired by the facet
 // — they are not read from the environment. VSPHERE_PASSWORD must be
 // supplied via secrets or the ambient environment; plaintext passwords are
-// never written to the shell config file.
+// never written to the shell config file. Every emitted key is registered as
+// managed, so WindsorEnvPrinter unsets it once a context switch stops this
+// printer from emitting it.
 func (e *VsphereEnvPrinter) GetEnvVars() (map[string]string, error) {
 	envVars := make(map[string]string)
 	global := e.shell.IsGlobal()
@@ -75,6 +77,9 @@ func (e *VsphereEnvPrinter) GetEnvVars() (map[string]string, error) {
 
 	cfg := e.configHandler.GetConfig()
 	if cfg == nil || cfg.VSphere == nil {
+		for key := range envVars {
+			e.SetManagedEnv(key)
+		}
 		return envVars, nil
 	}
 
@@ -87,6 +92,10 @@ func (e *VsphereEnvPrinter) GetEnvVars() (map[string]string, error) {
 	}
 	if v.Insecure != nil {
 		envVars["VSPHERE_ALLOW_UNVERIFIED_SSL"] = strconv.FormatBool(*v.Insecure)
+	}
+
+	for key := range envVars {
+		e.SetManagedEnv(key)
 	}
 
 	return envVars, nil

--- a/pkg/runtime/env/windsor_env.go
+++ b/pkg/runtime/env/windsor_env.go
@@ -67,13 +67,12 @@ func NewWindsorEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler,
 	}
 }
 
-// GetEnvVars constructs a map of Windsor-specific environment variables by retrieving
-// the current context, project root, and session token. It resolves secrets in custom
-// environment variables using configured providers, handles caching of values, and
-// manages environment variables and aliases. For secrets, it leverages the secrets cache
-// to avoid unnecessary decryption while ensuring variables are properly tracked in the
-// managed environment list. Windsor-prefixed variables are automatically included in
-// the final environment setup to provide a comprehensive configuration.
+// GetEnvVars sets WINDSOR_CONTEXT, WINDSOR_CONTEXT_ID, WINDSOR_PROJECT_ROOT,
+// WINDSOR_SESSION_TOKEN, and BUILD_ID. It evaluates secret expressions in the context's
+// custom environment variables and caches the resolved values. It merges GetManagedEnv
+// and GetManagedAlias from every printer into WINDSOR_MANAGED_ENV and WINDSOR_MANAGED_ALIAS.
+// This printer runs last among all env printers. It then unsets any key the previous
+// WINDSOR_MANAGED_ENV listed that no printer manages this round.
 func (e *WindsorEnvPrinter) GetEnvVars() (map[string]string, error) {
 	envVars := make(map[string]string)
 
@@ -127,15 +126,12 @@ func (e *WindsorEnvPrinter) GetEnvVars() (map[string]string, error) {
 		}
 	}
 
-	// Collect managed envs and aliases from all env printers
 	var allManagedEnv []string
 	var allManagedAlias []string
 
-	// Add our own managed envs and aliases
 	allManagedEnv = append(allManagedEnv, e.GetManagedEnv()...)
 	allManagedAlias = append(allManagedAlias, e.GetManagedAlias()...)
 
-	// Collect from other env printers
 	for _, printer := range e.allEnvPrinters {
 		if printer != nil && printer != e {
 			allManagedEnv = append(allManagedEnv, printer.GetManagedEnv()...)
@@ -143,11 +139,9 @@ func (e *WindsorEnvPrinter) GetEnvVars() (map[string]string, error) {
 		}
 	}
 
-	// Add Windsor prefixed vars to managed env (excluding BUILD_ID if not available)
 	windsorVars := make([]string, 0, len(WindsorPrefixedVars))
 	for _, varName := range WindsorPrefixedVars {
 		if varName == "BUILD_ID" {
-			// Only include BUILD_ID if it's actually set
 			if _, exists := envVars["BUILD_ID"]; exists {
 				windsorVars = append(windsorVars, varName)
 			}
@@ -157,7 +151,23 @@ func (e *WindsorEnvPrinter) GetEnvVars() (map[string]string, error) {
 	}
 	allManagedEnv = append(allManagedEnv, windsorVars...)
 
-	// Set the combined managed env and alias
+	if prevManagedEnv, exists := e.shims.LookupEnv("WINDSOR_MANAGED_ENV"); exists && prevManagedEnv != "" {
+		stillManaged := make(map[string]bool, len(allManagedEnv))
+		for _, k := range allManagedEnv {
+			stillManaged[k] = true
+		}
+		for k := range strings.SplitSeq(prevManagedEnv, ",") {
+			k = strings.TrimSpace(k)
+			if k == "" || stillManaged[k] {
+				continue
+			}
+			if _, alreadySet := envVars[k]; alreadySet {
+				continue
+			}
+			envVars[k] = ""
+		}
+	}
+
 	envVars["WINDSOR_MANAGED_ENV"] = strings.Join(allManagedEnv, ",")
 	envVars["WINDSOR_MANAGED_ALIAS"] = strings.Join(allManagedAlias, ",")
 

--- a/pkg/runtime/env/windsor_env_test.go
+++ b/pkg/runtime/env/windsor_env_test.go
@@ -784,6 +784,50 @@ contexts:
 			t.Errorf("Second token %q should be different from the first token %q", secondToken, firstToken)
 		}
 	})
+
+	t.Run("UnsetsKeysNoLongerManagedByAnyPrinter", func(t *testing.T) {
+		// Given a prior invocation's WINDSOR_MANAGED_ENV names keys no printer
+		// registers this round (e.g. a context switch away from Azure)
+		mocks := setupWindsorEnvMocks(t)
+		printer := NewWindsorEnvPrinter(mocks.Shell, mocks.ConfigHandler, nil, []EnvPrinter{})
+		printer.shims = mocks.Shims
+		t.Setenv("WINDSOR_MANAGED_ENV", "ARM_SUBSCRIPTION_ID,ARM_TENANT_ID")
+
+		// When GetEnvVars is called
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars returned an error: %v", err)
+		}
+
+		// Then both stale keys are explicitly unset
+		for _, key := range []string{"ARM_SUBSCRIPTION_ID", "ARM_TENANT_ID"} {
+			if got, ok := envVars[key]; !ok || got != "" {
+				t.Errorf("%s = %q, ok=%v, want empty string to unset it", key, got, ok)
+			}
+		}
+	})
+
+	t.Run("DoesNotUnsetKeysStillManagedByAnotherPrinter", func(t *testing.T) {
+		// Given a prior invocation's WINDSOR_MANAGED_ENV names a key that another
+		// printer still registers as managed this round
+		mocks := setupWindsorEnvMocks(t)
+		mockPrinter := NewMockEnvPrinter()
+		mockPrinter.GetManagedEnvFunc = func() []string { return []string{"AWS_REGION"} }
+		printer := NewWindsorEnvPrinter(mocks.Shell, mocks.ConfigHandler, nil, []EnvPrinter{mockPrinter})
+		printer.shims = mocks.Shims
+		t.Setenv("WINDSOR_MANAGED_ENV", "AWS_REGION")
+
+		// When GetEnvVars is called
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Fatalf("GetEnvVars returned an error: %v", err)
+		}
+
+		// Then AWS_REGION is not unset
+		if _, ok := envVars["AWS_REGION"]; ok {
+			t.Errorf("AWS_REGION should not be unset while still managed, got %q", envVars["AWS_REGION"])
+		}
+	})
 }
 
 // TestWindsorEnv_PostEnvHook tests the PostEnvHook method of the WindsorEnvPrinter


### PR DESCRIPTION
Closes #3245

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This touches the shared env-printer runtime that every `windsor env` / `windsor hook` invocation goes through across all cloud platforms, but the change is narrow, additive, and covered by both unit and integration tests.
>
> **Overview**
>
> Fixes a real bug: switching context away from a cloud platform (e.g. Azure) left that platform's env vars (ARM_*, TF_VAR_*, etc.) live in the shell instead of unsetting them. The AWS, Azure, GCP, and vSphere env printers now register every key they emit as "managed" via `SetManagedEnv`, and `WindsorEnvPrinter.GetEnvVars`, which runs last, diffs the previous `WINDSOR_MANAGED_ENV` against the current round's managed set and emits an empty value for any key that dropped out, which the shell renderer turns into an `unset`.
>
> `GOOGLE_APPLICATION_CREDENTIALS` is deliberately excluded from GCP's managed set because it's left untouched when already present in the shell, so Windsor can't distinguish its own prior export from an operator-set value and must not risk clearing the latter. A new integration test exercises the Azure case end-to-end (context switch away unsets ARM_* and TF_VAR_*), and new unit tests cover the stale-key-unset and still-managed-elsewhere cases in `WindsorEnvPrinter`.

<!-- /claude-code-review:summary -->
