### PR TITLE
fix(shell): guard terraform apply against a repeat interrupt

### DIFF
--- a/pkg/runtime/shell/shell.go
+++ b/pkg/runtime/shell/shell.go
@@ -91,14 +91,10 @@ type DefaultShell struct {
 	secretsMu    sync.Mutex
 }
 
-// interruptGuard relays exactly one interrupt to a supervised child process, then withholds
-// further interrupts for the rest of its run. Terraform's own graceful stop already cancels the
-// context of whatever operation is in flight on the first interrupt it receives, which is enough
-// on its own to leave a resource tainted mid-create — windsor cannot prevent that. What windsor
-// can prevent is a second, impatient interrupt bypassing that graceful stop with a hard kill,
-// which risks leaving state and reality disagreeing with no tainted marker at all. forward is
-// platform-specific: it delivers the guarded interrupt to the child's own process group so a
-// second terminal interrupt does not also reach it directly.
+// interruptGuard relays one interrupt to a child process. It blocks every interrupt
+// after that for the rest of the run. A second interrupt can force-kill the child
+// before it exits cleanly. forward sends the interrupt to the child's own process
+// group. This stops a second terminal interrupt from reaching the child directly.
 type interruptGuard struct {
 	forward   func() error
 	warn      io.Writer
@@ -419,7 +415,7 @@ func (s *DefaultShell) ExecProgressWithEnv(message string, command string, env m
 		if command == "sudo" {
 			cmd.Stdin = os.Stdin
 		}
-		defer s.startInterruptGuard(cmd, message)()
+		defer s.startInterruptGuard(cmd, command, message)()
 		if err := s.shims.CmdStart(cmd); err != nil {
 			return stdoutBuf.String(), fmt.Errorf("command start failed: %w", err)
 		}
@@ -448,7 +444,7 @@ func (s *DefaultShell) ExecProgressWithEnv(message string, command string, env m
 		return "", err
 	}
 
-	defer s.startInterruptGuard(cmd, message)()
+	defer s.startInterruptGuard(cmd, command, message)()
 	if err := s.shims.CmdStart(cmd); err != nil {
 		return "", err
 	}
@@ -915,13 +911,15 @@ func (s *DefaultShell) newScrubbingWriter(w io.Writer) *scrubbingWriter {
 	return &scrubbingWriter{writer: w, scrubWithMaxLen: s.scrubStringWithMaxLen}
 }
 
-// startInterruptGuard places cmd in its own process group and begins relaying exactly one
-// terminal interrupt to it, suppressing any further interrupt for the rest of its run — see
-// interruptGuard. Used around long-running, user-visible operations (terraform apply, privileged
-// network configuration) where a second, impatient interrupt hard-killing the child is worse than
-// letting the first one's graceful stop run its course. The returned stop func must be called
-// once cmd has exited.
-func (s *DefaultShell) startInterruptGuard(cmd *exec.Cmd, message string) (stop func()) {
+// startInterruptGuard places cmd in its own process group. It relays the first
+// terminal interrupt to cmd, then blocks every interrupt after that. See
+// interruptGuard. It skips sudo. Setpgid would strand sudo's password prompt on
+// SIGTTIN. Call the returned stop func once cmd exits. It no-ops when skipped.
+func (s *DefaultShell) startInterruptGuard(cmd *exec.Cmd, command string, message string) (stop func()) {
+	if command == "sudo" {
+		return func() {}
+	}
+
 	setProcessGroup(cmd)
 
 	sigCh := make(chan os.Signal, 4)
@@ -941,9 +939,10 @@ func (s *DefaultShell) startInterruptGuard(cmd *exec.Cmd, message string) (stop 
 	}
 }
 
-// watch relays the first signal received on sigCh to the guarded child via forward, then prints
-// a warning (without forwarding) for every subsequent signal until done is closed. It returns once
-// done is closed, which the caller does as soon as the child process exits.
+// watch forwards the first signal on sigCh to the child via forward. Every signal
+// after that prints a warning instead of forwarding. Each warning pauses the active
+// spinner first, since termSpinner redraws its line and would clobber the warning.
+// watch returns once done closes. The caller closes done when the child exits.
 func (g *interruptGuard) watch(sigCh <-chan os.Signal, done <-chan struct{}) {
 	forwarded := false
 	for {
@@ -951,13 +950,15 @@ func (g *interruptGuard) watch(sigCh <-chan os.Signal, done <-chan struct{}) {
 		case <-done:
 			return
 		case <-sigCh:
+			tui.Pause()
 			if !forwarded {
 				forwarded = true
-				fmt.Fprintf(g.warn, "windsor: interrupt received while applying %s; the in-flight resource operation may now be tainted in Terraform state. Waiting for terraform to stop gracefully — further interrupts will not force it. If it hangs, stop it from another terminal.\n", g.component)
+				fmt.Fprintf(g.warn, "warning: interrupt received during apply of %s. The resource may now be tainted in Terraform state. Windsor waits for terraform to stop gracefully. A further interrupt will not force it. If terraform hangs, stop it from another terminal.\n", g.component)
 				_ = g.forward()
-				continue
+			} else {
+				fmt.Fprintf(g.warn, "warning: still waiting for terraform to stop gracefully for %s. Forcing now can corrupt state. If it hangs, stop it from another terminal.\n", g.component)
 			}
-			fmt.Fprintf(g.warn, "windsor: still waiting for terraform to stop gracefully for %s. Forcing now can corrupt state. If it hangs, stop it from another terminal.\n", g.component)
+			tui.Resume()
 		}
 	}
 }

--- a/pkg/runtime/shell/shell.go
+++ b/pkg/runtime/shell/shell.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"maps"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"slices"
@@ -88,6 +89,20 @@ type DefaultShell struct {
 	shims        *Shims
 	secrets      []string
 	secretsMu    sync.Mutex
+}
+
+// interruptGuard relays exactly one interrupt to a supervised child process, then withholds
+// further interrupts for the rest of its run. Terraform's own graceful stop already cancels the
+// context of whatever operation is in flight on the first interrupt it receives, which is enough
+// on its own to leave a resource tainted mid-create — windsor cannot prevent that. What windsor
+// can prevent is a second, impatient interrupt bypassing that graceful stop with a hard kill,
+// which risks leaving state and reality disagreeing with no tainted marker at all. forward is
+// platform-specific: it delivers the guarded interrupt to the child's own process group so a
+// second terminal interrupt does not also reach it directly.
+type interruptGuard struct {
+	forward   func() error
+	warn      io.Writer
+	component string
 }
 
 // =============================================================================
@@ -404,6 +419,7 @@ func (s *DefaultShell) ExecProgressWithEnv(message string, command string, env m
 		if command == "sudo" {
 			cmd.Stdin = os.Stdin
 		}
+		defer s.startInterruptGuard(cmd, message)()
 		if err := s.shims.CmdStart(cmd); err != nil {
 			return stdoutBuf.String(), fmt.Errorf("command start failed: %w", err)
 		}
@@ -432,6 +448,7 @@ func (s *DefaultShell) ExecProgressWithEnv(message string, command string, env m
 		return "", err
 	}
 
+	defer s.startInterruptGuard(cmd, message)()
 	if err := s.shims.CmdStart(cmd); err != nil {
 		return "", err
 	}
@@ -896,6 +913,53 @@ func (s *DefaultShell) scrubStringWithMaxLen(input string) (string, int) {
 // newScrubbingWriter builds a scrubbingWriter over w bound to this shell's registered secrets.
 func (s *DefaultShell) newScrubbingWriter(w io.Writer) *scrubbingWriter {
 	return &scrubbingWriter{writer: w, scrubWithMaxLen: s.scrubStringWithMaxLen}
+}
+
+// startInterruptGuard places cmd in its own process group and begins relaying exactly one
+// terminal interrupt to it, suppressing any further interrupt for the rest of its run — see
+// interruptGuard. Used around long-running, user-visible operations (terraform apply, privileged
+// network configuration) where a second, impatient interrupt hard-killing the child is worse than
+// letting the first one's graceful stop run its course. The returned stop func must be called
+// once cmd has exited.
+func (s *DefaultShell) startInterruptGuard(cmd *exec.Cmd, message string) (stop func()) {
+	setProcessGroup(cmd)
+
+	sigCh := make(chan os.Signal, 4)
+	s.shims.SignalNotify(sigCh, os.Interrupt)
+	done := make(chan struct{})
+
+	guard := &interruptGuard{
+		forward:   func() error { return interruptProcessGroup(cmd) },
+		warn:      os.Stderr,
+		component: message,
+	}
+	go guard.watch(sigCh, done)
+
+	return func() {
+		close(done)
+		s.shims.SignalStop(sigCh)
+	}
+}
+
+// watch relays the first signal received on sigCh to the guarded child via forward, then prints
+// a warning (without forwarding) for every subsequent signal until done is closed. It returns once
+// done is closed, which the caller does as soon as the child process exits.
+func (g *interruptGuard) watch(sigCh <-chan os.Signal, done <-chan struct{}) {
+	forwarded := false
+	for {
+		select {
+		case <-done:
+			return
+		case <-sigCh:
+			if !forwarded {
+				forwarded = true
+				fmt.Fprintf(g.warn, "windsor: interrupt received while applying %s; the in-flight resource operation may now be tainted in Terraform state. Waiting for terraform to stop gracefully — further interrupts will not force it. If it hangs, stop it from another terminal.\n", g.component)
+				_ = g.forward()
+				continue
+			}
+			fmt.Fprintf(g.warn, "windsor: still waiting for terraform to stop gracefully for %s. Forcing now can corrupt state. If it hangs, stop it from another terminal.\n", g.component)
+		}
+	}
 }
 
 // PrintEnvVars is a platform-specific method that will be implemented by Unix/Windows-specific files

--- a/pkg/runtime/shell/shell_test.go
+++ b/pkg/runtime/shell/shell_test.go
@@ -9,11 +9,14 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
 	"text/template"
 	"time"
+
+	"github.com/windsorcli/cli/pkg/tui"
 )
 
 // The ShellTest is a test suite for the Shell interface and its implementations.
@@ -3793,12 +3796,15 @@ func TestShell_ExecProgress(t *testing.T) {
 	})
 }
 
-// syncWriter wraps a bytes.Buffer with a channel signaled after every Write, letting a test block
-// until the writer goroutine has processed a given signal instead of racing on a sleep.
+// syncWriter wraps a bytes.Buffer with a channel signaled after every Write. A test
+// can wait on the channel instead of racing on a sleep. onWrite, when set, runs
+// before the write is recorded. Use it to place a write among other events, such
+// as a spinner pause and resume.
 type syncWriter struct {
 	mu      sync.Mutex
 	buf     bytes.Buffer
 	written chan struct{}
+	onWrite func()
 }
 
 func newSyncWriter() *syncWriter {
@@ -3806,6 +3812,9 @@ func newSyncWriter() *syncWriter {
 }
 
 func (w *syncWriter) Write(p []byte) (int, error) {
+	if w.onWrite != nil {
+		w.onWrite()
+	}
 	w.mu.Lock()
 	n, err := w.buf.Write(p)
 	w.mu.Unlock()
@@ -3943,6 +3952,56 @@ func TestInterruptGuard_Watch(t *testing.T) {
 		close(done)
 		waitFinished(t, finished)
 	})
+
+	t.Run("PausesAndResumesTheSpinnerAroundEachWarning", func(t *testing.T) {
+		// termSpinner redraws its line every 100ms. An unpaused write here would
+		// get clobbered by the next frame. Each warning must pause, then resume.
+		originalActive := tui.Active
+		t.Cleanup(func() { tui.Active = originalActive })
+
+		var mu sync.Mutex
+		var events []string
+		spinner := tui.NewMockSpinner()
+		spinner.PauseFunc = func() {
+			mu.Lock()
+			events = append(events, "pause")
+			mu.Unlock()
+		}
+		spinner.ResumeFunc = func() {
+			mu.Lock()
+			events = append(events, "resume")
+			mu.Unlock()
+		}
+		tui.Active = spinner
+
+		warn := newSyncWriter()
+		warn.onWrite = func() {
+			mu.Lock()
+			events = append(events, "write")
+			mu.Unlock()
+		}
+		g := &interruptGuard{
+			forward:   func() error { return nil },
+			warn:      warn,
+			component: "cluster/aws-eks",
+		}
+		sigCh := make(chan os.Signal, 1)
+		done := make(chan struct{})
+
+		finished := runWatch(t, g, sigCh, done)
+		sigCh <- os.Interrupt
+		<-warn.written
+		close(done)
+		waitFinished(t, finished)
+
+		mu.Lock()
+		got := append([]string(nil), events...)
+		mu.Unlock()
+		want := []string{"pause", "write", "resume"}
+		if !slices.Equal(got, want) {
+			t.Errorf("expected %v, got %v", want, got)
+		}
+	})
 }
 
 func TestShell_ExecProgressWithEnv_InterruptGuard(t *testing.T) {
@@ -4031,6 +4090,31 @@ func TestShell_ExecProgressWithEnv_InterruptGuard(t *testing.T) {
 		// Then the guard should still be registered and stopped exactly once
 		if notifyCalls != 1 || stopCalls != 1 {
 			t.Errorf("expected exactly one SignalNotify and one SignalStop call, got %d and %d", notifyCalls, stopCalls)
+		}
+	})
+
+	t.Run("SkipsTheGuardForSudo", func(t *testing.T) {
+		// Setpgid would move a sudo child out of the terminal's foreground group.
+		// Its password prompt would then stall on SIGTTIN. The guard must not run.
+		shell, mocks := setup(t)
+
+		notifyCalls := 0
+		mocks.Shims.SignalNotify = func(c chan<- os.Signal, sig ...os.Signal) { notifyCalls++ }
+		var capturedCmd *exec.Cmd
+		mocks.Shims.Command = func(name string, args ...string) *exec.Cmd {
+			capturedCmd = exec.Command("sudo")
+			return capturedCmd
+		}
+
+		if _, err := shell.ExecProgressWithEnv("Applying test", "sudo", nil); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if notifyCalls != 0 {
+			t.Errorf("expected the interrupt guard not to register for sudo, got %d SignalNotify calls", notifyCalls)
+		}
+		if capturedCmd.SysProcAttr != nil {
+			t.Error("expected sudo's process group to be left untouched")
 		}
 	})
 }

--- a/pkg/runtime/shell/shell_test.go
+++ b/pkg/runtime/shell/shell_test.go
@@ -3793,6 +3793,248 @@ func TestShell_ExecProgress(t *testing.T) {
 	})
 }
 
