### PR TITLE
fix(test): wire up expect/exclude config: assertions

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -418,6 +418,11 @@ type Blueprint struct {
 	// text/when templates through composition; GenerateResolved evaluates each against composed
 	// scope, keeping only the when-true entries with interpolated text for the command to print.
 	Messages []Message `yaml:"messages,omitempty"`
+
+	// Config is the composed config scope: facet config: block names mapped to their fully
+	// evaluated values. TestRunner populates this field so a test case's expect:/exclude: can
+	// assert on it; production composition and windsor show leave it unset.
+	Config map[string]any `yaml:"config,omitempty"`
 }
 
 // CrdKustomizationName returns the name of the kustomization the provisioner synthesizes for a CRD
@@ -910,6 +915,7 @@ func (b *Blueprint) DeepCopy() *Blueprint {
 		Substitutions:       maps.Clone(b.Substitutions),
 		ConfigMaps:          configMapsCopy,
 		Messages:            slices.Clone(b.Messages),
+		Config:              deepCopyMapStringAny(b.Config),
 	}
 }
 

--- a/api/v1alpha1/blueprint_types_test.go
+++ b/api/v1alpha1/blueprint_types_test.go
@@ -2587,6 +2587,25 @@ func TestBlueprint_DeepCopy(t *testing.T) {
 			t.Errorf("Expected copy.Backend=\"cluster\", got %q", copy.Backend)
 		}
 	})
+
+	t.Run("DeepCopiesConfigIndependently", func(t *testing.T) {
+		// Given a blueprint with a nested config scope
+		blueprint := &Blueprint{
+			Config: map[string]any{
+				"cluster": map[string]any{"controlplanes": map[string]any{"cpu": 7}},
+			},
+		}
+
+		// When deep-copied and the original is mutated
+		copy := blueprint.DeepCopy()
+		blueprint.Config["cluster"].(map[string]any)["controlplanes"].(map[string]any)["cpu"] = 99
+
+		// Then the copy keeps its own value, unaffected by the mutation
+		copiedCPU := copy.Config["cluster"].(map[string]any)["controlplanes"].(map[string]any)["cpu"]
+		if copiedCPU != 7 {
+			t.Errorf("Expected copy.Config cpu=7, got %v", copiedCPU)
+		}
+	})
 }
 
 // Helper function to check if slice contains a value

--- a/integration/fixtures/test-config-assertion/contexts/_template/blueprint.yaml
+++ b/integration/fixtures/test-config-assertion/contexts/_template/blueprint.yaml
@@ -1,0 +1,5 @@
+kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: test-config-assertion
+  description: Exercises expect config assertions against the composed config scope

--- a/integration/fixtures/test-config-assertion/contexts/_template/facets/cluster.yaml
+++ b/integration/fixtures/test-config-assertion/contexts/_template/facets/cluster.yaml
@@ -1,0 +1,12 @@
+kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: cluster
+  description: contributes a config block for cluster sizing, gated on cluster.enabled
+
+config:
+  - name: cluster
+    when: (cluster.enabled ?? false)
+    value:
+      controlplanes:
+        cpu: 7

--- a/integration/fixtures/test-config-assertion/contexts/_template/tests/config-assertion.test.yaml
+++ b/integration/fixtures/test-config-assertion/contexts/_template/tests/config-assertion.test.yaml
@@ -1,0 +1,28 @@
+# Cases exercising expect: config: assertions against the composed config scope. These
+# assertions used to be silently inert no-ops regardless of what the facet actually resolved.
+
+cases:
+
+  # cluster.enabled is true: the cluster facet's config block fires and controlplanes.cpu
+  # resolves to 7, matching the expectation.
+  - name: config_matches_when_enabled
+    values:
+      cluster:
+        enabled: true
+    expect:
+      config:
+        cluster:
+          controlplanes:
+            cpu: 7
+
+  # cluster.enabled is false: the cluster facet's config block is gated off, so config.cluster
+  # never resolves. The same expectation must now fail rather than silently pass.
+  - name: config_mismatch_when_disabled
+    values:
+      cluster:
+        enabled: false
+    expect:
+      config:
+        cluster:
+          controlplanes:
+            cpu: 7

--- a/integration/fixtures/test-config-assertion/windsor.yaml
+++ b/integration/fixtures/test-config-assertion/windsor.yaml
@@ -1,0 +1,4 @@
+version: v1alpha1
+contexts:
+  default: {}
+  test: {}

