### PR TITLE
fix(env): scope backend_override.tf writes to active blueprint

### DIFF
--- a/pkg/runtime/env/terraform_env.go
+++ b/pkg/runtime/env/terraform_env.go
@@ -105,7 +105,10 @@ func (e *TerraformEnvPrinter) GetEnvVars() (map[string]string, error) {
 	return terraformVars, err
 }
 
-// PostEnvHook executes operations after setting the environment variables.
+// PostEnvHook executes operations after setting the environment variables. It writes
+// backend_override.tf only when the directory resolves to a component of the active context's
+// blueprint (see GetTerraformComponentForPath) — terraform module directories are shared on disk
+// across contexts, so a bare *.tf-file check is not enough to confirm directory belongs here.
 func (e *TerraformEnvPrinter) PostEnvHook(directory ...string) error {
 	var currentPath string
 	if len(directory) > 0 {
@@ -122,6 +125,9 @@ func (e *TerraformEnvPrinter) PostEnvHook(directory ...string) error {
 		return fmt.Errorf("error finding project path: %w", err)
 	}
 	if projectPath == "" {
+		return nil
+	}
+	if e.terraformProvider.GetTerraformComponentForPath(currentPath) == nil {
 		return nil
 	}
 	return e.terraformProvider.GenerateBackendOverride(currentPath)

--- a/pkg/runtime/env/terraform_env_test.go
+++ b/pkg/runtime/env/terraform_env_test.go
@@ -134,6 +134,12 @@ func setupMockTerraformProvider(mocks *EnvTestMocks) *terraform.MockTerraformPro
 		GetTerraformComponentsFunc: func() []blueprintv1alpha1.TerraformComponent {
 			return []blueprintv1alpha1.TerraformComponent{}
 		},
+		// Directory resolves to a component of the active blueprint by default, since most tests
+		// are exercising something other than this check. Tests for the "cwd not in the active
+		// blueprint" case override this to return nil.
+		GetTerraformComponentForPathFunc: func(directory string) *blueprintv1alpha1.TerraformComponent {
+			return &blueprintv1alpha1.TerraformComponent{FullPath: directory}
+		},
 		GetTFDataDirFunc: func(componentID string) (string, error) {
 			windsorScratchPath, err := mocks.ConfigHandler.GetWindsorScratchPath()
 			if err != nil {
@@ -885,6 +891,37 @@ func TestTerraformEnv_PostEnvHook(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "error writing backend_override.tf") {
 			t.Errorf("Expected error message to contain 'error writing backend_override.tf', got %v", err)
+		}
+	})
+
+	t.Run("SkipsWhenDirectoryNotInActiveBlueprint", func(t *testing.T) {
+		printer, mocks := setup(t)
+
+		// Given a directory that has *.tf files but resolves to no component of the active
+		// blueprint — e.g. a terraform module directory shared on disk with another context
+		mockProvider := setupMockTerraformProvider(mocks)
+		mockProvider.FindRelativeProjectPathFunc = func(directory ...string) (string, error) {
+			return "cluster/gcp-gke", nil
+		}
+		mockProvider.GetTerraformComponentForPathFunc = func(directory string) *blueprintv1alpha1.TerraformComponent {
+			return nil
+		}
+		generateCalled := false
+		mockProvider.GenerateBackendOverrideFunc = func(directory string) error {
+			generateCalled = true
+			return nil
+		}
+		printer = setupTerraformEnvPrinter(t, mocks, mockProvider)
+
+		// When the PostEnvHook function is called
+		err := printer.PostEnvHook()
+
+		// Then it succeeds without writing a backend override into the unrelated directory
+		if err != nil {
+			t.Errorf("Expected no error, got %v", err)
+		}
+		if generateCalled {
+			t.Error("Expected GenerateBackendOverride not to be called for a directory outside the active blueprint")
 		}
 	})
 }

--- a/pkg/runtime/terraform/mock_provider.go
+++ b/pkg/runtime/terraform/mock_provider.go
@@ -6,23 +6,24 @@ import (
 
 // MockTerraformProvider is a mock implementation of TerraformProvider for testing.
 type MockTerraformProvider struct {
-	FindRelativeProjectPathFunc func(directory ...string) (string, error)
-	IsInTerraformProjectFunc    func() bool
-	GenerateBackendOverrideFunc func(directory string) error
-	GenerateTerraformArgsFunc   func(componentID string, interactive bool) (*TerraformArgs, error)
-	GetTerraformComponentFunc   func(componentID string) *blueprintv1alpha1.TerraformComponent
-	GetTerraformComponentsFunc  func() []blueprintv1alpha1.TerraformComponent
-	SetTerraformComponentsFunc  func(components []blueprintv1alpha1.TerraformComponent)
-	SetConfigScopeFunc          func(scope map[string]any)
-	GetTerraformOutputsFunc     func(componentID string) (map[string]any, error)
-	CacheOutputsFunc            func(componentID string) error
-	GetTFDataDirFunc            func(componentID string) (string, error)
-	GetStatePathFunc            func(componentID string) (string, error)
-	BackendConfigCompleteFunc   func() bool
-	GetEnvVarsFunc              func(componentID string, interactive bool) (map[string]string, []string, *TerraformArgs, error)
-	FormatArgsForEnvFunc        func(args []string) string
-	ClearCacheFunc              func()
-	TerraformScopedEnvKeysFunc  func() ([]string, error)
+	FindRelativeProjectPathFunc      func(directory ...string) (string, error)
+	IsInTerraformProjectFunc         func() bool
+	GenerateBackendOverrideFunc      func(directory string) error
+	GenerateTerraformArgsFunc        func(componentID string, interactive bool) (*TerraformArgs, error)
+	GetTerraformComponentFunc        func(componentID string) *blueprintv1alpha1.TerraformComponent
+	GetTerraformComponentsFunc       func() []blueprintv1alpha1.TerraformComponent
+	GetTerraformComponentForPathFunc func(directory string) *blueprintv1alpha1.TerraformComponent
+	SetTerraformComponentsFunc       func(components []blueprintv1alpha1.TerraformComponent)
+	SetConfigScopeFunc               func(scope map[string]any)
+	GetTerraformOutputsFunc          func(componentID string) (map[string]any, error)
+	CacheOutputsFunc                 func(componentID string) error
+	GetTFDataDirFunc                 func(componentID string) (string, error)
+	GetStatePathFunc                 func(componentID string) (string, error)
+	BackendConfigCompleteFunc        func() bool
+	GetEnvVarsFunc                   func(componentID string, interactive bool) (map[string]string, []string, *TerraformArgs, error)
+	FormatArgsForEnvFunc             func(args []string) string
+	ClearCacheFunc                   func()
+	TerraformScopedEnvKeysFunc       func() ([]string, error)
 }
 
 // FindRelativeProjectPath implements TerraformProvider.
@@ -71,6 +72,14 @@ func (m *MockTerraformProvider) GetTerraformComponents() []blueprintv1alpha1.Ter
 		return m.GetTerraformComponentsFunc()
 	}
 	return []blueprintv1alpha1.TerraformComponent{}
+}
+
+// GetTerraformComponentForPath implements TerraformProvider.
+func (m *MockTerraformProvider) GetTerraformComponentForPath(directory string) *blueprintv1alpha1.TerraformComponent {
+	if m.GetTerraformComponentForPathFunc != nil {
+		return m.GetTerraformComponentForPathFunc(directory)
+	}
+	return nil
 }
 
 // SetTerraformComponents implements TerraformProvider.

