### PR TITLE
fix(composer): pin operator config values over facet writes

### DIFF
--- a/integration/fixtures/test-config-assertion/contexts/_template/tests/config-assertion.test.yaml
+++ b/integration/fixtures/test-config-assertion/contexts/_template/tests/config-assertion.test.yaml
@@ -26,3 +26,18 @@ cases:
         cluster:
           controlplanes:
             cpu: 7
+
+  # cluster.enabled is true, and the operator also sets controlplanes.cpu directly. The facet
+  # computes cpu unconditionally (no ?? guard of its own), but the operator's explicit value
+  # must still win over the facet's computed one.
+  - name: operator_value_wins_over_unconditional_facet_config
+    values:
+      cluster:
+        enabled: true
+        controlplanes:
+          cpu: 3
+    expect:
+      config:
+        cluster:
+          controlplanes:
+            cpu: 3

--- a/integration/test_test.go
+++ b/integration/test_test.go
@@ -136,3 +136,21 @@ func TestWindsorTest_ConfigAssertionRegressionFixture(t *testing.T) {
 		t.Errorf("expected diff to name config[cluster], got: %s", out)
 	}
 }
+
+// TestWindsorTest_OperatorConfigOverrideFixture exercises a composer bug: an operator's explicit
+// raw value did not survive a facet's unconditional config: block for the same key. The cluster
+// facet unconditionally computes controlplanes.cpu. The operator also sets it directly. The
+// operator's value must win.
+func TestWindsorTest_OperatorConfigOverrideFixture(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "test-config-assertion")
+	env = append(env, "WINDSOR_CONTEXT=test")
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"test", "operator_value_wins_over_unconditional_facet_config"}, env)
+	if err != nil {
+		t.Fatalf("windsor test: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
+	}
+	out := string(stdout) + string(stderr)
+	if !strings.Contains(out, "PASS") && !strings.Contains(out, "✓") {
+		t.Errorf("expected PASS or ✓ in output: %s", out)
+	}
+}

--- a/pkg/composer/blueprint/handler_test.go
+++ b/pkg/composer/blueprint/handler_test.go
@@ -2676,6 +2676,69 @@ func TestHandler_processAndCompose(t *testing.T) {
 		}
 	})
 