--- a/integration/test_test.go
+++ b/integration/test_test.go
@@ -101,3 +101,38 @@ func TestWindsorTest_FluxSystemTiersFixture(t *testing.T) {
 		t.Errorf("expected PASS or ✓ in output: %s", out)
 	}
 }
+
+// TestWindsorTest_ConfigAssertionFixture exercises expect.config against the composed config
+// scope: the cluster facet's config block fires when cluster.enabled is true, resolving
+// controlplanes.cpu to 7 as the case expects.
+func TestWindsorTest_ConfigAssertionFixture(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "test-config-assertion")
+	env = append(env, "WINDSOR_CONTEXT=test")
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"test", "config_matches_when_enabled"}, env)
+	if err != nil {
+		t.Fatalf("windsor test: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
+	}
+	out := string(stdout) + string(stderr)
+	if !strings.Contains(out, "PASS") && !strings.Contains(out, "✓") {
+		t.Errorf("expected PASS or ✓ in output: %s", out)
+	}
+}
+
+// TestWindsorTest_ConfigAssertionRegressionFixture exercises the bug report's reproduction:
+// the cluster facet's config block is gated off (cluster.enabled is false), so
+// config.cluster never resolves. The case still declares expect.config.cluster.controlplanes.cpu:
+// 7 — before the fix this passed unconditionally; it must now fail windsor test.
+func TestWindsorTest_ConfigAssertionRegressionFixture(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "test-config-assertion")
+	env = append(env, "WINDSOR_CONTEXT=test")
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"test", "config_mismatch_when_disabled"}, env)
+	if err == nil {
+		t.Fatalf("expected windsor test to fail, but it succeeded\nstdout: %s\nstderr: %s", stdout, stderr)
+	}
+	out := string(stdout) + string(stderr)
+	if !strings.Contains(out, "config[cluster]") {
+		t.Errorf("expected diff to name config[cluster], got: %s", out)
+	}
+}

--- a/pkg/composer/blueprint/handler.go
+++ b/pkg/composer/blueprint/handler.go
@@ -30,6 +30,7 @@ type BlueprintHandler interface {
 	GenerateResolved() (*blueprintv1alpha1.Blueprint, error)
 	Explain(path string) (*ExplainTrace, error)
 	GetDeferredPaths() map[string]bool
+	GetConfigScope() map[string]any
 }
 
 // =============================================================================
@@ -435,6 +436,13 @@ func (h *BaseBlueprintHandler) GetDeferredPaths() map[string]bool {
 		out[k] = v
 	}
 	return out
+}
+
+// GetConfigScope returns the composed config scope: facet config: block names mapped to their
+// fully evaluated values, merged with context values. Populated by LoadBlueprint(); nil before
+// the first successful load.
+func (h *BaseBlueprintHandler) GetConfigScope() map[string]any {
+	return h.composedScope
 }
 
 // =============================================================================

--- a/pkg/composer/blueprint/mock_blueprint_handler.go
+++ b/pkg/composer/blueprint/mock_blueprint_handler.go
@@ -18,6 +18,7 @@ type MockBlueprintHandler struct {
 	GenerateResolvedFunc       func() (*blueprintv1alpha1.Blueprint, error)
 	ExplainFunc                func(string) (*ExplainTrace, error)
 	GetDeferredPathsFunc       func() map[string]bool
+	GetConfigScopeFunc         func() map[string]any
 	skipValidation             bool
 }
 
