### PR TITLE
feat(debug): add --debug mode and kubelogin diagnostics

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/windsorcli/cli/pkg/debug"
 	"github.com/windsorcli/cli/pkg/project"
 	"github.com/windsorcli/cli/pkg/runtime/tools"
 	"github.com/windsorcli/cli/pkg/tui"
@@ -14,6 +15,10 @@ import (
 
 // verbose is a flag for verbose output
 var verbose bool
+
+// debugFlag turns on internal diagnostic logging via the debug package.
+// WINDSOR_DEBUG=true enables it too, for runs that cannot pass a flag.
+var debugFlag bool
 
 // noCache is a flag for bypassing the OCI artifact cache. When true, every
 // command's preflight sets NO_CACHE=true so ArtifactBuilder.Pull skips the
@@ -75,6 +80,8 @@ func init() {
 	// Define the --lock-timeout flag. Persistent so every command that acquires the stack
 	// lock (apply, up, destroy, plan, bootstrap, upgrade) inherits it.
 	rootCmd.PersistentFlags().DurationVar(&lockTimeout, "lock-timeout", 0, "Duration to wait for the stack lock before failing (e.g. 30s, 5m). Defaults to 0 (fail immediately).")
+	// Define the --debug flag. Persistent so every command inherits it.
+	rootCmd.PersistentFlags().BoolVar(&debugFlag, "debug", false, "Enable internal debug logging to stderr")
 }
 
 // commandPreflight orchestrates global CLI preflight checks and context initialization for all commands.
@@ -190,7 +197,8 @@ func silenceErrorsOnAncestors(cmd *cobra.Command) {
 // setting the env var is the smallest-blast-radius path that works for every command
 // without threading a flag through the project/runtime/composer construction chain.
 // An explicit --no-cache always wins; a pre-existing NO_CACHE in the environment is
-// preserved when the flag is not set.
+// preserved when the flag is not set. --debug and WINDSOR_DEBUG=true both enable
+// debug.Log output for the run; either one is enough.
 func setupGlobalContext(cmd *cobra.Command) error {
 	ctx := cmd.Root().Context()
 	if ctx == nil {
@@ -204,6 +212,8 @@ func setupGlobalContext(cmd *cobra.Command) error {
 			return fmt.Errorf("failed to set NO_CACHE environment variable: %w", err)
 		}
 	}
+	debug.Init(debugFlag || os.Getenv("WINDSOR_DEBUG") == "true")
+	debug.Log("debug logging enabled")
 	cmd.SetContext(ctx)
 	tui.Init(verbose)
 	return nil

--- a/integration/debug_test.go
+++ b/integration/debug_test.go
@@ -1,0 +1,62 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/windsorcli/cli/integration/helpers"
+)
+
+// =============================================================================
+// Integration Tests
+// =============================================================================
+
+// TestDebug_FlagEnablesDebugLogging verifies that --debug turns on the
+// "[debug]" diagnostic lines windsor writes to stderr while resolving
+// environment variables.
+func TestDebug_FlagEnablesDebugLogging(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "default")
+
+	_, stderr, err := helpers.RunCLI(dir, []string{"env", "--debug"}, env)
+	if err != nil {
+		t.Fatalf("env --debug: %v\nstderr: %s", err, stderr)
+	}
+	if !strings.Contains(string(stderr), "[debug]") {
+		t.Errorf("expected stderr to contain debug output, got:\n%s", stderr)
+	}
+}
+
+// TestDebug_DefaultIsSilent verifies that windsor writes no "[debug]" lines
+// when --debug is not passed and WINDSOR_DEBUG is not set.
+func TestDebug_DefaultIsSilent(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "default")
+
+	_, stderr, err := helpers.RunCLI(dir, []string{"env"}, env)
+	if err != nil {
+		t.Fatalf("env: %v\nstderr: %s", err, stderr)
+	}
+	if strings.Contains(string(stderr), "[debug]") {
+		t.Errorf("expected no debug output without --debug, got:\n%s", stderr)
+	}
+}
+
+// TestDebug_EnvVarEnablesDebugLogging verifies that WINDSOR_DEBUG=true enables
+// the same debug output as --debug, for runs that cannot pass a flag.
+func TestDebug_EnvVarEnablesDebugLogging(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "default")
+	env = append(env, "WINDSOR_DEBUG=true")
+
+	_, stderr, err := helpers.RunCLI(dir, []string{"env"}, env)
+	if err != nil {
+		t.Fatalf("env: %v\nstderr: %s", err, stderr)
+	}
+	if !strings.Contains(string(stderr), "[debug]") {
+		t.Errorf("expected stderr to contain debug output, got:\n%s", stderr)
+	}
+}

