### PR TITLE
fix(terraform): refresh a stale provider lock before migrating state

### DIFF
--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -1105,9 +1105,8 @@ func (s *TerraformStack) printComponentHeader(componentPath string) {
 // success, and (false, err) on any other failure. Shared by MigrateState (which
 // tolerates missing dirs by collecting skipped IDs) and MigrateComponentState (which
 // treats a missing dir as an error because the caller is asking for a specific
-// component to be migrated). refreshProviderLock runs first so a provider constraint
-// bumped upstream since this component's last init doesn't surface as an unexplained
-// failure on the one init path that must not silently bump providers itself.
+// component to be migrated). A failed init matching isStaleProviderLockError triggers
+// one refreshProviderLock call, then one retry, so a normal migration stays offline.
 func (s *TerraformStack) migrateOneComponent(component *blueprintv1alpha1.TerraformComponent, backendOverridePaths *[]string) (bool, error) {
 	if _, statErr := s.shims.Stat(component.FullPath); statErr != nil {
 		if os.IsNotExist(statErr) {
@@ -1125,21 +1124,24 @@ func (s *TerraformStack) migrateOneComponent(component *blueprintv1alpha1.Terraf
 		return false, err
 	}
 
-	if err := s.refreshProviderLock(component, terraformVars, scopedKeys); err != nil {
-		return false, err
+	migrateErr := s.runTerraformInit(component, terraformVars, scopedKeys, terraformArgs, "-migrate-state", "-force-copy")
+	if migrateErr != nil && isStaleProviderLockError(migrateErr) {
+		if refreshErr := s.refreshProviderLock(component, terraformVars, scopedKeys); refreshErr != nil {
+			return false, refreshErr
+		}
+		migrateErr = s.runTerraformInit(component, terraformVars, scopedKeys, terraformArgs, "-migrate-state", "-force-copy")
 	}
-
-	if err := s.runTerraformInit(component, terraformVars, scopedKeys, terraformArgs, "-migrate-state", "-force-copy"); err != nil {
-		return false, err
+	if migrateErr != nil {
+		return false, migrateErr
 	}
 	return true, nil
 }
 
-// refreshProviderLock runs `terraform init -upgrade -backend=false` for component, bringing a
-// stale .terraform.lock.hcl current with the module's present provider constraints. -backend=false
-// skips backend configuration entirely, so this never touches state or contends for a state lock —
-// only providers and modules are resolved. Runs independently of runTerraformInit's cache and
-// argument composition, since terraformArgs.InitArgs unconditionally carries -backend=true.
+// refreshProviderLock runs `terraform init -upgrade -backend=false` for component. This
+// brings a stale .terraform.lock.hcl current with the module's present provider
+// constraints. -backend=false skips backend configuration. The call never touches
+// state and never contends for a state lock. It builds its own init args rather than
+// reusing runTerraformInit, since terraformArgs.InitArgs always carries -backend=true.
 func (s *TerraformStack) refreshProviderLock(component *blueprintv1alpha1.TerraformComponent, terraformVars map[string]string, scopedKeys []string) error {
 	terraformCommand := s.runtime.ToolsManager.GetTerraformCommand()
 	initArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "init", "-upgrade", "-backend=false", "-input=false"}

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -1105,7 +1105,9 @@ func (s *TerraformStack) printComponentHeader(componentPath string) {
 // success, and (false, err) on any other failure. Shared by MigrateState (which
 // tolerates missing dirs by collecting skipped IDs) and MigrateComponentState (which
 // treats a missing dir as an error because the caller is asking for a specific
-// component to be migrated).
+// component to be migrated). refreshProviderLock runs first so a provider constraint
+// bumped upstream since this component's last init doesn't surface as an unexplained
+// failure on the one init path that must not silently bump providers itself.
 func (s *TerraformStack) migrateOneComponent(component *blueprintv1alpha1.TerraformComponent, backendOverridePaths *[]string) (bool, error) {
 	if _, statErr := s.shims.Stat(component.FullPath); statErr != nil {
 		if os.IsNotExist(statErr) {
@@ -1123,10 +1125,30 @@ func (s *TerraformStack) migrateOneComponent(component *blueprintv1alpha1.Terraf
 		return false, err
 	}
 
+	if err := s.refreshProviderLock(component, terraformVars, scopedKeys); err != nil {
+		return false, err
+	}
+
 	if err := s.runTerraformInit(component, terraformVars, scopedKeys, terraformArgs, "-migrate-state", "-force-copy"); err != nil {
 		return false, err
 	}
 	return true, nil
+}
+
+// refreshProviderLock runs `terraform init -upgrade -backend=false` for component, bringing a
+// stale .terraform.lock.hcl current with the module's present provider constraints. -backend=false
+// skips backend configuration entirely, so this never touches state or contends for a state lock —
+// only providers and modules are resolved. Runs independently of runTerraformInit's cache and
+// argument composition, since terraformArgs.InitArgs unconditionally carries -backend=true.
+func (s *TerraformStack) refreshProviderLock(component *blueprintv1alpha1.TerraformComponent, terraformVars map[string]string, scopedKeys []string) error {
+	terraformCommand := s.runtime.ToolsManager.GetTerraformCommand()
+	initArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "init", "-upgrade", "-backend=false", "-input=false"}
+	initArgs = append(initArgs, noColorArgs()...)
+	initEnv := selectTerraformCommandEnv(terraformVars, false, scopedKeys)
+	if _, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, initEnv, initArgs...); err != nil {
+		return fmt.Errorf("error refreshing provider lock for %s: %w", component.Path, err)
+	}
+	return nil
 }
 
 // hasResources reports whether this module or any descendant contains a resource in state.

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -836,21 +836,83 @@ func TestStack_MigrateState(t *testing.T) {
 		}
 	})
 
-	t.Run("DoesNotPassUpgradeFlag", func(t *testing.T) {
-		// MigrateState must not include -upgrade: its contract is moving state, not
-		// reinstalling providers or rewriting .terraform.lock.hcl. Execution flags are
-		// added per operation at each call site, and MigrateState's call site passes
-		// only -migrate-state + -force-copy.
+	t.Run("RefreshesProviderLockBeforeMigrating", func(t *testing.T) {
+		// A stale .terraform.lock.hcl left over from a prior init isn't invalidated
+		// when the module's provider constraint changes upstream, and -migrate-state
+		// itself must never carry -upgrade to self-heal it — so refreshProviderLock
+		// must run first, per component, ahead of the -migrate-state init.
 		stack, mocks := setup(t)
 		blueprint := createTestBlueprint()
 
-		var upgradeSeen bool
+		var calls []string
 		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
-			if len(args) >= 2 && args[1] == "init" {
-				for _, a := range args {
-					if a == "-upgrade" {
-						upgradeSeen = true
-					}
+			if len(args) < 2 || args[1] != "init" {
+				return "", nil
+			}
+			switch {
+			case slices.Contains(args, "-migrate-state"):
+				calls = append(calls, "migrate-state")
+			case slices.Contains(args, "-backend=false"):
+				calls = append(calls, "refresh")
+			}
+			return "", nil
+		}
+
+		if _, err := stack.MigrateState(blueprint); err != nil {
+			t.Fatalf("Expected MigrateState to succeed, got %v", err)
+		}
+
+		want := []string{"refresh", "migrate-state", "refresh", "migrate-state"}
+		if !slices.Equal(calls, want) {
+			t.Errorf("Expected refresh before migrate-state for each component, got %v", calls)
+		}
+	})
+
+	t.Run("StopsBeforeMigratingWhenRefreshFails", func(t *testing.T) {
+		// If the pre-flight provider-lock refresh fails, migrateOneComponent must not
+		// fall through to -migrate-state at all — a component whose providers can't
+		// even be resolved has no business attempting a state move.
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+
+		var migrateStateInits int
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) < 2 || args[1] != "init" {
+				return "", nil
+			}
+			if slices.Contains(args, "-migrate-state") {
+				migrateStateInits++
+				return "", nil
+			}
+			return "", fmt.Errorf("registry unreachable")
+		}
+
+		_, err := stack.MigrateState(blueprint)
+		if err == nil {
+			t.Fatal("Expected MigrateState to return an error when the provider-lock refresh fails")
+		}
+		if !strings.Contains(err.Error(), "registry unreachable") {
+			t.Errorf("Expected error to wrap the refresh failure, got: %v", err)
+		}
+		if migrateStateInits != 0 {
+			t.Errorf("Expected no -migrate-state init once the refresh failed, got %d", migrateStateInits)
+		}
+	})
+
+	t.Run("DoesNotPassUpgradeFlag", func(t *testing.T) {
+		// The -migrate-state init call itself must not include -upgrade: its
+		// contract is moving state, not reinstalling providers. The separate,
+		// backend-disconnected refreshProviderLock pre-step legitimately passes
+		// -upgrade before this runs — see TestTerraformStack_refreshProviderLock —
+		// but the migrate-state call must never carry it.
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+
+		var upgradeOnMigrateState bool
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == "init" && slices.Contains(args, "-migrate-state") {
+				if slices.Contains(args, "-upgrade") {
+					upgradeOnMigrateState = true
 				}
 			}
 			return "", nil
@@ -861,9 +923,9 @@ func TestStack_MigrateState(t *testing.T) {
 			t.Fatalf("Expected MigrateState to succeed, got %v", err)
 		}
 
-		// Then no init invocation carried -upgrade
-		if upgradeSeen {
-			t.Error("Expected MigrateState's init not to include -upgrade; state migration must not reinstall providers")
+		// Then the -migrate-state init call never carried -upgrade
+		if upgradeOnMigrateState {
+			t.Error("Expected the -migrate-state init call not to include -upgrade; state migration must not reinstall providers")
 		}
 	})
 
@@ -921,7 +983,7 @@ func TestStack_MigrateState(t *testing.T) {
 		blueprint := createTestBlueprint()
 
 		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
-			if len(args) >= 2 && args[1] == "init" {
+			if len(args) >= 2 && args[1] == "init" && slices.Contains(args, "-migrate-state") {
 				return "", fmt.Errorf("backend not reachable")
 			}
 			return "", nil
@@ -940,17 +1002,19 @@ func TestStack_MigrateState(t *testing.T) {
 	})
 
 	t.Run("HintsAtStaleProviderLockWithoutAddingUpgrade", func(t *testing.T) {
-		// Given a component whose migrate-state init fails with the stale-provider-lock
-		// signature — MigrateState must still never pass -upgrade (cli#3157: the hint is
-		// diagnostic only, not a retry, precisely because this contract must hold)
+		// Given a component whose migrate-state init still fails with the stale-
+		// provider-lock signature even after the pre-flight refreshProviderLock
+		// step succeeds — the -migrate-state call itself must still never pass
+		// -upgrade (cli#3157: the hint is diagnostic only, not a retry, precisely
+		// because this contract must hold)
 		stack, mocks := setup(t)
 		blueprint := createTestBlueprint()
 
-		var sawUpgrade bool
+		var upgradeOnMigrateState bool
 		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
-			if len(args) >= 2 && args[1] == "init" {
+			if len(args) >= 2 && args[1] == "init" && slices.Contains(args, "-migrate-state") {
 				if slices.Contains(args, "-upgrade") {
-					sawUpgrade = true
+					upgradeOnMigrateState = true
 				}
 				return "", fmt.Errorf("Error: Failed to query available provider packages\n\nCould not retrieve the list of available versions for provider hashicorp/aws: locked provider registry.terraform.io/hashicorp/aws 6.47.0 does not match configured version constraint 6.57.1; must use terraform init -upgrade to allow selection of new versions")
 			}
@@ -959,15 +1023,15 @@ func TestStack_MigrateState(t *testing.T) {
 
 		_, err := stack.MigrateState(blueprint)
 
-		// Then the error carries the hint but no init call ever added -upgrade
+		// Then the error carries the hint but the -migrate-state call never added -upgrade
 		if err == nil {
 			t.Fatal("Expected MigrateState to return an error")
 		}
 		if !strings.Contains(err.Error(), "provider version outside the current constraint") && !strings.Contains(err.Error(), "local terraform cache for this component is stale") {
 			t.Errorf("Expected a stale-provider-lock hint, got: %v", err)
 		}
-		if sawUpgrade {
-			t.Error("Expected MigrateState never to pass -upgrade, even when hinting at a stale lock")
+		if upgradeOnMigrateState {
+			t.Error("Expected the -migrate-state init call never to pass -upgrade, even when hinting at a stale lock")
 		}
 	})
 
@@ -1059,13 +1123,8 @@ func TestStack_MigrateComponentState(t *testing.T) {
 		var migrateStateInits int
 		var initChdirs []string
 		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
-			if len(args) >= 2 && args[1] == "init" {
-				for _, a := range args {
-					if a == "-migrate-state" {
-						migrateStateInits++
-						break
-					}
-				}
+			if len(args) >= 2 && args[1] == "init" && slices.Contains(args, "-migrate-state") {
+				migrateStateInits++
 				if strings.HasPrefix(args[0], "-chdir=") {
 					initChdirs = append(initChdirs, strings.TrimPrefix(args[0], "-chdir="))
 				}
@@ -1116,7 +1175,7 @@ func TestStack_MigrateComponentState(t *testing.T) {
 		targetID := blueprint.TerraformComponents[0].GetID()
 
 		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
-			if len(args) >= 2 && args[1] == "init" {
+			if len(args) >= 2 && args[1] == "init" && slices.Contains(args, "-migrate-state") {
 				return "", fmt.Errorf("backend not reachable")
 			}
 			return "", nil
@@ -1990,7 +2049,6 @@ func TestNewShims(t *testing.T) {
 	})
 }
 
-
 func TestTerraformStack_PlanComponentSummary(t *testing.T) {
 	setup := func(t *testing.T) (*TerraformStack, *TerraformTestMocks) {
 		t.Helper()
@@ -2069,7 +2127,6 @@ func TestTerraformStack_PlanComponentSummary(t *testing.T) {
 	})
 
 }
-
 
 // =============================================================================
 // Test Private Methods
@@ -4277,6 +4334,65 @@ contexts:
 	})
 }
 
+func TestTerraformStack_refreshProviderLock(t *testing.T) {
+	setup := func(t *testing.T) (*TerraformStack, *TerraformTestMocks) {
+		t.Helper()
+		mocks := setupWindsorStackMocks(t)
+		stack := NewStack(mocks.Runtime).(*TerraformStack)
+		stack.shims = mocks.Shims
+		return stack, mocks
+	}
+
+	component := &blueprintv1alpha1.TerraformComponent{
+		Path:     "backend/azurerm",
+		FullPath: "/tmp/scratch/terraform/backend",
+	}
+
+	t.Run("RunsUpgradeWithBackendDisabled", func(t *testing.T) {
+		// -backend=false skips backend configuration entirely, so this can never
+		// touch state or contend for a state lock — only providers and modules
+		// are resolved and the lock file is brought current.
+		stack, mocks := setup(t)
+
+		var args []string
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, a ...string) (string, error) {
+			args = a
+			return "", nil
+		}
+
+		if err := stack.refreshProviderLock(component, nil, nil); err != nil {
+			t.Fatalf("expected no error, got %v", err)
+		}
+
+		if !slices.Contains(args, "init") {
+			t.Errorf("expected an init invocation, got %v", args)
+		}
+		for _, want := range []string{"-upgrade", "-backend=false", "-input=false", "-chdir=/tmp/scratch/terraform/backend"} {
+			if !slices.Contains(args, want) {
+				t.Errorf("expected args to contain %q, got %v", want, args)
+			}
+		}
+		if slices.Contains(args, "-migrate-state") {
+			t.Error("expected no -migrate-state flag; this call must never touch state")
+		}
+	})
+
+	t.Run("WrapsTheUnderlyingError", func(t *testing.T) {
+		stack, mocks := setup(t)
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			return "", fmt.Errorf("registry unreachable")
+		}
+
+		err := stack.refreshProviderLock(component, nil, nil)
+		if err == nil {
+			t.Fatal("expected an error")
+		}
+		if !strings.Contains(err.Error(), "backend/azurerm") || !strings.Contains(err.Error(), "registry unreachable") {
+			t.Errorf("expected error to name the component and wrap the cause, got: %v", err)
+		}
+	})
+}
+
 func TestStack_InitCache(t *testing.T) {
 	setup := func(t *testing.T) (*TerraformStack, *TerraformTestMocks) {
 		t.Helper()
@@ -5365,4 +5481,3 @@ func TestExtractPlanErrorDiagnostics(t *testing.T) {
 		}
 	})
 }
-

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -836,24 +836,17 @@ func TestStack_MigrateState(t *testing.T) {
 		}
 	})
 
-	t.Run("RefreshesProviderLockBeforeMigrating", func(t *testing.T) {
-		// A stale .terraform.lock.hcl left over from a prior init isn't invalidated
-		// when the module's provider constraint changes upstream, and -migrate-state
-		// itself must never carry -upgrade to self-heal it — so refreshProviderLock
-		// must run first, per component, ahead of the -migrate-state init.
+	t.Run("DoesNotRefreshWhenMigrateStateSucceeds", func(t *testing.T) {
+		// refreshProviderLock reaches the provider registry. Running it on every call
+		// would break migrate-state in network-restricted or air-gapped environments
+		// that previously worked offline. It must run only after a failed init.
 		stack, mocks := setup(t)
 		blueprint := createTestBlueprint()
 
-		var calls []string
+		var refreshCalls int
 		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
-			if len(args) < 2 || args[1] != "init" {
-				return "", nil
-			}
-			switch {
-			case slices.Contains(args, "-migrate-state"):
-				calls = append(calls, "migrate-state")
-			case slices.Contains(args, "-backend=false"):
-				calls = append(calls, "refresh")
+			if len(args) >= 2 && args[1] == "init" && slices.Contains(args, "-backend=false") {
+				refreshCalls++
 			}
 			return "", nil
 		}
@@ -862,16 +855,47 @@ func TestStack_MigrateState(t *testing.T) {
 			t.Fatalf("Expected MigrateState to succeed, got %v", err)
 		}
 
-		want := []string{"refresh", "migrate-state", "refresh", "migrate-state"}
-		if !slices.Equal(calls, want) {
-			t.Errorf("Expected refresh before migrate-state for each component, got %v", calls)
+		if refreshCalls != 0 {
+			t.Errorf("Expected no provider-lock refresh when migrate-state succeeds, got %d calls", refreshCalls)
 		}
 	})
 
-	t.Run("StopsBeforeMigratingWhenRefreshFails", func(t *testing.T) {
-		// If the pre-flight provider-lock refresh fails, migrateOneComponent must not
-		// fall through to -migrate-state at all — a component whose providers can't
-		// even be resolved has no business attempting a state move.
+	t.Run("RefreshesAndRetriesAfterAStaleLockFailure", func(t *testing.T) {
+		// A stale .terraform.lock.hcl left over from a prior init isn't invalidated
+		// when the module's provider constraint changes upstream, and -migrate-state
+		// must never carry -upgrade to self-heal it. On that specific failure,
+		// migrateOneComponent refreshes the lock once, then retries -migrate-state once.
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+		targetID := blueprint.TerraformComponents[0].GetID()
+
+		var migrateStateInits int
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) < 2 || args[1] != "init" {
+				return "", nil
+			}
+			if slices.Contains(args, "-migrate-state") {
+				migrateStateInits++
+				if migrateStateInits == 1 {
+					return "", fmt.Errorf("Error: Failed to query available provider packages\n\nCould not retrieve the list of available versions for provider hashicorp/aws: locked provider registry.terraform.io/hashicorp/aws 6.47.0 does not match configured version constraint 6.57.1; must use terraform init -upgrade to allow selection of new versions")
+				}
+			}
+			return "", nil
+		}
+
+		if err := stack.MigrateComponentState(blueprint, targetID); err != nil {
+			t.Fatalf("Expected MigrateComponentState to succeed after the retry, got %v", err)
+		}
+
+		if migrateStateInits != 2 {
+			t.Errorf("Expected the -migrate-state init to run once, fail, then run once more, got %d calls", migrateStateInits)
+		}
+	})
+
+	t.Run("StopsAfterAFailedRefresh", func(t *testing.T) {
+		// If the provider-lock refresh itself fails, migrateOneComponent must not
+		// retry -migrate-state at all. A component with unresolved providers
+		// has no business attempting a state move.
 		stack, mocks := setup(t)
 		blueprint := createTestBlueprint()
 
@@ -882,7 +906,7 @@ func TestStack_MigrateState(t *testing.T) {
 			}
 			if slices.Contains(args, "-migrate-state") {
 				migrateStateInits++
-				return "", nil
+				return "", fmt.Errorf("Error: Failed to query available provider packages\n\nCould not retrieve the list of available versions for provider hashicorp/aws: locked provider registry.terraform.io/hashicorp/aws 6.47.0 does not match configured version constraint 6.57.1; must use terraform init -upgrade to allow selection of new versions")
 			}
 			return "", fmt.Errorf("registry unreachable")
 		}
@@ -894,8 +918,8 @@ func TestStack_MigrateState(t *testing.T) {
 		if !strings.Contains(err.Error(), "registry unreachable") {
 			t.Errorf("Expected error to wrap the refresh failure, got: %v", err)
 		}
-		if migrateStateInits != 0 {
-			t.Errorf("Expected no -migrate-state init once the refresh failed, got %d", migrateStateInits)
+		if migrateStateInits != 1 {
+			t.Errorf("Expected exactly one failed -migrate-state init and no retry, got %d", migrateStateInits)
 		}
 	})
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> Changes the shared Terraform state-migration path (`MigrateState`/`MigrateComponentState`) used across every backend bootstrap flow, and alters default behavior for every call rather than an isolated code path.
>
> **Overview**
>
> This PR adds a `refreshProviderLock` pre-flight step that runs `terraform init -upgrade -backend=false` for each component immediately before the existing `-migrate-state -force-copy` init, so a `.terraform.lock.hcl` left stale by an upstream provider-constraint bump gets refreshed without letting `-upgrade` leak into the migrate-state call itself (which must never reinitialize providers). `-backend=false` keeps the refresh from touching state or contending for a backend lock, and a refresh failure now aborts the migration before the state-touching init ever runs.
>
> The main behavioral shift: every migrate-state operation now unconditionally makes a provider-registry (or mirror) round trip that it didn't need before, since previously the migrate-state init relied solely on already-cached providers. In network-restricted or mirror-only environments this is a new failure mode for a previously local-only operation, though it mirrors the `-upgrade` behavior already default on every non-migrate init path. Tests cover ordering, failure propagation, and the no-`-upgrade`-on-migrate contract well.

<!-- /claude-code-review:summary -->
