### PR TITLE
fix(provisioner): recover local state stranded under a renamed component's old ID

### DIFF
--- a/pkg/provisioner/bootstrap_test.go
+++ b/pkg/provisioner/bootstrap_test.go
@@ -1100,13 +1100,16 @@ func TestProvisioner_recoverHalfMigratedComponents(t *testing.T) {
 		}
 	})
 
-	t.Run("RecoversLocalStateStrandedUnderAComponentsPreviousID", func(t *testing.T) {
+	t.Run("DetectsAndWarnsAboutStateStrandedUnderAComponentsPreviousID", func(t *testing.T) {
 		// Reproduces windsorcli/cli#3324: a component renamed since its last partial
 		// apply leaves local state behind under its old ID. Before this fix,
 		// recoverHalfMigratedComponents only iterated the current blueprint's
 		// componentIDs, so "crossplane-identity-gcp" (the old ID; the blueprint now
-		// only declares "crossplane-identity") was invisible to the sweep and its
-		// local state was never migrated or cleaned up.
+		// only declares "crossplane-identity") was invisible to the sweep. The fix
+		// only detects and warns — it deliberately does not migrate or remove
+		// anything, since an orphaned ID is just as consistent with a proper
+		// destroy-then-remove as with a rename, and the two can't be told apart from
+		// an on-disk ID alone.
 		mocks := setupProvisionerMocks(t)
 		bp := &blueprintv1alpha1.Blueprint{
 			TerraformComponents: []blueprintv1alpha1.TerraformComponent{
@@ -1124,79 +1127,72 @@ func TestProvisioner_recoverHalfMigratedComponents(t *testing.T) {
 			}
 			return ""
 		}
-		var ops []string
-		mockCH.SetFunc = func(key string, value any) error {
-			if key == "terraform.backend.type" {
-				ops = append(ops, fmt.Sprintf("set:%v", value))
-			}
-			return nil
-		}
+		var probed []string
 		mockStack := terraforminfra.NewMockStack()
 		mockStack.ListLocalStateComponentIDsFunc = func() ([]string, error) {
 			return []string{"crossplane-identity-gcp"}, nil
 		}
 		mockStack.HasLocalStateWithResourcesFunc = func(componentID string) (bool, error) {
-			ops = append(ops, fmt.Sprintf("probe-local:%s", componentID))
+			probed = append(probed, componentID)
 			// Only the old ID has local state — "crossplane-identity" (the current,
 			// renamed-to ID) has never run, so it has none.
 			return componentID == "crossplane-identity-gcp", nil
 		}
-		mockStack.HasOrphanedRemoteStateFunc = func(componentID string) (bool, error) {
-			ops = append(ops, fmt.Sprintf("probe-orphaned-remote:%s", componentID))
-			return false, nil
-		}
-		mockStack.InitOrphanedComponentFunc = func(componentID string) (bool, error) {
-			ops = append(ops, fmt.Sprintf("init-orphaned:%s", componentID))
-			return true, nil
-		}
-		mockStack.MigrateOrphanedComponentStateFunc = func(componentID string) error {
-			ops = append(ops, fmt.Sprintf("migrate-orphaned:%s", componentID))
-			return nil
-		}
-		mockStack.RemoveLocalStateFunc = func(componentID string) error {
-			ops = append(ops, fmt.Sprintf("remove-local:%s", componentID))
-			return nil
-		}
 		mockStack.UpFunc = func(_ *blueprintv1alpha1.Blueprint, _ ...func(id string) (bool, error)) (bool, error) {
-			ops = append(ops, "up")
 			return false, nil
 		}
-		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
 
-		if _, err := provisioner.Up(bp); err != nil {
+		// Capture stderr to verify the warning names the orphaned componentID.
+		r, w, pipeErr := os.Pipe()
+		if pipeErr != nil {
+			t.Fatalf("Pipe failed: %v", pipeErr)
+		}
+		origStderr := os.Stderr
+		os.Stderr = w
+		defer func() { os.Stderr = origStderr }()
+
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+		_, err := provisioner.Up(bp)
+
+		w.Close()
+		stderrBytes, _ := io.ReadAll(r)
+		stderrOutput := string(stderrBytes)
+
+		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
 
-		expected := []string{
-			// The current-blueprint sweep probes "crossplane-identity" (the new ID) and
-			// finds no local state, so it's skipped with no further ops. The orphan sweep
-			// then finds "crossplane-identity-gcp" (the old ID) still has local state.
-			"probe-local:crossplane-identity",
-			"probe-local:crossplane-identity-gcp",
-			"probe-orphaned-remote:crossplane-identity-gcp",
-			"set:local",
-			"init-orphaned:crossplane-identity-gcp",
-			"set:gcs",
-			"migrate-orphaned:crossplane-identity-gcp",
-			"remove-local:crossplane-identity-gcp",
-			"up",
+		// Both IDs get probed for local state — the current one by the sweep above,
+		// the orphaned one by the detection pass below.
+		expectedProbed := []string{"crossplane-identity", "crossplane-identity-gcp"}
+		if len(probed) != len(expectedProbed) {
+			t.Fatalf("Expected probes %v, got %v", expectedProbed, probed)
 		}
-		if len(ops) != len(expected) {
-			t.Fatalf("Expected ops %v, got %v", expected, ops)
-		}
-		for i, want := range expected {
-			if ops[i] != want {
-				t.Errorf("op %d: got %q, want %q (full: %v)", i, ops[i], want, ops)
+		for i, want := range expectedProbed {
+			if probed[i] != want {
+				t.Errorf("probe %d: got %q, want %q (full: %v)", i, probed[i], want, probed)
 			}
+		}
+		if !strings.Contains(stderrOutput, "crossplane-identity-gcp") {
+			t.Errorf("Expected a warning naming the orphaned componentID, got: %q", stderrOutput)
+		}
+		if !strings.Contains(stderrOutput, "not migrated automatically") {
+			t.Errorf("Expected the warning to say state was not migrated automatically, got: %q", stderrOutput)
 		}
 	})
 
-	t.Run("WarnsInsteadOfMigratingWhenOrphanedDirectoryIsGone", func(t *testing.T) {
-		// The orphaned component's local state file has resources, but its terraform
-		// directory no longer exists on disk (e.g. it was cleaned up separately).
-		// Recovery must not error or silently claim success — it warns and moves on.
+	t.Run("DoesNotTreatADisabledComponentAsOrphaned", func(t *testing.T) {
+		// A component the operator has merely toggled off (Enabled: false) is still
+		// declared in the blueprint — not renamed, not removed. The orphan-detection
+		// pass must not mistake it for one just because the enabled-only sweep above
+		// skips it before recording its ID.
 		mocks := setupProvisionerMocks(t)
-		bp := &blueprintv1alpha1.Blueprint{TerraformComponents: nil}
+		disabled := false
+		bp := &blueprintv1alpha1.Blueprint{
+			TerraformComponents: []blueprintv1alpha1.TerraformComponent{
+				{Path: "network", Enabled: &blueprintv1alpha1.BoolExpression{Value: &disabled, IsExpr: false}},
+			},
+		}
 
 		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
 		mockCH.GetStringFunc = func(key string, defaultValue ...string) string {
@@ -1210,40 +1206,44 @@ func TestProvisioner_recoverHalfMigratedComponents(t *testing.T) {
 		}
 		mockStack := terraforminfra.NewMockStack()
 		mockStack.ListLocalStateComponentIDsFunc = func() ([]string, error) {
-			return []string{"crossplane-identity-gcp"}, nil
+			return []string{"network"}, nil
 		}
+		probeLocalCalled := false
 		mockStack.HasLocalStateWithResourcesFunc = func(componentID string) (bool, error) {
+			probeLocalCalled = true
 			return true, nil
-		}
-		mockStack.HasOrphanedRemoteStateFunc = func(componentID string) (bool, error) {
-			return false, nil
-		}
-		mockStack.InitOrphanedComponentFunc = func(componentID string) (bool, error) {
-			return false, nil
-		}
-		migrateCalled := false
-		mockStack.MigrateOrphanedComponentStateFunc = func(componentID string) error {
-			migrateCalled = true
-			return nil
-		}
-		removeCalled := false
-		mockStack.RemoveLocalStateFunc = func(componentID string) error {
-			removeCalled = true
-			return nil
 		}
 		mockStack.UpFunc = func(_ *blueprintv1alpha1.Blueprint, _ ...func(id string) (bool, error)) (bool, error) {
 			return false, nil
 		}
-		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
 
-		if _, err := provisioner.Up(bp); err != nil {
+		r, w, pipeErr := os.Pipe()
+		if pipeErr != nil {
+			t.Fatalf("Pipe failed: %v", pipeErr)
+		}
+		origStderr := os.Stderr
+		os.Stderr = w
+		defer func() { os.Stderr = origStderr }()
+
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+		_, err := provisioner.Up(bp)
+
+		w.Close()
+		stderrBytes, _ := io.ReadAll(r)
+		stderrOutput := string(stderrBytes)
+
+		if err != nil {
 			t.Fatalf("Expected no error, got %v", err)
 		}
-		if migrateCalled {
-			t.Error("MigrateOrphanedComponentState must not run when the directory is gone")
+
+		// The enabled-only sweep skips "network" entirely (disabled), so its local
+		// state is never even probed there. The orphan-detection pass must also leave
+		// it alone — no probe, no warning — since "network" is still declared.
+		if probeLocalCalled {
+			t.Error("HasLocalStateWithResources must not be called for a disabled component")
 		}
-		if removeCalled {
-			t.Error("RemoveLocalState must not run when nothing was migrated")
+		if strings.Contains(stderrOutput, "network") {
+			t.Errorf("Expected no warning about a still-declared component, got: %q", stderrOutput)
 		}
 	})
 }

--- a/pkg/provisioner/bootstrap_test.go
+++ b/pkg/provisioner/bootstrap_test.go
@@ -1099,4 +1099,151 @@ func TestProvisioner_recoverHalfMigratedComponents(t *testing.T) {
 			t.Error("TerraformStack.Up must not run when recovery aborts")
 		}
 	})
+
+	t.Run("RecoversLocalStateStrandedUnderAComponentsPreviousID", func(t *testing.T) {
+		// Reproduces windsorcli/cli#3324: a component renamed since its last partial
+		// apply leaves local state behind under its old ID. Before this fix,
+		// recoverHalfMigratedComponents only iterated the current blueprint's
+		// componentIDs, so "crossplane-identity-gcp" (the old ID; the blueprint now
+		// only declares "crossplane-identity") was invisible to the sweep and its
+		// local state was never migrated or cleaned up.
+		mocks := setupProvisionerMocks(t)
+		bp := &blueprintv1alpha1.Blueprint{
+			TerraformComponents: []blueprintv1alpha1.TerraformComponent{
+				{Path: "crossplane-identity"},
+			},
+		}
+
+		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockCH.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "terraform.backend.type" {
+				return "gcs"
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
+		var ops []string
+		mockCH.SetFunc = func(key string, value any) error {
+			if key == "terraform.backend.type" {
+				ops = append(ops, fmt.Sprintf("set:%v", value))
+			}
+			return nil
+		}
+		mockStack := terraforminfra.NewMockStack()
+		mockStack.ListLocalStateComponentIDsFunc = func() ([]string, error) {
+			return []string{"crossplane-identity-gcp"}, nil
+		}
+		mockStack.HasLocalStateWithResourcesFunc = func(componentID string) (bool, error) {
+			ops = append(ops, fmt.Sprintf("probe-local:%s", componentID))
+			// Only the old ID has local state — "crossplane-identity" (the current,
+			// renamed-to ID) has never run, so it has none.
+			return componentID == "crossplane-identity-gcp", nil
+		}
+		mockStack.HasOrphanedRemoteStateFunc = func(componentID string) (bool, error) {
+			ops = append(ops, fmt.Sprintf("probe-orphaned-remote:%s", componentID))
+			return false, nil
+		}
+		mockStack.InitOrphanedComponentFunc = func(componentID string) (bool, error) {
+			ops = append(ops, fmt.Sprintf("init-orphaned:%s", componentID))
+			return true, nil
+		}
+		mockStack.MigrateOrphanedComponentStateFunc = func(componentID string) error {
+			ops = append(ops, fmt.Sprintf("migrate-orphaned:%s", componentID))
+			return nil
+		}
+		mockStack.RemoveLocalStateFunc = func(componentID string) error {
+			ops = append(ops, fmt.Sprintf("remove-local:%s", componentID))
+			return nil
+		}
+		mockStack.UpFunc = func(_ *blueprintv1alpha1.Blueprint, _ ...func(id string) (bool, error)) (bool, error) {
+			ops = append(ops, "up")
+			return false, nil
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+
+		if _, err := provisioner.Up(bp); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+
+		expected := []string{
+			// The current-blueprint sweep probes "crossplane-identity" (the new ID) and
+			// finds no local state, so it's skipped with no further ops. The orphan sweep
+			// then finds "crossplane-identity-gcp" (the old ID) still has local state.
+			"probe-local:crossplane-identity",
+			"probe-local:crossplane-identity-gcp",
+			"probe-orphaned-remote:crossplane-identity-gcp",
+			"set:local",
+			"init-orphaned:crossplane-identity-gcp",
+			"set:gcs",
+			"migrate-orphaned:crossplane-identity-gcp",
+			"remove-local:crossplane-identity-gcp",
+			"up",
+		}
+		if len(ops) != len(expected) {
+			t.Fatalf("Expected ops %v, got %v", expected, ops)
+		}
+		for i, want := range expected {
+			if ops[i] != want {
+				t.Errorf("op %d: got %q, want %q (full: %v)", i, ops[i], want, ops)
+			}
+		}
+	})
+
+	t.Run("WarnsInsteadOfMigratingWhenOrphanedDirectoryIsGone", func(t *testing.T) {
+		// The orphaned component's local state file has resources, but its terraform
+		// directory no longer exists on disk (e.g. it was cleaned up separately).
+		// Recovery must not error or silently claim success — it warns and moves on.
+		mocks := setupProvisionerMocks(t)
+		bp := &blueprintv1alpha1.Blueprint{TerraformComponents: nil}
+
+		mockCH := mocks.ConfigHandler.(*config.MockConfigHandler)
+		mockCH.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "terraform.backend.type" {
+				return "gcs"
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
+		mockStack := terraforminfra.NewMockStack()
+		mockStack.ListLocalStateComponentIDsFunc = func() ([]string, error) {
+			return []string{"crossplane-identity-gcp"}, nil
+		}
+		mockStack.HasLocalStateWithResourcesFunc = func(componentID string) (bool, error) {
+			return true, nil
+		}
+		mockStack.HasOrphanedRemoteStateFunc = func(componentID string) (bool, error) {
+			return false, nil
+		}
+		mockStack.InitOrphanedComponentFunc = func(componentID string) (bool, error) {
+			return false, nil
+		}
+		migrateCalled := false
+		mockStack.MigrateOrphanedComponentStateFunc = func(componentID string) error {
+			migrateCalled = true
+			return nil
+		}
+		removeCalled := false
+		mockStack.RemoveLocalStateFunc = func(componentID string) error {
+			removeCalled = true
+			return nil
+		}
+		mockStack.UpFunc = func(_ *blueprintv1alpha1.Blueprint, _ ...func(id string) (bool, error)) (bool, error) {
+			return false, nil
+		}
+		provisioner := NewProvisioner(mocks.Runtime, mocks.BlueprintHandler, &Provisioner{TerraformStack: mockStack})
+
+		if _, err := provisioner.Up(bp); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if migrateCalled {
+			t.Error("MigrateOrphanedComponentState must not run when the directory is gone")
+		}
+		if removeCalled {
+			t.Error("RemoveLocalState must not run when nothing was migrated")
+		}
+	})
 }

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -362,42 +362,6 @@ func (i *Provisioner) ListLocalStateComponentIDs() ([]string, error) {
 	return i.TerraformStack.ListLocalStateComponentIDs()
 }
 
-// InitOrphanedComponent runs `terraform init` for a componentID no longer declared in the
-// blueprint, using its on-disk directory in place of a blueprint lookup.
-func (i *Provisioner) InitOrphanedComponent(componentID string) (bool, error) {
-	if err := i.ensureTerraformStack(); err != nil {
-		return false, err
-	}
-	if i.TerraformStack == nil {
-		return false, fmt.Errorf("terraform is disabled")
-	}
-	return i.TerraformStack.InitOrphanedComponent(componentID)
-}
-
-// HasOrphanedRemoteState reports whether a componentID no longer declared in the blueprint
-// has non-empty state in the currently-configured backend.
-func (i *Provisioner) HasOrphanedRemoteState(componentID string) (bool, error) {
-	if err := i.ensureTerraformStack(); err != nil {
-		return false, err
-	}
-	if i.TerraformStack == nil {
-		return false, fmt.Errorf("terraform is disabled")
-	}
-	return i.TerraformStack.HasOrphanedRemoteState(componentID)
-}
-
-// MigrateOrphanedComponentState migrates local state for a componentID no longer declared in
-// the blueprint to the currently configured backend.
-func (i *Provisioner) MigrateOrphanedComponentState(componentID string) error {
-	if err := i.ensureTerraformStack(); err != nil {
-		return err
-	}
-	if i.TerraformStack == nil {
-		return fmt.Errorf("terraform is disabled")
-	}
-	return i.TerraformStack.MigrateOrphanedComponentState(componentID)
-}
-
 // Down destroys the "workstation" terraform component if it is present in the blueprint, then returns.
 // All other terraform components are left untouched; use Destroy / DestroyAll for those.
 // If terraform is disabled or the blueprint has no "workstation" component, Down is a no-op.
@@ -1971,17 +1935,20 @@ func hasEnabledTerraformComponent(blueprint *blueprintv1alpha1.Blueprint) bool {
 	return false
 }
 
-// recoverHalfMigratedComponents migrates leftover local state to the
-// configured remote backend for components with local state but no remote
-// state — typical residue from an interrupted bootstrap. Per affected
-// component: init under local override (resets the pointer to local), exit
-// override, migrate local→remote, remove the local file. Local-backend
-// contexts short-circuit. Probe failures abort with the underlying error
-// rather than fall through; -force-copy would otherwise overwrite good
-// remote state with stale local content. After sweeping the current
-// blueprint, recoverOrphanedLocalState runs the same recovery for
-// componentIDs that still have local state on disk but no longer appear in
-// the blueprint — typically because the component was renamed.
+// recoverHalfMigratedComponents migrates leftover local state to the configured remote
+// backend. It targets components with local state but no remote state — typical residue from
+// an interrupted bootstrap.
+//
+//   - Local backend: skip the sweep entirely.
+//   - Per component: init under a local backend override, exit the override, migrate the
+//     local state to remote, then remove the local file.
+//   - Probe failure: abort with the underlying error. Otherwise -force-copy could overwrite
+//     good remote state with a stale local file.
+//   - Disabled component: still counts as declared. The sweep above skips it, but it must
+//     not be mistaken for an orphan below.
+//
+// After the sweep, warnAboutOrphanedLocalState checks for local state under a componentID no
+// longer in the blueprint (usually a rename) and warns instead of migrating it.
 func (i *Provisioner) recoverHalfMigratedComponents(blueprint *blueprintv1alpha1.Blueprint) error {
 	backendType := i.configHandler.GetTerraformBackendType()
 	if backendType == "" || backendType == "local" {
@@ -1990,11 +1957,14 @@ func (i *Provisioner) recoverHalfMigratedComponents(blueprint *blueprintv1alpha1
 
 	currentIDs := make(map[string]bool, len(blueprint.TerraformComponents))
 	for _, c := range blueprint.TerraformComponents {
+		currentIDs[c.GetID()] = true
+	}
+
+	for _, c := range blueprint.TerraformComponents {
 		if c.Enabled != nil && !c.Enabled.IsEnabled() {
 			continue
 		}
 		componentID := c.GetID()
-		currentIDs[componentID] = true
 
 		hasLocal, err := i.HasLocalStateWithResources(componentID)
 		if err != nil {
@@ -2033,17 +2003,22 @@ func (i *Provisioner) recoverHalfMigratedComponents(blueprint *blueprintv1alpha1
 		}
 	}
 
-	return i.recoverOrphanedLocalState(backendType, currentIDs)
+	return i.warnAboutOrphanedLocalState(currentIDs)
 }
 
-// recoverOrphanedLocalState runs the same reset-and-migrate recovery as
-// recoverHalfMigratedComponents for componentIDs that still have local
-// state on disk but no longer appear in the blueprint. Without this, state
-// left behind under a component's previous ID is invisible to the sweep
-// above — which only iterates the current blueprint's componentIDs — and
-// never gets cleaned up or migrated. currentIDs is the set already handled
-// by that sweep, so this only visits IDs it skipped.
-func (i *Provisioner) recoverOrphanedLocalState(backendType string, currentIDs map[string]bool) error {
+// warnAboutOrphanedLocalState finds componentIDs that still have local Terraform state with
+// resources on disk but no longer appear in the blueprint — typically because the component
+// was renamed. Without this, such state is invisible to the sweep above, which only iterates
+// the current blueprint's componentIDs. currentIDs is the set already handled by that sweep,
+// so this only visits IDs it skipped.
+//
+// This deliberately only detects and warns; it does not migrate or remove anything. An
+// orphaned ID is just as consistent with the component having been properly destroyed and
+// removed from the blueprint as with a rename — the two are indistinguishable from an on-disk
+// ID alone — and force-copying into the shared remote backend is not safe to run unattended
+// for either case: a decommissioned component's stale local state would get published into
+// the shared backend forever, under an ID nothing will ever reference again.
+func (i *Provisioner) warnAboutOrphanedLocalState(currentIDs map[string]bool) error {
 	localIDs, err := i.ListLocalStateComponentIDs()
 	if err != nil {
 		return fmt.Errorf("error listing local state during recovery sweep: %w", err)
@@ -2062,40 +2037,7 @@ func (i *Provisioner) recoverOrphanedLocalState(backendType string, currentIDs m
 			continue
 		}
 
-		hasRemote, err := i.HasOrphanedRemoteState(componentID)
-		if err != nil {
-			return fmt.Errorf("recovery sweep aborted: could not probe configured backend for %q: %w. The reset-and-migrate path uses terraform init -migrate-state -force-copy which would unconditionally overwrite the destination, so a transient probe failure (auth, network, missing backend storage) must not be assumed-equivalent to \"no remote state\" — that assumption could silently replace valid remote state with the local file. Resolve the underlying probe failure (check credentials, connectivity, and backend storage availability) and retry", componentID, err)
-		}
-		if hasRemote {
-			continue
-		}
-
-		message := fmt.Sprintf("Migrating leftover local state for %s → %s", componentID, backendType)
-		if err := tui.WithProgress(message, func() error {
-			var found bool
-			if err := i.withBackendOverride("local-recovery-init", func() error {
-				var err error
-				found, err = i.InitOrphanedComponent(componentID)
-				return err
-			}); err != nil {
-				return fmt.Errorf("error resetting backend pointer: %w", err)
-			}
-			if !found {
-				fmt.Fprintf(os.Stderr, "warning: found leftover local state for %q, which is no longer in the blueprint, but its terraform directory is gone; reconcile it manually\n", componentID)
-				return nil
-			}
-
-			if err := i.MigrateOrphanedComponentState(componentID); err != nil {
-				return fmt.Errorf("error migrating local state: %w", err)
-			}
-
-			if err := i.RemoveLocalState(componentID); err != nil {
-				fmt.Fprintf(os.Stderr, "warning: failed to remove local state file for %q after recovery migration: %v\n", componentID, err)
-			}
-			return nil
-		}); err != nil {
-			return fmt.Errorf("recovery sweep failed for %s: %w", componentID, err)
-		}
+		fmt.Fprintf(os.Stderr, "warning: found local terraform state for %q, which is no longer in the blueprint; state was not migrated automatically — if this component was renamed, re-add it under this ID to migrate its state, or reconcile it manually\n", componentID)
 	}
 	return nil
 }

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -350,6 +350,54 @@ func (i *Provisioner) RemoveLocalState(componentID string) error {
 	return i.TerraformStack.RemoveLocalState(componentID)
 }
 
+// ListLocalStateComponentIDs returns every componentID with local Terraform state on disk,
+// whether or not it is still declared in the active blueprint.
+func (i *Provisioner) ListLocalStateComponentIDs() ([]string, error) {
+	if err := i.ensureTerraformStack(); err != nil {
+		return nil, err
+	}
+	if i.TerraformStack == nil {
+		return nil, fmt.Errorf("terraform is disabled")
+	}
+	return i.TerraformStack.ListLocalStateComponentIDs()
+}
+
+// InitOrphanedComponent runs `terraform init` for a componentID no longer declared in the
+// blueprint, using its on-disk directory in place of a blueprint lookup.
+func (i *Provisioner) InitOrphanedComponent(componentID string) (bool, error) {
+	if err := i.ensureTerraformStack(); err != nil {
+		return false, err
+	}
+	if i.TerraformStack == nil {
+		return false, fmt.Errorf("terraform is disabled")
+	}
+	return i.TerraformStack.InitOrphanedComponent(componentID)
+}
+
+// HasOrphanedRemoteState reports whether a componentID no longer declared in the blueprint
+// has non-empty state in the currently-configured backend.
+func (i *Provisioner) HasOrphanedRemoteState(componentID string) (bool, error) {
+	if err := i.ensureTerraformStack(); err != nil {
+		return false, err
+	}
+	if i.TerraformStack == nil {
+		return false, fmt.Errorf("terraform is disabled")
+	}
+	return i.TerraformStack.HasOrphanedRemoteState(componentID)
+}
+
+// MigrateOrphanedComponentState migrates local state for a componentID no longer declared in
+// the blueprint to the currently configured backend.
+func (i *Provisioner) MigrateOrphanedComponentState(componentID string) error {
+	if err := i.ensureTerraformStack(); err != nil {
+		return err
+	}
+	if i.TerraformStack == nil {
+		return fmt.Errorf("terraform is disabled")
+	}
+	return i.TerraformStack.MigrateOrphanedComponentState(componentID)
+}
+
 // Down destroys the "workstation" terraform component if it is present in the blueprint, then returns.
 // All other terraform components are left untouched; use Destroy / DestroyAll for those.
 // If terraform is disabled or the blueprint has no "workstation" component, Down is a no-op.
@@ -1930,18 +1978,23 @@ func hasEnabledTerraformComponent(blueprint *blueprintv1alpha1.Blueprint) bool {
 // override, migrate local→remote, remove the local file. Local-backend
 // contexts short-circuit. Probe failures abort with the underlying error
 // rather than fall through; -force-copy would otherwise overwrite good
-// remote state with stale local content.
+// remote state with stale local content. After sweeping the current
+// blueprint, recoverOrphanedLocalState runs the same recovery for
+// componentIDs that still have local state on disk but no longer appear in
+// the blueprint — typically because the component was renamed.
 func (i *Provisioner) recoverHalfMigratedComponents(blueprint *blueprintv1alpha1.Blueprint) error {
 	backendType := i.configHandler.GetTerraformBackendType()
 	if backendType == "" || backendType == "local" {
 		return nil
 	}
 
+	currentIDs := make(map[string]bool, len(blueprint.TerraformComponents))
 	for _, c := range blueprint.TerraformComponents {
 		if c.Enabled != nil && !c.Enabled.IsEnabled() {
 			continue
 		}
 		componentID := c.GetID()
+		currentIDs[componentID] = true
 
 		hasLocal, err := i.HasLocalStateWithResources(componentID)
 		if err != nil {
@@ -1968,6 +2021,71 @@ func (i *Provisioner) recoverHalfMigratedComponents(blueprint *blueprintv1alpha1
 			}
 
 			if err := i.MigrateComponentState(blueprint, componentID); err != nil {
+				return fmt.Errorf("error migrating local state: %w", err)
+			}
+
+			if err := i.RemoveLocalState(componentID); err != nil {
+				fmt.Fprintf(os.Stderr, "warning: failed to remove local state file for %q after recovery migration: %v\n", componentID, err)
+			}
+			return nil
+		}); err != nil {
+			return fmt.Errorf("recovery sweep failed for %s: %w", componentID, err)
+		}
+	}
+
+	return i.recoverOrphanedLocalState(backendType, currentIDs)
+}
+
+// recoverOrphanedLocalState runs the same reset-and-migrate recovery as
+// recoverHalfMigratedComponents for componentIDs that still have local
+// state on disk but no longer appear in the blueprint. Without this, state
+// left behind under a component's previous ID is invisible to the sweep
+// above — which only iterates the current blueprint's componentIDs — and
+// never gets cleaned up or migrated. currentIDs is the set already handled
+// by that sweep, so this only visits IDs it skipped.
+func (i *Provisioner) recoverOrphanedLocalState(backendType string, currentIDs map[string]bool) error {
+	localIDs, err := i.ListLocalStateComponentIDs()
+	if err != nil {
+		return fmt.Errorf("error listing local state during recovery sweep: %w", err)
+	}
+
+	for _, componentID := range localIDs {
+		if currentIDs[componentID] {
+			continue
+		}
+
+		hasLocal, err := i.HasLocalStateWithResources(componentID)
+		if err != nil {
+			return fmt.Errorf("error inspecting local state for %s during recovery sweep: %w", componentID, err)
+		}
+		if !hasLocal {
+			continue
+		}
+
+		hasRemote, err := i.HasOrphanedRemoteState(componentID)
+		if err != nil {
+			return fmt.Errorf("recovery sweep aborted: could not probe configured backend for %q: %w. The reset-and-migrate path uses terraform init -migrate-state -force-copy which would unconditionally overwrite the destination, so a transient probe failure (auth, network, missing backend storage) must not be assumed-equivalent to \"no remote state\" — that assumption could silently replace valid remote state with the local file. Resolve the underlying probe failure (check credentials, connectivity, and backend storage availability) and retry", componentID, err)
+		}
+		if hasRemote {
+			continue
+		}
+
+		message := fmt.Sprintf("Migrating leftover local state for %s → %s", componentID, backendType)
+		if err := tui.WithProgress(message, func() error {
+			var found bool
+			if err := i.withBackendOverride("local-recovery-init", func() error {
+				var err error
+				found, err = i.InitOrphanedComponent(componentID)
+				return err
+			}); err != nil {
+				return fmt.Errorf("error resetting backend pointer: %w", err)
+			}
+			if !found {
+				fmt.Fprintf(os.Stderr, "warning: found leftover local state for %q, which is no longer in the blueprint, but its terraform directory is gone; reconcile it manually\n", componentID)
+				return nil
+			}
+
+			if err := i.MigrateOrphanedComponentState(componentID); err != nil {
 				return fmt.Errorf("error migrating local state: %w", err)
 			}
 

--- a/pkg/provisioner/terraform/mock_stack.go
+++ b/pkg/provisioner/terraform/mock_stack.go
@@ -15,27 +15,31 @@ import (
 
 // MockStack is a mock implementation of the Stack interface for testing.
 type MockStack struct {
-	UpFunc                          func(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(id string) (bool, error)) (bool, error)
-	MigrateStateFunc                func(blueprint *blueprintv1alpha1.Blueprint) ([]string, error)
-	MigrateComponentStateFunc       func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
-	HasRemoteStateFunc              func(blueprint *blueprintv1alpha1.Blueprint, componentID string) (bool, error)
-	HasLocalStateWithResourcesFunc  func(componentID string) (bool, error)
-	InitComponentFunc               func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
-	RemoveLocalStateFunc            func(componentID string) error
-	PostApplyFunc                   func(fns ...func(id string) error)
-	DestroyAllFunc                  func(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyOutcome, error)
-	PlanFunc                        func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
-	PlanAllFunc                     func(blueprint *blueprintv1alpha1.Blueprint) error
-	PlanJSONFunc                    func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
-	PlanAllJSONFunc                 func(blueprint *blueprintv1alpha1.Blueprint) error
-	PlanResourceChangesJSONFunc     func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
-	PlanAllResourceChangesJSONFunc  func(blueprint *blueprintv1alpha1.Blueprint) error
-	ApplyFunc                       func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
-	DestroyFunc                     func(blueprint *blueprintv1alpha1.Blueprint, componentID string) (bool, error)
-	PlanSummaryFunc                 func(blueprint *blueprintv1alpha1.Blueprint) []TerraformComponentPlan
-	PlanComponentSummaryFunc        func(blueprint *blueprintv1alpha1.Blueprint, componentID string) TerraformComponentPlan
-	PlanDestroySummaryFunc          func(blueprint *blueprintv1alpha1.Blueprint) []TerraformComponentPlan
-	PlanDestroyComponentSummaryFunc func(blueprint *blueprintv1alpha1.Blueprint, componentID string) TerraformComponentPlan
+	UpFunc                            func(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(id string) (bool, error)) (bool, error)
+	MigrateStateFunc                  func(blueprint *blueprintv1alpha1.Blueprint) ([]string, error)
+	MigrateComponentStateFunc         func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
+	HasRemoteStateFunc                func(blueprint *blueprintv1alpha1.Blueprint, componentID string) (bool, error)
+	HasLocalStateWithResourcesFunc    func(componentID string) (bool, error)
+	InitComponentFunc                 func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
+	RemoveLocalStateFunc              func(componentID string) error
+	ListLocalStateComponentIDsFunc    func() ([]string, error)
+	InitOrphanedComponentFunc         func(componentID string) (bool, error)
+	HasOrphanedRemoteStateFunc        func(componentID string) (bool, error)
+	MigrateOrphanedComponentStateFunc func(componentID string) error
+	PostApplyFunc                     func(fns ...func(id string) error)
+	DestroyAllFunc                    func(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyOutcome, error)
+	PlanFunc                          func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
+	PlanAllFunc                       func(blueprint *blueprintv1alpha1.Blueprint) error
+	PlanJSONFunc                      func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
+	PlanAllJSONFunc                   func(blueprint *blueprintv1alpha1.Blueprint) error
+	PlanResourceChangesJSONFunc       func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
+	PlanAllResourceChangesJSONFunc    func(blueprint *blueprintv1alpha1.Blueprint) error
+	ApplyFunc                         func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
+	DestroyFunc                       func(blueprint *blueprintv1alpha1.Blueprint, componentID string) (bool, error)
+	PlanSummaryFunc                   func(blueprint *blueprintv1alpha1.Blueprint) []TerraformComponentPlan
+	PlanComponentSummaryFunc          func(blueprint *blueprintv1alpha1.Blueprint, componentID string) TerraformComponentPlan
+	PlanDestroySummaryFunc            func(blueprint *blueprintv1alpha1.Blueprint) []TerraformComponentPlan
+	PlanDestroyComponentSummaryFunc   func(blueprint *blueprintv1alpha1.Blueprint, componentID string) TerraformComponentPlan
 }
 
 // =============================================================================
@@ -103,6 +107,38 @@ func (m *MockStack) InitComponent(blueprint *blueprintv1alpha1.Blueprint, compon
 func (m *MockStack) RemoveLocalState(componentID string) error {
 	if m.RemoveLocalStateFunc != nil {
 		return m.RemoveLocalStateFunc(componentID)
+	}
+	return nil
+}
+
+// ListLocalStateComponentIDs is a mock implementation of the ListLocalStateComponentIDs method.
+func (m *MockStack) ListLocalStateComponentIDs() ([]string, error) {
+	if m.ListLocalStateComponentIDsFunc != nil {
+		return m.ListLocalStateComponentIDsFunc()
+	}
+	return nil, nil
+}
+
+// InitOrphanedComponent is a mock implementation of the InitOrphanedComponent method.
+func (m *MockStack) InitOrphanedComponent(componentID string) (bool, error) {
+	if m.InitOrphanedComponentFunc != nil {
+		return m.InitOrphanedComponentFunc(componentID)
+	}
+	return false, nil
+}
+
+// HasOrphanedRemoteState is a mock implementation of the HasOrphanedRemoteState method.
+func (m *MockStack) HasOrphanedRemoteState(componentID string) (bool, error) {
+	if m.HasOrphanedRemoteStateFunc != nil {
+		return m.HasOrphanedRemoteStateFunc(componentID)
+	}
+	return false, nil
+}
+
+// MigrateOrphanedComponentState is a mock implementation of the MigrateOrphanedComponentState method.
+func (m *MockStack) MigrateOrphanedComponentState(componentID string) error {
+	if m.MigrateOrphanedComponentStateFunc != nil {
+		return m.MigrateOrphanedComponentStateFunc(componentID)
 	}
 	return nil
 }

--- a/pkg/provisioner/terraform/mock_stack.go
+++ b/pkg/provisioner/terraform/mock_stack.go
@@ -15,31 +15,28 @@ import (
 
 // MockStack is a mock implementation of the Stack interface for testing.
 type MockStack struct {
-	UpFunc                            func(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(id string) (bool, error)) (bool, error)
-	MigrateStateFunc                  func(blueprint *blueprintv1alpha1.Blueprint) ([]string, error)
-	MigrateComponentStateFunc         func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
-	HasRemoteStateFunc                func(blueprint *blueprintv1alpha1.Blueprint, componentID string) (bool, error)
-	HasLocalStateWithResourcesFunc    func(componentID string) (bool, error)
-	InitComponentFunc                 func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
-	RemoveLocalStateFunc              func(componentID string) error
-	ListLocalStateComponentIDsFunc    func() ([]string, error)
-	InitOrphanedComponentFunc         func(componentID string) (bool, error)
-	HasOrphanedRemoteStateFunc        func(componentID string) (bool, error)
-	MigrateOrphanedComponentStateFunc func(componentID string) error
-	PostApplyFunc                     func(fns ...func(id string) error)
-	DestroyAllFunc                    func(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyOutcome, error)
-	PlanFunc                          func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
-	PlanAllFunc                       func(blueprint *blueprintv1alpha1.Blueprint) error
-	PlanJSONFunc                      func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
-	PlanAllJSONFunc                   func(blueprint *blueprintv1alpha1.Blueprint) error
-	PlanResourceChangesJSONFunc       func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
-	PlanAllResourceChangesJSONFunc    func(blueprint *blueprintv1alpha1.Blueprint) error
-	ApplyFunc                         func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
-	DestroyFunc                       func(blueprint *blueprintv1alpha1.Blueprint, componentID string) (bool, error)
-	PlanSummaryFunc                   func(blueprint *blueprintv1alpha1.Blueprint) []TerraformComponentPlan
-	PlanComponentSummaryFunc          func(blueprint *blueprintv1alpha1.Blueprint, componentID string) TerraformComponentPlan
-	PlanDestroySummaryFunc            func(blueprint *blueprintv1alpha1.Blueprint) []TerraformComponentPlan
-	PlanDestroyComponentSummaryFunc   func(blueprint *blueprintv1alpha1.Blueprint, componentID string) TerraformComponentPlan
+	UpFunc                          func(blueprint *blueprintv1alpha1.Blueprint, onApply ...func(id string) (bool, error)) (bool, error)
+	MigrateStateFunc                func(blueprint *blueprintv1alpha1.Blueprint) ([]string, error)
+	MigrateComponentStateFunc       func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
+	HasRemoteStateFunc              func(blueprint *blueprintv1alpha1.Blueprint, componentID string) (bool, error)
+	HasLocalStateWithResourcesFunc  func(componentID string) (bool, error)
+	InitComponentFunc               func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
+	RemoveLocalStateFunc            func(componentID string) error
+	ListLocalStateComponentIDsFunc  func() ([]string, error)
+	PostApplyFunc                   func(fns ...func(id string) error)
+	DestroyAllFunc                  func(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyOutcome, error)
+	PlanFunc                        func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
+	PlanAllFunc                     func(blueprint *blueprintv1alpha1.Blueprint) error
+	PlanJSONFunc                    func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
+	PlanAllJSONFunc                 func(blueprint *blueprintv1alpha1.Blueprint) error
+	PlanResourceChangesJSONFunc     func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
+	PlanAllResourceChangesJSONFunc  func(blueprint *blueprintv1alpha1.Blueprint) error
+	ApplyFunc                       func(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
+	DestroyFunc                     func(blueprint *blueprintv1alpha1.Blueprint, componentID string) (bool, error)
+	PlanSummaryFunc                 func(blueprint *blueprintv1alpha1.Blueprint) []TerraformComponentPlan
+	PlanComponentSummaryFunc        func(blueprint *blueprintv1alpha1.Blueprint, componentID string) TerraformComponentPlan
+	PlanDestroySummaryFunc          func(blueprint *blueprintv1alpha1.Blueprint) []TerraformComponentPlan
+	PlanDestroyComponentSummaryFunc func(blueprint *blueprintv1alpha1.Blueprint, componentID string) TerraformComponentPlan
 }
 
 // =============================================================================
@@ -117,30 +114,6 @@ func (m *MockStack) ListLocalStateComponentIDs() ([]string, error) {
 		return m.ListLocalStateComponentIDsFunc()
 	}
 	return nil, nil
-}
-
-// InitOrphanedComponent is a mock implementation of the InitOrphanedComponent method.
-func (m *MockStack) InitOrphanedComponent(componentID string) (bool, error) {
-	if m.InitOrphanedComponentFunc != nil {
-		return m.InitOrphanedComponentFunc(componentID)
-	}
-	return false, nil
-}
-
-// HasOrphanedRemoteState is a mock implementation of the HasOrphanedRemoteState method.
-func (m *MockStack) HasOrphanedRemoteState(componentID string) (bool, error) {
-	if m.HasOrphanedRemoteStateFunc != nil {
-		return m.HasOrphanedRemoteStateFunc(componentID)
-	}
-	return false, nil
-}
-
-// MigrateOrphanedComponentState is a mock implementation of the MigrateOrphanedComponentState method.
-func (m *MockStack) MigrateOrphanedComponentState(componentID string) error {
-	if m.MigrateOrphanedComponentStateFunc != nil {
-		return m.MigrateOrphanedComponentStateFunc(componentID)
-	}
-	return nil
 }
 
 // PostApply is a mock implementation of the PostApply method.

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -217,9 +217,6 @@ type Stack interface {
 	InitComponent(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
 	RemoveLocalState(componentID string) error
 	ListLocalStateComponentIDs() ([]string, error)
-	InitOrphanedComponent(componentID string) (bool, error)
-	HasOrphanedRemoteState(componentID string) (bool, error)
-	MigrateOrphanedComponentState(componentID string) error
 	PostApply(fns ...func(id string) error)
 	DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyOutcome, error)
 	Plan(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
@@ -476,58 +473,6 @@ func (s *TerraformStack) RemoveLocalState(componentID string) error {
 // TerraformProvider owns the on-disk .tfstate layout.
 func (s *TerraformStack) ListLocalStateComponentIDs() ([]string, error) {
 	return s.runtime.TerraformProvider.ListLocalStateComponentIDs()
-}
-
-// InitOrphanedComponent runs `terraform init` for a componentID no longer declared in the
-// blueprint, using the on-disk directory convention in place of a blueprint lookup. Returns
-// (false, nil), not an error, when no directory exists under either convention: module
-// resolution never recreates one for an ID absent from the blueprint, so there is nothing to
-// run terraform against.
-func (s *TerraformStack) InitOrphanedComponent(componentID string) (bool, error) {
-	fullPath := s.orphanedComponentFullPath(componentID)
-	if fullPath == "" {
-		return false, nil
-	}
-	component := &blueprintv1alpha1.TerraformComponent{Path: componentID, FullPath: fullPath}
-	terraformVars, scopedKeys, terraformArgs, err := s.setupTerraformEnvironment(*component)
-	if err != nil {
-		return false, err
-	}
-	return true, s.runTerraformInit(component, terraformVars, scopedKeys, terraformArgs, defaultInitFlags...)
-}
-
-// HasOrphanedRemoteState mirrors HasRemoteState for a componentID no longer declared in the
-// blueprint. Returns (false, nil) when its on-disk directory is gone.
-func (s *TerraformStack) HasOrphanedRemoteState(componentID string) (bool, error) {
-	fullPath := s.orphanedComponentFullPath(componentID)
-	if fullPath == "" {
-		return false, nil
-	}
-	component := &blueprintv1alpha1.TerraformComponent{Path: componentID, FullPath: fullPath}
-	terraformVars, scopedKeys, terraformArgs, err := s.setupTerraformEnvironment(*component)
-	if err != nil {
-		return false, err
-	}
-	if err := s.runTerraformInit(component, terraformVars, scopedKeys, terraformArgs, defaultInitFlags...); err != nil {
-		return false, err
-	}
-	return s.hasStateResources(component, terraformVars, scopedKeys)
-}
-
-// MigrateOrphanedComponentState mirrors MigrateComponentState for a componentID no longer
-// declared in the blueprint, running `terraform init -migrate-state -force-copy` against its
-// on-disk directory. A no-op when that directory is gone.
-func (s *TerraformStack) MigrateOrphanedComponentState(componentID string) error {
-	fullPath := s.orphanedComponentFullPath(componentID)
-	if fullPath == "" {
-		return nil
-	}
-	component := &blueprintv1alpha1.TerraformComponent{Path: componentID, FullPath: fullPath}
-	terraformVars, scopedKeys, terraformArgs, err := s.setupTerraformEnvironment(*component)
-	if err != nil {
-		return err
-	}
-	return s.runTerraformInit(component, terraformVars, scopedKeys, terraformArgs, "-migrate-state", "-force-copy")
 }
 
 // MigrateState runs `terraform init -migrate-state -force-copy` per component to move state
@@ -1156,24 +1101,6 @@ func (s *TerraformStack) PlanComponentSummary(blueprint *blueprintv1alpha1.Bluep
 // streaming its terraform output. Shared by every per-component loop over all components.
 func (s *TerraformStack) printComponentHeader(componentPath string) {
 	fmt.Fprintf(os.Stderr, "\n%s\n", tui.SectionHeader("Terraform: "+componentPath))
-}
-
-// orphanedComponentFullPath resolves the on-disk terraform module directory for a componentID
-// no longer declared in the blueprint (typically because the component was renamed), trying
-// both directory conventions resolveComponentPaths uses for a live component: the
-// windsor-managed scratch cache first (a source- or name-based component), then the plain
-// project-relative layout (a bare local component). Returns "" when neither exists.
-func (s *TerraformStack) orphanedComponentFullPath(componentID string) string {
-	projectRoot := s.runtime.ProjectRoot
-	scratchPath := filepath.FromSlash(filepath.Join(projectRoot, ".windsor", "contexts", s.runtime.ContextName, "terraform", componentID))
-	if _, err := s.shims.Stat(scratchPath); err == nil {
-		return scratchPath
-	}
-	localPath := filepath.FromSlash(filepath.Join(projectRoot, "terraform", componentID))
-	if _, err := s.shims.Stat(localPath); err == nil {
-		return localPath
-	}
-	return ""
 }
 
 // migrateOneComponent runs `terraform init -migrate-state -force-copy` for a single

--- a/pkg/provisioner/terraform/stack.go
+++ b/pkg/provisioner/terraform/stack.go
@@ -216,6 +216,10 @@ type Stack interface {
 	HasLocalStateWithResources(componentID string) (bool, error)
 	InitComponent(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
 	RemoveLocalState(componentID string) error
+	ListLocalStateComponentIDs() ([]string, error)
+	InitOrphanedComponent(componentID string) (bool, error)
+	HasOrphanedRemoteState(componentID string) (bool, error)
+	MigrateOrphanedComponentState(componentID string) error
 	PostApply(fns ...func(id string) error)
 	DestroyAll(blueprint *blueprintv1alpha1.Blueprint, continueOnError bool, excludeIDs ...string) (DestroyOutcome, error)
 	Plan(blueprint *blueprintv1alpha1.Blueprint, componentID string) error
@@ -465,6 +469,65 @@ func (s *TerraformStack) RemoveLocalState(componentID string) error {
 		return fmt.Errorf("error removing local state backup %s: %w", statePath, err)
 	}
 	return nil
+}
+
+// ListLocalStateComponentIDs returns every componentID with local Terraform state on disk,
+// whether or not it is still declared in the active blueprint. Thin passthrough:
+// TerraformProvider owns the on-disk .tfstate layout.
+func (s *TerraformStack) ListLocalStateComponentIDs() ([]string, error) {
+	return s.runtime.TerraformProvider.ListLocalStateComponentIDs()
+}
+
+// InitOrphanedComponent runs `terraform init` for a componentID no longer declared in the
+// blueprint, using the on-disk directory convention in place of a blueprint lookup. Returns
+// (false, nil), not an error, when no directory exists under either convention: module
+// resolution never recreates one for an ID absent from the blueprint, so there is nothing to
+// run terraform against.
+func (s *TerraformStack) InitOrphanedComponent(componentID string) (bool, error) {
+	fullPath := s.orphanedComponentFullPath(componentID)
+	if fullPath == "" {
+		return false, nil
+	}
+	component := &blueprintv1alpha1.TerraformComponent{Path: componentID, FullPath: fullPath}
+	terraformVars, scopedKeys, terraformArgs, err := s.setupTerraformEnvironment(*component)
+	if err != nil {
+		return false, err
+	}
+	return true, s.runTerraformInit(component, terraformVars, scopedKeys, terraformArgs, defaultInitFlags...)
+}
+
+// HasOrphanedRemoteState mirrors HasRemoteState for a componentID no longer declared in the
+// blueprint. Returns (false, nil) when its on-disk directory is gone.
+func (s *TerraformStack) HasOrphanedRemoteState(componentID string) (bool, error) {
+	fullPath := s.orphanedComponentFullPath(componentID)
+	if fullPath == "" {
+		return false, nil
+	}
+	component := &blueprintv1alpha1.TerraformComponent{Path: componentID, FullPath: fullPath}
+	terraformVars, scopedKeys, terraformArgs, err := s.setupTerraformEnvironment(*component)
+	if err != nil {
+		return false, err
+	}
+	if err := s.runTerraformInit(component, terraformVars, scopedKeys, terraformArgs, defaultInitFlags...); err != nil {
+		return false, err
+	}
+	return s.hasStateResources(component, terraformVars, scopedKeys)
+}
+
+// MigrateOrphanedComponentState mirrors MigrateComponentState for a componentID no longer
+// declared in the blueprint, running `terraform init -migrate-state -force-copy` against its
+// on-disk directory. A no-op when that directory is gone.
+func (s *TerraformStack) MigrateOrphanedComponentState(componentID string) error {
+	fullPath := s.orphanedComponentFullPath(componentID)
+	if fullPath == "" {
+		return nil
+	}
+	component := &blueprintv1alpha1.TerraformComponent{Path: componentID, FullPath: fullPath}
+	terraformVars, scopedKeys, terraformArgs, err := s.setupTerraformEnvironment(*component)
+	if err != nil {
+		return err
+	}
+	return s.runTerraformInit(component, terraformVars, scopedKeys, terraformArgs, "-migrate-state", "-force-copy")
 }
 
 // MigrateState runs `terraform init -migrate-state -force-copy` per component to move state
@@ -1093,6 +1156,24 @@ func (s *TerraformStack) PlanComponentSummary(blueprint *blueprintv1alpha1.Bluep
 // streaming its terraform output. Shared by every per-component loop over all components.
 func (s *TerraformStack) printComponentHeader(componentPath string) {
 	fmt.Fprintf(os.Stderr, "\n%s\n", tui.SectionHeader("Terraform: "+componentPath))
+}
+
+// orphanedComponentFullPath resolves the on-disk terraform module directory for a componentID
+// no longer declared in the blueprint (typically because the component was renamed), trying
+// both directory conventions resolveComponentPaths uses for a live component: the
+// windsor-managed scratch cache first (a source- or name-based component), then the plain
+// project-relative layout (a bare local component). Returns "" when neither exists.
+func (s *TerraformStack) orphanedComponentFullPath(componentID string) string {
+	projectRoot := s.runtime.ProjectRoot
+	scratchPath := filepath.FromSlash(filepath.Join(projectRoot, ".windsor", "contexts", s.runtime.ContextName, "terraform", componentID))
+	if _, err := s.shims.Stat(scratchPath); err == nil {
+		return scratchPath
+	}
+	localPath := filepath.FromSlash(filepath.Join(projectRoot, "terraform", componentID))
+	if _, err := s.shims.Stat(localPath); err == nil {
+		return localPath
+	}
+	return ""
 }
 
 // migrateOneComponent runs `terraform init -migrate-state -force-copy` for a single

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -1215,6 +1215,317 @@ func TestStack_MigrateComponentState(t *testing.T) {
 	})
 }
 
+// setupWindsorStackMocksForOrphanTests builds a stack for the orphaned-component recovery
+// tests below, matching the setup pattern TestStack_MigrateComponentState uses. Unlike the
+// shared default (which treats every path as existing), Stat delegates to the real filesystem:
+// these tests care specifically about which on-disk directory convention exists.
+func setupWindsorStackMocksForOrphanTests(t *testing.T) (*TerraformStack, *TerraformTestMocks) {
+	t.Helper()
+	mocks := setupWindsorStackMocks(t)
+	mocks.Shims.Stat = os.Stat
+	stack := NewStack(mocks.Runtime).(*TerraformStack)
+	stack.shims = mocks.Shims
+	return stack, mocks
+}
+
+func TestStack_ListLocalStateComponentIDs(t *testing.T) {
+	t.Run("DelegatesToTerraformProvider", func(t *testing.T) {
+		// Given a stack whose TerraformProvider reports two componentIDs with local state
+		stack, mocks := setupWindsorStackMocksForOrphanTests(t)
+		mocks.Runtime.TerraformProvider = &terraformRuntime.MockTerraformProvider{
+			ListLocalStateComponentIDsFunc: func() ([]string, error) {
+				return []string{"network", "crossplane-identity-gcp"}, nil
+			},
+		}
+
+		// When listing local state componentIDs
+		ids, err := stack.ListLocalStateComponentIDs()
+
+		// Then the TerraformProvider's own list is returned unchanged
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if len(ids) != 2 || ids[0] != "network" || ids[1] != "crossplane-identity-gcp" {
+			t.Errorf("Expected the provider's componentIDs, got %v", ids)
+		}
+	})
+
+	t.Run("PropagatesProviderError", func(t *testing.T) {
+		stack, mocks := setupWindsorStackMocksForOrphanTests(t)
+		mocks.Runtime.TerraformProvider = &terraformRuntime.MockTerraformProvider{
+			ListLocalStateComponentIDsFunc: func() ([]string, error) {
+				return nil, fmt.Errorf("scratch path error")
+			},
+		}
+
+		_, err := stack.ListLocalStateComponentIDs()
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+	})
+}
+
+func TestStack_InitOrphanedComponent(t *testing.T) {
+	t.Run("ReturnsFalseWhenNoDirectoryExistsUnderEitherConvention", func(t *testing.T) {
+		// Given a componentID with no scratch or local directory on disk
+		stack, _ := setupWindsorStackMocksForOrphanTests(t)
+
+		found, err := stack.InitOrphanedComponent("crossplane-identity-gcp")
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if found {
+			t.Error("Expected found=false when no directory exists")
+		}
+	})
+
+	t.Run("RunsInitAgainstScratchPathWhenItExists", func(t *testing.T) {
+		// Given a leftover scratch-cache directory for a componentID no longer in the
+		// blueprint (the shape a source- or name-based component leaves behind)
+		stack, mocks := setupWindsorStackMocksForOrphanTests(t)
+		projectRoot := os.Getenv("WINDSOR_PROJECT_ROOT")
+		contextName := mocks.Runtime.ContextName
+		dir := filepath.Join(projectRoot, ".windsor", "contexts", contextName, "terraform", "crossplane-identity-gcp")
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("Failed to create directory: %v", err)
+		}
+
+		var initChdirs []string
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == "init" {
+				initChdirs = append(initChdirs, strings.TrimPrefix(args[0], "-chdir="))
+			}
+			return "", nil
+		}
+
+		found, err := stack.InitOrphanedComponent("crossplane-identity-gcp")
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !found {
+			t.Error("Expected found=true when the scratch directory exists")
+		}
+		if len(initChdirs) != 1 || filepath.Clean(initChdirs[0]) != filepath.Clean(dir) {
+			t.Errorf("Expected init to run against %s, got %v", dir, initChdirs)
+		}
+	})
+
+	t.Run("FallsBackToLocalPathWhenNoScratchDirectoryExists", func(t *testing.T) {
+		// Given a leftover directory only under the bare local (no source/name) convention
+		stack, mocks := setupWindsorStackMocksForOrphanTests(t)
+		projectRoot := os.Getenv("WINDSOR_PROJECT_ROOT")
+		dir := filepath.Join(projectRoot, "terraform", "old-local-component")
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("Failed to create directory: %v", err)
+		}
+
+		var initChdirs []string
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == "init" {
+				initChdirs = append(initChdirs, strings.TrimPrefix(args[0], "-chdir="))
+			}
+			return "", nil
+		}
+
+		found, err := stack.InitOrphanedComponent("old-local-component")
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !found {
+			t.Error("Expected found=true when the local directory exists")
+		}
+		if len(initChdirs) != 1 || filepath.Clean(initChdirs[0]) != filepath.Clean(dir) {
+			t.Errorf("Expected init to run against %s, got %v", dir, initChdirs)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenInitFails", func(t *testing.T) {
+		stack, mocks := setupWindsorStackMocksForOrphanTests(t)
+		projectRoot := os.Getenv("WINDSOR_PROJECT_ROOT")
+		contextName := mocks.Runtime.ContextName
+		dir := filepath.Join(projectRoot, ".windsor", "contexts", contextName, "terraform", "crossplane-identity-gcp")
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("Failed to create directory: %v", err)
+		}
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == "init" {
+				return "", fmt.Errorf("backend not reachable")
+			}
+			return "", nil
+		}
+
+		_, err := stack.InitOrphanedComponent("crossplane-identity-gcp")
+		if err == nil {
+			t.Fatal("Expected error when terraform init fails")
+		}
+		if !strings.Contains(err.Error(), "backend not reachable") {
+			t.Errorf("Expected error to wrap the underlying cause, got %v", err)
+		}
+	})
+}
+
+func TestStack_HasOrphanedRemoteState(t *testing.T) {
+	t.Run("ReturnsFalseWhenNoDirectoryExists", func(t *testing.T) {
+		stack, _ := setupWindsorStackMocksForOrphanTests(t)
+
+		hasRemote, err := stack.HasOrphanedRemoteState("crossplane-identity-gcp")
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if hasRemote {
+			t.Error("Expected hasRemote=false when no directory exists")
+		}
+	})
+
+	t.Run("ReturnsTrueWhenStateHasResources", func(t *testing.T) {
+		stack, mocks := setupWindsorStackMocksForOrphanTests(t)
+		projectRoot := os.Getenv("WINDSOR_PROJECT_ROOT")
+		contextName := mocks.Runtime.ContextName
+		dir := filepath.Join(projectRoot, ".windsor", "contexts", contextName, "terraform", "crossplane-identity-gcp")
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("Failed to create directory: %v", err)
+		}
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" && len(args) >= 3 && args[1] == "show" && args[2] == "-json" {
+				return `{"values":{"root_module":{"resources":[{"address":"aws_s3_bucket.example"}]}}}`, nil
+			}
+			return "", nil
+		}
+
+		hasRemote, err := stack.HasOrphanedRemoteState("crossplane-identity-gcp")
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if !hasRemote {
+			t.Error("Expected hasRemote=true when state has resources")
+		}
+	})
+
+	t.Run("ReturnsFalseWhenStateIsEmpty", func(t *testing.T) {
+		stack, mocks := setupWindsorStackMocksForOrphanTests(t)
+		projectRoot := os.Getenv("WINDSOR_PROJECT_ROOT")
+		contextName := mocks.Runtime.ContextName
+		dir := filepath.Join(projectRoot, ".windsor", "contexts", contextName, "terraform", "crossplane-identity-gcp")
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("Failed to create directory: %v", err)
+		}
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if command == "terraform" && len(args) >= 3 && args[1] == "show" && args[2] == "-json" {
+				return `{}`, nil
+			}
+			return "", nil
+		}
+
+		hasRemote, err := stack.HasOrphanedRemoteState("crossplane-identity-gcp")
+
+		if err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if hasRemote {
+			t.Error("Expected hasRemote=false when state is empty")
+		}
+	})
+
+	t.Run("ReturnsErrorWhenInitFails", func(t *testing.T) {
+		stack, mocks := setupWindsorStackMocksForOrphanTests(t)
+		projectRoot := os.Getenv("WINDSOR_PROJECT_ROOT")
+		contextName := mocks.Runtime.ContextName
+		dir := filepath.Join(projectRoot, ".windsor", "contexts", contextName, "terraform", "crossplane-identity-gcp")
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("Failed to create directory: %v", err)
+		}
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == "init" {
+				return "", fmt.Errorf("auth timeout")
+			}
+			return "", nil
+		}
+
+		_, err := stack.HasOrphanedRemoteState("crossplane-identity-gcp")
+		if err == nil {
+			t.Fatal("Expected error when terraform init fails")
+		}
+	})
+}
+
+func TestStack_MigrateOrphanedComponentState(t *testing.T) {
+	t.Run("NoOpWhenNoDirectoryExists", func(t *testing.T) {
+		stack, mocks := setupWindsorStackMocksForOrphanTests(t)
+		execCalled := false
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			execCalled = true
+			return "", nil
+		}
+
+		if err := stack.MigrateOrphanedComponentState("crossplane-identity-gcp"); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if execCalled {
+			t.Error("Expected no terraform invocation when no directory exists")
+		}
+	})
+
+	t.Run("RunsInitWithMigrateStateAgainstOnDiskDirectory", func(t *testing.T) {
+		// Given a leftover local-state directory for a component that was renamed away
+		stack, mocks := setupWindsorStackMocksForOrphanTests(t)
+		projectRoot := os.Getenv("WINDSOR_PROJECT_ROOT")
+		contextName := mocks.Runtime.ContextName
+		dir := filepath.Join(projectRoot, ".windsor", "contexts", contextName, "terraform", "crossplane-identity-gcp")
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("Failed to create directory: %v", err)
+		}
+
+		var migrateStateInits int
+		var initChdirs []string
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == "init" && slices.Contains(args, "-migrate-state") {
+				migrateStateInits++
+				initChdirs = append(initChdirs, strings.TrimPrefix(args[0], "-chdir="))
+			}
+			return "", nil
+		}
+
+		if err := stack.MigrateOrphanedComponentState("crossplane-identity-gcp"); err != nil {
+			t.Fatalf("Expected no error, got %v", err)
+		}
+		if migrateStateInits != 1 {
+			t.Errorf("Expected 1 migrate-state init, got %d", migrateStateInits)
+		}
+		if len(initChdirs) != 1 || filepath.Clean(initChdirs[0]) != filepath.Clean(dir) {
+			t.Errorf("Expected init to run against %s, got %v", dir, initChdirs)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenInitFails", func(t *testing.T) {
+		stack, mocks := setupWindsorStackMocksForOrphanTests(t)
+		projectRoot := os.Getenv("WINDSOR_PROJECT_ROOT")
+		contextName := mocks.Runtime.ContextName
+		dir := filepath.Join(projectRoot, ".windsor", "contexts", contextName, "terraform", "crossplane-identity-gcp")
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("Failed to create directory: %v", err)
+		}
+		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
+			if len(args) >= 2 && args[1] == "init" && slices.Contains(args, "-migrate-state") {
+				return "", fmt.Errorf("backend not reachable")
+			}
+			return "", nil
+		}
+
+		err := stack.MigrateOrphanedComponentState("crossplane-identity-gcp")
+		if err == nil {
+			t.Fatal("Expected error when terraform init fails")
+		}
+		if !strings.Contains(err.Error(), "backend not reachable") {
+			t.Errorf("Expected error to wrap the underlying cause, got %v", err)
+		}
+	})
+}
+
 func TestStack_DestroyAll(t *testing.T) {
 	setup := func(t *testing.T) (*TerraformStack, *TerraformTestMocks) {
 		t.Helper()

--- a/pkg/provisioner/terraform/stack_test.go
+++ b/pkg/provisioner/terraform/stack_test.go
@@ -1215,23 +1215,18 @@ func TestStack_MigrateComponentState(t *testing.T) {
 	})
 }
 
-// setupWindsorStackMocksForOrphanTests builds a stack for the orphaned-component recovery
-// tests below, matching the setup pattern TestStack_MigrateComponentState uses. Unlike the
-// shared default (which treats every path as existing), Stat delegates to the real filesystem:
-// these tests care specifically about which on-disk directory convention exists.
-func setupWindsorStackMocksForOrphanTests(t *testing.T) (*TerraformStack, *TerraformTestMocks) {
-	t.Helper()
-	mocks := setupWindsorStackMocks(t)
-	mocks.Shims.Stat = os.Stat
-	stack := NewStack(mocks.Runtime).(*TerraformStack)
-	stack.shims = mocks.Shims
-	return stack, mocks
-}
-
 func TestStack_ListLocalStateComponentIDs(t *testing.T) {
+	setup := func(t *testing.T) (*TerraformStack, *TerraformTestMocks) {
+		t.Helper()
+		mocks := setupWindsorStackMocks(t)
+		stack := NewStack(mocks.Runtime).(*TerraformStack)
+		stack.shims = mocks.Shims
+		return stack, mocks
+	}
+
 	t.Run("DelegatesToTerraformProvider", func(t *testing.T) {
 		// Given a stack whose TerraformProvider reports two componentIDs with local state
-		stack, mocks := setupWindsorStackMocksForOrphanTests(t)
+		stack, mocks := setup(t)
 		mocks.Runtime.TerraformProvider = &terraformRuntime.MockTerraformProvider{
 			ListLocalStateComponentIDsFunc: func() ([]string, error) {
 				return []string{"network", "crossplane-identity-gcp"}, nil
@@ -1251,7 +1246,7 @@ func TestStack_ListLocalStateComponentIDs(t *testing.T) {
 	})
 
 	t.Run("PropagatesProviderError", func(t *testing.T) {
-		stack, mocks := setupWindsorStackMocksForOrphanTests(t)
+		stack, mocks := setup(t)
 		mocks.Runtime.TerraformProvider = &terraformRuntime.MockTerraformProvider{
 			ListLocalStateComponentIDsFunc: func() ([]string, error) {
 				return nil, fmt.Errorf("scratch path error")
@@ -1261,267 +1256,6 @@ func TestStack_ListLocalStateComponentIDs(t *testing.T) {
 		_, err := stack.ListLocalStateComponentIDs()
 		if err == nil {
 			t.Fatal("Expected error, got nil")
-		}
-	})
-}
-
-func TestStack_InitOrphanedComponent(t *testing.T) {
-	t.Run("ReturnsFalseWhenNoDirectoryExistsUnderEitherConvention", func(t *testing.T) {
-		// Given a componentID with no scratch or local directory on disk
-		stack, _ := setupWindsorStackMocksForOrphanTests(t)
-
-		found, err := stack.InitOrphanedComponent("crossplane-identity-gcp")
-
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if found {
-			t.Error("Expected found=false when no directory exists")
-		}
-	})
-
-	t.Run("RunsInitAgainstScratchPathWhenItExists", func(t *testing.T) {
-		// Given a leftover scratch-cache directory for a componentID no longer in the
-		// blueprint (the shape a source- or name-based component leaves behind)
-		stack, mocks := setupWindsorStackMocksForOrphanTests(t)
-		projectRoot := os.Getenv("WINDSOR_PROJECT_ROOT")
-		contextName := mocks.Runtime.ContextName
-		dir := filepath.Join(projectRoot, ".windsor", "contexts", contextName, "terraform", "crossplane-identity-gcp")
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			t.Fatalf("Failed to create directory: %v", err)
-		}
-
-		var initChdirs []string
-		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
-			if len(args) >= 2 && args[1] == "init" {
-				initChdirs = append(initChdirs, strings.TrimPrefix(args[0], "-chdir="))
-			}
-			return "", nil
-		}
-
-		found, err := stack.InitOrphanedComponent("crossplane-identity-gcp")
-
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if !found {
-			t.Error("Expected found=true when the scratch directory exists")
-		}
-		if len(initChdirs) != 1 || filepath.Clean(initChdirs[0]) != filepath.Clean(dir) {
-			t.Errorf("Expected init to run against %s, got %v", dir, initChdirs)
-		}
-	})
-
-	t.Run("FallsBackToLocalPathWhenNoScratchDirectoryExists", func(t *testing.T) {
-		// Given a leftover directory only under the bare local (no source/name) convention
-		stack, mocks := setupWindsorStackMocksForOrphanTests(t)
-		projectRoot := os.Getenv("WINDSOR_PROJECT_ROOT")
-		dir := filepath.Join(projectRoot, "terraform", "old-local-component")
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			t.Fatalf("Failed to create directory: %v", err)
-		}
-
-		var initChdirs []string
-		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
-			if len(args) >= 2 && args[1] == "init" {
-				initChdirs = append(initChdirs, strings.TrimPrefix(args[0], "-chdir="))
-			}
-			return "", nil
-		}
-
-		found, err := stack.InitOrphanedComponent("old-local-component")
-
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if !found {
-			t.Error("Expected found=true when the local directory exists")
-		}
-		if len(initChdirs) != 1 || filepath.Clean(initChdirs[0]) != filepath.Clean(dir) {
-			t.Errorf("Expected init to run against %s, got %v", dir, initChdirs)
-		}
-	})
-
-	t.Run("ReturnsErrorWhenInitFails", func(t *testing.T) {
-		stack, mocks := setupWindsorStackMocksForOrphanTests(t)
-		projectRoot := os.Getenv("WINDSOR_PROJECT_ROOT")
-		contextName := mocks.Runtime.ContextName
-		dir := filepath.Join(projectRoot, ".windsor", "contexts", contextName, "terraform", "crossplane-identity-gcp")
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			t.Fatalf("Failed to create directory: %v", err)
-		}
-		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
-			if len(args) >= 2 && args[1] == "init" {
-				return "", fmt.Errorf("backend not reachable")
-			}
-			return "", nil
-		}
-
-		_, err := stack.InitOrphanedComponent("crossplane-identity-gcp")
-		if err == nil {
-			t.Fatal("Expected error when terraform init fails")
-		}
-		if !strings.Contains(err.Error(), "backend not reachable") {
-			t.Errorf("Expected error to wrap the underlying cause, got %v", err)
-		}
-	})
-}
-
-func TestStack_HasOrphanedRemoteState(t *testing.T) {
-	t.Run("ReturnsFalseWhenNoDirectoryExists", func(t *testing.T) {
-		stack, _ := setupWindsorStackMocksForOrphanTests(t)
-
-		hasRemote, err := stack.HasOrphanedRemoteState("crossplane-identity-gcp")
-
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if hasRemote {
-			t.Error("Expected hasRemote=false when no directory exists")
-		}
-	})
-
-	t.Run("ReturnsTrueWhenStateHasResources", func(t *testing.T) {
-		stack, mocks := setupWindsorStackMocksForOrphanTests(t)
-		projectRoot := os.Getenv("WINDSOR_PROJECT_ROOT")
-		contextName := mocks.Runtime.ContextName
-		dir := filepath.Join(projectRoot, ".windsor", "contexts", contextName, "terraform", "crossplane-identity-gcp")
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			t.Fatalf("Failed to create directory: %v", err)
-		}
-		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
-			if command == "terraform" && len(args) >= 3 && args[1] == "show" && args[2] == "-json" {
-				return `{"values":{"root_module":{"resources":[{"address":"aws_s3_bucket.example"}]}}}`, nil
-			}
-			return "", nil
-		}
-
-		hasRemote, err := stack.HasOrphanedRemoteState("crossplane-identity-gcp")
-
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if !hasRemote {
-			t.Error("Expected hasRemote=true when state has resources")
-		}
-	})
-
-	t.Run("ReturnsFalseWhenStateIsEmpty", func(t *testing.T) {
-		stack, mocks := setupWindsorStackMocksForOrphanTests(t)
-		projectRoot := os.Getenv("WINDSOR_PROJECT_ROOT")
-		contextName := mocks.Runtime.ContextName
-		dir := filepath.Join(projectRoot, ".windsor", "contexts", contextName, "terraform", "crossplane-identity-gcp")
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			t.Fatalf("Failed to create directory: %v", err)
-		}
-		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
-			if command == "terraform" && len(args) >= 3 && args[1] == "show" && args[2] == "-json" {
-				return `{}`, nil
-			}
-			return "", nil
-		}
-
-		hasRemote, err := stack.HasOrphanedRemoteState("crossplane-identity-gcp")
-
-		if err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if hasRemote {
-			t.Error("Expected hasRemote=false when state is empty")
-		}
-	})
-
-	t.Run("ReturnsErrorWhenInitFails", func(t *testing.T) {
-		stack, mocks := setupWindsorStackMocksForOrphanTests(t)
-		projectRoot := os.Getenv("WINDSOR_PROJECT_ROOT")
-		contextName := mocks.Runtime.ContextName
-		dir := filepath.Join(projectRoot, ".windsor", "contexts", contextName, "terraform", "crossplane-identity-gcp")
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			t.Fatalf("Failed to create directory: %v", err)
-		}
-		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
-			if len(args) >= 2 && args[1] == "init" {
-				return "", fmt.Errorf("auth timeout")
-			}
-			return "", nil
-		}
-
-		_, err := stack.HasOrphanedRemoteState("crossplane-identity-gcp")
-		if err == nil {
-			t.Fatal("Expected error when terraform init fails")
-		}
-	})
-}
-
-func TestStack_MigrateOrphanedComponentState(t *testing.T) {
-	t.Run("NoOpWhenNoDirectoryExists", func(t *testing.T) {
-		stack, mocks := setupWindsorStackMocksForOrphanTests(t)
-		execCalled := false
-		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
-			execCalled = true
-			return "", nil
-		}
-
-		if err := stack.MigrateOrphanedComponentState("crossplane-identity-gcp"); err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if execCalled {
-			t.Error("Expected no terraform invocation when no directory exists")
-		}
-	})
-
-	t.Run("RunsInitWithMigrateStateAgainstOnDiskDirectory", func(t *testing.T) {
-		// Given a leftover local-state directory for a component that was renamed away
-		stack, mocks := setupWindsorStackMocksForOrphanTests(t)
-		projectRoot := os.Getenv("WINDSOR_PROJECT_ROOT")
-		contextName := mocks.Runtime.ContextName
-		dir := filepath.Join(projectRoot, ".windsor", "contexts", contextName, "terraform", "crossplane-identity-gcp")
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			t.Fatalf("Failed to create directory: %v", err)
-		}
-
-		var migrateStateInits int
-		var initChdirs []string
-		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
-			if len(args) >= 2 && args[1] == "init" && slices.Contains(args, "-migrate-state") {
-				migrateStateInits++
-				initChdirs = append(initChdirs, strings.TrimPrefix(args[0], "-chdir="))
-			}
-			return "", nil
-		}
-
-		if err := stack.MigrateOrphanedComponentState("crossplane-identity-gcp"); err != nil {
-			t.Fatalf("Expected no error, got %v", err)
-		}
-		if migrateStateInits != 1 {
-			t.Errorf("Expected 1 migrate-state init, got %d", migrateStateInits)
-		}
-		if len(initChdirs) != 1 || filepath.Clean(initChdirs[0]) != filepath.Clean(dir) {
-			t.Errorf("Expected init to run against %s, got %v", dir, initChdirs)
-		}
-	})
-
-	t.Run("ReturnsErrorWhenInitFails", func(t *testing.T) {
-		stack, mocks := setupWindsorStackMocksForOrphanTests(t)
-		projectRoot := os.Getenv("WINDSOR_PROJECT_ROOT")
-		contextName := mocks.Runtime.ContextName
-		dir := filepath.Join(projectRoot, ".windsor", "contexts", contextName, "terraform", "crossplane-identity-gcp")
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			t.Fatalf("Failed to create directory: %v", err)
-		}
-		mocks.Shell.ExecSilentWithEnvFunc = func(command string, env map[string]string, args ...string) (string, error) {
-			if len(args) >= 2 && args[1] == "init" && slices.Contains(args, "-migrate-state") {
-				return "", fmt.Errorf("backend not reachable")
-			}
-			return "", nil
-		}
-
-		err := stack.MigrateOrphanedComponentState("crossplane-identity-gcp")
-		if err == nil {
-			t.Fatal("Expected error when terraform init fails")
-		}
-		if !strings.Contains(err.Error(), "backend not reachable") {
-			t.Errorf("Expected error to wrap the underlying cause, got %v", err)
 		}
 	})
 }

--- a/pkg/runtime/terraform/mock_provider.go
+++ b/pkg/runtime/terraform/mock_provider.go
@@ -19,6 +19,7 @@ type MockTerraformProvider struct {
 	CacheOutputsFunc                 func(componentID string) error
 	GetTFDataDirFunc                 func(componentID string) (string, error)
 	GetStatePathFunc                 func(componentID string) (string, error)
+	ListLocalStateComponentIDsFunc   func() ([]string, error)
 	BackendConfigCompleteFunc        func() bool
 	GetEnvVarsFunc                   func(componentID string, interactive bool) (map[string]string, []string, *TerraformArgs, error)
 	FormatArgsForEnvFunc             func(args []string) string
@@ -126,6 +127,14 @@ func (m *MockTerraformProvider) GetStatePath(componentID string) (string, error)
 		return m.GetStatePathFunc(componentID)
 	}
 	return "", nil
+}
+
+// ListLocalStateComponentIDs implements TerraformProvider.
+func (m *MockTerraformProvider) ListLocalStateComponentIDs() ([]string, error) {
+	if m.ListLocalStateComponentIDsFunc != nil {
+		return m.ListLocalStateComponentIDsFunc()
+	}
+	return nil, nil
 }
 
 // BackendConfigComplete implements TerraformProvider. Default is true so most

