### PR TITLE
chore(deps): update dependency siderolabs/talos to v1.14.0

### DIFF
--- a/aqua.yaml
+++ b/aqua.yaml
@@ -11,7 +11,7 @@ registries:
   - type: standard
     ref: v4.558.1 # renovate: depName=aquaproj/aqua-registry
 packages:
-- name: siderolabs/talos@v1.13.9
+- name: siderolabs/talos@v1.14.0
 - name: siderolabs/omni/omnictl@v1.11.0
 - name: siderolabs/omni/omni@v1.11.0
 - name: kubernetes/kubectl@v1.34.3 # renovate: ignore

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -46,7 +46,7 @@ const DefaultGitLiveReloadWebhookLBPort = 9292
 const DefaultGitLiveReloadWebhookPath = "/hook/5dc88e45e809fb0872b749c0969067e2c1fd142e17aed07573fad20553cc0c59"
 
 // renovate: datasource=github-releases depName=siderolabs/talos
-const DefaultTalosImage = "ghcr.io/siderolabs/talos:v1.13.9"
+const DefaultTalosImage = "ghcr.io/siderolabs/talos:v1.14.0"
 
 const DefaultTalosAPIPort = 50000
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change bumps the pinned Talos version and is isolated to a single dependency reference used in two places, with no logic changes.
>
> **Overview**
>
> The PR updates the Talos dependency from v1.13.9 to v1.14.0 in `aqua.yaml` (the aqua package manager manifest) and `pkg/constants/constants.go` (the `DefaultTalosImage` constant used at runtime). Both references are kept in sync, and no other code depends on the old version string.
>
> This reapplies a change from a prior PR (#3262) that had developed a merge conflict against main after the omnictl bump (#3260) landed in `aqua.yaml`.

<!-- /claude-code-review:summary -->
