### PR TITLE
feat(kustomization): support external health check references

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -368,6 +368,23 @@ type HealthCheckExpr struct {
 	Failed string `yaml:"failed,omitempty"`
 }
 
+// HealthCheckRef names an external resource a Kustomization waits on before Ready, mirroring
+// Flux's spec.healthChecks. Setting any entry forces Wait to false and disables HealthCheckExprs,
+// since Flux only evaluates those when Wait is true.
+type HealthCheckRef struct {
+	// APIVersion of the resource to wait on.
+	APIVersion string `yaml:"apiVersion,omitempty"`
+
+	// Kind of the resource to wait on.
+	Kind string `yaml:"kind,omitempty"`
+
+	// Name of the resource to wait on.
+	Name string `yaml:"name,omitempty"`
+
+	// Namespace of the resource to wait on. Defaults to the Kustomization's own namespace.
+	Namespace string `yaml:"namespace,omitempty"`
+}
+
 // Blueprint is a configuration blueprint for initializing a project.
 type Blueprint struct {
 	// Kind is the blueprint type, following Kubernetes conventions.
@@ -659,6 +676,9 @@ type Kustomization struct {
 
 	// HealthCheckExprs are CEL health checks for custom resources kstatus cannot evaluate.
 	HealthCheckExprs []HealthCheckExpr `yaml:"healthCheckExprs,omitempty"`
+
+	// HealthChecks are external resources to wait on before Ready. See HealthCheckRef.
+	HealthChecks []HealthCheckRef `yaml:"healthChecks,omitempty"`
 
 	// Components to include in the kustomization.
 	Components []string `yaml:"components,omitempty"`
@@ -1395,6 +1415,7 @@ func (k *Kustomization) DeepCopy() *Kustomization {
 		Force:            k.Force,
 		Prune:            k.Prune,
 		HealthCheckExprs: slices.Clone(k.HealthCheckExprs),
+		HealthChecks:     slices.Clone(k.HealthChecks),
 		Components:       slices.Clone(k.Components),
 		Destroy:          k.Destroy.DeepCopy(),
 		DestroyOnly:      k.DestroyOnly,
@@ -1527,6 +1548,9 @@ func (k *Kustomization) ToFluxKustomization(namespace string, defaultSourceName 
 	if k.Wait != nil {
 		wait = *k.Wait
 	}
+	if len(k.HealthChecks) > 0 {
+		wait = false
+	}
 
 	force := constants.DefaultFluxKustomizationForce
 	if k.Force != nil {
@@ -1565,6 +1589,7 @@ func (k *Kustomization) ToFluxKustomization(namespace string, defaultSourceName 
 	}
 
 	healthCheckExprs := toFluxHealthCheckExprs(k.HealthCheckExprs)
+	healthChecks := toFluxHealthChecks(k.HealthChecks)
 
 	var postBuild *kustomizev1.PostBuild
 	if !IsCrdLayerName(k.Name) {
@@ -1628,6 +1653,7 @@ func (k *Kustomization) ToFluxKustomization(namespace string, defaultSourceName 
 			Force:            force,
 			Prune:            prune,
 			HealthCheckExprs: healthCheckExprs,
+			HealthChecks:     healthChecks,
 			DeletionPolicy:   deletionPolicy,
 			Patches:          patches,
 			Components:       k.Components,
@@ -1699,6 +1725,22 @@ func toFluxHealthCheckExprs(exprs []HealthCheckExpr) []kustomize.CustomHealthChe
 				InProgress: expr.InProgress,
 				Failed:     expr.Failed,
 			},
+		})
+	}
+	return converted
+}
+
+// toFluxHealthChecks converts blueprint external health check references to their Flux
+// equivalents, returning nil for an empty input so spec.healthChecks is omitted from the
+// rendered resource.
+func toFluxHealthChecks(refs []HealthCheckRef) []meta.NamespacedObjectKindReference {
+	var converted []meta.NamespacedObjectKindReference
+	for _, ref := range refs {
+		converted = append(converted, meta.NamespacedObjectKindReference{
+			APIVersion: ref.APIVersion,
+			Kind:       ref.Kind,
+			Name:       ref.Name,
+			Namespace:  ref.Namespace,
 		})
 	}
 	return converted
@@ -1812,19 +1854,26 @@ func (b *Blueprint) strategicMergeKustomization(kustomization Kustomization) err
 }
 
 // MergeKustomizationFields deep-merges overlay onto base and returns the result without mutating
-// either input: Components and DependsOn accumulate (deduplicated, Components sorted), Patches
-// accumulate, Substitutions copy in, HealthCheckExprs accumulate with overlay entries replacing
-// base entries of the same apiVersion and kind, and every other field is overridden by overlay when
-// overlay sets it. Callers that need
-// by-name matching within a Blueprint's Kustomizations list use strategicMergeKustomization, which
-// calls this once a match is found; callers merging two already-matched Kustomization values
-// directly (e.g. FluxSystem tiers, which carry no Name until tier compilation) call this directly.
+// either input. Components and DependsOn accumulate, deduplicated, with Components sorted.
+// Patches accumulate. Substitutions copy in. Every other field is overridden by overlay when
+// overlay sets it.
+//
+// HealthCheckExprs accumulate, with an overlay entry replacing a base entry of the same
+// APIVersion and Kind. HealthChecks accumulate the same way, matching on APIVersion, Kind, and
+// Name. Namespace is excluded from that match, since it defaults to the kustomization's own
+// namespace and so cannot reliably distinguish one entry from another.
+//
+// Callers that need by-name matching within a Blueprint's Kustomizations list use
+// strategicMergeKustomization, which calls this once a match is found; callers merging two
+// already-matched Kustomization values directly (e.g. FluxSystem tiers, which carry no Name
+// until tier compilation) call this directly.
 func MergeKustomizationFields(base, overlay Kustomization) Kustomization {
 	existing := base
 	existing.Components = slices.Clone(base.Components)
 	existing.DependsOn = slices.Clone(base.DependsOn)
 	existing.Patches = slices.Clone(base.Patches)
 	existing.HealthCheckExprs = slices.Clone(base.HealthCheckExprs)
+	existing.HealthChecks = slices.Clone(base.HealthChecks)
 	existing.Substitutions = maps.Clone(base.Substitutions)
 	for _, component := range overlay.Components {
 		if component == "" || !slices.Contains(existing.Components, component) {
@@ -1888,6 +1937,17 @@ func MergeKustomizationFields(base, overlay Kustomization) Kustomization {
 			continue
 		}
 		existing.HealthCheckExprs = append(existing.HealthCheckExprs, expr)
+	}
+	for _, ref := range overlay.HealthChecks {
+		index := slices.IndexFunc(existing.HealthChecks, func(candidate HealthCheckRef) bool {
+			return candidate.APIVersion == ref.APIVersion && candidate.Kind == ref.Kind &&
+				candidate.Name == ref.Name
+		})
+		if index >= 0 {
+			existing.HealthChecks[index] = ref
+			continue
+		}
+		existing.HealthChecks = append(existing.HealthChecks, ref)
 	}
 	if len(overlay.Substitutions) > 0 {
 		if existing.Substitutions == nil {

--- a/api/v1alpha1/blueprint_types_test.go
+++ b/api/v1alpha1/blueprint_types_test.go
@@ -3522,6 +3522,194 @@ healthCheckExprs:
 	})
 }
 
+func TestKustomization_HealthChecks(t *testing.T) {
+	webhookDeployment := HealthCheckRef{
+		APIVersion: "apps/v1",
+		Kind:       "Deployment",
+		Name:       "kyverno-admission-controller",
+		Namespace:  "system-policy",
+	}
+
+	t.Run("UnmarshalsCamelCaseKeys", func(t *testing.T) {
+		// Given a kustomization authored with healthChecks
+		yamlData := []byte(`name: policy-install
+healthChecks:
+  - apiVersion: apps/v1
+    kind: Deployment
+    name: kyverno-admission-controller
+    namespace: system-policy
+`)
+
+		// When unmarshaled
+		var k Kustomization
+		if err := yaml.Unmarshal(yamlData, &k); err != nil {
+			t.Fatalf("Failed to unmarshal Kustomization with healthChecks: %v", err)
+		}
+
+		// Then every camelCase key lands on its field
+		if len(k.HealthChecks) != 1 {
+			t.Fatalf("Expected 1 health check reference, got %d", len(k.HealthChecks))
+		}
+		ref := k.HealthChecks[0]
+		if ref.APIVersion != "apps/v1" {
+			t.Errorf("Expected APIVersion 'apps/v1', got %q", ref.APIVersion)
+		}
+		if ref.Kind != "Deployment" {
+			t.Errorf("Expected Kind 'Deployment', got %q", ref.Kind)
+		}
+		if ref.Name != "kyverno-admission-controller" {
+			t.Errorf("Expected Name 'kyverno-admission-controller', got %q", ref.Name)
+		}
+		if ref.Namespace != "system-policy" {
+			t.Errorf("Expected Namespace 'system-policy', got %q", ref.Namespace)
+		}
+	})
+
+	t.Run("ConvertsToFluxHealthChecksAndForcesWaitFalse", func(t *testing.T) {
+		// Given a kustomization that explicitly requests Wait true, alongside a health check ref
+		wait := true
+		kustomization := &Kustomization{
+			Name:         "policy-install",
+			Wait:         &wait,
+			HealthChecks: []HealthCheckRef{webhookDeployment},
+		}
+
+		// When converted to a Flux Kustomization
+		result := kustomization.ToFluxKustomization("system-gitops", "core", []Source{}, constants.GitopsModePull)
+
+		// Then the reference is carried onto spec.healthChecks
+		if len(result.Spec.HealthChecks) != 1 {
+			t.Fatalf("Expected 1 health check reference on the Flux spec, got %d", len(result.Spec.HealthChecks))
+		}
+		got := result.Spec.HealthChecks[0]
+		if got.APIVersion != webhookDeployment.APIVersion || got.Kind != webhookDeployment.Kind {
+			t.Errorf("Expected %s/%s, got %s/%s", webhookDeployment.APIVersion, webhookDeployment.Kind, got.APIVersion, got.Kind)
+		}
+		if got.Name != webhookDeployment.Name || got.Namespace != webhookDeployment.Namespace {
+			t.Errorf("Expected %s/%s, got %s/%s", webhookDeployment.Namespace, webhookDeployment.Name, got.Namespace, got.Name)
+		}
+
+		// And Flux's own Wait is forced false, since Flux ignores spec.healthChecks otherwise,
+		// even though this kustomization explicitly asked for Wait true
+		if result.Spec.Wait {
+			t.Error("Expected Wait forced false when HealthChecks is set, got true")
+		}
+	})
+
+	t.Run("OmitsFluxHealthChecksWhenUnsetAndLeavesWaitAlone", func(t *testing.T) {
+		// Given a kustomization with no health check references
+		kustomization := &Kustomization{Name: "policy"}
+
+		// When converted to a Flux Kustomization
+		result := kustomization.ToFluxKustomization("system-gitops", "core", []Source{}, constants.GitopsModePull)
+
+		// Then spec.healthChecks stays nil so it is omitted from the rendered output
+		if result.Spec.HealthChecks != nil {
+			t.Errorf("Expected nil HealthChecks, got %+v", result.Spec.HealthChecks)
+		}
+
+		// And Wait keeps its default rather than being forced false
+		if !result.Spec.Wait {
+			t.Error("Expected Wait to keep its default of true, got false")
+		}
+	})
+
+	t.Run("DeepCopyIndependentOfOriginal", func(t *testing.T) {
+		// Given a kustomization with a health check reference
+		original := &Kustomization{Name: "k", HealthChecks: []HealthCheckRef{webhookDeployment}}
+
+		// When deep-copied and the copy mutated
+		clone := original.DeepCopy()
+		clone.HealthChecks[0].Name = "other"
+
+		// Then the original is unchanged
+		if original.HealthChecks[0].Name != webhookDeployment.Name {
+			t.Errorf("Expected original unchanged, got %q", original.HealthChecks[0].Name)
+		}
+	})
+
+	t.Run("OverlayReplacesMatchingReference", func(t *testing.T) {
+		// Given a base and an overlay naming the same resource
+		base := Kustomization{Name: "k", HealthChecks: []HealthCheckRef{webhookDeployment}}
+		overlay := Kustomization{Name: "k", HealthChecks: []HealthCheckRef{{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+			Name:       "kyverno-admission-controller",
+			Namespace:  "system-policy",
+		}}}
+
+		// When merged
+		merged := MergeKustomizationFields(base, overlay)
+
+		// Then the overlay reference replaces the base one rather than duplicating it
+		if len(merged.HealthChecks) != 1 {
+			t.Fatalf("Expected 1 health check reference, got %d", len(merged.HealthChecks))
+		}
+	})
+
+	t.Run("OverlayReplacesMatchingReferenceRegardlessOfNamespace", func(t *testing.T) {
+		// Given a base entry with Namespace left empty (defaults to the kustomization's own
+		// namespace) and an overlay entry naming the same resource with Namespace spelled out
+		base := Kustomization{Name: "k", HealthChecks: []HealthCheckRef{{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+			Name:       "kyverno-admission-controller",
+		}}}
+		overlay := Kustomization{Name: "k", HealthChecks: []HealthCheckRef{webhookDeployment}}
+
+		// When merged
+		merged := MergeKustomizationFields(base, overlay)
+
+		// Then the two entries are recognized as the same resource and replace rather than
+		// duplicate, since Namespace does not participate in the identity match
+		if len(merged.HealthChecks) != 1 {
+			t.Fatalf("Expected 1 health check reference, got %d", len(merged.HealthChecks))
+		}
+		if merged.HealthChecks[0].Namespace != webhookDeployment.Namespace {
+			t.Errorf("Expected the overlay's namespace to win, got %q", merged.HealthChecks[0].Namespace)
+		}
+	})
+
+	t.Run("OverlayAppendsUnmatchedReferenceAndLeavesBaseIntact", func(t *testing.T) {
+		// Given a base naming one resource and an overlay naming another
+		base := Kustomization{Name: "k", HealthChecks: []HealthCheckRef{webhookDeployment}}
+		overlay := Kustomization{Name: "k", HealthChecks: []HealthCheckRef{{
+			APIVersion: "apps/v1",
+			Kind:       "Deployment",
+			Name:       "kyverno-background-controller",
+			Namespace:  "system-policy",
+		}}}
+
+		// When merged
+		merged := MergeKustomizationFields(base, overlay)
+
+		// Then both references survive and the base slice is not mutated
+		if len(merged.HealthChecks) != 2 {
+			t.Fatalf("Expected 2 health check references, got %d", len(merged.HealthChecks))
+		}
+		if merged.HealthChecks[0].Name != "kyverno-admission-controller" || merged.HealthChecks[1].Name != "kyverno-background-controller" {
+			t.Errorf("Expected admission-controller then background-controller, got %s then %s", merged.HealthChecks[0].Name, merged.HealthChecks[1].Name)
+		}
+		if len(base.HealthChecks) != 1 {
+			t.Errorf("Expected base left intact, got %d references", len(base.HealthChecks))
+		}
+	})
+
+	t.Run("EmptyOverlayLeavesBaseReferences", func(t *testing.T) {
+		// Given a base with a health check reference and an overlay without one
+		base := Kustomization{Name: "k", HealthChecks: []HealthCheckRef{webhookDeployment}}
+		overlay := Kustomization{Name: "k"}
+
+		// When merged
+		merged := MergeKustomizationFields(base, overlay)
+
+		// Then the base reference survives
+		if len(merged.HealthChecks) != 1 || merged.HealthChecks[0].Name != webhookDeployment.Name {
+			t.Errorf("Expected base reference preserved, got %+v", merged.HealthChecks)
+		}
+	})
+}
+
 func TestTerraformComponent_DeepCopy(t *testing.T) {
 	t.Run("Success", func(t *testing.T) {
 		component := &TerraformComponent{

--- a/docs/reference/blueprint.md
+++ b/docs/reference/blueprint.md
@@ -63,6 +63,7 @@ variable substitutions shared across them.
 | `enabled` | `boolean / string` | Whether to include this tier in the final blueprint. Boolean or expression. Defaults to true. |
 | `force` | `boolean` | Force-apply resources Flux would otherwise refuse to update. |
 | `healthCheckExprs` | `array<object>` | CEL health checks for custom resources kstatus cannot evaluate — those exposing no status.observedGeneration and no Reconciling/Stalled condition, which kstatus reports healthy the moment they are applied. Each entry gates 'wait' on the named resource kind, and with it any dependsOn edge pointing at this kustomization. |
+| `healthChecks` | `array<object>` | External resources to wait on before Ready, such as one a HelmRelease this kustomization applies creates indirectly. Any entry here disables 'wait' over this kustomization's own applied resources; it waits only on the resources named here instead. |
 | `interval` | `string` | Reconciliation interval as a Go duration string (e.g. '5m', '1h'). |
 | `namespace` | `string` | Namespace where the Flux Kustomization object lives. Defaults to the gitops namespace. |
 | `patches` | `array<object>` | Strategic-merge or Flux-style patches applied to this tier. |
@@ -98,6 +99,15 @@ variable substitutions shared across them.
 | `inProgress` | `string` | CEL expression matching a resource still converging. |
 | `kind` | `string` | Kind of the custom resource under evaluation. |
 
+#### flux[].install.healthChecks[]
+
+| Field | Type | Description |
+|------|------|-------------|
+| `apiVersion` | `string` | APIVersion of the resource to wait on. |
+| `kind` | `string` | Kind of the resource to wait on. |
+| `name` | `string` | Name of the resource to wait on. |
+| `namespace` | `string` | Namespace of the resource. Defaults to the kustomization's own namespace. |
+
 #### flux[].install.patches[]
 
 | Field | Type | Description |
@@ -118,6 +128,7 @@ variable substitutions shared across them.
 | `enabled` | `boolean / string` | Whether to include this variant in the final blueprint. Boolean or expression. Defaults to true. |
 | `force` | `boolean` | Force-apply resources Flux would otherwise refuse to update. |
 | `healthCheckExprs` | `array<object>` | CEL health checks for custom resources kstatus cannot evaluate — those exposing no status.observedGeneration and no Reconciling/Stalled condition, which kstatus reports healthy the moment they are applied. Each entry gates 'wait' on the named resource kind, and with it any dependsOn edge pointing at this kustomization. |
+| `healthChecks` | `array<object>` | External resources to wait on before Ready, such as one a HelmRelease this kustomization applies creates indirectly. Any entry here disables 'wait' over this kustomization's own applied resources; it waits only on the resources named here instead. |
 | `interval` | `string` | Reconciliation interval as a Go duration string (e.g. '5m', '1h'). |
 | `name` | `string` | Variant suffix ('<system>-resources-<name>'); omit for a single unnamed variant. |
 | `namespace` | `string` | Namespace where the Flux Kustomization object lives. Defaults to the gitops namespace. |
@@ -155,6 +166,15 @@ variable substitutions shared across them.
 | `inProgress` | `string` | CEL expression matching a resource still converging. |
 | `kind` | `string` | Kind of the custom resource under evaluation. |
 
+#### flux[].resources[].healthChecks[]
+
+| Field | Type | Description |
+|------|------|-------------|
+| `apiVersion` | `string` | APIVersion of the resource to wait on. |
+| `kind` | `string` | Kind of the resource to wait on. |
+| `name` | `string` | Name of the resource to wait on. |
+| `namespace` | `string` | Namespace of the resource. Defaults to the kustomization's own namespace. |
+
 #### flux[].resources[].patches[]
 
 | Field | Type | Description |
@@ -183,6 +203,7 @@ variable substitutions shared across them.
 | `enabled` | `boolean / string` | Whether to include this kustomization in the final blueprint. Boolean or expression. Defaults to true. |
 | `force` | `boolean` | Force-apply resources Flux would otherwise refuse to update. |
 | `healthCheckExprs` | `array<object>` | CEL health checks for custom resources kstatus cannot evaluate — those exposing no status.observedGeneration and no Reconciling/Stalled condition, which kstatus reports healthy the moment they are applied. Each entry gates 'wait' on the named resource kind, and with it any dependsOn edge pointing at this kustomization. |
+| `healthChecks` | `array<object>` | External resources to wait on before Ready, such as one a HelmRelease this kustomization applies creates indirectly. Any entry here disables 'wait' over this kustomization's own applied resources; it waits only on the resources named here instead. |
 | `interval` | `string` | Reconciliation interval, expressed as a Go duration string (e.g. '5m', '1h'). Defaults to 1m when source is unset (falls back to the blueprint's own repository, presumed live and actively pushed); defaults to 1h when source names a vendor entry (presumed pinned and explicitly re-triggered rather than continuously tracked). |
 | `namespace` | `string` | Namespace where the Flux Kustomization object itself lives. Defaults to the gitops namespace. DependsOn references always resolve in the gitops namespace; cross-namespace dependencies are not supported. |
 | `patches` | `array<object>` | Strategic-merge or Flux-style patches applied to the kustomization. Each entry is either a 'path:' to a patch file relative to the kustomization, or a 'patch:' inline YAML body with an optional 'target:' selector (kind / name / namespace). |
@@ -218,6 +239,15 @@ variable substitutions shared across them.
 | `failed` | `string` | CEL expression matching a resource that failed to converge. |
 | `inProgress` | `string` | CEL expression matching a resource still converging. |
 | `kind` | `string` | Kind of the custom resource under evaluation. |
+
+### kustomize[].healthChecks[]
+
+| Field | Type | Description |
+|------|------|-------------|
+| `apiVersion` | `string` | APIVersion of the resource to wait on. |
+| `kind` | `string` | Kind of the resource to wait on. |
+| `name` | `string` | Name of the resource to wait on. |
+| `namespace` | `string` | Namespace of the resource. Defaults to the kustomization's own namespace. |
 
 ### kustomize[].patches[]
 

--- a/pkg/runtime/config/schemas/artifacts/blueprint.yaml
+++ b/pkg/runtime/config/schemas/artifacts/blueprint.yaml
@@ -280,6 +280,29 @@ properties:
               failed:
                 type: string
                 description: CEL expression matching a resource that failed to converge.
+        healthChecks:
+          type: array
+          description: |
+            External resources to wait on before Ready, such as one a
+            HelmRelease this kustomization applies creates indirectly. Any
+            entry here disables 'wait' over this kustomization's own applied
+            resources; it waits only on the resources named here instead.
+          items:
+            type: object
+            additionalProperties: false
+            properties:
+              apiVersion:
+                type: string
+                description: APIVersion of the resource to wait on.
+              kind:
+                type: string
+                description: Kind of the resource to wait on.
+              name:
+                type: string
+                description: Name of the resource to wait on.
+              namespace:
+                type: string
+                description: Namespace of the resource. Defaults to the kustomization's own namespace.
         components:
           type: array
           items:
@@ -470,6 +493,29 @@ properties:
                   failed:
                     type: string
                     description: CEL expression matching a resource that failed to converge.
+            healthChecks:
+              type: array
+              description: |
+                External resources to wait on before Ready, such as one a
+                HelmRelease this kustomization applies creates indirectly. Any
+                entry here disables 'wait' over this kustomization's own applied
+                resources; it waits only on the resources named here instead.
+              items:
+                type: object
+                additionalProperties: false
+                properties:
+                  apiVersion:
+                    type: string
+                    description: APIVersion of the resource to wait on.
+                  kind:
+                    type: string
+                    description: Kind of the resource to wait on.
+                  name:
+                    type: string
+                    description: Name of the resource to wait on.
+                  namespace:
+                    type: string
+                    description: Namespace of the resource. Defaults to the kustomization's own namespace.
             components:
               type: array
               items:
@@ -601,6 +647,29 @@ properties:
                     failed:
                       type: string
                       description: CEL expression matching a resource that failed to converge.
+              healthChecks:
+                type: array
+                description: |
+                  External resources to wait on before Ready, such as one a
+                  HelmRelease this kustomization applies creates indirectly. Any
+                  entry here disables 'wait' over this kustomization's own applied
+                  resources; it waits only on the resources named here instead.
+                items:
+                  type: object
+                  additionalProperties: false
+                  properties:
+                    apiVersion:
+                      type: string
+                      description: APIVersion of the resource to wait on.
+                    kind:
+                      type: string
+                      description: Kind of the resource to wait on.
+                    name:
+                      type: string
+                      description: Name of the resource to wait on.
+                    namespace:
+                      type: string
+                      description: Namespace of the resource. Defaults to the kustomization's own namespace.
               components:
                 type: array
                 items:

--- a/pkg/runtime/config/schemas/artifacts/facets.yaml
+++ b/pkg/runtime/config/schemas/artifacts/facets.yaml
@@ -303,8 +303,8 @@ $defs:
       Inherits every field from the blueprint's Kustomization shape (name,
       path, source, namespace, targetNamespace, dependsOn, interval,
       retryInterval, timeout, patches, wait, force, prune, healthCheckExprs,
-      components, destroy, destroyOnly, enabled, substitutions, substitute)
-      and adds the conditional
+      healthChecks, components, destroy, destroyOnly, enabled, substitutions,
+      substitute) and adds the conditional
       fields below. See the [Blueprint reference](blueprint.md) for the inherited
       fields.
     properties:


### PR DESCRIPTION
Closes #3289

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This PR adds an opt-in field to the Kustomization blueprint type, and the change is additive, well-tested, and consistent with an existing analogous field.
>
> **Overview**
>
> The PR adds `healthChecks` to the `Kustomization` type, letting a kustomization wait on external resources (e.g. ones a HelmRelease creates indirectly) rather than only its own applied resources. The new `HealthCheckRef` type is converted to Flux's `spec.healthChecks` (`meta.NamespacedObjectKindReference`), wired through `DeepCopy` and `MergeKustomizationFields` (overlay entries replace base entries matching on APIVersion/Kind/Name, ignoring Namespace), and documented in the JSON schemas and blueprint reference docs.
>
> Setting any `healthChecks` entry forces `wait` to `false`, since Flux only evaluates `healthCheckExprs`/its own readiness check when `wait` is `true`. This is a behavioral coupling worth knowing about: a kustomization that sets both `wait: true` and `healthChecks` will silently have `wait` overridden.

<!-- /claude-code-review:summary -->
