### PR TITLE
fix(blueprint): render flux install tier without components

### DIFF
--- a/api/v1alpha1/blueprint_types.go
+++ b/api/v1alpha1/blueprint_types.go
@@ -1287,20 +1287,19 @@ func (sys FluxSystem) EffectivePath() string {
 }
 
 // compileFluxSystemTiers converts a pre-evaluated FluxSystem into its tier Kustomizations without
-// any expression evaluation. Install compiles to "<name>-install" at "<path>/install"; each
-// resources variant compiles to "<name>-resources[-<variant>]" at "<path>/resources". A timeout-less
-// install tier falls back to DefaultFluxKustomizationInstallTimeout instead of the generic default.
-// The system's Secrets attach to its namespace-owning tier — the install tier when emitted, else the
-// first resources tier (out[0]) — so placement finds them after FluxSystems are flattened away.
+// any expression evaluation. Install compiles to "<name>-install" at "<path>/install" whenever
+// declared, with or without components. A resources variant is never gated on its own component
+// count either. A timeout-less install tier falls back to DefaultFluxKustomizationInstallTimeout.
+// The system's Secrets attach to its namespace-owning tier — the install tier when declared, else
+// the first resources tier (out[0]).
 func compileFluxSystemTiers(sys FluxSystem) []Kustomization {
 	name := sys.Name
 	base := sys.EffectivePath()
 	installName := name + "-install"
 
 	var out []Kustomization
-	installEmitted := false
 
-	if sys.Install != nil && len(sys.Install.Components) > 0 {
+	if sys.Install != nil {
 		k := *sys.Install.DeepCopy()
 		k.Name = installName
 		k.Path = path.Join(base, "install")
@@ -1310,7 +1309,6 @@ func compileFluxSystemTiers(sys FluxSystem) []Kustomization {
 			k.Timeout = &DurationString{Duration: constants.DefaultFluxKustomizationInstallTimeout}
 		}
 		out = append(out, k)
-		installEmitted = true
 	}
 
 	for _, v := range sys.Resources {
@@ -1321,7 +1319,7 @@ func compileFluxSystemTiers(sys FluxSystem) []Kustomization {
 		k := *v.Kustomization.DeepCopy()
 		k.Name = variantName
 		k.Path = path.Join(base, "resources")
-		if installEmitted {
+		if sys.Install != nil {
 			k.DependsOn = append([]string{installName}, v.DependsOn...)
 		} else {
 			k.DependsOn = append(slices.Clone(sys.DependsOn), v.DependsOn...)

--- a/api/v1alpha1/blueprint_types_test.go
+++ b/api/v1alpha1/blueprint_types_test.go
@@ -5600,6 +5600,18 @@ func TestFluxSystem_TierNames(t *testing.T) {
 		}
 	})
 
+	t.Run("ReturnsInstallForADeclaredTierWithNoComponents", func(t *testing.T) {
+		// A declared install tier renders even with no components: its own
+		// kustomization.yaml can carry real content (a namespace, say) on its own.
+		sys := FluxSystem{Name: "cert-manager", Install: &Kustomization{}}
+
+		names := sys.TierNames()
+
+		if len(names) != 1 || names[0] != "cert-manager-install" {
+			t.Fatalf("expected [cert-manager-install], got %v", names)
+		}
+	})
+
 	t.Run("DoesNotLeakAnUnrelatedSystemsNamePrefixCollision", func(t *testing.T) {
 		// Given a system literally named "cert-manager-resources", distinct from "cert-manager"
 		sys := FluxSystem{

--- a/integration/fixtures/facet-install-tier-no-components/contexts/_template/blueprint.yaml
+++ b/integration/fixtures/facet-install-tier-no-components/contexts/_template/blueprint.yaml
@@ -1,0 +1,5 @@
+kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: facet-install-tier-no-components
+  description: Install tier with no components integration fixture

--- a/integration/fixtures/facet-install-tier-no-components/contexts/_template/facets/cert-manager.yaml
+++ b/integration/fixtures/facet-install-tier-no-components/contexts/_template/facets/cert-manager.yaml
@@ -1,0 +1,13 @@
+kind: Facet
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: cert-manager
+  description: Flux system whose install tier declares no components
+
+flux:
+- name: cert-manager
+  path: cert-manager
+  install: {}
+  resources:
+  - components:
+    - private-issuer/ca

--- a/integration/fixtures/facet-install-tier-no-components/contexts/_template/tests/install-tier.test.yaml
+++ b/integration/fixtures/facet-install-tier-no-components/contexts/_template/tests/install-tier.test.yaml
@@ -1,0 +1,14 @@
+# An install tier with no components still renders: its own kustomization.yaml can
+# carry real content (a namespace, say) on its own. windsor test confirms the
+# cert-manager-install tier compiles instead of being silently dropped.
+
+cases:
+
+  - name: install_tier_with_no_components_still_renders
+    values: {}
+    expect:
+      kustomize:
+        - name: cert-manager-install
+        - name: cert-manager-resources
+          dependsOn:
+            - cert-manager-install

--- a/integration/fixtures/facet-install-tier-no-components/windsor.yaml
+++ b/integration/fixtures/facet-install-tier-no-components/windsor.yaml
@@ -1,0 +1,3 @@
+version: v1alpha1
+contexts:
+  test: {}

--- a/integration/test_test.go
+++ b/integration/test_test.go
@@ -119,6 +119,24 @@ func TestWindsorTest_ConfigAssertionFixture(t *testing.T) {
 	}
 }
 
+// TestWindsorTest_InstallTierNoComponentsFixture reproduces the bug report. A flux system's
+// install tier declares no components. compileFluxSystemTiers used to skip the tier in this
+// case, dropping any base content its own kustomization.yaml carried. The fixture confirms
+// the tier now compiles.
+func TestWindsorTest_InstallTierNoComponentsFixture(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.PrepareFixture(t, "facet-install-tier-no-components")
+	env = append(env, "WINDSOR_CONTEXT=test")
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"test"}, env)
+	if err != nil {
+		t.Fatalf("windsor test: %v\nstdout: %s\nstderr: %s", err, stdout, stderr)
+	}
+	out := string(stdout) + string(stderr)
+	if !strings.Contains(out, "PASS") && !strings.Contains(out, "✓") {
+		t.Errorf("expected PASS or ✓ in output: %s", out)
+	}
+}
+
 // TestWindsorTest_ConfigAssertionRegressionFixture exercises the bug report's reproduction:
 // the cluster facet's config block is gated off (cluster.enabled is false), so
 // config.cluster never resolves. The case still declares expect.config.cluster.controlplanes.cpu:

--- a/pkg/composer/blueprint/processor.go
+++ b/pkg/composer/blueprint/processor.go
@@ -1454,19 +1454,10 @@ func (p *BaseBlueprintProcessor) evalDropEmpty(raw []string, facetPath string, s
 	return slices.DeleteFunc(evaluated, func(s string) bool { return s == "" }), nil
 }
 
-// collectFluxSystems evaluates a facet's flux: system descriptors — resolving expressions on
-// DependsOn, Install components/substitutions, and each resources variant — and stores the result
-// in fluxSystemByName. A resources variant is dropped only when its own when condition (combined
-// with the system's) is false — never merely because its components prune to empty, matching how
-// a plain kustomize: entry is always emitted regardless of its resolved component count; a
-// dependsOn reference to it stays valid whether or not the variant's own components ended up
-// empty. An install tier whose components prune to empty and carries no substitutions or patches sets
-// Install to nil, since install is optional per system and an empty install is equivalent to none
-// declared; a components-less tier that still carries substitutions or patches is kept so a downstream
-// facet can override an upstream system's install without redeclaring its components. The system's
-// when is cleared once inclusion is decided (mirroring each variant's when):
-// it has already gated the system and its variants here, and often references composition-only derived
-// config that does not exist downstream, so emitting it would leak an unresolvable condition.
+// collectFluxSystems evaluates a facet's flux: system descriptors and stores the result in
+// fluxSystemByName. It clears each system's when once inclusion is decided. Neither an install
+// tier nor a resources variant is dropped for an empty component list. Only a system's own
+// when controls whether it is included at all.
 func (p *BaseBlueprintProcessor) collectFluxSystems(facet blueprintv1alpha1.Facet, sourceName []string, fluxSystemByName map[string]*blueprintv1alpha1.FluxSystem, facetScope map[string]any) error {
 	for _, system := range facet.FluxSystems {
 		when := system.When
@@ -1506,16 +1497,12 @@ func (p *BaseBlueprintProcessor) collectFluxSystems(facet blueprintv1alpha1.Face
 			if err != nil {
 				return fmt.Errorf("error evaluating install components for system '%s': %w", system.Name, err)
 			}
-			if len(comps) > 0 || strategy == "remove" || len(system.Install.Substitutions) > 0 || len(system.Install.Patches) > 0 {
-				installCopy := *system.Install.DeepCopy()
-				installCopy.Components = comps
-				if err := p.evalKustomizationSubstitutions(&installCopy, facet.Path, "flux."+system.Name+".install.substitutions.", facetScope); err != nil {
-					return fmt.Errorf("error evaluating install substitutions for system '%s': %w", system.Name, err)
-				}
-				system.Install = &installCopy
-			} else {
-				system.Install = nil
+			installCopy := *system.Install.DeepCopy()
+			installCopy.Components = comps
+			if err := p.evalKustomizationSubstitutions(&installCopy, facet.Path, "flux."+system.Name+".install.substitutions.", facetScope); err != nil {
+				return fmt.Errorf("error evaluating install substitutions for system '%s': %w", system.Name, err)
 			}
+			system.Install = &installCopy
 		}
 
 		seenVariants := make(map[string]bool)

--- a/pkg/composer/blueprint/processor_test.go
+++ b/pkg/composer/blueprint/processor_test.go
@@ -3576,22 +3576,26 @@ func TestProcessor_ProcessFacets_Tiers(t *testing.T) {
 		}
 	})
 
-	t.Run("InstallPrunesToNothingWhenComponentsEmpty", func(t *testing.T) {
+	t.Run("InstallRendersWhenComponentsPruneToEmpty", func(t *testing.T) {
 		target := process(t, blueprintv1alpha1.FluxSystem{
 			Name:      "gateway",
 			Path:      "gateway",
 			Install:   &blueprintv1alpha1.Kustomization{Components: []string{"${false ? 'helm-release' : ''}"}},
 			Resources: []blueprintv1alpha1.FluxVariant{{Kustomization: blueprintv1alpha1.Kustomization{Components: []string{"internal"}}}},
 		})
-		if _, ok := find(target, "gateway-install"); ok {
-			t.Error("expected no install tier when its components prune to empty")
+		install, ok := find(target, "gateway-install")
+		if !ok {
+			t.Fatalf("expected an install tier even when its components prune to empty, got %+v", target.AllKustomizations())
+		}
+		if len(install.Components) != 0 {
+			t.Errorf("expected empty components, got %v", install.Components)
 		}
 		res, ok := find(target, "gateway-resources")
 		if !ok {
 			t.Fatalf("expected gateway-resources, got %+v", target.AllKustomizations())
 		}
-		if slices.Contains(res.DependsOn, "gateway-install") {
-			t.Errorf("expected no implicit install edge when install pruned away, got %v", res.DependsOn)
+		if !slices.Contains(res.DependsOn, "gateway-install") {
+			t.Errorf("expected the implicit install edge since install rendered, got %v", res.DependsOn)
 		}
 	})
 
@@ -3864,6 +3868,19 @@ func TestProcessor_ProcessFacets_Tiers(t *testing.T) {
 		}
 		if len(sys.Resources) != 1 || sys.Resources[0].Name != "external" {
 			t.Errorf("expected only the 'external' resources variant to remain, got %+v", sys.Resources)
+		}
+	})
+
+	t.Run("InstallWithNoComponentsAtAllIsKept", func(t *testing.T) {
+		target := process(t, blueprintv1alpha1.FluxSystem{
+			Name:    "cert-manager",
+			Install: &blueprintv1alpha1.Kustomization{Timeout: &blueprintv1alpha1.DurationString{Duration: 5 * time.Minute}},
+		})
+		if len(target.FluxSystems) != 1 || target.FluxSystems[0].Install == nil {
+			t.Fatalf("expected install to survive with no components declared, got %+v", target.FluxSystems)
+		}
+		if len(target.FluxSystems[0].Install.Components) != 0 {
+			t.Errorf("expected install components to stay empty, got %v", target.FluxSystems[0].Install.Components)
 		}
 	})
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> The change touches shared blueprint-composition code (`api/v1alpha1/blueprint_types.go` and `pkg/composer/blueprint/processor.go`) that every Flux-based blueprint compiles through, so its default-behavior shift has broad reach even though the change itself is small and well tested.
>
> **Overview**
>
> This fixes a bug where a Flux system's `install:` tier was silently dropped whenever its component list was empty (or pruned to empty by expression evaluation), discarding any base content — a namespace, patches, substitutions — that tier's own `kustomization.yaml` was meant to carry. `compileFluxSystemTiers` now emits the install tier whenever `Install` is declared at all, regardless of component count, and `collectFluxSystems` no longer nils out `Install` when components prune to empty.
>
> The net effect is a default-behavior change: any existing facet that declares an install tier with no components (previously invisible) will now render one, and the `-resources` variant's implicit dependency on `-install` follows the same always-declared rule. Unit tests in both files and a new integration fixture (`facet-install-tier-no-components`) cover the previously-dropped case.

<!-- /claude-code-review:summary -->
