### PR TITLE
fix(config): filter then as structural validation noise

### DIFF
--- a/pkg/runtime/config/schema_validator.go
+++ b/pkg/runtime/config/schema_validator.go
@@ -375,7 +375,7 @@ func collectSensitivePaths(schema map[string]any, prefix string, out *[]string) 
 
 // structuralValidationKeywords are keywords whose failure is a symptom of a nested, more
 // specific failure elsewhere rather than the actionable violation itself — "properties" only
-// ever says "property X doesn't match its schema", never why; "allOf"/"anyOf"/"oneOf"/"if"
+// ever says "property X doesn't match its schema", never why; "allOf"/"anyOf"/"oneOf"/"if"/"then"
 // are the same shape one level up. collectErrors sorts these after every other keyword so an
 // operator sees the specific cause (additionalProperties, const, required, type, ...) first,
 // instead of every ancestor schema that failed as a consequence of it.
@@ -385,6 +385,7 @@ var structuralValidationKeywords = map[string]bool{
 	"anyOf":      true,
 	"oneOf":      true,
 	"if":         true,
+	"then":       true,
 }
 
 // validationError pairs a formatted error line with its instance location, keyword, and message.

--- a/pkg/runtime/config/schema_validator_test.go
+++ b/pkg/runtime/config/schema_validator_test.go
@@ -986,6 +986,34 @@ func TestFlattenErrorList(t *testing.T) {
 		}
 	})
 
+	t.Run("FiltersThenAsStructuralNoise", func(t *testing.T) {
+		// Given a root "then" failure (the if condition matched but the then branch didn't),
+		// an unrelated required/type cascade, and one real const violation
+		list := &jsonschema.List{
+			Details: []jsonschema.List{
+				{InstanceLocation: "/", Errors: map[string]string{"then": "Value meets the 'if' condition but does not match the 'then' schema"}},
+				{InstanceLocation: "/", Errors: map[string]string{"required": "Required property 'identity' is missing"}},
+				{InstanceLocation: "/identity", Errors: map[string]string{"type": "Value is null but should be object"}},
+				{InstanceLocation: "/database/postgres/driver", Errors: map[string]string{"const": "Value does not match the constant value"}},
+			},
+		}
+
+		// When flattening
+		errs := flattenErrorList(list)
+
+		// Then only the const violation and a summary note survive; "then" does not leak
+		// through as if it were an actionable violation
+		if len(errs) != 2 {
+			t.Fatalf("Expected 2 errors, got %d: %v", len(errs), errs)
+		}
+		if !strings.Contains(errs[0], "/database/postgres/driver: const:") {
+			t.Errorf("Expected the const error first, got %v", errs)
+		}
+		if !strings.Contains(errs[1], "3 other error(s) are hidden") {
+			t.Errorf("Expected a summary note about hidden errors, got %v", errs)
+		}
+	})
+
 	t.Run("PreservesRelativeOrderWithinEachPriorityGroup", func(t *testing.T) {
 		// Given two specific (non-structural) failures and two structural failures, interleaved
 		list := &jsonschema.List{


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This change touches only config schema validation error formatting, is fully covered by a new unit test, and carries no behavioral risk beyond which error lines get hidden from operators.
>
> **Overview**
>
> The PR adds the JSON Schema `"then"` keyword to `structuralValidationKeywords`, so a failed `if`/`then` branch is treated as structural noise rather than an actionable violation, matching the existing treatment of `if`, `allOf`, `anyOf`, and `oneOf`. Without this, a schema using `if`/`then` would surface a non-actionable "does not match the 'then' schema" message alongside the real, specific violation that caused it.
>
> A new test, `FiltersThenAsStructuralNoise`, exercises a root `then` failure alongside an unrelated required/type cascade and one real `const` violation, confirming only the specific violation and a hidden-error-count summary survive.

<!-- /claude-code-review:summary -->
