### PR TITLE
fix(env): recompute GOOGLE_APPLICATION_CREDENTIALS when stale

### DIFF
--- a/pkg/runtime/env/env.go
+++ b/pkg/runtime/env/env.go
@@ -7,6 +7,7 @@ package env
 
 import (
 	"slices"
+	"strings"
 
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	"github.com/windsorcli/cli/pkg/runtime/dotenv"
@@ -99,6 +100,25 @@ func (e *BaseEnvPrinter) SetManagedEnv(env string) {
 		return
 	}
 	e.managedEnv = append(e.managedEnv, env)
+}
+
+// ShouldSetManagedValue reports whether a printer may set key. It returns true when
+// key has no value in the environment yet, or when the previous round's
+// WINDSOR_MANAGED_ENV already lists key as Windsor's own. It returns false when an
+// operator's own value occupies key, so that value is left untouched.
+func (e *BaseEnvPrinter) ShouldSetManagedValue(key string) bool {
+	_, exists := e.shims.LookupEnv(key)
+	if !exists {
+		return true
+	}
+
+	managedEnvStr := e.shims.Getenv("WINDSOR_MANAGED_ENV")
+	for _, managedKey := range strings.Split(managedEnvStr, ",") {
+		if strings.TrimSpace(managedKey) == key {
+			return true
+		}
+	}
+	return false
 }
 
 // SetManagedAlias sets the shell aliases that are managed by Windsor.

--- a/pkg/runtime/env/env_test.go
+++ b/pkg/runtime/env/env_test.go
@@ -27,6 +27,7 @@ func setupDefaultShims(tmpDir string) *Shims {
 	shims := NewShims()
 
 	shims.LookupEnv = func(key string) (string, bool) { return "", false }
+	shims.Getenv = func(key string) string { return "" }
 	shims.WriteFile = func(name string, data []byte, perm os.FileMode) error { return nil }
 	shims.ReadFile = func(name string) ([]byte, error) { return []byte{}, nil }
 	shims.MkdirAll = func(path string, perm os.FileMode) error { return nil }
@@ -329,6 +330,60 @@ func TestBaseEnvPrinter_SetManagedEnv(t *testing.T) {
 		}
 		if managedEnv[0] != "SET_TEST_VAR1" {
 			t.Errorf("expected [SET_TEST_VAR1], got %v", managedEnv)
+		}
+	})
+}
+
+// TestBaseEnvPrinter_ShouldSetManagedValue tests the ShouldSetManagedValue method of the BaseEnvPrinter struct
+func TestBaseEnvPrinter_ShouldSetManagedValue(t *testing.T) {
+	setup := func(t *testing.T) (*BaseEnvPrinter, *EnvTestMocks) {
+		t.Helper()
+		mocks := setupEnvMocks(t)
+		printer := NewBaseEnvPrinter(mocks.Shell, mocks.ConfigHandler)
+		printer.shims = mocks.Shims
+		return printer, mocks
+	}
+
+	t.Run("KeyNotSet", func(t *testing.T) {
+		// Given a key with no value in the environment
+		printer, mocks := setup(t)
+		mocks.Shims.LookupEnv = func(key string) (string, bool) { return "", false }
+
+		// When checking whether it should be set
+		// Then the printer may set it
+		if !printer.ShouldSetManagedValue("SOME_VAR") {
+			t.Error("expected ShouldSetManagedValue to return true for an unset key")
+		}
+	})
+
+	t.Run("KeySetByOperator", func(t *testing.T) {
+		// Given a key holding a value with no record in WINDSOR_MANAGED_ENV
+		printer, mocks := setup(t)
+		mocks.Shims.LookupEnv = func(key string) (string, bool) { return "operator-value", true }
+		mocks.Shims.Getenv = func(key string) string { return "" }
+
+		// When checking whether it should be set
+		// Then the operator's value is left alone
+		if printer.ShouldSetManagedValue("SOME_VAR") {
+			t.Error("expected ShouldSetManagedValue to return false for an operator-owned key")
+		}
+	})
+
+	t.Run("KeyPreviouslyManagedByWindsor", func(t *testing.T) {
+		// Given a key holding a value Windsor itself set on a prior round
+		printer, mocks := setup(t)
+		mocks.Shims.LookupEnv = func(key string) (string, bool) { return "windsor-value", true }
+		mocks.Shims.Getenv = func(key string) string {
+			if key == "WINDSOR_MANAGED_ENV" {
+				return "OTHER_VAR,SOME_VAR"
+			}
+			return ""
+		}
+
+		// When checking whether it should be set
+		// Then Windsor may recompute its own value
+		if !printer.ShouldSetManagedValue("SOME_VAR") {
+			t.Error("expected ShouldSetManagedValue to return true for a Windsor-managed key")
 		}
 	})
 }

