### PR TITLE
fix(cmd): hold the stack lock through Initialize and SaveConfig

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -174,9 +174,6 @@ windsor bootstrap prod --yes`,
 		// and wait. Every tool family may be exercised, so request the full set up front and
 		// let CheckAuth (called below) validate cloud credentials separately.
 		proj.SetToolRequirements(tools.AllRequirements())
-		if err := proj.Initialize(false, blueprintURL...); err != nil {
-			return err
-		}
 
 		// Cloud auth and SaveConfig are paired by the "auth gates state mutation" invariant:
 		// nothing writes config until cloud credentials have been validated. In --yes mode
@@ -207,21 +204,28 @@ windsor bootstrap prod --yes`,
 				}
 				return true
 			}
-		} else {
-			if err := requireCloudAuth(cmd, proj); err != nil {
-				return err
-			}
-			if err := proj.Runtime.SaveConfig(saveSet); err != nil {
-				return fmt.Errorf("failed to save configuration: %w", err)
-			}
 		}
 
-		// The bootstrap confirm prompt fires from inside proj.Bootstrap, so the operator
-		// briefly holds the stack lock while answering. Acceptable today since bootstrap
-		// is rare; revisit if the prompt grows into a longer flow.
+		// Run Initialize and, in --yes mode, SaveConfig inside the lock. This prevents two
+		// overlapping bootstrap runs from racing an unlocked read-modify-write on
+		// values.yaml. The interactive branch's SaveConfig already runs inside the lock,
+		// via confirmFn called from proj.Bootstrap below.
 		var applied, halted bool
 		var postRunMessages []blueprintv1alpha1.Message
 		if err := stacklock.With(cmd.Context(), proj.Runtime, "bootstrap", lockTimeout, func() error {
+			if err := proj.Initialize(false, blueprintURL...); err != nil {
+				return err
+			}
+
+			if bootstrapYes {
+				if err := requireCloudAuth(cmd, proj); err != nil {
+					return err
+				}
+				if err := proj.Runtime.SaveConfig(saveSet); err != nil {
+					return fmt.Errorf("failed to save configuration: %w", err)
+				}
+			}
+
 			_, ok, h, err := proj.Bootstrap(confirmFn)
 			finishPlan(err)
 			if err != nil {

--- a/cmd/bootstrap_test.go
+++ b/cmd/bootstrap_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -17,6 +18,7 @@ import (
 	"github.com/windsorcli/cli/pkg/provisioner"
 	fluxinfra "github.com/windsorcli/cli/pkg/provisioner/flux"
 	"github.com/windsorcli/cli/pkg/provisioner/kubernetes"
+	"github.com/windsorcli/cli/pkg/provisioner/stacklock"
 	terraforminfra "github.com/windsorcli/cli/pkg/provisioner/terraform"
 	"github.com/windsorcli/cli/pkg/runtime"
 	"github.com/windsorcli/cli/pkg/runtime/config"
@@ -201,10 +203,9 @@ func TestBootstrapCmd(t *testing.T) {
 	})
 
 	t.Run("DoesNotPanicWhenContextOverrideOmitsComposer", func(t *testing.T) {
-		// Reproduces windsorcli/cli#3348: a --context override (setupGlobalContext, root.go)
-		// injects a *project.Project carrying only Runtime, leaving Composer nil. Before the
-		// fix, bootstrap's own NewProject fallback ran only when proj itself was nil, so this
-		// non-nil-but-Composer-nil proj reached proj.Composer.ArtifactBuilder and panicked.
+		// Reproduces windsorcli/cli#3348. A --context override injects a project with only
+		// Runtime set, leaving Composer nil. Before the fix, the NewProject fallback ran
+		// only when proj was nil, so proj.Composer.ArtifactBuilder panicked below.
 		mocks := setupBootstrapTest(t)
 		fullProj := newBootstrapTestProject(mocks)
 		bareProj := &project.Project{Runtime: mocks.Runtime}
@@ -218,18 +219,53 @@ func TestBootstrapCmd(t *testing.T) {
 		cmd := createTestBootstrapCmd()
 		ctx := context.WithValue(context.Background(), projectOverridesKey, bareProj)
 		ctx = context.WithValue(ctx, composerOverridesKey, fullProj.Composer)
-		// A non-"local" context matches the actual repro and takes resolveBlueprintURL's
-		// early-return path, so this test doesn't also depend on a working ArtifactBuilder.
+		// A non-"local" context avoids resolveBlueprintURL's ArtifactBuilder path.
 		cmd.SetArgs([]string{"gcp-test", "--yes"})
 		cmd.SetContext(ctx)
 
-		// When executing bootstrap — this must not panic
+		// Must not panic.
 		_ = cmd.Execute()
 
-		// Then execution reached blueprint loading, which is only possible with a non-nil
-		// Composer — proving it got past the historical crash site.
+		// LoadBlueprint only runs with a non-nil Composer.
 		if !loadBlueprintCalled {
 			t.Error("Expected LoadBlueprint to be called, proving Composer was defaulted")
+		}
+	})
+
+	t.Run("HoldsStackLockThroughInitializeAndSaveConfig", func(t *testing.T) {
+		// Regression test for windsorcli/cli#3315. Two overlapping bootstrap runs could
+		// race an unlocked read-modify-write on values.yaml. Proves the fix by acquiring
+		// a second, contending lock (timeout 0) from inside LoadBlueprint, which
+		// Initialize calls. A busy result means the outer lock is already held.
+		mocks := setupBootstrapTest(t)
+		proj := newBootstrapTestProject(mocks)
+
+		var acquireErr error
+		mocks.BlueprintHandler.LoadBlueprintFunc = func(urls ...string) error {
+			lock, err := stacklock.ForRuntime(mocks.Runtime)
+			if err != nil {
+				t.Fatalf("Failed to resolve stack lock: %v", err)
+			}
+			var release stacklock.Release
+			release, acquireErr = lock.Acquire(context.Background(), stacklock.NewInfo(mocks.Runtime, "contender"), 0)
+			if release != nil {
+				release()
+			}
+			return nil
+		}
+
+		cmd := createTestBootstrapCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{"--yes"})
+		cmd.SetContext(ctx)
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Expected success, got %v", err)
+		}
+
+		var busyErr *stacklock.LockBusyError
+		if !errors.As(acquireErr, &busyErr) {
+			t.Fatalf("Expected a contending lock acquire during Initialize to be busy, got %v", acquireErr)
 		}
 	})
 

--- a/cmd/up.go
+++ b/cmd/up.go
@@ -85,32 +85,32 @@ windsor up --blueprint=ghcr.io/myorg/blueprint:v1.0.0`,
 		// values, and (for azure contexts) authenticates to AKS. Request the full set so any
 		// of those tools are validated up front.
 		proj.SetToolRequirements(tools.AllRequirements())
-		if err := proj.Initialize(false, blueprintURL...); err != nil {
-			return err
-		}
 
-		// Initialize already persisted config with overwrite=false; re-save with
-		// overwrite=true only when --set was provided so user values land in
-		// values.yaml. Runs before the workstation guard so non-workstation
-		// contexts can still receive --set overrides.
-		if len(upSetFlags) > 0 {
-			if err := proj.Runtime.SaveConfig(true); err != nil {
-				return fmt.Errorf("failed to save configuration: %w", err)
-			}
-		}
-
-		if proj.Workstation == nil {
-			fmt.Fprintln(os.Stderr, "windsor up is only applicable when a workstation is enabled; use windsor apply to apply infrastructure")
-			return nil
-		}
-
-		if err := requireCloudAuth(cmd, proj); err != nil {
-			return err
-		}
-
+		// Run Initialize and the --set re-save inside the lock. This prevents two
+		// overlapping up runs from racing an unlocked read-modify-write on values.yaml.
 		var halted bool
 		var postRunMessages []blueprintv1alpha1.Message
 		if err := stacklock.With(cmd.Context(), proj.Runtime, "up", lockTimeout, func() error {
+			if err := proj.Initialize(false, blueprintURL...); err != nil {
+				return err
+			}
+
+			// Re-save with overwrite=true only for --set. Runs before the workstation
+			// check so non-workstation contexts still receive --set overrides.
+			if len(upSetFlags) > 0 {
+				if err := proj.Runtime.SaveConfig(true); err != nil {
+					return fmt.Errorf("failed to save configuration: %w", err)
+				}
+			}
+
+			if proj.Workstation == nil {
+				return nil
+			}
+
+			if err := requireCloudAuth(cmd, proj); err != nil {
+				return err
+			}
+
 			_, h, err := proj.Up()
 			if err != nil {
 				return err
@@ -146,6 +146,11 @@ windsor up --blueprint=ghcr.io/myorg/blueprint:v1.0.0`,
 			return nil
 		}); err != nil {
 			return err
+		}
+
+		if proj.Workstation == nil {
+			fmt.Fprintln(os.Stderr, "windsor up is only applicable when a workstation is enabled; use windsor apply to apply infrastructure")
+			return nil
 		}
 
 		if !halted {

--- a/cmd/up_test.go
+++ b/cmd/up_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -15,6 +16,7 @@ import (
 	"github.com/windsorcli/cli/pkg/project"
 	"github.com/windsorcli/cli/pkg/provisioner"
 	"github.com/windsorcli/cli/pkg/provisioner/kubernetes"
+	"github.com/windsorcli/cli/pkg/provisioner/stacklock"
 	terraforminfra "github.com/windsorcli/cli/pkg/provisioner/terraform"
 	"github.com/windsorcli/cli/pkg/runtime"
 	"github.com/windsorcli/cli/pkg/runtime/config"
@@ -206,6 +208,43 @@ func TestUpCmd(t *testing.T) {
 		// Then no error should occur and a descriptive message is printed
 		if err != nil {
 			t.Errorf("Expected no error, got %v", err)
+		}
+	})
+
+	t.Run("HoldsStackLockThroughInitializeAndSaveConfig", func(t *testing.T) {
+		// Regression test for windsorcli/cli#3315. Two overlapping up runs could race an
+		// unlocked read-modify-write on values.yaml. Proves the fix by acquiring a second,
+		// contending lock (timeout 0) from inside LoadBlueprint, which Initialize calls.
+		// A busy result means the outer lock is already held.
+		mocks := setupUpTest(t)
+		proj := newUpTestProject(mocks, true)
+
+		var acquireErr error
+		mocks.BlueprintHandler.LoadBlueprintFunc = func(urls ...string) error {
+			lock, err := stacklock.ForRuntime(mocks.Runtime)
+			if err != nil {
+				t.Fatalf("Failed to resolve stack lock: %v", err)
+			}
+			var release stacklock.Release
+			release, acquireErr = lock.Acquire(context.Background(), stacklock.NewInfo(mocks.Runtime, "contender"), 0)
+			if release != nil {
+				release()
+			}
+			return nil
+		}
+
+		cmd := createTestUpCmd()
+		ctx := context.WithValue(context.Background(), projectOverridesKey, proj)
+		cmd.SetArgs([]string{})
+		cmd.SetContext(ctx)
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Expected success, got %v", err)
+		}
+
+		var busyErr *stacklock.LockBusyError
+		if !errors.As(acquireErr, &busyErr) {
+			t.Fatalf("Expected a contending lock acquire during Initialize to be busy, got %v", acquireErr)
 		}
 	})
 


### PR DESCRIPTION
<!-- claude-code-review:summary -->

> [!NOTE]
>
> **Medium Risk**
>
> This touches the shared `windsor bootstrap` and `windsor up` command paths and changes stack-lock scope, so a mistake would affect every context, though the change is easy to reason about and revert.
>
> **Overview**
>
> The PR widens the stack lock held by `bootstrap` and `up` so it now wraps `proj.Initialize` (and the config-save calls that follow it), not just the terraform/install/wait phase. This closes a race where two overlapping runs could interleave an unlocked read-modify-write on `values.yaml`. Both commands' RunE bodies are restructured so Initialize, conditional SaveConfig, the workstation-nil check, cloud auth, and the apply/install/wait sequence all run inside a single `stacklock.With` closure.
>
> One behavioral detail worth noting: `windsor up` on a non-workstation context now acquires the stack lock (for Initialize/SaveConfig) before printing its "not applicable" message, where previously it returned immediately without ever touching the lock. Both commands gain a regression test that proves the lock is held throughout by attempting a contending zero-timeout acquire from inside `LoadBlueprint`.

<!-- /claude-code-review:summary -->
