### PR TITLE
fix(terraform): freeze provider context against concurrent bootstrap

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -9,6 +9,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/windsorcli/cli/pkg/debug"
 	"github.com/windsorcli/cli/pkg/project"
+	"github.com/windsorcli/cli/pkg/runtime"
+	"github.com/windsorcli/cli/pkg/runtime/config"
+	"github.com/windsorcli/cli/pkg/runtime/shell"
 	"github.com/windsorcli/cli/pkg/runtime/tools"
 	"github.com/windsorcli/cli/pkg/tui"
 )
@@ -29,6 +32,9 @@ var noCache bool
 // failing. Defaults to 0 (fail immediately on contention, matching terraform's own
 // -lock-timeout default) rather than silently blocking; pass a duration to wait instead.
 var lockTimeout time.Duration
+
+// contextFlag overrides the windsor context for this invocation. See setupGlobalContext.
+var contextFlag string
 
 // Define a custom type for context keys
 type contextKey string
@@ -82,6 +88,8 @@ func init() {
 	rootCmd.PersistentFlags().DurationVar(&lockTimeout, "lock-timeout", 0, "Duration to wait for the stack lock before failing (e.g. 30s, 5m). Defaults to 0 (fail immediately).")
 	// Define the --debug flag. Persistent so every command inherits it.
 	rootCmd.PersistentFlags().BoolVar(&debugFlag, "debug", false, "Enable internal debug logging to stderr")
+	// Define the --context flag. Persistent so every command inherits it.
+	rootCmd.PersistentFlags().StringVarP(&contextFlag, "context", "c", "", "Override the windsor context for this command")
 }
 
 // commandPreflight orchestrates global CLI preflight checks and context initialization for all commands.