--- a/pkg/debug/debug.go
+++ b/pkg/debug/debug.go
@@ -1,0 +1,41 @@
+// The debug package provides centralized debug-output control for the Windsor CLI.
+// It gates internal diagnostic logging behind a single process-wide switch.
+// Init sets the switch once at startup; Log is a no-op until debug output is enabled.
+// Callers must not pass secret values to Log, since output is not scrubbed.
+
+package debug
+
+import (
+	"fmt"
+	"os"
+)
+
+// =============================================================================
+// Constructor
+// =============================================================================
+
+// enabled tracks whether debug output is turned on for the current process.
+var enabled bool
+
+// Init turns debug output on or off for the current run.
+func Init(on bool) {
+	enabled = on
+}
+
+// =============================================================================
+// Public Methods
+// =============================================================================
+
+// Enabled reports whether debug output is currently turned on.
+func Enabled() bool {
+	return enabled
+}
+
+// Log writes one line to stderr, prefixed "[debug]", when debug output is
+// enabled. It is a no-op otherwise. Args follow fmt.Sprintf conventions.
+func Log(format string, args ...any) {
+	if !enabled {
+		return
+	}
+	fmt.Fprintf(os.Stderr, "[debug] "+format+"\n", args...)
+}

--- a/pkg/debug/debug_test.go
+++ b/pkg/debug/debug_test.go
@@ -1,0 +1,104 @@
+package debug_test
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"testing"
+
+	"github.com/windsorcli/cli/pkg/debug"
+)
+
+// =============================================================================
+// Test Setup
+// =============================================================================
+
+func resetDebug(t *testing.T) {
+	t.Helper()
+	debug.Init(false)
+	t.Cleanup(func() { debug.Init(false) })
+}
+
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("failed to create pipe: %v", err)
+	}
+	old := os.Stderr
+	os.Stderr = w
+	fn()
+	w.Close()
+	os.Stderr = old
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	r.Close()
+	return buf.String()
+}
+
+// =============================================================================
+// Test Public Methods
+// =============================================================================
+
+func TestInit(t *testing.T) {
+	t.Run("EnablesDebugOutput", func(t *testing.T) {
+		// Given debug output is off
+		resetDebug(t)
+
+		// When Init is called with true
+		debug.Init(true)
+
+		// Then Enabled reports true
+		if !debug.Enabled() {
+			t.Fatal("expected Enabled to return true")
+		}
+	})
+
+	t.Run("DisablesDebugOutput", func(t *testing.T) {
+		// Given debug output is on
+		resetDebug(t)
+		debug.Init(true)
+
+		// When Init is called with false
+		debug.Init(false)
+
+		// Then Enabled reports false
+		if debug.Enabled() {
+			t.Fatal("expected Enabled to return false")
+		}
+	})
+}
+
+func TestLog(t *testing.T) {
+	t.Run("WritesToStderrWhenEnabled", func(t *testing.T) {
+		// Given debug output is enabled
+		resetDebug(t)
+		debug.Init(true)
+
+		// When Log is called with a formatted message
+		output := captureStderr(t, func() {
+			debug.Log("value is %s", "workloadidentity")
+		})
+
+		// Then the message is written with the debug prefix
+		want := "[debug] value is workloadidentity\n"
+		if output != want {
+			t.Fatalf("expected output %q, got %q", want, output)
+		}
+	})
+
+	t.Run("WritesNothingWhenDisabled", func(t *testing.T) {
+		// Given debug output is disabled
+		resetDebug(t)
+
+		// When Log is called
+		output := captureStderr(t, func() {
+			debug.Log("value is %s", "workloadidentity")
+		})
+
+		// Then nothing is written
+		if output != "" {
+			t.Fatalf("expected no output, got %q", output)
+		}
+	})
+}

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -20,6 +20,7 @@ import (
 
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/constants"
+	"github.com/windsorcli/cli/pkg/debug"
 	"github.com/windsorcli/cli/pkg/runtime"
 	envvars "github.com/windsorcli/cli/pkg/runtime/env"
 	"github.com/windsorcli/cli/pkg/tui"
@@ -333,6 +334,7 @@ func (s *TerraformStack) Up(blueprint *blueprintv1alpha1.Blueprint, onApply ...f
 			planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan", "-refresh=false"}
 			planArgs = append(planArgs, terraformArgs.PlanArgs...)
 			planEnv := selectTerraformCommandEnv(terraformVars, true, scopedKeys)
+			debug.Log("terraform plan for %s: TF_VAR_kubelogin_mode=%q (inherited process env)", component.Path, os.Getenv("TF_VAR_kubelogin_mode"))
 			if _, err = s.runtime.Shell.ExecSilentWithEnv(terraformCommand, planEnv, planArgs...); err != nil {
 				return fmt.Errorf("error running terraform plan for %s: %w", component.Path, err)
 			}
@@ -341,6 +343,7 @@ func (s *TerraformStack) Up(blueprint *blueprintv1alpha1.Blueprint, onApply ...f
 			applyArgs = append(applyArgs, noColorArgs()...)
 			applyArgs = append(applyArgs, terraformArgs.ApplyArgs...)
 			applyEnv := selectTerraformCommandEnv(terraformVars, false, scopedKeys)
+			debug.Log("terraform apply for %s: TF_VAR_kubelogin_mode=%q (inherited process env)", component.Path, os.Getenv("TF_VAR_kubelogin_mode"))
 			if _, err = s.runtime.Shell.ExecProgressWithEnv(fmt.Sprintf("Applying Terraform changes in %s", component.Path), terraformCommand, applyEnv, applyArgs...); err != nil {
 				return fmt.Errorf("error running terraform apply for %s: %w", component.Path, err)
 			}

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -334,7 +334,7 @@ func (s *TerraformStack) Up(blueprint *blueprintv1alpha1.Blueprint, onApply ...f
 			planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan", "-refresh=false"}
 			planArgs = append(planArgs, terraformArgs.PlanArgs...)
 			planEnv := selectTerraformCommandEnv(terraformVars, true, scopedKeys)
-			debug.Log("terraform plan for %s: TF_VAR_kubelogin_mode=%q (inherited process env)", component.Path, os.Getenv("TF_VAR_kubelogin_mode"))
+			debug.Log("terraform plan for %s: TF_VAR_kubelogin_mode=%q (effective)", component.Path, effectiveTerraformEnvValue(planEnv, "TF_VAR_kubelogin_mode"))
 			if _, err = s.runtime.Shell.ExecSilentWithEnv(terraformCommand, planEnv, planArgs...); err != nil {
 				return fmt.Errorf("error running terraform plan for %s: %w", component.Path, err)
 			}
@@ -343,7 +343,7 @@ func (s *TerraformStack) Up(blueprint *blueprintv1alpha1.Blueprint, onApply ...f
 			applyArgs = append(applyArgs, noColorArgs()...)
 			applyArgs = append(applyArgs, terraformArgs.ApplyArgs...)
 			applyEnv := selectTerraformCommandEnv(terraformVars, false, scopedKeys)
-			debug.Log("terraform apply for %s: TF_VAR_kubelogin_mode=%q (inherited process env)", component.Path, os.Getenv("TF_VAR_kubelogin_mode"))
+			debug.Log("terraform apply for %s: TF_VAR_kubelogin_mode=%q (effective)", component.Path, effectiveTerraformEnvValue(applyEnv, "TF_VAR_kubelogin_mode"))
 			if _, err = s.runtime.Shell.ExecProgressWithEnv(fmt.Sprintf("Applying Terraform changes in %s", component.Path), terraformCommand, applyEnv, applyArgs...); err != nil {
 				return fmt.Errorf("error running terraform apply for %s: %w", component.Path, err)
 			}
@@ -1946,6 +1946,17 @@ func selectTerraformCommandEnv(terraformVars map[string]string, includeTFVars bo
 		}
 	}
 	return selected
+}
+
+// effectiveTerraformEnvValue reports the value of key as the terraform subprocess would
+// actually see it: commandEnv's value when present (selectTerraformCommandEnv's output),
+// otherwise the CLI process's own inherited environment, since mergeEnvVars falls back to
+// that for any key commandEnv does not override.
+func effectiveTerraformEnvValue(commandEnv map[string]string, key string) string {
+	if value, exists := commandEnv[key]; exists {
+		return value
+	}
+	return os.Getenv(key)
 }
 
 // =============================================================================

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -2224,6 +2224,34 @@ func TestTerraformStack_setupTerraformEnvironment(t *testing.T) {
 			t.Error("Expected UNRELATED to be omitted since it isn't in scopedKeys")
 		}
 	})
+
+	t.Run("EffectiveEnvValuePrefersCommandEnvOverProcessEnv", func(t *testing.T) {
+		// Given a command env that overrides a key also set in the process env
+		t.Setenv("TF_VAR_kubelogin_mode", "azurecli")
+		commandEnv := map[string]string{"TF_VAR_kubelogin_mode": "workloadidentity"}
+
+		// When resolving the effective value
+		value := effectiveTerraformEnvValue(commandEnv, "TF_VAR_kubelogin_mode")
+
+		// Then the command env's value wins
+		if value != "workloadidentity" {
+			t.Errorf("Expected workloadidentity, got %q", value)
+		}
+	})
+
+	t.Run("EffectiveEnvValueFallsBackToProcessEnv", func(t *testing.T) {
+		// Given a command env that does not carry the key
+		t.Setenv("TF_VAR_kubelogin_mode", "azurecli")
+		commandEnv := map[string]string{}
+
+		// When resolving the effective value
+		value := effectiveTerraformEnvValue(commandEnv, "TF_VAR_kubelogin_mode")
+
+		// Then the inherited process env value is returned
+		if value != "azurecli" {
+			t.Errorf("Expected azurecli, got %q", value)
+		}
+	})
 }
 
 func TestStack_Plan(t *testing.T) {

--- a/pkg/runtime/env/azure_env.go
+++ b/pkg/runtime/env/azure_env.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 
 	"github.com/windsorcli/cli/api/v1alpha1"
+	"github.com/windsorcli/cli/pkg/debug"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
 )
