### PR TITLE
ci: raise claude review max-turns from 40 to 80

### DIFF
--- a/.github/workflows/claude-code-review.yaml
+++ b/.github/workflows/claude-code-review.yaml
@@ -125,7 +125,7 @@ jobs:
             edit the PR.
           claude_args: |
             --model claude-sonnet-5
-            --max-turns 40
+            --max-turns 80
             --allowedTools Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Write
             --disallowedTools WebSearch,WebFetch
       - name: Publish review
@@ -227,7 +227,7 @@ jobs:
             edit the PR.
           claude_args: |
             --model claude-sonnet-5
-            --max-turns 40
+            --max-turns 80
             --allowedTools Read,Grep,Glob,Bash(git diff:*),Bash(git log:*),Write
             --disallowedTools WebSearch,WebFetch
       - name: Publish review
@@ -337,6 +337,6 @@ jobs:
             description. Be fast.
           claude_args: |
             --model claude-sonnet-5
-            --max-turns 40
+            --max-turns 80
             --allowedTools Read,Bash(gh:*),Bash(cat:*),Bash(jq:*)
             --disallowedTools WebSearch,WebFetch


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!WARNING]
>
> **Review did not complete**
>
> The automated review produced no summary. See the [run](https://github.com/windsorcli/cli/actions/runs/34491175723).

<!-- /claude-code-review:summary -->
