### PR TITLE
fix(env): scope terraform empty-env unset to owned keys

### DIFF
--- a/pkg/runtime/env/terraform_env.go
+++ b/pkg/runtime/env/terraform_env.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/windsorcli/cli/pkg/runtime/config"
@@ -61,18 +62,20 @@ func NewTerraformEnvPrinter(shell shell.Shell, configHandler config.ConfigHandle
 // Public Methods
 // =============================================================================
 
-// terraformScopedEnvKeysVar is the managed env var recording which keys the current
-// contexts/<context>/terraform/.env last exported, so getEmptyEnvVars can unset exactly
-// those keys on a later invocation even if the file has since changed or been removed.
+// terraformScopedEnvKeysVar is the managed env var recording every key this printer's
+// GetEnvVars last exported — its own base vars, any dynamic TF_VAR_* from the current
+// component's inputs, and any contexts/<context>/terraform/.env content — so
+// getEmptyEnvVars can unset exactly those keys on a later invocation even if the current
+// component, its inputs, or the .env file have since changed.
 const terraformScopedEnvKeysVar = "WINDSOR_MANAGED_TERRAFORM_ENV"
 
 // GetEnvVars returns a map of environment variables for Terraform operations.
 // If not in a Terraform project directory, it unsets managed variables present in the environment.
 // Otherwise, it generates Terraform arguments for the current project, merged with any
 // contexts/<context>/terraform/.env content. Every returned key is tracked as managed so it
-// is unset cleanly when the operator leaves the directory; the terraform/.env key names are
-// additionally recorded in WINDSOR_MANAGED_TERRAFORM_ENV so getEmptyEnvVars can still unset
-// them later even if the file's contents change or the file is removed in the meantime.
+// is unset cleanly when the operator leaves the directory; the full set of emitted key names
+// is additionally recorded in WINDSOR_MANAGED_TERRAFORM_ENV so getEmptyEnvVars can still unset
+// them later even if the component, its inputs, or the .env file have since changed.
 // Returns the environment variable map or an error if resolution fails.
 func (e *TerraformEnvPrinter) GetEnvVars() (map[string]string, error) {
 	projectPath, err := e.terraformProvider.FindRelativeProjectPath()
@@ -84,18 +87,20 @@ func (e *TerraformEnvPrinter) GetEnvVars() (map[string]string, error) {
 		return e.getEmptyEnvVars(), nil
 	}
 
-	terraformVars, scopedKeys, _, err := e.terraformProvider.GetEnvVars(projectPath, true)
-	for key := range terraformVars {
-		e.SetManagedEnv(key)
+	terraformVars, _, _, err := e.terraformProvider.GetEnvVars(projectPath, true)
+	if terraformVars == nil {
+		terraformVars = make(map[string]string)
 	}
 
-	if len(scopedKeys) > 0 {
-		if terraformVars == nil {
-			terraformVars = make(map[string]string)
-		}
-		terraformVars[terraformScopedEnvKeysVar] = strings.Join(scopedKeys, ",")
-		e.SetManagedEnv(terraformScopedEnvKeysVar)
+	emittedKeys := make([]string, 0, len(terraformVars))
+	for key := range terraformVars {
+		emittedKeys = append(emittedKeys, key)
+		e.SetManagedEnv(key)
 	}
+	sort.Strings(emittedKeys)
+
+	terraformVars[terraformScopedEnvKeysVar] = strings.Join(emittedKeys, ",")
+	e.SetManagedEnv(terraformScopedEnvKeysVar)
 
 	return terraformVars, err
 }
@@ -136,11 +141,11 @@ func (e *TerraformEnvPrinter) restoreEnvVar(key, originalValue string) {
 }
 
 // getEmptyEnvVars returns env vars for unsetting managed variables when not in a terraform
-// project, including any keys the last-visited contexts/<context>/terraform/.env exported.
-// Those key names come from WINDSOR_MANAGED_TERRAFORM_ENV (recorded by GetEnvVars when the
-// keys were actually exported) rather than re-reading the current terraform/.env: the file
-// may have changed or been removed since, and re-reading it would miss keys it no longer
-// declares, leaking them in the shell indefinitely.
+// project, scoped to exactly the keys this printer itself emits: its fixed base-var list,
+// plus any contexts/<context>/terraform/.env keys named in WINDSOR_MANAGED_TERRAFORM_ENV
+// (recorded by GetEnvVars when those keys were actually exported, since the file may have
+// changed or been removed since). It never sweeps WINDSOR_MANAGED_ENV for other printers'
+// TF_VAR_* keys — cross-printer cleanup on a context switch is WindsorEnvPrinter's job.
 func (e *TerraformEnvPrinter) getEmptyEnvVars() map[string]string {
 	envVars := make(map[string]string)
 	managedVars := []string{
@@ -157,17 +162,6 @@ func (e *TerraformEnvPrinter) getEmptyEnvVars() map[string]string {
 		"TF_VAR_os_type",
 		"TF_VAR_operation",
 		terraformScopedEnvKeysVar,
-	}
-	if managedEnv := e.shims.Getenv("WINDSOR_MANAGED_ENV"); managedEnv != "" {
-		for _, key := range strings.Split(managedEnv, ",") {
-			key = strings.TrimSpace(key)
-			if key == "" {
-				continue
-			}
-			if strings.HasPrefix(key, "TF_VAR_") || strings.HasPrefix(key, "TF_CLI_ARGS_") || key == "TF_DATA_DIR" {
-				managedVars = append(managedVars, key)
-			}
-		}
 	}
 	if scoped := e.shims.Getenv(terraformScopedEnvKeysVar); scoped != "" {
 		for _, key := range strings.Split(scoped, ",") {

--- a/pkg/runtime/env/terraform_env_test.go
+++ b/pkg/runtime/env/terraform_env_test.go
@@ -378,11 +378,13 @@ func TestTerraformEnv_GetEnvVars(t *testing.T) {
 	})
 
 	t.Run("ResetManagedDynamicTFVarsWhenNoProjectPathFound", func(t *testing.T) {
+		// Given a prior GetEnvVars call recorded its dynamic component-input TF_VAR_*
+		// keys in WINDSOR_MANAGED_TERRAFORM_ENV, the durable record this printer owns
 		printer, mocks := setup(t)
 
 		mocks.Shims.Getenv = func(key string) string {
-			if key == "WINDSOR_MANAGED_ENV" {
-				return "WINDSOR_CONTEXT,TF_VAR_cluster_endpoint,TF_VAR_controlplanes,TF_CLI_ARGS_refresh"
+			if key == "WINDSOR_MANAGED_TERRAFORM_ENV" {
+				return "TF_VAR_cluster_endpoint,TF_VAR_controlplanes,TF_CLI_ARGS_refresh"
 			}
 			return ""
 		}
@@ -413,6 +415,42 @@ func TestTerraformEnv_GetEnvVars(t *testing.T) {
 		}
 		if val, exists := envVars["TF_CLI_ARGS_refresh"]; !exists || val != "" {
 			t.Errorf("Expected TF_CLI_ARGS_refresh to be empty string, got %v", val)
+		}
+	})
+
+	t.Run("LeavesAnotherPrinterManagedTFVarAloneWhenNoProjectPathFound", func(t *testing.T) {
+		// Given AzureEnvPrinter's TF_VAR_kubelogin_mode is currently set and listed in
+		// WINDSOR_MANAGED_ENV, but this printer never emitted it itself (windsorcli/cli#3253)
+		printer, mocks := setup(t)
+
+		mocks.Shims.Getenv = func(key string) string {
+			if key == "WINDSOR_MANAGED_ENV" {
+				return "WINDSOR_CONTEXT,TF_VAR_kubelogin_mode,ARM_SUBSCRIPTION_ID"
+			}
+			return ""
+		}
+		mocks.Shims.LookupEnv = func(key string) (string, bool) {
+			if key == "TF_VAR_kubelogin_mode" {
+				return "workloadidentity", true
+			}
+			return "", false
+		}
+
+		mockProvider := setupMockTerraformProvider(mocks)
+		mockProvider.FindRelativeProjectPathFunc = func(directory ...string) (string, error) {
+			return "", nil
+		}
+		printer = setupTerraformEnvPrinter(t, mocks, mockProvider)
+
+		// When GetEnvVars is called outside a Terraform directory
+		envVars, err := printer.GetEnvVars()
+
+		// Then the other printer's managed var is left untouched, not scheduled for unset
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if _, exists := envVars["TF_VAR_kubelogin_mode"]; exists {
+			t.Errorf("Expected TF_VAR_kubelogin_mode to be left alone, got an entry: %v", envVars["TF_VAR_kubelogin_mode"])
 		}
 	})
 
@@ -554,9 +592,10 @@ func TestTerraformEnv_GetEnvVars(t *testing.T) {
 			t.Errorf("Expected HYPERV_HOST to be tracked in managed env, got %v", managed)
 		}
 
-		// And the durable record of which keys came from terraform/.env should be set and managed
-		if envVars["WINDSOR_MANAGED_TERRAFORM_ENV"] != "HYPERV_HOST" {
-			t.Errorf("Expected WINDSOR_MANAGED_TERRAFORM_ENV=HYPERV_HOST, got %q", envVars["WINDSOR_MANAGED_TERRAFORM_ENV"])
+		// And the durable record of every emitted key, including the terraform/.env one,
+		// should be set and managed
+		if envVars["WINDSOR_MANAGED_TERRAFORM_ENV"] != "HYPERV_HOST,TF_DATA_DIR" {
+			t.Errorf("Expected WINDSOR_MANAGED_TERRAFORM_ENV=HYPERV_HOST,TF_DATA_DIR, got %q", envVars["WINDSOR_MANAGED_TERRAFORM_ENV"])
 		}
 		if !slices.Contains(managed, "WINDSOR_MANAGED_TERRAFORM_ENV") {
 			t.Errorf("Expected WINDSOR_MANAGED_TERRAFORM_ENV to be tracked in managed env, got %v", managed)


### PR DESCRIPTION
Closes #3253

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change is isolated to `TerraformEnvPrinter`'s environment-variable bookkeeping and fixes a scoping bug; it does not touch shared infrastructure or change any user-facing default.
>
> **Overview**
>
> `TerraformEnvPrinter.GetEnvVars` now records every key it actually emits (base vars, dynamic `TF_VAR_*` from the current component's inputs, and any `terraform/.env` content) in `WINDSOR_MANAGED_TERRAFORM_ENV`, and `getEmptyEnvVars` uses only that self-owned record plus its fixed base-var list to decide what to unset.
>
> Previously, `getEmptyEnvVars` additionally swept the global `WINDSOR_MANAGED_ENV` list for any `TF_VAR_*`/`TF_CLI_ARGS_*`/`TF_DATA_DIR` key, which could unset variables another printer (e.g. `AzureEnvPrinter`'s `TF_VAR_kubelogin_mode`) had set. That cross-printer sweep is removed; a new regression test confirms the other printer's variable is left alone.

<!-- /claude-code-review:summary -->
