### PR TITLE
fix(destroy): drop the kubernetes reachability preflight

### DIFF
--- a/integration/destroy_test.go
+++ b/integration/destroy_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/windsorcli/cli/integration/helpers"
 )
@@ -345,5 +346,57 @@ func TestDestroyTerraform_WarnsWhenPreventDestroySet(t *testing.T) {
 	}
 	if !strings.Contains(combined, "remove the lifecycle block") {
 		t.Errorf("expected remediation hint in output, got:\n%s", combined)
+	}
+}
+
+// TestDestroyTerraform_IgnoresStaleKubeconfigWhenNoComponentNeedsCluster verifies that a
+// leftover kubeconfig file does not block destroying a terraform component that never
+// dials a cluster. Windsor runs no reachability preflight; the component's own destroy
+// never talks to the stale endpoint below, so destroy is not slowed by it either.
+func TestDestroyTerraform_IgnoresStaleKubeconfigWhenNoComponentNeedsCluster(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "destroy-no-kube-preflight")
+	helpers.MarkAsGitRepo(t, dir)
+	_, stderr, err := helpers.RunCLI(dir, []string{"init", "local"}, env)
+	if err != nil {
+		t.Fatalf("init local: %v\nstderr: %s", err, stderr)
+	}
+	env = append(env, "WINDSOR_CONTEXT=local")
+	_, stderr, err = helpers.RunCLI(dir, []string{"apply", "terraform", "null"}, env)
+	if err != nil {
+		t.Fatalf("apply terraform null: %v\nstderr: %s", err, stderr)
+	}
+
+	kubeDir := filepath.Join(dir, "contexts", "local", ".kube")
+	if err := os.MkdirAll(kubeDir, 0o755); err != nil {
+		t.Fatalf("mkdir kube dir: %v", err)
+	}
+	staleKubeconfig := []byte(`apiVersion: v1
+kind: Config
+clusters:
+  - name: stale
+    cluster:
+      server: https://127.0.0.1:1
+contexts:
+  - name: stale
+    context:
+      cluster: stale
+current-context: stale
+`)
+	kubeconfigPath := filepath.Join(kubeDir, "config")
+	if err := os.WriteFile(kubeconfigPath, staleKubeconfig, 0o644); err != nil {
+		t.Fatalf("write stale kubeconfig: %v", err)
+	}
+	env = append(env, "KUBECONFIG="+kubeconfigPath)
+
+	start := time.Now()
+	_, stderr, err = helpers.RunCLI(dir, []string{"destroy", "--confirm=null", "terraform", "null"}, env)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("destroy terraform null: %v\nstderr: %s", err, stderr)
+	}
+	if elapsed > 10*time.Second {
+		t.Errorf("expected destroy to skip the Kubernetes reachability preflight and return quickly, took %v", elapsed)
 	}
 }

--- a/integration/fixtures/destroy-no-kube-preflight/contexts/_template/blueprint.yaml
+++ b/integration/fixtures/destroy-no-kube-preflight/contexts/_template/blueprint.yaml
@@ -1,0 +1,7 @@
+kind: Blueprint
+apiVersion: blueprints.windsorcli.dev/v1alpha1
+metadata:
+  name: destroy-no-kube-preflight
+  description: Fixture for the kubeconfig-present-but-unneeded destroy preflight
+terraform:
+  - path: "null"

--- a/integration/fixtures/destroy-no-kube-preflight/terraform/null/main.tf
+++ b/integration/fixtures/destroy-no-kube-preflight/terraform/null/main.tf
@@ -1,0 +1,1 @@
+resource "null_resource" "noop" {}

--- a/integration/fixtures/destroy-no-kube-preflight/windsor.yaml
+++ b/integration/fixtures/destroy-no-kube-preflight/windsor.yaml
@@ -1,0 +1,3 @@
+version: v1alpha1
+contexts:
+  local: {}

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -176,6 +176,9 @@ const DefaultKustomizationWaitMaxFailures = 5
 // Bounds a single `terraform destroy` invocation so a hung provider call fails, not blocks forever.
 const DefaultTerraformDestroyTimeout = 30 * time.Minute
 
+// Bounds terraform refresh before destroy. Short on purpose: a hung refresh means the provider is unreachable.
+const DefaultTerraformRefreshTimeout = 2 * time.Minute
+
 // Bounds the pre-destroy Kubernetes reachability preflight.
 const DefaultKubernetesReachabilityCheckTimeout = 30 * time.Second
 

--- a/pkg/provisioner/destroy.go
+++ b/pkg/provisioner/destroy.go
@@ -104,7 +104,7 @@ func (i *Provisioner) Teardown(blueprint *blueprintv1alpha1.Blueprint, terraform
 		if err != nil {
 			return err
 		}
-		tierResult, destroyErr := i.destroyAllTerraform(tierBP, continueOnError, false)
+		tierResult, destroyErr := i.destroyAllTerraform(tierBP, continueOnError)
 		result.Destroyed = append(result.Destroyed, tierResult.Destroyed...)
 		result.Skipped = mergeSkipped(result.Skipped, mergeSkipped(migrationSkipped, tierResult.Skipped))
 		result.Failed = append(result.Failed, tierResult.Failed...)

--- a/pkg/provisioner/destroy_test.go
+++ b/pkg/provisioner/destroy_test.go
@@ -565,57 +565,6 @@ func TestProvisioner_Teardown(t *testing.T) {
 		}
 	})
 
