### PR TITLE
feat(plan): add --output=json-plan for scanner-ready terraform plans

### DIFF
--- a/cmd/plan.go
+++ b/cmd/plan.go
@@ -21,6 +21,7 @@ import (
 var planNoColor bool
 var planSummary bool
 var planJSON bool
+var planOutput string
 
 var planCmd = &cobra.Command{
 	Use:   "plan [component]",
@@ -161,7 +162,13 @@ windsor plan terraform cluster
 windsor plan terraform --summary
 
 # Machine-readable JSON of all component plans
-windsor plan terraform --json`,
+windsor plan terraform --json
+
+# Full plan document for a security scanner (one component per run)
+windsor plan terraform cluster --output=json-plan | checkov -f -
+
+# One compact plan document per line, one line per component
+windsor plan terraform --output=json-plan`,
 	Annotations: map[string]string{
 		"docs.seealso": "[`plan`](plan.md), [`apply terraform`](apply-terraform.md), [`destroy terraform`](destroy-terraform.md)",
 		"docs.source": "cmd/plan.go",
@@ -179,9 +186,35 @@ windsor plan terraform --json`,
 			return err
 		}
 
+		if planOutput != "" {
+			if planOutput != "json-plan" {
+				return fmt.Errorf("invalid --output value %q: supported values: json-plan", planOutput)
+			}
+			if planSummary {
+				return fmt.Errorf("--output=json-plan cannot be combined with --summary")
+			}
+			if planJSON {
+				return fmt.Errorf("--output=json-plan cannot be combined with --json")
+			}
+		}
+
 		blueprint := proj.Composer.BlueprintHandler.Generate()
 
 		return stacklock.With(cmd.Context(), proj.Runtime, "plan", lockTimeout, func() error {
+			if planOutput != "" {
+				fmt.Fprintln(cmd.ErrOrStderr(), "This output can include sensitive values in plaintext. Handle it as sensitive data.")
+				if len(args) == 0 {
+					if err := proj.Provisioner.PlanTerraformAllResourceChangesJSON(blueprint); err != nil {
+						return fmt.Errorf("error running plan: %w", err)
+					}
+					return nil
+				}
+				if err := proj.Provisioner.PlanTerraformResourceChangesJSON(blueprint, args[0]); err != nil {
+					return fmt.Errorf("error planning terraform for %s: %w", args[0], err)
+				}
+				return nil
+			}
+
 			if len(args) == 0 {
 				if planJSON && !planSummary {
 					return proj.Provisioner.PlanTerraformAllJSON(blueprint)
@@ -301,6 +334,7 @@ func init() {
 	planCmd.PersistentFlags().BoolVar(&planNoColor, "no-color", false, "Disable color output.")
 	planCmd.PersistentFlags().BoolVar(&planSummary, "summary", false, "Show a compact summary table instead of streaming output.")
 	planCmd.PersistentFlags().BoolVar(&planJSON, "json", false, "Output as JSON. Streams full plan JSON on subcommands; emits the summary as JSON on root 'plan'.")
+	planTerraformCmd.Flags().StringVar(&planOutput, "output", "", "Set to 'json-plan' to print the plan document from 'terraform show -json', instead of the progress log.")
 	planCmd.AddCommand(planTerraformCmd)
 	planCmd.AddCommand(planKustomizeCmd)
 	rootCmd.AddCommand(planCmd)

--- a/cmd/plan_test.go
+++ b/cmd/plan_test.go
@@ -551,6 +551,138 @@ func TestPlanTerraformCmd(t *testing.T) {
 			t.Error("PlanAll must not run when credential preflight fails")
 		}
 	})
+
+	t.Run("OutputJSONPlanFlagCallsResourceChangesForComponent", func(t *testing.T) {
+		// Given a plan terraform command with --output=json-plan and a component
+		mocks := setupPlanTest(t)
+		var capturedComponentID string
+		mocks.TerraformStack.PlanResourceChangesJSONFunc = func(bp *blueprintv1alpha1.Blueprint, componentID string) error {
+			capturedComponentID = componentID
+			return nil
+		}
+		proj := newPlanProject(mocks)
+
+		// When executing with --output=json-plan and a component ID
+		cmd := createTestPlanTerraformCmd()
+		planOutput = "json-plan"
+		t.Cleanup(func() { planOutput = "" })
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"cluster"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then PlanResourceChangesJSON is called for that component
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if capturedComponentID != "cluster" {
+			t.Errorf("expected PlanResourceChangesJSON to be called with %q, got %q", "cluster", capturedComponentID)
+		}
+	})
+
+	t.Run("OutputJSONPlanFlagCallsResourceChangesForAllComponents", func(t *testing.T) {
+		// Given a plan terraform command with --output=json-plan and no component
+		mocks := setupPlanTest(t)
+		allCalled := false
+		mocks.TerraformStack.PlanAllResourceChangesJSONFunc = func(bp *blueprintv1alpha1.Blueprint) error {
+			allCalled = true
+			return nil
+		}
+		proj := newPlanProject(mocks)
+
+		// When executing with --output=json-plan and no component ID
+		cmd := createTestPlanTerraformCmd()
+		planOutput = "json-plan"
+		t.Cleanup(func() { planOutput = "" })
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then PlanAllResourceChangesJSON is called
+		if err != nil {
+			t.Errorf("expected no error, got %v", err)
+		}
+		if !allCalled {
+			t.Error("expected PlanAllResourceChangesJSON to be called for no-arg --output=json-plan")
+		}
+	})
+
+	t.Run("OutputFlagRejectsUnsupportedValue", func(t *testing.T) {
+		// Given a plan terraform command with an unsupported --output value
+		mocks := setupPlanTest(t)
+		proj := newPlanProject(mocks)
+
+		// When executing with --output=bogus
+		cmd := createTestPlanTerraformCmd()
+		planOutput = "bogus"
+		t.Cleanup(func() { planOutput = "" })
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"cluster"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then an error names the unsupported value
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `invalid --output value "bogus"`) {
+			t.Errorf("expected invalid --output error, got: %v", err)
+		}
+	})
+
+	t.Run("OutputFlagRejectsCombinationWithSummary", func(t *testing.T) {
+		// Given a plan terraform command with --output=json-plan and --summary together
+		mocks := setupPlanTest(t)
+		proj := newPlanProject(mocks)
+
+		// When executing with both flags set
+		cmd := createTestPlanTerraformCmd()
+		planOutput = "json-plan"
+		planSummary = true
+		t.Cleanup(func() {
+			planOutput = ""
+			planSummary = false
+		})
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"cluster"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then an error rejects the combination
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "cannot be combined with --summary") {
+			t.Errorf("expected combination error, got: %v", err)
+		}
+	})
+
+	t.Run("OutputFlagRejectsCombinationWithJSON", func(t *testing.T) {
+		// Given a plan terraform command with --output=json-plan and --json together
+		mocks := setupPlanTest(t)
+		proj := newPlanProject(mocks)
+
+		// When executing with both flags set
+		cmd := createTestPlanTerraformCmd()
+		planOutput = "json-plan"
+		planJSON = true
+		t.Cleanup(func() {
+			planOutput = ""
+			planJSON = false
+		})
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"cluster"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then an error rejects the combination
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "cannot be combined with --json") {
+			t.Errorf("expected combination error, got: %v", err)
+		}
+	})
 }
 
 func TestPlanKustomizeCmd(t *testing.T) {

--- a/docs/reference/commands/plan-terraform.md
+++ b/docs/reference/commands/plan-terraform.md
@@ -5,10 +5,16 @@ description: "Plan Terraform changes."
 # windsor plan terraform
 
 ```sh
-windsor plan terraform [component]
+windsor plan terraform [component] [flags]
 ```
 
 Stream 'terraform init' and 'terraform plan' for a specific component, or all components when no argument is given. Inherits --summary, --json, and --no-color from the parent 'plan' command.
+
+## Flags
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--output` | `""` | Set to 'json-plan' to print the plan document from 'terraform show -json', instead of the progress log. |
 
 ## Examples
 
@@ -21,6 +27,12 @@ windsor plan terraform --summary
 
 # Machine-readable JSON of all component plans
 windsor plan terraform --json
+
+# Full plan document for a security scanner (one component per run)
+windsor plan terraform cluster --output=json-plan | checkov -f -
+
+# One compact plan document per line, one line per component
+windsor plan terraform --output=json-plan
 ```
 
 ## See also

--- a/integration/plan_test.go
+++ b/integration/plan_test.go
@@ -188,6 +188,69 @@ func TestPlanTerraform_JSONFlagOutputsJSON(t *testing.T) {
 	}
 }
 
+func TestPlanTerraform_OutputJSONPlanFlagForComponent(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
+	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
+	if err != nil {
+		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
+	}
+	env = append(env, "WINDSOR_CONTEXT=local")
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"plan", "terraform", "null", "--output=json-plan"}, env)
+	if err != nil {
+		t.Fatalf("plan terraform null --output=json-plan: %v\nstderr: %s", err, stderr)
+	}
+	if !strings.Contains(string(stdout), `"format_version"`) || !strings.Contains(string(stdout), `"terraform_version"`) {
+		t.Errorf("expected a terraform plan document (format_version/terraform_version) in stdout, got: %s", stdout)
+	}
+	if !strings.Contains(string(stderr), "sensitive") {
+		t.Errorf("expected a sensitive-data advisory on stderr, got: %s", stderr)
+	}
+}
+
+func TestPlanTerraform_OutputJSONPlanFlagForAllComponents(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
+	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
+	if err != nil {
+		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
+	}
+	env = append(env, "WINDSOR_CONTEXT=local")
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"plan", "terraform", "--output=json-plan"}, env)
+	if err != nil {
+		t.Fatalf("plan terraform --output=json-plan: %v\nstderr: %s", err, stderr)
+	}
+	lines := strings.Split(strings.TrimSpace(string(stdout)), "\n")
+	if len(lines) == 0 || lines[0] == "" {
+		t.Fatalf("expected at least one plan document line, got: %s", stdout)
+	}
+	for _, line := range lines {
+		if !strings.Contains(line, `"format_version"`) {
+			t.Errorf("expected each line to be a terraform plan document, got: %s", line)
+		}
+	}
+}
+
+func TestPlanTerraform_OutputFlagRejectsUnsupportedValue(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "plan")
+	helpers.MarkAsGitRepo(t, dir)
+	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
+	if err != nil {
+		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
+	}
+	env = append(env, "WINDSOR_CONTEXT=local")
+	_, stderr, err = helpers.RunCLI(dir, []string{"plan", "terraform", "null", "--output=bogus"}, env)
+	if err == nil {
+		t.Fatal("expected failure for an unsupported --output value")
+	}
+	if !strings.Contains(string(stderr), "invalid --output value") {
+		t.Errorf("expected an invalid --output error, got: %s", stderr)
+	}
+}
+
 func TestPlanTerraform_SummaryFlagWithComponent(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "plan")

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -587,6 +587,38 @@ func (i *Provisioner) PlanTerraformJSON(blueprint *blueprintv1alpha1.Blueprint, 
 	return i.TerraformStack.PlanJSON(blueprint, componentID)
 }
 
+// PlanTerraformResourceChangesJSON runs terraform plan and show -json for a single component,
+// printing the resulting plan document directly to stdout. Returns an error if blueprint
+// is nil, the stack cannot be initialised, or the plan fails.
+func (i *Provisioner) PlanTerraformResourceChangesJSON(blueprint *blueprintv1alpha1.Blueprint, componentID string) error {
+	if blueprint == nil {
+		return fmt.Errorf("blueprint not provided")
+	}
+	if err := i.ensureTerraformStack(); err != nil {
+		return err
+	}
+	if i.TerraformStack == nil {
+		return fmt.Errorf("terraform is disabled")
+	}
+	return i.TerraformStack.PlanResourceChangesJSON(blueprint, componentID)
+}
+
+// PlanTerraformAllResourceChangesJSON runs terraform plan and show -json for every enabled
+// component, printing each component's plan document directly to stdout. Returns an error
+// if blueprint is nil, the stack cannot be initialised, or any component's plan fails.
+func (i *Provisioner) PlanTerraformAllResourceChangesJSON(blueprint *blueprintv1alpha1.Blueprint) error {
+	if blueprint == nil {
+		return fmt.Errorf("blueprint not provided")
+	}
+	if err := i.ensureTerraformStack(); err != nil {
+		return err
+	}
+	if i.TerraformStack == nil {
+		return fmt.Errorf("terraform is disabled")
+	}
+	return i.TerraformStack.PlanAllResourceChangesJSON(blueprint)
+}
+
 // PlanKustomizeJSON runs kustomize build for the named kustomization (or all when componentID
 // is "all") and writes the rendered manifests as JSON to stdout. Returns an error if blueprint
 // is nil, the stack cannot be initialised, or the build fails.

--- a/pkg/provisioner/terraform/mock_stack.go
+++ b/pkg/provisioner/terraform/mock_stack.go
@@ -15,21 +15,23 @@ import (
 
 // MockStack is a mock implementation of the Stack interface for testing.
 type MockStack struct {
-	UpFunc                    func(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(id string) (bool, error)) (bool, error)
-	MigrateStateFunc          func(blueprint *blueprintv1alpha1.Blueprint) ([]string, error)
-	MigrateComponentStateFunc func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
-	HasRemoteStateFunc             func(blueprint *blueprintv1alpha1.Blueprint, componentID string) (bool, error)
-	HasLocalStateWithResourcesFunc func(componentID string) (bool, error)
-	InitComponentFunc              func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
-	RemoveLocalStateFunc           func(componentID string) error
-	PostApplyFunc             func(fns ...func(id string) error)
-	DestroyAllFunc            func(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyOutcome, error)
-	PlanFunc                  func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
-	PlanAllFunc               func(blueprint *blueprintv1alpha1.Blueprint) error
-	PlanJSONFunc              func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
-	PlanAllJSONFunc           func(blueprint *blueprintv1alpha1.Blueprint) error
-	ApplyFunc                 func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
-	DestroyFunc               func(blueprint *blueprintv1alpha1.Blueprint, componentID string) (bool, error)
+	UpFunc                          func(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(id string) (bool, error)) (bool, error)
+	MigrateStateFunc                func(blueprint *blueprintv1alpha1.Blueprint) ([]string, error)
+	MigrateComponentStateFunc       func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
+	HasRemoteStateFunc              func(blueprint *blueprintv1alpha1.Blueprint, componentID string) (bool, error)
+	HasLocalStateWithResourcesFunc  func(componentID string) (bool, error)
+	InitComponentFunc               func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
+	RemoveLocalStateFunc            func(componentID string) error
+	PostApplyFunc                   func(fns ...func(id string) error)
+	DestroyAllFunc                  func(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyOutcome, error)
+	PlanFunc                        func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
+	PlanAllFunc                     func(blueprint *blueprintv1alpha1.Blueprint) error
+	PlanJSONFunc                    func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
+	PlanAllJSONFunc                 func(blueprint *blueprintv1alpha1.Blueprint) error
+	PlanResourceChangesJSONFunc     func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
+	PlanAllResourceChangesJSONFunc  func(blueprint *blueprintv1alpha1.Blueprint) error
+	ApplyFunc                       func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
+	DestroyFunc                     func(blueprint *blueprintv1alpha1.Blueprint, componentID string) (bool, error)
 	PlanSummaryFunc                 func(blueprint *blueprintv1alpha1.Blueprint) []TerraformComponentPlan
 	PlanComponentSummaryFunc        func(blueprint *blueprintv1alpha1.Blueprint, componentID string) TerraformComponentPlan
 	PlanDestroySummaryFunc          func(blueprint *blueprintv1alpha1.Blueprint) []TerraformComponentPlan
@@ -148,6 +150,22 @@ func (m *MockStack) PlanAllJSON(blueprint *blueprintv1alpha1.Blueprint) error {
 func (m *MockStack) PlanJSON(blueprint *blueprintv1alpha1.Blueprint, componentID string) error {
 	if m.PlanJSONFunc != nil {
 		return m.PlanJSONFunc(blueprint, componentID)
+	}
+	return nil
+}
+
+// PlanResourceChangesJSON is a mock implementation of the PlanResourceChangesJSON method.
+func (m *MockStack) PlanResourceChangesJSON(blueprint *blueprintv1alpha1.Blueprint, componentID string) error {
+	if m.PlanResourceChangesJSONFunc != nil {
+		return m.PlanResourceChangesJSONFunc(blueprint, componentID)
+	}
+	return nil
+}
+
+// PlanAllResourceChangesJSON is a mock implementation of the PlanAllResourceChangesJSON method.
+func (m *MockStack) PlanAllResourceChangesJSON(blueprint *blueprintv1alpha1.Blueprint) error {
+	if m.PlanAllResourceChangesJSONFunc != nil {
+		return m.PlanAllResourceChangesJSONFunc(blueprint)
 	}
 	return nil
 }

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -211,6 +211,8 @@ type Stack interface {
 	PlanAll(blueprint *blueprintv1alpha1.Blueprint) error
 	PlanJSON(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
 	PlanAllJSON(blueprint *blueprintv1alpha1.Blueprint) error
+	PlanResourceChangesJSON(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
+	PlanAllResourceChangesJSON(blueprint *blueprintv1alpha1.Blueprint) error
 	Apply(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
 	Destroy(blueprint *blueprintv1alpha1.Blueprint, componentID string) (bool, error)
 	PlanSummary(blueprint *blueprintv1alpha1.Blueprint) []TerraformComponentPlan
@@ -1081,6 +1083,12 @@ func (s *TerraformStack) PlanComponentSummary(blueprint *blueprintv1alpha1.Bluep
 // Private Methods
 // =============================================================================
 
+// printComponentHeader prints a section header naming the component to stderr, ahead of
+// streaming its terraform output. Shared by every per-component loop over all components.
+func (s *TerraformStack) printComponentHeader(componentPath string) {
+	fmt.Fprintf(os.Stderr, "\n%s\n", tui.SectionHeader("Terraform: "+componentPath))
+}
+
 // migrateOneComponent runs `terraform init -migrate-state -force-copy` for a single
 // component, registering any generated backend_override.tf for cleanup via
 // backendOverridePaths. Returns (false, nil) when the component's directory does not
@@ -1144,7 +1152,7 @@ func (s *TerraformStack) planComponents(blueprint *blueprintv1alpha1.Blueprint, 
 	for i := range components {
 		component := &components[i]
 
-		fmt.Fprintf(os.Stderr, "\n%s\n", tui.SectionHeader("Terraform: "+component.Path))
+		s.printComponentHeader(component.Path)
 
 		terraformVars, scopedKeys, terraformArgs, cleanup, err := s.prepareComponentEnv(component)
 		if err != nil {

--- a/pkg/provisioner/terraform/stack_show.go
+++ b/pkg/provisioner/terraform/stack_show.go
@@ -1,0 +1,136 @@
+package terraform
+
+// The stack_show file is a terraform plan document retriever for the Stack.
+// It provides PlanResourceChangesJSON and PlanAllResourceChangesJSON, which run
+// terraform plan and show -json and print the resulting resource-changes document.
+// Both plan and show steps use capture-only exec, since the document can contain
+// sensitive values and must never echo to the terminal, even under --verbose.
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+	envvars "github.com/windsorcli/cli/pkg/runtime/env"
+)
+
+// =============================================================================
+// Public Methods
+// =============================================================================
+
+// PlanResourceChangesJSON runs terraform init, plan, and show -json for a single component
+// identified by componentID, printing the resulting plan document to stdout. Returns an
+// error if the component is not found, the directory does not exist, or any terraform
+// operation fails.
+func (s *TerraformStack) PlanResourceChangesJSON(blueprint *blueprintv1alpha1.Blueprint, componentID string) error {
+	if blueprint == nil {
+		return fmt.Errorf("blueprint not provided")
+	}
+	if componentID == "" {
+		return fmt.Errorf("component ID not provided")
+	}
+
+	component, terraformVars, scopedKeys, terraformArgs, cleanup, err := s.prepareComponentOp(blueprint, componentID)
+	if err != nil {
+		return err
+	}
+	defer cleanup()
+
+	return s.planResourceChangesJSON(component, terraformVars, scopedKeys, terraformArgs)
+}
+
+// PlanAllResourceChangesJSON runs terraform init, plan, and show -json for every enabled
+// component in the blueprint, streaming each component's plan document directly to stdout.
+// Stops on the first error. Returns an error if blueprint is nil or any component's
+// terraform operation fails.
+func (s *TerraformStack) PlanAllResourceChangesJSON(blueprint *blueprintv1alpha1.Blueprint) error {
+	if blueprint == nil {
+		return fmt.Errorf("blueprint not provided")
+	}
+
+	projectRoot := s.runtime.ProjectRoot
+	if projectRoot == "" {
+		return fmt.Errorf("error getting project root: project root is empty")
+	}
+
+	components := s.resolveTerraformComponents(blueprint, projectRoot)
+	for i := range components {
+		component := &components[i]
+
+		s.printComponentHeader(component.Path)
+
+		terraformVars, scopedKeys, terraformArgs, cleanup, err := s.prepareComponentEnv(component)
+		if err != nil {
+			return err
+		}
+		err = s.planResourceChangesJSON(component, terraformVars, scopedKeys, terraformArgs)
+		cleanup()
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// =============================================================================
+// Private Methods
+// =============================================================================
+
+// planResourceChangesJSON runs terraform plan (writing a plan file), then terraform show
+// -json against that plan file, and prints the resulting document to stdout. Both steps use
+// ExecCaptureWithEnv, never ExecSilentWithEnv: the plan diff and the show document can both
+// carry the same sensitive plaintext, and neither may echo to the terminal under --verbose.
+//
+// Windsor's shell layer still scrubs any value registered via RegisterSecret (secrets sourced
+// through 'secret(...)' from a vault/SOPS provider) to "********" in this output, the same as
+// every other windsor command. Values a provider or resource computes itself (a generated
+// password, a TLS private key) are not registered, and so are not scrubbed: they reach stdout
+// as terraform produced them.
+func (s *TerraformStack) planResourceChangesJSON(component *blueprintv1alpha1.TerraformComponent, terraformVars map[string]string, scopedKeys []string, terraformArgs *envvars.TerraformArgs) error {
+	terraformVars["TF_VAR_operation"] = "apply"
+
+	if err := s.runTerraformInit(component, terraformVars, scopedKeys, terraformArgs, defaultInitFlags...); err != nil {
+		return err
+	}
+
+	terraformCommand := s.runtime.ToolsManager.GetTerraformCommand()
+	planEnv := selectTerraformCommandEnv(terraformVars, true, scopedKeys)
+
+	planArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "plan", "-no-color"}
+	planArgs = append(planArgs, terraformArgs.PlanArgs...)
+	if _, err := s.runtime.Shell.ExecCaptureWithEnv(terraformCommand, planEnv, planArgs...); err != nil {
+		return fmt.Errorf("error running terraform plan for %s: %w", component.Path, err)
+	}
+
+	tfPlanPath := filepath.ToSlash(filepath.Join(terraformArgs.TFDataDir, "terraform.tfplan"))
+	showArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "show", "-json", tfPlanPath}
+	showOutput, err := s.runtime.Shell.ExecCaptureWithEnv(terraformCommand, planEnv, showArgs...)
+	if err != nil {
+		return fmt.Errorf("error reading terraform plan JSON for %s: %w", component.Path, err)
+	}
+
+	compacted, err := compactPlanJSON(showOutput)
+	if err != nil {
+		return fmt.Errorf("error parsing terraform plan JSON for %s: %w", component.Path, err)
+	}
+	fmt.Fprintln(os.Stdout, compacted)
+
+	return nil
+}
+
+// compactPlanJSON strips insignificant whitespace from a terraform show -json document, so
+// PlanAllResourceChangesJSON's per-component output is newline-delimited and safe to split.
+// It uses json.Compact rather than a decode/re-encode round trip: json.Compact validates and
+// reformats the raw bytes without touching values, so it neither reorders terraform's object
+// keys nor HTML-escapes characters like '&' the way json.Marshal would.
+func compactPlanJSON(raw string) (string, error) {
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, []byte(raw)); err != nil {
+		return "", err
+	}
+	return buf.String(), nil
+}

--- a/pkg/provisioner/terraform/stack_show_test.go
+++ b/pkg/provisioner/terraform/stack_show_test.go
@@ -1,0 +1,360 @@
+package terraform
+
+// Test coverage for stack_show.go: PlanResourceChangesJSON, PlanAllResourceChangesJSON,
+// and the shared planResourceChangesJSON helper.
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+)
+
+// =============================================================================
+// Test Public Methods
+// =============================================================================
+
+func TestStack_PlanResourceChangesJSON(t *testing.T) {
+	setup := func(t *testing.T) (*TerraformStack, *TerraformTestMocks) {
+		t.Helper()
+		mocks := setupWindsorStackMocks(t)
+		stack := NewStack(mocks.Runtime).(*TerraformStack)
+		stack.shims = mocks.Shims
+		return stack, mocks
+	}
+
+	t.Run("PrintsShowOutputToStdout", func(t *testing.T) {
+		// Given a stack whose show -json returns a fixed plan document
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+		mocks.Shell.ExecCaptureWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 1 && args[1] == "show" {
+				return `{"format_version":"1.2","resource_changes":[]}`, nil
+			}
+			return "", nil
+		}
+
+		r, w, pipeErr := os.Pipe()
+		if pipeErr != nil {
+			t.Fatalf("Pipe failed: %v", pipeErr)
+		}
+		origStdout := os.Stdout
+		os.Stdout = w
+		defer func() { os.Stdout = origStdout }()
+
+		// When PlanResourceChangesJSON is called
+		err := stack.PlanResourceChangesJSON(blueprint, "local/path")
+
+		w.Close()
+		stdoutBytes, _ := io.ReadAll(r)
+
+		// Then the plan document is printed to stdout, compacted onto one line
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got := string(stdoutBytes); got != "{\"format_version\":\"1.2\",\"resource_changes\":[]}\n" {
+			t.Errorf("unexpected stdout: %q", got)
+		}
+	})
+
+	t.Run("RunsPlanBeforeShowOnThePlanFile", func(t *testing.T) {
+		// Given a stack that records the order and args of plan/show invocations
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+		var planArgs, showArgs []string
+		mocks.Shell.ExecCaptureWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 1 && args[1] == "plan" {
+				planArgs = args
+				return "", nil
+			}
+			if len(args) > 1 && args[1] == "show" {
+				showArgs = args
+				return "{}", nil
+			}
+			return "", nil
+		}
+
+		// When PlanResourceChangesJSON is called
+		err := stack.PlanResourceChangesJSON(blueprint, "local/path")
+
+		// Then plan writes a plan file, and show reads that same plan file as JSON
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if planArgs == nil {
+			t.Fatal("expected terraform plan to be invoked")
+		}
+		var outArg string
+		for _, a := range planArgs {
+			if strings.HasPrefix(a, "-out=") {
+				outArg = strings.TrimPrefix(a, "-out=")
+			}
+		}
+		if outArg == "" {
+			t.Fatal("expected plan args to include -out=<planfile>")
+		}
+		if showArgs == nil {
+			t.Fatal("expected terraform show to be invoked")
+		}
+		if showArgs[len(showArgs)-1] != outArg {
+			t.Errorf("expected show to read the plan file %q, got args %v", outArg, showArgs)
+		}
+		if showArgs[1] != "show" || showArgs[2] != "-json" {
+			t.Errorf("expected show args to be [show -json <planfile>], got %v", showArgs)
+		}
+	})
+
+	t.Run("ReturnsErrorForNilBlueprint", func(t *testing.T) {
+		// Given a stack with a nil blueprint
+		stack, _ := setup(t)
+
+		// When PlanResourceChangesJSON is called
+		err := stack.PlanResourceChangesJSON(nil, "local/path")
+
+		// Then an error is returned
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "blueprint not provided") {
+			t.Errorf("expected blueprint not provided error, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorForEmptyComponentID", func(t *testing.T) {
+		// Given a stack with a blueprint
+		stack, _ := setup(t)
+		blueprint := createTestBlueprint()
+
+		// When PlanResourceChangesJSON is called with an empty component ID
+		err := stack.PlanResourceChangesJSON(blueprint, "")
+
+		// Then an error is returned
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "component ID not provided") {
+			t.Errorf("expected component ID error, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorForUnknownComponent", func(t *testing.T) {
+		// Given a stack and a blueprint with known components
+		stack, _ := setup(t)
+		blueprint := createTestBlueprint()
+
+		// When PlanResourceChangesJSON is called for a component that does not exist
+		err := stack.PlanResourceChangesJSON(blueprint, "does/not/exist")
+
+		// Then an error names the missing component
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), `"does/not/exist" not found`) {
+			t.Errorf("expected not found error, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenPlanFails", func(t *testing.T) {
+		// Given a stack whose terraform plan fails
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+		mocks.Shell.ExecCaptureWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 1 && args[1] == "plan" {
+				return "", fmt.Errorf("mock error running terraform plan")
+			}
+			return "", nil
+		}
+
+		// When PlanResourceChangesJSON is called
+		err := stack.PlanResourceChangesJSON(blueprint, "local/path")
+
+		// Then the plan failure is surfaced
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "error running terraform plan for") {
+			t.Errorf("expected plan error, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenShowFails", func(t *testing.T) {
+		// Given a stack whose terraform show -json fails
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+		mocks.Shell.ExecCaptureWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 1 && args[1] == "show" {
+				return "", fmt.Errorf("mock error")
+			}
+			return "", nil
+		}
+
+		// When PlanResourceChangesJSON is called
+		err := stack.PlanResourceChangesJSON(blueprint, "local/path")
+
+		// Then the show failure is surfaced
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "error reading terraform plan JSON for") {
+			t.Errorf("expected show error, got: %v", err)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenShowOutputIsNotValidJSON", func(t *testing.T) {
+		// Given a stack whose terraform show -json returns malformed output
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+		mocks.Shell.ExecCaptureWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 1 && args[1] == "show" {
+				return "not json", nil
+			}
+			return "", nil
+		}
+
+		// When PlanResourceChangesJSON is called
+		err := stack.PlanResourceChangesJSON(blueprint, "local/path")
+
+		// Then a parse error is surfaced
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "error parsing terraform plan JSON for") {
+			t.Errorf("expected parse error, got: %v", err)
+		}
+	})
+
+	t.Run("NeverStreamsPlanOrShowThroughTheVerboseEchoPath", func(t *testing.T) {
+		// Given a stack whose ExecSilentWithEnv fails the test if called for plan or show:
+		// both steps can carry sensitive plaintext, and ExecSilentWithEnv echoes its
+		// captured output to the terminal under --verbose, unlike ExecCaptureWithEnv. Init
+		// output is not sensitive plan data and is exempt.
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 1 && (args[1] == "plan" || args[1] == "show") {
+				t.Fatalf("unexpected ExecSilentWithEnv call with args %v; plan and show must use ExecCaptureWithEnv", args)
+			}
+			return "", nil
+		}
+		mocks.Shell.ExecCaptureWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			return "{}", nil
+		}
+
+		// When PlanResourceChangesJSON is called
+		err := stack.PlanResourceChangesJSON(blueprint, "local/path")
+
+		// Then no error occurs and ExecSilentWithEnv was never reached for plan/show
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+}
+
+func TestStack_PlanAllResourceChangesJSON(t *testing.T) {
+	setup := func(t *testing.T) (*TerraformStack, *TerraformTestMocks) {
+		t.Helper()
+		mocks := setupWindsorStackMocks(t)
+		stack := NewStack(mocks.Runtime).(*TerraformStack)
+		stack.shims = mocks.Shims
+		return stack, mocks
+	}
+
+	t.Run("ReturnsErrorForNilBlueprint", func(t *testing.T) {
+		// Given a stack with a nil blueprint
+		stack, _ := setup(t)
+
+		// When PlanAllResourceChangesJSON is called
+		err := stack.PlanAllResourceChangesJSON(nil)
+
+		// Then an error is returned
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+	})
+
+	t.Run("ReturnsErrorForEmptyProjectRoot", func(t *testing.T) {
+		// Given a stack with an empty project root
+		stack, mocks := setup(t)
+		mocks.Runtime.ProjectRoot = ""
+		blueprint := createTestBlueprint()
+
+		// When PlanAllResourceChangesJSON is called
+		err := stack.PlanAllResourceChangesJSON(blueprint)
+
+		// Then an error is returned
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "project root is empty") {
+			t.Errorf("expected project root error, got: %v", err)
+		}
+	})
+
+	t.Run("RunsPlanAndShowForEveryComponent", func(t *testing.T) {
+		// Given a stack with multiple components in the blueprint
+		stack, mocks := setup(t)
+		var planCalls, showCalls int
+		mocks.Shell.ExecCaptureWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" && len(args) > 1 && args[1] == "plan" {
+				planCalls++
+			}
+			if command == "terraform" && len(args) > 1 && args[1] == "show" {
+				showCalls++
+			}
+			return "{}", nil
+		}
+		bp := &blueprintv1alpha1.Blueprint{
+			TerraformComponents: []blueprintv1alpha1.TerraformComponent{
+				{Name: "alpha", Path: "local/alpha"},
+				{Name: "beta", Path: "local/beta"},
+			},
+		}
+
+		// When PlanAllResourceChangesJSON is called
+		err := stack.PlanAllResourceChangesJSON(bp)
+
+		// Then both components are planned and shown
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if planCalls != 2 {
+			t.Errorf("expected 2 plan calls, got %d", planCalls)
+		}
+		if showCalls != 2 {
+			t.Errorf("expected 2 show calls, got %d", showCalls)
+		}
+	})
+
+	t.Run("StopsOnFirstError", func(t *testing.T) {
+		// Given a stack whose show -json fails for the first component
+		stack, mocks := setup(t)
+		var showCalls int
+		mocks.Shell.ExecCaptureWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" && len(args) > 1 && args[1] == "show" {
+				showCalls++
+				return "", fmt.Errorf("mock error")
+			}
+			return "", nil
+		}
+		bp := &blueprintv1alpha1.Blueprint{
+			TerraformComponents: []blueprintv1alpha1.TerraformComponent{
+				{Name: "alpha", Path: "local/alpha"},
+				{Name: "beta", Path: "local/beta"},
+			},
+		}
+
+		// When PlanAllResourceChangesJSON is called
+		err := stack.PlanAllResourceChangesJSON(bp)
+
+		// Then the first failure stops the loop before the second component runs
+		if err == nil {
+			t.Error("expected error, got nil")
+		}
+		if showCalls != 1 {
+			t.Errorf("expected 1 show call before stopping, got %d", showCalls)
+		}
+	})
+}


### PR DESCRIPTION
Closes #3274

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This change adds a new CLI output mode to `windsor plan terraform` that can print full terraform plan documents, including plaintext sensitive values, to stdout.
>
> **Overview**
>
> The PR adds `--output=json-plan` to `windsor plan terraform`, which runs `terraform plan` followed by `terraform show -json` for one component (or every enabled component) and prints the resulting plan document, intended for scanners like Checkov. The new `PlanResourceChangesJSON`/`PlanAllResourceChangesJSON` methods thread through `Provisioner` and `TerraformStack`, reusing the existing component resolution, env setup, and init helpers.
>
> Both the plan and show steps deliberately use `ExecCaptureWithEnv`, which never echoes to the terminal even under `--verbose`, since the plan document can contain sensitive plaintext beyond what Windsor's secret scrubber knows about. The command prints an explicit stderr advisory before emitting output, and `--output=json-plan` is rejected when combined with `--summary` or `--json`.

<!-- /claude-code-review:summary -->