+// syncWriter wraps a bytes.Buffer with a channel signaled after every Write, letting a test block
+// until the writer goroutine has processed a given signal instead of racing on a sleep.
+type syncWriter struct {
+	mu      sync.Mutex
+	buf     bytes.Buffer
+	written chan struct{}
+}
+
+func newSyncWriter() *syncWriter {
+	return &syncWriter{written: make(chan struct{}, 16)}
+}
+
+func (w *syncWriter) Write(p []byte) (int, error) {
+	w.mu.Lock()
+	n, err := w.buf.Write(p)
+	w.mu.Unlock()
+	w.written <- struct{}{}
+	return n, err
+}
+
+func (w *syncWriter) String() string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return w.buf.String()
+}
+
+func TestInterruptGuard_Watch(t *testing.T) {
+	setup := func() (*interruptGuard, *syncWriter, func() int) {
+		warn := newSyncWriter()
+		var mu sync.Mutex
+		forwardCount := 0
+		g := &interruptGuard{
+			forward: func() error {
+				mu.Lock()
+				forwardCount++
+				mu.Unlock()
+				return nil
+			},
+			warn:      warn,
+			component: "cluster/aws-eks",
+		}
+		count := func() int {
+			mu.Lock()
+			defer mu.Unlock()
+			return forwardCount
+		}
+		return g, warn, count
+	}
+
+	runWatch := func(t *testing.T, g *interruptGuard, sigCh chan os.Signal, done chan struct{}) <-chan struct{} {
+		t.Helper()
+		finished := make(chan struct{})
+		go func() {
+			g.watch(sigCh, done)
+			close(finished)
+		}()
+		return finished
+	}
+
+	waitFinished := func(t *testing.T, finished <-chan struct{}) {
+		t.Helper()
+		select {
+		case <-finished:
+		case <-time.After(time.Second):
+			t.Fatal("watch did not return after done was closed")
+		}
+	}
+
+	t.Run("ReturnsWithoutForwardingWhenNoSignalArrives", func(t *testing.T) {
+		g, warn, count := setup()
+		sigCh := make(chan os.Signal, 1)
+		done := make(chan struct{})
+
+		finished := runWatch(t, g, sigCh, done)
+		close(done)
+		waitFinished(t, finished)
+
+		if count() != 0 {
+			t.Errorf("expected forward not to be called, got %d calls", count())
+		}
+		if warn.String() != "" {
+			t.Errorf("expected no warning output, got %q", warn.String())
+		}
+	})
+
+	t.Run("ForwardsOnlyTheFirstOfSeveralSignals", func(t *testing.T) {
+		g, warn, count := setup()
+		sigCh := make(chan os.Signal, 4)
+		done := make(chan struct{})
+
+		finished := runWatch(t, g, sigCh, done)
+
+		sigCh <- os.Interrupt
+		<-warn.written
+		sigCh <- os.Interrupt
+		<-warn.written
+		sigCh <- os.Interrupt
+		<-warn.written
+
+		close(done)
+		waitFinished(t, finished)
+
+		if count() != 1 {
+			t.Errorf("expected forward to be called exactly once, got %d", count())
+		}
+		lines := strings.Count(warn.String(), "\n")
+		if lines != 3 {
+			t.Errorf("expected one warning line per signal (3), got %d in %q", lines, warn.String())
+		}
+		if !strings.Contains(warn.String(), "cluster/aws-eks") {
+			t.Errorf("expected warning to mention the component, got %q", warn.String())
+		}
+	})
+
+	t.Run("SecondWarningIsDistinctFromTheFirst", func(t *testing.T) {
+		g, warn, _ := setup()
+		sigCh := make(chan os.Signal, 2)
+		done := make(chan struct{})
+
+		finished := runWatch(t, g, sigCh, done)
+
+		sigCh <- os.Interrupt
+		<-warn.written
+		sigCh <- os.Interrupt
+		<-warn.written
+
+		close(done)
+		waitFinished(t, finished)
+
+		lines := strings.Split(strings.TrimRight(warn.String(), "\n"), "\n")
+		if len(lines) != 2 {
+			t.Fatalf("expected exactly two warning lines, got %d: %q", len(lines), warn.String())
+		}
+		if lines[0] == lines[1] {
+			t.Errorf("expected a distinct follow-up warning, got the same line twice: %q", lines[0])
+		}
+		if !strings.Contains(lines[1], "corrupt") {
+			t.Errorf("expected the second warning to warn that forcing can corrupt state, got %q", lines[1])
+		}
+	})
+
+	t.Run("ReturnsPromptlyOnceDoneIsClosed", func(t *testing.T) {
+		g, _, _ := setup()
+		sigCh := make(chan os.Signal, 1)
+		done := make(chan struct{})
+
+		finished := runWatch(t, g, sigCh, done)
+		close(done)
+		waitFinished(t, finished)
+	})
+}
+
+func TestShell_ExecProgressWithEnv_InterruptGuard(t *testing.T) {
+	setup := func(t *testing.T) (*DefaultShell, *ShellTestMocks) {
+		t.Helper()
+		mocks := setupShellMocks(t)
+		shell := NewDefaultShell()
+		shell.shims = mocks.Shims
+		return shell, mocks
+	}
+
+	t.Run("RegistersAndStopsAnInterruptGuardAroundTheCommand", func(t *testing.T) {
+		// Given a shell whose SignalNotify/SignalStop calls are observed
+		shell, mocks := setup(t)
+
+		var notifiedSignals []os.Signal
+		var notifyCh chan<- os.Signal
+		stopped := false
+		mocks.Shims.SignalNotify = func(c chan<- os.Signal, sig ...os.Signal) {
+			notifyCh = c
+			notifiedSignals = sig
+		}
+		mocks.Shims.SignalStop = func(c chan<- os.Signal) {
+			if c == notifyCh {
+				stopped = true
+			}
+		}
+
+		// When executing a command with progress
+		if _, err := shell.ExecProgressWithEnv("Applying test", "test", nil); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Then the guard registered for os.Interrupt and stopped once the command finished
+		if len(notifiedSignals) != 1 || notifiedSignals[0] != os.Interrupt {
+			t.Errorf("expected SignalNotify to be called with os.Interrupt, got %v", notifiedSignals)
+		}
+		if !stopped {
+			t.Error("expected SignalStop to be called with the same channel passed to SignalNotify")
+		}
+	})
+
+	t.Run("PlacesTheCommandInItsOwnProcessGroup", func(t *testing.T) {
+		// Given a shell that captures the command built for execution
+		shell, mocks := setup(t)
+
+		var capturedCmd *exec.Cmd
+		mocks.Shims.Command = func(name string, args ...string) *exec.Cmd {
+			capturedCmd = exec.Command("test")
+			return capturedCmd
+		}
+
+		// When executing a command with progress
+		if _, err := shell.ExecProgressWithEnv("Applying test", "test", nil); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Then setProcessGroup should have set SysProcAttr, isolating it from a repeat
+		// terminal interrupt so only the guard's forwarded signal reaches it
+		if capturedCmd.SysProcAttr == nil {
+			t.Error("expected SysProcAttr to be set so the command runs in its own process group")
+		}
+	})
+
+	t.Run("VerboseModeAlsoRegistersAndStopsTheGuard", func(t *testing.T) {
+		// Given a verbose shell whose SignalNotify/SignalStop calls are observed
+		shell, mocks := setup(t)
+		shell.SetVerbosity(true)
+
+		notifyCalls := 0
+		stopCalls := 0
+		mocks.Shims.SignalNotify = func(c chan<- os.Signal, sig ...os.Signal) { notifyCalls++ }
+		mocks.Shims.SignalStop = func(c chan<- os.Signal) { stopCalls++ }
+		mocks.Shims.Command = func(name string, args ...string) *exec.Cmd {
+			cmd := exec.Command("test")
+			cmd.Stdout = new(bytes.Buffer)
+			cmd.Stderr = new(bytes.Buffer)
+			return cmd
+		}
+
+		// When executing a command with progress in verbose mode
+		if _, err := shell.ExecProgressWithEnv("Applying test", "test", nil); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		// Then the guard should still be registered and stopped exactly once
+		if notifyCalls != 1 || stopCalls != 1 {
+			t.Errorf("expected exactly one SignalNotify and one SignalStop call, got %d and %d", notifyCalls, stopCalls)
+		}
+	})
+}
+
 // =============================================================================
 // Secret Management Tests
 // =============================================================================