@@ -89,6 +90,7 @@ func (e *AzureEnvPrinter) GetEnvVars() (map[string]string, error) {
 	}
 
 	envVars["TF_VAR_kubelogin_mode"] = e.resolveKubeloginMode(config)
+	debug.Log("azure env: resolved TF_VAR_kubelogin_mode=%q", envVars["TF_VAR_kubelogin_mode"])
 
 	for key := range envVars {
 		e.SetManagedEnv(key)

--- a/pkg/runtime/env/windsor_env.go
+++ b/pkg/runtime/env/windsor_env.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/windsorcli/cli/pkg/debug"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	"github.com/windsorcli/cli/pkg/runtime/evaluator"
 	"github.com/windsorcli/cli/pkg/runtime/secrets"
@@ -164,6 +165,7 @@ func (e *WindsorEnvPrinter) GetEnvVars() (map[string]string, error) {
 			if _, alreadySet := envVars[k]; alreadySet {
 				continue
 			}
+			debug.Log("windsor env: unsetting stale managed var %s (no printer reports it this round)", k)
 			envVars[k] = ""
 		}
 	}


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> The change adds an opt-in `--debug` diagnostic mode; it is additive, gated behind a new flag/env var, and does not alter default CLI behavior.
>
> **Overview**
>
> This PR introduces a small `pkg/debug` package with a process-wide `Init`/`Log`/`Enabled` switch, wires it into `cmd/root.go` via a new persistent `--debug` flag (or `WINDSOR_DEBUG=true`), and adds a handful of `debug.Log` call sites in the Terraform stack runner and the Azure/Windsor env printers to surface `TF_VAR_kubelogin_mode` resolution. Unit tests cover the new package directly, and an integration test verifies the flag and env var both enable `[debug]`-prefixed stderr output while it stays silent by default.
>
> The two new debug lines in `pkg/provisioner/terraform/stack.go` log `os.Getenv("TF_VAR_kubelogin_mode")` — the CLI process's own environment — rather than the value actually placed into `planEnv`/`applyEnv` for the Terraform subprocess, which is computed separately from `terraformVars`. See inline comment.

<!-- /claude-code-review:summary -->
