### PR TITLE
fix(kubernetes): remove real-clock flakiness from timing tests

### DIFF
--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -194,10 +194,10 @@ func (k *BaseKubernetesManager) DeleteKustomization(name, namespace string) erro
 		return err
 	}
 
-	start := time.Now()
+	start := k.shims.TimeNow()
 	waitFor := k.kustomizationReconcileTimeout
 	var lastObj *unstructured.Unstructured
-	for time.Now().Before(start.Add(waitFor)) {
+	for k.shims.TimeNow().Before(start.Add(waitFor)) {
 		obj, err := k.client.GetResource(gvr, namespace, name)
 		if err != nil && isNotFoundError(err) {
 			return nil
@@ -213,7 +213,7 @@ func (k *BaseKubernetesManager) DeleteKustomization(name, namespace string) erro
 			}
 		}
 
-		time.Sleep(k.kustomizationWaitPollInterval)
+		k.shims.TimeSleep(k.kustomizationWaitPollInterval)
 	}
 
 	inspectCmd := fmt.Sprintf("`kubectl get kustomization %s -n %s -o yaml`", name, namespace)
@@ -1210,7 +1210,7 @@ func (k *BaseKubernetesManager) WaitForKubernetesHealthy(ctx context.Context, en
 
 	deadline, ok := ctx.Deadline()
 	if !ok {
-		deadline = time.Now().Add(5 * time.Minute)
+		deadline = k.shims.TimeNow().Add(5 * time.Minute)
 	}
 
 	pollInterval := k.healthCheckPollInterval
@@ -1222,7 +1222,7 @@ func (k *BaseKubernetesManager) WaitForKubernetesHealthy(ctx context.Context, en
 	if settleDuration == 0 {
 		settleDuration = 30 * time.Second
 	}
-	if remaining := time.Until(deadline) - pollInterval; settleDuration > remaining {
+	if remaining := deadline.Sub(k.shims.TimeNow()) - pollInterval; settleDuration > remaining {
 		if remaining < 0 {
 			remaining = 0
 		}
@@ -1231,7 +1231,7 @@ func (k *BaseKubernetesManager) WaitForKubernetesHealthy(ctx context.Context, en
 
 	var lastErr error
 	var settleSince time.Time
-	for time.Now().Before(deadline) {
+	for k.shims.TimeNow().Before(deadline) {
 		select {
 		case <-ctx.Done():
 			return healthyTimeoutError(lastErr)
@@ -1261,9 +1261,9 @@ func (k *BaseKubernetesManager) WaitForKubernetesHealthy(ctx context.Context, en
 			}
 
 			if settleSince.IsZero() {
-				settleSince = time.Now()
+				settleSince = k.shims.TimeNow()
 			}
-			if time.Since(settleSince) < settleDuration {
+			if k.shims.TimeNow().Sub(settleSince) < settleDuration {
 				select {
 				case <-ctx.Done():
 					return healthyTimeoutError(lastErr)

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -83,6 +83,24 @@ func setupDefaultShims() *Shims {
 	return shims
 }
 
+// fakeClock gives a real-time polling loop a deterministic, instantly-advancing Now/Sleep pair,
+// so tests asserting on elapsed time don't depend on actual CI scheduler timing.
+type fakeClock struct {
+	now time.Time
+}
+
+func newFakeClock() *fakeClock {
+	return &fakeClock{now: time.Now()}
+}
+
+func (c *fakeClock) Now() time.Time {
+	return c.now
+}
+
+func (c *fakeClock) Sleep(d time.Duration) {
+	c.now = c.now.Add(d)
+}
+
 func TestBaseKubernetesManager_ApplyKustomization(t *testing.T) {
 	setup := func(t *testing.T) *BaseKubernetesManager {
 		t.Helper()
@@ -222,6 +240,9 @@ func TestBaseKubernetesManager_DeleteKustomization(t *testing.T) {
 		manager.kustomizationWaitPollInterval = 50 * time.Millisecond
 		manager.kustomizationReconcileTimeout = 100 * time.Millisecond
 		manager.kustomizationReconcileSleep = 50 * time.Millisecond
+		clock := newFakeClock()
+		manager.shims.TimeNow = clock.Now
+		manager.shims.TimeSleep = clock.Sleep
 		return manager
 	}
 
@@ -649,9 +670,9 @@ func TestBaseKubernetesManager_DeleteKustomization(t *testing.T) {
 		manager.client = kubernetesClient
 
 		// When DeleteKustomization times out
-		start := time.Now()
+		start := manager.shims.TimeNow()
 		err := manager.DeleteKustomization("test-kustomization", "test-namespace")
-		elapsed := time.Since(start)
+		elapsed := manager.shims.TimeNow().Sub(start)
 
 		// Then it waits past the base timeout, scaled by the 100-entry inventory
 		// (100 * 1ms = 100ms extra), instead of aborting at the fixed 20ms window
@@ -698,9 +719,9 @@ func TestBaseKubernetesManager_DeleteKustomization(t *testing.T) {
 		manager.client = kubernetesClient
 
 		// When DeleteKustomization times out
-		start := time.Now()
+		start := manager.shims.TimeNow()
 		err := manager.DeleteKustomization("test-kustomization", "test-namespace")
-		elapsed := time.Since(start)
+		elapsed := manager.shims.TimeNow().Sub(start)
 
 		// Then a later, populated read still scales the wait window — the empty
 		// first read does not permanently lock in the unscaled base timeout
@@ -3544,16 +3565,20 @@ func TestBaseKubernetesManager_WaitForKubernetesHealthy(t *testing.T) {
 		// configured settle duration itself (e.g. windsor destroy's fail-fast
 		// reachability check, which hands WaitForKubernetesHealthy a 30s context
 		// against the same 30s default settle duration), and a health check that
-		// always succeeds
+		// always succeeds. The poll interval is widened from the suite default so
+		// the real slack between the clamped settle window and the context
+		// deadline (exactly one poll interval, by construction) has enough
+		// absolute headroom to absorb CI scheduler jitter.
 		manager := setup(t)
-		manager.healthCheckSettleDuration = 300 * time.Millisecond
+		manager.healthCheckPollInterval = 150 * time.Millisecond
+		manager.healthCheckSettleDuration = 900 * time.Millisecond
 		kubernetesClient := client.NewMockKubernetesClient()
 		kubernetesClient.CheckHealthFunc = func(ctx context.Context, endpoint string) error {
 			return nil
 		}
 		manager.client = kubernetesClient
 
-		ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+		ctx, cancel := context.WithTimeout(context.Background(), 900*time.Millisecond)
 		defer cancel()
 
 		// When it waits for health

--- a/pkg/provisioner/kubernetes/shims.go
+++ b/pkg/provisioner/kubernetes/shims.go
@@ -24,6 +24,7 @@ type Shims struct {
 	YamlUnmarshal     func(data []byte, v any, opts ...yaml.JSONOpt) error
 	K8sYamlUnmarshal  func(data []byte, v any, opts ...yaml.JSONOpt) error
 	TimeSleep         func(d time.Duration)
+	TimeNow           func() time.Time
 	ToUnstructured    func(obj any) (map[string]any, error)
 	FromUnstructured  func(obj map[string]any, target any) error
 }
@@ -40,6 +41,7 @@ func NewShims() *Shims {
 		YamlUnmarshal:     yaml.Unmarshal,
 		K8sYamlUnmarshal:  yaml.Unmarshal,
 		TimeSleep:         time.Sleep,
+		TimeNow:           time.Now,
 		ToUnstructured: func(obj any) (map[string]any, error) {
 			return runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
 		},


### PR DESCRIPTION
Closes #3248

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> The change touches test-support code and one internal shim in the Kubernetes provisioner; production timing behavior is unchanged because the new shim defaults to the real clock.
>
> **Overview**
>
> This PR adds a `TimeNow` field to the `kubernetes` package's `Shims` struct and routes the real-clock reads in `DeleteKustomization` and `WaitForKubernetesHealthy` through it, mirroring the existing `TimeSleep` shim. The `DeleteKustomization` test suite now injects a deterministic `fakeClock`, whose `Sleep` instantly advances a fake `Now`, so elapsed-time assertions no longer depend on actual CI scheduler timing.
>
> The `WaitForKubernetesHealthy` tests were not wired to the fake clock; the one flake-prone subtest (settle duration clamped to the caller's deadline) is instead fixed by widening the poll interval and settle/context durations, keeping the same one-poll-interval margin but with more absolute headroom against jitter. That subtest still depends on real wall-clock scheduling, so a (much smaller) flake risk remains there.

<!-- /claude-code-review:summary -->