@@ -134,6 +135,14 @@ func (m *MockBlueprintHandler) Explain(path string) (*ExplainTrace, error) {
 func (m *MockBlueprintHandler) GetDeferredPaths() map[string]bool {
 	if m.GetDeferredPathsFunc != nil {
 		return m.GetDeferredPathsFunc()
+	}
+	return nil
+}
+
+// GetConfigScope calls the mock GetConfigScopeFunc if set, otherwise returns nil.
+func (m *MockBlueprintHandler) GetConfigScope() map[string]any {
+	if m.GetConfigScopeFunc != nil {
+		return m.GetConfigScopeFunc()
 	}
 	return nil
 }

--- a/pkg/test/runner.go
+++ b/pkg/test/runner.go
@@ -265,6 +265,7 @@ func (r *TestRunner) createGenerator(terraformOutputs map[string]map[string]any,
 		if bp == nil {
 			return nil, fmt.Errorf("failed to generate blueprint")
 		}
+		bp.Config = testBlueprintHandler.GetConfigScope()
 
 		if err := validateTerraformOutputReferences(bp, referencedComponents, &referencedMu); err != nil {
 			return nil, err
@@ -480,11 +481,13 @@ func (r *TestRunner) runTestCase(tc blueprintv1alpha1.TestCase) (TestResult, err
 // matchBlueprint compares the actual composed blueprint against expected blueprint structure and returns
 // a list of differences. It uses partial matching semantics: only fields explicitly specified in the expect
 // blueprint are validated, allowing tests to focus on specific aspects without asserting the entire structure.
-// The function validates Terraform components, Kustomizations, and the crds: layer, checking for presence
-// and matching properties. For each expected component, it searches the actual blueprint, reports missing
-// components, and compares specified properties (source, path, dependsOn, etc.); each expect.crds entry must
-// appear in the blueprint's crds: list. Returns an empty slice if all expectations are met, or a list of
-// descriptive difference messages if mismatches are found.
+// The function validates Terraform components, Kustomizations, the crds: layer, and the config: scope,
+// checking for presence and matching properties. For each expected component, it searches the actual
+// blueprint, reports missing components, and compares specified properties (source, path, dependsOn, etc.);
+// each expect.crds entry must appear in the blueprint's crds: list. Each expect.config entry is matched by
+// top-level block name against bp.Config using subset semantics (see deepEqualInputsValue), so a nested
+// path like config: cluster: controlplanes: cpu: 7 checks only the keys named. Returns an empty slice if
+// all expectations are met, or a list of descriptive difference messages if mismatches are found.
 func (r *TestRunner) matchBlueprint(bp *blueprintv1alpha1.Blueprint, expect *blueprintv1alpha1.Blueprint) []string {
 	var diffs []string
 
@@ -535,6 +538,17 @@ func (r *TestRunner) matchBlueprint(bp *blueprintv1alpha1.Blueprint, expect *blu
 		}
 	}
 
+	for name, expectedValue := range expect.Config {
+		actualValue, exists := bp.Config[name]
+		if !exists {
+			diffs = append(diffs, fmt.Sprintf("config[%s]: key not found", name))
+			continue
+		}
+		if !deepEqualInputsValue(expectedValue, actualValue) {
+			diffs = append(diffs, fmt.Sprintf("config[%s]: expected %v, got %v", name, expectedValue, actualValue))
+		}
+	}
+
 	return diffs
 }
 
@@ -545,9 +559,11 @@ func (r *TestRunner) matchBlueprint(bp *blueprintv1alpha1.Blueprint, expect *blu
 // name for Kustomizations. A Kustomization exclusion that also sets components: doesn't assert the
 // whole entry is absent — the containing kustomization is expected to exist, so this asserts only
 // that those specific components are absent from it (see matchComponentExclusion); a
-// bare name: with no components: keeps whole-entry-absence semantics. If any excluded component is
-// found in the blueprint, a descriptive error message is added to the differences list. Returns an
-// empty slice if all exclusions are satisfied.
+// bare name: with no components: keeps whole-entry-absence semantics. Each exclude.config entry is
+// matched by top-level block name against bp.Config using the same subset semantics matchBlueprint
+// uses for expect.config; a match is a violation, a missing key or a non-matching value is not. If
+// any excluded component or config value is found in the blueprint, a descriptive error message is
+// added to the differences list. Returns an empty slice if all exclusions are satisfied.
 func (r *TestRunner) matchExclusions(bp *blueprintv1alpha1.Blueprint, exclude *blueprintv1alpha1.Blueprint) []string {
 	var diffs []string
 
@@ -593,6 +609,16 @@ func (r *TestRunner) matchExclusions(bp *blueprintv1alpha1.Blueprint, exclude *b
 	for _, ref := range exclude.Crds {
 		if blueprintInstallsCrd(bp, ref) {
 			diffs = append(diffs, fmt.Sprintf("crd reference should not exist: %s", ref))
+		}
+	}
+
+	for name, excludeValue := range exclude.Config {
+		actualValue, exists := bp.Config[name]
+		if !exists {
+			continue
+		}
+		if deepEqualInputsValue(excludeValue, actualValue) {
+			diffs = append(diffs, fmt.Sprintf("config[%s] should not match: %v", name, excludeValue))
 		}
 	}
 

--- a/pkg/test/runner_test.go
+++ b/pkg/test/runner_test.go
@@ -772,6 +772,48 @@ terraform:
 		}
 	})
 
+	t.Run("ReturnsFailedResultWhenExpectConfigDisagreesWithComposedValue", func(t *testing.T) {
+		// Given a facet whose config: block is gated by when:, mirroring the reported bug: an
+		// expect: config: assertion must fail once the contributing facet stops firing, not
+		// silently keep passing against a stale expectation
+		mocks := setupTestRunnerMocks(t)
+		templateDir := filepath.Join(mocks.TmpDir, "contexts", "_template")
+		facetsDir := filepath.Join(templateDir, "facets")
+		createTestFile(t, facetsDir, "cluster.yaml", `kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: cluster
+config:
+  - name: cluster
+    when: (cluster.enabled ?? false)
+    value:
+      controlplanes:
+        cpu: 7
+`)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		tc := blueprintv1alpha1.TestCase{
+			Name:   "config-expectation",
+			Values: map[string]any{"cluster": map[string]any{"enabled": false}},
+			Expect: &blueprintv1alpha1.Blueprint{
+				Config: map[string]any{
+					"cluster": map[string]any{"controlplanes": map[string]any{"cpu": 7}},
+				},
+			},
+		}
+
+		// When running the test case with the facet's when: forced false
+		result, err := runner.runTestCase(tc)
+
+		// Then the test fails because the config block never resolved
+		if err != nil {
+			t.Errorf("Expected no error, got: %v", err)
+		}
+		if result.Passed {
+			t.Error("Expected test to fail when the expected config block did not resolve")
+		}
+	})
+
 	t.Run("ReturnsPassedResultWhenErrorExpectedAndOccurs", func(t *testing.T) {
 		// Given a test case expecting an error and composition fails
 		// Set up a test runner without a blueprint.yaml so composition will fail
@@ -1260,6 +1302,80 @@ func TestTestRunner_matchBlueprint(t *testing.T) {
 			t.Errorf("Expected variant-not-found diff, got: %v", diffs)
 		}
 	})
+
+	t.Run("ReturnsNoDiffsWhenConfigMatches", func(t *testing.T) {
+		// Given a composed blueprint carrying a resolved config scope
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Config: map[string]any{
+				"cluster": map[string]any{"controlplanes": map[string]any{"cpu": 7}},
+			},
+		}
+
+		// When the expectation asserts a nested subset of the config scope
+		expect := &blueprintv1alpha1.Blueprint{
+			Config: map[string]any{
+				"cluster": map[string]any{"controlplanes": map[string]any{"cpu": 7}},
+			},
+		}
+		diffs := runner.matchBlueprint(blueprint, expect)
+
+		// Then no diffs are returned
+		if len(diffs) != 0 {
+			t.Errorf("Expected no diffs, got: %v", diffs)
+		}
+	})
+
+	t.Run("ReturnsDiffWhenConfigValueMismatches", func(t *testing.T) {
+		// Given a composed blueprint whose config scope disagrees with the expectation
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Config: map[string]any{
+				"cluster": map[string]any{"controlplanes": map[string]any{"cpu": 4}},
+			},
+		}
+
+		expect := &blueprintv1alpha1.Blueprint{
+			Config: map[string]any{
+				"cluster": map[string]any{"controlplanes": map[string]any{"cpu": 7}},
+			},
+		}
+
+		// When matching the blueprint
+		diffs := runner.matchBlueprint(blueprint, expect)
+
+		// Then a single diff reports the mismatched config value
+		if len(diffs) != 1 || !strings.Contains(diffs[0], "config[cluster]:") {
+			t.Errorf("Expected a config mismatch diff, got: %v", diffs)
+		}
+	})
+
+	t.Run("ReturnsDiffWhenConfigBlockNotFound", func(t *testing.T) {
+		// Given a composed blueprint that never resolved the expected config block, e.g. because
+		// the contributing facet's when: evaluated to false
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{}
+
+		expect := &blueprintv1alpha1.Blueprint{
+			Config: map[string]any{
+				"cluster": map[string]any{"controlplanes": map[string]any{"cpu": 7}},
+			},
+		}
+
+		// When matching the blueprint
+		diffs := runner.matchBlueprint(blueprint, expect)
+
+		// Then a diff reports the missing config block
+		if len(diffs) != 1 || !strings.Contains(diffs[0], "config[cluster]: key not found") {
+			t.Errorf("Expected a config-not-found diff, got: %v", diffs)
+		}
+	})
 }
 
 func TestTestRunner_matchExclusions(t *testing.T) {
@@ -1739,6 +1855,59 @@ func TestTestRunner_matchExclusions(t *testing.T) {
 		}
 		if len(diffs) == 1 && strings.Contains(diffs[0], "variant should not exist") {
 			t.Errorf("Expected a narrowed diff, not whole-variant-absence, got: %v", diffs)
+		}
+	})
+
+	t.Run("ReportsExcludedConfigValuePresent", func(t *testing.T) {
+		// Given a composed blueprint whose config scope still carries the excluded value, e.g.
+		// because the contributing facet's when: was not actually forced off
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Config: map[string]any{
+				"cluster": map[string]any{"controlplanes": map[string]any{"cpu": 7}},
+			},
+		}
+
+		exclude := &blueprintv1alpha1.Blueprint{
+			Config: map[string]any{
+				"cluster": map[string]any{"controlplanes": map[string]any{"cpu": 7}},
+			},
+		}
+
+		// When matching exclusions
+		diffs := runner.matchExclusions(blueprint, exclude)
+
+		// Then a diff reports the config value should not match
+		if len(diffs) != 1 || !strings.Contains(diffs[0], "config[cluster] should not match:") {
+			t.Errorf("Expected a config exclusion diff, got: %v", diffs)
+		}
+	})
+
+	t.Run("ReturnsNoDiffsWhenExcludedConfigValueAbsent", func(t *testing.T) {
+		// Given a composed blueprint whose config scope no longer matches the excluded value
+		mocks := setupTestRunnerMocks(t)
+		runner := createRunnerWithMockGenerator(mocks)
+
+		blueprint := &blueprintv1alpha1.Blueprint{
+			Config: map[string]any{
+				"cluster": map[string]any{"controlplanes": map[string]any{"cpu": 4}},
+			},
+		}
+
+		exclude := &blueprintv1alpha1.Blueprint{
+			Config: map[string]any{
+				"cluster": map[string]any{"controlplanes": map[string]any{"cpu": 7}},
+			},
+		}
+
+		// When matching exclusions
+		diffs := runner.matchExclusions(blueprint, exclude)
+
+		// Then no diffs are returned
+		if len(diffs) != 0 {
+			t.Errorf("Expected no diffs, got: %v", diffs)
 		}
 	})
 }
