### PR TITLE
fix(config): refuse a values.yaml write that would drop a section

### DIFF
--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -248,6 +248,36 @@ func TestInit_PreservesUserValuesAcrossInit(t *testing.T) {
 	}
 }
 
+// TestInit_SetPreservesUntouchedNestedValuesInExistingContext guards against the incident that
+// motivated patch writes: a --set against one nested field silently dropping an untouched sibling.
+func TestInit_SetPreservesUntouchedNestedValuesInExistingContext(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "default")
+	helpers.MarkAsGitRepo(t, dir)
+	contextDir := filepath.Join(dir, "contexts", "prod")
+	if err := os.MkdirAll(contextDir, 0755); err != nil {
+		t.Fatalf("expected no error creating context dir, got %v", err)
+	}
+	valuesPath := filepath.Join(contextDir, "values.yaml")
+	initial := "custom:\n    keep: me\n    change: old\nprovider: aws\n"
+	if err := os.WriteFile(valuesPath, []byte(initial), 0644); err != nil {
+		t.Fatalf("expected no error writing initial values.yaml, got %v", err)
+	}
+
+	_, stderr, err := helpers.RunCLI(dir, []string{"init", "prod", "--set", "custom.change=new"}, env)
+	if err != nil {
+		t.Fatalf("init prod --set custom.change=new: %v\nstderr: %s", err, stderr)
+	}
+
+	values := readYAMLFile(t, valuesPath)
+	if changed, ok := getPathValue(values, "custom", "change"); !ok || changed != "new" {
+		t.Errorf("expected custom.change=new, got %v", changed)
+	}
+	if kept, ok := getPathValue(values, "custom", "keep"); !ok || kept != "me" {
+		t.Errorf("expected custom.keep=me to survive the --set untouched, got %v", kept)
+	}
+}
+
 func TestInit_SetContextThenInitUsesSelectedContext(t *testing.T) {
 	t.Parallel()
 	dir, env := helpers.CopyFixtureOnly(t, "default")

--- a/pkg/runtime/config/accessors.go
+++ b/pkg/runtime/config/accessors.go
@@ -267,6 +267,7 @@ func (c *configHandler) Set(path string, value any) error {
 	setValueInMap(c.data, pathKeys, convertedValue)
 
 	if convertedValue == nil && len(pathKeys) == 1 {
+		delete(c.pendingOverrides, pathKeys[0])
 		if c.pendingDeletes == nil {
 			c.pendingDeletes = map[string]bool{}
 		}
@@ -274,6 +275,7 @@ func (c *configHandler) Set(path string, value any) error {
 		return nil
 	}
 
+	delete(c.pendingDeletes, pathKeys[0])
 	if c.pendingOverrides == nil {
 		c.pendingOverrides = map[string]any{}
 	}

--- a/pkg/runtime/config/accessors.go
+++ b/pkg/runtime/config/accessors.go
@@ -234,7 +234,8 @@ func (c *configHandler) GetStringMap(key string, defaultValue ...map[string]stri
 // Set does not validate against the schema; callers that compose configuration via multiple Set calls leave
 // the map in transient states that only satisfy cross-field rules once composition completes. Run
 // ValidateContextValues after composition to surface schema violations. Returns an error if the path is
-// invalid or if value assignment encounters an issue. Changes are in-memory; persist via SaveConfig.
+// invalid or if value assignment encounters an issue. Changes are in-memory; persist via SaveConfig,
+// which also records the path for a later patch write.
 func (c *configHandler) Set(path string, value any) error {
 	if path == "" {
 		return fmt.Errorf("path cannot be empty")
@@ -246,6 +247,19 @@ func (c *configHandler) Set(path string, value any) error {
 	convertedValue := c.convertStringValue(value)
 	pathKeys := parsePath(path)
 	setValueInMap(c.data, pathKeys, convertedValue)
+
+	if convertedValue == nil && len(pathKeys) == 1 {
+		if c.pendingDeletes == nil {
+			c.pendingDeletes = map[string]bool{}
+		}
+		c.pendingDeletes[pathKeys[0]] = true
+		return nil
+	}
+
+	if c.pendingOverrides == nil {
+		c.pendingOverrides = map[string]any{}
+	}
+	setValueInMap(c.pendingOverrides, pathKeys, convertedValue)
 	return nil
 }
 

--- a/pkg/runtime/config/accessors_test.go
+++ b/pkg/runtime/config/accessors_test.go
@@ -248,6 +248,42 @@ additionalProperties: false
 			t.Fatal("Expected validation error from ValidateContextValues for disallowed key")
 		}
 	})
+
+	t.Run("SetAfterDeleteOfSameKeyWinsOverTheDelete", func(t *testing.T) {
+		handler, _ := setupPrivateTestHandler(t)
+
+		if err := handler.Set("provider", nil); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if err := handler.Set("provider", "docker"); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		if handler.pendingDeletes["provider"] {
+			t.Error("Expected the later Set to clear the pending delete")
+		}
+		if got := handler.pendingOverrides["provider"]; got != "docker" {
+			t.Errorf("Expected the later Set to win, got %v", got)
+		}
+	})
+
+	t.Run("DeleteAfterSetOfSameKeyWinsOverTheSet", func(t *testing.T) {
+		handler, _ := setupPrivateTestHandler(t)
+
+		if err := handler.Set("provider", "docker"); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if err := handler.Set("provider", nil); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		if _, exists := handler.pendingOverrides["provider"]; exists {
+			t.Error("Expected the later delete to clear the pending override")
+		}
+		if !handler.pendingDeletes["provider"] {
+			t.Error("Expected the delete to be pending")
+		}
+	})
 }
 
 func TestConfigHandler_AccessorTypeCoercionHelpers(t *testing.T) {

--- a/pkg/runtime/config/handler.go
+++ b/pkg/runtime/config/handler.go
@@ -93,6 +93,10 @@ type configHandler struct {
 	defaultConfig   *v1alpha1.Context
 	providers       map[string]ValueProvider
 
+	// pendingOverrides and pendingDeletes feed SaveConfig's patch write.
+	pendingOverrides map[string]any
+	pendingDeletes   map[string]bool
+
 	// applySchemaDefaults forces schema-default materialization in GetContextValues even for a
 	// test context, which otherwise skips it. Consumers that want the production composition path
 	// under a test context (the facet test runner, per case) set this; it is a no-op elsewhere.
@@ -268,11 +272,9 @@ func (c *configHandler) LoadConfigForContext(contextName string) error {
 	return nil
 }
 
-// SaveConfig writes the current configuration state to a single values.yaml file within the
-// context directory under the project root. The root windsor.yaml is created if missing.
-// Context-level windsor.yaml is no longer generated; all context configuration goes to values.yaml.
-// If overwrite is specified, an existing values.yaml will be overwritten; otherwise, it is only
-// created if missing. Returns an error if writing fails or required dependencies are uninitialized.
+// SaveConfig writes the current configuration to values.yaml for the context, creating the root
+// windsor.yaml first if missing. A missing values.yaml gets the full config; an existing one is
+// patched at Set-touched paths when overwrite is true, and left alone otherwise.
 func (c *configHandler) SaveConfig(overwrite ...bool) error {
 	if c.shell == nil {
 		return fmt.Errorf("shell not initialized")
@@ -294,10 +296,17 @@ func (c *configHandler) SaveConfig(overwrite ...bool) error {
 		}
 	}
 
+	deletes := make([]string, 0, len(c.pendingDeletes))
+	for key := range c.pendingDeletes {
+		deletes = append(deletes, key)
+	}
+
 	if err := c.values.Save(
 		projectRoot,
 		c.GetContext(),
 		c.data,
+		c.pendingOverrides,
+		deletes,
 		shouldOverwrite,
 		c.getPersistencePolicyInput(),
 	); err != nil {
@@ -413,6 +422,8 @@ func (c *configHandler) WithContext(name string) ConfigHandler {
 	cp.context = name
 	cp.data = maps.Clone(c.data)
 	cp.providers = maps.Clone(c.providers)
+	cp.pendingOverrides = maps.Clone(c.pendingOverrides)
+	cp.pendingDeletes = maps.Clone(c.pendingDeletes)
 	return &cp
 }
 

--- a/pkg/runtime/config/handler.go
+++ b/pkg/runtime/config/handler.go
@@ -275,7 +275,8 @@ func (c *configHandler) LoadConfigForContext(contextName string) error {
 
 // SaveConfig writes the current configuration to values.yaml for the context, creating the root
 // windsor.yaml first if missing. A missing values.yaml gets the full config; an existing one is
-// patched at Set-touched paths when overwrite is true, and left alone otherwise.
+// patched at Set-touched paths when overwrite is true, and left alone otherwise. A successful
+// write clears the pending Set paths, so a later SaveConfig only patches what changed since.
 func (c *configHandler) SaveConfig(overwrite ...bool) error {
 	if c.shell == nil {
 		return fmt.Errorf("shell not initialized")
@@ -302,7 +303,7 @@ func (c *configHandler) SaveConfig(overwrite ...bool) error {
 		deletes = append(deletes, key)
 	}
 
-	if err := c.values.Save(
+	wrote, err := c.values.Save(
 		projectRoot,
 		c.GetContext(),
 		c.data,
@@ -310,8 +311,13 @@ func (c *configHandler) SaveConfig(overwrite ...bool) error {
 		deletes,
 		shouldOverwrite,
 		c.getPersistencePolicyInput(),
-	); err != nil {
+	)
+	if err != nil {
 		return err
+	}
+	if wrote {
+		c.pendingOverrides = nil
+		c.pendingDeletes = nil
 	}
 
 	return nil
@@ -416,15 +422,16 @@ func (c *configHandler) GetContext() string {
 // WithContext returns a new ConfigHandler that is a shallow copy of the receiver with an
 // in-memory context override applied. The override takes highest priority in GetContext,
 // bypassing the .windsor/context file and the WINDSOR_CONTEXT env var. The original handler
-// is not modified. Maps (data, providers) are copied shallowly to prevent aliasing.
+// is not modified. Maps (data, providers) are copied shallowly to prevent aliasing. Pending
+// Set paths are not carried over: they target the receiver's own values.yaml, not the copy's.
 // Use this for ephemeral overrides (e.g. windsor test) that must not touch the filesystem.
 func (c *configHandler) WithContext(name string) ConfigHandler {
 	cp := *c
 	cp.context = name
 	cp.data = maps.Clone(c.data)
 	cp.providers = maps.Clone(c.providers)
-	cp.pendingOverrides = maps.Clone(c.pendingOverrides)
-	cp.pendingDeletes = maps.Clone(c.pendingDeletes)
+	cp.pendingOverrides = nil
+	cp.pendingDeletes = nil
 	return &cp
 }
 

--- a/pkg/runtime/config/handler_test.go
+++ b/pkg/runtime/config/handler_test.go
@@ -721,6 +721,11 @@ properties:
 		valuesPath := filepath.Join(contextDir, "values.yaml")
 		os.WriteFile(valuesPath, []byte("existing_key: old_value\n"), 0644)
 
+		// LoadConfig first, as every real caller does, so existing_key carries into
+		// c.data. A save that never loaded it would look like a drop otherwise.
+		if err := handler.LoadConfig(); err != nil {
+			t.Fatalf("Expected no error loading config, got %v", err)
+		}
 		handler.Set("dynamic_key", "new_value")
 		if err := handler.SaveConfig(); err != nil {
 			t.Fatalf("Expected no error saving without overwrite, got %v", err)

--- a/pkg/runtime/config/handler_test.go
+++ b/pkg/runtime/config/handler_test.go
@@ -744,6 +744,41 @@ properties:
 		}
 	})
 
+	t.Run("ClearsPendingWritesAfterASuccessfulSaveSoALaterSaveDoesNotReapplyAStaleDelete", func(t *testing.T) {
+		handler, tmpDir := setupPrivateTestHandler(t)
+		handler.SetContext("test-context")
+		contextDir := filepath.Join(tmpDir, "contexts", "test-context")
+		os.MkdirAll(contextDir, 0755)
+		valuesPath := filepath.Join(contextDir, "values.yaml")
+		os.WriteFile(valuesPath, []byte("provider: docker\n"), 0644)
+
+		if err := handler.LoadConfig(); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		handler.Set("provider", nil)
+		if err := handler.SaveConfig(true); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		firstSave, _ := os.ReadFile(valuesPath)
+		if contains(string(firstSave), "provider:") {
+			t.Fatalf("Expected provider removed by the first save, got:\n%s", string(firstSave))
+		}
+
+		// Something else legitimately writes provider back afterward. A later save,
+		// triggered by an unrelated Set, must not silently strip it again just
+		// because it was deleted once, earlier in this handler's life.
+		os.WriteFile(valuesPath, []byte("provider: docker\nid: abc123\n"), 0644)
+		handler.Set("id", "abc123")
+		if err := handler.SaveConfig(true); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		secondSave, _ := os.ReadFile(valuesPath)
+		if !contains(string(secondSave), "provider: docker") {
+			t.Errorf("Expected the stale delete not to reapply on a later save, got:\n%s", string(secondSave))
+		}
+	})
+
 	t.Run("SaveAndReloadPreservesExplicitData", func(t *testing.T) {
 		handler, _ := setupPrivateTestHandler(t)
 		handler.SetContext("save-test")
@@ -1776,6 +1811,21 @@ func TestConfigHandler_WithContext(t *testing.T) {
 
 		if context != "override-context" {
 			t.Errorf("Expected 'override-context', got '%s'", context)
+		}
+	})
+
+	t.Run("DoesNotCarryPendingWritesToTheCopy", func(t *testing.T) {
+		handler, _ := setupPrivateTestHandler(t)
+		handler.Set("provider", "docker")
+		handler.Set("provider", nil)
+
+		override := handler.WithContext("override-context").(*configHandler)
+
+		if len(override.pendingOverrides) != 0 {
+			t.Errorf("Expected no pending overrides on the copy, got %v", override.pendingOverrides)
+		}
+		if len(override.pendingDeletes) != 0 {
+			t.Errorf("Expected no pending deletes on the copy, got %v", override.pendingDeletes)
 		}
 	})
 }

--- a/pkg/runtime/config/persistence_policy.go
+++ b/pkg/runtime/config/persistence_policy.go
@@ -106,6 +106,21 @@ func (p *persistencePolicy) isWorkstationManagedKey(key string) bool {
 	return false
 }
 
+// volatileTopLevelKeys lists top-level keys this policy may relocate or discard depending on
+// input (see shouldPersistPlatform) or the provider→platform migration in Runtime.SaveConfig.
+// Their absence from one save compared to an earlier one is never itself evidence of dropped
+// data, unlike an ordinary key such as "terraform".
+var volatileTopLevelKeys = map[string]bool{
+	"provider": true,
+	"platform": true,
+}
+
+// isVolatile reports whether key is a top-level key Partition may legitimately relocate or
+// discard on its own, independent of isWorkstationManagedKey.
+func (p *persistencePolicy) isVolatile(key string) bool {
+	return volatileTopLevelKeys[key] || p.isWorkstationManagedKey(key)
+}
+
 // networkCIDRBlock extracts the cidr_block field from a network config map, if present.
 func networkCIDRBlock(value any) (any, bool) {
 	network, ok := value.(map[string]any)

--- a/pkg/runtime/config/persistence_policy.go
+++ b/pkg/runtime/config/persistence_policy.go
@@ -106,21 +106,6 @@ func (p *persistencePolicy) isWorkstationManagedKey(key string) bool {
 	return false
 }
 
-// volatileTopLevelKeys lists top-level keys this policy may relocate or discard depending on
-// input (see shouldPersistPlatform) or the provider→platform migration in Runtime.SaveConfig.
-// Their absence from one save compared to an earlier one is never itself evidence of dropped
-// data, unlike an ordinary key such as "terraform".
-var volatileTopLevelKeys = map[string]bool{
-	"provider": true,
-	"platform": true,
-}
-
-// isVolatile reports whether key is a top-level key Partition may legitimately relocate or
-// discard on its own, independent of isWorkstationManagedKey.
-func (p *persistencePolicy) isVolatile(key string) bool {
-	return volatileTopLevelKeys[key] || p.isWorkstationManagedKey(key)
-}
-
 // networkCIDRBlock extracts the cidr_block field from a network config map, if present.
 func networkCIDRBlock(value any) (any, bool) {
 	network, ok := value.(map[string]any)

--- a/pkg/runtime/config/values_source.go
+++ b/pkg/runtime/config/values_source.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 )
 
 // The ValuesSource is a configuration source for context values.yaml files.
@@ -101,6 +102,13 @@ func (s *valuesSource) Save(
 	}
 
 	partition := s.policy.Partition(data, input)
+
+	if valuesExists {
+		if dropped := s.droppedTopLevelKeys(valuesPath, partition.Values); len(dropped) > 0 {
+			return fmt.Errorf("refusing to write values.yaml for context %q: this write would drop top-level section(s) %v present in the current file. This looks like a bug, not an intended change. No changes were written", contextName, dropped)
+		}
+	}
+
 	marshaled, err := s.shims.YamlMarshal(partition.Values)
 	if err != nil {
 		return fmt.Errorf("error marshalling values.yaml: %w", err)
@@ -111,4 +119,39 @@ func (s *valuesSource) Save(
 	}
 
 	return nil
+}
+
+// =============================================================================
+// Private Methods
+// =============================================================================
+
+// droppedTopLevelKeys compares the top-level keys already on disk at valuesPath against next,
+// the map about to be written, and returns any key present on disk but absent from next. Save
+// persists the full merged config, a superset of disk by construction, so a legitimate write
+// should never produce a strict subset of the prior top-level keys. isVolatile keys are skipped,
+// since the policy may relocate or discard those on its own. An unreadable or unparseable
+// existing file returns no dropped keys rather than blocking the write, since there is nothing
+// trustworthy left to compare against.
+func (s *valuesSource) droppedTopLevelKeys(valuesPath string, next map[string]any) []string {
+	current, err := s.shims.ReadFile(valuesPath)
+	if err != nil {
+		return nil
+	}
+
+	var existing map[string]any
+	if err := s.shims.YamlUnmarshal(current, &existing); err != nil {
+		return nil
+	}
+
+	var dropped []string
+	for key := range existing {
+		if s.policy.isVolatile(key) {
+			continue
+		}
+		if _, ok := next[key]; !ok {
+			dropped = append(dropped, key)
+		}
+	}
+	sort.Strings(dropped)
+	return dropped
 }

--- a/pkg/runtime/config/values_source.go
+++ b/pkg/runtime/config/values_source.go
@@ -130,10 +130,11 @@ func (s *valuesSource) Save(
 // missing from next. It walks into nested maps rather than stopping at the top level, since a
 // field buried inside a section that itself survives the write is just as much a loss as the
 // whole section disappearing. Save persists the full merged config, a superset of disk by
-// construction, so a legitimate write should never lose a path that was there before. isVolatile
-// keys are skipped at every depth, since the policy may relocate or discard those on its own. An
-// unreadable or unparseable existing file returns no dropped keys rather than blocking the write,
-// since there is nothing trustworthy left to compare against.
+// construction, so a legitimate write should never lose a path that was there before. A
+// top-level isVolatile key is skipped, since the policy may relocate or discard those on its
+// own; the same name reappearing nested is an unrelated field and is not exempted. An
+// unreadable or unparseable existing file returns no dropped keys rather than blocking the
+// write, since there is nothing trustworthy left to compare against.
 func (s *valuesSource) droppedKeys(valuesPath string, next map[string]any) []string {
 	current, err := s.shims.ReadFile(valuesPath)
 	if err != nil {
@@ -154,11 +155,13 @@ func (s *valuesSource) droppedKeys(valuesPath string, next map[string]any) []str
 // path with prefix so a nested miss reads as "terraform.backend.type" rather than bare "type".
 // A key present in existing but absent from next is dropped outright. A key present in both as a
 // map recurses; a key present in both as anything else is left alone, since droppedKeys only
-// tracks disappearance, not value changes.
+// tracks disappearance, not value changes. isVolatile only exempts a top-level key (prefix ""),
+// matching its own top-level-only contract; a nested key that happens to share a volatile name
+// (e.g. "secrets.provider") is an unrelated field and is tracked like any other.
 func (s *valuesSource) droppedKeysIn(prefix string, existing, next map[string]any) []string {
 	var dropped []string
 	for key, existingValue := range existing {
-		if s.policy.isVolatile(key) {
+		if prefix == "" && s.policy.isVolatile(key) {
 			continue
 		}
 

--- a/pkg/runtime/config/values_source.go
+++ b/pkg/runtime/config/values_source.go
@@ -104,8 +104,8 @@ func (s *valuesSource) Save(
 	partition := s.policy.Partition(data, input)
 
 	if valuesExists {
-		if dropped := s.droppedTopLevelKeys(valuesPath, partition.Values); len(dropped) > 0 {
-			return fmt.Errorf("refusing to write values.yaml for context %q: this write would drop top-level section(s) %v present in the current file. This looks like a bug, not an intended change. No changes were written", contextName, dropped)
+		if dropped := s.droppedKeys(valuesPath, partition.Values); len(dropped) > 0 {
+			return fmt.Errorf("refusing to write values.yaml for context %q: this write would drop %v present in the current file. This looks like a bug, not an intended change. No changes were written", contextName, dropped)
 		}
 	}
 
@@ -125,14 +125,16 @@ func (s *valuesSource) Save(
 // Private Methods
 // =============================================================================
 
-// droppedTopLevelKeys compares the top-level keys already on disk at valuesPath against next,
-// the map about to be written, and returns any key present on disk but absent from next. Save
-// persists the full merged config, a superset of disk by construction, so a legitimate write
-// should never produce a strict subset of the prior top-level keys. isVolatile keys are skipped,
-// since the policy may relocate or discard those on its own. An unreadable or unparseable
-// existing file returns no dropped keys rather than blocking the write, since there is nothing
-// trustworthy left to compare against.
-func (s *valuesSource) droppedTopLevelKeys(valuesPath string, next map[string]any) []string {
+// droppedKeys compares the file already on disk at valuesPath against next, the map about to be
+// written, and returns each dotted path (e.g. "terraform.backend.type") present on disk but
+// missing from next. It walks into nested maps rather than stopping at the top level, since a
+// field buried inside a section that itself survives the write is just as much a loss as the
+// whole section disappearing. Save persists the full merged config, a superset of disk by
+// construction, so a legitimate write should never lose a path that was there before. isVolatile
+// keys are skipped at every depth, since the policy may relocate or discard those on its own. An
+// unreadable or unparseable existing file returns no dropped keys rather than blocking the write,
+// since there is nothing trustworthy left to compare against.
+func (s *valuesSource) droppedKeys(valuesPath string, next map[string]any) []string {
 	current, err := s.shims.ReadFile(valuesPath)
 	if err != nil {
 		return nil
@@ -143,15 +145,39 @@ func (s *valuesSource) droppedTopLevelKeys(valuesPath string, next map[string]an
 		return nil
 	}
 
+	dropped := s.droppedKeysIn("", existing, next)
+	sort.Strings(dropped)
+	return dropped
+}
+
+// droppedKeysIn walks one level of the comparison droppedKeys performs, prefixing every reported
+// path with prefix so a nested miss reads as "terraform.backend.type" rather than bare "type".
+// A key present in existing but absent from next is dropped outright. A key present in both as a
+// map recurses; a key present in both as anything else is left alone, since droppedKeys only
+// tracks disappearance, not value changes.
+func (s *valuesSource) droppedKeysIn(prefix string, existing, next map[string]any) []string {
 	var dropped []string
-	for key := range existing {
+	for key, existingValue := range existing {
 		if s.policy.isVolatile(key) {
 			continue
 		}
-		if _, ok := next[key]; !ok {
-			dropped = append(dropped, key)
+
+		path := key
+		if prefix != "" {
+			path = prefix + "." + key
+		}
+
+		nextValue, ok := next[key]
+		if !ok {
+			dropped = append(dropped, path)
+			continue
+		}
+
+		if existingMap, isMap := existingValue.(map[string]any); isMap {
+			if nextMap, isMap := nextValue.(map[string]any); isMap {
+				dropped = append(dropped, s.droppedKeysIn(path, existingMap, nextMap)...)
+			}
 		}
 	}
-	sort.Strings(dropped)
 	return dropped
 }

--- a/pkg/runtime/config/values_source.go
+++ b/pkg/runtime/config/values_source.go
@@ -77,6 +77,8 @@ func (s *valuesSource) Load(projectRoot, contextName string) (map[string]any, bo
 }
 
 // Save writes values.yaml for a context, patching an existing file at overrides/deletes only.
+// wrote reports whether a write actually happened, so a caller tracking pending writes knows
+// whether they were consumed or are still outstanding.
 func (s *valuesSource) Save(
 	projectRoot string,
 	contextName string,
@@ -85,14 +87,14 @@ func (s *valuesSource) Save(
 	deletes []string,
 	overwrite bool,
 	input persistencePolicyInput,
-) error {
+) (wrote bool, err error) {
 	contextDir := filepath.Join(projectRoot, "contexts", contextName)
 	if err := s.shims.MkdirAll(contextDir, 0755); err != nil {
-		return fmt.Errorf("error creating context directory: %w", err)
+		return false, fmt.Errorf("error creating context directory: %w", err)
 	}
 
 	if len(data) == 0 {
-		return nil
+		return false, nil
 	}
 
 	valuesPath := filepath.Join(contextDir, "values.yaml")
@@ -102,7 +104,7 @@ func (s *valuesSource) Save(
 	}
 
 	if valuesExists && !overwrite {
-		return nil
+		return false, nil
 	}
 
 	partition := s.policy.Partition(data, input)
@@ -113,14 +115,14 @@ func (s *valuesSource) Save(
 
 	marshaled, err := s.shims.YamlMarshal(partition.Values)
 	if err != nil {
-		return fmt.Errorf("error marshalling values.yaml: %w", err)
+		return false, fmt.Errorf("error marshalling values.yaml: %w", err)
 	}
 
 	if err := s.shims.WriteFile(valuesPath, marshaled, 0644); err != nil {
-		return fmt.Errorf("error writing values.yaml: %w", err)
+		return false, fmt.Errorf("error writing values.yaml: %w", err)
 	}
 
-	return nil
+	return true, nil
 }
 
 // =============================================================================
@@ -129,29 +131,29 @@ func (s *valuesSource) Save(
 
 // patchValues merges overrides and removes deletes at valuesPath, or writes fullValues whole
 // when the existing file can't be parsed.
-func (s *valuesSource) patchValues(valuesPath string, overrides map[string]any, deletes []string, fullValues map[string]any, input persistencePolicyInput) error {
+func (s *valuesSource) patchValues(valuesPath string, overrides map[string]any, deletes []string, fullValues map[string]any, input persistencePolicyInput) (bool, error) {
 	overridesPartition := s.policy.Partition(overrides, input)
 	if len(overridesPartition.Values) == 0 && len(deletes) == 0 {
-		return nil
+		return false, nil
 	}
 
 	merged, patchable := s.mergedValuesYAML(valuesPath, overridesPartition.Values, deletes)
 	if !patchable {
 		if len(fullValues) == 0 {
-			return nil
+			return false, nil
 		}
 		var err error
 		merged, err = s.shims.YamlMarshal(fullValues)
 		if err != nil {
-			return fmt.Errorf("error marshalling values.yaml: %w", err)
+			return false, fmt.Errorf("error marshalling values.yaml: %w", err)
 		}
 	}
 
 	if err := s.shims.WriteFile(valuesPath, merged, 0644); err != nil {
-		return fmt.Errorf("error writing values.yaml: %w", err)
+		return false, fmt.Errorf("error writing values.yaml: %w", err)
 	}
 
-	return nil
+	return true, nil
 }
 
 // mergedValuesYAML merges overrideValues and deletes into valuesPath's content, or false if

--- a/pkg/runtime/config/values_source.go
+++ b/pkg/runtime/config/values_source.go
@@ -4,13 +4,15 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
+	"strings"
+
+	"github.com/goccy/go-yaml/ast"
+	"github.com/goccy/go-yaml/parser"
 )
 
 // The ValuesSource is a configuration source for context values.yaml files.
-// It provides load and save operations for dynamic context configuration values,
-// The ValuesSource applies schema validation warnings during load and workstation filtering on save,
-// and keeps values.yaml persistence behavior isolated from handler orchestration.
+// It loads and saves dynamic context configuration values.
+// Save patches an existing file at changed paths only; other writes are full.
 
 // =============================================================================
 // Types
@@ -74,11 +76,13 @@ func (s *valuesSource) Load(projectRoot, contextName string) (map[string]any, bo
 	return values, true, nil
 }
 
-// Save writes values.yaml for a context, with optional overwrite and workstation-key cleaning.
+// Save writes values.yaml for a context, patching an existing file at overrides/deletes only.
 func (s *valuesSource) Save(
 	projectRoot string,
 	contextName string,
 	data map[string]any,
+	overrides map[string]any,
+	deletes []string,
 	overwrite bool,
 	input persistencePolicyInput,
 ) error {
@@ -104,9 +108,7 @@ func (s *valuesSource) Save(
 	partition := s.policy.Partition(data, input)
 
 	if valuesExists {
-		if dropped := s.droppedKeys(valuesPath, partition.Values); len(dropped) > 0 {
-			return fmt.Errorf("refusing to write values.yaml for context %q: this write would drop %v present in the current file. This looks like a bug, not an intended change. No changes were written", contextName, dropped)
-		}
+		return s.patchValues(valuesPath, overrides, deletes, partition.Values, input)
 	}
 
 	marshaled, err := s.shims.YamlMarshal(partition.Values)
@@ -125,62 +127,117 @@ func (s *valuesSource) Save(
 // Private Methods
 // =============================================================================
 
-// droppedKeys compares the file already on disk at valuesPath against next, the map about to be
-// written, and returns each dotted path (e.g. "terraform.backend.type") present on disk but
-// missing from next. It walks into nested maps rather than stopping at the top level, since a
-// field buried inside a section that itself survives the write is just as much a loss as the
-// whole section disappearing. Save persists the full merged config, a superset of disk by
-// construction, so a legitimate write should never lose a path that was there before. A
-// top-level isVolatile key is skipped, since the policy may relocate or discard those on its
-// own; the same name reappearing nested is an unrelated field and is not exempted. An
-// unreadable or unparseable existing file returns no dropped keys rather than blocking the
-// write, since there is nothing trustworthy left to compare against.
-func (s *valuesSource) droppedKeys(valuesPath string, next map[string]any) []string {
-	current, err := s.shims.ReadFile(valuesPath)
-	if err != nil {
+// patchValues merges overrides and removes deletes at valuesPath, or writes fullValues whole
+// when the existing file can't be parsed.
+func (s *valuesSource) patchValues(valuesPath string, overrides map[string]any, deletes []string, fullValues map[string]any, input persistencePolicyInput) error {
+	overridesPartition := s.policy.Partition(overrides, input)
+	if len(overridesPartition.Values) == 0 && len(deletes) == 0 {
 		return nil
 	}
 
-	var existing map[string]any
-	if err := s.shims.YamlUnmarshal(current, &existing); err != nil {
-		return nil
+	merged, patchable := s.mergedValuesYAML(valuesPath, overridesPartition.Values, deletes)
+	if !patchable {
+		if len(fullValues) == 0 {
+			return nil
+		}
+		var err error
+		merged, err = s.shims.YamlMarshal(fullValues)
+		if err != nil {
+			return fmt.Errorf("error marshalling values.yaml: %w", err)
+		}
 	}
 
-	dropped := s.droppedKeysIn("", existing, next)
-	sort.Strings(dropped)
-	return dropped
+	if err := s.shims.WriteFile(valuesPath, merged, 0644); err != nil {
+		return fmt.Errorf("error writing values.yaml: %w", err)
+	}
+
+	return nil
 }
 
-// droppedKeysIn walks one level of the comparison droppedKeys performs, prefixing every reported
-// path with prefix so a nested miss reads as "terraform.backend.type" rather than bare "type".
-// A key present in existing but absent from next is dropped outright. A key present in both as a
-// map recurses; a key present in both as anything else is left alone, since droppedKeys only
-// tracks disappearance, not value changes. isVolatile only exempts a top-level key (prefix ""),
-// matching its own top-level-only contract; a nested key that happens to share a volatile name
-// (e.g. "secrets.provider") is an unrelated field and is tracked like any other.
-func (s *valuesSource) droppedKeysIn(prefix string, existing, next map[string]any) []string {
-	var dropped []string
-	for key, existingValue := range existing {
-		if prefix == "" && s.policy.isVolatile(key) {
-			continue
-		}
+// mergedValuesYAML merges overrideValues and deletes into valuesPath's content, or false if
+// either side fails to parse as a YAML mapping.
+func (s *valuesSource) mergedValuesYAML(valuesPath string, overrideValues map[string]any, deletes []string) ([]byte, bool) {
+	current, err := s.shims.ReadFile(valuesPath)
+	if err != nil {
+		return nil, false
+	}
 
-		path := key
-		if prefix != "" {
-			path = prefix + "." + key
-		}
+	dstMap, ok := parseRootMapping(current)
+	if !ok {
+		return nil, false
+	}
 
-		nextValue, ok := next[key]
+	if len(overrideValues) > 0 {
+		srcBytes, err := s.shims.YamlMarshal(overrideValues)
+		if err != nil {
+			return nil, false
+		}
+		srcMap, ok := parseRootMapping(srcBytes)
 		if !ok {
-			dropped = append(dropped, path)
+			return nil, false
+		}
+		mergeMappingNodes(dstMap, srcMap)
+	}
+
+	removeMappingKeys(dstMap, deletes)
+
+	rendered := dstMap.String()
+	if !strings.HasSuffix(rendered, "\n") {
+		rendered += "\n"
+	}
+	return []byte(rendered), true
+}
+
+// parseRootMapping parses source and returns its root mapping node, or false on failure.
+func parseRootMapping(source []byte) (*ast.MappingNode, bool) {
+	file, err := parser.ParseBytes(source, parser.ParseComments)
+	if err != nil || len(file.Docs) == 0 || file.Docs[0].Body == nil {
+		return nil, false
+	}
+	m, ok := file.Docs[0].Body.(*ast.MappingNode)
+	return m, ok
+}
+
+// mergeMappingNodes recursively merges src into dst, leaving dst-only keys untouched.
+func mergeMappingNodes(dst, src *ast.MappingNode) {
+	byKey := make(map[string]*ast.MappingValueNode, len(dst.Values))
+	for _, v := range dst.Values {
+		byKey[v.Key.String()] = v
+	}
+
+	for _, srcVal := range src.Values {
+		dstVal, exists := byKey[srcVal.Key.String()]
+		if !exists {
+			dst.Values = append(dst.Values, srcVal)
 			continue
 		}
 
-		if existingMap, isMap := existingValue.(map[string]any); isMap {
-			if nextMap, isMap := nextValue.(map[string]any); isMap {
-				dropped = append(dropped, s.droppedKeysIn(path, existingMap, nextMap)...)
-			}
+		dstChild, dstIsMap := dstVal.Value.(*ast.MappingNode)
+		srcChild, srcIsMap := srcVal.Value.(*ast.MappingNode)
+		if dstIsMap && srcIsMap {
+			mergeMappingNodes(dstChild, srcChild)
+			continue
+		}
+		dstVal.Value = srcVal.Value
+	}
+}
+
+// removeMappingKeys drops each named top-level key from m, in place.
+func removeMappingKeys(m *ast.MappingNode, keys []string) {
+	if len(keys) == 0 {
+		return
+	}
+
+	remove := make(map[string]bool, len(keys))
+	for _, key := range keys {
+		remove[key] = true
+	}
+
+	kept := m.Values[:0]
+	for _, v := range m.Values {
+		if !remove[v.Key.String()] {
+			kept = append(kept, v)
 		}
 	}
-	return dropped
+	m.Values = kept
 }

--- a/pkg/runtime/config/values_source_test.go
+++ b/pkg/runtime/config/values_source_test.go
@@ -126,7 +126,7 @@ func TestValuesSource_Save(t *testing.T) {
 			"workstation": map[string]any{"runtime": "colima"},
 		}
 
-		if err := source.Save(projectRoot, contextName, data, nil, nil, true, persistencePolicyInput{IsDevMode: true}); err != nil {
+		if _, err := source.Save(projectRoot, contextName, data, nil, nil, true, persistencePolicyInput{IsDevMode: true}); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
@@ -161,8 +161,12 @@ func TestValuesSource_Save(t *testing.T) {
 		}
 
 		data := map[string]any{"cluster": map[string]any{"driver": "talos"}}
-		if err := source.Save(projectRoot, contextName, data, data, nil, false, persistencePolicyInput{IsDevMode: true}); err != nil {
+		wrote, err := source.Save(projectRoot, contextName, data, data, nil, false, persistencePolicyInput{IsDevMode: true})
+		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
+		}
+		if wrote {
+			t.Error("Expected wrote=false when overwrite is false and the file already exists")
 		}
 
 		valuesPath := filepath.Join(contextDir, "values.yaml")
@@ -191,7 +195,7 @@ func TestValuesSource_Save(t *testing.T) {
 		}
 
 		overrides := map[string]any{"terraform": map[string]any{"backend": map[string]any{"type": "gcs"}}}
-		if err := source.Save(projectRoot, contextName, overrides, overrides, nil, true, persistencePolicyInput{}); err != nil {
+		if _, err := source.Save(projectRoot, contextName, overrides, overrides, nil, true, persistencePolicyInput{}); err != nil {
 			t.Fatalf("Expected no error patching a nested override, got %v", err)
 		}
 
@@ -229,7 +233,7 @@ func TestValuesSource_Save(t *testing.T) {
 		}
 
 		overrides := map[string]any{"terraform": map[string]any{"backend": map[string]any{"type": "gcs"}}}
-		if err := source.Save(projectRoot, contextName, overrides, overrides, nil, true, persistencePolicyInput{}); err != nil {
+		if _, err := source.Save(projectRoot, contextName, overrides, overrides, nil, true, persistencePolicyInput{}); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
@@ -258,7 +262,7 @@ func TestValuesSource_Save(t *testing.T) {
 		}
 
 		overrides := map[string]any{"gcp": map[string]any{"project_id": "new-project"}}
-		if err := source.Save(projectRoot, contextName, overrides, overrides, nil, true, persistencePolicyInput{}); err != nil {
+		if _, err := source.Save(projectRoot, contextName, overrides, overrides, nil, true, persistencePolicyInput{}); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
@@ -287,7 +291,7 @@ func TestValuesSource_Save(t *testing.T) {
 		}
 
 		overrides := map[string]any{"platform": "docker", "dns": map[string]any{"enabled": false}}
-		if err := source.Save(projectRoot, contextName, overrides, overrides, nil, true, persistencePolicyInput{IsDevMode: true}); err != nil {
+		if _, err := source.Save(projectRoot, contextName, overrides, overrides, nil, true, persistencePolicyInput{IsDevMode: true}); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
@@ -319,7 +323,7 @@ func TestValuesSource_Save(t *testing.T) {
 		}
 
 		overrides := map[string]any{"platform": "docker"}
-		if err := source.Save(projectRoot, contextName, overrides, overrides, []string{"provider"}, true, persistencePolicyInput{}); err != nil {
+		if _, err := source.Save(projectRoot, contextName, overrides, overrides, []string{"provider"}, true, persistencePolicyInput{}); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
@@ -350,8 +354,12 @@ func TestValuesSource_Save(t *testing.T) {
 		}
 
 		data := map[string]any{"id": "abc123"}
-		if err := source.Save(projectRoot, contextName, data, nil, nil, true, persistencePolicyInput{}); err != nil {
+		wrote, err := source.Save(projectRoot, contextName, data, nil, nil, true, persistencePolicyInput{})
+		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
+		}
+		if wrote {
+			t.Error("Expected wrote=false when nothing was overridden or deleted")
 		}
 
 		content, err := os.ReadFile(valuesPath)
@@ -378,7 +386,7 @@ func TestValuesSource_Save(t *testing.T) {
 
 		data := map[string]any{"id": "abc123", "gcp": map[string]any{"project_id": "p"}}
 		overrides := map[string]any{"id": "abc123"}
-		if err := source.Save(projectRoot, contextName, data, overrides, nil, true, persistencePolicyInput{}); err != nil {
+		if _, err := source.Save(projectRoot, contextName, data, overrides, nil, true, persistencePolicyInput{}); err != nil {
 			t.Fatalf("Expected the write to fall back to the full config, got %v", err)
 		}
 

--- a/pkg/runtime/config/values_source_test.go
+++ b/pkg/runtime/config/values_source_test.go
@@ -247,6 +247,42 @@ func TestValuesSource_Save(t *testing.T) {
 		}
 	})
 
+	t.Run("RefusesAnOverwriteThatWouldDropANestedKeySharingAVolatileName", func(t *testing.T) {
+		// isVolatile's exemption is documented as top-level only. A nested field that happens
+		// to share a volatile name, like secrets.provider, is an unrelated value and must still
+		// be caught if it disappears.
+		source := newValuesSource(NewShims(), nil, newPersistencePolicy())
+		projectRoot := t.TempDir()
+		contextName := "local"
+		contextDir := filepath.Join(projectRoot, "contexts", contextName)
+		if err := os.MkdirAll(contextDir, 0755); err != nil {
+			t.Fatalf("Expected no error creating context dir, got %v", err)
+		}
+		initial := "id: abc123\nsecrets:\n    provider: onepassword\n"
+		valuesPath := filepath.Join(contextDir, "values.yaml")
+		if err := os.WriteFile(valuesPath, []byte(initial), 0644); err != nil {
+			t.Fatalf("Expected no error writing initial values file, got %v", err)
+		}
+
+		data := map[string]any{"id": "abc123", "secrets": map[string]any{}}
+		err := source.Save(projectRoot, contextName, data, true, persistencePolicyInput{})
+
+		if err == nil {
+			t.Fatal("Expected an error when the write would drop secrets.provider")
+		}
+		if !contains(err.Error(), "secrets.provider") || !contains(err.Error(), "drop") {
+			t.Errorf("Expected the error to name the dropped nested path, got: %v", err)
+		}
+
+		content, readErr := os.ReadFile(valuesPath)
+		if readErr != nil {
+			t.Fatalf("Expected values.yaml to still be readable, got %v", readErr)
+		}
+		if string(content) != initial {
+			t.Errorf("Expected values.yaml to be unchanged after the refused write, got %s", string(content))
+		}
+	})
+
 	t.Run("AllowsAnOverwriteThatKeepsEveryPriorKey", func(t *testing.T) {
 		source := newValuesSource(NewShims(), nil, newPersistencePolicy())
 		projectRoot := t.TempDir()

--- a/pkg/runtime/config/values_source_test.go
+++ b/pkg/runtime/config/values_source_test.go
@@ -208,6 +208,45 @@ func TestValuesSource_Save(t *testing.T) {
 		}
 	})
 
+	t.Run("RefusesAnOverwriteThatWouldDropANestedKey", func(t *testing.T) {
+		// A field can disappear from inside a section that itself survives the write, e.g.
+		// terraform.backend.type vanishing while terraform stays present with other content.
+		// The top-level key alone is not enough to prove nothing was lost.
+		source := newValuesSource(NewShims(), nil, newPersistencePolicy())
+		projectRoot := t.TempDir()
+		contextName := "local"
+		contextDir := filepath.Join(projectRoot, "contexts", contextName)
+		if err := os.MkdirAll(contextDir, 0755); err != nil {
+			t.Fatalf("Expected no error creating context dir, got %v", err)
+		}
+		initial := "id: abc123\nterraform:\n    backend:\n        type: gcs\n    component: cluster\n"
+		valuesPath := filepath.Join(contextDir, "values.yaml")
+		if err := os.WriteFile(valuesPath, []byte(initial), 0644); err != nil {
+			t.Fatalf("Expected no error writing initial values file, got %v", err)
+		}
+
+		data := map[string]any{
+			"id":        "abc123",
+			"terraform": map[string]any{"component": "cluster", "backend": map[string]any{}},
+		}
+		err := source.Save(projectRoot, contextName, data, true, persistencePolicyInput{})
+
+		if err == nil {
+			t.Fatal("Expected an error when the write would drop terraform.backend.type")
+		}
+		if !contains(err.Error(), "terraform.backend.type") || !contains(err.Error(), "drop") {
+			t.Errorf("Expected the error to name the dropped nested path, got: %v", err)
+		}
+
+		content, readErr := os.ReadFile(valuesPath)
+		if readErr != nil {
+			t.Fatalf("Expected values.yaml to still be readable, got %v", readErr)
+		}
+		if string(content) != initial {
+			t.Errorf("Expected values.yaml to be unchanged after the refused write, got %s", string(content))
+		}
+	})
+
 	t.Run("AllowsAnOverwriteThatKeepsEveryPriorKey", func(t *testing.T) {
 		source := newValuesSource(NewShims(), nil, newPersistencePolicy())
 		projectRoot := t.TempDir()

--- a/pkg/runtime/config/values_source_test.go
+++ b/pkg/runtime/config/values_source_test.go
@@ -173,4 +173,127 @@ func TestValuesSource_Save(t *testing.T) {
 			t.Errorf("Expected values.yaml to be unchanged, got %s", string(content))
 		}
 	})
+
+	t.Run("RefusesAnOverwriteThatWouldDropATopLevelKey", func(t *testing.T) {
+		// Save persists the full merged config, a superset of disk by construction. A write
+		// that would drop a top-level key like "terraform" is never legitimate.
+		source := newValuesSource(NewShims(), nil, newPersistencePolicy())
+		projectRoot := t.TempDir()
+		contextName := "local"
+		contextDir := filepath.Join(projectRoot, "contexts", contextName)
+		if err := os.MkdirAll(contextDir, 0755); err != nil {
+			t.Fatalf("Expected no error creating context dir, got %v", err)
+		}
+		initial := "id: abc123\nterraform:\n    backend:\n        type: gcs\n"
+		valuesPath := filepath.Join(contextDir, "values.yaml")
+		if err := os.WriteFile(valuesPath, []byte(initial), 0644); err != nil {
+			t.Fatalf("Expected no error writing initial values file, got %v", err)
+		}
+
+		err := source.Save(projectRoot, contextName, map[string]any{"id": "abc123"}, true, persistencePolicyInput{})
+
+		if err == nil {
+			t.Fatal("Expected an error when the write would drop the terraform section")
+		}
+		if !contains(err.Error(), "terraform") || !contains(err.Error(), "drop") {
+			t.Errorf("Expected the error to name the dropped section, got: %v", err)
+		}
+
+		content, readErr := os.ReadFile(valuesPath)
+		if readErr != nil {
+			t.Fatalf("Expected values.yaml to still be readable, got %v", readErr)
+		}
+		if string(content) != initial {
+			t.Errorf("Expected values.yaml to be unchanged after the refused write, got %s", string(content))
+		}
+	})
+
+	t.Run("AllowsAnOverwriteThatKeepsEveryPriorKey", func(t *testing.T) {
+		source := newValuesSource(NewShims(), nil, newPersistencePolicy())
+		projectRoot := t.TempDir()
+		contextName := "local"
+		contextDir := filepath.Join(projectRoot, "contexts", contextName)
+		if err := os.MkdirAll(contextDir, 0755); err != nil {
+			t.Fatalf("Expected no error creating context dir, got %v", err)
+		}
+		initial := "id: abc123\nterraform:\n    backend:\n        type: gcs\n"
+		valuesPath := filepath.Join(contextDir, "values.yaml")
+		if err := os.WriteFile(valuesPath, []byte(initial), 0644); err != nil {
+			t.Fatalf("Expected no error writing initial values file, got %v", err)
+		}
+
+		data := map[string]any{
+			"id":        "abc123",
+			"terraform": map[string]any{"backend": map[string]any{"type": "gcs"}},
+			"gcp":       map[string]any{"project_id": "new-project"},
+		}
+		if err := source.Save(projectRoot, contextName, data, true, persistencePolicyInput{}); err != nil {
+			t.Fatalf("Expected no error when every prior key is kept, got %v", err)
+		}
+
+		content, err := os.ReadFile(valuesPath)
+		if err != nil {
+			t.Fatalf("Expected values.yaml to be readable, got %v", err)
+		}
+		if !contains(string(content), "gcp:") {
+			t.Errorf("Expected the new gcp key to be written, got %s", string(content))
+		}
+	})
+
+	t.Run("AllowsAVolatileKeyToDisappearOnOverwrite", func(t *testing.T) {
+		// provider is dropped outright by the provider→platform migration in
+		// Runtime.SaveConfig, and platform relocates to workstation.yaml under dev/
+		// workstation-runtime input. Neither absence is evidence of a bug.
+		source := newValuesSource(NewShims(), nil, newPersistencePolicy())
+		projectRoot := t.TempDir()
+		contextName := "local"
+		contextDir := filepath.Join(projectRoot, "contexts", contextName)
+		if err := os.MkdirAll(contextDir, 0755); err != nil {
+			t.Fatalf("Expected no error creating context dir, got %v", err)
+		}
+		initial := "provider: docker\nplatform: docker\nid: abc123\n"
+		valuesPath := filepath.Join(contextDir, "values.yaml")
+		if err := os.WriteFile(valuesPath, []byte(initial), 0644); err != nil {
+			t.Fatalf("Expected no error writing initial values file, got %v", err)
+		}
+
+		data := map[string]any{"platform": "docker", "id": "abc123"}
+		if err := source.Save(projectRoot, contextName, data, true, persistencePolicyInput{IsDevMode: true}); err != nil {
+			t.Fatalf("Expected no error when only volatile keys disappear, got %v", err)
+		}
+
+		content, err := os.ReadFile(valuesPath)
+		if err != nil {
+			t.Fatalf("Expected values.yaml to be readable, got %v", err)
+		}
+		if contains(string(content), "provider:") {
+			t.Errorf("Expected provider to be gone from values.yaml, got %s", string(content))
+		}
+	})
+
+	t.Run("FailsOpenWhenTheExistingFileIsUnparseable", func(t *testing.T) {
+		source := newValuesSource(NewShims(), nil, newPersistencePolicy())
+		projectRoot := t.TempDir()
+		contextName := "local"
+		contextDir := filepath.Join(projectRoot, "contexts", contextName)
+		if err := os.MkdirAll(contextDir, 0755); err != nil {
+			t.Fatalf("Expected no error creating context dir, got %v", err)
+		}
+		valuesPath := filepath.Join(contextDir, "values.yaml")
+		if err := os.WriteFile(valuesPath, []byte("not: valid: yaml: [\n"), 0644); err != nil {
+			t.Fatalf("Expected no error writing initial values file, got %v", err)
+		}
+
+		if err := source.Save(projectRoot, contextName, map[string]any{"id": "abc123"}, true, persistencePolicyInput{}); err != nil {
+			t.Fatalf("Expected the write to proceed despite an unparseable prior file, got %v", err)
+		}
+
+		content, err := os.ReadFile(valuesPath)
+		if err != nil {
+			t.Fatalf("Expected values.yaml to be readable, got %v", err)
+		}
+		if !contains(string(content), "id:") {
+			t.Errorf("Expected the new content to be written, got %s", string(content))
+		}
+	})
 }

--- a/pkg/runtime/config/values_source_test.go
+++ b/pkg/runtime/config/values_source_test.go
@@ -126,7 +126,7 @@ func TestValuesSource_Save(t *testing.T) {
 			"workstation": map[string]any{"runtime": "colima"},
 		}
 
-		if err := source.Save(projectRoot, contextName, data, true, persistencePolicyInput{IsDevMode: true}); err != nil {
+		if err := source.Save(projectRoot, contextName, data, nil, nil, true, persistencePolicyInput{IsDevMode: true}); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
@@ -160,7 +160,8 @@ func TestValuesSource_Save(t *testing.T) {
 			t.Fatalf("Expected no error writing initial values file, got %v", err)
 		}
 
-		if err := source.Save(projectRoot, contextName, map[string]any{"cluster": map[string]any{"driver": "talos"}}, false, persistencePolicyInput{IsDevMode: true}); err != nil {
+		data := map[string]any{"cluster": map[string]any{"driver": "talos"}}
+		if err := source.Save(projectRoot, contextName, data, data, nil, false, persistencePolicyInput{IsDevMode: true}); err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
@@ -174,9 +175,8 @@ func TestValuesSource_Save(t *testing.T) {
 		}
 	})
 
-	t.Run("RefusesAnOverwriteThatWouldDropATopLevelKey", func(t *testing.T) {
-		// Save persists the full merged config, a superset of disk by construction. A write
-		// that would drop a top-level key like "terraform" is never legitimate.
+	t.Run("PatchesOnlyTheOverriddenPathLeavingSiblingsIntact", func(t *testing.T) {
+		// backend.type must patch in without disturbing backend.bucket or component.
 		source := newValuesSource(NewShims(), nil, newPersistencePolicy())
 		projectRoot := t.TempDir()
 		contextName := "local"
@@ -184,141 +184,37 @@ func TestValuesSource_Save(t *testing.T) {
 		if err := os.MkdirAll(contextDir, 0755); err != nil {
 			t.Fatalf("Expected no error creating context dir, got %v", err)
 		}
-		initial := "id: abc123\nterraform:\n    backend:\n        type: gcs\n"
+		initial := "id: abc123\nterraform:\n    component: cluster\n    backend:\n        type: s3\n        bucket: mybucket\n"
 		valuesPath := filepath.Join(contextDir, "values.yaml")
 		if err := os.WriteFile(valuesPath, []byte(initial), 0644); err != nil {
 			t.Fatalf("Expected no error writing initial values file, got %v", err)
 		}
 
-		err := source.Save(projectRoot, contextName, map[string]any{"id": "abc123"}, true, persistencePolicyInput{})
-
-		if err == nil {
-			t.Fatal("Expected an error when the write would drop the terraform section")
-		}
-		if !contains(err.Error(), "terraform") || !contains(err.Error(), "drop") {
-			t.Errorf("Expected the error to name the dropped section, got: %v", err)
-		}
-
-		content, readErr := os.ReadFile(valuesPath)
-		if readErr != nil {
-			t.Fatalf("Expected values.yaml to still be readable, got %v", readErr)
-		}
-		if string(content) != initial {
-			t.Errorf("Expected values.yaml to be unchanged after the refused write, got %s", string(content))
-		}
-	})
-
-	t.Run("RefusesAnOverwriteThatWouldDropANestedKey", func(t *testing.T) {
-		// A field can disappear from inside a section that itself survives the write, e.g.
-		// terraform.backend.type vanishing while terraform stays present with other content.
-		// The top-level key alone is not enough to prove nothing was lost.
-		source := newValuesSource(NewShims(), nil, newPersistencePolicy())
-		projectRoot := t.TempDir()
-		contextName := "local"
-		contextDir := filepath.Join(projectRoot, "contexts", contextName)
-		if err := os.MkdirAll(contextDir, 0755); err != nil {
-			t.Fatalf("Expected no error creating context dir, got %v", err)
-		}
-		initial := "id: abc123\nterraform:\n    backend:\n        type: gcs\n    component: cluster\n"
-		valuesPath := filepath.Join(contextDir, "values.yaml")
-		if err := os.WriteFile(valuesPath, []byte(initial), 0644); err != nil {
-			t.Fatalf("Expected no error writing initial values file, got %v", err)
-		}
-
-		data := map[string]any{
-			"id":        "abc123",
-			"terraform": map[string]any{"component": "cluster", "backend": map[string]any{}},
-		}
-		err := source.Save(projectRoot, contextName, data, true, persistencePolicyInput{})
-
-		if err == nil {
-			t.Fatal("Expected an error when the write would drop terraform.backend.type")
-		}
-		if !contains(err.Error(), "terraform.backend.type") || !contains(err.Error(), "drop") {
-			t.Errorf("Expected the error to name the dropped nested path, got: %v", err)
-		}
-
-		content, readErr := os.ReadFile(valuesPath)
-		if readErr != nil {
-			t.Fatalf("Expected values.yaml to still be readable, got %v", readErr)
-		}
-		if string(content) != initial {
-			t.Errorf("Expected values.yaml to be unchanged after the refused write, got %s", string(content))
-		}
-	})
-
-	t.Run("RefusesAnOverwriteThatWouldDropANestedKeySharingAVolatileName", func(t *testing.T) {
-		// isVolatile's exemption is documented as top-level only. A nested field that happens
-		// to share a volatile name, like secrets.provider, is an unrelated value and must still
-		// be caught if it disappears.
-		source := newValuesSource(NewShims(), nil, newPersistencePolicy())
-		projectRoot := t.TempDir()
-		contextName := "local"
-		contextDir := filepath.Join(projectRoot, "contexts", contextName)
-		if err := os.MkdirAll(contextDir, 0755); err != nil {
-			t.Fatalf("Expected no error creating context dir, got %v", err)
-		}
-		initial := "id: abc123\nsecrets:\n    provider: onepassword\n"
-		valuesPath := filepath.Join(contextDir, "values.yaml")
-		if err := os.WriteFile(valuesPath, []byte(initial), 0644); err != nil {
-			t.Fatalf("Expected no error writing initial values file, got %v", err)
-		}
-
-		data := map[string]any{"id": "abc123", "secrets": map[string]any{}}
-		err := source.Save(projectRoot, contextName, data, true, persistencePolicyInput{})
-
-		if err == nil {
-			t.Fatal("Expected an error when the write would drop secrets.provider")
-		}
-		if !contains(err.Error(), "secrets.provider") || !contains(err.Error(), "drop") {
-			t.Errorf("Expected the error to name the dropped nested path, got: %v", err)
-		}
-
-		content, readErr := os.ReadFile(valuesPath)
-		if readErr != nil {
-			t.Fatalf("Expected values.yaml to still be readable, got %v", readErr)
-		}
-		if string(content) != initial {
-			t.Errorf("Expected values.yaml to be unchanged after the refused write, got %s", string(content))
-		}
-	})
-
-	t.Run("AllowsAnOverwriteThatKeepsEveryPriorKey", func(t *testing.T) {
-		source := newValuesSource(NewShims(), nil, newPersistencePolicy())
-		projectRoot := t.TempDir()
-		contextName := "local"
-		contextDir := filepath.Join(projectRoot, "contexts", contextName)
-		if err := os.MkdirAll(contextDir, 0755); err != nil {
-			t.Fatalf("Expected no error creating context dir, got %v", err)
-		}
-		initial := "id: abc123\nterraform:\n    backend:\n        type: gcs\n"
-		valuesPath := filepath.Join(contextDir, "values.yaml")
-		if err := os.WriteFile(valuesPath, []byte(initial), 0644); err != nil {
-			t.Fatalf("Expected no error writing initial values file, got %v", err)
-		}
-
-		data := map[string]any{
-			"id":        "abc123",
-			"terraform": map[string]any{"backend": map[string]any{"type": "gcs"}},
-			"gcp":       map[string]any{"project_id": "new-project"},
-		}
-		if err := source.Save(projectRoot, contextName, data, true, persistencePolicyInput{}); err != nil {
-			t.Fatalf("Expected no error when every prior key is kept, got %v", err)
+		overrides := map[string]any{"terraform": map[string]any{"backend": map[string]any{"type": "gcs"}}}
+		if err := source.Save(projectRoot, contextName, overrides, overrides, nil, true, persistencePolicyInput{}); err != nil {
+			t.Fatalf("Expected no error patching a nested override, got %v", err)
 		}
 
 		content, err := os.ReadFile(valuesPath)
 		if err != nil {
 			t.Fatalf("Expected values.yaml to be readable, got %v", err)
 		}
-		if !contains(string(content), "gcp:") {
-			t.Errorf("Expected the new gcp key to be written, got %s", string(content))
+		values := map[string]any{}
+		if err := NewShims().YamlUnmarshal(content, &values); err != nil {
+			t.Fatalf("Expected the patched file to still be valid YAML, got %v: %s", err, content)
+		}
+		if got := getPathValue(t, values, "terraform", "backend", "type"); got != "gcs" {
+			t.Errorf("Expected terraform.backend.type=gcs, got %v", got)
+		}
+		if got := getPathValue(t, values, "terraform", "backend", "bucket"); got != "mybucket" {
+			t.Errorf("Expected terraform.backend.bucket to survive the patch untouched, got %v", got)
+		}
+		if got := getPathValue(t, values, "terraform", "component"); got != "cluster" {
+			t.Errorf("Expected terraform.component to survive the patch untouched, got %v", got)
 		}
 	})
 
-	t.Run("AllowsAVolatileKeyToDisappearOnOverwrite", func(t *testing.T) {
-		// provider is dropped outright by the provider→platform migration in
-		// Runtime.SaveConfig, and platform relocates to workstation.yaml under dev/
-		// workstation-runtime input. Neither absence is evidence of a bug.
+	t.Run("PatchPreservesKeyOrderAndComments", func(t *testing.T) {
 		source := newValuesSource(NewShims(), nil, newPersistencePolicy())
 		projectRoot := t.TempDir()
 		contextName := "local"
@@ -326,15 +222,105 @@ func TestValuesSource_Save(t *testing.T) {
 		if err := os.MkdirAll(contextDir, 0755); err != nil {
 			t.Fatalf("Expected no error creating context dir, got %v", err)
 		}
-		initial := "provider: docker\nplatform: docker\nid: abc123\n"
+		initial := "zed: last\nid: abc123\n# a note about terraform\nterraform:\n    backend:\n        type: s3\nabc: first\n"
 		valuesPath := filepath.Join(contextDir, "values.yaml")
 		if err := os.WriteFile(valuesPath, []byte(initial), 0644); err != nil {
 			t.Fatalf("Expected no error writing initial values file, got %v", err)
 		}
 
-		data := map[string]any{"platform": "docker", "id": "abc123"}
-		if err := source.Save(projectRoot, contextName, data, true, persistencePolicyInput{IsDevMode: true}); err != nil {
-			t.Fatalf("Expected no error when only volatile keys disappear, got %v", err)
+		overrides := map[string]any{"terraform": map[string]any{"backend": map[string]any{"type": "gcs"}}}
+		if err := source.Save(projectRoot, contextName, overrides, overrides, nil, true, persistencePolicyInput{}); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		content, err := os.ReadFile(valuesPath)
+		if err != nil {
+			t.Fatalf("Expected values.yaml to be readable, got %v", err)
+		}
+		expected := "zed: last\nid: abc123\n# a note about terraform\nterraform:\n    backend:\n        type: gcs\nabc: first\n"
+		if string(content) != expected {
+			t.Errorf("Expected order and comments preserved with only type changed,\nwant: %q\ngot:  %q", expected, string(content))
+		}
+	})
+
+	t.Run("PatchAppendsANewTopLevelKey", func(t *testing.T) {
+		source := newValuesSource(NewShims(), nil, newPersistencePolicy())
+		projectRoot := t.TempDir()
+		contextName := "local"
+		contextDir := filepath.Join(projectRoot, "contexts", contextName)
+		if err := os.MkdirAll(contextDir, 0755); err != nil {
+			t.Fatalf("Expected no error creating context dir, got %v", err)
+		}
+		initial := "id: abc123\n"
+		valuesPath := filepath.Join(contextDir, "values.yaml")
+		if err := os.WriteFile(valuesPath, []byte(initial), 0644); err != nil {
+			t.Fatalf("Expected no error writing initial values file, got %v", err)
+		}
+
+		overrides := map[string]any{"gcp": map[string]any{"project_id": "new-project"}}
+		if err := source.Save(projectRoot, contextName, overrides, overrides, nil, true, persistencePolicyInput{}); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		content, err := os.ReadFile(valuesPath)
+		if err != nil {
+			t.Fatalf("Expected values.yaml to be readable, got %v", err)
+		}
+		if !contains(string(content), "id: abc123") || !contains(string(content), "gcp:") {
+			t.Errorf("Expected both the prior id and the new gcp key present, got %s", string(content))
+		}
+	})
+
+	t.Run("PatchRoutesPlatformAwayWhileStillWritingOtherOverrides", func(t *testing.T) {
+		// platform must not land in values.yaml even alongside a real override.
+		source := newValuesSource(NewShims(), nil, newPersistencePolicy())
+		projectRoot := t.TempDir()
+		contextName := "local"
+		contextDir := filepath.Join(projectRoot, "contexts", contextName)
+		if err := os.MkdirAll(contextDir, 0755); err != nil {
+			t.Fatalf("Expected no error creating context dir, got %v", err)
+		}
+		initial := "id: abc123\n"
+		valuesPath := filepath.Join(contextDir, "values.yaml")
+		if err := os.WriteFile(valuesPath, []byte(initial), 0644); err != nil {
+			t.Fatalf("Expected no error writing initial values file, got %v", err)
+		}
+
+		overrides := map[string]any{"platform": "docker", "dns": map[string]any{"enabled": false}}
+		if err := source.Save(projectRoot, contextName, overrides, overrides, nil, true, persistencePolicyInput{IsDevMode: true}); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		content, err := os.ReadFile(valuesPath)
+		if err != nil {
+			t.Fatalf("Expected values.yaml to be readable, got %v", err)
+		}
+		if contains(string(content), "platform:") {
+			t.Errorf("Expected platform to be routed away from values.yaml, got %s", string(content))
+		}
+		if !contains(string(content), "dns:") {
+			t.Errorf("Expected dns to still be written, got %s", string(content))
+		}
+	})
+
+	t.Run("PatchRemovesADeletedTopLevelKey", func(t *testing.T) {
+		// A merge alone can't remove a key; deletes must.
+		source := newValuesSource(NewShims(), nil, newPersistencePolicy())
+		projectRoot := t.TempDir()
+		contextName := "local"
+		contextDir := filepath.Join(projectRoot, "contexts", contextName)
+		if err := os.MkdirAll(contextDir, 0755); err != nil {
+			t.Fatalf("Expected no error creating context dir, got %v", err)
+		}
+		initial := "provider: docker\nid: abc123\n"
+		valuesPath := filepath.Join(contextDir, "values.yaml")
+		if err := os.WriteFile(valuesPath, []byte(initial), 0644); err != nil {
+			t.Fatalf("Expected no error writing initial values file, got %v", err)
+		}
+
+		overrides := map[string]any{"platform": "docker"}
+		if err := source.Save(projectRoot, contextName, overrides, overrides, []string{"provider"}, true, persistencePolicyInput{}); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
 		}
 
 		content, err := os.ReadFile(valuesPath)
@@ -342,11 +328,42 @@ func TestValuesSource_Save(t *testing.T) {
 			t.Fatalf("Expected values.yaml to be readable, got %v", err)
 		}
 		if contains(string(content), "provider:") {
-			t.Errorf("Expected provider to be gone from values.yaml, got %s", string(content))
+			t.Errorf("Expected provider to be removed, got %s", string(content))
+		}
+		if !contains(string(content), "id: abc123") || !contains(string(content), "platform: docker") {
+			t.Errorf("Expected id and the new platform to remain, got %s", string(content))
 		}
 	})
 
-	t.Run("FailsOpenWhenTheExistingFileIsUnparseable", func(t *testing.T) {
+	t.Run("SkipsTheWriteWhenNothingIsOverriddenOrDeleted", func(t *testing.T) {
+		source := newValuesSource(NewShims(), nil, newPersistencePolicy())
+		projectRoot := t.TempDir()
+		contextName := "local"
+		contextDir := filepath.Join(projectRoot, "contexts", contextName)
+		if err := os.MkdirAll(contextDir, 0755); err != nil {
+			t.Fatalf("Expected no error creating context dir, got %v", err)
+		}
+		initial := "id: abc123\n"
+		valuesPath := filepath.Join(contextDir, "values.yaml")
+		if err := os.WriteFile(valuesPath, []byte(initial), 0644); err != nil {
+			t.Fatalf("Expected no error writing initial values file, got %v", err)
+		}
+
+		data := map[string]any{"id": "abc123"}
+		if err := source.Save(projectRoot, contextName, data, nil, nil, true, persistencePolicyInput{}); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		content, err := os.ReadFile(valuesPath)
+		if err != nil {
+			t.Fatalf("Expected values.yaml to be readable, got %v", err)
+		}
+		if string(content) != initial {
+			t.Errorf("Expected values.yaml to be untouched, got %s", string(content))
+		}
+	})
+
+	t.Run("FallsBackToAFullRewriteWhenTheExistingFileIsUnparseable", func(t *testing.T) {
 		source := newValuesSource(NewShims(), nil, newPersistencePolicy())
 		projectRoot := t.TempDir()
 		contextName := "local"
@@ -359,16 +376,36 @@ func TestValuesSource_Save(t *testing.T) {
 			t.Fatalf("Expected no error writing initial values file, got %v", err)
 		}
 
-		if err := source.Save(projectRoot, contextName, map[string]any{"id": "abc123"}, true, persistencePolicyInput{}); err != nil {
-			t.Fatalf("Expected the write to proceed despite an unparseable prior file, got %v", err)
+		data := map[string]any{"id": "abc123", "gcp": map[string]any{"project_id": "p"}}
+		overrides := map[string]any{"id": "abc123"}
+		if err := source.Save(projectRoot, contextName, data, overrides, nil, true, persistencePolicyInput{}); err != nil {
+			t.Fatalf("Expected the write to fall back to the full config, got %v", err)
 		}
 
 		content, err := os.ReadFile(valuesPath)
 		if err != nil {
 			t.Fatalf("Expected values.yaml to be readable, got %v", err)
 		}
-		if !contains(string(content), "id:") {
-			t.Errorf("Expected the new content to be written, got %s", string(content))
+		if !contains(string(content), "id:") || !contains(string(content), "gcp:") {
+			t.Errorf("Expected the full config written as the fallback, got %s", string(content))
 		}
 	})
+}
+
+// getPathValue walks a decoded YAML map through keys, failing the test if any step is missing
+// or not itself a map.
+func getPathValue(t *testing.T, values map[string]any, keys ...string) any {
+	t.Helper()
+	var current any = values
+	for _, key := range keys {
+		m, ok := current.(map[string]any)
+		if !ok {
+			t.Fatalf("Expected a map while walking to %v, got %T at %q", keys, current, key)
+		}
+		current, ok = m[key]
+		if !ok {
+			t.Fatalf("Expected key %q present while walking %v", key, keys)
+		}
+	}
+	return current
 }


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This changes how `windsor init`/`up`/`bootstrap` persist `values.yaml` for every existing context, replacing a full-file rewrite with a targeted patch of only the paths that changed — a core, frequently-exercised part of config persistence.
>
> **Overview**
>
> The PR reworks `ConfigHandler.Set` to record which top-level keys were deleted (set to `nil`) and which paths were overridden, then has `valuesSource.Save` merge those overrides and deletions directly into the existing `values.yaml` AST (via `goccy/go-yaml`'s parser) instead of re-marshalling the whole in-memory config. This preserves key order, comments, and any sibling keys the handler never loaded, closing the "silent drop" failure class the last few commits were chasing. A prior, more surgical "refuse to overwrite if it would drop a key" guard (and its `isVolatile` plumbing) is removed in favor of this patch-based approach, and an integration test now locks in that a `--set` on one nested field cannot clobber an untouched sibling.
>
> One behavioral detail worth noting: `pendingOverrides`/`pendingDeletes` accumulate on the handler for its whole lifetime and are never cleared after a save, and a patch always applies overrides before deletes regardless of the order the corresponding `Set` calls actually happened in. See the inline comment for a concrete mechanism where this could matter.

<!-- /claude-code-review:summary -->