--- a/pkg/runtime/shell/shims.go
+++ b/pkg/runtime/shell/shims.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"text/template"
 
@@ -84,6 +85,10 @@ type Shims struct {
 
 	// Terminal operations
 	IsTerminal func(fd int) bool
+
+	// Signal operations
+	SignalNotify func(c chan<- os.Signal, sig ...os.Signal)
+	SignalStop   func(c chan<- os.Signal)
 }
 
 // =============================================================================
@@ -176,6 +181,10 @@ func NewShims() *Shims {
 
 		// Terminal operations
 		IsTerminal: term.IsTerminal,
+
+		// Signal operations
+		SignalNotify: signal.Notify,
+		SignalStop:   signal.Stop,
 	}
 	return s
 }

--- a/pkg/runtime/shell/unix_shell.go
+++ b/pkg/runtime/shell/unix_shell.go
@@ -137,15 +137,14 @@ func (s *DefaultShell) ExecSudo(message string, command string, args ...string) 
 	return s.scrubString(stdoutBuf.String()), nil
 }
 
-// setProcessGroup places cmd in its own process group so a second terminal interrupt (Ctrl+C) is
-// not also delivered to it directly — only the one an interruptGuard forwards via
-// interruptProcessGroup reaches it.
+// setProcessGroup places cmd in its own process group. A second terminal interrupt
+// then reaches cmd only through interruptGuard's call to interruptProcessGroup.
 func setProcessGroup(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 }
 
