### PR TITLE
fix(kubernetes): rewrite destroy timeout errors as plain STE

### DIFF
--- a/pkg/provisioner/kubernetes/kubernetes_manager.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager.go
@@ -205,7 +205,7 @@ func (k *BaseKubernetesManager) deleteKustomization(name, namespace string, expe
 		return nil
 	}
 	if err != nil {
-		return err
+		return fmt.Errorf("error deleting kustomization %s/%s: %w", namespace, name, err)
 	}
 
 	start := k.shims.TimeNow()
@@ -226,10 +226,10 @@ func (k *BaseKubernetesManager) deleteKustomization(name, namespace string, expe
 			if entry.Namespace != "" {
 				inspectCmd = fmt.Sprintf("`kubectl get %s %s -n %s`", entry.gvr.Resource, entry.Name, entry.Namespace)
 			}
-			return fmt.Errorf("kustomization %s/%s disappeared but %s/%s from its inventory is still live. Flux likely gave up waiting and removed the finalizer early. Inspect it with %s before retrying", namespace, name, entry.Kind, entry.Name, inspectCmd)
+			return fmt.Errorf("kustomization %s/%s disappeared. %s/%s from its inventory is still live. Flux likely gave up waiting and removed the finalizer early. Inspect it with %s before retrying", namespace, name, entry.Kind, entry.Name, inspectCmd)
 		}
 		if err != nil {
-			return fmt.Errorf("error checking kustomization deletion status: %w", err)
+			return fmt.Errorf("error checking kustomization %s/%s deletion status: %w", namespace, name, err)
 		}
 		lastObj = obj
 
@@ -248,20 +248,20 @@ func (k *BaseKubernetesManager) deleteKustomization(name, namespace string, expe
 
 	entries, inventoryFound := inventoryEntriesFromObject(lastObj)
 	if drained, checkErr := k.allInventoryEntriesGone(entries); inventoryFound && checkErr == nil && drained {
-		return fmt.Errorf("kustomization %s/%s is fully drained (every inventory item confirmed gone) but its own finalizer is stuck. This is Flux bookkeeping, not leaked infrastructure. Clear it with `kubectl patch kustomization %s -n %s --type=merge -p '{\"metadata\":{\"finalizers\":null}}'`", namespace, name, name, namespace)
+		return fmt.Errorf("kustomization %s/%s is fully drained. Every inventory item is confirmed gone, but its own finalizer is stuck. This is Flux bookkeeping, not leaked infrastructure. Clear it with `kubectl patch kustomization %s -n %s --type=merge -p '{\"metadata\":{\"finalizers\":null}}'`", namespace, name, name, namespace)
 	}
 
 	reason := describeStuckKustomization(lastObj) + k.describeStuckHelmReleases(name, namespace)
 	if waitForTermination, ok := kustomizationDeletionPolicy(lastObj, expectWaitForTermination); ok && !waitForTermination {
 		if reason == "" {
-			return fmt.Errorf("timeout waiting for kustomization %s/%s to be deleted after %s. It uses MirrorPrune instead of WaitForTermination. MirrorPrune deletes resources without waiting for them. A timeout here does not mean an inventory item is stuck. Check for a suspended reconcile or an RBAC failure. Inspect with %s and %s", namespace, name, waitFor, inspectCmd, terminatingCmd)
+			return fmt.Errorf("windsor timed out after %s waiting for kustomization %s/%s to delete. It uses MirrorPrune, which deletes resources without waiting for confirmation, so this timeout does not mean an inventory item is stuck. Check for a suspended reconcile or an RBAC failure. Inspect with %s and %s", waitFor, namespace, name, inspectCmd, terminatingCmd)
 		}
-		return fmt.Errorf("timeout waiting for kustomization %s/%s to be deleted%s. It uses MirrorPrune instead of WaitForTermination. MirrorPrune deletes resources without waiting for them. A timeout here does not mean an inventory item is stuck. Inspect with %s (status.conditions) and %s", namespace, name, reason, inspectCmd, terminatingCmd)
+		return fmt.Errorf("windsor timed out after %s waiting for kustomization %s/%s to delete%s. It uses MirrorPrune, which deletes resources without waiting for confirmation, so this timeout does not mean an inventory item is stuck. Inspect with %s (status.conditions) and %s", waitFor, namespace, name, reason, inspectCmd, terminatingCmd)
 	}
 	if reason == "" {
-		return fmt.Errorf("timeout waiting for kustomization %s/%s to be deleted after %s; no status condition confirms a stuck finalizer, but that does not rule one out — check whether %s (status.inventory) is still shrinking before retrying; if it is not shrinking, find the stuck object with %s", namespace, name, waitFor, inspectCmd, terminatingCmd)
+		return fmt.Errorf("windsor timed out after %s waiting for kustomization %s/%s to delete. No status condition confirms a stuck finalizer. Check its inventory with %s:\n  - if it is still shrinking, wait and retry\n  - if it is not shrinking, find the stuck object with %s", waitFor, namespace, name, inspectCmd, terminatingCmd)
 	}
-	return fmt.Errorf("timeout waiting for kustomization %s/%s to be deleted%s; an inventory item is likely stuck on a cloud-controller finalizer — inspect with %s (status.conditions, status.inventory) and %s to find the stuck object", namespace, name, reason, inspectCmd, terminatingCmd)
+	return fmt.Errorf("windsor timed out after %s waiting for kustomization %s/%s to delete%s. An inventory item is likely stuck on a cloud-controller finalizer. Inspect with %s (status.conditions, status.inventory) and %s to find the stuck object", waitFor, namespace, name, reason, inspectCmd, terminatingCmd)
 }
 
 // inventorySize counts a Kustomization's status.inventory.entries. It returns 0 for a
