### PR TITLE
fix(bootstrap): default Composer when --context override omits it

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -127,8 +127,16 @@ windsor bootstrap prod --yes`,
 			flagOverrides[parts[0]] = parts[1]
 		}
 
-		if proj == nil {
-			projectOpts := &project.Project{Runtime: rt}
+		// A --context override injects a project carrying only Runtime (setupGlobalContext,
+		// root.go), leaving Composer nil even though proj isn't. Route through NewProject
+		// whenever Composer is missing, not just when proj is nil, so it gets defaulted like
+		// every other command gets from configureProject. Reusing proj as the overrides
+		// preserves whatever it already set.
+		if proj == nil || proj.Composer == nil {
+			projectOpts := proj
+			if projectOpts == nil {
+				projectOpts = &project.Project{Runtime: rt}
+			}
 			if composerOverrideVal := cmd.Context().Value(composerOverridesKey); composerOverrideVal != nil {
 				projectOpts.Composer = composerOverrideVal.(*composer.Composer)
 			}

--- a/cmd/bootstrap_test.go
+++ b/cmd/bootstrap_test.go
@@ -200,6 +200,39 @@ func TestBootstrapCmd(t *testing.T) {
 		}
 	})
 
+	t.Run("DoesNotPanicWhenContextOverrideOmitsComposer", func(t *testing.T) {
+		// Reproduces windsorcli/cli#3348: a --context override (setupGlobalContext, root.go)
+		// injects a *project.Project carrying only Runtime, leaving Composer nil. Before the
+		// fix, bootstrap's own NewProject fallback ran only when proj itself was nil, so this
+		// non-nil-but-Composer-nil proj reached proj.Composer.ArtifactBuilder and panicked.
+		mocks := setupBootstrapTest(t)
+		fullProj := newBootstrapTestProject(mocks)
+		bareProj := &project.Project{Runtime: mocks.Runtime}
+
+		loadBlueprintCalled := false
+		mocks.BlueprintHandler.LoadBlueprintFunc = func(urls ...string) error {
+			loadBlueprintCalled = true
+			return nil
+		}
+
+		cmd := createTestBootstrapCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, bareProj)
+		ctx = context.WithValue(ctx, composerOverridesKey, fullProj.Composer)
+		// A non-"local" context matches the actual repro and takes resolveBlueprintURL's
+		// early-return path, so this test doesn't also depend on a working ArtifactBuilder.
+		cmd.SetArgs([]string{"gcp-test", "--yes"})
+		cmd.SetContext(ctx)
+
+		// When executing bootstrap — this must not panic
+		_ = cmd.Execute()
+
+		// Then execution reached blueprint loading, which is only possible with a non-nil
+		// Composer — proving it got past the historical crash site.
+		if !loadBlueprintCalled {
+			t.Error("Expected LoadBlueprint to be called, proving Composer was defaulted")
+		}
+	})
+
 	t.Run("WaitFailureIsNonFatalWhenBlueprintHasMessages", func(t *testing.T) {
 		// Given a blueprint that carries a post-run message (a facet-declared manual step) and a wait
 		// that does not converge — a kustomization legitimately pending on that step


### PR DESCRIPTION
Closes #3348

<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Low Risk**
>
> This is an isolated, well-tested bugfix confined to `cmd/bootstrap.go`'s project-construction fallback, with no change to public behavior for the common case.
>
> **Overview**
>
> `windsor bootstrap --context <name>` injects a `*project.Project` carrying only `Runtime` (via `setupGlobalContext` in `root.go`), leaving `Composer` nil. Bootstrap's fallback to `project.NewProject` previously only triggered when the whole `proj` was nil, so this non-nil-but-Composer-nil case slipped through and later panicked on `proj.Composer.ArtifactBuilder`. The fix widens the guard to `proj == nil || proj.Composer == nil` and reuses the existing `proj` as `NewProject`'s overrides when present, so any `Provisioner`/`Workstation` already set on it are preserved while `Composer` gets defaulted.
>
> A new regression test reproduces the exact panic scenario (bare `Runtime`-only project plus a `composerOverridesKey` context value) and asserts `LoadBlueprint` is reached instead of a panic. Existing bootstrap tests are unaffected since they all construct a project with `Composer` already set.

<!-- /claude-code-review:summary -->