+	t.Run("ExplicitOperatorValueWinsOverUnconditionalFacetConfig", func(t *testing.T) {
+		// Given an operator's own explicit value for a key. A facet unconditionally computes a
+		// different value for that same key, with no `??` guard of its own.
+		mocks := setupHandlerMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{}, nil
+		}
+		operatorValues := map[string]any{
+			"cluster": map[string]any{"controlplanes": map[string]any{"cpu": 3}},
+		}
+		mocks.ConfigHandler.GetSetValuesFunc = func() map[string]any { return operatorValues }
+		handler := NewBlueprintHandler(mocks.Runtime, mocks.ArtifactBuilder)
+
+		templateBp := &blueprintv1alpha1.Blueprint{}
+		handler.sourceBlueprintLoaders["template"] = &mockLoaderImpl{
+			getBlueprintFunc:  func() *blueprintv1alpha1.Blueprint { return templateBp },
+			getSourceNameFunc: func() string { return "template" },
+			getFacetsFunc: func() []blueprintv1alpha1.Facet {
+				return []blueprintv1alpha1.Facet{
+					{
+						Metadata: blueprintv1alpha1.Metadata{Name: "cluster-sizing"},
+						Config: []blueprintv1alpha1.ConfigBlock{
+							{
+								Name: "cluster",
+								Body: map[string]any{"value": map[string]any{"controlplanes": map[string]any{"cpu": 7}}},
+							},
+						},
+					},
+				}
+			},
+		}
+		trueVal := true
+		handler.userBlueprintLoader = &mockLoaderImpl{
+			getBlueprintFunc: func() *blueprintv1alpha1.Blueprint {
+				return &blueprintv1alpha1.Blueprint{
+					Sources: []blueprintv1alpha1.Source{
+						{Name: "template", Install: &blueprintv1alpha1.BoolExpression{Value: &trueVal, IsExpr: false}},
+					},
+				}
+			},
+			getSourceNameFunc: func() string { return "user" },
+		}
+
+		// When processing and composing
+		if err := handler.processAndCompose(); err != nil {
+			t.Fatalf("processAndCompose failed: %v", err)
+		}
+
+		// Then the composed scope reflects the operator's explicit value, not the facet's
+		// unconditional computation
+		cluster, ok := handler.composedScope["cluster"].(map[string]any)
+		if !ok {
+			t.Fatal("Expected composed scope to contain 'cluster'")
+		}
+		controlplanes, ok := cluster["controlplanes"].(map[string]any)
+		if !ok {
+			t.Fatalf("Expected cluster.controlplanes to be a map, got %T", cluster["controlplanes"])
+		}
+		if cpu := controlplanes["cpu"]; cpu != 3 {
+			t.Errorf("Expected operator's explicit cpu=3 to win over facet-computed cpu=7, got %v", cpu)
+		}
+	})
+
 	t.Run("CallsSetConfigScopeWhenProviderExists", func(t *testing.T) {
 		// Given a handler with terraform provider and loaders
 		mocks := setupHandlerMocks(t)

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -3,6 +3,7 @@ package blueprint
 import (
 	"fmt"
 	"maps"
+	"math"
 	"reflect"
 	"slices"
 	"sort"
@@ -209,6 +210,8 @@ func facetProvides(facet blueprintv1alpha1.Facet) []string {
 // An active facet contributes its config blocks (not its components) even while its requires are unmet, so
 // facets with mutually dependent config and requires resolve across rounds; a facet still unsatisfied when the
 // loop settles fails composition, so a permanently-blocked facet never leaks config into a successful blueprint.
+// An operator's own explicit value wins over a facet's computed value for the same key. This
+// matches the guarantee ProcessGlobally provides.
 func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Blueprint, facets []blueprintv1alpha1.Facet, sourceName ...string) (map[string]any, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -233,7 +236,11 @@ func (p *BaseBlueprintProcessor) ProcessFacets(target *blueprintv1alpha1.Bluepri
 		return sortedFacets[i].Metadata.Name < sortedFacets[j].Metadata.Name
 	})
 
-	globalScope, scope, includedFacets, err := p.resolveConfigAndInclusion(sortedFacets, contextScope, nil)
+	var operatorOverlay map[string]any
+	if p.runtime != nil && p.runtime.ConfigHandler != nil {
+		operatorOverlay = p.runtime.ConfigHandler.GetSetValues()
+	}
+	globalScope, scope, includedFacets, err := p.resolveConfigAndInclusion(sortedFacets, contextScope, operatorOverlay)
 	if err != nil {
 		return nil, err
 	}
@@ -272,7 +279,8 @@ type SourceFacetSet struct {
 // each source's included components into its own target blueprint. Facets are ranked by a
 // depth-adjusted ordinal so a deeper source's config wins over a shallower one's for the same key,
 // while derivations resolve against the final merged scope and an upstream facet's when: sees a
-// downstream source's config. Returns the resolved global scope.
+// downstream source's config. Returns the resolved global scope. An operator's explicit raw value
+// always wins over a facet's computed value for the same key — see resolveConfigAndInclusion.
 func (p *BaseBlueprintProcessor) ProcessGlobally(sources []SourceFacetSet) (map[string]any, error) {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -338,6 +346,12 @@ func (p *BaseBlueprintProcessor) ProcessGlobally(sources []SourceFacetSet) (map[
 // included-facet set and the resolved config scope both match the prior round, since a config block's
 // `when:` can depend on a block only just included this round. It errors if the scope never settles
 // within maxFacetRounds, instead of silently returning whichever round ran last.
+//
+// A config: block always computes its own value. It cannot defer to an operator's raw
+// override on its own. Each round, after facets merge their blocks, operatorOverlay joins as one
+// more contributor. It carries the highest ordinal. mergeConfigBlocks' existing precedence rule
+// then makes it win. This runs before block bodies evaluate. So a block referencing another
+// block's key sees the operator's corrected value too.
 func (p *BaseBlueprintProcessor) resolveConfigAndInclusion(sortedFacets []blueprintv1alpha1.Facet, contextScope map[string]any, operatorOverlay map[string]any) (map[string]any, map[string]any, []blueprintv1alpha1.Facet, error) {
 	scope := contextScope
 	var globalScope map[string]any
@@ -385,6 +399,13 @@ func (p *BaseBlueprintProcessor) resolveConfigAndInclusion(sortedFacets []bluepr
 			}
 			includedFacets = append(includedFacets, facet)
 		}
+		if incoming := operatorOverlayConfigBlocks(globalScope, operatorOverlay); len(incoming) > 0 {
+			var err error
+			globalScope, cfgEntries, err = p.mergeConfigBlocks(globalScope, cfgEntries, incoming)
+			if err != nil {
+				return nil, nil, nil, err
+			}
+		}
 		if err := p.evaluateGlobalScopeConfig(globalScope, contextScope); err != nil {
 			return nil, nil, nil, err
 		}
@@ -393,9 +414,6 @@ func (p *BaseBlueprintProcessor) resolveConfigAndInclusion(sortedFacets []bluepr
 			mergeBase = make(map[string]any)
 		}
 		passScope = blueprintv1alpha1.DeepMergeMaps(mergeBase, globalScope)
-		if len(operatorOverlay) > 0 {
-			passScope = blueprintv1alpha1.DeepMergeMaps(passScope, operatorOverlay)
-		}
 		scope = passScope
 		currSet := make(map[string]bool, len(includedFacets))
 		for _, f := range includedFacets {
@@ -2839,6 +2857,38 @@ func blockWrittenKeys(body map[string]any) (keys []string, wholeName bool) {
 		keys = append(keys, k)
 	}
 	return keys, false
+}
+
+// operatorOverlayConfigBlocks builds synthetic config-block entries from operatorOverlay.
+// operatorOverlay holds the operator's own explicit values (ConfigHandler.GetSetValues), never
+// schema defaults. One entry is built per name globalScope already has. Each entry carries the
+// highest possible ordinal. mergeConfigBlocks' own precedence rule then makes it win. That is the
+// same rule that settles every facet-vs-facet conflict. Each entry uses "merge" strategy. An
+// untouched key still surfaces from the facet's own value. A name absent from globalScope is
+// skipped. No facet claims it this round, so it is context, not config. An operator value alone
+// must never manufacture a new config: scope entry.
+func operatorOverlayConfigBlocks(globalScope map[string]any, operatorOverlay map[string]any) map[string]*blueprintv1alpha1.ConfigBlock {
+	if len(globalScope) == 0 || len(operatorOverlay) == 0 {
+		return nil
+	}
+	maxOrdinal := math.MaxInt
+	var incoming map[string]*blueprintv1alpha1.ConfigBlock
+	for name := range globalScope {
+		value, ok := operatorOverlay[name]
+		if !ok {
+			continue
+		}
+		if incoming == nil {
+			incoming = make(map[string]*blueprintv1alpha1.ConfigBlock)
+		}
+		incoming[name] = &blueprintv1alpha1.ConfigBlock{
+			Name:     name,
+			Strategy: "merge",
+			Ordinal:  &maxOrdinal,
+			Body:     map[string]any{"value": value},
+		}
+	}
+	return incoming
 }
 
 // mergeBlockValueOverContext overlays a config block's in-progress value on the context value under

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -2,7 +2,9 @@ package blueprint
 
 import (
 	"fmt"
+	"math"
 	"os"
+	"reflect"
 	"slices"
 	"strings"
 	"testing"
@@ -1194,6 +1196,41 @@ func TestProcessor_ProcessFacets(t *testing.T) {
 		}
 	})
 
+	t.Run("RemoveStrategyLeavesNoNameForAnOperatorValueToCorrect", func(t *testing.T) {
+		// Given a remove: strategy block wins, so no facet ends up contributing 'cluster' this
+		// round, and the operator separately set a raw value under that same name
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetSetValuesFunc = func() map[string]any {
+			return map[string]any{"cluster": map[string]any{"endpoint": "operator-value"}}
+		}
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "add-cluster"},
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "cluster", Body: map[string]any{"value": map[string]any{"endpoint": "x"}}},
+				},
+			},
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "remove-cluster"},
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "cluster", Strategy: "remove", Body: map[string]any{"value": nil}},
+				},
+			},
+		}
+		target := &blueprintv1alpha1.Blueprint{}
+		scope, err := processor.ProcessFacets(target, facets)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// Then 'cluster' stays absent: no facet claims the name, so the operator's raw value
+		// is context, not config, and does not resurrect a config: scope entry
+		if _, ok := scope["cluster"]; ok {
+			t.Error("Expected 'cluster' to stay removed; an operator value alone must not resurrect it")
+		}
+	})
+
 	t.Run("ReturnsErrorForInvalidConfigBlockStrategy", func(t *testing.T) {
 		mocks := setupProcessorMocks(t)
 		processor := NewBlueprintProcessor(mocks.Runtime)
@@ -2256,6 +2293,82 @@ func TestProcessor_ProcessFacets_ConfigBlockReadsContextUnderOwnName(t *testing.
 		}
 		if ips["start"] != "10.9.1.10" {
 			t.Errorf("Expected loadbalancer_ips.start derived from block value, got %v", ips["start"])
+		}
+	})
+
+	t.Run("OperatorExplicitValueWinsOverUnconditionalBlockOnSingleSourcePath", func(t *testing.T) {
+		// Given an operator's own explicit value, and a block that unconditionally computes a
+		// different value for that same key, via ProcessFacets (the single-source path)
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{}, nil
+		}
+		operatorValues := map[string]any{
+			"cluster": map[string]any{"controlplanes": map[string]any{"cpu": 3}},
+		}
+		mocks.ConfigHandler.GetSetValuesFunc = func() map[string]any { return operatorValues }
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "cluster-sizing"},
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "cluster", Body: map[string]any{"value": map[string]any{
+						"controlplanes": map[string]any{"cpu": 7},
+					}}},
+				},
+			},
+		}
+
+		// When the facets are processed
+		scope, err := processor.ProcessFacets(&blueprintv1alpha1.Blueprint{}, facets)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the operator's explicit value wins, matching ProcessGlobally's guarantee
+		controlplanes := scope["cluster"].(map[string]any)["controlplanes"].(map[string]any)
+		if controlplanes["cpu"] != 3 {
+			t.Errorf("Expected operator cpu=3 to win over facet-computed cpu=7, got %v", controlplanes["cpu"])
+		}
+	})
+
+	t.Run("OperatorOverrideVisibleToASiblingBlockDerivingFromItInTheSameRound", func(t *testing.T) {
+		// Given one block the operator overrides, and a sibling block that derives its own
+		// value from the first block's key
+		mocks := setupProcessorMocks(t)
+		mocks.ConfigHandler.GetContextValuesFunc = func() (map[string]any, error) {
+			return map[string]any{}, nil
+		}
+		operatorValues := map[string]any{
+			"cluster": map[string]any{"controlplanes": map[string]any{"cpu": 3}},
+		}
+		mocks.ConfigHandler.GetSetValuesFunc = func() map[string]any { return operatorValues }
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		facets := []blueprintv1alpha1.Facet{
+			{
+				Metadata: blueprintv1alpha1.Metadata{Name: "cluster-sizing"},
+				Config: []blueprintv1alpha1.ConfigBlock{
+					{Name: "cluster", Body: map[string]any{"value": map[string]any{
+						"controlplanes": map[string]any{"cpu": 7},
+					}}},
+					{Name: "vm_sizing", Body: map[string]any{"value": map[string]any{
+						"memory": "${cluster.controlplanes.cpu * 4}",
+					}}},
+				},
+			},
+		}
+
+		// When the facets are processed
+		scope, err := processor.ProcessFacets(&blueprintv1alpha1.Blueprint{}, facets)
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the sibling block's derivation used the operator's value (3), not the facet's
+		// unconditional computation (7): 3*4=12, not 7*4=28
+		vmSizing := scope["vm_sizing"].(map[string]any)
+		if vmSizing["memory"] != 12 {
+			t.Errorf("Expected memory derived from the operator's cpu=3 (12), got %v", vmSizing["memory"])
 		}
 	})
 
