### PR TITLE
fix(runtime): default workstation.runtime for docker/incus

### DIFF
--- a/pkg/runtime/runtime.go
+++ b/pkg/runtime/runtime.go
@@ -560,9 +560,13 @@ func (rt *Runtime) PrepareToolsFor(reqs tools.Requirements) error {
 // Private Methods
 // =============================================================================
 
-// setConfigDefaults holds the defaulting work for ApplyConfigDefaults, and is also what
-// ResolveConfig calls directly for its post-load pass, once LoadConfig has already run and
-// dev mode is fully resolved (unlike ApplyConfigDefaults, this never defers).
+// setConfigDefaults applies the shared config defaults.
+// ApplyConfigDefaults calls this once, before ResolveConfig loads the config file.
+// ResolveConfig calls this again right after the load. The second call never defers.
+//
+// It sets workstation.runtime in dev mode. It also sets workstation.runtime when
+// this run passes an explicit docker or incus platform. A platform saved from an
+// earlier run does not trigger this default.
 func (rt *Runtime) setConfigDefaults(flagOverrides ...map[string]any) error {
 	existingPlatform := rt.canonicalPlatform()
 	isDevMode := rt.ConfigHandler.IsDevMode(rt.ContextName)
@@ -590,8 +594,10 @@ func (rt *Runtime) setConfigDefaults(flagOverrides ...map[string]any) error {
 	if effectivePlatform == "" {
 		effectivePlatform = existingPlatform
 	}
-	needsWorkstationRuntime := effectivePlatform == "" || effectivePlatform == "docker" || effectivePlatform == "incus"
-	if isDevMode && workstationRuntime == "" && needsWorkstationRuntime {
+	needsWorkstationRuntime := effectivePlatform == "" || isWorkstationPlatform(effectivePlatform)
+	explicitWorkstationPlatform := isWorkstationPlatform(overridePlatform)
+	shouldDefaultWorkstationRuntime := isDevMode || explicitWorkstationPlatform
+	if shouldDefaultWorkstationRuntime && workstationRuntime == "" && needsWorkstationRuntime {
 		switch runtime.GOOS {
 		case "darwin", "windows":
 			workstationRuntime = "docker-desktop"
@@ -600,7 +606,7 @@ func (rt *Runtime) setConfigDefaults(flagOverrides ...map[string]any) error {
 		}
 	}
 
-	if isDevMode && !hadRuntime && workstationRuntime != "" {
+	if shouldDefaultWorkstationRuntime && !hadRuntime && workstationRuntime != "" {
 		if err := rt.ConfigHandler.Set("workstation.runtime", workstationRuntime); err != nil {
 			return fmt.Errorf("failed to set workstation.runtime: %w", err)
 		}
@@ -651,6 +657,11 @@ func (rt *Runtime) setConfigDefaults(flagOverrides ...map[string]any) error {
 	}
 
 	return nil
+}
+
+// isWorkstationPlatform reports whether platform requires a workstation runtime.
+func isWorkstationPlatform(platform string) bool {
+	return platform == "docker" || platform == "incus"
 }
 
 // explicitPlatformFromOverrides extracts an explicitly provided platform selection from CLI overrides.

--- a/pkg/runtime/runtime_test.go
+++ b/pkg/runtime/runtime_test.go
@@ -1940,6 +1940,110 @@ func TestRuntime_ApplyConfigDefaults(t *testing.T) {
 		}
 	})
 
+	t.Run("DefaultsWorkstationRuntimeForFlagOverridePlatformOutsideDevMode", func(t *testing.T) {
+		for _, platform := range []string{"docker", "incus"} {
+			t.Run(platform, func(t *testing.T) {
+				mocks := setupRuntimeMocks(t)
+				rt := mocks.Runtime
+				rt.ContextName = "docker"
+
+				mockConfigHandler := mocks.ConfigHandler.(*config.MockConfigHandler)
+				// Config is loaded here, matching ResolveConfig's post-load call to
+				// setConfigDefaults, which is the call bootstrap actually reaches.
+				mockConfigHandler.IsLoadedFunc = func() bool { return true }
+				mockConfigHandler.IsDevModeFunc = func(_ string) bool { return false }
+				mockConfigHandler.GetStringFunc = func(_ string, defaultValue ...string) string {
+					if len(defaultValue) > 0 {
+						return defaultValue[0]
+					}
+					return ""
+				}
+				mockConfigHandler.SetDefaultFunc = func(_ v1alpha1.Context) error { return nil }
+
+				setCalls := make(map[string]any)
+				mockConfigHandler.SetFunc = func(key string, value any) error {
+					setCalls[key] = value
+					return nil
+				}
+
+				if err := rt.ApplyConfigDefaults(map[string]any{"platform": platform}); err != nil {
+					t.Fatalf("Expected no error, got: %v", err)
+				}
+				if _, ok := setCalls["workstation.runtime"]; !ok {
+					t.Errorf("Expected workstation.runtime to be set for platform=%q outside dev mode, got setCalls=%v", platform, setCalls)
+				}
+			})
+		}
+	})
+
+	t.Run("SkipsWorkstationRuntimeDefaultWhenNoPlatformOutsideDevMode", func(t *testing.T) {
+		mocks := setupRuntimeMocks(t)
+		rt := mocks.Runtime
+		rt.ContextName = "docker"
+
+		mockConfigHandler := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockConfigHandler.IsLoadedFunc = func() bool { return true }
+		mockConfigHandler.IsDevModeFunc = func(_ string) bool { return false }
+		mockConfigHandler.GetStringFunc = func(_ string, defaultValue ...string) string {
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
+		mockConfigHandler.SetDefaultFunc = func(_ v1alpha1.Context) error { return nil }
+
+		setCalls := make(map[string]any)
+		mockConfigHandler.SetFunc = func(key string, value any) error {
+			setCalls[key] = value
+			return nil
+		}
+
+		if err := rt.ApplyConfigDefaults(); err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if _, ok := setCalls["workstation.runtime"]; ok {
+			t.Errorf("Expected workstation.runtime NOT to be set with no platform outside dev mode, got setCalls=%v", setCalls)
+		}
+	})
+
+	t.Run("SkipsWorkstationRuntimeDefaultForPersistedPlatformOutsideDevMode", func(t *testing.T) {
+		for _, platform := range []string{"docker", "incus"} {
+			t.Run(platform, func(t *testing.T) {
+				mocks := setupRuntimeMocks(t)
+				rt := mocks.Runtime
+				rt.ContextName = "docker"
+
+				mockConfigHandler := mocks.ConfigHandler.(*config.MockConfigHandler)
+				mockConfigHandler.IsLoadedFunc = func() bool { return true }
+				mockConfigHandler.IsDevModeFunc = func(_ string) bool { return false }
+				mockConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+					if key == "platform" {
+						return platform
+					}
+					if len(defaultValue) > 0 {
+						return defaultValue[0]
+					}
+					return ""
+				}
+				mockConfigHandler.SetDefaultFunc = func(_ v1alpha1.Context) error { return nil }
+
+				setCalls := make(map[string]any)
+				mockConfigHandler.SetFunc = func(key string, value any) error {
+					setCalls[key] = value
+					return nil
+				}
+
+				// No --platform flag this run; platform comes only from persisted config.
+				if err := rt.ApplyConfigDefaults(); err != nil {
+					t.Fatalf("Expected no error, got: %v", err)
+				}
+				if _, ok := setCalls["workstation.runtime"]; ok {
+					t.Errorf("Expected workstation.runtime NOT to be set for persisted platform=%q outside dev mode, got setCalls=%v", platform, setCalls)
+				}
+			})
+		}
+	})
+
 	t.Run("DefaultsWorkstationRuntimeWhenNoPlatformInDevMode", func(t *testing.T) {
 		mocks := setupRuntimeMocks(t)
 		rt := mocks.Runtime


### PR DESCRIPTION
Closes #3257

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> The change alters a config-defaulting rule used by every CLI bootstrap, so a mistake here would affect workstation.runtime selection broadly, though the change itself is small and behavior-additive.
>
> **Overview**
>
> This PR extends `setConfigDefaults` in `pkg/runtime/runtime.go` so that `workstation.runtime` is defaulted not only in dev mode, but also outside dev mode when the current invocation passes an explicit `--platform` (or legacy `--provider`) of `docker` or `incus`. Previously this default only ever applied under `isDevMode`. The shared platform check is pulled out into a small `isWorkstationPlatform` helper reused for both the "needs a runtime" and "explicit platform this run" conditions.
>
> A platform value that was merely persisted from an earlier run (not passed as a flag on this invocation) does not trigger the new default, matching the updated function comment. The three added subtests in `runtime_test.go` exercise exactly this distinction: explicit `--platform docker|incus` outside dev mode now sets the default, no platform outside dev mode still skips it, and a persisted-only platform outside dev mode still skips it too.

<!-- /claude-code-review:summary -->