-	t.Run("Stage2SkipsReachabilityCheckAfterClusterAlreadyDestroyed", func(t *testing.T) {
-		// Stage 1 destroys the cluster component itself (it is never a tier
-		// member), so by the time Stage 2 runs the kubeconfig on disk is stale
-		// and WaitForKubernetesHealthy fails against a host that no longer
-		// exists. That is the expected post-Stage-1 state, not broken auth —
-		// Stage 2's tier-only destroy must still proceed.
-		mocks := setupProvisionerMocks(t)
-		bp := &blueprintv1alpha1.Blueprint{
-			Backend:  "backend",
-			Metadata: blueprintv1alpha1.Metadata{Name: "test"},
-			TerraformComponents: []blueprintv1alpha1.TerraformComponent{
-				{Path: "backend"},
-				{Path: "cluster"},
-			},
-		}
-		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
-		mockCH.GetStringFunc = func(key string, defaultValue ...string) string {
-			if key == "terraform.backend.type" {
-				return "s3"
-			}
-			if len(defaultValue) > 0 {
-				return defaultValue[0]
-			}
-			return ""
-		}
-		mockCH.SetFunc = func(_ string, _ any) error { return nil }
-		destroyAllCalls := 0
-		mockStack := terraforminfra.NewMockStack()
-		mockStack.DestroyAllFunc = func(_ *blueprintv1alpha1.Blueprint, _ bool, _ ...string) (terraforminfra.DestroyOutcome, error) {
-			destroyAllCalls++
-			return terraforminfra.DestroyOutcome{}, nil
-		}
-		// Stage 1's own reachability check must still pass (the cluster is still up
-		// going into Stage 1); only once Stage 1's DestroyAll has torn it down does
-		// the kubeconfig on disk go stale, which is what Stage 2 must tolerate.
-		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
-			if destroyAllCalls == 0 {
-				return nil
-			}
-			return fmt.Errorf("dial tcp: lookup cluster-w0820el4.hcp.eastus.azmk8s.io: no such host")
-		}
-		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack})
-
-		if _, err := provisioner.Teardown(bp, true, false); err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if destroyAllCalls != 2 {
-			t.Errorf("Expected Stage 1 + Stage 2 DestroyAll calls (2), got %d", destroyAllCalls)
-		}
-	})
-
 	t.Run("MultiComponentTierDestroyedTogether", func(t *testing.T) {
 		// VPC + IAM + cluster as the tier. Stage 1 destroys non-tier (workloads)
 		// against the configured backend; Stage 2a migrates all three tier members'

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -395,10 +395,10 @@ func (i *Provisioner) Down(blueprint *blueprintv1alpha1.Blueprint) error {
 // even when a later component fails. Skipped components had nothing in state to destroy (never
 // applied, fully torn down already, or upstream destroy collapsed their cloud objects out from
 // under them); cmd-layer callers surface them in the user-facing summary so an operator can see
-// "these were no-ops" alongside "these were destroyed". Runs checkKubernetesReachableForDestroy
-// once terraform is confirmed enabled.
+// "these were no-ops" alongside "these were destroyed". TerraformStack bounds refresh and
+// destroy with a timeout, so an unreachable provider fails within that time instead of hanging.
 func (i *Provisioner) DestroyAllTerraform(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyResult, error) {
-	return i.destroyAllTerraform(blueprint, continueOnError, true, excludeIDs...)
+	return i.destroyAllTerraform(blueprint, continueOnError, excludeIDs...)
 }
 
 // Apply runs terraform init, plan, and apply for a single component identified by componentID.
@@ -424,8 +424,8 @@ func (i *Provisioner) Apply(blueprint *blueprintv1alpha1.Blueprint, componentID 
 // Returns (skipped, nil) when the component's state is empty (nothing to destroy), (false, nil)
 // when destroy ran successfully, or (false, err) on any failure. Returns an error if the
 // blueprint is nil, terraform is disabled, the stack cannot be initialized, the component is
-// not found, or any terraform operation fails. Runs checkKubernetesReachableForDestroy once
-// terraform is confirmed enabled.
+// not found, or any terraform operation fails. TerraformStack bounds refresh and destroy
+// with a timeout, so an unreachable provider fails within that time instead of hanging.
 func (i *Provisioner) Destroy(blueprint *blueprintv1alpha1.Blueprint, componentID string) (bool, error) {
 	if blueprint == nil {
 		return false, fmt.Errorf("blueprint not provided")
@@ -435,9 +435,6 @@ func (i *Provisioner) Destroy(blueprint *blueprintv1alpha1.Blueprint, componentI
 	}
 	if i.TerraformStack == nil {
 		return false, fmt.Errorf("terraform is disabled")
-	}
-	if err := i.checkKubernetesReachableForDestroy(); err != nil {
-		return false, err
 	}
 	skipped, err := i.TerraformStack.Destroy(blueprint, componentID)
 	if err != nil {
@@ -490,8 +487,8 @@ func (i *Provisioner) DestroyKustomize(blueprint *blueprintv1alpha1.Blueprint, c
 // last). Returns the IDs of terraform components that were skipped because their state
 // was empty (never applied, already torn down) alongside any error from either step —
 // paired with the error so callers see what was no-op'd even when a later step fails.
-// Returns an error if either step fails. checkKubernetesReachableForDestroy runs after the
-// kustomize step (so it never fires if kustomize already hard-failed) and before terraform.
+// Returns an error if either step fails. TerraformStack bounds refresh and destroy with a
+// timeout, so an unreachable provider fails within that time instead of hanging.
 func (i *Provisioner) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyResult, error) {
 	var result DestroyResult
 	if blueprint == nil {
@@ -517,9 +514,6 @@ func (i *Provisioner) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continu
 		return result, err
 	}
 	if i.TerraformStack != nil {
-		if err := i.checkKubernetesReachableForDestroy(); err != nil {
-			return result, err
-		}
 		outcome, err := i.TerraformStack.DestroyAll(blueprint, continueOnError, excludeIDs...)
 		result.Destroyed = append(result.Destroyed, outcome.Destroyed...)
 		result.Skipped = append(result.Skipped, outcome.Skipped...)
@@ -1720,11 +1714,8 @@ func sortedStringKeys(m map[string]struct{}) []string {
 	return out
 }
 
-// destroyAllTerraform is the shared implementation behind DestroyAllTerraform. checkReachability
-// is false only for Teardown's Stage 2 tier destroy. By that stage, Stage 1 has already destroyed
-// the cluster, so an unreachable Kubernetes API is expected, not a sign of broken auth. The
-// backend tier also has no kubernetes/helm provider dependency for the check to protect.
-func (i *Provisioner) destroyAllTerraform(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, checkReachability bool, excludeIDs ...string) (DestroyResult, error) {
+// destroyAllTerraform is the shared implementation behind DestroyAllTerraform.
+func (i *Provisioner) destroyAllTerraform(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyResult, error) {
 	var result DestroyResult
 	if blueprint == nil {
 		return result, fmt.Errorf("blueprint not provided")
@@ -1734,11 +1725,6 @@ func (i *Provisioner) destroyAllTerraform(blueprint *blueprintv1alpha1.Blueprint
 	}
 	if i.TerraformStack == nil {
 		return result, fmt.Errorf("terraform is disabled")
-	}
-	if checkReachability {
-		if err := i.checkKubernetesReachableForDestroy(); err != nil {
-			return result, err
-		}
 	}
 	outcome, err := i.TerraformStack.DestroyAll(blueprint, continueOnError, excludeIDs...)
 	result.Destroyed = outcome.Destroyed

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -376,27 +376,18 @@ func (i *Provisioner) Down(blueprint *blueprintv1alpha1.Blueprint) error {
 	if i.TerraformStack == nil {
 		return nil
 	}
-	// Down ignores the skipped flag from Destroy: an empty-state workstation component is
-	// effectively a successful tear-down for the workstation flow's purposes (nothing to
-	// destroy = nothing left). The cmd-level destroy paths surface skip status; Down does
-	// not need to.
 	if _, err := i.TerraformStack.Destroy(blueprint, "workstation"); err != nil {
 		return fmt.Errorf("failed to destroy workstation terraform component: %w", err)
 	}
 	return nil
 }
 
-// DestroyAllTerraform destroys all terraform components in the stack in reverse dependency order.
-// Components with Destroy set to false are skipped. excludeIDs are skipped entirely (used by the
-// cmd-layer symmetric-destroy flow to peel the backend component off the bulk pass and migrate
-// it before destroying it last). If terraform is disabled, returns an error. Returns the IDs of
-// components that were skipped because their state was empty alongside any error, mirroring the
-// MigrateState contract — the slice is paired with the error so callers see partial progress
-// even when a later component fails. Skipped components had nothing in state to destroy (never
-// applied, fully torn down already, or upstream destroy collapsed their cloud objects out from
-// under them); cmd-layer callers surface them in the user-facing summary so an operator can see
-// "these were no-ops" alongside "these were destroyed". TerraformStack bounds refresh and
-// destroy with a timeout, so an unreachable provider fails within that time instead of hanging.
+// DestroyAllTerraform destroys all terraform components in reverse dependency order.
+// Components with Destroy set to false, or listed in excludeIDs, are skipped. The
+// cmd-layer symmetric-destroy flow excludes the backend component here, to migrate
+// and destroy it last.
+// Returns the IDs of components skipped for empty state, alongside any error, so
+// callers see partial progress even when a later component fails.
 func (i *Provisioner) DestroyAllTerraform(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyResult, error) {
 	return i.destroyAllTerraform(blueprint, continueOnError, excludeIDs...)
 }
@@ -475,20 +466,13 @@ func (i *Provisioner) DestroyKustomize(blueprint *blueprintv1alpha1.Blueprint, c
 	return nil
 }
 
-// DestroyAll destroys all infrastructure components: first uninstalls all kustomizations,
-// then destroys all terraform components. The kustomization uninstall step is skipped
-// when no kubeconfig exists at the context-scoped path — the cluster is gone (or was
-// never bootstrapped past terraform), so trying to talk to its API would fail with a
-// stat error and abort the whole destroy. Skipping idempotently lets `windsor destroy`
-// run cleanly after the cluster's already been torn down by a prior partial destroy or
-// out-of-band action. excludeIDs are forwarded to the terraform destroy pass so
-// cmd-layer callers can peel off the backend component for the symmetric-destroy flow
-// (destroy non-backend against live remote state, then migrate-and-destroy backend
-// last). Returns the IDs of terraform components that were skipped because their state
-// was empty (never applied, already torn down) alongside any error from either step —
-// paired with the error so callers see what was no-op'd even when a later step fails.
-// Returns an error if either step fails. TerraformStack bounds refresh and destroy with a
-// timeout, so an unreachable provider fails within that time instead of hanging.
+// DestroyAll destroys every infrastructure component: kustomizations first, then terraform.
+// It skips the kustomization step when no kubeconfig exists, since the cluster is
+// already gone. This keeps `windsor destroy` idempotent after a partial teardown.
+// excludeIDs skips components in the terraform pass. cmd-layer callers use it to
+// destroy the backend component last, after migrating its state.
+// Returns the IDs of terraform components skipped for empty state, alongside any
+// error, so callers see partial progress even when a later step fails.
 func (i *Provisioner) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyResult, error) {
 	var result DestroyResult
 	if blueprint == nil {

--- a/pkg/provisioner/provisioner_test.go
+++ b/pkg/provisioner/provisioner_test.go
@@ -829,7 +829,9 @@ func TestProvisioner_DestroyAllTerraform(t *testing.T) {
 		}
 	})
 
-	t.Run("ErrorKubernetesUnreachable", func(t *testing.T) {
+	t.Run("DoesNotGateOnKubernetesReachability", func(t *testing.T) {
+		// Provisioner runs no reachability preflight at all; an unreachable cluster only
+		// ever surfaces from the terraform refresh/destroy timeout, not an upfront block.
 		mocks := setupProvisionerMocks(t)
 		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
 			return fmt.Errorf("connection refused")
@@ -843,16 +845,11 @@ func TestProvisioner_DestroyAllTerraform(t *testing.T) {
 		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
-		_, err := provisioner.DestroyAllTerraform(createTestBlueprint(), false)
-
-		if err == nil {
-			t.Fatal("Expected error when kubernetes is unreachable")
+		if _, err := provisioner.DestroyAllTerraform(createTestBlueprint(), false); err != nil {
+			t.Fatalf("Expected no error: Provisioner must not gate on Kubernetes reachability, got: %v", err)
 		}
-		if !strings.Contains(err.Error(), "kubernetes API is unreachable") {
-			t.Errorf("Expected specific error message, got: %v", err)
-		}
-		if destroyAllCalled {
-			t.Error("Expected terraform DestroyAll not to run when kubernetes is unreachable")
+		if !destroyAllCalled {
+			t.Error("Expected terraform DestroyAll to run: Provisioner must not gate on Kubernetes reachability itself")
 		}
 	})
 }
@@ -2441,7 +2438,9 @@ func TestProvisioner_Destroy(t *testing.T) {
 		}
 	})
 
-	t.Run("ErrorKubernetesUnreachable", func(t *testing.T) {
+	t.Run("DoesNotGateOnKubernetesReachability", func(t *testing.T) {
+		// Provisioner runs no reachability preflight at all; an unreachable cluster only
+		// ever surfaces from the terraform refresh/destroy timeout, not an upfront block.
 		mocks := setupProvisionerMocks(t)
 		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
 			return fmt.Errorf("connection refused")
@@ -2455,16 +2454,11 @@ func TestProvisioner_Destroy(t *testing.T) {
 		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
-		_, err := provisioner.Destroy(createTestBlueprint(), "remote/path")
-
-		if err == nil {
-			t.Fatal("Expected error when kubernetes is unreachable")
+		if _, err := provisioner.Destroy(createTestBlueprint(), "remote/path"); err != nil {
+			t.Fatalf("Expected no error: Provisioner must not gate on Kubernetes reachability, got: %v", err)
 		}
-		if !strings.Contains(err.Error(), "kubernetes API is unreachable") {
-			t.Errorf("Expected specific error message, got: %v", err)
-		}
-		if destroyCalled {
-			t.Error("Expected terraform Destroy not to run when kubernetes is unreachable")
+		if !destroyCalled {
+			t.Error("Expected terraform Destroy to run: Provisioner must not gate on Kubernetes reachability itself")
 		}
 	})
 }
@@ -2771,7 +2765,9 @@ func TestProvisioner_DestroyAll(t *testing.T) {
 		}
 	})
 
-	t.Run("ErrorKubernetesUnreachable", func(t *testing.T) {
+	t.Run("DoesNotGateOnKubernetesReachability", func(t *testing.T) {
+		// Provisioner runs no reachability preflight at all; an unreachable cluster only
+		// ever surfaces from the terraform refresh/destroy timeout, not an upfront block.
 		mocks := setupProvisionerMocks(t)
 		mocks.KubernetesManager.DeleteBlueprintFunc = func(bp *blueprintv1alpha1.Blueprint, namespace string) error { return nil }
 		mocks.KubernetesManager.WaitForKubernetesHealthyFunc = func(ctx context.Context, endpoint string, outputFunc func(string), nodeNames ...string) error {
@@ -2786,16 +2782,11 @@ func TestProvisioner_DestroyAll(t *testing.T) {
 		opts := &Provisioner{KubernetesManager: mocks.KubernetesManager, TerraformStack: mockStack}
 		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, opts)
 
-		_, err := provisioner.DestroyAll(createTestBlueprint(), false)
-
-		if err == nil {
-			t.Fatal("Expected error when kubernetes is unreachable")
+		if _, err := provisioner.DestroyAll(createTestBlueprint(), false); err != nil {
+			t.Fatalf("Expected no error: Provisioner must not gate on Kubernetes reachability, got: %v", err)
 		}
-		if !strings.Contains(err.Error(), "kubernetes API is unreachable") {
-			t.Errorf("Expected specific error message, got: %v", err)
-		}
-		if destroyAllCalled {
-			t.Error("Expected terraform DestroyAll not to run when kubernetes is unreachable")
+		if !destroyAllCalled {
+			t.Error("Expected terraform DestroyAll to run: Provisioner must not gate on Kubernetes reachability itself")
 		}
 	})
 }

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -10,6 +10,7 @@ package terraform
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -24,6 +25,7 @@ import (
 	"github.com/windsorcli/cli/pkg/debug"
 	"github.com/windsorcli/cli/pkg/runtime"
 	envvars "github.com/windsorcli/cli/pkg/runtime/env"
+	"github.com/windsorcli/cli/pkg/runtime/shell"
 	"github.com/windsorcli/cli/pkg/tui"
 )
 
@@ -583,7 +585,7 @@ func (s *TerraformStack) MigrateComponentState(blueprint *blueprintv1alpha1.Blue
 // is migrated to local). When continueOnError is true, per-component destroy errors are
 // collected in DestroyOutcome.Failed and the loop proceeds to the next component; when
 // false, the first error aborts and is returned alongside a partial DestroyOutcome. Each
-// destroy is bounded by constants.DefaultTerraformDestroyTimeout.
+// destroy is bounded by constants.DefaultTerraformDestroyTimeout; refresh by refreshBeforeDestroy.
 func (s *TerraformStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyOutcome, error) {
 	var result DestroyOutcome
 	if blueprint == nil {
@@ -668,20 +670,9 @@ func (s *TerraformStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, cont
 				return nil
 			}
 
-			// Tolerate refresh failures for non-empty-state components. A transient refresh
-			// issue (network blip, credential rotation, provider API hiccup) must not make a
-			// live component undestroyable. The pre-refresh check confirmed state is non-empty,
-			// so we know there is something to destroy; fall through to `terraform destroy
-			// -refresh=true` and let terraform's own refresh have a second shot. Persistent
-			// refresh problems will then surface from destroy itself with a more actionable
-			// error than the refresh step would have. The warning is emitted to stderr so the
-			// operator can correlate a later destroy failure with the upstream refresh hiccup
-			// — without it, a recurring credential or connectivity issue is invisible until
-			// destroy errors out, and a successful fallback leaves no trace at all.
-			refreshFailed := false
-			if err := s.refreshComponentState(&component, terraformVars, scopedKeys, terraformArgs, constants.DefaultTerraformDestroyTimeout); err != nil {
-				refreshFailed = true
-				fmt.Fprintf(s.warningWriter, "warning: terraform refresh failed for %s; falling through to destroy -refresh=true (terraform will retry refresh during destroy): %v\n", component.Path, err)
+			refreshFailed, err := s.refreshBeforeDestroy(&component, terraformVars, scopedKeys, terraformArgs)
+			if err != nil {
+				return err
 			}
 
 			// Skip the post-refresh empty-state check when refresh failed — the state we would
@@ -889,7 +880,7 @@ func (s *TerraformStack) Apply(blueprint *blueprintv1alpha1.Blueprint, component
 // for backend) would otherwise produce inconsistent "Destroying X" / "Destroying terraform
 // for X" lines side by side. The terraform destroy exec runs silently inside the spinner
 // for the same reason: the bulk loop is silent, so single-component Destroy must be too.
-// Bounded by constants.DefaultTerraformDestroyTimeout.
+// Destroy is bounded by constants.DefaultTerraformDestroyTimeout; refresh by refreshBeforeDestroy.
 func (s *TerraformStack) Destroy(blueprint *blueprintv1alpha1.Blueprint, componentID string) (bool, error) {
 	if blueprint == nil {
 		return false, fmt.Errorf("blueprint not provided")
@@ -921,10 +912,9 @@ func (s *TerraformStack) Destroy(blueprint *blueprintv1alpha1.Blueprint, compone
 			return nil
 		}
 
-		refreshFailed := false
-		if err := s.refreshComponentState(component, terraformVars, scopedKeys, terraformArgs, constants.DefaultTerraformDestroyTimeout); err != nil {
-			refreshFailed = true
-			fmt.Fprintf(s.warningWriter, "warning: terraform refresh failed for %s; falling through to destroy -refresh=true (terraform will retry refresh during destroy): %v\n", component.Path, err)
+		refreshFailed, err := s.refreshBeforeDestroy(component, terraformVars, scopedKeys, terraformArgs)
+		if err != nil {
+			return err
 		}
 
 		if !refreshFailed {
@@ -1244,11 +1234,8 @@ func (s *TerraformStack) refreshIfStateNonEmpty(component *blueprintv1alpha1.Ter
 }
 
 // refreshComponentState runs `terraform refresh` to reconcile state with cloud reality.
-// Errors are returned to the caller. Destroy callers tolerate refresh failures for non-
-// empty-state components by falling through to `terraform destroy -refresh=true`; see
-// Destroy / DestroyAll for the rationale. A zero timeout runs unbounded; destroy callers
-// pass constants.DefaultTerraformDestroyTimeout, since refresh is where a resource's own
-// kubernetes/helm provider would hang dialing an unreachable cluster.
+// A timeout wraps shell.ErrCommandTimedOut. A zero timeout runs unbounded. See
+// refreshBeforeDestroy for how destroy callers bound and classify the result.
 func (s *TerraformStack) refreshComponentState(component *blueprintv1alpha1.TerraformComponent, terraformVars map[string]string, scopedKeys []string, terraformArgs *envvars.TerraformArgs, timeout time.Duration) error {
 	terraformCommand := s.runtime.ToolsManager.GetTerraformCommand()
 	refreshArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "refresh"}
@@ -1264,6 +1251,24 @@ func (s *TerraformStack) refreshComponentState(component *blueprintv1alpha1.Terr
 		return fmt.Errorf("error refreshing terraform state for %s: %w", component.Path, err)
 	}
 	return nil
+}
+
+// refreshBeforeDestroy runs refreshComponentState bounded by constants.DefaultTerraformRefreshTimeout
+// and classifies the result for a destroy caller. Returns (refreshFailed, err):
+//   - A timeout means the provider is unreachable. err is non-nil. The caller aborts this
+//     component now, instead of retrying refresh inside a full-length destroy.
+//   - Any other failure is plausibly transient. refreshFailed is true, err is nil. The caller
+//     falls through to `terraform destroy -refresh=true` for a second chance.
+func (s *TerraformStack) refreshBeforeDestroy(component *blueprintv1alpha1.TerraformComponent, terraformVars map[string]string, scopedKeys []string, terraformArgs *envvars.TerraformArgs) (bool, error) {
+	err := s.refreshComponentState(component, terraformVars, scopedKeys, terraformArgs, constants.DefaultTerraformRefreshTimeout)
+	if err == nil {
+		return false, nil
+	}
+	if errors.Is(err, shell.ErrCommandTimedOut) {
+		return false, fmt.Errorf("kubernetes API is unreachable, refusing to destroy %s. terraform refresh did not respond within %s: %w", component.Path, constants.DefaultTerraformRefreshTimeout, err)
+	}
+	fmt.Fprintf(s.warningWriter, "warning: terraform refresh failed for %s; falling through to destroy -refresh=true (terraform will retry refresh during destroy): %v\n", component.Path, err)
+	return true, nil
 }
 
 // backendPointerPath returns the per-component backend pointer file path — the

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -1265,7 +1265,7 @@ func (s *TerraformStack) refreshBeforeDestroy(component *blueprintv1alpha1.Terra
 		return false, nil
 	}
 	if errors.Is(err, shell.ErrCommandTimedOut) {
-		return false, fmt.Errorf("kubernetes API is unreachable, refusing to destroy %s. terraform refresh did not respond within %s: %w", component.Path, constants.DefaultTerraformRefreshTimeout, err)
+		return false, fmt.Errorf("terraform refresh for %s timed out after %s; its provider looks unreachable: %w", component.Path, constants.DefaultTerraformRefreshTimeout, err)
 	}
 	fmt.Fprintf(s.warningWriter, "warning: terraform refresh failed for %s; falling through to destroy -refresh=true (terraform will retry refresh during destroy): %v\n", component.Path, err)
 	return true, nil

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -17,6 +17,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	blueprintv1alpha1 "github.com/windsorcli/cli/api/v1alpha1"
 	"github.com/windsorcli/cli/pkg/constants"
@@ -678,7 +679,7 @@ func (s *TerraformStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, cont
 			// — without it, a recurring credential or connectivity issue is invisible until
 			// destroy errors out, and a successful fallback leaves no trace at all.
 			refreshFailed := false
-			if err := s.refreshComponentState(&component, terraformVars, scopedKeys, terraformArgs); err != nil {
+			if err := s.refreshComponentState(&component, terraformVars, scopedKeys, terraformArgs, constants.DefaultTerraformDestroyTimeout); err != nil {
 				refreshFailed = true
 				fmt.Fprintf(s.warningWriter, "warning: terraform refresh failed for %s; falling through to destroy -refresh=true (terraform will retry refresh during destroy): %v\n", component.Path, err)
 			}
@@ -921,7 +922,7 @@ func (s *TerraformStack) Destroy(blueprint *blueprintv1alpha1.Blueprint, compone
 		}
 
 		refreshFailed := false
-		if err := s.refreshComponentState(component, terraformVars, scopedKeys, terraformArgs); err != nil {
+		if err := s.refreshComponentState(component, terraformVars, scopedKeys, terraformArgs, constants.DefaultTerraformDestroyTimeout); err != nil {
 			refreshFailed = true
 			fmt.Fprintf(s.warningWriter, "warning: terraform refresh failed for %s; falling through to destroy -refresh=true (terraform will retry refresh during destroy): %v\n", component.Path, err)
 		}
@@ -1236,7 +1237,7 @@ func (s *TerraformStack) refreshIfStateNonEmpty(component *blueprintv1alpha1.Ter
 	if !hasResources {
 		return nil
 	}
-	if err := s.refreshComponentState(component, terraformVars, scopedKeys, terraformArgs); err != nil {
+	if err := s.refreshComponentState(component, terraformVars, scopedKeys, terraformArgs, 0); err != nil {
 		fmt.Fprintf(s.warningWriter, "warning: terraform refresh failed for %s; continuing with plan against the last-known state (plan runs with -refresh=false; any persistent state divergence will surface as a plan error): %v\n", component.Path, err)
 	}
 	return nil
@@ -1245,13 +1246,21 @@ func (s *TerraformStack) refreshIfStateNonEmpty(component *blueprintv1alpha1.Ter
 // refreshComponentState runs `terraform refresh` to reconcile state with cloud reality.
 // Errors are returned to the caller. Destroy callers tolerate refresh failures for non-
 // empty-state components by falling through to `terraform destroy -refresh=true`; see
-// Destroy / DestroyAll for the rationale.
-func (s *TerraformStack) refreshComponentState(component *blueprintv1alpha1.TerraformComponent, terraformVars map[string]string, scopedKeys []string, terraformArgs *envvars.TerraformArgs) error {
+// Destroy / DestroyAll for the rationale. A zero timeout runs unbounded; destroy callers
+// pass constants.DefaultTerraformDestroyTimeout, since refresh is where a resource's own
+// kubernetes/helm provider would hang dialing an unreachable cluster.
+func (s *TerraformStack) refreshComponentState(component *blueprintv1alpha1.TerraformComponent, terraformVars map[string]string, scopedKeys []string, terraformArgs *envvars.TerraformArgs, timeout time.Duration) error {
 	terraformCommand := s.runtime.ToolsManager.GetTerraformCommand()
 	refreshArgs := []string{fmt.Sprintf("-chdir=%s", component.FullPath), "refresh"}
 	refreshArgs = append(refreshArgs, terraformArgs.RefreshArgs...)
 	refreshEnv := selectTerraformCommandEnv(terraformVars, true, scopedKeys)
-	if _, err := s.runtime.Shell.ExecSilentWithEnv(terraformCommand, refreshEnv, refreshArgs...); err != nil {
+	var err error
+	if timeout > 0 {
+		_, err = s.runtime.Shell.ExecSilentWithEnvAndTimeout(terraformCommand, refreshEnv, refreshArgs, timeout)
+	} else {
+		_, err = s.runtime.Shell.ExecSilentWithEnv(terraformCommand, refreshEnv, refreshArgs...)
+	}
+	if err != nil {
 		return fmt.Errorf("error refreshing terraform state for %s: %w", component.Path, err)
 	}
 	return nil

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -1311,8 +1311,8 @@ func TestStack_DestroyAll(t *testing.T) {
 		if !sawRefresh {
 			t.Fatal("Expected terraform refresh to run via ExecSilentWithEnvAndTimeout")
 		}
-		if gotTimeout != constants.DefaultTerraformDestroyTimeout {
-			t.Errorf("Expected timeout %v, got %v", constants.DefaultTerraformDestroyTimeout, gotTimeout)
+		if gotTimeout != constants.DefaultTerraformRefreshTimeout {
+			t.Errorf("Expected timeout %v, got %v", constants.DefaultTerraformRefreshTimeout, gotTimeout)
 		}
 	})
 
@@ -1918,6 +1918,39 @@ func TestStack_DestroyAll(t *testing.T) {
 		}
 		if strings.Contains(warningOutput, "warning: terraform refresh failed for remote/path") {
 			t.Errorf("No warning expected for remote/path (refresh succeeded), got: %q", warningOutput)
+		}
+	})
+
+	t.Run("RefreshTimeoutAbortsWithoutDestroyFallback", func(t *testing.T) {
+		// Given a component whose refresh times out. A timeout means the provider is
+		// unreachable, not that the failure is transient, so destroy must abort this
+		// component now instead of retrying refresh inside `terraform destroy -refresh=true`.
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+
+		var sawDestroy bool
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			if command == "terraform" && len(args) >= 2 && args[1] == "refresh" {
+				return "", fmt.Errorf("%w after %v", shell.ErrCommandTimedOut, timeout)
+			}
+			if command == "terraform" && len(args) >= 2 && args[1] == "destroy" {
+				sawDestroy = true
+			}
+			return "", nil
+		}
+
+		// When DestroyAll runs
+		_, err := stack.DestroyAll(blueprint, false)
+
+		// Then it fails fast with an actionable error and never runs destroy
+		if err == nil {
+			t.Fatal("Expected DestroyAll to fail when refresh times out")
+		}
+		if !strings.Contains(err.Error(), "kubernetes API is unreachable") {
+			t.Errorf("Expected an actionable unreachable-provider error, got %v", err)
+		}
+		if sawDestroy {
+			t.Error("Expected terraform destroy not to run after a refresh timeout")
 		}
 	})
 
@@ -3382,8 +3415,8 @@ func TestStack_Destroy(t *testing.T) {
 		if !sawRefresh {
 			t.Fatal("Expected terraform refresh to run via ExecSilentWithEnvAndTimeout")
 		}
-		if gotTimeout != constants.DefaultTerraformDestroyTimeout {
-			t.Errorf("Expected timeout %v, got %v", constants.DefaultTerraformDestroyTimeout, gotTimeout)
+		if gotTimeout != constants.DefaultTerraformRefreshTimeout {
+			t.Errorf("Expected timeout %v, got %v", constants.DefaultTerraformRefreshTimeout, gotTimeout)
 		}
 	})
 
@@ -3971,6 +4004,39 @@ func TestStack_Destroy(t *testing.T) {
 		}
 		if !strings.Contains(warningOutput, "mock error refreshing state") {
 			t.Errorf("Expected warning to include underlying refresh error for diagnostics, got: %q", warningOutput)
+		}
+	})
+
+	t.Run("RefreshTimeoutAbortsWithoutDestroyFallback", func(t *testing.T) {
+		// Given a component whose refresh times out. A timeout means the provider is
+		// unreachable, not that the failure is transient, so destroy must abort now
+		// instead of retrying refresh inside `terraform destroy -refresh=true`.
+		stack, mocks := setup(t)
+		blueprint := createTestBlueprint()
+
+		var sawDestroy bool
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			if command == "terraform" && len(args) >= 2 && args[1] == "refresh" {
+				return "", fmt.Errorf("%w after %v", shell.ErrCommandTimedOut, timeout)
+			}
+			if command == "terraform" && len(args) >= 2 && args[1] == "destroy" {
+				sawDestroy = true
+			}
+			return "", nil
+		}
+
+		// When destroying the component
+		_, err := stack.Destroy(blueprint, "local/path")
+
+		// Then it fails fast with an actionable error and never runs destroy
+		if err == nil {
+			t.Fatal("Expected Destroy to fail when refresh times out")
+		}
+		if !strings.Contains(err.Error(), "kubernetes API is unreachable") {
+			t.Errorf("Expected an actionable unreachable-provider error, got %v", err)
+		}
+		if sawDestroy {
+			t.Error("Expected terraform destroy not to run after a refresh timeout")
 		}
 	})
 

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -1287,6 +1287,35 @@ func TestStack_DestroyAll(t *testing.T) {
 		}
 	})
 
+	t.Run("UsesRefreshTimeout", func(t *testing.T) {
+		// Given a stack whose terraform refresh exec is bounded by a timeout
+		stack, mocks := setup(t)
+		var gotTimeout time.Duration
+		var sawRefresh bool
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			if command == "terraform" && len(args) >= 2 && args[1] == "refresh" {
+				sawRefresh = true
+				gotTimeout = timeout
+			}
+			return "", nil
+		}
+		blueprint := createTestBlueprint()
+
+		// When DestroyAll runs
+		if _, err := stack.DestroyAll(blueprint, false); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the refresh exec runs with the bounded timeout: a component's own
+		// kubernetes/helm provider can't hang the whole destroy dialing a broken cluster
+		if !sawRefresh {
+			t.Fatal("Expected terraform refresh to run via ExecSilentWithEnvAndTimeout")
+		}
+		if gotTimeout != constants.DefaultTerraformDestroyTimeout {
+			t.Errorf("Expected timeout %v, got %v", constants.DefaultTerraformDestroyTimeout, gotTimeout)
+		}
+	})
+
 	t.Run("ErrorGettingCurrentDirectory", func(t *testing.T) {
 		stack, mocks := setup(t)
 		mocks.Shims.Getwd = func() (string, error) {
@@ -3326,6 +3355,35 @@ func TestStack_Destroy(t *testing.T) {
 		}
 		if !slices.Contains(destroyArgs, "-no-color") {
 			t.Errorf("Expected destroy args to contain -no-color, got %v", destroyArgs)
+		}
+	})
+
+	t.Run("UsesRefreshTimeout", func(t *testing.T) {
+		// Given a stack whose terraform refresh exec is bounded by a timeout
+		stack, mocks := setup(t)
+		var gotTimeout time.Duration
+		var sawRefresh bool
+		mocks.Shell.ExecSilentWithEnvAndTimeoutFunc = func(command string, env map[string]string, args []string, timeout time.Duration) (string, error) {
+			if command == "terraform" && len(args) >= 2 && args[1] == "refresh" {
+				sawRefresh = true
+				gotTimeout = timeout
+			}
+			return "", nil
+		}
+		blueprint := createTestBlueprint()
+
+		// When destroying the component
+		if _, err := stack.Destroy(blueprint, "local/path"); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		// Then the refresh exec runs with the bounded timeout: a component's own
+		// kubernetes/helm provider can't hang the whole destroy dialing a broken cluster
+		if !sawRefresh {
+			t.Fatal("Expected terraform refresh to run via ExecSilentWithEnvAndTimeout")
+		}
+		if gotTimeout != constants.DefaultTerraformDestroyTimeout {
+			t.Errorf("Expected timeout %v, got %v", constants.DefaultTerraformDestroyTimeout, gotTimeout)
 		}
 	})
 

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -1946,7 +1946,7 @@ func TestStack_DestroyAll(t *testing.T) {
 		if err == nil {
 			t.Fatal("Expected DestroyAll to fail when refresh times out")
 		}
-		if !strings.Contains(err.Error(), "kubernetes API is unreachable") {
+		if !strings.Contains(err.Error(), "timed out") || !strings.Contains(err.Error(), "provider looks unreachable") {
 			t.Errorf("Expected an actionable unreachable-provider error, got %v", err)
 		}
 		if sawDestroy {
@@ -4032,7 +4032,7 @@ func TestStack_Destroy(t *testing.T) {
 		if err == nil {
 			t.Fatal("Expected Destroy to fail when refresh times out")
 		}
-		if !strings.Contains(err.Error(), "kubernetes API is unreachable") {
+		if !strings.Contains(err.Error(), "timed out") || !strings.Contains(err.Error(), "provider looks unreachable") {
 			t.Errorf("Expected an actionable unreachable-provider error, got %v", err)
 		}
 		if sawDestroy {

--- a/pkg/runtime/shell/shell.go
+++ b/pkg/runtime/shell/shell.go
@@ -2,6 +2,7 @@ package shell
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"maps"
@@ -39,6 +40,13 @@ const SessionTokenPrefix = ".session."
 // Short common words/values ("true", "1", "admin", "dev") carry no real confidentiality, and
 // scrubbing them would mangle unrelated output every time that substring happens to appear.
 const minRegisteredSecretLength = 8
+
+// =============================================================================
+// Errors
+// =============================================================================
+
+// ErrCommandTimedOut marks a command killed for exceeding its timeout.
+var ErrCommandTimedOut = errors.New("command timed out")
 
 // =============================================================================
 // Types
@@ -1033,7 +1041,7 @@ func executeWithTimeout(execFn func() (string, error), cleanupFn func(), timeout
 		return res.out, res.err
 	case <-time.After(timeout):
 		cleanupOnce.Do(cleanupFn)
-		return "", fmt.Errorf("command timed out after %v", timeout)
+		return "", fmt.Errorf("%w after %v", ErrCommandTimedOut, timeout)
 	}
 }
 


### PR DESCRIPTION
Closes #3330

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This changes the terraform destroy path shared by every `windsor destroy` invocation, trading an upfront cluster-reachability block for a bounded refresh step, so a regression here affects the default teardown flow rather than an edge case.
>
> **Overview**
>
> The PR removes the pre-destroy Kubernetes reachability preflight that previously blocked `Destroy`, `DestroyAll`, and `destroyAllTerraform` whenever a kubeconfig was present but the cluster was unreachable. In its place, `terraform refresh` before a destroy now runs under a new short `DefaultTerraformRefreshTimeout` (2 minutes) via `refreshBeforeDestroy`, distinguishing a refresh timeout (abort now) from any other refresh failure (fall through to `terraform destroy -refresh=true` as before).
>
> A new `shell.ErrCommandTimedOut` sentinel lets callers detect a timeout specifically via `errors.Is`, and an integration test confirms a stale kubeconfig no longer slows down a destroy for a component that doesn't need the cluster.

<!-- /claude-code-review:summary -->
