### PR TITLE
fix(artifact): parse @sha256 digests in OCI source references

### DIFF
--- a/pkg/composer/artifact/artifact.go
+++ b/pkg/composer/artifact/artifact.go
@@ -199,10 +199,14 @@ func (a *ArtifactBuilder) Write(outputPath string, tag string) (string, error) {
 }
 
 // ParseOCIRef parses an OCI reference into registry, repository, and tag components.
-// Requires the format "oci://registry/repository:tag". The registry may itself contain a
-// colon (an explicit port, e.g. "localhost:5000/repo:tag"), so registry/repository are split
-// on the first "/" before the tag is found at the last ":" — a repository containing a colon
-// (e.g. "repo:tag:extra") is rejected rather than silently misparsed.
+// Requires the format "oci://registry/repository:tag" or "oci://registry/repository@sha256:digest".
+// The registry may itself contain a colon (an explicit port, e.g. "localhost:5000/repo:tag"), so
+// registry/repository are split on the first "/" before the tag is found at the last ":" — a
+// repository containing a colon (e.g. "repo:tag:extra") is rejected rather than silently
+// misparsed. A digest reference is checked first, since "sha256:<hex>" itself contains a colon
+// that the last-":" tag split would otherwise misparse. The returned tag is the bare
+// "sha256:<hex>" string (no "@") for a digest reference — callers pass it to FormatOCIRef, which
+// reconstructs the correct "@" or ":" separator.
 func (a *ArtifactBuilder) ParseOCIRef(ociRef string) (registry, repository, tag string, err error) {
 	if !strings.HasPrefix(ociRef, "oci://") {
 		return "", "", "", fmt.Errorf("invalid OCI reference format: %s", ociRef)
@@ -215,19 +219,40 @@ func (a *ArtifactBuilder) ParseOCIRef(ociRef string) (registry, repository, tag 
 		return "", "", "", fmt.Errorf("invalid OCI reference format, expected registry/repository:tag: %s", ociRef)
 	}
 	registry = ref[:firstSlash]
-	repoAndTag := ref[firstSlash+1:]
+	repoAndVersion := ref[firstSlash+1:]
 
-	lastColon := strings.LastIndex(repoAndTag, ":")
-	if lastColon <= 0 || lastColon == len(repoAndTag)-1 {
+	if atIdx := strings.Index(repoAndVersion, "@sha256:"); atIdx >= 0 {
+		repository = repoAndVersion[:atIdx]
+		tag = repoAndVersion[atIdx+1:]
+		if repository == "" || strings.Contains(repository, ":") {
+			return "", "", "", fmt.Errorf("invalid OCI reference format, expected registry/repository@sha256:digest: %s", ociRef)
+		}
+		return registry, repository, tag, nil
+	}
+
+	lastColon := strings.LastIndex(repoAndVersion, ":")
+	if lastColon <= 0 || lastColon == len(repoAndVersion)-1 {
 		return "", "", "", fmt.Errorf("invalid OCI reference format, expected registry/repository:tag: %s", ociRef)
 	}
-	repository = repoAndTag[:lastColon]
-	tag = repoAndTag[lastColon+1:]
+	repository = repoAndVersion[:lastColon]
+	tag = repoAndVersion[lastColon+1:]
 	if strings.Contains(repository, ":") {
 		return "", "", "", fmt.Errorf("invalid OCI reference format, expected registry/repository:tag: %s", ociRef)
 	}
 
 	return registry, repository, tag, nil
+}
+
+// FormatOCIRef reconstructs a "registry/repository:tag" reference, or "registry/repository@tag"
+// when tag is a digest (the "sha256:<hex>" form ParseOCIRef returns for an "@sha256:" reference).
+// The single formatting point every ParseOCIRef caller uses to rebuild a reference or cache key,
+// so a digest reference round-trips correctly everywhere instead of each call site reassembling
+// registry/repository:tag by hand.
+func FormatOCIRef(registry, repository, tag string) string {
+	if strings.HasPrefix(tag, "sha256:") {
+		return fmt.Sprintf("%s/%s@%s", registry, repository, tag)
+	}
+	return fmt.Sprintf("%s/%s:%s", registry, repository, tag)
 }
 
 // ListTags returns the tags published for the repository of an OCI reference (the tag in ociRef is
@@ -257,7 +282,7 @@ func (a *ArtifactBuilder) GetCliVersionConstraint(ociRef string) (string, error)
 		return "", err
 	}
 
-	ref := fmt.Sprintf("%s/%s:%s", registry, repository, tag)
+	ref := FormatOCIRef(registry, repository, tag)
 	parsedRef, err := a.shims.ParseReference(ref)
 	if err != nil {
 		return "", fmt.Errorf("failed to parse reference %s: %w", ref, err)
@@ -294,7 +319,7 @@ func (a *ArtifactBuilder) VerifyCliVersionCompatibility(ociRef string) error {
 	if err != nil {
 		return err
 	}
-	cacheKey := fmt.Sprintf("%s/%s:%s", registry, repository, tag)
+	cacheKey := FormatOCIRef(registry, repository, tag)
 	cacheDir, ok := artifacts[cacheKey]
 	if !ok {
 		return fmt.Errorf("failed to retrieve cache directory for %s", ociRef)
@@ -360,15 +385,15 @@ func ResolveCompatibleTag(artifactBuilder Artifact, urlPrefix string, tags []str
 
 // GetCacheDir returns the cache directory path for an OCI artifact identified by registry, repository, and tag.
 // The cache directory is located at <projectRoot>/.windsor/cache/oci/<extractionKey> where extractionKey
-// is the cacheKey with / and : replaced with _ for filesystem safety.
+// is the cacheKey with /, :, and @ replaced with _ for filesystem safety.
 // Returns an error if project root is empty.
 func (a *ArtifactBuilder) GetCacheDir(registry, repository, tag string) (string, error) {
 	if a.runtime == nil || a.runtime.ProjectRoot == "" {
 		return "", fmt.Errorf("project root is not set")
 	}
 
-	cacheKey := fmt.Sprintf("%s/%s:%s", registry, repository, tag)
-	extractionKey := strings.ReplaceAll(strings.ReplaceAll(cacheKey, "/", "_"), ":", "_")
+	cacheKey := FormatOCIRef(registry, repository, tag)
+	extractionKey := strings.NewReplacer("/", "_", ":", "_", "@", "_").Replace(cacheKey)
 	cacheDir := filepath.Join(a.runtime.ProjectRoot, ".windsor", "cache", "oci", extractionKey)
 
 	return cacheDir, nil
@@ -502,7 +527,7 @@ func (a *ArtifactBuilder) Pull(ociRefs []string) (map[string]string, error) {
 			return nil, fmt.Errorf("failed to parse OCI reference %s: %w", ref, err)
 		}
 
-		cacheKey := fmt.Sprintf("%s/%s:%s", registry, repository, tag)
+		cacheKey := FormatOCIRef(registry, repository, tag)
 
 		cacheDir, err := a.GetCacheDir(registry, repository, tag)
 		if err != nil {
@@ -534,7 +559,7 @@ func (a *ArtifactBuilder) Pull(ociRefs []string) (map[string]string, error) {
 					return fmt.Errorf("failed to parse OCI reference %s: %w", ref, err)
 				}
 
-				cacheKey := fmt.Sprintf("%s/%s:%s", registry, repository, tag)
+				cacheKey := FormatOCIRef(registry, repository, tag)
 
 				artifactData, err := a.downloadOCIArtifact(registry, repository, tag)
 				if err != nil {
@@ -646,7 +671,9 @@ func (a *ArtifactBuilder) ExtractModulePath(registry, repository, tag, modulePat
 // =============================================================================
 
 // ParseOCIReference parses a blueprint reference string in OCI URL or org/repo:tag format and returns an OCIArtifactInfo struct.
-// Accepts full OCI URLs (e.g., oci://ghcr.io/org/repo:v1.0.0) and org/repo:v1.0.0 formats only.
+// Accepts full OCI URLs (e.g., oci://ghcr.io/org/repo:v1.0.0), org/repo:v1.0.0, and a
+// "@sha256:<hex>" digest in place of the tag in either form. Tag holds the bare "sha256:<hex>"
+// string (no "@") for a digest reference.
 // Returns nil if the reference is empty, missing a version, or not in a supported format.
 func ParseOCIReference(ociRef string) (*OCIArtifactInfo, error) {
 	if ociRef == "" {
@@ -658,31 +685,41 @@ func ParseOCIReference(ociRef string) (*OCIArtifactInfo, error) {
 	if strings.HasPrefix(ociRef, "oci://") {
 		fullURL = ociRef
 		remaining := strings.TrimPrefix(ociRef, "oci://")
-		if lastColon := strings.LastIndex(remaining, ":"); lastColon > 0 {
+		// Checked before the last-":" split below: "sha256:<hex>" itself contains a colon,
+		// which that split would otherwise misparse as part of the version.
+		var pathPart string
+		if atIdx := strings.Index(remaining, "@sha256:"); atIdx >= 0 {
+			version = remaining[atIdx+1:]
+			pathPart = remaining[:atIdx]
+		} else if lastColon := strings.LastIndex(remaining, ":"); lastColon > 0 {
 			version = remaining[lastColon+1:]
-			pathPart := remaining[:lastColon]
+			pathPart = remaining[:lastColon]
+		} else {
+			return nil, fmt.Errorf("blueprint reference '%s' is missing a version (e.g., core:v1.0.0)", ociRef)
+		}
+		if lastSlash := strings.LastIndex(pathPart, "/"); lastSlash >= 0 {
+			name = pathPart[lastSlash+1:]
+		} else {
+			return nil, fmt.Errorf("blueprint reference '%s' is missing a version (e.g., core:v1.0.0)", ociRef)
+		}
+	} else {
+		var pathPart string
+		if atIdx := strings.Index(ociRef, "@sha256:"); atIdx >= 0 {
+			version = ociRef[atIdx+1:]
+			pathPart = ociRef[:atIdx]
+		} else if colonIdx := strings.LastIndex(ociRef, ":"); colonIdx > 0 {
+			version = ociRef[colonIdx+1:]
+			pathPart = ociRef[:colonIdx]
+		} else {
+			return nil, fmt.Errorf("blueprint reference '%s' is missing a version (e.g., core:v1.0.0)", ociRef)
+		}
+		if strings.Count(pathPart, "/") >= 1 {
 			if lastSlash := strings.LastIndex(pathPart, "/"); lastSlash >= 0 {
 				name = pathPart[lastSlash+1:]
 			} else {
 				return nil, fmt.Errorf("blueprint reference '%s' is missing a version (e.g., core:v1.0.0)", ociRef)
 			}
-		} else {
-			return nil, fmt.Errorf("blueprint reference '%s' is missing a version (e.g., core:v1.0.0)", ociRef)
-		}
-	} else {
-		if colonIdx := strings.LastIndex(ociRef, ":"); colonIdx > 0 {
-			pathPart := ociRef[:colonIdx]
-			version = ociRef[colonIdx+1:]
-			if strings.Count(pathPart, "/") >= 1 {
-				if lastSlash := strings.LastIndex(pathPart, "/"); lastSlash >= 0 {
-					name = pathPart[lastSlash+1:]
-				} else {
-					return nil, fmt.Errorf("blueprint reference '%s' is missing a version (e.g., core:v1.0.0)", ociRef)
-				}
-				fullURL = "oci://ghcr.io/" + ociRef
-			} else {
-				return nil, fmt.Errorf("blueprint reference '%s' is missing a version (e.g., core:v1.0.0)", ociRef)
-			}
+			fullURL = "oci://ghcr.io/" + ociRef
 		} else {
 			return nil, fmt.Errorf("blueprint reference '%s' is missing a version (e.g., core:v1.0.0)", ociRef)
 		}
@@ -1511,7 +1548,7 @@ func (a *ArtifactBuilder) extractArtifactToCache(artifactData []byte, extraction
 // If the anonymous retry also fails, the original keychain error is returned so the
 // underlying auth failure remains visible.
 func (a *ArtifactBuilder) downloadOCIArtifact(registry, repository, tag string) ([]byte, error) {
-	ref := fmt.Sprintf("%s/%s:%s", registry, repository, tag)
+	ref := FormatOCIRef(registry, repository, tag)
 
 	parsedRef, err := a.shims.ParseReference(ref)
 	if err != nil {

--- a/pkg/composer/artifact/artifact.go
+++ b/pkg/composer/artifact/artifact.go
@@ -198,15 +198,12 @@ func (a *ArtifactBuilder) Write(outputPath string, tag string) (string, error) {
 	return finalOutputPath, nil
 }
 
-// ParseOCIRef parses an OCI reference into registry, repository, and tag components.
-// Requires the format "oci://registry/repository:tag" or "oci://registry/repository@sha256:digest".
-// The registry may itself contain a colon (an explicit port, e.g. "localhost:5000/repo:tag"), so
-// registry/repository are split on the first "/" before the tag is found at the last ":" — a
-// repository containing a colon (e.g. "repo:tag:extra") is rejected rather than silently
-// misparsed. A digest reference is checked first, since "sha256:<hex>" itself contains a colon
-// that the last-":" tag split would otherwise misparse. The returned tag is the bare
-// "sha256:<hex>" string (no "@") for a digest reference — callers pass it to FormatOCIRef, which
-// reconstructs the correct "@" or ":" separator.
+// ParseOCIRef parses an OCI reference into registry, repository, and tag.
+// Accepts "oci://registry/repository:tag" or "oci://registry/repository@sha256:digest".
+// The registry may contain a port, so repository and tag split on the last colon.
+// A repository containing a colon is rejected to avoid a wrong split.
+// A digest reference returns tag as the bare "sha256:<hex>" string.
+// Pass tag to FormatOCIRef to rebuild the correct separator.
 func (a *ArtifactBuilder) ParseOCIRef(ociRef string) (registry, repository, tag string, err error) {
 	if !strings.HasPrefix(ociRef, "oci://") {
 		return "", "", "", fmt.Errorf("invalid OCI reference format: %s", ociRef)
@@ -243,11 +240,9 @@ func (a *ArtifactBuilder) ParseOCIRef(ociRef string) (registry, repository, tag 
 	return registry, repository, tag, nil
 }
 
-// FormatOCIRef reconstructs a "registry/repository:tag" reference, or "registry/repository@tag"
-// when tag is a digest (the "sha256:<hex>" form ParseOCIRef returns for an "@sha256:" reference).
-// The single formatting point every ParseOCIRef caller uses to rebuild a reference or cache key,
-// so a digest reference round-trips correctly everywhere instead of each call site reassembling
-// registry/repository:tag by hand.
+// FormatOCIRef builds "registry/repository:tag", or "registry/repository@tag" when tag is a
+// digest ("sha256:<hex>"). Every ParseOCIRef caller uses this to rebuild a reference or cache
+// key, so a digest round-trips correctly.
 func FormatOCIRef(registry, repository, tag string) string {
 	if strings.HasPrefix(tag, "sha256:") {
 		return fmt.Sprintf("%s/%s@%s", registry, repository, tag)
@@ -671,9 +666,9 @@ func (a *ArtifactBuilder) ExtractModulePath(registry, repository, tag, modulePat
 // =============================================================================
 
 // ParseOCIReference parses a blueprint reference string in OCI URL or org/repo:tag format and returns an OCIArtifactInfo struct.
-// Accepts full OCI URLs (e.g., oci://ghcr.io/org/repo:v1.0.0), org/repo:v1.0.0, and a
-// "@sha256:<hex>" digest in place of the tag in either form. Tag holds the bare "sha256:<hex>"
-// string (no "@") for a digest reference.
+// Accepts full OCI URLs (e.g., oci://ghcr.io/org/repo:v1.0.0) and org/repo:v1.0.0 formats.
+// Both formats also accept a "@sha256:<hex>" digest in place of the tag, checked before the
+// version colon since the digest itself contains one. Tag holds the bare digest string, without "@".
 // Returns nil if the reference is empty, missing a version, or not in a supported format.
 func ParseOCIReference(ociRef string) (*OCIArtifactInfo, error) {
 	if ociRef == "" {
@@ -685,8 +680,6 @@ func ParseOCIReference(ociRef string) (*OCIArtifactInfo, error) {
 	if strings.HasPrefix(ociRef, "oci://") {
 		fullURL = ociRef
 		remaining := strings.TrimPrefix(ociRef, "oci://")
-		// Checked before the last-":" split below: "sha256:<hex>" itself contains a colon,
-		// which that split would otherwise misparse as part of the version.
 		var pathPart string
 		if atIdx := strings.Index(remaining, "@sha256:"); atIdx >= 0 {
 			version = remaining[atIdx+1:]

--- a/pkg/composer/artifact/artifact_helpers_test.go
+++ b/pkg/composer/artifact/artifact_helpers_test.go
@@ -60,6 +60,26 @@ func TestParseOCIReference(t *testing.T) {
 			expected:    nil,
 			expectError: true,
 		},
+		{
+			name:  "FullOCIURLWithDigest",
+			input: "oci://ghcr.io/windsorcli/core@sha256:abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234",
+			expected: &OCIArtifactInfo{
+				Name: "core",
+				URL:  "oci://ghcr.io/windsorcli/core@sha256:abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234",
+				Tag:  "sha256:abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234",
+			},
+			expectError: false,
+		},
+		{
+			name:  "ShortFormatWithDigest",
+			input: "windsorcli/core@sha256:abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234",
+			expected: &OCIArtifactInfo{
+				Name: "core",
+				URL:  "oci://ghcr.io/windsorcli/core@sha256:abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234",
+				Tag:  "sha256:abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234",
+			},
+			expectError: false,
+		},
 	}
 
 	for _, tc := range testCases {

--- a/pkg/composer/artifact/artifact_private_test.go
+++ b/pkg/composer/artifact/artifact_private_test.go
@@ -1282,6 +1282,52 @@ func TestArtifactBuilder_ParseOCIRef(t *testing.T) {
 			t.Errorf("expected tag 'v1.0.0', got %s", tag)
 		}
 	})
+
+	t.Run("DigestReference", func(t *testing.T) {
+		// Given an ArtifactBuilder
+		builder, _ := setup(t)
+
+		// When ParseOCIRef is called with an "@sha256:" digest instead of a tag
+		registry, repository, tag, err := builder.ParseOCIRef("oci://ghcr.io/windsorcli/core@sha256:abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234")
+
+		// Then no error should occur
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+
+		// And the digest is not mistaken for a tag containing a colon
+		if registry != "ghcr.io" {
+			t.Errorf("expected registry 'ghcr.io', got %s", registry)
+		}
+		if repository != "windsorcli/core" {
+			t.Errorf("expected repository 'windsorcli/core', got %s", repository)
+		}
+		if tag != "sha256:abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234" {
+			t.Errorf("expected tag 'sha256:abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234', got %s", tag)
+		}
+	})
+}
+
+func TestFormatOCIRef(t *testing.T) {
+	t.Run("Tag", func(t *testing.T) {
+		// When FormatOCIRef is called with a plain tag
+		result := FormatOCIRef("ghcr.io", "windsorcli/core", "v1.0.0")
+
+		// Then it joins registry and repository with a colon
+		if result != "ghcr.io/windsorcli/core:v1.0.0" {
+			t.Errorf("expected 'ghcr.io/windsorcli/core:v1.0.0', got %s", result)
+		}
+	})
+
+	t.Run("Digest", func(t *testing.T) {
+		// When FormatOCIRef is called with a "sha256:<hex>" digest
+		result := FormatOCIRef("ghcr.io", "windsorcli/core", "sha256:abcd1234")
+
+		// Then it joins registry and repository with an "@", not a colon
+		if result != "ghcr.io/windsorcli/core@sha256:abcd1234" {
+			t.Errorf("expected 'ghcr.io/windsorcli/core@sha256:abcd1234', got %s", result)
+		}
+	})
 }
 
 func TestArtifactBuilder_downloadOCIArtifact(t *testing.T) {

--- a/pkg/composer/blueprint/loader.go
+++ b/pkg/composer/blueprint/loader.go
@@ -208,7 +208,7 @@ func (l *BaseBlueprintLoader) loadFromOCI() error {
 		return fmt.Errorf("failed to parse OCI reference: %w", err)
 	}
 
-	cacheKey := fmt.Sprintf("%s/%s:%s", registry, repository, tag)
+	cacheKey := artifact.FormatOCIRef(registry, repository, tag)
 	cacheDir, exists := artifacts[cacheKey]
 	if !exists {
 		return fmt.Errorf("failed to retrieve cache directory for %s", l.sourceURL)

--- a/pkg/composer/terraform/oci_module_resolver.go
+++ b/pkg/composer/terraform/oci_module_resolver.go
@@ -161,7 +161,7 @@ func (h *OCIModuleResolver) extractOCIModule(resolvedSource string, ociArtifacts
 		return "", fmt.Errorf("failed to parse OCI reference: %w", err)
 	}
 
-	cacheKey := fmt.Sprintf("%s/%s:%s", registry, repository, tag)
+	cacheKey := artifact.FormatOCIRef(registry, repository, tag)
 	if _, exists := ociArtifacts[cacheKey]; !exists {
 		return "", fmt.Errorf("OCI artifact %s not found in cache", cacheKey)
 	}

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -2288,7 +2288,14 @@ func (k *BaseKubernetesManager) applyBlueprintOCIRepository(source blueprintv1al
 	ociURL := source.Url
 	var ref *sourcev1.OCIRepositoryRef
 
-	if lastColon := strings.LastIndex(ociURL, ":"); lastColon > len("oci://") {
+	// Checked before the tag split below: "sha256:<hex>" itself contains a colon, which the
+	// last-":" tag split would otherwise misparse as part of the tag.
+	if atIdx := strings.Index(ociURL, "@sha256:"); atIdx > len("oci://") {
+		ociURL = ociURL[:atIdx]
+		ref = &sourcev1.OCIRepositoryRef{
+			Digest: source.Url[atIdx+1:],
+		}
+	} else if lastColon := strings.LastIndex(ociURL, ":"); lastColon > len("oci://") {
 		if tagPart := ociURL[lastColon+1:]; tagPart != "" && !strings.Contains(tagPart, "/") {
 			ociURL = ociURL[:lastColon]
 			ref = &sourcev1.OCIRepositoryRef{

--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -2284,12 +2284,11 @@ func (k *BaseKubernetesManager) applyBlueprintGitRepository(source blueprintv1al
 // applyBlueprintOCIRepository converts and applies a blueprint Source as an OCIRepository.
 // isPrimary selects the short, continuously-polled interval default for the blueprint's own
 // repository rather than the long pinned-vendor-source default; see constants.FluxSourceInterval.
+// Checks for a "@sha256:<hex>" digest before the tag split, since the digest also has a colon.
 func (k *BaseKubernetesManager) applyBlueprintOCIRepository(source blueprintv1alpha1.Source, namespace string, isPrimary bool) error {
 	ociURL := source.Url
 	var ref *sourcev1.OCIRepositoryRef
 
-	// Checked before the tag split below: "sha256:<hex>" itself contains a colon, which the
-	// last-":" tag split would otherwise misparse as part of the tag.
 	if atIdx := strings.Index(ociURL, "@sha256:"); atIdx > len("oci://") {
 		ociURL = ociURL[:atIdx]
 		ref = &sourcev1.OCIRepositoryRef{

--- a/pkg/provisioner/kubernetes/kubernetes_manager_private_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_private_test.go
@@ -1472,8 +1472,6 @@ func TestBaseKubernetesManager_applyBlueprintOCIRepository(t *testing.T) {
 		}
 		repo := *captured
 
-		// The digest is not mistaken for a tag containing a colon: the URL is truncated to the
-		// bare repository, and the digest lands in Reference.Digest, not Reference.Tag.
 		if repo.Spec.URL != "oci://ghcr.io/windsorcli/core" {
 			t.Errorf("expected URL 'oci://ghcr.io/windsorcli/core', got %s", repo.Spec.URL)
 		}

--- a/pkg/provisioner/kubernetes/kubernetes_manager_private_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_private_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	sourcev1 "github.com/fluxcd/source-controller/api/v1"
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/constants"
 	"github.com/windsorcli/cli/pkg/provisioner/kubernetes/client"
@@ -1415,4 +1416,97 @@ func equalStringSlice(a, b []string) bool {
 		}
 	}
 	return true
+}
+
+func TestBaseKubernetesManager_applyBlueprintOCIRepository(t *testing.T) {
+	// setup returns a manager whose ToUnstructured shim intercepts the *sourcev1.OCIRepository
+	// applyBlueprintOCIRepository builds, capturing it into *captured so the test can inspect
+	// the Spec fields the digest/tag parsing logic actually produced.
+	setup := func(t *testing.T) (manager *BaseKubernetesManager, captured **sourcev1.OCIRepository) {
+		t.Helper()
+		mocks := setupKubernetesMocks(t)
+		manager = NewKubernetesManager(mocks.KubernetesClient, mocks.ConfigHandler)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			return nil, fmt.Errorf("not found")
+		}
+		kubernetesClient.ApplyResourceFunc = func(gvr schema.GroupVersionResource, obj *unstructured.Unstructured, opts metav1.ApplyOptions) (*unstructured.Unstructured, error) {
+			return obj, nil
+		}
+		manager.client = kubernetesClient
+
+		var repo *sourcev1.OCIRepository
+		captured = &repo
+		manager.shims.ToUnstructured = func(obj any) (map[string]any, error) {
+			r, ok := obj.(*sourcev1.OCIRepository)
+			if !ok {
+				return nil, fmt.Errorf("expected *sourcev1.OCIRepository, got %T", obj)
+			}
+			*captured = r
+			return map[string]any{
+				"apiVersion": "source.toolkit.fluxcd.io/v1",
+				"kind":       "OCIRepository",
+				"metadata": map[string]any{
+					"name":      r.Name,
+					"namespace": r.Namespace,
+				},
+				"spec": map[string]any{
+					"url": r.Spec.URL,
+				},
+			}, nil
+		}
+		return manager, captured
+	}
+
+	t.Run("DigestReference", func(t *testing.T) {
+		manager, captured := setup(t)
+
+		source := blueprintv1alpha1.Source{
+			Name: "core",
+			Url:  "oci://ghcr.io/windsorcli/core@sha256:abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234",
+		}
+
+		err := manager.applyBlueprintSource(source, "system-gitops", true)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		repo := *captured
+
+		// The digest is not mistaken for a tag containing a colon: the URL is truncated to the
+		// bare repository, and the digest lands in Reference.Digest, not Reference.Tag.
+		if repo.Spec.URL != "oci://ghcr.io/windsorcli/core" {
+			t.Errorf("expected URL 'oci://ghcr.io/windsorcli/core', got %s", repo.Spec.URL)
+		}
+		if repo.Spec.Reference == nil {
+			t.Fatalf("expected a non-nil Reference")
+		}
+		if repo.Spec.Reference.Digest != "sha256:abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234abcd1234" {
+			t.Errorf("expected Digest 'sha256:abcd...', got %q", repo.Spec.Reference.Digest)
+		}
+		if repo.Spec.Reference.Tag != "" {
+			t.Errorf("expected empty Tag for a digest reference, got %q", repo.Spec.Reference.Tag)
+		}
+	})
+
+	t.Run("TagReference", func(t *testing.T) {
+		manager, captured := setup(t)
+
+		source := blueprintv1alpha1.Source{
+			Name: "core",
+			Url:  "oci://ghcr.io/windsorcli/core:latest",
+		}
+
+		err := manager.applyBlueprintSource(source, "system-gitops", true)
+		if err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+		repo := *captured
+
+		if repo.Spec.URL != "oci://ghcr.io/windsorcli/core" {
+			t.Errorf("expected URL 'oci://ghcr.io/windsorcli/core', got %s", repo.Spec.URL)
+		}
+		if repo.Spec.Reference == nil || repo.Spec.Reference.Tag != "latest" {
+			t.Errorf("expected Reference.Tag 'latest', got %+v", repo.Spec.Reference)
+		}
+	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This PR extends OCI reference parsing to recognize `@sha256:<hex>` digests alongside tags, touching artifact resolution, blueprint/terraform cache-key construction, and Flux `OCIRepository` generation; the change is additive and backward compatible, and existing tag-based paths are unaffected.
>
> **Overview**
>
> `ParseOCIRef` and `ParseOCIReference` now check for `@sha256:` before falling back to the existing last-colon tag split, so a digest's embedded colon is no longer misparsed as part of a tag. A new `FormatOCIRef` helper centralizes reference reconstruction (`registry/repository:tag` vs `registry/repository@sha256:digest`) and replaces every ad hoc `fmt.Sprintf("%s/%s:%s", ...)` call site across the artifact, blueprint loader, and terraform OCI module resolver packages, so cache keys stay consistent everywhere.
>
> `applyBlueprintOCIRepository` in the Kubernetes provisioner gains matching digest handling, setting `OCIRepositoryRef.Digest` instead of `Tag` when a blueprint source URL carries a digest. Cache directory naming (`GetCacheDir`) is updated to also strip `@` for filesystem safety. New unit tests cover both the parsing and the Flux resource generation paths for digest and tag references.

<!-- /claude-code-review:summary -->
