### PR TITLE
fix(terraform): clear backend pointer for destroy:false components

### DIFF
--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -577,15 +577,18 @@ func (s *TerraformStack) MigrateComponentState(blueprint *blueprintv1alpha1.Blue
 	return nil
 }
 
-// DestroyAll destroys components in reverse dependency order using the idempotent flow:
-// init → pre-refresh state check → refresh → post-refresh state check → destroy, skipping
-// the rest when state is empty at either check. Components with Destroy=false are skipped.
-// excludeIDs are skipped entirely (used by symmetric-destroy flow at the cmd layer to peel
-// off the backend component from the bulk pass — it gets destroyed last, after its state
-// is migrated to local). When continueOnError is true, per-component destroy errors are
-// collected in DestroyOutcome.Failed and the loop proceeds to the next component; when
-// false, the first error aborts and is returned alongside a partial DestroyOutcome. Each
-// destroy is bounded by constants.DefaultTerraformDestroyTimeout; refresh by refreshBeforeDestroy.
+// DestroyAll destroys components in reverse dependency order. For each component, it runs
+// init, checks state, refreshes, checks state again, then destroys, skipping the rest of
+// the flow once state is empty.
+//
+//   - Destroy=false: skips the component, but still clears its backend pointer.
+//   - excludeIDs: skips the component entirely. The cmd layer uses this to destroy the
+//     backend component last, after migrating its state to local.
+//   - continueOnError=true: collects each error in DestroyOutcome.Failed and continues.
+//   - continueOnError=false: stops at the first error and returns a partial DestroyOutcome.
+//
+// Each destroy is bounded by constants.DefaultTerraformDestroyTimeout; each refresh by
+// refreshBeforeDestroy.
 func (s *TerraformStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyOutcome, error) {
 	var result DestroyOutcome
 	if blueprint == nil {
@@ -629,6 +632,9 @@ func (s *TerraformStack) DestroyAll(blueprint *blueprintv1alpha1.Blueprint, cont
 		if component.Destroy != nil {
 			destroy := component.Destroy.ToBool()
 			if destroy != nil && !*destroy {
+				if terraformVars, _, _, err := s.runtime.TerraformProvider.GetEnvVars(component.GetID(), false); err == nil {
+					s.clearBackendPointer(terraformVars)
+				}
 				continue
 			}
 		}

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -1532,6 +1532,49 @@ func TestStack_DestroyAll(t *testing.T) {
 		}
 	})
 
+	t.Run("ClearsBackendPointerForComponentWithDestroyFalse", func(t *testing.T) {
+		// A skipped destroy: false component still gets its backend pointer cleared.
+		stack, mocks := setup(t)
+
+		mocks.Runtime.TerraformProvider.ClearCache()
+
+		var removed []string
+		mocks.Shims.Remove = func(path string) error {
+			removed = append(removed, filepath.ToSlash(path))
+			return nil
+		}
+
+		projectRoot := os.Getenv("WINDSOR_PROJECT_ROOT")
+		destroyFalse := false
+		blueprint := createTestBlueprint()
+		blueprint.TerraformComponents = []blueprintv1alpha1.TerraformComponent{
+			{
+				Source:   "source1",
+				Path:     "module/path1",
+				FullPath: filepath.Join(projectRoot, ".windsor", "contexts", "local", "terraform", "module/path1"),
+				Destroy:  &blueprintv1alpha1.BoolExpression{Value: &destroyFalse, IsExpr: false},
+			},
+		}
+		if err := os.MkdirAll(blueprint.TerraformComponents[0].FullPath, 0755); err != nil {
+			t.Fatalf("Failed to create directory: %v", err)
+		}
+
+		if _, err := stack.DestroyAll(blueprint, false); err != nil {
+			t.Errorf("Expected DestroyAll to return nil, got %v", err)
+		}
+
+		var pointerRemoved bool
+		for _, p := range removed {
+			if strings.HasSuffix(p, "/terraform.tfstate") {
+				pointerRemoved = true
+				break
+			}
+		}
+		if !pointerRemoved {
+			t.Errorf("Expected the backend pointer for the skipped component to be removed, got removals: %v", removed)
+		}
+	})
+
 	t.Run("ErrorRunningTerraformDestroy", func(t *testing.T) {
 		// DestroyAll runs every terraform subcommand via ExecSilentWithEnv so the outer
 		// "Destroying <path>" progress span is the only label the user sees. state list


### PR DESCRIPTION
Closes #3342

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> The change is isolated to the `Destroy=false` skip branch of `TerraformStack.DestroyAll`, and it fails silently on error, so it cannot break the main destroy path.
>
> **Overview**
>
> When a component has `Destroy: false`, `DestroyAll` now clears that component's backend pointer file (`TF_DATA_DIR/terraform.tfstate`) before skipping it, instead of leaving it untouched. This fixes stale pointers that could later cause "backend changed" init errors once the backend a pointer refers to is torn down elsewhere in the same destroy run.
>
> The fetch of `terraformVars` for the pointer path uses `TerraformProvider.GetEnvVars` directly rather than the fuller `setupTerraformEnvironment` helper, so no backend-override file or Terraform init/refresh work happens for skipped components — only the pointer file is affected. The function header comment was also restructured into a bulleted list per the flag semantics, consistent with the doc style used elsewhere in the file.

<!-- /claude-code-review:summary -->