-// interruptProcessGroup sends SIGINT to cmd's process group. The negative pid targets the whole
-// group, mirroring what the terminal would otherwise deliver directly.
+// interruptProcessGroup sends SIGINT to cmd's process group. The negative pid
+// targets the whole group, the same as a terminal-delivered interrupt would.
 func interruptProcessGroup(cmd *exec.Cmd) error {
 	if cmd.Process == nil {
 		return nil

--- a/pkg/runtime/shell/unix_shell.go
+++ b/pkg/runtime/shell/unix_shell.go
@@ -7,8 +7,10 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"os/exec"
 	"sort"
 	"strings"
+	"syscall"
 
 	"github.com/windsorcli/cli/pkg/tui"
 )
@@ -62,7 +64,6 @@ func (s *DefaultShell) RenderAliases(aliases map[string]string) string {
 	}
 	return result.String()
 }
-
 
 // ExecSudo runs a command with 'sudo', ensuring elevated privileges. It handles password prompts by
 // connecting to the terminal and captures the command's output. If verbose mode is enabled or no TTY
@@ -136,6 +137,22 @@ func (s *DefaultShell) ExecSudo(message string, command string, args ...string) 
 	return s.scrubString(stdoutBuf.String()), nil
 }
 
+// setProcessGroup places cmd in its own process group so a second terminal interrupt (Ctrl+C) is
+// not also delivered to it directly — only the one an interruptGuard forwards via
+// interruptProcessGroup reaches it.
+func setProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}
+
+// interruptProcessGroup sends SIGINT to cmd's process group. The negative pid targets the whole
+// group, mirroring what the terminal would otherwise deliver directly.
+func interruptProcessGroup(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	return syscall.Kill(-cmd.Process.Pid, syscall.SIGINT)
+}
+
 // =============================================================================
 // Private Methods
 // =============================================================================