@@ -3366,6 +3535,44 @@ terraform:
 		// Then composition succeeds: dns-zone is in the composition and its output resolves
 		if err != nil {
 			t.Fatalf("Expected no error when component is registered, got: %v", err)
+		}
+	})
+
+	t.Run("PopulatesBlueprintConfigFromFacetConfigBlock", func(t *testing.T) {
+		// Given a facet contributing a config: block
+		mocks := setupTestRunnerMocks(t)
+		templateDir := filepath.Join(mocks.TmpDir, "contexts", "_template")
+		facetsDir := filepath.Join(templateDir, "facets")
+		createTestFile(t, facetsDir, "cluster.yaml", `kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: cluster
+config:
+  - name: cluster
+    value:
+      controlplanes:
+        cpu: 7
+`)
+		runner := createRunnerWithMockGenerator(mocks)
+		generator := runner.createGenerator(nil, nil, false)
+
+		// When the generator composes the blueprint
+		bp, err := generator(map[string]any{})
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+
+		// Then the composed blueprint's Config carries the facet's resolved config block
+		cluster, ok := bp.Config["cluster"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected bp.Config[\"cluster\"] to be a map, got: %#v", bp.Config["cluster"])
+		}
+		controlplanes, ok := cluster["controlplanes"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected controlplanes to be a map, got: %#v", cluster["controlplanes"])
+		}
+		if fmt.Sprint(controlplanes["cpu"]) != "7" {
+			t.Errorf("Expected cpu=7, got: %v", controlplanes["cpu"])
 		}
 	})
 


### PR DESCRIPTION
Closes #3268

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change is scoped to the `windsor test` assertion path and adds a new optional field to the `Blueprint` type; production composition and `windsor show` never populate it, so behavior outside the test runner is unchanged.
>
> **Overview**
>
> The PR wires up `expect.config` / `exclude.config` test assertions to the actual composed config scope. Previously these assertions were silent no-ops: `Blueprint` had no `Config` field, so any `expect.config` or `exclude.config` block in a test case matched nothing and the test passed regardless of what the underlying facet actually resolved. Now `BlueprintHandler` exposes `GetConfigScope()`, the test generator copies that scope onto `bp.Config`, and `matchBlueprint`/`matchExclusions` compare it against expectations using the existing subset-equality semantics.
>
> A regression test fixture reproduces the original bug report directly: a facet's `config:` block gated by `when:` is forced off, and a test case that still expects the block's values now correctly fails instead of passing.

<!-- /claude-code-review:summary -->