--- a/pkg/runtime/terraform/provider.go
+++ b/pkg/runtime/terraform/provider.go
@@ -95,6 +95,7 @@ type TerraformProvider interface {
 	CacheOutputs(componentID string) error
 	GetTFDataDir(componentID string) (string, error)
 	GetStatePath(componentID string) (string, error)
+	ListLocalStateComponentIDs() ([]string, error)
 	BackendConfigComplete() bool
 	GetEnvVars(componentID string, interactive bool) (map[string]string, []string, *TerraformArgs, error)
 	FormatArgsForEnv(args []string) string
@@ -728,6 +729,32 @@ func (p *terraformProvider) GetStatePath(componentID string) (string, error) {
 	return statePath, nil
 }
 
+// ListLocalStateComponentIDs returns every componentID with a local Terraform state file on
+// disk, whether or not that componentID is still declared in the active blueprint. Used by the
+// bootstrap recovery sweep to find state stranded under a component's previous ID after a
+// rename — recoverHalfMigratedComponents only iterates the current blueprint's componentIDs, so
+// a renamed component's old state is otherwise invisible to it. Walks the same directory tree
+// GetStatePath writes into, so the two stay in sync by construction. A missing .tfstate root is
+// not an error: it just means nothing has ever applied locally.
+func (p *terraformProvider) ListLocalStateComponentIDs() ([]string, error) {
+	_, _, windsorScratchPath, err := p.providerScope()
+	if err != nil {
+		return nil, fmt.Errorf("error resolving provider scope: %w", err)
+	}
+
+	root := filepath.Join(windsorScratchPath, ".tfstate")
+	if prefix := p.configHandler.GetString("terraform.backend.prefix", ""); prefix != "" {
+		root = filepath.Join(root, prefix)
+	}
+
+	var ids []string
+	if err := p.walkLocalStateDir(root, "", &ids); err != nil {
+		return nil, err
+	}
+	sort.Strings(ids)
+	return ids, nil
+}
+
 // BackendConfigComplete reports whether the configured remote backend has
 // enough config — a backend.tfvars file or a populated nested config block —
 // for `terraform init` to even attempt connecting. Local/empty backends are
@@ -783,6 +810,41 @@ func (p *terraformProvider) BackendConfigComplete() bool {
 // =============================================================================
 // Private Methods
 // =============================================================================
+
+// walkLocalStateDir recursively visits dir, collecting one componentID (its path relative to
+// the .tfstate root, using "/" as the separator) per directory that directly contains a
+// terraform.tfstate file. componentIDs may nest — a component's Path can itself contain
+// slashes — so this walks the full tree rather than assuming a flat, one-level layout.
+func (p *terraformProvider) walkLocalStateDir(dir, rel string, ids *[]string) error {
+	entries, err := p.Shims.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("error reading local state directory %s: %w", dir, err)
+	}
+
+	hasState := false
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			if entry.Name() == "terraform.tfstate" {
+				hasState = true
+			}
+			continue
+		}
+		childRel := entry.Name()
+		if rel != "" {
+			childRel = rel + "/" + entry.Name()
+		}
+		if err := p.walkLocalStateDir(filepath.Join(dir, entry.Name()), childRel, ids); err != nil {
+			return err
+		}
+	}
+	if hasState && rel != "" {
+		*ids = append(*ids, rel)
+	}
+	return nil
+}
 
 // providerScope resolves the active context, config root, and Windsor scratch path once, then
 // reuses the result. configHandler.GetContext() reads a file shared by every windsor process in