@@ -161,4 +178,3 @@ func (s *DefaultShell) renderEnvVarsWithExport(envVars map[string]string) string
 	}
 	return result.String()
 }
-

--- a/pkg/runtime/shell/unix_shell_test.go
+++ b/pkg/runtime/shell/unix_shell_test.go
@@ -5,9 +5,12 @@ package shell
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"syscall"
 	"testing"
+	"time"
 )
 
 // The UnixShellTest is a test suite for Unix-specific shell operations.
@@ -400,6 +403,67 @@ func TestDefaultShell_PrintEnvVars(t *testing.T) {
 		}
 		if strings.Contains(output, "export") {
 			t.Errorf("Expected no export commands, got: %s", output)
+		}
+	})
+}
+
+// TestSetProcessGroup_InterruptProcessGroup verifies the real syscalls behind the interrupt
+// guard: a command placed in its own process group survives outside that group's signal
+// delivery, and interruptProcessGroup can still reach and terminate it directly.
+func TestSetProcessGroup_InterruptProcessGroup(t *testing.T) {
+	t.Run("PlacesTheChildInADifferentProcessGroupFromTheTestProcess", func(t *testing.T) {
+		cmd := exec.Command("sleep", "5")
+		setProcessGroup(cmd)
+
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("failed to start test process: %v", err)
+		}
+		defer func() { _ = cmd.Process.Kill() }()
+
+		ownPgid, err := syscall.Getpgid(os.Getpid())
+		if err != nil {
+			t.Fatalf("failed to get own pgid: %v", err)
+		}
+		childPgid, err := syscall.Getpgid(cmd.Process.Pid)
+		if err != nil {
+			t.Fatalf("failed to get child pgid: %v", err)
+		}
+		if childPgid == ownPgid {
+			t.Errorf("expected child to be in its own process group, got the test process's group %d", ownPgid)
+		}
+	})
+
+	t.Run("TerminatesTheChildEvenThoughItIsInADifferentProcessGroup", func(t *testing.T) {
+		cmd := exec.Command("sleep", "5")
+		setProcessGroup(cmd)
+
+		if err := cmd.Start(); err != nil {
+			t.Fatalf("failed to start test process: %v", err)
+		}
+
+		if err := interruptProcessGroup(cmd); err != nil {
+			_ = cmd.Process.Kill()
+			t.Fatalf("interruptProcessGroup returned an error: %v", err)
+		}
+
+		waitErr := make(chan error, 1)
+		go func() { waitErr <- cmd.Wait() }()
+
+		select {
+		case err := <-waitErr:
+			if err == nil {
+				t.Error("expected the child to exit with an error from the delivered signal, got nil")
+			}
+		case <-time.After(2 * time.Second):
+			_ = cmd.Process.Kill()
+			t.Fatal("child did not exit after interruptProcessGroup")
+		}
+	})
+
+	t.Run("NoOpWhenTheProcessHasNotStarted", func(t *testing.T) {
+		cmd := exec.Command("sleep", "5")
+		if err := interruptProcessGroup(cmd); err != nil {
+			t.Errorf("expected no error for an unstarted process, got %v", err)
 		}
 	})
 }

