### PR TITLE
fix(destroy): refuse teardown when Backend is unresolved

### DIFF
--- a/cmd/destroy.go
+++ b/cmd/destroy.go
@@ -75,6 +75,12 @@ windsor destroy --confirm=local --continue`,
 		blueprint := proj.Composer.BlueprintHandler.Generate()
 
 		if len(args) == 0 {
+			// A stale Backend name must surface before the plan and confirmation
+			// prompt, the same way CheckComponentDestroyable does for a targeted
+			// destroy, so the operator never confirms a run that would fail on it.
+			if err := proj.Provisioner.ValidateBackendTier(blueprint); err != nil {
+				return err
+			}
 			// Auth must precede the plan: terraform plan -destroy and the live
 			// inventory query both need credentials, and a credential failure
 			// should surface before the operator is asked to confirm.
@@ -230,6 +236,11 @@ windsor destroy terraform --confirm=local`,
 		blueprint := proj.Composer.BlueprintHandler.Generate()
 
 		if len(args) == 0 {
+			// A stale Backend name must surface before the plan and confirmation
+			// prompt; see the matching check in the top-level destroy command.
+			if err := proj.Provisioner.ValidateBackendTier(blueprint); err != nil {
+				return err
+			}
 			if err := requireCloudAuth(cmd, proj); err != nil {
 				return err
 			}

--- a/cmd/destroy_test.go
+++ b/cmd/destroy_test.go
@@ -415,6 +415,51 @@ func TestDestroyCmd(t *testing.T) {
 		}
 	})
 
