### PR TITLE
fix(kubernetes): detect abandoned inventory after kustomization delete

### DIFF
--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -169,12 +169,18 @@ func (k *BaseKubernetesManager) ApplyKustomization(kustomization kustomizev1.Kus
 	return k.applyWithRetry(gvr, obj, opts)
 }
 
+// abandonedInventoryGraceChecks bounds how many extra polls DeleteKustomization spends
+// re-checking a still-live inventory entry after the Kustomization disappears. It gives a
+// resource still finishing its own normal termination a chance to clear before the delete
+// is reported as abandoned rather than clean.
+const abandonedInventoryGraceChecks = 3
+
 // DeleteKustomization deletes a Kustomization and waits for it to disappear. The wait
 // floor rises to spec.timeout when set, and scales with inventory size (see
-// kustomizationSpecTimeoutCeiling). On timeout, it checks whether every inventory item
-// is already gone (see allInventoryEntriesGone); if so, the error names this as a stuck
-// Flux finalizer rather than a guess, since infrastructure has not leaked. Any less
-// certain timeout falls back to the condition-based diagnosis below.
+// kustomizationSpecTimeoutCeiling). On timeout or a clean disappearance, it checks the
+// last-known inventory (see allInventoryEntriesGone, describeAbandonedInventory) before
+// trusting the result. A still-live entry gets a few retries first, to rule out normal
+// in-flight termination.
 func (k *BaseKubernetesManager) DeleteKustomization(name, namespace string) error {
 	gvr := schema.GroupVersionResource{
 		Group:    "kustomize.toolkit.fluxcd.io",
@@ -201,7 +207,19 @@ func (k *BaseKubernetesManager) DeleteKustomization(name, namespace string) erro
 	for k.shims.TimeNow().Before(start.Add(waitFor)) {
 		obj, err := k.client.GetResource(gvr, namespace, name)
 		if err != nil && isNotFoundError(err) {
-			return nil
+			entry := k.describeAbandonedInventory(lastObj)
+			for i := 0; entry != nil && i < abandonedInventoryGraceChecks; i++ {
+				k.shims.TimeSleep(k.kustomizationWaitPollInterval)
+				entry = k.describeAbandonedInventory(lastObj)
+			}
+			if entry == nil {
+				return nil
+			}
+			inspectCmd := fmt.Sprintf("`kubectl get %s %s`", entry.gvr.Resource, entry.Name)
+			if entry.Namespace != "" {
+				inspectCmd = fmt.Sprintf("`kubectl get %s %s -n %s`", entry.gvr.Resource, entry.Name, entry.Namespace)
+			}
+			return fmt.Errorf("kustomization %s/%s disappeared but %s/%s from its inventory is still live. Flux likely gave up waiting and removed the finalizer early. Inspect it with %s before retrying", namespace, name, entry.Kind, entry.Name, inspectCmd)
 		}
 		if err != nil {
 			return fmt.Errorf("error checking kustomization deletion status: %w", err)
@@ -262,6 +280,21 @@ func specTimeout(obj *unstructured.Unstructured) (time.Duration, bool) {
 		return 0, false
 	}
 	return d, true
+}
+
+// waitsForTermination reports whether a Kustomization's own spec.deletionPolicy is
+// WaitForTermination; see ToFluxKustomization. A destroy:false kustomization gets
+// MirrorPrune instead. MirrorPrune deletes resources without waiting for them. A live
+// entry there does not mean Flux gave up.
+func waitsForTermination(obj *unstructured.Unstructured) bool {
+	if obj == nil {
+		return false
+	}
+	value, found, err := unstructured.NestedString(obj.Object, "spec", "deletionPolicy")
+	if err != nil || !found {
+		return false
+	}
+	return value == "WaitForTermination"
 }
 
 // extendWaitFor raises waitFor to candidate when candidate is larger, otherwise
@@ -2143,16 +2176,36 @@ func (k *BaseKubernetesManager) resolveScopedGVR(gvk schema.GroupVersionKind, na
 }
 
 // allInventoryEntriesGone reports whether every inventory entry's own live object is
-// confirmed absent, independent of the Kustomization's finalizer state. An entry whose
-// API type no longer exists counts as gone. It returns false on the first entry still
-// present. It returns an error, not false, on any inconclusive lookup: a wrong "all
-// gone" reading here is exactly what could clear a finalizer while resources still exist.
+// confirmed absent, independent of the Kustomization's finalizer state. It returns an
+// error, not false, on any inconclusive lookup: a wrong "all gone" reading here is
+// exactly what could clear a finalizer while resources still exist.
 func (k *BaseKubernetesManager) allInventoryEntriesGone(entries []InventoryEntry) (bool, error) {
+	live, err := k.firstLiveInventoryEntry(entries)
+	if err != nil {
+		return false, err
+	}
+	return live == nil, nil
+}
+
+// liveInventoryEntry is an inventory entry confirmed still live, paired with its
+// resolved GVR. The GVR's Resource is the plural name kubectl accepts, not a guess
+// from Kind.
+type liveInventoryEntry struct {
+	InventoryEntry
+	gvr schema.GroupVersionResource
+}
+
+// firstLiveInventoryEntry returns the first inventory entry whose own live object is
+// still present, or nil if every entry is confirmed absent. An entry whose API type no
+// longer exists counts as gone. It returns an error, not a false negative, on an
+// inconclusive lookup. A wrong "gone" reading could clear a finalizer or report a
+// false clean delete.
+func (k *BaseKubernetesManager) firstLiveInventoryEntry(entries []InventoryEntry) (*liveInventoryEntry, error) {
 	for _, entry := range entries {
 		gvk := schema.GroupVersionKind{Group: entry.Group, Kind: entry.Kind}
 		gvr, namespace, ok, err := k.resolveScopedGVR(gvk, entry.Namespace)
 		if err != nil {
-			return false, err
+			return nil, err
 		}
 		if !ok {
 			continue
@@ -2161,11 +2214,32 @@ func (k *BaseKubernetesManager) allInventoryEntriesGone(entries []InventoryEntry
 			if isNotFoundError(err) {
 				continue
 			}
-			return false, err
+			return nil, err
 		}
-		return false, nil
+		return &liveInventoryEntry{InventoryEntry: entry, gvr: gvr}, nil
 	}
-	return true, nil
+	return nil, nil
+}
+
+// describeAbandonedInventory checks lastObj's last-known inventory for an entry whose
+// live object is confirmed still present, after the Kustomization itself has already
+// disappeared. It only applies to a WaitForTermination kustomization; see
+// waitsForTermination. A MirrorPrune one is expected to leave live entries behind.
+// Returns nil when there is no inventory to check, or the lookup is inconclusive. A
+// genuinely clean delete is never second-guessed.
+func (k *BaseKubernetesManager) describeAbandonedInventory(lastObj *unstructured.Unstructured) *liveInventoryEntry {
+	if !waitsForTermination(lastObj) {
+		return nil
+	}
+	entries, found := inventoryEntriesFromObject(lastObj)
+	if !found {
+		return nil
+	}
+	live, err := k.firstLiveInventoryEntry(entries)
+	if err != nil {
+		return nil
+	}
+	return live
 }
 
 // gitopsMode returns the configured gitops mode, defaulting to pull. Centralising

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -847,6 +847,12 @@ func TestBaseKubernetesManager_DeleteKustomization(t *testing.T) {
 		}}
 	}
 
+	waitForTerminationKustomization := func() *unstructured.Unstructured {
+		obj := drainedKustomization()
+		obj.Object["spec"] = map[string]any{"deletionPolicy": "WaitForTermination"}
+		return obj
+	}
+
 	t.Run("TimeoutReportsDrainedKustomizationAsStuckFinalizer", func(t *testing.T) {
 		// Given every inventory entry's own live object confirmed gone
 		manager := setup(t)
@@ -985,6 +991,195 @@ func TestBaseKubernetesManager_DeleteKustomization(t *testing.T) {
 		}
 		if strings.Contains(err.Error(), "fully drained") {
 			t.Errorf("Expected fallback wording when no inventory was ever reported, got: %v", err)
+		}
+	})
+
+	t.Run("DisappearedReportsAbandonedInventoryWhenEntryStillLive", func(t *testing.T) {
+		// Given a WaitForTermination kustomization that disappears after one tick, and
+		// its last-known inventory entry stays live through the grace retries —
+		// kustomize-controller gave up and stripped its own finalizer early
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			return nil
+		}
+		calls := 0
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			if name == "test-kustomization" {
+				calls++
+				if calls == 1 {
+					return waitForTerminationKustomization(), nil
+				}
+				return nil, fmt.Errorf("the server could not find the requested resource")
+			}
+			if name == "entry-one" {
+				return &unstructured.Unstructured{Object: map[string]any{}}, nil
+			}
+			return nil, fmt.Errorf("the server could not find the requested resource")
+		}
+		manager.client = kubernetesClient
+
+		// When DeleteKustomization sees the object disappear
+		err := manager.DeleteKustomization("test-kustomization", "test-namespace")
+
+		// Then it reports the still-live entry instead of a clean delete
+		if err == nil {
+			t.Fatal("Expected an error naming the abandoned inventory, got nil")
+		}
+		if !strings.Contains(err.Error(), "entry-one") {
+			t.Errorf("Expected error to name the still-live entry, got: %v", err)
+		}
+	})
+
+	t.Run("DisappearedRecoversWhenEntrySettlesDuringGracePeriod", func(t *testing.T) {
+		// Given a still-live entry that finishes its own normal termination within the
+		// grace retries — not a sign Flux gave up, just a resource a moment from gone
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			return nil
+		}
+		calls, entryCalls := 0, 0
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			if name == "test-kustomization" {
+				calls++
+				if calls == 1 {
+					return waitForTerminationKustomization(), nil
+				}
+				return nil, fmt.Errorf("the server could not find the requested resource")
+			}
+			if name == "entry-one" {
+				entryCalls++
+				if entryCalls == 1 {
+					return &unstructured.Unstructured{Object: map[string]any{}}, nil
+				}
+			}
+			return nil, fmt.Errorf("the server could not find the requested resource")
+		}
+		manager.client = kubernetesClient
+
+		// When DeleteKustomization sees the object disappear
+		err := manager.DeleteKustomization("test-kustomization", "test-namespace")
+
+		// Then it reports success once the entry settles
+		if err != nil {
+			t.Errorf("Expected no error once the entry settles within the grace period, got %v", err)
+		}
+	})
+
+	t.Run("DisappearedIsCleanWhenPolicyIsMirrorPrune", func(t *testing.T) {
+		// Given a MirrorPrune kustomization (destroy:false) whose last-known inventory
+		// entry is still live — MirrorPrune deletes resources without waiting for them,
+		// so a live entry here is expected, not a sign of a stuck finalizer
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			return nil
+		}
+		calls := 0
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			if name == "test-kustomization" {
+				calls++
+				if calls == 1 {
+					return drainedKustomization(), nil
+				}
+				return nil, fmt.Errorf("the server could not find the requested resource")
+			}
+			if name == "entry-one" {
+				return &unstructured.Unstructured{Object: map[string]any{}}, nil
+			}
+			return nil, fmt.Errorf("the server could not find the requested resource")
+		}
+		manager.client = kubernetesClient
+
+		// When DeleteKustomization sees the object disappear
+		err := manager.DeleteKustomization("test-kustomization", "test-namespace")
+
+		// Then it reports success rather than a false abandoned-inventory error
+		if err != nil {
+			t.Errorf("Expected no error for a MirrorPrune delete, got %v", err)
+		}
+	})
+
+	t.Run("DisappearedIsCleanWhenLastKnownInventoryIsDrained", func(t *testing.T) {
+		// Given a kustomization that disappears after one tick, and every last-known
+		// inventory entry is confirmed gone — a genuinely clean delete
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			return nil
+		}
+		calls := 0
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			if name == "test-kustomization" {
+				calls++
+				if calls == 1 {
+					return waitForTerminationKustomization(), nil
+				}
+			}
+			return nil, fmt.Errorf("the server could not find the requested resource")
+		}
+		manager.client = kubernetesClient
+
+		// When DeleteKustomization sees the object disappear
+		err := manager.DeleteKustomization("test-kustomization", "test-namespace")
+
+		// Then it reports success
+		if err != nil {
+			t.Errorf("Expected no error for a drained delete, got %v", err)
+		}
+	})
+
+	t.Run("DisappearedIsCleanWhenInventoryCheckInconclusive", func(t *testing.T) {
+		// Given a kustomization that disappears after one tick, but the live-check on
+		// its last-known inventory entry fails with a real API error — nothing may be
+		// asserted from an inconclusive lookup
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			return nil
+		}
+		calls := 0
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			if name == "test-kustomization" {
+				calls++
+				if calls == 1 {
+					return waitForTerminationKustomization(), nil
+				}
+				return nil, fmt.Errorf("the server could not find the requested resource")
+			}
+			return nil, fmt.Errorf("connection refused")
+		}
+		manager.client = kubernetesClient
+
+		// When DeleteKustomization sees the object disappear
+		err := manager.DeleteKustomization("test-kustomization", "test-namespace")
+
+		// Then it falls back to reporting success rather than a false positive
+		if err != nil {
+			t.Errorf("Expected no error on an inconclusive check, got %v", err)
+		}
+	})
+
+	t.Run("DisappearedIsCleanWhenNoInventoryWasEverReported", func(t *testing.T) {
+		// Given a kustomization that disappears on the very first check — no
+		// last-known object was ever captured
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.DeleteResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string, opts metav1.DeleteOptions) error {
+			return nil
+		}
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			return nil, fmt.Errorf("the server could not find the requested resource")
+		}
+		manager.client = kubernetesClient
+
+		// When DeleteKustomization sees the object disappear
+		err := manager.DeleteKustomization("test-kustomization", "test-namespace")
+
+		// Then it reports success
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
 		}
 	})
 }


### PR DESCRIPTION
Closes #3292

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This PR changes `DeleteKustomization`'s success criteria in `pkg/provisioner/kubernetes/kubernetes_manager.go`, so a delete that previously reported success can now return an error; the change is well-guarded and covered by tests, but it touches a shared destroy path used across apply and cleanup flows.
>
> **Overview**
>
> When a Kustomization disappears from the API server, the code now cross-checks its last-known inventory before declaring the delete clean. If an inventory entry is still live, it retries a bounded number of times (`abandonedInventoryGraceChecks`, currently 3) to rule out normal in-flight termination, then returns a descriptive error naming the still-live object instead of reporting success.
>
> This check only applies when the Kustomization's `spec.deletionPolicy` is `WaitForTermination` (via the new `waitsForTermination` helper); `MirrorPrune` kustomizations, inconclusive lookups, and kustomizations with no captured inventory all continue to report a clean delete, matching the existing conservative bias toward not falsely claiming leaked infrastructure.

<!-- /claude-code-review:summary -->
