### PR TITLE
fix(kubernetes): silence deprecation warnings unless verbose

### DIFF
--- a/pkg/provisioner/kubernetes/client/client.go
+++ b/pkg/provisioner/kubernetes/client/client.go
@@ -22,6 +22,8 @@ import (
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/restmapper"
 	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/windsorcli/cli/pkg/runtime/shell"
 )
 
 // =============================================================================
@@ -63,15 +65,17 @@ type DynamicKubernetesClient struct {
 	client   dynamic.Interface
 	mapper   meta.RESTMapper
 	endpoint string
+	shell    shell.Shell
 }
 
 // =============================================================================
 // Constructor
 // =============================================================================
 
-// NewDynamicKubernetesClient creates a new DynamicKubernetesClient
-func NewDynamicKubernetesClient() *DynamicKubernetesClient {
-	return &DynamicKubernetesClient{}
+// NewDynamicKubernetesClient creates a new DynamicKubernetesClient. The shell's verbosity
+// controls whether server-side API deprecation warnings are printed.
+func NewDynamicKubernetesClient(shell shell.Shell) *DynamicKubernetesClient {
+	return &DynamicKubernetesClient{shell: shell}
 }
 
 // =============================================================================
@@ -254,6 +258,7 @@ func (c *DynamicKubernetesClient) GetNodeReadyStatus(ctx context.Context, nodeNa
 // no API calls until the first ResourceFor lookup. Returns error if client setup fails at any stage.
 // Safe for concurrent use: initialization is guarded by a mutex so callers issuing overlapping
 // requests (e.g. a wait loop polling several resources at once) don't race the first setup.
+// Suppresses server-side API deprecation warnings unless the shell is in verbose mode.
 func (c *DynamicKubernetesClient) ensureClient() error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -265,6 +270,9 @@ func (c *DynamicKubernetesClient) ensureClient() error {
 	config, err := c.restConfig()
 	if err != nil {
 		return err
+	}
+	if c.shell == nil || !c.shell.IsVerbose() {
+		config.WarningHandler = rest.NoWarnings{}
 	}
 
 	cli, err := dynamic.NewForConfig(config)

--- a/pkg/provisioner/kubernetes/client/client.go
+++ b/pkg/provisioner/kubernetes/client/client.go
@@ -271,9 +271,7 @@ func (c *DynamicKubernetesClient) ensureClient() error {
 	if err != nil {
 		return err
 	}
-	if c.shell == nil || !c.shell.IsVerbose() {
-		config.WarningHandler = rest.NoWarnings{}
-	}
+	config.WarningHandler = warningHandlerFor(c.shell)
 
 	cli, err := dynamic.NewForConfig(config)
 	if err != nil {
@@ -311,6 +309,16 @@ func (c *DynamicKubernetesClient) restConfig() (*rest.Config, error) {
 		kubeconfig = home + "/.kube/config"
 	}
 	return clientcmd.BuildConfigFromFlags("", kubeconfig)
+}
+
+// warningHandlerFor returns the REST config warning handler to use for the given shell.
+// Suppresses server-side API deprecation warnings unless the shell is in verbose mode.
+// A nil shell is treated as non-verbose.
+func warningHandlerFor(sh shell.Shell) rest.WarningHandler {
+	if sh == nil || !sh.IsVerbose() {
+		return rest.NoWarnings{}
+	}
+	return nil
 }
 
 // isNodeReady checks if a node is in Ready state by examining its conditions.

--- a/pkg/provisioner/kubernetes/client/client_test.go
+++ b/pkg/provisioner/kubernetes/client/client_test.go
@@ -1,0 +1,45 @@
+package client
+
+import (
+	"testing"
+
+	"k8s.io/client-go/rest"
+
+	"github.com/windsorcli/cli/pkg/runtime/shell"
+)
+
+// =============================================================================
+// Private Methods
+// =============================================================================
+
+func TestWarningHandlerFor(t *testing.T) {
+	t.Run("SuppressesWhenNotVerbose", func(t *testing.T) {
+		mockShell := shell.NewMockShell()
+		mockShell.IsVerboseFunc = func() bool { return false }
+
+		handler := warningHandlerFor(mockShell)
+
+		if _, ok := handler.(rest.NoWarnings); !ok {
+			t.Errorf("Expected rest.NoWarnings, got %T", handler)
+		}
+	})
+
+	t.Run("PassesThroughWhenVerbose", func(t *testing.T) {
+		mockShell := shell.NewMockShell()
+		mockShell.IsVerboseFunc = func() bool { return true }
+
+		handler := warningHandlerFor(mockShell)
+
+		if handler != nil {
+			t.Errorf("Expected nil handler, got %T", handler)
+		}
+	})
+
+	t.Run("SuppressesWhenShellNil", func(t *testing.T) {
+		handler := warningHandlerFor(nil)
+
+		if _, ok := handler.(rest.NoWarnings); !ok {
+			t.Errorf("Expected rest.NoWarnings, got %T", handler)
+		}
+	})
+}

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -173,7 +173,7 @@ func NewProvisioner(rt *runtime.Runtime, blueprintHandler blueprint.BlueprintHan
 	}
 
 	if provisioner.KubernetesClient == nil {
-		provisioner.KubernetesClient = k8sclient.NewDynamicKubernetesClient()
+		provisioner.KubernetesClient = k8sclient.NewDynamicKubernetesClient(rt.Shell)
 	}
 
 	if provisioner.KubernetesManager == nil {


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change touches only the Kubernetes dynamic client constructor and its single call site, with no behavioral change to existing callers beyond suppressing noisy log output.
>
> **Overview**
>
> `DynamicKubernetesClient` now takes a `shell.Shell` at construction time and uses it in `ensureClient` to decide whether to install a `rest.NoWarnings{}` handler on the REST config. When the shell is nil or not in verbose mode, server-side API deprecation warnings are silenced; in verbose mode they pass through as before.
>
> The only caller, `NewProvisioner`, is updated to pass `rt.Shell` through. No test file exists for `client.go` today, so the new verbosity branch (and the nil-shell fallback) has no direct unit coverage, though the change is small and low-blast-radius.

<!-- /claude-code-review:summary -->
