### PR TITLE
fix(config): fall back to the platform default backend everywhere

### DIFF
--- a/cmd/flag_overrides.go
+++ b/cmd/flag_overrides.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/windsorcli/cli/pkg/composer/artifact"
 	"github.com/windsorcli/cli/pkg/constants"
+	"github.com/windsorcli/cli/pkg/runtime/config"
 )
 
 // =============================================================================
@@ -47,29 +48,17 @@ func applyWorkstationFlagOverrides(overrides map[string]any, vmDriver, platform 
 
 // defaultTerraformBackendType fills in terraform.backend.type from
 // overrides["platform"] when the key is absent, so explicit --set values
-// (merged into the same map by callers after this runs) always win:
-//
-//   - aws     → s3       (S3 is the canonical state store on AWS)
-//   - azure   → azurerm  (Azure Blob Storage via the azurerm backend)
-//   - metal, docker, incus, hetzner, hyperv, vsphere → kubernetes  (the cluster
-//     IS the state store; each component's state lives as a Secret in the
-//     cluster it manages. Hetzner joins this group because its Object Storage
-//     keys can't be provisioned via API, so in-cluster state avoids a manual
-//     key step)
-//   - gcp     → gcs       (Cloud Storage is the canonical state store on GCP)
+// (merged into the same map by callers after this runs) always win. The
+// platform-to-backend mapping lives in config.DefaultTerraformBackendTypeForPlatform,
+// the same function ConfigHandler.GetTerraformBackendType falls back to when the
+// key is unset at read time, so init-time and runtime defaulting can't drift apart.
 func defaultTerraformBackendType(overrides map[string]any) {
 	if _, set := overrides["terraform.backend.type"]; set {
 		return
 	}
-	switch overrides["platform"] {
-	case "aws":
-		overrides["terraform.backend.type"] = "s3"
-	case "azure":
-		overrides["terraform.backend.type"] = "azurerm"
-	case "gcp":
-		overrides["terraform.backend.type"] = "gcs"
-	case "metal", "docker", "incus", "hetzner", "hyperv", "vsphere":
-		overrides["terraform.backend.type"] = "kubernetes"
+	platform, _ := overrides["platform"].(string)
+	if def := config.DefaultTerraformBackendTypeForPlatform(platform); def != "" {
+		overrides["terraform.backend.type"] = def
 	}
 }
 

--- a/cmd/get.go
+++ b/cmd/get.go
@@ -97,9 +97,7 @@ var getContextsCmd = &cobra.Command{
 				} else if p := ctxConfigHandler.GetString("provider"); p != "" {
 					platform = p
 				}
-				if b := ctxConfigHandler.GetString("terraform.backend.type"); b != "" {
-					backend = b
-				}
+				backend = ctxConfigHandler.GetTerraformBackendType()
 			}
 
 			contextInfos = append(contextInfos, contextInfo{

--- a/cmd/get_test.go
+++ b/cmd/get_test.go
@@ -148,6 +148,73 @@ func TestGetContextsCmd(t *testing.T) {
 		}
 	})
 
+	t.Run("ShowsTheFallbackBackendWhenTypeIsUnset", func(t *testing.T) {
+		stdout, _ := setup(t)
+		tmpDir := t.TempDir()
+
+		contextsDir := filepath.Join(tmpDir, "contexts")
+		if err := os.MkdirAll(contextsDir, 0755); err != nil {
+			t.Fatalf("Failed to create contexts directory: %v", err)
+		}
+
+		gcpDir := filepath.Join(contextsDir, "gcp-test")
+		if err := os.MkdirAll(gcpDir, 0755); err != nil {
+			t.Fatalf("Failed to create gcp-test context directory: %v", err)
+		}
+		noneDir := filepath.Join(contextsDir, "bare")
+		if err := os.MkdirAll(noneDir, 0755); err != nil {
+			t.Fatalf("Failed to create bare context directory: %v", err)
+		}
+
+		windsorYaml := filepath.Join(tmpDir, "windsor.yaml")
+		if err := os.WriteFile(windsorYaml, []byte("version: v1alpha1\n"), 0644); err != nil {
+			t.Fatalf("Failed to create windsor.yaml: %v", err)
+		}
+
+		// Neither context sets terraform.backend.type explicitly.
+		gcpConfig := filepath.Join(gcpDir, "windsor.yaml")
+		if err := os.WriteFile(gcpConfig, []byte("platform: gcp\n"), 0644); err != nil {
+			t.Fatalf("Failed to create gcp-test config: %v", err)
+		}
+		noneConfig := filepath.Join(noneDir, "windsor.yaml")
+		if err := os.WriteFile(noneConfig, []byte("version: v1alpha1\n"), 0644); err != nil {
+			t.Fatalf("Failed to create bare config: %v", err)
+		}
+
+		mockShell := shell.NewMockShell()
+		mockShell.GetProjectRootFunc = func() (string, error) {
+			return tmpDir, nil
+		}
+
+		rtOverride := &runtime.Runtime{
+			Shell:       mockShell,
+			ProjectRoot: tmpDir,
+		}
+		rt := runtime.NewRuntime(rtOverride)
+		if rt == nil {
+			t.Fatal("Failed to create runtime")
+		}
+
+		ctx := context.WithValue(context.Background(), runtimeOverridesKey, rt)
+		rootCmd.SetContext(ctx)
+
+		rootCmd.SetArgs([]string{"get", "contexts"})
+
+		err := Execute()
+
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+
+		output := stdout.String()
+		if !strings.Contains(output, "gcs") {
+			t.Errorf("Expected the gcp-test context to show the platform-derived backend gcs, got %q", output)
+		}
+		if !strings.Contains(output, "local") {
+			t.Errorf("Expected the bare context to show the local fallback backend, got %q", output)
+		}
+	})
+
 	t.Run("ExcludesTemplateDirectory", func(t *testing.T) {
 		stdout, _ := setup(t)
 		tmpDir := t.TempDir()

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -242,7 +242,7 @@ func (p *Project) Bootstrap(confirm provisioner.BootstrapConfirmFn) (*blueprintv
 	}
 
 	if confirm != nil {
-		backendType := p.configHandler.GetString("terraform.backend.type", "local")
+		backendType := p.configHandler.GetTerraformBackendType()
 		summary := provisioner.BuildBootstrapSummary(blueprint, p.contextName, backendType)
 		if !confirm(summary) {
 			return blueprint, false, false, nil

--- a/pkg/provisioner/bootstrap.go
+++ b/pkg/provisioner/bootstrap.go
@@ -151,7 +151,7 @@ func blueprintWithoutComponents(bp *blueprintv1alpha1.Blueprint, components []*b
 // withBackendOverride pins terraform.backend.type to "local" for the duration of fn,
 // restoring the previously-configured value via defer.
 func (i *Provisioner) withBackendOverride(opLabel string, fn func() error) error {
-	original := i.configHandler.GetString("terraform.backend.type", "local")
+	original := i.configHandler.GetTerraformBackendType()
 	if err := i.configHandler.Set("terraform.backend.type", "local"); err != nil {
 		return fmt.Errorf("failed to override backend for %s: %w", opLabel, err)
 	}

--- a/pkg/provisioner/destroy.go
+++ b/pkg/provisioner/destroy.go
@@ -55,7 +55,7 @@ type DestroyResult struct {
 // treated as "no tier" — see resolveBackendTier.
 func (i *Provisioner) Teardown(blueprint *blueprintv1alpha1.Blueprint, terraformOnly bool, continueOnError bool) (DestroyResult, error) {
 	var result DestroyResult
-	backendType := i.configHandler.GetString("terraform.backend.type", "local")
+	backendType := i.configHandler.GetTerraformBackendType()
 	if backendType == "kubernetes" && blueprint.Backend == "" {
 		return result, fmt.Errorf("blueprint configures terraform.backend.type=kubernetes but does not declare Blueprint.Backend; set `backend: <cluster-component-id>` at the blueprint top level to name the terraform component that provisions the cluster")
 	}
@@ -132,7 +132,7 @@ func (i *Provisioner) TeardownComponent(blueprint *blueprintv1alpha1.Blueprint, 
 // component tries to reach a kubernetes backend whose cluster may already be gone. A Backend that names
 // no real component also refuses outright — see resolveBackendTier.
 func (i *Provisioner) CheckComponentDestroyable(blueprint *blueprintv1alpha1.Blueprint, componentID string) error {
-	backendType := i.configHandler.GetString("terraform.backend.type", "local")
+	backendType := i.configHandler.GetTerraformBackendType()
 	if backendType == "" || backendType == "local" {
 		return nil
 	}
@@ -168,7 +168,7 @@ func (i *Provisioner) ValidateBackendTier(blueprint *blueprintv1alpha1.Blueprint
 // cluster is gone (a resumed teardown) the state was already migrated on the earlier pass and is the local
 // copy, so it proceeds against it. Returns whether it pivoted; a non-kubernetes backend is a no-op.
 func (i *Provisioner) PrepareLocalTeardown(blueprint *blueprintv1alpha1.Blueprint) (bool, error) {
-	backendType := i.configHandler.GetString("terraform.backend.type", "local")
+	backendType := i.configHandler.GetTerraformBackendType()
 	if backendType == "" || backendType == "local" {
 		return false, nil
 	}
@@ -199,7 +199,7 @@ func (i *Provisioner) PrepareLocalTeardown(blueprint *blueprintv1alpha1.Blueprin
 // the cluster is up and on the already-migrated local state once the cluster is gone. A reachable cluster or
 // non-kubernetes backend is a no-op. Returns whether it pivoted.
 func (i *Provisioner) PivotToLocalIfClusterGone() (bool, error) {
-	backendType := i.configHandler.GetString("terraform.backend.type", "local")
+	backendType := i.configHandler.GetTerraformBackendType()
 	if backendType == "" || backendType == "local" {
 		return false, nil
 	}

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -219,7 +219,7 @@ func (i *Provisioner) Up(blueprint *blueprintv1alpha1.Blueprint, onApply ...func
 		return false, fmt.Errorf("blueprint not provided")
 	}
 
-	backendType := i.configHandler.GetString("terraform.backend.type", "local")
+	backendType := i.configHandler.GetTerraformBackendType()
 	applyFlat := func() (bool, error) {
 		if backendType == "kubernetes" && hasEnabledTerraformComponent(blueprint) && !i.kubeconfigPresent() {
 			return false, fmt.Errorf("context has no kubeconfig (cluster not yet created) and the blueprint declares no backend tier for the kubernetes backend; add `backend: <component-id>` to the blueprint naming the component that creates the cluster, or set terraform.backend.type to \"local\" until it exists")
@@ -1962,7 +1962,7 @@ func hasEnabledTerraformComponent(blueprint *blueprintv1alpha1.Blueprint) bool {
 // rather than fall through; -force-copy would otherwise overwrite good
 // remote state with stale local content.
 func (i *Provisioner) recoverHalfMigratedComponents(blueprint *blueprintv1alpha1.Blueprint) error {
-	backendType := i.configHandler.GetString("terraform.backend.type", "local")
+	backendType := i.configHandler.GetTerraformBackendType()
 	if backendType == "" || backendType == "local" {
 		return nil
 	}

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -1614,7 +1614,7 @@ func (s *TerraformStack) runTerraformInit(component *blueprintv1alpha1.Terraform
 	migrateState := slices.Contains(extraFlags, "-migrate-state")
 	key := initCacheKey{
 		componentID:  component.GetID(),
-		backendType:  s.runtime.ConfigHandler.GetString("terraform.backend.type", "local"),
+		backendType:  s.runtime.ConfigHandler.GetTerraformBackendType(),
 		migrateState: migrateState,
 	}
 	s.initCacheMu.Lock()
@@ -1690,7 +1690,7 @@ func (s *TerraformStack) clearStaleBackendPointer(terraformVars map[string]strin
 		_ = s.shims.Remove(pointerPath)
 		return
 	}
-	configuredBackend := s.runtime.ConfigHandler.GetString("terraform.backend.type", "local")
+	configuredBackend := s.runtime.ConfigHandler.GetTerraformBackendType()
 	if pointer.Backend.Type != "" && pointer.Backend.Type != configuredBackend {
 		_ = s.shims.Remove(pointerPath)
 	}

--- a/pkg/runtime/config/accessors.go
+++ b/pkg/runtime/config/accessors.go
@@ -88,6 +88,24 @@ func (c *configHandler) GetString(key string, defaultValue ...string) string {
 	return fmt.Sprintf("%v", value)
 }
 
+// GetTerraformBackendType returns the effective terraform.backend.type: the explicit value when
+// set, else the canonical default for the context's platform (see
+// DefaultTerraformBackendTypeForPlatform), else "local". Platform falls back to the deprecated
+// "provider" key when "platform" is unset, matching how the rest of config treats that migration.
+func (c *configHandler) GetTerraformBackendType() string {
+	if explicit := c.GetString("terraform.backend.type"); explicit != "" {
+		return explicit
+	}
+	platform := c.GetString("platform")
+	if platform == "" {
+		platform = c.GetString("provider")
+	}
+	if def := DefaultTerraformBackendTypeForPlatform(platform); def != "" {
+		return def
+	}
+	return "local"
+}
+
 // GetInt retrieves an integer value for the specified key from the configuration.
 // It accepts an optional default value. The function safely converts supported types (int, int64, uint64, uint)
 // to int with appropriate overflow protection, and parses string values if they represent valid integer literals.

--- a/pkg/runtime/config/accessors.go
+++ b/pkg/runtime/config/accessors.go
@@ -88,10 +88,10 @@ func (c *configHandler) GetString(key string, defaultValue ...string) string {
 	return fmt.Sprintf("%v", value)
 }
 
-// GetTerraformBackendType returns the effective terraform.backend.type: the explicit value when
-// set, else the canonical default for the context's platform (see
-// DefaultTerraformBackendTypeForPlatform), else "local". Platform falls back to the deprecated
-// "provider" key when "platform" is unset, matching how the rest of config treats that migration.
+// GetTerraformBackendType returns the explicit terraform.backend.type when set, else the cloud
+// default for platform (aws/azure/gcp), else "local". Platform falls back to "provider" when
+// unset. It skips the kubernetes default, since that needs a live cluster that only
+// init/up/bootstrap sets up explicitly.
 func (c *configHandler) GetTerraformBackendType() string {
 	if explicit := c.GetString("terraform.backend.type"); explicit != "" {
 		return explicit
@@ -100,7 +100,7 @@ func (c *configHandler) GetTerraformBackendType() string {
 	if platform == "" {
 		platform = c.GetString("provider")
 	}
-	if def := DefaultTerraformBackendTypeForPlatform(platform); def != "" {
+	if def := DefaultTerraformBackendTypeForPlatform(platform); def != "" && def != "kubernetes" {
 		return def
 	}
 	return "local"

--- a/pkg/runtime/config/accessors_test.go
+++ b/pkg/runtime/config/accessors_test.go
@@ -327,7 +327,7 @@ func TestConfigHandler_GetTerraformBackendType(t *testing.T) {
 		}
 	})
 
-	t.Run("FallsBackToThePlatformDefault", func(t *testing.T) {
+	t.Run("FallsBackToTheCloudPlatformDefault", func(t *testing.T) {
 		testCases := []struct {
 			platform string
 			want     string
@@ -335,12 +335,6 @@ func TestConfigHandler_GetTerraformBackendType(t *testing.T) {
 			{"aws", "s3"},
 			{"azure", "azurerm"},
 			{"gcp", "gcs"},
-			{"metal", "kubernetes"},
-			{"docker", "kubernetes"},
-			{"incus", "kubernetes"},
-			{"hetzner", "kubernetes"},
-			{"hyperv", "kubernetes"},
-			{"vsphere", "kubernetes"},
 		}
 		for _, tc := range testCases {
 			t.Run(tc.platform, func(t *testing.T) {
@@ -350,6 +344,21 @@ func TestConfigHandler_GetTerraformBackendType(t *testing.T) {
 
 				if got := handler.GetTerraformBackendType(); got != tc.want {
 					t.Errorf("Expected platform %q to default to %q, got %q", tc.platform, tc.want, got)
+				}
+			})
+		}
+	})
+
+	t.Run("FallsBackToLocalForAWorkstationPlatformWithNoExplicitBackend", func(t *testing.T) {
+		// The kubernetes default needs a live cluster, so it stays out of this fallback.
+		for _, platform := range []string{"metal", "docker", "incus", "hetzner", "hyperv", "vsphere"} {
+			t.Run(platform, func(t *testing.T) {
+				mocks := setupConfigMocks(t)
+				handler := NewConfigHandler(mocks.Shell)
+				handler.Set("platform", platform)
+
+				if got := handler.GetTerraformBackendType(); got != "local" {
+					t.Errorf("Expected platform %q to fall back to local, not the kubernetes default, got %q", platform, got)
 				}
 			})
 		}

--- a/pkg/runtime/config/accessors_test.go
+++ b/pkg/runtime/config/accessors_test.go
@@ -314,3 +314,73 @@ func TestConfigHandler_AccessorTypeCoercionHelpers(t *testing.T) {
 		}
 	})
 }
+
+func TestConfigHandler_GetTerraformBackendType(t *testing.T) {
+	t.Run("ExplicitValueWins", func(t *testing.T) {
+		mocks := setupConfigMocks(t)
+		handler := NewConfigHandler(mocks.Shell)
+		handler.Set("platform", "gcp")
+		handler.Set("terraform.backend.type", "local")
+
+		if got := handler.GetTerraformBackendType(); got != "local" {
+			t.Errorf("Expected the explicit value to win over the platform default, got %q", got)
+		}
+	})
+
+	t.Run("FallsBackToThePlatformDefault", func(t *testing.T) {
+		testCases := []struct {
+			platform string
+			want     string
+		}{
+			{"aws", "s3"},
+			{"azure", "azurerm"},
+			{"gcp", "gcs"},
+			{"metal", "kubernetes"},
+			{"docker", "kubernetes"},
+			{"incus", "kubernetes"},
+			{"hetzner", "kubernetes"},
+			{"hyperv", "kubernetes"},
+			{"vsphere", "kubernetes"},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.platform, func(t *testing.T) {
+				mocks := setupConfigMocks(t)
+				handler := NewConfigHandler(mocks.Shell)
+				handler.Set("platform", tc.platform)
+
+				if got := handler.GetTerraformBackendType(); got != tc.want {
+					t.Errorf("Expected platform %q to default to %q, got %q", tc.platform, tc.want, got)
+				}
+			})
+		}
+	})
+
+	t.Run("FallsBackToProviderWhenPlatformUnset", func(t *testing.T) {
+		mocks := setupConfigMocks(t)
+		handler := NewConfigHandler(mocks.Shell)
+		handler.Set("provider", "gcp")
+
+		if got := handler.GetTerraformBackendType(); got != "gcs" {
+			t.Errorf("Expected the deprecated provider key to drive the default, got %q", got)
+		}
+	})
+
+	t.Run("FallsBackToLocalForAnUnrecognizedPlatform", func(t *testing.T) {
+		mocks := setupConfigMocks(t)
+		handler := NewConfigHandler(mocks.Shell)
+		handler.Set("platform", "none")
+
+		if got := handler.GetTerraformBackendType(); got != "local" {
+			t.Errorf("Expected local for a platform with no canonical backend, got %q", got)
+		}
+	})
+
+	t.Run("FallsBackToLocalWhenNeitherPlatformNorProviderIsSet", func(t *testing.T) {
+		mocks := setupConfigMocks(t)
+		handler := NewConfigHandler(mocks.Shell)
+
+		if got := handler.GetTerraformBackendType(); got != "local" {
+			t.Errorf("Expected local with no platform information at all, got %q", got)
+		}
+	})
+}

--- a/pkg/runtime/config/defaults.go
+++ b/pkg/runtime/config/defaults.go
@@ -14,3 +14,21 @@ var DefaultConfig = v1alpha1.Context{
 
 // DefaultConfig_Dev provides defaults for all dev contexts (docker-desktop, colima, incus).
 var DefaultConfig_Dev = v1alpha1.Context{}
+
+// DefaultTerraformBackendTypeForPlatform returns the canonical terraform state backend for a
+// platform, or "" when the platform has no default backend (the caller falls back to "local").
+// Kept in sync with the platform description in configuration.yaml.
+func DefaultTerraformBackendTypeForPlatform(platform string) string {
+	switch platform {
+	case "aws":
+		return "s3"
+	case "azure":
+		return "azurerm"
+	case "gcp":
+		return "gcs"
+	case "metal", "docker", "incus", "hetzner", "hyperv", "vsphere":
+		return "kubernetes"
+	default:
+		return ""
+	}
+}

--- a/pkg/runtime/config/defaults_test.go
+++ b/pkg/runtime/config/defaults_test.go
@@ -32,3 +32,30 @@ func TestDefaultConfigurations(t *testing.T) {
 		}
 	})
 }
+
+func TestDefaultTerraformBackendTypeForPlatform(t *testing.T) {
+	testCases := []struct {
+		platform string
+		want     string
+	}{
+		{"aws", "s3"},
+		{"azure", "azurerm"},
+		{"gcp", "gcs"},
+		{"metal", "kubernetes"},
+		{"docker", "kubernetes"},
+		{"incus", "kubernetes"},
+		{"hetzner", "kubernetes"},
+		{"hyperv", "kubernetes"},
+		{"vsphere", "kubernetes"},
+		{"none", ""},
+		{"", ""},
+		{"unrecognized", ""},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.platform, func(t *testing.T) {
+			if got := DefaultTerraformBackendTypeForPlatform(tc.platform); got != tc.want {
+				t.Errorf("Expected platform %q to map to %q, got %q", tc.platform, tc.want, got)
+			}
+		})
+	}
+}

--- a/pkg/runtime/config/handler.go
+++ b/pkg/runtime/config/handler.go
@@ -34,6 +34,7 @@ type ConfigHandler interface {
 	LoadConfigForContext(contextName string) error
 	LoadConfigString(content string) error
 	GetString(key string, defaultValue ...string) string
+	GetTerraformBackendType() string
 	GetInt(key string, defaultValue ...int) int
 	GetBool(key string, defaultValue ...bool) bool
 	GetStringSlice(key string, defaultValue ...[]string) []string

--- a/pkg/runtime/config/mock_handler.go
+++ b/pkg/runtime/config/mock_handler.go
@@ -9,39 +9,40 @@ import (
 
 // MockConfigHandler is a mock implementation of the ConfigHandler interface
 type MockConfigHandler struct {
-	contextOverride string
-	LoadConfigFunc             func() error
-	LoadConfigForContextFunc   func(contextName string) error
-	LoadConfigStringFunc       func(content string) error
-	IsLoadedFunc               func() bool
-	GetStringFunc              func(key string, defaultValue ...string) string
-	GetIntFunc                 func(key string, defaultValue ...int) int
-	GetBoolFunc                func(key string, defaultValue ...bool) bool
-	GetStringSliceFunc         func(key string, defaultValue ...[]string) []string
-	GetStringMapFunc           func(key string, defaultValue ...map[string]string) map[string]string
-	SetFunc                    func(key string, value any) error
-	SaveConfigFunc             func(overwrite ...bool) error
-	SaveWorkstationStateFunc func() error
-	GetFunc                  func(key string) any
-	SetDefaultFunc             func(context v1alpha1.Context) error
-	GetConfigFunc              func() *v1alpha1.Context
-	GetContextFunc             func() string
-	IsDevModeFunc              func(contextName string) bool
-	SetContextFunc             func(context string) error
-	GetConfigRootFunc          func() (string, error)
-	GetWindsorScratchPathFunc  func() (string, error)
-	CleanFunc                  func() error
-	GenerateContextIDFunc      func() error
-	LoadSchemaFunc             func(schemaPath string) error
-	LoadSchemaFromBytesFunc    func(schemaContent []byte) error
-	GetSchemaFunc              func() map[string]any
-	GetContextValuesFunc       func() (map[string]any, error)
-	GetSetValuesFunc           func() map[string]any
-	SetApplySchemaDefaultsFunc func(enabled bool)
-	GetSensitivePathsFunc      func() []string
-	IsSensitivePathFunc        func(path string) bool
-	RegisterProviderFunc       func(prefix string, provider ValueProvider)
-	ValidateContextValuesFunc  func() error
+	contextOverride             string
+	LoadConfigFunc              func() error
+	LoadConfigForContextFunc    func(contextName string) error
+	LoadConfigStringFunc        func(content string) error
+	IsLoadedFunc                func() bool
+	GetStringFunc               func(key string, defaultValue ...string) string
+	GetTerraformBackendTypeFunc func() string
+	GetIntFunc                  func(key string, defaultValue ...int) int
+	GetBoolFunc                 func(key string, defaultValue ...bool) bool
+	GetStringSliceFunc          func(key string, defaultValue ...[]string) []string
+	GetStringMapFunc            func(key string, defaultValue ...map[string]string) map[string]string
+	SetFunc                     func(key string, value any) error
+	SaveConfigFunc              func(overwrite ...bool) error
+	SaveWorkstationStateFunc    func() error
+	GetFunc                     func(key string) any
+	SetDefaultFunc              func(context v1alpha1.Context) error
+	GetConfigFunc               func() *v1alpha1.Context
+	GetContextFunc              func() string
+	IsDevModeFunc               func(contextName string) bool
+	SetContextFunc              func(context string) error
+	GetConfigRootFunc           func() (string, error)
+	GetWindsorScratchPathFunc   func() (string, error)
+	CleanFunc                   func() error
+	GenerateContextIDFunc       func() error
+	LoadSchemaFunc              func(schemaPath string) error
+	LoadSchemaFromBytesFunc     func(schemaContent []byte) error
+	GetSchemaFunc               func() map[string]any
+	GetContextValuesFunc        func() (map[string]any, error)
+	GetSetValuesFunc            func() map[string]any
+	SetApplySchemaDefaultsFunc  func(enabled bool)
+	GetSensitivePathsFunc       func() []string
+	IsSensitivePathFunc         func(path string) bool
+	RegisterProviderFunc        func(prefix string, provider ValueProvider)
+	ValidateContextValuesFunc   func() error
 }
 
 // =============================================================================
@@ -98,6 +99,16 @@ func (m *MockConfigHandler) GetString(key string, defaultValue ...string) string
 		return defaultValue[0]
 	}
 	return "mock-string"
+}
+
+// GetTerraformBackendType calls the mock GetTerraformBackendTypeFunc if set, otherwise falls back
+// to GetString("terraform.backend.type", "local") so a test that only stubs GetStringFunc keeps
+// working without also stubbing this method.
+func (m *MockConfigHandler) GetTerraformBackendType() string {
+	if m.GetTerraformBackendTypeFunc != nil {
+		return m.GetTerraformBackendTypeFunc()
+	}
+	return m.GetString("terraform.backend.type", "local")
 }
 
 // GetInt calls the mock GetIntFunc if set, otherwise returns a reasonable default int

--- a/pkg/runtime/terraform/provider.go
+++ b/pkg/runtime/terraform/provider.go
@@ -1167,9 +1167,11 @@ func (p *terraformProvider) generateBackendConfigArgs(projectPath, configRoot st
 		appendBackendTfvars()
 		keyPath := fmt.Sprintf("%s%s", prefix, filepath.ToSlash(filepath.Join(projectPath, "terraform.tfstate")))
 		addBackendConfigArg("key", keyPath)
-		if backend := p.configHandler.GetConfig().Terraform.Backend.S3; backend != nil {
-			if err := p.processBackendConfig(backend, addBackendConfigArg); err != nil {
-				return nil, fmt.Errorf("error processing S3 backend config: %w", err)
+		if tfConfig := p.configHandler.GetConfig().Terraform; tfConfig != nil && tfConfig.Backend != nil {
+			if backend := tfConfig.Backend.S3; backend != nil {
+				if err := p.processBackendConfig(backend, addBackendConfigArg); err != nil {
+					return nil, fmt.Errorf("error processing S3 backend config: %w", err)
+				}
 			}
 		}
 	case "kubernetes":
@@ -1180,27 +1182,33 @@ func (p *terraformProvider) generateBackendConfigArgs(projectPath, configRoot st
 		}
 		secretSuffix = sanitizeForK8s(secretSuffix)
 		addBackendConfigArg("secret_suffix", secretSuffix)
-		if backend := p.configHandler.GetConfig().Terraform.Backend.Kubernetes; backend != nil {
-			if err := p.processBackendConfig(backend, addBackendConfigArg); err != nil {
-				return nil, fmt.Errorf("error processing Kubernetes backend config: %w", err)
+		if tfConfig := p.configHandler.GetConfig().Terraform; tfConfig != nil && tfConfig.Backend != nil {
+			if backend := tfConfig.Backend.Kubernetes; backend != nil {
+				if err := p.processBackendConfig(backend, addBackendConfigArg); err != nil {
+					return nil, fmt.Errorf("error processing Kubernetes backend config: %w", err)
+				}
 			}
 		}
 	case "azurerm":
 		appendBackendTfvars()
 		keyPath := fmt.Sprintf("%s%s", prefix, filepath.ToSlash(filepath.Join(projectPath, "terraform.tfstate")))
 		addBackendConfigArg("key", keyPath)
-		if backend := p.configHandler.GetConfig().Terraform.Backend.AzureRM; backend != nil {
-			if err := p.processBackendConfig(backend, addBackendConfigArg); err != nil {
-				return nil, fmt.Errorf("error processing AzureRM backend config: %w", err)
+		if tfConfig := p.configHandler.GetConfig().Terraform; tfConfig != nil && tfConfig.Backend != nil {
+			if backend := tfConfig.Backend.AzureRM; backend != nil {
+				if err := p.processBackendConfig(backend, addBackendConfigArg); err != nil {
+					return nil, fmt.Errorf("error processing AzureRM backend config: %w", err)
+				}
 			}
 		}
 	case "gcs":
 		appendBackendTfvars()
 		prefixPath := fmt.Sprintf("%s%s", prefix, filepath.ToSlash(projectPath))
 		addBackendConfigArg("prefix", prefixPath)
-		if backend := p.configHandler.GetConfig().Terraform.Backend.GCS; backend != nil {
-			if err := p.processBackendConfig(backend, addBackendConfigArg); err != nil {
-				return nil, fmt.Errorf("error processing GCS backend config: %w", err)
+		if tfConfig := p.configHandler.GetConfig().Terraform; tfConfig != nil && tfConfig.Backend != nil {
+			if backend := tfConfig.Backend.GCS; backend != nil {
+				if err := p.processBackendConfig(backend, addBackendConfigArg); err != nil {
+					return nil, fmt.Errorf("error processing GCS backend config: %w", err)
+				}
 			}
 		}
 	default:

--- a/pkg/runtime/terraform/provider.go
+++ b/pkg/runtime/terraform/provider.go
@@ -203,7 +203,7 @@ func (p *terraformProvider) IsInTerraformProject() bool {
 // the override file if it exists. Otherwise, it writes a backend_override.tf file with the appropriate
 // backend stanza for local, s3, kubernetes, azurerm, or gcs backends. Returns an error for unsupported backend types.
 func (p *terraformProvider) GenerateBackendOverride(directory string) error {
-	backend := p.configHandler.GetString("terraform.backend.type", "local")
+	backend := p.configHandler.GetTerraformBackendType()
 
 	var backendConfig string
 	switch backend {
@@ -721,7 +721,7 @@ func (p *terraformProvider) GetStatePath(componentID string) (string, error) {
 // don't know what's required — let the probe run and surface real init
 // failures via the warning path rather than silently disable detection.
 func (p *terraformProvider) BackendConfigComplete() bool {
-	backendType := p.configHandler.GetString("terraform.backend.type", "local")
+	backendType := p.configHandler.GetTerraformBackendType()
 	if backendType == "" || backendType == "local" {
 		return true
 	}
@@ -1126,7 +1126,7 @@ func (p *terraformProvider) restoreEnvVars(originalEnvVars map[string]string) {
 // Returns a slice of backend configuration arguments or an error if required configuration or paths are unavailable.
 func (p *terraformProvider) generateBackendConfigArgs(projectPath, configRoot string) ([]string, error) {
 	var backendConfigArgs []string
-	backend := p.configHandler.GetString("terraform.backend.type", "local")
+	backend := p.configHandler.GetTerraformBackendType()
 
 	addBackendConfigArg := func(key, value string) {
 		if value != "" {


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This PR touches terraform backend-type resolution across `cmd/get`, `cmd/init`/`up`/`bootstrap` flag handling, the provisioner (up, destroy, teardown, half-migration recovery), and the terraform stack/provider — a change to the shared logic ripples into state-backend selection for real infrastructure operations.
>
> **Overview**
>
> The PR centralizes the platform-to-backend default mapping (aws→s3, azure→azurerm, gcp→gcs, metal/docker/incus/hetzner/hyperv/vsphere→kubernetes) into a single `config.DefaultTerraformBackendTypeForPlatform` function and a new `ConfigHandler.GetTerraformBackendType()` accessor. Every production call site that previously read `terraform.backend.type` with a hardcoded `"local"` default is switched to the new accessor, so init-time flag defaulting and runtime reads can no longer drift apart.
>
> One behavioral side effect: `windsor get-contexts` now shows the resolved default backend (e.g. `local` or a platform-derived value) instead of `<none>` for contexts that never set `terraform.backend.type` explicitly. This isn't covered by an updated test in `cmd/get_test.go`, though it matches the PR's stated intent of applying the fallback everywhere.

<!-- /claude-code-review:summary -->