+	t.Run("HaltsBeforeConfirmationWhenBackendUnresolved", func(t *testing.T) {
+		// Given a blueprint whose Backend field names no real component.
+		mocks := setupDestroyTest(t)
+		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockCH.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "terraform.backend.type" {
+				return "s3"
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
+		mocks.BlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint {
+			return &blueprintv1alpha1.Blueprint{
+				Metadata:            blueprintv1alpha1.Metadata{Name: "test"},
+				Backend:             "backend",
+				TerraformComponents: []blueprintv1alpha1.TerraformComponent{{Path: "cluster"}},
+			}
+		}
+		destroyed := false
+		mocks.TerraformStack.DestroyAllFunc = func(*blueprintv1alpha1.Blueprint, bool, ...string) (terraforminfra.DestroyOutcome, error) {
+			destroyed = true
+			return terraforminfra.DestroyOutcome{}, nil
+		}
+		proj := newDestroyProject(mocks)
+
+		cmd := createTestDestroyCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--confirm=test-context"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then it refuses before the confirmation gate and destroys nothing.
+		if err == nil {
+			t.Fatal("Expected unresolved-backend error, got nil")
+		}
+		if !strings.Contains(err.Error(), `"backend"`) {
+			t.Errorf("Expected error naming the unresolved backend, got: %v", err)
+		}
+		if destroyed {
+			t.Error("Expected no destroy to run when the backend field is unresolved")
+		}
+	})
+
 	t.Run("ErrorDestroyAllWrongConfirmation", func(t *testing.T) {
 		// Given wrong interactive confirmation input.
 		mocks := setupDestroyTest(t)
@@ -938,6 +983,48 @@ func TestDestroyTerraformCmd(t *testing.T) {
 		}
 		if destroyed {
 			t.Error("Expected no destroy to run when plan generation failed")
+		}
+	})
+
+	t.Run("HaltsBeforeConfirmationWhenBackendUnresolved", func(t *testing.T) {
+		// Given a blueprint whose Backend field names no real component.
+		mocks := setupDestroyTest(t)
+		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockCH.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "terraform.backend.type" {
+				return "s3"
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
+		mocks.BlueprintHandler.GenerateFunc = func() *blueprintv1alpha1.Blueprint {
+			return &blueprintv1alpha1.Blueprint{
+				Metadata:            blueprintv1alpha1.Metadata{Name: "test"},
+				Backend:             "backend",
+				TerraformComponents: []blueprintv1alpha1.TerraformComponent{{Path: "cluster"}},
+			}
+		}
+		destroyed := false
+		mocks.TerraformStack.DestroyAllFunc = func(*blueprintv1alpha1.Blueprint, bool, ...string) (terraforminfra.DestroyOutcome, error) {
+			destroyed = true
+			return terraforminfra.DestroyOutcome{}, nil
+		}
+		proj := newDestroyProject(mocks)
+
+		cmd := createTestDestroyTerraformCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--confirm=test-context"})
+		cmd.SetContext(ctx)
+		err := cmd.Execute()
+
+		// Then it refuses before the confirmation gate and destroys nothing.
+		if err == nil || !strings.Contains(err.Error(), `"backend"`) {
+			t.Fatalf("Expected error naming the unresolved backend, got: %v", err)
+		}
+		if destroyed {
+			t.Error("Expected no destroy to run when the backend field is unresolved")
 		}
 	})
 

--- a/pkg/provisioner/destroy.go
+++ b/pkg/provisioner/destroy.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
+	composerblueprint "github.com/windsorcli/cli/pkg/composer/blueprint"
 	terraforminfra "github.com/windsorcli/cli/pkg/provisioner/terraform"
 )
 
@@ -44,33 +45,37 @@ type DestroyResult struct {
 // Public Methods
 // =============================================================================
 
-// Teardown reverses Bootstrap. With no backend tier it forwards to DestroyAll
+// Teardown reverses Bootstrap. With no backend tier, it forwards to DestroyAll
 // (or DestroyAllTerraform when terraformOnly). With a tier declared via
-// Blueprint.Backend, Stage 1 destroys non-tier components against the
-// configured backend, then Stage 2 pins local, pulls every tier member's state
-// to local, and destroys the tier in reverse declaration order. When
-// continueOnError is true, per-component destroy errors in Stage 1 are
-// collected rather than aborting the loop; the backend tier is only attempted
-// when Stage 1 produced zero failures, to avoid destroying the state store
-// while other components still depend on it. The tier-deferred flag on the
-// result signals when Stage 2 was skipped for this reason. Stage 2's tier
-// destroy skips the Kubernetes-reachability preflight: Stage 1 has, by
-// design, already destroyed the cluster (it is never a tier member), so an
-// unreachable API at this point is the expected state, not a broken-auth
-// signal, and the backend tier never has a kubernetes/helm provider
-// dependency for the check to protect.
+// Blueprint.Backend, Stage 1 destroys non-tier components; Stage 2 migrates
+// tier state to local and destroys the tier, but only when Stage 1 had zero
+// failures — see hasTerraformFailure — so the state store never goes before
+// its dependents. TierDeferred marks a skipped Stage 2. On a remote backend,
+// a Backend that names no real component is refused rather than silently
+// treated as "no tier" — see resolveBackendTier.
 func (i *Provisioner) Teardown(blueprint *blueprintv1alpha1.Blueprint, terraformOnly bool, continueOnError bool) (DestroyResult, error) {
 	var result DestroyResult
 	backendType := i.configHandler.GetString("terraform.backend.type", "local")
 	if backendType == "kubernetes" && blueprint.Backend == "" {
 		return result, fmt.Errorf("blueprint configures terraform.backend.type=kubernetes but does not declare Blueprint.Backend; set `backend: <cluster-component-id>` at the blueprint top level to name the terraform component that provisions the cluster")
 	}
-	tier := blueprint.BackendTier()
-	if backendType == "" || backendType == "local" || len(tier) == 0 {
+
+	destroyFlat := func() (DestroyResult, error) {
 		if terraformOnly {
 			return i.DestroyAllTerraform(blueprint, continueOnError)
 		}
 		return i.DestroyAll(blueprint, continueOnError)
+	}
+	if backendType == "" || backendType == "local" {
+		return destroyFlat()
+	}
+
+	tier, err := resolveBackendTier(blueprint)
+	if err != nil {
+		return result, err
+	}
+	if len(tier) == 0 {
+		return destroyFlat()
 	}
 
 	tierIDs := make([]string, 0, len(tier))
@@ -94,7 +99,7 @@ func (i *Provisioner) Teardown(blueprint *blueprintv1alpha1.Blueprint, terraform
 	}
 
 	tierBP := blueprintWithComponents(blueprint, tier)
-	err := i.withBackendOverride("destroy", func() error {
+	err = i.withBackendOverride("destroy", func() error {
 		migrationSkipped, err := i.MigrateState(tierBP)
 		if err != nil {
 			return err
@@ -124,13 +129,32 @@ func (i *Provisioner) TeardownComponent(blueprint *blueprintv1alpha1.Blueprint, 
 // On a non-local backend a backend-tier member is refused: its state provides the backend every other
 // component uses, so destroying it directly would orphan their state. Callers run this before generating a
 // destroy plan so the refusal is surfaced up front, rather than as a raw terraform init error when the
-// component tries to reach a kubernetes backend whose cluster may already be gone.
+// component tries to reach a kubernetes backend whose cluster may already be gone. A Backend that names
+// no real component also refuses outright — see resolveBackendTier.
 func (i *Provisioner) CheckComponentDestroyable(blueprint *blueprintv1alpha1.Blueprint, componentID string) error {
 	backendType := i.configHandler.GetString("terraform.backend.type", "local")
-	if backendType != "" && backendType != "local" && blueprint.IsBackendTierMember(componentID) {
-		return fmt.Errorf("cannot destroy backend-tier component %q in isolation: its state provides the %s backend that every other component uses, so destroying it directly would orphan their state. Run `windsor destroy` (no arguments) for the full-cycle teardown that migrates state to local first", componentID, backendType)
+	if backendType == "" || backendType == "local" {
+		return nil
+	}
+	tier, err := resolveBackendTier(blueprint)
+	if err != nil {
+		return err
+	}
+	for _, c := range tier {
+		if c.GetID() == componentID {
+			return fmt.Errorf("cannot destroy backend-tier component %q in isolation: its state provides the %s backend that every other component uses, so destroying it directly would orphan their state. Run `windsor destroy` (no arguments) for the full-cycle teardown that migrates state to local first", componentID, backendType)
+		}
 	}
 	return nil
+}
+
+// ValidateBackendTier reports an error when Blueprint.Backend is set but names no real
+// component. Callers run this before generating a destroy plan, the same way
+// CheckComponentDestroyable does for a targeted destroy, so a stale backend name is refused up
+// front rather than after the operator has already confirmed.
+func (i *Provisioner) ValidateBackendTier(blueprint *blueprintv1alpha1.Blueprint) error {
+	_, err := resolveBackendTier(blueprint)
+	return err
 }
 
 // PrepareLocalTeardown makes a kubernetes-backend teardown operate entirely against local state. Because
@@ -202,6 +226,18 @@ func (i *Provisioner) clusterReachableForTeardown() bool {
 // =============================================================================
 // Private Helpers
 // =============================================================================
+
+// resolveBackendTier resolves the backend tier named by Blueprint.Backend.
+// It runs ValidateComposedBlueprint first: destroy and apply skip blueprint
+// validation at load time (to tolerate a deployed-but-misordered blueprint),
+// so a stale Backend name must still fail loud here rather than silently
+// collapse BackendTier to "no tier" and leave the backend unprotected.
+func resolveBackendTier(blueprint *blueprintv1alpha1.Blueprint) ([]*blueprintv1alpha1.TerraformComponent, error) {
+	if err := composerblueprint.ValidateComposedBlueprint(blueprint); err != nil {
+		return nil, err
+	}
+	return blueprint.BackendTier(), nil
+}
 
 // hasTerraformFailure reports whether the failure list contains any entry
 // that belongs to a terraform component (i.e., not the kustomize-aggregate

--- a/pkg/provisioner/destroy.go
+++ b/pkg/provisioner/destroy.go
@@ -228,10 +228,10 @@ func (i *Provisioner) clusterReachableForTeardown() bool {
 // =============================================================================
 
 // resolveBackendTier resolves the backend tier named by Blueprint.Backend.
-// It runs ValidateComposedBlueprint first: destroy and apply skip blueprint
-// validation at load time (to tolerate a deployed-but-misordered blueprint),
-// so a stale Backend name must still fail loud here rather than silently
-// collapse BackendTier to "no tier" and leave the backend unprotected.
+// It runs ValidateComposedBlueprint first: destroy (and down/env) skip
+// blueprint validation at load time, so a stale Backend name must still
+// fail loud here. Apply already validates at load, so this same check is
+// defense-in-depth there, not load-bearing.
 func resolveBackendTier(blueprint *blueprintv1alpha1.Blueprint) ([]*blueprintv1alpha1.TerraformComponent, error) {
 	if err := composerblueprint.ValidateComposedBlueprint(blueprint); err != nil {
 		return nil, err

--- a/pkg/provisioner/destroy_test.go
+++ b/pkg/provisioner/destroy_test.go
@@ -61,6 +61,23 @@ func TestProvisioner_CheckComponentDestroyable(t *testing.T) {
 			t.Errorf("expected local backend to allow any component, got %v", err)
 		}
 	})
+
+	t.Run("RefusesWhenBackendFieldUnresolved", func(t *testing.T) {
+		// Tier membership is undeterminable; refuse rather than guess.
+		unresolved := &blueprintv1alpha1.Blueprint{
+			Backend: "ghost",
+			TerraformComponents: []blueprintv1alpha1.TerraformComponent{
+				{Name: "compute", Path: "compute/hcloud"},
+			},
+		}
+		mocks := setupProvisionerMocks(t)
+		kubernetesBackend(mocks)
+		prov := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{})
+		err := prov.CheckComponentDestroyable(unresolved, "compute")
+		if err == nil || !strings.Contains(err.Error(), `"ghost"`) {
+			t.Errorf("expected refusal naming the unresolved backend, got %v", err)
+		}
+	})
 }
 
 func TestProvisioner_PivotToLocalIfClusterGone(t *testing.T) {
@@ -408,6 +425,46 @@ func TestProvisioner_Teardown(t *testing.T) {
 		}
 		if migrateCalled {
 			t.Error("MigrateState must not run when there is no backend tier")
+		}
+	})
+
+	t.Run("RefusesUnresolvedBackendField", func(t *testing.T) {
+		// Backend names no real component; must not collapse to "no tier".
+		mocks := setupProvisionerMocks(t)
+		bp := &blueprintv1alpha1.Blueprint{
+			Backend: "backend",
+			TerraformComponents: []blueprintv1alpha1.TerraformComponent{
+				{Path: "network/gcp-vpc"},
+				{Path: "cluster/gcp-gke"},
+			},
+		}
+		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockCH.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "terraform.backend.type" {
+				return "gcs"
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
+		mockStack := terraforminfra.NewMockStack()
+		destroyAllCalled := false
+		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyOutcome, error) {
+			destroyAllCalled = true
+			return terraforminfra.DestroyOutcome{}, nil
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack})
+
+		_, err := provisioner.Teardown(bp, true, false)
+		if err == nil {
+			t.Fatal("Expected error for unresolved Backend field, got nil")
+		}
+		if !strings.Contains(err.Error(), `"backend"`) {
+			t.Errorf("Expected error to name the unresolved backend, got: %v", err)
+		}
+		if destroyAllCalled {
+			t.Error("DestroyAll must not run when the backend tier cannot be resolved")
 		}
 	})
 

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -211,19 +211,31 @@ func (i *Provisioner) OnTerraformPostApply(fn func(id string) error) {
 // including from cmd/apply.go and cmd/up.go; confirmation is a cmd/bootstrap.go concern, not
 // this method's. Without a declared tier it applies directly. A kubernetes backend with no
 // tier and no kubeconfig yet is refused with an actionable error instead of a raw terraform
-// connection failure. Returns (halted, err); halted=true means a hook stopped after a component.
+// connection failure. On a remote backend, a declared Backend that names no real component is
+// refused rather than silently treated as "no tier" — see resolveBackendTier. Returns
+// (halted, err); halted=true means a hook stopped after a component.
 func (i *Provisioner) Up(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(id string) (bool, error)) (bool, error) {
 	if blueprint == nil {
 		return false, fmt.Errorf("blueprint not provided")
 	}
 
 	backendType := i.configHandler.GetString("terraform.backend.type", "local")
-	tier := blueprint.BackendTier()
-	if backendType == "" || backendType == "local" || len(tier) == 0 {
-		if backendType == "kubernetes" && len(tier) == 0 && hasEnabledTerraformComponent(blueprint) && !i.kubeconfigPresent() {
+	applyFlat := func() (bool, error) {
+		if backendType == "kubernetes" && hasEnabledTerraformComponent(blueprint) && !i.kubeconfigPresent() {
 			return false, fmt.Errorf("context has no kubeconfig (cluster not yet created) and the blueprint declares no backend tier for the kubernetes backend; add `backend: <component-id>` to the blueprint naming the component that creates the cluster, or set terraform.backend.type to \"local\" until it exists")
 		}
 		return i.applyDirect(blueprint, onApply...)
+	}
+	if backendType == "" || backendType == "local" {
+		return applyFlat()
+	}
+
+	tier, err := resolveBackendTier(blueprint)
+	if err != nil {
+		return false, err
+	}
+	if len(tier) == 0 {
+		return applyFlat()
 	}
 	return i.applyWithBackendPivot(blueprint, tier, onApply...)
 }

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -437,6 +437,32 @@ func TestProvisioner_Up(t *testing.T) {
 		}
 	})
 
+	t.Run("RefusesUnresolvedBackendField", func(t *testing.T) {
+		// Backend names no real component; must not collapse to "no tier".
+		mocks := setupProvisionerMocks(t)
+		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockCH.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "terraform.backend.type" {
+				return "gcs"
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler)
+
+		bp := &blueprintv1alpha1.Blueprint{
+			Backend: "backend",
+			TerraformComponents: []blueprintv1alpha1.TerraformComponent{
+				{Path: "network/gcp-vpc"},
+			},
+		}
+		_, err := provisioner.Up(bp)
+		if err == nil || !strings.Contains(err.Error(), `"backend"`) {
+			t.Errorf("expected refusal naming the unresolved backend, got %v", err)
+		}
+	})
 }
 
 func TestProvisioner_MigrateState(t *testing.T) {


### PR DESCRIPTION
Closes #3273

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> The change tightens validation in the terraform provisioner's destroy and apply paths; it is additive, backward-compatible for well-formed blueprints, and only changes behavior for a misconfigured edge case.
>
> **Overview**
>
> This PR closes a gap where a `Blueprint.Backend` field naming a nonexistent terraform component silently collapsed to "no backend tier" instead of failing. A new `resolveBackendTier` helper now runs `ValidateComposedBlueprint` before consulting `BackendTier()`, and is threaded through `Teardown`, `CheckComponentDestroyable`, and `Provisioner.Up`. A new `ValidateBackendTier` method lets `cmd/destroy.go` surface this error before the confirmation prompt, matching the existing targeted-destroy check.
>
> The practical effect: on a non-local backend, a stale `backend:` field now refuses upfront in `destroy`, `destroy terraform`, and `apply`/`up`, rather than either silently destroying the wrong scope or failing later with a confusing raw error. Unit tests cover the new refusal path in both cmd and provisioner layers.

<!-- /claude-code-review:summary -->