--- a/pkg/runtime/env/gcp_env.go
+++ b/pkg/runtime/env/gcp_env.go
@@ -45,13 +45,14 @@ func NewGcpEnvPrinter(shell shell.Shell, configHandler config.ConfigHandler) *Gc
 // =============================================================================
 
 // GetEnvVars returns the GCP environment variables for the current context. Project mode
-// always sets CLOUDSDK_CONFIG. Google client libraries do not read it, so
-// GOOGLE_APPLICATION_CREDENTIALS bridges the gap: gcp.credentials_path first, then the
-// service-account file, then the gcloud ADC file, else it stays unset. A set-but-missing
+// always sets CLOUDSDK_CONFIG. Google client libraries do not read it. GOOGLE_APPLICATION_CREDENTIALS
+// bridges the gap. Windsor tries gcp.credentials_path first, then the service-account
+// file, then the gcloud ADC file, else it leaves the variable unset. A set-but-missing
 // path breaks Google client libraries outright, so Windsor never guesses one. Global mode
 // defers to the operator's ambient gcloud setup. GOOGLE_CLOUD_PROJECT, GCLOUD_PROJECT, and
-// GOOGLE_CLOUD_QUOTA_PROJECT need a gcp: field. Windsor never overwrites an existing
-// GOOGLE_APPLICATION_CREDENTIALS value.
+// GOOGLE_CLOUD_QUOTA_PROJECT need a gcp: field. Windsor recomputes GOOGLE_APPLICATION_CREDENTIALS
+// on every call unless an operator's own value already occupies it. This lets a removed
+// service-account file or a switch to ADC take effect on the next command.
 func (e *GcpEnvPrinter) GetEnvVars() (map[string]string, error) {
 	envVars := make(map[string]string)
 	global := e.shell.IsGlobal()
@@ -61,6 +62,8 @@ func (e *GcpEnvPrinter) GetEnvVars() (map[string]string, error) {
 	if config != nil && config.GCP != nil {
 		credentialsPath = config.GCP.CredentialsPath
 	}
+
+	shouldSetCredentials := e.ShouldSetManagedValue("GOOGLE_APPLICATION_CREDENTIALS")
 
 	if !global {
 		configRoot, err := e.configHandler.GetConfigRoot()
@@ -74,7 +77,7 @@ func (e *GcpEnvPrinter) GetEnvVars() (map[string]string, error) {
 		}
 		envVars["CLOUDSDK_CONFIG"] = filepath.ToSlash(gcloudConfigDir)
 
-		if _, exists := e.shims.LookupEnv("GOOGLE_APPLICATION_CREDENTIALS"); !exists {
+		if shouldSetCredentials {
 			if credentialsPath != nil {
 				envVars["GOOGLE_APPLICATION_CREDENTIALS"] = *credentialsPath
 			} else {
@@ -87,10 +90,8 @@ func (e *GcpEnvPrinter) GetEnvVars() (map[string]string, error) {
 				}
 			}
 		}
-	} else if credentialsPath != nil {
-		if _, exists := e.shims.LookupEnv("GOOGLE_APPLICATION_CREDENTIALS"); !exists {
-			envVars["GOOGLE_APPLICATION_CREDENTIALS"] = *credentialsPath
-		}
+	} else if credentialsPath != nil && shouldSetCredentials {
+		envVars["GOOGLE_APPLICATION_CREDENTIALS"] = *credentialsPath
 	}
 
 	if config != nil && config.GCP != nil {
@@ -105,9 +106,6 @@ func (e *GcpEnvPrinter) GetEnvVars() (map[string]string, error) {
 	}
 
 	for key := range envVars {
-		if key == "GOOGLE_APPLICATION_CREDENTIALS" {
-			continue
-		}
 		e.SetManagedEnv(key)
 	}
 

--- a/pkg/runtime/env/gcp_env_test.go
+++ b/pkg/runtime/env/gcp_env_test.go
@@ -569,6 +569,149 @@ contexts:
 		}
 	})
 
+	t.Run("RecomputesWhenWindsorManagedValueIsStale", func(t *testing.T) {
+		// Given a shell where Windsor previously set GOOGLE_APPLICATION_CREDENTIALS
+		// (tracked in WINDSOR_MANAGED_ENV) to a service-account file that was since removed,
+		// and the operator has since logged in with ADC instead
+		mocks := setupGcpEnvMocks(t)
+		configStr := `
+version: v1alpha1
+contexts:
+  test-context:
+    gcp:
+      enabled: true
+`
+		if err := mocks.ConfigHandler.LoadConfigString(configStr); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+		printer := NewGcpEnvPrinter(mocks.Shell, mocks.ConfigHandler)
+		printer.shims = mocks.Shims
+
+		configRoot, err := mocks.ConfigHandler.GetConfigRoot()
+		if err != nil {
+			t.Fatalf("Failed to get config root: %v", err)
+		}
+		adcPath := filepath.Join(configRoot, ".gcp", "gcloud", "application_default_credentials.json")
+
+		mocks.Shims.Getenv = func(key string) string {
+			if key == "WINDSOR_MANAGED_ENV" {
+				return "GOOGLE_APPLICATION_CREDENTIALS,CLOUDSDK_CONFIG"
+			}
+			return ""
+		}
+		mocks.Shims.LookupEnv = func(key string) (string, bool) {
+			if key == "GOOGLE_APPLICATION_CREDENTIALS" {
+				return "/removed/service-account.json", true
+			}
+			return "", false
+		}
+		mocks.Shims.Stat = func(name string) (os.FileInfo, error) {
+			if name == adcPath {
+				return nil, nil
+			}
+			return nil, os.ErrNotExist
+		}
+
+		// When GetEnvVars runs
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		// Then it recomputes to the ADC file rather than keeping the stale path
+		expectedPath := filepath.ToSlash(adcPath)
+		if got := envVars["GOOGLE_APPLICATION_CREDENTIALS"]; got != expectedPath {
+			t.Errorf("GetEnvVars returned GOOGLE_APPLICATION_CREDENTIALS=%v, want %v", got, expectedPath)
+		}
+	})
+
+	t.Run("OmitsCredentialsWhenWindsorManagedFileIsGone", func(t *testing.T) {
+		// Given a shell where Windsor previously set GOOGLE_APPLICATION_CREDENTIALS
+		// and neither the service-account file nor an ADC file exists any more
+		mocks := setupGcpEnvMocks(t)
+		configStr := `
+version: v1alpha1
+contexts:
+  test-context:
+    gcp:
+      enabled: true
+`
+		if err := mocks.ConfigHandler.LoadConfigString(configStr); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+		printer := NewGcpEnvPrinter(mocks.Shell, mocks.ConfigHandler)
+		printer.shims = mocks.Shims
+
+		mocks.Shims.Getenv = func(key string) string {
+			if key == "WINDSOR_MANAGED_ENV" {
+				return "GOOGLE_APPLICATION_CREDENTIALS"
+			}
+			return ""
+		}
+		mocks.Shims.LookupEnv = func(key string) (string, bool) {
+			if key == "GOOGLE_APPLICATION_CREDENTIALS" {
+				return "/removed/service-account.json", true
+			}
+			return "", false
+		}
+		mocks.Shims.Stat = func(name string) (os.FileInfo, error) {
+			return nil, os.ErrNotExist
+		}
+
+		// When GetEnvVars runs
+		envVars, err := printer.GetEnvVars()
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		// Then it omits the key rather than reporting the now-missing stale path, so the
+		// caller (WindsorEnvPrinter) unsets it in the shell.
+		if _, exists := envVars["GOOGLE_APPLICATION_CREDENTIALS"]; exists {
+			t.Errorf("Expected no GOOGLE_APPLICATION_CREDENTIALS when the managed file no longer exists, got %v", envVars["GOOGLE_APPLICATION_CREDENTIALS"])
+		}
+	})
+
+	t.Run("SetsManagedEnvWhenCredentialsAreComputed", func(t *testing.T) {
+		// Given a fresh shell with no prior GOOGLE_APPLICATION_CREDENTIALS
+		mocks := setupGcpEnvMocks(t)
+		configStr := `
+version: v1alpha1
+contexts:
+  test-context:
+    gcp:
+      enabled: true
+      credentials_path: "/path/to/credentials.json"
+`
+		if err := mocks.ConfigHandler.LoadConfigString(configStr); err != nil {
+			t.Fatalf("Failed to load config: %v", err)
+		}
+		printer := NewGcpEnvPrinter(mocks.Shell, mocks.ConfigHandler)
+		printer.shims = mocks.Shims
+
+		mocks.Shims.LookupEnv = func(key string) (string, bool) {
+			return "", false
+		}
+
+		// When GetEnvVars runs
+		if _, err := printer.GetEnvVars(); err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		// Then GOOGLE_APPLICATION_CREDENTIALS is tracked as managed, so a later run can
+		// tell Windsor's own value apart from an operator-supplied one.
+		managed := printer.GetManagedEnv()
+		found := false
+		for _, k := range managed {
+			if k == "GOOGLE_APPLICATION_CREDENTIALS" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Expected GOOGLE_APPLICATION_CREDENTIALS to be tracked in managed env, got %v", managed)
+		}
+	})
+
 	t.Run("OnlyProjectIDSet", func(t *testing.T) {
 		mocks := setupGcpEnvMocks(t)
 		configStr := `

--- a/pkg/runtime/env/virt_env.go
+++ b/pkg/runtime/env/virt_env.go
@@ -10,7 +10,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	"github.com/windsorcli/cli/pkg/runtime/shell"
@@ -59,18 +58,7 @@ func (e *VirtEnvPrinter) GetEnvVars() (map[string]string, error) {
 	workstationRuntime := e.configHandler.GetString("workstation.runtime")
 	platform := e.configHandler.GetString("platform")
 
-	isDockerHostManaged := false
-	if managedEnvStr := e.shims.Getenv("WINDSOR_MANAGED_ENV"); managedEnvStr != "" {
-		for _, key := range strings.Split(managedEnvStr, ",") {
-			if strings.TrimSpace(key) == "DOCKER_HOST" {
-				isDockerHostManaged = true
-				break
-			}
-		}
-	}
-
-	_, dockerHostExists := e.shims.LookupEnv("DOCKER_HOST")
-	shouldSetDockerHost := !dockerHostExists || isDockerHostManaged
+	shouldSetDockerHost := e.ShouldSetManagedValue("DOCKER_HOST")
 
 	if platform != "incus" && workstationRuntime != "" {
 		homeDir, err := e.shims.UserHomeDir()


### PR DESCRIPTION
Closes #3276

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> The change is scoped to GCP and Docker environment-variable computation in `pkg/runtime/env`, with full unit test coverage added; it changes a default (credentials are now recomputed instead of frozen) but stays within one package.
>
> **Overview**
>
> This PR extracts the "should Windsor set this managed value" check (previously duplicated ad hoc for `DOCKER_HOST` in `virt_env.go`) into a shared `BaseEnvPrinter.ShouldSetManagedValue` helper, and reuses it for `GOOGLE_APPLICATION_CREDENTIALS` in `gcp_env.go`. `virt_env.go` is refactored to call the shared helper with no behavior change.
>
> The notable behavioral change is in `gcp_env.go`: `GOOGLE_APPLICATION_CREDENTIALS` is now recomputed on every run when Windsor itself previously set it (tracked via `WINDSOR_MANAGED_ENV`), rather than being left untouched forever once any value is present. This lets a removed service-account file or a switch to ADC take effect without a manual unset, and the value is now registered in `WINDSOR_MANAGED_ENV` so it can be unset automatically when no path resolves. One transitional detail: since older Windsor builds never tracked this key as managed, a shell session that already exported it under the old binary won't be recomputed until a fresh shell is opened.

<!-- /claude-code-review:summary -->