--- a/pkg/runtime/terraform/provider.go
+++ b/pkg/runtime/terraform/provider.go
@@ -79,6 +79,7 @@ type TerraformProvider interface {
 	GenerateTerraformArgs(componentID string, interactive bool) (*TerraformArgs, error)
 	GetTerraformComponent(componentID string) *blueprintv1alpha1.TerraformComponent
 	GetTerraformComponents() []blueprintv1alpha1.TerraformComponent
+	GetTerraformComponentForPath(directory string) *blueprintv1alpha1.TerraformComponent
 	SetTerraformComponents(components []blueprintv1alpha1.TerraformComponent)
 	SetConfigScope(scope map[string]any)
 	GetTerraformOutputs(componentID string) (map[string]any, error)
@@ -377,6 +378,21 @@ func (p *terraformProvider) GetTerraformComponent(componentID string) *blueprint
 	components := p.GetTerraformComponents()
 	for i := range components {
 		if components[i].Path == componentID || (components[i].Name != "" && components[i].Name == componentID) {
+			return &components[i]
+		}
+	}
+	return nil
+}
+
+// GetTerraformComponentForPath finds the loaded blueprint component whose resolved FullPath
+// matches directory. Terraform module directories are shared on disk across contexts, so this
+// confirms directory actually belongs to the active context's blueprint before a caller treats
+// it as one of its components. Returns nil if no component resolves to directory.
+func (p *terraformProvider) GetTerraformComponentForPath(directory string) *blueprintv1alpha1.TerraformComponent {
+	directory = filepath.Clean(directory)
+	components := p.GetTerraformComponents()
+	for i := range components {
+		if filepath.Clean(components[i].FullPath) == directory {
 			return &components[i]
 		}
 	}

--- a/pkg/runtime/terraform/provider_public_test.go
+++ b/pkg/runtime/terraform/provider_public_test.go
@@ -1258,6 +1258,73 @@ terraform:
 	})
 }
 
