### PR TITLE
fix(init): disclose when init reuses an ancestor windsor.yaml

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -70,8 +70,12 @@ windsor init staging --platform=aws --aws-profile=staging`,
 			if err := shell.EnsureGitRepository(); err != nil {
 				return err
 			}
-			if err := shell.EnsureProjectAnchor(); err != nil {
+			anchorDir, err := shell.EnsureProjectAnchor()
+			if err != nil {
 				return fmt.Errorf("failed to initialize project: %w", err)
+			}
+			if cwd, err := os.Getwd(); err == nil && anchorDir != cwd {
+				fmt.Fprintf(os.Stderr, "Windsor uses the existing project at %s.\n", anchorDir)
 			}
 		}
 

--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -365,7 +365,8 @@ func TestInit_RejectsNonGitDirectory(t *testing.T) {
 
 // TestInit_NoAnchorWhenProjectExistsInParent verifies that running
 // `windsor init` in a subdirectory of an existing project reuses the parent's
-// windsor.yaml instead of creating a stray one in the subdirectory.
+// windsor.yaml instead of creating a stray one in the subdirectory, and that
+// it discloses the resolved parent root rather than resolving silently.
 func TestInit_NoAnchorWhenProjectExistsInParent(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "default")
@@ -382,6 +383,15 @@ func TestInit_NoAnchorWhenProjectExistsInParent(t *testing.T) {
 
 	if _, err := os.Stat(filepath.Join(subDir, "windsor.yaml")); err == nil {
 		t.Error("expected no windsor.yaml in subdir because parent already has one")
+	}
+
+	resolvedDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		t.Fatalf("resolve dir symlinks: %v", err)
+	}
+	wantNotice := "Windsor uses the existing project at " + resolvedDir
+	if !strings.Contains(string(stderr), wantNotice) {
+		t.Errorf("expected stderr to contain %q, got: %s", wantNotice, stderr)
 	}
 }
 

--- a/pkg/runtime/shell/anchor.go
+++ b/pkg/runtime/shell/anchor.go
@@ -49,18 +49,20 @@ func EnsureGitRepository() error {
 // anchors `windsor init` to the cwd so subsequent runtime resolution does not
 // fall back to global mode and silently operate against $HOME/.config/windsor.
 // If a project file already exists at or above the cwd, this is a no-op.
-func EnsureProjectAnchor() error {
+// Returns the directory holding the project file: cwd when this call created
+// it, or the ancestor directory when one already existed there.
+func EnsureProjectAnchor() (string, error) {
 	cwd, err := os.Getwd()
 	if err != nil {
-		return fmt.Errorf("failed to get working directory: %w", err)
+		return "", fmt.Errorf("failed to get working directory: %w", err)
 	}
 	dir := cwd
 	for i := 0; i <= MaxFolderSearchDepth; i++ {
 		if _, err := os.Stat(filepath.Join(dir, "windsor.yaml")); err == nil {
-			return nil
+			return dir, nil
 		}
 		if _, err := os.Stat(filepath.Join(dir, "windsor.yml")); err == nil {
-			return nil
+			return dir, nil
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
@@ -68,7 +70,8 @@ func EnsureProjectAnchor() error {
 		}
 		dir = parent
 	}
-	// windsor.yaml is user-readable project config, 0644 matches the project
-	// convention used by typed_source.EnsureRoot.
-	return os.WriteFile(filepath.Join(cwd, "windsor.yaml"), []byte("version: v1alpha1\n"), 0644) // #nosec G306
+	if err := os.WriteFile(filepath.Join(cwd, "windsor.yaml"), []byte("version: v1alpha1\n"), 0644); err != nil { // #nosec G306
+		return "", err
+	}
+	return cwd, nil
 }

--- a/pkg/runtime/shell/anchor_test.go
+++ b/pkg/runtime/shell/anchor_test.go
@@ -36,7 +36,8 @@ func TestEnsureProjectAnchor(t *testing.T) {
 		tmpDir := setup(t)
 
 		// When EnsureProjectAnchor is called
-		if err := EnsureProjectAnchor(); err != nil {
+		resolved, err := EnsureProjectAnchor()
+		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
@@ -47,6 +48,9 @@ func TestEnsureProjectAnchor(t *testing.T) {
 		}
 		if !strings.Contains(string(data), "version: v1alpha1") {
 			t.Errorf("Expected minimal v1alpha1 root config, got: %s", string(data))
+		}
+		if resolved != tmpDir {
+			t.Errorf("Expected resolved dir %s, got %s", tmpDir, resolved)
 		}
 	})
 
@@ -59,7 +63,8 @@ func TestEnsureProjectAnchor(t *testing.T) {
 		}
 
 		// When EnsureProjectAnchor is called
-		if err := EnsureProjectAnchor(); err != nil {
+		resolved, err := EnsureProjectAnchor()
+		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
@@ -70,6 +75,9 @@ func TestEnsureProjectAnchor(t *testing.T) {
 		}
 		if string(data) != string(existing) {
 			t.Errorf("Expected existing windsor.yaml preserved, got: %s", string(data))
+		}
+		if resolved != tmpDir {
+			t.Errorf("Expected resolved dir %s, got %s", tmpDir, resolved)
 		}
 	})
 
@@ -88,13 +96,17 @@ func TestEnsureProjectAnchor(t *testing.T) {
 		}
 
 		// When EnsureProjectAnchor is called
-		if err := EnsureProjectAnchor(); err != nil {
+		resolved, err := EnsureProjectAnchor()
+		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
-		// Then no windsor.yaml should be created in the subdir
+		// Then no windsor.yaml should be created in the subdir, and the parent is reported
 		if _, err := os.Stat(filepath.Join(subDir, "windsor.yaml")); err == nil {
 			t.Error("Expected no windsor.yaml in subdir (parent already has one)")
+		}
+		if resolved != tmpDir {
+			t.Errorf("Expected resolved dir %s, got %s", tmpDir, resolved)
 		}
 	})
 }


### PR DESCRIPTION
Closes #3272

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change only affects the `windsor init` startup path and is additive, reversible, and covered by both unit and integration tests.
>
> **Overview**
>
> `EnsureProjectAnchor` now returns the directory holding the resolved `windsor.yaml` (the cwd if it created one, or the ancestor directory if one already existed) instead of just an error. `cmd/init.go` uses this to print a one-line notice to stderr when init silently reused a parent project's config, instead of resolving the ancestor anchor without telling the operator.
>
> The behavior change is purely informational: no file-write or resolution logic changed, only what is reported back. Existing callers and control flow are otherwise untouched, and the new stderr message is only emitted when the resolved directory differs from the cwd.

<!-- /claude-code-review:summary -->