@@ -1520,7 +1520,7 @@ func (k *BaseKubernetesManager) DeleteBlueprint(blueprint *blueprintv1alpha1.Blu
 		expectWaitForTermination := destroy == nil || *destroy
 		if err := k.deleteKustomization(kustomization.Name, namespace, &expectWaitForTermination); err != nil {
 			tui.Fail()
-			return k.abortDestroy(eligible, namespace, fmt.Errorf("destroy aborted: failed to delete kustomization %q: %w (further deletions skipped to avoid cascading orphans)", kustomization.Name, err))
+			return k.abortDestroy(eligible, namespace, fmt.Errorf("destroy aborted: failed to delete kustomization: %w. Windsor skipped the remaining kustomizations to avoid orphaning them", err))
 		}
 		tui.Done()
 	}

--- a/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
+++ b/pkg/provisioner/kubernetes/kubernetes_manager_public_test.go
@@ -319,7 +319,7 @@ func TestBaseKubernetesManager_DeleteKustomization(t *testing.T) {
 		if err == nil {
 			t.Fatal("Expected timeout error, got nil")
 		}
-		if !strings.Contains(err.Error(), "timeout") {
+		if !strings.Contains(err.Error(), "timed out") {
 			t.Errorf("Expected error mentioning timeout, got: %v", err)
 		}
 		if !strings.Contains(err.Error(), "test-kustomization") {
@@ -513,7 +513,7 @@ func TestBaseKubernetesManager_DeleteKustomization(t *testing.T) {
 		if err == nil {
 			t.Fatal("Expected timeout error, got nil")
 		}
-		if !strings.Contains(err.Error(), "timeout") {
+		if !strings.Contains(err.Error(), "timed out") {
 			t.Errorf("Expected error mentioning timeout, got: %v", err)
 		}
 	})
@@ -535,7 +535,7 @@ func TestBaseKubernetesManager_DeleteKustomization(t *testing.T) {
 		if err == nil {
 			t.Error("Expected error, got nil")
 		}
-		if !strings.Contains(err.Error(), "error checking kustomization deletion status") {
+		if !strings.Contains(err.Error(), "error checking kustomization test-namespace/test-kustomization deletion status") {
 			t.Errorf("Expected error checking status, got: %v", err)
 		}
 	})
@@ -594,7 +594,7 @@ func TestBaseKubernetesManager_DeleteKustomization(t *testing.T) {
 		if strings.Contains(err.Error(), "is likely stuck on a cloud-controller finalizer") {
 			t.Errorf("Expected no unconfirmed stuck-finalizer claim, got: %v", err)
 		}
-		if !strings.Contains(err.Error(), "does not rule one out") {
+		if !strings.Contains(err.Error(), "No status condition confirms a stuck finalizer") {
 			t.Errorf("Expected error to acknowledge the uncertainty, got: %v", err)
 		}
 	})
@@ -636,7 +636,7 @@ func TestBaseKubernetesManager_DeleteKustomization(t *testing.T) {
 		if !strings.Contains(err.Error(), "is likely stuck on a cloud-controller finalizer") {
 			t.Errorf("Expected confirmed stuck-finalizer wording, got: %v", err)
 		}
-		if strings.Contains(err.Error(), "does not rule one out") {
+		if strings.Contains(err.Error(), "No status condition confirms a stuck finalizer") {
 			t.Errorf("Expected no unconfirmed-deletion wording, got: %v", err)
 		}
 	})


### PR DESCRIPTION
Closes #3333

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> The change is confined to error-message text in the Kubernetes provisioner's kustomization-deletion path, with no changes to control flow, timing, or return types.
>
> **Overview**
>
> This PR rewrites the error strings produced by `deleteKustomization` (and the destroy-abort wrapper around it) into plain, single-instruction-per-sentence prose, and threads the affected kustomization's namespace/name into two errors that previously omitted it (`error deleting kustomization`, `error checking kustomization ... deletion status`). The long timeout messages are restructured into shorter sentences, and one is reformatted as a vertical checklist instead of a single run-on sentence.
>
> Accompanying unit tests are updated to match the new wording (`"timeout"` → `"timed out"`, `"does not rule one out"` → `"No status condition confirms a stuck finalizer"`, etc.); the assertions still target the same semantic conditions, so behavioral coverage is unchanged.

<!-- /claude-code-review:summary -->