+func TestTerraformProvider_GetTerraformComponentForPath(t *testing.T) {
+	setup := func(t *testing.T) *Mocks {
+		t.Helper()
+		mocks := setupMocks(t)
+
+		configRoot := "/test/config"
+		mocks.ConfigHandler.GetConfigRootFunc = func() (string, error) {
+			return configRoot, nil
+		}
+
+		blueprintYAML := `apiVersion: blueprints.windsorcli.dev/v1alpha1
+kind: Blueprint
+metadata:
+  name: test
+terraform:
+  - path: test/path`
+
+		mocks.Provider.Shims.ReadFile = func(path string) ([]byte, error) {
+			if path == filepath.Join(configRoot, "blueprint.yaml") {
+				return []byte(blueprintYAML), nil
+			}
+			return nil, os.ErrNotExist
+		}
+
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return "/test/project", nil
+		}
+
+		mocks.ConfigHandler.GetContextFunc = func() string {
+			return "default"
+		}
+
+		return mocks
+	}
+
+	t.Run("FindsComponentByFullPath", func(t *testing.T) {
+		// Given a blueprint with a component whose FullPath resolves under the project root
+		mocks := setup(t)
+		wantPath := filepath.Join("/test/project", "terraform", "test/path")
+
+		// When resolving that exact directory
+		component := mocks.Provider.GetTerraformComponentForPath(wantPath)
+
+		// Then the matching component is returned
+		if component == nil {
+			t.Fatal("Expected component to be found")
+		}
+		if component.Path != "test/path" {
+			t.Errorf("Expected component path to be 'test/path', got %s", component.Path)
+		}
+	})
+
+	t.Run("ReturnsNilWhenDirectoryNotInBlueprint", func(t *testing.T) {
+		// Given the same blueprint, and a directory none of its components resolve to — e.g. a
+		// terraform module directory shared on disk with a different context's blueprint
+		mocks := setup(t)
+
+		// When resolving an unrelated directory
+		component := mocks.Provider.GetTerraformComponentForPath("/test/project/terraform/cluster/gcp-gke")
+
+		// Then no component is returned
+		if component != nil {
+			t.Errorf("Expected nil for a directory outside the active blueprint, got %+v", component)
+		}
+	})
+}
+
 func TestTerraformProvider_ResolveModulePath(t *testing.T) {
 	t.Run("ResolvesPathForComponentWithName", func(t *testing.T) {
 		// Given a component with name


### PR DESCRIPTION
Closes #3325

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This change touches `TerraformEnvPrinter.PostEnvHook`, a shared code path used both by the interactive `windsor env` shell hook and by the terraform apply/destroy stack, and it changes a default: `backend_override.tf` is no longer written unconditionally for any directory containing `*.tf` files.
>
> **Overview**
>
> The PR adds `GetTerraformComponentForPath` to `TerraformProvider`, which resolves a directory to a loaded blueprint component by matching its cleaned `FullPath`. `PostEnvHook` now calls this before writing `backend_override.tf`, skipping the write when the current directory does not resolve to a component of the active context's blueprint. This fixes a real bug: terraform module directories can be shared on disk across contexts, so a bare `*.tf`-file check was not enough to confirm a directory belongs to the active blueprint.
>
> The match is a strict string comparison (`filepath.Clean` only, no symlink resolution) between the working directory and the component's precomputed `FullPath`, which are produced by different code paths depending on the caller (`os.Getwd()` in the shell-hook case vs. `filepath.Join` composition elsewhere). Test coverage for the new method and the skip path looks solid, but only exercises the mocked provider, not this real-path matching behavior end-to-end.

<!-- /claude-code-review:summary -->
