### PR TITLE
fix(kubernetes): wait for a resumed Kustomization to settle before delete

### DIFF
--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -248,7 +248,7 @@ func (k *BaseKubernetesManager) deleteKustomization(name, namespace string, expe
 
 	entries, inventoryFound := inventoryEntriesFromObject(lastObj)
 	if drained, checkErr := k.allInventoryEntriesGone(entries); inventoryFound && checkErr == nil && drained {
-		return fmt.Errorf("kustomization %s/%s is fully drained (every inventory item confirmed gone) but its own finalizer is stuck; this is Flux bookkeeping, not leaked infrastructure — clear it with `kubectl patch kustomization %s -n %s --type=merge -p '{\"metadata\":{\"finalizers\":null}}'`", namespace, name, name, namespace)
+		return fmt.Errorf("kustomization %s/%s is fully drained (every inventory item confirmed gone) but its own finalizer is stuck. This is Flux bookkeeping, not leaked infrastructure. Clear it with `kubectl patch kustomization %s -n %s --type=merge -p '{\"metadata\":{\"finalizers\":null}}'`", namespace, name, name, namespace)
 	}
 
 	reason := describeStuckKustomization(lastObj) + k.describeStuckHelmReleases(name, namespace)
@@ -1465,7 +1465,9 @@ func (k *BaseKubernetesManager) ApplyBlueprint(blueprint *blueprintv1alpha1.Blue
 // disappears. Phase 2 aborts on the first per-Kustomization failure rather than risk orphaning
 // cloud resources a later Kustomization still needs; a retry picks up where it left off. Every
 // abort path runs abortDestroy first to un-suspend the full eligible set, since
-// Install/ApplyBlueprint never resets spec.suspend on existing objects.
+// Install/ApplyBlueprint never resets spec.suspend on existing objects. waitForResumeReconcile
+// runs between each resume and its delete, giving the resume's own reconcile a chance to settle
+// first.
 func (k *BaseKubernetesManager) DeleteBlueprint(blueprint *blueprintv1alpha1.Blueprint, namespace string) error {
 	defaultSourceName := blueprint.Metadata.Name
 
@@ -1513,6 +1515,7 @@ func (k *BaseKubernetesManager) DeleteBlueprint(blueprint *blueprintv1alpha1.Blu
 			tui.Fail()
 			return k.abortDestroy(eligible, namespace, fmt.Errorf("destroy aborted: failed to resume kustomization %q before delete: %w", kustomization.Name, err))
 		}
+		k.waitForResumeReconcile(kustomization.Name, namespace)
 		destroy := kustomization.Destroy.ToBool()
 		expectWaitForTermination := destroy == nil || *destroy
 		if err := k.deleteKustomization(kustomization.Name, namespace, &expectWaitForTermination); err != nil {
@@ -2144,6 +2147,46 @@ func (k *BaseKubernetesManager) setKustomizationSuspend(name, namespace string, 
 		return err
 	}
 	return nil
+}
+
+// waitForResumeReconcile polls up to kustomizationReconcileSleep for a Kustomization's
+// status.observedGeneration to catch up to metadata.generation after a resume. A resume
+// triggers a reconcile. Deleting before that reconcile settles can race
+// kustomize-controller and strand the object mid-delete. This check is best effort. It
+// returns on any read error or on timeout. Each sleep between polls is capped to the
+// time left in the budget, so it never adds a full kustomizationWaitPollInterval on top
+// of an already-expired deadline. deleteKustomization's own wait loop is the real safety
+// net.
+func (k *BaseKubernetesManager) waitForResumeReconcile(name, namespace string) {
+	deadline := k.shims.TimeNow().Add(k.kustomizationReconcileSleep)
+	for {
+		obj, err := k.client.GetResource(kustomizationsGVR, namespace, name)
+		if err != nil {
+			return
+		}
+		if reconcileGenerationSettled(obj) {
+			return
+		}
+		remaining := deadline.Sub(k.shims.TimeNow())
+		if remaining <= 0 {
+			return
+		}
+		k.shims.TimeSleep(min(k.kustomizationWaitPollInterval, remaining))
+	}
+}
+
+// reconcileGenerationSettled reports whether a Kustomization's status.observedGeneration
+// has caught up to metadata.generation. A match means the most recent spec change has
+// been through a full reconcile.
+func reconcileGenerationSettled(obj *unstructured.Unstructured) bool {
+	if obj == nil {
+		return false
+	}
+	observed, found, err := unstructured.NestedInt64(obj.Object, "status", "observedGeneration")
+	if err != nil || !found {
+		return false
+	}
+	return observed >= obj.GetGeneration()
 }
 
 // resolveScopedGVR resolves gvk to its GroupVersionResource and correct namespace scope

--- a/pkg/provisioner/kubernetes/kubernetes_manager_private_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_private_test.go
@@ -1508,3 +1508,121 @@ func TestBaseKubernetesManager_applyBlueprintOCIRepository(t *testing.T) {
 		}
 	})
 }