--- a/pkg/runtime/terraform/provider_public_test.go
+++ b/pkg/runtime/terraform/provider_public_test.go
@@ -3930,3 +3930,145 @@ func TestTerraformProvider_TerraformScopedEnvKeys(t *testing.T) {
 		}
 	})
 }
+
+func TestTerraformProvider_ListLocalStateComponentIDs(t *testing.T) {
+	t.Run("ReturnsComponentIDsForEveryLocalStateFile", func(t *testing.T) {
+		// Given a scratch path with local state under a flat componentID, a nested one
+		// (a component whose Path has slashes), and an empty directory with no state file
+		scratchPath := t.TempDir()
+		for _, dir := range []string{
+			filepath.Join(scratchPath, ".tfstate", "network"),
+			filepath.Join(scratchPath, ".tfstate", "provisioning", "crossplane-identity", "gcp"),
+			filepath.Join(scratchPath, ".tfstate", "empty"),
+		} {
+			if err := os.MkdirAll(dir, 0755); err != nil {
+				t.Fatalf("Failed to create directory: %v", err)
+			}
+		}
+		for _, dir := range []string{"network", filepath.Join("provisioning", "crossplane-identity", "gcp")} {
+			statePath := filepath.Join(scratchPath, ".tfstate", dir, "terraform.tfstate")
+			if err := os.WriteFile(statePath, []byte("{}"), 0644); err != nil {
+				t.Fatalf("Failed to write state file: %v", err)
+			}
+		}
+
+		mocks := setupMocks(t)
+		mocks.ConfigHandler.GetWindsorScratchPathFunc = func() (string, error) {
+			return scratchPath, nil
+		}
+
+		// When listing local state componentIDs
+		ids, err := mocks.Provider.ListLocalStateComponentIDs()
+
+		// Then both componentIDs are returned, sorted, and the empty directory is excluded
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		expected := []string{"network", "provisioning/crossplane-identity/gcp"}
+		if len(ids) != len(expected) {
+			t.Fatalf("Expected %v, got %v", expected, ids)
+		}
+		for i, want := range expected {
+			if ids[i] != want {
+				t.Errorf("Expected %v, got %v", expected, ids)
+				break
+			}
+		}
+	})
+
+	t.Run("ReturnsEmptyWhenTfstateRootDoesNotExist", func(t *testing.T) {
+		// Given a scratch path with no .tfstate directory at all
+		mocks := setupMocks(t)
+		mocks.ConfigHandler.GetWindsorScratchPathFunc = func() (string, error) {
+			return filepath.Join(t.TempDir(), "does-not-exist"), nil
+		}
+
+		// When listing local state componentIDs
+		ids, err := mocks.Provider.ListLocalStateComponentIDs()
+
+		// Then no error and no componentIDs are returned
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		if len(ids) != 0 {
+			t.Errorf("Expected no componentIDs, got %v", ids)
+		}
+	})
+
+	t.Run("ScopesToBackendPrefixWhenConfigured", func(t *testing.T) {
+		// Given a scratch path with state under a backend-prefixed subtree
+		scratchPath := t.TempDir()
+		prefixedDir := filepath.Join(scratchPath, ".tfstate", "team-a", "network")
+		if err := os.MkdirAll(prefixedDir, 0755); err != nil {
+			t.Fatalf("Failed to create directory: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(prefixedDir, "terraform.tfstate"), []byte("{}"), 0644); err != nil {
+			t.Fatalf("Failed to write state file: %v", err)
+		}
+
+		mocks := setupMocks(t)
+		mocks.ConfigHandler.GetWindsorScratchPathFunc = func() (string, error) {
+			return scratchPath, nil
+		}
+		mocks.ConfigHandler.GetStringFunc = func(key string, defaultValue ...string) string {
+			if key == "terraform.backend.prefix" {
+				return "team-a"
+			}
+			if len(defaultValue) > 0 {
+				return defaultValue[0]
+			}
+			return ""
+		}
+
+		// When listing local state componentIDs
+		ids, err := mocks.Provider.ListLocalStateComponentIDs()
+
+		// Then the componentID is relative to the prefixed root, not the bare .tfstate root
+		if err != nil {
+			t.Fatalf("Expected no error, got: %v", err)
+		}
+		expected := []string{"network"}
+		if len(ids) != len(expected) || ids[0] != expected[0] {
+			t.Errorf("Expected %v, got %v", expected, ids)
+		}
+	})
+
+	t.Run("ReturnsErrorWhenScopeFails", func(t *testing.T) {
+		// Given a provider whose scope resolution fails
+		mocks := setupMocks(t)
+		mocks.ConfigHandler.GetWindsorScratchPathFunc = func() (string, error) {
+			return "", fmt.Errorf("scratch path error")
+		}
+
+		// When listing local state componentIDs
+		_, err := mocks.Provider.ListLocalStateComponentIDs()
+
+		// Then an error is returned
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+	})
+
+	t.Run("ReturnsErrorWhenReadDirFailsForOtherReason", func(t *testing.T) {
+		// Given a .tfstate root that exists but fails to read for a non-NotExist reason
+		mocks := setupMocks(t)
+		scratchPath := t.TempDir()
+		mocks.ConfigHandler.GetWindsorScratchPathFunc = func() (string, error) {
+			return scratchPath, nil
+		}
+		mocks.Provider.Shims.ReadDir = func(path string) ([]os.DirEntry, error) {
+			return nil, fmt.Errorf("mock permission denied")
+		}
+
+		// When listing local state componentIDs
+		_, err := mocks.Provider.ListLocalStateComponentIDs()
+
+		// Then an error is returned
+		if err == nil {
+			t.Fatal("Expected error, got nil")
+		}
+		if !strings.Contains(err.Error(), "error reading local state directory") {
+			t.Errorf("Unexpected error message: %v", err)
+		}
+	})
+}

--- a/pkg/runtime/terraform/shims.go
+++ b/pkg/runtime/terraform/shims.go
@@ -32,6 +32,7 @@ type Shims struct {
 	Stat           func(string) (os.FileInfo, error)
 	Remove         func(string) error
 	WriteFile      func(string, []byte, os.FileMode) error
+	ReadDir        func(string) ([]os.DirEntry, error)
 	Getwd          func() (string, error)
 	YamlUnmarshal  func([]byte, any) error
 	YamlMarshal    func(any) ([]byte, error)
@@ -58,6 +59,7 @@ func NewShims() *Shims {
 		Stat:           os.Stat,
 		Remove:         os.Remove,
 		WriteFile:      os.WriteFile,
+		ReadDir:        os.ReadDir,
 		Getwd:          os.Getwd,
 		YamlUnmarshal:  yaml.Unmarshal,
 		YamlMarshal:    yaml.Marshal,


### PR DESCRIPTION
Closes #3324

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This changes the `windsor up` recovery sweep that runs for every remote-backend user, adding a full directory walk of local Terraform state on each invocation — the blast radius is broad even though the new behavior is additive and warn-only.
>
> **Overview**
>
> The PR adds `ListLocalStateComponentIDs` (provider → stack → provisioner) to enumerate every componentID with local Terraform state on disk, regardless of whether it's still declared in the blueprint. `recoverHalfMigratedComponents` now uses this to detect state stranded under a renamed or removed component's old ID, which was previously invisible to the sweep since it only iterated the current blueprint's componentIDs.
>
> Rather than auto-migrating orphaned state (which could silently publish a decommissioned component's stale state into the shared remote backend forever), the new `warnAboutOrphanedLocalState` only emits a stderr warning naming the orphaned ID. Disabled-but-still-declared components are correctly excluded from "orphaned" via a `currentIDs` set built before the enabled filter is applied. Tests cover the rename-recovery scenario, the disabled-component exclusion, nested componentIDs, backend-prefix scoping, and I/O error propagation.

<!-- /claude-code-review:summary -->
