### PR TITLE
fix(terraform): surface the real diagnostic on a failed plan

### DIFF
--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -77,6 +77,14 @@ type initCacheKey struct {
 	migrateState bool
 }
 
+// planDiagnostic mirrors one `diagnostic` event from a terraform -json plan stream.
+type planDiagnostic struct {
+	Severity string `json:"severity"`
+	Summary  string `json:"summary"`
+	Address  string `json:"address"`
+	Detail   string `json:"detail"`
+}
+
 // TerraformComponentPlan holds the plan result for a single Terraform component.
 // ComponentID is the unique identifier (Name when set, else Path). Path carries the
 // component's blueprint Path field (e.g., "cluster/aws-eks") so renderers can show
@@ -802,7 +810,8 @@ func (s *TerraformStack) PlanJSON(blueprint *blueprintv1alpha1.Blueprint, compon
 	planEnv := selectTerraformCommandEnv(terraformVars, true, scopedKeys)
 	planOutput, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, planEnv, planArgs...)
 	if err != nil {
-		return fmt.Errorf("error running terraform plan for %s: %w", component.Path, err)
+		wrapped := fmt.Errorf("error running terraform plan for %s: %w", component.Path, err)
+		return wrapPlanError(wrapped, extractPlanErrorDiagnostics(planOutput))
 	}
 	if planOutput != "" {
 		fmt.Fprint(os.Stdout, planOutput)
@@ -1175,7 +1184,8 @@ func (s *TerraformStack) planComponents(blueprint *blueprintv1alpha1.Blueprint, 
 		planOutput, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, planEnv, planArgs...)
 		cleanup()
 		if err != nil {
-			return fmt.Errorf("error running terraform plan for %s: %w", component.Path, err)
+			wrapped := fmt.Errorf("error running terraform plan for %s: %w", component.Path, err)
+			return wrapPlanError(wrapped, extractPlanErrorDiagnostics(planOutput))
 		}
 		if planOutput != "" {
 			fmt.Fprint(os.Stdout, planOutput)
@@ -1400,7 +1410,8 @@ func (s *TerraformStack) planOneTerraformSummary(component *blueprintv1alpha1.Te
 	planEnv := selectTerraformCommandEnv(terraformVars, true, scopedKeys)
 	planOutput, err := s.runtime.Shell.ExecCaptureWithEnv(terraformCommand, planEnv, planArgs...)
 	if err != nil {
-		result.Err = fmt.Errorf("error running terraform plan for %s: %w", component.Path, err)
+		wrapped := fmt.Errorf("error running terraform plan for %s: %w", component.Path, err)
+		result.Err = wrapPlanError(wrapped, extractPlanErrorDiagnostics(planOutput))
 		return result
 	}
 
@@ -1453,28 +1464,29 @@ func (s *TerraformStack) planOneTerraformDestroySummary(component *blueprintv1al
 	planArgs = append(planArgs, terraformArgs.PlanDestroyArgs...)
 	planEnv := selectTerraformCommandEnv(terraformVars, true, scopedKeys)
 	planOutput, err := s.runtime.Shell.ExecCaptureWithEnv(terraformCommand, planEnv, planArgs...)
-	// terraform exits non-zero when any resource has prevent_destroy = true,
-	// but still emits the diagnostic events naming them. Look for those addresses
-	// regardless of exec error so the warning can surface them; otherwise the
-	// operator just sees a raw plan failure.
-	protected := extractPreventDestroyAddresses(planOutput)
-	if err != nil {
-		if len(protected) > 0 {
-			// Parse whatever planned_change / change_summary events terraform
-			// emitted before the diagnostic — without this, plan counts stay
-			// zero and the renderer shows "(no changes)" while the warning
-			// says N resources can't be destroyed, two directly contradictory
-			// signals to the operator.
-			result.Add, result.Change, result.Destroy, result.NoChanges, result.Resources = parseTerraformPlanJSON(planOutput)
-			result.Protected = protected
-			return result
-		}
-		result.Err = fmt.Errorf("error running terraform plan -destroy for %s: %w", component.Path, err)
+	if err == nil {
+		result.Add, result.Change, result.Destroy, result.NoChanges, result.Resources = parseTerraformPlanJSON(planOutput)
 		return result
 	}
 
+	// A protected resource and a real error can occur in the same run; check both.
+	diags := planDiagnostics(planOutput)
+	protected := preventDestroyAddressesFromDiagnostics(diags)
+	skip := map[string]bool{}
+	if len(protected) > 0 {
+		skip[preventDestroySummary] = true
+	}
+	otherErrors := planErrorMessages(diags, skip)
+
+	// Parse counts even on failure, so a protected-resource warning isn't paired with "(no changes)".
 	result.Add, result.Change, result.Destroy, result.NoChanges, result.Resources = parseTerraformPlanJSON(planOutput)
 	result.Protected = protected
+	if len(protected) > 0 && len(otherErrors) == 0 {
+		return result
+	}
+
+	wrapped := fmt.Errorf("error running terraform plan -destroy for %s: %w", component.Path, err)
+	result.Err = wrapPlanError(wrapped, otherErrors)
 	return result
 }
 
@@ -1821,30 +1833,19 @@ func parseTerraformPlanJSON(output string) (add, change, destroy int, noChanges 
 	return
 }
 
-// extractPreventDestroyAddresses scans the line-delimited JSON event stream
-// emitted by `terraform plan -destroy -json` for diagnostic events that
-// terraform produces when a resource has `lifecycle { prevent_destroy = true }`.
-// The diagnostic summary is the canonical signal — terraform emits
-// "Instance cannot be destroyed" verbatim for this case. The address comes from
-// `diagnostic.address` when present (newer terraform/tofu), with a fallback to
-// parsing the `detail` string which always starts with "Resource <addr> has
-// lifecycle.prevent_destroy set". Returns the addresses in the order they
-// appear; duplicates are preserved so callers see each occurrence. Lines that
-// aren't JSON or don't parse are silently skipped, since terraform interleaves
-// non-event output.
-func extractPreventDestroyAddresses(output string) []string {
-	type diagnostic struct {
-		Severity string `json:"severity"`
-		Summary  string `json:"summary"`
-		Address  string `json:"address"`
-		Detail   string `json:"detail"`
-	}
+// preventDestroySummary is the diagnostic summary terraform emits verbatim for
+// a resource protected by `lifecycle { prevent_destroy = true }`.
+const preventDestroySummary = "Instance cannot be destroyed"
+
+// planDiagnostics returns every diagnostic event from a `plan [-destroy]
+// -json` stream, in order. Non-event lines are skipped.
+func planDiagnostics(output string) []planDiagnostic {
 	type event struct {
-		Type       string      `json:"type"`
-		Diagnostic *diagnostic `json:"diagnostic,omitempty"`
+		Type       string          `json:"type"`
+		Diagnostic *planDiagnostic `json:"diagnostic,omitempty"`
 	}
 
-	var addresses []string
+	var diags []planDiagnostic
 	for _, line := range strings.Split(output, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || !strings.HasPrefix(line, "{") {
@@ -1857,15 +1858,23 @@ func extractPreventDestroyAddresses(output string) []string {
 		if ev.Type != "diagnostic" || ev.Diagnostic == nil {
 			continue
 		}
-		if ev.Diagnostic.Severity != "error" {
+		diags = append(diags, *ev.Diagnostic)
+	}
+	return diags
+}
+
+// preventDestroyAddressesFromDiagnostics returns the addresses of resources
+// protected by `lifecycle { prevent_destroy = true }`, in order. Falls back to
+// parsing detail when address is absent.
+func preventDestroyAddressesFromDiagnostics(diags []planDiagnostic) []string {
+	var addresses []string
+	for _, d := range diags {
+		if d.Severity != "error" || d.Summary != preventDestroySummary {
 			continue
 		}
-		if ev.Diagnostic.Summary != "Instance cannot be destroyed" {
-			continue
-		}
-		addr := ev.Diagnostic.Address
+		addr := d.Address
 		if addr == "" {
-			addr = preventDestroyAddressFromDetail(ev.Diagnostic.Detail)
+			addr = preventDestroyAddressFromDetail(d.Detail)
 		}
 		if addr == "" {
 			continue
@@ -1873,6 +1882,57 @@ func extractPreventDestroyAddresses(output string) []string {
 		addresses = append(addresses, stripModuleMain(addr))
 	}
 	return addresses
+}
+
+// extractPreventDestroyAddresses runs preventDestroyAddressesFromDiagnostics
+// over a raw -json plan stream. See that function for the extraction rules.
+func extractPreventDestroyAddresses(output string) []string {
+	return preventDestroyAddressesFromDiagnostics(planDiagnostics(output))
+}
+
+// planErrorMessages formats each error-severity diagnostic as "summary:
+// detail", skipping summaries named in skip. Flattens embedded newlines and
+// drops duplicates.
+func planErrorMessages(diags []planDiagnostic, skip map[string]bool) []string {
+	var messages []string
+	seen := make(map[string]bool, len(diags))
+	for _, d := range diags {
+		if d.Severity != "error" || d.Summary == "" || skip[d.Summary] {
+			continue
+		}
+		msg := sanitizeDiagnosticLine(d.Summary)
+		if d.Detail != "" {
+			msg = fmt.Sprintf("%s: %s", msg, sanitizeDiagnosticLine(d.Detail))
+		}
+		if seen[msg] {
+			continue
+		}
+		seen[msg] = true
+		messages = append(messages, msg)
+	}
+	return messages
+}
+
+// sanitizeDiagnosticLine collapses a diagnostic summary or detail to one
+// line, replacing embedded newlines with a space.
+func sanitizeDiagnosticLine(s string) string {
+	return strings.Join(strings.Fields(s), " ")
+}
+
+// extractPlanErrorDiagnostics returns every error diagnostic in a raw -json
+// plan stream. `plan -json` reports its real error on stdout, not stderr, so
+// a bare exec error carries none of it.
+func extractPlanErrorDiagnostics(output string) []string {
+	return planErrorMessages(planDiagnostics(output), nil)
+}
+
+// wrapPlanError appends messages to err's text, one per line. Returns err
+// unchanged when messages is empty.
+func wrapPlanError(err error, messages []string) error {
+	if len(messages) == 0 {
+		return err
+	}
+	return fmt.Errorf("%w\n%s", err, strings.Join(messages, "\n"))
 }
 
 // preventDestroyAddressFromDetail extracts the resource address from a

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -2575,6 +2575,33 @@ func TestStack_PlanAll(t *testing.T) {
 	})
 }
 
+func TestStack_PlanAllJSON(t *testing.T) {
+	t.Run("SurfacesTheRealDiagnosticOnPlanFailure", func(t *testing.T) {
+		// Given a plan that fails with a real provider error
+		mocks := setupWindsorStackMocks(t)
+		stack := NewStack(mocks.Runtime).(*TerraformStack)
+		stack.shims = mocks.Shims
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 1 && args[1] == "plan" {
+				output := `{"type":"diagnostic","diagnostic":{"severity":"error","summary":"Error 403: Permission denied","detail":"googleapi: Error 403"}}` + "\n"
+				return output, fmt.Errorf("exit status 1")
+			}
+			return "", nil
+		}
+
+		// When PlanAllJSON is called
+		err := stack.PlanAllJSON(createTestBlueprint())
+
+		// Then the real diagnostic reaches the caller, not just "exit status 1"
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if !strings.Contains(err.Error(), "Error 403: Permission denied") {
+			t.Errorf("expected the real diagnostic in the error, got: %v", err)
+		}
+	})
+}
+
 func TestStack_PlanJSON(t *testing.T) {
 	setup := func(t *testing.T) (*TerraformStack, *TerraformTestMocks) {
 		t.Helper()
@@ -2606,6 +2633,29 @@ func TestStack_PlanJSON(t *testing.T) {
 		}
 		if capturedEnv["TF_VAR_operation"] != "apply" {
 			t.Errorf("Expected TF_VAR_operation to be %q, got %q", "apply", capturedEnv["TF_VAR_operation"])
+		}
+	})
+
+	t.Run("SurfacesTheRealDiagnosticOnPlanFailure", func(t *testing.T) {
+		// Given a plan that fails with a real provider error
+		stack, mocks := setup(t)
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 1 && args[1] == "plan" {
+				output := `{"type":"diagnostic","diagnostic":{"severity":"error","summary":"Error 403: Permission denied","detail":"googleapi: Error 403"}}` + "\n"
+				return output, fmt.Errorf("exit status 1")
+			}
+			return "", nil
+		}
+
+		// When PlanJSON is called
+		err := stack.PlanJSON(createTestBlueprint(), "local/path")
+
+		// Then the real diagnostic reaches the caller, not just "exit status 1"
+		if err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if !strings.Contains(err.Error(), "Error 403: Permission denied") {
+			t.Errorf("expected the real diagnostic in the error, got: %v", err)
 		}
 	})
 }
@@ -4660,6 +4710,39 @@ func TestStack_PlanSummary(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("SurfacesTheRealDiagnosticOnPlanFailure", func(t *testing.T) {
+		// Given a plan that fails with a real provider error
+		stack, mocks := setup(t)
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 2 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[{"address":"google_container_cluster.main"}]}}}`, nil
+			}
+			if len(args) > 1 && args[1] == "plan" {
+				output := `{"type":"diagnostic","diagnostic":{"severity":"error","summary":"Error 403: Permission denied","detail":"googleapi: Error 403: Required 'compute.instances.create' permission"}}` + "\n"
+				return output, fmt.Errorf("exit status 1")
+			}
+			return "", nil
+		}
+		bp := &blueprintv1alpha1.Blueprint{
+			Metadata:            blueprintv1alpha1.Metadata{Name: "t"},
+			TerraformComponents: []blueprintv1alpha1.TerraformComponent{{Path: "cluster"}},
+		}
+
+		// When PlanSummary runs
+		results := stack.PlanSummary(bp)
+
+		// Then the result's error carries the real diagnostic, not just "exit status 1"
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d: %#v", len(results), results)
+		}
+		if results[0].Err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if !strings.Contains(results[0].Err.Error(), "Error 403: Permission denied") || !strings.Contains(results[0].Err.Error(), "compute.instances.create") {
+			t.Errorf("expected the real diagnostic in the error, got: %v", results[0].Err)
+		}
+	})
 }
 
 func TestStack_PlanDestroySummary(t *testing.T) {
@@ -4802,6 +4885,83 @@ func TestStack_PlanDestroySummary(t *testing.T) {
 		}
 		if results[0].Path != "b" {
 			t.Errorf("expected path=b, got %q", results[0].Path)
+		}
+	})
+
+	t.Run("SurfacesTheRealDiagnosticOnPlanFailure", func(t *testing.T) {
+		// Given a plan -destroy that fails with a real provider error, not a
+		// prevent_destroy diagnostic
+		stack, mocks := setup(t)
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 2 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[{"address":"google_container_cluster.main"}]}}}`, nil
+			}
+			if len(args) > 1 && args[1] == "plan" {
+				output := `{"type":"diagnostic","diagnostic":{"severity":"error","summary":"Error 403: Permission denied","detail":"googleapi: Error 403: Required 'compute.instances.delete' permission"}}` + "\n"
+				return output, fmt.Errorf("exit status 1")
+			}
+			return "", nil
+		}
+		bp := &blueprintv1alpha1.Blueprint{
+			Metadata:            blueprintv1alpha1.Metadata{Name: "t"},
+			TerraformComponents: []blueprintv1alpha1.TerraformComponent{{Path: "cluster"}},
+		}
+
+		// When PlanDestroySummary runs
+		results := stack.PlanDestroySummary(bp)
+
+		// Then the result's error carries the real diagnostic, not just "exit status 1"
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d: %#v", len(results), results)
+		}
+		if results[0].Err == nil {
+			t.Fatal("expected an error, got nil")
+		}
+		if !strings.Contains(results[0].Err.Error(), "Error 403: Permission denied") || !strings.Contains(results[0].Err.Error(), "compute.instances.delete") {
+			t.Errorf("expected the real diagnostic in the error, got: %v", results[0].Err)
+		}
+	})
+
+	t.Run("SurfacesARealErrorAlongsideAProtectedResource", func(t *testing.T) {
+		// Given a plan -destroy that fails with both a prevent_destroy diagnostic
+		// for one resource and an unrelated real error for another — the
+		// protected-resource warning must never mask the real error
+		stack, mocks := setup(t)
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) > 2 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[{"address":"x.y"}]}}}`, nil
+			}
+			if len(args) > 1 && args[1] == "plan" {
+				output := strings.Join([]string{
+					`{"type":"diagnostic","diagnostic":{"severity":"error","summary":"Instance cannot be destroyed","address":"null_resource.guarded"}}`,
+					`{"type":"diagnostic","diagnostic":{"severity":"error","summary":"Error 403: Permission denied","detail":"googleapi: Error 403"}}`,
+					``,
+				}, "\n")
+				return output, fmt.Errorf("exit status 1")
+			}
+			return "", nil
+		}
+		bp := &blueprintv1alpha1.Blueprint{
+			Metadata:            blueprintv1alpha1.Metadata{Name: "t"},
+			TerraformComponents: []blueprintv1alpha1.TerraformComponent{{Path: "cluster"}},
+		}
+
+		// When PlanDestroySummary runs
+		results := stack.PlanDestroySummary(bp)
+
+		// Then both the protected resource and the real error are reported
+		if len(results) != 1 {
+			t.Fatalf("expected 1 result, got %d: %#v", len(results), results)
+		}
+		r := results[0]
+		if len(r.Protected) != 1 || r.Protected[0] != "null_resource.guarded" {
+			t.Errorf("expected the protected resource reported, got: %#v", r.Protected)
+		}
+		if r.Err == nil {
+			t.Fatal("expected the unrelated error to still be reported, got nil")
+		}
+		if !strings.Contains(r.Err.Error(), "Error 403: Permission denied") {
+			t.Errorf("expected the real diagnostic in the error, got: %v", r.Err)
 		}
 	})
 }
@@ -5094,6 +5254,114 @@ func TestExtractPreventDestroyAddresses(t *testing.T) {
 		// Then nothing is reported — silent skip beats reporting empty strings
 		if got != nil {
 			t.Errorf("expected nil for unparseable diagnostics, got %#v", got)
+		}
+	})
+}
+
+func TestExtractPlanErrorDiagnostics(t *testing.T) {
+	t.Run("ReturnsNilForEmptyOrNonDiagnosticOutput", func(t *testing.T) {
+		// Given an event stream with only planned_change and change_summary events
+		output := strings.Join([]string{
+			`{"type":"planned_change","change":{"resource":{"addr":"module.main.aws_s3_bucket.x"},"action":"delete"}}`,
+			`{"type":"change_summary","changes":{"add":0,"change":0,"remove":1}}`,
+			``,
+		}, "\n")
+
+		// When extracting error diagnostics
+		got := extractPlanErrorDiagnostics(output)
+
+		// Then none are reported
+		if got != nil {
+			t.Errorf("expected nil, got %#v", got)
+		}
+		if extractPlanErrorDiagnostics("") != nil {
+			t.Error("expected nil for empty output")
+		}
+	})
+
+	t.Run("ExtractsSummaryAndDetailForEveryErrorDiagnostic", func(t *testing.T) {
+		// Given a provider error diagnostic like a real destroy-plan failure would emit
+		output := strings.Join([]string{
+			`Initialising backend...`,
+			`{"type":"diagnostic","diagnostic":{"severity":"error","summary":"Error 403: Permission denied","detail":"googleapi: Error 403: Required 'compute.instances.delete' permission, forbidden"}}`,
+			`trailing junk`,
+			``,
+		}, "\n")
+
+		// When extracting
+		got := extractPlanErrorDiagnostics(output)
+
+		// Then the summary and detail both reach the caller
+		if len(got) != 1 {
+			t.Fatalf("expected 1 diagnostic, got %d: %#v", len(got), got)
+		}
+		if !strings.Contains(got[0], "Error 403: Permission denied") || !strings.Contains(got[0], "compute.instances.delete") {
+			t.Errorf("expected summary and detail both present, got %q", got[0])
+		}
+	})
+
+	t.Run("OmitsDetailWhenAbsent", func(t *testing.T) {
+		// Given a diagnostic with only a summary
+		output := `{"type":"diagnostic","diagnostic":{"severity":"error","summary":"Provider produced inconsistent result"}}`
+
+		// When extracting
+		got := extractPlanErrorDiagnostics(output)
+
+		// Then the bare summary is reported with no trailing separator
+		if len(got) != 1 || got[0] != "Provider produced inconsistent result" {
+			t.Errorf("expected bare summary, got %#v", got)
+		}
+	})
+
+	t.Run("IgnoresNonErrorSeverityAndNonDiagnosticEvents", func(t *testing.T) {
+		// Given a warning and a differently-typed event carrying a diagnostic field
+		output := strings.Join([]string{
+			`{"type":"diagnostic","diagnostic":{"severity":"warning","summary":"deprecated argument"}}`,
+			`{"type":"some_other_event","diagnostic":{"severity":"error","summary":"should not surface"}}`,
+			``,
+		}, "\n")
+
+		// When extracting
+		got := extractPlanErrorDiagnostics(output)
+
+		// Then neither qualifies
+		if got != nil {
+			t.Errorf("expected nil, got %#v", got)
+		}
+	})
+
+	t.Run("CollapsesDuplicateMessages", func(t *testing.T) {
+		// Given the same diagnostic repeated, e.g. once per affected resource instance
+		output := strings.Join([]string{
+			`{"type":"diagnostic","diagnostic":{"severity":"error","summary":"Error 500","detail":"internal error"}}`,
+			`{"type":"diagnostic","diagnostic":{"severity":"error","summary":"Error 500","detail":"internal error"}}`,
+			``,
+		}, "\n")
+
+		// When extracting
+		got := extractPlanErrorDiagnostics(output)
+
+		// Then it is reported once
+		if len(got) != 1 {
+			t.Errorf("expected duplicates collapsed to 1, got %d: %#v", len(got), got)
+		}
+	})
+
+	t.Run("FlattensEmbeddedNewlinesToOneLine", func(t *testing.T) {
+		// Given a detail that spans multiple lines — callers render each returned
+		// line as its own bullet, so an unflattened detail would look like
+		// several distinct diagnostics
+		output := `{"type":"diagnostic","diagnostic":{"severity":"error","summary":"Error 403","detail":"googleapi: Error 403:\nRequired permission denied\nfor project x"}}`
+
+		// When extracting
+		got := extractPlanErrorDiagnostics(output)
+
+		// Then it is reported as a single, newline-free line
+		if len(got) != 1 {
+			t.Fatalf("expected 1 diagnostic, got %d: %#v", len(got), got)
+		}
+		if strings.Contains(got[0], "\n") {
+			t.Errorf("expected no embedded newlines, got %q", got[0])
 		}
 	})
 }


### PR DESCRIPTION
Closes #3283

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> The change touches core terraform provisioner error handling used by every plan and destroy path in the CLI, though the behavior change is additive and only activates when a plan already fails.
>
> **Overview**
>
> `terraform plan [-destroy] -json` reports its real failure as a `diagnostic` event on stdout rather than on stderr, so a failed plan previously surfaced only a bare "command execution failed: exit status 1" even under `--verbose`. This PR parses that diagnostic stream once per call and folds the real summary/detail into the returned error across `PlanJSON`, `planComponents`, `planOneTerraformSummary`, and `planOneTerraformDestroySummary`, deduplicating messages and flattening multi-line details to one line each.
>
> The destroy-plan path is reworked so a `prevent_destroy` diagnostic and an unrelated real error are detected independently: previously any exec error alongside a protected-resource diagnostic silently swallowed the real error, now both surface (`result.Protected` and `result.Err` can both be populated). `stack_show.go`'s `--output=json-plan` path has the same symptom from a different cause and is explicitly left for follow-up.

<!-- /claude-code-review:summary -->
