### PR TITLE
fix(config): suppress cascading errors on invalid platform

### DIFF
--- a/pkg/runtime/config/schema_validator.go
+++ b/pkg/runtime/config/schema_validator.go
@@ -387,11 +387,11 @@ var structuralValidationKeywords = map[string]bool{
 	"if":         true,
 }
 
-// validationError pairs a fully formatted error line with the keyword that produced it, so
-// collectErrors can dedup and prioritize without re-parsing the formatted string.
+// validationError pairs a formatted error line with its instance location and keyword.
 type validationError struct {
-	keyword string
-	line    string
+	location string
+	keyword  string
+	line     string
 }
 
 // collectErrors flattens a kaptinlin EvaluationResult into a deduplicated, prioritized list of
@@ -429,6 +429,8 @@ func flattenErrorList(list *jsonschema.List) []string {
 		deduped = append(deduped, e)
 	}
 
+	deduped = focusOnInvalidPlatform(deduped)
+
 	sort.SliceStable(deduped, func(i, j int) bool {
 		return !structuralValidationKeywords[deduped[i].keyword] && structuralValidationKeywords[deduped[j].keyword]
 	})
@@ -455,13 +457,33 @@ func walkList(list *jsonschema.List, parent string, errs *[]validationError) {
 	}
 	for keyword, msg := range list.Errors {
 		*errs = append(*errs, validationError{
-			keyword: keyword,
-			line:    fmt.Sprintf("%s: %s: %s", display, keyword, msg),
+			location: display,
+			keyword:  keyword,
+			line:     fmt.Sprintf("%s: %s: %s", display, keyword, msg),
 		})
 	}
 	for i := range list.Details {
 		walkList(&list.Details[i], loc, errs)
 	}
+}
+
+// focusOnInvalidPlatform hides other errors when platform fails its enum check. An invalid
+// platform value matches no platform-conditional branch, so those branches also report
+// unrelated required and type errors.
+func focusOnInvalidPlatform(errs []validationError) []validationError {
+	var platformErrs []validationError
+	for _, e := range errs {
+		if e.keyword == "enum" && e.location == "/platform" {
+			platformErrs = append(platformErrs, e)
+		}
+	}
+	if len(platformErrs) == 0 || len(platformErrs) == len(errs) {
+		return errs
+	}
+
+	suppressed := len(errs) - len(platformErrs)
+	note := fmt.Sprintf("%d other error(s) are hidden because 'platform' is invalid. Fix 'platform' and run the command again.", suppressed)
+	return append(platformErrs, validationError{line: note})
 }
 
 // joinInstanceLocation concatenates two JSON Pointer fragments, treating "" and "/" as the

--- a/pkg/runtime/config/schema_validator.go
+++ b/pkg/runtime/config/schema_validator.go
@@ -467,23 +467,36 @@ func walkList(list *jsonschema.List, parent string, errs *[]validationError) {
 	}
 }
 
-// focusOnInvalidPlatform hides other errors when platform fails its enum check. An invalid
-// platform value matches no platform-conditional branch, so those branches also report
-// unrelated required and type errors.
+// cascadeProneKeywords are keywords a missed platform branch reports as fallout, not a real
+// violation.
+var cascadeProneKeywords = map[string]bool{
+	"required": true,
+	"type":     true,
+}
+
+// focusOnInvalidPlatform hides cascade-prone errors when platform fails its enum check. It
+// keeps specific violations, like a bad pattern, since those hold regardless of platform.
 func focusOnInvalidPlatform(errs []validationError) []validationError {
 	var platformErrs []validationError
+	var kept []validationError
+	hidden := 0
 	for _, e := range errs {
-		if e.keyword == "enum" && e.location == "/platform" {
+		switch {
+		case e.keyword == "enum" && e.location == "/platform":
 			platformErrs = append(platformErrs, e)
+		case cascadeProneKeywords[e.keyword] || structuralValidationKeywords[e.keyword]:
+			hidden++
+		default:
+			kept = append(kept, e)
 		}
 	}
-	if len(platformErrs) == 0 || len(platformErrs) == len(errs) {
+	if len(platformErrs) == 0 || hidden == 0 {
 		return errs
 	}
 
-	suppressed := len(errs) - len(platformErrs)
-	note := fmt.Sprintf("%d other error(s) are hidden because 'platform' is invalid. Fix 'platform' and run the command again.", suppressed)
-	return append(platformErrs, validationError{line: note})
+	note := fmt.Sprintf("%d other error(s) are hidden because 'platform' is invalid. Fix 'platform' and run the command again.", hidden)
+	result := append(platformErrs, kept...)
+	return append(result, validationError{line: note})
 }
 
 // joinInstanceLocation concatenates two JSON Pointer fragments, treating "" and "/" as the

--- a/pkg/runtime/config/schema_validator_test.go
+++ b/pkg/runtime/config/schema_validator_test.go
@@ -1013,6 +1013,53 @@ func TestFlattenErrorList(t *testing.T) {
 		}
 	})
 
