### PR TITLE
fix(artifact): exempt nightly build from cliVersion check

### DIFF
--- a/pkg/composer/artifact/artifact.go
+++ b/pkg/composer/artifact/artifact.go
@@ -777,7 +777,9 @@ func IsAuthenticationError(err error) bool {
 // ValidateCliVersion validates that the provided CLI version satisfies the cliVersion constraint
 // specified in the template metadata. If constraint is empty, validation is skipped.
 // If cliVersion is empty, validation is skipped (caller cannot determine version).
-// If the CLI version is "dev" or "main" or "latest", validation is skipped as these are development builds.
+// If the CLI version is "dev", "main", or "latest", validation is skipped as these are development builds.
+// If the CLI version starts with "nightly", validation is skipped: the nightly release builds a
+// non-SemVer snapshot string ("nightly-SNAPSHOT-<sha>") that has no real version to check.
 // A pre-release CLI version (e.g. "0.9.0-rc.1") is checked against its release version
 // (Masterminds/semver excludes pre-releases from a range unless the constraint itself
 // declares one, which would otherwise fail every release-candidate build against an
@@ -793,6 +795,10 @@ func ValidateCliVersion(cliVersion, constraint string) error {
 	}
 
 	if cliVersion == "dev" || cliVersion == "main" || cliVersion == "latest" {
+		return nil
+	}
+
+	if strings.HasPrefix(cliVersion, "nightly") {
 		return nil
 	}
 

--- a/pkg/composer/artifact/artifact_helpers_test.go
+++ b/pkg/composer/artifact/artifact_helpers_test.go
@@ -442,6 +442,17 @@ func TestValidateCliVersion(t *testing.T) {
 		}
 	})
 
+	t.Run("ReturnsNilForNightlyVersion", func(t *testing.T) {
+		// Given the nightly release's snapshot version string
+		// When validating
+		err := ValidateCliVersion("nightly-SNAPSHOT-c6a65a53", ">=1.0.0")
+
+		// Then should return nil
+		if err != nil {
+			t.Errorf("Expected nil for nightly version, got: %v", err)
+		}
+	})
+
 	t.Run("ReturnsErrorForInvalidCliVersionFormat", func(t *testing.T) {
 		// Given an invalid CLI version format
 		// When validating


### PR DESCRIPTION
Closes #3300

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change is isolated to a single version-validation helper in the artifact composer and adds a matching unit test, with no impact on other call paths.
>
> **Overview**
>
> `ValidateCliVersion` now skips SemVer validation when the CLI version string starts with `"nightly"`, alongside the existing bypass for `"dev"`, `"main"`, and `"latest"`. This accounts for the nightly release process, which produces a non-SemVer snapshot string such as `nightly-SNAPSHOT-<sha>` that cannot be parsed or compared against a `cliVersion` constraint.
>
> The function header comment is updated to document the new bypass, and a new test case confirms `ValidateCliVersion` returns `nil` for a representative nightly version string against a non-trivial constraint.

<!-- /claude-code-review:summary -->