--- a/pkg/runtime/shell/unix_shell_test.go
+++ b/pkg/runtime/shell/unix_shell_test.go
@@ -407,9 +407,9 @@ func TestDefaultShell_PrintEnvVars(t *testing.T) {
 	})
 }
 
-// TestSetProcessGroup_InterruptProcessGroup verifies the real syscalls behind the interrupt
-// guard: a command placed in its own process group survives outside that group's signal
-// delivery, and interruptProcessGroup can still reach and terminate it directly.
+// TestSetProcessGroup_InterruptProcessGroup verifies the real syscalls behind the
+// interrupt guard. A command in its own process group sits outside the test
+// process's signal delivery. interruptProcessGroup can still reach and terminate it.
 func TestSetProcessGroup_InterruptProcessGroup(t *testing.T) {
 	t.Run("PlacesTheChildInADifferentProcessGroupFromTheTestProcess", func(t *testing.T) {
 		cmd := exec.Command("sleep", "5")

--- a/pkg/runtime/shell/windows_shell.go
+++ b/pkg/runtime/shell/windows_shell.go
@@ -92,16 +92,15 @@ func (s *DefaultShell) ExecSudo(message string, command string, args ...string) 
 	return s.Exec(command, args...)
 }
 
-// setProcessGroup places cmd in its own console process group so a second terminal interrupt
-// (Ctrl+C) is not also delivered to it directly — only the one an interruptGuard forwards via
-// interruptProcessGroup reaches it.
+// setProcessGroup places cmd in its own console process group. A second terminal
+// interrupt then reaches cmd only through interruptGuard's call to interruptProcessGroup.
 func setProcessGroup(cmd *exec.Cmd) {
 	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windows.CREATE_NEW_PROCESS_GROUP}
 }
 
-// interruptProcessGroup sends CTRL_BREAK_EVENT to cmd's console process group. Windows has no
-// SIGINT to relay directly; a process in its own process group (set by setProcessGroup) receives
-// CTRL_BREAK_EVENT the same way it would receive Ctrl+C in the foreground group.
+// interruptProcessGroup sends CTRL_BREAK_EVENT to cmd's console process group.
+// Windows has no SIGINT. A process in its own group (set by setProcessGroup)
+// receives CTRL_BREAK_EVENT the way a foreground process receives Ctrl+C.
 func interruptProcessGroup(cmd *exec.Cmd) error {
 	if cmd.Process == nil {
 		return nil

--- a/pkg/runtime/shell/windows_shell.go
+++ b/pkg/runtime/shell/windows_shell.go
@@ -6,8 +6,12 @@ package shell
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"sort"
 	"strings"
+	"syscall"
+
+	"golang.org/x/sys/windows"
 )
 
 // The WindowsShell is a platform-specific implementation of shell operations for Windows systems.
@@ -88,6 +92,22 @@ func (s *DefaultShell) ExecSudo(message string, command string, args ...string) 
 	return s.Exec(command, args...)
 }
 
+// setProcessGroup places cmd in its own console process group so a second terminal interrupt
+// (Ctrl+C) is not also delivered to it directly — only the one an interruptGuard forwards via
+// interruptProcessGroup reaches it.
+func setProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{CreationFlags: windows.CREATE_NEW_PROCESS_GROUP}
+}
+
+// interruptProcessGroup sends CTRL_BREAK_EVENT to cmd's console process group. Windows has no
+// SIGINT to relay directly; a process in its own process group (set by setProcessGroup) receives
+// CTRL_BREAK_EVENT the same way it would receive Ctrl+C in the foreground group.
+func interruptProcessGroup(cmd *exec.Cmd) error {
+	if cmd.Process == nil {
+		return nil
+	}
+	return windows.GenerateConsoleCtrlEvent(windows.CTRL_BREAK_EVENT, uint32(cmd.Process.Pid)) // #nosec G115 -- process IDs are small, safe to cast to uint32
+}
 
 // =============================================================================
 // Private Methods


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> Changes shared shell-execution infrastructure (`pkg/runtime/shell`) used by every progress-tracked command, including Terraform apply and privileged network configuration, so a defect here has wide reach even though the change itself is narrowly scoped.
>
> **Overview**
>
> The PR adds an interrupt guard around `ExecProgressWithEnv`: the child command is placed in its own process group, the first Ctrl+C is relayed to it alone (letting Terraform's own graceful stop run), and any further interrupt is swallowed and merely warned about instead of hard-killing the child. Unix relays via a `SIGINT` to the process group; Windows relays via `CTRL_BREAK_EVENT` to the console process group. `Shims` gains `SignalNotify`/`SignalStop` seams, and both platform files get new unit tests exercising the real syscalls.
>
> The guard writes its warnings straight to `os.Stderr` without pausing the active TUI spinner, and the pre-existing `sudo`-stdin wiring in `ExecProgressWithEnv` is now paired with process-group isolation for the first time — see inline comments for both.

<!-- /claude-code-review:summary -->