+
+func TestBaseKubernetesManager_waitForResumeReconcile(t *testing.T) {
+	setup := func(t *testing.T) *BaseKubernetesManager {
+		t.Helper()
+		mocks := setupKubernetesMocks(t)
+		manager := NewKubernetesManager(mocks.KubernetesClient, mocks.ConfigHandler)
+		manager.kustomizationWaitPollInterval = 10 * time.Millisecond
+		manager.kustomizationReconcileSleep = 30 * time.Millisecond
+		clock := newFakeClock()
+		manager.shims.TimeNow = clock.Now
+		manager.shims.TimeSleep = clock.Sleep
+		return manager
+	}
+
+	staleObj := func() *unstructured.Unstructured {
+		return &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"generation": int64(2)},
+			"status":   map[string]any{"observedGeneration": int64(1)},
+		}}
+	}
+
+	t.Run("ReturnsAsSoonAsGenerationSettles", func(t *testing.T) {
+		// Given a Kustomization whose observedGeneration catches up on the second read
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		calls := 0
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			calls++
+			if calls >= 2 {
+				return &unstructured.Unstructured{Object: map[string]any{
+					"metadata": map[string]any{"generation": int64(2)},
+					"status":   map[string]any{"observedGeneration": int64(2)},
+				}}, nil
+			}
+			return staleObj(), nil
+		}
+		manager.client = kubernetesClient
+
+		// When waiting for the resume to settle
+		manager.waitForResumeReconcile("test-kustomization", "test-namespace")
+
+		// Then it stops polling right after the generations match
+		if calls != 2 {
+			t.Errorf("Expected exactly 2 GetResource calls before settling, got %d", calls)
+		}
+	})
+
+	t.Run("GivesUpAfterTheBudgetWithoutSettling", func(t *testing.T) {
+		// Given a Kustomization whose observedGeneration never catches up
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			return staleObj(), nil
+		}
+		manager.client = kubernetesClient
+
+		// When waiting for the resume to settle, it must return once the fake clock
+		// passes kustomizationReconcileSleep rather than loop forever
+		manager.waitForResumeReconcile("test-kustomization", "test-namespace")
+	})
+
+	t.Run("ReturnsImmediatelyOnAReadError", func(t *testing.T) {
+		// Given the Kustomization can't be read at all
+		manager := setup(t)
+		kubernetesClient := client.NewMockKubernetesClient()
+		calls := 0
+		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
+			calls++
+			return nil, fmt.Errorf("the server could not find the requested resource")
+		}
+		manager.client = kubernetesClient
+
+		// When waiting for the resume to settle
+		manager.waitForResumeReconcile("test-kustomization", "test-namespace")
+
+		// Then it gives up on the first error rather than retrying
+		if calls != 1 {
+			t.Errorf("Expected exactly 1 GetResource call before giving up on error, got %d", calls)
+		}
+	})
+}
+
+func TestReconcileGenerationSettled(t *testing.T) {
+	t.Run("FalseForNilObject", func(t *testing.T) {
+		if reconcileGenerationSettled(nil) {
+			t.Error("Expected false for a nil object")
+		}
+	})
+
+	t.Run("FalseWhenObservedGenerationMissing", func(t *testing.T) {
+		obj := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"generation": int64(2)},
+		}}
+		if reconcileGenerationSettled(obj) {
+			t.Error("Expected false when status.observedGeneration is missing")
+		}
+	})
+
+	t.Run("FalseWhenObservedGenerationLagsBehind", func(t *testing.T) {
+		obj := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"generation": int64(3)},
+			"status":   map[string]any{"observedGeneration": int64(2)},
+		}}
+		if reconcileGenerationSettled(obj) {
+			t.Error("Expected false when observedGeneration lags generation")
+		}
+	})
+
+	t.Run("TrueWhenObservedGenerationCaughtUp", func(t *testing.T) {
+		obj := &unstructured.Unstructured{Object: map[string]any{
+			"metadata": map[string]any{"generation": int64(3)},
+			"status":   map[string]any{"observedGeneration": int64(3)},
+		}}
+		if !reconcileGenerationSettled(obj) {
+			t.Error("Expected true when observedGeneration matches generation")
+		}
+	})
+}

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -5657,9 +5657,10 @@ func TestBaseKubernetesManager_DeleteBlueprint(t *testing.T) {
 		kubernetesClient.GetResourceFunc = func(gvr schema.GroupVersionResource, namespace, name string) (*unstructured.Unstructured, error) {
 			if name == "test-kustomization" {
 				calls++
-				// The first call is remediateLoadBalancerOwners' pre-destroy inventory
-				// snapshot; the delete wait loop's own first check is the second.
-				if calls <= 2 {
+				// Call 1 is remediateLoadBalancerOwners' pre-destroy inventory snapshot,
+				// calls 2-3 are waitForResumeReconcile's checks after resume, and the
+				// delete wait loop's own first check is the fourth.
+				if calls <= 4 {
 					return liveObj, nil
 				}
 				return nil, fmt.Errorf("the server could not find the requested resource")


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> The change is isolated to the Kubernetes provisioner's blueprint-destroy path and adds a bounded, best-effort wait; it does not alter any public API or error behavior on the happy path.
>
> **Overview**
>
> This PR adds `waitForResumeReconcile`, a short bounded poll that waits for a Kustomization's `status.observedGeneration` to catch up to `metadata.generation` after a resume, before `DeleteBlueprint` deletes it. This avoids a race where kustomize-controller has not yet picked up the resume when the delete is issued. The wait is capped at `kustomizationReconcileSleep` (2s), gives up immediately on any read error, and never blocks the destroy flow since it swallows its own timeout rather than returning an error.
>
> A pre-existing error message also gets reformatted to use separate sentences instead of em-dash clauses, matching the Simplified Technical English style used elsewhere for CLI error text.

<!-- /claude-code-review:summary -->