@@ -3838,6 +3951,84 @@ func TestProcessor_mergeHelpers(t *testing.T) {
 		}
 	})
 
+	t.Run("OperatorOverlayConfigBlocksBuildsAnEntryForACollidingName", func(t *testing.T) {
+		globalScope := map[string]any{
+			"cluster": map[string]any{"controlplanes": map[string]any{"cpu": 7}},
+		}
+		operatorOverlay := map[string]any{
+			"cluster": map[string]any{"controlplanes": map[string]any{"cpu": 3}},
+		}
+		incoming := operatorOverlayConfigBlocks(globalScope, operatorOverlay)
+		cluster, ok := incoming["cluster"]
+		if !ok {
+			t.Fatal("Expected a synthetic entry for 'cluster'")
+		}
+		if cluster.Strategy != "merge" {
+			t.Errorf("Expected strategy 'merge', got %q", cluster.Strategy)
+		}
+		if cluster.Ordinal == nil || *cluster.Ordinal != math.MaxInt {
+			t.Errorf("Expected ordinal math.MaxInt, got %v", cluster.Ordinal)
+		}
+		if !reflect.DeepEqual(cluster.Body["value"], operatorOverlay["cluster"]) {
+			t.Errorf("Expected body value %v, got %v", operatorOverlay["cluster"], cluster.Body["value"])
+		}
+	})
+
+	t.Run("OperatorOverlayConfigBlocksSkipsNamesAbsentFromGlobalScope", func(t *testing.T) {
+		globalScope := map[string]any{
+			"cluster": map[string]any{"controlplanes": map[string]any{"cpu": 7}},
+		}
+		operatorOverlay := map[string]any{
+			"cluster":   map[string]any{"controlplanes": map[string]any{"cpu": 3}},
+			"terraform": map[string]any{"enabled": true},
+		}
+		incoming := operatorOverlayConfigBlocks(globalScope, operatorOverlay)
+		if _, exists := incoming["terraform"]; exists {
+			t.Error("Expected an operator key with no matching config block to be skipped")
+		}
+	})
+
+	t.Run("OperatorOverlayConfigBlocksHandlesNilGlobalScope", func(t *testing.T) {
+		if incoming := operatorOverlayConfigBlocks(nil, map[string]any{"cluster": map[string]any{"cpu": 3}}); incoming != nil {
+			t.Errorf("Expected nil for nil globalScope, got %v", incoming)
+		}
+	})
+
+	t.Run("OperatorOverlayConfigBlocksHandlesEmptyOverlay", func(t *testing.T) {
+		globalScope := map[string]any{"cluster": map[string]any{"cpu": 7}}
+		if incoming := operatorOverlayConfigBlocks(globalScope, nil); incoming != nil {
+			t.Errorf("Expected nil for an empty overlay, got %v", incoming)
+		}
+	})
+
+	t.Run("OperatorOverlayConfigBlocksMergedIntoScopeOverridesCollidingKeyAndKeepsSiblings", func(t *testing.T) {
+		// Given a merge helper's synthetic entry fed through the same mergeConfigBlocks
+		// pipeline every facet-vs-facet conflict already uses
+		mocks := setupProcessorMocks(t)
+		processor := NewBlueprintProcessor(mocks.Runtime)
+		globalScope := map[string]any{
+			"cluster": map[string]any{"controlplanes": map[string]any{"cpu": 7, "memory": 16}},
+		}
+		operatorOverlay := map[string]any{
+			"cluster": map[string]any{"controlplanes": map[string]any{"cpu": 3}},
+		}
+		incoming := operatorOverlayConfigBlocks(globalScope, operatorOverlay)
+
+		// When merged via mergeConfigBlocks
+		out, _, err := processor.mergeConfigBlocks(globalScope, nil, incoming)
+		if err != nil {
+			t.Fatalf("mergeConfigBlocks failed: %v", err)
+		}
+
+		// Then the operator's value wins at the colliding key, and the untouched sibling remains
+		controlplanes := out["cluster"].(map[string]any)["controlplanes"].(map[string]any)
+		if controlplanes["cpu"] != 3 {
+			t.Errorf("Expected operator cpu=3 to win, got %v", controlplanes["cpu"])
+		}
+		if controlplanes["memory"] != 16 {
+			t.Errorf("Expected untouched key memory=16 to remain, got %v", controlplanes["memory"])
+		}
+	})
 }
 
 // =============================================================================


### PR DESCRIPTION
Closes #3269

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> The change alters core config-resolution precedence shared by every blueprint composition (`ProcessFacets`/`ProcessGlobally`), so its blast radius extends to any project where an operator's explicit value collides with a facet-computed one.
>
> **Overview**
>
> This PR fixes a bug where a facet's unconditionally-computed `config:` value could silently override an operator's explicit setting for the same key in the final composed scope, even though downstream expression evaluation already saw the corrected value. The fix folds the operator's raw values (`ConfigHandler.GetSetValues`) into `globalScope` itself, each round, as synthetic config-block entries carrying the highest possible ordinal (`math.MaxInt`), so the existing ordinal/strategy precedence in `mergeConfigBlocks` makes them win consistently — for both the returned scope and any sibling block deriving from it in the same round.
>
> One behavioral detail worth noting: the old code re-applied the operator overlay unconditionally after the round, which could resurrect a key a facet had explicitly removed via `remove:` strategy. The new code only builds a synthetic entry for names already present in `globalScope`, so a removed key stays removed — this is covered by a new regression test.

<!-- /claude-code-review:summary -->