+	t.Run("SuppressesCascadingErrorsWhenPlatformEnumFails", func(t *testing.T) {
+		// Given an invalid platform value plus the required/type/properties failures that
+		// cascade from no platform-conditional branch matching it
+		list := &jsonschema.List{
+			Details: []jsonschema.List{
+				{InstanceLocation: "/", Errors: map[string]string{"required": "Required property 'identity' is missing"}},
+				{InstanceLocation: "/identity", Errors: map[string]string{"type": "Value is null but should be object"}},
+				{InstanceLocation: "/", Errors: map[string]string{"required": "Required property 'cluster' is missing"}},
+				{InstanceLocation: "/cluster", Errors: map[string]string{"type": "Value is null but should be object"}},
+				{InstanceLocation: "/platform", Errors: map[string]string{"enum": "Value gcp should be one of the allowed values: none, aws, azure"}},
+				{InstanceLocation: "/", Errors: map[string]string{"properties": "Property 'platform' does not match the schema"}},
+			},
+		}
+
+		// When flattening
+		errs := flattenErrorList(list)
+
+		// Then only the platform error and a summary note survive
+		if len(errs) != 2 {
+			t.Fatalf("Expected 2 errors, got %d: %v", len(errs), errs)
+		}
+		if !strings.Contains(errs[0], "/platform: enum:") {
+			t.Errorf("Expected the platform enum error first, got %v", errs)
+		}
+		if !strings.Contains(errs[1], "5 other error(s) are hidden") || !strings.Contains(errs[1], "'platform' is invalid") {
+			t.Errorf("Expected a summary note about hidden errors, got %v", errs)
+		}
+	})
+
+	t.Run("LeavesUnrelatedErrorsAloneWhenPlatformIsValid", func(t *testing.T) {
+		// Given failures with no enum error on /platform at all
+		list := &jsonschema.List{
+			Details: []jsonschema.List{
+				{InstanceLocation: "/", Errors: map[string]string{"required": "Required property 'identity' is missing"}},
+				{InstanceLocation: "/network/cidr_block", Errors: map[string]string{"pattern": "Value does not match the required pattern"}},
+			},
+		}
+
+		// When flattening
+		errs := flattenErrorList(list)
+
+		// Then nothing is suppressed
+		if len(errs) != 2 {
+			t.Errorf("Expected 2 errors unchanged, got %d: %v", len(errs), errs)
+		}
+	})
+
 	t.Run("ReturnsPlaceholderWhenListHasNoErrors", func(t *testing.T) {
 		// Given a list with no error entries anywhere
 		list := &jsonschema.List{}

--- a/pkg/runtime/config/schema_validator_test.go
+++ b/pkg/runtime/config/schema_validator_test.go
@@ -1060,6 +1060,37 @@ func TestFlattenErrorList(t *testing.T) {
 		}
 	})
 
+	t.Run("KeepsIndependentErrorsAlongsideAnInvalidPlatform", func(t *testing.T) {
+		// Given an invalid platform value, a cascade-prone required error, and a specific,
+		// self-contained pattern violation that holds regardless of platform
+		list := &jsonschema.List{
+			Details: []jsonschema.List{
+				{InstanceLocation: "/platform", Errors: map[string]string{"enum": "Value gcp should be one of the allowed values: none, aws, azure"}},
+				{InstanceLocation: "/", Errors: map[string]string{"required": "Required property 'identity' is missing"}},
+				{InstanceLocation: "/network/cidr_block", Errors: map[string]string{"pattern": "Value does not match the required pattern"}},
+			},
+		}
+
+		// When flattening
+		errs := flattenErrorList(list)
+
+		// Then the platform error and the independent pattern error both survive, and only the
+		// cascade-prone required error is hidden
+		if len(errs) != 3 {
+			t.Fatalf("Expected 3 errors, got %d: %v", len(errs), errs)
+		}
+		if !strings.Contains(errs[0], "/platform: enum:") {
+			t.Errorf("Expected the platform enum error first, got %v", errs)
+		}
+		joined := strings.Join(errs, "\n")
+		if !strings.Contains(joined, "/network/cidr_block: pattern:") {
+			t.Errorf("Expected the independent pattern error to survive, got %v", errs)
+		}
+		if !strings.Contains(joined, "1 other error(s) are hidden") {
+			t.Errorf("Expected exactly one hidden error noted, got %v", errs)
+		}
+	})
+
 	t.Run("ReturnsPlaceholderWhenListHasNoErrors", func(t *testing.T) {
 		// Given a list with no error entries anywhere
 		list := &jsonschema.List{}


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This changes how validation errors are presented to CLI users when `platform` fails its enum check, so a regression here directly affects what operators see when debugging a bad config.
>
> **Overview**
>
> The PR adds `focusOnInvalidPlatform`, which runs after error deduplication in `flattenErrorList` and, whenever `/platform` fails its `enum` check, drops every other collected error and replaces them with a single count-based note ("N other error(s) are hidden because 'platform' is invalid."). The `validationError` struct gains a `location` field so the new function can match on instance path. Tests cover the pure-cascade case and the platform-valid case.
>
> The suppression is unconditional on the source of the other errors: it assumes any error present alongside an invalid `/platform` is a cascade from unmatched platform-conditional branches, with no check that the other errors are actually nested under such a branch. A genuinely unrelated error elsewhere in the config would also be hidden until `platform` is fixed and the command is rerun.

<!-- /claude-code-review:summary -->