@@ -198,7 +206,9 @@ func silenceErrorsOnAncestors(cmd *cobra.Command) {
 // without threading a flag through the project/runtime/composer construction chain.
 // An explicit --no-cache always wins; a pre-existing NO_CACHE in the environment is
 // preserved when the flag is not set. --debug and WINDSOR_DEBUG=true both enable
-// debug.Log output for the run; either one is enough.
+// debug.Log output for the run; either one is enough. --context builds a runtime override
+// through NewRuntime, so every field (Evaluator, ToolsManager, ...) is fully hydrated, then
+// injects it under both override keys a caller might read.
 func setupGlobalContext(cmd *cobra.Command) error {
 	ctx := cmd.Root().Context()
 	if ctx == nil {
@@ -210,6 +220,20 @@ func setupGlobalContext(cmd *cobra.Command) error {
 	if noCache {
 		if err := os.Setenv("NO_CACHE", "true"); err != nil {
 			return fmt.Errorf("failed to set NO_CACHE environment variable: %w", err)
+		}
+	}
+	if contextFlag != "" {
+		sh := shell.NewDefaultShell()
+		rtOverride := runtime.NewRuntime(&runtime.Runtime{
+			Shell:         sh,
+			ConfigHandler: config.NewConfigHandler(sh).WithContext(contextFlag),
+			ContextName:   contextFlag,
+		})
+		if ctx.Value(runtimeOverridesKey) == nil {
+			ctx = context.WithValue(ctx, runtimeOverridesKey, rtOverride)
+		}
+		if ctx.Value(projectOverridesKey) == nil {
+			ctx = context.WithValue(ctx, projectOverridesKey, &project.Project{Runtime: rtOverride})
 		}
 	}
 	debug.Init(debugFlag || os.Getenv("WINDSOR_DEBUG") == "true")

--- a/integration/context_flag_test.go
+++ b/integration/context_flag_test.go
@@ -1,0 +1,61 @@
+//go:build integration
+// +build integration
+
+package integration
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/windsorcli/cli/integration/helpers"
+)
+
+// =============================================================================
+// Integration Tests
+// =============================================================================
+
+func TestContextFlag_OverridesActiveContextForOneInvocation(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "default")
+	helpers.MarkAsGitRepo(t, dir)
+	_, stderr, err := helpers.RunCLI(dir, []string{"init", "default"}, env)
+	if err != nil {
+		t.Fatalf("init default: %v\nstderr: %s", err, stderr)
+	}
+
+	stdout, stderr, err := helpers.RunCLI(dir, []string{"get", "context"}, env)
+	if err != nil {
+		t.Fatalf("get context: %v\nstderr: %s", err, stderr)
+	}
+	if got := strings.TrimSpace(string(stdout)); got != "default" {
+		t.Fatalf("expected baseline context 'default', got %q", got)
+	}
+
+	stdout, stderr, err = helpers.RunCLI(dir, []string{"get", "context", "--context", "test"}, env)
+	if err != nil {
+		t.Fatalf("get context --context test: %v\nstderr: %s", err, stderr)
+	}
+	if got := strings.TrimSpace(string(stdout)); got != "test" {
+		t.Errorf("expected --context to override to 'test', got %q", got)
+	}
+
+	stdout, stderr, err = helpers.RunCLI(dir, []string{"get", "context"}, env)
+	if err != nil {
+		t.Fatalf("get context (after override): %v\nstderr: %s", err, stderr)
+	}
+	if got := strings.TrimSpace(string(stdout)); got != "default" {
+		t.Errorf("expected --context override not to persist to .windsor/context, got %q", got)
+	}
+}
+
+func TestContextFlag_DoesNotBypassTrustedDirectoryCheck(t *testing.T) {
+	t.Parallel()
+	dir, env := helpers.CopyFixtureOnly(t, "default")
+	_, stderr, err := helpers.RunCLI(dir, []string{"plan", "terraform", "cluster", "--context", "test"}, env)
+	if err == nil {
+		t.Fatal("expected failure but command succeeded")
+	}
+	if !strings.Contains(string(stderr), "trusted") {
+		t.Errorf("expected stderr to mention 'trusted', got: %s", stderr)
+	}
+}

--- a/pkg/project/project.go
+++ b/pkg/project/project.go
@@ -24,14 +24,14 @@ import (
 // It coordinates context, provisioner, composer, and workstation managers
 // to provide a unified interface for project initialization and management.
 type Project struct {
-	Runtime           *runtime.Runtime
-	configHandler     config.ConfigHandler
-	contextName       string
-	projectRoot       string
-	Provisioner       *provisioner.Provisioner
-	Composer          *composer.Composer
-	Workstation       *workstation.Workstation
-	toolRequirements  *tools.Requirements
+	Runtime          *runtime.Runtime
+	configHandler    config.ConfigHandler
+	contextName      string
+	projectRoot      string
+	Provisioner      *provisioner.Provisioner
+	Composer         *composer.Composer
+	Workstation      *workstation.Workstation
+	toolRequirements *tools.Requirements
 }
 
 // =============================================================================
@@ -45,6 +45,8 @@ type Project struct {
 // Panics if required dependencies are nil. After creation, call Configure() to apply flag overrides.
 // Optional overrides can be provided via opts to inject mocks for testing.
 // If opts contains a Project with Runtime set, that runtime will be reused.
+// An explicit contextName also sets rt.ConfigHandler's own context, not just
+// rt.ContextName/rt.ConfigRoot, since most lookups call rt.ConfigHandler.GetContext() directly.
 func NewProject(contextName string, opts ...*Project) *Project {
 	var rt *runtime.Runtime
 
@@ -76,6 +78,8 @@ func NewProject(contextName string, opts ...*Project) *Project {
 		if contextName == "" {
 			contextName = "local"
 		}
+	} else {
+		rt.ConfigHandler = rt.ConfigHandler.WithContext(contextName)
 	}
 
 	rt.ContextName = contextName

--- a/pkg/project/project_test.go
+++ b/pkg/project/project_test.go
@@ -1396,6 +1396,20 @@ func TestProject_Up(t *testing.T) {
 			}
 			return false
 		}
+		mockConfig.GetStringFunc = func(key string, defaultValue ...string) string {
+			switch key {
+			case "cluster.driver":
+				return "talos"
+			case "workstation.runtime":
+				return "colima"
+			case "provider":
+				return ""
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
 		proj := NewProject("test-context", &Project{
 			Runtime:     mocks.Runtime,
 			Composer:    mocks.Composer,
@@ -1412,20 +1426,6 @@ func TestProject_Up(t *testing.T) {
 		}
 		proj.Workstation.VirtualMachine = mockVM
 		proj.Workstation.NetworkManager = nil
-		mockConfig.GetStringFunc = func(key string, defaultValue ...string) string {
-			switch key {
-			case "cluster.driver":
-				return "talos"
-			case "workstation.runtime":
-				return "colima"
-			case "provider":
-				return ""
-			}
-			if len(defaultValue) > 0 {
-				return defaultValue[0]
-			}
-			return ""
-		}
 
 		_, _, err := proj.Up()
 

--- a/pkg/runtime/terraform/provider.go
+++ b/pkg/runtime/terraform/provider.go
@@ -41,6 +41,15 @@ type terraformProvider struct {
 	configScope   map[string]any
 	warningWriter io.Writer
 	mu            sync.RWMutex
+
+	// scopeMu is separate from mu. GetTerraformComponents holds mu while calling
+	// loadTerraformComponents, which calls providerScope.
+	scopeMu            sync.RWMutex
+	scopeResolved      bool
+	scopeErr           error
+	contextName        string
+	configRoot         string
+	windsorScratchPath string
 }
 
 // terraformContext provides a scoped environment for Terraform operations with automatic cleanup.
@@ -253,14 +262,9 @@ func (p *terraformProvider) GenerateBackendOverride(directory string) error {
 // and builds the init, plan, apply, refresh, import, destroy, and plan-destroy arg sets.
 // Returns a fully populated TerraformArgs structure or an error if processing or lookup fails.
 func (p *terraformProvider) GenerateTerraformArgs(componentID string, interactive bool) (*TerraformArgs, error) {
-	configRoot, err := p.configHandler.GetConfigRoot()
+	_, configRoot, windsorScratchPath, err := p.providerScope()
 	if err != nil {
-		return nil, fmt.Errorf("error getting config root: %w", err)
-	}
-
-	windsorScratchPath, err := p.configHandler.GetWindsorScratchPath()
-	if err != nil {
-		return nil, fmt.Errorf("error getting windsor scratch path: %w", err)
+		return nil, fmt.Errorf("error resolving provider scope: %w", err)
 	}
 
 	component := p.GetTerraformComponent(componentID)
@@ -431,9 +435,9 @@ func (p *terraformProvider) SetConfigScope(scope map[string]any) {
 // This path is used by Terraform to store its working directory data and state.
 // Returns the path with forward slashes or an error if scratch path lookup fails.
 func (p *terraformProvider) GetTFDataDir(componentID string) (string, error) {
-	windsorScratchPath, err := p.configHandler.GetWindsorScratchPath()
+	_, _, windsorScratchPath, err := p.providerScope()
 	if err != nil {
-		return "", fmt.Errorf("error getting windsor scratch path: %w", err)
+		return "", fmt.Errorf("error resolving provider scope: %w", err)
 	}
 
 	component := p.GetTerraformComponent(componentID)
@@ -545,9 +549,9 @@ func (p *terraformProvider) GetEnvVars(componentID string, interactive bool) (ma
 // without resolving any values or paying secret-resolution cost. Used to identify which
 // environment variables to unset when leaving a Terraform directory.
 func (p *terraformProvider) TerraformScopedEnvKeys() ([]string, error) {
-	configRoot, err := p.configHandler.GetConfigRoot()
+	_, configRoot, _, err := p.providerScope()
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving config root: %w", err)
+		return nil, fmt.Errorf("error resolving provider scope: %w", err)
 	}
 
 	dotEnvPath := filepath.Join(configRoot, "terraform", ".env")
@@ -688,9 +692,9 @@ func (p *terraformProvider) ClearCache() {
 // If a backend prefix is configured, it is included in the path to support multi-tenant or
 // multi-environment deployments where state files need to be namespaced.
 func (p *terraformProvider) GetStatePath(componentID string) (string, error) {
-	windsorScratchPath, err := p.configHandler.GetWindsorScratchPath()
+	_, _, windsorScratchPath, err := p.providerScope()
 	if err != nil {
-		return "", fmt.Errorf("error getting windsor scratch path: %w", err)
+		return "", fmt.Errorf("error resolving provider scope: %w", err)
 	}
 
 	component := p.GetTerraformComponent(componentID)
@@ -726,7 +730,7 @@ func (p *terraformProvider) BackendConfigComplete() bool {
 		return true
 	}
 
-	if configRoot, err := p.configHandler.GetConfigRoot(); err == nil {
+	if _, configRoot, _, err := p.providerScope(); err == nil {
 		for _, candidate := range []string{
 			filepath.Join(configRoot, "backend.tfvars"),
 			filepath.Join(configRoot, "terraform", "backend.tfvars"),
@@ -763,6 +767,34 @@ func (p *terraformProvider) BackendConfigComplete() bool {
 // =============================================================================
 // Private Methods
 // =============================================================================
+
+// providerScope resolves the active context, config root, and Windsor scratch path once, then
+// reuses the result. configHandler.GetContext() reads a file shared by every windsor process in
+// the checkout. A live read on each call would let a concurrent windsor process for another
+// context change this provider's Terraform args mid-run.
+func (p *terraformProvider) providerScope() (contextName, configRoot, windsorScratchPath string, err error) {
+	p.scopeMu.RLock()
+	if p.scopeResolved {
+		defer p.scopeMu.RUnlock()
+		return p.contextName, p.configRoot, p.windsorScratchPath, p.scopeErr
+	}
+	p.scopeMu.RUnlock()
+
+	p.scopeMu.Lock()
+	defer p.scopeMu.Unlock()
+	if p.scopeResolved {
+		return p.contextName, p.configRoot, p.windsorScratchPath, p.scopeErr
+	}
+
+	p.contextName = p.configHandler.GetContext()
+	p.configRoot, p.scopeErr = p.configHandler.GetConfigRoot()
+	if p.scopeErr == nil {
+		p.windsorScratchPath, p.scopeErr = p.configHandler.GetWindsorScratchPath()
+	}
+	p.scopeResolved = true
+
+	return p.contextName, p.configRoot, p.windsorScratchPath, p.scopeErr
+}
 
 // registerTerraformOutputHelper registers the terraform_output helper function with the evaluator.
 // This allows blueprint expressions to reference Terraform outputs from other components using
@@ -856,9 +888,9 @@ func (p *terraformProvider) getOutput(componentID, key string, expression string
 // These variables ensure Terraform can locate its state, use the correct backend configuration,
 // and have access to context-specific information during execution.
 func (p *terraformProvider) getBaseEnvVarsForComponent(terraformArgs *TerraformArgs) (map[string]string, error) {
-	configRoot, err := p.configHandler.GetConfigRoot()
+	contextName, configRoot, _, err := p.providerScope()
 	if err != nil {
-		return nil, fmt.Errorf("error getting config root: %w", err)
+		return nil, fmt.Errorf("error resolving provider scope: %w", err)
 	}
 	projectRoot, err := p.shell.GetProjectRoot()
 	if err != nil {
@@ -873,7 +905,7 @@ func (p *terraformProvider) getBaseEnvVarsForComponent(terraformArgs *TerraformA
 	envVars["TF_CLI_ARGS_refresh"] = p.FormatArgsForEnv(terraformArgs.RefreshArgs)
 	envVars["TF_CLI_ARGS_import"] = p.FormatArgsForEnv(terraformArgs.ImportArgs)
 	envVars["TF_CLI_ARGS_destroy"] = p.FormatArgsForEnv(terraformArgs.DestroyArgs)
-	envVars["TF_VAR_context"] = p.configHandler.GetContext()
+	envVars["TF_VAR_context"] = contextName
 	envVars["TF_VAR_project_root"] = filepath.ToSlash(projectRoot)
 	envVars["TF_VAR_context_path"] = filepath.ToSlash(configRoot)
 	envVars["TF_VAR_context_id"] = p.configHandler.GetString("id", "")
@@ -896,9 +928,9 @@ func (p *terraformProvider) getBaseEnvVarsForComponent(terraformArgs *TerraformA
 func (p *terraformProvider) loadTerraformScopedEnv() (map[string]string, error) {
 	envVars := make(map[string]string)
 
-	configRoot, err := p.configHandler.GetConfigRoot()
+	_, configRoot, _, err := p.providerScope()
 	if err != nil {
-		return nil, fmt.Errorf("error retrieving config root: %w", err)
+		return nil, fmt.Errorf("error resolving provider scope: %w", err)
 	}
 
 	dotEnvPath := filepath.Join(configRoot, "terraform", ".env")
@@ -1016,7 +1048,7 @@ func (p *terraformProvider) withTerraformContext(componentID string, fn func(*te
 // of a Source field and the resolved project root. Components with a Source are located in Windsor scratch
 // space, while local components are in the project root. Returns the list of TerraformComponents found with FullPath fields set.
 func (p *terraformProvider) loadTerraformComponents() []blueprintv1alpha1.TerraformComponent {
-	configRoot, err := p.configHandler.GetConfigRoot()
+	contextName, configRoot, _, err := p.providerScope()
 	if err != nil {
 		return []blueprintv1alpha1.TerraformComponent{}
 	}
@@ -1034,8 +1066,7 @@ func (p *terraformProvider) loadTerraformComponents() []blueprintv1alpha1.Terraf
 
 	projectRoot, err := p.shell.GetProjectRoot()
 	if err == nil {
-		context := p.configHandler.GetContext()
-		windsorScratchPath := filepath.Join(projectRoot, ".windsor", "contexts", context)
+		windsorScratchPath := filepath.Join(projectRoot, ".windsor", "contexts", contextName)
 		for i := range blueprint.TerraformComponents {
 			component := &blueprint.TerraformComponents[i]
 			componentID := component.GetID()
@@ -1067,7 +1098,7 @@ func (p *terraformProvider) resolveModulePath(component *blueprintv1alpha1.Terra
 
 	useScratchPath := component.Name != "" || component.Source != ""
 	if useScratchPath {
-		windsorScratchPath, err := p.configHandler.GetWindsorScratchPath()
+		_, _, windsorScratchPath, err := p.providerScope()
 		if err != nil {
 			return "", err
 		}
@@ -1135,7 +1166,7 @@ func (p *terraformProvider) generateBackendConfigArgs(projectPath, configRoot st
 	}
 
 	appendBackendTfvars := func() {
-		if p.configHandler.GetContext() == "" {
+		if contextName, _, _, _ := p.providerScope(); contextName == "" {
 			return
 		}
 		backendTfvarsPath := filepath.Join(configRoot, "backend.tfvars")

--- a/pkg/runtime/terraform/provider_private_test.go
+++ b/pkg/runtime/terraform/provider_private_test.go
@@ -864,8 +864,8 @@ func TestTerraformProvider_generateBackendConfigArgs(t *testing.T) {
 		if err == nil {
 			t.Error("Expected error when GetWindsorScratchPath fails")
 		}
-		if !strings.Contains(err.Error(), "windsor scratch path") {
-			t.Errorf("Expected error about windsor scratch path, got: %v", err)
+		if !strings.Contains(err.Error(), "scratch path error") {
+			t.Errorf("Expected error about scratch path, got: %v", err)
 		}
 	})
 
@@ -1401,4 +1401,78 @@ func TestTerraformProvider_restoreEnvVars(t *testing.T) {
 		}
 	})
 
+}
+
+func TestTerraformProvider_providerScope(t *testing.T) {
+	t.Run("ResolvesOnceAndReusesResultOnSubsequentCalls", func(t *testing.T) {
+		// Given context and paths that change between calls, simulating a concurrent windsor
+		// process overwriting the shared context file
+		mocks := setupMocks(t)
+		provider := mocks.Provider
+		mockConfig := provider.configHandler.(*config.MockConfigHandler)
+
+		callCount := 0
+		mockConfig.GetContextFunc = func() string {
+			callCount++
+			if callCount == 1 {
+				return "ctxA"
+			}
+			return "ctxB"
+		}
+		mockConfig.GetConfigRootFunc = func() (string, error) {
+			if callCount <= 1 {
+				return "/contexts/ctxA", nil
+			}
+			return "/contexts/ctxB", nil
+		}
+		mockConfig.GetWindsorScratchPathFunc = func() (string, error) {
+			if callCount <= 1 {
+				return "/.windsor/contexts/ctxA", nil
+			}
+			return "/.windsor/contexts/ctxB", nil
+		}
+
+		// When resolving scope twice
+		context1, configRoot1, scratch1, err1 := provider.providerScope()
+		context2, configRoot2, scratch2, err2 := provider.providerScope()
+
+		// Then both calls return the first-resolved values
+		if err1 != nil || err2 != nil {
+			t.Fatalf("Expected no error, got %v / %v", err1, err2)
+		}
+		if context1 != "ctxA" || context2 != "ctxA" {
+			t.Errorf("Expected both calls to return 'ctxA', got %q and %q", context1, context2)
+		}
+		if configRoot1 != "/contexts/ctxA" || configRoot2 != "/contexts/ctxA" {
+			t.Errorf("Expected both calls to return the ctxA config root, got %q and %q", configRoot1, configRoot2)
+		}
+		if scratch1 != "/.windsor/contexts/ctxA" || scratch2 != "/.windsor/contexts/ctxA" {
+			t.Errorf("Expected both calls to return the ctxA scratch path, got %q and %q", scratch1, scratch2)
+		}
+	})
+
+	t.Run("CachesErrorAndDoesNotRetry", func(t *testing.T) {
+		// Given GetConfigRoot always fails
+		mocks := setupMocks(t)
+		provider := mocks.Provider
+		mockConfig := provider.configHandler.(*config.MockConfigHandler)
+
+		callCount := 0
+		mockConfig.GetConfigRootFunc = func() (string, error) {
+			callCount++
+			return "", fmt.Errorf("config root error")
+		}
+
+		// When resolving scope twice
+		_, _, _, err1 := provider.providerScope()
+		_, _, _, err2 := provider.providerScope()
+
+		// Then both calls return the error, and GetConfigRoot is called only once
+		if err1 == nil || err2 == nil {
+			t.Fatal("Expected both calls to return an error")
+		}
+		if callCount != 1 {
+			t.Errorf("Expected GetConfigRoot to be called exactly once, got %d calls", callCount)
+		}
+	})
 }

--- a/pkg/runtime/terraform/provider_public_test.go
+++ b/pkg/runtime/terraform/provider_public_test.go
@@ -2624,8 +2624,8 @@ terraform:
 		if err == nil {
 			t.Error("Expected error when GetWindsorScratchPath fails")
 		}
-		if !strings.Contains(err.Error(), "windsor scratch path") {
-			t.Errorf("Expected error about windsor scratch path, got: %v", err)
+		if !strings.Contains(err.Error(), "scratch path error") {
+			t.Errorf("Expected error about scratch path, got: %v", err)
 		}
 	})
 }
@@ -3386,13 +3386,9 @@ terraform:
 		}
 		mocks.Provider.SetTerraformComponents([]blueprintv1alpha1.TerraformComponent{component})
 
-		callCount := 0
-		mocks.ConfigHandler.GetConfigRootFunc = func() (string, error) {
-			callCount++
-			if callCount <= 1 {
-				return "/test/config", nil
-			}
-			return "", errors.New("config root error")
+		// Only getBaseEnvVarsForComponent calls GetProjectRoot in this flow.
+		mocks.Shell.GetProjectRootFunc = func() (string, error) {
+			return "", errors.New("project root error")
 		}
 
 		_, _, _, err := mocks.Provider.GetEnvVars("cluster", false)
@@ -3400,8 +3396,8 @@ terraform:
 		if err == nil {
 			t.Fatal("Expected error when getBaseEnvVarsForComponent fails")
 		}
-		if !strings.Contains(err.Error(), "config root") {
-			t.Errorf("Expected error to mention config root, got: %v", err)
+		if !strings.Contains(err.Error(), "project root") {
+			t.Errorf("Expected error to mention project root, got: %v", err)
 		}
 	})
 


### PR DESCRIPTION
Closes #3337

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This change touches the internal `terraformProvider` used by every Terraform operation (plan, apply, destroy, env vars), so a mistake here has wide blast radius even though the diff itself is small and well tested.
>
> **Overview**
>
> The PR adds a `providerScope()` method that resolves the active context, config root, and Windsor scratch path once per `terraformProvider` instance, behind a dedicated `scopeMu` lock, and reuses that result for the lifetime of the instance. Every call site that previously called `configHandler.GetContext()`, `GetConfigRoot()`, or `GetWindsorScratchPath()` directly now goes through this single cached resolution, guarding against a concurrent `windsor` process rewriting the shared `.windsor/context` file mid-run and changing a component's Terraform args partway through a single command.
>
> One notable detail: resolution errors are cached too, not just successes, and `ClearCache()` does not reset this new scope cache. Today every call site constructs the provider only after the context is already resolved, so this isn't currently reachable, but it's worth keeping in mind if the provider is ever reused across a context change within one process.

<!-- /claude-code-review:summary -->
