### PR TITLE
fix(terraform): detect a wrapped stale-provider-lock marker

### DIFF
--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -1731,12 +1731,15 @@ var staleProviderLockMarkers = []string{
 }
 
 // isStaleProviderLockError reports whether err is Terraform's stale-provider-lock failure, the
-// one -upgrade actually resolves. See staleProviderLockMarkers.
+// one -upgrade actually resolves. See staleProviderLockMarkers. Terraform's own diagnostic
+// renderer word-wraps its message at a fixed column width, so a marker can straddle a line
+// break in the captured text; whitespace (including newlines) is collapsed before matching so
+// wrap position never affects detection.
 func isStaleProviderLockError(err error) bool {
 	if err == nil {
 		return false
 	}
-	msg := err.Error()
+	msg := strings.Join(strings.Fields(err.Error()), " ")
 	for _, marker := range staleProviderLockMarkers {
 		if !strings.Contains(msg, marker) {
 			return false

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -1990,7 +1990,6 @@ func TestNewShims(t *testing.T) {
 	})
 }
 
-
 func TestTerraformStack_PlanComponentSummary(t *testing.T) {
 	setup := func(t *testing.T) (*TerraformStack, *TerraformTestMocks) {
 		t.Helper()
@@ -2069,7 +2068,6 @@ func TestTerraformStack_PlanComponentSummary(t *testing.T) {
 	})
 
 }
-
 
 // =============================================================================
 // Test Private Methods
@@ -4146,6 +4144,15 @@ func TestIsStaleProviderLockError(t *testing.T) {
 			t.Error("Expected false when only one marker is present")
 		}
 	})
+
+	t.Run("MatchesWhenTerraformWrapsTheMarkerAcrossLines", func(t *testing.T) {
+		// Terraform's diagnostic renderer word-wraps at a fixed column width; here that
+		// wrap lands between "terraform" and "init -upgrade", splitting the second marker.
+		err := fmt.Errorf("Error: Failed to query available provider packages\n\nCould not retrieve the list of available versions for provider\nhashicorp/azurerm: locked provider registry.terraform.io/hashicorp/azurerm\n5.0.1 does not match configured version constraint 5.4.0; must use terraform\ninit -upgrade to allow selection of new versions")
+		if !isStaleProviderLockError(err) {
+			t.Error("Expected true when the marker is split across a wrapped line")
+		}
+	})
 }
 
 func TestNoColorArgs(t *testing.T) {
@@ -5365,4 +5372,3 @@ func TestExtractPlanErrorDiagnostics(t *testing.T) {
 		}
 	})
 }
-


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> The change is isolated to a single error-detection helper in the Terraform provisioner and is fully covered by new unit tests.
>
> **Overview**
>
> This PR fixes `isStaleProviderLockError` in `pkg/provisioner/terraform/stack.go` so it reliably detects Terraform's stale-provider-lock diagnostic even when Terraform's own renderer word-wraps the message and splits one of the two required marker substrings across a line break. The fix normalizes whitespace (collapsing newlines and repeated spaces to single spaces) before running the existing substring checks, rather than changing the detection logic itself.
>
> A new test case, `MatchesWhenTerraformWrapsTheMarkerAcrossLines`, reproduces a wrapped diagnostic where `terraform` and `init -upgrade` land on separate lines and confirms detection still succeeds. The test file also drops a couple of stray blank lines and a trailing blank line unrelated to the fix itself.

<!-- /claude-code-review:summary -->
