### PR TITLE
fix(kubernetes): derive delete-wait timeout from spec.timeout

### DIFF
--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -100,6 +100,7 @@ type BaseKubernetesManager struct {
 	kustomizationReconcileSleep          time.Duration
 	kustomizationDeletionPerEntryTimeout time.Duration
 	kustomizationDeletionMaxExtraTimeout time.Duration
+	kustomizationSpecTimeoutCeiling      time.Duration
 
 	notReadyDescribeBudget time.Duration
 
@@ -128,6 +129,7 @@ func NewKubernetesManager(kubernetesClient client.KubernetesClient, configHandle
 		kustomizationReconcileSleep:          2 * time.Second,
 		kustomizationDeletionPerEntryTimeout: 3 * time.Second,
 		kustomizationDeletionMaxExtraTimeout: 20 * time.Minute,
+		kustomizationSpecTimeoutCeiling:      2 * time.Hour,
 		notReadyDescribeBudget:               10 * time.Second,
 		healthCheckPollInterval:              10 * time.Second,
 		healthCheckSettleDuration:            30 * time.Second,
@@ -169,11 +171,15 @@ func (k *BaseKubernetesManager) ApplyKustomization(kustomization kustomizev1.Kus
 }
 
 // DeleteKustomization removes a Kustomization using background deletion and waits for
-// it to disappear, scaling the wait by inventory size for CRD-heavy layers. On timeout
-// it returns an error instead of stripping finalizers, which would orphan inventory
-// items and let terraform destroy the cluster while their cloud resources leak. The
-// error asserts a stuck finalizer only when a status condition confirms one; otherwise
-// it reports the timeout as unconfirmed.
+// it to disappear. The wait floor rises to the Kustomization's own spec.timeout when
+// it declares one larger than the default, capped at kustomizationSpecTimeoutCeiling.
+// A slow-to-delete resource (e.g. a Crossplane-managed database) often sets a long
+// install timeout; deletion deserves the same allowance. The wait also scales with
+// inventory size for CRD-heavy layers. On timeout it returns an error instead of
+// stripping finalizers, which would orphan inventory items and let terraform destroy
+// the cluster while their cloud resources leak. The error asserts a stuck finalizer
+// only when a status condition confirms one; otherwise it reports the timeout as
+// unconfirmed.
 func (k *BaseKubernetesManager) DeleteKustomization(name, namespace string) error {
 	gvr := schema.GroupVersionResource{
 		Group:    "kustomize.toolkit.fluxcd.io",
@@ -208,9 +214,10 @@ func (k *BaseKubernetesManager) DeleteKustomization(name, namespace string) erro
 		lastObj = obj
 
 		if size := inventorySize(obj); size > 0 {
-			if scaled := k.kustomizationDeletionTimeout(size); scaled > waitFor {
-				waitFor = scaled
-			}
+			waitFor = extendWaitFor(waitFor, k.kustomizationDeletionTimeout(size))
+		}
+		if specTO, ok := specTimeout(obj); ok {
+			waitFor = extendWaitFor(waitFor, min(specTO, k.kustomizationSpecTimeoutCeiling))
 		}
 
 		k.shims.TimeSleep(k.kustomizationWaitPollInterval)
@@ -237,6 +244,33 @@ func inventorySize(obj *unstructured.Unstructured) int {
 		return 0
 	}
 	return len(entries)
+}
+
+// specTimeout reads a Kustomization's own spec.timeout. Windsor writes this field from
+// the blueprint's Kustomization.Timeout at apply time; see ToFluxKustomization. It
+// returns false for a nil object or a missing or unparseable value.
+func specTimeout(obj *unstructured.Unstructured) (time.Duration, bool) {
+	if obj == nil {
+		return 0, false
+	}
+	value, found, err := unstructured.NestedString(obj.Object, "spec", "timeout")
+	if err != nil || !found {
+		return 0, false
+	}
+	d, err := time.ParseDuration(value)
+	if err != nil {
+		return 0, false
+	}
+	return d, true
+}
+
+// extendWaitFor raises waitFor to candidate when candidate is larger, otherwise
+// returns waitFor unchanged.
+func extendWaitFor(waitFor, candidate time.Duration) time.Duration {
+	if candidate > waitFor {
+		return candidate
+	}
+	return waitFor
 }
 
 // kustomizationDeletionTimeout scales DeleteKustomization's wait window by inventory

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -732,6 +732,106 @@ func TestBaseKubernetesManager_DeleteKustomization(t *testing.T) {
 			t.Errorf("Expected wait window scaled by a later inventory read (>=100ms), got %s", elapsed)
 		}
 	})
+
+	t.Run("TimeoutWindowRespectsSpecTimeout", func(t *testing.T) {
+		// Given a kustomization whose own spec.timeout is larger than the base window
+		// (an operator-configured allowance for a slow-to-delete resource)
+		manager := setup(t)
+		manager.kustomizationReconcileTimeout = 20 * time.Millisecond
+		manager.kustomizationWaitPollInterval = 10 * time.Millisecond
+
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			return nil
+		}
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			return &unstructured.Unstructured{Object: map[string]any{
+				"spec": map[string]any{"timeout": "150ms"},
+			}}, nil
+		}
+		manager.client = kubernetesClient
+
+		// When DeleteKustomization times out
+		start := manager.shims.TimeNow()
+		err := manager.DeleteKustomization("test-kustomization", "test-namespace")
+		elapsed := manager.shims.TimeNow().Sub(start)
+
+		// Then it waits out spec.timeout instead of aborting at the base window,
+		// and does not run away past it on every poll tick
+		if err == nil {
+			t.Fatal("Expected timeout error, got nil")
+		}
+		if elapsed < 150*time.Millisecond {
+			t.Errorf("Expected wait window raised to spec.timeout (>=150ms), got %s", elapsed)
+		}
+		if elapsed > 250*time.Millisecond {
+			t.Errorf("Expected wait window bounded near spec.timeout (<=250ms), got %s", elapsed)
+		}
+	})
+
+	t.Run("TimeoutWindowCapsSpecTimeoutAtCeiling", func(t *testing.T) {
+		// Given a spec.timeout far larger than the configured ceiling (a corrupted
+		// or absurd value, e.g. from a hand-edited blueprint)
+		manager := setup(t)
+		manager.kustomizationReconcileTimeout = 20 * time.Millisecond
+		manager.kustomizationWaitPollInterval = 10 * time.Millisecond
+		manager.kustomizationSpecTimeoutCeiling = 100 * time.Millisecond
+
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			return nil
+		}
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			return &unstructured.Unstructured{Object: map[string]any{
+				"spec": map[string]any{"timeout": "876000h"},
+			}}, nil
+		}
+		manager.client = kubernetesClient
+
+		// When DeleteKustomization times out
+		start := manager.shims.TimeNow()
+		err := manager.DeleteKustomization("test-kustomization", "test-namespace")
+		elapsed := manager.shims.TimeNow().Sub(start)
+
+		// Then the wait is bounded by the ceiling, not the declared spec.timeout
+		if err == nil {
+			t.Fatal("Expected timeout error, got nil")
+		}
+		if elapsed < 100*time.Millisecond || elapsed > 250*time.Millisecond {
+			t.Errorf("Expected wait window capped near the ceiling (~100ms), got %s", elapsed)
+		}
+	})
+
+	t.Run("TimeoutIgnoresUnparseableSpecTimeout", func(t *testing.T) {
+		// Given a kustomization whose spec.timeout is present but malformed
+		manager := setup(t)
+		manager.kustomizationReconcileTimeout = 20 * time.Millisecond
+		manager.kustomizationWaitPollInterval = 10 * time.Millisecond
+
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			return nil
+		}
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			return &unstructured.Unstructured{Object: map[string]any{
+				"spec": map[string]any{"timeout": "not-a-duration"},
+			}}, nil
+		}
+		manager.client = kubernetesClient
+
+		// When DeleteKustomization times out
+		start := manager.shims.TimeNow()
+		err := manager.DeleteKustomization("test-kustomization", "test-namespace")
+		elapsed := manager.shims.TimeNow().Sub(start)
+
+		// Then it falls back to the base window rather than erroring on the bad value
+		if err == nil {
+			t.Fatal("Expected timeout error, got nil")
+		}
+		if elapsed > 100*time.Millisecond {
+			t.Errorf("Expected base window (~20ms) when spec.timeout is unparseable, got %s", elapsed)
+		}
+	})
 }
 
 func TestBaseKubernetesManager_describeNotReadyKustomizations(t *testing.T) {


### PR DESCRIPTION
Closes #3277

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This changes the wait-timeout behavior of `DeleteKustomization`, a shared function on the `destroy` path used for every Flux Kustomization teardown, so a timing regression here would affect all users, not just an edge case.
>
> **Overview**
>
> `DeleteKustomization` previously waited only `kustomizationReconcileTimeout`, scaled up for large inventories, before giving up and reporting a possibly-stuck finalizer. This PR adds a second floor: it now also reads the Kustomization's own `spec.timeout` from the live object and raises the wait to match it (capped at a new `kustomizationSpecTimeoutCeiling`, 2 hours), so a Kustomization configured with a long install timeout (e.g. for a slow Crossplane-managed resource) gets the same allowance on delete.
>
> The two floors (inventory-size scaling and spec.timeout) are combined via a new `extendWaitFor` helper that only ever raises the wait, never lowers it, and an unparseable or missing `spec.timeout` silently falls back to the existing behavior. New tests cover the raised floor, the ceiling cap, and the unparseable fallback, using the same timing-window style as existing tests in this file.

<!-- /claude-code-review:summary -->
