### PR TITLE
fix(kubernetes): distinguish stuck Flux finalizer from a leak

### DIFF
--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -170,16 +170,12 @@ func (k *BaseKubernetesManager) ApplyKustomization(kustomization kustomizev1.Kus
 	return k.applyWithRetry(gvr, obj, opts)
 }
 
-// DeleteKustomization removes a Kustomization using background deletion and waits for
-// it to disappear. The wait floor rises to the Kustomization's own spec.timeout when
-// it declares one larger than the default, capped at kustomizationSpecTimeoutCeiling.
-// A slow-to-delete resource (e.g. a Crossplane-managed database) often sets a long
-// install timeout; deletion deserves the same allowance. The wait also scales with
-// inventory size for CRD-heavy layers. On timeout it returns an error instead of
-// stripping finalizers, which would orphan inventory items and let terraform destroy
-// the cluster while their cloud resources leak. The error asserts a stuck finalizer
-// only when a status condition confirms one; otherwise it reports the timeout as
-// unconfirmed.
+// DeleteKustomization deletes a Kustomization and waits for it to disappear. The wait
+// floor rises to spec.timeout when set, and scales with inventory size (see
+// kustomizationSpecTimeoutCeiling). On timeout, it checks whether every inventory item
+// is already gone (see allInventoryEntriesGone); if so, the error names this as a stuck
+// Flux finalizer rather than a guess, since infrastructure has not leaked. Any less
+// certain timeout falls back to the condition-based diagnosis below.
 func (k *BaseKubernetesManager) DeleteKustomization(name, namespace string) error {
 	gvr := schema.GroupVersionResource{
 		Group:    "kustomize.toolkit.fluxcd.io",
@@ -225,6 +221,11 @@ func (k *BaseKubernetesManager) DeleteKustomization(name, namespace string) erro
 
 	inspectCmd := fmt.Sprintf("`kubectl get kustomization %s -n %s -o yaml`", name, namespace)
 	const terminatingCmd = "`kubectl get pvc,svc,ingress,certificate -A | grep Terminating`"
+
+	entries, inventoryFound := inventoryEntriesFromObject(lastObj)
+	if drained, checkErr := k.allInventoryEntriesGone(entries); inventoryFound && checkErr == nil && drained {
+		return fmt.Errorf("kustomization %s/%s is fully drained (every inventory item confirmed gone) but its own finalizer is stuck; this is Flux bookkeeping, not leaked infrastructure — clear it with `kubectl patch kustomization %s -n %s --type=merge -p '{\"metadata\":{\"finalizers\":null}}'`", namespace, name, name, namespace)
+	}
 
 	reason := describeStuckKustomization(lastObj) + k.describeStuckHelmReleases(name, namespace)
 	if reason == "" {
@@ -1189,6 +1190,29 @@ func (k *BaseKubernetesManager) GetKustomizationInventory(name, namespace string
 	if !found {
 		return []InventoryEntry{}, nil
 	}
+	return decodeInventoryEntries(rawEntries), nil
+}
+
+// inventoryEntriesFromObject decodes status.inventory.entries directly from an
+// already-fetched object, avoiding another API round trip. found reports whether the
+// object has ever reported an inventory at all — false for a Kustomization that has
+// not reconciled that far, which is not the same as a reconciled, now-empty one.
+// Callers must not treat "not found" as "confirmed empty."
+func inventoryEntriesFromObject(obj *unstructured.Unstructured) (entries []InventoryEntry, found bool) {
+	if obj == nil {
+		return nil, false
+	}
+	rawEntries, found, err := unstructured.NestedSlice(obj.Object, "status", "inventory", "entries")
+	if err != nil || !found {
+		return nil, false
+	}
+	return decodeInventoryEntries(rawEntries), true
+}
+
+// decodeInventoryEntries decodes a raw status.inventory.entries slice. Individual
+// entries that fail to decode (malformed IDs, unexpected field shapes) are dropped
+// rather than failing the whole read.
+func decodeInventoryEntries(rawEntries []any) []InventoryEntry {
 	entries := make([]InventoryEntry, 0, len(rawEntries))
 	for _, raw := range rawEntries {
 		entryMap, ok := raw.(map[string]any)
@@ -1202,7 +1226,7 @@ func (k *BaseKubernetesManager) GetKustomizationInventory(name, namespace string
 		}
 		entries = append(entries, entry)
 	}
-	return entries, nil
+	return entries
 }
 
 // decodeInventoryID parses a flux inventory ID of the form
@@ -1996,23 +2020,12 @@ func (k *BaseKubernetesManager) ownedRootForService(svc *unstructured.Unstructur
 			return ownedTarget{}, false, nil
 		}
 		gvk := gv.WithKind(owner.Kind)
-		gvr, err := k.client.ResourceFor(gvk)
+		gvr, ownerNamespace, ok, err := k.resolveScopedGVR(gvk, namespace)
 		if err != nil {
-			if apimeta.IsNoMatchError(err) {
-				return ownedTarget{}, false, nil
-			}
 			return ownedTarget{}, false, fmt.Errorf("error resolving load balancer owner %s %q: %w", owner.Kind, owner.Name, err)
 		}
-		namespaced, err := k.client.IsNamespaced(gvk)
-		if err != nil {
-			if apimeta.IsNoMatchError(err) {
-				return ownedTarget{}, false, nil
-			}
-			return ownedTarget{}, false, fmt.Errorf("error resolving scope of load balancer owner %s %q: %w", owner.Kind, owner.Name, err)
-		}
-		ownerNamespace := namespace
-		if !namespaced {
-			ownerNamespace = ""
+		if !ok {
+			return ownedTarget{}, false, nil
 		}
 		if owned[inventoryKey(gv.Group, owner.Kind, ownerNamespace, owner.Name)] {
 			return ownedTarget{gvr: gvr, namespace: ownerNamespace, name: owner.Name}, true, nil
@@ -2135,19 +2148,11 @@ func (k *BaseKubernetesManager) applyBlueprintSource(source blueprintv1alpha1.So
 }
 
 // setKustomizationSuspend patches spec.suspend on a Kustomization. DeleteBlueprint
-// suspends every eligible Kustomization up front to freeze reconciliation: an
-// un-deleted Kustomization that keeps reconciling can re-create a (often
-// cluster-scoped) resource that another component's Helm uninstall is mid-way
-// through deleting, deadlocking it — Helm waits for the resource to disappear while
-// Flux restores it, so the HelmRelease never drops its finalizers.fluxcd.io
-// finalizer and the namespace hangs in Terminating until destroy times out. The
-// frozen Kustomizations are then resumed (suspend=false) one at a time, each
-// immediately before its own delete: the kustomize-controller's finalizer prunes
-// managed inventory only when the object is NOT suspended, so deleting a still-
-// suspended Kustomization strips its finalizer without garbage-collecting its
-// resources, orphaning them and letting destroy race ahead. Resuming just before
-// delete keeps every other Kustomization frozen while letting the one being deleted
-// prune. A NotFound Kustomization is treated as success.
+// suspends every eligible Kustomization up front, since an un-deleted one that keeps
+// reconciling can re-create a resource another component's Helm uninstall is mid-way
+// through deleting, deadlocking it. It then resumes each one right before deleting it,
+// since the finalizer only prunes inventory when not suspended — deleting while still
+// suspended would orphan resources. A NotFound Kustomization is treated as success.
 func (k *BaseKubernetesManager) setKustomizationSuspend(name, namespace string, suspend bool) error {
 	gvr := schema.GroupVersionResource{
 		Group:    "kustomize.toolkit.fluxcd.io",
@@ -2163,6 +2168,56 @@ func (k *BaseKubernetesManager) setKustomizationSuspend(name, namespace string, 
 		return err
 	}
 	return nil
+}
+
+// resolveScopedGVR resolves gvk to its GroupVersionResource and correct namespace scope
+// via discovery. namespace is the caller's default scope, cleared when the resolved kind
+// is cluster-scoped. ok is false when the API type no longer exists.
+func (k *BaseKubernetesManager) resolveScopedGVR(gvk schema.GroupVersionKind, namespace string) (gvr schema.GroupVersionResource, scopedNamespace string, ok bool, err error) {
+	gvr, err = k.client.ResourceFor(gvk)
+	if err != nil {
+		if apimeta.IsNoMatchError(err) {
+			return schema.GroupVersionResource{}, "", false, nil
+		}
+		return schema.GroupVersionResource{}, "", false, err
+	}
+	namespaced, err := k.client.IsNamespaced(gvk)
+	if err != nil {
+		if apimeta.IsNoMatchError(err) {
+			return schema.GroupVersionResource{}, "", false, nil
+		}
+		return schema.GroupVersionResource{}, "", false, err
+	}
+	if !namespaced {
+		namespace = ""
+	}
+	return gvr, namespace, true, nil
+}
+
+// allInventoryEntriesGone reports whether every inventory entry's own live object is
+// confirmed absent, independent of the Kustomization's finalizer state. An entry whose
+// API type no longer exists counts as gone. It returns false on the first entry still
+// present. It returns an error, not false, on any inconclusive lookup: a wrong "all
+// gone" reading here is exactly what could clear a finalizer while resources still exist.
+func (k *BaseKubernetesManager) allInventoryEntriesGone(entries []InventoryEntry) (bool, error) {
+	for _, entry := range entries {
+		gvk := schema.GroupVersionKind{Group: entry.Group, Kind: entry.Kind}
+		gvr, namespace, ok, err := k.resolveScopedGVR(gvk, entry.Namespace)
+		if err != nil {
+			return false, err
+		}
+		if !ok {
+			continue
+		}
+		if _, err := k.client.GetResource(gvr, namespace, entry.Name); err != nil {
+			if isNotFoundError(err) {
+				continue
+			}
+			return false, err
+		}
+		return false, nil
+	}
+	return true, nil
 }
 
 // gitopsMode returns the configured gitops mode, defaulting to pull. Centralising

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/windsorcli/cli/pkg/provisioner/kubernetes/client"
 	"github.com/windsorcli/cli/pkg/runtime/config"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -830,6 +831,160 @@ func TestBaseKubernetesManager_DeleteKustomization(t *testing.T) {
 		}
 		if elapsed > 100*time.Millisecond {
 			t.Errorf("Expected base window (~20ms) when spec.timeout is unparseable, got %s", elapsed)
+		}
+	})
+
+	drainedKustomization := func() *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]any{
+			"status": map[string]any{
+				"inventory": map[string]any{
+					"entries": []any{
+						map[string]any{"id": "test-namespace_entry-one__ConfigMap"},
+						map[string]any{"id": "test-namespace_entry-two_apps_Deployment"},
+					},
+				},
+			},
+		}}
+	}
+
+	t.Run("TimeoutReportsDrainedKustomizationAsStuckFinalizer", func(t *testing.T) {
+		// Given every inventory entry's own live object confirmed gone
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			return nil
+		}
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			if name == "test-kustomization" {
+				return drainedKustomization(), nil
+			}
+			return nil, fmt.Errorf("the server could not find the requested resource")
+		}
+		manager.client = kubernetesClient
+
+		// When DeleteKustomization times out
+		err := manager.DeleteKustomization("test-kustomization", "test-namespace")
+
+		// Then it reports the drained state and a manual fix, not a suspected leak
+		if err == nil {
+			t.Fatal("Expected timeout error, got nil")
+		}
+		if !strings.Contains(err.Error(), "fully drained") || !strings.Contains(err.Error(), "kubectl patch") {
+			t.Errorf("Expected drained-and-stuck-finalizer wording naming a fix, got: %v", err)
+		}
+	})
+
+	t.Run("TimeoutDoesNotClaimDrainedWhenEntryStillLive", func(t *testing.T) {
+		// Given one inventory entry whose live object still exists — the safety-critical
+		// case: nothing here may be treated as drained
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			return nil
+		}
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			if name == "test-kustomization" {
+				return drainedKustomization(), nil
+			}
+			if name == "entry-one" {
+				return &unstructured.Unstructured{Object: map[string]any{}}, nil
+			}
+			return nil, fmt.Errorf("the server could not find the requested resource")
+		}
+		manager.client = kubernetesClient
+
+		// When DeleteKustomization times out
+		err := manager.DeleteKustomization("test-kustomization", "test-namespace")
+
+		// Then it does not claim the kustomization is drained
+		if err == nil {
+			t.Fatal("Expected timeout error, got nil")
+		}
+		if strings.Contains(err.Error(), "fully drained") {
+			t.Errorf("Expected fallback wording when an entry is still live, got: %v", err)
+		}
+	})
+
+	t.Run("TimeoutFallsBackWhenInventoryCheckInconclusive", func(t *testing.T) {
+		// Given an inventory entry whose live status can't be determined (a real API error,
+		// not a NotFound) — a false "all gone" reading here is the exact risk to avoid
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			return nil
+		}
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			if name == "test-kustomization" {
+				return drainedKustomization(), nil
+			}
+			return nil, fmt.Errorf("connection refused")
+		}
+		manager.client = kubernetesClient
+
+		// When DeleteKustomization times out
+		err := manager.DeleteKustomization("test-kustomization", "test-namespace")
+
+		// Then it falls back to the original diagnosis rather than claiming drained
+		if err == nil {
+			t.Fatal("Expected timeout error, got nil")
+		}
+		if strings.Contains(err.Error(), "fully drained") {
+			t.Errorf("Expected fallback wording on an inconclusive check, got: %v", err)
+		}
+	})
+
+	t.Run("TimeoutTreatsDeletedResourceTypeAsGone", func(t *testing.T) {
+		// Given an inventory entry whose CRD no longer exists — nothing left to leak
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			return nil
+		}
+		kubernetesClient.ResourceForFunc = func(gvk schema.GroupVersionKind) (schema.GroupVersionResource, error) {
+			return schema.GroupVersionResource{}, &apimeta.NoKindMatchError{GroupKind: gvk.GroupKind()}
+		}
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			if name == "test-kustomization" {
+				return drainedKustomization(), nil
+			}
+			return nil, fmt.Errorf("should not be called when the type cannot be resolved")
+		}
+		manager.client = kubernetesClient
+
+		// When DeleteKustomization times out
+		err := manager.DeleteKustomization("test-kustomization", "test-namespace")
+
+		// Then a deleted resource type still counts as drained
+		if err == nil {
+			t.Fatal("Expected timeout error, got nil")
+		}
+		if !strings.Contains(err.Error(), "fully drained") {
+			t.Errorf("Expected drained wording when the entry's type no longer exists, got: %v", err)
+		}
+	})
+
+	t.Run("TimeoutIgnoresInventoryNeverReported", func(t *testing.T) {
+		// Given a Kustomization that has never reconciled far enough to report an
+		// inventory at all — not the same as a reconciled, now-empty one
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			return nil
+		}
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			return &unstructured.Unstructured{Object: map[string]any{}}, nil
+		}
+		manager.client = kubernetesClient
+
+		// When DeleteKustomization times out
+		err := manager.DeleteKustomization("test-kustomization", "test-namespace")
+
+		// Then it does not claim the kustomization is drained
+		if err == nil {
+			t.Fatal("Expected timeout error, got nil")
+		}
+		if strings.Contains(err.Error(), "fully drained") {
+			t.Errorf("Expected fallback wording when no inventory was ever reported, got: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
Related to #3279 — this covers the issue's diagnostic ask (distinguish a confirmed-drained, stuck-finalizer Kustomization from a genuine leak) but not the recovery-path automation; leaving #3279 open for that.

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> The change is confined to Kubernetes Kustomization delete-timeout diagnostics in one provisioner file, and only affects the wording and confidence of an error path that already existed.
>
> **Overview**
>
> When `DeleteKustomization` times out, it now checks whether every inventory item's live object is actually gone before blaming the timeout on a stuck finalizer. If every entry is confirmed absent (or its API type no longer exists), the error now names this precisely as a stuck Flux finalizer and gives a `kubectl patch` fix, instead of a generic "might be stuck" message. Any inconclusive lookup (a real API error, not NotFound) falls back to the original, more cautious diagnosis, so the change only adds confidence — it never asserts "drained" without positive confirmation.
>
> A related refactor extracts a `resolveScopedGVR` helper (GVR + namespace-scope resolution) shared between the new inventory check and the existing load-balancer-owner lookup, collapsing two near-duplicate blocks into one. Five new table-driven tests cover the drained, still-live, inconclusive, deleted-type, and never-reported-inventory cases.

<!-- /claude-code-review:summary -->
